### PR TITLE
fix(meta): sync MeanValueTheoremOQ02OQ04OQ01.lean leanFiles to canonical counts

### DIFF
--- a/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json
@@ -136,11 +136,11 @@
     {
       "path": "Proofs/MeanValueTheoremOQ02OQ04OQ01.lean",
       "filename": "MeanValueTheoremOQ02OQ04OQ01.lean",
-      "lineCount": 400,
-      "theoremCount": 9,
+      "lineCount": 758,
+      "theoremCount": 12,
       "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 1,
+      "defCount": 3,
+      "sorryCount": 12,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean"
     }


### PR DESCRIPTION
## Fix

Updates the stale `leanFiles[]` entry for `Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` in `mean-value-theorem-oq-02-oq-04-oq-01.json` to match the current file (it has nearly doubled in size since the metadata was last refreshed).

## Canonical mechanic counts

For `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean`:

| Field | Old | New | Method |
|-------|-----|-----|--------|
| `lineCount` | 400 | 758 | `wc -l` (newline count) |
| `theoremCount` | 9 | 12 | `^(protected \| private \| noncomputable )*(theorem\|lemma) ` |
| `axiomCount` | 0 | 0 | unchanged |
| `defCount` | 2 | 3 | `^(noncomputable \| protected \| private )*(def\|opaque) ` |
| `sorryCount` | 1 | 12 | `\bsorry\b` raw word match |

The sorryCount jump (1 → 12) reflects the canonical raw `\bsorry\b` match used by recent merged batch-sync PRs (e.g., #20105) — it counts every word-boundary `sorry` token, including those in commentary/scaffolding documentation.

## Scope

- Single file edit: `src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json`
- Only the one `leanFiles[]` entry for `MeanValueTheoremOQ02OQ04OQ01.lean` is touched
- JSON revalidated with `python3 -c "import json; json.load(open(...))"`

---

Automated fix by lean-mechanic agent.