### PR TITLE
research(erdos-1179-oq-01): S2 STATE-SYNC — Erdos1179OQ01.lean lineCount 709→710

### DIFF
--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "theoremCount": 28,
     "definitionCount": 7,
-    "lineCount": 709,
+    "lineCount": 710,
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "open-question",
@@ -223,7 +223,7 @@
       "Real"
     ],
     "namespace": "Erdos1179OQ01",
-    "lineCount": 709,
+    "lineCount": 710,
     "axiomCount": 0,
     "theoremCount": 28,
     "definitionCount": 7,


### PR DESCRIPTION
## Summary

S2 STATE-SYNC for `erdos-1179-oq-01` ("Erdős #1179 OQ-01"). Pure metadata sync — no Lean changes.

`Erdos1179OQ01.lean` ends with a trailing newline, so `wc -l` returns 709 while the canonical `split('\n').length` formula used by `scripts/enrich-research.ts` returns 710.

### Changes

`src/data/proofs/erdos-1179-oq-01/meta.json`
- `meta.lineCount`: **709 → 710**
- `leanFile.lineCount`: **709 → 710**

### Already canonical (no change)

Gallery (Erdos1179OQ01.lean):
- `axiomCount: 0`, `sorries: 0`
- `theoremCount: 28` (broad), `definitionCount: 7` (broad — narrow grep returns 5; left untouched per drift-priority order `lineCount > sorries > axiomCount > theoremCount`)
- `status: verified`, `badge: mathlib`

Registry `leanFiles[]` already canonical for both files:
- `Erdos1179OQ01.lean`: lc=710, thm=11 (narrow), ax=0, def=5 (narrow), 0S
- `Erdos1179Problem.lean`: lc=317, thm=10, ax=3 (encoding the upstream open conjecture), def=3, 0S

### Context

The slug is registry-COMPLETE per `knowledge.progressSummary`: *"COMPLETE: 0 axioms, 0 sorries. All lemmas fully proved including character_orthogonality and reprCount_fourier_expansion."*

The 3 axioms in the sibling `Erdos1179Problem.lean` file encode the upstream open Erdős conjecture; the OQ-01 lemma slug itself is fully proved.

Pool stays `in-progress` (parent erdos-1179 conjecture work continues; registry phase is `ACT`, status `active`); claim released post-sync.

## Test plan

- [x] `python3 -c \"print(len(open('proofs/Proofs/Erdos1179OQ01.lean').read().split('\\n')))\"` → 710
- [x] `grep -cE '^axiom ' proofs/Proofs/Erdos1179OQ01.lean` → 0
- [x] `grep -c sorry proofs/Proofs/Erdos1179OQ01.lean` → 0
- [x] No Lean changes — doc-only metadata sync
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)