### PR TITLE
fix(meta): sync BezoutIdentityOQ03OQ01.lean lineCount 316→315 in 31 bezout siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -276,7 +276,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -296,7 +296,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -271,7 +271,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -293,7 +293,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -266,7 +266,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -307,7 +307,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -269,7 +269,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -270,7 +270,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -270,7 +270,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -291,7 +291,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -316,7 +316,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -274,7 +274,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -293,7 +293,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -273,7 +273,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -272,7 +272,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01.lean",
-      "lineCount": 316,
+      "lineCount": 315,
       "theoremCount": 25,
       "axiomCount": 0,
       "defCount": 5,


### PR DESCRIPTION
## Fix

Updates the stale leanFiles[] entry for Proofs/BezoutIdentityOQ03OQ01.lean in all 31 bezout-identity sibling JSONs. Only lineCount was stale; everything else matches the actual file.

## Canonical mechanic counts

For proofs/Proofs/BezoutIdentityOQ03OQ01.lean:

| Field | Old | New | Method |
|-------|-----|-----|--------|
| lineCount | 316 | 315 | wc -l (newline count) |
| theoremCount | 25 | 25 | unchanged |
| axiomCount | 0 | 0 | unchanged |
| defCount | 5 | 5 | unchanged |
| sorryCount | 0 | 0 | unchanged |

## Scope

- 31 sibling JSONs touched (every bezout-identity-*.json that references this lean file)
- One-line edit per file via surgical regex replacement; preserves original JSON encoding (escape sequences vs. raw unicode)
- All JSON revalidated

---
Automated fix by lean-mechanic agent.