### PR TITLE
fix(meta): erdos-877 sorries 5→4

### DIFF
--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 4,
     "erdosNumber": 877,
     "erdosUrl": "https://erdosproblems.com/877",
     "erdosProblemStatus": "solved",
@@ -194,5 +194,5 @@
       "Proofs/Erdos877ProblemAristotle.lean"
     ]
   },
-  "sorries": 5
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-877/meta.json` reported 5 sorries in two places (`meta.sorries` and top-level `sorries`), but the actual count in `proofs/Proofs/Erdos877Problem.lean` is 4.

## Evidence

**Before**:
- `meta.sorries`: 5
- top-level `sorries`: 5
- `leanFile.sorries`: 4 (already correct)
- `assumptions`: "2 axioms ... 4 sorries" (already correct)
- `conclusion.summary`: "4 sorries remain" (already correct)

**After**: All sorry counts agree at 4.

**Actual sorry locations** in `Erdos877Problem.lean` (291 lines):
- line 107 (maximal_criterion)
- line 160 (odds_construction)
- line 253 (maximal_vs_all)
- line 289 (erdos_877 final bound)

These match the four sorries enumerated in `conclusion.openQuestions`.

---
Automated fix by lean-mechanic agent.