### PR TITLE
research(erdos-1084-oq-01): S2 STATE-SYNC — registry-COMPLETED slug + research-wave-bypass + research JSON drift catchup (doc-only)

### DIFF
--- a/src/data/research/problems/erdos-1084-oq-01.json
+++ b/src/data/research/problems/erdos-1084-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1084-oq-01",
   "title": "Is f₃(n) = 6n - Θ(n^{2/3})",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -31,13 +31,13 @@
   },
   "currentState": {
     "phase": "COMPLETED",
-    "since": "2026-03-26T00:00:00Z",
-    "iteration": 1,
-    "focus": "Formalization complete: 16 theorems, 9 axioms, 0 sorry. Gallery entry created.",
+    "since": "2026-05-17T07:30:00Z",
+    "iteration": 2,
+    "focus": "S2 STATE-SYNC: mirrored top-level phase/status to COMPLETED, refreshed leanFiles[] numerics (OQ01 lineCount 608→607/theoremCount 20→23/sorryCount 1→0, Problem lineCount 319→318/theoremCount 4→7); meta.json (gallery) already canonical (axiomatized, axiomCount 4, sorries 0).",
     "blockers": [],
-    "nextAction": "None — initial formalization complete. Future work: prove handshaking lemma, prove FCC lower bound.",
+    "nextAction": "None — formalization complete with 4 deep axiomatized published results. Future work: prove handshaking lemma, prove FCC lower bound.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
@@ -102,26 +102,26 @@
     ]
   },
   "started": "2026-03-24T00:48:59.904Z",
-  "lastUpdate": "2026-03-26T00:00:00Z",
+  "lastUpdate": "2026-05-17T07:30:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1084OQ01.lean",
       "filename": "Erdos1084OQ01.lean",
-      "lineCount": 608,
-      "theoremCount": 20,
+      "lineCount": 607,
+      "theoremCount": 23,
       "axiomCount": 4,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1084OQ01.lean"
     },
     {
       "path": "Proofs/Erdos1084Problem.lean",
       "filename": "Erdos1084Problem.lean",
-      "lineCount": 319,
-      "theoremCount": 4,
+      "lineCount": 318,
+      "theoremCount": 7,
       "axiomCount": 1,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

erdos-1084-oq-01 was registry-graduated 2026-03-26T23:05:29Z via the original formalization arc (#6975 → #7003 → #7027, the last of which eliminated 4 of 8 axioms via concrete kissingNumber def + rfl proofs). The research JSON registry was created 2026-05-16 via the unrelated sperner PR #19454 directory sweep, using 2026-03-26-era numerics that have since drifted relative to the current Lean files.

Four simultaneous drift surfaces (all in research JSON / pool):

1. **Top-level phase/status stayed ACT/active** even though currentState already said COMPLETED — inverse of the erdos-268 (PR #20153) drift pattern where top-level was COMPLETED and currentState was OBSERVE.
2. **leanFiles[] numerics drifted**:
   - Erdos1084OQ01.lean: lineCount 608→607 (-1), theoremCount 20→23 (+3), sorryCount 1→0 (the "1" was a `grep -cE '\bsorry\b'` match on the word `sorry` in a docstring line "Proved theorems (0 sorry):" at L582).
   - Erdos1084Problem.lean: lineCount 319→318 (-1), theoremCount 4→7 (+3).
3. **lastUpdate / iteration / since** stuck at 2026-03-26 / iteration 1.
4. **`.lean/state/candidate-pool.json`** still shows `status: in-progress` — one of the documented 728-slug systemic registry-vs-pool drifts. Fixed post-merge via `claim-problem.sh update completed`.

`src/data/proofs/erdos-1084-oq-01/meta.json` is **already correct** (`status: axiomatized`, `badge: axiom`, `axiomCount: 4`, `sorries: 0`, `lineCount: 607`, `theoremCount: 23`, `definitionCount: 7` — gallery counts the 2 `structure`s as defs, hence 5 `def` + 2 `structure` = 7). No meta.json edits in this PR.

No `research/problems/erdos-1084-oq-01/` directory exists, so no state.md to update. Thin 1-file PR.

## What ships (doc-only, 1 file, 13 +/- 13 lines)

`src/data/research/problems/erdos-1084-oq-01.json`:
- Top-level phase: `ACT` → `COMPLETED` (mirror currentState)
- Top-level status: `active` → `completed` (mirror currentState)
- Top-level lastUpdate: `2026-03-26T00:00:00Z` → `2026-05-17T07:30:00Z`
- currentState.since: `2026-03-26T00:00:00Z` → `2026-05-17T07:30:00Z`
- currentState.iteration: 1 → 2
- currentState.focus: refreshed to document S2 STATE-SYNC contents
- currentState.nextAction: minor wording refresh
- currentState.attemptCounts.total: 1 → 2
- leanFiles[0] (Erdos1084OQ01.lean): lineCount 608→607, theoremCount 20→23, sorryCount 1→0
- leanFiles[1] (Erdos1084Problem.lean): lineCount 319→318, theoremCount 4→7

## Numerical verification

\`\`\`
\$ wc -l proofs/Proofs/Erdos1084{OQ01,Problem}.lean
     607 / 318
\$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) '
      23 /   7
\$ grep -cE '^(protected |private |noncomputable )*def '
       5 /   2
\$ grep -cE '^axiom '
       4 /   1
\$ grep -nE '\\bsorry\\b' Erdos1084OQ01.lean
     582:   Proved theorems (0 sorry):       ← word in docstring only
\`\`\`

All match post-sync research JSON leanFiles[] entries.

## Context: 3rd consecutive STATE-SYNC of session

This is the 3rd consecutive doc-only STATE-SYNC of this researcher-10 session:

1. PR #20140 — erdos-1153 S2 STATE-SYNC (5-file, ~310 LOC NEW memo)
2. PR #20153 — erdos-268 S3 STATE-SYNC (3-file, ~280 LOC NEW memo)
3. **This PR** — erdos-1084-oq-01 S2 STATE-SYNC (1-file surgical)

Successively thinner as the pattern becomes more recognizable. Per the systemic-pool-drift memory, the cleanest long-term fix is a batch script that walks the registry COMPLETED+graduated slugs and flips all 728 pool entries simultaneously — these per-slug STATE-SYNCs are remediation, not the root fix.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` — JSON valid.
- [x] Numerical fields cross-checked against current `proofs/Proofs/Erdos1084*.lean` via `wc -l` + `grep -cE`.
- [x] meta.json (gallery) confirmed already correct — no edits needed.
- [x] No .lean edits — doc-only safe.
- [ ] Post-merge: `scripts/research/claim-problem.sh update erdos-1084-oq-01 completed` to flip pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)