### PR TITLE
research(erdos-1095-incomplete-01): S3 STATE-SYNC — parent gallery lineCount 180→181 + research-JSON refresh

### DIFF
--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 7,
     "assumptions": "7 axioms: g (function), g_gt, g_spec, g_minimal, ees_lower_bound, ees_upper_bound, konyagin_lower_bound. 0 sorries. Concrete values g(2)=6, g(3)=7, g(4)=7, g(5)=23 are proved theorems.",
-    "lineCount": 180,
+    "lineCount": 181,
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
     "definitionCount": 6
@@ -187,7 +187,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos1095",
-    "lineCount": 180,
+    "lineCount": 181,
     "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 6,

--- a/src/data/research/problems/erdos-1095-incomplete-01.json
+++ b/src/data/research/problems/erdos-1095-incomplete-01.json
@@ -29,8 +29,8 @@
   "currentState": {
     "phase": "SURVEYED",
     "since": "2026-03-28T20:57:10.257Z",
-    "iteration": 2,
-    "focus": "No separate Lean file for incomplete-01 workstream; the main Erdos1095Problem.lean has 7 axioms (g, g_gt, g_spec, g_minimal + 3 deep bounds: ees_lower_bound, ees_upper_bound, konyagin_lower_bound).",
+    "iteration": 3,
+    "focus": "No separate Lean file for incomplete-01 workstream; the main Erdos1095Problem.lean has 7 axioms (g, g_gt, g_spec, g_minimal + 3 deep bounds: ees_lower_bound, ees_upper_bound, konyagin_lower_bound) and 181 LOC. Parent erdos-1095 gallery is axiomatized.",
     "blockers": [],
     "nextAction": "Either (a) merge this workstream into erdos-1095 since no separate file exists, or (b) build Erdos1095Incomplete01.lean with the bound-strengthening axiom that is currently encoded only as comments.",
     "attemptCounts": {
@@ -96,7 +96,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T20:57:10.257Z",
-  "lastUpdate": "2026-03-28T20:57:10.257Z",
+  "lastUpdate": "2026-05-17T18:00:00.000Z",
   "significance": 6,
   "tractability": 5
 }


### PR DESCRIPTION
## Summary

claim-random selected erdos-1095-incomplete-01 (SURVEYED, T-50d stale since 2026-03-28). The slug has no dedicated gallery dir or Lean file — work lives in parent Erdos1095Problem.lean (axiomatized, 181 LOC, 7 axioms). Two state-sync drift surfaces fixed.

## What landed (2 files, +5/-5, doc-only)

1. src/data/proofs/erdos-1095/meta.json — meta.lineCount and leanFile.lineCount both 180 → 181 (canonical split-newline count per enrich-research.ts; wc -l gives 180 because the file terminates with a newline).

2. src/data/research/problems/erdos-1095-incomplete-01.json —
   - currentState.iteration 2 → 3
   - currentState.focus extended to mention 181 LOC + parent axiomatized state
   - lastUpdate 2026-03-28 → 2026-05-17

Insights, builtItems, knownResults preserved — prior knowledge untouched.

Parent erdos-1095 status: axiomatized (open conjecture — Erdős-Selfridge function asymptotic). No proof progress claimed.

## Test plan
- [x] grep -c "^axiom " Proofs/Erdos1095Problem.lean returns 7
- [x] split('\n') returns 181 lines
- [x] Both lineCount fields synced

🤖 Generated with [Claude Code](https://claude.com/claude-code)