### PR TITLE
fix(meta): batch sync AreaOfCircleOQ05OQ02.lean leanFiles in 30 area-of-circle siblings (lineCount 190->189, theoremCount 2->3)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -383,8 +383,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -377,8 +377,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -323,8 +323,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -314,8 +314,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -391,8 +391,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -413,8 +413,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -377,8 +377,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -372,8 +372,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -395,8 +395,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -402,8 +402,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -371,8 +371,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -364,8 +364,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -390,8 +390,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -375,8 +375,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -366,8 +366,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -365,8 +365,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -381,8 +381,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -398,8 +398,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -372,8 +372,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -377,8 +377,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -370,8 +370,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -368,8 +368,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -397,8 +397,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -369,8 +369,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -469,8 +469,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -375,8 +375,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
+      "lineCount": 189,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `AreaOfCircleOQ05OQ02.lean` leanFiles[26] metadata in 30 sibling research JSONs to match canonical mechanic-convention counts.

## Evidence

**Canonical counts** (raw, in `proofs/Proofs/AreaOfCircleOQ05OQ02.lean`):

| Field | Stale | Canonical | Convention |
|---|---|---|---|
| `lineCount` | 190 | **189** | `wc -l` |
| `theoremCount` | 2 | **3** | `^(protected\|private\|noncomputable )*(theorem\|lemma) ` |
| `defCount` | 0 | 0 | `^(def\|noncomputable def\|opaque def) ` |
| `sorryCount` | 0 | 0 | raw `\bsorry\b` |
| `axiomCount` | 0 | 0 | `^axiom ` |

**Before**: all 30 sibling JSONs show `lineCount: 190, theoremCount: 2` at `leanFiles[26]`.
**After**: all 30 sibling JSONs show `lineCount: 189, theoremCount: 3` at `leanFiles[26]`.

Diff is exactly 60 lines (30 files × 2 field rewrites each). No other fields touched.

## Scope

Slug-batch (all 30 `area-of-circle-*` research JSONs referencing this file).
No `.lean` source modified.
No `pnpm build` run (per mechanic convention — validated with `python3 json.load` only).

---
Automated fix by lean-mechanic agent.