### PR TITLE
research(erdos-890): S2 STATE-SYNC — registry ACT→AXIOMATIZED + state.md NEW→AXIOMATIZED + lineCount off-by-one (2-file doc-only)

### DIFF
--- a/research/problems/erdos-890/state.md
+++ b/research/problems/erdos-890/state.md
@@ -1,27 +1,60 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: AXIOMATIZED
 **Since**: 2026-01-15T10:57:29.901Z
-**Iteration**: 1
+**Iteration**: 2
+**Last Update**: 2026-05-17T06:30:00Z (S2 STATE-SYNC)
 
 ## Current Focus
 
-Initial exploration of the problem.
+S2 STATE-SYNC: Reconcile research JSON registry, this state.md, and gallery `meta.json` with the actual Lean file. Before S2, registry top-level `phase` and `currentState.phase` were both `ACT` from 2026-03-13 (T-65d) and state.md was still on the initial NEW template from 2026-01-15. Gallery `meta.json` already correctly marked `status: "axiomatized"` and `badge: "axiom"`.
+
+## Status Summary
+
+| Surface | Value | Source |
+|---------|-------|--------|
+| Lean file | `proofs/Proofs/Erdos890Problem.lean` (210 LOC, 9 thm, 6 def, 2 axioms, 0 sorries) | `wc -l` + canonical inclusive grep |
+| Axioms | `erdos_selfridge_lower_bound`, `classical_omega_limsup` | `grep '^axiom '` |
+| Gallery dir | `src/data/proofs/erdos-890/` (annotations.json + index.ts + meta.json) | `ls` |
+| Gallery badge | `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` | `src/data/proofs/erdos-890/meta.json` |
+| Conjecture status | OPEN (Erdős-Selfridge 1967) | `erdosproblems.com/890` |
 
 ## Active Approach
 
-None yet.
+None as of S2 — slug is at AXIOMATIZED rest state with both conjectures open.
+
+The lone proven Lean result is `conjecture1_k1` (Conjecture 1 verified for k=1, via `Nat.exists_infinite_primes`). The sandwich theorem `erdos_890_liminf_sandwich` pins the liminf to {k+π(k)-1, k+π(k)} conditional on Conjecture 1 holding for general k. Monotonicity `S_{k+1}(n) ≥ S_k(n)` via `Finset.sum_le_sum_of_subset`.
 
 ## Blockers
 
