### PR TITLE
fix(meta): Erdos5PrimeGaps lineCount 657→658 (2 siblings)

### DIFF
--- a/src/data/proofs/erdos-5-prime-gaps/meta.json
+++ b/src/data/proofs/erdos-5-prime-gaps/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
     "assumptions": "3 axioms for deep analytic number theory results: westzynthius_large_gaps (Westzynthius 1931: arbitrarily large prime gaps exist, i.e., ∞ ∈ S), zhang_bounded_gaps (Zhang 2013: ∃H, infinitely many prime gaps ≤ H, i.e., 0 ∈ S via bounded gaps), hildebrand_maier_large_limit_points (Hildebrand-Maier: S contains arbitrarily large finite values). The full conjecture S = [0,∞) remains open.",
-    "lineCount": 657,
+    "lineCount": 658,
     "theoremCount": 33,
     "definitionCount": 9,
     "originalContributions": [
@@ -69,7 +69,7 @@
   },
   "leanFile": {
     "namespace": "Erdos5",
-    "lineCount": 657,
+    "lineCount": 658,
     "axiomCount": 3,
     "theoremCount": 33,
     "definitionCount": 9,

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 657,
+    "lineCount": 658,
     "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 26 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density), frequently_near_of_isLimitPoint and erdos_5_iff_dense_at_every_point (forward density direction giving the iff characterization), and unconditional oscillation lemmas frequently_normalizedGap_lt and frequently_normalizedGap_gt.",
     "mathlib_version": "4.26.0",
     "theoremCount": 33,
@@ -164,7 +164,7 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 657,
+    "lineCount": 658,
     "axiomCount": 3,
     "theoremCount": 33,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Sync canonical lineCount for `Proofs/Erdos5PrimeGaps.lean` (657→658) across both gallery siblings that embed `leanFile` blocks pointing at this file.

## Evidence

- Actual line count: `python3 -c "open('proofs/Proofs/Erdos5PrimeGaps.lean').read().split('\n').__len__()"` → **658** (file ends with newline; matches canonical counter in `scripts/research/enrich-research.ts`).
- Before: `lineCount: 657` in
  - `src/data/proofs/erdos-5/meta.json` (`meta.lineCount` and `leanFile.lineCount`)
  - `src/data/proofs/erdos-5-prime-gaps/meta.json` (`meta.lineCount` and `leanFile.lineCount`)
- After: `lineCount: 658` in all four locations.

No Lean source changes; metadata-only fix matching the canonical sync pattern used by recent mechanic PRs.

---
Automated fix by lean-mechanic agent.