### PR TITLE
fix(meta): erdos-1018 sorries 22→7 + lineCount 260→261 (canonical sync)

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 22,
+    "sorries": 7,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",
@@ -26,7 +26,7 @@
       "erdos-945"
     ],
     "axiomCount": 7,
-    "lineCount": 260,
+    "lineCount": 261,
     "assumptions": "7 axioms: K5_nonplanar (K₅ is non-planar), K33_nonplanar (K₃,₃ is non-planar), kuratowski_theorem (non-planar iff contains K₅ or K₃,₃ subdivision), kostochka_pyber (ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices, 1988), constant_grows (C(ε) → ∞ as ε → 0), planar_linear_bound (planar graphs have ≤ 3n−6 edges), kostochka_pyber_explicit (polynomial bound in 1/ε). 7 sorries (incomplete topological and density definitions).",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
@@ -38,7 +38,7 @@
   "overview": {
     "historicalContext": "**Planarity, Density, and Topological Obstructions**\n\nThe study of planar graphs has deep roots: Euler's formula (1752) implies that planar graphs on $n \\ge 3$ vertices have at most $3n - 6$ edges—a linear bound. Kuratowski (1930) characterized non-planarity: a graph is non-planar if and only if it contains a subdivision of $K_5$ or $K_{3,3}$. Wagner (1937) proved the equivalent minor characterization.\n\nErdős asked a quantitative refinement: if a graph has $n^{1+\\varepsilon}$ edges (super-linear density), must non-planarity be concentrated in a *small* subgraph? Specifically, does there exist a constant $C_\\varepsilon$, depending only on $\\varepsilon$ and not on $n$, such that every such graph contains a non-planar subgraph on at most $C_\\varepsilon$ vertices?\n\n**Kostochka and Pyber (1988)** resolved this affirmatively, proving that graphs with $n^{1+\\varepsilon}$ edges contain $K_5$ subdivisions on $O_\\varepsilon(1)$ vertices. Their proof uses the probabilistic method combined with extremal graph theory. Mader (1967) had earlier shown that the Turán number for $K_t$ subdivisions is $O(t\\sqrt{\\log t} \\cdot n)$, establishing a linear threshold for topological containment. The Kostochka-Pyber result goes further by bounding the *size* of the subdivision found.\n\nErdős also observed that $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$: as the density approaches linear, non-planarity becomes more diffuse and cannot be localized to a small subgraph. This tradeoff between density and obstruction size is a recurring theme in extremal graph theory.",
     "problemStatement": "**Problem Statement**\n\nLet ε > 0. Is there a constant C_ε such that, for all large n, every graph on n vertices with at least n^(1+ε) edges must contain a non-planar subgraph on at most C_ε vertices?\n\n**Status**: SOLVED (Kostochka-Pyber 1988)\n\n**Answer**: YES. Dense graphs contain K₅ subdivisions with O_ε(1) vertices.\n\n**Note**: Erdős observed C_ε → ∞ as ε → 0 (sparser graphs hide non-planarity in larger structures).",
-    "text": "A formalization of Erdős Problem #1018 in 260 lines with 7 axioms, 7 sorries, and 15 definitions. The file formalizes the graph-theoretic framework (edge count, density, planarity, Kuratowski's characterization, induced subgraphs) and the main question: for $\\varepsilon > 0$, does every $n$-vertex graph with $n^{1+\\varepsilon}$ edges contain a non-planar subgraph on $O_\\varepsilon(1)$ vertices? The Kostochka-Pyber (1988) positive resolution is axiomatized, with the quantitative bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$ and the Mader Turán number $\\text{ex}(n, TK_5) = O(n)$ as key supporting axioms. The density-size tradeoff $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$ is formalized via Mathlib's `Filter.Tendsto`.",
+    "text": "A formalization of Erdős Problem #1018 in 261 lines with 7 axioms, 7 sorries, and 15 definitions. The file formalizes the graph-theoretic framework (edge count, density, planarity, Kuratowski's characterization, induced subgraphs) and the main question: for $\\varepsilon > 0$, does every $n$-vertex graph with $n^{1+\\varepsilon}$ edges contain a non-planar subgraph on $O_\\varepsilon(1)$ vertices? The Kostochka-Pyber (1988) positive resolution is axiomatized, with the quantitative bound $C_\\varepsilon = \\lceil 1/\\varepsilon^2 \\rceil$ and the Mader Turán number $\\text{ex}(n, TK_5) = O(n)$ as key supporting axioms. The density-size tradeoff $C_\\varepsilon \\to \\infty$ as $\\varepsilon \\to 0$ is formalized via Mathlib's `Filter.Tendsto`.",
     "proofStrategy": "**Proof Approach (Kostochka-Pyber)**\n\n1. **Density Threshold**: Graphs with n^(1+ε) edges are 'super-linearly dense'.\n\n2. **Finding Structure**: Use probabilistic or extremal methods to find vertices of high degree.\n\n3. **K₅ Subdivision**: High-degree vertices connect through short paths, forming a K₅ subdivision.\n\n4. **Bounding Size**: The total vertices used (5 branch vertices + path vertices) is O_ε(1).\n\n**Key Insight**: Super-linear edge density forces enough local structure that K₅ subdivisions must appear in bounded-size subgraphs.",
     "keyInsights": [
       "**Linear planarity threshold**: Euler's formula gives $|E| \\le 3n - 6$ for planar graphs, so the density exponent $1 + \\varepsilon$ with $\\varepsilon > 0$ is the precise threshold where planarity breaks down",
@@ -238,7 +238,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1018",
-    "lineCount": 260,
+    "lineCount": 261,
     "axiomCount": 7,
     "theoremCount": 4,
     "definitionCount": 15,
@@ -248,5 +248,5 @@
       "Proofs/Erdos1018Aristotle.lean"
     ]
   },
-  "sorries": 22
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Sync `erdos-1018` meta.json with canonical Lean source stats. The `assumptions` text already said "7 sorries" and `leanFile.sorries` was already 7; this PR catches up the structured `sorries` fields (top-level + nested) and `lineCount` to match actual source.

## Evidence

`proofs/Proofs/Erdos1018Problem.lean`:
- canonical `lineCount = content.split('\n').length = 261` (per `scripts/research/enrich-research.ts:174`); meta said 260
- real sorry count = 7 (verified by stripping `/- ... -/` and `-- ...` comments before `\bsorry\b` grep); meta `sorries` said 22

Changes:
- `meta.sorries`: 22 → 7
- top-level `sorries`: 22 → 7
- `meta.lineCount`: 260 → 261
- `leanFile.lineCount`: 260 → 261
- `overview.text` prose: "260 lines" → "261 lines"

axiomCount (7), theoremCount (4), definitionCount (15), and `leanFile.sorries` (already 7) all canonical and unchanged.

---
Automated fix by lean-mechanic agent.