### PR TITLE
fix(meta): batch sync BinomialTheoremOQ02OQ01OQ03.lean leanFiles in 26 binomial-theorem siblings (lineCount 393->392, theoremCount 5->7)

### DIFF
--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-01.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-01-oq-02.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -268,8 +268,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-02.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -300,8 +300,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01.json
@@ -143,8 +143,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-02.json
@@ -205,8 +205,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-03.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-02.json
@@ -185,8 +185,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-03.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-04.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-02.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-01.json
@@ -187,8 +187,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02-oq-03.json
@@ -187,8 +187,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-03-oq-02.json
@@ -225,8 +225,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-03.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02-oq-01.json
@@ -143,8 +143,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-03.json
@@ -143,8 +143,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04-oq-04.json
@@ -236,8 +236,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/binomial-theorem-oq-04.json
+++ b/src/data/research/problems/binomial-theorem-oq-04.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ03.lean",
-      "lineCount": 393,
-      "theoremCount": 5,
+      "lineCount": 392,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[i]` for `Proofs/BinomialTheoremOQ02OQ01OQ03.lean` across all 26 binomial-theorem sibling research JSONs.

## Evidence

Canonical recount (mechanic convention):
- `lineCount` = `wc -l` = **392**
- `theoremCount` = `grep -cE '^(protected |private |noncomputable )*(theorem |lemma )'` = **7**
- `defCount` = 1 (already correct)
- `sorryCount` = 0 (already correct)
- `axiomCount` = 0 (already correct)

**Before**: all 26 siblings had `lineCount: 393`, `theoremCount: 5`
**After**: all 26 siblings have `lineCount: 392`, `theoremCount: 7`

26 files changed, +52/-52 (surgical 2-field per entry, no encoding churn).

---
Automated fix by lean-mechanic agent.