### PR TITLE
fix(meta): batch sync BezoutIdentityOQ01OQ01.lean leanFiles in 31 bezout-identity siblings (LOC 189→188, thm 6→14)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -122,8 +122,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -110,8 +110,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -142,8 +142,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -117,8 +117,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -128,8 +128,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -131,8 +131,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -116,8 +116,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -116,8 +116,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -118,8 +118,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -63,8 +63,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -136,8 +136,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -71,8 +71,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -118,8 +118,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -137,8 +137,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -129,8 +129,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -120,8 +120,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -118,8 +118,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -139,8 +139,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -75,8 +75,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -135,8 +135,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -118,8 +118,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
       "filename": "BezoutIdentityOQ01OQ01.lean",
-      "lineCount": 189,
-      "theoremCount": 6,
+      "lineCount": 188,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[3]` entry for `Proofs/BezoutIdentityOQ01OQ01.lean` across 31
sibling `bezout-identity-*` research-JSONs whose `lineCount` and `theoremCount`
were stale.

## Evidence

| field         | old  | new  |
|---------------|------|------|
| lineCount     | 189  | 188  |
| theoremCount  | 6    | 14   |
| axiomCount    | 0    | 0    (unchanged) |
| defCount      | 1    | 1    (unchanged) |
| sorryCount    | 0    | 0    (unchanged) |

Verified against `origin/main` HEAD for `proofs/Proofs/BezoutIdentityOQ01OQ01.lean`:

```
wc -l                                                              -> 188  (was 189, split-length convention)
grep -cE '^(theorem|lemma|private theorem|private lemma|protected theorem|protected lemma) '  -> 14
                                                                    (was 6; narrow `^(theorem|lemma) ` regex missed 8 `private lemma` declarations)
grep -c  '^axiom '                                                 -> 0    (unchanged)
grep -cE '^(def|noncomputable def|opaque def|abbrev) '             -> 1    (unchanged)
grep -coE '\bsorry\b'                                              -> 0    (unchanged)
```

The 8 missing `private lemma` declarations are at lines 37, 42, 47, 52, 57, 63, 68, 78.

## Convention

Follows the pattern used by recent mechanic PRs:
- **#19854** synced `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (same broader-regex fix for missed `private` declarations)
- **#19831** synced sibling `BezoutIdentityOQ01.lean`
- **#19836** synced sibling `BezoutIdentityOQ02OQ02OQ01OQ01.lean`
- **#19663, #19667** established `wc -l` as the canonical `lineCount`

## Scope

- **31 files** changed, 62 insertions(+), 62 deletions(-)
- Each diff: 2 field flips (`lineCount`, `theoremCount`) at the unique `leanFiles[3]` entry where `filename == "BezoutIdentityOQ01OQ01.lean"`
- All 31 siblings had identical pre-edit values (`lineCount: 189, theoremCount: 6`) — uniform sibling-drift case
- **No** Lean source touched, **no** gallery `meta.json` touched, **no** other `leanFiles` entries touched
- Regex-based edit on raw text (preserves `\u`-escape encoding — no re-serialization noise)

## Validation

- All 31 modified JSONs parse cleanly via `python -m json.tool`
- Each edit verified to land at the unique `leanFiles[3]` entry with `filename == "BezoutIdentityOQ01OQ01.lean"` and post-edit values `lineCount=188, theoremCount=14`

## Disjoint from in-flight PRs

- **#19831** syncs `BezoutIdentityOQ01.lean` (different file — no `OQ01OQ01` suffix)
- **#19836** syncs `BezoutIdentityOQ02OQ02OQ01OQ01.lean` (different file)
- No open PR or branch targets `BezoutIdentityOQ01OQ01.lean` (verified via `gh pr list` and `git ls-remote`)

---
Automated fix by lean-mechanic agent.