### PR TITLE
fix(meta): erdos-831 STATE-SYNC — meta lineCount 717→718 + research JSON axiomCount 0→1

### DIFF
--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -54,7 +54,7 @@
       "erdos_831_summary, erdos_831_open_question: summary theorems"
     ],
     "axiomCount": 1,
-    "lineCount": 717,
+    "lineCount": 718,
     "assumptions": "1 axiom: erdos_831_growing (h(n) → ∞ as n → ∞ — the central open question). h(4)=1 (corrected), h_upper_bound, and h_three all proved. 23 theorems, 0 sorries.",
     "theoremCount": 23,
     "definitionCount": 18
@@ -186,7 +186,7 @@
       "Finset"
     ],
     "namespace": "Erdos831",
-    "lineCount": 717,
+    "lineCount": 718,
     "axiomCount": 1,
     "theoremCount": 23,
     "definitionCount": 18,

--- a/src/data/research/problems/erdos-831.json
+++ b/src/data/research/problems/erdos-831.json
@@ -89,16 +89,16 @@
     "mathlib": []
   },
   "started": "2026-01-15T09:46:19.704Z",
-  "lastUpdate": "2026-05-08T17:50:00Z",
+  "lastUpdate": "2026-05-17T16:30:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos831Problem.lean",
       "filename": "Erdos831Problem.lean",
-      "lineCount": 713,
+      "lineCount": 718,
       "theoremCount": 14,
-      "axiomCount": 0,
+      "axiomCount": 1,
       "defCount": 12,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

Two-file STATE-SYNC for erdos-831 (\"circumradii of point sets in general position\"; status: axiomatized, badge: axiom; OPEN).

**meta.json** (gallery, 2 fields):
- `meta.lineCount`: 717 → 718
- `leanFile.lineCount`: 717 → 718

Erdos831Problem.lean `split('\n').length = 718` (canonical per `scripts/research/enrich-research.ts:145+174`); meta had the `wc -l` value (717). Off-by-one expected for files with trailing newline.

**research JSON** (`src/data/research/problems/erdos-831.json`, 3 fields):
- `leanFiles[0].lineCount`: 713 → 718
- `leanFiles[0].axiomCount`: 0 → 1  ← stale despite `lastUpdate: 2026-05-08`
- `lastUpdate`: 2026-05-08 → 2026-05-17

The axiom `erdos_831_growing` was added in PR #15625 (merged 2026-05-04, see state.md \"Approaches Tried\" #8). research JSON had a 4-day-later refresh stamp but still showed `axiomCount: 0` — a real consistency bug, not just freshness lag.

## Verified canonical counts unchanged

Per the two different counting conventions in this repo:

| Field | meta convention | actual | research JSON convention | actual |
|-------|-----------------|--------|--------------------------|--------|
| theoremCount | 23 (broad: incl protected/private) | 23 | 14 (narrow: `^(theorem\|lemma) `) | 14 |
| definitionCount / defCount | 18 (def+abbrev+structure) | 18 | 12 (`^(def\|noncomputable def\|opaque def) `) | 12 |
| axiomCount | 1 | 1 | 1 (was 0) | 1 |
| sorries / sorryCount | 0 | 0 | 0 | 0 |

## Scope

- No Lean source touched (doc-only).
- Open conjecture status preserved (`status: axiomatized`, `badge: axiom`).
- State.md (2026-05-04) is current per its own claim of \"717 lines\" — left untouched since wc -l 717 prose is a valid alternative convention; this PR aligns only the structured JSON fields with the script's canonical convention.

## Test plan

- [x] Both JSON files parse
- [x] 2 lineCount fields in meta + 1 in research JSON → all 718
- [x] research JSON axiomCount matches Lean grep ^axiom = 1
- [x] No Lean source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)