### PR TITLE
fix(meta): batch sync AreaOfCircleOQ05OQ01.lean leanFiles in 30 area-of-circle siblings (lc 232->231, thm 9->10)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -361,8 +361,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -292,8 +292,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -369,8 +369,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -391,8 +391,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -350,8 +350,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -373,8 +373,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -380,8 +380,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -349,8 +349,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -342,8 +342,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -353,8 +353,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -344,8 +344,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -343,8 +343,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -359,8 +359,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -376,8 +376,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -350,8 +350,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -355,8 +355,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -348,8 +348,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -346,8 +346,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -375,8 +375,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -347,8 +347,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -447,8 +447,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -353,8 +353,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
-      "lineCount": 232,
-      "theoremCount": 9,
+      "lineCount": 231,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch-sync `leanFiles[24]` entries for `AreaOfCircleOQ05OQ01.lean` across 30 sibling research JSONs to match the canonical Lean source.

## Drift

| Field | Stale | Canonical |
|---|---|---|
| `lineCount` | 232 | **231** |
| `theoremCount` | 9 | **10** |

Other fields (`defCount=0`, `sorryCount=0`, `axiomCount=0`) unchanged.

## Canonical verification (against `proofs/Proofs/AreaOfCircleOQ05OQ01.lean`)

```
wc -l                                                                          = 231
grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '              = 10
grep -cE '^(noncomputable )?(def|opaque def) '                                 = 0
grep -c '\bsorry\b'                                                            = 0
grep -cE '^axiom '                                                             = 0
```

## Scope

30 sibling JSONs at `src/data/research/problems/area-of-circle-*.json` (60 insertions / 60 deletions; pure leanFiles[24] field flip). Gallery meta `src/data/proofs/area-of-circle-oq-05-oq-01/meta.json` is already correct -- not touched.

---
Automated fix by lean-mechanic agent.