### PR TITLE
fix(meta): platonic-solids-oq-01 lineCount 628→629 (canonical split-newline)

### DIFF
--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "theoremCount": 53,
     "defCount": 28,
-    "lineCount": 628,
+    "lineCount": 629,
     "mathlibDependencies": [
       {
         "theorem": "native_decide",
@@ -166,7 +166,7 @@
     ],
     "opens": [],
     "namespace": "RegularPolytopes",
-    "lineCount": 628,
+    "lineCount": 629,
     "axiomCount": 0,
     "theoremCount": 53,
     "definitionCount": 31,


### PR DESCRIPTION
## Summary

Thin 1-file doc-only fix for `platonic-solids-oq-01` (Regular Polytopes in Higher Dimensions, verified).

## Drift surface

- `src/data/proofs/platonic-solids-oq-01/meta.json` lineCount 628→629 (×2 occurrences: meta + leanFile sections)
- Canonical per `enrich-research.ts`: `content.split('\n').length` = 629 for `PlatonicSolidsOQ01.lean` (`wc -l` reports 628 for no-trailing-newline files)

## Lean state (unchanged)

- `Proofs/PlatonicSolidsOQ01.lean`: 629 lines (canonical), 0 sorries, 0 axioms, 53 theorems, 31 definitions
- meta.json `status: verified` (correct — 0 axiom declarations, no assumption-carrying structures: `QSqrt5` and `Polytope4Data` are pure data records)

## Pool flip (out-of-band)

`claim-problem.sh update platonic-solids-oq-01 completed` — pool status in-progress → completed to match registry COMPLETED/graduated 2026-03-29.

## Test plan

- [x] Lean file untouched (only meta.json doc edits)
- [x] meta.json valid JSON
- [x] verified status confirmed (no sorries, no axioms, no assumption-carrying structures)

Generated with Claude Code