### PR TITLE
research(erdos-687): S5 STATE-SYNC — meta.lineCount 547→548 + state.md NEW→COMPLETED

### DIFF
--- a/research/problems/erdos-687/state.md
+++ b/research/problems/erdos-687/state.md
@@ -1,27 +1,60 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-14T19:46:33.202Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-05-17T17:55:00Z
+**Iteration**: 5
 
 ## Current Focus
 
-Initial exploration of the problem.
+Gallery proof is fully formalized at `proofs/Proofs/Erdos687Problem.lean` (548 lines, status `axiomatized`).
+state.md catches up with the realized work: covering systems, Jacobsthal function, and the
+$1,000 Erdős conjecture are encoded with explicit axiom dependencies on known results.
 
 ## Active Approach
 
-None yet.
+Axiomatized formalization (final): all four classical/conjectural inputs are stated as `axiom`
+declarations and the open conjecture is derived from them.
+
+Canonical inventory (per `proofs/Proofs/Erdos687Problem.lean`):
+- 548 lines (split('\n').length), 0 sorries
+- 4 axioms: `jacobsthalY_eq_jacobsthal_sub_one`, `iwaniec_upper`, `fgkmt_lower`,
+  `maier_pomerance_conjecture`
+- 5 definitions: `primorial`, `IsCovered`, `jacobsthalSet`, `jacobsthalY`, `jacobsthal`
+- 26 theorems (broad count, includes private CRT helper lemmas; 21 by narrow
+  `^(theorem|lemma) ` regex — both conventions are present in repo tooling)
+- Proved (not axiomatized): `jacobsthalSet_bddAbove` (CRT-induction argument that any
+  covering system leaves gaps within one primorial period), `erdos_687_conjecture`
+  (derived from the stronger Maier–Pomerance conjecture), `jacobsthalY_three`
+  (the concrete value Y(3) = 3 by exhaustive residue case analysis)
 
 ## Blockers
 
-None.
+None. The four `axiom` declarations are honest dependencies on open/unformalized
+results — they are the assumptions, not gaps:
+
+1. `jacobsthalY_eq_jacobsthal_sub_one` — bridging identity $Y(x) = g(P(x)) - 1$
+   between covering Y(x) and the Jacobsthal function $g$ of the primorial $P(x)$;
+   requires CRT periodicity + careful index handling (off-by-one corrected in earlier
+   iteration).
+2. `iwaniec_upper` — Iwaniec (1978) Selberg-sieve bound $Y(x) \ll x^2$.
+3. `fgkmt_lower` — Ford–Green–Konyagin–Maynard–Tao (2018) lower bound
+   $Y(x) \gg x \cdot (\log x)(\log\log\log x)/(\log\log x)$.
+4. `maier_pomerance_conjecture` — conjectural upper bound
+   $Y(x) \ll x \cdot (\log x)^{2 + o(1)}$ (open).
+
+The $1,000 prize statement $Y(x) = o(x^2)$ would follow unconditionally from a
+proof of `maier_pomerance_conjecture` (or any sub-$x^{2-\epsilon}$ upper bound).
 
 ## Next Action
 
-Begin problem exploration.
+Maintenance only. Future research iterations could attempt to replace one of the
+four axioms (most tractable target: a quantitative formalization of Iwaniec's
+Selberg-sieve argument, which is the only fully proved upper bound). No active
+work is scheduled.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 1
+- Approaches tried: 1 (axiomatized formalization with proved CRT structure +
+  proved Y(3) = 3 base case)

--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 547,
+    "lineCount": 548,
     "assumptions": "4 axioms: jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. jacobsthalSet_bddAbove proved via CRT induction. erdos_687_conjecture proved from maier_pomerance_conjecture. Y(3) = 3 proved by parity-residue case analysis. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 26,
@@ -140,7 +140,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 547,
+    "lineCount": 548,
     "axiomCount": 4,
     "theoremCount": 26,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

Bring `research/problems/erdos-687/state.md` and `src/data/proofs/erdos-687/meta.json` into agreement with the canonical Lean source `proofs/Proofs/Erdos687Problem.lean` (status=axiomatized, 0 sorries, 4 axioms, 5 definitions, 26 theorems).

## Drift detected

| Field | Current | Canonical | Source |
|-------|---------|-----------|--------|
| `meta.lineCount` (top-level) | 547 | **548** | `content.split('\n').length` per `scripts/research/enrich-research.ts:174` |
| `meta.leanFile.lineCount` | 547 | **548** | same |
| `state.md` Phase | NEW iter 1 (since 2026-01-14) | COMPLETED iter 5 | reflects realized work in Lean file |
| `axiomCount` | 4 | 4 | unchanged ✓ |
| `theoremCount` | 26 (broad) | 26 (broad) | unchanged ✓ |
| `definitionCount` | 5 | 5 | unchanged ✓ |
| `sorries` | 0 | 0 | unchanged ✓ |

`wc -l` reports 547 (newline count); `split('\n').length` returns 548 because the file has a trailing newline. The enricher script convention is the canonical one — see memory `feedback_mechanic_2_post_skip_recovery_2nd_cycle_navier_stokes_batch_sync` for prior precedent.

## state.md rewrite

The prior state.md was a 4-month-old NEW-phase stub that never advanced past "Begin problem exploration." The Lean file has been a fully-developed axiomatized formalization for some time. The rewrite captures the actual structure:

- 4 axioms — explicit dependencies on classical and conjectural results (Iwaniec 1978 upper bound, FGKMT 2018 lower bound, Maier–Pomerance conjecture, the bridging identity Y(x) = g(P(x)) − 1)
- Proved-not-axiomatized: `jacobsthalSet_bddAbove` (CRT induction), `erdos_687_conjecture` (from the stronger Maier–Pomerance conjecture), `jacobsthalY_three` (Y(3) = 3 by parity-residue case analysis)
- Status: `axiomatized` is the terminal state for this $1,000-prize open conjecture — no sorries, all assumptions honestly declared

## Test plan

- [x] `meta.json` validates as JSON (`require()` succeeds)
- [x] `content.split('\n').length === 548` for `proofs/Proofs/Erdos687Problem.lean`
- [x] `grep -c "^axiom " Erdos687Problem.lean` = 4 (matches `axiomCount`)
- [x] `grep -c "sorry" Erdos687Problem.lean` = 0 (matches `sorries`)
- [x] No Lean changes — no rebuild required

## Notes

- Pool flip (in-progress → completed) handled out-of-band via `claim-problem.sh`.
- Per project policy: math agents do not add `loom:review-requested`; deployer merges math PRs directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)