### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ03OQ01.lean leanFiles in 33 cauchy-schwarz siblings (thm 5→6, LOC 177→176)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -208,8 +208,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -231,8 +231,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -210,8 +210,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -223,8 +223,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -213,8 +213,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -244,8 +244,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -206,8 +206,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -211,8 +211,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -208,8 +208,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -210,8 +210,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -210,8 +210,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -212,8 +212,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -210,8 +210,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -221,8 +221,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -208,8 +208,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -253,8 +253,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -247,8 +247,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -246,8 +246,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -225,8 +225,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -268,8 +268,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -235,8 +235,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -249,8 +249,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -248,8 +248,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -232,8 +232,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -231,8 +231,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -239,8 +239,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -232,8 +232,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -238,8 +238,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ03OQ01.lean",
-      "lineCount": 177,
-      "theoremCount": 5,
+      "lineCount": 176,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` entries for `proofs/Proofs/CauchySchwarzIntegralOQ01OQ03OQ01.lean` across 33 cauchy-schwarz sibling research JSONs to canonical metrics @ `origin/main`.

## Evidence

**Canonical numerics** (from `origin/main` HEAD `1c038f78428`):

| metric | command | value |
|---|---|---|
| lineCount | `wc -l` | **176** |
| theoremCount | `^(?:protected \|private \|noncomputable )*(?:theorem\|lemma) ` | **6** |
| defCount | `^(?:def\|noncomputable def\|opaque def) ` | 0 |
| sorryCount | `\bsorry\b` | 0 |
| axiomCount | `^axiom ` | 0 |

**Drift**: all 33 siblings carried `lineCount: 177` and `theoremCount: 5`. The +1 lineCount is the legacy `split('\n').length` convention (= `wc -l + 1`) leaked by a prior `pnpm build` run; the −1 theoremCount missed `private lemma eLpNorm_ofReal_eq` at line 51, an exact parallel to the ballot-problem fix in PR #19989.

The file was last touched in PR #19454 (S2-A ACT for sperner-ndim-mathlib-oq-01-oq-04 bulk re-export); subsequent regex updates were not back-filled across cauchy-schwarz siblings.

**Affected siblings (single 2-metric update — `theoremCount: 5 → 6`, `lineCount: 177 → 176`):**

- 20× `cauchy-schwarz-integral-oq-*` (leanFiles index 12 or 14)
- 13× `cauchy-schwarz-oq-*` (leanFiles index 13 or 14)

`defCount`, `sorryCount`, `axiomCount` left unchanged across all 33 siblings (already in sync at 0).

**Excluded**: `cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-02.json` and `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01-oq-01.json` are untracked on the worktree (leaked from prior mechanic/research runs) and not on `origin/main`, so excluded from this PR.

## Validation

- `python3 -c "import json; json.load(open(f))"` passes on all 33 modified files
- `git diff --shortstat`: 33 files / +66 / −66 (two-line `theoremCount: 5 → 6` + `lineCount: 177 → 176`)
- No Lean code touched, no `pnpm build` (skipped per mechanic memory: batch sync metadata only)

---
Automated fix by lean-mechanic agent.