### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02OQ03OQ03.lean leanFiles in 29 amgm-inequality siblings (lineCount 67->66, theoremCount 2->3)

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -166,8 +166,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -185,8 +185,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -201,8 +201,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -123,8 +123,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -141,8 +141,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -177,8 +177,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -173,8 +173,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -180,8 +180,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -164,8 +164,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -174,8 +174,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -189,8 +189,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -181,8 +181,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -175,8 +175,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -171,8 +171,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -137,8 +137,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -188,8 +188,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -176,8 +176,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -169,8 +169,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -195,8 +195,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -197,8 +197,8 @@
     {
       "path": "Proofs/AmgmInequalityOQ02OQ03OQ03.lean",
       "filename": "AmgmInequalityOQ02OQ03OQ03.lean",
-      "lineCount": 67,
-      "theoremCount": 2,
+      "lineCount": 66,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Fix

Batch sync `AmgmInequalityOQ02OQ03OQ03.lean` `leanFiles[]` metadata in 29 sibling `amgm-inequality-*` research JSONs to match canonical mechanic-convention counts.

## Evidence

**Canonical counts** (raw, in `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean`):

| Field | Stale | Canonical | Convention |
|---|---|---|---|
| `lineCount` | 67 | **66** | `wc -l` |
| `theoremCount` | 2 | **3** | `^(protected\|private\|noncomputable )*(theorem\|lemma) ` |
| `defCount` | 0 | 0 | `^(def\|noncomputable def\|opaque def) ` |
| `sorryCount` | 0 | 0 | raw `\bsorry\b` |
| `axiomCount` | 0 | 0 | `^axiom ` |

**Before**: all 29 sibling JSONs show `lineCount: 67, theoremCount: 2` at the `AmgmInequalityOQ02OQ03OQ03.lean` entry.
**After**: all 29 sibling JSONs show `lineCount: 66, theoremCount: 3`.

Diff is exactly 58 lines (29 files × 2 field rewrites each). No other fields touched. All 29 JSONs revalidated as parseable.

## Scope

Slug-batch (all 29 `amgm-inequality-*` research JSONs referencing this file).
No `.lean` source modified.

---
Automated fix by lean-mechanic agent.