### PR TITLE
research(yang-mills-lattice-oq-01): S2 STATE-SYNC — lineCount 579→580

### DIFF
--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "assumptions": "2 axioms: (1) os_reconstruction — the GNS construction from reflection-positive lattice OS data producing a WightmanQFT; this is mathematically proven (Osterwalder-Schrader 1973, Osterwalder-Seiler 1978) but requires functional analysis (Bochner's theorem, GNS construction) beyond current Mathlib. (2) os_mass_gap_transfer — that exponential decay of Schwinger functions implies a spectral gap in the reconstructed Hilbert space via the Kallen-Lehmann representation; similarly proven but requires the full OS machinery. The 2D results (Migdal formula, string tension, SU(2) computation) are fully proved with 0 axioms.",
-    "lineCount": 579,
+    "lineCount": 580,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_neg",
@@ -153,7 +153,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 579,
+    "lineCount": 580,
     "structureCount": 7,
     "axiomCount": 2,
     "theoremCount": 28,

--- a/src/data/research/problems/yang-mills-lattice-oq-01.json
+++ b/src/data/research/problems/yang-mills-lattice-oq-01.json
@@ -19,7 +19,7 @@
       "The Migdal-level reciprocity σ · ξ = 1 holds for any irrep (unit-normalized), mirroring the abstract OS-transfer-matrix Δ · ξ · a = 1"
     ],
     "builtItems": [
-      "YangMillsLatticeOQ01.lean: 579 lines, 2 axioms, 0 sorries (28 theorems, 11 defs)",
+      "YangMillsLatticeOQ01.lean: 580 lines, 2 axioms, 0 sorries (28 theorems, 11 defs)",
       "LatticeOSData structure encoding OS1-OS5 for finite 4D hypercubic lattice",
       "OSTransferMatrix extending TransferMatrix with OS2-derived positivity properties",
       "os_hamiltonian_nonneg: OS transfer matrix → H = -ln(T)/a ≥ 0",
@@ -60,7 +60,7 @@
     {
       "path": "Proofs/YangMillsLatticeOQ01.lean",
       "filename": "YangMillsLatticeOQ01.lean",
-      "lineCount": 579,
+      "lineCount": 580,
       "theoremCount": 28,
       "axiomCount": 2,
       "defCount": 11,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for `yang-mills-lattice-oq-01` (Clay Millennium: "Yang-Mills Lattice — Continuum limit as Wightman QFT"). Pure metadata sync — no Lean changes.

`YangMillsLatticeOQ01.lean` drifted by +1 line vs the canonical `split('\n').length` formula used by the gallery enrichment pipeline (`scripts/enrich-research.ts`). File ends with a trailing newline (so `wc -l` = 579 while `split('\n').length` = 580).

### Changes (3 lineCount surfaces + 1 prose mention)

`src/data/proofs/yang-mills-lattice-oq-01/meta.json`
- `meta.lineCount`: **579 → 580**
- `leanFile.lineCount`: **579 → 580**

`src/data/research/problems/yang-mills-lattice-oq-01.json`
- `leanFiles[0].lineCount`: **579 → 580**
- `knowledge.builtItems[0]` prose: `"579 lines"` → `"580 lines"`

### Already canonical (no change)

- `axiomCount: 2` (os_reconstruction, os_mass_gap_transfer — upstream OS-reconstruction theorems requiring functional analysis beyond Mathlib)
- `theoremCount: 28` (narrow grep matches gallery convention)
- `definitionCount: 11` (narrow def count)
- `sorries: 0`
- `meta.status: axiomatized`, `meta.badge: axiom`

### Skipped this cycle

- `leanFile.structureCount` in `meta.json` shows `7` but `grep -cE '^(structure|class|inductive) '` returns `5` — soft metadata convention skipped per drift-priority order `lineCount > sorries > axiomCount > theoremCount`; `structureCount` sits further down the trust ladder.
- No `state.md` — `research/problems/yang-mills-lattice-oq-01/` does not exist as a directory. The registry `knowledge.progressSummary` captures the work record (\"ACT: 2D Migdal infrastructure expanded — SU(N) fundamental + SU(2) adjoint string tensions + Migdal correlation length\").

### Context

The slug remains genuinely IN-PROGRESS (Clay Millennium Yang-Mills mass gap formalization — 4D continuum limit requires functional-analysis infrastructure not yet in Mathlib). 2D Migdal subsection is fully proved with 0 axioms.

Pool stays `in-progress`; claim released post-sync.

## Test plan

- [x] `python3 -c \"print(len(open('proofs/Proofs/YangMillsLatticeOQ01.lean').read().split('\\n')))\"` → 580
- [x] `grep -cE '^(theorem|lemma) ' proofs/Proofs/YangMillsLatticeOQ01.lean` → 28
- [x] `grep -cE '^axiom ' proofs/Proofs/YangMillsLatticeOQ01.lean` → 2
- [x] `grep -cE '^(def|noncomputable def|abbrev) ' proofs/Proofs/YangMillsLatticeOQ01.lean` → 11
- [x] `grep -c sorry proofs/Proofs/YangMillsLatticeOQ01.lean` → 0
- [x] No Lean changes — doc-only metadata sync
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)