### PR TITLE
fix(meta): sync erdos-891 theoremCount 35→30

### DIFF
--- a/src/data/proofs/erdos-891/meta.json
+++ b/src/data/proofs/erdos-891/meta.json
@@ -67,7 +67,7 @@
     "axiomCount": 0,
     "lineCount": 439,
     "assumptions": "",
-    "theoremCount": 35,
+    "theoremCount": 30,
     "definitionCount": 11
   },
   "overview": {
@@ -188,7 +188,7 @@
     "namespace": "Erdos891",
     "lineCount": 439,
     "axiomCount": 0,
-    "theoremCount": 35,
+    "theoremCount": 30,
     "definitionCount": 11,
     "path": "Proofs/Erdos891Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Single-field metadata sync for `erdos-891` gallery `meta.json`.

- `theoremCount`: 35 → 30 (top-level + leanFile blocks)

Direct count via `grep -cE '^(theorem|lemma|example) ' proofs/Proofs/Erdos891Problem.lean` gives **30**, which matches `state.md` prose ("30 theorems/lemmas") and the actual Lean source. Other numerics are already canonical: `lineCount: 439`, `definitionCount: 11`, `axiomCount: 0`, `sorries: 0`.

## Context

`erdos-891` is registry-COMPLETED+graduated since 2026-03-24 per `research/registry.json`. Lean formalization complete since PR #16320 (2026-05-06). The `theoremCount: 35` figure pre-dated several minor refactors; this PR aligns gallery metadata with the source.

## Test plan
- [x] `grep -cE '^(theorem|lemma|example) ' proofs/Proofs/Erdos891Problem.lean` → 30
- [x] `grep -cE '^(def|noncomputable def|abbrev) ' proofs/Proofs/Erdos891Problem.lean` → 11
- [x] `wc -l proofs/Proofs/Erdos891Problem.lean` → 439
- [x] No Lean changes — doc-only metadata sync
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)