### PR TITLE
fix(meta): batch sync BinaryGcdOQ03.lean leanFiles in 9 binary-gcd siblings (lineCount 491→488, theoremCount 14→15)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-01-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-01.json
@@ -107,8 +107,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-01-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-02.json
@@ -118,8 +118,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-01-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-03.json
@@ -105,8 +105,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
@@ -110,8 +110,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-02-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-02-oq-01.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -129,8 +129,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-03-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-01.json
@@ -143,8 +143,8 @@
     {
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
-      "lineCount": 491,
-      "theoremCount": 14,
+      "lineCount": 488,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -274,7 +274,7 @@
       "path": "Proofs/BinaryGcdOQ03.lean",
       "filename": "BinaryGcdOQ03.lean",
       "lineCount": 488,
-      "theoremCount": 14,
+      "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[]` entry for `Proofs/BinaryGcdOQ03.lean` across 9 binary-gcd sibling research JSONs.

## Evidence

**Actual file state on origin/main (3a6d56a3189):**

```
$ wc -l proofs/Proofs/BinaryGcdOQ03.lean
488

$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/BinaryGcdOQ03.lean
15

$ grep -cE '^(def|noncomputable def|opaque def) ' proofs/Proofs/BinaryGcdOQ03.lean
13

$ grep -oE '\bsorry\b' proofs/Proofs/BinaryGcdOQ03.lean | wc -l
0

$ grep -cE '^axiom ' proofs/Proofs/BinaryGcdOQ03.lean
0
```

**Before / After:**

| Slug | Before | After |
|------|--------|-------|
| binary-gcd-oq-01 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-01-oq-01 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-01-oq-02 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-01-oq-03 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-01-oq-04-oq-01 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-02 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-02-oq-01 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-03-oq-01 | LOC=491, thm=14 | LOC=488, thm=15 |
| binary-gcd-oq-03-oq-02 | LOC=488, thm=14 | LOC=488, thm=15 |

The 8 sibling slugs all carry an identical stale snapshot. The canonical slug oq-03-oq-02 picked up the LOC update at some prior point but missed the theorem-count refresh after S47 ACT (PR #19702, which added PART XXXI's outerGuard firing-count theorems in `PathA.lean` — also expanded `BinaryGcdOQ03.lean` indirectly).

Per-file unicode escape style preserved (oq-03-oq-02 keeps `\uXXXX` escapes; other 8 keep raw UTF-8). Minimal diff: 9 files, 17 lines total.

---
Automated fix by lean-mechanic agent.