### PR TITLE
fix(meta): batch sync AbelRuffiniOQ04OQ01.lean leanFiles in 16 abel-ruffini siblings (lineCount 1499→1498, theoremCount 36→64)

### DIFF
--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -400,7 +400,7 @@
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
       "lineCount": 1498,
-      "theoremCount": 36,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-02.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-03.json
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
@@ -110,8 +110,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
@@ -104,8 +104,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
@@ -82,8 +82,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -133,8 +133,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -127,8 +127,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
@@ -105,8 +105,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
@@ -213,8 +213,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -78,8 +78,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,

--- a/src/data/research/problems/abel-ruffini-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-09.json
@@ -142,8 +142,8 @@
     {
       "path": "Proofs/AbelRuffiniOQ04OQ01.lean",
       "filename": "AbelRuffiniOQ04OQ01.lean",
-      "lineCount": 1499,
-      "theoremCount": 36,
+      "lineCount": 1498,
+      "theoremCount": 64,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entries for `proofs/Proofs/AbelRuffiniOQ04OQ01.lean` across 16 abel-ruffini sibling research JSONs to canonical mechanic counts.

## Evidence

**Lean source** `proofs/Proofs/AbelRuffiniOQ04OQ01.lean`:
- `wc -l` = **1498** (15 siblings claimed 1499; 1 already at 1498)
- `^(protected |private |noncomputable )*(theorem|lemma) ` = **64** (was claimed 36 — enrich-research's narrower `^(theorem|lemma) ` regex misses 28 prefixed lemmas, all `private`)
- `^(def|noncomputable def|opaque def) ` = 5 (unchanged)
- `^axiom ` = 0 (unchanged)
- `\bsorry\b` raw = 0 (unchanged)

**Before** (15 siblings at lc=1499, 1 sibling at lc=1498; all 16 thm=36):
```
"lineCount": 1499,
"theoremCount": 36,
```

**After**:
```
"lineCount": 1498,
"theoremCount": 64,
```

16 sibling JSONs at the matching `leanFiles[]` index, single-block surgical text replace (no JSON reformat, 31 lines changed total — 15 lc + 16 thm).

Per memory note: canonical mechanic counts use raw `wc -l`, broader thm regex including `protected|private|noncomputable` prefixes (matches gallery meta.json convention + recent mechanic PRs #20037/#20043/#20066/#20067/#20073).

---
Automated fix by lean-mechanic agent.