### PR TITLE
fix(meta): erdos-771 sorries 9 → 7 (match Lean source)

### DIFF
--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 7,
     "erdosNumber": 771,
     "erdosUrl": "https://erdosproblems.com/771",
     "erdosProblemStatus": "solved",
@@ -239,5 +239,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ],
-  "sorries": 9
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Corrected stale `sorries` field at two locations in `src/data/proofs/erdos-771/meta.json` to match actual sorry count in `proofs/Proofs/Erdos771Problem.lean`.

## Evidence

```
$ grep -cE "\bsorry\b" proofs/Proofs/Erdos771Problem.lean
7
$ grep -nE "\bsorry\b" proofs/Proofs/Erdos771Problem.lean
81:  sorry
122:  sorry
127:  sorry
162:  sorry
180:  sorry
189:  sorry
194:  sorry
```

**Before**:
- `meta.sorries: 9` ❌
- `leanFile.sorries: 7` ✅ (already correct)
- top-level `sorries: 9` ❌

**After**: all three locations consistent at `7`.

`axiomCount: 2`, `status: axiomatized`, `badge: axiom` remain accurate
(file has 2 axioms: `erdos_graham_lower_bound`, `alon_freiman_upper_bound`).

Closes #19935

---
Automated fix by lean-mechanic agent.