### PR TITLE
fix(meta): puiseux-theorem-oq-02 lineCount 238→239 align with leanFile (split convention)

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-02/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/meta.json
@@ -32,7 +32,7 @@
       "Dimensional facts: multiHahn_zero, multiHahn_one, multiHahn_succ"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 238,
+    "lineCount": 239,
     "theoremCount": 6,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"
@@ -154,7 +154,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "PuiseuxTheoremOQ02",
-    "lineCount": 238,
+    "lineCount": 239,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

- Sync `meta.lineCount` and `leanFile.lineCount` 238 → 239 in `puiseux-theorem-oq-02/meta.json`
- Aligns with canonical `split('\n').length` convention used by `scripts/enrich-research.ts`

## Drift Analysis

`PuiseuxTheoremOQ02.lean` ends with a trailing newline:
- `wc -l` → 238 (counts newlines)
- `split('\n').length` → 239 (substrings between newlines, plus empty trailing)

The enricher script uses split-newline as canonical. Both fields previously
held 238 from a `wc -l`-style write. This PR reconciles to 239 in both
locations (top-level meta + leanFile sub-object).

## Other Counts (Already Aligned)

| Field | meta.json | Lean file | Status |
|-------|-----------|-----------|--------|
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 4 | 4 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| status | verified / original | (no axiom-encoded assumptions) | ✓ |

## Test plan

- [x] wc -l proofs/Proofs/PuiseuxTheoremOQ02.lean → 238
- [x] node split-newline length → 239
- [x] grep theorem/lemma → 6
- [x] grep def → 4
- [x] grep sorry → 0, grep '^axiom ' → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)