### PR TITLE
fix(meta): batch sync BorsukUlamOQ03OQ01.lean leanFiles in 24 borsuk-ulam siblings (lineCount 1164→1163, theoremCount 41→47)

### DIFF
--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-01.json
@@ -183,8 +183,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03-oq-02.json
@@ -250,8 +250,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01-oq-02.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-02.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02.json
@@ -393,8 +393,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-03.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04-oq-01.json
@@ -245,8 +245,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01-oq-04.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-01.json
@@ -202,8 +202,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-02.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-03.json
@@ -185,8 +185,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02-oq-04.json
@@ -184,8 +184,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-02.json
+++ b/src/data/research/problems/borsuk-ulam-oq-02.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01-oq-01.json
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-01.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-03.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-04.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-03-oq-05.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03-oq-05.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-03.json
@@ -415,8 +415,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-01.json
@@ -184,8 +184,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-04-oq-03.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04-oq-03.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -225,8 +225,8 @@
     {
       "path": "Proofs/BorsukUlamOQ03OQ01.lean",
       "filename": "BorsukUlamOQ03OQ01.lean",
-      "lineCount": 1164,
-      "theoremCount": 41,
+      "lineCount": 1163,
+      "theoremCount": 47,
       "axiomCount": 1,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Syncs `leanFiles[i]` entries for `Proofs/BorsukUlamOQ03OQ01.lean` across 24 `borsuk-ulam-*` sibling research JSONs to match the current file on disk.

## Evidence

**Before** (in 24 sibling JSONs):
- `lineCount: 1164`
- `theoremCount: 41`

**After** (canonical):
- `lineCount: 1163` (raw `wc -l proofs/Proofs/BorsukUlamOQ03OQ01.lean` = 1163; file ends with `\n`)
- `theoremCount: 47` (inclusive regex `^(protected |private |noncomputable )*(theorem|lemma) ` = 47)

Other fields already correct (`defCount=3`, `sorryCount=0`, `axiomCount=1`) — left untouched.

Drift signature uniform across all 24 siblings — single-file batch sync.

## Convention

Matches recent mechanic batch PRs (#19663, #19667, #19816, #19818, #19934).

- Validated each JSON with `python3 -c "import json; json.load(open(...))"` — all 24 valid
- `python json.dump(... ensure_ascii=False)` used to preserve any UTF-8 characters

## Files (24)

All under `src/data/research/problems/borsuk-ulam-*.json` — diff is exactly 4 lines per file (2 ins / 2 del at the `BorsukUlamOQ03OQ01.lean` entry).

---
Automated fix by lean-mechanic agent.