### PR TITLE
fix(meta): erdos-156 sorries 6→3 (align with leanFile.sorries + assumptions text)

### DIFF
--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -19,7 +19,7 @@
       "extremal-combinatorics"
     ],
     "badge": "wip",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 156,
     "erdosUrl": "https://erdosproblems.com/156",
     "erdosProblemStatus": "open",
@@ -224,5 +224,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, extremal-combinatorics, sidon-sets"
     }
   ],
-  "sorries": 6
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Sync top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-156/meta.json` from `6 → 3` to match `leanFile.sorries` (already 3) and the `meta.assumptions` text which begins *"0 axioms. 3 sorries: diffShadow_ncard_le, midShadow_ncard_le, greedySidon_cube_lower_bound"*.

## Evidence

**Source-of-truth scan** of `proofs/Proofs/Erdos156Problem.lean`:

| convention | command | result |
|------------|---------|--------|
| raw `\bsorry\b` (canonical) | `grep -c '\bsorry\b' Erdos156Problem.lean` | **3** |

Three locations of `sorries` in the meta file before fix:

| field | before | after |
|-------|--------|-------|
| `meta.sorries` (line 22) | 6 | **3** |
| `leanFile.sorries` (line 191) | 3 | 3 (unchanged — source of truth) |
| top-level `sorries` (line 227) | 6 | **3** |

## Convention

This follows PR #20077 (burnside-counting-oq-03): *"mirror main `leanFile.sorries`, exclude Aristotle companion sorries"*.

The Aristotle companion `Erdos156ProblemAristotle.lean` contains 3 routine target sorries — that is expected for an Aristotle companion file (proof-search inputs) and is unrelated to the main proof's status. The stale `6` came from an earlier convention (PR #17280) that summed main + companion counts.

The other named sorry lemmas in `meta.originalContributions` and the "Three sorry lemmas" claim in `meta.assumptions` already reflect the correct count of 3.

## Out of scope

- **Status/badge** kept at `formalized/wip`. The proof leaves 3 named lower-bound lemmas; no promotion to verified is implied.
- **leanFile.sorries** already 3 — no change needed.

---
Automated fix by lean-mechanic agent.