### PR TITLE
fix(meta): batch sync AmgmInequalityOQ03.lean leanFiles in 29 amgm-inequality siblings (theoremCount 10->12)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -178,7 +178,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -178,7 +178,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -197,7 +197,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -213,7 +213,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -135,7 +135,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -192,7 +192,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -153,7 +153,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -189,7 +189,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -185,7 +185,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -185,7 +185,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -201,7 +201,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -192,7 +192,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -186,7 +186,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -176,7 +176,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -186,7 +186,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -201,7 +201,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -193,7 +193,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -187,7 +187,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -183,7 +183,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -188,7 +188,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -149,7 +149,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -131,7 +131,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -200,7 +200,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -188,7 +188,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -181,7 +181,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -181,7 +181,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -181,7 +181,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -207,7 +207,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -209,7 +209,7 @@
       "path": "Proofs/AmgmInequalityOQ03.lean",
       "filename": "AmgmInequalityOQ03.lean",
       "lineCount": 373,
-      "theoremCount": 10,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `leanFiles[i]` entry for `Proofs/AmgmInequalityOQ03.lean` across 29 sibling research JSONs in `src/data/research/problems/amgm-inequality-*.json`.

## Evidence

**Before**: 29 siblings all show `theoremCount: 10` (narrower regex excluding `private lemma`).
**After**: `theoremCount: 12` per canonical mechanic convention (broader regex `^(?:protected |private |noncomputable )*(?:theorem|lemma) `).

Canonical counts (computed against `proofs/Proofs/AmgmInequalityOQ03.lean` @ origin/main `b63c713b751`):

| Field | Value | Source |
|---|---|---|
| `lineCount` | 373 | `wc -l` |
| `theoremCount` | **12** | broad regex (10 theorem + 1 lemma + 2 private lemma) |
| `defCount` | 3 | `^(def\|noncomputable def\|opaque def) ` |
| `sorryCount` | 0 | raw `\bsorry\b` |
| `axiomCount` | 0 | `^axiom ` |

The 2 additional theorems captured: `private lemma weighted_sum_pos` (line 253) and `private lemma weightedPowerMean_pos` (line 273). Only `theoremCount` changed; all other fields already canonical.

Convention precedent: PRs #19934 / #19816 / #19818.

---
Automated fix by lean-mechanic agent.