### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01.lean lineCount 153->154 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -110,7 +110,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -53,7 +53,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -91,7 +91,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -127,7 +127,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -121,7 +121,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01.lean",
-      "lineCount": 153,
+      "lineCount": 154,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync `leanFiles[]` metadata for `Proofs/CauchySchwarzIntegralOQ01OQ01.lean` across the 33 sibling research entries that reference it. One field had drifted from the actual Lean source:

- `lineCount`: 153 -> 154 (canonical `content.split('\n').length` convention used by `scripts/research/enrich-research.ts:174`)

## Evidence

**Before**: 33 research entries in `src/data/research/problems/` claim `lineCount: 153` for this Lean file.
**After**: all 33 entries report `lineCount: 154`, matching the source.

Computed canonically:

```
$ node -e "const fs=require('fs');const c=fs.readFileSync('proofs/Proofs/CauchySchwarzIntegralOQ01OQ01.lean','utf-8');console.log(c.split('\n').length)"
154
```

(`wc -l` reports 153 because it counts newlines; the canonical script uses `content.split('\n').length` which yields 154 for files with a trailing newline.)

Other fields (`theoremCount=10`, `axiomCount=0`, `defCount=0`, `sorryCount=0`) already match and were not touched.

## Scope

- 0 gallery `meta.json` changes (no gallery proof references this file)
- 33 research problem JSONs (`leanFiles[]` entries)

No Lean code changes, no semantic changes; only metadata reconciliation with the actual `.lean` source.

---
Automated fix by lean-mechanic agent.