### PR TITLE
fix(meta): pell-equation-oq-01 lineCount 195→196 align with leanFile

### DIFF
--- a/src/data/proofs/pell-equation-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-30",
-    "lineCount": 195,
+    "lineCount": 196,
     "originalContributions": [
       "pellNorm and pellRegulator definitions",
       "pellNorm_pos_of_pos: norm bound for positive solutions",
@@ -107,7 +107,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 195,
+    "lineCount": 196,
     "axiomCount": 0,
     "path": "Proofs/PellEquationOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for long-completed pell-equation-oq-01 (Fundamental Solution Size for Pell Equations). Registry shows COMPLETED+graduated 2026-03-30. Lean file at 196 lines / 5 theorems / 6 defs / 0 axioms / 0 sorries. Only canonical-count drift remained.

## Drift Surface

- `meta.lineCount`: 195 → 196
- `leanFile.lineCount`: 195 → 196

Canonical lineCount = `content.split('\n').length` per `scripts/research/enrich-research.ts:145-174`. File `proofs/Proofs/PellEquationOQ01.lean` has trailing newline: `wc -l = 195`, split-length `= 196`.

## Other Meta Fields (Verified Canonical, No Change)

| Field | meta.json | grep | Match |
|-------|-----------|------|-------|
| axiomCount | 0 | 0 | OK |
| theoremCount | 5 | 5 | OK |
| definitionCount | 6 | 4 def + 2 noncomputable def | OK |
| sorries | 0 | 0 | OK |

## Status Field (Deliberately Unchanged)

`status: axiomatized` + `badge: wip` retained. The 4 open conjectures (`PellRegulatorBound`, `AverageRegulatorConjecture`, `DirichletClassNumberFormula`, `PellPolynomialTime`) are encoded as unproved `Prop` definitions. Per CLAUDE.md "When in doubt, use 'axiomatized' — overclaiming 'verified' damages credibility", no status flip attempted here.

## Pool Flip (Out-of-Band)

`research/candidate-pool.json` flipped in-progress → completed via `scripts/research/claim-problem.sh update pell-equation-oq-01 completed`. File is gitignored — change is local-state coordination only, not in this PR.

## Doc-Only Risk

1 file +2/-2, no Lean changes, no docker build required.

## Test plan

- [x] wc -l and split-length verified on actual Lean file
- [x] Other canonical counts verified via grep
- [x] Pool entry flipped via claim-problem.sh
- [ ] CI green