### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-01-oq-01 gallery leanFile sync (lc 2348→2437, thm 60→62)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -97,9 +97,9 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 2348,
+    "lineCount": 2437,
     "axiomCount": 0,
-    "theoremCount": 60,
+    "theoremCount": 62,
     "definitionCount": 12,
     "path": "Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean",
     "sorries": 2,


### PR DESCRIPTION
## Fix

Sync stale inner `leanFile` block in `src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json` to match the already-updated top-level `meta` block and the actual bearer file `proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean`.

## Evidence

The bearer file grew via recent ACT iterations (#19984 S44 +46 LOC and other edits) but the inner `leanFile` block was not updated. The top-level `meta` block is already in sync; only the nested `leanFile` block is stale.

**Canonical counts (verified at HEAD `b63c713b751`)**:

| Field | Before | After | Tool |
|-------|--------|-------|------|
| `leanFile.lineCount` | 2348 | **2437** | `wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` |
| `leanFile.theoremCount` | 60 | **62** | `grep -cE '^(private \|protected \|noncomputable \|@\[[^]]*\] +)*(theorem\|lemma) '` |

Both edits make `leanFile.{lineCount, theoremCount}` agree with the top-level `meta.{lineCount, theoremCount}` (already 2437 and 62, respectively) and with the bearer file.

**Unchanged** (already consistent):
- `leanFile.axiomCount`: 0
- `leanFile.definitionCount`: 12 (matches top-level `meta.definitionCount`)
- `leanFile.sorries`: 2 (matches comment-stripped sorry count)
- `leanFile.path`, `imports`, `opens`, `namespace`, `additionalFiles`

## Scope

- 1 file, +2/-2 lines.
- Inner `leanFile` block only — top-level `meta` block unchanged.
- No Lean source changes, no narrative/description changes, no status/badge changes.
- Sibling research JSONs (under `src/data/research/problems/ballot-problem-*.json`) are addressed by open PRs #20047 / #20050; this PR closes the gallery-`meta.json` leg of the same upstream Lean edit.
- JSON validated via `python3 -c "import json; json.load(open(...))"`.

---
Automated fix by lean-mechanic agent.