### PR TITLE
fix(meta): batch sync BezoutIdentityOQ04OQ02.lean lineCount 139→138 across 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -375,7 +375,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -363,7 +363,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -395,7 +395,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -367,7 +367,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -370,7 +370,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -368,7 +368,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -392,7 +392,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -365,7 +365,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -366,7 +366,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -406,7 +406,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -368,7 +368,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -372,7 +372,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -367,7 +367,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -369,7 +369,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -369,7 +369,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -366,7 +366,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -371,7 +371,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -316,7 +316,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -389,7 +389,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -324,7 +324,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -371,7 +371,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -390,7 +390,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -426,7 +426,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -366,7 +366,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -373,7 +373,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -371,7 +371,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -392,7 +392,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -372,7 +372,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -328,7 +328,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -388,7 +388,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -371,7 +371,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04OQ02.lean",
       "filename": "BezoutIdentityOQ04OQ02.lean",
-      "lineCount": 139,
+      "lineCount": 138,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` for `Proofs/BezoutIdentityOQ04OQ02.lean` from the stale value `139` to the canonical `138` across 31 sibling research JSON `leanFiles[]` entries.

## Evidence

Canonical Lean source matches gallery meta record:

```
$ wc -l proofs/Proofs/BezoutIdentityOQ04OQ02.lean
138
```

Gallery (`src/data/proofs/bezout-identity-*/meta.json`) records `additionalFiles[i].lineCount: 138` for this `.lean` file.

**Before**: 31 sibling research JSONs recorded `lineCount: 139` for this shared `.lean` file. All other fields (`theoremCount: 5`, `sorryCount: 0`, `defCount: 0`, `axiomCount: 0`) already matched the canonical Lean source — only `lineCount` was off by one.

**After**: All 31 sibling JSONs record `lineCount: 138`, matching gallery.

## Method

Byte-level surgical edit via Python regex anchored on the unique `"path": "Proofs/BezoutIdentityOQ04OQ02.lean"` block, preserving existing escaped-Unicode encoding byte-for-byte (one `139` → `138` substitution per file). Convention follows recent merged mechanic batch syncs (#19663, #19667, #19931, #19933).

Diff is exactly +31/-31 (one numeric edit per file). JSON parse validated via `json.load` on all 31 modified files. No `pnpm build` regeneration of unrelated JSONs.

---
Automated fix by lean-mechanic agent.