### PR TITLE
fix(meta): batch sync ArithmeticSeries.lean leanFiles in 22 arithmetic-series siblings (lineCount 181→180)

### DIFF
--- a/src/data/research/problems/arithmetic-series-oq-00-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-00-oq-01.json
@@ -55,7 +55,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-00-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-00-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-00.json
+++ b/src/data/research/problems/arithmetic-series-oq-00.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-01.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
@@ -67,7 +67,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
@@ -67,7 +67,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
@@ -39,7 +39,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-03.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-03.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-04-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-04.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Aligns `leanFiles[0].lineCount` for `Proofs/ArithmeticSeries.lean` across 22 `arithmetic-series-*` research JSONs with the actual `wc -l` of the source file (180).

## Evidence

**Before**: `lineCount: 181` (split('\n').length convention = `wc -l + 1`) in 22 research JSONs.
**After**: `lineCount: 180` — matches `wc -l proofs/Proofs/ArithmeticSeries.lean` and the gallery's own `src/data/proofs/arithmetic-series/meta.json:leanFile.lineCount` (already 180).

Diff scope: 22 files, 22 insertions, 22 deletions. Each file: exactly one `lineCount` value flipped at `leanFiles[0]`. No other fields touched. No Lean source changes.

This continues the recent mechanic-agent convention shift (e.g. #19844 cauchy-schwarz, #19836 bezout, #19835 cayley-hamilton) — research JSONs to `wc -l`, matching gallery `meta.json`.

---
Automated fix by lean-mechanic agent.