### PR TITLE
audit(cycle 6): 3 definitionCount fixes (erdos-733/735/722) + 6 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9110,9 +9110,9 @@
     },
     "erdos-710": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T00:08:12Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
+      "result": "clean"
     },
     "erdos-711": {
       "agentId": "auditor-loop",
@@ -9178,8 +9178,8 @@
     },
     "erdos-720": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T00:34:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
       "result": "clean"
     },
     "erdos-721": {
@@ -9190,15 +9190,15 @@
     },
     "erdos-722": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T00:22:11Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
       "result": "issues-fixed"
     },
     "erdos-723": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-30T23:26:12Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
+      "result": "clean"
     },
     "erdos-724": {
       "agentId": "auditor-cycle-20-batch",
@@ -9226,9 +9226,9 @@
     },
     "erdos-728": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-30T23:20:37Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
+      "result": "clean"
     },
     "erdos-728-factorial-divisibility": {
       "agentId": "auditor-cycle-20-batch",
@@ -9238,9 +9238,9 @@
     },
     "erdos-729": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-30T23:12:03Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-17T03:12:52Z",
+      "result": "clean"
     },
     "erdos-73": {
       "agentId": "auditor-cycle-20-batch",
@@ -9250,9 +9250,9 @@
     },
     "erdos-730": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-30T23:13:10Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
+      "result": "clean"
     },
     "erdos-731": {
       "agentId": "auditor-cycle-20-batch",
@@ -9268,8 +9268,8 @@
     },
     "erdos-733": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T10:53:55Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
       "result": "issues-fixed"
     },
     "erdos-734": {
@@ -9280,8 +9280,8 @@
     },
     "erdos-735": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-30T23:11:59Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-17T03:12:52Z",
       "result": "issues-fixed"
     },
     "erdos-736": {

--- a/src/data/proofs/erdos-722/meta.json
+++ b/src/data/proofs/erdos-722/meta.json
@@ -53,7 +53,7 @@
     "lineCount": 302,
     "assumptions": "3 axioms: fano_plane_exists, wilson_theorem_r2, keevash_theorem. 0 sorries.",
     "theoremCount": 5,
-    "definitionCount": 11
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "**Steiner systems** are among the most studied objects in combinatorial design theory. A Steiner system $S(r,k,n)$ is a collection of $k$-subsets (blocks) of an $n$-element set such that every $r$-subset appears in exactly one block.\n\n**Jakob Steiner** (1796–1863) introduced these systems, though **Thomas Kirkman** (1806–1895) studied them first. Kirkman's 1847 paper 'On a problem in combinations' solved the case $S(2,3,n)$: Steiner triple systems exist if and only if $n \\equiv 1$ or $3 \\pmod{6}$ and $n \\geq 7$. His famous 'schoolgirl problem' (1850) asks for a resolvable $S(2,3,15)$.\n\nThe **Fano plane** $S(2,3,7)$ is the smallest nontrivial Steiner triple system, with 7 points and 7 lines. It is also the projective plane $\\mathrm{PG}(2,2)$ over $\\mathbb{F}_2$, connecting design theory to finite geometry.\n\n**Haim Hanani** (1961) extended Kirkman's work in 'The existence and construction of balanced incomplete block designs' (*Ann. Math. Statist.*), characterizing existence for $S(3,4,n)$, $S(2,4,n)$, and $S(2,5,n)$.\n\n**Richard M. Wilson** (1972) resolved the entire $r = 2$ case in 'An existence theory for pairwise balanced designs' (*J. Combinatorial Theory Ser. A*), proving that $S(2,k,n)$ exists for all sufficiently large $n$ satisfying the divisibility conditions. This established the foundations of existence theory for combinatorial designs.\n\n**Peter Keevash** (2014) achieved the breakthrough in 'The existence of designs' (arXiv:1401.3665), proving that $S(r,k,n)$ exists for ALL $r < k$ when $n$ is sufficiently large and the divisibility conditions hold. His **randomized algebraic construction** combined probabilistic methods (random greedy, nibble), algebraic structures (Latin squares, quasirandom clique decompositions), and absorbing techniques to handle the general case. This resolved a century-old open problem and was recognized as one of the most important results in combinatorics of the decade.",
@@ -210,7 +210,7 @@
     "lineCount": 302,
     "axiomCount": 3,
     "theoremCount": 5,
-    "definitionCount": 11,
+    "definitionCount": 10,
     "path": "Proofs/Erdos722Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos-733/meta.json
+++ b/src/data/proofs/erdos-733/meta.json
@@ -68,7 +68,7 @@
       "Grid constructions in discrete geometry"
     ],
     "assumptions": "2 axioms: lower_bound, upper_bound. 2 sorries.",
