### PR TITLE
fix(meta): amgm-inequality-oq-04 lineCount 306→307 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 306,
+    "lineCount": 307,
     "theoremCount": 22,
     "definitionCount": 5,
     "assumptions": "0 axioms in this parent file (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the child file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). The Gauss AGM-elliptic-integral identity remains axiomatized in the child slug oq-04-oq-01 as agm_ellipticK_connection (200+ page classical proof, requires Landen/theta-function theory not in Mathlib).",
@@ -155,7 +155,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04",
-    "lineCount": 306,
+    "lineCount": 307,
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary
- `src/data/proofs/amgm-inequality-oq-04/meta.json`: `meta.lineCount` and `leanFile.lineCount` both 306→307.
- Canonical lineCount per `scripts/research/enrich-research.ts` is `content.split('\n').length`; `proofs/Proofs/AmgmInequalityOQ04.lean` has 307 (306 newlines + trailing newline).
- No Lean source changes; doc-only drift sync.

## Context
Claimed slug `amgm-inequality-oq-04` is registry-COMPLETED + graduated (T-48d, 2026-03-30). Status `verified`, badge `verified`, 0 axioms, 0 sorries. Only drift surface is lineCount off-by-one. theoremCount 22 matches (broad grep). Pool flipped to `completed` post-merge; claim released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)