### PR TITLE
fix(meta): erdos-673 sorries 30→20 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -18,7 +18,7 @@
       "distribution"
     ],
     "badge": "wip",
-    "sorries": 30,
+    "sorries": 20,
     "erdosNumber": 673,
     "erdosUrl": "https://erdosproblems.com/673",
     "erdosProblemStatus": "solved",
@@ -253,5 +253,5 @@
       "description": "Related Erdős problem sharing themes: analytic-number-theory, arithmetic-functions, number-theory"
     }
   ],
-  "sorries": 30
+  "sorries": 20
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-673/meta.json` reported 30 sorries at both the top-level `sorries` and nested `meta.sorries` fields, but the source Lean file (`proofs/Proofs/Erdos673Problem.lean`) contains only 20 `sorry` placeholders. The `leanFile.sorries: 20` (computed) and `meta.assumptions: "20 sorry(s). No axioms."` were already correct — only the two summary counts were stale.

## Evidence

**Before**: `sorries: 30` (top-level and `meta.sorries`)
**After**: `sorries: 20` (matches `leanFile.sorries`, matches `grep -cE "\\bsorry\\b" proofs/Proofs/Erdos673Problem.lean` = 20, matches `meta.assumptions` text)

No code changes; metadata-only sync.

---
Automated fix by lean-mechanic agent.