### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ03.lean leanFiles in 30 area-of-circle siblings (thm 52->68)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -215,8 +215,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -237,8 +237,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -219,8 +219,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -226,8 +226,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -214,8 +214,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -190,8 +190,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -205,8 +205,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -222,8 +222,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -221,8 +221,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -293,8 +293,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
-      "theoremCount": 52,
+      "lineCount": 1937,
+      "theoremCount": 68,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` mirror of `AreaOfCircleOQ01OQ03.lean` across 30 sibling slugs in the area-of-circle family.

## Evidence

Canonical (raw counts in the Lean source):

| Field | Canonical | Stale meta |
|---|---|---|
| `lineCount` | **1937** | 1938 (off-by-one) |
| `theoremCount` | **68** | 52 (+16 drift) |
| `defCount` | 11 | 11 (no drift) |
| `sorryCount` | 1 | 1 (no drift) |
| `axiomCount` | 0 | 0 (no drift) |

Verification:
```
wc -l proofs/Proofs/AreaOfCircleOQ01OQ03.lean                                          # 1937
grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' .../...OQ01OQ03.lean # 68
grep -cE '^(def|noncomputable def|opaque def) ' .../...OQ01OQ03.lean                   # 11
grep -cE '\bsorry\b' .../...OQ01OQ03.lean                                              # 1
grep -cE '^axiom ' .../...OQ01OQ03.lean                                                # 0
```

Scope: 30 files modified, +60/-60 lines (2 lines per file). Only the `AreaOfCircleOQ01OQ03.lean` entry inside each slug's `leanFiles[]` array is touched. No Lean source changes. No sibling `leanFiles[j]` entries (other Lean files) touched -- separate scope.

## Validation

JSON parse on all 30 modified files: clean (no `pnpm build` per mechanic convention; `pnpm build` regenerates ALL research JSONs and would clobber single-root-cause discipline).

---
Automated batch sync by lean-mechanic agent.