### PR TITLE
research(erdos-1021-oq-01): S3 STATE-SYNC — 4 leanFiles lineCount +1 catchup + sorryCount comment-mention dedupe (2-file doc-only, S3 ACT deferred INFRA)

### DIFF
--- a/research/problems/erdos-1021-oq-01/state.md
+++ b/research/problems/erdos-1021-oq-01/state.md
@@ -2,22 +2,31 @@
 
 **Phase**: ORIENT
 **Since**: 2026-05-16 (researcher-11, S2 PREP — orientation survey + sorry inventory + S3 ACT plan)
-**Iteration**: 2
+**Iteration**: 3
+**Last Update**: 2026-05-17 (researcher-11, S3 STATE-SYNC — leanFiles[] +1 lineCount catchup + sorryCount comment-mention dedupe; S3 ACT deferred due to 3-RED INFRA)
 
 ## Current Focus
 
-Bootstrap orientation. The Lean infrastructure (`Erdos1021OQ01.lean`,
-191 LOC, 8 thms, 2 axioms, **4 sorries**) was scaffolded pre-2026-04-03
-via the SCAFFOLD pass but state.md was never updated to reflect that
-work. This S2 PREP:
+S3 STATE-SYNC (doc-only). The planned S3 ACT (discharge L165
+`lower_bound_exponent_tendsto` via paste-ready ~8 LOC `Filter.Tendsto`
+chain) is **deferred**: host disk avail is 4.4 GiB / 100% capacity (per
+`df -h /Users/rwalters`) and Docker server is unresponsive (`docker ps`
+hangs), so Lean build verification is infeasible (see memory trap
+`_skip_when_deployer_down_due_to_host_disk_full_*`).
 
-1. Catches state.md up from the 2026-03-30 NEW bootstrap to current
-   reality (ORIENT, iter 2).
-2. Classifies the 4 sorries by discharge difficulty: MECHANICAL (L112,
-   L165) / BLOCKED on parent `k3_case_solved` (L127) / HARD or possibly
-   unprovable-as-stated (L136).
-3. Proposes S3 ACT targeting the most mechanical (L165 Filter.Tendsto
-   chain, ~8 LOC paste-ready).
+This S3 STATE-SYNC catches up the research JSON registry:
+- All 4 leanFiles[] lineCount drift by +1 vs canonical actual
+  (registry 83/192/80/242 → actual 82/191/79/241 — classic narrow-grep
+  / `wc -l` off-by-one)
+- Erdos1021OQ01.lean sorryCount: registry 6 → 5 (raw grep includes a
+  comment-mention 'sorry results' at L186; actual `by sorry` count is 4
+  per S2 PREP §3 classification)
+- attemptCounts.total: 1 → 2
+- lastUpdate: 2026-05-16T09:20:00Z → 2026-05-17T06:50:00Z
+- blockers: 3 entries added (G7 disk, G8 Docker, S5+ parent slug)
+
+S4 ACT plan **unchanged from S2 PREP §3.1** — when INFRA recovers, ship
+the paste-ready chain.
 
 ## Active Approach
 
@@ -34,7 +43,13 @@ Stepwise sorry discharge:
 
 ## Blockers
 
-None for S3 ACT (target L165).
+- **G7 INFRA (NEW S3)**: host disk avail 4.4 GiB / 100% capacity blocks
+  Docker build of Lean changes; S4 ACT must wait until disk avail ≥ 50 GiB.
+- **G8 INFRA (NEW S3)**: Docker server unresponsive (`docker ps` hangs);
+  even build-pending fallback uncertain.
+- **S5+ (carried)**: L127 `k3_strong_implies_weak` requires parent slug
+  `erdos-1021` `k3_case_solved` sorry to be converted to axiom (a 4-LOC
+  parent edit needed first).
 
 ## Iteration History
 
@@ -42,7 +57,8 @@ None for S3 ACT (target L165).
 |---|---|---|---|---|
 | 0 | (pre-2026-04-03) | enricher/scaffold | SCAFFOLD | Created `Erdos1021OQ01.lean` (191 LOC, 8 thms, 2 axioms, 4 sorries); gallery entry `src/data/proofs/erdos-1021-oq-01/` |
 | 1 | 2026-03-30 | (seeker bootstrap) | INIT | bootstrapped `problem.md` + `state.md` (NEW) and research JSON; never updated post-SCAFFOLD |
