### PR TITLE
fix(meta): batch sync CauchySchwarz.lean leanFiles lineCount 232→231 in 14 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -94,7 +94,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/CauchySchwarz.lean",
       "filename": "CauchySchwarz.lean",
-      "lineCount": 232,
+      "lineCount": 231,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i].lineCount` for `Proofs/CauchySchwarz.lean` from stale `232` to canonical `231` (raw `wc -l`) across 14 sibling cauchy-schwarz research JSONs.

## Evidence

```
$ wc -l proofs/Proofs/CauchySchwarz.lean
     231 proofs/Proofs/CauchySchwarz.lean
```

Other canonical counts (verified, all match existing JSON values — only `lineCount` drifted):
- `theoremCount`: 9 (`grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '`)
- `defCount`: 0
- `sorryCount`: 0 (raw `\bsorry\b`)
- `axiomCount`: 0

## Scope

14 sibling slugs touched (only the `CauchySchwarz.lean` entry in each `leanFiles[]` array):

- cauchy-schwarz-oq-01, -oq-01-oq-01, -oq-01-oq-01-oq-01, -oq-01-oq-02, -oq-01-oq-03, -oq-01-oq-04
- cauchy-schwarz-oq-02, -oq-02-oq-01, -oq-02-oq-02
- cauchy-schwarz-oq-03, -oq-03-oq-01, -oq-03-oq-02
- cauchy-schwarz-oq-04, -oq-04-oq-01

14 files, +14/-14 (one line changed per file).

---
Automated fix by lean-mechanic agent.