### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ02.lean lineCount 68->67 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -176,7 +176,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -208,7 +208,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -205,7 +205,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -178,7 +178,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -208,7 +208,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -182,7 +182,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -182,7 +182,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -202,7 +202,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -203,7 +203,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -206,7 +206,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -205,7 +205,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -201,7 +201,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02.lean",
-      "lineCount": 68,
+      "lineCount": 67,
       "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[].lineCount` for `Proofs/BezoutIdentityOQ02OQ01OQ02.lean` from 68 → 67 across all 31 sibling research-problem JSONs that reference it.

## Evidence

**Before**: `leanFiles[].lineCount = 68` (split('\n').length convention)
**After**: `leanFiles[].lineCount = 67` (`wc -l` canonical, matching the merged mechanic convention)

`wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean` = 67.

Same off-by-one pattern fixed in recent merged batches:
- ArithmeticSeriesOQ00OQ01.lean (#20076: 283→282)
- AreaOfCircleOQ01OQ03OQ02.lean (566→565)
- BezoutIdentityOQ02OQ01OQ01OQ01.lean (#20379: 128→127)
- BrouwerFixedPointOQ04OQ02.lean (#20392: 520→519)

Only the `lineCount` field within the specific `Proofs/BezoutIdentityOQ02OQ01OQ02.lean` entry in each sibling's `leanFiles[]` array is touched. All other fields and all other `leanFiles` entries are unchanged.

## Validation

- All 31 modified JSONs parse cleanly (\`JSON.parse\` round-trip verified)
- \`wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ02.lean\` = 67

---
Automated fix by lean-mechanic agent.