### PR TITLE
research(erdos-200): S2 STATE-SYNC — registry catchup to state.md iter 8 + lineCount/theoremCount

### DIFF
--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -74,7 +74,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
     "theoremCount": 11,
-    "lineCount": 229,
+    "lineCount": 230,
     "assumptions": "3 axioms: prime_ap_pnt_upper (PNT upper bound), green_tao (Green-Tao 2008), erdos_200 (open conjecture). 0 sorries.",
     "mathlib_version": "4.26.0",
     "definitionCount": 3
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 229,
+    "lineCount": 230,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 3,

--- a/src/data/research/problems/erdos-200.json
+++ b/src/data/research/problems/erdos-200.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-200",
   "title": "Erdős #200",
-  "phase": "OBSERVE",
+  "phase": "ACTIVE_RESEARCH",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,20 +16,20 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-01-12T10:06:12.674Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACTIVE_RESEARCH",
+    "since": "2026-05-08T00:00:00.000Z",
+    "iteration": 8,
+    "focus": "Strengthen the structural relationship between Green–Tao (lower bound) and PNT (upper bound) on longestPrimeAP(N): factor bddAbove_isPrimeAP / nonempty_isPrimeAP / longest_prime_ap_monotone and strengthen pnt_green_tao_bracket so M is a free parameter (was existentially quantified and trivially satisfied with M = 0).",
+    "blockers": ["Build verification deferred (broken proofs/.lake symlink in main repo forces a fresh Mathlib clone). PR #17195 marked as build pending per convention."],
+    "nextAction": "Iteration 9 candidates: add prime_ap_8 (d=210, length-8 starting at 199) and prime_ap_10 (d=210, length-10 ending at 2089); prove quantitative lower bound on smallest N containing a length-k prime AP (combine ap_difference_primorial with primorial growth); replace inline le_csSup in longest_prime_ap_unbounded with factored bddAbove_isPrimeAP lemma (cleanup).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 8,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 3A in file (was 1A — added prime_ap_pnt_upper and erdos_200), 7T proved (was 6T — added pnt_green_tao_bracket), 0S. 180 lines.",
+    "progressSummary": "PROGRESS (iter 8): 3 axioms (prime_ap_pnt_upper, green_tao, erdos_200), 11 theorems broad (8 narrow top-level — added bddAbove_isPrimeAP / nonempty_isPrimeAP / longest_prime_ap_monotone alongside strengthened pnt_green_tao_bracket with free parameter M), 3 definitions (IsPrimeAP, longestPrimeAP, plus helper), 0 sorries, 230 lines (was 180).",
     "builtItems": [
       "Proved exists_dvd_in_ap helper lemma (ZMod witness) in Erdos200Problem.lean:129",
       "Proved ap_difference_primorial theorem in Erdos200Problem.lean:150 (was false axiom)",
@@ -66,15 +66,15 @@
     "mathlib": []
   },
   "started": "2026-01-12T10:06:12.675Z",
-  "lastUpdate": "2026-03-13T07:52:17.044Z",
+  "lastUpdate": "2026-05-08T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos200Problem.lean",
       "filename": "Erdos200Problem.lean",
-      "lineCount": 180,
-      "theoremCount": 6,
+      "lineCount": 230,
+      "theoremCount": 11,
       "axiomCount": 3,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for `erdos-200` ("Does the longest AP of primes in {1,..,N} have length o(log N)?"). Pure metadata sync — no Lean changes.

Registry top-level and `leanFiles[0]` had drifted from the actual filesystem after merged iter 8 (PR #17195, 2026-05-08) and subsequent mass-import directory sweeps (sperner #19454, angle-trisection #18059).

### Drift summary

| Surface | Before | After | Source of truth |
|---|---|---|---|
| `meta.json` `lineCount` (both fields) | 229 | **230** | `split('\n').length` (`scripts/enrich-research.ts`) |
| Registry `leanFiles[0].lineCount` | 180 | **230** | same |
| Registry `leanFiles[0].theoremCount` | 6 | **11** | broad grep, matches gallery meta convention |
| Registry `phase` | `OBSERVE` | **`ACTIVE_RESEARCH`** | state.md L3 |
| Registry `lastUpdate` | 2026-03-13 | **2026-05-08** | state.md L4 |
| Registry `currentState.iteration` | 1 | **8** | state.md L5 |
| Registry `currentState.focus` | "Initial exploration" | iter 8 bracket-strengthening | state.md L7-14 |
| Registry `currentState.blockers` | [] | [".lake symlink build deferred"] | state.md L33-36 |
| Registry `currentState.nextAction` | "Begin problem exploration" | iter 9 candidates | state.md L40-46 |
| Registry `attemptCounts.total` | 0 | **8** | state.md L50 |
| Registry `knowledge.progressSummary` | "180 lines / 7T" stale | "230 lines / 11T / 3A / 0S" w/ iter 8 delta | derived from current file |

### Already canonical (no change)

- `axiomCount: 3` (prime_ap_pnt_upper, green_tao, erdos_200 — encoding upstream open mathematics)
- `definitionCount: 3` (IsPrimeAP, longestPrimeAP, exists_dvd_in_ap)
- `sorries: 0`
- `meta.status: axiomatized`, `meta.badge: axiom`

### Untouched

- `state.md` — already current as of iter 8, used as source of truth
- `knowledge.md`, `problem.md` — content unchanged
- Section line ranges in `meta.json` — pre-existing drift outside this iter's scope (sections end at line 180; file is now 230 lines)

### Context

`erdos-200` remains genuinely IN-PROGRESS (open Erdős conjecture). The 3 axioms encode upstream mathematics:
- `prime_ap_pnt_upper`: PNT upper bound `longestPrimeAP(N) ≤ (1+ε)·log N`
- `green_tao`: Green-Tao 2008 (primes contain APs of every length)
- `erdos_200`: the open conjecture itself, `longestPrimeAP(N) < ε·log N`

Pool stays `in-progress`; claim released post-sync.

## Test plan

- [x] `python3 -c \"print(len(open('proofs/Proofs/Erdos200Problem.lean').read().split('\\n')))\"` → 230
- [x] `grep -cE '(theorem|lemma) ' proofs/Proofs/Erdos200Problem.lean` → 11 (broad, matches gallery)
- [x] `grep -cE '^axiom ' proofs/Proofs/Erdos200Problem.lean` → 3
- [x] `grep -cE '^(def|noncomputable def|abbrev) ' proofs/Proofs/Erdos200Problem.lean` → 3
- [x] `grep -c sorry proofs/Proofs/Erdos200Problem.lean` → 0
- [x] No Lean changes — doc-only metadata sync
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)