### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 154->153)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -53,7 +53,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 154,
+      "lineCount": 153,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Align all 33 sibling research JSONs that reference `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean` so the `lineCount` field matches the actual file (`wc -l`).

## Evidence

**Before**: 33 sibling JSONs stored `lineCount: 154` (the legacy `split('\n').length` convention = `wc -l + 1`)
**After**:  33 sibling JSONs store `lineCount: 153` (matches `wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean`)

Other `leanFiles[i]` fields verified unchanged and already consistent with the file:

| Field | Value | Verification command |
|---|---|---|
| `theoremCount` | 10 | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) ' proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean` |
| `defCount`     | 0 | `grep -cE '^(def\|noncomputable def\|opaque def) ' proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean` |
| `axiomCount`   | 0 | `grep -c '^axiom ' proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean` |
| `sorryCount`   | 0 | `grep -oE '\bsorry\b' proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean \| wc -l` |

## Diff shape

\`\`\`
33 files changed, 33 insertions(+), 33 deletions(-)
\`\`\`

Exactly one line per file changed (only the `lineCount` value in the relevant `leanFiles[]` entry). All 33 modified JSONs parse cleanly via \`python3 -c "import json; json.load(open(...))"\`.

This follows the same convention fix as prior batches:
- #19815 (CauchySchwarzIntegralOQ01.lean, 33 siblings)
- #19825 (CauchySchwarzIntegral.lean, 33 siblings)
- c1e1a9ae9ba (CayleyHamiltonMinpolyOQ05OQ01OQ02.lean, 28 siblings, "split-length -> wc -l")

---
Automated fix by lean-mechanic agent.