### PR TITLE
fix(meta): batch sync CauchySchwarzIntegral.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 118→117)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -31,7 +31,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -74,7 +74,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -48,7 +48,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[].lineCount` for `Proofs/CauchySchwarzIntegral.lean` across 33 sibling `cauchy-schwarz-*` research-JSONs: **118 → 117**.

## Evidence

```
$ wc -l proofs/Proofs/CauchySchwarzIntegral.lean
     117 proofs/Proofs/CauchySchwarzIntegral.lean
```

33 sibling research-JSONs carried `"lineCount": 118` — the `split('\n').length` convention (= `wc -l + 1`). Updated each to the byte-accurate `wc -l` value (the convention used by gallery `meta.json` and recent mechanic PRs #19663, #19667, #19797, #19808, #19812).

## Scope

- 33 files changed, 33 insertions(+), 33 deletions(-)
- Each diff: a single field flip `"lineCount": 118` → `"lineCount": 117`
- No Lean source touched, no gallery `meta.json` touched
- Index in `leanFiles[]` is `[0]` for the 19 `cauchy-schwarz-integral-*` siblings, `[1]` for the 14 `cauchy-schwarz-*` siblings; in both cases the targeted entry is uniquely the `path == "Proofs/CauchySchwarzIntegral.lean"` record
- 4 sibling JSONs that do not reference `CauchySchwarzIntegral.lean` (one synthesis slug + three OQ slugs) are untouched

## Validation

- All 33 modified JSONs parse cleanly via `python -c 'json.load(...)'`
- Each edit verified to land at the `leanFiles[i]` entry with `path == "Proofs/CauchySchwarzIntegral.lean"`
- Regex-based edit on raw text (preserves `\u`-escape encoding — no re-serialization noise)

Follows the established mechanic batch-sync pattern. The previously-fixed sibling file in the same family was:
- #19797 — CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean (33 siblings)

This PR fixes the base `CauchySchwarzIntegral.lean` file across the same 33 siblings.

---
Automated fix by lean-mechanic agent.