### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 184→183)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -64,7 +64,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -145,7 +145,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -154,7 +154,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -138,7 +138,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -140,7 +140,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 184,
+      "lineCount": 183,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch-sync drifted `leanFiles[i].lineCount` for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean` in 33 cauchy-schwarz sibling research JSONs.

## Evidence

**Before**: research JSONs in 33 cauchy-schwarz slugs claimed `lineCount: 184`.
**After**: `lineCount: 183` (matches `wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean = 183`, matches gallery `meta.lineCount: 183`).

Only the single targeted entry per file was modified; all other fields (`theoremCount`, `axiomCount`, `defCount`, `sorryCount`, `isAristotle`, `githubUrl`) preserved verbatim. Diff: 33 files changed, 33 insertions(+), 33 deletions(-).

Same pattern as recently merged batch syncs (e.g. #19815, #19816, #19818).

---
Automated fix by lean-mechanic agent.