### PR TITLE
fix(meta): batch sync Erdos1007OQ01.lean leanFiles in 15 erdos siblings (lineCount 1338→1337, theoremCount 63→89)

### DIFF
--- a/src/data/research/problems/erdos-1-oq-01.json
+++ b/src/data/research/problems/erdos-1-oq-01.json
@@ -715,8 +715,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-03.json
+++ b/src/data/research/problems/erdos-1-oq-03.json
@@ -738,8 +738,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1-oq-04.json
+++ b/src/data/research/problems/erdos-1-oq-04.json
@@ -725,8 +725,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10-oq-01.json
+++ b/src/data/research/problems/erdos-10-oq-01.json
@@ -503,8 +503,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-10.json
+++ b/src/data/research/problems/erdos-10.json
@@ -486,8 +486,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-01.json
+++ b/src/data/research/problems/erdos-100-oq-01.json
@@ -275,8 +275,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-100-oq-02-oq-02.json
@@ -350,8 +350,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-02.json
+++ b/src/data/research/problems/erdos-100-oq-02.json
@@ -341,8 +341,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100-oq-04.json
+++ b/src/data/research/problems/erdos-100-oq-04.json
@@ -339,8 +339,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-100.json
+++ b/src/data/research/problems/erdos-100.json
@@ -381,8 +381,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1007-oq-01-oq-01.json
+++ b/src/data/research/problems/erdos-1007-oq-01-oq-01.json
@@ -98,8 +98,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1007-oq-01.json
+++ b/src/data/research/problems/erdos-1007-oq-01.json
@@ -69,8 +69,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1007-oq-02.json
+++ b/src/data/research/problems/erdos-1007-oq-02.json
@@ -57,8 +57,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,

--- a/src/data/research/problems/erdos-1007-oq-05.json
+++ b/src/data/research/problems/erdos-1007-oq-05.json
@@ -75,8 +75,8 @@
     {
       "path": "Proofs/Erdos1007OQ01.lean",
       "filename": "Erdos1007OQ01.lean",
-      "lineCount": 1338,
-      "theoremCount": 63,
+      "lineCount": 1337,
+      "theoremCount": 89,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch-sync `leanFiles[i]` entries for `Erdos1007OQ01.lean` across 15 erdos-family slugs to match canonical metrics from the Lean source.

## Evidence

**Source-of-truth metrics** (`proofs/Proofs/Erdos1007OQ01.lean`):
- `wc -l` → 1337
- `grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` → 89
- `grep -cE '^(protected |private |noncomputable )*def '` → 13 (unchanged)
- raw `\bsorry\b` → 0 (unchanged)
- `grep -cE '^axiom '` → 0 (unchanged)

**Before** (in all 15 slugs): `lineCount: 1338, theoremCount: 63`
**After** (in all 15 slugs): `lineCount: 1337, theoremCount: 89`

The theoremCount drift (+26) reflects the now-canonical broader regex that catches `private`/`protected`/`noncomputable` lemma forms (per recent mechanic precedent: #19934, #19840, #19885, #19983).

## Slugs touched (15)

- `erdos-1-oq-01`, `erdos-1-oq-02`, `erdos-1-oq-03`, `erdos-1-oq-04`
- `erdos-10`, `erdos-10-oq-01`
- `erdos-100`, `erdos-100-oq-01`, `erdos-100-oq-02`, `erdos-100-oq-02-oq-02`, `erdos-100-oq-04`
- `erdos-1007-oq-01`, `erdos-1007-oq-01-oq-01`, `erdos-1007-oq-02`, `erdos-1007-oq-05`

Each file: 2 insertions, 2 deletions — only the two drifted fields.

---
Automated fix by lean-mechanic agent.