### PR TITLE
fix(meta): erdos-348 lineCount 570→571 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -61,7 +61,7 @@
       "Main conjecture as disjunction: all (m,m+1) valid or cutoff exists"
     ],
     "axiomCount": 1,
-    "lineCount": 570,
+    "lineCount": 571,
     "assumptions": "1 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": "Erdos348",
-    "lineCount": 570,
+    "lineCount": 571,
     "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 14,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for long-completed erdos-348 (Erdős Problem #348: Robustness of Complete Sequences, joint with Graham). Registry shows COMPLETED+graduated 2026-03-24. Lean file is mature (571 lines / 18 theorems / 14 defs / 1 axiom / 0 sorries). Only canonical-count drift remained.

## Drift Surface

- `meta.lineCount`: 570 → 571
- `leanFile.lineCount`: 570 → 571

Canonical lineCount = `content.split('\n').length` per `scripts/research/enrich-research.ts:145-174`. File `proofs/Proofs/Erdos348Problem.lean` has trailing newline: `wc -l = 570`, split-length `= 571`.

## Other Meta Fields (Verified Canonical, No Change)

| Field | meta.json | grep | Match |
|-------|-----------|------|-------|
| axiomCount | 1 | 1 | OK |
| theoremCount | 18 | 7 theorem + 11 lemma (broad) | OK |
| definitionCount | 14 | 13 def + 1 noncomputable def | OK |
| sorries | 0 | 0 | OK |
| status | axiomatized | (1 axiom) | OK |
| badge | axiom | | OK |

## Pool Flip (Out-of-Band)

`research/candidate-pool.json` flipped in-progress → completed via `scripts/research/claim-problem.sh update erdos-348 completed`. File is gitignored — change is local-state coordination only, not in this PR.

## Note on state.md

`research/problems/erdos-348/state.md` still reads "Phase: NEW, Iteration: 1, attempts: 0" — clearly stale vs. mature Lean file and registry COMPLETED status. Out of scope for this thin sync; deferred to a separate state.md rewrite cycle.

## Doc-Only Risk

1 file +2/-2, no Lean changes, no docker build required.

## Test plan

- [x] wc -l and split-length verified on actual Lean file
- [x] Other canonical counts verified via grep
- [x] Pool entry flipped via claim-problem.sh
- [ ] CI green