### PR TITLE
audit(erdos-732): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9262,9 +9262,9 @@
     },
     "erdos-732": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T10:50:13Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T02:49:43Z",
+      "result": "clean"
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Periodic gallery integrity re-audit of `erdos-732` (Block-Compatible Sequences; Erdős 1981 problem, Q2 solved by Alon, Q1 open). Counts verified against `proofs/Proofs/Erdos732Problem.lean` (canonical conventions).

| field            | meta | actual |
|------------------|------|--------|
| lineCount        | 316  | 316    |
| axiomCount       | 3    | 3      |
| theoremCount     | 4    | 4      |
| definitionCount  | 10   | 10     |
| sorryCount       | 0    | 0      |
| True stubs       | n/a  | 0      |

- Status `axiomatized` / badge `axiom` correct: 3 declared axioms (`pair_count_necessary`, `alon_lower_bound`, `question_2_solved`).
- `mathlibDependencies` lists `Finset.card`, `Finset.powerset`, `Real.exp`, `Real.sqrt` — primitives, not theorems used to obtain the main result, so no Mathlib-wrapper masking risk.
- Tracker `erdos-732`: `auditCount` 3 → 4, `result` `issues-fixed` → `clean`, `lastAudited` 2026-04-29 → 2026-05-17.

## Test plan

- [x] `wc -l` / `grep -cE` canonical regexes confirm meta.json claims
- [x] `npx tsx scripts/auditor/find-targets.ts` puts erdos-732 in priority window (4th-tier non-contested, not present in open batch PR #20040 / #20021)
- [x] `claim-target.sh complete erdos-732 clean` ran cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)