### PR TITLE
fix(meta): batch sync AmgmInequalityPowerMeanLimits.lean leanFiles[].theoremCount 12->19 in 30 amgm-inequality siblings

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -277,7 +277,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -277,7 +277,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -296,7 +296,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -312,7 +312,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -234,7 +234,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -291,7 +291,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -252,7 +252,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -288,7 +288,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -284,7 +284,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -284,7 +284,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -300,7 +300,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -291,7 +291,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -285,7 +285,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -275,7 +275,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -285,7 +285,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -300,7 +300,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -292,7 +292,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -286,7 +286,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -282,7 +282,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -287,7 +287,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -248,7 +248,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -230,7 +230,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -299,7 +299,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -287,7 +287,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -280,7 +280,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -306,7 +306,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -308,7 +308,7 @@
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
       "lineCount": 272,
-      "theoremCount": 12,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch-sync drift in 30 sibling research JSONs (`src/data/research/problems/amgm-inequality-*.json`) whose `leanFiles[]` entry for `Proofs/AmgmInequalityPowerMeanLimits.lean` carried stale `theoremCount: 12` against the canonical Lean source value of `19`.

## Evidence

Canonical counts from `proofs/Proofs/AmgmInequalityPowerMeanLimits.lean`:

| Field | Canonical | Was in siblings | New in siblings |
|---|---|---|---|
| `lineCount` | 272 | 272 | 272 (unchanged) |
| `theoremCount` | 19 | 12 | **19** |
| `defCount` | 3 | 3 | 3 (unchanged) |
| `sorryCount` | 0 | 0 | 0 (unchanged) |
| `axiomCount` | 0 | 0 | 0 (unchanged) |

Validation:
```
$ wc -l proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
     272 proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' \
    proofs/Proofs/AmgmInequalityPowerMeanLimits.lean
19
```

30 sibling JSONs touched, each a single-line `theoremCount: 12` → `theoremCount: 19` flip in the `AmgmInequalityPowerMeanLimits.lean` `leanFiles[]` entry (+30/-30).

JSON integrity verified via `python3 -c "import json; json.load(open(p))"` on every changed file.

## Scope

Doc-only. No `.lean`, gallery `meta.json`, `problem.md`, `state.md`, sessions/, lake-manifest, or other surfaces touched. Strictly the stale-`theoremCount` discharge across the 30 amgm-inequality siblings.

---
Automated fix by lean-mechanic agent.