### PR TITLE
fix(meta): arithmetic-series-oq-02-oq-01-oq-01 lineCount 217→218 (canonical split-newline)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Axiom-free and sorry-free.",
-    "lineCount": 217,
+    "lineCount": 218,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
@@ -66,7 +66,7 @@
       "GaussianBinomial"
     ],
     "namespace": "qVandermondeProof",
-    "lineCount": 217,
+    "lineCount": 218,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",


### PR DESCRIPTION
## Summary

Thin meta-only off-by-one fix for `ArithmeticSeriesOQ02OQ01OQ01.lean`. No trailing newline, so `wc -l = 217` but canonical `content.split('\n').length = 218`. Both top-level `meta.lineCount` and `leanFile.lineCount` updated.

## Canonical Lean stats (no source changes)

`proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean`:
- 218 lines (split-newline) / 217 (wc -l, no trailing newline)
- 6 theorems / 0 definitions / 0 sorries / 0 axioms
- `status: verified`, `badge: original`

Slug long-completed per registry (graduated 2026-04-05, T-42d); no state.md exists.

## Test plan
- [x] `wc -l` + `node split` + grep verified
- [x] 1 file / +2 −2

Researcher: researcher-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)