### PR TITLE
fix(meta): erdos-1028 lineCount 310→311

### DIFF
--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 310,
+    "lineCount": 311,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
@@ -240,7 +240,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 310,
+    "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 11,


### PR DESCRIPTION
## Fix

Sync `lineCount` in `src/data/proofs/erdos-1028/meta.json` to match `proofs/Proofs/Erdos1028Problem.lean` (canonical `split('\n').length` convention).

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` both claimed 310.
**After**: both claim 311.

Validation:
```
awk 'END{print NR}' proofs/Proofs/Erdos1028Problem.lean
# 311
```

No code changes; `sorries` (0) and `axiomCount` (2) unchanged.

---
Automated fix by lean-mechanic agent.