### PR TITLE
fix(meta): batch sync BezoutIdentityOQ01Aristotle.lean leanFiles lineCount 45->44 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -52,7 +52,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -60,7 +60,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -64,7 +64,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ01Aristotle.lean",
       "filename": "BezoutIdentityOQ01Aristotle.lean",
-      "lineCount": 45,
+      "lineCount": 44,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[].lineCount` for `Proofs/BezoutIdentityOQ01Aristotle.lean` from `45` → `44` across 31 bezout-identity sibling research JSONs.

## Evidence

**Canonical metrics** for `proofs/Proofs/BezoutIdentityOQ01Aristotle.lean`:

```
wc -l                                                                  → 44
grep -cE '^(?:protected |private |noncomputable )*(theorem|lemma) '    → 5
grep -cE '^(noncomputable |opaque )?def '                              → 0
grep -cE '\bsorry\b'                                                   → 0
grep -cE '^axiom '                                                     → 0
```

**Before** (31 siblings): `lineCount: 45, theoremCount: 5, defCount: 0, sorryCount: 0, axiomCount: 0`
**After** (31 siblings): `lineCount: 44, theoremCount: 5, defCount: 0, sorryCount: 0, axiomCount: 0`

Only `lineCount` drifts; other counts already canonical.

## Scope

Surgical regex edit, anchored on the path field and limited to the matching `leanFiles` entry. 31 files changed, +31/-31 (1 line each). No JSON reformat.

Validated via `python3 -c "import json; json.load(open(f))"` for all 31 files — 0 failures.

---
Automated fix by lean-mechanic agent.