### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean leanFiles in 29 amgm-inequality siblings (LOC 91→117, sorry 3→0)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -122,11 +122,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -122,11 +122,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -141,11 +141,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -79,11 +79,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -136,11 +136,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -97,11 +97,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -133,11 +133,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -129,11 +129,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -129,11 +129,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -145,11 +145,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -136,11 +136,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -130,11 +130,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -120,11 +120,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -130,11 +130,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -145,11 +145,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -137,11 +137,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -131,11 +131,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -127,11 +127,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -132,11 +132,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -93,11 +93,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -75,11 +75,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -144,11 +144,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -132,11 +132,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -125,11 +125,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -125,11 +125,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -125,11 +125,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -151,11 +151,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -153,11 +153,11 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 91,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean"
     },


### PR DESCRIPTION
## Fix

Batch sync of `Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean` `leanFiles[]` entry across 29 `amgm-inequality-*` sibling research JSONs.

The Aristotle companion file grew from the original 91-line stub (3 sorries) to a 117-line completed file (all 3 Newton-Girard corollary sorries proved):
- `psum_one_eq_esymm_one`
- `psum_two_eq`
- `psum_three_eq`

28 of 29 siblings carried the stale stub values; 1 carried the post-completion off-by-one (`lineCount: 118` from the legacy `split('\n').length` convention vs canonical `wc -l`).

## Evidence

**Before**:
- 28 siblings: `lineCount: 91, sorryCount: 3`
- 1 sibling (`amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03`): `lineCount: 118, sorryCount: 0`

**After**:
- All 29 siblings: `lineCount: 117, sorryCount: 0`

Other fields verified unchanged against the actual file:
- `theoremCount`: 3 (3 theorems, no lemmas at top level)
- `axiomCount`: 0 (`grep -cE '^axiom '` → 0)
- `defCount`: 0 (`grep -cE '^(def|noncomputable def|opaque def) '` → 0)

Net diff: 29 files × (2 fields per stub-sibling | 1 field per outlier) = 57 insertions, 57 deletions; no unrelated text changes. All modified JSONs parse cleanly with `python json.load`.

Consistent with recent mechanic batch-sync PRs (#19815, #19818, #19822, #19823, #19825, #19826).

---
Automated fix by lean-mechanic agent.