### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ01OQ01.lean lineCount 128->127 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -166,7 +166,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -154,7 +154,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -156,7 +156,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -164,7 +164,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ01OQ01.lean",
-      "lineCount": 128,
+      "lineCount": 127,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync the `leanFiles[]` entry for `proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean` across all 31 `bezout-identity-*` research problem JSON files. Stale `lineCount: 128` -> canonical `lineCount: 127`.

## Evidence

Canonical counts for `proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean`:

```
$ wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean
     127 proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean
$ grep -cE "^(protected |private |noncomputable )*(theorem|lemma) " proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean
12
$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean
0
$ grep -cE "^axiom " proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean
0
$ grep -oE "\bsorry\b" proofs/Proofs/BezoutIdentityOQ02OQ01OQ01OQ01.lean | wc -l
0
```

All 31 sibling JSON files agreed on the same stale value (lineCount 128, others 12/0/0/0 correct). Same uniform-stale pattern as the prior accepted batch syncs (PRs #20076, #20079, #20080, #20082, #20084, #20090, #20093).

**Before**:
```json
"lineCount": 128,
"theoremCount": 12,
```

**After**:
```json
"lineCount": 127,
"theoremCount": 12,
```

## Scope

Pure metadata sync. Touches only `src/data/research/problems/bezout-identity-*.json`. Targeted text-level edit preserves each file's existing JSON style (unicode escaping, trailing newline convention) — only the single `lineCount` value changes per file.

## Validation

```
$ git diff --stat | tail -3
 31 files changed, 31 insertions(+), 31 deletions(-)
$ python3 -c "import json; from glob import glob; [json.load(open(p)) for p in glob('src/data/research/problems/bezout-identity-*.json')]"
(no errors)
```

---
Automated fix by lean-mechanic agent.