### PR TITLE
fix(research/contribute): replace YOUR_USERNAME placeholder with rjwalters

### DIFF
--- a/src/components/research/ContributeSection.tsx
+++ b/src/components/research/ContributeSection.tsx
@@ -86,10 +86,10 @@ export function ContributeSection() {
                 </div>
                 <div className="space-y-2">
                   <p className="text-xs text-muted-foreground">
-                    Fork the repository on GitHub, then clone your fork:
+                    Clone the repo (fork it first via the button below if you plan to open a PR):
                   </p>
                   <pre className="text-xs bg-background/50 rounded p-2 overflow-x-auto">
-                    <code className="text-annotation">git clone https://github.com/YOUR_USERNAME/lean-genius.git{'\n'}cd lean-genius</code>
+                    <code className="text-annotation">git clone https://github.com/rjwalters/lean-genius.git{'\n'}cd lean-genius</code>
                   </pre>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

The "Contribute Research" expandable panel on `/research` was showing a clone command with a literal `YOUR_USERNAME` placeholder:

\`\`\`
git clone https://github.com/YOUR_USERNAME/lean-genius.git
\`\`\`

The intent was "fork first, then clone your fork", but the ALL-CAPS placeholder reads as a leftover template variable, not an instruction.

This PR replaces `YOUR_USERNAME` with `rjwalters` so the upstream clone command works as-is when copy-pasted (matching the "Fork on GitHub" CTA href in the same component, which also points at `rjwalters/lean-genius`). The hint above the snippet is updated to keep the fork step discoverable for contributors planning to open a PR.

Only one occurrence in the codebase (`grep -rln YOUR_USERNAME src/ scripts/ research/`).

## Test plan

- [x] No remaining `YOUR_USERNAME` strings in `src/`, `scripts/`, or `research/`.
- [ ] After deploy: visit `/research` → expand "Contribute Research" → step 1 shows the real upstream URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)