### PR TITLE
fix(meta): batch sync ArithmeticSeries.lean leanFiles in 22 arithmetic-series siblings (lineCount 181→180)

### DIFF
--- a/src/data/research/problems/arithmetic-series-oq-00-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-00-oq-01.json
@@ -55,7 +55,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-00-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-00-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-00.json
+++ b/src/data/research/problems/arithmetic-series-oq-00.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-01.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
@@ -31,7 +31,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
@@ -67,7 +67,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
@@ -67,7 +67,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
@@ -39,7 +39,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-03.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-03.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-04-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/arithmetic-series-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-04.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/ArithmeticSeries.lean",
       "filename": "ArithmeticSeries.lean",
-      "lineCount": 181,
+      "lineCount": 180,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i].lineCount` for `ArithmeticSeries.lean` from the stale split-length convention (181) to `wc -l` (180) across 22 sibling research JSONs.

## Evidence

**Before**: `lineCount: 181` (split('\n').length convention, which is wc -l + 1).
**After**: `lineCount: 180` (wc -l, matches gallery meta.json `src/data/proofs/arithmetic-series/meta.json:leanFile.lineCount=180`).

```
$ wc -l proofs/Proofs/ArithmeticSeries.lean
180 proofs/Proofs/ArithmeticSeries.lean
```

Other counts (theoremCount=11, defCount=1, sorryCount=0, axiomCount=0) match the file and are preserved verbatim.

## Scope

Targeted edit using `jq --indent 2` updating only the leanFiles[i] entry where `filename == "ArithmeticSeries.lean"` in each of 22 sibling JSONs:

- arithmetic-series-oq-00.json (+oq-01, oq-02)
- arithmetic-series-oq-01.json
- arithmetic-series-oq-02*.json (×17 nested variants)
- arithmetic-series-oq-03.json
- arithmetic-series-oq-04.json (+oq-01)

22 files changed, 22 insertions(+), 22 deletions(-).

## Validation

- All 22 JSONs parse cleanly (`python3 -c 'import json; json.load(open(...))'`).
- No remaining drift for this filename: `lineCount drift remaining: 0`.
- No `pnpm build` (per `_mechanic_pnpm_build_regenerates_all_research_jsons` memory — single-file targeted fix).

---

Automated fix by lean-mechanic agent.