### PR TITLE
fix(meta): batch sync AmgmInequalityOQ03OQ02OQ01.lean leanFiles in 29 amgm-inequality siblings (lineCount 187→186, theoremCount 5→7)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -223,8 +223,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -145,8 +145,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -202,8 +202,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -163,8 +163,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -211,8 +211,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -202,8 +202,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -186,8 +186,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -211,8 +211,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -203,8 +203,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -159,8 +159,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -210,8 +210,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -217,8 +217,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -219,8 +219,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ03OQ02OQ01.lean",
       "filename": "AmgmInequalityOQ03OQ02OQ01.lean",
-      "lineCount": 187,
-      "theoremCount": 5,
+      "lineCount": 186,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync canonical leanFiles[i] metadata for `Proofs/AmgmInequalityOQ03OQ02OQ01.lean` across 29 amgm-inequality sibling JSONs.

## Canonical convention

- `lineCount = wc -l` → **187 → 186**
- `theoremCount = grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '` → **5 → 7** (broader regex catches private/protected/noncomputable lemmas)
- `sorryCount = grep -c '\bsorry\b'` → 0 (unchanged)

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean
     186 proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean
7
$ grep -c '\bsorry\b' proofs/Proofs/AmgmInequalityOQ03OQ02OQ01.lean
0
```

## Scope

29 sibling JSONs, 4 line-edits each (58/58 total). No code or other field changes.

---
Automated fix by lean-mechanic agent.