### PR TITLE
research(erdos-36): S3 STATE-SYNC — meta lineCount 380→381 + research-JSON refresh

### DIFF
--- a/src/data/proofs/erdos-36/meta.json
+++ b/src/data/proofs/erdos-36/meta.json
@@ -65,7 +65,7 @@
       "Asymptotic analysis: limit of M(N)/N"
     ],
     "assumptions": "3 axiom declarations: erdos_36_limit_exists (the limit c = lim M(N)/N exists), white_lower (White's 0.379 lower bound), upper_bound (Haugland's 0.381 upper bound). small_values is now a theorem proved computationally via native_decide on a computable mirror function MC.",
-    "lineCount": 380,
+    "lineCount": 381,
     "relatedProblems": [
       {
         "id": "erdos-335",
@@ -80,7 +80,7 @@
     "definitionCount": 9
   },
   "leanFile": {
-    "lineCount": 380,
+    "lineCount": 381,
     "axiomCount": 3,
     "theoremCount": 15,
     "definitionCount": 9,

--- a/src/data/research/problems/erdos-36.json
+++ b/src/data/research/problems/erdos-36.json
@@ -18,8 +18,8 @@
   "currentState": {
     "phase": "NEW",
     "since": "2026-01-12T06:58:30.838Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "iteration": 2,
+    "focus": "Erdos36Problem.lean is axiomatized: 381 LOC, 0 sorries, 3 axioms (erdos_36_limit_exists, white_lower 0.379, upper_bound 0.381 from Haugland). small_values is a proved theorem via native_decide on computable mirror MC.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -75,7 +75,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T06:58:30.838Z",
-  "lastUpdate": "2026-03-13T07:52:17.043Z",
+  "lastUpdate": "2026-05-17T18:10:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

claim-random selected erdos-36 (NEW iteration 1 "Initial exploration", T-65d stale since 2026-03-13). Lean file is axiomatized (0 sorries, 3 axioms) but meta.lineCount and research-JSON currentState carried stale init values. Doc-only state-sync.

## What landed (2 files, +5/-5)

1. **src/data/proofs/erdos-36/meta.json** — meta.lineCount and leanFile.lineCount both 380 → 381 (canonical split-newline per enrich-research.ts; wc -l returns 380 because file terminates with newline).

2. **src/data/research/problems/erdos-36.json** —
   - currentState.iteration 1 → 2
   - currentState.focus rewritten: "Initial exploration of the problem" → axiomatized state (381 LOC, 0 sorries, 3 axioms with names)
   - lastUpdate 2026-03-13 → 2026-05-17

Insights, builtItems, knownResults, leanFiles[] preserved. The leanFiles entry for Erdos36Problem.lean was already correct (381 LOC).

## Canonical counts (Erdos36Problem.lean)

| count | meta (after) | actual |
|-------|-------------|--------|
| lineCount | 381 | 381 |
| axiomCount | 3 | 3 |
| theoremCount | 15 | 15 (broad incl private) |
| definitionCount | 9 | 9 |
| sorries | 0 | 0 |

Parent erdos-36 status: axiomatized (open conjecture — limit M(N)/N exists with Haugland upper bound 0.381 and White lower bound 0.379).

🤖 Generated with [Claude Code](https://claude.com/claude-code)