### PR TITLE
fix(meta): sync BezoutIdentityOQ02OQ02OQ01 lineCount 201→200 in 31 sibling JSONs

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -220,7 +220,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -252,7 +252,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -227,7 +227,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -222,7 +222,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -226,7 +226,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -226,7 +226,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -173,7 +173,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -230,7 +230,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -245,7 +245,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -228,7 +228,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ02OQ02OQ01.lean",
       "filename": "BezoutIdentityOQ02OQ02OQ01.lean",
-      "lineCount": 201,
+      "lineCount": 200,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i].lineCount` entries for `Proofs/BezoutIdentityOQ02OQ02OQ01.lean` (canonical value 200) across 31 sibling `src/data/research/problems/bezout-identity-*.json` files.

## Evidence

- **Before**: `lineCount: 201` (stale)
- **After**: `lineCount: 200` (matches `wc -l proofs/Proofs/BezoutIdentityOQ02OQ02OQ01.lean` = 200)

Other fields for this leanFile entry (`theoremCount=11`, `sorryCount=0`, `defCount=2`, `axiomCount=0`) were already consistent and were not touched. Surgical context-anchored regex edit; all JSONs re-validated as parseable.

---
Automated fix by lean-mechanic agent.