### PR TITLE
research(infinitude-primes-oq-03): fix progressSummary drift — InfinitudePrimes4k3.lean (230,7)→(256,8) (doc-only)

### DIFF
--- a/src/data/research/problems/infinitude-primes-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-oq-03.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE. All three sorries discharged by PR #8074 (researcher-10, commit c82c22b4). InfinitudePrimes3k2.lean now has 0 sorries / 0 axioms / 7 theorems / 196 lines and the gallery sits at status verified, badge mathlib. Helper files InfinitudePrimes.lean (127 lines, 7 theorems), InfinitudePrimes4k1.lean (177 lines, 5 theorems), InfinitudePrimes4k3.lean (230 lines, 7 theorems), and InfinitudePrimes4k3OQ03.lean (103 lines, 4 theorems) are also clean.",
+    "progressSummary": "COMPLETE. All three sorries discharged by PR #8074 (researcher-10, commit c82c22b4). InfinitudePrimes3k2.lean now has 0 sorries / 0 axioms / 7 theorems / 196 lines and the gallery sits at status verified, badge mathlib. Helper files InfinitudePrimes.lean (127 lines, 7 theorems), InfinitudePrimes4k1.lean (177 lines, 5 theorems), InfinitudePrimes4k3.lean (256 lines, 8 theorems), and InfinitudePrimes4k3OQ03.lean (103 lines, 4 theorems) are also clean.",
     "builtItems": [
       "Created proofs/Proofs/InfinitudePrimes3k2.lean — elementary proof of primes ≡ 2 (mod 3)",
       "lemma mul_mod_three_one: product of 1 (mod 3) stays 1 (mod 3)",


### PR DESCRIPTION
## Summary

- Slug **infinitude-primes-oq-03** is registry-COMPLETED + status=graduated (2026-03-30, T-48d) with research JSON `phase=COMPLETE` / `iter=2` since 2026-05-07.
- All five Lean files for the infinitude-primes family are clean: 0 axioms, 0 sorries.
- Only one drift surface: `knowledge.progressSummary` quoted `InfinitudePrimes4k3.lean (230 lines, 7 theorems)`, but the actual file is **256 lines / 8 theorems** (canonical per `src/data/proofs/infinitude-primes-4k3/meta.json` and `wc -l proofs/Proofs/InfinitudePrimes4k3.lean`).
- All other embedded helper counts already match the actual files.

## Drift surface

| File | Stat | research JSON `progressSummary` | Actual |
|------|------|---|---|
| InfinitudePrimes4k3.lean | lineCount | 230 | **256** |
| InfinitudePrimes4k3.lean | theoremCount | 7 | **8** |
| InfinitudePrimes.lean | (127, 7) | 127/7 | 127/7 ✓ |
| InfinitudePrimes4k1.lean | (177, 5) | 177/5 | 177/5 ✓ |
| InfinitudePrimes4k3OQ03.lean | (103, 4) | 103/4 | 103/4 ✓ |
| InfinitudePrimes3k2.lean (primary) | (196, 7) | 196/7 | 196/7 ✓ |

The numeric `leanFiles[]` array in the same JSON is already canonical at 256/8 — the prose summary just didn't get updated in lockstep when 4k3 grew.

## Files

- \`src/data/research/problems/infinitude-primes-oq-03.json\` — single substring change in \`knowledge.progressSummary\` (+1/−1).

## Test plan

- [x] \`jq -e . src/data/research/problems/infinitude-primes-oq-03.json\` — JSON valid post-edit
- [x] Numeric \`leanFiles[3]\` for 4k3 already at 256/8 — diff confirms only prose substring changed
- [x] No Lean edits, no gallery \`meta.json\` edits, no \`state.md\` (slug has no \`research/problems/<slug>/\` directory; pool flip handled outside the PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)