### PR TITLE
fix(meta): batch sync BallotProblemOQ03OQ01OQ02Helpers.lean leanFiles in 23 ballot-problem siblings (lineCount 15996→15995, theoremCount 79→527)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-01.json
@@ -297,8 +297,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -366,8 +366,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02.json
@@ -314,8 +314,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01.json
@@ -298,8 +298,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01-oq-02.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-01.json
@@ -290,8 +290,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02-oq-02.json
@@ -348,8 +348,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-02.json
@@ -258,8 +258,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04-oq-01.json
@@ -320,8 +320,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-04.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01.json
@@ -293,8 +293,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-02-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-02.json
@@ -289,8 +289,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-02.json
@@ -294,8 +294,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -477,8 +477,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01.json
@@ -295,8 +295,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-02.json
@@ -606,8 +606,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-04.json
@@ -300,8 +300,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01.json
@@ -258,8 +258,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-02.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-02.json
@@ -317,8 +317,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-03.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-03.json
+++ b/src/data/research/problems/ballot-problem-oq-03.json
@@ -300,8 +300,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-04.json
+++ b/src/data/research/problems/ballot-problem-oq-04.json
@@ -292,8 +292,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,

--- a/src/data/research/problems/ballot-problem-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-05.json
@@ -292,8 +292,8 @@
     {
       "path": "Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean",
       "filename": "BallotProblemOQ03OQ01OQ02Helpers.lean",
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
       "axiomCount": 0,
       "defCount": 15,
       "sorryCount": 9,


### PR DESCRIPTION
## Fix

Batch sync of `leanFiles[]` entries for `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` in 23 sibling ballot-problem research JSONs.

The helpers file (15,995 lines, 527 theorems on disk) was stored in all 23 ballot sibling JSONs with **stale** values frozen at an early stage of the file:

- `lineCount: 15996` — off-by-one from the old `split('\n').length` convention (canonical mechanic convention is raw `wc -l`)
- `theoremCount: 79` — stale; the helpers file has grown to **527 theorems** while the JSONs were never resynced

Other fields (`defCount: 15`, `sorryCount: 9`, `axiomCount: 0`) were already in sync across all 23 siblings.

## Canonical metrics

Computed against `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` using the same convention as recent mechanic batch syncs (#19961, #19960, #20012, #20014, #20016):

| Field         | Value | Regex / Command |
|---------------|-------|-----------------|
| `lineCount`   | 15995 | `wc -l` raw |
| `theoremCount`| 527   | `^(protected \| private \| noncomputable )*(theorem\|lemma) ` |
| `defCount`    | 15    | `^(noncomputable \| opaque )?def ` |
| `sorryCount`  | 9     | `\bsorry\b` raw (no comment strip per established convention) |
| `axiomCount`  | 0     | `^axiom ` |

## Sibling diff

All 23 sibling JSONs receive the identical 2-field update:

```diff
-      "lineCount": 15996,
-      "theoremCount": 79,
+      "lineCount": 15995,
+      "theoremCount": 527,
```

No other fields are touched. `ballot-problem-oq-03-oq-01-oq-02-incomplete-01.json` mentions this file in a comment but does not have it in `leanFiles[]`, so it is intentionally excluded.

## Validation

All 23 modified JSONs re-parse cleanly via `python3 -c "import json; json.load(open(p))"`. No Lean source / gallery `meta.json` / `state.md` / `sessions/` / `lake-manifest` edits.

---
Automated fix by lean-mechanic agent.