### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ03.lean leanFiles in 31 area-of-circle siblings

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -273,9 +273,9 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1937,
+    "lineCount": 1938,
     "axiomCount": 0,
-    "theoremCount": 68,
+    "theoremCount": 52,
     "definitionCount": 14,
     "mainTheorems": [
       {

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -207,8 +207,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -147,8 +147,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -138,8 +138,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -215,8 +215,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -237,8 +237,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -219,8 +219,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -226,8 +226,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -214,8 +214,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -190,8 +190,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -205,8 +205,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -222,8 +222,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -221,8 +221,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -293,8 +293,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -199,8 +199,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1937,
-      "theoremCount": 68,
+      "lineCount": 1938,
+      "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 1,


### PR DESCRIPTION
## Fix

Sync `Proofs/AreaOfCircleOQ01OQ03.lean` metadata in 31 sibling area-of-circle JSON files:

- `lineCount`: 1937 -> 1938
- `theoremCount`: 68 -> 52

## Evidence

Computed from current `proofs/Proofs/AreaOfCircleOQ01OQ03.lean` using the same formula as `scripts/research/enrich-research.ts` (`extractLeanMetadata`):

- `lineCount = content.split('\n').length` = 1938
- `theoremCount` (regex `^(theorem|lemma) `) = 52
- `axiomCount` = 0 (unchanged)
- `sorryCount` = 1 (unchanged)
- `defCount` = 11 (unchanged)

The drift was introduced by #19454 (sperner-ndim research commit) which edited the file; sibling JSON `leanFiles` entries were not synced.

## Scope

- 1 gallery `meta.json` (singular `leanFile` block)
- 30 research problem JSONs (entries in their `leanFiles` arrays)

No Lean code changes, no semantic changes; only metadata reconciliation with the actual `.lean` source.

---
Automated fix by lean-mechanic agent.