### PR TITLE
fix(meta): batch sync Erdos1006OQ04.lean leanFiles in 19 erdos siblings (lineCount 164→193, theoremCount 11→15)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -693,8 +693,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -261,8 +261,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -716,8 +716,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -703,8 +703,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -481,8 +481,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -464,8 +464,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-01.json
+++ b/src/data/research/problems/erdos-100-oq-01.json
@@ -253,8 +253,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-100-oq-02-oq-02.json
@@ -328,8 +328,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-02.json
+++ b/src/data/research/problems/erdos-100-oq-02.json
@@ -319,8 +319,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-04.json
+++ b/src/data/research/problems/erdos-100-oq-04.json
@@ -317,8 +317,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -359,8 +359,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-01.json
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-02.json
@@ -86,8 +86,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-01.json
@@ -104,8 +104,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-02-oq-01.json
+++ b/src/data/research/problems/erdos-1006-oq-02-oq-01.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-02-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-02-oq-03.json
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-02.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-03.json
+++ b/src/data/research/problems/erdos-1006-oq-03.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1006-oq-04.json
+++ b/src/data/research/problems/erdos-1006-oq-04.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/Erdos1006OQ04.lean",
       "filename": "Erdos1006OQ04.lean",
-      "lineCount": 164,
-      "theoremCount": 11,
+      "lineCount": 193,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `Proofs/Erdos1006OQ04.lean` `leanFiles` entries across all 19 research-JSON siblings.

## Evidence

**Before** (19/19 siblings):
- `lineCount: 164`
- `theoremCount: 11`

**After** (matches actual file state):
- `lineCount: 193` (= `wc -l proofs/Proofs/Erdos1006OQ04.lean`)
- `theoremCount: 15` (top-level `theorem`/`lemma` decls)

**Other fields verified unchanged vs file**:
- `axiomCount: 0` (no `^axiom ` declarations)
- `defCount: 0` (no top-level `def` declarations)
- `sorryCount: 0` (no `sorry` outside comments)

## Scope

- 19 surgical 2-line edits (`lineCount` + `theoremCount` only)
- All 1917 `src/data/research/problems/*.json` parse cleanly via `python3 json.load`
- No `.lean`, no gallery `meta.json`, no other files touched

## Drift origin

Predecessor researcher PR(s) appended ~29 LOC + 4 new theorem/lemma decls to `Erdos1006OQ04.lean`; sibling JSONs (other research problems that reference this shared file in their `leanFiles[]` cross-references) were not updated.

---
Automated fix by lean-mechanic agent.