### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ02.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 152→151)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -178,7 +178,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -140,7 +140,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -145,7 +145,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -187,7 +187,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -202,7 +202,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -182,7 +182,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -166,7 +166,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -173,7 +173,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -166,7 +166,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -172,7 +172,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 152,
+      "lineCount": 151,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `leanFiles[*].lineCount` for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean`: **152 → 151** across 33 sibling research-problem JSONs (19 `cauchy-schwarz-integral-*` + 14 `cauchy-schwarz-*` slugs).

## Evidence

Actual canonical counts (file SHA from #19454; unchanged since merge):

```
$ wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
     151
$ grep -cE "^(theorem|lemma) " proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
8
$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
0
$ grep -c "^axiom " proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
1
$ grep -cE "\bsorry\b" proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
0
```

**Before** (33 sibling JSONs):
```json
"path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
"lineCount": 152, "theoremCount": 8, "axiomCount": 1, "defCount": 0, "sorryCount": 0
```

**After** (canonical):
```json
"lineCount": 151
```

Only `lineCount` drifts; `theoremCount` / `axiomCount` / `defCount` / `sorryCount` were already canonical. The 152 value is the legacy `content.split('\n').length` (= `wc -l + 1` when file ends with newline); mechanic convention is raw `wc -l`.

## Context

Recent same-family mechanic batch syncs (all merged to main): #19920 (`...OQ01OQ01.lean` 154→153), #19921 (`...OQ01OQ01OQ01OQ02OQ02.lean` 188→187), #19898 (`...OQ02OQ01OQ01.lean` sorryCount 11→0), #19858 (`...OQ02OQ02OQ01.lean` 118→117), #19895 (`...OQ02.lean` 264→263), #19882 (`...OQ01OQ01OQ01OQ02.lean` 218→217), #19876 (`...OQ01OQ01OQ01.lean` 184→183), #19871 (`...OQ01OQ02.lean` 601→600). This PR addresses the next-largest unsynced item in the family.

## Scope

- 33 files changed, 33 insertions, 33 deletions (1 line each).
- No `.lean` source changes.
- No gallery `meta.json` changes — `src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json` has `lineCount: null` (not authoritative for this slug).
- No other `leanFiles[i]` entries touched.
- Indices vary across siblings (6 / 7 / 8); filename-based lookup used.

## Validation

```
$ python3 -c "import json, glob; [json.load(open(f)) for f in glob.glob('src/data/research/problems/cauchy-schwarz*.json')]; print('OK')"
OK
```

Per mechanic memory: `pnpm build` is intentionally skipped (regenerates ALL ~1047 research JSONs via `research:enrich` and leaks untracked JSON files for new slugs). Python `json.load` is the validated path for single-file metadata fixes.

---
Automated fix by lean-mechanic agent.