### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01.lean lineCount 228->229 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -99,7 +99,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -42,7 +42,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -123,7 +123,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -90,7 +90,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -59,7 +59,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -126,7 +126,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -116,7 +116,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Align research entry `leanFiles[].lineCount` with the canonical `split('\n').length` convention used by `scripts/research/enrich-research.ts`.

## Evidence

**Before**: 33 cauchy-schwarz sibling research entries report `lineCount: 228` for `Proofs/CauchySchwarzIntegralOQ01.lean`.

**After**: All 33 entries report `lineCount: 229`, matching the actual line count.

```
$ node -e "console.log(require('fs').readFileSync('proofs/Proofs/CauchySchwarzIntegralOQ01.lean','utf-8').split('\n').length)"
229
```

Other counts (theoremCount=9, axiomCount=0, sorryCount=0) already match the source — only lineCount drifted.

---
Automated fix by lean-mechanic agent.