### PR TITLE
research(newton-inductive-step-oq-02): STATE-SYNC — graduate state.md + lineCount 611→612

### DIFF
--- a/research/problems/newton-inductive-step-oq-02/problem.md
+++ b/research/problems/newton-inductive-step-oq-02/problem.md
@@ -2,7 +2,7 @@
 
 **Slug**: newton-inductive-step-oq-02
 **Created**: 2026-03-30
-**Status**: Active
+**Status**: COMPLETED (graduated 2026-04-03; see `state.md`)
 **Source**: gallery-gap (open question from newton-inductive-step proof)
 
 ## Problem Statement

--- a/research/problems/newton-inductive-step-oq-02/state.md
+++ b/research/problems/newton-inductive-step-oq-02/state.md
@@ -1,25 +1,30 @@
 # Research State: newton-inductive-step-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-03-30T15:14:17-07:00
+**Since**: 2026-04-03T04:02:48Z
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Slug graduated per `research/registry.json` (status: graduated, completed 2026-04-03). Gallery entry `src/data/proofs/newton-inductive-step-oq-02/` is canonical with `proofs/Proofs/NewtonInductiveStepOQ02.lean` (612 LOC / 6 theorems / 0 sorries / 0 axioms / 0 definitions; verified, badge: original).
 
 ## Active Approach
-None yet.
+Done — three theorems shipped:
+1. Ultra-log-concavity of binomial coefficients: `C(n,k)^4 ≥ C(n,k-1)^2·C(n,k+1)^2`
+2. Cleared-denominator Newton: `C(n,k-1)·C(n,k+1)·e_k^2 ≥ C(n,k)^2·e_{k-1}·e_{k+1}`
+3. Unnormalized Newton: `e_k^2 ≥ e_{k-1}·e_{k+1}` (corollary)
+
+k=1 and k=n boundary cases reduce to quadratic-nonneg via the identity `2·C(n+1,p+1) = n·(n+1)` (Pascal's rule).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (full path COMPLETED)
+- Approaches tried: 1 (normalized cleared-denominator induction)
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+None — graduated. Future work (separate slugs):
+- Strict version of inequality (when roots distinct)
+- Multivariate analogue via Lorentzian polynomials (Brändén–Huh 2020)

--- a/src/data/proofs/newton-inductive-step-oq-02/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 611,
+    "lineCount": 612,
     "theoremCount": 6,
     "definitionCount": 0,
     "prerequisites": [
@@ -153,7 +153,7 @@
       "Nat"
     ],
     "namespace": "NewtonInductiveStepOQ02",
-    "lineCount": 611,
+    "lineCount": 612,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Long-completed slug catch-up (registry COMPLETED/graduated 2026-04-03, T-44d). Three doc-only drift surfaces:

1. **state.md**: `Phase: OBSERVE / Iteration 1 / "Initial problem understanding"` (frozen since creation 2026-03-30) → rewritten to `COMPLETED` with brief approach summary
2. **problem.md** header: `Status: Active` → `COMPLETED (graduated 2026-04-03)`
3. **meta.json** `lineCount` (both top-level meta and leanFile block): `611 → 612` (off-by-one fix per the enricher convention `content.split('\n').length`, where `NewtonInductiveStepOQ02.lean` lacks a trailing newline so `wc -l = 611` while canonical split-newline = 612)

## Canonical Lean state (no changes)

`proofs/Proofs/NewtonInductiveStepOQ02.lean`:
- 612 lines (split-newline)
- 6 theorems (broad grep)
- 0 sorries / 0 axioms / 0 definitions
- `status: verified`, `badge: original`, `mathlib_version: 4.26.0`

Theorems shipped (per meta.originalContributions):
1. Ultra-log-concavity of binomial coefficients: `C(n,k)⁴ ≥ C(n,k-1)² · C(n,k+1)²`
2. Cleared-denominator Newton inequality: `C(n,k-1) · C(n,k+1) · e_k² ≥ C(n,k)² · e_{k-1} · e_{k+1}`
3. Unnormalized Newton inequality: `e_k² ≥ e_{k-1} · e_{k+1}` (corollary)

## Test plan
- [x] `git diff --stat` → 3 files / +17 −12 (doc-only)
- [x] No Lean source modified; canonical stats verified via `wc -l` + `node split` + grep
- [x] Registry already says graduated; state.md catches up

Researcher: researcher-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)