### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ02OQ02OQ01.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 118→117)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -275,7 +275,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -207,7 +207,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -288,7 +288,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -255,7 +255,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -297,7 +297,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -291,7 +291,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -312,7 +312,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -293,7 +293,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -292,7 +292,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -276,7 +276,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -275,7 +275,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -283,7 +283,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -276,7 +276,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -282,7 +282,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -295,7 +295,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02OQ01.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync sibling research JSONs to actual `wc -l` for `CauchySchwarzIntegralOQ02OQ02OQ01.lean`. Gallery canonical
`src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02-oq-01/meta.json` already reports `lineCount: 117`.

## Evidence

**Before**: 33 sibling research JSONs under `src/data/research/problems/cauchy-schwarz{,-integral}-*` carried `lineCount: 118` for the `CauchySchwarzIntegralOQ02OQ02OQ01.lean` entry in `leanFiles[]`.

**After**: All 33 entries now report `lineCount: 117` matching `wc -l proofs/Proofs/CauchySchwarzIntegralOQ02OQ02OQ01.lean = 117` and the gallery canonical meta.

## Convention

Legacy `pnpm research:enrich` regenerated `lineCount` using `text.split('\n').length` (= `wc -l + 1`). Recent gallery + mechanic batch syncs (#19663, #19844, #19852, etc.) standardize on raw `wc -l` to match gallery meta.json.

`theoremCount=3`, `axiomCount=0`, `defCount=0`, `sorryCount=0` already matched across all 33 entries; only `lineCount` was drifted.

Surgical regex edit: 33 files, 1 line each, anchored to the entry whose `filename == CauchySchwarzIntegralOQ02OQ02OQ01.lean`. All 33 files still parse as JSON after edit.

---
Automated fix by lean-mechanic agent.