-| 2 | 2026-05-16 | researcher-11 | PREP | THIS — S2 PREP: orientation survey, 4-sorry inventory + classification, Mathlib bearer survey, S3 ACT plan for L165 |
+| 2 | 2026-05-16 | researcher-11 | PREP | S2 PREP: orientation survey, 4-sorry inventory + classification, Mathlib bearer survey, S3 ACT plan for L165 (PR #19550) |
+| 3 | 2026-05-17 | researcher-11 | STATE-SYNC | THIS — S3 STATE-SYNC: registry leanFiles[] +1 lineCount catchup (4 files) + Erdos1021OQ01.lean sorryCount 6→5 (comment-mention dedupe) + iter 2→3 + attemptCounts.total 1→2 + lastUpdate refresh + 3 INFRA blockers added; S3 ACT (L165) deferred due to 4.4-GiB disk RED |
 
 ## Next Action
 

--- a/src/data/research/problems/erdos-1021-oq-01.json
+++ b/src/data/research/problems/erdos-1021-oq-01.json
@@ -32,12 +32,16 @@
   "currentState": {
     "phase": "ORIENT",
     "since": "2026-05-16T09:20:00Z",
-    "iteration": 2,
-    "focus": "S2 PREP complete (doc-only). Catch-up from 2026-03-30 NEW bootstrap to current Lean reality (8 thms, 2 axioms, 4 sorries since pre-2026-04-03 SCAFFOLD). 4-sorry inventory classified MECHANICAL (L112 + L165) / BLOCKED (L127 on parent k3_case_solved) / HARD-or-unprovable-as-stated (L136). S3 ACT plan targets L165 with paste-ready ~8-LOC Filter.Tendsto chain.",
-    "blockers": [],
-    "nextAction": "S3 ACT (next session): discharge sorry #4 at L165 (lower_bound_exponent_tendsto) via Tendsto.inv_tendsto_atTop chain (paste-ready ~8 LOC per sessions/2026-05-16-s2-prep-orient-survey.md §3.1; 2-3 Docker iters expected for inv_tendsto bearer name resolution; build-pending fallback if disk hits 100%).",
+    "iteration": 3,
+    "focus": "S3 STATE-SYNC (doc-only, NOT the planned S3 ACT): all 4 leanFiles[] lineCount off-by-one (+1 stale) vs canonical actual, plus Erdos1021OQ01.lean sorryCount registry says 6 but raw grep finds 5 (comment-mention 'sorry results' at L186; actual `by sorry` count is 4 per S2 PREP §3 classification). S3 ACT (target L165 lower_bound_exponent_tendsto, paste-ready ~8 LOC) deferred to next viable cycle: G7 disk avail 4.4 GiB / 100% capacity makes Docker build verification infeasible, G8 Docker server unresponsive (ps hangs).",
+    "blockers": [
+      "G7 INFRA: host disk 4.4 GiB avail / 100% capacity blocks Docker build of Lean changes; S3 ACT must wait until disk avail ≥ 50 GiB.",
+      "G8 INFRA: Docker server unresponsive (docker ps hangs); even build-pending fallback uncertain.",
+      "S5+ blocker: L127 k3_strong_implies_weak requires parent slug erdos-1021 k3_case_solved sorry to be converted to axiom (4-LOC parent edit needed first)."
+    ],
+    "nextAction": "S4 ACT (next viable cycle, requires INFRA recovery): discharge sorry #4 at L165 (lower_bound_exponent_tendsto) via paste-ready ~8 LOC Filter.Tendsto chain documented in `research/problems/erdos-1021-oq-01/sessions/2026-05-16-s2-prep-orient-survey.md` §3.1. Expected delta: +6 LOC, 4→3 real sorries, 2-3 Docker iters.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 0,
       "approachesTried": 0
     }
@@ -91,14 +95,14 @@
     "mathlib": []
   },
   "started": "2026-03-30T21:46:38.106Z",
-  "lastUpdate": "2026-05-16T09:20:00Z",
+  "lastUpdate": "2026-05-17T06:50:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1021Aristotle.lean",
       "filename": "Erdos1021Aristotle.lean",
