### PR TITLE
research(twin-primes-special-oq-01): S3 STATE-SYNC — restore canonical lineCount 150→151 (S2 reversed it)

### DIFF
--- a/research/problems/twin-primes-special-oq-01/state.md
+++ b/research/problems/twin-primes-special-oq-01/state.md
@@ -4,13 +4,24 @@
 **Phase**: COMPLETED (axiomatized)
 **Path**: full
 **Since**: 2026-05-16
-**Iteration**: 2
+**Iteration**: 3
 
 ## Current Focus
 
-S2 STATE-SYNC catchup (2026-05-16): the implementation was merged out-of-band as PR #14871 (`feat(twin-primes): add TPC OQ-01 gallery entry with 25 verified twin prime pairs`, 2026-05-02) without updating researcher tracking artifacts. State.md + JSON were frozen at the S1 SURVEYED state from 2026-04-27. This S2 brings the artifacts into alignment with disk reality.
+S3 STATE-SYNC (2026-05-17 researcher-12): correct the lineCount convention
+that S2 (2026-05-16) reversed. S2 changed `leanFiles[0].lineCount` 151→150
+to match a then-stale `meta.json`; canonical is the other way around per
+`enrich-research.ts` (`content.split('\n').length`, not `wc -l`). This S3
+fixes both `meta.json` (150→151 in `meta.lineCount` and `leanFile.lineCount`)
+and `research/.../JSON` (`leanFiles[0].lineCount` 150→151). Pool also
+re-flipped `available` → `completed`.
 
-**Disk reality**: `proofs/Proofs/TwinPrimesSpecialOQ01.lean` exists (150 LOC, 25 theorems via `decide` + conditional consequences, 0 standalone axioms, 0 sorries, inherits `twin_prime_conjecture` from parent `TwinPrimes.lean`). Gallery entry `src/data/proofs/twin-primes-special-oq-01/{meta.json,annotations.json,index.ts}` exists with `status: "axiomatized"`, `badge: "axiom"`.
+**Disk reality**: `proofs/Proofs/TwinPrimesSpecialOQ01.lean` exists (151 LOC
+per `split('\n').length`, 150 newlines, ends with trailing `\n`; 25
+theorems via `decide` + conditional consequences, 0 standalone axioms,
+0 sorries, inherits `twin_prime_conjecture` from parent `TwinPrimes.lean`).
+Gallery entry `src/data/proofs/twin-primes-special-oq-01/{meta.json,annotations.json,index.ts}`
+exists with `status: "axiomatized"`, `badge: "axiom"`.
 
 ## Active Approach
 
@@ -40,11 +51,12 @@ None of these are scheduled. The slug stands as-is.
 
 - 2026-04-23: Problem created (gallery-gap, seeker batch #11863)
 - 2026-04-27 (S1): Survey complete; port plan documented; no code change (no build access)
-- 2026-05-02 (out-of-band): PR #14871 implemented the port plan — Lean file 150 LOC + gallery entry created
-- 2026-05-16 (S2): STATE-SYNC catchup — state.md/JSON aligned with disk reality; leanFiles[0].lineCount 151→150 to match gallery; sessions/ bootstrapped
+- 2026-05-02 (out-of-band): PR #14871 implemented the port plan — Lean file 150 newlines (151 LOC split) + gallery entry created
+- 2026-05-16 (S2): STATE-SYNC catchup — state.md/JSON aligned with then-stale gallery; **leanFiles[0].lineCount erroneously rolled 151→150** to match a wc-l-style meta.json
+- 2026-05-17 (S3): STATE-SYNC re-reconciliation — restore canonical `split('\n').length` convention: meta.json 150→151, registry leanFiles[0].lineCount 150→151, pool re-flipped `available` → `completed`
 
 ## Attempt Count
 
-- Total attempts: 2
+- Total attempts: 3
 - Current approach attempts: 1 (port-from-SG-OQ-01 strategy)
 - Approaches tried: 1

--- a/src/data/proofs/twin-primes-special-oq-01/meta.json
+++ b/src/data/proofs/twin-primes-special-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 150,
+    "lineCount": 151,
     "theoremCount": 25,
     "definitionCount": 0,
     "assumptions": "1 axiom: `twin_prime_conjecture` (inherited from parent TwinPrimes.lean, states the unproved Twin Prime Conjecture).",
@@ -221,7 +221,7 @@
       "TwinPrimes"
     ],
     "namespace": "TwinPrimesSpecialOQ01",
-    "lineCount": 150,
+    "lineCount": 151,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 0,

--- a/src/data/research/problems/twin-primes-special-oq-01.json
+++ b/src/data/research/problems/twin-primes-special-oq-01.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/TwinPrimesSpecialOQ01.lean",
       "filename": "TwinPrimesSpecialOQ01.lean",
-      "lineCount": 150,
+      "lineCount": 151,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Summary

S3 STATE-SYNC for `twin-primes-special-oq-01` (axiomatized; inherits `twin_prime_conjecture` from parent). Restores canonical `split('\n').length` convention that S2 erroneously reversed.

**Background**: S2 (2026-05-16, PR #19842) rolled `leanFiles[0].lineCount` 151 → 150 to match a then-stale `meta.json`. Canonical convention per `enrich-research.ts` is `content.split('\n').length`, NOT `wc -l`. `TwinPrimesSpecialOQ01.lean` has 150 newlines + trailing `\n` → split-length 151.

**Three surfaces**:

1. `src/data/proofs/twin-primes-special-oq-01/meta.json` — `lineCount` 150 → 151 (both `meta.lineCount` and `leanFile.lineCount`)
2. `src/data/research/problems/twin-primes-special-oq-01.json` — `leanFiles[0].lineCount` 150 → 151
3. `research/problems/twin-primes-special-oq-01/state.md` — iter 2 → 3, lineCount 150 → 151 in prose, history line for S3 added, `attemptCounts.total` 2 → 3

Pool entry also flipped `available` → `completed` locally (`.lean/state/candidate-pool.json` is gitignored; not in this PR's diff).

## Verification

- Registry `phase=COMPLETED`, `status=completed` ✓
- Gallery dir canonical (`annotations.json`, `index.ts`, `meta.json`) ✓
- 1 leanFile `TwinPrimesSpecialOQ01.lean` 151 lc_split (file unchanged) ✓
- 0 in-file axioms; meta `axiomCount=1` correctly counts the inherited `twin_prime_conjecture` from parent `TwinPrimes.lean` per CLAUDE.md Axiom Integrity Policy — NOT touched by this PR
- `TwinPrimesSpecialOQ01.lean` referenced only by this slug (no cross-slug pollution; safe to fix in single PR alongside meta.json)
- No code changes; build status unchanged

## Environment

- Disk: 90 GiB GREEN
- Docker daemon: hung RED — but no build needed for doc-only STATE-SYNC
- Deployer: parked T-11h since #20117 @ 04:23:18Z; pile = 30 OPEN PRs

## Test plan

- [x] All 3 JSON/MD files validate
- [x] No `.lean` / code changes
- [x] No cross-slug surfaces touched
- [x] Reverses S2 lineCount regression with explicit history entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)