### PR TITLE
research(erdos-107-incomplete-01): S3 STATE-SYNC — flip NEW/active/ACT → COMPLETED to match registry + Lean (doc-only)

### DIFF
--- a/src/data/research/problems/erdos-107-incomplete-01.json
+++ b/src/data/research/problems/erdos-107-incomplete-01.json
@@ -1,12 +1,12 @@
 {
   "slug": "erdos-107-incomplete-01",
   "title": "Complete proof of Erdos Problem #107: The Happy Ending Problem",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
+    "formal": "Let f(n) be minimal such that any f(n) points in R^2, no three collinear, contain n points forming a convex n-gon. Conjecture: f(n) = 2^{n-2} + 1 (Erdos-Szekeres, OPEN).",
     "plain": "Formal mathematical investigation: Complete proof of Erdos Problem #107: The Happy Ending Problem.",
     "whyMatters": []
   },
@@ -16,72 +16,55 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-03-28T20:57:10.257Z",
-    "iteration": 2,
-    "focus": "Prove upper bound f(4)<=5 to complete f_four_eq",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
-    "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
-    }
+    "phase": "COMPLETED",
+    "since": "2026-05-17T05:50:00Z",
+    "iteration": 3,
+    "focus": "Slug graduated: Lean file is 0 sorries, 6 axioms (deep combinatorial bounds), 12 theorems, 6 definitions. Gallery meta.json fully aligned. Main conjecture HappyEndingConjecture remains as Prop (correctly open). Registry has had this slug at phase=COMPLETED/status=graduated since 2026-03-28T22:27:17.977Z; pool and research JSON now synced to match."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: cardSet_four_lower_bound proved (f(4)>=5). 0 sorries. 6 axioms (all deep). Lower bound for f_four_eq is now independently proved.",
+    "progressSummary": "COMPLETED: 0 sorries, 6 axioms (all deep external bounds: f(4)=5 Klein 1931, f(5)=9 Makai-Turan, ersz_lower_bound 2^{n-2}+1, ersz_upper_bound C(2n-4,n-2)+1, suk_bound 2^{(1+o(1))n}, hmpt_bound 2^{n+O(sqrt(n log n))}). 12 theorems proved including f_finite (from ersz_lower_bound), f_3_value (f(3)=3 via convexHull/affineSpan), f_4_lb / f_4_ub, f_5_lb / f_5_ub, ersz_bounds, plus 4 structural lemmas. Main conjecture stated as Prop (correctly OPEN — $500 Erdos prize).",
     "builtItems": [
-      "Proved cardSet_three_lower_bound in Erdos107Problem.lean:170-206",
-      "Proved InGeneralPosition.mono in Erdos107Problem.lean:165-167",
-      "Proved CardSet.mono in Erdos107Problem.lean:172-178",
-      "Proved f_4_lb (4 < f 4) from f_four_eq axiom",
-      "Proved f_4_ub (f 4 ≤ 5) from f_four_eq axiom",
-      "Proved f_3_value : f 3 = 3 in Erdos107Problem.lean:230-256",
-      "not_collinear_of_cross lemma in Erdos107Problem.lean:282-319",
-      "four_points_gp_no_quad lemma in Erdos107Problem.lean:327-422",
-      "cardSet_four_lower_bound lemma in Erdos107Problem.lean:429-497"
+      "InGeneralPosition (def): no three collinear via Mathlib's Collinear",
+      "IsConvexNGon (def): |S|=n with every point an extreme point of convexHull",
+      "HasConvexNGon (def): exists S' subset of S with IsConvexNGon n S'",
+      "CardSet (def): threshold set { m | every general-position S with |S|=m has a convex n-gon }",
+      "f (noncomputable def): sInf (CardSet n)",
+      "HappyEndingConjecture (def, Prop): forall n>=3, f n = 2^(n-2)+1",
+      "f_finite: (CardSet n).Nonempty for n>=3, proved by contradiction from ersz_lower_bound",
+      "HasConvexNGon.card_le: structural lemma on cardinality of guaranteed n-gon witnesses",
+      "not_hasConvexNGon_of_card_lt: contrapositive form for case analysis",
+      "InGeneralPosition.mono: hereditary property — subsets of GP sets are GP",
+      "CardSet.mono: upward closure via Finset.exists_smaller_set",
+      "cardSet_three_lower_bound: forall m in CardSet 3, 3 <= m (interval_cases + triangle+collinear-witness)",
+      "f_3_value: f(3) = 3, proved via convexHull_subset_affineSpan + collinear_insert_of_mem_affineSpan_pair + InGeneralPosition contradiction",
+      "f_4_lb: 4 < f(4), follows from f_four_eq axiom",
+      "f_4_ub: f(4) <= 5, follows from f_four_eq axiom",
+      "f_5_lb: 8 < f(5), follows from f_five_eq axiom",
+      "f_5_ub: f(5) <= 9, follows from f_five_eq axiom",
+      "ersz_bounds: combined lower+upper bound corollary for general n",
+      "Companion Aristotle file (Erdos107Aristotle.lean): cardSet_three_lower_bound, f_3_lb, hasConvexNGon_three_card_ge, no_convex_ngon_of_lt"
     ],
     "insights": [
-      "5 sorries: f_three_eq (duplicate of f_3_value), f_finite, f_3_value, f_4_lb, f_4_ub",
-      "6 axioms: f_four_eq, f_five_eq, ersz_lower_bound, ersz_upper_bound, suk_bound, hmpt_bound",
-      "f_three_eq and f_3_value are DUPLICATES — both claim f(3) = 3",
-      "f(3) = 3 is trivial (3 non-collinear points form a triangle) but needs convexHull machinery",
-      "If f_4_lb (4 < f(4)) and f_4_ub (f(4) ≤ 5) are proved, axiom f_four_eq becomes redundant",
-      "All proofs require EuclideanSpace, Collinear, convexHull — heavyweight Mathlib objects",
-      "The definition of InGeneralPosition uses negation of Collinear on 3-element subsets",
-      "CardSet n is the set of N guaranteeing convex n-gons — f(n) = sInf of this set",
-      "f(3) proof approach: any 3 non-collinear points are automatically in convex position",
-      "f_4_lb proof: exhibit 4 points (triangle + interior point) with no convex quadrilateral",
-      "f_4_ub (Klein): case analysis on convex hull of 5 points (triangle or quad/pent cases)",
-      "All 5 sorries require geometric reasoning about convex hulls in EuclideanSpace ℝ (Fin 2)",
-      "Mathlib convexHull API is abstract — computing with concrete point configurations is very hard",
-      "f(3)=3 could be proved but requires showing non-collinear points are extreme points of their convex hull",
-      "f_finite requires full Ramsey-theoretic argument (Erdős-Szekeres 1935)",
-      "cardSet_three_lower_bound PROVED: interval_cases m < 3 with witness construction",
-      "InGeneralPosition.mono PROVED: hereditary property for subsets",
-      "CardSet.mono PROVED: threshold set is upward-closed via Finset.exists_smaller_set",
-      "For f_3_value, key missing piece: Collinear definition in Mathlib4",
-      "convexHull_subset_affineSpan available - chain to Collinear is sole gap for f_3_value",
-      "Docker unavailable for build verification - proof needs compilation check",
-      "f_4_lb and f_4_ub are trivial consequences of f_four_eq axiom; 2 sorries eliminated",
-      "f_3_value PROVED: f(3)=3 via convexHull_subset_affineSpan + collinear_insert_of_mem_affineSpan_pair + InGeneralPosition contradiction",
-      "Proof avoids decomposing pts into named elements - uses Finset.card_eq_two to extract q,r abstractly",
-      "Only 1 sorry remains: f_finite (Erdős-Szekeres existence, deep Ramsey-theoretic argument)",
-      "cardSet_four_lower_bound: f(4)>=5 proved via triangle+interior-point counterexample for m=4 case",
-      "not_collinear_of_cross: general non-collinearity lemma using cross product and collinear_iff_exists_forall_eq_smul_vadd",
-      "Convex hull membership via 2-step convex combination: (1/3)A + (2/3)((1/2)B + (1/2)C) = (2,2)"
+      "All 5 sorries originally listed (f_three_eq, f_finite, f_3_value, f_4_lb, f_4_ub) are discharged in current Lean (0 sorries remaining)",
+      "6 axioms encode established bounds from the literature: f(4)=5, f(5)=9, ersz_lower_bound, ersz_upper_bound, suk_bound, hmpt_bound — all OUTSIDE the slug's research scope (deep Mathlib/external results)",
+      "Slug status is 'axiomatized' per gallery meta.json (not 'verified') because the 6 axioms encode external math, not sorry-discharge debt",
+      "Main conjecture HappyEndingConjecture is correctly stated as a Prop (not asserted as theorem) to reflect its OPEN status — $500 Erdos prize unclaimed",
+      "f(3)=3 proof avoids decomposing pts into named elements; uses Finset.card_eq_two to extract q,r abstractly, then convexHull_subset_affineSpan + InGeneralPosition contradiction",
+      "f_4_lb / f_4_ub / f_5_lb / f_5_ub all follow trivially from the small-case axioms f_four_eq, f_five_eq (Klein 1931, Makai-Turan)",
+      "f_finite proof: contradiction from ersz_lower_bound n hn — if CardSet n is empty then sInf = 0, but 2^(n-2)+1 <= 0 is false for n>=3",
+      "InGeneralPosition.mono + CardSet.mono together capture the two basic monotonicity properties needed for any Ramsey-style threshold function",
+      "Suk bound formalized using Filter.atTop for the o(1) asymptotic term (Lean 4 idiom for 'exists N, forall n >= N, ...')",
+      "HMPT bound uses existential constant C for the O(sqrt(n log n)) error term",
+      "Gallery meta.json fully aligned with Lean file: 255 lines, 0 sorries, 6 axioms, 12 theorems, 6 definitions, mathlib 4.26.0",
+      "Companion Aristotle file exposes only provable supporting lemmas (cardSet_three_lower_bound, f_3_lb, hasConvexNGon_three_card_ge, no_convex_ngon_of_lt) per SORRY-CLASSIFICATION.md template",
+      "Research registry.json has slug at phase=COMPLETED status=graduated since 2026-03-28T22:27:17.977Z; pool flip + JSON phase flip captures this in pool + per-slug ledger"
     ],
     "mathlibGaps": [
-      "Need Collinear for EuclideanSpace ℝ (Fin 2) — should be in Mathlib.Analysis.InnerProductSpace",
-      "convexHull ℝ for finite point sets in ℝ² — in Mathlib but proof-heavy to work with",
-      "No existing formalization of Erdős-Szekeres theorem in Mathlib"
+      "Mathlib lacks a formalized Erdős-Szekeres theorem proving f_finite directly (current proof uses ersz_lower_bound axiom)",
+      "Mathlib lacks formalized Suk 2017 / HMPT 2020 bounds (axiomatized here)",
+      "Working with convexHull of concrete finite point sets in EuclideanSpace ℝ (Fin 2) remains heavy — proof-development friction even for f(3)=3"
     ],
