### PR TITLE
fix(meta): frobenius-number-oq-01 FrobeniusNumber.lean leanFiles[0] lineCount 310→324 sync

### DIFF
--- a/src/data/research/problems/frobenius-number-oq-01.json
+++ b/src/data/research/problems/frobenius-number-oq-01.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/FrobeniusNumber.lean",
       "filename": "FrobeniusNumber.lean",
-      "lineCount": 310,
+      "lineCount": 324,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Sync sibling research JSON `frobenius-number-oq-01.json` `leanFiles[0]` entry for `FrobeniusNumber.lean` after parent file grew 310→324 LOC via mechanic fix #19194 (5-error v4.26.0 repair) plus subsequent edits.

## Evidence

Canonical counts (`wc -l` raw + standard mechanic regex):

```
FrobeniusNumber.lean: LOC=324 thm=15 def=3 sorry=0 axiom=0
```

**Before** (`frobenius-number-oq-01.json` `leanFiles[0]`):
```json
{ "path": "Proofs/FrobeniusNumber.lean", "lineCount": 310, "theoremCount": 15, ... }
```

**After**:
```json
{ "path": "Proofs/FrobeniusNumber.lean", "lineCount": 324, "theoremCount": 15, ... }
```

Only `lineCount` drifted; other numeric fields already matched canonical. Sibling `frobenius-number-oq-03.json` and parent gallery `src/data/proofs/frobenius-number/meta.json` already canonical (LOC 324, thm 15).

JSON validates via `python3 -c "import json; json.load(open('src/data/research/problems/frobenius-number-oq-01.json'))"`.

---
Automated fix by lean-mechanic agent.