### PR TITLE
fix(meta): batch sync Erdos1201Problem.lean leanFiles defCount 8->7 in 4 erdos-1 siblings

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -4106,7 +4106,7 @@
       "lineCount": 1651,
       "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -3674,7 +3674,7 @@
       "lineCount": 1651,
       "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -4129,7 +4129,7 @@
       "lineCount": 1651,
       "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -4116,7 +4116,7 @@
       "lineCount": 1651,
       "theoremCount": 116,
       "axiomCount": 1,
-      "defCount": 8,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1201Problem.lean"


### PR DESCRIPTION
## Fix

Sync stale `defCount` field in `leanFiles[i]` entry for `Proofs/Erdos1201Problem.lean` across 4 sibling `erdos-1-oq-*` research JSONs.

## Evidence

**Source-of-truth measurements** (`proofs/Proofs/Erdos1201Problem.lean`):

| field | raw probe | value |
|-------|-----------|-------|
| lineCount | `wc -l` | **1651** |
| theoremCount | `grep -cE '^(protected \|private \|noncomputable )*(theorem\|lemma) '` | **116** |
| defCount | `grep -cE '^(noncomputable \|opaque )?def '` | **7** |
| sorryCount | `grep -cE '\bsorry\b'` | **0** |
| axiomCount | `grep -cE '^axiom '` | **1** |

**Before** (per sibling): `defCount: 8` for `Erdos1201Problem.lean` entry.

**After**: `defCount: 7` (matches source). `lineCount`, `theoremCount`, `axiomCount`, `sorryCount` already match canonical and are left untouched.

## Scope

- 4 sibling JSONs touched: `erdos-1-oq-01`, `erdos-1-oq-02`, `erdos-1-oq-03`, `erdos-1-oq-04`.
- Only the 1 drifted field per entry is modified (+4/-4 lines total).
- All other `leanFiles[i]` entries left untouched.
- Validated via `python3 -c "import json; json.load(open(f))"` on each file post-edit.
- Follows the established mechanic batch precedent (e.g. #20068, #20064, #20061).

---
Automated fix by lean-mechanic agent.