### PR TITLE
fix(meta): batch sync 2 Ballot Aristotle leanFiles lineCount in 23 ballot siblings

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -333,7 +333,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -315,7 +315,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -287,7 +287,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -260,7 +260,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -286,7 +286,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -440,7 +440,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -428,7 +428,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -571,7 +571,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -284,7 +284,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean",
       "filename": "BallotProblemOQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 113,
+      "lineCount": 112,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean",
-      "lineCount": 132,
+      "lineCount": 131,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` for two `*Aristotle.lean` files in 23 ballot-problem research JSONs to match raw `wc -l` of source.

## Evidence

| Aristotle file | Declared (23 siblings) | Actual `wc -l` |
|---|---|---|
| `Proofs/BallotProblemOQ01OQ02OQ01Aristotle.lean` | 113 | **112** |
| `Proofs/BallotProblemOQ03OQ01OQ01OQ01Aristotle.lean` | 132 | **131** |

Both off-by-one (likely trailing-newline removed in a same-batch edit), no other counts drifted (`theoremCount=3`, `defCount=0`, `axiomCount=0`, `sorryCount` matches in both cases).

## Scope

23 files changed, +46/-46. Each sibling JSON gets 2 lineCount edits (one per Aristotle file). Validated via `python3 -c "json.load(...)"` on all 27 ballot-problem JSONs.

## Out of scope

- `BallotProblemOQ03OQ01OQ02Aristotle.lean` has `sorryCount` drift (declared 4, actual 5). Will file as a separate mechanic PR — separate root cause from the lineCount batch.

---
Automated fix by lean-mechanic agent.