### PR TITLE
fix(meta): batch sync BezoutIdentityOQ03.lean leanFiles lineCount 277->276 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -285,7 +285,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -260,7 +260,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -282,7 +282,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -255,7 +255,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -296,7 +296,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -206,7 +206,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -214,7 +214,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -280,7 +280,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -305,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -282,7 +282,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -278,7 +278,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03.lean",
       "filename": "BezoutIdentityOQ03.lean",
-      "lineCount": 277,
+      "lineCount": 276,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Canonical `wc -l` for `proofs/Proofs/BezoutIdentityOQ03.lean` is **276**; all 31 `bezout-identity-*` sibling research JSONs had stale `leanFiles[i].lineCount: 277`. This PR aligns them to canonical.

## Evidence

**Before** (sample):
```json
{
  "path": "Proofs/BezoutIdentityOQ03.lean",
  "filename": "BezoutIdentityOQ03.lean",
  "lineCount": 277,
  "theoremCount": 10,
  "axiomCount": 0,
  "defCount": 1,
```

**After**:
```json
  "lineCount": 276,
```

**Canonical counts** (verified at HEAD of `main`):
- `wc -l` = 276
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` = 10
- `grep -cE '^(def|noncomputable def|opaque def) '` = 1
- `grep -oE '\bsorry\b' | wc -l` = 0
- `grep -cE '^axiom '` = 0

Only `lineCount` drifted; the other four fields already match canonical.

## Scope

- 31 files changed, 31 insertions, 31 deletions (one `lineCount` line per file)
- Surgical text-mode patch on the `path`/`filename`/`lineCount` triplet to avoid `json.dump` unicode-escape churn — existing files store `ℤ`, `√-5` as `\uXXXX` escapes; `ensure_ascii=False` would unescape them and add ~130 lines of noise.
- All 31 edited JSONs validated via `python3 -c "import json; json.load(open(f))"`.

---
Automated fix by lean-mechanic agent.