-    "nextSteps": [
-      "Prove f_3_value : f 3 = 3 (remove duplicate f_three_eq)",
-      "Prove f_4_lb : 4 < f 4 by exhibiting counterexample (triangle + interior point)",
-      "Prove f_4_ub : f 4 ≤ 5 (Klein 1931 — case analysis on convex hull)",
-      "If f_4_lb + f_4_ub proved, convert f_four_eq from axiom to theorem"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "erdos",
@@ -101,7 +84,8 @@
     "mathlib": []
   },
   "started": "2026-03-28T20:57:10.257Z",
-  "lastUpdate": "2026-03-29T18:50:00.000Z",
+  "lastUpdate": "2026-05-17T05:50:00Z",
+  "completed": "2026-05-17T05:50:00Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

Long-completed slug doc-only STATE-SYNC: research JSON for `erdos-107-incomplete-01` (the Happy Ending Problem) was stuck at `phase=NEW`, `status=active`, `currentState.phase=ACT`, `iteration=2`, `attemptCounts.total=0`, `lastUpdate=2026-03-29T18:50` while:

- `research/registry.json` has the slug at `phase=COMPLETED`, `status=graduated`, `completed=2026-03-28T22:27:17.977Z` (T-49d)
- `proofs/Proofs/Erdos107Problem.lean` is fully fleshed: 255 lines, **0 sorries**, 6 axioms (all deep external bounds: Klein 1931 f(4)=5, Makai-Turan f(5)=9, ES lower 2^{n-2}+1, ES upper C(2n-4,n-2)+1, Suk 2017 2^{(1+o(1))n}, HMPT 2020 2^{n+O(√(n log n))}), 12 theorems, 6 definitions
- `src/data/proofs/erdos-107/meta.json` fully aligned with Lean: `status=axiomatized`, `badge=axiom`, `sorries=0`, `axiomCount=6`, `theoremCount=12`, `definitionCount=6`, `lineCount=255`, `mathlib_version=4.26.0`

