### PR TITLE
research(erdos-1153): S2 STATE-SYNC — long-completed slug + research-JSON / pool drift catchup (doc-only)

### DIFF
--- a/research/problems/erdos-1153/knowledge.md
+++ b/research/problems/erdos-1153/knowledge.md
@@ -2,18 +2,53 @@
 
 ## Problem Statement
 
-Problem statement not found
+**Erdős Problem #1153** (Vaughan's survey [Va99, 2.44]):
+
+For nodes $x_1, \ldots, x_n \in [-1, 1]$, let
+$$l_k(x) = \prod_{i \neq k} \frac{x - x_i}{x_k - x_i}$$
+be the Lagrange basis polynomials, and
+$$\lambda(x) = \sum_k |l_k(x)|$$
+the Lebesgue function. Is it true that for any fixed $-1 \leq a < b \leq 1$,
+$$\max_{x \in [a,b]} \lambda(x) > \left(\frac{2}{\pi} - o(1)\right) \log n?$$
+
+**Status**: Proved (yes).
+
+The sharp constant $2/\pi$ was established by Erdős (1961), sharpening
+Bernstein's earlier (1931) logarithmic lower bound. Chebyshev polynomial
+roots achieve this constant: $\Lambda_n \leq (2/\pi + o(1)) \log n$, making
+them optimal interpolation nodes.
 
 ## Status
 
-**Erdős Database Status**: OPEN
+**Erdős Database Status**: SOLVED (1961, by Erdős)
+
+**Formalization Status**: AXIOMATIZED in
+`proofs/Proofs/Erdos1153Problem.lean`. The main asymptotic lower bound
+`erdos_1153` is stated as an axiom (classical complex/approximation
+analysis content beyond current Mathlib coverage). The full-interval
+corollary `erdos_1153_full_interval` is derived from the axiom by
+instantiation. Structural Lagrange / Lebesgue identities are fully proved
+machine-checked.
 
 **Tractability Score**: 6/10
-**Aristotle Suitable**: No
+**Aristotle Suitable**: No (definitions and structural lemmas already
+proved; remaining axiom is the substantive open content)
 
 ## Tags
 
 - erdos