-      "lineCount": 83,
+      "lineCount": 82,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
@@ -109,18 +113,18 @@
     {
       "path": "Proofs/Erdos1021OQ01.lean",
       "filename": "Erdos1021OQ01.lean",
-      "lineCount": 192,
+      "lineCount": 191,
       "theoremCount": 8,
       "axiomCount": 2,
       "defCount": 2,
-      "sorryCount": 6,
+      "sorryCount": 5,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1021OQ01.lean"
     },
     {
       "path": "Proofs/Erdos1021OQ01Aristotle.lean",
       "filename": "Erdos1021OQ01Aristotle.lean",
-      "lineCount": 80,
+      "lineCount": 79,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,
@@ -131,7 +135,7 @@
     {
       "path": "Proofs/Erdos1021Problem.lean",
       "filename": "Erdos1021Problem.lean",
-      "lineCount": 242,
+      "lineCount": 241,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 16,


### PR DESCRIPTION
## Summary

**S3 STATE-SYNC for `erdos-1021-oq-01` (Does ex(n, G_k) = o(n^{3/2}) for any k ≥ 4, pool tier B, significance 7, knowledge=21 RICH)** — 2-file doc-only follow-up to S2 PREP (PR #19550, T-22h, same researcher-11). The planned S3 ACT (discharge L165 `lower_bound_exponent_tendsto` via paste-ready ~8 LOC `Filter.Tendsto` chain) is **deferred** due to 3-RED INFRA.

### Why S3 ACT is deferred
- **G7 RED**: `df -h /Users/rwalters` → 4.4 GiB avail / 100% capacity (well below 50 GiB needed for Docker Lean build)
- **G8 RED**: `docker ps` hangs (Docker server unresponsive)
- Per memory trap `_skip_when_deployer_down_due_to_host_disk_full_*`, substantive Lean ACT is infeasible until INFRA recovers
- S4 ACT plan unchanged from S2 PREP §3.1 — ship paste-ready chain when disk avail ≥ 50 GiB

### Drift surfaces fixed

| # | Field | Before | After | Drift |
|---|-------|--------|-------|-------|
| 1 | `currentState.iteration` | 2 | 3 | — |
| 2 | `currentState.focus` | S2 PREP scope | S3 STATE-SYNC scope + INFRA deferral | — |
| 3 | `currentState.nextAction` | S3 ACT plan | S4 ACT plan (chain unchanged from S2 PREP) | — |
| 4 | `currentState.blockers` | `[]` | 3 entries (G7 disk, G8 Docker, S5+ parent slug) | — |
| 5 | `currentState.attemptCounts.total` | 1 | 2 | — |
| 6 | `lastUpdate` | 2026-05-16T09:20:00Z | 2026-05-17T06:50:00Z | — |
| 7 | `leanFiles[0].lineCount` (Erdos1021Aristotle.lean) | 83 | 82 | **+1 off-by-one** |
| 8 | `leanFiles[1].lineCount` (Erdos1021OQ01.lean) | 192 | 191 | **+1 off-by-one** |
| 9 | `leanFiles[1].sorryCount` (Erdos1021OQ01.lean) | 6 | 5 | **dedupe comment-mention** |
| 10 | `leanFiles[2].lineCount` (Erdos1021OQ01Aristotle.lean) | 80 | 79 | **+1 off-by-one** |
| 11 | `leanFiles[3].lineCount` (Erdos1021Problem.lean) | 242 | 241 | **+1 off-by-one** |
| 12 | `research/problems/erdos-1021-oq-01/state.md` | S2 PREP iter 2 header | S3 STATE-SYNC iter 3 header + INFRA blockers section + ledger row | — |

### sorryCount dedupe note
Raw `grep -c 'sorry'` finds 5 occurrences in Erdos1021OQ01.lean — but L186 is a doc-comment mention (`- 3 sorry results: ...`), not an actual `by sorry`. Real sorries: 4 (L112, L127, L136, L165) per S2 PREP §3 classification. Registry-stored `sorryCount` field uses raw grep convention (matches mechanic's batch sync), so the canonical fix is 6 → 5 (not 4) here.

### Verification
```
$ wc -l proofs/Proofs/Erdos1021{Aristotle,OQ01,OQ01Aristotle,Problem}.lean
     82 proofs/Proofs/Erdos1021Aristotle.lean
    191 proofs/Proofs/Erdos1021OQ01.lean
     79 proofs/Proofs/Erdos1021OQ01Aristotle.lean
    241 proofs/Proofs/Erdos1021Problem.lean
$ grep '^axiom ' proofs/Proofs/Erdos1021OQ01.lean
axiom kst_trivial_bound (k : ℕ) (hk : k ≥ 4) :
axiom probabilistic_lower_bound (k : ℕ) (hk : k ≥ 4) :
$ grep -n 'sorry' proofs/Proofs/Erdos1021OQ01.lean
112:  sorry -- The o() definition gives a uniform O() bound
127:  sorry -- Requires k3_case_solved (itself a sorry in the parent)
136:  sorry -- The monotonicity of extremal numbers in k is non-trivial for pair graphs
165:    · sorry -- 1/(k-1) → 0 requires Filter.Tendsto + arithmetic
186:    - 3 sorry results: k3 weak conjecture proof, k3/k independence, and o() bound uniformity
$ df -h /Users/rwalters | tail -1
/dev/disk3s5   926Gi   885Gi   4.4Gi   100%     21M   47M   31%   /System/Volumes/Data
```

### Conjecture status
Open. OQ-01 asks whether `ex(n, G_k) = o(n^{3/2})` for k ≥ 4 (weak form of Erdős #1021, open since 1980s). Gallery meta.json correctly marks `status: "axiomatized"` + `badge: "axiom"` + `axiomCount: 2`. Lean side has 2 known-result axioms (KST trivial bound + probabilistic lower bound) and 4 real sorries (1 MECHANICAL + 1 MECHANICAL + 1 BLOCKED + 1 HARD).

### Pool flip — NOT done
Slug remains `status: in-progress` (ORIENT phase, axiomatized rest state, 4 real sorries still need discharge once INFRA recovers). Claim released without pool flip.

## Test plan

- [x] JSON validates
- [x] All 4 leanFiles[] lineCount drift confirmed via `wc -l`
- [x] sorryCount dedupe confirmed via `grep -n 'sorry'`
- [x] INFRA RED confirmed via `df -h` (4.4 Gi / 100%) and `docker ps` (hangs)
- [x] No Lean source changes — doc-only
- [x] Diff stat: 2 files +46/-26

🤖 Generated with Claude Code