### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01.lean theoremCount 10→11 in 14 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -155,7 +155,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -149,7 +149,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -148,7 +148,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -127,7 +127,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -170,7 +170,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -137,7 +137,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -151,7 +151,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -139,7 +139,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -134,7 +134,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -133,7 +133,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -141,7 +141,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -134,7 +134,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -140,7 +140,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -153,7 +153,7 @@
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "lineCount": 183,
-      "theoremCount": 10,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Synchronize stale `leanFiles[4].theoremCount` for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean` across 14 `cauchy-schwarz-oq-*` sibling research JSONs.

## Evidence

**Canonical (from `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean`):**
- `wc -l` = 183
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` = **11**
- `grep -cE '^(def |noncomputable def |opaque def )'` = 0
- `grep -cE '\bsorry\b'` = 0
- `grep -cE '^axiom '` = 0

**Before**: 14 cauchy-schwarz siblings had `leanFiles[4].theoremCount = 10` (drifted).
**After**: 14 cauchy-schwarz siblings have `leanFiles[4].theoremCount = 11` (matches canonical).

**Untouched (already correct):** 19 `cauchy-schwarz-integral-oq-*` siblings at `idx=3` already have `theoremCount = 11`.

## Scope

- Only `theoremCount` on the single `idx=4` entry was changed per JSON. All other fields (`lineCount`, `definitionCount`, `sorryCount`, `axiomCount`) preserved verbatim.
- Other `leanFiles[i]` entries in these JSONs were not touched (out of scope; separate single-root-cause fixes).

## Validation

```bash
python3 -c "import json,os; [json.load(open(f'src/data/research/problems/{fn}')) for fn in os.listdir('src/data/research/problems') if fn.startswith('cauchy-schwarz-') and not fn.startswith('cauchy-schwarz-integral-') and fn.endswith('.json')]"
# OK
```

---
Automated fix by lean-mechanic agent.