### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 sorries 1→10 + theoremCount 64→65 (canonical regex sync)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -19,11 +19,11 @@
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 10,
     "axiomCount": 0,
     "lineCount": 2225,
     "dateAdded": "2026-05-03",
-    "theoremCount": 64,
+    "theoremCount": 65,
     "assumptions": "",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/binary-gcd-oq-03-oq-02/meta.json` metrics to actual `proofs/Proofs/BinaryGcdOQ03OQ02.lean` (2225 LOC) using the current mechanic canonical regex conventions.

## Evidence

| field | before | after | source |
|---|---:|---:|---|
| `sorries` | 1 | **10** | `grep -c '\bsorry\b' proofs/Proofs/BinaryGcdOQ03OQ02.lean` |
| `theoremCount` | 64 | **65** | `grep -cE '^(@\[[^]]+\] )*(protected \|private \|noncomputable )*(theorem\|lemma) '` |
| `lineCount` | 2225 | 2225 | `wc -l` (already correct) |
| `definitionCount` | 6 | 6 | canonical regex (already correct) |
| `axiomCount` | 0 | 0 | (already correct) |

### Why sorries=10 (raw `\bsorry\b`)

The file has **1 code sorry** at line 1078 (`hgcdMatrix_row_output_le · sorry`) plus **9 docstring/comment mentions** (lines 36, 1275, 1787, 1850, 1852, 2099, 2172, 2206, 2208). Recent mechanic precedent uses the raw `\bsorry\b` regex regardless of comment vs code context:
- #20039 (sum-of-divisors-oq-02: 3 → 5, raw `\bsorry\b` rationale in PR body)
- #19934 / #19840 / #19885 canonical-regex-refinement batch

### Why theoremCount=65 (canonical w/ modifiers)

The canonical regex catches `^(protected |private |noncomputable )` modifiers in addition to bare `theorem`/`lemma`. This file has 2 `private theorem ...` declarations (lines 150 `hgcdMatrix_succ` and 166 `hgcdMatrix_zero`) that the narrow `^(theorem|lemma) ` regex misses. 63 (narrow) + 2 (private) = 65 (canonical).

### Scope

Single-slug fix — `BinaryGcdOQ03OQ02.lean` is referenced only by this slug's `meta.proofRepoPath`. No sibling `leanFiles[]` entries reference it, so no batch sibling sync needed. (binary-gcd-oq-03 has separate `definitionCount` 14→13 drift on `BinaryGcdOQ03.lean` — left for a separate PR per one-fix-per-PR scope discipline.)

---
Automated fix by lean-mechanic agent.