### PR TITLE
fix(meta): batch sync BezoutIdentityOQ03OQ04OQ01.lean leanFiles in 31 bezout-identity siblings (lineCount 130→129)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -342,7 +342,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -330,7 +330,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -362,7 +362,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -334,7 +334,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -337,7 +337,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -335,7 +335,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -359,7 +359,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -332,7 +332,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -333,7 +333,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -373,7 +373,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -335,7 +335,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -339,7 +339,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -334,7 +334,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -336,7 +336,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -336,7 +336,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -333,7 +333,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -338,7 +338,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -283,7 +283,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -356,7 +356,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -291,7 +291,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -338,7 +338,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -357,7 +357,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -382,7 +382,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -333,7 +333,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -340,7 +340,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -338,7 +338,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -359,7 +359,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -339,7 +339,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -295,7 +295,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -355,7 +355,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -338,7 +338,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ04OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ04OQ01.lean",
-      "lineCount": 130,
+      "lineCount": 129,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entry for `BezoutIdentityOQ03OQ04OQ01.lean` across 31 sibling `bezout-identity-*` research JSONs.

## Evidence

Canonical counts via the conventional regexes (`wc -l` for `lineCount`; `^(?:protected|private|noncomputable )*(theorem|lemma) ` for `theoremCount`; `^(?:noncomputable|opaque )*def ` for `defCount`; raw `\bsorry\b` for `sorryCount`; `^axiom ` for `axiomCount`):

| Field | Before | After |
| --- | --- | --- |
| `lineCount` | 130 | **129** |
| `theoremCount` | 6 | 6 (unchanged) |
| `defCount` | 1 | 1 (unchanged) |
| `sorryCount` | 0 | 0 (unchanged) |
| `axiomCount` | 0 | 0 (unchanged) |

Only one field changed; surgical text-level replace preserves each file's existing JSON serialization (ASCII-escape and trailing-newline conventions). All 31 files validated via `json.load`. Diff: 31 files changed, 31 +/-31 (1 line per file).

---
Automated fix by lean-mechanic agent.