### PR TITLE
fix(meta): sync CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean stats across 29 cayley-hamilton siblings

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-01.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01-oq-02.json
@@ -262,11 +262,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-01.json
@@ -265,11 +265,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
@@ -295,11 +295,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
@@ -272,11 +272,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01.json
@@ -267,11 +267,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-01.json
@@ -258,11 +258,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02-oq-02.json
@@ -261,11 +261,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -300,11 +300,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -268,11 +268,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02.json
@@ -271,11 +271,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-01.json
@@ -218,11 +218,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03-oq-02.json
@@ -340,11 +340,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-03.json
@@ -314,11 +314,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-04.json
@@ -271,11 +271,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-01.json
@@ -282,11 +282,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-02.json
@@ -295,11 +295,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -304,11 +304,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04.json
@@ -302,11 +302,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01.json
@@ -263,11 +263,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-02.json
@@ -296,11 +296,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05.json
@@ -223,11 +223,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-01.json
@@ -304,11 +304,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-02.json
@@ -298,11 +298,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01-oq-03.json
@@ -325,11 +325,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-oq-01.json
@@ -301,10 +301,10 @@
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "lineCount": 306,
-      "theoremCount": 5,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-oq-02.json
@@ -305,11 +305,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },

--- a/src/data/research/problems/cayley-hamilton-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-oq-03.json
@@ -303,11 +303,11 @@
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
       "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
+      "lineCount": 306,
+      "theoremCount": 11,
       "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
+      "defCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
     },


### PR DESCRIPTION
## Fix

Batch-sync `leanFiles[]` entries for `CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean` across 29 sibling research problem JSONs to match the actual Lean source.

## Evidence

Recomputed canonical counts on `proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean`:

| Field | Stale (in 29 JSONs) | Canonical (recomputed) | Method |
|---|---|---|---|
| `lineCount` | 307 (in 28 JSONs; `cayley-hamilton-oq-01.json` already at 306) | **306** | `wc -l` |
| `theoremCount` | 5 | **11** | `grep -cE "^(protected\|private\|noncomputable )*(theorem\|lemma) "` |
| `defCount` | 2 | **3** | `grep -cE "^(protected\|private\|noncomputable )*(def\|abbrev) "` |
| `sorryCount` | 4 | **0** | auditor strips comments; the 4 raw `sorry` matches are all in the file's header docstring (lines 4, 15, 20, 21), no real `sorry` term remains. The slug's gallery `meta.json` (`cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01/meta.json`) also reports `sorries: 0`. |
| `axiomCount` | 1 | 1 | already canonical (no change) |

29 files changed, 115 insertions, 115 deletions. All JSONs revalidate as parseable.

---
Automated fix by lean-mechanic agent.