+- analysis
+- polynomials
+- interpolation
+- approximation-theory
+- solved
+
+## Gallery Integration
+
+- `src/data/proofs/erdos-1153/` (meta.json, annotations.json, index.ts)
+- `proofs/Proofs/Erdos1153Problem.lean` — 169 LOC, 4 defs, 6 theorems,
+  1 axiom, 0 sorries, namespace `Erdos1153`
+- Mathlib pin: `v4.26.0` (commit `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
 
 ## Related Problems
 
@@ -24,14 +59,28 @@ Problem statement not found
 - Problem #39
 - Problem #1
 
+Related gallery slugs (per `crossReferences` in `meta.json`):
+
+- `erdos-1129` — related Erdős problem on interpolation and Lebesgue
+  constants
+- `erdos-1132` — related Erdős problem on polynomial interpolation
+
 ## References
 
-- (None available)
+- Bernstein (1931): "On the distribution of zeros of Lagrange interpolation
+  polynomials"
+- Erdős (1961): "Problems and results on the theory of interpolation, II"
+  [Er61c]
+- Vaughan [Va99, 2.44]: Survey of Erdős problems in analysis
+- https://erdosproblems.com/1153
 
 ## Sessions
 
-(No research sessions yet)
+| Session | Date | Phase | Type | PR |
+|---------|------|-------|------|----|
+| S1 (stub) | 2026-01-15 | NEW | scaffold | — (auto-generated stub) |
+| S2 | 2026-05-17 | COMPLETED | STATE-SYNC (this PR) | research/erdos-1153-s2-statesync-completed-drift-catchup |
 
 ---
 
-*Generated from erdosproblems.com on 2026-01-15*
+*Generated from erdosproblems.com on 2026-01-15; S2 STATE-SYNC catchup 2026-05-17 by researcher-10.*

--- a/research/problems/erdos-1153/problem.md
+++ b/research/problems/erdos-1153/problem.md
@@ -3,11 +3,21 @@
 ## Statement
 
 ### Plain Language
-Problem statement not found
+
+For any subinterval $[a, b]$ of $[-1, 1]$ and any $n$ distinct interpolation
+nodes in $[-1, 1]$, the maximum on $[a, b]$ of the Lebesgue function
+$\lambda(x) = \sum_k |l_k(x)|$ (where $l_k$ are the Lagrange basis
+polynomials) exceeds $(2/\pi - o(1)) \log n$. The constant $2/\pi$ is
+sharp, achieved asymptotically by Chebyshev polynomial roots.
 
 ### Formal Statement
+
 $$
-(LaTeX not available)
+\forall \varepsilon > 0,\ \forall -1 \leq a < b \leq 1,\
+\exists N \in \mathbb{N},\ \forall n \geq N,\
+\forall (x_k)_{k=1}^n \subset [-1,1] \text{ distinct},\
+\exists x \in [a, b]:\
+\lambda(x) \geq \left(\tfrac{2}{\pi} - \varepsilon\right) \log n.
 $$
 
 ## Classification
@@ -21,22 +31,49 @@ erdosUrl: https://erdosproblems.com/1153
 
 tags:
   - erdos
+  - analysis
+  - polynomials
+  - interpolation
+  - approximation-theory
+  - solved
 ```
 
 **Significance**: 7/10
 **Tractability**: 6/10
+**Database status**: SOLVED (Erdős 1961, sharpening Bernstein 1931)
 
 ## Why This Matters
 
-1. **Erdős Legacy** - Part of Paul Erdős's influential problem collection
-2. **Mathematical significance** - open problem; short statement
+1. **Erdős Legacy** — Part of Paul Erdős's influential problem collection
+   on approximation theory and polynomial interpolation.
+2. **Fundamental barrier** — Demonstrates a universal logarithmic lower
+   bound for the condition number of Lagrange interpolation, independent
+   of node placement strategy.
+3. **Chebyshev optimality** — The sharp constant $2/\pi$ is achieved by
+   Chebyshev polynomial roots, providing a concrete optimal node family.
+4. **Subinterval universality** — The growth cannot be avoided even on
+   small subintervals; the phenomenon is locally intrinsic.
 
+## Formalization Status
+
+Already formalized in `proofs/Proofs/Erdos1153Problem.lean`:
+
+- 4 definitions: `lagrangeBasis`, `lebesgueFunction`, `NodesInInterval`,
+  `DistinctNodes`
+- 6 theorems (Kronecker delta, nonnegativity, value at nodes, full-interval
+  corollary)
+- 1 axiom: `erdos_1153` — the asymptotic logarithmic lower bound
+- 0 sorries
+
+Gallery entry: `src/data/proofs/erdos-1153/` (status `axiomatized`,
+badge `axiom`).
 
 ## Related Gallery Proofs
 
 | Proof | Relevance |
 |-------|-----------|
-| --- | --- |
+| `erdos-1129` | Related Erdős problem on interpolation and Lebesgue constants |
+| `erdos-1132` | Related Erdős problem on polynomial interpolation |
 
 ## Related Problems
 
@@ -49,7 +86,11 @@ tags:
 
 ## References
 
-(No references available)
+- Bernstein, S. (1931): "On the distribution of zeros of Lagrange
+  interpolation polynomials" — original logarithmic lower bound.
+- Erdős, P. (1961): "Problems and results on the theory of interpolation,
+  II" [Er61c] — sharp $2/\pi$ constant.
+- Vaughan [Va99, 2.44]: Survey of Erdős problems in analysis.
 
 ## OEIS Sequences
 

--- a/research/problems/erdos-1153/sessions/session-2-statesync-completed-drift-catchup.md
+++ b/research/problems/erdos-1153/sessions/session-2-statesync-completed-drift-catchup.md
@@ -1,0 +1,319 @@
+# erdos-1153 — Session 2 (STATE-SYNC, COMPLETED drift catchup)
+
+**Researcher**: researcher-10
+**Date**: 2026-05-17T05:44Z (claim) → 2026-05-17T06:10Z (PR)
+**Phase**: COMPLETED (registry was already, research-local state.md still NEW)
+**Type**: doc-only STATE-SYNC
+**Branch**: `research/erdos-1153-s2-statesync-completed-drift-catchup`
+**Base**: `main @ d4cacd5d3b6` (Keep herald scanner help dependency-light, #20060)
+**Mathlib pin**: `v4.26.0` (commit `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+## §0. TL;DR
+
+The gallery proof `proofs/Proofs/Erdos1153Problem.lean` was authored long
+before this session (gallery integration ≥ 2026-03-27 per PR #7112). The
+`research/registry.json` entry flipped to `phase: COMPLETED`, `status:
+graduated` on 2026-03-26. But three layers of research-side metadata
+never caught up:
+
+1. `research/problems/erdos-1153/state.md` still said `Phase: NEW`,
+   `Iteration: 1`, "Initial exploration of the problem."
+2. `research/problems/erdos-1153/problem.md` and
+   `research/problems/erdos-1153/knowledge.md` still said "Problem
+   statement not found" (auto-stub from the 2026-01-15 scrape).
+3. `.lean/state/candidate-pool.json` had this slug as `"status":
+   "in-progress"` with notes still echoing the NEW-phase stub.
+
+Additionally, the gallery `meta.json` itself had prose-vs-structure drift:
+
+4. `conclusion.summary` claimed "160 lines of Lean 4 code with 2 axioms",
+   but the actual Lean file is 169 lines with 1 axiom.
+5. `originalContributions` listed `chebyshev_lebesgue_upper`, which does
+   not exist as a Lean declaration in the file (only as an inline comment).
+6. `proofStrategy` claimed "Tightness via Chebyshev nodes is stated as a
+   matching upper bound axiom" — no such axiom exists.
+7. `sections[*].endLine` boundaries were off by 2–9 lines each.
+
+This PR ships a doc-only catchup that synchronizes all of the above with
+the actual Lean file. No Lean code changes. After merge, the pool will
+be flipped `in-progress → completed` via
+`scripts/research/claim-problem.sh update completed`.
+
+## §1. Claim and discovery
+
+```
+claim-random output:
+  Selected erdos-1153 (1283 available, tier: MODERATE+ (depth-first), 458 in tier)
+  Claimed erdos-1153 by researcher-79165
+  Knowledge score: 14 (MODERATE)
+  Expires: 2026-05-17T07:14:01Z
+```
+
+Pre-claim recency probes (per memory rule
+`_hot_moderate_plus_slug_parallel_collision_duplicate_state_sync_ships`):
+
+- `gh pr list --search 'erdos-1153 in:title' --state open` → `[]`
+  (no open PR for this slug)
+- `gh pr list --search 'erdos-1153 in:title' --state closed --limit 10`
+  → 5 historical PRs, most recent `#18850` (mechanic-only, 2026-05-13,
+  index.ts annotation wiring) — 4 days ago.
+
+No same-iteration race. Safe to proceed.
+
+## §2. Audit — drift surfaces
+
+### §2.1 Research-local stubs (3 files)
+
+```
+research/problems/erdos-1153/
+├── state.md      — Phase: NEW, Iteration: 1
+├── problem.md    — "Problem statement not found"
+└── knowledge.md  — "Problem statement not found"
+```
+
+These three files are the 2026-01-15 auto-stub from `erdosproblems.com`
+scraping where the scraped HTML didn't yield a parseable statement. They
+were never edited.
+
+### §2.2 Registry vs research-local
+
+```json
+// research/registry.json (problems[slug=erdos-1153])
+{
+  "slug": "erdos-1153",
+  "phase": "COMPLETED",
+  "path": "full",
+  "started": "2026-01-15T16:46:42.683Z",
+  "status": "graduated",
+  "lastUpdate": "2026-03-26T23:43:21.713Z",
+  "completed": "2026-03-26T23:43:21.712Z"
+}
+```
+
+Registry has been `COMPLETED + graduated` for ~52 days, but
+research-local state.md continues to assert NEW phase, iteration 1.
+
+### §2.3 Pool vs registry
+
+```json
+// .lean/state/candidate-pool.json (candidates[id=erdos-1153])
+{
+  "id": "erdos-1153",
+  "name": "Erdős #1153",
+  "tier": "A",
+  "significance": 7,
+  "tractability": 6,
+  "status": "in-progress",
+  "notes": "IN-PROGRESS: Problem statement not found | Focus: Initial exploration of the problem. | Stats: 8 items built",
+  "tags": ["erdos"]
+}
+```
+
+Pool says `in-progress` and the notes prose echoes the stale stub state.md.
+This is why `claim-random` even selected this slug (otherwise it would be
+excluded from the eligible pool).
+
+This will be flipped post-merge via
+`scripts/research/claim-problem.sh update completed` — that's the only
+write path that recomputes the notes consistently.
+
+### §2.4 Lean file ↔ meta.json structure (already aligned)
+
+```
+$ wc -l proofs/Proofs/Erdos1153Problem.lean
+    169
+$ grep -c "^axiom " proofs/Proofs/Erdos1153Problem.lean
+    1
+$ grep -cE "^(theorem|lemma) " proofs/Proofs/Erdos1153Problem.lean
+    6
+$ grep -cE "^(def|noncomputable def) " proofs/Proofs/Erdos1153Problem.lean
+    4
+$ grep -c '\bsorry\b' proofs/Proofs/Erdos1153Problem.lean
+    0
+```
+
+meta.json structured fields match:
+
+- `meta.lineCount: 169` ✓
+- `meta.axiomCount: 1` ✓
+- `meta.theoremCount: 6` ✓
+- `meta.definitionCount: 4` ✓
+- `meta.sorries: 0` ✓
+- `leanFile.{lineCount, axiomCount, theoremCount, definitionCount,
+  sorries}: matching` ✓
+- `meta.assumptions: "1 axiom: erdos_1153 ..."` ✓
+
+So structured numerics are clean. Drift is only in prose / contribution
+lists / section boundaries.
+
+### §2.5 Lean file ↔ meta.json prose (drifted)
+
+| Field | Stated | Actual |
+|-------|--------|--------|
+| `conclusion.summary` line count | 160 | 169 |
+| `conclusion.summary` axiom count | 2 | 1 |
+| `conclusion.summary` "Chebyshev tightness are axiomatized" | yes | no — only inline comment |
+| `overview.proofStrategy` "matching upper bound axiom" | yes | no — only inline comment |
+| `meta.originalContributions[11]` | `chebyshev_lebesgue_upper` | not a declaration in the file |
+| `sections[0]` (header-imports) endLine | 41 | 46 (set_options at 41-42, namespace at 44, open Finset at 46) |
+| `sections[1]` (definitions) startLine | 42 | 48 (`## Definitions` header) |
+| `sections[1]` (definitions) endLine | 68 | 70 (DistinctNodes body ends at 70) |
+| `sections[2]` (lagrange-properties) startLine | 69 | 72 (Section 1 header) |
+| `sections[2]` (lagrange-properties) endLine | 93 | 96 (lagrangeBasis_self body ends at 96) |
+| `sections[3]` (lebesgue-properties) startLine | 94 | 98 (Section 2 header) |
+| `sections[3]` (lebesgue-properties) endLine | 126 | 133 (lebesgueFunction_at_node_eq body ends at 133) |
+| `sections[4]` (main-result) startLine | 127 | 135 (Section 3 header) |
+| `sections[4]` (main-result) endLine | 160 | 169 (end Erdos1153 at 169) |
+| `sections[4]` summary "Chebyshev upper bound as axioms" | yes | no |
+| `sections[4]` mathContext "Matching upper bound: ... (axiom)" | yes | no |
+
+### §2.6 Boundary line samples (cross-validation)
+
+```
+  41: set_option linter.unusedVariables false
+  42: set_option linter.unusedTactic false
+  44: namespace Erdos1153
+  46: open Finset
+  48: /-
+  49: ## Definitions
+  50: -/
+  68: -- Nodes are distinct (required for well-defined interpolation)
+  69: def DistinctNodes (n : ℕ) (nodes : Fin n → ℝ) : Prop :=
+  70:   Function.Injective nodes
+  72: /-
+  73: ## Section 1: Properties of Lagrange Basis Polynomials
+  ...
+  96:   exact div_self (sub_ne_zero.mpr hne)
+  98: /-
+  99: ## Section 2: Properties of the Lebesgue Function
+  100: -/
+  ...
+  133:   simp
+  135: /-
+  136: ## Section 3: The Main Result and Tightness
+  ...
+  167: -- The n-th Chebyshev polynomial roots give Lebesgue constant ≤ (2/π + ε) log n
+  168:
+  169: end Erdos1153
+```
+
+## §3. Decision matrix — doc-only STATE-SYNC chosen
+
+| Option | Cost | Risk | Outcome |
+|--------|------|------|---------|
+| A. Doc-only S2 STATE-SYNC (chosen) | ~30 min | trivial | 3 research-local files + 1 meta.json drift catchup + pool flip + sessions memo |
+| B. Lean ACT — try to prove `erdos_1153` axiom directly | unknown weeks/months | very high; classical Bernstein/Erdős proof requires complex-analysis machinery beyond current Mathlib | — |
+| C. Lean ACT — add `chebyshev_lebesgue_upper` as a stated (but axiomatized) upper bound | ~1-2 hours + Docker build under 3-RED INFRA (see §4) | medium; would expand axiom count from 1 to 2, weakening the meta.json claim | — |
+| D. Release without PR | 0 | low | leaves all 7 drift surfaces unaddressed; pool stays `in-progress` |
+
+Option A is the right call: the drift inventory is concrete and reachable
+without touching Lean, and pre-claim recency probes show no collision
+with other agents.
+
+Option C was rejected because **adding an axiom for an already-noted-as-
+comment statement is a regression in formalization status**. The comment
+at line 167 is the right form — anything beyond it should be either a
+proper formalization (option B-adjacent) or remain a comment.
+
+## §4. INFRA snapshot
+
+(From parallel session-end memos of other researchers, this session
+window ~05:00–06:00Z 2026-05-17 — not re-measured here because doc-only
+PRs are insensitive to host INFRA state.)
+
+Carry-forward from sibling sessions:
+
+- **G7 (host disk)**: RED — multiple researchers report 2–4 GiB available
+  on the system disk in the last 24h, below the 5 GiB soft-floor; the
+  `mosertardos`, `dissection-of-cubes-oq-05`, `ballot-problem-oq-03`,
+  `minkowski-theorem-oq-04`, `four-square-distribution-oq-01`, and
+  `schauder-fixed-point-oq-03-oq-01-incomplete-01` sessions today all
+  flagged this.
+- **G8 (Docker)**: RED — `docker info` reports the Docker server has been
+  hung for ≥20h+ across multiple sessions. Doc-only PRs do not require
+  `proofs/scripts/docker-build.sh`, so this does not gate the present
+  work.
+- **G9 (.lake symlink)**: RED — `proofs/.lake` is a self-cycle symlink
+  per multiple recent reports. Again, not relevant to doc-only catchup.
+
+This PR is **doc-only and INFRA-insensitive**. It would be appropriate
+to ship under any INFRA state.
+
+## §5. Files changed
+
+```
+research/problems/erdos-1153/state.md                                  (rewrite)
+research/problems/erdos-1153/problem.md                                (rewrite)
+research/problems/erdos-1153/knowledge.md                              (rewrite)
+research/problems/erdos-1153/sessions/session-2-statesync-completed-
+  drift-catchup.md                                                     (NEW, this file)
+src/data/proofs/erdos-1153/meta.json                                   (surgical)
+```
+
+`meta.json` edits — five surgical changes:
+
+1. `meta.originalContributions`: drop `"chebyshev_lebesgue_upper"`
+   (11 entries, was 12).
+2. `overview.proofStrategy`: drop "Tightness via Chebyshev nodes is
+   stated as a matching upper bound axiom"; add the corrected description
+   (instantiation derivation of `erdos_1153_full_interval` from
+   `erdos_1153`; Chebyshev tightness is comment-only).
+3. `sections[0..4]` startLine/endLine: bring to actual file boundaries.
+4. `sections[4]` summary + mathContext: drop the "matching upper bound
+   axiom" claim; describe as inline comment only.
+5. `conclusion.summary`: 160→169 lines, 2→1 axioms, and revise the
+   Chebyshev tightness claim from "axiomatized" to "comment-only".
+
+## §6. Post-merge cleanup
+
+After merge, run from any researcher worktree (or main):
+
+```bash
+cd /Users/rwalters/GitHub/lean-genius
+/Users/rwalters/GitHub/lean-genius/scripts/research/claim-problem.sh \
+  update erdos-1153 completed
+```
+
+This will rewrite the `.lean/state/candidate-pool.json` entry from
+`in-progress` to `completed` and refresh the notes prose so it stops
+echoing the stale stub state.md.
+
+The `research/claims/erdos-1153.json` claim (TTL 90 min, expires
+2026-05-17T07:14:01Z) will be released as the final step of this PR
+cycle via `claim-problem.sh release erdos-1153`.
+
+## §7. Memory writeback
+
+This session matches the pattern saved as
+`_first_claim_lands_on_long_completed_slug_with_T_18d_lean_pr_predecessor_split_with_audit_but_not_research_json_registry_drift_catchup`
+— but with these distinguishing details:
+
+- No "T-18d Lean PR predecessor split" here; instead the gallery Lean
+  file was authored ≥ 2026-03-27 (~51 days ago) via PR #7112 which only
+  touched line-count drift, not a substantive Lean ACT.
+- No "non-researcher Lean PR" predecessor with audit; just three legacy
+  enrichment PRs (#7112, #9750, #18850) plus the original NEW-stub from
+  2026-01-15.
+- No "drift below threshold = release" applies: there are 7 distinct
+  drift surfaces (3 research-local rewrites + 4 meta.json corrections +
+  pool flip) — well above any release threshold.
+
+The conclusion.summary `160 lines / 2 axioms` drift is the type of stale
+prose-vs-structure drift that survives mechanic batch passes (mechanic
+fixes the structured numeric fields but does not touch
+`conclusion.summary` prose). Future researchers claiming long-completed
+slugs should grep prose fields for round-number line counts that don't
+match `meta.lineCount` as a quick-tell.
+
+## §8. Sign-off
+
+PR: `research(erdos-1153): S2 STATE-SYNC — long-completed slug + research-
+JSON / state.md / pool drift catchup + meta.json prose-vs-structure fix
+(doc-only)`
+
+5 files changed: 4 rewritten + 1 NEW + 1 surgical meta.json. No Lean
+file changes. No new axioms. No new theorems. Mathlib pin unchanged.
+Build-pending status: N/A (doc-only). Auditor-friendly: every claim in
+this memo is grounded in a specific file/line citation above.
+
+Iteration 1 → 2. Attempt counts unchanged (1).

--- a/research/problems/erdos-1153/state.md
+++ b/research/problems/erdos-1153/state.md
@@ -1,16 +1,42 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T16:46:42.683Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-01-15T16:46:42.683Z (initial); registry COMPLETED+graduated 2026-03-26; state.md sync S2 2026-05-17
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Completed. `proofs/Proofs/Erdos1153Problem.lean` (169 lines, namespace
+`Erdos1153`) formalizes Erdős Problem #1153 (Lebesgue constants of Lagrange
+interpolation) with:
+
+- 4 definitions: `lagrangeBasis`, `lebesgueFunction`, `NodesInInterval`,
+  `DistinctNodes`
+- 6 theorems: `lagrangeBasis_other`, `lagrangeBasis_self`,
+  `lebesgueFunction_nonneg`, `lebesgueFunction_at_node`,
+  `lebesgueFunction_at_node_eq`, `erdos_1153_full_interval`
+- 1 axiom: `erdos_1153` (the asymptotic logarithmic lower bound itself,
+  attributed to Bernstein/Erdős)
+- 0 sorries
+
+Structural results proved:
+- Kronecker delta property for the Lagrange basis (`l_k(x_j) = δ_{kj}`)
+- Lebesgue function nonnegativity
+- `λ(x_k) ≥ 1` (lower bound at nodes)
+- `λ(x_k) = 1` (exact value at nodes, for distinct node sets)
+- Full-interval corollary `erdos_1153_full_interval` derived from the
+  axiomatized subinterval theorem by instantiation
+
+Tightness via Chebyshev nodes is acknowledged as a final inline comment but
+is NOT formalized as an axiom or theorem in the file.
 
 ## Active Approach
 
-None yet.
+None — work is done. The single remaining axiom is the Bernstein/Erdős
+logarithmic lower bound itself, which is the substantive content of the
+problem and would require classical complex / approximation-analysis
+machinery beyond what Mathlib currently exposes for a direct elementary
+proof.
 
 ## Blockers
 
@@ -18,10 +44,34 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+None — pool entry being flipped from `in-progress` → `completed` via
+`scripts/research/claim-problem.sh update completed` as part of this S2
+catchup. Registry was already `phase: COMPLETED, status: graduated` since
+2026-03-26.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
+
+## Iteration Ledger
+
+| Iter | Date | Phase | Type | Output |
+|------|------|-------|------|--------|
+| 1 | 2026-01-15 | NEW (stub) | scaffold | initial generated state.md / problem.md / knowledge.md from erdosproblems.com scrape (statements absent in upstream HTML) |
+| 2 | 2026-05-17 | COMPLETED | STATE-SYNC | this PR — state.md / problem.md / knowledge.md drift catchup + meta.json prose-vs-structure drift fix + pool flip |
+
+## Predecessor Lean Work (not by researcher pipeline)
+
+The proof file `proofs/Proofs/Erdos1153Problem.lean` predates this S2
+catchup. Gallery enrichment history (best-effort from `gh pr list`):
+
+| Date | PR | Title |
+|------|------|-------|
+| 2026-03-27 | #7112 | Fix: stale line counts in erdos-1084-oq-01, erdos-1153 |
+| 2026-04-05 | #9750 | Enrich erdos-1153: add 5th keyInsight, expand historicalContext, fix annotation coverage |
+| 2026-05-13 | #18850 | fix(mechanic): wire annotations into erdos-1153 index.ts |
+
+The research-side `state.md` / `problem.md` / `knowledge.md` were never
+updated to reflect that the gallery proof exists and is built. This S2 STATE-SYNC closes that gap.

--- a/src/data/proofs/erdos-1153/meta.json
+++ b/src/data/proofs/erdos-1153/meta.json
@@ -50,8 +50,7 @@
       "lebesgueFunction_at_node",
       "lebesgueFunction_at_node_eq",
       "erdos_1153",
-      "erdos_1153_full_interval",
-      "chebyshev_lebesgue_upper"
+      "erdos_1153_full_interval"
     ],
     "axiomCount": 1,
     "lineCount": 169,
@@ -63,7 +62,7 @@
     "historicalContext": "The Lebesgue constant measures the worst-case error amplification in polynomial interpolation. Sergei Bernstein (1931) proved the first quantitative lower bound: for any choice of $n$ interpolation nodes in $[-1,1]$, the maximum of the Lebesgue function $\\lambda(x) = \\sum_k |l_k(x)|$ must grow at least logarithmically in $n$. Erdős (1961) sharpened this to the tight form $\\Lambda_n > (2/\\pi) \\log n - O(1)$ for the full interval $[-1,1]$, establishing the sharp constant $2/\\pi$.\n\nThis lower bound is achieved by the roots of the Chebyshev polynomials of the first kind, $x_k = \\cos\\left(\\frac{2k-1}{2n}\\pi\\right)$, which give $\\Lambda_n < (2/\\pi) \\log n + O(1)$. The contrast with equally-spaced nodes is dramatic: for equidistant nodes, the Lebesgue constant grows exponentially ($\\Lambda_n \\sim 2^n / (e \\cdot n \\log n)$), leading to the Runge phenomenon where interpolation of smooth functions (like $f(x) = 1/(1+25x^2)$) diverges despite the function being analytic.\n\nProblem #1153 asks whether the $(2/\\pi) \\log n$ lower bound persists on arbitrary proper subintervals $[a,b] \\subsetneq [-1,1]$, which was answered affirmatively. This universality shows the logarithmic growth is a local phenomenon intrinsic to Lagrange interpolation in any interval, not a global effect.",
     "problemStatement": "**Erdős Problem #1153** ([Va99, 2.44]):\n\nFor $x_1,\\ldots,x_n \\in [-1,1]$, let $l_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$ be the Lagrange basis polynomials and $\\lambda(x) = \\sum_k |l_k(x)|$ the Lebesgue function. Is it true that for any fixed $-1 \\leq a < b \\leq 1$,\n$$\\max_{x \\in [a,b]} \\lambda(x) > \\left(\\frac{2}{\\pi} - o(1)\\right) \\log n?$$\n\n**Status**: Proved (yes).",
     "text": "For any subinterval [a,b] of [-1,1], the maximum of the Lebesgue function over any n interpolation nodes exceeds (2/π - o(1))log n. The constant 2/π is optimal, achieved by Chebyshev polynomial roots.",
-    "proofStrategy": "The formalization defines Lagrange basis polynomials as finite products and the Lebesgue function as their absolute value sum. The Kronecker delta property (lₖ(xⱼ) = δₖⱼ) is fully proved from the definitions. The main theorem is stated in asymptotic form: for any ε > 0 and subinterval, for sufficiently large n, the Lebesgue function exceeds (2/π - ε)log n. Tightness via Chebyshev nodes is stated as a matching upper bound axiom.",
+    "proofStrategy": "The formalization defines Lagrange basis polynomials as finite products and the Lebesgue function as their absolute value sum. The Kronecker delta property (lₖ(xⱼ) = δₖⱼ) is fully proved from the definitions. The main theorem is stated in asymptotic form as the single axiom `erdos_1153`: for any ε > 0 and subinterval, for sufficiently large n, the Lebesgue function exceeds (2/π - ε)log n. The full-interval corollary `erdos_1153_full_interval` is derived from the axiom by instantiation with a = -1, b = 1. Tightness via Chebyshev nodes is noted in a final inline comment only — it is not formalized as a Lean axiom or theorem.",
     "keyInsights": [
       "**Lagrange interpolation and condition number**: The Lebesgue function λ(x) measures how much interpolation can amplify errors. It bounds the ratio of interpolation error to best polynomial approximation error.",
       "**Universal logarithmic growth**: No matter how cleverly nodes are placed in [-1,1], the Lebesgue function must grow at least as (2/π)log n. This is a fundamental limitation of polynomial interpolation.",
@@ -82,44 +81,44 @@
       "id": "header-imports",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 41,
-      "summary": "Imports Mathlib.Analysis.SpecialFunctions.Log.Basic, Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic, Mathlib.Tactic. Module docstring and namespace setup."
+      "endLine": 46,
+      "summary": "Imports Mathlib.Analysis.SpecialFunctions.Log.Basic, Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic, Mathlib.Tactic. Module docstring, linter set_options, namespace Erdos1153, open Finset."
     },
     {
       "id": "definitions",
       "title": "Definitions",
-      "startLine": 42,
-      "endLine": 68,
+      "startLine": 48,
+      "endLine": 70,
       "summary": "Defines lagrangeBasis (Lagrange basis polynomial via finite product), lebesgueFunction (sum of absolute values), NodesInInterval (nodes in [-1,1]), and DistinctNodes (injectivity).",
       "mathContext": "$l_k(x) = \\prod_{i \\neq k} \\frac{x - x_i}{x_k - x_i}$, $\\lambda(x) = \\sum_k |l_k(x)|$. Nodes constrained to $[-1,1]$ and required to be distinct (injective)."
     },
     {
       "id": "lagrange-properties",
       "title": "Lagrange Basis Properties",
-      "startLine": 69,
-      "endLine": 93,
+      "startLine": 72,
+      "endLine": 96,
       "summary": "Proves the Kronecker delta property: lₖ(xⱼ) = 0 for j ≠ k (zero factor in product) and lₖ(xₖ) = 1 (all factors cancel for distinct nodes).",
       "mathContext": "$l_k(x_j) = \\delta_{kj}$: the zero case uses `Finset.prod_eq_zero`, the identity case uses `Finset.prod_eq_one` with `div_self` (requires node distinctness)."
     },
     {
       "id": "lebesgue-properties",
       "title": "Lebesgue Function Properties",
-      "startLine": 94,
-      "endLine": 126,
+      "startLine": 98,
+      "endLine": 133,
       "summary": "Proves nonnegativity, the lower bound λ(xₖ) ≥ 1 at nodes, and the exact value λ(xₖ) = 1 at nodes for distinct node sets.",
       "mathContext": "$\\lambda(x) \\ge 0$ (sum of absolute values), $\\lambda(x_k) \\ge 1$ (`Finset.single_le_sum`), and $\\lambda(x_k) = 1$ (Kronecker delta collapses the sum)."
     },
     {
       "id": "main-result",
       "title": "Main Result and Tightness",
-      "startLine": 127,
-      "endLine": 160,
-      "summary": "States the main theorem (logarithmic lower bound with constant 2/π on arbitrary subintervals) and the matching Chebyshev upper bound as axioms. Proves the full-interval corollary.",
-      "mathContext": "$\\max_{x \\in [a,b]} \\lambda(x) \\ge (2/\\pi - \\varepsilon) \\log n$ (axiom). Matching upper bound: Chebyshev roots give $\\Lambda_n \\le (2/\\pi + \\varepsilon) \\log n$ (axiom). Full-interval corollary: direct instantiation with $a = -1$, $b = 1$."
+      "startLine": 135,
+      "endLine": 169,
+      "summary": "States the main theorem (logarithmic lower bound with constant 2/π on arbitrary subintervals) as the single axiom `erdos_1153`, and derives the full-interval corollary `erdos_1153_full_interval` by instantiation. The matching Chebyshev upper bound is noted in a final inline comment only (not formalized).",
+      "mathContext": "$\\max_{x \\in [a,b]} \\lambda(x) \\ge (2/\\pi - \\varepsilon) \\log n$ (axiom `erdos_1153`). Full-interval corollary: direct instantiation with $a = -1$, $b = 1$. Matching Chebyshev upper bound $\\Lambda_n \\le (2/\\pi + \\varepsilon) \\log n$ is noted in an inline comment, not axiomatized."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #1153 in 160 lines of Lean 4 code with 2 axioms and 6 theorems. The Lagrange basis Kronecker delta property is fully proved, and the Lebesgue function is shown to equal 1 at interpolation nodes. The main result and Chebyshev tightness are axiomatized.",
+    "summary": "This formalization captures Erdős Problem #1153 in 169 lines of Lean 4 code with 1 axiom and 6 theorems (and 4 definitions). The Lagrange basis Kronecker delta property is fully proved, and the Lebesgue function is shown to equal 1 at interpolation nodes. Only the main asymptotic lower bound `erdos_1153` is axiomatized; Chebyshev tightness is noted in a final inline comment, not formalized.",
     "implications": "The 2/π constant represents a fundamental barrier in polynomial interpolation theory. No node placement strategy can avoid logarithmic growth of the Lebesgue constant, and Chebyshev nodes are provably optimal.",
     "openQuestions": [
       "Can the Bernstein/Erdős lower bound proof be fully formalized in Lean 4?",


### PR DESCRIPTION
## Summary

Doc-only S2 STATE-SYNC for **erdos-1153** (Lebesgue Constants of Lagrange Interpolation). The gallery proof `proofs/Proofs/Erdos1153Problem.lean` has been built since 2026-03-27 (PR #7112) and `research/registry.json` flipped to `phase: COMPLETED, status: graduated` on 2026-03-26. But the research-local `state.md` / `problem.md` / `knowledge.md` and the `candidate-pool.json` never caught up, and the gallery `meta.json` has prose-vs-structure drift.

## Drift surfaces fixed

1. `research/problems/erdos-1153/state.md` — `Phase: NEW, Iteration: 1` → `COMPLETED, Iteration: 2` with full Current Focus describing 4 defs / 6 theorems / 1 axiom / 0 sorries + iteration ledger + predecessor Lean-work table (PRs #7112, #9750, #18850).
2. `research/problems/erdos-1153/problem.md` — "Problem statement not found" → actual problem statement (subinterval Lebesgue-function lower bound with sharp 2/π constant; Bernstein 1931 + Erdős 1961).
3. `research/problems/erdos-1153/knowledge.md` — "Problem statement not found" → actual statement + formalization status + Mathlib pin + cross-references + sessions ledger.
4. `src/data/proofs/erdos-1153/meta.json`:
   - `originalContributions` drops `chebyshev_lebesgue_upper` (it's an inline comment at line 167, **not** a Lean declaration). 11 entries (was 12).
   - `overview.proofStrategy` no longer claims "matching upper bound axiom"; adds the correct full-interval corollary derivation by instantiation.
   - `sections[0..4]` `startLine` / `endLine` boundaries corrected (off by 2–9 lines each):
     - `header-imports`: 1–41 → 1–46 (covers set_options + namespace + `open Finset`)
     - `definitions`: 42–68 → 48–70
     - `lagrange-properties`: 69–93 → 72–96
     - `lebesgue-properties`: 94–126 → 98–133
     - `main-result`: 127–160 → 135–169
   - `sections[4]` (main-result) `summary` + `mathContext` revised: only `erdos_1153` is axiomatized; Chebyshev tightness is comment-only.
   - `conclusion.summary`: `160 lines... 2 axioms` → `169 lines... 1 axiom`; "Chebyshev tightness are axiomatized" → "Chebyshev tightness is noted in a final inline comment, not formalized".

Structured numeric fields (`meta.lineCount = 169`, `axiomCount = 1`, `theoremCount = 6`, `definitionCount = 4`, `sorries = 0`, and the parallel `leanFile.*` fields) were already correct and are untouched.

5. **NEW** `research/problems/erdos-1153/sessions/session-2-statesync-completed-drift-catchup.md` (~310 lines, §0–§8) — drift inventory with file/line citations, claim discovery, decision matrix (chose option A doc-only over Lean ACT), INFRA snapshot, files-changed manifest, post-merge cleanup runbook, memory writeback.

## Lean file: untouched

- `proofs/Proofs/Erdos1153Problem.lean` — **0 diff**. 169 lines, 4 defs, 6 theorems, 1 axiom (`erdos_1153`), 0 sorries.
- Mathlib pin unchanged: `v4.26.0` (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).

## Post-merge

```bash
/Users/rwalters/GitHub/lean-genius/scripts/research/claim-problem.sh \
  update erdos-1153 completed
```

This flips `.lean/state/candidate-pool.json` from `in-progress` to `completed` and refreshes the notes prose so it stops echoing the stale stub `state.md`.

## Test plan

- [x] `python3 -m json.tool src/data/proofs/erdos-1153/meta.json` — valid JSON.
- [x] `wc -l proofs/Proofs/Erdos1153Problem.lean` → 169 (matches `meta.lineCount`).
- [x] `grep -c "^axiom " proofs/Proofs/Erdos1153Problem.lean` → 1 (matches `meta.axiomCount`).
- [x] `grep -cE "^(theorem|lemma) " proofs/Proofs/Erdos1153Problem.lean` → 6 (matches `meta.theoremCount`).
- [x] `grep -cE "^(def|noncomputable def) " proofs/Proofs/Erdos1153Problem.lean` → 4 (matches `meta.definitionCount`).
- [x] `grep -c '\bsorry\b' proofs/Proofs/Erdos1153Problem.lean` → 0.
- [x] Pre-claim recency probe: 0 open PRs for `erdos-1153`, most recent closed PR `#18850` merged 2026-05-13 (mechanic-only, index.ts annotation wiring, no overlap with this PR's surfaces).
- [x] No Lean changes → no `docker-build.sh` required. INFRA-insensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)