### PR TITLE
fix(meta): batch sync AmgmInequalityPowerMeanLimits.lean leanFiles[].theoremCount 12->19 in 30 amgm-inequality siblings

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -277,7 +277,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -277,7 +277,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -296,7 +296,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -312,7 +312,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -234,7 +234,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -291,7 +291,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -252,7 +252,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -288,7 +288,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -284,7 +284,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -284,7 +284,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -300,7 +300,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -291,7 +291,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -285,7 +285,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -275,7 +275,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -285,7 +285,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -300,7 +300,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -292,7 +292,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -286,7 +286,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -282,7 +282,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -287,7 +287,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -248,7 +248,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -230,7 +230,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -299,7 +299,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -287,7 +287,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -306,7 +306,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -308,7 +308,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch-sync stale `leanFiles[i].theoremCount` for `Proofs/AmgmInequalityPowerMeanLimits.lean` across 30 sibling research JSONs.

## Evidence

**Canonical counts** for `proofs/Proofs/AmgmInequalityPowerMeanLimits.lean`:

| Field         | Canonical | Source                                                                    |
|---------------|-----------|---------------------------------------------------------------------------|
| `lineCount`   | 272       | `wc -l` (already matched, no change)                                      |
| `theoremCount`| **19**    | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '`    |
| `defCount`    | 3         | `grep -cE '^(noncomputable \|opaque )?def '` (already matched)            |
| `sorryCount`  | 0         | raw `\bsorry\b` (already matched)                                         |
| `axiomCount`  | 0         | `^axiom ` (already matched)                                               |

**Before**: 30 sibling research JSONs stored `theoremCount: 12` for `AmgmInequalityPowerMeanLimits.lean` entry.
**After**: All 30 store `theoremCount: 19` (canonical).

Single-field, single-(old,new)-pair surgical batch sync — diff is 30 files x 1 line each (+30/-30).

## Affected files

All `src/data/research/problems/amgm-inequality-*.json` files whose `leanFiles[]` array contains an entry with `path: "Proofs/AmgmInequalityPowerMeanLimits.lean"`.

## Validation

- JSON parse via `python3 -c "import json; json.load(open(f))"` — all 30 files valid.
- Python dump uses `ensure_ascii=False` to preserve UTF-8 (no escape blow-up).
- `pnpm build` deliberately skipped (would regenerate ~1047 unrelated JSONs).

---
Automated fix by lean-mechanic agent.