### PR TITLE
research(erdos-390): S3 STATE-SYNC — refresh research/ docs after PR #15930 f(7)/f(8) extension (doc-only)

### DIFF
--- a/research/problems/erdos-390/knowledge.md
+++ b/research/problems/erdos-390/knowledge.md
@@ -33,8 +33,8 @@ the `Filter.Tendsto` open `Prop`, neither of which Aristotle handles)
 
 ## What Is Verified (this formalization)
 
-Located at `proofs/Proofs/Erdos390Problem.lean` (538 lines, 14 theorems, 1 axiom,
-0 sorries; gallery slug `erdos-390`).
+Located at `proofs/Proofs/Erdos390Problem.lean` (558 lines, 16 theorems, 10 definitions,
+1 axiom, 0 sorries; gallery slug `erdos-390`).
 
 | Theorem / Definition | Content |
 |---|---|
@@ -112,7 +112,30 @@ axiom), those could be Aristotle candidates.
   requires resolving the open conjecture itself or replacing the EGS axiom
   with a fully formalized 1982-paper-style proof.
 
+### PR #15930: GCovering framework (borsuk-ulam-oq-04) + f(7), f(8) exact values
+
+- Added concrete witness defs `vf7`, `vf8` and the `factorizationMax_7_le/_ge`,
+  `factorizationMax_8_le/_ge` pairs plus closure theorems
+  `factorizationMax_7_eq` and `factorizationMax_8_eq`.
+- Lean file grew from 538 → 558 lines (+20) and 14 → 16 theorems (+2).
+- This iteration was on a different slug (`borsuk-ulam-oq-04`) but bundled
+  the erdos-390 extension; `state.md` / `problem.md` / `knowledge.md` were
+  not refreshed at that time.
+
+### 2026-05-17 (researcher-9, S3 STATE-SYNC): Doc-only count refresh
+
+- Synced `state.md` Provenance and Current Focus block (538→558 lines,
+  14→16 theorems), and bumped Iteration 2→3, attempts 2→3,
+  Since 2026-04-27→2026-05-17.
+- Updated `problem.md` Current Lean Formalization line (538→558 lines,
+  added theoremCount 16 and definitionCount 10).
+- Updated `knowledge.md` "What Is Verified" header line (538→558 lines,
+  14→16 theorems, added 10 definitions); this Sessions entry.
+- Gallery `meta.json` is already canonical (lineCount 558, theoremCount 16,
+  definitionCount 10, axiomCount 1, sorries 0). No drift there.
+- Lean source untouched.
+
 ---
 
 *Original seed generated from erdosproblems.com on 2026-01-13*
-*Reconciled 2026-04-27 by researcher-1*
+*Reconciled 2026-04-27 by researcher-1; S3 STATE-SYNC 2026-05-17 by researcher-9*

--- a/research/problems/erdos-390/problem.md
+++ b/research/problems/erdos-390/problem.md
@@ -61,7 +61,7 @@ bound)
 ## Current Lean Formalization
 
 **Status**: `axiomatized` (gallery), `MATURE-AXIOMATIZED` (research)
-**Source**: `proofs/Proofs/Erdos390Problem.lean` (538 lines)
+**Source**: `proofs/Proofs/Erdos390Problem.lean` (558 lines, 16 theorems, 10 definitions)
 **Sorries**: 0
 **Axioms**: 1 (`factorizationMax_asymptotic`, the EGS two-sided bound)
 

--- a/research/problems/erdos-390/state.md
+++ b/research/problems/erdos-390/state.md
@@ -1,8 +1,8 @@
 # Current State
 
 **Phase**: MATURE-AXIOMATIZED
-**Since**: 2026-04-27
-**Iteration**: 2
+**Since**: 2026-05-17 (S3 STATE-SYNC; phase unchanged from iter 2, just refreshed counts)
+**Iteration**: 3
 
 ## Current Focus
 
@@ -13,7 +13,7 @@ itself.
 ## Active Approach
 
 Maintenance/reconciliation only. The Lean formalization
-(`proofs/Proofs/Erdos390Problem.lean`, 538 lines) captures:
+(`proofs/Proofs/Erdos390Problem.lean`, 558 lines) captures:
 
 1. `ValidFactorization n` structure (sorted factors $> n$, product $= n!$)
 2. `factorizationMax n` as the noncomputable `sInf` of maximum factors
@@ -43,14 +43,14 @@ Hold at `axiomatized` status. Possible future enrichment (not blocking):
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 1 (reconciliation iteration)
+- Total attempts: 3 (initial formalization + f(7)/f(8) extension PR #15930 + this STATE-SYNC)
+- Current approach attempts: 2 (reconciliation iteration)
 - Approaches tried: 1 (constructive witness + axiomatized asymptotic + open Prop)
 
 ## Provenance
 
 - Gallery slug: `erdos-390`
-- Lean source: `proofs/Proofs/Erdos390Problem.lean` (538 lines, 14 theorems, 1 axiom, 0 sorries)
+- Lean source: `proofs/Proofs/Erdos390Problem.lean` (558 lines, 16 theorems, 1 axiom, 0 sorries)
 - Gallery meta: `src/data/proofs/erdos-390/meta.json` (status `axiomatized`)
 - OEIS reference: A193429
 - Primary citation: Erdős, Guy, Selfridge (1982), "Another property of 239 and some related questions"


### PR DESCRIPTION
## Summary

Doc-only S3 STATE-SYNC for **erdos-390** (Factorial Factorization: f(n) − 2n asymptotic). Registry-COMPLETED + graduated 2026-03-24. PR #15930 grew the Lean file from 538 → 558 lines and added 2 theorems (factorizationMax_7_eq, factorizationMax_8_eq) without refreshing `research/problems/erdos-390/`. The sperner-ndim-mathlib-oq-01-oq-04 mass-import (PR #19454, T-1d) touched the docs without correcting them.

- **state.md**: Provenance "538 lines, 14 theorems" → "558 lines, 16 theorems"; Active Approach line count; Iteration 2→3; Since 2026-04-27→2026-05-17; Total attempts 2→3.
- **problem.md**: "538 lines" → "558 lines, 16 theorems, 10 definitions".
- **knowledge.md**: "What Is Verified" line "538 lines, 14 theorems" → "558 lines, 16 theorems, 10 definitions"; new Sessions entries for PR #15930 and this S3 STATE-SYNC.

Gallery `meta.json` is already canonical (lineCount 558, theoremCount 16, definitionCount 10, axiomCount 1, sorries 0, status `axiomatized`, badge `axiom`). No drift there.

## Why this is doc-only

- No `proofs/Proofs/Erdos390Problem.lean` files are touched.
- No JSON registry / pool files touched (registry already COMPLETED + graduated; pool consistent).
- All edits inside `research/problems/erdos-390/{state,problem,knowledge}.md`.

## Verification

Live counts:

- `Proofs/Erdos390Problem.lean`: 558 lines, 16 theorems, 10 definitions (1 structure + 9 defs), 1 axiom (`factorizationMax_asymptotic`, line 542), 0 sorries.

Open mathematical conjecture remains: existence/value of $c = \lim_{n \to \infty} (f(n) - 2n) \log n / n$ is unresolved in the literature; EGS asymptotic is axiomatized by design.

## Test plan

- [x] Verify `state.md`/`problem.md`/`knowledge.md` count fixes match `wc -l` and grep on the live Lean file.
- [x] Verify gallery `meta.json` is already canonical (no drift to fix there).
- [x] `git diff --stat`: 3 files, +33/-10 (no Lean source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)