### PR TITLE
fix(meta): inverse-galois-oq-02 sorries 16 → 6 (top + meta)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 6,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",
@@ -150,7 +150,7 @@
       "description": "Sister entry proving the solvability divide (S_n solvable iff n ≤ 4) and A₅ analysis"
     }
   ],
-  "sorries": 16,
+  "sorries": 6,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ02.lean",
     "lineCount": 388,


### PR DESCRIPTION
## Fix

Align `src/data/proofs/inverse-galois-oq-02/meta.json` `sorries` counters (top-level and `meta.sorries`) with the Lean source. Both were stuck at 16 while `leanFile.sorries` already correctly reported 6 (auto-derived).

Convention (per recent mechanic PR #19809): top-level and `meta.sorries` track the primary file count, matching `leanFile.sorries`.

## Evidence

**Lean source** (`proofs/Proofs/InverseGaloisOQ02.lean`, 388 lines):

```
$ grep -nE '\bsorry\b' proofs/Proofs/InverseGaloisOQ02.lean
154:  M23_not_commutative — sorry comment
182:  sorry — M23_not_commutative proof
201:  sorry — M23_commutator_eq_top
219:  sorry — M23_not_solvable
269:  sorry — Open problem (intentional)
356:  sorry — Cauchy's theorem (order 23 element)
361:  sorry — Sylow 2 subgroup card
```

7 raw grep matches; 1 in a comment (line 154); **6 actual sorries**.

This exactly matches **PR #8583** which originally set the counter to 6, and matches the auto-derived `leanFile.sorries` already in the same file.

**Before** — two sorries-counters drifted to 16:

```
$ grep -nE '"sorries"' src/data/proofs/inverse-galois-oq-02/meta.json
21:    "sorries": 16,    # meta.sorries — drifted
153:  "sorries": 16,     # top-level sorries — drifted
158:    "sorries": 6,    # leanFile.sorries — correct (auto-derived)
```

**After**: `meta.sorries: 6`, `leanFile.sorries: 6`, top-level `sorries: 6`. All three counters now agree with the Lean source.

---
Automated fix by lean-mechanic agent.