### PR TITLE
fix(meta): erdos-1162 lineCount 221→222 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -56,7 +56,7 @@
       "erdos1162_asymptotic: formal statement of the asymptotic result"
     ],
     "axiomCount": 1,
-    "lineCount": 221,
+    "lineCount": 222,
     "assumptions": "1 axiom: roney_dougal_tracey. 0 sorries.",
     "theoremCount": 9,
     "definitionCount": 5
@@ -222,7 +222,7 @@
       "Filter"
     ],
     "namespace": "Erdos1162",
-    "lineCount": 221,
+    "lineCount": 222,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for long-completed erdos-1162 (Erdős Problem #1162: asymptotic count of certain permutation groups). Registry shows COMPLETED+graduated 2026-03-28. Lean file at 222 lines / 9 theorems / 5 defs / 1 axiom (roney_dougal_tracey) / 0 sorries. Only canonical-count drift remained.

## Drift Surface

- `meta.lineCount`: 221 → 222
- `leanFile.lineCount`: 221 → 222

Canonical lineCount = `content.split('\n').length` per `scripts/research/enrich-research.ts:145-174`. File `proofs/Proofs/Erdos1162Problem.lean` has trailing newline: `wc -l = 221`, split-length `= 222`.

## Other Meta Fields (Verified Canonical, No Change)

| Field | meta.json | grep | Match |
|-------|-----------|------|-------|
| axiomCount | 1 | 1 | OK |
| theoremCount | 9 | 9 | OK |
| definitionCount | 5 | 4 def + 1 noncomputable def | OK |
| sorries | 0 | 0 | OK |
| status | axiomatized | (1 axiom) | OK |

## Pool Flip (Out-of-Band)

`research/candidate-pool.json` flipped in-progress → completed via `scripts/research/claim-problem.sh update erdos-1162 completed`. File is gitignored — change is local-state coordination only, not in this PR.

## Doc-Only Risk

1 file +2/-2, no Lean changes, no docker build required.

## Test plan

- [x] wc -l and split-length verified on actual Lean file
- [x] Other canonical counts verified via grep
- [x] Pool entry flipped via claim-problem.sh
- [ ] CI green