### PR TITLE
fix(meta): erdos-795 sorries 24→14 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -17,7 +17,7 @@
       "distinct-products"
     ],
     "badge": "wip",
-    "sorries": 24,
+    "sorries": 14,
     "erdosNumber": 795,
     "erdosUrl": "https://erdosproblems.com/795",
     "erdosProblemStatus": "solved",
@@ -199,5 +199,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, number-theory"
     }
   ],
-  "sorries": 24
+  "sorries": 14
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-795/meta.json` reported 24 sorries at both the top-level `sorries` and nested `meta.sorries` fields, but the source Lean file (`proofs/Proofs/Erdos795Problem.lean`) contains only 14 `sorry` placeholders. The `leanFile.sorries: 14` (computed) and `meta.assumptions: "14 sorry(s)."` were already correct — only the two summary counts were stale.

## Evidence

**Before**: `sorries: 24` (top-level and `meta.sorries`)
**After**: `sorries: 14` (matches `leanFile.sorries`, matches `grep -cE "\bsorry\b" proofs/Proofs/Erdos795Problem.lean` = 14, matches `meta.assumptions` text)

No code changes; metadata-only sync. Same pattern as #20421 (erdos-673) and #20420 (erdos-1021-oq-01).

---
Automated fix by lean-mechanic agent.