### PR TITLE
fix(meta): batch sync Derangements.lean leanFiles lineCount 228→227 in 8 derangements siblings

### DIFF
--- a/src/data/research/problems/derangements-oq-01.json
+++ b/src/data/research/problems/derangements-oq-01.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-02-oq-01.json
+++ b/src/data/research/problems/derangements-oq-02-oq-01.json
@@ -71,7 +71,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-02-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02-oq-02.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/derangements-oq-03-oq-01-oq-02.json
@@ -59,7 +59,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-03-oq-01.json
+++ b/src/data/research/problems/derangements-oq-03-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-03-oq-02.json
+++ b/src/data/research/problems/derangements-oq-03-oq-02.json
@@ -74,7 +74,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/derangements-oq-03.json
+++ b/src/data/research/problems/derangements-oq-03.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/Derangements.lean",
       "filename": "Derangements.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[0].lineCount` for `Proofs/Derangements.lean` across 8 sibling
research problem JSONs.

## Evidence

**Before**: 8 sibling JSONs claim `lineCount: 228` at `leanFiles[0]`
**After**:  All 8 updated to `lineCount: 227` (matches `wc -l proofs/Proofs/Derangements.lean = 227`)

Other counts (theoremCount=10, defCount=0, sorryCount=0, axiomCount=0) already match the
Lean source — no other fields touched.

```
$ wc -l proofs/Proofs/Derangements.lean
     227 proofs/Proofs/Derangements.lean
```

Canonical mechanic convention: `lineCount = wc -l` (raw), per #19663/#19667 + recent batch
sync PRs (#20101 cauchy-schwarz, #20093 bezout-identity, #20092 cayley-hamilton, etc.).

## Siblings touched

- derangements-oq-01
- derangements-oq-02
- derangements-oq-02-oq-01
- derangements-oq-02-oq-02
- derangements-oq-03
- derangements-oq-03-oq-01
- derangements-oq-03-oq-01-oq-02
- derangements-oq-03-oq-02

## Test plan

- [x] `wc -l` matches new claim (227)
- [x] `python3 -c "import json; json.load(...)"` passes for all 8 files
- [x] Diff strictly 8 insertions / 8 deletions (one line per file)
- [x] No Lean source edits

---
Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)