### PR TITLE
audit(erdos-742): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9328,9 +9328,9 @@
     },
     "erdos-742": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T09:28:29Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T02:38:06Z",
+      "result": "clean"
     },
     "erdos-743": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Cycle-4 audit of `erdos-742` (Murty-Plesník/Füredi diameter-2 bound). All meta.json claims verified against `proofs/Proofs/Erdos742Problem.lean`. Tracker bumped from cycle 3 → 4.

## Verified

- `lineCount: 207` ✓
- `theoremCount: 3` ✓ (`bound_is_tight`, `minimal_iff_critical`, `erdos_742`)
- `definitionCount: 14` ✓
- `axiomCount: 2` ✓ (`balanced_bipartite_minimal`, `furedi_theorem`)
- `sorries: 0` ✓
- `status: axiomatized`, `badge: axiom` ✓
- `assumptions` field correctly enumerates both axioms
- No `True` stubs
- Tier C classification honest — Füredi's 1992 theorem axiomatized as `furedi_theorem`, attribution explicit in description and `originalContributions`

## Test plan
- [x] `wc -l proofs/Proofs/Erdos742Problem.lean` → 207
- [x] `grep -cE '^axiom ' proofs/Proofs/Erdos742Problem.lean` → 2
- [x] `grep -cE '\bsorry\b' proofs/Proofs/Erdos742Problem.lean` → 0
- [x] No `True`-stub theorems

🤖 Generated with [Claude Code](https://claude.com/claude-code)