### PR TITLE
audit: erdos-789 definitionCount 7 → 6 + 9 erdos slugs clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9562,10 +9562,10 @@
       "result": "clean"
     },
     "erdos-777": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:26:21Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "clean"
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",
@@ -9574,9 +9574,9 @@
       "result": "clean"
     },
     "erdos-779": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:13:45Z",
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T23:48:40Z",
       "result": "clean"
     },
     "erdos-78": {
@@ -9610,28 +9610,28 @@
       "result": "clean"
     },
     "erdos-784": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T01:25:10Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "clean"
     },
     "erdos-785": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:01:09Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "clean"
     },
     "erdos-786": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:07:17Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "clean"
     },
     "erdos-787": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T01:23:07Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 4,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "clean"
     },
     "erdos-788": {
       "agentId": "auditor-cycle-20-batch",
@@ -9640,22 +9640,22 @@
       "result": "clean"
     },
     "erdos-789": {
-      "agentId": "auditor-loop-2026-04-29-789",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T03:52:26Z",
-      "result": "clean",
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "erdos-79": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T04:29:43Z",
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T23:48:40Z",
       "result": "clean"
     },
     "erdos-790": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T04:40:07Z",
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T23:48:40Z",
       "result": "clean"
     },
     "erdos-791": {
@@ -9761,10 +9761,10 @@
       "result": "clean"
     },
     "erdos-806": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T01:32:13Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-5-batch",
+      "auditCount": 5,
+      "lastAudited": "2026-05-16T23:48:40Z",
+      "result": "clean"
     },
     "erdos-807": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-789/meta.json
+++ b/src/data/proofs/erdos-789/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 242,
     "assumptions": "3 axioms: h, straus_1966_upper, erdos_choi_1974_lower. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "**The Sum-Length-Free Property**\\n\\nA set B is sum-length-free if whenever two sums of elements from B are equal, they must involve the same number of terms. This is weaker than the Sidon property (which requires the actual terms to be equal).\\n\\n**Erdős's Original Work (1962)**\\n\\nErdős proved h(n) ≪ n^{5/6} and h(n) ≫ n^{1/3}. The lower bound used a beautiful probabilistic construction: for random α, the set of elements whose fractional parts {αa} lie in a small interval tends to be sum-length-free.\\n\\n**Straus's Improvement (1966)**\\n\\nStraus dramatically improved the upper bound to h(n) ≪ √n using a clever counting argument on sum representations.\\n\\n**Erdős-Choi (1974)**\\n\\nChoi improved the lower bound to h(n) ≫ (n log n)^{1/3} by refining Erdős's probabilistic argument.\\n\\n**The Gap**\\n\\nThe gap between (n log n)^{1/3} and √n is substantial. For n = 10^6, this is roughly 239 vs 1000. Closing this gap is the main open problem.",


### PR DESCRIPTION
## Summary

Gallery integrity audit pass over 10 axiomatized erdős problems. One drift fixed (erdos-789), nine clean.

## Verification

For each slug, verified:
- `sorries` field matches actual `sorry` count in Lean source
- `axiomCount` matches actual `^axiom ` declaration count
- `lineCount` matches `wc -l`
- `theoremCount` / `definitionCount` match canonical mechanic counts
- No `True`-stub theorems / `:= trivial` placeholders
- status/badge consistency (`axiomatized` + `axiom`)

## Slugs audited

| Slug | Axioms | Sorries | LOC | Thm | Def | Status | Result |
|------|-------:|--------:|----:|----:|----:|--------|--------|
| erdos-787 | 4 | 0 | 138 | 3 | 5 | axiomatized | clean |
| erdos-784 | 5 | 0 | 251 | 6 | 7 | axiomatized | clean |
| erdos-806 | 2 | 0 | 219 | 3 | 4 | axiomatized | clean |
| erdos-789 | 3 | 0 | 242 | 4 | **6** (was 7) | axiomatized | **issues-fixed** |
| erdos-785 | 2 | 0 | 199 | 3 | 9 | axiomatized | clean |
| erdos-786 | 2 | 0 | 166 | 1 | 5 | axiomatized | clean |
| erdos-779 | 1 | 0 | 218 | 8 | 7 | axiomatized | clean |
| erdos-777 | 3 | 0 | 336 | 8 | 9 | axiomatized | clean |
| erdos-79  | 4 | 1 | 238 | 5 | 12 | axiomatized | clean |
| erdos-790 | 5 | 0 | 129 | 2 | 5 | axiomatized | clean |

## Issue fixed: erdos-789

`definitionCount: 7` in `src/data/proofs/erdos-789/meta.json` overcounted by 1: the 7th item was `structure SumRep` (line 48 of `Erdos789Problem.lean`), which is not a `def` under the canonical mechanic convention (`^(def|noncomputable def|opaque def) `). Counts present: SumRep.length, SumRep.value, SumLengthFree, h_exists, IsSidonSet, possible_growth_rates = 6 `def` total. Mirrors prior fixes #19662 (erdos-905 10→9) and #19668 (erdos-894 12→11).

## Test plan

- [x] `python3 json.load` on both modified files (parse-clean)
- [x] All 10 slugs counted from canonical mechanic regexes
- [x] No semantic changes to overview/sections/strategy prose
- [x] No `.lean` file changes — pure meta + tracker bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)