### PR TITLE
research(factor-remainder-theorem-oq-03): S2 STATE-SYNC — registry COMPLETED + 3 lineCount off-by-one + 8 meta refresh (1-file doc-only)

### DIFF
--- a/src/data/research/problems/factor-remainder-theorem-oq-03.json
+++ b/src/data/research/problems/factor-remainder-theorem-oq-03.json
@@ -1,13 +1,13 @@
 {
   "slug": "factor-remainder-theorem-oq-03",
   "title": "factor-remainder-theorem-oq-03",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
     "formal": "",
-    "plain": "",
+    "plain": "Bridge the univariate Factor Theorem (`f(a) = 0 ↔ (X - a) ∣ f`) to Hilbert's multivariate Nullstellensatz via the V-I Galois connection between subsets of affine space and ideals of `MvPolynomial σ k`. The univariate weak Nullstellensatz follows from `IsAlgClosed.exists_root`; the multivariate weak Nullstellensatz remains the lone forward goal (requires Jacobson ring theory or the Zariski lemma).",
     "whyMatters": []
   },
   "knownResults": {
@@ -16,20 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "COMPLETED",
     "since": "2026-03-29T19:03:48-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "S2 STATE-SYNC: research JSON registry was stuck at OBSERVE iter 1 despite knowledge.progressSummary declaring COMPLETE and leanFiles[] cataloguing 3 files at 258/102/286 LOC, 35 theorems, 2 defs, 0 axioms, 0 sorries. All 3 leanFiles lineCounts had +1 off-by-one drift vs canonical actual; phase, iteration, attemptCounts.total, lastUpdate, and focus prose were all stale from T-48d (2026-03-30). No `research/problems/factor-remainder-theorem-oq-03/` dir exists. Gallery dir lives under sibling slug `src/data/proofs/factor-remainder-nullstellensatz/`. Lone open lever (multivariate weak Nullstellensatz proof) is forward-only — not encoded as sorry or axiom — so Lean files are 100% machine-checked.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Slug is COMPLETED on the Lean side (0 sorries, 0 axioms across 3 files). Forward research lever for the multivariate weak Nullstellensatz proof (requires Mathlib Jacobson ring theory infrastructure) belongs in a follow-up sibling slug or under `factor-remainder-nullstellensatz` if/when Mathlib gains the needed API.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: FactorRemainderTheoremOQ03.lean — 6 theorems, 0 sorries, 0 axioms. Factor Theorem as ideal membership, weak Nullstellensatz (univariate), linear factor existence, degree bound, Nullstellensatz hierarchy documentation.",
+    "progressSummary": "COMPLETE: 3 Lean files (FactorRemainderTheorem.lean / FactorRemainderTheoremOQ02.lean / FactorRemainderTheoremOQ03.lean) at 258 + 102 + 286 = 646 LOC, 35 theorems (14 + 6 + 15 inclusive canonical regex), 2 defs (`zeroLocus`, `vanishingIdeal` in OQ03), 0 axioms, 0 sorries. Factor Theorem as ideal membership, weak Nullstellensatz (univariate), linear factor existence, degree bound, multivariate `zeroLocus` / `vanishingIdeal` definitions, V-I Galois connection (antimonotone + subset_*), V(I(V)) = V and I(V(I)) = I idempotence, and Nullstellensatz hierarchy documentation. Forward lever: multivariate weak Nullstellensatz proof (Jacobson ring theory).",
     "builtItems": [
       "factor_theorem_ideal: Factor Theorem as ideal membership f(a)=0 ↔ (X-a)|f",
       "weak_nullstellensatz_univariate: nonconstant polys have roots over algebraically closed fields",
@@ -59,12 +59,12 @@
     "mathlib": []
   },
   "started": "2026-03-30T02:13:21.170Z",
-  "lastUpdate": "2026-03-30T02:13:21.223Z",
+  "lastUpdate": "2026-05-17T06:22:54Z",
   "leanFiles": [
     {
       "path": "Proofs/FactorRemainderTheorem.lean",
       "filename": "FactorRemainderTheorem.lean",
-      "lineCount": 259,
+      "lineCount": 258,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/FactorRemainderTheoremOQ02.lean",
       "filename": "FactorRemainderTheoremOQ02.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/FactorRemainderTheoremOQ03.lean",
       "filename": "FactorRemainderTheoremOQ03.lean",
-      "lineCount": 287,
+      "lineCount": 286,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Summary

**S2 STATE-SYNC for `factor-remainder-theorem-oq-03` (Multivariate Nullstellensatz from Factor Theorem, pool tier A, significance 8)** — 1-file doc-only registry refresh. The research JSON registry was stuck at `phase: OBSERVE` / `iteration: 1` / `attemptCounts.total: 0` / `lastUpdate: 2026-03-30` (T-48d) despite `knowledge.progressSummary` declaring **COMPLETE** and `leanFiles[]` cataloguing 3 fully machine-checked files. All three `leanFiles[].lineCount` had a +1 off-by-one vs canonical actual.

**No Lean changes**, no state.md (slug has no `research/problems/.../` dir). Gallery dir lives under sibling slug `src/data/proofs/factor-remainder-nullstellensatz/`.

### Predecessor
- PR #8138 (`Research: factor-remainder-theorem-oq-03 — multivariate V-I Galois connection`) — created the Lean files; never updated the research JSON registry past initial template
- PR #19454 (sperner mass import, 2026-05-16, T-1d) — last touch to the Lean files via directory sweep; did not touch this slug's research JSON

### 14 drift surfaces fixed in `src/data/research/problems/factor-remainder-theorem-oq-03.json`

| # | Field | Before | After |
|---|------|--------|-------|
| 1 | top-level `phase` | `OBSERVE` | `COMPLETED` |
| 2 | top-level `status` | `active` | `completed` |
| 3 | `currentState.phase` | `OBSERVE` | `COMPLETED` |
| 4 | `currentState.iteration` | 1 | 2 |
| 5 | `currentState.focus` | stale stub | S2 STATE-SYNC scope note |
| 6 | `currentState.nextAction` | stale stub | completion note + forward lever |
| 7 | `currentState.attemptCounts.total` | 0 | 1 |
| 8 | `currentState.attemptCounts.approachesTried` | 0 | 1 |
| 9 | `lastUpdate` | 2026-03-30T02:13:21Z | 2026-05-17T06:22:54Z |
| 10 | `knowledge.progressSummary` | 1-file (6 thm) | 3-file (35 thm, 2 defs) canonical |
| 11 | `problemStatement.plain` | (empty) | filled in |
| 12 | `leanFiles[0].lineCount` (FactorRemainderTheorem.lean) | 259 | 258 |
| 13 | `leanFiles[1].lineCount` (FactorRemainderTheoremOQ02.lean) | 103 | 102 |
| 14 | `leanFiles[2].lineCount` (FactorRemainderTheoremOQ03.lean) | 287 | 286 |

### Verification
```
$ wc -l proofs/Proofs/FactorRemainderTheorem.lean
    258 proofs/Proofs/FactorRemainderTheorem.lean
$ wc -l proofs/Proofs/FactorRemainderTheoremOQ02.lean
    102 proofs/Proofs/FactorRemainderTheoremOQ02.lean
$ wc -l proofs/Proofs/FactorRemainderTheoremOQ03.lean
    286 proofs/Proofs/FactorRemainderTheoremOQ03.lean
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/FactorRemainderTheorem*.lean
proofs/Proofs/FactorRemainderTheorem.lean:14
proofs/Proofs/FactorRemainderTheoremOQ02.lean:6
proofs/Proofs/FactorRemainderTheoremOQ03.lean:15
$ grep -cE '^(protected |private |noncomputable )*def ' proofs/Proofs/FactorRemainderTheorem*.lean
proofs/Proofs/FactorRemainderTheorem.lean:0
proofs/Proofs/FactorRemainderTheoremOQ02.lean:0
proofs/Proofs/FactorRemainderTheoremOQ03.lean:2
$ grep -c '^axiom ' proofs/Proofs/FactorRemainderTheorem*.lean
proofs/Proofs/FactorRemainderTheorem.lean:0
proofs/Proofs/FactorRemainderTheoremOQ02.lean:0
proofs/Proofs/FactorRemainderTheoremOQ03.lean:0
```

All `theoremCount`/`defCount`/`axiomCount`/`sorryCount` are unchanged — only `lineCount` had drift.

### Forward lever (out of scope for this PR)
The lone open item is the multivariate weak Nullstellensatz proof (file-internal status checklist line 38). It is forward-only — not encoded as `sorry` or `axiom` in any of the 3 files — so the slug is genuinely **COMPLETED** on the Lean side. Future Mathlib Jacobson ring theory infrastructure would unlock this in a follow-up sibling slug or under `factor-remainder-nullstellensatz`.

### Pool flip
Slug currently `status: in-progress` in `.lean/state/candidate-pool.json`. Post-merge, will flip via `scripts/research/claim-problem.sh update factor-remainder-theorem-oq-03 completed`.

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [x] All 3 lineCount drift confirmed via `wc -l`
- [x] No Lean source changes — doc-only
- [x] No state.md / sessions memo (research dir does not exist)
- [x] Diff stat: 1 file +14/-14

🤖 Generated with Claude Code