### PR TITLE
fix(meta): batch sync WeakGoldbach.lean leanFiles in 2 weak-goldbach siblings (lineCount 481→661, thm 24→29, axiom 9→7, def 15→14)

### DIFF
--- a/src/data/research/problems/weak-goldbach-oq-01.json
+++ b/src/data/research/problems/weak-goldbach-oq-01.json
@@ -58,10 +58,10 @@
     {
       "path": "Proofs/WeakGoldbach.lean",
       "filename": "WeakGoldbach.lean",
-      "lineCount": 481,
-      "theoremCount": 24,
-      "axiomCount": 9,
-      "defCount": 15,
+      "lineCount": 661,
+      "theoremCount": 29,
+      "axiomCount": 7,
+      "defCount": 14,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WeakGoldbach.lean"

--- a/src/data/research/problems/weak-goldbach.json
+++ b/src/data/research/problems/weak-goldbach.json
@@ -78,10 +78,10 @@
     {
       "path": "Proofs/WeakGoldbach.lean",
       "filename": "WeakGoldbach.lean",
-      "lineCount": 481,
-      "theoremCount": 24,
-      "axiomCount": 9,
-      "defCount": 15,
+      "lineCount": 661,
+      "theoremCount": 29,
+      "axiomCount": 7,
+      "defCount": 14,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/WeakGoldbach.lean"


### PR DESCRIPTION
## Fix

Sync \`leanFiles[]\` entry for \`Proofs/WeakGoldbach.lean\` in 2 weak-goldbach sibling research JSONs to match canonical counts on current file (4 fields drifted, sorryCount unchanged at 0).

## Evidence

Canonical counts on \`proofs/Proofs/WeakGoldbach.lean\` at base SHA \`3a6d56a3189\`:

| field | before | after | delta | convention |
|---|---|---|---|---|
| lineCount | 481 | 661 | +180 | \`wc -l\` |
| theoremCount | 24 | 29 | +5 | \`^(protected\|private\|noncomputable)*(theorem\|lemma) \` |
| defCount | 15 | 14 | -1 | \`^(def\|noncomputable def\|opaque def) \` |
| axiomCount | 9 | 7 | -2 | \`^axiom \` |
| sorryCount | 0 | 0 | — | raw \`\bsorry\b\` |

Counts independently match the gallery \`src/data/proofs/weak-goldbach/meta.json\` for \`lineCount\` (661), \`theoremCount\` (29), and \`axiomCount\` (7); gallery's \`definitionCount: 15\` appears stale from the S2 \`abbrev replaces def\` era (per \`weak-goldbach-oq-03.json\` progressSummary) and is out of scope here.

The \`axiomCount: 9 -> 7\` reflects the S5 ACT (PR #18265) upgrade of \`ramare_six_primes\` and \`tao_five_primes\` from \`axiom\` to \`theorem\` proven from \`helfgott_weak_goldbach\`.

## Slugs touched (2)

- \`weak-goldbach\`
- \`weak-goldbach-oq-01\`

---
Automated fix by lean-mechanic agent.