### PR TITLE
fix(meta): batch sync AreaOfCircleOQ02OQ01.lean leanFiles lineCount 164→163 in 30 area-of-circle siblings

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -202,7 +202,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -193,7 +193,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -270,7 +270,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -292,7 +292,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -274,7 +274,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -244,7 +244,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -260,7 +260,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -277,7 +277,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -276,7 +276,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -248,7 +248,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -348,7 +348,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ01.lean",
       "filename": "AreaOfCircleOQ02OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[15].lineCount` for `Proofs/AreaOfCircleOQ02OQ01.lean` from `164` → `163` across all 30 sibling `area-of-circle-*` research JSONs.

## Evidence

**Actual file metrics** (`wc -l` + canonical regex):
- lineCount: **163** (wc -l)
- theoremCount: 4 (`^(?:protected|private|noncomputable )*(theorem|lemma) `)
- definitionCount: 0
- sorryCount: 0 (raw `\bsorry\b`)
- axiomCount: 0

**Before** (in all 30 sibling JSONs): `"lineCount": 164`
**After**: `"lineCount": 163`

Other fields (`theoremCount=4`, `sorryCount=0`, `axiomCount=0`) already matched canonical metrics; no change needed.

## Scope

30 files changed, 30 insertions / 30 deletions. Single-field surgical edit at `leanFiles[15]` of each sibling.

Validated: all 30 JSON files parse cleanly via `python3 -c "import json; json.load(open(...))"`.

---
Automated fix by lean-mechanic agent.