### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02Defs.lean theoremCount 12→21 in 29 amgm sibling JSONs

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -90,7 +90,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -90,7 +90,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -109,7 +109,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -114,7 +114,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -47,7 +47,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -104,7 +104,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -65,7 +65,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -101,7 +101,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -97,7 +97,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -97,7 +97,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -113,7 +113,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -104,7 +104,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -98,7 +98,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -88,7 +88,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -98,7 +98,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -113,7 +113,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -105,7 +105,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -99,7 +99,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -95,7 +95,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -100,7 +100,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -61,7 +61,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -43,7 +43,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -112,7 +112,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -100,7 +100,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -93,7 +93,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -119,7 +119,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -121,7 +121,7 @@
       "path": "Proofs/AmgmInequalityOQ02Defs.lean",
       "filename": "AmgmInequalityOQ02Defs.lean",
       "lineCount": 394,
-      "theoremCount": 12,
+      "theoremCount": 21,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Updates `theoremCount: 12 → 21` for the `proofs/Proofs/AmgmInequalityOQ02Defs.lean` entry in 29 amgm-inequality sibling research JSONs. Stored value reflects an older regex convention that omitted the `noncomputable` modifier; canonical mechanic convention (per PR #19949) includes it.

## Evidence

**Canonical counts** (file `proofs/Proofs/AmgmInequalityOQ02Defs.lean`):

| Field | Value |
|------:|:------|
| `lineCount` | 394 (stored; canonical `wc -l` = 393, off-by-1 separate scope) |
| `theoremCount` | **21** (was 12 in 29 siblings) |
| `defCount` | 2 (unchanged) |
| `sorryCount` | 0 (unchanged) |
| `axiomCount` | 0 (unchanged) |

**Verification** (via `grep -nE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/AmgmInequalityOQ02Defs.lean`):

The 21 declarations comprise 12 `theorem`/`lemma`-prefixed and 9 `private (theorem|lemma)`-prefixed (which the older regex `^(theorem|lemma) ` missed):

1. `elemSymm_zero` (L40, theorem)
2. `elemSymm_one` (L44, theorem)
3. `elemSymm_nonneg` (L48, theorem)
4. `maclaurin_m1_ge_m2_n2` (L59, theorem)
5. `maclaurin_m1sq_ge_m2_n3` (L72, theorem)
6. `maclaurin_m1sq_ge_m2_n4` (L79, theorem)
7. `cauchy_schwarz_sum` (L86, private lemma)
8. `mapEmb_eq` (L115, private lemma)
9. `fin_univ_insert_last` (L118, private lemma)
10. `fin_last_not_mem_map` (L126, private lemma)
11. `pc_disj` (L131, private lemma)
12. `prod_map_csEmb` (L146, private lemma)
13. `elemSymm_two_succ` (L151, private lemma)
14. `sq_sum_eq_sum_sq_add_two_elemSymm` (L195, private theorem)
15. `maclaurin_sq_m1_ge_m2_general` (L220, theorem)
16. `maclaurinMean_nonneg` (L272, theorem)
17. `amgm_from_maclaurin` (L286, theorem)
18. `pc_disj_general` (L308, private lemma)
19. `elemSymm_succ` (L327, theorem)
20. `elemSymm_gt_eq_zero` (L371, theorem)
21. `elemSymm_n_eq_prod` (L384, theorem)

## Scope

- 29 files modified (one-line edit each: `"theoremCount": 12` → `"theoremCount": 21`).
- All other fields preserved; field order preserved; no JSON re-serialization.
- Validated all 29 JSONs parse cleanly post-edit.
- Two amgm siblings (`oq-03-oq-03-incomplete-01`, `oq-04-oq-02`) do not reference this `.lean` file and are unaffected.

**Out of scope** (separate mechanic PRs):
- `lineCount` off-by-1 drift (stored 394 = old `split('\n').length`; canonical `wc -l` = 393)
- `theoremCount` drift on other `AmgmInequality*.lean` entries (e.g. OQ02 16→25, OQ02OQ02 14→17, OQ03 10→12)

---
Automated fix by lean-mechanic agent.