### PR TITLE
fix(meta): erdos-876 sorries 7→2 (align with leanFile + assumptions text)

### DIFF
--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -17,7 +17,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 2,
     "erdosNumber": 876,
     "erdosUrl": "https://erdosproblems.com/876",
     "erdosProblemStatus": "open",
@@ -189,5 +189,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, partially-solved"
     }
   ],
-  "sorries": 7
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Update the top-level `sorries` and `meta.sorries` fields from `7` to `2` to match the actual sorry count in `Proofs/Erdos876Problem.lean`.

## Evidence

**Before**:
- `sorries: 7` (top-level)
- `meta.sorries: 7`
- `leanFile.sorries: 2` (correct, from AST)
- `assumptions: "1 axiom: graham_result. 2 sorries."` (already correct)

**After**: All three numeric sorry counts agree on `2`.

`grep -n sorry proofs/Proofs/Erdos876Problem.lean` reports two occurrences (lines 76 and 206), both `by sorry` tactics.

---
Automated fix by lean-mechanic agent.