### PR TITLE
fix(meta): batch sync BuffonsNeedleOQ01OQ01OQ04.lean leanFiles in 15 buffons-needle siblings (LOC 395→568, thm 25→27, sorry 1→0)

### DIFF
--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-01.json
@@ -117,11 +117,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-02.json
@@ -104,11 +104,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-03.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04-oq-01.json
@@ -127,11 +127,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01-oq-04.json
@@ -131,11 +131,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-01.json
@@ -111,11 +111,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02-oq-01.json
@@ -108,11 +108,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-02.json
@@ -146,11 +146,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-03.json
@@ -109,11 +109,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01-oq-04.json
+++ b/src/data/research/problems/buffons-needle-oq-01-oq-04.json
@@ -110,11 +110,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-01.json
@@ -115,11 +115,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02-oq-01.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-01.json
@@ -65,11 +65,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02-oq-02.json
@@ -85,11 +85,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-02.json
+++ b/src/data/research/problems/buffons-needle-oq-02.json
@@ -111,11 +111,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },

--- a/src/data/research/problems/buffons-needle-oq-03.json
+++ b/src/data/research/problems/buffons-needle-oq-03.json
@@ -119,11 +119,11 @@
     {
       "path": "Proofs/BuffonsNeedleOQ01OQ01OQ04.lean",
       "filename": "BuffonsNeedleOQ01OQ01OQ04.lean",
-      "lineCount": 395,
-      "theoremCount": 25,
+      "lineCount": 568,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 4,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean"
     },


### PR DESCRIPTION
## Fix

Sync `BuffonsNeedleOQ01OQ01OQ04.lean` stats in `leanFiles[4]` across 15 sibling buffons-needle research JSONs after the file was added at its current shape by PR #19454.

## Evidence

PR #19454 (sperner-ndim-mathlib-oq-01-oq-04 S2-A ACT) added `BuffonsNeedleOQ01OQ01OQ04.lean` to the tree at 568 lines / 27 theorems / 4 defs / 0 sorries. File content is the higher-dimensional Cauchy–Crofton formula (matches the `buffons-needle-oq-01-oq-01-oq-04` subject; the sperner PR title reflects the bundling commit, not the file topic). 15 sibling slugs still held pre-add values.

| field         | old | new |
|---------------|-----|-----|
| lineCount     | 395 | 568 |
| theoremCount  | 25  | 27  |
| axiomCount    | 0   | 0   (unchanged) |
| defCount      | 4   | 4   (unchanged) |
| sorryCount    | 1   | 0   |

Validated by:
- \`wc -l proofs/Proofs/BuffonsNeedleOQ01OQ01OQ04.lean\` → 568
- \`grep -cE '^(theorem|lemma) ' ...\` → 27
- \`grep -cE '^axiom ' ...\` → 0
- \`grep -cE '^(noncomputable )?(def|abbrev) ' ...\` → 4
- \`grep -coE '\bsorry\b' ...\` → 0

All 15 JSON files re-validated with \`python3 -m json.tool\`. No \`.lean\`, gallery meta, or other slug changes.

## Slugs touched (15)

- buffons-needle-oq-01
- buffons-needle-oq-01-oq-01
- buffons-needle-oq-01-oq-01-oq-01
- buffons-needle-oq-01-oq-01-oq-02
- buffons-needle-oq-01-oq-01-oq-03
- buffons-needle-oq-01-oq-01-oq-04
- buffons-needle-oq-01-oq-01-oq-04-oq-01
- buffons-needle-oq-01-oq-02
- buffons-needle-oq-01-oq-02-oq-01
- buffons-needle-oq-01-oq-03
- buffons-needle-oq-01-oq-04
- buffons-needle-oq-02
- buffons-needle-oq-02-oq-01
- buffons-needle-oq-02-oq-02
- buffons-needle-oq-03

---
Automated fix by lean-mechanic agent.