### PR TITLE
fix(meta): batch sync CantorDiagonalizationOQ02OQ03.lean leanFiles in 19 cantor-diagonalization siblings (lineCount 143→142, theoremCount 6→7)

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
@@ -290,8 +290,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03.json
@@ -206,8 +206,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
@@ -187,8 +187,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01.json
@@ -168,7 +168,7 @@
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
       "lineCount": 142,
-      "theoremCount": 6,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
@@ -181,8 +181,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
@@ -127,8 +127,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03.json
@@ -167,8 +167,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
@@ -187,8 +187,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
@@ -172,8 +172,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cantor-diagonalization-oq-04.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/CantorDiagonalizationOQ02OQ03.lean",
       "filename": "CantorDiagonalizationOQ02OQ03.lean",
-      "lineCount": 143,
-      "theoremCount": 6,
+      "lineCount": 142,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch-sync `leanFiles[i]` entries for `CantorDiagonalizationOQ02OQ03.lean` across 19 cantor-diagonalization sibling research JSONs in `src/data/research/problems/`.

## Evidence

Verified on `proofs/Proofs/CantorDiagonalizationOQ02OQ03.lean` at origin/main HEAD `f4b0e35be0d`:

- `wc -l` → 142
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` → 7
- `grep -cE '^(noncomputable |opaque )?def '` → 0
- `grep -cE '\bsorry\b'` → 0
- `grep -cE '^axiom '` → 0

**Before**: 18 siblings had `lineCount: 143`, `theoremCount: 6`; 1 sibling (`cantor-diagonalization-oq-01`) had `lineCount: 142`, `theoremCount: 6`.

**After**: All 19 siblings carry `lineCount: 142`, `theoremCount: 7`. `axiomCount`, `defCount`, `sorryCount` already correct (0).

## Scope

One canonical Lean file, two fields, 19 sibling JSONs (`cantor-diagonalization-oq-*`). 37/37 line additions/removals. JSONs validated via `python3 -c "json.load(open(...))"`. No `pnpm build` invoked (would regenerate ~1000+ JSONs and leak untracked files per prior mechanic precedent).

---
Automated fix by lean-mechanic agent.