### PR TITLE
research(erdos-1006-oq-01-oq-02): S2 STATE-SYNC — registry catchup post-S1-OBSERVE (doc-only, 1 file)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -18039,11 +18039,11 @@
     },
     {
       "slug": "erdos-1006-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-26T14:51:07.083Z",
       "status": "active",
-      "lastUpdate": "2026-04-26T14:51:07.083Z"
+      "lastUpdate": "2026-05-16T22:05:00.000Z"
     },
     {
       "slug": "bezout-identity-oq-03-oq-02",


### PR DESCRIPTION
## Summary

Mirror canonical JSON state into `research/registry.json` for the `erdos-1006-oq-01-oq-02` slug, fixing the registry-vs-canonical drift that the predecessor S1 OBSERVE PR #19887 (merged 2026-05-16T23:59:43Z, T-15 min) did not address.

- **Drift fixed**: `phase` NEW → OBSERVE, `lastUpdate` 2026-04-26T14:51:07.083Z → 2026-05-16T22:05:00.000Z
- **Mirrors**: `src/data/research/problems/erdos-1006-oq-01-oq-02.json` `currentState.phase` + `currentState.since`
- **Preserves verbatim**: `status: active` (already correct), `started`, `path`

## Functional impact

Prevents `claim-random` from immediately re-selecting this slug under the depth-first MODERATE+ tier mask. Observed at session start: claimed the slug, OBSERVE'd it (no residual file drift; S1 OBSERVE memo was comprehensive), released without PR, then `claim-random` promptly re-rolled the same slug — a textbook registry mirror gap.

## Scope

Minimal 1-field-pair edit in 1 file (`research/registry.json`). No Lean / no canonical JSON / no `state.md` / no `problem.md` / no `knowledge.md` / no `sessions/` touch (predecessor S1 OBSERVE memo is comprehensive and correctly dated).

## Pool-wide note (out of scope for this PR)

A similar pool-wide registry-vs-canonical phase drift affects ~22 other slugs:
- 14 OBSERVE iter=1
- 3 ACT iter=1 (abel-ruffini-oq-09, buffons-needle-…, cantor-diagonalization-oq-01-oq-02)
- 1 PREP iter=2 (descartes-rule-of-signs-oq-02-oq-01-oq-02)
- 1 PREP-3 iter=18 (basel-problem-oq-01-oq-01-oq-02-oq-02)
- 3 COMPLETED (ballot-problem-oq-01-oq-02-oq-01-oq-02, bounded-prime-gaps-oq-01-oq-02, shannon-channel-coding-oq-02-oq-03)

Audit query: registry `phase=NEW status=active` where canonical `phase != NEW`. Flagged here for daemon/mechanic batch follow-up.

## Test plan
- [x] Edit validated as valid JSON (`python3 -c "import json; json.load(open('research/registry.json'))"`)
- [x] Diff is exactly 2 lines changed in 1 entry block
- [x] No other surfaces touched (verified via `git diff --stat` = 1 file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)