### PR TITLE
research(erdos-301): S3 STATE-SYNC — meta lineCount 158→159 + research-JSON refresh

### DIFF
--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/301",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 158,
+    "lineCount": 159,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
@@ -109,7 +109,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 158,
+    "lineCount": 159,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

claim-random selected erdos-301 (NEW iteration 1 "Initial exploration", T-65d stale since 2026-03-13). Egyptian Fraction Avoidance Sets — main conjecture f(N)=(1/2+o(1))N is OPEN and is not encoded; only supporting lemmas are formalized. Doc-only state-sync.

## What landed (2 files, +5/-5)

1. **src/data/proofs/erdos-301/meta.json** — meta.lineCount and leanFile.lineCount both 158 → 159 (canonical split-newline per enrich-research.ts; wc -l returns 158 because file terminates with newline).

2. **src/data/research/problems/erdos-301.json** —
   - currentState.iteration 1 → 2
   - currentState.focus rewritten: "Initial exploration" → 159 LOC, 0 axioms, 0 sorries, 7 theorems, 4 defs; supporting lemmas verified; main conjecture explicitly noted as not encoded
   - lastUpdate 2026-03-13 → 2026-05-17

leanFiles[0] entry was already correct (159 LOC).

## Canonical counts (Erdos301Problem.lean)

| count | meta (after) | actual |
|-------|-------------|--------|
| lineCount | 159 | 159 |
| axiomCount | 0 | 0 |
| theoremCount | 7 | 7 |
| definitionCount | 4 | 4 |
| sorries | 0 | 0 |

Note on status: meta.status="axiomatized" with axiomCount=0 + 0 sorries + 0 structures is technically a per-CLAUDE.md anomaly (axiomatized requires axioms or structure assumptions). The "wip" badge and the OPEN conjecture not being encoded suggest "formalized" might be more accurate, but that classification change is out of scope for this thin state-sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)