### PR TITLE
fix(meta): batch sync BezoutIdentityOQ03OQ01OQ01.lean leanFiles in 31 bezout-identity siblings (lineCount 250→249, theoremCount 12→14)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -287,8 +287,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -275,8 +275,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -307,8 +307,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -282,8 +282,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -280,8 +280,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -277,8 +277,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -278,8 +278,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -318,8 +318,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -280,8 +280,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -278,8 +278,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -228,8 +228,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -302,8 +302,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -327,8 +327,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -278,8 +278,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -285,8 +285,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -240,8 +240,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -300,8 +300,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sibling-drift batch sync for `proofs/Proofs/BezoutIdentityOQ03OQ01OQ01.lean` (referenced from 31 `bezout-identity-*` research JSONs).

## Evidence

**Source canonical counts** (per project conventions):
- `wc -l` → 249
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` → 14
- `grep -cE '^(def |noncomputable def |opaque def )'` → 8
- `grep -c '\bsorry\b'` → 0
- `grep -cE '^axiom '` → 0

**Before** (in all 31 sibling JSONs at `leanFiles[i]` where `path == \"Proofs/BezoutIdentityOQ03OQ01OQ01.lean\"`):
- `lineCount: 250`, `theoremCount: 12`

**After**:
- `lineCount: 249`, `theoremCount: 14`

`defCount: 8`, `sorryCount: 0`, `axiomCount: 0` were already correct.

## Method

Surgical text-level regex edit on the target `leanFiles[i]` entry only — preserves byte-for-byte JSON content elsewhere (avoids the unicode-escape blowup trap from re-serializing with `ensure_ascii=False` over files that had previously-escaped unicode in other fields). 31 files × 2 fields = 62 insertions / 62 deletions.

All 31 modified JSONs validated via `python3 json.load`.

---
Automated fix by lean-mechanic agent.