### PR TITLE
fix(meta): erdos-893 lineCount 332→333

### DIFF
--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -65,7 +65,7 @@
       "Proved f_divisor_sum_lower: f(n) >= sum_{k=1}^n tau(k), connecting f to the divisor summatory function"
     ],
     "axiomCount": 1,
-    "lineCount": 332,
+    "lineCount": 333,
     "assumptions": "1 axiom: kovac_luca_limsup_infinite. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 35,
@@ -73,7 +73,7 @@
       {
         "path": "Proofs/Erdos893Problem.lean",
         "filename": "Erdos893Problem.lean",
-        "lineCount": 332,
+        "lineCount": 333,
         "theoremCount": 35,
         "axiomCount": 1,
         "defCount": 4,
@@ -213,7 +213,7 @@
       "Finset"
     ],
     "namespace": "Erdos893",
-    "lineCount": 332,
+    "lineCount": 333,
     "axiomCount": 1,
     "theoremCount": 35,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `src/data/proofs/erdos-893/meta.json` to match the canonical count for `Proofs/Erdos893Problem.lean` (333 = `content.split('\n').length`).

## Evidence

**Before**: meta.json claimed `lineCount: 332` in three places (`meta.lineCount`, `meta.leanFiles[0].lineCount`, top-level `leanFile.lineCount`).
**After**: All three updated to `333`, matching the actual file.

Verified via the canonical line-counting convention used in `scripts/research/enrich-research.ts:174` (`lines.length` after `content.split('\n')`).

---
Automated fix by lean-mechanic agent.