### PR TITLE
fix(meta): erdos-977 sorries 26→23 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -16,7 +16,7 @@
       "mersenne"
     ],
     "badge": "wip",
-    "sorries": 26,
+    "sorries": 23,
     "erdosNumber": 977,
     "erdosUrl": "https://erdosproblems.com/977",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
Updates meta.sorries from 26 to 23 to match leanFile.sorries and assumptions text. Verified by grep: file has 23 sorries.