### PR TITLE
fix(meta): cramers-rule-oq-01-oq-02-oq-01-oq-01 badge original→wip

### DIFF
--- a/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cramers-rule-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
       "schur-complement",
       "recursion"
     ],
-    "badge": "original",
+    "badge": "wip",
     "sorries": 1,
     "axiomCount": 0,
     "lineCount": 293,


### PR DESCRIPTION
## Fix

Demote `badge: "original"` → `"wip"` for cramers-rule-oq-01-oq-02-oq-01-oq-01: the proof still carries one deferred `sorry`, so the "original" badge (which per CLAUDE.md axiom integrity policy claims a fully machine-checked proof with 0 sorries) overclaims completeness.

## Evidence

**Before**:
```json
"badge": "original",
"sorries": 1,
```

**After**:
```json
"badge": "wip",
"sorries": 1,
```

- The single remaining `sorry` is on `qdetN_step_eq_qdetF` (line 287 of `Proofs/CramersRuleOQ01OQ02OQ01OQ01.lean`), the S3 SCAFFOLD field-consistency bridge deferred to S4 cofactor expansion. The meta.json `assumptions` field already documents this.
- `status: "formalized"` is preserved (per CLAUDE.md, `formalized` is the status for proofs with remaining sorries).
- `badge: "wip"` is what `scripts/erdos/update-badges.ts` would assign for `sorries > 0` (line 105: `Has ${sorryCount} sorry`).

No Lean source changes; this is a pure metadata correction.

---
Automated fix by lean-mechanic agent.