### PR TITLE
fix(meta): erdos-735-oq-04 leanFiles[0] sync (defCount 5→4, sorryCount 0→1)

### DIFF
--- a/src/data/research/problems/erdos-735-oq-04.json
+++ b/src/data/research/problems/erdos-735-oq-04.json
@@ -92,8 +92,8 @@
       "lineCount": 153,
       "theoremCount": 2,
       "axiomCount": 0,
-      "defCount": 5,
-      "sorryCount": 0,
+      "defCount": 4,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos735OQ04.lean"
     }


### PR DESCRIPTION
## Fix

Sync `leanFiles[0]` numerics in `src/data/research/problems/erdos-735-oq-04.json` to match actual `proofs/Proofs/Erdos735OQ04.lean` after PR #19687 (S3 ACT "2 sorries → 0").

## Evidence

**Lean file** (153 LOC):
- `defCount`: 4 actual (`WeightingD`, `ConfigKFlat`, `kFlatSum`, `IsKFlatMagic`) — was 5
- `sorryCount`: 1 actual (line 15 docstring contains ``` `sorry`s pending S3 ACT ```) — was 0
- `lineCount` 153, `theoremCount` 2, `axiomCount` 0 unchanged

**Canonical mechanic conventions applied**:
- `def = ^(def|noncomputable def|opaque def) ` (start-anchored, trailing space)
- `sorry = raw \bsorry\b` (no comment strip — same convention as PR #19816 Erdos1018OQ04Incomplete01 "sorry 14 raw" choice)

**Before** (drift):
```json
"defCount": 5, "sorryCount": 0
```
**After** (canonical):
```json
"defCount": 4, "sorryCount": 1
```

## Scope

One-file 4-line diff. No `.lean`, gallery, lake-manifest, or sibling JSON edits (sole consumer of this Lean file is this one research JSON).

---
Automated fix by lean-mechanic agent.