### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ03.lean leanFiles in 30 area-of-circle siblings (lineCount 1938→1937, theoremCount 52→68)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -215,8 +215,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -237,8 +237,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -219,8 +219,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -226,8 +226,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -214,8 +214,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -190,8 +190,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -205,8 +205,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -222,8 +222,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -221,8 +221,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -293,8 +293,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,


### PR DESCRIPTION
## Fix

Batch-sync `leanFiles[10]` for `Proofs/AreaOfCircleOQ01OQ03.lean` across all **30** area-of-circle research JSONs. The stored counts (1938 LOC, 52 theorems) were baked-in miscounts present since the file's initial commit; the file itself is unchanged.

## Evidence

**Before** (stored in all 30 sibling JSONs at `leanFiles[10]`):
```json
{
  "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
  "filename": "AreaOfCircleOQ01OQ03.lean",
  "lineCount": 1938,
  "theoremCount": 52,
  "axiomCount": 0,
  "defCount": 11,
  "sorryCount": 1
}
```

**After**:
```json
{
  "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
  "filename": "AreaOfCircleOQ01OQ03.lean",
  "lineCount": 1937,
  "theoremCount": 68,
  "axiomCount": 0,
  "defCount": 11,
  "sorryCount": 1
}
```

**Canonical recount** (against current `proofs/Proofs/AreaOfCircleOQ01OQ03.lean` on `main`):
- `wc -l` → **1937**
- `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '` → **68**
- `defCount`, `axiomCount`, `sorryCount` unchanged.

The file has had these counts since its initial commit (`ecb47b35601`). The leanFiles entries appear to have been generated with a different counting convention at file-add time.

## Diff scope

`30 files changed, 60 insertions(+), 60 deletions(-)` — exactly 2 lines per file (the two stale fields).

Only `leanFiles[10]` is touched; all other entries and all other fields are preserved verbatim.

## Validation

- `python3 -c "import json; json.load(open(p))"` succeeds on all 30 modified files.
- No `\uXXXX` regressions (Python `json.dump` called with `ensure_ascii=False`).
- `pnpm build` intentionally skipped (regenerates all ~1047 research JSONs and would clobber siblings).

---
Automated fix by lean-mechanic agent.