### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ01OQ01OQ01.lean leanFiles in 23 ballot-problem siblings (lineCount 2348/2349→2391, theoremCount 10→51)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -253,8 +253,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -322,8 +322,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2349,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -270,8 +270,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -254,8 +254,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -257,8 +257,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -246,8 +246,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -214,8 +214,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -276,8 +276,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -260,8 +260,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -249,8 +249,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -245,8 +245,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -250,8 +250,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -434,7 +434,7 @@
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
       "lineCount": 2391,
-      "theoremCount": 10,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -562,8 +562,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2349,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -256,8 +256,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -214,8 +214,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -273,8 +273,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -257,8 +257,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -256,8 +256,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -248,8 +248,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -248,8 +248,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
       "filename": "BallotProblemOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 2348,
-      "theoremCount": 10,
+      "lineCount": 2391,
+      "theoremCount": 51,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 17,


### PR DESCRIPTION
## Fix

Batch sync of `leanFiles[]` entries for `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` in 23 sibling research JSONs.

PR #19984 (S44 prefix-Sym fresh-rebase) added +43 LOC / +1 lemma and updated the
owning slug's `leanFiles[20].lineCount` (2348→2391), but missed `theoremCount`
(stuck at long-stale `10`). All sibling JSONs likewise stored stale values from
when the file had only ~10 theorems early in development.

## Canonical metrics

Computed via the same grep convention used in prior mechanic batch syncs
(e.g. #19999, #19960, PR #20010 just shipped):

| Field         | Value | Regex / Command |
|---------------|-------|-----------------|
| `lineCount`   | 2391  | `wc -l` raw |
| `theoremCount`| 51    | `^(protected \| private \| noncomputable )*(theorem\|lemma) ` |
| `defCount`    | 6     | `^(noncomputable \| opaque )?def ` |
| `sorryCount`  | 17    | `\bsorry\b` raw (comment occurrences included per established convention) |
| `axiomCount`  | 0     | `^axiom ` |

## Sibling diff

- 21 sibling JSONs: `lineCount 2348 → 2391`, `theoremCount 10 → 51`
- 1 sibling JSON (`ballot-problem-oq-01-oq-01-oq-02-oq-01` and `ballot-problem-oq-03-oq-01-oq-02`): `lineCount 2349 → 2391`, `theoremCount 10 → 51` (off-by-one stored value)
- 1 sibling JSON (`ballot-problem-oq-03-oq-01-oq-01-oq-01` — the owning slug): only `theoremCount 10 → 51` (lineCount already 2391 from PR #19984's partial update)

Other fields (`axiomCount`, `defCount`, `sorryCount`) were already in sync across all 23.

## Validation

All 23 files re-parse cleanly via `python3 -c "import json; json.load(open(p))"`. No Lean / gallery meta.json / state.md / sessions / lake-manifest edits.

---

Automated fix by lean-mechanic agent.