### PR TITLE
fix(meta): batch sync Erdos1019Problem.lean leanFiles in 9 erdos siblings (axiom→theorem-with-sorry: 4→3 axioms + 0→1 sorries, lc 442→478, thm 10→13)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -1122,11 +1122,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -690,11 +690,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -1145,11 +1145,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -1132,11 +1132,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -910,11 +910,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -893,11 +893,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-101-oq-04.json
+++ b/src/data/research/problems/erdos-101-oq-04.json
@@ -320,11 +320,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-101.json
+++ b/src/data/research/problems/erdos-101.json
@@ -321,11 +321,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     },

--- a/src/data/research/problems/erdos-1019-oq-04.json
+++ b/src/data/research/problems/erdos-1019-oq-04.json
@@ -85,11 +85,11 @@
     {
       "path": "Proofs/Erdos1019Problem.lean",
       "filename": "Erdos1019Problem.lean",
-      "lineCount": 442,
-      "theoremCount": 10,
-      "axiomCount": 4,
+      "lineCount": 478,
+      "theoremCount": 13,
+      "axiomCount": 3,
       "defCount": 19,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1019Problem.lean"
     }


### PR DESCRIPTION
## Fix

Surgical 4-field `leanFiles[i]` catchup for `Proofs/Erdos1019Problem.lean` across **9 sibling research JSON entries**, reflecting the prior `K4_saturated_planar` conversion from axiom to theorem-with-sorry (commits b65b6040851 / 91cefd1336c).

## Evidence

Canonical counts per mechanic convention (ref #19663 / #19667 / #19969 / #20037 / #20056):

| Field | Before | After | Source |
|---|---|---|---|
| `lineCount` | 442 | **478** | `wc -l proofs/Proofs/Erdos1019Problem.lean` |
| `theoremCount` | 10 | **13** | regex `^(protected\|private\|noncomputable )*(theorem\|lemma) ` |
| `defCount` | 19 | 19 (unchanged) | regex `^(def\|noncomputable def\|opaque def) ` |
| `sorryCount` | 0 | **1** | raw `\bsorry\b`, single sorry at line 267 in `K4_saturated_planar` |
| `axiomCount` | 4 | **3** | 3 remaining axioms at lines 293/316/343 (`cyclePlus2K1_saturated_planar`, `erdos_construction_exists`, `simonovits_theorem`) |

**Before**: JSONs claimed 442 LOC, 10 theorems, 4 axioms, 0 sorries.
**After**: JSONs report 478 LOC, 13 theorems, 3 axioms, 1 sorry — matching the file's current axiomatized + 1-sorry status.

## Method

Text-level regex edit scoped to the target `leanFiles[i]` block only (anchor on `"path": "Proofs/Erdos1019Problem.lean"` start; terminate at the entry's closing brace). Preserves byte-for-byte the surrounding file content (avoids the `ensure_ascii` unicode-escape trap from #19879).

Each sibling: 4 fields changed = 4 line edits. **9 files × 4 = 36 insertions / 36 deletions.**

All 9 modified JSONs validated via `python3 -c "import json; json.load(open(p))"`.

## Slugs touched

- `erdos-1`, `erdos-1-oq-01`, `erdos-1-oq-02`, `erdos-1-oq-03`, `erdos-1-oq-04`
- `erdos-10`, `erdos-10-oq-01`
- `erdos-101`, `erdos-101-oq-04`
- `erdos-1019-oq-04` (parent slug for this Lean file)

## Scope notes

- Gallery `src/data/proofs/erdos-1019/meta.json` is **already correct** (lc=478, theoremCount=13, axiomCount=3, sorries=1 in `leanFile`, `status=axiomatized`) — no edit needed there.
- `defCount` stays at 19 (no drift on that field).
- Scope-distinct from in-flight `fix(meta)` PRs: #20056 Erdos1100, #20053 BezoutIdentityOQ04, #20052 AreaOfCircleOQ02, #20050/#20047 BallotProblemOQ03OQ01OQ01OQ01, #20045 AbelRuffini, #20044/#20043 BezoutIdentityOQ03OQ01OQ01, #20038 MinpolyCharpoly, #20037 BezoutIdentityOQ02OQ01OQ01OQ01OQ01.

---
Automated fix by lean-mechanic agent.