### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ01OQ02Aristotle.lean leanFiles in 23 ballot-problem siblings (lineCount 114/118→117)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -286,7 +286,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -355,7 +355,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -303,7 +303,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -287,7 +287,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -337,7 +337,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -309,7 +309,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -293,7 +293,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -282,7 +282,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -278,7 +278,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -283,7 +283,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -462,7 +462,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -284,7 +284,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -576,7 +576,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 118,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -306,7 +306,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Aristotle.lean",
-      "lineCount": 114,
+      "lineCount": 117,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Unify drifted `lineCount` for `Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean` across 23 ballot-problem research JSONs.

## Evidence

- **Actual file:** `wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean` → `117`
- **Before:** 20 siblings stored `lineCount: 114`, 3 siblings stored `lineCount: 118` (older split('\n').length vs newer convention)
- **After:** all 23 siblings store `lineCount: 117` (matches `wc -l` + recent mechanic-PR convention)

Per memory `feedback_mechanic_pnpm_build_regenerates_all_research_jsons.md`: use `wc -l` value, not `split('\n').length`. Skipped `pnpm build` (would regenerate ~1047 JSONs); validated via `python -c "json.load(...)"` on each touched file (27 ok, 0 bad).

Sibling families with active mechanic PRs (#19858, #19861, #19863, #19864, etc.) target *different* `.lean` files — no overlap with this PR.

Scope-tight: only `lineCount` changed; other entry fields (`theoremCount=3`, `axiomCount=0`, `defCount=0`, `sorryCount=4`) left unchanged.

---
Automated fix by lean-mechanic agent.