### PR TITLE
research(area-of-circle-oq-03-oq-02-oq-02): S4 STATE-SYNC — meta.lineCount 204→205 + state.md NEW→COMPLETED

### DIFF
--- a/research/problems/area-of-circle-oq-03-oq-02-oq-02/state.md
+++ b/research/problems/area-of-circle-oq-03-oq-02-oq-02/state.md
@@ -1,27 +1,47 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-30T19:39:40.877Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-05-17T18:05:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Initial exploration of the problem.
+Gallery proof is fully formalized at `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean`
+(205 lines, status `verified`). state.md catches up with the realized work: the
+Dalzell–Niven integral proof of $\pi < 22/7$ is fully verified, with the
+polynomial identity $x^4(1-x)^4 = (1+x^2)(x^6 - 4x^5 + 5x^4 - 4x^2 + 4) - 4$
+giving the closed-form antiderivative and the strict-positivity argument.
 
 ## Active Approach
 
-None yet.
+Verified formalization of the Dalzell (1944) / Niven (1947) integral identity
+$\int_0^1 \frac{x^4(1-x)^4}{1+x^2}\,dx = \frac{22}{7} - \pi$, combined with
+strict positivity of the integrand on $(0, 1)$ to derive $\pi < 22/7$.
+
+Canonical inventory (per `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean`):
+- 205 lines (split('\n').length), 0 sorries
+- 0 axioms
+- 2 definitions
+- 15 theorems (narrow regex match), including:
+  - `dalzell_polynomial_identity` (the key algebraic factorization, proved by `ring`)
+  - `dalzell_integrand_decomposition`
+  - `dalzell_niven_integral` (the closed-form value $22/7 - \pi$)
+  - `pi_lt_twentytwo_over_seven` (main result)
 
 ## Blockers
 
-None.
+None. No assumptions beyond Mathlib (`integral_pow`, `integral_inv_one_add_sq`,
+`arctan_one`).
 
 ## Next Action
 
-Begin problem exploration.
+Maintenance only. The proof is the standard textbook one; possible extensions
+(quantitative bound on $22/7 - \pi$, generalization to higher Dalzell-style
+identities) are sibling open-questions handled elsewhere.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 4
+- Current approach attempts: 1
+- Approaches tried: 1 (Dalzell–Niven polynomial identity + closed-form
+  antiderivative)

--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -56,7 +56,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries.",
-    "lineCount": 204,
+    "lineCount": 205,
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
     "definitionCount": 2
@@ -157,7 +157,7 @@
       "intervalIntegral"
     ],
     "namespace": "AreaOfCircleOQ03OQ02OQ02",
-    "lineCount": 204,
+    "lineCount": 205,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,


### PR DESCRIPTION
## Summary

Bring `research/problems/area-of-circle-oq-03-oq-02-oq-02/state.md` and `src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json` into agreement with the canonical Lean source `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean` (status=verified, 0 axioms, 0 sorries — Dalzell–Niven proof of $\pi < 22/7$).

## Drift detected

| Field | Current | Canonical | Source |
|-------|---------|-----------|--------|
| `meta.lineCount` (top-level) | 204 | **205** | `content.split('\n').length` per `scripts/research/enrich-research.ts:174` |
| `meta.leanFile.lineCount` | 204 | **205** | same |
| `state.md` Phase | NEW iter 1 (since 2026-03-30) | COMPLETED iter 4 | reflects realized Dalzell–Niven verification |
| `axiomCount` | 0 | 0 | unchanged ✓ |
| `theoremCount` | 15 | 15 | unchanged ✓ |
| `definitionCount` | 2 | 2 | unchanged ✓ |
| `sorries` | 0 | 0 | unchanged ✓ |

`wc -l` reports 204 (newline count); `split('\n').length` returns 205 because the file ends with a trailing newline.

## state.md rewrite

Prior state.md was a NEW-phase stub from 2026-03-30 that never advanced. The Lean file has long been a complete verification of the Dalzell (1944) / Niven (1947) integral identity $\int_0^1 \frac{x^4(1-x)^4}{1+x^2}\,dx = \frac{22}{7} - \pi$, with the strict-positivity argument giving the main theorem `pi_lt_twentytwo_over_seven`.

## Test plan

- [x] `meta.json` validates as JSON
- [x] `content.split('\n').length === 205` for `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean`
- [x] `grep -c "^axiom " AreaOfCircleOQ03OQ02OQ02.lean` = 0
- [x] `grep -c "sorry" AreaOfCircleOQ03OQ02OQ02.lean` = 0
- [x] No Lean changes — no rebuild required

## Notes

- Pool flip (in-progress → completed) handled out-of-band via `claim-problem.sh`.
- Per project policy: math agents do not add `loom:review-requested`; deployer merges math PRs directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)