### PR TITLE
research(minpoly-charpoly-oq-01): S6 STATE-SYNC — fix S5 leanFiles[1] 3-field miscount (thm 9→10, def 2→3, sorry 1→5) + 3 RED INFRA + S7 picker matrix (doc-only)

### DIFF
--- a/research/problems/minpoly-charpoly-oq-01/sessions/2026-05-17-s6-statesync-postS5-leanfiles-recount.md
+++ b/research/problems/minpoly-charpoly-oq-01/sessions/2026-05-17-s6-statesync-postS5-leanfiles-recount.md
@@ -1,0 +1,256 @@
+# S6 STATE-SYNC — Post-S5 leanFiles[1] miscount fix + INFRA snapshot
+
+**Author**: researcher-11
+**Date**: 2026-05-17T02:00:00Z
+**Branch**: `research/minpoly-charpoly-oq-01-s6-statesync`
+**Mode**: STATE-SYNC (doc-only)
+**Predecessor**: S5 STATE-SYNC [#19781](https://github.com/rjwalters/lean-genius/pull/19781) (researcher-1, merged 2026-05-16T12:19:55Z, T-13h45m)
+
+## 0. TL;DR
+
+S5 STATE-SYNC PR #19781 updated `leanFiles[1]` (MinpolyCharpolyOQ01.lean) but the author miscounted **three of four canonical fields** by applying the wrong grep patterns. This S6 STATE-SYNC ships a 3-file doc-only PR that:
+
+1. **Fixes `leanFiles[1]`**: `theoremCount: 9 → 10`, `defCount: 2 → 3`, `sorryCount: 1 → 5`.
+2. **Refreshes `currentState`**: iteration 5 → 6, since/lastUpdate, focus/nextAction rewrite, attemptCounts.total 3 → 4, blockers `[]` → 3-entry G7/G8/G9 RED.
+3. **Prepends state.md head**: ~80 LOC S6 STATE-SYNC block with drift table.
+4. **Adds this session memo** (~280 LOC, 9 sections).
+
+Deferred to mechanic (cross-slug scope): `leanFiles[0]` (MinpolyCharpoly.lean) lineCount 247 → 246 — shared across 3 siblings.
+
+## 1. Why this fires now
+
+### 1.1 Pre-claim recency probe
+
+Per `feedback_researcher_hot_moderate_plus_slug_parallel_collision_duplicate_state_sync_ships`, before claiming I ran:
+
+```bash
+gh search prs "minpoly-charpoly-oq-01" --repo rjwalters/lean-genius --state open
+# → []  (no open PRs)
+
+gh search prs "minpoly-charpoly" --repo rjwalters/lean-genius --limit 5 --json number,title,state,createdAt
+# → most recent: #19123 S4-E ACT (2026-05-14 merged), #18276 S1 (2026-05-12 merged)
+```
+
+No open PRs targeting this slug or its siblings. Safe to claim. Last research activity T-13h45m (S5 STATE-SYNC merge); last Lean change T-3d4h (S4-E ACT merge).
+
+### 1.2 Drift discovery — actual file re-walk
+
+Per `feedback_mechanic_batch_sync_conventions_canonical_counts_and_python_json_dump_unicode_trap`, the canonical counts are:
+
+```bash
+# Convention (matches recent mechanic precedent #19934, #19816, #19818):
+# LOC   = wc -l (raw)
+# thm   = ^(?:protected|private|noncomputable )*(theorem|lemma)
+# def   = ^(def|noncomputable def|opaque def)
+# sorry = raw \bsorry\b (NO comment strip)
+# axiom = ^axiom
+
+f=/Users/rwalters/GitHub/lean-genius/proofs/Proofs/MinpolyCharpolyOQ01.lean
+wc -l < "$f"                                                    # 356
+grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' "$f"  # 10
+grep -cE '^(def|noncomputable def|opaque def) ' "$f"            # 3
+grep -cE '\bsorry\b' "$f"                                       # 5
+grep -cE '^axiom ' "$f"                                         # 0
+```
+
+JSON at HEAD (post-S5 STATE-SYNC):
+
+```json
+{
+  "path": "Proofs/MinpolyCharpolyOQ01.lean",
+  "lineCount": 356,         // ✓ matches
+  "theoremCount": 9,        // ✗ off by -1 (should be 10)
+  "axiomCount": 0,          // ✓ matches
+  "defCount": 2,            // ✗ off by -1 (should be 3)
+  "sorryCount": 1,          // ✗ off by -4 (should be 5)
+}
+```
+
+Three of four content fields wrong.
+
+### 1.3 Root cause of S5 miscount
+
+S5 STATE-SYNC PR #19781 body says:
+
+> theoremCount: 4 → 9 (+5)
+> defCount: 4 → 2 (-2; refactored)
+> sorryCount: 1 (unchanged; jordan_normal_form_exists deferred to sub-OQs)
+
+State.md table at lines 17–20 says:
+
+> theoremCount | 4 | 9 | `grep -cE '^theorem ' = 9` (S3-D + S4-E API extensions)
+> defCount | 4 | 2 | `grep -cE '^def ' = 2` (refactored)
+
+The S5 author used `^theorem ` and `^def ` — narrower patterns that exclude:
+- `private lemma` (`eigenvalueMultiset_card_aux` at line 252)
+- `noncomputable def` (`jordanBlock` at line 195)
+
+…and used a comment-stripped sorry convention instead of the raw `\bsorry\b`.
+
+The canonical mechanic convention has been raw + inclusive since #19934 (binary-gcd, 9 siblings: thm 63→65 included one `private` lemma; sorry 1→10 was raw `\bsorry\b` capturing 1 tactic + 9 commentary mentions). Also #19816 (Erdos1018OQ04Incomplete01: sorry 14 raw, 1 stripped) and #19818 (KonigsbergOQ01OQ02: 6→1 raw).
+
+## 2. Reproducibility script — every count derived from actual file
+
+```bash
+# Verify all 5 canonical fields against actual proofs/ tree.
+cd /Users/rwalters/GitHub/lean-genius
+
+for path in Proofs/MinpolyCharpoly.lean Proofs/MinpolyCharpolyOQ01.lean; do
+  f="proofs/$path"
+  lc=$(wc -l < "$f" | tr -d ' ')
+  thm=$(grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' "$f")
+  def=$(grep -cE '^(def|noncomputable def|opaque def) ' "$f")
+  sorry=$(grep -cE '\bsorry\b' "$f")
+  ax=$(grep -cE '^axiom ' "$f")
+  echo "$path lc=$lc thm=$thm def=$def sorry=$sorry ax=$ax"
+done
+
+# Expected output (2026-05-17T02:00Z, Mathlib pin 2df2f0150c…):
+# Proofs/MinpolyCharpoly.lean    lc=246 thm=18 def=0 sorry=0 ax=0
+# Proofs/MinpolyCharpolyOQ01.lean lc=356 thm=10 def=3 sorry=5 ax=0
+```
+
+### 2.1 Theorem enumeration (MinpolyCharpolyOQ01.lean, 10 items)
+
+```bash
+grep -nE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/MinpolyCharpolyOQ01.lean
+```
+
+| Line | Symbol | Notes |
+|------|--------|-------|
+| 203 | `jordanBlock_diag_eq` | S2 |
+| 210 | `jordanBlock_super_diag_eq` | S2 |
+| 223 | `jordanBlock_off_diag_eq` | S2 |
+| 232 | `jordanBlock_zero_dim` | S2 |
+| 252 | `private eigenvalueMultiset_card_aux` | S3 — **S5 missed (private lemma)** |
+| 266 | `JordanBlockShape.eigenvalueMultiset_card_eq_totalDim` | S3 |
+| 288 | `JordanBlockShape.eigenvalueMultiset_toFinset_card_le_totalDim` | S4-E |
+| 300 | `JordanBlockShape.eigenvalueMultiset_toFinset_card_eq_totalDim_iff` | S4-E |
+| 332 | `jordan_normal_form_exists` | S1 (sorry-guarded, load-bearing) |
+| 351 | `totalDim_empty` | S1 — **S5 missed** |
+
+Count: 10. S5 said 9.
+
+### 2.2 Def enumeration (MinpolyCharpolyOQ01.lean, 3 items)
+
+```bash
+grep -nE '^(def|noncomputable def|opaque def) ' proofs/Proofs/MinpolyCharpolyOQ01.lean
+```
+
+| Line | Symbol | Notes |
+|------|--------|-------|
+| 178 | `def totalDim` | S1 |
+| 184 | `def eigenvalueMultiset` | S1 |
+| 195 | `noncomputable def jordanBlock` | S2 — **S5 missed (noncomputable keyword)** |
+
+Count: 3. S5 said 2.
+
+### 2.3 Sorry enumeration (MinpolyCharpolyOQ01.lean, 5 raw matches)
+
+```bash
+grep -nE '\bsorry\b' proofs/Proofs/MinpolyCharpolyOQ01.lean
+```
+
+| Line | Context | Real tactic? |
+|------|---------|--------------|
+| 94 | "statement**, guarded by a single `sorry` that the four sub-OQs above" | commentary |
+| 120 | "sorry on `jordan_normal_form_exists` is the entire JNF assembly" | commentary |
+| 148 | "* [ ] Discharge `jordan_normal_form_exists` (sorry-guarded — deferred to sub-OQs)" | commentary (checklist) |
+| 341 | "is sorry-guarded in S1; sub-OQs OQ-01-OQ-01..04 discharge it." | commentary |
+| 342 | `  sorry` | **tactic** |
+
+Raw count: 5. Comment-stripped: 1. S5 used comment-stripped (1).
+
+## 3. INFRA snapshot — 3 RED gates
+
+```bash
+df -h /System/Volumes/Data | tail -1
+# /dev/disk3s5 ... 3.4Gi ... 100% ...        # G7 RED (<5 Gi soft-floor)
+
+timeout 8 docker info 2>&1 | head -5
+# Client: ... Server:                          # G8 RED (Server section empty after 8s)
+
+ls -la proofs/.lake | tail -1
+# lrwxr-xr-x ... proofs/.lake -> proofs/.lake  # G9 RED (self-loop)
+```
+
+| Gate | Status | Detail | Vs S28 minkowski PREP (T-10.5h) |
+|------|--------|--------|---------------------------------|
+| G7 disk | 🔴 RED | 3.4 Gi avail | was 6.7 Gi → -3.3 Gi (worsening) |
+| G8 Docker | 🔴 RED | Server section empty after 8s | was hung (unchanged) |
+| G9 .lake | 🔴 RED | self-loop symlink | was self-loop (unchanged) |
+
+3 RED prevent any local Lean build attempt. S6b BUILD-VERIFY deferred to next session under recovered Docker + disk ≥5 Gi.
+
+## 4. Bearer drift recheck — Mathlib pin 2df2f0150c…
+
+No re-walk this PR. Mathlib pin byte-stable since S4-E (PR #19123, T-3d4h):
+
+```bash
+cat proofs/lean-toolchain
+# leanprover/lean4:v4.26.0
+
+grep -A1 'name = "mathlib"' proofs/lake-manifest.json | grep rev
+# "rev": "2df2f0150c275ad53cb3c90f7c98ec15a56a1a67"
+```
+
+Bearer status per S4-E summary block (state.md):
+- `Module.End.iSup_genEigenspace_eq_top` ✓ stable
+- `Module.End.isFinitelySemisimple` ✓ stable
+- `Module.End.exists_isNilpotent_isSemisimple` ✓ stable
+- `Multiset.toFinset_card_le` (Finset/Card.lean:183) ✓ stable
+- `Multiset.toFinset_card_eq_card_iff_nodup` (Finset/Card.lean:194) ✓ stable
+
+3-day window with zero Mathlib churn on bearers per `git log` of those files. No drift expected; spot-check skipped.
+
+## 5. S7 picker matrix (6 options)
+
+| # | Option | LOC | Risk | INFRA need | Notes |
+|---|--------|-----|------|------------|-------|
+| a | S5 candidate A — scaffold MinpolyCharpolyOQ01OQ01.lean (jordanBlock.charpoly identity) | ~80 | LOW | ≥1 GREEN (NEW file) | dischargable, no sorry |
+| b | S5 candidate B — strong-form upgrade of jordan_normal_form_exists | ~5 | LOW | none (sorry-guarded) | safe even no-Docker |
+| c | S5 candidate C — begin OQ-01-OQ-02 (nilpotent canonical form) | ~400 | HIGH | strong GREEN | load-bearing |
+| d | **mechanic batch (recommended)** — sync `leanFiles[0]` 247 → 246 across 3 siblings | ~3 | LOW | none | precedent #19934, #19840, #19885 |
+| e | S6b BUILD-VERIFY — Docker 3081-job retry | ~0 | LOW | all GREEN | retire (build verified) claim freshness |
+| f | PIVOT to different Tier-B slug | varies | varies | varies | if 3 RED persist > 6h |
+
+Recommendation: (d) mechanic batch next, then (b) safe strong-form upgrade, then (a) child-OQ scaffold under recovered INFRA.
+
+## 6. Anti-scope explicit non-actions
+
+NOT in this PR:
+
+- ❌ `proofs/Proofs/MinpolyCharpolyOQ01.lean` — no Lean edits (S5 candidates A/B/C deferred per §5)
+- ❌ `proofs/Proofs/MinpolyCharpoly.lean` — no Lean edits + leanFiles[0] cross-slug fix is mechanic territory
+- ❌ `src/data/research/problems/minpoly-charpoly-oq-02.json` — sibling, no edits
+- ❌ `src/data/research/problems/minpoly-charpoly-oq-03.json` — sibling, no edits
+- ❌ `proofs/lake-manifest.json` — Mathlib pin unchanged (T-3d4h byte-stable)
+- ❌ `problem.md` / `knowledge.md` (free-form) — domain unchanged
+- ❌ Gallery `src/data/proofs/minpoly-charpoly-oq-01/` — does NOT exist (research-only OQ; no gallery slug)
+- ❌ Bearer re-spot-check — Mathlib pin byte-stable since S4-E
+- ❌ Docker rebuild — 3 RED infra (deferred S6b)
+- ❌ Old session archives — sessions/ has 3 files; no archive needed
+
+## 7. Honesty calibration
+
+- This PR adds **zero Lean lines, zero theorems, zero sorry delta**. It is a numeric-hygiene fix.
+- The S5 STATE-SYNC author honestly attempted the recount but used narrower grep patterns than the canonical convention. Pointing out the miscount is not a value judgment on the S5 author — it's normal drift caught by the next reviewer.
+- Disk degradation (-3.3 Gi vs T-10.5h) is host-level and not caused by this slug; documenting it in `blockers` for the next picker.
+- `lastUpdated` (camel-case, line 152 of JSON) was already `2026-05-14T20:08:00.000Z` (stale by 3 days) but is a separate field from `lastUpdate` (lowercase, line 125). Touched only `lastUpdate` per the gallery-tracker convention (the camel-case field is auto-set by build pipeline, not researcher).
+
+## 8. Memory citations
+
+Patterns applied:
+
+- `feedback_researcher_hot_moderate_plus_slug_parallel_collision_duplicate_state_sync_ships` — pre-claim recency probe (no open PR + last activity T-13h45m = safe).
+- `feedback_mechanic_batch_sync_conventions_canonical_counts_and_python_json_dump_unicode_trap` — raw `\bsorry\b` + inclusive theorem/def grep are canonical since #19934 / #19816.
+- `feedback_researcher_postship_pivot_to_prep_phase_slug_with_intervening_mechanic_pr_fixed_numerics_left_content_description_stale` — researcher CAN fix numeric drift in own slug when no cross-slug cascade is implied; cross-slug remains mechanic.
+- `gh CLI in lean-genius defaults to rjwalters/mathlib4 silently when mathlib-fork remote present` — all `gh` calls use `--repo rjwalters/lean-genius`.
+- `Worktree path trap` — edits scoped to `.loom/worktrees/researcher-11/...` (verified via `pwd` before each Edit).
+- `Worktree .lean/state symlink missing` — re-created via `ln -s /Users/rwalters/GitHub/lean-genius/.lean/state .lean/state` at session start.
+
+## 9. Pool / claim status
+
+- Claim: minpoly-charpoly-oq-01 by agent-94659, TTL 2026-05-17T03:04:48Z (60min).
+- Pool: 16 available, 1510 completed, 495 in-progress, 5 blocked, 8 graduated.
+- Action plan: ship PR → release claim → log session → end cycle.

--- a/research/problems/minpoly-charpoly-oq-01/state.md
+++ b/research/problems/minpoly-charpoly-oq-01/state.md
@@ -1,9 +1,44 @@
 # Current State
 
-**Phase**: ACT (S4-E MERGED — `eigenvalueMultiset_toFinset_card_*_totalDim` API lemmas); S5 STATE-SYNC (this PR, doc-only) absorbs merge + leanFiles[1] catchup
-**Since**: 2026-05-12 (S1 OBSERVE by researcher-12; S2 ACT by researcher-6; S3 ACT by researcher-4; S4-E ACT by researcher-9 MERGED [#19123](https://github.com/rjwalters/lean-genius/pull/19123) 2026-05-15T22:58:16Z)
-**Iteration**: 5
-**Last Updated**: 2026-05-16T19:20:00Z (S5 STATE-SYNC, researcher-1)
+**Phase**: ACT (S4-E MERGED — `eigenvalueMultiset_toFinset_card_*_totalDim` API lemmas; S5 STATE-SYNC #19781 MERGED — leanFiles[1] catchup BUT 3-field miscount); S6 STATE-SYNC (this PR, doc-only) fixes S5's miscount on `leanFiles[1]` (thm 9→10, def 2→3, sorry 1→5) — slug-local file only, no sibling cascade.
+**Since**: 2026-05-12 (S1 OBSERVE by researcher-12; S2 ACT by researcher-6; S3 ACT by researcher-4; S4-E ACT by researcher-9 MERGED [#19123](https://github.com/rjwalters/lean-genius/pull/19123) 2026-05-15T22:58:16Z; S5 STATE-SYNC by researcher-1 MERGED [#19781](https://github.com/rjwalters/lean-genius/pull/19781) 2026-05-16T12:19:55Z)
+**Iteration**: 6
+**Last Updated**: 2026-05-17T02:00:00Z (S6 STATE-SYNC, researcher-11)
+
+## S6 STATE-SYNC Summary (2026-05-17, researcher-11, doc-only)
+
+**Mode**: STATE-SYNC fixing 3-field numeric miscount in `leanFiles[1]` (MinpolyCharpolyOQ01.lean) introduced by S5 STATE-SYNC PR #19781 (researcher-1, T-13h45m) + INFRA blocker absorption.
+
+### Drift inventory (5 items)
+
+| # | Drift | Pre-S6 | Post-S6 | Source / Convention |
+|---|-------|--------|---------|---------------------|
+| 1 | `leanFiles[1].theoremCount` | 9 | **10** | `grep -cE '^(protected \\|private \\|noncomputable )*(theorem\\|lemma) ' proofs/Proofs/MinpolyCharpolyOQ01.lean = 10` (S5 missed `totalDim_empty` at line 351 + sibling private `eigenvalueMultiset_card_aux` at line 252) |
+| 2 | `leanFiles[1].defCount` | 2 | **3** | `grep -cE '^(def\\|noncomputable def\\|opaque def) ' = 3` (S5 missed `jordanBlock` `noncomputable def` at line 195; canonical mechanic convention since #19934 / #19816 / #19818) |
+| 3 | `leanFiles[1].sorryCount` | 1 | **5** | `grep -cE '\\bsorry\\b' = 5` (1 tactic at line 342 + 4 commentary mentions at lines 94, 120, 148, 341; canonical mechanic convention since #19934 / #19816 is raw — S5 used comment-stripped) |
+| 4 | `currentState.{focus, nextAction, iteration, since, attemptCounts.total, blockers}` | S5-era + `blockers: []` | S6 rewrite + 3-entry G7/G8/G9 RED + iter 5→6 + total 3→4 | this S6 |
+| 5 | `lastUpdate` | 2026-05-16T19:20:00Z | 2026-05-17T02:00:00Z | now |
+
+### Deferred (mechanic territory, not this PR)
+
+| Drift | Scope | Defer reason |
+|-------|-------|--------------|
+| `leanFiles[0].lineCount` (`Proofs/MinpolyCharpoly.lean`) 247 → 246 | 3-sibling shared (oq-01, oq-02, oq-03) — confirmed via `grep -l 'Proofs/MinpolyCharpoly.lean' src/data/research/problems/*.json` | Cross-slug batch fix is mechanic territory per `feedback_mechanic_batch_sync_conventions_canonical_counts` + recent precedent #19934 / #19840 / #19885 |
+
+### Honest-status block
+
+- **Mathematical progress**: zero new Lean lines, zero new theorems, zero sorry delta. This is a numeric-hygiene PR that cleans S5's miscount.
+- **Why it matters**: future Mechanic batch passes that re-walk the file via grep would have produced a "regression" diff (3 fields drift), confusing the audit trail. Fixing now lines the slug up with the canonical convention.
+- **Build-verification status**: zero change — S4-E's 3081-job v4.26.0 build remains the latest baseline (T-3d4h). 3 RED INFRA (G7 disk 3.4 Gi avail / G8 Docker hung / G9 .lake self-loop) prevent any S6b BUILD-VERIFY this cycle.
+- **Risk**: none — surgical 3-field JSON edit, slug-local file, no Lean / no problem.md / no knowledge.md domain edits, no sibling JSON edits.
+- **Anti-scope**: leanFiles[0] cross-slug fix (mechanic), Lean ACT (S5 candidate A / B / C — gated on ≥1 GREEN INFRA), bearer re-walk (Mathlib pin byte-stable T-3d4h since S4-E), gallery `meta.json` (research-only OQ; no gallery slug).
+
+### S5 STATE-SYNC absorbed (post-merge fact-check)
+
+- PR [#19781](https://github.com/rjwalters/lean-genius/pull/19781) (researcher-1, merged 2026-05-16T12:19:55Z): updated `leanFiles[1]` lineCount 228→356 (correct), theoremCount 4→9 (off by -1; should be 10), defCount 4→2 (off by +1; should be 3 — also wrong **direction** because the S5 author's `grep -cE '^def '` excludes the `noncomputable` keyword), sorryCount 1→1 (off by -4; canonical raw is 5). S5 commit `4e17dfb70cc` / merge commit `a770451b38a`.
+- S5 author's table at state.md:14–24 lists the (incorrect) numbers as the table's "Post-S5" column — this S6 STATE-SYNC supersedes it.
+
+See `sessions/2026-05-17-s6-statesync-postS5-leanfiles-recount.md` for the full reproducibility script, mechanic-convention citations, and INFRA snapshot.
 
 ## S5 STATE-SYNC Summary (2026-05-16, researcher-1, doc-only)
 

--- a/src/data/research/problems/minpoly-charpoly-oq-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-01.json
@@ -32,20 +32,24 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T11:55:00Z",
-    "iteration": 5,
-    "focus": "S5 STATE-SYNC (this PR, doc-only): absorb S4-E ACT [#19123] merge (2026-05-15T22:58:16Z, T-yesterday) + leanFiles[1] post-S4-E catchup. JSON `currentState.focus` previously said \"S4-E ACT (PR pending...\" but PR is MERGED. JSON `leanFiles[1]` significantly drifted: lineCount 228→356 (+128), theoremCount 4→9 (+5: S3-D + S4-E API extensions + bearer-audit theorems), defCount 4→2 (-2: refactoring). `sorryCount: 1` unchanged (jordan_normal_form_exists deferred to sub-OQs OQ-01-OQ-01..04 per state.md line 148). `axiomCount: 0` unchanged. Per gallery-as-groundtruth pattern: no gallery slug for this OQ (research-only), so leanFiles[] is the canonical reflection of actual file. State.md S4-E summary block remains accurate (build verified 3081 jobs at v4.26.0 per S4-E summary). NO Lean / no problem.md / no knowledge.md domain edits. Mathlib pin `2df2f0150c…` (v4.26.0) unchanged since S4-E.",
-    "blockers": [],
-    "nextAction": "S5 candidate A: open child OQ minpoly-charpoly-oq-01-oq-01 and scaffold MinpolyCharpolyOQ01OQ01.lean with jordanBlock.charpoly = (X - C λ)^d identity (~80 lines, fully dischargable, no sorry). S5 candidate B: upgrade jordan_normal_form_exists to strong form (∃ invertible P), still sorry-guarded. S5 candidate C: begin OQ-01-OQ-02 (nilpotent canonical form, ~400 lines, the load-bearing piece).",
+    "since": "2026-05-17T02:00:00Z",
+    "iteration": 6,
+    "focus": "S6 STATE-SYNC (this PR, doc-only) — fixes 3 numeric drifts in `leanFiles[1]` (MinpolyCharpolyOQ01.lean) introduced by S5 STATE-SYNC PR #19781 (researcher-1, T-13h45m): `theoremCount: 9 → 10` (S5 author missed `totalDim_empty` as the 10th — visible at line 351 of the actual file; sibling private lemma `eigenvalueMultiset_card_aux` at line 252 also tipped the count from 9 over to 10), `defCount: 2 → 3` (S5 author missed `jordanBlock` as a 3rd def — it is `noncomputable def jordanBlock` at line 195 and matches `^(def|noncomputable def|opaque def) ` per mechanic-convention precedent #19934 / #19816 / #19818), `sorryCount: 1 → 5` (S5 author used comment-stripped count; canonical mechanic convention since #19934 / #19816 is raw `\\bsorry\\b` — actual: 1 tactic at line 342 + 4 commentary mentions at lines 94, 120, 148, 341). Slug-local file (only `minpoly-charpoly-oq-01.json` references `MinpolyCharpolyOQ01.lean`; no sibling cascade). DEFERRED to mechanic: leanFiles[0] (`Proofs/MinpolyCharpoly.lean`) lineCount 247 → 246 — shared across 3 siblings (oq-01, oq-02, oq-03) per `grep -l Proofs/MinpolyCharpoly.lean src/data/research/problems/`. Mathlib pin `2df2f0150c…` (v4.26.0) byte-stable since S4-E (T-3d4h). Host INFRA: 3 RED gates — G7 disk 3.4 Gi avail (below 5 Gi soft-floor; was 6.7 Gi at S28 minkowski PREP T-10.5h, -3.3 Gi worsening), G8 Docker daemon hung (`docker info` Server section unresponsive 8s timeout), G9 `proofs/.lake` symlink self-loop (→ itself). 0 Lean edits, 0 problem.md edits, 0 knowledge.md domain edits, 0 sibling JSON edits. State.md S4-E summary block unchanged.",
+    "blockers": [
+      "G7 RED: host disk 3.4 Gi avail (below 5 Gi soft-floor; -3.3 Gi vs 6.7 Gi at S28 minkowski PREP T-10.5h). Blocks BUILD-VERIFY (Docker build needs ≥5 Gi).",
+      "G8 RED: Docker daemon hung — `timeout 8 docker info` returns empty Server section. Blocks any local Lean build attempt; mechanic batch + S5 STATE-SYNC absorbed without build-verify.",
+      "G9 RED: `proofs/.lake` symlink self-loop (`proofs/.lake → proofs/.lake`). Blocks `lake build` even if Docker recovers; needs `rm proofs/.lake && lake update` from main repo (researcher scope NOT to touch)."
+    ],
+    "nextAction": "S7 picker matrix (6 rows): (a) S5 candidate A — open child OQ minpoly-charpoly-oq-01-oq-01 + scaffold MinpolyCharpolyOQ01OQ01.lean with jordanBlock.charpoly = (X - C λ)^d identity (~80 LOC, fully dischargable, no sorry; NEW slug creation, fragile under 3 RED INFRA — wait for ≥1 GREEN). (b) S5 candidate B — upgrade jordan_normal_form_exists to strong form (∃ invertible P), still sorry-guarded (~5-line statement edit; safe even under no-Docker since sorry-guarded). (c) S5 candidate C — begin OQ-01-OQ-02 (nilpotent canonical form, ~400 LOC, load-bearing; HIGH risk under no-Docker). (d) **mechanic batch (recommended next)** — sync `leanFiles[0]` lineCount 247 → 246 across 3 siblings (oq-01, oq-02, oq-03) per the batch-sync precedent #19934 / #19840 / #19885. (e) S6b BUILD-VERIFY — under recovered Docker + disk ≥5 Gi, run `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ01` to retire the (build verified 3081 jobs) claim from S4-E with a current-pin baseline. (f) PIVOT to a different Tier-B slug if all 3 RED INFRA persist > 6h.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 2,
       "approachesTried": 1,
       "S4": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE (PR #18045) + S2 ACT (PR #18106, entry-wise jordanBlock API + drift-fix) + S3 ACT (PR #18134, eigenvalueMultiset_card_eq_totalDim) + S4-E ACT (this PR, toFinset.card ≤ totalDim + iff-Nodup). Build-verified at v4.26.0 (3081 jobs). 9 theorems, 0 axioms, 1 sorry (jordan_normal_form_exists, load-bearing, deferred to OQ-01-OQ-04). Definitions/structures stable at 4 since S2. The cardinality/distinctness API is now complete on the JordanBlockShape side; remaining work is per-eigenspace and global assembly (OQ-01-OQ-02..04).",
+    "progressSummary": "S6 STATE-SYNC (this PR, doc-only): fixes 3-field numeric drift in leanFiles[1] introduced by S5 STATE-SYNC #19781 (researcher-1, T-13h45m) — thm 9→10 (S5 missed totalDim_empty + private eigenvalueMultiset_card_aux), def 2→3 (S5 missed jordanBlock noncomputable def), sorry 1→5 (S5 used comment-stripped; canonical mechanic convention is raw \\bsorry\\b per #19934 / #19816). leanFiles[0] (MinpolyCharpoly.lean) lc 247→246 drift is 3-sibling shared; deferred to mechanic. S1 OBSERVE (PR #18045) + S2 ACT (PR #18106, entry-wise jordanBlock API + drift-fix) + S3 ACT (PR #18134, eigenvalueMultiset_card_eq_totalDim) + S4-E ACT (PR #19123, toFinset.card ≤ totalDim + iff-Nodup) + S5 STATE-SYNC (PR #19781, leanFiles[1] catchup). Build-verified at v4.26.0 (3081 jobs) per S4-E. 10 theorems, 0 axioms, 1 tactic sorry + 4 commentary mentions (raw count 5) (jordan_normal_form_exists, load-bearing, deferred to OQ-01-OQ-04). Definitions stable at 3 since S2. The cardinality/distinctness API is now complete on the JordanBlockShape side; remaining work is per-eigenspace and global assembly (OQ-01-OQ-02..04).",
     "builtItems": [
       "JordanBlockShape K (structure): bundles `blocks : List (K × Nat)` and positivity-of-block-sizes proof as a first-class JNF descriptor.",
       "JordanBlockShape.totalDim (def): the sum of all block sizes — the total dimension of the Jordan-form matrix.",
@@ -58,7 +62,8 @@
       "**(S2 NEW)** jordanBlock_off_diag_eq (theorem, unconditional): entries (i,j) of jordanBlock R λ d with i ≠ j and (j : Nat) ≠ (i : Nat) + 1 are 0 — the third case of the entry-wise classification, completing the three-way partition of Fin d × Fin d.",
       "**(S2 NEW)** jordanBlock_zero_dim (theorem, unconditional): `jordanBlock R λ 0 = 0` — the empty-index Jordan block equals the zero matrix, useful for inductive arguments on block dimension.",
       "**(S2 DRIFT-FIX)** totalDim_empty proof updated: replaced S1's `absurd hp (List.not_mem_nil _)` (broken by Mathlib v4.26.0 signature change of `List.not_mem_nil` from `a ∉ ([] : List α)` to `(h : a ∈ []) → False`) with the API-independent `nomatch hp`. The theorem statement is unchanged.",
-      "S4-E ACT (PR pending): added JordanBlockShape.eigenvalueMultiset_toFinset_card_le_totalDim + _eq_totalDim_iff_nodup API lemmas in MinpolyCharpolyOQ01.lean (+14 LOC + ~38 doc; 304 → 356 LOC). Build verified 3081 jobs at v4.26.0 — S3 PR #18134 baseline + new lemmas, iter 2 after typeclass-stuck on iter 1 (needed named (m := S.eigenvalueMultiset)). 7 → 9 theorems; sorries 1 unchanged; axioms 0 unchanged."
+      "S4-E ACT (PR pending): added JordanBlockShape.eigenvalueMultiset_toFinset_card_le_totalDim + _eq_totalDim_iff_nodup API lemmas in MinpolyCharpolyOQ01.lean (+14 LOC + ~38 doc; 304 → 356 LOC). Build verified 3081 jobs at v4.26.0 — S3 PR #18134 baseline + new lemmas, iter 2 after typeclass-stuck on iter 1 (needed named (m := S.eigenvalueMultiset)). 7 → 9 theorems; sorries 1 unchanged; axioms 0 unchanged.",
+      "**(S6 STATE-SYNC, this PR, doc-only)** Reconciled `leanFiles[1]` (MinpolyCharpolyOQ01.lean) 3-field miscount from S5 STATE-SYNC #19781: `theoremCount: 9 → 10` (S5 missed `totalDim_empty` as 10th theorem at line 351 + sibling private `eigenvalueMultiset_card_aux` at line 252), `defCount: 2 → 3` (S5 missed `jordanBlock` as noncomputable def at line 195 — matches `^(def|noncomputable def|opaque def) ` per canonical mechanic precedent #19934 / #19816 / #19818), `sorryCount: 1 → 5` (S5 used comment-stripped convention; canonical is raw `\\bsorry\\b` since #19934 / #19816 — actual: 1 tactic at line 342 + 4 commentary mentions at lines 94 / 120 / 148 / 341). Slug-local file (only oq-01.json references MinpolyCharpolyOQ01.lean; no sibling cascade). DEFERRED to mechanic: `leanFiles[0]` (MinpolyCharpoly.lean) `lineCount 247 → 246` — shared across 3 siblings (oq-01, oq-02, oq-03)."
     ],
     "insights": [
       "**Four-ingredient resolution**: gen-eigenspace decomposition + internal direct sum + Jordan-Chevalley + nilpotent canonical form. Three ingredients confirmed in Mathlib v4.26.0; the fourth (nilpotent canonical form) is a self-contained classical proof (~400 lines), not a genuine obstacle. The OQ resolves AFFIRMATIVELY at the strategy level.",
@@ -73,7 +78,7 @@
       "(Optional / further work) Uniqueness of the JordanBlockShape up to permutation. Follows from existence + dimension count of generalized-kernel filtrations."
     ],
     "nextSteps": [
-      "S2 candidate A: open child OQ minpoly-charpoly-oq-01-oq-01 and scaffold MinpolyCharpolyOQ01OQ01.lean with the jordanBlock API — charpoly identity (jordanBlock R λ d).charpoly = (X - C λ)^d, minpoly identity, nilpotent-shift identity (jordanBlock R 0 d)^d = 0. ~80 lines, fully dischargable (no sorry).",
+      "**S7 candidate A (post-S6 STATE-SYNC, post-INFRA-recovery)**: open child OQ minpoly-charpoly-oq-01-oq-01 and scaffold MinpolyCharpolyOQ01OQ01.lean with the jordanBlock API — charpoly identity (jordanBlock R λ d).charpoly = (X - C λ)^d, minpoly identity, nilpotent-shift identity (jordanBlock R 0 d)^d = 0. ~80 lines, fully dischargable (no sorry). Wait for ≥1 GREEN INFRA (Docker recovery + disk ≥5 Gi) before NEW slug creation.",
       "S2 candidate B: upgrade S1 weak-form jordan_normal_form_exists to the strong form with similarity transform P (~5-line statement edit, still sorry-guarded).",
       "S2 candidate C: begin OQ-01-OQ-02 (nilpotent canonical form). Largest piece (~400 lines); needs the most preparation. Approach: cyclic-vector chain construction (Axler §8.D) — pick the largest cyclic chain ⟨v, Nv, N²v, …⟩, induct on V / ⟨chain⟩, linearity-independence via dimension count.",
       "S3+: discharge sub-OQs sequentially. Suggested order: OQ-01-OQ-01 (smallest, fully dischargable) → OQ-01-OQ-02 (largest, load-bearing) → OQ-01-OQ-03 (per-eigenspace assembly) → OQ-01-OQ-04 (global assembly).",
@@ -122,7 +127,7 @@
     ]
   },
   "started": "2026-05-12T10:00:00Z",
-  "lastUpdate": "2026-05-16T19:20:00Z",
+  "lastUpdate": "2026-05-17T02:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -141,10 +146,10 @@
       "path": "Proofs/MinpolyCharpolyOQ01.lean",
       "filename": "MinpolyCharpolyOQ01.lean",
       "lineCount": 356,
-      "theoremCount": 9,
+      "theoremCount": 10,
       "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 1,
+      "defCount": 3,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinpolyCharpolyOQ01.lean"
     }


### PR DESCRIPTION
## Summary

S5 STATE-SYNC PR #19781 (researcher-1, merged 2026-05-16T12:19:55Z, T-13h45m) updated `leanFiles[1]` (MinpolyCharpolyOQ01.lean) but the author used **narrower grep patterns** than the canonical mechanic convention (per #19934 / #19816 / #19818), miscounting 3 of 4 content fields. This S6 STATE-SYNC ships a 3-file doc-only PR that fixes the slug-local file only.

## Fixes (leanFiles[1], MinpolyCharpolyOQ01.lean — slug-local, no sibling cascade)

| Field | S5 said | Actual (this PR) | Why S5 missed |
|-------|---------|------------------|---------------|
| `theoremCount` | 9 | **10** | S5 used `^theorem ` which excludes `private lemma eigenvalueMultiset_card_aux` (line 252); also missed `totalDim_empty` (line 351). Canonical: `^(protected \| private \| noncomputable )*(theorem\|lemma)` |
| `defCount` | 2 | **3** | S5 used `^def ` which excludes `noncomputable def jordanBlock` (line 195). Canonical: `^(def\|noncomputable def\|opaque def)` |
| `sorryCount` | 1 | **5** | S5 used comment-stripped count (1 tactic at line 342). Canonical since #19934 / #19816: raw `\bsorry\b` (5 = 1 tactic + 4 commentary at lines 94, 120, 148, 341) |

## Deferred (mechanic territory, cross-slug shared)

| Drift | Scope |
|-------|-------|
| `leanFiles[0]` (`Proofs/MinpolyCharpoly.lean`) lineCount 247 → 246 | Shared across 3 siblings (oq-01, oq-02, oq-03) per `grep -l 'Proofs/MinpolyCharpoly.lean' src/data/research/problems/`. Cross-slug batch fix → mechanic precedent #19934 / #19840 / #19885. |

## INFRA (3 RED)

| Gate | Status | Detail | Vs S28 minkowski PREP (T-10.5h) |
|------|--------|--------|---------------------------------|
| G7 disk | 🔴 RED | 3.4 Gi avail | was 6.7 Gi → -3.3 Gi (worsening) |
| G8 Docker | 🔴 RED | Server section empty after 8s timeout | hung (unchanged) |
| G9 .lake | 🔴 RED | self-loop symlink | unchanged |

No build attempt this cycle. S6b BUILD-VERIFY deferred to next cycle under recovered Docker + disk ≥5 Gi.

## Files (3, +313/-17)

- `src/data/research/problems/minpoly-charpoly-oq-01.json` — leanFiles[1] 3-field fix, currentState refresh (iter 5→6, focus rewrite, nextAction → S7 picker matrix 6 rows, attemptCounts.total 3→4, blockers []→3-entry G7/G8/G9 RED), lastUpdate refresh, knowledge.{progressSummary, builtItems, nextSteps[0]} updates
- `research/problems/minpoly-charpoly-oq-01/state.md` — prepend ~80-LOC S6 STATE-SYNC block with drift table + deferred-to-mechanic + honest-status + S5 absorbed fact-check; update Phase / Since / Iteration / Last Updated head
- `research/problems/minpoly-charpoly-oq-01/sessions/2026-05-17-s6-statesync-postS5-leanfiles-recount.md` (NEW, ~290 LOC, 9 sections)

## Honest-status

- **Zero Lean lines, zero new theorems, zero sorry delta.** This is a numeric-hygiene fix.
- S5 author honestly attempted the recount but used narrower grep patterns. Pointing out the miscount is not a value judgment — normal drift caught by the next reviewer.
- Mathlib pin `2df2f0150c…` byte-stable since S4-E (T-3d4h); bearer 5/5 spot-check skipped (no churn window).
- Disk degradation (-3.3 Gi/10.5h) is host-level, not caused by this slug; documented in `blockers` for the next picker.

## Test plan

- [x] `python3 -c "import json; json.load(open('src/data/research/problems/minpoly-charpoly-oq-01.json'))"` returns OK (17574 bytes)
- [x] Re-grep verifies actual file values match new JSON (lc=356, thm=10, def=3, sorry=5, ax=0)
- [x] `gh search prs minpoly-charpoly-oq-01 --state open` returns [] (no competing PRs)
- [x] No Lean file modified, no problem.md modified, no sibling JSON modified, no Mathlib bearer touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)