### PR TITLE
fix(meta): erdos-117-oq-01 sorries 14->1 + lineCount 269->270 (canonical sync)

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -19,13 +19,13 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 1,
     "axiomCount": 3,
     "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 1 sorry: base_implies_behavior (limit → exponential behavior, requires Tendsto with nhds ε-balls). limInf_ge_log_c1 now fully proved.",
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 269,
+    "lineCount": 270,
     "theoremCount": 8,
     "definitionCount": 9,
     "additionalFiles": [
@@ -137,7 +137,7 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 269,
+    "lineCount": 270,
     "axiomCount": 3,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,
@@ -149,5 +149,5 @@
       "Proofs/Erdos117OQ01Aristotle.lean"
     ]
   },
-  "sorries": 14
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Sync `erdos-117-oq-01` metadata to canonical conventions:

- `sorries` (top-level + `meta.sorries`): **14 → 1** — main file `Proofs/Erdos117OQ01.lean` has exactly 1 actual sorry (`base_implies_behavior` at line 198), matching the `assumptions` prose ("1 sorry: base_implies_behavior"). The stale 14 summed in the 13 sorries from the Aristotle companion file, but the canonical convention aligns top-level/`meta.sorries` with `leanFile.sorries` (main file only).
- `lineCount` (`meta.lineCount` + `leanFile.lineCount`): **269 → 270** — canonical convention per `scripts/research/enrich-research.ts:174` is `content.split('\n').length`, which is `wc -l + 1` for files without trailing newline.

## Evidence

**Before**: `sorries: 14` contradicted `leanFile.sorries: 1` and the assumptions text. `lineCount: 269` differed from `split('\n').length` by 1.

**After**: All three `sorries` slots agree at 1. All `lineCount` slots agree at 270.

Other fields (`axiomCount: 3`, `theoremCount: 8`, `definitionCount: 9`, status/badge) already canonical — left unchanged.

Companion file `Proofs/Erdos117OQ01Aristotle.lean` (13 sorries) untouched.

---
Automated fix by lean-mechanic agent.