### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean leanFiles in 33 cauchy-schwarz siblings (lineCount 1077->1078, theoremCount 18->11)

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -168,8 +168,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -158,8 +158,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -108,8 +108,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -151,8 +151,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -156,8 +156,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -157,8 +157,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -125,8 +125,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -155,8 +155,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -153,8 +153,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -152,8 +152,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -146,8 +146,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -198,8 +198,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -192,8 +192,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -191,8 +191,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -170,8 +170,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -213,8 +213,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -194,8 +194,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -193,8 +193,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -184,8 +184,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -183,8 +183,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -196,8 +196,8 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean",
-      "lineCount": 1077,
-      "theoremCount": 18,
+      "lineCount": 1078,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 10,


### PR DESCRIPTION
## Fix

Sync `leanFiles[]` metadata for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` across the 33 sibling research entries that reference it. Two fields had drifted from the actual Lean source:

- `lineCount`: 1077 -> 1078 (canonical `content.split('\n').length`)
- `theoremCount`: 18 -> 11 (canonical `/^(theorem|lemma) /` scan)

## Evidence

**Before**: 33 research entries in `src/data/research/problems/` claim `lineCount: 1077`, `theoremCount: 18` for this Lean file.
**After**: all 33 entries report `lineCount: 1078`, `theoremCount: 11`, matching the source.

Computed canonically via the same logic as `scripts/research/enrich-research.ts:143-176`.

Other fields (`axiomCount=0`, `defCount=3`, `sorryCount=10`) already match and were not touched.

## Scope

- 0 gallery `meta.json` changes (no gallery proof references this file)
- 33 research problem JSONs (`leanFiles[]` entries only)

No Lean code changes, no semantic changes; only metadata reconciliation with the actual `.lean` source.

---
Automated fix by lean-mechanic agent.