### PR TITLE
research(erdos-327): S5 STATE-SYNC — iter 1 NEW → 5 COMPLETED doc catchup post-PRs-#3481/#4970/#4984 (state.md only)

### DIFF
--- a/research/problems/erdos-327/state.md
+++ b/research/problems/erdos-327/state.md
@@ -1,27 +1,104 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-12T23:55:09.604Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-03-23T04:30:45Z (registry graduated)
+**Iteration**: 5
+**Last Updated**: 2026-05-17
 
-## Current Focus
+## Status Summary
 
-Initial exploration of the problem.
+Sum-Divides-Product Avoidance: structural lemmas + Van Doorn's
+(25/28 + o(1))·N upper bound axiomatized; the underlying Erdős conjecture
+(can A be substantially larger than the odd numbers?) remains open.
+Registry graduated 2026-03-23 after PRs #3481 (oddNumbers + coprime),
+#4970 (GCD characterization), #4984 (axiom elimination 2→1). Gallery
+`meta.json` reflects current Lean state (198 LOC / 8 thm / 5 def / 1 axiom
+/ 0 sorry, status `axiomatized`, badge `axiom`).
 
-## Active Approach
+## Lean File Canonical Counts
 
-None yet.
+`proofs/Proofs/Erdos327Problem.lean` (198 LOC):
+
+| Surface       | Count |
+|---------------|-------|
+| theorem/lemma | 8     |
+| def           | 5     |
+| axiom         | 1     |
+| sorry         | 0     |
+
+## Axiom Inventory (1)
+
+1. `vanDoorn_bound (N : ℕ) (A : Finset ℕ)` (line 53)
+   — Van Doorn's (25/28 + o(1))·N upper bound: if |A| ≥ (25/28 + o(1))·N
+   then A must contain a, b with a + b ∣ a·b. Axiomatized pending Lean
+   formalization of the analytic-NT proof.
+
+## Theorem Inventory (8)
+
+- `sumDvdProd_iff_unitFraction` (line 70) — bridge to unit fractions
+  (a + b ∣ a·b ⇔ 1/a + 1/b is a unit fraction); was an axiom until PR
+  #4984 derived it from Mathlib divisibility lemmas
+- `sumNotDvdProd_empty` (line 105) — trivial base case
+- `sumNotDvdProd_singleton` (line 109) — trivial 1-element case
+- `sumNotDvdProd_subset` (line 115) — monotonicity under ⊆
+- `oddNumbers_sumNotDvdProd` (line 124) — the odd numbers in {1,…,N}
+  satisfy SumNotDvdProd; gives the lower bound A ≈ N/2 (PR #3481)
+- `coprime_sumNotDvdProd` (line 144) — pairwise-coprime pairs satisfy
+  the avoidance condition (PR #3481)
+- `sumNotDvdProd_of_pairwise_coprime` (line 158) — pairwise-coprime
+  Finsets satisfy SumNotDvdProd globally
+- `sumDvdProd_iff_reduced_divides_gcd` (line 174) — GCD characterization:
+  a + b ∣ a·b iff (a/g + b/g) ∣ g where g = gcd(a,b) (PR #4970)
+
+## Definition Inventory (5)
+
+- `def SumNotDvdProd` (line 30) — main avoidance predicate
+- `def SumNotDvdTwoProd` (line 34) — variant predicate (factor of 2)
+- `noncomputable def maxAvoidSize` (line 38) — extremal function over
+  subsets of {1,…,N}
+- `def ErdosProblem327` (line 45) — formal problem statement
+- `def ErdosProblem327_variant` (line 61) — formal variant statement
+
+## Open Conjecture
+
+The Erdős problem itself (can A be much larger than ≈ N/2?) remains open.
+The standing axiom `vanDoorn_bound` encodes Van Doorn's published upper
+bound (analytic number theory, beyond current Mathlib coverage). Further
+axiom elimination would require Lean formalization of Van Doorn's paper —
+a substantial dedicated project.
+
+The SumNotDvdTwoProd variant (must |A| = o(N) if a+b ∤ 2·a·b for distinct
+a,b?) has no Lean content beyond the definition; it is a sibling open
+question.
 
 ## Blockers
 
-None.
+None for the current state. The slug is at its honest rest-state pending
+either (a) Lean formalization of Van Doorn's bound or (b) progress on the
+underlying conjecture.
 
 ## Next Action
 
-Begin problem exploration.
+`COMPLETED` — no further iteration planned without external mathematics.
+Pool flipped to `completed`; claim released. Re-open with a SCOPED phase
+if Van Doorn's bound becomes formalizable or if the SumNotDvdTwoProd
+variant gets traction.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5 (iter 1 OBSERVE → iter 2 oddNumbers+coprime PR #3481
+  → iter 3 GCD characterization PR #4970 → iter 4 axiom 2→1 PR #4984
+  → iter 5 STATE-SYNC)
+- Current approach attempts: 0 (rest state)
+- Approaches tried: OBSERVE/enhance, structural-lemma-development,
+  GCD-characterization, axiom-elimination-via-Mathlib, documentation sync
+
+## Iteration Ledger
+
+| Iter | Date       | Phase / Action                                         | PR     |
+|------|------------|--------------------------------------------------------|--------|
+| 1    | 2026-01-26 | OBSERVE — initial Lean file w/ 2 axioms + variants     | #1175  |
+| 2    | 2026-03-11 | ACT — `oddNumbers_sumNotDvdProd` + coprime lemmas      | #3481  |
+| 3    | 2026-03-22 | ACT — `sumDvdProd_iff_reduced_divides_gcd`             | #4970  |
+| 4    | 2026-03-22 | ACT — eliminate `sumDvdProd_iff_unitFraction` (2→1)    | #4984  |
+| 5    | 2026-05-17 | STATE-SYNC — docs catch up to gallery (registry T-55d) | (this) |


### PR DESCRIPTION
## Summary

S5 STATE-SYNC for `erdos-327` (Sum-Divides-Product Avoidance): doc-only state.md rewrite catching up to gallery + Lean reality 55 days after registry graduation.

- **Phase**: NEW (iter 1) → **COMPLETED** (iter 5)
- **Trigger**: state.md never updated past iter-1 NEW despite 4 Lean development cycles between 2026-01-26 and 2026-03-22, ending with registry graduation on 2026-03-23 (T-55d). Gallery `meta.json` is canonical (`axiomatized`/`axiom`/198/8/5/1/0); state.md said "Phase NEW, Initial exploration, attemptCounts=0"
- **state.md mass-import lineage**: file's last touch was sperner PR #19454 directory sweep (2026-05-16, T-1d), which carried the stale state.md forward without content updates — classic mass-import-via-unrelated-PR pattern
- **Pool**: flipped to `completed` (was `in-progress` with stale "Initial exploration" notes); claim released post-merge

## Drift surfaces fixed in state.md

| Surface              | Was                          | Now                                       |
|----------------------|------------------------------|-------------------------------------------|
| Phase                | NEW                          | COMPLETED                                 |
| Since                | 2026-01-12 (slug creation)   | 2026-03-23 (registry graduation)          |
| Iteration            | 1                            | 5                                         |
| Last Updated         | (missing)                    | 2026-05-17                                |
| Current Focus        | "Initial exploration"        | (replaced w/ Status Summary)              |
| Active Approach      | "None yet"                   | (replaced w/ inventories)                 |
| Next Action          | "Begin problem exploration"  | "COMPLETED; reopen if Van Doorn formalizes" |
| Attempt Counts total | 0                            | 5                                         |
| Approaches tried     | 0                            | 5 (OBSERVE → … → STATE-SYNC)              |

## What's added

- Lean canonical counts table (198 LOC / 8 thm / 5 def / 1 axiom / 0 sorry)
- 8 theorem inventory with line numbers + provenance PRs (#3481, #4970, #4984)
- 5 definition inventory with line numbers
- 1 axiom inventory (`vanDoorn_bound`) w/ irreducibility rationale (analytic-NT proof beyond current Mathlib)
- Open-conjecture note covering both `ErdosProblem327` and the `SumNotDvdTwoProd` variant
- 5-row iteration ledger spanning PRs #1175 → #3481 → #4970 → #4984 → STATE-SYNC

## What's NOT changing

- `proofs/Proofs/Erdos327Problem.lean` — file is canonical; no Lean edits
- `src/data/proofs/erdos-327/meta.json` — already canonical (matches grep)
- The standing axiom `vanDoorn_bound` is an irreducible mathematical assumption; the Erdős conjecture itself remains open

## Test plan

- [x] Theorem count verified: `grep -cE '^\s*(private |protected |noncomputable )*(theorem|lemma) ' Proofs/Erdos327Problem.lean` → 8
- [x] Definition count verified via same broader pattern → 5
- [x] Axiom count verified: 1 (`vanDoorn_bound`)
- [x] Sorry count verified: `grep -cE '\bsorry\b'` → 0
- [x] Line count verified: `wc -l` → 198
- [x] Diff is doc-only (1 file, +89/-12, `state.md`); no source code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)