### PR TITLE
fix(meta): batch sync ArithmeticSeriesOQ00OQ01.lean leanFiles in 22 arithmetic-series siblings (lineCount 283→282, theoremCount 10→12)

### DIFF
--- a/src/data/research/problems/arithmetic-series-oq-00-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-00-oq-01.json
@@ -77,8 +77,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-00-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-00-oq-02.json
@@ -94,8 +94,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-00.json
+++ b/src/data/research/problems/arithmetic-series-oq-00.json
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-01.json
@@ -95,8 +95,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01-oq-01.json
@@ -133,8 +133,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-01.json
@@ -104,8 +104,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-01.json
@@ -53,8 +53,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-02.json
@@ -94,8 +94,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-04.json
@@ -94,8 +94,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03.json
@@ -89,8 +89,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-04.json
@@ -89,8 +89,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02.json
@@ -61,8 +61,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-03.json
@@ -103,8 +103,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02.json
@@ -106,8 +106,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04-oq-01.json
@@ -117,8 +117,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-04.json
@@ -95,8 +95,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-02.json
+++ b/src/data/research/problems/arithmetic-series-oq-02.json
@@ -98,8 +98,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-03.json
+++ b/src/data/research/problems/arithmetic-series-oq-03.json
@@ -94,8 +94,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-04-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-04-oq-01.json
@@ -122,8 +122,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/arithmetic-series-oq-04.json
+++ b/src/data/research/problems/arithmetic-series-oq-04.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
       "filename": "ArithmeticSeriesOQ00OQ01.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
+      "lineCount": 282,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entries for `proofs/Proofs/ArithmeticSeriesOQ00OQ01.lean` across 22 arithmetic-series sibling research JSONs to canonical mechanic counts.

## Evidence

**Lean source** `proofs/Proofs/ArithmeticSeriesOQ00OQ01.lean`:
- `wc -l` = **282** (was claimed 283)
- `^(protected |private |noncomputable )*(theorem|lemma) ` = **12** (was claimed 10 — enrich-research's narrower `^(theorem|lemma) ` regex misses prefixed lemmas)
- `^(def|noncomputable def|opaque def) ` = 1 (unchanged)
- `^axiom ` = 0 (unchanged)
- `\bsorry\b` raw = 0 (unchanged)

**Before** (uniform across all 22 siblings):
```
"lineCount": 283,
"theoremCount": 10,
```

**After**:
```
"lineCount": 282,
"theoremCount": 12,
```

22 sibling JSONs at index 2, single-block surgical text replace (no JSON reformat, 44 lines changed total).

Per memory note: canonical mechanic counts use raw `wc -l`, broader thm regex including `protected|private|noncomputable` prefixes (matches gallery meta.json convention + recent mechanic PRs #19663/#19667/#20029/#20037/#20044).

---
Automated fix by lean-mechanic agent.