### PR TITLE
fix(meta): batch sync ShannonChannelCoding family leanFiles in 10 sibling JSONs (99 entries)

### DIFF
--- a/src/data/research/problems/shannon-channel-coding-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-01.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -81,8 +81,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -131,8 +131,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -153,7 +153,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -208,7 +208,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -117,7 +117,7 @@
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
       "lineCount": 312,
       "theoremCount": 6,
-      "axiomCount": 0,
+      "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -148,8 +148,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -159,8 +159,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -170,7 +170,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -181,8 +181,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -192,7 +192,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -203,7 +203,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-03.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -99,8 +99,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -132,8 +132,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -143,8 +143,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -154,7 +154,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -165,8 +165,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -176,7 +176,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -187,7 +187,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-04.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -92,8 +92,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -136,8 +136,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-02.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -135,8 +135,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -146,8 +146,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-03.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-03.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -93,8 +93,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -126,8 +126,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -137,8 +137,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -159,8 +159,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -170,7 +170,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04-oq-01.json
@@ -42,7 +42,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -53,8 +53,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -64,7 +64,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -86,8 +86,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -97,8 +97,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding-oq-04.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-04.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -81,8 +81,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/shannon-channel-coding.json
+++ b/src/data/research/problems/shannon-channel-coding.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02.lean",
       "filename": "ShannonChannelCodingOQ02.lean",
-      "lineCount": 298,
+      "lineCount": 297,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
@@ -91,8 +91,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01.lean",
       "filename": "ShannonChannelCodingOQ02OQ01.lean",
-      "lineCount": 182,
-      "theoremCount": 3,
+      "lineCount": 312,
+      "theoremCount": 6,
       "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean",
       "filename": "ShannonChannelCodingOQ02OQ01Aristotle.lean",
-      "lineCount": 112,
+      "lineCount": 111,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ03.lean",
       "filename": "ShannonChannelCodingOQ02OQ03.lean",
-      "lineCount": 163,
+      "lineCount": 162,
       "theoremCount": 5,
       "axiomCount": 1,
       "defCount": 1,
@@ -124,8 +124,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ02OQ04.lean",
       "filename": "ShannonChannelCodingOQ02OQ04.lean",
-      "lineCount": 249,
-      "theoremCount": 10,
+      "lineCount": 248,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,
@@ -135,8 +135,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03.lean",
       "filename": "ShannonChannelCodingOQ03.lean",
-      "lineCount": 665,
-      "theoremCount": 8,
+      "lineCount": 664,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ03Aristotle.lean",
       "filename": "ShannonChannelCodingOQ03Aristotle.lean",
-      "lineCount": 105,
+      "lineCount": 104,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 3,
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04.lean",
       "filename": "ShannonChannelCodingOQ04.lean",
-      "lineCount": 225,
-      "theoremCount": 8,
+      "lineCount": 224,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -168,7 +168,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01.lean",
-      "lineCount": 127,
+      "lineCount": 126,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/ShannonChannelCodingOQ04OQ01OQ01.lean",
       "filename": "ShannonChannelCodingOQ04OQ01OQ01.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync 99 stale `leanFiles[]` entries across 10 shannon-channel-coding sibling research JSONs to canonical counts from `proofs/Proofs/ShannonChannelCoding*.lean`.

This addresses the explicit mechanic handoff from PR #19819 (shannon-channel-coding-oq-02-oq-03 S2 STATE-SYNC, drift-inventory rows 0-3, 5-10).

## Evidence

**Canonical counts** (from `wc -l` + grep on pinned Mathlib SHA `2df2f0150c…`):

| File | LOC | thm | def | sorry | axiom |
|------|-----|-----|-----|-------|-------|
| `ShannonChannelCoding.lean`                  | 555 | 16 | 6 | 0 | 3 |
| `ShannonChannelCodingOQ02.lean`              | 297 | 13 | 1 | 0 | 0 |
| `ShannonChannelCodingOQ02OQ01.lean`          | 312 |  6 | 0 | 0 | 1 |
| `ShannonChannelCodingOQ02OQ01Aristotle.lean` | 111 |  4 | 0 | 5 | 0 |
| `ShannonChannelCodingOQ02OQ03.lean`          | 162 |  5 | 1 | 0 | 1 |
| `ShannonChannelCodingOQ02OQ04.lean`          | 248 | 11 | 1 | 0 | 0 |
| `ShannonChannelCodingOQ03.lean`              | 664 | 10 | 3 | 0 | 0 |
| `ShannonChannelCodingOQ03Aristotle.lean`     | 104 |  4 | 3 | 4 | 0 |
| `ShannonChannelCodingOQ04.lean`              | 224 | 10 | 2 | 0 | 0 |
| `ShannonChannelCodingOQ04OQ01.lean`          | 126 |  4 | 0 | 0 | 0 |
| `ShannonChannelCodingOQ04OQ01OQ01.lean`      | 102 |  4 | 0 | 0 | 0 |

**Notable drift**:
- `OQ02OQ01.lean`: JSON `lineCount: 182 / theoremCount: 3` → canon `312 / 6` (substantial, +130 LOC)
- `OQ02OQ04.lean`: JSON `theoremCount: 10` → canon `11`
- `OQ03.lean`: JSON `theoremCount: 8` → canon `10`
- `OQ04.lean`: JSON `theoremCount: 8` → canon `10`
- Other entries: ±1 LOC drift (split-length → wc -l convention)

**Slugs touched** (10):
- `shannon-channel-coding-oq-01`, `-oq-02`, `-oq-02-oq-01`, `-oq-02-oq-01-oq-01`, `-oq-02-oq-03`, `-oq-02-oq-04`, `-oq-03`, `-oq-04`, `-oq-04-oq-01`, and `shannon-channel-coding` itself.
- `shannon-channel-coding-wip-01` skipped (no `leanFiles[]` array).

## Validation

- All 10 JSONs validate via `python3 -m json.tool` (parseable)
- Diff: `138 insertions(+), 138 deletions(-)` — balanced, numbers-only, no unicode escapes (`ensure_ascii=False`)
- No `.lean` file edits (drift is in metadata only)
- No gallery `meta.json` edits

---
Automated fix by lean-mechanic agent.