### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 theoremCount 13→14 (post-S22-ACT #19671)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -63,7 +63,7 @@
     ],
     "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; S11.A.body landed S13/2026-05-09, so the theorem's body is sorry-free, but it transitively depends on the sorry-stubbed `exists_continuous_proj_convex` helper pending S11.B — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 4
   },
   "overview": {
@@ -214,7 +214,7 @@
     "namespace": "KakutaniFromBrouwer",
     "lineCount": 1284,
     "axiomCount": 2,
-    "theoremCount": 13,
+    "theoremCount": 14,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Gallery `meta.json` `theoremCount` drift for `schauder-fixed-point-oq-03-oq-01`: actual `SchauderFixedPointOQ03OQ01.lean` has **14** theorems/lemmas under the canonical gallery regex `^(?:protected |private |noncomputable )*(theorem|lemma) `; both `meta.theoremCount` (line 66) and `leanFile.theoremCount` (line 217) said **13**.

## Evidence

```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
1284

$ grep -cE "^(protected |private |noncomputable )*(theorem|lemma) " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
14

$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
4

$ grep -cE "^axiom " proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
2
```

The 14 entries (by line):
108, 149, 218 (lemma); 371 (theorem); 609, 653, 693, 748, 824, 921, 959 (private lemma); 985, 1019, 1146 (theorem).

S22 ACT (PR #19671, merged 2026-05-16) added `private lemma exists_nearest_in_image_F` at line 959 — that's the +1 that brought the count from 13 → 14. The gallery `meta.json` wasn't updated at that ACT.

## Other fields verified in-sync

- `lineCount: 1284` ✓ matches `wc -l`
- `definitionCount: 4` ✓
- `axiomCount: 2` ✓
- `sorries: 0` ✓ (3 raw `\bsorry\b` matches at lines 217, 342, 1247 are all in docstrings saying "end-to-end sorry-free" — gallery uses comment-stripped convention)

## Sibling JSON scope (not touched)

Sibling research JSONs (`oq-01`/`oq-02`/`oq-03`/`oq-03-oq-01`/`-incomplete-01`) use the simpler `^(theorem|lemma) ` convention (per mechanic PR #19707 which set them) and all currently say `theoremCount: 7`. S22's added lemma is `private` so it doesn't increment under that convention — those remain in-sync. No change needed there.

**Before**: `theoremCount: 13` (two occurrences)
**After**: `theoremCount: 14` (two occurrences)

---
Automated fix by lean-mechanic agent.