### PR TITLE
fix(meta): sync BinomialTheoremOQ02OQ01OQ01OQ03.lean leanFiles in 2 binomial-theorem siblings

### DIFF
--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -246,11 +246,11 @@
     {
       "path": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
       "filename": "BinomialTheoremOQ02OQ01OQ01OQ03.lean",
-      "lineCount": 545,
+      "lineCount": 712,
       "theoremCount": 16,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 11,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean"
     },

--- a/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/binomial-theorem-oq-02-oq-01-oq-01-oq-03.json
@@ -315,7 +315,7 @@
       "theoremCount": 16,
       "axiomCount": 1,
       "defCount": 3,
-      "sorryCount": 0,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean"
     }


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entries for `Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean` in 2 sibling research JSONs, applying the `wc -l` lineCount convention established in the maintainer-merged precedent of #19812, #19823, and #20067.

## Convention

Recent merged mechanic PRs converge on these scanner outputs:
- `lineCount` = `wc -l` (newline bytes), explicitly migrating away from `split('\n').length` (see #19812 commit body: "split-length → wc -l")
- `sorryCount` = count of `\bsorry\b` matches (no comment stripping)
- `theoremCount` / `defCount` / `axiomCount` = `^(theorem|lemma|def|axiom) ` bare-regex line starts

## Evidence

For `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`:

| Field | Command | Value |
|-------|---------|-------|
| lineCount | `wc -l` | **712** |
| sorryCount | `grep -oE "\bsorry\b" \| wc -l` | **2** (lines 62 + 85, in comments — scanner matches anyway) |
| theoremCount | `grep -cE "^(theorem\|lemma) "` | 16 (unchanged) |
| defCount | `grep -cE "^(def\|noncomputable def\|opaque def) "` | 3 (unchanged) |
| axiomCount | `grep -cE "^axiom "` | 1 (unchanged) |

**Before**:
- `binomial-theorem-oq-02-oq-01-oq-01-oq-01-oq-01.json`: lineCount=545, sorryCount=11 (stale; pre-rewrite)
- `binomial-theorem-oq-02-oq-01-oq-01-oq-03.json`: lineCount=712, sorryCount=0

**After** (both files): lineCount=712, sorryCount=2.

Surgical 3-line diff. JSON validated via `python3 -c "import json; json.load(open(...))"` on both files.

---
Automated fix by lean-mechanic agent.