### PR TITLE
fix(meta): batch sync AngleTrisectionCos20Gal.lean defCount 0->4 in 26 angle-trisection siblings

### DIFF
--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-01.json
@@ -66,7 +66,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02.json
@@ -81,7 +81,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02.json
@@ -77,7 +77,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-cos-20-gal-oq-01-oq-03.json
@@ -101,7 +101,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-01-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-03.json
@@ -103,7 +103,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-01-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-01-oq-04.json
@@ -107,7 +107,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-01.json
@@ -104,7 +104,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -155,7 +155,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -118,7 +118,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01.json
@@ -54,7 +54,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-02.json
@@ -122,7 +122,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01.json
@@ -129,7 +129,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-02.json
@@ -114,7 +114,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-01.json
@@ -117,7 +117,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03-oq-03.json
@@ -108,7 +108,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-03.json
@@ -113,7 +113,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04-oq-01.json
@@ -60,7 +60,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-04.json
@@ -119,7 +119,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-02.json
@@ -111,7 +111,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-03-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-01.json
@@ -118,7 +118,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-03-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03-oq-03.json
@@ -112,7 +112,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-03.json
@@ -111,7 +111,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-04-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-02.json
@@ -102,7 +102,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-04-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-03.json
@@ -60,7 +60,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-05-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-01.json
@@ -63,7 +63,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"

--- a/src/data/research/problems/angle-trisection-oq-05.json
+++ b/src/data/research/problems/angle-trisection-oq-05.json
@@ -117,7 +117,7 @@
       "lineCount": 474,
       "theoremCount": 33,
       "axiomCount": 0,
-      "defCount": 0,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AngleTrisectionCos20Gal.lean"


### PR DESCRIPTION
## Fix

Updates the stale `leanFiles[]` entry for `Proofs/AngleTrisectionCos20Gal.lean` in all 26 angle-trisection sibling JSONs. Only `defCount` was stale; everything else already matches the actual file.

## Canonical mechanic counts

For `proofs/Proofs/AngleTrisectionCos20Gal.lean`:

| Field | Old | New | Method |
|-------|-----|-----|--------|
| lineCount | 474 | 474 | unchanged (newline count) |
| theoremCount | 33 | 33 | unchanged |
| axiomCount | 0 | 0 | unchanged |
| defCount | 0 | 4 | regex match against top-level def/abbrev/instance (private + noncomputable variants) |
| sorryCount | 0 | 0 | unchanged |

The 4 definitions:

- private noncomputable abbrev p : Q[X] (line 69)
- private noncomputable def q_eis_int (line 96)
- private noncomputable def q_eis_rat (line 138)
- private noncomputable def root_in_sf (line 257)

## Scope

- 26 sibling JSONs touched (every angle-trisection-*.json that references this lean file)
- One-line edit per file via surgical regex replacement; preserves original JSON encoding
- All JSON revalidated

---
Automated fix by lean-mechanic agent.