### PR TITLE
fix(meta): sync ZsqrtdNegTwoOQ03.lean theoremCount 29→13 in zsqrtd-neg-two-oq-03 research JSON

### DIFF
--- a/src/data/research/problems/zsqrtd-neg-two-oq-03.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03.json
@@ -137,7 +137,7 @@
       "sorries": 0,
       "axiomCount": 0,
       "definitionCount": 3,
-      "theoremCount": 29
+      "theoremCount": 13
     }
   ]
 }


### PR DESCRIPTION
## Fix

Single-slug `leanFiles[].theoremCount` drift: 29 (recorded) → 13 (canonical at HEAD).

## Evidence

**Before**: `src/data/research/problems/zsqrtd-neg-two-oq-03.json` leanFiles[0].theoremCount = 29

**After**: leanFiles[0].theoremCount = 13

Canonical from current source:
```
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' \
    proofs/Proofs/ZsqrtdNegTwoOQ03.lean
13
$ wc -l proofs/Proofs/ZsqrtdNegTwoOQ03.lean
426
```

The file has been stable at 426 LOC since PR #19008 (S3 ACT — EuclideanDomain Eisenstein via rounding, build verified 3058 jobs). Other leanFiles[0] fields verified correct: lineCount=426, sorries=0, axiomCount=0, definitionCount=3.

## Scope

- 1 file, 1 line: `theoremCount: 29 → 13`
- No other research JSON or gallery `meta.json` references `ZsqrtdNegTwoOQ03.lean` (confirmed via `grep -rl`)
- No Lean / problem.md / knowledge.md / state.md / meta.json edits

---
Automated fix by lean-mechanic agent.