### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean leanFiles in 31 bezout-identity siblings (LOC 324→323, thm 18→20)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -210,8 +210,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -230,8 +230,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -202,8 +202,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -205,8 +205,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -203,8 +203,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -227,8 +227,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -200,8 +200,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -241,8 +241,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -203,8 +203,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -202,8 +202,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -204,8 +204,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -204,8 +204,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -206,8 +206,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -151,8 +151,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -224,8 +224,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -159,8 +159,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -206,8 +206,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -225,8 +225,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -239,8 +239,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -208,8 +208,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -206,8 +206,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -227,8 +227,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -223,8 +223,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -206,8 +206,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean",
-      "lineCount": 324,
-      "theoremCount": 18,
+      "lineCount": 323,
+      "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[]` entries in 31 sibling research JSONs under `src/data/research/problems/bezout-identity-*` to match canonical counts of `proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean`.

## Evidence

**Before** (in all 31 sibling JSONs, entry for `Proofs/BezoutIdentityOQ02OQ01OQ02OQ02OQ03.lean`):
- `lineCount`: 324
- `theoremCount`: 18

**After** (matches mechanic canonical conventions: `wc -l` raw + `^(protected |private |noncomputable )*(theorem|lemma) `):
- `lineCount`: 323
- `theoremCount`: 20

Other fields (`axiomCount: 0`, `defCount: 1`, `sorryCount: 0`) already match canonical and were not touched.

## Validation

- `python3 -c "import json; json.load(...)"` parse check for all 31 modified JSONs (in-script).
- No Lean source changes; metadata only.
- Diff: 31 files changed, 62 insertions, 62 deletions (2-line surgical edit per sibling).

---
Automated fix by lean-mechanic agent.