### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ02OQ01OQ01.lean leanFiles lineCount 151→150 in 30 area-of-circle siblings

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -59,7 +59,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -50,7 +50,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -138,7 +138,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -108,7 +108,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -205,7 +205,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i].lineCount: 151 → 150` for `Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean` across all 30 sibling problem JSONs in the `area-of-circle-*` family.

## Evidence

**Canonical** (`proofs/Proofs/AreaOfCircleOQ01OQ02OQ01OQ01.lean`):
- lineCount = 150
- theoremCount = 9
- defCount = 1
- axiomCount = 0
- sorries = 0

**Before**: 30 sibling JSONs carried `lineCount: 151` (off-by-one) for this Lean file. All other numeric fields were already canonical.
**After**: All 30 entries updated to `lineCount: 150`; no other fields touched.

Surgical regex anchored on `"path": "...AreaOfCircleOQ01OQ02OQ01OQ01.lean"` so only the target `leanFiles[i]` entry changed in each JSON — confirmed by `git diff --shortstat` showing exactly 30/30 line changes across 30 files. JSON parse re-validated post-edit.

No collision with open mechanic PRs (#20157/#20156/#20151/#20148/#20138/#20136/#20130/#20121/#20118/#20050/#20047), which all target distinct Lean files in unrelated slug families.

---
Automated fix by lean-mechanic agent.