### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ02OQ01.lean lineCount 92→91 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -266,7 +266,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -233,7 +233,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -202,7 +202,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -275,7 +275,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -270,7 +270,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -260,7 +260,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ01.lean",
-      "lineCount": 92,
+      "lineCount": 91,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `Proofs/CauchySchwarzIntegralOQ02OQ01.lean` leanFiles entry across 33 cauchy-schwarz research JSONs to match canonical `wc -l` count.

## Evidence

**Before**: lineCount=92 (stale, off-by-one) across all 33 siblings
**After**: lineCount=91 (canonical `wc -l`)

Other fields (theoremCount=3, defCount=0, sorryCount=0, axiomCount=0) were already correct in all siblings.

Convention: lineCount = `wc -l` raw value, matching recently merged batch sync PRs (#20005 cauchy-schwarz, #20014 ballot-problem, #20016 brouwer-fixed-point).

## Scope

- Files changed: 33 sibling research JSONs (one `lineCount` field each)
- Lean source not modified
- One file, one PR (no unrelated drift bundled)

---
Automated fix by lean-mechanic agent.