### PR TITLE
fix(meta): burnside-counting-oq-03 sorries 4→0 (align with leanFile.sorries + assumptions text)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -21,7 +21,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 4,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
@@ -185,5 +185,5 @@
       "Proofs/BurnsideCountingOQ03Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Sync top-level `sorries` and `meta.sorries` in `src/data/proofs/burnside-counting-oq-03/meta.json` from `4 → 0` to match `leanFile.sorries` (already 0) and the `meta.assumptions` text which begins *"No sorries, no axioms."*

## Evidence

**Source-of-truth scan** of `proofs/Proofs/BurnsideCountingOQ03.lean`:

| convention | command | result |
|------------|---------|--------|
| raw `\bsorry\b` (canonical, see PR #20070) | `grep -oE '\bsorry\b' \| wc -l` | **0** |

Three locations of `sorries` in the meta file before fix:

| line | field | before | after |
|------|-------|--------|-------|
| 24 | `meta.sorries` | 4 | **0** |
| 181 | `leanFile.sorries` | 0 | 0 (unchanged — source of truth) |
| 188 | top-level `sorries` | 4 | **0** |

## Convention check

Sibling proofs with Aristotle companions verified for the *"mirror main `leanFile.sorries`, exclude Aristotle companion sorries"* convention:

| slug | d.sorries | d.meta.sorries | leanFile.sorries | additionalFiles |
|------|-----------|----------------|-------------------|------------------|
| amgm-inequality | 0 | 0 | 0 | AMGMInequalityAristotle.lean |
| algebraic-numbers-countable | 0 | 0 | 0 | AlgebraicNumbersCountableAristotle.lean |
| arithmetic-series-oq-02-oq-03 | 0 | 0 | 0 | ArithmeticSeriesOQ02OQ03Aristotle.lean |
| basel-problem-oq-02 | 0 | 0 | 0 | BaselProblemOQ02Aristotle.lean |

The Aristotle companion `BurnsideCountingOQ03Aristotle.lean` does contain 4 routine target sorries — that is expected for an Aristotle companion file (proof-search inputs) and is unrelated to the main proof's status.

## Out of scope

- **Status/badge** kept at `formalized/mathlib`. The proof states the general Pólya necklace formula conditionally on Burnside's lemma as a hypothesis, so the conservative classification stands. Promotion to `verified` is a separate decision.
- **leanFiles[] batch sync** N/A — this slug uses singular `leanFile` (already correct).

## Test plan

- [x] `python3 -m json.tool` validates modified meta.json
- [x] No JSON formatting drift (2-field surgical Edit, not `json.dump`)
- [x] `git diff --stat` shows `1 file changed, 2 insertions(+), 2 deletions(-)`
- [x] No open PR or issue on `burnside-counting-oq-03` (verified via `gh pr list/issue list --search`)

---
Automated fix by lean-mechanic agent.