### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean leanFiles in 33 cauchy-schwarz siblings (LOC 1078→1077, thm 11→18)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -108,8 +108,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -151,8 +151,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -156,8 +156,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -152,8 +152,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -146,8 +146,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -213,8 +213,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -184,8 +184,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -183,8 +183,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1078,
-      "theoremCount": 11,
+      "lineCount": 1077,
+      "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` entry for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`
across 33 sibling `cauchy-schwarz-*` research-JSONs whose `lineCount` and
`theoremCount` were stale.

## Evidence

| field         | old  | new  |
|---------------|------|------|
| lineCount     | 1078 | 1077 |
| theoremCount  | 11   | 18   |
| axiomCount    | 0    | 0    (unchanged) |
| defCount      | 3    | 3    (unchanged) |
| sorryCount    | 10   | 10   (unchanged) |

Verified against `origin/main` HEAD for `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean`:

```
wc -l                                                              -> 1077  (was 1078, split-length convention)
grep -cE '^(theorem|lemma|private theorem|private lemma|protected theorem|protected lemma) '  -> 18
                                                                    (was 11; narrow `^(theorem|lemma) ` regex missed 7 `private theorem` declarations)
grep -c  '^axiom '                                                 -> 0     (unchanged)
grep -cE '^(def|noncomputable def|opaque def|abbrev) '             -> 3     (unchanged)
grep -coE '\bsorry\b'                                              -> 10    (unchanged; raw enricher convention)
```

The 7 missing `private theorem` declarations are at lines 431, 520, 551, 560, 582, 591, 612.

## Convention

Follows the pattern used by recent mechanic PRs:
- **#19797** synced `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean` (sibling of this file)
- **#19758** synced `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`
- **#19674** used the broader `private|protected` theorem regex when syncing `Hilbert15OQ02OQ03OQ01.lean`
- **#19663, #19667** established `wc -l` as the canonical `lineCount`

## Scope

- **33 files** changed, 66 insertions(+), 66 deletions(-)
- Each diff: 2 field flips (`lineCount`, `theoremCount`) at the unique `leanFiles[i]` entry where `filename == "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"`
- Index `[7]` for 19 `cauchy-schwarz-integral-*` siblings, `[8]` for 13 `cauchy-schwarz-*` siblings, `[9]` for `cauchy-schwarz-oq-02-oq-02`
- **No** Lean source touched, **no** gallery `meta.json` touched, **no** other `leanFiles` entries touched
- Regex-based edit on raw text (preserves `\u`-escape encoding — no re-serialization noise)

## Validation

- All 33 modified JSONs parse cleanly via `python -m json.tool`
- Each edit verified to land at the unique `leanFiles[i]` entry with `filename == "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"`
- Pre-edit state (`lineCount: 1078, theoremCount: 11`) was identical across all 33 siblings — confirming this is a uniform sibling-drift case

## Disjoint from in-flight PRs

- **#19844** / **#19825** sync `CauchySchwarzIntegral.lean` (different Lean file)
- No open PR or branch targets `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (verified via `gh pr list` and `git ls-remote`)

---
Automated fix by lean-mechanic agent.