### PR TITLE
fix(meta): abel-ruffini lineCount 187→188

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -143,7 +143,7 @@
         "relationship": "Cantor's 1874 theorem that the algebraic closure ℚ̄ is countable (|ℚ̄| = ℵ₀) via degree-by-degree enumeration of ℚ[X], each polynomial having finitely many roots. Sits one tier above Abel-Ruffini in the algebraic-vs-radical-vs-transcendental hierarchy: ℚ̄ is countable, but the *radically expressible* sub-subset is a strict (still countable) subset, and Abel-Ruffini exhibits explicit elements of ℚ̄ (roots of x⁵ − 4x + 2) that escape it. Combined with |ℝ| = 2^ℵ₀, Cantor's countability gives the existence of transcendentals (cf. `liouville-theorem`); Abel-Ruffini delivers a parallel impossibility one tier down — algebraic non-radicals exist among the countable ℚ̄. The implications section's 'impossibility paradigm' (#7) and 'transcendence hierarchy' (#8) place both results on the same Galois-(1832)–Cantor-(1874)–Lindemann-(1882) lineage of cardinality- and expressibility-based barriers."
       }
     ],
-    "lineCount": 187,
+    "lineCount": 188,
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
     "definitionCount": 0
@@ -264,7 +264,7 @@
     ],
     "opens": [],
     "namespace": "AbelRuffini",
-    "lineCount": 187,
+    "lineCount": 188,
     "axiomCount": 0,
     "theoremCount": 9,
     "substantiveTheoremCount": 3,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/abel-ruffini/meta.json` with the actual line count of `proofs/Proofs/AbelRuffini.lean` using the canonical `split('\n').length` convention.

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 187
**After**: both fields = 188

---
Automated fix by lean-mechanic agent.