### PR TITLE
fix(meta): batch sync BrouwerFixedPointOQ02OQ01.lean leanFiles in 17 brouwer-fixed-point siblings (LOC 1072→1071, thm 6→33)

### DIFF
--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -306,8 +306,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
@@ -187,8 +187,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
@@ -154,8 +154,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01.json
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -221,8 +221,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -150,8 +150,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-03.json
@@ -151,8 +151,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
@@ -154,8 +154,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ02OQ01.lean",
       "filename": "BrouwerFixedPointOQ02OQ01.lean",
-      "lineCount": 1072,
-      "theoremCount": 6,
+      "lineCount": 1071,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 14,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync canonical `leanFiles[]` stats for `BrouwerFixedPointOQ02OQ01.lean` in all 17 brouwer-fixed-point research-side sibling JSONs to match actual Lean source.

## Evidence

**Before** (across all 17 siblings):
- lineCount: 1072
- theoremCount: 6

**After** (matches `proofs/Proofs/BrouwerFixedPointOQ02OQ01.lean` actual):
- lineCount: 1071 (raw `wc -l`)
- theoremCount: 33 (regex `^(?:protected|private|noncomputable )*(theorem|lemma) `)
- defCount: 14 (unchanged)
- axiomCount: 0 (unchanged)
- sorryCount: 0 (unchanged)

Doc-only: no `.lean` / gallery / lakefile changes.

---
Automated fix by lean-mechanic agent.