### PR TITLE
fix(meta): batch sync BinaryGcdOQ03OQ02.lean leanFiles in 9 binary-gcd siblings (thm 63→65, sorryCount 1→10)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-01-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-01.json
@@ -130,10 +130,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-02.json
@@ -141,10 +141,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-03.json
@@ -128,10 +128,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
@@ -133,10 +133,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -142,10 +142,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-02-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-02-oq-01.json
@@ -138,10 +138,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -152,10 +152,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-03-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-01.json
@@ -166,10 +166,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -296,10 +296,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     },


### PR DESCRIPTION
## Fix

Sync research-JSON `leanFiles[i]` entries for `Proofs/BinaryGcdOQ03OQ02.lean` across the 9 binary-gcd sibling slugs to match canonical file metrics.

## Evidence

**Canonical metrics** for `proofs/Proofs/BinaryGcdOQ03OQ02.lean` at HEAD:

```
$ wc -l proofs/Proofs/BinaryGcdOQ03OQ02.lean
2225
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/BinaryGcdOQ03OQ02.lean
65
$ grep -cE '^(def|noncomputable def|opaque def) ' proofs/Proofs/BinaryGcdOQ03OQ02.lean
6
$ grep -oE '\bsorry\b' proofs/Proofs/BinaryGcdOQ03OQ02.lean | wc -l
10
$ grep -cE '^axiom ' proofs/Proofs/BinaryGcdOQ03OQ02.lean
0
```

**Before** (all 9 siblings):

```json
{
  "path": "Proofs/BinaryGcdOQ03OQ02.lean",
  "lineCount": 2225,
  "theoremCount": 63,
  "axiomCount": 0,
  "defCount": 6,
  "sorryCount": 1,
  ...
}
```

**After**:

```json
{
  "path": "Proofs/BinaryGcdOQ03OQ02.lean",
  "lineCount": 2225,
  "theoremCount": 65,
  "axiomCount": 0,
  "defCount": 6,
  "sorryCount": 10,
  ...
}
```

`lineCount=2225`, `defCount=6`, `axiomCount=0` already correct in all 9 siblings — preserved verbatim. Drift was in `theoremCount` (63 → 65) and `sorryCount` (1 → 10, raw `\bsorry\b` per mechanic convention; 9 of the 10 occurrences are in comments/docstrings discussing the open `hgcdMatrix_row_output_le` sorry, 1 is the actual `sorry` tactic at line 1078).

## Files updated (2 fields × 9 files = 18 line edits)

- `binary-gcd-oq-01.json`
- `binary-gcd-oq-01-oq-01.json`
- `binary-gcd-oq-01-oq-02.json`
- `binary-gcd-oq-01-oq-03.json`
- `binary-gcd-oq-01-oq-04-oq-01.json`
- `binary-gcd-oq-02.json`
- `binary-gcd-oq-02-oq-01.json`
- `binary-gcd-oq-03-oq-01.json`
- `binary-gcd-oq-03-oq-02.json`

`binary-gcd-oq-02-oq-02.json` does not reference `BinaryGcdOQ03OQ02.lean` (correctly skipped).

## Validation

Each edited file re-parses cleanly via `python3 -c 'import json; json.load(open(...))'`. No `pnpm build` run per the `_mechanic_pnpm_build_regenerates_all_research_jsons` memory (single batch-sync of one shared file, no slug-graph changes).

---

Automated fix by lean-mechanic agent.