### PR TITLE
fix(meta): batch sync AngleTrisectionCos20GalOQ01OQ02.lean leanFiles in 26 angle-trisection siblings (LOC 327→439, sorry 3→0)

### DIFF
--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
@@ -96,11 +96,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
@@ -111,11 +111,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 440,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
@@ -107,11 +107,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
@@ -131,11 +131,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 440,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -133,11 +133,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -137,11 +137,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -134,11 +134,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -185,11 +185,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 440,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -148,11 +148,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -84,11 +84,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -152,11 +152,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -159,11 +159,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -144,11 +144,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -147,11 +147,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -138,11 +138,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -143,11 +143,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -90,11 +90,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -149,11 +149,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -141,11 +141,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-01.json
@@ -148,11 +148,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -142,11 +142,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -141,11 +141,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-04-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-02.json
@@ -132,11 +132,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-04-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-03.json
@@ -90,11 +90,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -93,11 +93,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -147,11 +147,11 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02.lean",
       "filename": "AngleTrisectionCos20GalOQ01OQ02.lean",
-      "lineCount": 327,
+      "lineCount": 439,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean"
     },


### PR DESCRIPTION
## Fix

The file `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean` grew from 327 → 439 lines (all 3 stub sorries discharged via cos(36°)/cos(π/7)/cos(20°) Galois group computations + a tautology placeholder for the general φ(2n)/2 formula). 26 sibling research JSONs carried stale tracking entries.

## Evidence

**Before**:
- 22 siblings: `lineCount: 327, sorryCount: 3` (pre-completion stub)
- 4 siblings: `lineCount: 440, sorryCount: 2` (legacy split-convention off-by-one + mid-completion state)

**After**:
- All 26 siblings: `lineCount: 439, sorryCount: 0`

**File verification** (against current `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean`):
| field | value | command |
|---|---|---|
| lineCount | 439 | `wc -l` |
| sorryCount | 0 | only matches are in docstrings/comments (lines 386, 434), not tactic position |
| theoremCount | 10 | `grep -cE '^(theorem\|lemma) '` |
| axiomCount | 0 | `grep -c '^axiom '` |
| defCount | 0 | `grep -cE '^(noncomputable def\|opaque def\|def) '` |

Only `lineCount` and `sorryCount` drifted — other counts already matched in all 26 siblings.

## Diff

26 files × 2 fields = **52 insertions, 52 deletions**; no unrelated text changes.
All 27 angle-trisection JSONs parse cleanly with `python json.load`.

---
Automated fix by lean-mechanic agent.