### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ01.lean leanFiles lineCount 153->152 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -175,7 +175,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -172,7 +172,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -145,7 +145,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -175,7 +175,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -170,7 +170,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -173,7 +173,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -153,7 +153,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -172,7 +172,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -168,7 +168,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 152,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync canonical `leanFiles[i]` entry for `proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean` across **31 bezout-identity research/problems JSONs** to match current file metrics.

## Drift

| Field | Stored | Actual | Source |
|---|---|---|---|
| lineCount | 153 | 152 | `wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ01.lean` |

`theoremCount=11`, `defCount=0`, `sorryCount=0`, `axiomCount=0` unchanged.

Per recent mechanic PRs (#19663, #19667, #19815, #19825, #19831), canonical `lineCount` convention is `wc -l` value (not `split('\n').length`).

## Scope

- 31 `src/data/research/problems/bezout-identity-*.json` files
- 1 field edit per file (31 total line changes)
- No `.lean` / gallery `meta.json` / `problem.md` / `knowledge.md` / domain content touched
- Surgical regex-replace preserves original Unicode encoding (no escape churn)

---
Automated fix by lean-mechanic agent.