### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01.lean theoremCount 10→11 in 19 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -110,7 +110,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -122,7 +122,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -112,7 +112,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -125,7 +125,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -115,7 +115,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -65,7 +65,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -146,7 +146,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -108,7 +108,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -113,7 +113,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -110,7 +110,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -112,7 +112,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -112,7 +112,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -114,7 +114,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -82,7 +82,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -112,7 +112,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -123,7 +123,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -110,7 +110,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -109,7 +109,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -103,7 +103,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Updates `theoremCount: 10 → 11` for the `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean` entry in 19 cauchy-schwarz sibling research JSONs. Canonical .lean file count drift was detected by mechanic agent.

## Evidence

**Canonical counts** (at SHA `43bed8ca045`, file `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean`):

| Field | Value |
|------:|:------|
| `lineCount` | 183 (unchanged) |
| `theoremCount` | **11** (was 10 in siblings) |
| `definitionCount` | 0 (unchanged) |
| `sorryCount` | 0 (unchanged) |
| `axiomCount` | 0 (unchanged) |

Theorem list (verified via `grep -nE '^(protected \|private \|noncomputable )*(theorem\|lemma) ' proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean`):

1. `cs_sq_R2` (L33)
2. `cs_sq_R3` (L40)
3. `young_two` (L53)
4. `young_epsilon` (L58)
5. `amgm_two` (L76)
6. `amgm_sq` (L84)
7. `qm_am` (L90)
8. `titu_two` (L101)
9. `nesbitt` (L118)
10. `schur_sorted` (L139, `private`)
11. `schur_one` (L151)

## Scope

- 19 files modified (one-line edit each: `"theoremCount": 10` → `"theoremCount": 11`).
- All other fields preserved; field order preserved; no JSON re-serialization.
- Validated all 33 cauchy-schwarz JSONs parse cleanly post-edit.
- Out of scope: separate off-by-1 `lineCount` drifts in other CauchySchwarzIntegral*.lean entries (covered by sibling mechanic PRs e.g. #19943).

---
Automated fix by lean-mechanic agent.