### PR TITLE
fix(meta): algebraic-numbers-countable-oq-05 theoremCount 12→13

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 296,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
     "assumptions": "",
@@ -171,7 +171,7 @@
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
     "lineCount": 296,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "axiomCount": 0,
     "definitionCount": 2,
     "sorries": 0


### PR DESCRIPTION
## Fix

Single-slug, single-field gallery meta drift: bump `theoremCount` 12 → 13 in both `meta.theoremCount` and `leanFile.theoremCount`.

## Evidence

Canonical count via `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/AlgebraicNumbersCountableOQ05.lean` = **13**.

The 13 theorems/lemmas (lines 71–260):

| # | Symbol | Line |
|---|--------|------|
| 1 | `cantorHeight_degree_le` | 71 |
| 2 | `cantorHeight_sum_le` | 76 |
| 3 | `cantorHeight_coeff_le` | 85 |
| 4 | `cantorHeight_pos_of_ne_zero` | 97 |
| 5 | `poly_eq_fin_sum` (private) | 115 |
| 6 | `finite_polys_of_height` | 138 |
| 7 | `finite_real_roots` | 161 |
| 8 | `finite_algebraicRealsOfHeight` | 181 |
| 9 | `algebraic_reals_eq_iUnion_height` | 205 |
| 10 | `algebraic_reals_countable_via_height` | 239 |
| 11 | `algebraicRealsOfHeight_mono` | 249 |
| 12 | `card_algebraic_reals_eq_aleph0` | 255 |
| 13 | `finite_algebraicReals_bounded_height` | 260 |

**Before**: `meta.theoremCount=12`, `leanFile.theoremCount=12`
**After**: `meta.theoremCount=13`, `leanFile.theoremCount=13`

Other counts already correct: `lineCount=296`, `definitionCount=2`, `axiomCount=0`, `sorries=0`.

## Scope

- Only `src/data/proofs/algebraic-numbers-countable-oq-05/meta.json` references `AlgebraicNumbersCountableOQ05.lean`; no sibling slugs affected.
- Research JSON `src/data/research/problems/algebraic-numbers-countable-oq-05.json` already has `theoremCount: 13` at `leanFiles[6]` — no change needed.
- No Lean code changes.

---
Automated fix by lean-mechanic agent.