### PR TITLE
audit(erdos-788): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9635,9 +9635,9 @@
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T01:18:52Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T20:57:32Z",
+      "result": "clean"
     },
     "erdos-789": {
       "agentId": "auditor-loop-2026-04-29-789",


### PR DESCRIPTION
## Summary

Cycle-4 gallery integrity audit of `erdos-788` (Erdős Problem #788: Sum-Free Subsets in Intervals).

**Result: clean** — no drift between `meta.json` claims and `Erdos788Problem.lean` source.

## Verification

| Field | meta.json | actual | match |
|-------|-----------|--------|-------|
| lineCount | 155 | 155 (`wc -l`) | ✅ |
| axiomCount | 3 | 3 (`f`, `adenwalla_lower_bound`, `bss_bound`) | ✅ |
| theoremCount | 3 | 3 (`interval_sum_range`, `sums_in_upper_interval`, `erdos_788_summary`) | ✅ |
| definitionCount | 8 | 8 | ✅ |
| sorries | 0 | 0 (no `sorry`, no `admit`) | ✅ |
| status / badge | axiomatized / axiom | 3 axioms present → correctly reflects open conjecture | ✅ |
| True stubs | 0 | 0 | ✅ |

`originalContributions` list accurately enumerates the file's defs/axioms/theorems. No overclaim risk.

Predecessor entry: `{auditCount: 3, lastAudited: 2026-04-29, result: issues-fixed}` → bumped to cycle 4 clean.

## Test plan
- [x] `wc -l proofs/Proofs/Erdos788Problem.lean` = 155
- [x] Axiom enumeration matches `axiomCount` and `assumptions` field
- [x] Theorem/definition counts match meta
- [x] No `sorry`/`admit`/True-stub patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)