### PR TITLE
fix(meta): lovasz-local-lemma-oq-02 sorries 9→1 (post-LLL-tightness ACT drift)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -17,7 +17,7 @@
       "polynomial-inequalities"
     ],
     "badge": "wip",
-    "sorries": 9,
+    "sorries": 1,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
     "assumptions": "1 sorry remains: lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization (all terms equal iff x = 1/(d+1)). Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
@@ -202,5 +202,5 @@
       "leanType": "(d : ℕ) → 0 < d → (p : ℚ) → 0 ≤ p → (∃ x : ℚ, 0 ≤ x ∧ x ≤ 1 ∧ p ≤ x * (1-x)^d) ↔ p ≤ lllThreshold d"
     }
   ],
-  "sorries": 9
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/lovasz-local-lemma-oq-02/meta.json` declared `sorries: 9` in two places (`meta.sorries`, top-level `sorries`), but the source-of-truth Lean file `proofs/Proofs/LovaszLocalLemmaOQ02.lean` contains only **1** real `sorry` (`lllThreshold_strict_maximum` equality case, line 207). The second `grep` hit at line 223 is inside a docstring (`...by lllThreshold_is_maximum. (sorry)`) — narrative, not a tactic.

## Evidence

```
$ wc -l proofs/Proofs/LovaszLocalLemmaOQ02.lean
     240 proofs/Proofs/LovaszLocalLemmaOQ02.lean
$ grep -nE '^\s*sorry\b' proofs/Proofs/LovaszLocalLemmaOQ02.lean
207:    sorry
```

The `leanFile.sorries` field (line 136 in meta.json) already correctly read `1`. The `meta.assumptions` field already correctly stated "1 sorry remains: lllThreshold_strict_maximum equality case". So only the two summary-count fields needed to be brought in line.

**Before** (drift):

| Field                          | Value |
|--------------------------------|-------|
| `meta.sorries`                 | 9     |
| `leanFile.sorries`             | 1     |
| top-level `sorries`            | 9     |

**After** (consistent):

| Field                          | Value |
|--------------------------------|-------|
| `meta.sorries`                 | 1     |
| `leanFile.sorries`             | 1     |
| top-level `sorries`            | 1     |

No status / badge / lineCount / theoremCount changes needed — verified all other fields match the current Lean file (240 LOC, 13 theorems, 0 defs, 0 axioms; `status: formalized`, `badge: wip` remain appropriate).

---
Automated fix by lean-mechanic agent.