### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ02OQ01OQ01.lean leanFiles in 31 bezout siblings (LOC 183→182, sorry 1→0)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -243,11 +243,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -231,11 +231,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -263,11 +263,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -235,11 +235,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -238,11 +238,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -236,11 +236,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -260,11 +260,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -233,11 +233,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -234,11 +234,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -274,11 +274,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -236,11 +236,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -240,11 +240,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -235,11 +235,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -237,11 +237,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -237,11 +237,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -234,11 +234,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -239,11 +239,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -184,11 +184,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -192,11 +192,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -239,11 +239,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -283,11 +283,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -234,11 +234,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -241,11 +241,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -239,11 +239,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -260,11 +260,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -240,11 +240,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -196,11 +196,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -256,11 +256,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -239,11 +239,11 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01OQ01.lean",
-      "lineCount": 183,
+      "lineCount": 182,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean"
     },


### PR DESCRIPTION
## Fix

Batch sync of `Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean` `leanFiles[]` entry across 31 `bezout-identity-*` sibling research JSONs.

The entry across all 31 siblings carries stale values:
- `lineCount: 183` — legacy `split('\n').length` convention (= `wc -l` + 1)
- `sorryCount: 1` — stale stub value

The actual Lean source has `wc -l = 182` and 0 real sorries (the only "sorry" string at line 141 is inside a docstring comment).

## Evidence

**Before** (uniform across all 31 siblings):
- `lineCount: 183`
- `sorryCount: 1`

**After**:
- `lineCount: 182` (matches `wc -l proofs/Proofs/BezoutIdentityOQ02OQ02OQ01OQ01.lean`)
- `sorryCount: 0`

Ground truth verified against gallery canonical meta at `src/data/proofs/bezout-identity-oq-02-oq-02-oq-01-oq-01/meta.json`:
- `meta.lineCount: 182`
- `leanFile.lineCount: 182`
- `theoremCount: 6`
- `axiomCount: 0`
- `definitionCount: 2`

Other fields (`theoremCount: 6`, `axiomCount: 0`, `defCount: 2`) already matched and were left untouched.

Net diff: 31 files × 2 fields = 62 insertions, 62 deletions; no unrelated text changes. All modified JSONs parse cleanly with `python json.load`.

Consistent with recent mechanic batch-sync PRs (#19815, #19818, #19822, #19823, #19825, #19826, #19828).

---
Automated fix by lean-mechanic agent.