### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ02.lean leanFiles in 23 ballot-problem siblings (defCount 24→29)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -322,7 +322,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -391,7 +391,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -339,7 +339,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -323,7 +323,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -326,7 +326,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -315,7 +315,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -373,7 +373,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -283,7 +283,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -345,7 +345,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -329,7 +329,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -318,7 +318,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -314,7 +314,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -319,7 +319,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -498,7 +498,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -320,7 +320,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -612,7 +612,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -325,7 +325,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -283,7 +283,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -342,7 +342,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -326,7 +326,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -325,7 +325,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -317,7 +317,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -317,7 +317,7 @@
       "lineCount": 2532,
       "theoremCount": 28,
       "axiomCount": 0,
-      "defCount": 24,
+      "defCount": 29,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"


### PR DESCRIPTION
## Fix

Sync stale `defCount: 24` → `defCount: 29` in the `leanFiles[*]` entry for `BallotProblemOQ03OQ02.lean` across 23 ballot-problem sibling research JSONs.

## Evidence

**Source-of-truth re-derivation** from `proofs/Proofs/BallotProblemOQ03OQ02.lean`:

| Field        | Actual | Sibling JSON | Status |
|--------------|--------|--------------|--------|
| `wc -l`      | 2532   | 2532         | OK     |
| theorems     | 28     | 28           | OK     |
| axioms       | 0      | 0            | OK     |
| sorries      | 0      | 0            | OK     |
| top-level def| 29     | 24           | FIX    |

Top-level def count: `grep -cE "^(def\|noncomputable def\|private def\|protected def)" proofs/Proofs/BallotProblemOQ03OQ02.lean` = `29`.

**Before**: 23 sibling research JSONs carried stale `defCount: 24`.
**After**: All 23 updated to `defCount: 29`. Pure single-field, single-line diff per file.

## Scope

- 23 `src/data/research/problems/ballot-problem-*.json` files
- No `.lean` source changes
- No gallery `src/data/proofs/.../meta.json` changes (uses different extraction convention: th=92, def=46 — full-AST not top-level grep, out of scope)
- No prose drift (combinations-formula-oq-01-oq-04.json references file in prose only, no leanFiles entry — excluded)

## Provenance

Drift accumulated since file's initial landing in PR #19454 (sperner-ndim mass-add). S78 ACT #19554 added 1 private lemma; def count was already 29 then. Sibling leanFiles[] entries were last populated when the file had 24 defs; subsequent ACTs added 5 more without sibling sync.

Convention matches recent batch-sync wave:
- #19797 CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean (33 siblings)
- #19800 BezoutIdentity.lean (31 siblings)
- #19802 BorsukUlamOQ04.lean (22 siblings)
- #19808 AreaOfCircle.lean (30 siblings)

---
Doc-only; 23 files, +23/-23. No Lean source touched; no build needed.
Automated fix by lean-mechanic agent.