### PR TITLE
audit: erdos-{767,775,778} definitionCount fixes + 6 erdos slugs clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9452,9 +9452,9 @@
     },
     "erdos-760": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T08:57:16Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-17T01:31:12Z",
+      "result": "clean"
     },
     "erdos-761": {
       "agentId": "auditor-cycle-20-batch",
@@ -9470,21 +9470,21 @@
     },
     "erdos-763": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T06:03:20Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T01:31:12Z",
+      "result": "clean"
     },
     "erdos-764": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T09:09:14Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T01:31:13Z",
+      "result": "clean"
     },
     "erdos-765": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T08:51:04Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T01:31:12Z",
+      "result": "clean"
     },
     "erdos-766": {
       "agentId": "auditor-cycle-20-batch",
@@ -9494,8 +9494,8 @@
     },
     "erdos-767": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T06:01:58Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T01:31:13Z",
       "result": "issues-fixed"
     },
     "erdos-768": {
@@ -9533,15 +9533,15 @@
     },
     "erdos-772": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T05:47:24Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-17T01:31:12Z",
+      "result": "clean"
     },
     "erdos-773": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T06:35:02Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-17T01:31:12Z",
+      "result": "clean"
     },
     "erdos-774": {
       "agentId": "auditor-cycle-20-batch",
@@ -9551,8 +9551,8 @@
     },
     "erdos-775": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T06:43:11Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-17T01:31:13Z",
       "result": "issues-fixed"
     },
     "erdos-776": {
@@ -9569,9 +9569,9 @@
     },
     "erdos-778": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T05:19:10Z",
