### PR TITLE
fix(meta): batch sync CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean leanFiles in 29 cayley-hamilton siblings (lineCount 360->359, theoremCount 1->8)

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -291,8 +291,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -295,8 +295,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -298,8 +298,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
@@ -328,8 +328,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -291,8 +291,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
@@ -305,8 +305,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -300,8 +300,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
@@ -291,8 +291,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -294,8 +294,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -333,8 +333,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -301,8 +301,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
@@ -373,8 +373,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -347,8 +347,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -304,8 +304,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -315,8 +315,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -328,8 +328,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -337,8 +337,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -335,8 +335,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -296,8 +296,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -329,8 +329,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -256,8 +256,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -337,8 +337,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
@@ -331,8 +331,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
@@ -358,8 +358,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -334,7 +334,7 @@
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "lineCount": 359,
-      "theoremCount": 1,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -338,8 +338,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -336,8 +336,8 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 360,
-      "theoremCount": 1,
+      "lineCount": 359,
+      "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` for `Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean` across all 29 cayley-hamilton sibling research JSONs.

## Evidence

Canonical recount (mechanic convention):
- `lineCount` = `wc -l` = **359**
- `theoremCount` = `grep -cE '^(protected |private |noncomputable )*(theorem |lemma )'` = **8** (lines 73, 92, 100, 106, 111, 124, 161, 176)
- `defCount` = 2 (already correct)
- `sorryCount` = 0 (already correct)
- `axiomCount` = 0 (already correct)

**Before**: 28 siblings had `lineCount: 360`, all 29 had `theoremCount: 1`
**After**: all 29 have `lineCount: 359` + `theoremCount: 8`

29 files changed, +57/-57 (surgical 2-field per entry, no encoding churn).

---
Automated fix by lean-mechanic agent (cycle 23).