### PR TITLE
fix(meta): batch sync CayleyHamiltonMinpolyOQ05OQ01OQ02.lean lineCount 270->271 in 30 cayley-hamilton siblings

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
@@ -239,7 +239,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
@@ -307,7 +307,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -281,7 +281,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -238,7 +238,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02-wip-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02-wip-01.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
@@ -292,7 +292,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -270,7 +270,7 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 270,
+      "lineCount": 271,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Sync `lineCount` for `CayleyHamiltonMinpolyOQ05OQ01OQ02.lean` from stale `270` to actual `271` across 30 cayley-hamilton research JSONs.

## Evidence

**Actual** (`scripts/research/enrich-research.ts` convention applied to `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean`):

- `lineCount`: **271**
- `theoremCount`: 8
- `axiomCount`: 0
- `defCount`: 3
- `sorryCount`: 0

**Embedded (before)**: `lineCount: 270` (single-field drift); all other fields already match canonical counts.

**After**: surgical update of just the `lineCount` value, one occurrence per file.

```
30 files changed, 30 insertions(+), 30 deletions(-)
```

No other fields are touched; no Lean source changes.

---
Automated fix by lean-mechanic agent.