### PR TITLE
fix(meta): erdos-695 lineCount 299→300 align with leanFile (split('\n').length convention)

### DIFF
--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -63,7 +63,7 @@
       "Asymptotic notation (big-O, little-o)",
       "Lean 4 / Mathlib (Filter.Tendsto, Asymptotics.IsLittleO, Nat.Prime)"
     ],
-    "lineCount": 299,
+    "lineCount": 300,
     "assumptions": "1 axiom: small_prime_conjecture (conjectured). 1 sorry: conjecture_implies_question2. Proved question1_equiv (rpow/tendsto equivalence) and fixed smallestPrimeCongruentOne (Dirichlet's theorem from Mathlib).",
     "theoremCount": 8,
     "definitionCount": 10
@@ -181,7 +181,7 @@
       "Real"
     ],
     "namespace": "Erdos695",
-    "lineCount": 299,
+    "lineCount": 300,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary

Single-file STATE-SYNC fixing meta.json lineCount drift for erdos-695.

- `meta.lineCount`: 299 → 300
- `leanFile.lineCount`: 299 → 300

Erdos695Problem.lean `split('\n').length` = 300 (canonical per `enrich-research.ts`), matches `src/data/research/problems/erdos-695.json` `leanFiles[1].lineCount=300`. meta.json had the `wc -l` value (299), which differs by +1 for files with a trailing newline.

## Verified counts unchanged

| Field | meta.json | actual |
|-------|-----------|--------|
| theoremCount | 8 | 8 |
| definitionCount | 10 | 10 |
| axiomCount | 1 | 1 |
| sorries | 1 | 1 |

## Scope

State.md (2026-05-13 prior STATE-SYNC) explicitly carves out Aristotle JSON drift (`leanFiles[0].lineCount=102→120`, `sorryCount=13→2`) as auditor/mechanic territory; this PR honors that scope.

Open conjecture status preserved: `status: axiomatized` / `badge: axiom`. Both Erdős questions remain mathematically OPEN.

## Test plan

- [x] meta.json valid JSON (Edit tool succeeded)
- [x] Two lineCount fields updated (top-level + leanFile)
- [x] No Lean source touched (doc-only)
- [x] Other counts (theoremCount, definitionCount, axiomCount, sorries) verified canonical via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)