### PR TITLE
fix(meta): chebyshev-pnt-bridge-oq-01 sorries 2→0 + status verified (canonical sync)

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -4,7 +4,7 @@
   "slug": "chebyshev-pnt-bridge-oq-01",
   "description": "Proves the prime power factorization bound for central binomial coefficients: p^{v_p(C(2n,n))} ≤ 2n. Key ingredient in Chebyshev's proof of Bertrand's postulate. Uses the carry-counting interpretation of Kummer's theorem.",
   "meta": {
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/ChebyshevPNTBridgeOQ01.lean",
     "tags": [
       "number-theory",
@@ -14,7 +14,7 @@
       "research"
     ],
     "badge": "mathlib",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 210,
     "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound.",


### PR DESCRIPTION
## Fix

Sync `chebyshev-pnt-bridge-oq-01` meta.json with reality of the Lean source.

## Evidence

**Before**:
- `status: "formalized"`
- `sorries: 2`

**After**:
- `status: "verified"`
- `sorries: 0`

The Lean source `proofs/Proofs/ChebyshevPNTBridgeOQ01.lean` contains:
- 0 actual `sorry` occurrences (`grep -c '\bsorry\b'` = 0)
- 0 `axiom` declarations
- 210 lines (matches `lineCount`)

The `assumptions` text already correctly states *"0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound."* — only the numeric `sorries` field and `status` were stale.

Per CLAUDE.md axiom integrity policy: with 0 sorries + 0 axioms + 0 structure-encoded assumptions, status must be `verified`. Badge `mathlib` is retained since the main bound uses Mathlib's `Nat.pow_factorization_choose_le`.

---
Automated fix by lean-mechanic agent.