### PR TITLE
fix(meta): batch sync AmgmInequalityOQ04OQ01.lean leanFiles in 29 amgm siblings (lineCount 186→187)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -211,7 +211,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -277,7 +277,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -277,7 +277,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -207,7 +207,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -276,7 +276,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -283,7 +283,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -285,7 +285,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
       "filename": "AmgmInequalityOQ04OQ01.lean",
-      "lineCount": 186,
+      "lineCount": 187,
       "theoremCount": 10,
       "axiomCount": 1,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/AmgmInequalityOQ04OQ01.lean` across 29 sibling research JSONs in the `amgm-inequality-*` family. Off-by-one drift from the historical `split('\n').length` convention vs. the canonical `wc -l` used by recent mechanic PRs.

## Evidence

**Before**: 29 of 29 siblings carried `lineCount: 186` for `Proofs/AmgmInequalityOQ04OQ01.lean`.
**After**: All 29 carry `lineCount: 187` (matches `wc -l proofs/Proofs/AmgmInequalityOQ04OQ01.lean`).

Other fields verified unchanged against the actual file:
- `theoremCount: 10`  (`grep -cE '^(theorem|lemma) '` → 10)
- `axiomCount: 1`     (`grep -cE '^axiom '` → 1)
- `defCount: 2`       (`grep -cE '^(noncomputable\s+)?(def|structure|class|inductive|instance|abbrev) '` → 2)
- `sorryCount: 1`     (`grep -cE '\bsorry\b'` → 1)

Net diff: 29 files changed, 29 insertions, 29 deletions (1 field × 29 files); no unrelated text changes. All 29 modified JSONs parse cleanly with `python json.load`.

Same drift pattern as recent mechanic PRs #19815, #19812, #19808, #19785.

---
Automated fix by lean-mechanic agent.