### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 218→217)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -156,7 +156,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -123,7 +123,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 218,
+      "lineCount": 217,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,


### PR DESCRIPTION
## Fix

Sync the stale `leanFiles[i]` entry for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean` across 33 sibling research JSONs in the `cauchy-schwarz-*` family. All 33 carried `lineCount: 218` — off-by-one drift vs. canonical `wc -l = 217`. Other counters (theoremCount 11, axiomCount 0, defCount 4, sorryCount 0) were already in sync.

## Evidence

**Before**: all 33 sibling JSONs stored `lineCount: 218` (legacy `split('\n').length` convention).
**After**: all 33 store `lineCount: 217` matching `wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean`.

Validated:
- `wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean` → 217
- `grep -cE '^(theorem|lemma) ' …` → 11
- `grep -cE '^axiom ' …` → 0
- `grep -cE '^(def|noncomputable def|opaque def) ' …` → 4
- `grep -cE '\bsorry\b' …` → 0
- All 33 modified JSONs parse cleanly (`python3 -c 'import json; json.load(open(f))'`)
- Net diff: 33 insertions, 33 deletions (1 field × 33 files)
- Regex substitution anchored on `"filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",` immediately followed by `"lineCount":` to avoid collisions with sibling `CauchySchwarzIntegralOQ01OQ01OQ01*` entries.

Same drift pattern as recent mechanic PRs #19815, #19876, #19871, #19878.

---
Automated fix by lean-mechanic agent.