### PR TITLE
research(erdos-700): S2 STATE-SYNC — registry OBSERVE/ACT→AXIOMATIZED + state.md NEW→AXIOMATIZED + leanFiles substantial catchup (2-file doc-only)

### DIFF
--- a/research/problems/erdos-700/state.md
+++ b/research/problems/erdos-700/state.md
@@ -1,27 +1,74 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: AXIOMATIZED
 **Since**: 2026-01-14T21:07:11.724Z
-**Iteration**: 1
+**Iteration**: 4
+**Last Update**: 2026-05-17T06:40:00Z (S2 STATE-SYNC)
 
 ## Current Focus
 
-Initial exploration of the problem.
+S2 STATE-SYNC: Reconcile research JSON registry, this state.md, and gallery `meta.json` with the actual Lean file. Before S2, the registry had top-level `phase: OBSERVE` and `currentState.phase: ACT` from 2026-03-13 (T-65d), state.md was still on the initial NEW-iter-1 template from 2026-01-14, and `leanFiles[0]` was substantially behind canonical (lineCount 420 vs actual 427, theoremCount 8 vs 14, axiomCount 0 vs 2). Gallery `meta.json` already correctly marked `status: "axiomatized"` + `badge: "axiom"` + canonical counts.
+
+## Status Summary
+
+| Surface | Value | Source |
+|---------|-------|--------|
+| Lean file | `proofs/Proofs/Erdos700Problem.lean` (427 LOC, 14 thm, 3 def, 2 axioms, 0 sorries) | `wc -l` + canonical inclusive grep |
+| Axioms | `erdos_700_question2` (∞ many composite n with f(n)>√n), `erdos_700_question3` (f(n)≪_A n/(log n)^A) | `grep '^axiom '` |
+| Gallery dir | `src/data/proofs/erdos-700/` (annotations.json + index.ts + meta.json) | `ls` |
+| Gallery badge | `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` | `src/data/proofs/erdos-700/meta.json` |
+| Conjecture status | OPEN (Erdős-Szekeres 1978) | `erdosproblems.com/700` |
 
 ## Active Approach
 
-None yet.
+None as of S2 — slug is at AXIOMATIZED rest state with all 3 Erdős-Szekeres questions still open. The 2 remaining axioms encode questions 2 and 3 specifically; question 1 is a characterisation problem rather than a conjecture to discharge.
+
+## Major Progress Arc (iterations 1–3)
+
+Initial scaffolding had 6 axioms. Incremental elimination via:
+
+- **`prime_not_dvd_choose_shift`** (~80 lines, Kummer zero-carry argument): for prime power p^a and m with p∤m, p does not divide C(p^a·m, p^a). Key insight: K=p^a−1 and N−K=p^a·(m−1) have non-overlapping base-p digit support ⇒ 0 carries.
+- **`gcd_choose_prime_pow_eq`**: gcd(p^a·m, C(p^a·m, p^a)) = m.
+- **`choose_eq_mul_choose_pred`**: absorption identity C(n,k) = (n/k)·C(n-1,k-1).
+- **`f_semiprime`** (sandwich argument): f(pq) = p for primes p ≤ q.
+- **`f_upper_bound`** (originally axiomatized, converted to theorem via Kummer): f(n) ≤ n/P(n) for composite n.
+- **infrastructure glue sorry**: connecting fBinom Finset.min definition to f-bound theorems — discharged.
+
+Proven results: f(p²)=p (exact), f(pq)=p for primes p≤q, f(30)=6, bounds f(n)≥p(n) and f(n)≤n/P(n) for composite n.
 
 ## Blockers
 
-None.
+- Question 1 (characterise composite n with f(n) = n/P(n)) is open. Known examples: n=pq (semiprimes) and n=30.
+- Question 2 (∞ many composite n with f(n) > n^{1/2}) is open — currently only the n=p² family gives f(n) ≥ n^{1/2} non-strictly.
+- Question 3 (f(n) ≪_A n/(log n)^A for every A>0) is open — connects to Hardy-Ramanujan-style asymptotic density.
 
 ## Next Action
 
