### PR TITLE
fix(meta): batch sync AngleTrisectionOQ02OQ01OQ02Incomplete01.lean leanFiles in 22 angle-trisection siblings (LOC 612→639, sorry 6→4)

### DIFF
--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -243,11 +243,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -247,11 +247,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -244,11 +244,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -328,7 +328,7 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 640,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -194,11 +194,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -262,11 +262,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -269,11 +269,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -254,11 +254,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -248,11 +248,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -253,11 +253,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -200,11 +200,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -259,11 +259,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -251,11 +251,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-01.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -252,11 +252,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -251,11 +251,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-04-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-02.json
@@ -242,11 +242,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-04-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-03.json
@@ -200,11 +200,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -203,11 +203,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -257,11 +257,11 @@
     {
       "path": "Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
       "filename": "AngleTrisectionOQ02OQ01OQ02Incomplete01.lean",
-      "lineCount": 612,
+      "lineCount": 639,
       "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 6,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean"
     },


### PR DESCRIPTION
## Fix

Sync stale leanFiles[] entries for `Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` across 22 angle-trisection research/problems JSONs.

## Evidence

Source-of-truth re-derivation from `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean`:

| Field        | Truth | Sibling state                              |
|--------------|-------|--------------------------------------------|
| `lineCount`  | 639   | 21 stale at 612, 1 split-length at 640     |
| `theoremCount` | 16  | matches — no fix needed                    |
| `axiomCount` | 0     | matches — no fix needed                    |
| `sorryCount` | 4     | 21 stale at 6, 1 already at 4              |
| `defCount`   | 1     | matches — no fix needed                    |

**Before**: leanFiles[] entries showed `lineCount: 612, sorryCount: 6` (or split-length 640) for the file across 22 sibling slugs.

**After**: all 22 entries match the actual file: `lineCount: 639, sorryCount: 4`.

22 files changed, 43 insertions(+), 43 deletions(-).

Doc-only; zero Lean source changes.

---
Automated fix by lean-mechanic agent.