### PR TITLE
fix(meta): batch sync BinaryGcdOQ03OQ02.lean leanFiles in 9 binary-gcd siblings (thm 63→65, sorry 1→10)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-01-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-01.json
@@ -130,10 +130,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-02.json
@@ -141,10 +141,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-03.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-03.json
@@ -128,10 +128,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01-oq-04-oq-01.json
@@ -133,10 +133,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-01.json
@@ -142,10 +142,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-02-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-02-oq-01.json
@@ -138,10 +138,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02.json
@@ -152,10 +152,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-03-oq-01.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-01.json
@@ -166,10 +166,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     }

--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -296,10 +296,10 @@
       "path": "Proofs/BinaryGcdOQ03OQ02.lean",
       "filename": "BinaryGcdOQ03OQ02.lean",
       "lineCount": 2225,
-      "theoremCount": 63,
+      "theoremCount": 65,
       "axiomCount": 0,
       "defCount": 6,
-      "sorryCount": 1,
+      "sorryCount": 10,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02.lean"
     },


### PR DESCRIPTION
## Fix

Sync canonical research JSON `leanFiles[6]` snapshot for `BinaryGcdOQ03OQ02.lean` across all 9 binary-gcd siblings. PART XIV (Session 17) added the row-vector counterexample family — five `native_decide` theorems plus the existential refutation `hgcdMatrix_row_invariant_counterexample` — and acknowledged commentary sorry mentions piled up across PARTS IX/XII/XV (referencing the single `sorry` tactic at line 1078, `hgcdMatrix_row_output_le`).

## Evidence

**Before** (research JSON, all 9 siblings):
- `lineCount: 2225`
- `theoremCount: 63`
- `defCount: 6`
- `sorryCount: 1`
- `axiomCount: 0`

**After** (verified against working tree):
- `lineCount: 2225` ← `wc -l proofs/Proofs/BinaryGcdOQ03OQ02.lean` (no change)
- `theoremCount: 65` ← `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '`
- `defCount: 6` (no change)
- `sorryCount: 10` ← `grep -cE '\bsorry\b'` (raw: 1 tactic at line 1078 + 9 commentary mentions)
- `axiomCount: 0` (no change)

The actual `sorry` tactic count is **1** (line 1078, `hgcdMatrix_row_output_le`); the other 9 raw matches are commentary mentions documenting it (PART IX, XII, XIV, XV docstring references). Canonical `leanFiles[]` convention is raw `\bsorry\b` count (no comment strip) — matches recent precedent #19816 (Erdos1018OQ04Incomplete01: sorry 14 raw, 1 stripped), #19818 (KonigsbergOQ01OQ02: 6→1 raw).

## Scope

- 9 siblings updated (all share `Proofs/BinaryGcdOQ03OQ02.lean` as `leanFiles[6]`)
- Diff: 18+/-18, exactly 2 numeric edits per file
- Per-file encoding convention preserved: 8 utf8 files + 1 `\\uXXXX`-escaped file (the active `oq-03-oq-02` slug) — round-tripped with matching `ensure_ascii` to keep diff tight
- Gallery `src/data/proofs/binary-gcd-oq-03-oq-02/meta.json` not touched (separate semantic-sorry convention; `meta.sorries: 1` already matches the single active `sorry` tactic)
- Validation: `python3 -c "import json; json.load(open(f))"` x9 → JSON OK

Siblings:
  - `binary-gcd-oq-01.json`
  - `binary-gcd-oq-01-oq-01.json`
  - `binary-gcd-oq-01-oq-02.json`
  - `binary-gcd-oq-01-oq-03.json`
  - `binary-gcd-oq-01-oq-04-oq-01.json`
  - `binary-gcd-oq-02.json`
  - `binary-gcd-oq-02-oq-01.json`
  - `binary-gcd-oq-03-oq-01.json`
  - `binary-gcd-oq-03-oq-02.json`

---
Automated fix by lean-mechanic agent.