-Begin problem exploration.
+Forward levers (none unblockable without substantial new mathematics):
+
+- **A.** Characterize the f(n)=n/P(n) family for Q1 (e.g., n=pq with p<q gives f(n)=p=n/q=n/P(n); does n=30 generalise to n=p₁p₂p₃ with constraints?).
+- **B.** Find a single composite n outside the p² family witnessing f(n)>√n strictly — would discharge `erdos_700_question2` axiom.
+- **C.** Lower-bound study connecting f(n) growth to ω(n) or σ(n) for Q3.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 4
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 4 (initial scaffold + 2 axiom-elimination iterations + S2 STATE-SYNC)
+
+## Iteration Ledger
+
+| Iter | Date | Agent | Result | Scope |
+|------|------|-------|--------|-------|
+| 1 | 2026-01-14 | (legacy) | NEW — created Erdos700Problem.lean scaffold with 6 axioms | initial creation |
+| 2 | (legacy) | (legacy) | OBSERVE → ACT — eliminated 3 axioms via Kummer + sandwich + absorption | substantive Lean work, ~4 axioms remaining |
+| 3 | 2026-03-13 | (legacy) | ACT — eliminated f_upper_bound axiom, 1 sorry in infrastructure glue noted | registry last touched here |
+| (gap) | 2026-03-13 → 2026-05-17 | — | infrastructure glue sorry discharged in subsequent unrecorded work; registry stayed at iter 3 | T-65d drift |
+| 4 | 2026-05-17 | researcher-11 | AXIOMATIZED STATE-SYNC — registry phase OBSERVE/ACT → AXIOMATIZED, state.md rewrite, leanFiles[0] catchup (420→427/8→14/0→2), attemptCounts.total 0→4 | doc-only, 2 files |
+
+## Cross-references
+
+- Research JSON registry: `src/data/research/problems/erdos-700.json`
+- Gallery dir: `src/data/proofs/erdos-700/` (meta.json already canonical at AXIOMATIZED)
+- Lean source: `proofs/Proofs/Erdos700Problem.lean`
+- Sibling problems: erdos-7, erdos-70 (per `relatedProofs`)

--- a/src/data/research/problems/erdos-700.json
+++ b/src/data/research/problems/erdos-700.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-700",
   "title": "Erdős #700",
-  "phase": "OBSERVE",
+  "phase": "AXIOMATIZED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,20 +16,24 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "AXIOMATIZED",
     "since": "2026-01-14T21:07:11.724Z",
