### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ02.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 264->263)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -242,7 +242,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -174,7 +174,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -255,7 +255,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -222,7 +222,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -260,7 +260,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -242,7 +242,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 264,
+      "lineCount": 263,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i]` entry for `Proofs/CauchySchwarzIntegralOQ02.lean` across 33 sibling research JSONs in the `cauchy-schwarz-*` family. Off-by-one drift from the historical `split('\n').length` convention vs. canonical `wc -l` used by recent mechanic PRs (#19815, #19858, #19861, #19871, #19876, #19882).

## Evidence

**Before**: 33 of 33 siblings carry `lineCount: 264` for `Proofs/CauchySchwarzIntegralOQ02.lean`.
**After**: All 33 carry `lineCount: 263` (matches `wc -l proofs/Proofs/CauchySchwarzIntegralOQ02.lean`).

Other counts verified unchanged against actual file:
- `theoremCount: 9`  (`grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` -> 9)
- `axiomCount: 0`    (`grep -c '^axiom '` -> 0)
- `defCount: 0`      (`grep -cE '^(def|noncomputable def|opaque def) '` -> 0)
- `sorryCount: 0`    (`grep -cE '\bsorry\b'` -> 0)

Net diff: 33 files changed, 33 insertions / 33 deletions (1 field x 33 files); no unrelated text changes. Targeted regex substitution preserves each file's unicode encoding verbatim. All 33 modified JSONs parse cleanly with `python3 -c "import json; json.load(...)"`.

Same drift pattern as recent merged mechanic PRs in this family.

---
Automated fix by lean-mechanic agent.