-      "result": "clean"
+      "auditCount": 5,
+      "lastAudited": "2026-05-17T01:29:38Z",
+      "result": "issues-fixed"
     },
     "erdos-779": {
       "agentId": "auditor-cycle-5-batch",

--- a/src/data/proofs/erdos-767/meta.json
+++ b/src/data/proofs/erdos-767/meta.json
@@ -60,7 +60,7 @@
     "lineCount": 193,
     "assumptions": "4 axioms: g_k, czipszer_upper, erdos_lower, jiang_2004. 0 sorries.",
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős Problem #767 concerns extremal graph theory: given a forbidden substructure (cycles with many chords at a vertex), what is the maximum number of edges a graph can have? A chord of a cycle is an edge connecting two non-adjacent vertices on the cycle. The problem asks for g_k(n), the maximum edges in an n-vertex graph where no cycle has k or more chords incident to a single vertex.\n\nThe problem has a rich history. Czipszer first showed that g_k(n) is finite, bounded by (k+1)n. Erdős provided a matching lower bound construction giving g_k(n) >= (k+1)n - (k+1)² and conjectured equality for large n. Pósa proved the exact formula for k=1 (g_1(n) = 2n-4 for n >= 4), and Erdős himself verified the cases k=2 and k=3.\n\nThe full conjecture was resolved by Jiang in 2004, who proved g_k(n) = (k+1)n - (k+1)² for all n >= 3k+3. Interestingly, Erdős mentioned in 1969 that Lewin claimed to disprove the conjecture, but this was either for small n values or incorrect — Jiang's proof confirms the conjecture definitively.",
@@ -165,7 +165,7 @@
     "lineCount": 193,
     "axiomCount": 4,
     "theoremCount": 3,
-    "definitionCount": 8,
+    "definitionCount": 7,
     "path": "Proofs/Erdos767Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-775/meta.json
+++ b/src/data/proofs/erdos-775/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 281,
     "assumptions": "3 axioms: spencer_graph_construction, gao_upper_bound, gaoFunction_tendsto_infinity. 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 9
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "**Erdős Problem #775**\n\nThis problem explores the combinatorial structure of hypergraphs, specifically asking about the diversity of clique sizes.\n\n**Key History:**\n- Moon and Moser (1965): Proved that graphs on n vertices have at most n - log₂n + O(1) different clique sizes\n- Spencer (1971): Constructed graphs achieving this optimal bound\n- Erdős: Constructed 3-uniform hypergraphs with n - log*n different clique sizes, and asked if n - O(1) is achievable\n- Gao (2025): Proved the answer is NO for all k ≥ 3\n\n**Mathematical Setting:**\nA k-uniform hypergraph has edges that are exactly k-element subsets of vertices. For k=2, this is an ordinary graph. A clique (maximal complete subgraph) is a set where every k-subset is an edge. The question asks: how many different sizes of cliques can coexist?",
@@ -191,7 +191,7 @@
     "lineCount": 281,
     "axiomCount": 3,
     "theoremCount": 4,
-    "definitionCount": 9,
+    "definitionCount": 7,
     "path": "Proofs/Erdos775Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-778/meta.json
+++ b/src/data/proofs/erdos-778/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 225,
     "assumptions": "3 axioms: playGame, malekshahian_spiro_alice_n_bob_n123, malekshahian_spiro_alice_n_bob_n12_degree. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 20
+    "definitionCount": 18
   },
   "overview": {
     "historicalContext": "**Erdős Problem #778: Clique-Building Games on Complete Graphs**\n\nThis problem, posed by Erdős (referenced in Gu83), concerns competitive edge-coloring games on complete graphs — a topic at the intersection of combinatorial game theory and Ramsey theory.\n\n**Three Game Variants:**\nAlice and Bob alternate coloring edges of K_n red (Alice) and blue (Bob), with Alice going first. Variant 1 (Clique Game): Alice wins if her largest red clique exceeds Bob's largest blue clique. Variant 2 (Modified Game): Bob colors 2 edges per turn; he wins if his largest clique strictly exceeds Alice's. Variant 3 (Degree Game): Alice wins if the maximum degree in the red subgraph exceeds that of the blue.\n\n**Erdős's Belief:** Erdős conjectured that Bob should always have a winning strategy in the clique game for n ≥ 3, reflecting the general principle that the second player often has a structural advantage in such games.\n\n**Recent Progress:** Malekshahian and Spiro (arXiv:2410.18304, 2024) proved significant partial results. For the clique game, they showed Bob wins for a set of n with natural density at least 3/4, and that if Alice ever wins at some n, then Bob wins at the next three values n+1, n+2, n+3. For the degree game, Bob wins with density at least 2/3, with a similar recovery property over two consecutive values. These results strongly support Erdős's conjecture but the complete answer remains open.",
@@ -171,7 +171,7 @@
     "lineCount": 225,
     "axiomCount": 3,
     "theoremCount": 2,
-    "definitionCount": 20,
+    "definitionCount": 18,
     "path": "Proofs/Erdos778Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Cycle-5 batch audit of 9 erdos gallery entries. Three required definitionCount corrections; six were clean (counts match Lean source verbatim).

## Fixes (issues-fixed)

Canonical mechanic convention: `definitionCount = grep -cE '^(def|noncomputable def|opaque def) '`. Structures, inductives, and abbrevs are NOT counted as definitions (consistent with PR #19926 erdos-789 precedent).

- **erdos-767**: `definitionCount` 8 → 7 (`abbrev Graph` at line 39 not counted)
- **erdos-775**: `definitionCount` 9 → 7 (`structure UniformHypergraph` + `abbrev Hypergraph3` at lines 59/66 not counted)
- **erdos-778**: `definitionCount` 20 → 18 (`inductive EdgeColor` + `structure GameState` at lines 44/51 not counted)

Each fix updates both `meta.definitionCount` and `leanFile.definitionCount`.

## Clean audits

All counts (lineCount, axiomCount, sorries, theoremCount, definitionCount) match Lean source:

| slug | axioms | sorries | LOC | thm | def |
|------|--------|---------|-----|-----|-----|
| erdos-772 | 3 | 0 | 249 | 2 | 7 |
| erdos-763 | 2 | 0 | 271 | 4 | 9 |
| erdos-773 | 2 | 0 | 236 | 3 | 8 |
| erdos-765 | 2 | 0 | 215 | 6 | 7 |
| erdos-760 | 2 | 0 | 232 | 2 | 6 |
| erdos-764 | 4 | 0 | 192 | 2 | 10 |

All entries: `status: axiomatized, badge: axiom` — consistent with axiom integrity policy (each file has explicit `axiom` declarations).

## Test plan

- [x] `python3 -c "import json; json.load(...)"` validates all 4 modified JSONs
- [x] `grep -cE '^(def|noncomputable def|opaque def) '` confirms each Lean def count
- [x] Status `axiomatized` justified for all 9 (each has ≥ 1 `^axiom ` declaration)
- [x] No True stubs in any file
- [x] audit-tracker.json updated for all 9 slugs (auditCount bumped, lastAudited current)

🤖 Generated with [Claude Code](https://claude.com/claude-code)