### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ04.lean lineCount 171->170 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -254,7 +254,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -242,7 +242,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -274,7 +274,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -244,7 +244,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -285,7 +285,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -248,7 +248,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -248,7 +248,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -195,7 +195,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -203,7 +203,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -207,7 +207,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ04.lean",
       "filename": "BezoutIdentityOQ02OQ04.lean",
-      "lineCount": 171,
+      "lineCount": 170,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[].lineCount` for `Proofs/BezoutIdentityOQ02OQ04.lean` from 171 → 170 across 31 sibling research-problem JSONs that reference it.

## Evidence

- `wc -l proofs/Proofs/BezoutIdentityOQ02OQ04.lean` = **170**
- Stale value `171` came from the older `split('\n').length` convention.
- All 31 affected JSONs had uniform stale `171`; updated to canonical `170`.

**Before**: `lineCount: 171` (split-newline convention)
**After**: `lineCount: 170` (wc -l canonical, matches merged mechanic convention)

Diff: 31 files, 31 insertions, 31 deletions — only the single `lineCount` field on the matching `leanFiles[]` entry per JSON.

---
Automated fix by lean-mechanic agent.