The May 4-5 batch research wave (PRs #15825, #15841, #15861, #15865, #15844, #15994, #15850, #15860) discharged the remaining sorries but did not flip the research JSON or pool — drift accumulated. This is the catchup ledger update.

## Changes (1 file, +46/-62 net)

| Field | Before | After |
|---|---|---|
| `phase` | `NEW` | `COMPLETED` |
| `status` | `active` | `completed` |
| `currentState.phase` | `ACT` | `COMPLETED` |
| `currentState.since` | `2026-03-28T20:57:10.257Z` | `2026-05-17T05:50:00Z` |
| `currentState.iteration` | `2` | `3` (S3 STATE-SYNC) |
| `currentState.attemptCounts` | `{total:0,...}` | (dropped, matches completed template) |
| `currentState.blockers` | `[]` | (dropped) |
| `currentState.nextAction` | "Begin problem exploration." | (dropped) |
| `currentState.focus` | "Prove upper bound f(4)<=5..." | Graduation summary |
| `knowledge.progressSummary` | "PROGRESS: cardSet_four_lower_bound proved..." | "COMPLETED: 0 sorries, 6 axioms..." |
| `knowledge.builtItems` | 9 entries | 19 entries (all 12 theorems + 6 defs + companion) |
| `knowledge.insights` | 26 stale ("Only 1 sorry remains: f_finite") | 13 accurate |
| `knowledge.mathlibGaps` | 3 (stale: "Need Collinear...") | 3 (current: missing ES/Suk/HMPT theorems, convexHull friction) |
| `knowledge.nextSteps` | 4 entries (all done) | `[]` |
| `lastUpdate` | `2026-03-29T18:50:00.000Z` | `2026-05-17T05:50:00Z` |
| `completed` | (absent) | `2026-05-17T05:50:00Z` (NEW field, mirrors registry pattern) |

## Why ship now

- Pool currently lists slug as `status: in-progress`, blocking other researchers from understanding it is graduated.
- Research JSON is the canonical per-slug ledger; persistent NEW/active state misrepresents the slug to downstream consumers (Aristotle queue, seeker, herald).
- 14+ drift surfaces in a single file is well above the empirical threshold for ship-vs-release.

## Companion follow-up (non-PR)

After merge, pool flip via `./scripts/research/claim-problem.sh update erdos-107-incomplete-01 completed` to align `.lean/state/candidate-pool.json`. The script's quality gate (non-empty `progressSummary`, `insights+builtItems >= 3`) is satisfied (19 builtItems + 13 insights = 32 >> 3).

## Status field correctness

Slug status `axiomatized` (not `verified`) is the right designation: the 6 axioms encode external math bounds from the literature, not internal sorry-discharge debt. Main conjecture `HappyEndingConjecture` remains as `Prop` (correctly OPEN — $500 Erdős prize unclaimed). Per the project's Axiom Integrity Policy, this is the correct framing for an open conjecture with established partial results.

## Test plan

- [x] JSON syntactically valid (`jq . src/data/research/problems/erdos-107-incomplete-01.json`)
- [x] Lean file unchanged (no build needed — doc-only)
- [x] Gallery meta.json unchanged (already aligned)
- [x] No state.md or sessions/ directories created (none existed for this slug; minimal-scope STATE-SYNC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)