### PR TITLE
fix(meta): batch sync Erdos1100Problem{,Provable}.lean leanFiles in 2 erdos-1100 siblings (axiomatized 3 sorries→3 axioms)

### DIFF
--- a/src/data/research/problems/erdos-1100-oq-01.json
+++ b/src/data/research/problems/erdos-1100-oq-01.json
@@ -89,11 +89,11 @@
     {
       "path": "Proofs/Erdos1100Problem.lean",
       "filename": "Erdos1100Problem.lean",
-      "lineCount": 329,
-      "theoremCount": 6,
-      "axiomCount": 0,
+      "lineCount": 331,
+      "theoremCount": 7,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100Problem.lean"
     },
@@ -111,11 +111,11 @@
     {
       "path": "Proofs/Erdos1100ProblemProvable.lean",
       "filename": "Erdos1100ProblemProvable.lean",
-      "lineCount": 329,
-      "theoremCount": 6,
-      "axiomCount": 0,
+      "lineCount": 331,
+      "theoremCount": 7,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100ProblemProvable.lean"
     }

--- a/src/data/research/problems/erdos-1100-oq-02.json
+++ b/src/data/research/problems/erdos-1100-oq-02.json
@@ -70,11 +70,11 @@
     {
       "path": "Proofs/Erdos1100Problem.lean",
       "filename": "Erdos1100Problem.lean",
-      "lineCount": 329,
-      "theoremCount": 6,
-      "axiomCount": 0,
+      "lineCount": 331,
+      "theoremCount": 7,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100Problem.lean"
     },
@@ -92,11 +92,11 @@
     {
       "path": "Proofs/Erdos1100ProblemProvable.lean",
       "filename": "Erdos1100ProblemProvable.lean",
-      "lineCount": 329,
-      "theoremCount": 6,
-      "axiomCount": 0,
+      "lineCount": 331,
+      "theoremCount": 7,
+      "axiomCount": 3,
       "defCount": 7,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1100ProblemProvable.lean"
     }


### PR DESCRIPTION
## Fix

Surgical 4-field leanFiles[i] catchup for two identical `Proofs/Erdos1100{Problem,ProblemProvable}.lean` files (md5 identical) across 2 sibling `research/problems/erdos-1100-oq-0{1,2}.json` entries, reflecting the proof's axiomatization (3 sorries converted to 3 axioms).

## Evidence

Canonical counts (per mechanic convention, ref #19663/#19667/#19969/#20037/#20053):
- `wc -l proofs/Proofs/Erdos1100Problem.lean` → **331** (was 329)
- theoremCount **7** (was 6) — `^(protected|private|noncomputable )*(theorem|lemma) ` regex
- defCount **7** (unchanged)
- sorryCount **0** (was 3) — raw `\bsorry\b` match, all 3 proof sorries converted to axioms
- axiomCount **3** (was 0) — three `axiom` declarations at lines 78, 204, 225 (`tau_perp_lower_bound`, `erdos_hall_max_lower_bound`, `erdos_simonovits_bounds`)

**Before**: JSONs claimed 3 unresolved sorries and 0 axioms.
**After**: JSONs report 0 sorries and 3 axiomatized assumptions, matching the Erdős #1100 "open conjecture" status.

## Method

Text-level regex edit limited to the target `leanFiles[i]` entry only (scoped by `"path": "Proofs/Erdos1100Problem.lean"` start marker, terminated at object close). Avoids JSON round-trip to preserve byte-for-byte the unicode-escaped contents of other fields in these files (ensure_ascii trap from prior #19879 lessons).

2 files × (4 lines × 2 entries) = 16 insertions / 16 deletions.

Both modified JSONs validated via `python3 json.load` post-edit.

## Scope notes

- Note: gallery meta.json for `erdos-1100-oq-0{1,2}` does not exist (research-only slugs), so no gallery sync needed.
- `erdos-1100-incomplete-01.json` does not have a `leanFiles[]` entry for these files, so no edit needed there.
- Scope-distinct from in-flight `fix(meta)` PRs (#20053 BezoutIdentityOQ04, #20052 AreaOfCircleOQ02, etc.)

---
Automated fix by lean-mechanic agent.