### PR TITLE
fix(meta): batch sync BorsukUlamOQ03.lean leanFiles in 24 borsuk-ulam siblings (lineCount 5140→5139)

### DIFF
--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
@@ -172,7 +172,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02.json
@@ -239,7 +239,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
@@ -177,7 +177,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
@@ -178,7 +178,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -382,7 +382,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04-oq-01.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
@@ -174,7 +174,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
@@ -173,7 +173,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
@@ -182,7 +182,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-04.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-05.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-05.json
@@ -178,7 +178,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -404,7 +404,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
@@ -173,7 +173,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-03.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -214,7 +214,7 @@
     {
       "path": "Proofs/BorsukUlamOQ03.lean",
       "filename": "BorsukUlamOQ03.lean",
-      "lineCount": 5140,
+      "lineCount": 5139,
       "theoremCount": 211,
       "axiomCount": 2,
       "defCount": 35,


### PR DESCRIPTION
## Fix

Align `leanFiles[*].lineCount` for `proofs/Proofs/BorsukUlamOQ03.lean` (`wc -l = 5139`) across all 24 sibling research JSONs that reference it. Previous value `5140` was the `split('\n').length` convention emitted by `scripts/research/enrich-research.ts` (= `wc -l + 1`); gallery + recent mechanic PRs standardize on `wc -l`.

## Evidence

**Before**: 24 research JSONs each list `leanFiles[*].lineCount: 5140` for `Proofs/BorsukUlamOQ03.lean`.
**After**: All 24 list `lineCount: 5139` (matches `wc -l proofs/Proofs/BorsukUlamOQ03.lean`).

No other field drift in this entry — `theoremCount`/`axiomCount`/`defCount`/`sorryCount` unchanged. One-line edit per file; 24 files / +24 / -24.

## Slugs touched (24)

borsuk-ulam-oq-02, borsuk-ulam-oq-02-oq-01, borsuk-ulam-oq-02-oq-01-oq-01, borsuk-ulam-oq-02-oq-01-oq-01-oq-01, borsuk-ulam-oq-02-oq-01-oq-01-oq-02, borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02, borsuk-ulam-oq-02-oq-01-oq-02, borsuk-ulam-oq-02-oq-01-oq-03, borsuk-ulam-oq-02-oq-01-oq-03-oq-02, borsuk-ulam-oq-02-oq-01-oq-04, borsuk-ulam-oq-02-oq-01-oq-04-oq-01, borsuk-ulam-oq-02-oq-02, borsuk-ulam-oq-02-oq-02-oq-01, borsuk-ulam-oq-02-oq-03, borsuk-ulam-oq-02-oq-04, borsuk-ulam-oq-03, borsuk-ulam-oq-03-oq-01, borsuk-ulam-oq-03-oq-01-oq-01, borsuk-ulam-oq-03-oq-03, borsuk-ulam-oq-03-oq-04, borsuk-ulam-oq-03-oq-05, borsuk-ulam-oq-04, borsuk-ulam-oq-04-oq-01, borsuk-ulam-oq-04-oq-03.

---
Automated fix by lean-mechanic agent.