### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ02.lean leanFiles in 23 ballot siblings (thm 28→92, def 29→23)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -320,9 +320,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -389,9 +389,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -337,9 +337,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -321,9 +321,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -324,9 +324,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -313,9 +313,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -371,9 +371,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -281,9 +281,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -343,9 +343,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -327,9 +327,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -316,9 +316,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -312,9 +312,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -317,9 +317,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -496,9 +496,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -318,9 +318,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -627,9 +627,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -323,9 +323,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -281,9 +281,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -340,9 +340,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -324,9 +324,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -323,9 +323,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -315,9 +315,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -315,9 +315,9 @@
       "path": "Proofs/BallotProblemOQ03OQ02.lean",
       "filename": "BallotProblemOQ03OQ02.lean",
       "lineCount": 2532,
-      "theoremCount": 28,
+      "theoremCount": 92,
       "axiomCount": 0,
-      "defCount": 29,
+      "defCount": 23,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ03OQ02.lean"


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` entries for `proofs/Proofs/BallotProblemOQ03OQ02.lean` across 23 ballot-problem sibling research JSONs to canonical metrics @ `origin/main`.

## Evidence

**Canonical numerics** (from `origin/main` HEAD `9034990819b`):

| metric | command | value |
|---|---|---|
| lineCount | `wc -l` | 2532 |
| theoremCount | `^(?:protected \|private \|noncomputable )*(?:theorem\|lemma) ` | **92** |
| defCount | `^(?:def\|noncomputable def\|opaque def) ` | **23** |
| sorryCount | `\bsorry\b` | 0 |
| axiomCount | `^axiom ` | 0 |

**Drift**: 23 siblings all had `theoremCount: 28` / `defCount: 29` (off by −64 thm, +6 def). The 64 missed theorems are `private lemma` lines that the canonical mechanic regex includes via `(protected \|private \|noncomputable )*` but a prior round counted with simple `^(theorem\|lemma) `.

Likely originated from PR #19454 (S2-A ACT for sperner-ndim-mathlib-oq-01-oq-04 bulk re-export) which last touched the file alongside many others. Subsequent S78 ACT (#19554) added +9/-4 LOC but did not backfill siblings.

**Affected siblings (single 2-metric update — theoremCount 28→92, defCount 29→23):**
23 ballot-problem-* JSONs (see git diff for full list with leanFiles[i] indices).

`lineCount`, `sorryCount`, `axiomCount` left unchanged across all siblings (already in sync).

**Excluded**: `ballot-problem-oq-01-oq-02-oq-01-oq-01.json` is untracked on the worktree (leaked from a prior mechanic run) and not on `origin/main`, so excluded from this PR.

## Validation

- `python3 -c "import json; json.load(open(f))"` passes on all 23 modified files
- `git diff --stat`: 23 files / +46 / −46 (two-line `theoremCount: 28 → 92` + `defCount: 29 → 23`)
- No Lean code touched, no `pnpm build` (skipped per mechanic memory: batch sync metadata only)

---
Automated fix by lean-mechanic agent.