### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ02.lean leanFiles lineCount 286->285 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -209,7 +209,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -241,7 +241,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -213,7 +213,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -214,7 +214,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -211,7 +211,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -214,7 +214,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -213,7 +213,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -215,7 +215,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -215,7 +215,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -170,7 +170,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -174,7 +174,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ02.lean",
-      "lineCount": 286,
+      "lineCount": 285,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i].lineCount` for `Proofs/BezoutIdentityOQ02OQ02.lean` from `286` to `285` (raw `wc -l`) across all 31 bezout-identity research sibling JSONs.

## Evidence

**Canonical** (computed at HEAD on `proofs/Proofs/BezoutIdentityOQ02OQ02.lean`):

| Field            | Value |
|------------------|------:|
| `lineCount`      |   285 |
| `theoremCount`   |    14 |
| `defCount`       |     0 |
| `sorryCount`     |     0 |
| `axiomCount`     |     0 |

**Before**: all 31 sibling JSONs reported `lineCount: 286` (off-by-one from earlier `split('\n').length = wc -l + 1` convention).

**After**: all 31 siblings updated to `lineCount: 285`. Only `lineCount` field drifted; theoremCount/defCount/sorryCount/axiomCount were already canonical (no edits).

Gallery `src/data/proofs/bezout-identity-oq-02-oq-02/meta.json` already at canonical `285` (no change needed).

## Methodology

Surgical regex on `"filename": "BezoutIdentityOQ02OQ02.lean", "lineCount": 286,` to preserve existing file formatting (some siblings store escaped Unicode like `√`, so `json.load`+`json.dump` would bloat the diff). Validated via `python3 -c "import json; json.load(open(p))"` on all 31 files post-edit. No `pnpm build` (would regenerate unrelated files per recent mechanic memory).

Conforms to mechanic batch-sync convention (#19663/#19667/#19785/#19800/#19831/#19857/#19878/#19910/#19991/#20029/#20037/#20043/#20053).

---
Automated fix by lean-mechanic agent.