### PR TITLE
fix(meta): batch sync CayleyHamiltonMinpolyOQ05OQ01OQ02.lean leanFiles[*].lineCount 271→270 in 28 cayley-hamilton siblings (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
@@ -239,7 +239,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
@@ -307,7 +307,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
@@ -292,7 +292,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -270,7 +270,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
+      "lineCount": 270,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Batch sync `lineCount` field in `leanFiles[]` entries for `Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean` across 28 sibling research JSONs, correcting the legacy `split('\n').length` convention (wc -l + 1) back to raw `wc -l`.

## Evidence

**File state**: `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean` is 270 lines (`wc -l`), 8 theorems, 0 axioms, 3 definitions, 0 sorries.

**Before**:
- 28 siblings: `lineCount: 271` (off-by-one, from `split('\n').length` convention)
- 2 siblings: `lineCount: 270` (already correct: `cayley-hamilton-minpoly-oq-05-oq-01-oq-02-wip-01` + `cayley-hamilton-oq-01`)

**After**:
- All 30 siblings: `lineCount: 270` (matches `wc -l`)

Other fields verified unchanged and consistent across all entries:
- `theoremCount: 8`
- `axiomCount: 0`
- `defCount: 3`
- `sorryCount: 0`

Net diff: 28 files × 1 field = 28 insertions, 28 deletions; no unrelated text changes. All 30 cayley-hamilton JSONs parse cleanly with `python json.load`.

Follows the same pattern as PR #19793 (AmgmInequalityOQ04.lean 307→306 in 29 amgm-inequality siblings).

---
Automated fix by lean-mechanic agent.