### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01.lean leanFiles in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -53,7 +53,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/CauchySchwarzIntegralOQ01OQ01.lean` across 33 sibling research JSONs in the `cauchy-schwarz-*` family. Off-by-one drift from the historical `split('\n').length` convention vs. the canonical `wc -l` used by recent mechanic PRs.

## Evidence

**Before**: 33 of 33 siblings carried `lineCount: 154` for `Proofs/CauchySchwarzIntegralOQ01OQ01.lean`.
**After**: All 33 carry `lineCount: 153` (matches `wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean`).

Other fields verified unchanged against the actual file:
- `theoremCount: 10`  (`grep -cE '^(private |protected |noncomputable )?(theorem|lemma) '` → 10)
- `axiomCount: 0`     (`grep -cE '^axiom '` → 0)
- `defCount: 0`       (`grep -cE '^(def|noncomputable def|opaque def) '` → 0)
- `sorryCount: 0`     (no `\bsorry\b` matches in code)

Net diff: 33 files changed, 33 insertions, 33 deletions (1 field × 33 files); no unrelated text changes. All 33 modified JSONs parse cleanly with `python json.load`.

## Scope

- One Lean file × 33 sibling JSONs (`leanFiles[i]` entry for `CauchySchwarzIntegralOQ01OQ01.lean`)
- Sibling family-mate PR `#19815` synced `CauchySchwarzIntegralOQ01.lean` (228→227) across the same 33 slugs yesterday; this PR continues the same family clean-up for the next file in the chain
- Other shared files in the family (`OQ01OQ01OQ01.lean` 184→183, `OQ01OQ02.lean` 601→600, etc.) still carry the same off-by-one drift and will be addressed in follow-up batch syncs

Same drift pattern as recent mechanic PRs #19815, #19808, #19812, #19785, #19758, #19771, #19767.

---
Automated fix by lean-mechanic agent.