### PR TITLE
research(amgm-inequality-oq-02-oq-01-oq-02-oq-01): S2 STATE-SYNC — lineCount 91→92 + 117→118

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2026-04-25",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 91,
+    "lineCount": 92,
     "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "Core results obtained via Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum and MvPolynomial.psum_one/esymm_one. The three corollaries (k=1,2,3) are derived from these Mathlib theorems. 0 sorries, 0 axiom declarations.",
@@ -193,7 +193,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean",
-    "lineCount": 91,
+    "lineCount": 92,
     "theoremCount": 3,
     "definitionCount": 0,
     "axiomCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
       "filename": "AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for `amgm-inequality-oq-02-oq-01-oq-02-oq-01` ("Full Newton-Girard Recurrence"). Pure metadata sync — no Lean changes.

Both Lean files for this slug drifted by +1 line vs the canonical `split('\n').length` formula used by the gallery enrichment pipeline (`scripts/enrich-research.ts`). Both files end with a trailing newline (so `wc -l` = 91/117 while `split('\n').length` = 92/118).

### Changes

`src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json`
- `meta.lineCount`: **91 → 92** (AmgmInequalityOQ02OQ01OQ02OQ01.lean)
- `leanFile.lineCount`: **91 → 92** (same file, scalar sibling field)

`src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json`
- `leanFiles[5].lineCount` (AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean): **117 → 118**

### Already canonical (no change)

- Main file: 92 LOC, 3 theorems, 0 definitions, 0 axioms, 0 sorries
- Aristotle file: 118 LOC, 3 theorems, 0 definitions, 0 axioms, 0 sorries
- `meta.status`: `verified`, `meta.badge`: `mathlib`
- Registry `knowledge.progressSummary`: *"COMPLETE: All 3 Newton-Girard corollaries proved, 0 sorries, 0 axioms"*

### Context

The slug is registry-complete per the 2026-04-26 `knowledge.md` session log (3 corollaries `p₁=e₁`, `p₂=e₁²−2e₂`, `p₃=e₁p₂−e₂p₁+3e₃` derived from Mathlib's `MvPolynomial.psum_eq_mul_esymm_sub_sum`).

## Test plan

- [x] `python3 -c \"print(len(open('proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean').read().split('\\n')))\"` → 92
- [x] `python3 -c \"print(len(open('proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean').read().split('\\n')))\"` → 118
- [x] `grep -cE '^(theorem|lemma) ' proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` → 3
- [x] `grep -cE '^axiom ' proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` → 0
- [x] `grep -c sorry proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` → 0
- [x] No Lean changes — doc-only metadata sync
- [ ] CI green

Pool: post-merge flip via `claim-problem.sh update amgm-inequality-oq-02-oq-01-oq-02-oq-01 completed` (separate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)