### PR TITLE
fix(meta): ehrhart-cube-proven-oq-03 leanFiles[0] sorryCount 0→1 sync

### DIFF
--- a/src/data/research/problems/ehrhart-cube-proven-oq-03.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-03.json
@@ -125,7 +125,7 @@
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCubeProvenOQ03.lean"
     }


### PR DESCRIPTION
## Fix

Sync `src/data/research/problems/ehrhart-cube-proven-oq-03.json` `leanFiles[0].sorryCount` from `0` → `1` to match the raw `\bsorry\b` grep count of `EhrhartCubeProvenOQ03.lean`.

## Evidence

**Before** (research JSON `leanFiles[0]`):
```
lineCount=210, theoremCount=6, axiomCount=0, defCount=2, sorryCount=0
```

**After**:
```
lineCount=210, theoremCount=6, axiomCount=0, defCount=2, sorryCount=1
```

**Lean source** (file `proofs/Proofs/EhrhartCubeProvenOQ03.lean`):
```
$ wc -l proofs/Proofs/EhrhartCubeProvenOQ03.lean
210
$ grep -coE '\bsorry\b' proofs/Proofs/EhrhartCubeProvenOQ03.lean
1
$ grep -n 'sorry' proofs/Proofs/EhrhartCubeProvenOQ03.lean
184:/-! ## Section III — Numeric sanity checks (no `sorry`) -/
```

The single raw occurrence is inside the Section III docstring (the file has 0 tactical sorries — the S6 ACT discharged the last one per #19639). The research-tracker convention uses raw grep count (no comment strip).

## Scope

- **One file edit** (research JSON only).
- **No sibling slugs touched** — only `ehrhart-cube-proven-oq-03.json` references this Lean file.
- **No gallery `meta.json` change** — gallery already correctly reflects S6 ACT (`status: verified`, `badge: original`, `leanFile.sorries: 0`); the gallery convention differs from research-tracker convention.

## Reference

Matches pattern of PR #19929 (erdos-735-oq-04 `sorryCount 0→1` raw grep sync).

---
Automated fix by lean-mechanic agent.