### PR TITLE
fix(meta): batch sync MinpolyCharpoly.lean lineCount 247→246 in 3 minpoly-charpoly siblings

### DIFF
--- a/src/data/research/problems/minpoly-charpoly-oq-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-01.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/MinpolyCharpoly.lean",
       "filename": "MinpolyCharpoly.lean",
-      "lineCount": 247,
+      "lineCount": 246,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/minpoly-charpoly-oq-02.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/MinpolyCharpoly.lean",
       "filename": "MinpolyCharpoly.lean",
-      "lineCount": 247,
+      "lineCount": 246,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/MinpolyCharpoly.lean",
       "filename": "MinpolyCharpoly.lean",
-      "lineCount": 247,
+      "lineCount": 246,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Cross-slug shared file `MinpolyCharpoly.lean` drifted from canonical `wc -l` (246) to stale 247 across 3 sibling research JSONs. Discharges mechanic deferral from researcher PR #20027 (minpoly-charpoly-oq-01 S6 STATE-SYNC) per #19934/#19840/#19885 precedent (researcher fixes slug-local file 3-field numerics; cross-slug shared file batch sync deferred to mechanic for single-root-cause scope discipline).

## Evidence

**Before** (3 siblings — minpoly-charpoly-oq-{01,02,03}):
```
leanFiles[0]:
  path: Proofs/MinpolyCharpoly.lean
  lineCount: 247   ← stale
  theoremCount: 18
  defCount: 0
  axiomCount: 0
  sorryCount: 0
```

**After**:
```
  lineCount: 246   ← matches wc -l
```

**Canonical verification** (post-fix):
- `wc -l proofs/Proofs/MinpolyCharpoly.lean` → `246`
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` → `18` ✓
- `grep -cE '^(def |noncomputable def |opaque def )'` → `0` ✓
- `grep -cE '\bsorry\b'` → `0` ✓
- `grep -cE '^axiom '` → `0` ✓

## Scope

- 3 files modified (research JSONs)
- 3 insertions, 3 deletions (lineCount only)
- No edits to: `.lean`, `meta.json`, `state.md`, `problem.md`, registry, sessions/, lake-manifest, sibling slug-local files

JSON validated via `python3 -c "import json; json.load(...)"`. No `pnpm build` (would regenerate ~1047 JSONs and use split('\n').length convention vs canonical wc -l).

---
Automated fix by lean-mechanic agent.