-    "definitionCount": 7
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "**Erdos Problem #733**\n\nThis problem concerns the combinatorics of point-line incidences.\n\n**Key History:**\n- Erdos posed the problem about counting line-compatible sequences\n- He noted the lower bound exp(c*sqrt(n)) was 'easy' via grid constructions\n- Szemeredi-Trotter (1983) proved the matching upper bound\n\n**Related Problems:**\n- Problem #607: Similar problem without multiplicities\n- Problem #732: Related incidence problem\n\n**The Szemeredi-Trotter Theorem:**\nThe key tool is their incidence theorem: n points and m lines have O(n^{2/3}m^{2/3} + n + m) incidences.",
@@ -189,7 +189,7 @@
     "lineCount": 274,
     "axiomCount": 2,
     "theoremCount": 6,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/Erdos733Problem.lean",
     "sorries": 2
   },

--- a/src/data/proofs/erdos-735/meta.json
+++ b/src/data/proofs/erdos-735/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "7 axioms: collinear_is_magic, general_position_is_magic, magic_classification, three_collinear_card, three_collinear_collinear, triangle_card, triangle_general_position. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 17
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "Murty conjectured in the 1970s that only four types of point configurations in the plane can be 'magic' — admitting positive weights with equal sums on all lines through at least two points. The conjecture remained open for decades until Ackerman, Buchin, Knauer, Pinchasi, and Rote proved it in their 2008 paper 'There are not too many magic configurations.' Their proof analyzes the linear system of equations $Aw = c\\mathbf{1}$ (where $A$ is the point-line incidence matrix) and shows that for configurations outside the four classes, the positive orthant intersected with this affine subspace is empty. The problem connects to classical topics in incidence geometry: the Sylvester-Gallai theorem (every non-collinear set has an ordinary line), the Melchior-Hirzebruch inequality on line arrangements, and the theory of weighted incidence structures in projective geometry. The four magic classes are: (1) collinear, (2) general position (no 3 collinear), (3) near-pencil ($n-1$ points on a line), and (4) projective images of the triangle-incenter configuration.",
@@ -150,7 +150,7 @@
     "lineCount": 223,
     "axiomCount": 7,
     "theoremCount": 3,
-    "definitionCount": 17,
+    "definitionCount": 16,
     "path": "Proofs/Erdos735Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Cycle-6 batch audit of 9 high-priority targets (all `last 2026-04-29/30`). 3 definitionCount overcounts fixed; 6 entries verified clean.

## Fixes (3)

Canonical convention per PR #20021: `^(def|noncomputable def|opaque def) ` excludes `abbrev` and `structure`.

| slug | overcount source | fix |
|------|------------------|-----|
| erdos-733 | `abbrev PointSet` line 49 | meta.definitionCount + leanFile.definitionCount: 7 → 6 |
| erdos-735 | 1 abbrev | 17 → 16 |
| erdos-722 | 1 structure | 11 → 10 |

## Clean re-audits (6)

| slug | status/badge | counts (lc/thm/def/ax/sorry) |
|------|--------------|------------------------------|
| erdos-729 | axiomatized/axiom | 217/6/8/4/0 ✓ |
| erdos-730 | axiomatized/axiom | 148/5/4/1/0 ✓ |
| erdos-728 | axiomatized/axiom | 246/5/6/2/1 ✓ |
| erdos-723 | axiomatized/axiom | 174/13/1/1/0 ✓ |
| erdos-710 | axiomatized/axiom | 320/5/7/3/0 ✓ |
| erdos-720 | axiomatized/axiom | 257/3/20/8/0 ✓ |

## Methodology

Canonical regexes:
- `lineCount`: raw `wc -l`
- `theoremCount`: `^(?:protected|private|noncomputable\s+)*(theorem|lemma)\s`
- `definitionCount`: `^(def|noncomputable def|opaque def)\s` (excludes abbrev/structure)
- `axiomCount`: `^(?:(?:private|noncomputable)\s+)*axiom\s`
- `sorries`: raw `\bsorry\b`
- True stubs: theorem/lemma lines containing `:= trivial` or `: True`

## Test plan

- [x] All 4 modified meta.json files validate via `python3 -m json.tool`
- [x] No `opens` or other formatting drift (targeted text Edits, not `json.dump`)
- [x] No scope overlap with open audit PRs #20021/#20040/#20046/#20049/#20054 (different slugs)
- [x] Zero True stubs across all 9 files
- [x] Status/badge consistency: all 9 are `axiomatized` + `axiom` with declared axioms in Lean

🤖 Generated with [Claude Code](https://claude.com/claude-code)