### PR TITLE
fix(meta): batch sync AbelRuffiniGaloisExtensionsOQ07.lean leanFiles in 2 sibling JSONs (LOC 1290/1532→1898, thm 28/19→38, sorry 1/9→7)

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -195,11 +195,11 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
       "filename": "AbelRuffiniGaloisExtensionsOQ07.lean",
-      "lineCount": 1290,
-      "theoremCount": 28,
+      "lineCount": 1898,
+      "theoremCount": 38,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean"
     },

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
@@ -191,11 +191,11 @@
     {
       "path": "Proofs/AbelRuffiniGaloisExtensionsOQ07.lean",
       "filename": "AbelRuffiniGaloisExtensionsOQ07.lean",
-      "lineCount": 1532,
-      "theoremCount": 19,
+      "lineCount": 1898,
+      "theoremCount": 38,
       "axiomCount": 1,
       "defCount": 0,
-      "sorryCount": 9,
+      "sorryCount": 7,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean"
     },


### PR DESCRIPTION
## Fix

Synchronize cached `leanFiles[i]` stats for `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` across the 2 sibling research JSONs that reference it.

## Evidence

**Before** (per-slug cached values):
| slug | LOC | thm | def | ax | sorry |
|---|---|---|---|---|---|
| `abel-ruffini-galois-extensions-oq-07` | 1290 | 28 | 0 | 1 | 1 |
| `abel-ruffini-oq-04-oq-09` | 1532 | 19 | 0 | 1 | 9 |

**After** (matches actual file, single source of truth):
| | LOC | thm | def | ax | sorry |
|---|---|---|---|---|---|
| actual (this PR) | 1898 | 38 | 0 | 1 | 7 |

Conventions used (matching `scripts/research/enrich-research.ts` and recent mechanic PRs):
- `lineCount = wc -l` (raw newline count)
- `theoremCount = ^(?:protected \|private \|noncomputable )*(theorem\|lemma) ` line matches
- `axiomCount = ^axiom ` line matches
- `defCount = ^(def\|noncomputable def\|opaque def) ` line matches
- `sorryCount = raw \bsorry\b matches` (per `enrich-research.ts`; here all 7 occurrences are inside docstring/comment narrative, no actual proof sorries)

Note: `abel-ruffini-galois-extensions-oq-06.json` also has `Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` referenced (via filename prefix), but its `leanFiles` is `null`, so this PR does not touch it.

---
Automated fix by lean-mechanic agent.