### PR TITLE
fix(meta): batch sync AngleTrisectionCos20GalOQ01.lean leanFiles in 26 angle-trisection siblings (lineCount 417→416, theoremCount 5→32, defCount 0→3)

### DIFF
--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
@@ -74,10 +74,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
@@ -89,10 +89,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
@@ -85,10 +85,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
@@ -109,10 +109,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -111,10 +111,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -115,10 +115,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -112,10 +112,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -163,10 +163,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -126,10 +126,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -62,10 +62,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -130,10 +130,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -137,10 +137,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -122,10 +122,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -125,10 +125,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -116,10 +116,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -121,10 +121,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -68,10 +68,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -127,10 +127,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -119,10 +119,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-01.json
@@ -126,10 +126,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -120,10 +120,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -119,10 +119,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-04-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-02.json
@@ -110,10 +110,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-04-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-03.json
@@ -68,10 +68,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -71,10 +71,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -125,10 +125,10 @@
     {
       "path": "Proofs/AngleTrisectionCos20GalOQ01.lean",
       "filename": "AngleTrisectionCos20GalOQ01.lean",
-      "lineCount": 417,
-      "theoremCount": 5,
+      "lineCount": 416,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20GalOQ01.lean"


### PR DESCRIPTION
## Fix

Refresh stored `leanFiles[i]` metrics for `Proofs/AngleTrisectionCos20GalOQ01.lean` across 26 `angle-trisection` sibling research JSONs so they match the canonical grep counts on the Lean source.

## Evidence

**Source-of-truth canonical metrics** (current `proofs/Proofs/AngleTrisectionCos20GalOQ01.lean`):

| Metric | Command | Canonical | Stored (was) |
|---|---|---|---|
| lineCount | `wc -l` | 416 | 417 |
| theoremCount | `grep -cE '^(protected \| private \| noncomputable )*(theorem\|lemma) '` | 32 | 5 |
| defCount | `grep -cE '^(protected \| private \| noncomputable )*def '` | 3 | 0 |
| axiomCount | `grep -cE '^axiom '` | 0 | 0 (canonical) |
| sorryCount | `grep -cE '\bsorry\b'` | 0 | 0 (canonical) |

**Why the theoremCount / defCount drift is large**: the file uses `private theorem`, `private noncomputable def` etc. throughout (29 of 32 theorems are `private`; all 3 defs are `private noncomputable`). The older leanFiles entries were populated using narrow `^theorem ` / `^def ` regexes that miss the modifier prefixes. The recent mechanic precedent (#20148, #20151, #20156) uses the canonical raw regex above; this PR brings the angle-trisection cohort into alignment.

**lineCount drift (-1)**: routine off-by-one likely from a trailing/internal line trim after the leanFiles entries were last refreshed.

## Scope

- Only the three drifted fields (`lineCount`, `theoremCount`, `defCount`) are touched in the matching `leanFiles[i]` entry.
- `axiomCount` and `sorryCount` were already canonical and are left untouched.
- Non-target `leanFiles[i]` entries (other Lean files referenced in the same sibling JSONs) are not touched.
- 26 files × 3 lines each = 78 +/- 78.

---
Automated fix by lean-mechanic agent.