### PR TITLE
fix(meta): batch sync Erdos1065BatemanHorn.lean leanFiles in 10 erdos siblings (lineCount 386→460, theoremCount 32→35)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -2123,8 +2123,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -1691,8 +1691,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -2146,8 +2146,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -2133,8 +2133,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -1911,8 +1911,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -1894,8 +1894,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-106-oq-02.json
+++ b/src/data/research/problems/erdos-106-oq-02.json
@@ -167,8 +167,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1065-oq-05-oq-01.json
+++ b/src/data/research/problems/erdos-1065-oq-05-oq-01.json
@@ -61,8 +61,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1065-oq-05.json
+++ b/src/data/research/problems/erdos-1065-oq-05.json
@@ -78,8 +78,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1065-oq-06.json
+++ b/src/data/research/problems/erdos-1065-oq-06.json
@@ -81,8 +81,8 @@
     {
       "path": "Proofs/Erdos1065BatemanHorn.lean",
       "filename": "Erdos1065BatemanHorn.lean",
-      "lineCount": 386,
-      "theoremCount": 32,
+      "lineCount": 460,
+      "theoremCount": 35,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sole canonical owner `erdos-1065.json` had already-synced values (`lc=460, thm=35, def=3, ax=1, sorries=0`) from PR #19454's `pnpm build` sweep, but **10 sibling JSONs** that cite `Proofs/Erdos1065BatemanHorn.lean` in their `leanFiles[]` were left at stale `(lc=386, thm=32)` — a **~74-LOC + 3-theorem drift** relative to the current source.

## Evidence

Canonical values verified via:

```
wc -l proofs/Proofs/Erdos1065BatemanHorn.lean    -> 460
grep -cE '^(@\[.*\]\s*)*(theorem|lemma)\s+\w+'   -> 35
grep -cE '^(@\[.*\]\s*)*def\s+\w+'               -> 3
grep -cE '^(@\[.*\]\s*)*axiom\s+\w+'             -> 1
grep -c '\bsorry\b'                              -> 0
```

Matches owner `erdos-1065.json` verbatim. `defCount` / `axiomCount` / `sorryCount` already correct in all 10 siblings — only `lineCount` + `theoremCount` fields touched.

| Slug | Was | Now |
| --- | --- | --- |
| erdos-1 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1-oq-01 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1-oq-02 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1-oq-03 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1-oq-04 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-10 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-10-oq-01 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-106-oq-02 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1065-oq-05 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1065-oq-05-oq-01 | lc=386, thm=32 | lc=460, thm=35 |
| erdos-1065-oq-06 | lc=386, thm=32 | lc=460, thm=35 |

(11 rows above include owner `erdos-1` whose entry was already at the new value — listed only to disambiguate.)

Diff: 10 files / 20 insertions / 20 deletions. No `.lean` source, no gallery `meta.json`, no other research JSON fields touched.

---
Automated fix by lean-mechanic agent.