### PR TITLE
fix(meta): batch sync BrouwerFixedPoint.lean leanFiles[].lineCount 250→249 in 17 brouwer-fixed-point siblings

### DIFF
--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
@@ -66,7 +66,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -62,7 +62,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-03.json
@@ -63,7 +63,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -65,7 +65,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
@@ -25,7 +25,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
@@ -66,7 +66,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BrouwerFixedPoint.lean",
       "filename": "BrouwerFixedPoint.lean",
-      "lineCount": 250,
+      "lineCount": 249,
       "theoremCount": 5,
       "axiomCount": 2,
       "defCount": 5,


### PR DESCRIPTION
## Fix

Sibling-batch sync of `leanFiles[].lineCount` for `proofs/Proofs/BrouwerFixedPoint.lean` across 17 `brouwer-fixed-point-*` research JSONs (250 → 249).

## Evidence

| field | recorded (all 17) | canonical | source |
|---|---|---|---|
| **lineCount** | **250** | **249** | `wc -l proofs/Proofs/BrouwerFixedPoint.lean` |
| theoremCount | 5 | 5 ✓ | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '` |
| defCount | 5 | 5 ✓ | `grep -cE '^(def\|noncomputable def\|opaque def) '` |
| sorryCount | 0 | 0 ✓ | `grep -cE '\bsorry\b'` |
| axiomCount | 2 | 2 ✓ | `grep -cE '^axiom '` |

Cross-check: `src/data/proofs/brouwer-fixed-point/meta.json` gallery already records `lineCount: 249`.

Root cause: file was introduced in PR #19454 (`research(sperner-ndim-mathlib-oq-01-oq-04): S2-A ACT`) at 249 LOC. The `research:enrich` build step uses `split('\n').length` (= `wc -l + 1`) to populate JSONs, while the mechanic-batch convention is raw `wc -l` (matches gallery meta.json + prior PRs #19988, #19991, #19982, #19978, etc.).

## Scope

17 surgical 1-line edits, 17 insertions(+), 17 deletions(-). No other fields touched. Validated with `python3 -c "import json; json.load(open(p))"` on all 17 files.

Excluded: `brouwer-fixed-point-oq-04-oq-02-incomplete-01.json` (no `BrouwerFixedPoint.lean` entry in its `leanFiles[]`).

---
Automated fix by lean-mechanic agent.