### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-04 lineCount 234→235

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 234,
+    "lineCount": 235,
     "theoremCount": 3,
     "definitionCount": 2,
     "originalContributions": [
@@ -75,7 +75,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-    "lineCount": 234,
+    "lineCount": 235,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Sync canonical `lineCount` for `Proofs/AbelRuffiniGaloisExtensionsOQ04.lean` in `src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json`.

## Evidence

- Actual line count: `node -e "console.log(require('fs').readFileSync('proofs/Proofs/AbelRuffiniGaloisExtensionsOQ04.lean','utf-8').split('\n').length)"` → **235** (file ends with newline; matches canonical counter in `scripts/research/enrich-research.ts:174`).
- Before: `lineCount: 234` in both `meta.lineCount` and `leanFile.lineCount`.
- After: `235` in both locations.

No Lean source changes; metadata-only fix matching the canonical sync pattern used by recent mechanic PRs (e.g. #20361, #20359, #20357).

---
Automated fix by lean-mechanic agent.