### PR TITLE
fix(meta): batch sync CantorsTheoremOQ01.lean leanFiles lineCount 273->295 in 8 cantors-theorem siblings

### DIFF
--- a/src/data/research/problems/cantors-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/cantors-theorem-oq-01-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/cantors-theorem-oq-01-oq-02.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/cantors-theorem-oq-01-oq-03.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-01.json
+++ b/src/data/research/problems/cantors-theorem-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/cantors-theorem-oq-02-oq-01.json
@@ -66,7 +66,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-02.json
+++ b/src/data/research/problems/cantors-theorem-oq-02.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-03.json
+++ b/src/data/research/problems/cantors-theorem-oq-03.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantors-theorem-oq-04.json
+++ b/src/data/research/problems/cantors-theorem-oq-04.json
@@ -71,7 +71,7 @@
     {
       "path": "Proofs/CantorsTheoremOQ01.lean",
       "filename": "CantorsTheoremOQ01.lean",
-      "lineCount": 273,
+      "lineCount": 295,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i].lineCount` for `Proofs/CantorsTheoremOQ01.lean` from 273 -> 295 across 8 sibling research JSONs in the `cantors-theorem` family.

## Evidence

**Before**: `lineCount: 273` in all 8 siblings.
**After**: `lineCount: 295` matching `wc -l proofs/Proofs/CantorsTheoremOQ01.lean = 295`.

Other canonical counts (theoremCount=17, axiomCount=0, sorryCount=0) already match the file and are unchanged.

| Slug | leanFiles[i] | lineCount before | lineCount after |
|---|---|---|---|
| cantors-theorem-oq-01 | [1] | 273 | 295 |
| cantors-theorem-oq-01-oq-01 | [1] | 273 | 295 |
| cantors-theorem-oq-01-oq-02 | [1] | 273 | 295 |
| cantors-theorem-oq-01-oq-03 | [1] | 273 | 295 |
| cantors-theorem-oq-02 | [1] | 273 | 295 |
| cantors-theorem-oq-02-oq-01 | [1] | 273 | 295 |
| cantors-theorem-oq-03 | [1] | 273 | 295 |
| cantors-theorem-oq-04 | [1] | 273 | 295 |

## Methodology

Canonical mechanic conventions:
- lineCount = wc -l raw

One sibling (cantors-theorem-oq-01-oq-02) was also missing a trailing newline on its closing brace; added for consistency with the other 7 siblings.

---
Automated fix by lean-mechanic agent.