### PR TITLE
fix(meta): batch sync Erdos1201Problem.lean leanFiles in 4 erdos-1 siblings (LOC 1154→1651, thm 83→116, def 5→8)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -4103,10 +4103,10 @@
     {
       "path": "Proofs/Erdos1201Problem.lean",
       "filename": "Erdos1201Problem.lean",
-      "lineCount": 1154,
-      "theoremCount": 83,
+      "lineCount": 1651,
+      "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 5,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -3671,10 +3671,10 @@
     {
       "path": "Proofs/Erdos1201Problem.lean",
       "filename": "Erdos1201Problem.lean",
-      "lineCount": 1154,
-      "theoremCount": 83,
+      "lineCount": 1651,
+      "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 5,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -4126,10 +4126,10 @@
     {
       "path": "Proofs/Erdos1201Problem.lean",
       "filename": "Erdos1201Problem.lean",
-      "lineCount": 1154,
-      "theoremCount": 83,
+      "lineCount": 1651,
+      "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 5,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -4113,10 +4113,10 @@
     {
       "path": "Proofs/Erdos1201Problem.lean",
       "filename": "Erdos1201Problem.lean",
-      "lineCount": 1154,
-      "theoremCount": 83,
+      "lineCount": 1651,
+      "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 5,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"


### PR DESCRIPTION
## Fix

Batch sync `Erdos1201Problem.lean` `leanFiles[331]` entry across 4 `erdos-1-oq-0X` sibling research JSONs.

## Evidence

**Before** (all 4 siblings, identical drift):
```
lineCount=1154  theoremCount=83  axiomCount=1  defCount=5  sorryCount=0
```

**After** (canonical from gallery `src/data/proofs/erdos-1201/meta.json` + actual `wc -l`):
```
lineCount=1651  theoremCount=116  axiomCount=1  defCount=8  sorryCount=0
```

Deltas: +497 LOC, +33 thm, +3 def, axiom/sorry unchanged. File grew without back-syncing.

## Validation

```
$ wc -l proofs/Proofs/Erdos1201Problem.lean
    1651 proofs/Proofs/Erdos1201Problem.lean
$ python3 -c "import json; [json.load(open(f'src/data/research/problems/erdos-1-oq-0{i}.json')) for i in range(1,5)]; print('JSON OK')"
JSON OK
```

## Not touched

- Other `leanFiles[]` entries in same JSONs (separate-PR territory)
- Gallery `meta.json` (already canonical)
- `currentState.*`, `knowledge.*` — pure metadata sync

---
Automated fix by lean-mechanic agent.