### PR TITLE
fix(meta): batch sync BezoutIdentityOQ04.lean leanFiles lineCount 350->349 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -353,7 +353,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -341,7 +341,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -373,7 +373,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -345,7 +345,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -348,7 +348,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -346,7 +346,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -370,7 +370,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -343,7 +343,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -344,7 +344,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -384,7 +384,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -346,7 +346,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -350,7 +350,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -345,7 +345,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -347,7 +347,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -347,7 +347,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -344,7 +344,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -349,7 +349,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -367,7 +367,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -302,7 +302,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -349,7 +349,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -368,7 +368,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -393,7 +393,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -344,7 +344,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -351,7 +351,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -349,7 +349,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -370,7 +370,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -350,7 +350,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -306,7 +306,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -366,7 +366,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -349,7 +349,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ04.lean",
       "filename": "BezoutIdentityOQ04.lean",
-      "lineCount": 350,
+      "lineCount": 349,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sibling-drift batch sync for `proofs/Proofs/BezoutIdentityOQ04.lean` (referenced from 31 `bezout-identity-*` research JSONs).

## Evidence

**Source canonical counts** (per project conventions):
- `wc -l proofs/Proofs/BezoutIdentityOQ04.lean` -> **349**
- `grep -cE '^(theorem|lemma) '` -> 8 (unchanged)
- `grep -cE '^(def |noncomputable def |opaque def )'` -> 0 (unchanged)
- `grep -cE '\bsorry\b'` -> 0 (unchanged)
- `grep -cE '^axiom '` -> 0 (unchanged)

**Before** (in all 31 sibling JSONs at `leanFiles[i]` where `path == "Proofs/BezoutIdentityOQ04.lean"`):
- `lineCount: 350`

**After**:
- `lineCount: 349`

`theoremCount: 8`, `defCount: 0`, `sorryCount: 0`, `axiomCount: 0` were already correct.

## Method

Surgical text-level regex edit on the target `leanFiles[i]` entry only — preserves byte-for-byte JSON content elsewhere (avoids the unicode-escape blowup trap from re-serializing with `ensure_ascii=False` over files that had previously-escaped unicode in other fields). 31 files × 1 field = 31 insertions / 31 deletions.

All 31 modified JSONs validated via `python3 json.load`.

## Scope discipline

Scope-distinct from in-flight bezout-identity batch PRs (different `leanFiles[i]` entry, different `.lean` source file):
- #20029 `BezoutIdentityOQ02OQ01.lean`
- #20037 `BezoutIdentityOQ02OQ01OQ01OQ01OQ01.lean`
- #20043 / #20044 `BezoutIdentityOQ03OQ01OQ01.lean`

Single source file, single field, conflict-free with the above.

---
Automated fix by lean-mechanic agent.