### PR TITLE
fix(meta): batch sync AbelRuffiniGaloisExtensions.lean defCount 0->1 in 23 siblings

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-01.json
@@ -56,7 +56,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-02.json
@@ -61,7 +61,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-03.json
@@ -61,7 +61,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
@@ -71,7 +71,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-05.json
@@ -61,7 +61,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json
@@ -187,7 +187,7 @@
       "lineCount": 534,
       "theoremCount": 57,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-galois-extensions.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions.json
@@ -65,7 +65,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-01.json
@@ -369,7 +369,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-02.json
@@ -83,7 +83,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-03.json
@@ -82,7 +82,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01-oq-04.json
@@ -80,7 +80,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-01.json
@@ -110,7 +110,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-01.json
@@ -74,7 +74,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02-oq-03.json
@@ -52,7 +52,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -103,7 +103,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-03.json
@@ -97,7 +97,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-06.json
@@ -75,7 +75,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-07.json
@@ -111,7 +111,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-09.json
@@ -150,7 +150,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-oq-04.json
@@ -48,7 +48,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-05.json
+++ b/src/data/research/problems/abel-ruffini-oq-05.json
@@ -79,7 +79,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-oq-06.json
@@ -81,7 +81,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"

--- a/src/data/research/problems/abel-ruffini-oq-09.json
+++ b/src/data/research/problems/abel-ruffini-oq-09.json
@@ -112,7 +112,7 @@
       "lineCount": 534,
       "theoremCount": 59,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensions.lean"


### PR DESCRIPTION
## Fix

Update `defCount` from 0 to 1 for `AbelRuffiniGaloisExtensions.lean` across 23 sibling research JSONs.

## Evidence

Canonical mechanic counts for `proofs/Proofs/AbelRuffiniGaloisExtensions.lean`:
- `defCount`: `^(noncomputable |protected |private )*(def|opaque) ` = **1** (was 0)

The file contains one definition: `private def klein_four` (line 107).

Other fields (lineCount=534, theoremCount=59, axiomCount=0, sorryCount=0) already match the actual file.

**Before**: 23 sibling JSONs report `defCount: 0` for AbelRuffiniGaloisExtensions.lean
**After**: All siblings report `defCount: 1`, matching the actual file

Companion fix to #20045 which synced `theoremCount` but missed `defCount`.

---
Automated fix by lean-mechanic agent.