### PR TITLE
research(sophie-germain-oq-01): S2 STATE-SYNC — meta.json lineCount 196→197 + state.md iter 1→2

### DIFF
--- a/research/problems/sophie-germain-oq-01/state.md
+++ b/research/problems/sophie-germain-oq-01/state.md
@@ -4,12 +4,13 @@
 **Phase**: COMPLETED
 **Path**: full
 **Since**: 2026-04-26T00:00:00+00:00
-**Iteration**: 1
+**Iteration**: 2
 
 ## Current Focus
-Gallery proof verified. SophieGermainOQ01.lean (196 lines, 0 sorries, 0 own
-axioms; gallery axiomCount=1 reflects the inherited `sophie_germain_conjecture`
-axiom from the parent SophieGermain.lean), status: axiomatized, badge: axiom,
+Gallery proof verified. SophieGermainOQ01.lean (197 lines per canonical
+`split('\n').length` convention, 0 sorries, 0 own axioms; gallery
+axiomCount=1 reflects the inherited `sophie_germain_conjecture` axiom from
+the parent SophieGermain.lean), status: axiomatized, badge: axiom,
 dateAdded 2026-04-26.
 
 ## Active Approach
@@ -33,4 +34,8 @@ the parity barrier (Selberg) and beyond all current sieve methods.
 None — proof complete. Gallery contributes 5 originalContributions (safe prime
 equivalence, no-max reformulation, 15 additional verified primes, conditional
 mod-12 infinitude, conditional no-finite-cover). Pool entry reconciled
-`available` → `completed` 2026-04-28 by researcher-1.
+`available` → `completed` 2026-04-28 by researcher-1; re-reconciled
+2026-05-17 by researcher-12 (pool had reverted to `available`, likely due to
+local-pool-not-git-tracked drift across worktrees) alongside
+`src/data/proofs/.../meta.json` lineCount 196→197 (canonical
+`split('\n').length` convention per enrich-research.ts, not `wc -l`).

--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 196,
+    "lineCount": 197,
     "theoremCount": 26,
     "definitionCount": 1,
     "assumptions": "1 axiom: `sophie_germain_conjecture` (inherited from parent, states the unproved Sophie Germain prime conjecture).",
@@ -205,7 +205,7 @@
       "SophieGermain"
     ],
     "namespace": "SophieGermainOQ01",
-    "lineCount": 196,
+    "lineCount": 197,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 1,


### PR DESCRIPTION
## Summary

Doc-only STATE-SYNC for long-completed axiomatized slug `sophie-germain-oq-01` (lastUpdate 2026-04-28T~, T-19d). Two file edits, +12/-7.

- **`src/data/proofs/.../meta.json`**: `lineCount` 196 → 197 (both `meta.lineCount` and `leanFile.lineCount`). Canonical convention is `content.split('\n').length` per `enrich-research.ts`, not `wc -l`. `SophieGermainOQ01.lean` has 196 newlines + trailing `\n` → split-length 197. Registry already at 197 (canonical in `sophie-germain-oq-01.json` leanFiles[1]); meta.json was the lone wc-l-style holdout.
- **`research/problems/.../state.md`**: iteration 1 → 2, lineCount 196 → 197 in prose, "Next Action" notes the 2nd reconciliation pass.

Pool entry flipped `available` → `completed` locally (the canonical pool at `.lean/state/candidate-pool.json` is gitignored; not in this PR's diff).

## Verification

- Registry `phase=COMPLETED`, `status=completed`, 0 own sorries / 0 own axioms ✓
- 1 **inherited** axiom (`sophie_germain_conjecture` from parent `SophieGermain.lean`) correctly counted in meta `axiomCount=1` per CLAUDE.md Axiom Integrity Policy; NOT touched by this PR
- Gallery dir canonical (`annotations.json`, `index.ts`, `meta.json`) ✓
- 3 leanFiles match registry: `SophieGermain.lean` (297), `SophieGermainOQ01.lean` (197), `SophieGermainOQ02.lean` (157) ✓
- `SophieGermainOQ01.lean` only owned by this slug (twin-primes-special-oq-01 references it in description text but not in `leanFiles[]`)
- No code changes; build status unchanged

## Environment

- Disk: 90 GiB GREEN
- Docker daemon: hung RED — but no build needed for doc-only STATE-SYNC
- Deployer: parked T-11h since #20117 @ 04:23:18Z; pile = 30 OPEN PRs

## Test plan

- [x] `meta.json` validates as JSON
- [x] `state.md` reads cleanly
- [x] No `.lean` / code changes
- [x] No cross-slug surfaces touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)