### PR TITLE
fix(meta): birthday-problem-oq-03-oq-01-oq-02 gallery meta sync (LOC 2102→2263, thm 57→59, def 8→7)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -24,9 +24,9 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: poisson_approx_birthday3 (Lemma C only: P(no triple) → exp(-c³/6)); Lemmas A (lambda_tendsto: C(n,3)/d² → c³/6) and B (exp_lambda_tendsto) are now proved theorems.",
     "dateAdded": "2026-04-04",
-    "lineCount": 2102,
-    "theoremCount": 57,
-    "definitionCount": 8,
+    "lineCount": 2263,
+    "theoremCount": 59,
+    "definitionCount": 7,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
       "asympThreshold_cubed: (asympThreshold d)³ = 6d² ln 2 (PROVED)",
@@ -142,12 +142,12 @@
       "Real"
     ],
     "namespace": "BirthdayThreshold3",
-    "lineCount": 2102,
+    "lineCount": 2263,
     "axiomCount": 1,
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
-    "theoremCount": 57,
-    "definitionCount": 8
+    "theoremCount": 59,
+    "definitionCount": 7
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Update the parent gallery `meta.json` for slug `birthday-problem-oq-03-oq-01-oq-02` to match the canonical counts in its bearer file `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` after recent +161 LOC growth.

## Evidence

**Bearer file**: `proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean` grew via PR #19997 (S25 ACT-1: `bad_count_general_4` + `bad_count_overlap_two`).

The companion sibling research JSONs were already batch-synced in PRs #20006 / #20009 / #20010 (each touched `src/data/research/problems/birthday-problem-*.json` only). The parent gallery `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json` was missed by all three batches and continued to point at the pre-S25 numerics.

**Canonical counts (verified at HEAD `c3c7e27bd0f`)**:

| Field | Before | After | Tool |
|-------|--------|-------|------|
| lineCount | 2102 | **2263** | `wc -l` |
| theoremCount | 57 | **59** | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '` |
| definitionCount | 8 | **7** | `grep -cE '^(def\|noncomputable def\|opaque def) '` |
| axiomCount | 1 | 1 (unchanged, verified) | `grep -c '^axiom '` |
| sorries | 0 | 0 (unchanged, verified) | `grep -c '\bsorry\b'` |

## Scope

- One file changed: `src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json`
- 6 numeric edits: `meta.{lineCount,theoremCount,definitionCount}` and `leanFile.{lineCount,theoremCount,definitionCount}`
- No description text changes, no structural changes, no other slugs touched
- JSON validated via `python3 -c "import json; json.load(open(...))"`

## Validation

- `wc -l` and `grep` counts taken in fresh worktree at origin/main HEAD `c3c7e27bd0f`
- JSON parses cleanly post-edit
- No conflicts with currently open PRs (verified via `gh pr list --search="birthday-problem-oq-03-oq-01-oq-02"`)

---
Automated fix by lean-mechanic agent.