### PR TITLE
fix(meta): batch sync BezoutIdentityOQ02OQ01OQ02OQ02.lean lineCount 194->193 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -199,7 +199,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -187,7 +187,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -194,7 +194,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -192,7 +192,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -189,7 +189,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -192,7 +192,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -193,7 +193,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -193,7 +193,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -195,7 +195,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -140,7 +140,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -213,7 +213,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -195,7 +195,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -214,7 +214,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -197,7 +197,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -195,7 +195,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -196,7 +196,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -152,7 +152,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -195,7 +195,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean",
       "filename": "BezoutIdentityOQ02OQ01OQ02OQ02.lean",
-      "lineCount": 194,
+      "lineCount": 193,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Batch sync stale `leanFiles[i].lineCount` entries for `Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean` across 31 sibling research JSONs (`src/data/research/problems/bezout-identity-*.json`).

## Evidence

**Before**: `leanFiles[i].lineCount = 194` (stale)
**After**: `leanFiles[i].lineCount = 193` (matches `wc -l proofs/Proofs/BezoutIdentityOQ02OQ01OQ02OQ02.lean`)

Other fields (theoremCount=14, sorryCount=0, defCount=0, axiomCount=0) already match the actual file -- only `lineCount` was stale.

Surgical text edit: each of the 31 files changed exactly 1 line (regex-targeted at the path block for this specific Lean file). No reformatting; all files re-validated as parseable JSON.

---
Automated fix by lean-mechanic agent.