### PR TITLE
fix(meta): cramers-rule-oq-03 lineCount 175→176 align with leanFile (split('\n').length convention)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 175,
+    "lineCount": 176,
     "assumptions": "None. Fully verified over any DivisionRing D.",
     "originalContributions": [
       "Defined quasidet₀₀ and quasidet₁₁: Gelfand-Retakh quasideterminants for 2×2 matrices",
@@ -147,7 +147,7 @@
       "Finset"
     ],
     "namespace": "CramersRuleOQ03",
-    "lineCount": 175,
+    "lineCount": 176,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3,


### PR DESCRIPTION
## Summary

STATE-SYNC: `src/data/proofs/cramers-rule-oq-03/meta.json` had `lineCount: 175` in both top-level `meta` and the `leanFile` object, but `proofs/Proofs/CramersRuleOQ03.lean` contains 176 lines under the canonical `content.split('\n').length` convention used by `enrich-research.ts` (file ends with a trailing newline, so `wc -l` reports 175).

## Changes

- `meta.json:21` — top-level `meta.lineCount` 175 → 176
- `meta.json:150` — `leanFile.lineCount` 175 → 176

## Verification

```bash
$ wc -l proofs/Proofs/CramersRuleOQ03.lean
175
$ node -e "console.log(require('fs').readFileSync('proofs/Proofs/CramersRuleOQ03.lean','utf8').split('\n').length)"
176
```

No Lean source changes; no recount of axioms/theorems/sorries (still 0/8/0). Verified status preserved (mathlib-backed, DivisionRing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)