### PR TITLE
fix(meta): batch sync Erdos1006OQ04.lean leanFiles in 19 erdos siblings (LOC 164→193, thm 11→15)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -693,8 +693,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -261,8 +261,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -716,8 +716,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -703,8 +703,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -481,8 +481,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -464,8 +464,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-01.json
+++ b/src/data/research/problems/erdos-100-oq-01.json
@@ -253,8 +253,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-100-oq-02-oq-02.json
@@ -328,8 +328,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-02.json
+++ b/src/data/research/problems/erdos-100-oq-02.json
@@ -319,8 +319,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-04.json
+++ b/src/data/research/problems/erdos-100-oq-04.json
@@ -317,8 +317,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -359,8 +359,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-01.json
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-02.json
@@ -86,8 +86,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01.json
@@ -104,8 +104,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-02-oq-01.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-02-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-02-oq-03.json
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-02.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-03.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-04.json
+++ b/src/data/research/problems/erdos-1006-oq-04.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `Proofs/Erdos1006OQ04.lean` `leanFiles[*]` entries across 19 sibling research JSONs to match current file stats.

## Evidence

**Before**: `lineCount: 164, theoremCount: 11`  
**After**:  `lineCount: 193, theoremCount: 15`

Ground truth (`proofs/Proofs/Erdos1006OQ04.lean`):
- `wc -l` → 193
- `grep -cE '^(theorem|lemma) '` → 15
- `grep -cE '^axiom '` → 0
- `grep -cE '^(def|noncomputable def|opaque def) '` → 0
- `\bsorry\b` occurrences → 0

The file was expanded (164 → 193 LOC, +4 theorems) but the 19 sibling JSONs were not re-enriched. Other fields (axiomCount, defCount, sorryCount, isAristotle, githubUrl, path, filename) verified consistent with file and unchanged.

Net diff: 19 files × 2 fields = 38 insertions, 38 deletions; no unrelated text. All modified JSONs parse cleanly with `python json.load`.

Slugs touched (19 total):
- erdos-1-oq-01, erdos-1-oq-02, erdos-1-oq-03, erdos-1-oq-04
- erdos-10, erdos-10-oq-01
- erdos-100, erdos-100-oq-01, erdos-100-oq-02, erdos-100-oq-02-oq-02, erdos-100-oq-04
- erdos-1006-oq-01, erdos-1006-oq-01-oq-01, erdos-1006-oq-01-oq-02
- erdos-1006-oq-02, erdos-1006-oq-02-oq-01, erdos-1006-oq-02-oq-03
- erdos-1006-oq-03, erdos-1006-oq-04

---
Automated fix by lean-mechanic agent.