### PR TITLE
fix(meta): batch sync AbelRuffini.lean leanFiles[*].lineCount 188→187 in 15 abel-ruffini siblings

### DIFF
--- a/src/data/research/problems/abel-ruffini-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-02.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-03.json
@@ -68,7 +68,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
@@ -66,7 +66,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
@@ -60,7 +60,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
@@ -38,7 +38,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
@@ -61,7 +61,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -34,7 +34,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -65,7 +65,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -67,7 +67,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-09.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/AbelRuffini.lean",
       "filename": "AbelRuffini.lean",
-      "lineCount": 188,
+      "lineCount": 187,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Extends PR #19767 (which fixed `abel-ruffini-oq-01.json`) to the 15 remaining sibling slugs that still reference `Proofs/AbelRuffini.lean` with the stale `split('\n').length` value of **188** — actual `wc -l` is **187**.

This is the same `split-length → wc -l` off-by-one drift pattern addressed in #19767 / #19772 / #19663 / #19667; the canonical mechanic value is `wc -l` (matches gallery `meta.json` and prior mechanic PRs).

## Evidence

**Lean file metrics** (current `origin/main`):

```bash
$ F=proofs/Proofs/AbelRuffini.lean
$ wc -l $F                                            # → 187 (canonical)
$ awk 'END{print NR+1}' $F                            # → 188 (stale split-length)
$ grep -cE '^(theorem|lemma) ' $F                     # → 9   (matches all entries)
$ grep -cE '^(def|noncomputable def|opaque def) ' $F  # → 0   (matches)
$ grep -cE '\bsorry\b' $F                              # → 0   (matches)
$ grep -cE '^axiom ' $F                                # → 0   (matches)
```

All non-`lineCount` fields (`theoremCount: 9`, `defCount: 0`, `sorryCount: 0`, `axiomCount: 0`, `filename`, `isAristotle`, `githubUrl`) were already in sync between the canonical slug and the 15 siblings — only `lineCount` was off-by-one.

**Before** (15 siblings):
```json
"path": "Proofs/AbelRuffini.lean",
"lineCount": 188,
```
**After** (matches canonical `abel-ruffini-oq-01.json` from #19767):
```json
"path": "Proofs/AbelRuffini.lean",
"lineCount": 187,
```

## Scope

15 files × 1-line diff each = 15 insertions, 15 deletions. Targeted via `sed` range anchored on `"path": "Proofs/AbelRuffini.lean",` (NOT touching `AbelRuffiniGaloisExtensions.lean` / `AbelRuffiniOQ04.lean` / other `AbelRuffini*.lean` entries in the same JSONs).

Affected slugs:
- abel-ruffini-oq-02, -oq-03, -oq-04, -oq-05, -oq-06, -oq-09
- abel-ruffini-oq-04-oq-01, -oq-01-oq-04, -oq-02, -oq-02-oq-01, -oq-02-oq-03, -oq-03, -oq-06, -oq-07, -oq-09

All 15 JSONs validate via `python3 -c "import json; json.load(open(p))"`. No `.lean`, gallery `meta.json`, `lake-manifest`, or other-field edits.

## Verification convention

`wc -l` (raw) — matches gallery `meta.json` `lineCount` and recent mechanic PRs #19663 / #19667 / #19767 / #19772 / #19929 / #19940. The `split('\n').length` value of 188 is what `enrich-research.ts` writes; `pnpm build` would overwrite back to 188, which is why mechanic-fix PRs do not run `pnpm build`.

---
Automated fix by lean-mechanic agent.