### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02OQ02.lean leanFiles in 29 amgm-inequality siblings (lineCount 960→959, theoremCount 14→17)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -144,8 +144,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -144,8 +144,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -101,8 +101,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -151,8 +151,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -151,8 +151,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -167,8 +167,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -152,8 +152,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -142,8 +142,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -152,8 +152,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -167,8 +167,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -159,8 +159,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -149,8 +149,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -154,8 +154,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -115,8 +115,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -97,8 +97,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -154,8 +154,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
       "filename": "AmgmInequalityOQ02OQ02.lean",
-      "lineCount": 960,
-      "theoremCount": 14,
+      "lineCount": 959,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync drifted `leanFiles[i]` canonical counts for `Proofs/AmgmInequalityOQ02OQ02.lean` across 29 amgm-inequality sibling research JSONs.

## Evidence

**Before** (stored, identical across all 29 refs):
- `lineCount`: 960
- `theoremCount`: 14

**After** (canonical from current Lean source):
- `lineCount`: 959 (`wc -l proofs/Proofs/AmgmInequalityOQ02OQ02.lean`)
- `theoremCount`: 17 (regex `^(?:protected|private|noncomputable )*(?:theorem|lemma)\s`)

Other counts (`defCount=1`, `sorryCount=0`, `axiomCount=0`) were already canonical and unchanged.

## Scope

- 29 files in `src/data/research/problems/amgm-inequality-*.json`
- 58 insertions / 58 deletions (2 fields × 29 files)
- All JSONs validated via `python3 -c "json.load(open(...))"` after edit
- Lean source itself unchanged

---
Automated fix by lean-mechanic agent.