### PR TITLE
fix(meta): BallotProblemOQ02OQ05.lean sorryCount 4→6 in 2 ballot-problem research JSONs (raw \bsorry\b match)

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-02-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-05.json
@@ -146,7 +146,7 @@
       "path": "proofs/Proofs/BallotProblemOQ02OQ05.lean",
       "lineCount": 229,
       "axiomCount": 1,
-      "sorryCount": 4,
+      "sorryCount": 6,
       "theoremCount": 4,
       "defCount": 7,
       "addedInIteration": 2

--- a/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json
@@ -404,7 +404,7 @@
       "theoremCount": 4,
       "axiomCount": 1,
       "defCount": 7,
-      "sorryCount": 4,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BallotProblemOQ02OQ05.lean"
     },


### PR DESCRIPTION
## Fix

Sync `leanFiles[].sorryCount` for `proofs/Proofs/BallotProblemOQ02OQ05.lean` (4 → 6) in the 2 research JSONs that reference it.

## Evidence

`grep -c '\bsorry\b' proofs/Proofs/BallotProblemOQ02OQ05.lean` → **6** matches:

| Line | Context | Type |
|------|---------|------|
| 39   | `- [ ] Discrete reflection identity (S3, sorry-free target)` | docstring |
| 134  | `acknowledged \`sorry\`s. The design is fully scoped in S5 PREP:` | docstring |
| 185  | `sorry  -- R4: ...` | tactic |
| 196  | `sorry  -- R5: ...` | tactic |
| 206  | `sorry  -- LOW: ...` | tactic |
| 225  | `sorry  -- R6: ...` | tactic |

S6 ACT PR #19675 wrote `sorryCount=4` in both JSONs (the "acknowledged sorries" tactic-only interpretation), but canonical mechanic convention is raw `\bsorry\b` with NO comment strip — same convention used by:

- #19663 / #19667 (Erdos batch syncs)
- #20019 (`binary-gcd-oq-03-oq-02` sorryCount 0→1 matching docstring "sorry" only)

## Canonical metrics

| Field         | Recorded | Actual | Match |
|---------------|----------|--------|-------|
| `lineCount`   | 229      | 229    | ✓     |
| `theoremCount`| 4        | 4      | ✓     |
| `defCount`    | 7        | 7      | ✓     |
| `axiomCount`  | 1        | 1      | ✓     |
| `sorryCount`  | 4        | **6**  | ✗ → fix |

## Files changed

Both receive the identical 1-field update (`"sorryCount": 4` → `"sorryCount": 6`):

- `src/data/research/problems/ballot-problem-oq-02-oq-05.json` (main slug, single `leanFiles[0]`, `path`-only entry style)
- `src/data/research/problems/ballot-problem-oq-03-oq-01-oq-01-oq-01.json` (sibling that imports this file, full `path`+`filename`+`githubUrl` entry style)

`grep -rln "BallotProblemOQ02OQ05.lean" src/data/research/problems/` → 2 hits (both updated).

## Validation

- Both JSONs reparse cleanly via `python3 -c "import json; json.load(open(p))"`
- No Lean source / gallery `meta.json` / `state.md` / `sessions/` / `lake-manifest` edits
- Diff is exactly 2 lines (1 per JSON)

---
Automated fix by lean-mechanic agent.