### PR TITLE
fix(meta): batch sync AreaOfCircleOQ02.lean leanFiles in 30 area-of-circle siblings (lineCount 212->211, theoremCount 16->17)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -245,8 +245,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -182,8 +182,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -259,8 +259,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -245,8 +245,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -240,8 +240,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -263,8 +263,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -270,8 +270,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -239,8 +239,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -232,8 +232,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -258,8 +258,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -243,8 +243,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -234,8 +234,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -233,8 +233,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -249,8 +249,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -266,8 +266,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -240,8 +240,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -245,8 +245,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -238,8 +238,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -265,8 +265,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -237,8 +237,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -337,8 +337,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -243,8 +243,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
-      "lineCount": 212,
-      "theoremCount": 16,
+      "lineCount": 211,
+      "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[14]` numerics for `proofs/Proofs/AreaOfCircleOQ02.lean` across 30 sibling research JSONs to match canonical mechanic conventions.

## Evidence

Canonical counts on `proofs/Proofs/AreaOfCircleOQ02.lean` (at `origin/main`):

| field | canonical | was | source |
|---|---|---|---|
| `lineCount` | **211** | 212 | `wc -l` raw |
| `theoremCount` | **17** | 16 | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '` |
| `defCount` | 1 | 1 | `grep -cE '^(def\|noncomputable def\|opaque def) '` |
| `axiomCount` | 1 | 1 | `grep -cE '^axiom '` |
| `sorryCount` | 0 | 0 | `grep -cE '\bsorry\b'` |

The two drift fields match the well-known pattern: `pnpm build` (research:enrich) regenerates JSONs using `split('\n').length` (= `wc -l + 1`) and a narrower theorem regex; the canonical mechanic convention is raw `wc -l` and the broader theorem regex (matches recent batch PRs #19663, #19667, #20002, #20005, #20025).

## Scope

- 30 files touched, all `src/data/research/problems/area-of-circle-*.json`.
- Each diff: 2 lines changed inside `leanFiles[14]` (lineCount, theoremCount). No other fields touched.
- Validated: every modified JSON parses via `python3 json.load`.
- Bytes written with `ensure_ascii=False` to preserve UTF-8 in adjacent fields.

## Out of scope

- Gallery `src/data/proofs/<slug>/meta.json` mirror (separate mechanic pass if drift exists there).
- Other `leanFiles[j]` entries in the same JSONs (only sync the file in scope).

---
Automated fix by lean-mechanic agent.