### PR TITLE
fix(meta): sync AmgmInequalityPowerMeanLimits.lean leanFiles in 30 amgm-inequality siblings (line 272->273, thm 19->12)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -276,8 +276,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -276,8 +276,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -295,8 +295,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -311,8 +311,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -233,8 +233,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -290,8 +290,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -251,8 +251,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -287,8 +287,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -283,8 +283,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -299,8 +299,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -290,8 +290,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -274,8 +274,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -284,8 +284,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -299,8 +299,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -291,8 +291,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -285,8 +285,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -281,8 +281,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -286,8 +286,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-incomplete-01.json
@@ -92,8 +92,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -247,8 +247,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -229,8 +229,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -298,8 +298,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -286,8 +286,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -279,8 +279,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -305,8 +305,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -307,8 +307,8 @@
     {
       "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",
       "filename": "AmgmInequalityPowerMeanLimits.lean",
-      "lineCount": 272,
-      "theoremCount": 19,
+      "lineCount": 273,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync the `AmgmInequalityPowerMeanLimits.lean` `leanFiles` entry in 30 amgm-inequality sibling `meta.json` files to match what `extractLeanMetadata()` in `scripts/research/enrich-research.ts` produces.

## Evidence

`scripts/research/enrich-research.ts` extracts metadata via:
- `lineCount: content.split('\n').length`
- `theoremCount`: count of lines matching `^(theorem|lemma) `

Verification on `proofs/Proofs/AmgmInequalityPowerMeanLimits.lean`:
- `wc -l` reports 272 newlines, so `split('\n').length = 273`
- `grep -cE "^(theorem|lemma) "` returns 12

**Before**: leanFiles entries recorded `lineCount: 272`, `theoremCount: 19`.
**After**: leanFiles entries record `lineCount: 273`, `theoremCount: 12`.

Other fields (`axiomCount: 0`, `defCount: 3`, `sorryCount: 0`) already match the extractor and are unchanged.

---
Automated fix by lean-mechanic agent.