### PR TITLE
fix(meta): batch sync ChineseRemainderConstructive.lean leanFiles lineCount 417→416 in 10 chinese-remainder-constructive siblings

### DIFF
--- a/src/data/research/problems/chinese-remainder-constructive-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-01.json
@@ -62,7 +62,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-02.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-02.json
@@ -67,7 +67,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-01.json
@@ -55,7 +55,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-03-oq-03.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-03.json
@@ -61,7 +61,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03-oq-01.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03-oq-01.json
@@ -65,7 +65,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-03.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-04.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-04-oq-04.json
@@ -73,7 +73,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive-oq-04.json
+++ b/src/data/research/problems/chinese-remainder-constructive-oq-04.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/chinese-remainder-constructive.json
+++ b/src/data/research/problems/chinese-remainder-constructive.json
@@ -65,7 +65,7 @@
     {
       "path": "Proofs/ChineseRemainderConstructive.lean",
       "filename": "ChineseRemainderConstructive.lean",
-      "lineCount": 417,
+      "lineCount": 416,
       "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Sync `leanFiles[0].lineCount` from drifted 417 → actual 416 for `Proofs/ChineseRemainderConstructive.lean` across 10 of 11 chinese-remainder-constructive sibling research JSONs.

## Evidence

**Actual file**: `proofs/Proofs/ChineseRemainderConstructive.lean`
- `wc -l` = **416** (raw, canonical convention per recent mechanic PRs #19663/#19667/#19840/#19885)
- theoremCount (`^(?:protected|private|noncomputable )*(theorem|lemma) `) = 17 (matches all siblings)
- defCount (`^(def|noncomputable def|opaque def) `) = 2 (matches all siblings)
- sorryCount (raw `\bsorry\b`) = 0
- axiomCount (`^axiom `) = 0

**Before**: 10 siblings had `lineCount: 417` (off-by-one, likely `wc -l + 1` legacy convention)
**After**: All 10 siblings have `lineCount: 416` (raw `wc -l`)

The 11th sibling (`chinese-remainder-constructive-oq-04-oq-02.json`) already had `lineCount: 416` and was skipped.

## Scope

- 10 files changed, 10 insertions, 10 deletions (1-line diff per file)
- No other fields touched (theoremCount, defCount, sorryCount, axiomCount were already correct)
- JSON validated via `python3 -c "import json; json.load(open(...))"`
- Did NOT run `pnpm build` (would regenerate all ~1047 research JSONs per memory note)

---
Automated fix by lean-mechanic agent.