### PR TITLE
fix(meta): angle-trisection-oq-01 lineCount 366→367

### DIFF
--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 366,
+    "lineCount": 367,
     "theoremCount": 44,
     "definitionCount": 3,
     "originalContributions": [
@@ -68,7 +68,7 @@
   },
   "leanFile": {
     "namespace": "AngleTrisectionOQ01",
-    "lineCount": 366,
+    "lineCount": 367,
     "axiomCount": 0,
     "theoremCount": 44,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/angle-trisection-oq-01/meta.json` with the actual line count of `proofs/Proofs/AngleTrisectionOQ01.lean` using the canonical `split('\n').length` convention.

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 366
**After**: both fields = 367

Verified:
- `len(content.split('\n'))` = 367
- File ends with trailing newline (so `wc -l` reports 366)

---
Automated fix by lean-mechanic agent.