### PR TITLE
fix(meta): batch sync CauchySchwarzIntegral.lean lineCount 117->118 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -31,7 +31,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -74,7 +74,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -48,7 +48,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -69,7 +69,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegral.lean",
       "filename": "CauchySchwarzIntegral.lean",
-      "lineCount": 117,
+      "lineCount": 118,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Summary

Bumps `leanFiles[].lineCount` 117→118 on the `Proofs/CauchySchwarzIntegral.lean` entry in **33 sibling research-problem JSONs** under `src/data/research/problems/` (cauchy-schwarz and cauchy-schwarz-integral families).

## Canonical lineCount semantic

`proofs/Proofs/CauchySchwarzIntegral.lean` ends without a trailing newline:

```
nlines=117 (wc -l, counts newline chars)
trailing_nl=False
content.split('\n').length=118 (canonical)
```

The gallery's enrichment script `scripts/research/enrich-research.ts` uses:

```ts
const lines = content.split('\n')
lineCount: lines.length,
```

`content.split('\n')` on a no-trailing-newline file returns one element per logical line → 118. Pre-existing values (117) reflected `wc -l` (newline count) and were off by one. Same off-by-one pattern as PR #20218 (`NavierStokes.lean` 21110→21111) and the gallery counterpart PR #20213 (`cauchy-schwarz-integral` meta.json 117→118).

## Scope discipline

- Only the `lineCount` field is touched.
- Only the `Proofs/CauchySchwarzIntegral.lean` entry within `leanFiles[]` is touched.
- All other `leanFiles[]` entries (e.g., `CauchySchwarzIntegralOQ01.lean`, etc.) and all other JSON fields are left intact.
- `theoremCount: 6`, `axiomCount: 0`, `defCount: 0`, `sorryCount: 0` already match canonical counts — no edits needed there.

## Verification

- 33 sibling JSONs modified, 1 line edit each: `git diff --stat` → 33 files changed, 33 insertions(+), 33 deletions(-)
- Only the two-line lineCount delta appears in the unified diff (`git diff -U0 | grep ^[+-]` yields only `lineCount: 117/118` rows).
- All 33 files re-validated as parseable JSON via `jq -e .`.
- Independent recompute via the canonical regex (`scripts/research/enrich-research.ts:143-182`) confirms `{lineCount:118, theoremCount:6, axiomCount:0, defCount:0, sorryCount:0}`.

## Test plan

- [x] `git diff --stat` shows exactly 33 files, 33 line edits
- [x] No edits to non-lineCount numerics
- [x] No edits to non-CauchySchwarzIntegral.lean entries
- [x] All edited files remain valid JSON

---
Automated fix by lean-mechanic agent.