### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ02OQ01.lean leanFiles in 30 area-of-circle siblings (lineCount 291→290)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -48,7 +48,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -39,7 +39,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -116,7 +116,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -138,7 +138,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -90,7 +90,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -123,7 +123,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -94,7 +94,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -194,7 +194,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01.lean",
-      "lineCount": 291,
+      "lineCount": 290,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Sync `leanFiles[].lineCount` for `Proofs/AreaOfCircleOQ01OQ02OQ01.lean` across 30 sibling `area-of-circle-*` research-JSONs: **291 → 290**.

## Evidence

```
$ wc -l proofs/Proofs/AreaOfCircleOQ01OQ02OQ01.lean
     290 proofs/Proofs/AreaOfCircleOQ01OQ02OQ01.lean
```

30 sibling research-JSONs carried `"lineCount": 291` — the `split('\n').length` convention (= `wc -l + 1`). Updated each to the byte-accurate `wc -l` value (the convention used by gallery `meta.json` — confirmed: `src/data/proofs/area-of-circle-oq-01-oq-02-oq-01/meta.json` `additionalFiles[].lineCount` == 290 — and recent mechanic PRs #19663, #19667, #19797, #19808, #19812, #19825, #19844).

## Scope

- 30 files changed, 30 insertions(+), 30 deletions(-)
- Each diff: a single field flip `"lineCount": 291` → `"lineCount": 290`
- All 30 entries are `leanFiles[1]` (uniquely the `path == "Proofs/AreaOfCircleOQ01OQ02OQ01.lean"` record)
- No Lean source touched; no gallery `meta.json` touched
- Other fields (`theoremCount=26`, `sorryCount=0`, `axiomCount=0`, `defCount=3`) uniform across all 30 — no other drift

## Validation

- All 30 modified JSONs parse cleanly via `python -c 'json.load(...)'`
- Each edit verified to land at the `leanFiles[i]` entry with `path == "Proofs/AreaOfCircleOQ01OQ02OQ01.lean"`
- Regex-based edit on raw text (preserves `\u`-escape encoding — no re-serialization noise)

Follows the established mechanic batch-sync pattern.

---
Automated fix by lean-mechanic agent.