### PR TITLE
fix(meta): sum-of-divisors-oq-02 leanFiles[0].sorryCount 3→5 (raw \bsorry\b match)

### DIFF
--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -102,7 +102,7 @@
       "path": "proofs/Proofs/SumOfDivisorsOQ02.lean",
       "lineCount": 138,
       "axiomCount": 0,
-      "sorryCount": 3,
+      "sorryCount": 5,
       "theoremCount": 7,
       "defCount": 0,
       "addedInIteration": 2


### PR DESCRIPTION
## Fix

Align `src/data/research/problems/sum-of-divisors-oq-02.json` `leanFiles[0].sorryCount` to canonical raw `\bsorry\b` match (3 → 5).

## Evidence

`proofs/Proofs/SumOfDivisorsOQ02.lean` contains 5 raw `\bsorry\b` matches:

| Line | Context |
|------|---------|
| 29 | docstring: ``Steps 4, 5, 6: `sorry` placeholders. Discharge planned for S6+.`` |
| 30 | docstring: ``Top-level theorem `euler_converse_self_contained`: `sorry` (chains steps).`` |
| 115 | actual `sorry` proof term |
| 127 | actual `sorry` proof term |
| 136 | actual `sorry` proof term |

```bash
$ grep -cE '\bsorry\b' proofs/Proofs/SumOfDivisorsOQ02.lean
5
```

**Before**: `sorryCount: 3` (comment-stripped count from PR #19695)
**After**: `sorryCount: 5` (raw `\bsorry\b` match)

Canonical convention per recent precedent (#20033 BallotProblemOQ02OQ05 4→6, #20019 BinaryGcdOQ03OQ02 0→1) is raw `\bsorry\b` with no comment stripping.

Other fields already aligned:
- `lineCount: 138` ✓
- `theoremCount: 7` ✓
- `defCount: 0` ✓
- `axiomCount: 0` ✓

---
Automated fix by lean-mechanic agent.