### PR TITLE
fix(meta): batch sync CayleyHamiltonMinpolyOQ05.lean leanFiles lineCount 233->232 in 28 cayley-hamilton siblings

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -192,7 +192,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -199,7 +199,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -192,7 +192,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
@@ -206,7 +206,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -201,7 +201,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
@@ -192,7 +192,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -195,7 +195,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -202,7 +202,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -205,7 +205,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
@@ -274,7 +274,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -248,7 +248,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -205,7 +205,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -197,7 +197,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -239,7 +239,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -237,7 +237,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
       "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 23,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Update `leanFiles[i].lineCount` from **233 → 232** for `Proofs/CayleyHamiltonMinpolyOQ05.lean` references across **28** cayley-hamilton sibling research JSONs (one sibling already correct).

## Evidence

| Source of truth | Value |
|---|---|
| `wc -l proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean` | **232** |
| Prior meta in 28 siblings | 233 (off-by-one) |
| `cayley-hamilton-oq-01.json` | 232 (already canonical) |

Other `leanFiles[i]` fields (theoremCount=23, sorryCount=0, axiomCount=0, defCount=0) verified matching canonical greps; no other drift.

Canonical convention: raw `wc -l` (since #19663/#19667; reaffirmed #19934/#19840/#19885; recent cayley-hamilton precedent #20064/#20066).

## Scope

- Single-field surgical edit (`lineCount`) across 28 JSON files
- No Lean source changes
- All 28 JSONs validated via `python3 -c "json.load(open(f))"` post-edit
- Diff: 28 files changed, 28 insertions(+), 28 deletions(-)

---
Automated fix by lean-mechanic agent.