### PR TITLE
fix(meta): batch sync CantorDiagonalization.lean leanFiles in 18 cantor-diagonalization siblings (lineCount 176→175)

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
@@ -39,7 +39,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-04.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 176,
+      "lineCount": 175,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[0].lineCount` for `Proofs/CantorDiagonalization.lean`
across 18 sibling `cantor-diagonalization-*` research-JSONs whose stored
`lineCount` (176) drifted off-by-one from the canonical `wc -l` value (175).

## Evidence

Canonical counts at `origin/main` revision `3a6d56a3189` for `proofs/Proofs/CantorDiagonalization.lean`:

| measurement | command | value |
|---|---|---|
| lineCount | `wc -l` | **175** |
| axiomCount | `grep -cE '^axiom '` | 0 |
| theoremCount | `grep -cE '^(protected \| private \| noncomputable )*(theorem\|lemma) '` | 6 |
| defCount | `grep -cE '^(def\|noncomputable def\|opaque def\|abbrev) '` | 2 |
| sorryCount | `grep -oE '\bsorry\b' \| wc -l` | 0 |

Only `lineCount` drifted; all other fields already matched across siblings.

| field | before | after |
|---|---|---|
| lineCount | 176 | **175** |
| theoremCount | 6 | 6 (unchanged) |
| axiomCount | 0 | 0 (unchanged) |
| defCount | 2 | 2 (unchanged) |
| sorryCount | 0 | 0 (unchanged) |

## Scope

- **18 files** changed, 18 insertions(+), 18 deletions(-)
- Each diff is exactly one line: the `lineCount` value at the unique `leanFiles[i]` entry where `filename == \"CantorDiagonalization.lean\"`
- Targeted text replacement preserves all `\\u`-escape encoding (no re-serialization noise)

### Skipped (no change required)

- `cantor-diagonalization-oq-01.json` — already at 175
- `cantor-diagonalization-oq-02-oq-03-oq-02-incomplete-01.json` — entry absent
- `cantor-diagonalization-oq-03-oq-01-incomplete-01.json` — entry absent
- `src/data/proofs/cantor-diagonalization/meta.json` — gallery entry already at 175

## Convention

Follows the pattern used by recent mechanic batch-sync PRs:
- **#19854** synced `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (33 siblings)
- **#19825** synced `CauchySchwarzIntegral.lean` (33 siblings, same single-field lineCount drift)
- **#19815** synced `CauchySchwarzIntegralOQ01.lean` (33 siblings)

Established convention: `lineCount` follows `wc -l` (raw newline count), correcting the prior `split('\\n').length` convention (which inflates by 1 for files without trailing newline).

## Validation

- All 18 modified JSONs parse cleanly via `python3 -c \"import json; json.load(open(p))\"`
- Pre-edit state (`lineCount: 176`) was identical across all 18 siblings — confirms uniform sibling-drift case
- Targeted regex matches only the `CantorDiagonalization.lean` entry; other `leanFiles[i]` entries untouched

## Disjoint from in-flight PRs

- `gh pr list --search cantor` shows only stale research PRs from May 8 (none touching meta counts)
- No open `fix/mechanic-cantor*` or `fix/mechanic-CantorDiagonalization*` branch

---

Automated fix by lean-mechanic agent.