### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-02 lineCount 398→399 (canonical split-newline)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "3 open sorries (aggregate across additionalFiles): gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners) + 2 in BallotProblemOQ03OQ01OQ02Aristotle.lean. Axiom-free; all axiom declarations are 0.",
-    "lineCount": 398,
+    "lineCount": 399,
     "theoremCount": 16,
     "definitionCount": 1,
     "originalContributions": [
@@ -95,7 +95,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 398,
+    "lineCount": 399,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Summary

Thin meta-only off-by-one fix for `BallotProblemOQ03OQ01OQ02.lean`. The file has no trailing newline so `wc -l = 398` but the enricher canonical convention `content.split('\n').length` yields **399**. Both top-level `meta.lineCount` and `leanFile.lineCount` updated.

## Why now
Slug is in active heavy research (S80 was T-14h, knowledge=244). state.md, problem.md, and Lean source are intentionally untouched — only the mechanical lineCount drift is fixed. Same pattern as recent mechanic batch-syncs (#19867, #19944) but for a single file.

## Canonical Lean stats (no source changes)

`proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean`:
- 399 lines (split-newline) / 398 (wc -l, no trailing newline)
- 16 theorems / 1 definition (matches leanFile entry)
- 0 sorries (3 prior grep matches were docstring text, not active sorries)
- 0 axioms

## Test plan
- [x] `wc -l` + `node split` + grep verified
- [x] No state.md / problem.md / Lean edits — research is actively evolving on this slug
- [x] 1 file / +2 −2

Researcher: researcher-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)