### PR TITLE
research(erdos-1149): S4 STATE-SYNC — sync research/ docs to post-PR-#15578 axiom-elimination state (doc-only)

### DIFF
--- a/research/problems/erdos-1149/knowledge.md
+++ b/research/problems/erdos-1149/knowledge.md
@@ -12,9 +12,10 @@ $$
 
 **Erdős Database Status**: SOLVED (Bergelson–Richter 2017)
 
-**Lean Formalization**: 0 sorries, 2 axioms
+**Lean Formalization**: 0 sorries, 1 axiom
 - `bergelson_richter` — main theorem (deep ergodic theory).
-- `random_coprime_density` — classical 6/π² coprime probability.
+
+(`random_coprime_density` was previously axiomatized but was proved in PR #15578 via Möbius+Tannery.)
 
 **Tractability Score**: 6/10
 **Aristotle Suitable**: Companion file (`Erdos1149Aristotle.lean`) is 0-sorry; no further candidates.
@@ -37,21 +38,23 @@ $$
 - Möbius detection: ∑_{d ∣ gcd(a,b)} μ(d) = [gcd(a,b) = 1] (proved as `moebius_sum_divisors_eq`).
 - Counting identity (open in Lean): C(N) := |{(a,b) ∈ [1,N]² : gcd(a,b) = 1}| = ∑_{d=1}^N μ(d) ⌊N/d⌋² (follows from `moebius_sum_divisors_eq` + `card_multiples` + `pairs_with_common_factor`, all proved).
 
-## Path-to-Proof for `random_coprime_density`
+## Path-to-Proof for `random_coprime_density` (HISTORICAL — now proved)
 
-Existing infrastructure already proved in `Erdos1149Problem.lean`:
+This subgoal was completed in PR #15578. The actual proof reuses the Möbius infrastructure listed below and delegates the analytic crux (Möbius–Tannery interchange) to `BaselProblemOQ04OQ03.coprime_pair_density_limit`, rather than re-deriving it inline.
+
+Infrastructure preserved in `Erdos1149Problem.lean`:
 
 1. `moebius_sum_divisors_eq`: ∑_{d ∣ n} μ(d) = [n = 1] (Dirichlet identity μ * ζ = ε).
 2. `card_multiples`: |{a ∈ [1,N] : d ∣ a}| = ⌊N/d⌋.
 3. `pairs_with_common_factor`: for prime p, |{(a,b) : p ∣ gcd(a,b)}| = ⌊N/p⌋².
 
-Remaining work to eliminate the `random_coprime_density` axiom:
+Historical step-by-step plan (the path that was actually followed):
 
-- **Step A** (counting identity): `countCoprimePairs N = ∑_{d=1}^N μ(d) * (⌊N/d⌋)²`. Uses `moebius_sum_divisors_eq` plus a sum-swap on (a,b,d) with d ∣ gcd(a,b). The `pairs_with_common_factor` lemma generalises straightforwardly from prime p to arbitrary d.
-- **Step B** (asymptotic interchange — Möbius–Tannery): `(1/N²) ∑_{d=1}^N μ(d) ⌊N/d⌋² → ∑_{d=1}^∞ μ(d)/d²`. The natural tool is dominated convergence / Tannery's theorem on `Filter.atTop`. The dominating series `∑ 1/d²` converges (Mathlib: `summable_one_div_nat_pow_of_one_lt`).
-- **Step C** (closed-form sum): `∑_{d=1}^∞ μ(d)/d² = 1/ζ(2) = 6/π²`. Mathlib has `hasSum_zeta_two` (Basel: ∑1/n² = π²/6); combine with the fact that `(∑μ(d)/d^s)(ζ(s)) = 1` (Dirichlet inversion, see `ArithmeticFunction.moebius_mul_coe_zeta`). At s=2 this gives `∑ μ(d)/d² = 1/ζ(2)`.
+- **Step A** (counting identity): `countCoprimePairs N = ∑_{d=1}^N μ(d) * (⌊N/d⌋)²`. Uses `moebius_sum_divisors_eq` plus a sum-swap on (a,b,d) with d ∣ gcd(a,b).
+- **Step B** (asymptotic interchange — Möbius–Tannery): `(1/N²) ∑_{d=1}^N μ(d) ⌊N/d⌋² → ∑_{d=1}^∞ μ(d)/d²`. Imported from `BaselProblemOQ04OQ03.coprime_pair_density_limit` to avoid re-proving Tannery.
+- **Step C** (closed-form sum): `∑_{d=1}^∞ μ(d)/d² = 1/ζ(2) = 6/π²`. Mathlib's `hasSum_zeta_two` plus `ArithmeticFunction.moebius_mul_coe_zeta`.
 
-Difficulty estimate: ~150–250 lines of Lean. Step A is the mechanical accounting; Step B is the analytic core (Tannery); Step C is a known Mathlib pattern. None of the three steps require results outside Mathlib.
+Final realised cost: a single theorem in the main file (`random_coprime_density`, line 162) bridging Set/Finset cardinality back to the `BaselProblemOQ04OQ03` density limit, plus light infrastructure already in place. The hard analytic step lives in the Basel companion slug.
 
 ## Bergelson–Richter Axiom
 
@@ -77,9 +80,11 @@ These ingredients are far from Mathlib. Leaving this axiom in place is the right
 
 - 2026-03-11 (researcher-5): Initial formalization, 16 theorems, 2 axioms.
 - 2026-03-13: Möbius inversion infrastructure (`moebius_sum_divisors_eq`, `card_multiples`, `pairs_with_common_factor`).
-- 2026-03-24: Gallery integration polished.
+- 2026-03-24: Gallery integration polished; registry marks slug COMPLETED + graduated.
 - 2026-04-27 (researcher-8): JSON metadata reconciled (sorryCount 1→0 for Aristotle file, line counts corrected, problemStatement and knownResults populated). Documented concrete path-to-proof for `random_coprime_density` axiom.
+- PR #15578: Axiom-elimination ACT — `random_coprime_density` proved via Möbius+Tannery (delegating asymptotic interchange to `BaselProblemOQ04OQ03.coprime_pair_density_limit`). Main file axiom count 2→1. The remaining axiom (`bergelson_richter`) is retained by design.
+- 2026-05-17 (researcher-9, S4 STATE-SYNC): Doc-only sync — corrected `problem.md` counts (320→335 lines, 17→18 theorems, 2→1 axioms), updated `knowledge.md` axiom listing (`random_coprime_density` is now a proved theorem, not an axiom), and updated `state.md` from ACT→COMPLETED. Gallery `meta.json` was already canonical. No Lean source touched.
 
 ---
 
-*Last updated: 2026-04-27*
+*Last updated: 2026-05-17*

--- a/research/problems/erdos-1149/problem.md
+++ b/research/problems/erdos-1149/problem.md
@@ -45,12 +45,13 @@ tags:
 
 ## Formalization Status
 
-- `Proofs/Erdos1149Problem.lean` (320 lines, 17 theorems, 5 definitions, **0 sorries, 2 axioms**)
+- `Proofs/Erdos1149Problem.lean` (335 lines, 18 theorems, 5 definitions, **0 sorries, 1 axiom**)
 - `Proofs/Erdos1149Aristotle.lean` (106 lines, 14 theorems, **0 sorries, 0 axioms**)
 
-The 2 axioms in the main file:
+The 1 axiom in the main file:
 - `bergelson_richter` — main theorem, deep ergodic theory; unlikely Mathlib-provable.
-- `random_coprime_density` — classical Cesàro result; **infrastructure is in place** (`moebius_sum_divisors_eq`, `card_multiples`, `pairs_with_common_factor`) plus Mathlib's `hasSum_zeta_two`. Remaining gap is the Möbius–Tannery asymptotic interchange.
+
+`random_coprime_density` (classical Cesàro result) was originally axiomatized but was proved in PR #15578 via Möbius inversion + Tannery's theorem, drawing on `BaselProblemOQ04OQ03.coprime_pair_density_limit`. The supporting infrastructure (`moebius_sum_divisors_eq`, `card_multiples`, `pairs_with_common_factor`) is preserved in the file as proved lemmas.
 
 ## Related Gallery Proofs
 

--- a/research/problems/erdos-1149/state.md
+++ b/research/problems/erdos-1149/state.md
@@ -1,33 +1,33 @@
 # Current State
 
-**Phase**: ACT (axiom-elimination opportunity)
-**Since**: 2026-04-27
-**Iteration**: 3
+**Phase**: COMPLETED (axiom-elimination subgoal achieved; Bergelson–Richter axiom retained by design)
+**Since**: 2026-05-17 (S4 STATE-SYNC; subgoal completed by PR #15578 on an earlier date)
+**Iteration**: 4
 
 ## Current Focus
 
-Eliminating the `random_coprime_density` axiom. The Bergelson–Richter axiom is left in place as a deep ergodic-theory result not currently in Mathlib's reach.
+No active research focus. The `random_coprime_density` axiom-elimination subgoal that motivated the ACT phase (iter 3) was completed by PR #15578 — `random_coprime_density` is now a proved theorem in `Erdos1149Problem.lean` (line 162), reducing the file's axiom count from 2 to 1.
+
+The remaining `bergelson_richter` axiom is retained by mathematical-design judgment: it encapsulates the deep ergodic-theory main theorem of Bergelson–Richter (2017), which sits well outside Mathlib's current reach (Bergelson–Host–Kra structure theorem, nilfactor analysis, multiplicative-function-along-polynomial-sequences machinery).
 
 ## Active Approach
 
-Möbius inversion + Tannery's theorem on the partial sums:
-
-1. Counting identity: `countCoprimePairs N = ∑_{d=1}^N μ(d) ⌊N/d⌋²`.
-2. Asymptotic interchange: `(1/N²) ∑_{d=1}^N μ(d) ⌊N/d⌋² → ∑_d μ(d)/d²`.
-3. Closed form: `∑_d μ(d)/d² = 1/ζ(2) = 6/π²` via Mathlib's `hasSum_zeta_two` and `moebius_mul_coe_zeta`.
-
-All three steps stay within Mathlib's toolkit; no external theory needed.
+None active. The Möbius+Tannery approach previously documented as the elimination path was successfully executed in PR #15578 (via `BaselProblemOQ04OQ03.coprime_pair_density_limit`).
 
 ## Blockers
 
-- None hard. Step B (Möbius–Tannery interchange) is the analytic crux; expect ~80–120 lines.
+None. The slug is in a stable rest state: gallery `status: axiomatized`, `badge: axiom`, 1 axiom (`bergelson_richter`) by design.
 
 ## Next Action
 
-Implement Step A (counting identity) as a standalone lemma `countCoprimePairs_eq_moebius_sum`, generalizing `pairs_with_common_factor` from prime p to arbitrary d ≥ 1.
+No queued action. Future re-engagement candidates (low priority, all stretch):
+
+- **A. Bergelson–Richter formalization** — Multi-year effort; would require building Bergelson–Host–Kra and a nilfactor library. Not tractable in current Mathlib.
+- **B. Alternative elementary proofs of Bergelson–Richter** — Survey for any post-2017 elementary or simpler proofs that could shrink the formalization gap.
+- **C. Strengthen related infrastructure** — The Möbius and density lemmas in `Erdos1149Problem.lean` may be useful for sibling Erdős slugs; consider abstracting reusable pieces.
 
 ## Attempt Counts
 
-- Total attempts: 0 (axiom-elimination not yet attempted)
+- Total attempts: 1 (this STATE-SYNC after PR #15578 already eliminated the documented axiom-elimination target)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (Möbius+Tannery — succeeded in PR #15578)


### PR DESCRIPTION
## Summary

Doc-only S4 STATE-SYNC for **erdos-1149** (Coprimality of n and ⌊n^α⌋). The slug is registry-COMPLETED + graduated (2026-03-24); PR #15578 then proved `random_coprime_density`, reducing the main file's axiom count from 2 to 1. Gallery `meta.json` already reflects the post-elimination state, but the `research/problems/erdos-1149/` markdown files were stale (last meaningfully touched 2026-04-27, mass-imported on 2026-05-16 by an unrelated sperner-ndim-mathlib-oq-01-oq-04 directory sweep without content change).

- **problem.md**: lineCount 320→335, theoremCount 17→18, axiomCount 2→1; removed `random_coprime_density` from the live axiom list and noted that PR #15578 proved it via `BaselProblemOQ04OQ03.coprime_pair_density_limit`.
- **knowledge.md**: Status block 2→1 axiom; rewrote the "Path-to-Proof for `random_coprime_density`" section as historical with realised cost (a single bridge theorem + delegation to Basel); appended PR #15578 and S4 STATE-SYNC sessions entries; lastUpdate 2026-04-27 → 2026-05-17.
- **state.md**: Phase ACT → COMPLETED (axiom-elimination subgoal achieved); iteration 3 → 4; Active Approach / Blockers / Next Action rewritten to reflect rest state; Attempt Counts 0 → 1.

Gallery `meta.json` is already canonical (lineCount 335, theoremCount 18, definitionCount 5, axiomCount 1, sorries 0, status `axiomatized`, badge `axiom`). No drift there.

## Why this is doc-only

- No `proofs/Proofs/Erdos1149*.lean` files are touched.
- No JSON registry / pool files are touched (registry already at COMPLETED + graduated; pool is consistent).
- All edits are inside `research/problems/erdos-1149/{state,problem,knowledge}.md`.

## Verification

Live counts (`wc -l`, grep for `^theorem `/`^lemma `, `^def `/`^structure`, `^axiom `, `\bsorry\b`):

- `Proofs/Erdos1149Problem.lean`: 335 lines, 18 theorems, 5 definitions, 1 axiom (`bergelson_richter`, line 88), 0 sorries.
- `Proofs/Erdos1149Aristotle.lean`: 106 lines, 14 theorems, 0 definitions, 0 axioms, 0 sorries (the lone "sorry" match is in a header comment).

`random_coprime_density` is a proved theorem at line 162 of `Erdos1149Problem.lean`. The remaining `bergelson_richter` axiom is retained by mathematical-design judgment (deep ergodic theory, Bergelson–Host–Kra + nilfactor analysis, far from Mathlib).

## Test plan

- [x] Verify `problem.md` count fixes match `wc -l` and grep counts on the live Lean files.
- [x] Verify `knowledge.md` axiom listing matches the single `axiom bergelson_richter` declaration.
- [x] Verify `state.md` phase change is consistent with the gallery `meta.json` (`status: axiomatized`, 1 axiom — slug is in a stable rest state).
- [x] `git diff --stat`: 3 files, +35/-29 (no Lean source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)