### PR TITLE
fix(meta): batch sync BirthdayProblemOQ03OQ01OQ02.lean leanFiles in 13 birthday-problem siblings (lineCount 2102→2263, theoremCount 57→59, defCount 8→7)

### DIFF
--- a/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01-oq-01.json
@@ -157,10 +157,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -171,10 +171,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-03.json
@@ -147,10 +147,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-02.json
@@ -124,10 +124,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-02.json
@@ -152,10 +152,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01-oq-03.json
@@ -146,10 +146,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-01.json
@@ -153,10 +153,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02-oq-01.json
@@ -260,10 +260,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01-oq-02.json
@@ -196,10 +196,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-01.json
@@ -162,10 +162,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03-oq-03.json
@@ -159,10 +159,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-03.json
@@ -188,10 +188,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"

--- a/src/data/research/problems/birthday-problem-oq-04.json
+++ b/src/data/research/problems/birthday-problem-oq-04.json
@@ -153,10 +153,10 @@
     {
       "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
       "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
-      "lineCount": 2102,
-      "theoremCount": 57,
+      "lineCount": 2263,
+      "theoremCount": 59,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"


### PR DESCRIPTION
## Fix

Batch sync of `leanFiles[]` entries for `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` in 13 sibling research JSONs.

PR #19997 (S25 ACT-1) added +161 LOC and 2 theorems (`bad_count_general_4`, `bad_count_overlap_two`) but did not propagate the metrics to other birthday-problem siblings that reference the same file via `leanFiles[]`.

## Canonical metrics

Computed via the same grep regex used in prior mechanic batch syncs (e.g. #19999, #19960):

| Field         | Value | Regex / Command |
|---------------|-------|-----------------|
| `lineCount`   | 2263  | `wc -l` raw |
| `theoremCount`| 59    | `^(protected \| private \| noncomputable )*(theorem\|lemma) ` |
| `defCount`    | 7     | `^(noncomputable \| opaque )?def ` (excludes `private def`) |
| `sorryCount`  | 0     | `\bsorry\b` raw |
| `axiomCount`  | 1     | `^axiom ` |

## Sibling diff

All 13 sibling research JSONs stored the same stale tuple:
- `lineCount: 2102` → `2263` (+161 from PR #19997)
- `theoremCount: 57` → `59` (+2)
- `defCount: 8` → `7` (convention reconcile — `private def tripleCountFinset` excluded per the canonical def regex used by recent mechanic batch syncs)

Uniform 6-line diff per file (3 insertions + 3 deletions).

## Touched files (13)

- `birthday-problem-oq-02-oq-01-oq-01.json` (leanFiles[8])
- `birthday-problem-oq-02-oq-01.json` (leanFiles[8])
- `birthday-problem-oq-02-oq-03.json` (leanFiles[8])
- `birthday-problem-oq-02.json` (leanFiles[8])
- `birthday-problem-oq-03-oq-01-oq-01-oq-02.json` (leanFiles[8])
- `birthday-problem-oq-03-oq-01-oq-01-oq-03.json` (leanFiles[8])
- `birthday-problem-oq-03-oq-01-oq-01.json` (leanFiles[8])
- `birthday-problem-oq-03-oq-01-oq-02-oq-01.json` (leanFiles[10]) — canonical slug, S25 PR author
- `birthday-problem-oq-03-oq-01-oq-02.json` (leanFiles[8])
- `birthday-problem-oq-03-oq-01.json` (leanFiles[8])
- `birthday-problem-oq-03-oq-03.json` (leanFiles[8])
- `birthday-problem-oq-03.json` (leanFiles[8])
- `birthday-problem-oq-04.json` (leanFiles[8])

## Validation

All 13 files re-parse cleanly via `python3 -c "import json; json.load(open(p))"`. No Lean / meta.json / state.md / sessions / lake-manifest edits.

---

Automated fix by lean-mechanic agent.