### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ03OQ02.lean leanFiles in 30 area-of-circle siblings (lineCount 566→565, sorryCount 8→6)

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -240,11 +240,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -225,11 +225,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -225,11 +225,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -234,11 +234,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -180,11 +180,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -171,11 +171,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -248,11 +248,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -270,11 +270,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -234,11 +234,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -229,11 +229,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -252,11 +252,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -259,11 +259,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -228,11 +228,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -221,11 +221,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -247,11 +247,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -225,11 +225,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -225,11 +225,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -232,11 +232,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -223,11 +223,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -222,11 +222,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -238,11 +238,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -255,11 +255,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -229,11 +229,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -234,11 +234,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -227,11 +227,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -225,11 +225,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -254,11 +254,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -226,11 +226,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -326,11 +326,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -232,11 +232,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },


### PR DESCRIPTION
Surgical 2-field per entry across 30 area-of-circle sibling research JSONs.

Canonical mechanic recount for proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean:
- lineCount: wc -l = 565 (was 566 stale)
- sorryCount: 6 real (was 8 stale; raw scan = 8 but lines 547, 551 are doc mentions). Real placeholders on lines 99, 100, 296, 300, 340, 386.
- theoremCount / axiomCount / defCount unchanged at 15 / 2 / 4.

---
Automated fix by lean-mechanic agent.