### PR TITLE
fix(meta): erdos-1021-oq-01 sorries 17→4 (align with leanFile.sorries + assumptions text)

### DIFF
--- a/src/data/proofs/erdos-1021-oq-01/meta.json
+++ b/src/data/proofs/erdos-1021-oq-01/meta.json
@@ -17,7 +17,7 @@
       "zarankiewicz"
     ],
     "badge": "axiom",
-    "sorries": 17,
+    "sorries": 4,
     "axiomCount": 2,
     "lineCount": 191,
     "assumptions": "2 axioms: (1) kst_trivial_bound — Kővári-Sós-Turán O(n^{3/2}) upper bound (proven 1954, axiomatized); (2) probabilistic_lower_bound — ex(n, G_k) ≥ c·n^{3/2-1/(k-1)} (probabilistic method, axiomatized). 4 sorries in dependency chain: 4 in this file + 2 in parent Erdos1021Problem.lean (k3_case_solved, trivial_bound).",
@@ -140,5 +140,5 @@
       "Proofs/Erdos1021OQ01Aristotle.lean"
     ]
   },
-  "sorries": 17
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Sync top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-1021-oq-01/meta.json` from `17 → 4` to match `leanFile.sorries` (already 4) and the `meta.assumptions` text which states *"4 in this file"*.

## Evidence

**Source-of-truth scan** of `proofs/Proofs/Erdos1021OQ01.lean`:

| convention | command | result |
|------------|---------|--------|
| `sorry` outside comments | regex `\bsorry\b` on de-commented content | **4** |
| `grep -c sorry` (raw, includes 1 comment mention) | `grep -c sorry` | 5 |

Three locations of `sorries` in the meta file before fix:

| line | field | before | after |
|------|-------|--------|-------|
| 20  | `meta.sorries`      | 17 | **4** |
| 137 | `leanFile.sorries`  | 4  | 4 (unchanged — source of truth) |
| 143 | top-level `sorries` | 17 | **4** |

The `assumptions` text already correctly states *"4 sorries in dependency chain: 4 in this file + 2 in parent Erdos1021Problem.lean"*. The stale value 17 did not match any consistent count — neither the file count (4), the dependency-chain sum (6), nor the parent's own count.

## Out of scope

- **assumptions text** already correctly reflects 4 sorries; no edit needed.
- **status/badge** kept at `axiomatized/axiom` — file has 2 unproven axioms, classification unchanged.
- **leanFile section** unchanged (already accurate: lineCount=191, axiomCount=2, theoremCount=8, definitionCount=2, sorries=4).
- **Companion file** `Erdos1021OQ01Aristotle.lean` not touched; its routine sorries are unrelated to main proof status.

## Test plan

- [x] `python3 -m json.tool` validates modified meta.json
- [x] `git diff --stat` shows `1 file changed, 2 insertions(+), 2 deletions(-)`
- [x] No conflicting open PR or issue on `erdos-1021-oq-01` meta.json (open PR #20164 only touches `research/` and `src/data/research/`)

---
Automated fix by lean-mechanic agent.