### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 183->184, theoremCount 11->10)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -121,8 +121,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -124,8 +124,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -64,8 +64,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -145,8 +145,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -107,8 +107,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -112,8 +112,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -113,8 +113,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -81,8 +81,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -111,8 +111,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -122,8 +122,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -109,8 +109,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -108,8 +108,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -102,8 +102,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -154,8 +154,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -148,8 +148,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -126,8 +126,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -136,8 +136,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -150,8 +150,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -133,8 +133,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -132,8 +132,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -140,8 +140,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -133,8 +133,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -139,8 +139,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -152,8 +152,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 184,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles` records for `CauchySchwarzIntegralOQ01OQ01OQ01.lean` across 33 sibling problem JSONs.

## Evidence

**Before** (recorded in sibling JSONs):
- `lineCount: 183`
- `theoremCount: 11`

**After** (matches actual Lean source via `extractLeanMetadata` in `scripts/research/enrich-research.ts`):
- `lineCount: 184` (file is 184 lines via `content.split('\n').length`)
- `theoremCount: 10` (10 lines starting with `theorem ` or `lemma `)

Affected files: all 33 `cauchy-schwarz*` and `cauchy-schwarz-integral*` problem JSONs that reference this Lean file.

---
Automated fix by lean-mechanic agent.