### PR TITLE
audit: erdos-{744,734} definitionCount fixes + 8 slugs clean (cycle 6)

### DIFF
--- a/src/data/proofs/erdos-734/meta.json
+++ b/src/data/proofs/erdos-734/meta.json
@@ -62,7 +62,7 @@
     "lineCount": 206,
     "assumptions": "2 axioms: deBruijn_erdos, projective_plane_exists. 0 sorries.",
     "theoremCount": 1,
-    "definitionCount": 7
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "Erdős posed Problem #734 in his 1981 paper 'On the combinatorial problems which I would most like to see solved.' He asked whether, for all large n, there exists a non-trivial pairwise balanced block design (PBD) on n points where every block size t appears in at most O(n^{1/2}) blocks. Erdős wrote that this would 'probably not be very difficult to prove' but admitted he had been unsuccessful.\n\nThe foundational result for this problem is the de Bruijn-Erdős theorem (1948), which states that any non-trivial PBD on n points has at least n blocks. By a pigeonhole argument, since block sizes range from 2 to n, at least one size must appear with frequency proportional to √n. The question is whether ALL sizes can be kept at this threshold simultaneously.\n\nClassical constructions like projective and affine planes fail the frequency condition because they have uniform block size — all blocks are the same size, concentrating frequency in a single value. No construction achieving the O(√n) bound for all sizes is known, and the problem remains open. It connects to broader questions in combinatorial design theory about how block sizes can be distributed in balanced structures.",
@@ -174,7 +174,7 @@
     "lineCount": 206,
     "axiomCount": 2,
     "theoremCount": 1,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos734Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-744/meta.json
+++ b/src/data/proofs/erdos-744/meta.json
@@ -61,7 +61,7 @@
     "lineCount": 344,
     "assumptions": "2 axioms: chromaticNumber, rodl_tuza_theorem. 1 sorries.",
     "theoremCount": 8,
-    "definitionCount": 11
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Erdős Problem #744 originates from a question posed by Erdős, Hajnal, and Szemerédi in the early 1980s (references [Er81] and [EHS82]). The problem concerns a fundamental question about the structure of k-chromatic critical graphs: how many edges must be removed to make such a graph bipartite? The function f_k(n) measures the minimum number of edge deletions needed across all k-critical graphs on n vertices.\n\nThe case k = 3 is trivial: the only 3-critical graphs are odd cycles, and removing any single edge yields a path (which is bipartite), so f_3(n) = 1. For k ≥ 4, early results were encouraging for the conjecture. Gallai (1968) established that f_4(n) ≤ O(√n), and Lovász extended this to f_k(n) ≤ O(n^{1-1/(k-2)}) for general k. Erdős and collaborators conjectured that f_k(n) → ∞ as n → ∞, and specifically asked whether f_4(n) grows at least as fast as log(n).\n\nIn a surprising turn, Rödl and Tuza disproved the conjecture entirely in 1985. They showed that for every fixed k ≥ 3, the function f_k(n) is eventually constant: f_k(n) = C(k-1, 2) = (k-1)(k-2)/2 for all sufficiently large n. This means the non-bipartiteness of large k-critical graphs is concentrated in a bounded substructure, regardless of the total graph size.",
@@ -189,7 +189,7 @@
     "lineCount": 344,
     "axiomCount": 2,
     "theoremCount": 8,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos744Problem.lean",
     "sorries": 1
   },


### PR DESCRIPTION
## Summary
- 2 definitionCount fixes: erdos-744 (11→10), erdos-734 (7→6) — structures excluded per canonical mechanic convention `^(def|noncomputable def|opaque def) `
- 8 clean audits: isoperimetric-theorem-oq-02, erdos-{755,742,739,743,754,748,741} — meta.json counts match Lean source exactly
- Audit tracker bumped for 10 entries

## Test plan
- [x] JSON validity verified for both meta.json edits (python3 json.load)
- [x] All counts cross-checked via canonical greps
- [x] Status/badge consistency verified (axiomatized + axiom for axiom-bearing entries)

🤖 Generated with [Claude Code](https://claude.com/claude-code)