### PR TITLE
fix(meta): batch sync BezoutIdentityOQ03OQ01OQ01.lean leanFiles in 31 bezout-identity siblings (lineCount 250->249, theoremCount 12->14)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -287,8 +287,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -275,8 +275,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -307,8 +307,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -282,8 +282,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -280,8 +280,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -277,8 +277,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -278,8 +278,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -318,8 +318,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -280,8 +280,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -278,8 +278,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -228,8 +228,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -302,8 +302,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -327,8 +327,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -278,8 +278,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -285,8 +285,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -240,8 +240,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -300,8 +300,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01.lean",
-      "lineCount": 250,
-      "theoremCount": 12,
+      "lineCount": 249,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Surgical \`leanFiles[i]\` resync for \`Proofs/BezoutIdentityOQ03OQ01OQ01.lean\` across all 31 sibling \`research/problems/bezout-identity-*.json\` entries.

## Evidence

**Before**: \`lineCount: 250\`, \`theoremCount: 12\` in 31 siblings
**After**: \`lineCount: 249\`, \`theoremCount: 14\` (matches actual file)

Canonical counts (per mechanic convention, ref #19663/#19667/#19969/#20037):
- \`wc -l proofs/Proofs/BezoutIdentityOQ03OQ01OQ01.lean\` -> **249**
- \`grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/BezoutIdentityOQ03OQ01OQ01.lean\` -> **14**
- \`grep -cE '^(def|noncomputable def|opaque def) ' ...\` -> 8 (unchanged)
- \`grep -cE '\bsorry\b' ...\` -> 0 (unchanged)
- \`grep -cE '^axiom ' ...\` -> 0 (unchanged)

Scope discipline: 7-line block surgical edit (not JSON round-trip) -- 2 lines per file changed x 31 files = 62 insertions / 62 deletions; no prose, Unicode-escape normalization, or unrelated leanFiles[j] touched.

Validation: all 31 JSONs parse via \`python3 json.load\`.

Scope-distinct from in-flight PR #20037 (\`BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean\`) and PR #20029 (\`BezoutIdentityOQ02OQ01.lean\`) -- different file, different \`leanFiles[i]\` index.

---
Automated fix by lean-mechanic agent.