### PR TITLE
fix(meta): batch sync AngleTrisectionCos20Gal.lean leanFiles in 26 angle-trisection siblings (lineCount 475->474, theoremCount 6->33)

### DIFF
--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
@@ -63,8 +63,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
@@ -78,8 +78,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
@@ -74,8 +74,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
@@ -98,8 +98,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -100,8 +100,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -104,8 +104,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -101,8 +101,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -152,8 +152,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -51,8 +51,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -126,8 +126,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -105,8 +105,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -110,8 +110,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -57,8 +57,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -116,8 +116,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -108,8 +108,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-01.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -108,8 +108,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-04-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-02.json
@@ -99,8 +99,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-04-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-03.json
@@ -57,8 +57,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -60,8 +60,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/AngleTrisectionCos20Gal.lean",
       "filename": "AngleTrisectionCos20Gal.lean",
-      "lineCount": 475,
-      "theoremCount": 6,
+      "lineCount": 474,
+      "theoremCount": 33,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entries for `Proofs/AngleTrisectionCos20Gal.lean` across 26 sibling research JSONs whose values (`lineCount=475`, `theoremCount=6`) predate the file's current state.

## Evidence

Canonical counts from disk (mechanic convention, see #19934 / #19816 / #19818):

| Field | regex / command | actual | JSON had | new value |
|---|---|---:|---:|---:|
| `lineCount` | `wc -l` | 474 | 475 | **474** |
| `theoremCount` | `^(protected\|private\|noncomputable )*(theorem\|lemma) ` | 33 | 6 | **33** |
| `defCount` | `^(def\|noncomputable def\|opaque def) ` | 0 | 0 | unchanged |
| `sorryCount` | raw `\bsorry\b` | 0 | 0 | unchanged |
| `axiomCount` | `^axiom ` | 0 | 0 | unchanged |

The gallery `meta.json` (`src/data/proofs/angle-trisection-cos-20-gal/meta.json`) already reports `lineCount: 474`, `theoremCount: 33` — only the research sibling JSONs (`src/data/research/problems/angle-trisection-*.json`) were stale.

## Scope

- **26 files modified**, 2 fields per file (52 insertions, 52 deletions).
- Only the `Proofs/AngleTrisectionCos20Gal.lean` entry within each `leanFiles` array changed.
- 5 other `AngleTrisectionCos20Gal*.lean` variants (OQ01, OQ01OQ01, OQ01OQ02, OQ03, OQ03OQ01) also have drift but are left untouched per "one .lean file per PR" scope discipline.
- No Lean source changes, no gallery `meta.json` changes, no build impact.

## Safety

- All 26 JSONs round-trip identically with `json.dump(..., indent=2, ensure_ascii=False)` + trailing newline — minimal 4-line diff per file.
- All 26 files validated as parseable JSON post-edit.
- No open PR currently touches these JSONs (verified via `gh pr list --search "angle-trisection"` — only `#17906` for `oq-01-oq-03` research, which does not touch `leanFiles[0]` for the `Gal.lean` file).
- Disjoint from open mechanic batches in flight (bezout-identity, area-of-circle, ballot-problem, abel-ruffini-galois-extensions, sum-of-divisors-oq-02, minpoly-charpoly).

---
Automated batch repair by lean-mechanic agent.