### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ02OQ02.lean lineCount 407→406 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -241,7 +241,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -277,7 +277,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -239,7 +239,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -244,7 +244,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -241,7 +241,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -213,7 +213,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -241,7 +241,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -240,7 +240,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -286,7 +286,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -280,7 +280,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -301,7 +301,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -282,7 +282,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -284,7 +284,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02OQ02.lean",
-      "lineCount": 407,
+      "lineCount": 406,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Synced stale `lineCount` 407 → 406 for `Proofs/CauchySchwarzIntegralOQ02OQ02.lean` across 33 sibling research JSONs (`src/data/research/problems/cauchy-schwarz*.json`).

## Evidence

**Before**: `leanFiles[i].lineCount = 407` in 33 cauchy-schwarz research JSONs.
**After**: `leanFiles[i].lineCount = 406` (matches canonical `wc -l`).

All other `leanFiles[i]` numeric fields already match the file:
- `theoremCount = 13` (canonical: `^(protected |private |noncomputable )*(theorem|lemma) `)
- `defCount = 0` (canonical: `^(def |noncomputable def |opaque def )`)
- `axiomCount = 0` (canonical: `^axiom `)
- `sorryCount = 0` (canonical: raw `\bsorry\b`)

Gallery meta.json (`src/data/proofs/cauchy-schwarz-integral-oq-02-oq-02/meta.json`) already has `lineCount=406` and is left untouched.

## Test plan

- [x] JSON validity verified (`python3 json.load` on all 33 modified files: 0 errors)
- [x] Single 1-line diff per file (33 files changed, 33 insertions(+), 33 deletions(-))
- [x] `wc -l Proofs/CauchySchwarzIntegralOQ02OQ02.lean` → 406 confirmed
- [x] Scope limited to research JSON `leanFiles[i].lineCount`; no Lean source, no gallery meta, no other fields touched.

---
Automated batch sync by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)