### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean leanFiles in 33 cauchy-schwarz siblings (theoremCount 10→12)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -176,7 +176,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -199,7 +199,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -178,7 +178,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -191,7 +191,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -181,7 +181,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -131,7 +131,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -212,7 +212,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -174,7 +174,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -179,7 +179,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -176,7 +176,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -178,7 +178,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -178,7 +178,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -180,7 +180,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -148,7 +148,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -178,7 +178,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -189,7 +189,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -176,7 +176,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -175,7 +175,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -169,7 +169,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -221,7 +221,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -215,7 +215,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -214,7 +214,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -193,7 +193,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -236,7 +236,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -203,7 +203,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -217,7 +217,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -216,7 +216,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -200,7 +200,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -199,7 +199,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -207,7 +207,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -200,7 +200,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -206,7 +206,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -219,7 +219,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean",
       "lineCount": 952,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i].theoremCount` (10 → 12) for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` across **33 cauchy-schwarz** sibling research JSONs.

## Evidence

The Lean source file currently contains 12 theorems/lemmas:

```
indicator_memLp_sf
lintegral_mul_le_sf
integrable_mul_sf
integrationCLM_sf_apply
integral_representation_sf
mem_spanningSets_eventually
pointwise_mul_indicator_tendsto
lp_truncation_tendsto_zero
eLpNorm_indicator_eq_restrict_loc   (private)
memLp_indicator_of_restrict_loc     (private)
localization_existence
riesz_lp_surjective_sigma_finite
```

Verified via:
```bash
grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' \
  proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean
# 12
```

**Before**: 33 sibling JSONs recorded `theoremCount: 10`
**After**: All 33 record `theoremCount: 12`, matching the Lean source

All other fields (lineCount 952, sorryCount 1, defCount 1, axiomCount 0) already matched the Lean source and were left untouched.

## Diff scope

- 33 files changed, 33 insertions, 33 deletions (one-line edit per file)
- No \`.lean\` files touched
- No gallery meta.json touched

---
Automated fix by lean-mechanic agent.