### PR TITLE
fix(meta): batch sync AreaOfCircleOQ05OQ01.lean leanFiles in 30 area-of-circle siblings (lineCount 232->231, theoremCount 9->10)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -361,8 +361,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -292,8 +292,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -369,8 +369,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -391,8 +391,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -350,8 +350,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -373,8 +373,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -380,8 +380,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -349,8 +349,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -342,8 +342,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -353,8 +353,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -344,8 +344,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -343,8 +343,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -359,8 +359,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -376,8 +376,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -350,8 +350,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -348,8 +348,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -375,8 +375,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -347,8 +347,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -447,8 +447,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -353,8 +353,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` entries for `AreaOfCircleOQ05OQ01.lean` across all 30 sibling area-of-circle research JSONs to match canonical counts from the source `.lean` file.

## Evidence

**Source-of-truth measurements** (`proofs/Proofs/AreaOfCircleOQ05OQ01.lean`):

| field | raw probe | value |
|-------|-----------|-------|
| lineCount | `wc -l` | **231** |
| theoremCount | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '` | **10** |
| defCount | `grep -cE '^(noncomputable \|opaque )?def '` | **0** |
| sorryCount | `grep -cE '\bsorry\b'` | **0** |
| axiomCount | `grep -cE '^axiom '` | **0** |

**Before** (per sibling): `lineCount: 232, theoremCount: 9` (drift accumulated as 1 new theorem was added and a trailing-newline convention shifted)

**After**: `lineCount: 231, theoremCount: 10` (matches source). `defCount`, `sorryCount`, `axiomCount` unchanged.

## Scope

- 30 sibling JSONs touched: every `src/data/research/problems/area-of-circle-*.json` that lists this file.
- Only the 2 drifted fields per entry are modified (+60/-60 lines total).
- All other `leanFiles[i]` entries (28–29 unrelated files per JSON) left untouched.
- Follows the established mechanic batch precedent (#20065 `AreaOfCircleOQ01OQ02OQ03.lean`, #20052 `AreaOfCircleOQ02.lean`).

---
Automated fix by lean-mechanic agent.