### PR TITLE
audit(clean): bump tracker for isoperimetric-theorem-oq-02

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13748,8 +13748,8 @@
       "issues": []
     },
     "isoperimetric-theorem-oq-02": {
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T05:43:30Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T02:19:15Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Clean audit of `isoperimetric-theorem-oq-02` (Discrete Isoperimetric Inequality 1D). All integrity claims verified against `proofs/Proofs/IsoperimetricTheoremOQ02.lean`.

| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|----|
| lineCount | 136 | 136 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 1 | 1 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| Structure-encoded assumptions | — | none | ✓ |

`status: "verified"`, `badge: "mathlib"`: appropriately conservative (Tier B — uses Mathlib's `Finset.min'/max'/min'_lt_max'_of_card/Icc` API; the isoperimetric reasoning itself — boundary witnesses via min'/max' and equality case analysis — is in this file). `originalContributions` vs `mathlibDependencies` are cleanly separated.

No source or meta.json changes required.

## Test plan

- [x] Re-counted theorems/definitions/axioms/sorries via grep — match meta.json
- [x] No True stubs (`:= trivial`, `: True :=`, `: True`) present
- [x] No structure-encoded assumptions
- [x] tracker bump 3 → 4, result "clean"

🤖 Generated with [Claude Code](https://claude.com/claude-code)