### PR TITLE
fix(meta): batch sync CantorDiagonalization.lean lineCount 175->176 in 19 cantor-diagonalization siblings

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-03.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-02.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-01.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02-oq-01.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02-oq-03.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-02.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-01.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-02.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01-oq-03.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
@@ -39,7 +39,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04-oq-03.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/cantor-diagonalization-oq-04.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-04.json
@@ -72,7 +72,7 @@
     {
       "path": "Proofs/CantorDiagonalization.lean",
       "filename": "CantorDiagonalization.lean",
-      "lineCount": 175,
+      "lineCount": 176,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` field in 19 `cantor-diagonalization-*` problem JSONs to match the actual Lean source.

## Evidence

`proofs/Proofs/CantorDiagonalization.lean`:
- Actual `wc -l` -> 175 newlines
- Actual `split('\n').length` -> 176 (file ends with newline; this is the canonical convention used by `extractLeanMetadata()` in `scripts/research/enrich-research.ts`)
- Theorem/lemma count: 6 (already correct, unchanged)

**Before**: 19 sibling problem JSONs recorded `"lineCount": 175` for the shared `leanFiles` entry.
**After**: All bumped to `"lineCount": 176`. No other fields touched.

Closes none — proactive meta sync (no auditor issue filed).

---
Automated fix by lean-mechanic agent.