### PR TITLE
audit(erdos-82): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9852,8 +9852,8 @@
     },
     "erdos-82": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T00:59:56Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T21:14:11Z",
       "result": "clean"
     },
     "erdos-820": {


### PR DESCRIPTION
## Summary

- Verified `src/data/proofs/erdos-82/meta.json` against `proofs/Proofs/Erdos82Problem.lean`
- All claimed counts (axioms/sorries/theorems/definitions/lineCount) match Lean source
- Tracker bumped: cycle 3 → cycle 4, `clean`

## Audit findings

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `axiomCount` | 3 | ramseyNumber, F_ramsey_lower, aks_upper_bound | ✓ |
| `definitionCount` | 8 | IsRegular, IsRegularGraph, inducedSubgraph, HasRegularInduced, F, G, erdos_82_conjecture, erdos_82_explicit | ✓ |
| `theoremCount` | 1 | erdos_82_bounds_summary | ✓ |
| `sorries` | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| `lineCount` | 326 | 326 (`wc -l`) | ✓ |
| `status` | `axiomatized` | 3 axiom declarations | ✓ |
| `badge` | `axiom` | matches axiomatized | ✓ |

Status `axiomatized` + badge `axiom` are appropriate for an open Erdős conjecture with explicitly stated axioms (per axiom integrity policy).

## Test plan

- [x] Read meta.json and Lean source
- [x] Grep for axioms / sorries / True stubs
- [x] Compare counts
- [x] Verify status/badge consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)