### PR TITLE
fix(meta): batch sync BrouwerFixedPointOQ04OQ02.lean lineCount 520->519 in 17 brouwer-fixed-point siblings

### DIFF
--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-01.json
@@ -226,7 +226,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -372,7 +372,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02.json
@@ -253,7 +253,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-03.json
@@ -220,7 +220,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-01.json
@@ -287,7 +287,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02-oq-01.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02-oq-02.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-02.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-03.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-02.json
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-03.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-04.json
@@ -220,7 +220,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,

--- a/src/data/research/problems/brouwer-fixed-point-oq-04.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/BrouwerFixedPointOQ04OQ02.lean",
       "filename": "BrouwerFixedPointOQ04OQ02.lean",
-      "lineCount": 520,
+      "lineCount": 519,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 8,


### PR DESCRIPTION
## Fix

Sync `leanFiles[].lineCount` for `Proofs/BrouwerFixedPointOQ04OQ02.lean` from 520 → 519 across all 17 sibling research-problem JSONs that reference it.

## Evidence

**Before**: `leanFiles[].lineCount = 520` (split('\n').length convention)
**After**: `leanFiles[].lineCount = 519` (wc -l canonical, matching the gallery `meta.json` value and the merged mechanic convention)

Same off-by-one pattern fixed in recent merged batches:
- ArithmeticSeriesOQ00OQ01.lean (#20076: 283→282)
- AreaOfCircleOQ01OQ03OQ02.lean (566→565)
- CauchySchwarzIntegralOQ02OQ02.lean (407→406)
- BezoutIdentityOQ02OQ01OQ01OQ01.lean (128→127)

Only the `lineCount` field within the specific `Proofs/BrouwerFixedPointOQ04OQ02.lean` entry in each sibling's `leanFiles[]` array is touched. All other fields and all other `leanFiles` entries are unchanged.

## Validation

- All 17 modified JSONs parse cleanly (`JSON.parse` round-trip verified)
- `wc -l proofs/Proofs/BrouwerFixedPointOQ04OQ02.lean` = 519
- Gallery `src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json` already has `lineCount: 519`

---
Automated fix by lean-mechanic agent.