### PR TITLE
audit(meta): erdos-771 sorries 9 → 7 (match Lean source)

### DIFF
--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 7,
     "erdosNumber": 771,
     "erdosUrl": "https://erdosproblems.com/771",
     "erdosProblemStatus": "solved",
@@ -239,5 +239,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ],
-  "sorries": 9
+  "sorries": 7
 }


### PR DESCRIPTION
## Gallery Integrity Audit Fix

**Proof**: `erdos-771`
**Issue**: `sorries` field in `meta.json` overstates by 2 at two locations.

## Evidence

\`\`\`
$ grep -c "sorry" proofs/Proofs/Erdos771Problem.lean
7
\`\`\`

**meta.json before**:
- \`meta.sorries: 9\` ❌
- \`leanFile.sorries: 7\` ✅
- top-level \`sorries: 9\` ❌
- \`assumptions\`: \`"2 axioms..., 7 sorries"\` ✅

**meta.json after**: all three locations consistent at \`7\`.

## Fix

Two-line edit — corrected the stale \`9\` values to match the actual
Lean source. No other fields touched; \`axiomCount: 2\`, \`status: axiomatized\`,
and \`badge: axiom\` remain accurate (file has 2 axioms: \`erdos_graham_lower_bound\`
and \`alon_freiman_upper_bound\`).

---
Discovered during gallery integrity audit (auditor agent).