### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02.lean leanFiles in 31 bezout-identity siblings (lineCount 193→192)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -153,7 +153,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -123,7 +123,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -153,7 +153,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -74,7 +74,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02.lean",
       "filename": "BezoutIdentityOQ02.lean",
-      "lineCount": 193,
+      "lineCount": 192,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[].lineCount` entries for `BezoutIdentityOQ02.lean` across 31 bezout-identity sibling research JSONs.

## Evidence

**Before**: 31 research JSONs listed `BezoutIdentityOQ02.lean` with `lineCount: 193`.
**After**: Updated to `lineCount: 192` matching `wc -l proofs/Proofs/BezoutIdentityOQ02.lean = 192`.

Single-line targeted replacement; Unicode encoding (`\u…` escapes) preserved verbatim.

Same pattern as recently-merged sibling sync PRs (#19857, #19815, etc.).

---
Automated fix by lean-mechanic agent.