### PR TITLE
fix(meta): sync DescartesRuleOfSignsOQ02OQ01.lean leanFiles in 11 descartes siblings

### DIFF
--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01.json
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-02.json
@@ -129,8 +129,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-03.json
@@ -121,8 +121,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-04.json
@@ -114,8 +114,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01.json
@@ -123,8 +123,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 191,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-01.json
@@ -142,8 +142,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-03.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-03.json
@@ -120,8 +120,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-04.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-04.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,

--- a/src/data/research/problems/descartes-rule-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-oq-01-oq-01.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/DescartesRuleOfSignsOQ02OQ01.lean",
       "filename": "DescartesRuleOfSignsOQ02OQ01.lean",
-      "lineCount": 192,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync of stale `leanFiles[]` entries for `Proofs/DescartesRuleOfSignsOQ02OQ01.lean` across 11 descartes-rule-of-signs research JSONs.

## Evidence

Canonical values per `scripts/research/enrich-research.ts` extractor (`split('\n').length` + `^(theorem|lemma) ` regex):

| Field         | Canonical | Before  | Files affected |
|---------------|-----------|---------|----------------|
| `lineCount`   | 240       | 192     | 10 |
| `lineCount`   | 240       | 191     | 1  |
| `theoremCount`| 6         | 4       | 11 |
| `axiomCount`  | 0         | 0       | (already correct) |
| `defCount`    | 1         | 1       | (already correct) |
| `sorryCount`  | 0         | 0       | (already correct) |

After this PR, all 11 JSONs report the same correct entry.

Surgical context-anchored regex edit (11 files x 2 lines each). All files re-validated as parseable JSON.

---
Automated fix by lean-mechanic agent.