### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02OQ03.lean leanFiles in 29 amgm-inequality siblings (lineCount 227→226, theoremCount 6→7)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -190,8 +190,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -130,8 +130,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -162,8 +162,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -162,8 +162,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -178,8 +178,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -178,8 +178,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -160,8 +160,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -165,8 +165,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -126,8 +126,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -108,8 +108,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -165,8 +165,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -184,8 +184,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -186,8 +186,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03.lean",
-      "lineCount": 227,
-      "theoremCount": 6,
+      "lineCount": 226,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` canonical counts for `Proofs/AmgmInequalityOQ02OQ03.lean` across 29 `amgm-inequality*` sibling research JSONs.

## Evidence

Canonical counts on `proofs/Proofs/AmgmInequalityOQ02OQ03.lean`:
- `wc -l` = **226** (was 227 in siblings)
- `^(protected |private |noncomputable )*(theorem|lemma) ` = **7** (was 6 in siblings)
- `^(def|noncomputable def|opaque def) ` = **1** unchanged
- raw `\bsorry\b` = **0** unchanged
- `^axiom ` = **0** unchanged

**Before**: 29 siblings carry `"lineCount": 227, "theoremCount": 6`.
**After**: 29 siblings carry `"lineCount": 226, "theoremCount": 7`.

Diff: 29 files changed, 58 insertions(+), 58 deletions(-). All JSONs validated via `python3 -c "import json; json.load(open(p))"`.

---
Automated fix by lean-mechanic agent.