### PR TITLE
fix(meta): erdos-101 definitionCount 6→5 (2 siblings)

### DIFF
--- a/src/data/proofs/erdos-101/meta.json
+++ b/src/data/proofs/erdos-101/meta.json
@@ -23,7 +23,7 @@
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 23,
-    "definitionCount": 6
+    "definitionCount": 5
   },
   "sections": [
     {
@@ -249,7 +249,7 @@
     "lineCount": 758,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/Erdos101Problem.lean",
     "sorries": 0
   },

--- a/src/data/proofs/erdos101-problem/meta.json
+++ b/src/data/proofs/erdos101-problem/meta.json
@@ -37,7 +37,7 @@
     "dateAdded": "2026-05-04",
     "lineCount": 758,
     "theoremCount": 23,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -106,7 +106,7 @@
     "lineCount": 758,
     "axiomCount": 0,
     "theoremCount": 23,
-    "definitionCount": 6,
+    "definitionCount": 5,
     "path": "Proofs/Erdos101Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Update `definitionCount` from 6 to 5 for `Erdos101Problem.lean` across both sibling research JSONs (`erdos-101` and `erdos101-problem`).

## Evidence

Canonical mechanic counts for `proofs/Proofs/Erdos101Problem.lean` (758 lines, 5 defs):

```
30:def collinear (p q r : ℝ × ℝ) : Prop :=
34:def NoFiveCollinear (P : PlanarPointSet) : Prop :=
44:noncomputable def fourPointLineCount (P : PlanarPointSet) : ℕ :=
603:noncomputable def fourCollinearFamily (P : PlanarPointSet) : Finset (Finset (ℝ × ℝ)) :=
619:noncomputable def fourCollinearThrough (P : PlanarPointSet) (p : ℝ × ℝ) :
```

Count: `^(noncomputable |protected |private )*(def|opaque) ` → **5** (was 6).

**Before**: Both siblings report `definitionCount: 6` for Erdos101Problem.lean
**After**: Both siblings report `definitionCount: 5`, matching the actual file

Other fields (`lineCount=758`, `theoremCount=23`, `axiomCount=0`, `sorries=0`) already match the actual file in both meta.json files.

Updates both occurrences in each meta.json:
- `meta.definitionCount`
- `leanFile.definitionCount`

---
Automated fix by lean-mechanic agent.