### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean leanFiles in 31 bezout-identity siblings (lineCount 193→192, theoremCount 8→10)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -165,8 +165,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -172,8 +172,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -167,8 +167,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -118,8 +118,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -126,8 +126,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -130,8 +130,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -190,8 +190,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean",
-      "lineCount": 193,
-      "theoremCount": 8,
+      "lineCount": 192,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Surgical `leanFiles[i]` resync for `Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean` across all 31 sibling `research/problems/bezout-identity-*.json` entries.

## Evidence

**Before**: `lineCount: 193`, `theoremCount: 8` in 31 siblings
**After**: `lineCount: 192`, `theoremCount: 10` (matches actual file)

Canonical counts (per mechanic convention):
- `wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean` → **192**
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean` → **10**
- `axiomCount` / `defCount` / `sorryCount`: unchanged (already correct: 0/3/0)

Scope discipline: line-level surgical edit (not JSON round-trip) — no prose, Unicode-escape normalization, or unrelated lines touched. Only 2 lines per file × 31 files = 62 insertions / 62 deletions.

Validation: all 31 JSONs parse via `python3 json.load`.

Scope-distinct from in-flight PR #20029 (which targets `BezoutIdentityOQ02OQ01.lean` — different file, different `leanFiles[i]` index).

---
Automated fix by lean-mechanic agent.