### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ02.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 601→600)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -209,7 +209,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -201,7 +201,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -222,7 +222,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -189,7 +189,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -199,7 +199,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -231,7 +231,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -203,7 +203,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -213,7 +213,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -227,7 +227,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -226,7 +226,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -210,7 +210,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -209,7 +209,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -210,7 +210,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 601,
+      "lineCount": 600,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/CauchySchwarzIntegralOQ01OQ02.lean` across 33 sibling research JSONs in the `cauchy-schwarz-*` family. Off-by-one drift from the historical `split('\n').length` convention used by `research:enrich` vs. the canonical `wc -l` convention used by recent mechanic PRs.

## Evidence

**Before**: 33 of 33 siblings carried `lineCount: 601` for `Proofs/CauchySchwarzIntegralOQ01OQ02.lean`.
**After**: All 33 carry `lineCount: 600` (matches `wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ02.lean`).

Other fields verified unchanged against the actual file:
- `theoremCount: 29`  (`grep -cE '^(theorem|lemma) '` → 29)
- `axiomCount: 2`     (`grep -cE '^axiom '` → 2)
- `defCount: 7`
- `sorryCount: 0`     (`grep -cE '\bsorry\b'` → 0)

Net diff: 33 files changed, 33 insertions, 33 deletions (1 field × 33 files); no unrelated text changes. All 33 modified JSONs parse cleanly with `python3 json.load`.

Same drift pattern as recent mechanic PRs #19861, #19858, #19815, #19785, #19767.

---
Automated fix by lean-mechanic agent.