### PR TITLE
fix(meta): batch sync NavierStokes.lean lineCount 21110→21111 in 4 navier-stokes siblings

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21110,
+    "lineCount": 21111,
     "mathlib_version": "4.26.0",
     "theoremCount": 845,
     "definitionCount": 366
@@ -266,7 +266,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "relatedProblems": [
       {
@@ -183,7 +183,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0",
     "theoremCount": 845,
@@ -204,7 +204,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,

--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21110,
+    "lineCount": 21111,
     "theoremCount": 845,
     "definitionCount": 366
   },
@@ -365,7 +365,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21110,
+    "lineCount": 21111,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 845,


### PR DESCRIPTION
## Summary

- Bumps `lineCount` 21110→21111 in **4 navier-stokes sibling slugs** that all reference `proofs/Proofs/NavierStokes.lean`.
- Each slug has two `lineCount` fields (top-level `meta.lineCount` + `leanFile.lineCount`) — both updated.
- `endLine: 21110` annotation inside `navier-stokes-oq-01/meta.json` `sections[]` is left untouched (it references a specific theorem block, not the file end).

## Canonical lineCount semantic

`NavierStokes.lean` ends without a trailing newline:

```
proofs/Proofs/NavierStokes.lean: nlines=21110 trailing_nl=False logical_lines=21111
```

The gallery's enrichment script `scripts/research/enrich-research.ts` uses:

```ts
const lines = content.split('\n')
lineCount: lines.length,
```

`content.split('\n')` on a no-trailing-newline file returns one element per logical line → 21111. The pre-existing meta.json values (21110) reflected `wc -l` (newline count), so they were off by one.

This is the same convention used by PR #20213 (`cauchy-schwarz-integral` lineCount 117→118, identical no-trailing-newline pattern).

## Slugs updated

| Slug | Path |
|------|------|
| `navier-stokes` | `src/data/proofs/navier-stokes/meta.json` |
| `navier-stokes-existence` | `src/data/proofs/navier-stokes-existence/meta.json` |
| `navier-stokes-oq-01` | `src/data/proofs/navier-stokes-oq-01/meta.json` |
| `navier-stokes-oq-02` | `src/data/proofs/navier-stokes-oq-02/meta.json` |

## Verification

Other numerics (`axiomCount`, `theoremCount: 845`, `definitionCount: 366`, `sorries: 0`) verified canonical via grep against `NavierStokes.lean` — only `lineCount` drifted.

## Test plan

- [x] `git diff --stat` shows exactly 4 files, 8 line edits, all `lineCount` field
- [x] No edits to `endLine` annotation in `navier-stokes-oq-01` sections[]
- [x] No edits to non-lineCount numerics

Automated fix by lean-mechanic agent.