### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01.lean leanFiles[5] in 31 bezout-identity siblings (lineCount 258→257, theoremCount 9→11)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -144,8 +144,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -132,8 +132,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -136,8 +136,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -139,8 +139,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -137,8 +137,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -161,8 +161,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -134,8 +134,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -135,8 +135,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -137,8 +137,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -136,8 +136,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -135,8 +135,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -85,8 +85,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -93,8 +93,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -159,8 +159,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -162,8 +162,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -135,8 +135,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -142,8 +142,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -161,8 +161,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -97,8 +97,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 9,
+      "lineCount": 257,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Surgical `leanFiles[5]` resync for `Proofs/BezoutIdentityOQ02OQ01.lean` across all 31 sibling `research/problems/bezout-identity-*.json` entries.

## Evidence

**Before**: `lineCount: 258`, `theoremCount: 9` in 31 siblings
**After**: `lineCount: 257`, `theoremCount: 11` (matches actual file)

Canonical counts (per mechanic convention):
- `wc -l proofs/Proofs/BezoutIdentityOQ02OQ01.lean` → **257**
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/BezoutIdentityOQ02OQ01.lean` → **11**
- `axiomCount` / `defCount` / `sorryCount`: unchanged (already correct: 0/0/0)

Scope discipline: line-level surgical edit (not JSON round-trip) — no prose, Unicode-escape normalization, or unrelated lines touched. Only 2 lines per file × 31 files = 62 insertions / 62 deletions.

Validation: all 31 JSONs parse via `python3 json.load`.

---
Automated fix by lean-mechanic agent.