### PR TITLE
fix(meta): batch sync AbelRuffiniGaloisExtensions.lean theoremCount 57→59 in 22 abel-ruffini sibling research JSONs

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
@@ -54,7 +54,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-02.json
@@ -59,7 +59,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-03.json
@@ -59,7 +59,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
@@ -69,7 +69,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-05.json
@@ -59,7 +59,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-galois-extensions.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions.json
@@ -63,7 +63,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -367,7 +367,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-02.json
@@ -81,7 +81,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-03.json
@@ -80,7 +80,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
@@ -78,7 +78,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -108,7 +108,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
@@ -72,7 +72,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
@@ -50,7 +50,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -101,7 +101,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -95,7 +95,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
@@ -73,7 +73,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -109,7 +109,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
@@ -148,7 +148,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -46,7 +46,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -77,7 +77,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -79,7 +79,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-09.json
@@ -110,7 +110,7 @@
       "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "filename": "AbelRuffiniGaloisExtensions.lean",
       "lineCount": 534,
-      "theoremCount": 57,
+      "theoremCount": 59,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Align `theoremCount` for the shared `Proofs/AbelRuffiniGaloisExtensions.lean` entry across **22 abel-ruffini sibling research JSONs** (`57 → 59`).

## Evidence

`proofs/Proofs/AbelRuffiniGaloisExtensions.lean` contains **59** theorem/lemma declarations (canonical convention: raw `^(protected |private |noncomputable )*(theorem|lemma) ` match):

```bash
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/AbelRuffiniGaloisExtensions.lean
59
```

Other fields already correct:
- `lineCount: 534` ✓ (`wc -l` raw)
- `axiomCount: 0` ✓
- `defCount: 0` ✓
- `sorryCount: 0` ✓

**Before**: `theoremCount: 57` (stale; pre-PR-#19454 normalization sweep value)
**After**: `theoremCount: 59` (canonical raw match)

## Scope

Single-root-cause batch sync of **one Lean file's `theoremCount` field** across the 22 siblings that reference it:

```
abel-ruffini-galois-extensions{,-oq-01..oq-05}.json   (6)
abel-ruffini-oq-01, -oq-02, -oq-03                    (3)
abel-ruffini-oq-04{,-oq-01,-oq-01-oq-04,-oq-02,
                   -oq-02-oq-01,-oq-02-oq-03,-oq-03,
                   -oq-06,-oq-07,-oq-09}              (10)
abel-ruffini-oq-05, -oq-06, -oq-09                    (3)
                                                  Total 22
```

## Excluded

- `abel-ruffini-galois-extensions-oq-07.json` — open research PRs #17587, #17685 modify the same JSON (separate scope; defer to follow-up after those merge/close).

## Convention precedent

Per recent mechanic batch syncs:
- #20017 — `CauchySchwarzIntegralOQ01OQ01OQ01.lean` theoremCount 10→11 across 14 cauchy-schwarz siblings
- #20002 — `AreaOfCircleOQ01OQ03.lean` theoremCount 52→68 + lineCount 1938→1937 across 30 area-of-circle siblings
- #19969 — `LawOfCosinesOQ05.lean` lineCount + sorryCount across 10 law-of-cosines siblings

---
Automated fix by lean-mechanic agent.