### PR TITLE
fix(meta): batch sync AmgmInequalityOQ03OQ04.lean leanFiles in 29 amgm-inequality siblings (lineCount 233→232, theoremCount 7→10)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -232,8 +232,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -232,8 +232,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -267,8 +267,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -246,8 +246,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -243,8 +243,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -239,8 +239,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -239,8 +239,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -255,8 +255,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -246,8 +246,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -240,8 +240,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -230,8 +230,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -240,8 +240,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -255,8 +255,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -247,8 +247,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -241,8 +241,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -237,8 +237,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -242,8 +242,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -203,8 +203,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -185,8 +185,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -254,8 +254,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -242,8 +242,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -235,8 +235,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -235,8 +235,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -235,8 +235,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -261,8 +261,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -263,8 +263,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ04.lean",
       "filename": "AmgmInequalityOQ03OQ04.lean",
-      "lineCount": 233,
-      "theoremCount": 7,
+      "lineCount": 232,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `leanFiles[*]` entry for `Proofs/AmgmInequalityOQ03OQ04.lean` across **29 sibling `amgm-inequality-*.json` files** in `src/data/research/problems/` to canonical mechanic counts.

## Evidence

| Field          | Before | After |
|----------------|--------|-------|
| `lineCount`    | 233    | 232   |
| `theoremCount` | 7      | 10    |
| `defCount`     | 2      | 2     |
| `sorryCount`   | 0      | 0     |
| `axiomCount`   | 0      | 0     |

Canonical greps (raw, per recent mechanic precedent — `#20074`, `#20088`, `#20103`):

```bash
$ wc -l < proofs/Proofs/AmgmInequalityOQ03OQ04.lean
232
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' \
    proofs/Proofs/AmgmInequalityOQ03OQ04.lean
10
$ grep -cE '^(def|noncomputable def|opaque def) ' \
    proofs/Proofs/AmgmInequalityOQ03OQ04.lean
2
$ grep -cE '\bsorry\b' proofs/Proofs/AmgmInequalityOQ03OQ04.lean
0
$ grep -cE '^axiom ' proofs/Proofs/AmgmInequalityOQ03OQ04.lean
0
```

## Scope

- **29 sibling JSONs touched** (all `amgm-inequality-*.json` files referencing this lean file)
- **28 at `leanFiles[15]`**, **1 at `leanFiles[16]`** (`amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03`)
- Diff: +58 / -58 (29 × 2-line surgical edit; same shape as recent batch sync PRs)
- All other fields preserved untouched; JSON validity verified via `python3 json.load`

## Test plan

- [x] All 29 modified JSONs round-trip cleanly via `python3 json.load`
- [x] Canonical greps verified against current `proofs/Proofs/AmgmInequalityOQ03OQ04.lean`
- [x] Diff is surgical (only `lineCount` + `theoremCount` lines changed within the targeted `leanFiles[idx]` block)

---
Automated fix by lean-mechanic agent.