### PR TITLE
research(napoleons-theorem-oq-02): S2 STATE-SYNC — meta.json lineCount 346→347 + state.md iter 1→2

### DIFF
--- a/research/problems/napoleons-theorem-oq-02/state.md
+++ b/research/problems/napoleons-theorem-oq-02/state.md
@@ -4,12 +4,13 @@
 **Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-04-23T00:00:00+00:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Gallery proof verified. NapoleonsTheoremOQ02.lean (346 lines, 0 sorries, 0 axioms,
-status: verified, badge: original, dateAdded 2026-04-23). DFT-based formulation
-of Napoleon's theorem.
+Gallery proof verified. NapoleonsTheoremOQ02.lean (347 lines per canonical
+`split('\n').length` convention, 0 sorries, 0 axioms, status: verified,
+badge: original, dateAdded 2026-04-23). DFT-based formulation of Napoleon's
+theorem.
 
 ## Active Approach
 Discrete Fourier Transform on triangle vertices: ω = e^{2πi/3} as primitive cube
@@ -27,4 +28,8 @@ None.
 
 ## Next Action
 None — proof complete. Gallery contributes 7 original DFT-based identities.
-Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1.
+Pool entry reconciled `available` → `completed` 2026-04-28 by researcher-1;
+re-reconciled 2026-05-17 by researcher-12 (pool had reverted to `available`,
+likely due to local-pool-not-git-tracked drift across worktrees) alongside
+`src/data/proofs/.../meta.json` lineCount 346→347 (canonical
+`split('\n').length` convention per enrich-research.ts, not `wc -l`).

--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "lineCount": 346,
+    "lineCount": 347,
     "assumptions": "0 axioms. 0 sorries. Fully verified using only 1+ω+ω²=0, ω³=1, and √3²=3.",
     "mathlib_version": "4.26.0",
     "parentProof": "napoleons-theorem",
@@ -183,7 +183,7 @@
       "NapoleonsTheorem"
     ],
     "namespace": "NapoleonsTheoremOQ02",
-    "lineCount": 346,
+    "lineCount": 347,
     "axiomCount": 0,
     "theoremCount": 11,
     "sorries": 0,


### PR DESCRIPTION
## Summary

Doc-only STATE-SYNC for long-completed slug `napoleons-theorem-oq-02` (lastUpdate 2026-04-28T13:00Z, T-19d). Two file edits, +12/-7.

- **`src/data/proofs/.../meta.json`**: `lineCount` 346 → 347 (both `meta.lineCount` and `leanFile.lineCount`). Canonical convention is `content.split('\n').length` per `enrich-research.ts`, not `wc -l`. `NapoleonsTheoremOQ02.lean` has 346 newlines + trailing `\n` → split-length 347. Registry already at 347 across both sibling research JSONs (oq-01, oq-02); meta.json was the lone wc-l-style holdout.

- **`research/problems/.../state.md`**: iteration 1 → 2, lineCount 346 → 347 in prose, "Next Action" notes the 2nd reconciliation pass.

Pool entry flipped `available` → `completed` locally (the canonical pool at `.lean/state/candidate-pool.json` is gitignored; not in this PR's diff).

## Verification

- Registry `phase=COMPLETED`, `status=completed`, 0 sorries / 0 axioms ✓
- Gallery dir canonical (`annotations.json`, `index.ts`, `meta.json`) ✓
- 2 leanFiles match registry: `NapoleonsTheorem.lean` (356), `NapoleonsTheoremOQ02.lean` (347) ✓
- `theoremCount` delta (meta=11 broad incl 1 private; registry=10 narrow) **intentionally NOT touched** — theoremCount is a known minefield (narrow-vs-broad grep convention ambiguity); ship lineCount drifts FIRST in isolation
- `NapoleonsTheoremOQ02.lean` referenced only by napoleons-theorem-oq-01, oq-02 research JSONs + oq-02 meta.json (no cross-slug pollution)
- No code changes; build status unchanged

## Environment

- Disk: 90 GiB GREEN (recovered from 4.6 GiB earlier today)
- Docker daemon: hung RED (B2 — empty `Server:` section in `docker info`); not needed for doc-only STATE-SYNC
- Deployer: parked T-11h since #20117 @ 04:23:18Z; pile = 30 OPEN PRs

## Test plan

- [x] `meta.json` validates as JSON
- [x] `state.md` reads cleanly
- [x] No `.lean`/code changes
- [x] No cross-slug surfaces touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)