### PR TITLE
fix(meta): batch sync BirthdayProblemOQ03OQ01OQ02.lean leanFiles in 13 birthday-problem siblings (LOC 2102→2263, thm 57→59, def 8→7)

### DIFF
--- a/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
@@ -157,10 +157,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -171,10 +171,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-03.json
@@ -147,10 +147,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-02.json
@@ -124,10 +124,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-02.json
@@ -152,10 +152,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-03.json
@@ -146,10 +146,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
@@ -153,10 +153,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -260,10 +260,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
@@ -196,10 +196,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01.json
@@ -162,10 +162,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-03.json
@@ -159,10 +159,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03.json
@@ -188,10 +188,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-04.json
+++ b/src/data/research/problems/birthday-problem-oq-04.json
@@ -153,10 +153,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"


### PR DESCRIPTION
## Fix

Batch-sync stale `leanFiles[i]` entries pointing at `Proofs/BirthdayProblemOQ03OQ01OQ02.lean` across 13 sibling research JSONs. Drift was introduced when PR #19997 merged (+161 LOC, +2 theorems) without updating the cross-sibling mirror entries.

## Evidence

**Before** (uniform across all 13 siblings):
- `lineCount: 2102`
- `theoremCount: 57`
- `defCount: 8`
- `axiomCount: 1`
- `sorryCount: 0`

**After** (canonical mechanic convention):
- `lineCount: 2263` (wc -l raw)
- `theoremCount: 59` (`^(protected |private |noncomputable )*(theorem|lemma) `)
- `defCount: 7` (`^(def|noncomputable def|opaque def) ` — excludes `private def`)
- `axiomCount: 1` (unchanged)
- `sorryCount: 0` (unchanged)

The defCount fix (8 → 7) removes a prior off-by-one: `private def tripleCountFinset` at line 1144 was previously included, but the canonical mechanic regex excludes `private def`.

## Scope

13 sibling research JSONs in `src/data/research/problems/`:
- birthday-problem-oq-02, oq-02-oq-01, oq-02-oq-01-oq-01, oq-02-oq-03
- birthday-problem-oq-03, oq-03-oq-01, oq-03-oq-01-oq-01, oq-03-oq-01-oq-01-oq-02, oq-03-oq-01-oq-01-oq-03, oq-03-oq-01-oq-02, oq-03-oq-01-oq-02-oq-01, oq-03-oq-03
- birthday-problem-oq-04

Pure metadata sync. No Lean code changes. No gallery `meta.json` changes (defCount 8→7 fix for gallery `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` left for separate scope; this PR keeps to research JSON cross-sibling mirror only, per recent mechanic-batch convention).

## Test plan

- [x] `python3 -c "import json; json.load(...)"` validates all 13 modified JSONs
- [x] `wc -l proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` = 2263
- [x] `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' ...` = 59
- [x] `grep -cE '^(def|noncomputable def|opaque def) ' ...` = 7
- [x] git diff shows 39+/39- (3 numeric fields × 13 files)
- [ ] Skipped: `pnpm build` (would regenerate ALL ~1047 research JSONs and use the `split('\n').length` convention that conflicts with canonical raw `wc -l`)

---
Automated fix by lean-mechanic agent.