### PR TITLE
fix(meta): sync InfinitudePrimes4k3OQ03.lean lineCount 104→103 in 4 sibling JSONs (split-length → wc -l)

### DIFF
--- a/src/data/research/problems/infinitude-primes-4k3.json
+++ b/src/data/research/problems/infinitude-primes-4k3.json
@@ -71,7 +71,7 @@
     {
       "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
       "filename": "InfinitudePrimes4k3OQ03.lean",
-      "lineCount": 104,
+      "lineCount": 103,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-01.json
+++ b/src/data/research/problems/infinitude-primes-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
       "filename": "InfinitudePrimes4k3OQ03.lean",
-      "lineCount": 104,
+      "lineCount": 103,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-02.json
+++ b/src/data/research/problems/infinitude-primes-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
       "filename": "InfinitudePrimes4k3OQ03.lean",
-      "lineCount": 104,
+      "lineCount": 103,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/infinitude-primes-oq-04.json
+++ b/src/data/research/problems/infinitude-primes-oq-04.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/InfinitudePrimes4k3OQ03.lean",
       "filename": "InfinitudePrimes4k3OQ03.lean",
-      "lineCount": 104,
+      "lineCount": 103,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `InfinitudePrimes4k3OQ03.lean` `lineCount` from `104 → 103` in 4 ancestor / sibling `infinitude-primes-*` research JSONs.

## Evidence

**Before**: 4 of 5 sibling JSONs referenced `InfinitudePrimes4k3OQ03.lean` with `lineCount: 104` (likely from old `split('\n').length` convention = `wc -l + 1`).

**After**: All 5 sibling JSONs + gallery canonical (`src/data/proofs/infinitude-primes-4k3-oq-03/meta.json`) consistently record `lineCount: 103`, matching `wc -l proofs/Proofs/InfinitudePrimes4k3OQ03.lean = 103`.

| slug                     | lineCount |
|--------------------------|-----------|
| `infinitude-primes-4k3`   | 104 → 103 |
| `infinitude-primes-oq-01` | 104 → 103 |
| `infinitude-primes-oq-02` | 104 → 103 |
| `infinitude-primes-oq-04` | 104 → 103 |
| `infinitude-primes-oq-03` | 103 (already correct) |

`InfinitudePrimes4k3OQ03.lean` was added in PR #15040 (2026-01) and has been stable at 103 lines since. Other fields (`theoremCount=4, axiomCount=0, defCount=0, sorryCount=0`) were already correct on all 5 slugs and remain unchanged.

Convention follows recent precedent PR #19835 (cayley-hamilton split-length → wc -l).

All 4 JSONs re-validated with `python3 -m json.tool`. No `.lean` changes, no gallery meta changes, no other slugs touched.

---
Automated fix by lean-mechanic agent.