-    "iteration": 3,
-    "focus": "f_upper_bound axiom eliminated via Kummer. 1 sorry remains in definition glue.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "iteration": 4,
+    "focus": "S2 STATE-SYNC: registry was at top-level phase OBSERVE / currentState.phase ACT / iter 3 since 2026-03-13 (T-65d) despite Lean file Erdos700Problem.lean at 427 LOC with 14 theorems, 3 defs, 2 axioms (erdos_700_question2, erdos_700_question3), 0 sorries (the previously-noted 'infrastructure glue sorry' has since been discharged). leanFiles[0] catalogue lagged actuals by 7 lines + 6 theorems + 2 axioms; gallery meta.json already at canonical AXIOMATIZED (status=axiomatized, badge=axiom, axiomCount=2, lineCount=427, theoremCount=14, definitionCount=3). The 2 remaining axioms encode open Erdős-Szekeres questions 2 (∞ many composite n with f(n)>√n) and 3 (f(n)≪_A n/(log n)^A).",
+    "blockers": [
+      "Question 1 (characterise composite n with f(n) = n/P(n)) is open and answer depends on prime factorization shape.",
+      "Question 2 (∞ many composite n with f(n) > n^{1/2}) is open — currently only the n=p² family gives f(n) ≥ n^{1/2} non-strictly, and erdos_700_question2 axiomatizes the strict-inequality version.",
+      "Question 3 (f(n) ≪_A n/(log n)^A for every A>0) is open — connects to Hardy-Ramanujan-style asymptotic density."
+    ],
+    "nextAction": "Slug is AXIOMATIZED with the lone remaining sorry discharged. Forward levers: (A) characterize the f(n)=n/P(n) family for Q1 (e.g. n=pq with p<q gives f(n)=p=n/q=n/P(n)); (B) find a single composite n other than the p² family witnessing f(n)>√n strictly, would discharge erdos_700_question2 axiom; (C) lower-bound study connecting f(n) growth to ω(n) or σ(n) for Q3.",
     "attemptCounts": {
-      "total": 0,
+      "total": 4,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 4
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: f_upper_bound axiom eliminated (3→2 axioms). Key lemma prime_not_dvd_choose_shift proved via Kummer zero-carry argument. Remaining sorry is infrastructure glue connecting to fBinom/largestPrimeFactor definitions.",
+    "progressSummary": "AXIOMATIZED: Erdos700Problem.lean — 427 LOC, 14 theorems, 3 defs, 2 axioms (erdos_700_question2 + erdos_700_question3 encoding open conjectures), 0 sorries. Major progress arc: started with 6 axioms (initial scaffolding); incrementally eliminated 4 via Kummer zero-carry argument (prime_not_dvd_choose_shift ~80 lines), sandwich argument (f_semiprime), absorption identity (choose_eq_mul_choose_pred), and infrastructure glue. Proven: f(p²)=p, f(pq)=p (for primes p≤q), f(30)=6, bounds f(n)≥p(n) and f(n)≤n/P(n) for composite n. Forward levers for the 2 remaining open-conjecture axioms documented in nextAction.",
     "builtItems": [
       "Defined fBinom via Finset.min in Erdos700Problem.lean:41-46",
       "Proved minFac_prime_sq in Erdos700Problem.lean:51-57",
@@ -72,16 +76,16 @@
     "mathlib": []
   },
   "started": "2026-01-14T21:07:11.724Z",
-  "lastUpdate": "2026-03-13T07:52:17.051Z",
+  "lastUpdate": "2026-05-17T06:40:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos700Problem.lean",
       "filename": "Erdos700Problem.lean",
-      "lineCount": 420,
-      "theoremCount": 8,
-      "axiomCount": 0,
+      "lineCount": 427,
+      "theoremCount": 14,
+      "axiomCount": 2,
       "defCount": 3,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

**S2 STATE-SYNC for `erdos-700` (Erdős Problem #700 — GCD of n with binomial coefficients, pool tier B, significance 6, knowledge=20 RICH)** — 2-file doc-only registry + state.md refresh. The research JSON registry had top-level `phase: OBSERVE` and `currentState.phase: ACT` from 2026-03-13 (T-65d), state.md was still on the initial NEW-iter-1 template from 2026-01-14, and `leanFiles[0]` was **substantially** behind canonical (lineCount 420 vs actual 427, theoremCount 8 vs 14, axiomCount 0 vs 2). The previously-noted '1 sorry in infrastructure glue' has since been discharged in unrecorded subsequent work.

**No Lean changes.** Lean file is at AXIOMATIZED rest state (427 LOC, 14 thm, 3 def, 2 axioms, 0 sorries).

### Gallery already canonical, registry behind
Gallery `src/data/proofs/erdos-700/meta.json` already marks `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2`, `lineCount: 427`, `theoremCount: 14`, `definitionCount: 3`. The research JSON registry had drifted behind.

### Drift surfaces fixed

| # | Field | Before | After | Drift |
|---|-------|--------|-------|-------|
| 1 | top-level `phase` | `OBSERVE` | `AXIOMATIZED` | — |
| 2 | `currentState.phase` | `ACT` | `AXIOMATIZED` | — |
| 3 | `currentState.iteration` | 3 | 4 | — |
| 4 | `currentState.focus` | T-65d stub | S2 STATE-SYNC scope note | — |
| 5 | `currentState.nextAction` | T-many-month stub | 3-lever forward menu (A/B/C) | — |
| 6 | `currentState.blockers` | `[]` | Q1/Q2/Q3 enumeration | — |
| 7 | `currentState.attemptCounts.total` | 0 | 4 | — |
| 8 | `currentState.attemptCounts.approachesTried` | 0 | 4 | — |
| 9 | `lastUpdate` | 2026-03-13T07:52:17Z | 2026-05-17T06:40:00Z | — |
| 10 | `knowledge.progressSummary` | "PROGRESS: 1 sorry remains" | "AXIOMATIZED: 0 sorries" with full Major Progress Arc | — |
| 11 | `leanFiles[0].lineCount` | 420 | 427 | **-7** |
| 12 | `leanFiles[0].theoremCount` | 8 | 14 | **-6** |
| 13 | `leanFiles[0].axiomCount` | 0 | 2 | **-2** |
| 14 | `research/problems/erdos-700/state.md` | NEW-iter-1 initial template | AXIOMATIZED-iter-4 with iteration ledger | — |

### Verification
```
$ wc -l proofs/Proofs/Erdos700Problem.lean
    427 proofs/Proofs/Erdos700Problem.lean
$ grep '^axiom ' proofs/Proofs/Erdos700Problem.lean
axiom erdos_700_question2 :
axiom erdos_700_question3 :
$ grep -cE '^(protected |private |noncomputable )*(theorem|lemma) ' proofs/Proofs/Erdos700Problem.lean
14
$ grep -cE '^(protected |private |noncomputable )*def ' proofs/Proofs/Erdos700Problem.lean
3
$ grep -c 'sorry' proofs/Proofs/Erdos700Problem.lean
0
$ jq '.meta.status, .meta.badge, .meta.axiomCount, .meta.lineCount, .meta.theoremCount, .meta.definitionCount' src/data/proofs/erdos-700/meta.json
"axiomatized"
"axiom"
2
427
14
3
```

### Major Progress Arc summary (iterations 1–3, captured in state.md ledger)
Initial scaffolding had 6 axioms. Incremental elimination via:
- `prime_not_dvd_choose_shift` (~80 lines, Kummer zero-carry argument)
- `gcd_choose_prime_pow_eq` and `choose_eq_mul_choose_pred` (absorption identity)
- `f_semiprime` (sandwich argument): f(pq) = p for primes p ≤ q
- `f_upper_bound`: f(n) ≤ n/P(n) for composite n
- infrastructure glue sorry discharged in subsequent unrecorded work

Proven: f(p²)=p, f(pq)=p, f(30)=6, bounds f(n)≥p(n) and f(n)≤n/P(n).

### Conjecture status
Erdős #700 remains **open** (Erdős-Szekeres 1978, all 3 questions). The 2 axioms encode:
- `erdos_700_question2`: ∞ many composite n with f(n) > n^{1/2} strictly (open; n=p² gives f(n) ≥ n^{1/2} non-strictly)
- `erdos_700_question3`: f(n) ≪_A n/(log n)^A for every A>0 (open; Hardy-Ramanujan-style asymptotic density)

### Pool flip — NOT done
Slug remains `status: in-progress` (AXIOMATIZED with open conjectures). Claim released without pool flip.

## Test plan

- [x] JSON validates
- [x] All leanFiles[0] catchup confirmed (lineCount/theoremCount/axiomCount)
- [x] Gallery meta.json canonical (untouched)
- [x] No Lean source changes — doc-only
- [x] Diff stat: 2 files +72/-21

🤖 Generated with Claude Code