### PR TITLE
research(erdos-892): S3 PREP catch-up — research JSON currentState NEW iter 1 → ORIENT iter 3 + leanFiles lineCount off-by-one (doc-only)

### DIFF
--- a/src/data/research/problems/erdos-892.json
+++ b/src/data/research/problems/erdos-892.json
@@ -17,15 +17,15 @@
   },
   "currentState": {
     "phase": "ORIENT",
-    "since": "2026-01-15T11:22:53.228Z",
-    "iteration": 1,
-    "focus": "Surveyed: 0 sorries, 4 deep axioms, 1 potentially eliminable",
+    "since": "2026-05-13T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "S3 PREP (2026-05-13, researcher-9, complement to PR #18763): Mathlib API pinned to lake SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 for axiom #2 elimination recipe via Cauchy condensation; uniform-in-k condensed-term bound (2^k + 2 ≤ 2^(k+2), valid for all k ∈ ℕ) replaces the k ≥ 1 form to drop the k=0 edge case. Erdos892Problem.lean at 2 axioms (primitive_reciprocal_log_convergent is the deep Erdős 1935 result and stays; harmonic_log_plus2_diverges is the eliminable Cauchy-condensation axiom), 7 theorems, 6 defs, 0 sorries, 333 lines. Erdos892Aristotle.lean has 1 sorry (counterexample-removed reciprocal_log_comparison), 2 theorems, 0 axioms, 32 lines.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "ACT: eliminate `axiom harmonic_log_plus2_diverges` (Erdos892Problem.lean:172) per the 6-step S3 PREP recipe in research/problems/erdos-892/state.md (~50 LOC) using the pinned Mathlib lemmas (PSeries.lean:228, InfiniteSum/Real.lean:61, PSeries.lean:337, Log/Basic.lean:148/152/173/273). Drop-in ACT skeleton in PR #18763's sessions file (researcher-11, 2026-05-13). Use the uniform-in-k condensed-term bound 2^k · f(2^k) ≥ 1/(4·(k+2)·log 2) from S3 PREP §3 to avoid the k=0 edge case.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/Erdos892Aristotle.lean",
       "filename": "Erdos892Aristotle.lean",
-      "lineCount": 33,
+      "lineCount": 32,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/Erdos892Problem.lean",
       "filename": "Erdos892Problem.lean",
-      "lineCount": 334,
+      "lineCount": 333,
       "theoremCount": 7,
       "axiomCount": 2,
       "defCount": 6,


### PR DESCRIPTION
## Summary

- \`state.md\` was advanced to **S3 PREP iter 3** on 2026-05-13 (researcher-9, complement to PR #18763) but \`src/data/research/problems/erdos-892.json\`'s \`currentState\` object was never refreshed.
- \`currentState\` still carried the January NEW snapshot (\`Surveyed: 0 sorries, 4 deep axioms, 1 potentially eliminable\` / \`Begin problem exploration.\` / iteration 1 / attemptCounts 0/0/0), while the top-level \`phase\` was already \`S3-PREP\` and \`lastUpdate\` was 2026-05-13.
- Also fixes a +1 off-by-one in both \`leanFiles[].lineCount\` entries — actual \`wc -l\` is 32 (Erdos892Aristotle.lean) and 333 (Erdos892Problem.lean); both already match the gallery's canonical \`meta.json\`.

## Drift surface (single file)

| Field | Before | After |
|------|--------|-------|
| \`currentState.since\` | \`2026-01-15T11:22:53Z\` | \`2026-05-13T00:00:00Z\` |
| \`currentState.iteration\` | 1 | **3** |
| \`currentState.focus\` | "Surveyed: 0 sorries, 4 deep axioms, 1 potentially eliminable" | S3 PREP description with pinned Mathlib SHA \`2df2f015…\` + axiom inventory + canonical line counts |
| \`currentState.nextAction\` | "Begin problem exploration." | ACT recipe pointing to \`state.md\` Steps 1–6 + PR #18763 skeleton + uniform-in-k bound \`2^k · f(2^k) ≥ 1/(4·(k+2)·log 2)\` |
| \`currentState.attemptCounts\` | \`{0,0,0}\` | \`{2,1,2}\` (matches state.md "Attempt Counts") |
| \`leanFiles[0].lineCount\` (Erdos892Aristotle) | 33 | **32** |
| \`leanFiles[1].lineCount\` (Erdos892Problem) | 334 | **333** |

## Files

- \`src/data/research/problems/erdos-892.json\` — single-file edit (+9/−9).

## What this PR does NOT touch

- No Lean edits (Erdos892Problem.lean canonical at 333 LOC / 7 thm / 6 def / 2 axiom / 0 sorry; Erdos892Aristotle.lean canonical at 32 LOC / 2 thm / 0 axiom / 1 sorry).
- No \`state.md\` edits (already at S3 PREP iter 3 from PR researcher-9 2026-05-13).
- No gallery \`meta.json\` edits (already canonical at lineCount 333, theoremCount 7, axiomCount 2, defCount 6, sorries 0, status axiomatized, badge axiom).
- The slug remains **AXIOMATIZED + open conjecture** (Erdős–Sárközy–Szemerédi 1968 problem — no known sufficient condition characterization).

## Test plan

- [x] \`jq -e . src/data/research/problems/erdos-892.json\` — JSON valid post-edit
- [x] \`wc -l proofs/Proofs/Erdos892*.lean\` — confirms 32 and 333 (canonical, matches gallery)
- [x] \`currentState.attemptCounts\` and \`currentState.iteration\` match state.md's "Attempt Counts" / "Iteration: 3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)