-None.
+- Mathlib lacks the Erdős-Selfridge $S_k(n) \geq k + \pi(k) - 1$ lower bound (1967 paper, requires Pólya's theorem on $k$-smooth gaps).
+- Mathlib lacks the Hardy-Ramanujan $\limsup \omega(n) \cdot \log\log n / \log n = 1$ (1917 result).
+- Both conjectures themselves remain open since Erdős-Selfridge 1967.
 
 ## Next Action
 
-Begin problem exploration.
+Slug is AXIOMATIZED with 2 deep classical axioms encoding the lone proven lower bound (Erdős-Selfridge) and the limsup base case (Hardy-Ramanujan). Forward levers (none unblockable without upstream Mathlib infrastructure):
+
+- **A.** Extend `conjecture1_kN` to general $k$ via the sandwich approach once Mathlib gains a usable Pólya $k$-smooth gaps API.
+- **B.** Reformulate axioms in terms of Mathlib's `Nat.primeCounting` and `ArithmeticFunction.omega` API.
+- **C.** Explore connection to Jacobsthal's function $g(k)$ (maximal gap in $\{1, \ldots, m\}$ coprime to first $k$ primes).
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 1
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (S2 STATE-SYNC, doc-only)
+
+## Iteration Ledger
+
+| Iter | Date | Agent | Result | Scope |
+|------|------|-------|--------|-------|
+| 1 | 2026-01-15 → 2026-03-13 | (legacy) | ACT — proved Conjecture 1 k=1 + 4 structural lemmas + 2 axioms (Erdos890Problem.lean 210 LOC) | initial creation through #5884 |
+| 2 | 2026-05-17 | researcher-11 | AXIOMATIZED STATE-SYNC — registry phase ACT→AXIOMATIZED, state.md rewrite from NEW template, leanFiles[0].lineCount 211→210, attemptCounts.total 0→1, lastUpdate refresh, focus/nextAction refresh, progressSummary extension | doc-only, 2 files |
+
+## Cross-references
+
+- Research JSON registry: `src/data/research/problems/erdos-890.json`
+- Gallery dir: `src/data/proofs/erdos-890/` (meta.json already canonical at AXIOMATIZED)
+- Lean source: `proofs/Proofs/Erdos890Problem.lean`
+- Sibling problems: erdos-8, erdos-89 (per `relatedProofs`)

--- a/src/data/research/problems/erdos-890.json
+++ b/src/data/research/problems/erdos-890.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-890",
   "title": "Erdős #890",
-  "phase": "ACT",
+  "phase": "AXIOMATIZED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,20 +16,24 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "AXIOMATIZED",
     "since": "2026-01-15T10:57:29.901Z",
-    "iteration": 1,
-    "focus": "Proved Conjecture 1 for k=1, added structural lemmas",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 2,
+    "focus": "S2 STATE-SYNC: registry was at phase ACT iter 1 since 2026-03-13 (T-65d) despite Lean file Erdos890Problem.lean encoding 2 axioms (erdos_selfridge_lower_bound, classical_omega_limsup) — should be AXIOMATIZED. state.md was still on initial NEW template (Phase: NEW, iteration 1, focus 'Initial exploration') from 2026-01-15. Gallery meta.json already correctly marked status=axiomatized, badge=axiom, axiomCount=2. Single Lean file at 210 LOC (registry had +1 off-by-one: 211→210), 9 theorems, 6 defs, 2 axioms, 0 sorries. Conjecture 1 verified for k=1 via Nat.exists_infinite_primes; sandwich theorem conditional on Conjecture 1; both Erdős-Selfridge lower bound and Hardy-Ramanujan limsup remain axiomatized as deep classical results not in Mathlib.",
+    "blockers": [
+      "Mathlib lacks the Erdős-Selfridge S_k(n) ≥ k + π(k) - 1 lower bound (1967 paper, requires Pólya's k-smooth gaps theorem).",
+      "Mathlib lacks the Hardy-Ramanujan limsup ω(n)·log log n / log n = 1 (1917 result).",
+      "Both conjectures themselves are open since Erdős-Selfridge 1967."
+    ],
+    "nextAction": "Slug is AXIOMATIZED with 2 deep classical axioms encoding the lone proven lower bound (Erdős-Selfridge) and the limsup base case (Hardy-Ramanujan). Forward levers: (A) extend conjecture1_kN to general k using sandwich approach; (B) reformulate axioms in terms of Mathlib's Nat.primeCounting and ArithmeticFunction.omega API once Pólya k-smooth gaps lands in Mathlib; (C) explore Jacobsthal function g(k) connection. None of these blockers unblock without upstream Mathlib infrastructure.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Assessed and marked complete.",
+    "progressSummary": "AXIOMATIZED: Erdos890Problem.lean — 210 LOC, 9 theorems, 6 defs, 2 axioms, 0 sorries. Definitions: cumulativeOmega, LiminfAtMost, LiminfAtLeast, LimsupRatioIsOne, ErdosConjecture890_liminf, ErdosConjecture890_limsup. Axioms: erdos_selfridge_lower_bound (S_k(n) ≥ k + π(k) - 1), classical_omega_limsup (Hardy-Ramanujan). Proven: conjecture1_k1 (k=1 case via Nat.exists_infinite_primes), omega_prime (ω(p)=1), cumulativeOmega_one/zero/add (sum splitting), monotonicity S_{k+1} ≥ S_k, erdos_890_liminf_sandwich (conditional pin to {k+π(k)-1, k+π(k)}). Forward lever: extend k=1 to general k once Mathlib gains Pólya k-smooth gaps API.",
     "builtItems": [
       "conjecture1_k1: Conjecture 1 verified for k=1 using Nat.exists_infinite_primes",
       "omega_prime: ω(p)=1 for prime p, proved from primeFactors characterization",
@@ -59,14 +63,14 @@
     "mathlib": []
   },
   "started": "2026-01-15T10:57:29.901Z",
-  "lastUpdate": "2026-03-13T07:52:17.054Z",
+  "lastUpdate": "2026-05-17T06:30:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos890Problem.lean",
       "filename": "Erdos890Problem.lean",
-      "lineCount": 211,
+      "lineCount": 210,
       "theoremCount": 9,
       "axiomCount": 2,
       "defCount": 6,


### PR DESCRIPTION
## Summary

**S2 STATE-SYNC for `erdos-890` (Erdős Problem #890 — sum of $\omega$ over consecutive integers, pool tier B, significance 6)** — 2-file doc-only registry and state.md refresh. The research JSON registry was stuck at `phase: ACT` / `iteration: 1` since 2026-03-13 (T-65d) despite the Lean file `Erdos890Problem.lean` encoding **2 axioms** (`erdos_selfridge_lower_bound`, `classical_omega_limsup`), and state.md was still on the initial NEW-template from 2026-01-15. Gallery `meta.json` already correctly marked `status: "axiomatized"` and `badge: "axiom"`.

**No Lean changes.** Lean file is at AXIOMATIZED rest state (210 LOC, 9 thm, 6 def, 2 axioms, 0 sorries).

### Predecessor
- PR #5884 (legacy, `Research: erdos-890 — prove Conjecture 1 for k=1, add structural lemmas`) — initial substantive Lean work
- PR #19454 (sperner mass import, 2026-05-16, T-1d) — last touch via directory sweep; did not advance registry phase

### Drift surfaces fixed

| # | Field | Before | After |
|---|-------|--------|-------|
| 1 | top-level `phase` | `ACT` | `AXIOMATIZED` |
| 2 | `currentState.phase` | `ACT` | `AXIOMATIZED` |
| 3 | `currentState.iteration` | 1 | 2 |
| 4 | `currentState.focus` | T-65d stub | S2 STATE-SYNC scope note |
| 5 | `currentState.nextAction` | T-65d stub | 3-lever forward menu (A/B/C) |
| 6 | `currentState.blockers` | `[]` | 3 Mathlib infrastructure gaps |
| 7 | `currentState.attemptCounts.total` | 0 | 1 |
| 8 | `currentState.attemptCounts.approachesTried` | 0 | 1 |
| 9 | `lastUpdate` | 2026-03-13T07:52:17Z | 2026-05-17T06:30:00Z |
| 10 | `knowledge.progressSummary` | "COMPLETE: Assessed and marked complete." stub | full content (axioms, theorems, defs, forward lever) |
| 11 | `leanFiles[0].lineCount` | 211 | 210 |
| 12 | `research/problems/erdos-890/state.md` | NEW-iter-1 initial template | AXIOMATIZED-iter-2 with iteration ledger + status table + 3-lever menu |

### Verification
```
$ wc -l proofs/Proofs/Erdos890Problem.lean
    210 proofs/Proofs/Erdos890Problem.lean
$ grep '^axiom ' proofs/Proofs/Erdos890Problem.lean
axiom erdos_selfridge_lower_bound :
axiom classical_omega_limsup : LimsupRatioIsOne (fun n => ω n)
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/Erdos890Problem.lean
9
$ grep -cE '^(protected |private |noncomputable )*def ' proofs/Proofs/Erdos890Problem.lean
6
$ grep -c 'sorry' proofs/Proofs/Erdos890Problem.lean
0
$ jq '.meta.status, .meta.badge, .meta.axiomCount, .meta.lineCount' src/data/proofs/erdos-890/meta.json
"axiomatized"
"axiom"
2
210
```

All `theoremCount`, `defCount`, `axiomCount`, `sorryCount` are unchanged in registry — only `lineCount` had drift.

### Conjecture status
Erdős #890 remains **open** (Erdős-Selfridge 1967). The 2 axioms encode:
- `erdos_selfridge_lower_bound`: $S_k(n) \geq k + \pi(k) - 1$ (lower bound; requires Pólya's k-smooth gaps theorem, not in Mathlib)
- `classical_omega_limsup`: $\limsup \omega(n) \cdot \log\log n / \log n = 1$ (Hardy-Ramanujan 1917, not in Mathlib)

Proven (no axioms): `conjecture1_k1` (k=1 case via `Nat.exists_infinite_primes`); monotonicity $S_{k+1} \geq S_k$; sandwich theorem conditional on Conjecture 1 holding for general k.

### Pool flip — NOT done
Slug remains `status: in-progress` in pool (AXIOMATIZED with open conjecture — forward research levers remain available). Claim will be released without pool flip.

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [x] lineCount drift confirmed via `wc -l` (211 → 210)
- [x] All 2 axioms confirmed via `grep '^axiom '`
- [x] Gallery `meta.json` AXIOMATIZED canonical (untouched)
- [x] No Lean source changes — doc-only
- [x] Diff stat: 2 files +56/-19

🤖 Generated with Claude Code