### PR TITLE
fix(meta): erdos-1018-oq-04-incomplete-01 sorries 8→1 + lineCount 737→738

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,10 +18,10 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 1,
     "axiomCount": 1,
     "theoremCount": 11,
-    "lineCount": 737,
+    "lineCount": 738,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 1 sorry in this file: planar_graphs_edge_bound (Euler's formula |E| ≤ 3|V| - 6, not yet in Lean Mathlib). K₃ and K₄ planarity proved with explicit coordinates and linear-functional convex hull arguments.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0",
@@ -134,7 +134,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 737,
+    "lineCount": 738,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",


### PR DESCRIPTION
## Summary

Single-file meta.json STATE-SYNC for `erdos-1018-oq-04-incomplete-01` (\"Hypergraph Non-Planar Density: Concrete Embeddability Definition\"; `status: axiomatized`, `badge: axiom`).

Three drift fixes:

- `meta.sorries`: 8 → 1
  Aligns with `meta.assumptions` prose (\"1 sorry in this file: planar_graphs_edge_bound\") and `leanFile.sorries: 1` (already correct). The Lean file `Erdos1018OQ04Incomplete01.lean` has exactly 1 actual code `sorry` at line 652 (Euler-formula planar edge bound). Other `\bsorry\b` regex matches in the file are in docstrings/comments only (lines 6, 7, 9, 16, 23, 712, 714, 717, 719, 720, 722, 723 — all inside `/-! ... -/` or `/-- ... -/` blocks).

- `meta.lineCount`: 737 → 738
- `leanFile.lineCount`: 737 → 738

`Erdos1018OQ04Incomplete01.lean` `split('\n').length = 738` (canonical per `scripts/research/enrich-research.ts:145+174`); meta had the `wc -l` value (737).

## Verified canonical counts unchanged

| Field | meta.json | actual |
|-------|-----------|--------|
| axiomCount | 1 | 1 (`^axiom ` grep) |
| theoremCount | 11 | 11 (`^(theorem\|lemma) ` grep, narrow + broad both match) |
| definitionCount | 1 | 1 (`^(def\|noncomputable def\|opaque def) ` grep) |
| leanFile.sorries | 1 | 1 (actual code sorry) |

## Scope

- No Lean source touched (doc-only)
- Open conjecture status preserved (`status: axiomatized`, `badge: axiom`)
- 1 axiom retained: `kostochka_pyber_r2` (graph-case Kostochka-Pyber, proven 1988 in math)
- 1 sorry retained: `planar_graphs_edge_bound` (Euler formula |E| ≤ 3|V| − 6 — not yet in Mathlib)

State.md is a stub-form NEW/iteration-1 from 2026-03-30 but actual file is well-developed (738 LOC, 11 theorems, concrete `isEmbeddableConc` def replacing parent `sorry`). State.md upgrade and research JSON `leanFiles` array population are auditor/mechanic territory and out of scope for this minimal-blast-radius fix.

## Test plan

- [x] meta.json valid JSON (Edit succeeded)
- [x] sorries 8→1 matches both assumptions prose and leanFile.sorries
- [x] lineCount 737→738 matches split('\\n').length convention
- [x] No Lean source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)