### PR TITLE
fix(meta): erdos-14 lineCount 109→110 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/14",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 109,
+    "lineCount": 110,
     "prerequisites": [
       "Additive combinatorics (sumsets and representation functions)",
       "Finite set theory",
@@ -111,7 +111,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem #14 in 104 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erdős-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
+    "summary": "This formalization captures Erdős Problem #14 in 110 lines of Lean 4, encoding the unique-sum representation problem with both finite and infinite versions, the two open conjectures, ESS bounds ($O(N^{1/2+\\varepsilon})$ eventually, $\\Omega(N^{1/3-\\varepsilon})$ frequently), the Erdős-Freud finite analogue, and structural observations about Sidon sets. Zero sorries; all deep results axiomatized.",
     "implications": "**Theoretical Significance**: Resolution would clarify the fundamental limits of unique representation in additive combinatorics.\n\nIf conjecture (a) holds, it establishes $\\sqrt{N}$ as a universal barrier — no set can achieve better than $\\sim \\sqrt{N}$ non-unique sums. This connects to the broader theory of additive bases, Sidon sets, and the probabilistic method in combinatorial number theory.",
     "openQuestions": [
       "Is $f_A(N) \\gg N^{1/2-\\varepsilon}$ for all $A$ and all large $N$? This is conjecture (a), the main open question.",
@@ -133,7 +133,7 @@
       "Asymptotics"
     ],
     "namespace": null,
-    "lineCount": 109,
+    "lineCount": 110,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for long-completed erdos-14 (Erdős #14: Unique Sums and Non-Unique Representation). Registry shows COMPLETED+graduated 2026-03-24, state.md Phase COMPLETED since 2026-05-03, file at 0 sorries / 2 axioms — only canonical-count drift remained.

## Drift Surface

- `meta.lineCount`: 109 → 110
- `conclusion.summary` prose: "104 lines" → "110 lines"
- `leanFile.lineCount`: 109 → 110

Canonical lineCount = `content.split('\n').length` per `scripts/research/enrich-research.ts:145-174`. File `proofs/Proofs/Erdos14Problem.lean` has trailing newline: `wc -l = 109`, split-length `= 110`.

## Other Meta Fields (Verified Canonical, No Change)

| Field | meta.json | grep | Match |
|-------|-----------|------|-------|
| axiomCount | 2 | 2 | OK |
| theoremCount | 1 | 1 (broad) | OK |
| definitionCount | 6 | 5 def + 1 noncomputable def | OK |
| sorries | 0 | 0 | OK |
| status | axiomatized | (2 open conjectures encoded) | OK |

## Pool Flip (Out-of-Band)

`research/candidate-pool.json` flipped in-progress → completed via `scripts/research/claim-problem.sh update erdos-14 completed`. File is gitignored — change is local-state coordination only, not in this PR.

## Doc-Only Risk

1 file +3/-3, no Lean changes, no docker build required.

## Test plan

- [x] wc -l and split-length verified on actual Lean file
- [x] Other canonical counts (axioms, theorems, defs, sorries) verified via grep
- [x] Pool entry flipped via claim-problem.sh
- [ ] CI green