### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ02OQ03.lean leanFiles in 30 area-of-circle siblings (lineCount 218->217, theoremCount 12->14)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -185,8 +185,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -116,8 +116,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -215,8 +215,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -204,8 +204,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -167,8 +167,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -183,8 +183,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -200,8 +200,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -172,8 +172,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -271,8 +271,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
-      "lineCount": 218,
-      "theoremCount": 12,
+      "lineCount": 217,
+      "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `leanFiles[i]` entries for `proofs/Proofs/AreaOfCircleOQ01OQ02OQ03.lean` across 30 sibling `area-of-circle*` research JSONs to match canonical counts from the Lean source.

## Evidence

**Canonical** (raw `wc -l` + canonical regexes):
- `lineCount`: 217 (raw `wc -l`)
- `theoremCount`: 14 (`^(protected |private |noncomputable )*(theorem|lemma) ` → 14 matches)
- `defCount`: 3
- `sorryCount`: 0
- `axiomCount`: 0

**Before**: All 30 siblings had `lineCount=218`, `theoremCount=12` (stale since post-#9319 file evolution through #18059 and #19454).

**After**: All 30 siblings have `lineCount=217`, `theoremCount=14` (matches `proofs/Proofs/AreaOfCircleOQ01OQ02OQ03.lean` HEAD).

## Scope

- Only `leanFiles[i]` entries where `path` matches `AreaOfCircleOQ01OQ02OQ03.lean` were touched
- 30 JSON files × 2 lines each = 60 line diff
- All other `leanFiles[]` entries left untouched
- JSON written with `ensure_ascii=False` to preserve UTF-8 characters

---
Automated fix by lean-mechanic agent.