### PR TITLE
fix(meta): batch sync FourierSeriesOQ02Incomplete01.lean leanFiles in 10 fourier-series siblings (lineCount 423→422, oq-02-incomplete-01 sorryCount 5→1)

### DIFF
--- a/src/data/research/problems/fourier-series-oq-01-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-01-oq-02.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-01.json
+++ b/src/data/research/problems/fourier-series-oq-01.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
+++ b/src/data/research/problems/fourier-series-oq-02-incomplete-01.json
@@ -95,11 +95,11 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 240,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 5,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FourierSeriesOQ02Incomplete01.lean"
     }

--- a/src/data/research/problems/fourier-series-oq-02-oq-01.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-01.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-02-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-03-oq-02.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-02-oq-03.json
+++ b/src/data/research/problems/fourier-series-oq-02-oq-03.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-02.json
+++ b/src/data/research/problems/fourier-series-oq-02.json
@@ -164,7 +164,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-03.json
+++ b/src/data/research/problems/fourier-series-oq-03.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/fourier-series-oq-04.json
+++ b/src/data/research/problems/fourier-series-oq-04.json
@@ -56,7 +56,7 @@
     {
       "path": "Proofs/FourierSeriesOQ02Incomplete01.lean",
       "filename": "FourierSeriesOQ02Incomplete01.lean",
-      "lineCount": 423,
+      "lineCount": 422,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Align `leanFiles[*]` entries for `proofs/Proofs/FourierSeriesOQ02Incomplete01.lean` across all 10 sibling research JSONs that reference it. Ground truth: `wc -l = 422`, theorems = 10, sorries = 1, axioms = 0, defs = 0.

## Evidence

**Before**:
- 9 siblings list `lineCount: 423` (one-field off-by-one — the `split('\n').length` convention emitted by `scripts/research/enrich-research.ts`, = `wc -l + 1`).
- 1 sibling (`fourier-series-oq-02-incomplete-01`, the canonical `leanFiles[0]` slug) lists `lineCount: 240, sorryCount: 5` — stale from when the file was 240 LOC with 5 sorries.

**After**: All 10 list `lineCount: 422`; the canonical slug also gets `sorryCount: 5 → 1`. No other field drift in any entry — `theoremCount`/`axiomCount`/`defCount` unchanged.

10 files / +11 / -11.

## Slugs touched (10)

fourier-series-oq-01, fourier-series-oq-01-oq-02, fourier-series-oq-02, fourier-series-oq-02-incomplete-01, fourier-series-oq-02-oq-01, fourier-series-oq-02-oq-02, fourier-series-oq-02-oq-03, fourier-series-oq-02-oq-03-oq-02, fourier-series-oq-03, fourier-series-oq-04.

---
Automated fix by lean-mechanic agent.