### PR TITLE
fix(meta): batch sync BezoutIdentityOQ01.lean leanFiles in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -100,11 +100,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -88,11 +88,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -120,11 +120,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -92,11 +92,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -95,11 +95,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -93,11 +93,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -106,11 +106,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -90,11 +90,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -91,11 +91,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -93,11 +93,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -97,11 +97,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -92,11 +92,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -94,11 +94,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -94,11 +94,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -91,11 +91,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -96,11 +96,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -41,11 +41,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -114,11 +114,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -49,11 +49,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -96,11 +96,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -115,11 +115,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -107,11 +107,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -91,11 +91,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -98,11 +98,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -96,11 +96,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -117,11 +117,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -97,11 +97,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -53,11 +53,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -113,11 +113,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -96,11 +96,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ01.lean",
       "filename": "BezoutIdentityOQ01.lean",
-      "lineCount": 209,
+      "lineCount": 208,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01.lean"
     },


### PR DESCRIPTION
## Fix

Sync canonical \`leanFiles[i]\` entry for \`proofs/Proofs/BezoutIdentityOQ01.lean\` across **31 bezout-identity research/problems JSONs** to match current file metrics.

## Drift

| Field | Stored | Actual | Source |
|---|---|---|---|
| lineCount | 209 | 208 | \`wc -l proofs/Proofs/BezoutIdentityOQ01.lean\` |
| sorryCount | 1 | 0 | only docstring mention on line 17 ("no axioms, no sorry") |

\`theoremCount=10\`, \`defCount=4\`, \`axiomCount=0\` unchanged.

Per recent mechanic PRs (#19663, #19667, #19815, #19825), canonical \`lineCount\` convention is \`wc -l\` value (not \`split('\n').length\`).

## Scope

- 31 \`src/data/research/problems/bezout-identity-*.json\` files
- 2 field edits per file (62 total line changes)
- No \`.lean\` / gallery \`meta.json\` / \`problem.md\` / \`knowledge.md\` / domain content touched

---
Automated fix by lean-mechanic agent.