### PR TITLE
audit(erdos-771): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9526,10 +9526,10 @@
       ]
     },
     "erdos-771": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T04:45:25Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T00:50:00Z",
+      "result": "clean"
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of **Erdos Problem #771** (Subsets Avoiding a Given Sum). Cycle 4. Result: **clean**.

## Verified

All meta.json numerics match `proofs/Proofs/Erdos771Problem.lean`:

| Field | meta.json | Source | ✓ |
|---|---|---|---|
| lineCount | 244 | wc -l | ✓ |
| sorries | 7 | grep -c `\bsorry\b` | ✓ |
| axiomCount | 2 | grep -c `^axiom ` | ✓ |
| theoremCount | 11 | grep -cE `^(theorem\|lemma) ` | ✓ |
| definitionCount | 16 | grep -cE `^(def\|noncomputable def\|opaque def) ` | ✓ |

Both axioms named (`erdos_graham_lower_bound`, `alon_freiman_upper_bound`) are disclosed in the `assumptions` field.

Status `axiomatized` with badge `axiom` correctly reflects the 2-axiom + 7-sorry posture per project axiom integrity policy. No True stubs detected. Description openly states the conjecture is RESOLVED in the literature (Erdos-Graham lower, Alon-Freiman 1988 upper) while the formalization sits at the axiomatized-with-sorries tier.

## Test plan

- [x] grep counts match meta.json
- [x] axiom names align with `assumptions` field
- [x] no True stubs
- [x] badge/status consistent with axiomatized posture