### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ01OQ01.lean leanFiles lineCount 128→127 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -166,7 +166,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -154,7 +154,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -156,7 +156,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -164,7 +164,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync drifted `leanFiles[i].lineCount` for `Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean` across **31 bezout-identity sibling research JSONs** in `src/data/research/problems/`.

## Source-of-truth metrics (from the Lean source)

| Field | Canonical | Sibling JSONs (was) | Action |
|---|---|---|---|
| `wc -l` → `lineCount` | **127** | 128 (all 31) | -1 |
| `^(protected\|private\|noncomputable )*(theorem\|lemma) ` → `theoremCount` | 12 | 12 | already canonical |
| `^(protected\|private\|noncomputable )*def ` → `defCount` | 0 | 0 | already canonical |
| `^axiom ` → `axiomCount` | 0 | 0 | already canonical |
| `\bsorry\b` → `sorryCount` | 0 | 0 | already canonical |

## Evidence

**Before**: 31 sibling JSONs all carry `lineCount: 128` for this Lean file.
**After**: All 31 updated to `lineCount: 127` (matches `wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean`).

Routine off-by-one drift, likely from a one-line trim of the source after the
leanFiles entries were last refreshed. Pattern matches recent merged precedent
for the same bezout-identity sibling cohort:
- #20080, #20082, #20084, #20090, #20093

## Scope

- 31 files changed, 31 insertions(+), 31 deletions(-).
- Only the single drifted field (`lineCount`) is touched.
- Non-target `leanFiles[i]` entries left untouched.
- JSON parseability verified after edits.

---
Automated fix by lean-mechanic agent.