### PR TITLE
research: state-sync erdos-413 (NEW->COMPLETED, 0 sorries verified)

### DIFF
--- a/research/problems/erdos-413/state.md
+++ b/research/problems/erdos-413/state.md
@@ -1,27 +1,43 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-13T02:41:06.675Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-03-28T09:20:00Z
+**Iteration**: 2
+**Completed**: 2026-03-23T22:15:18Z
+**Graduated**: yes (registry status: graduated)
 
 ## Current Focus
 
-Initial exploration of the problem.
+Graduated formalization: 109 theorems, 19 definitions, 1 axiom (open conjecture), 0 sorries, 1115 LOC.
+
+Erdős #413 is an open conjecture (are there infinitely many ω-barriers?). The formalization is comprehensive — only the conjecture itself remains as an axiom, with 2 prior axioms (`erdos_expProd_positive_density`, `selfridge_bigOmega_barrier`) eliminated as unused Prop defs.
 
 ## Active Approach
 
-None yet.
+None — formalization complete. Future work would require new mathematics, not Lean engineering.
 
 ## Blockers
 
-None.
+None. Single remaining axiom `erdos_413_conjecture` is the OPEN conjecture itself; cannot be resolved without a mathematical breakthrough.
 
 ## Next Action
 
-Begin problem exploration.
+None — formalization complete. Slug remains in `completed`/`graduated` registry status.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 0 (graduated without iteration churn)
 - Current approach attempts: 0
 - Approaches tried: 0
+
+## Files
+
+- `proofs/Proofs/Erdos413Problem.lean` — 1115 LOC, 109 theorems, 19 defs, 1 axiom (open conjecture), 0 sorries
+- `src/data/proofs/erdos-413/meta.json` — gallery entry, status=axiomatized, badge=axiom
+
+## Notes
+
+- Registry status: COMPLETED + graduated since 2026-03-23T22:15:18Z
+- Per-slug research JSON `currentState.phase`: COMPLETED since 2026-03-28T09:20:00Z
+- Gallery meta.json (`src/data/proofs/erdos-413/meta.json`) is canonical: status=axiomatized, sorries=0, axiomCount=1, theoremCount=109, definitionCount=19, lineCount=1115
+- Prior state.md was NEW/iter-1 — never updated after registry graduation (T~55d stale). This refresh propagates registry+per-slug-JSON state into state.md.

--- a/src/data/research/problems/erdos-413.json
+++ b/src/data/research/problems/erdos-413.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-413",
   "title": "Erdős #413",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -19,7 +19,7 @@
     "phase": "COMPLETED",
     "since": "2026-03-28T09:20:00Z",
     "iteration": 2,
-    "focus": "Graduated: 108 theorems, 0 sorries, 3 deep axioms",
+    "focus": "Graduated: 109 theorems, 19 definitions, 1 axiom (open conjecture), 0 sorries; 1115 LOC",
     "blockers": [],
     "nextAction": "None — formalization complete.",
     "attemptCounts": {
@@ -69,15 +69,16 @@
     "mathlib": []
   },
   "started": "2026-01-13T02:41:06.675Z",
-  "lastUpdate": "2026-03-13T07:52:17.048Z",
+  "lastUpdate": "2026-05-17T14:36:00Z",
+  "completed": "2026-03-23T22:15:18.939Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos413Problem.lean",
       "filename": "Erdos413Problem.lean",
-      "lineCount": 1116,
-      "theoremCount": 108,
+      "lineCount": 1115,
+      "theoremCount": 109,
       "axiomCount": 1,
       "defCount": 19,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

State-sync for erdos-413 ω-barriers slug. Registry has been COMPLETED+graduated since 2026-03-23 (T-55d), but per-slug `state.md` and research JSON top-level were never updated past NEW/OBSERVE.

## Drift surfaces refreshed (2 files, +31/-14)

**`src/data/research/problems/erdos-413.json`**
- top-level: `phase` OBSERVE→COMPLETED, `status` active→completed
- `currentState.focus`: refreshed to "109 theorems, 19 definitions, 1 axiom (open conjecture), 0 sorries; 1115 LOC"
- `lastUpdate` 2026-03-13 → 2026-05-17
- `completed` field added (2026-03-23T22:15:18Z, matches registry)
- `leanFiles[0].lineCount` 1116 → 1115 (off-by-one fix)
- `leanFiles[0].theoremCount` 108 → 109 (missed 1 theorem)

**`research/problems/erdos-413/state.md`**
- Full rewrite from NEW/iter1 stale → COMPLETED/iter2 reflecting graduation

## Verification

\`\`\`
wc -l proofs/Proofs/Erdos413Problem.lean       → 1115
grep -cE '^(private )?(noncomputable )?theorem |^(private )?(noncomputable )?lemma ' → 109
grep -cE '^(private )?(noncomputable )?def '   → 19
grep -c '^axiom '                              → 1
grep -c sorry                                  → 0
\`\`\`

Matches gallery \`src/data/proofs/erdos-413/meta.json\` (already canonical: status=axiomatized, badge=axiom, sorries=0, axiomCount=1, theoremCount=109, definitionCount=19, lineCount=1115).

## Why state.md was stale

Registry was set COMPLETED+graduated on 2026-03-23 and per-slug JSON \`currentState.phase\` was set COMPLETED on 2026-03-28, but \`state.md\` was never refreshed (left at NEW/iter1/2026-01-13 template). This is the canonical "long-completed slug with stale state.md" STATE-SYNC pattern.

## Lean file unchanged

No code changes — slug remains in graduated state with 1 remaining axiom (\`erdos_413_conjecture\`, the open conjecture itself).

## Pool

Flipped \`in-progress\` → \`completed\` pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)