### PR TITLE
research(schauder-fixed-point-oq-03-oq-01-incomplete-01): S24 STATE-SYNC — registry mirror to canonical ACT iter=27 (doc-only, 1 file)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -16959,11 +16959,11 @@
     },
     {
       "slug": "schauder-fixed-point-oq-03-oq-01-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-04-21T15:44:50.655Z",
       "status": "active",
-      "lastUpdate": "2026-04-21T15:44:50.679Z"
+      "lastUpdate": "2026-05-16T21:50:00.000Z"
     },
     {
       "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-01-incomplete-01",


### PR DESCRIPTION
## Summary

Mirror canonical JSON state into `research/registry.json` for the `schauder-fixed-point-oq-03-oq-01-incomplete-01` slug, fixing a 25-day registry-vs-canonical phase drift that the predecessor S23 STATE-SYNC PR #19883 (merged 2026-05-17T00:00:10Z, T-50min) did not address.

- **Drift fixed**: `phase` OBSERVE → ACT, `lastUpdate` 2026-04-21T15:44:50.679Z → 2026-05-16T21:50:00.000Z
- **Mirrors**: `src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json` top-level `phase: "ACT"` and `currentState.since: "2026-05-16T21:50:00Z"` (predecessor S23 STATE-SYNC's iteration boundary)
- **Preserves verbatim**: `status: active` (correct), `started`, `path`

Mirrors PR #19942 (erdos-1006-oq-01-oq-02 S2 STATE-SYNC, T-37min) and PR #19967 (erdos-1151-oq-04 S34 STATE-SYNC, T-5min self-precedent) pattern: tight 1-file 2-field-pair registry mirror. PR #19942's body flagged a pool-wide audit listing ~22 slugs with registry-vs-canonical phase drift; this slug is one of them (registry seeded OBSERVE 2026-04-21, never advanced through 22 PREP iterations + S22 ACT + S23 STATE-SYNC on the canonical side).

## Functional impact

Prevents `claim-random` from re-rolling this slug under depth-first MODERATE+ tier mask on the strength of its stale registry phase. **Observed in-session:** claimed slug, surveyed (S23 STATE-SYNC PR #19883 merged T-38min covers canonical-side catchup; 3 RED INFRA preclude S23b BUILD-VERIFY discharge), released without PR — and `claim-random` promptly re-rolled the same slug. Textbook registry mirror gap exactly as PR #19942's pool-wide audit anticipated.

## Scope

Minimal 1-field-pair edit in 1 file (`research/registry.json`). No Lean / no canonical JSON / no `state.md` / no `problem.md` / no `knowledge.md` / no `sessions/` / no pool touch. Predecessor S23 STATE-SYNC PR #19883 is the comprehensive canonical-side catchup; this is the registry mirror.

## Test plan
- [x] `python3 -c "import json; json.load(open('research/registry.json'))"` — valid JSON
- [x] Diff is exactly 2 lines changed in 1 entry block
- [x] No other surfaces touched (`git diff --stat` = 1 file, +2/-2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)