### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-04 leanFiles[0].sorryCount 0→4 (raw \bsorry\b match)

### DIFF
--- a/src/data/research/problems/algebraic-numbers-countable-oq-02-oq-04.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-02-oq-04.json
@@ -143,7 +143,7 @@
       "theoremCount": 31,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 0,
+      "sorryCount": 4,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"
     }


### PR DESCRIPTION
## Fix

Align `src/data/research/problems/algebraic-numbers-countable-oq-02-oq-04.json` `leanFiles[0].sorryCount` to canonical raw `\bsorry\b` match (0 → 4).

## Evidence

`proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean` contains 4 raw `\bsorry\b` matches, all in docstrings (the file is fully verified — no actual proof sorries):

| Line | Context |
|------|---------|
| 87  | docstring: `- **S1**: SCAFFOLD — IsComputable definition + main theorem (sorry).` |
| 90  | docstring: `exact equality stated (contingent on the S1 sorry).` |
| 136 | docstring: `cardinality (and originally to discharge the S1 sorry in` |
| 329 | docstring: `after S3 discharged the main sorry) and aleph0_le_card_computable_reals` |

```
$ grep -cE '\bsorry\b' proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
4
```

**Before**: `sorryCount: 0` (S6f STATE-SYNC used comment-strip / actual-proof-sorry counting)
**After**: `sorryCount: 4` (raw `\bsorry\b` match)

Canonical convention per recent precedent (#20039 SumOfDivisorsOQ02 3→5, #20033 BallotProblemOQ02OQ05 4→6, #20019 BinaryGcdOQ03OQ02 0→1) is raw `\bsorry\b` with no comment stripping.

Other fields already aligned:
- `lineCount: 656` ✓ (wc -l)
- `theoremCount: 31` ✓
- `defCount: 3` ✓
- `axiomCount: 0` ✓

Single-slug fix — `AlgebraicNumbersCountableOQ02OQ04.lean` is referenced only by this one JSON.

---
Automated fix by lean-mechanic agent.