### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02OQ03OQ03.lean leanFiles in 29 amgm-inequality siblings (lineCount 67→66, theoremCount 2→3)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -185,8 +185,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -123,8 +123,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -181,8 +181,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -137,8 +137,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entries across 29 sibling research problem JSONs to canonical counts for `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean`.

## Evidence

**Before** (all 29 siblings identical):
```
lineCount=67, theoremCount=2, axiomCount=0, defCount=0, sorryCount=0
```

**After** (canonical):
```
lineCount=66, theoremCount=3, axiomCount=0, defCount=0, sorryCount=0
```

### Why the drift

| Field | Before | After | Cause |
|-------|-------:|------:|-------|
| `lineCount` | 67 | 66 | `pnpm build` (research:enrich) uses `split('\n').length` (= `wc -l + 1`); canonical is raw `wc -l` |
| `theoremCount` | 2 | 3 | Narrow `^theorem ` regex misses `private lemma maclaurin_chain_aux` at line 40 |

### Canonical regex (per mechanic convention)

```
lineCount      = wc -l (raw)
axiomCount     = ^axiom
theoremCount   = ^(protected|private|noncomputable )*(theorem|lemma)
defCount       = ^(def|noncomputable def|opaque def)
sorryCount     = \bsorry\b (raw, no comment strip)
```

### Theorem/lemma lines in source

\`\`\`
40: private lemma maclaurin_chain_aux ...
55: theorem maclaurin_full_chain ...
62: theorem maclaurin_m1_ge_mn ...
\`\`\`

## Test plan

- [x] python3 json.load on all 29 files — valid
- [x] 29 × 4 lines changed (2 per file: lineCount + theoremCount), no other edits
- [x] No pnpm build (would regenerate all 1916 research JSONs)

---
Automated fix by lean-mechanic agent.