### PR TITLE
fix(meta): sync cauchy-schwarz-integral lineCount 117→118

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 117,
+    "lineCount": 118,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -189,7 +189,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 117,
+    "lineCount": 118,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Single-field metadata sync for `cauchy-schwarz-integral` gallery `meta.json`.

- `lineCount`: 117 → 118 (top-level + `leanFile` block)

Direct count via `wc -l proofs/Proofs/CauchySchwarzIntegral.lean` gives **118**, matching the actual Lean source.

## Context

`cauchy-schwarz-integral` is `status: verified`, `badge: mathlib`, 0 axioms, 0 sorries. Other numerics are already canonical:

- `theoremCount: 6` — confirmed via `grep -cE '^(theorem|lemma|example) ' proofs/Proofs/CauchySchwarzIntegral.lean` = 6 (narrow and broad agree)
- `definitionCount: 0` — confirmed via `grep -cE '^(def |noncomputable def |structure |inductive |abbrev )'` = 0
- `axiomCount: 0` — confirmed via `grep -cE '^axiom '` = 0 and `grep -cE '^opaque '` = 0
- `sorries: 0` — `grep -nE '\bsorry\b'` finds no occurrences

Last touched by batch sync PRs #19622 and #19608 (lineCount drift). The off-by-one survived those batches because they targeted `leanFile.lineCount` only; here both `meta.lineCount` and `leanFile.lineCount` are off by the same +1.

## Validation

`jq -e . src/data/proofs/cauchy-schwarz-integral/meta.json` passes.

---
Automated fix by lean-mechanic agent.