### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02.lean leanFiles in 29 amgm-inequality siblings (lineCount 544->543, theoremCount 16->25)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -67,8 +67,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -67,8 +67,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -86,8 +86,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -91,8 +91,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -24,8 +24,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -81,8 +81,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -42,8 +42,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -78,8 +78,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -74,8 +74,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -74,8 +74,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -90,8 +90,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -81,8 +81,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -75,8 +75,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -65,8 +65,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -75,8 +75,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -90,8 +90,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -82,8 +82,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -76,8 +76,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -72,8 +72,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -77,8 +77,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -38,8 +38,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -20,8 +20,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -89,8 +89,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -77,8 +77,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -70,8 +70,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -70,8 +70,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -70,8 +70,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -96,8 +96,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -98,8 +98,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
       "filename": "AmgmInequalityOQ02.lean",
-      "lineCount": 544,
-      "theoremCount": 16,
+      "lineCount": 543,
+      "theoremCount": 25,
       "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 1,


### PR DESCRIPTION
## Fix

Sync canonical `leanFiles[0]` entry for `proofs/Proofs/AmgmInequalityOQ02.lean` across **29 amgm-inequality research/problems JSONs** to match current file metrics.

## Drift

| Field          | Stored | Actual | Source                                              |
|----------------|--------|--------|-----------------------------------------------------|
| lineCount      | 544    | 543    | `wc -l proofs/Proofs/AmgmInequalityOQ02.lean`        |
| theoremCount   | 16     | 25     | `grep -cE '^(protected\|private\|noncomputable )*(theorem\|lemma) '` |

`defCount=2`, `sorryCount=1`, `axiomCount=2` unchanged (already correct).

The +9 theoremCount delta reflects new private lemmas and theorems added since the last sync (cauchy_schwarz_sum, mapEmb_eq, fin_univ_insert_last, fin_last_not_mem_map, pc_disj, prod_map_csEmb, elemSymm_two_succ, sq_sum_eq_sum_sq_add_two_elemSymm, pc_disj_general, etc.).

Per recent mechanic PRs (#19663, #19667, #19815, #19825, #19831), canonical `lineCount` convention is `wc -l` value (not `split('\n').length`).

## Scope

- 29 `src/data/research/problems/amgm-inequality-*.json` files
- 2 field edits per file (58 total line changes)
- No `.lean` / gallery `meta.json` / `problem.md` / `knowledge.md` / domain content touched

---
Automated fix by lean-mechanic agent.