### PR TITLE
research(divisibility-truncation-general-oq-03): S2 STATE-SYNC — meta.json lineCount 221→222 + state.md iter 1→2

### DIFF
--- a/research/problems/divisibility-truncation-general-oq-03/state.md
+++ b/research/problems/divisibility-truncation-general-oq-03/state.md
@@ -4,11 +4,12 @@
 **Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-04-24T00:00:00+00:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Gallery proof verified. DivisibilityTruncationGeneralOQ03.lean (221 lines,
-0 sorries, 0 axioms, status: verified, dateAdded 2026-04-24).
+Gallery proof verified. DivisibilityTruncationGeneralOQ03.lean (222 lines per
+canonical `split('\n').length` convention, 0 sorries, 0 axioms, status:
+verified, dateAdded 2026-04-24).
 
 ## Active Approach
 Completed.
@@ -23,4 +24,8 @@ None.
 
 ## Next Action
 None — proof complete and graduated to gallery as `verified`.
-Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1;
+re-reconciled 2026-05-17 by researcher-12 (pool had reverted to `available`,
+likely due to local-pool-not-git-tracked drift across worktrees) alongside
+`src/data/proofs/.../meta.json` lineCount 221→222 (canonical
+`split('\n').length` convention per enrich-research.ts, not `wc -l`).

--- a/src/data/proofs/divisibility-truncation-general-oq-03/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-03/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using only Mathlib.",
-    "lineCount": 221,
+    "lineCount": 222,
     "theoremCount": 21,
     "definitionCount": 1,
     "originalContributions": [
@@ -111,7 +111,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 221,
+    "lineCount": 222,
     "path": "Proofs/DivisibilityTruncationGeneralOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Summary

Doc-only STATE-SYNC for long-completed slug `divisibility-truncation-general-oq-03` (lastUpdate 2026-04-28T00:00Z, T-19d). Two file edits, +11/-6.

- **`src/data/proofs/.../meta.json`**: `lineCount` 221 → 222 (both `meta.lineCount` and `leanFile.lineCount`). Canonical convention is `content.split('\n').length` per `enrich-research.ts`, not `wc -l`. `DivisibilityTruncationGeneralOQ03.lean` has 221 newlines + trailing `\n` → split-length 222. Registry already at 222 (canonical) across all 3 sibling research JSONs (oq-01, oq-02, oq-03); meta.json was the lone wc-l-style holdout.

- **`research/problems/.../state.md`**: iteration 1 → 2, lineCount 221 → 222 in prose, "Next Action" notes the 2nd reconciliation pass (the 2026-04-28 reconciliation by researcher-1 had reverted to `available` — likely local-pool-not-git-tracked drift across worktrees).

Pool entry flipped `available` → `completed` locally (the canonical pool at `.lean/state/candidate-pool.json` is gitignored; not in this PR's diff).

## Verification

- Registry `phase=DONE`, `status=completed`, 0 sorries / 0 axioms ✓
- Gallery dir canonical (`annotations.json`, `index.ts`, `meta.json`) ✓
- 3 leanFiles match registry canonical: `DivisibilityTruncationGeneral.lean` (256), `DivisibilityTruncationGeneralOQ01.lean` (160), `DivisibilityTruncationGeneralOQ03.lean` (222) ✓
- `DivisibilityTruncationGeneralOQ03.lean` referenced only by oq-01, oq-02, oq-03 research JSONs + oq-03 meta.json (no cross-slug pollution; safe to fix in single PR)
- No code changes; build status unchanged.

## Environment

- Disk: 91 GiB GREEN (recovered from 4.6 GiB earlier in the cycle; cleared researcher-12 SKIP-chain N=45)
- Docker daemon: hung RED (B2 sibling memos `descartes-rule-of-signs-oq-02-oq-01` etc.) — but no build needed for doc-only STATE-SYNC
- Deployer: parked T-11h since #20117 @ 04:23:18Z; pile = 30 OPEN PRs

## Test plan

- [x] `meta.json` validates as JSON
- [x] `state.md` reads cleanly
- [x] No `.lean`/code changes
- [x] No cross-slug surfaces touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)