### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 1077->1078, sorryCount 10->0)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -153,11 +153,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -176,11 +176,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -168,11 +168,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -158,11 +158,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -108,11 +108,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -189,11 +189,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -151,11 +151,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -156,11 +156,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -153,11 +153,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -157,11 +157,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -125,11 +125,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -155,11 +155,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -166,11 +166,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -153,11 +153,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -152,11 +152,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -146,11 +146,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -198,11 +198,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -192,11 +192,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -191,11 +191,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -170,11 +170,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -213,11 +213,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -180,11 +180,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -194,11 +194,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -193,11 +193,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -177,11 +177,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -176,11 +176,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -184,11 +184,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -177,11 +177,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -183,11 +183,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -196,11 +196,11 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
+      "lineCount": 1078,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
-      "sorryCount": 10,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean"
     },


### PR DESCRIPTION
## Fix

Sync `leanFiles[]` metadata for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` across the 33 sibling research entries that reference it. Two fields had drifted from the actual Lean source:

- `lineCount`: 1077 -> 1078 (canonical `split('\n').length` convention used by `scripts/research/enrich-research.ts`)
- `sorryCount`: 10 -> 0 (file was completed; meta never resynced)

## Evidence

**Before**: 33 research entries in `src/data/research/problems/` claim `lineCount: 1077` and `sorryCount: 10` for this Lean file.
**After**: all 33 entries report `lineCount: 1078` and `sorryCount: 0`, matching the source.

Verified via:

\`\`\`
\$ wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
1077  # wc -l counts newlines; split('\n').length = 1078
\$ grep -c '\\bsorry\\b' proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean
0
\`\`\`

Other fields (`theoremCount`, `axiomCount`, `defCount`) already match and were not touched.

---
Automated fix by lean-mechanic agent.