### PR TITLE
fix(meta): batch sync SchauderFixedPointOQ03OQ01.lean leanFiles in 5 schauder-fixed-point siblings (thm 7→14)

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-01.json
@@ -96,7 +96,7 @@
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
       "lineCount": 1284,
-      "theoremCount": 7,
+      "theoremCount": 14,
       "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,

--- a/src/data/research/problems/schauder-fixed-point-oq-02.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-02.json
@@ -95,7 +95,7 @@
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
       "lineCount": 1284,
-      "theoremCount": 7,
+      "theoremCount": 14,
       "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
@@ -147,7 +147,7 @@
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
       "lineCount": 1284,
-      "theoremCount": 7,
+      "theoremCount": 14,
       "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
@@ -94,7 +94,7 @@
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
       "lineCount": 1284,
-      "theoremCount": 7,
+      "theoremCount": 14,
       "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,

--- a/src/data/research/problems/schauder-fixed-point-oq-03.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03.json
@@ -92,7 +92,7 @@
       "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
       "filename": "SchauderFixedPointOQ03OQ01.lean",
       "lineCount": 1284,
-      "theoremCount": 7,
+      "theoremCount": 14,
       "axiomCount": 2,
       "defCount": 4,
       "sorryCount": 3,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` entries for `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` across 5 schauder-fixed-point sibling research JSONs to canonical metrics @ `origin/main`.

## Evidence

**Canonical numerics** (from `origin/main`):

| metric | command | value |
|---|---|---|
| lineCount | `wc -l` | 1284 |
| theoremCount | `^(?:protected \|private \|noncomputable )*(?:theorem\|lemma) ` | **14** |
| defCount | `^(?:def\|noncomputable def\|opaque def) ` | 4 |
| sorryCount | `\bsorry\b` | 3 |
| axiomCount | `^axiom ` | 2 |

**Drift**: 5 siblings all had `theoremCount: 7` while canonical is **14** (off by −7). Other fields already in sync.

Likely originated when S22 ACT (#19671) added `exists_nearest_in_image_F` (+51 LOC) without backfilling sibling JSONs.

**Affected siblings (single-metric update — theoremCount 7→14):**
- `schauder-fixed-point-oq-01.json` (leanFiles[3])
- `schauder-fixed-point-oq-02.json` (leanFiles[3])
- `schauder-fixed-point-oq-03.json` (leanFiles[3])
- `schauder-fixed-point-oq-03-oq-01.json` (leanFiles[3])
- `schauder-fixed-point-oq-03-oq-01-incomplete-01.json` (leanFiles[0])

`lineCount`, `defCount`, `sorryCount`, `axiomCount` left unchanged across all siblings.

## Validation

- `python3 -c "import json; json.load(open(f))"` passes on all 5 modified files
- `git diff --stat`: 5 files / +5 / −5 (single-line `theoremCount: 7 → 14`)
- No Lean code touched, no `pnpm build` (skipped per mechanic memory: batch sync metadata only)

---
Automated fix by lean-mechanic agent.