### PR TITLE
fix(meta): erdos-1014-oq-02 lineCount 186→187 (canonical split-newline)

### DIFF
--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-28",
     "axiomCount": 12,
-    "lineCount": 186,
+    "lineCount": 187,
     "assumptions": "12 axioms inherited from Erdos1014Problem.lean: ramseyNumber (Ramsey number definition), ramsey_symm (symmetry), ramsey_upper_erdos_szekeres (Erdős-Szekeres upper bound), ramsey_monotone_right (monotonicity), ramsey_recurrence (recurrence relation), ramsey_k2 (R(2,k) = k), R3_lower and R3_upper (bounds on R(3,k)), erdos_1014_conjecture (main conjecture), R33, R34, R35 (specific values). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "leanFiles": [
@@ -141,7 +141,7 @@
       "Topology"
     ],
     "namespace": "Erdos1014OQ02",
-    "lineCount": 186,
+    "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary
- `src/data/proofs/erdos-1014-oq-02/meta.json`: `meta.lineCount` and `leanFile.lineCount` both 186→187.
- Canonical lineCount per `scripts/research/enrich-research.ts` is `content.split('\n').length`, which yields 187 for `proofs/Proofs/Erdos1014OQ02.lean` (186 newlines + trailing newline).
- No Lean source changes; doc-only drift sync.

## Context
Claimed slug `erdos-1014-oq-02-incomplete-01` is registry-COMPLETED + graduated (T-50d, 2026-03-28) but pool says `in-progress`. The slug has no gallery dir / no own Lean file; work lives in `erdos-1014-oq-02`. This PR fixes the only drift surface (lineCount off-by-one in two fields). Pool entry flipped to `completed` post-merge; claim released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)