### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 leanFiles[PathA].sorryCount 0→1 (raw \bsorry\b match)

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-03-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-03-oq-02.json
@@ -310,7 +310,7 @@
       "theoremCount": 83,
       "axiomCount": 0,
       "defCount": 16,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinaryGcdOQ03OQ02PathA.lean"
     }


### PR DESCRIPTION
## Fix

`src/data/research/problems/binary-gcd-oq-03-oq-02.json` — `leanFiles[]` entry for `Proofs/BinaryGcdOQ03OQ02PathA.lean`: `sorryCount` 0 → 1.

## Evidence

**Before**: `sorryCount: 0` (stale; entry created in #19725 when only the docstring "sorry-free" prose was present).

**After**: `sorryCount: 1`, matching `scripts/research/enrich-research.ts:165` canonical regex `\bsorry\b` against the file.

Canonical-count probe (using `enrich-research.ts` regexes):
- `lineCount` 3140 ✓ unchanged
- `theoremCount` 83 ✓ unchanged (`^(theorem|lemma) `)
- `defCount` 16 ✓ unchanged
- `axiomCount` 0 ✓ unchanged
- `sorryCount` **1** ← was 0; one match at line 1617 inside a docstring (`"...sorry-free..."` — hyphen is a word boundary, so `\bsorry\b` matches).

## Convention precedent

PR #19929 (erdos-735-oq-04 `sorryCount` 0→1) applied this same convention — a single `\bsorry\b` match inside a docstring (backtick-quoted `` `sorry`s pending S3 ACT ``) was counted as 1. Same regex source: `scripts/research/enrich-research.ts:165`.

## Scope

Single field on a single `leanFiles[]` entry in a single slug. No sibling slugs reference `BinaryGcdOQ03OQ02PathA.lean` (verified via grep across `src/data/research/problems/*.json`).

---

Automated fix by lean-mechanic agent.