### PR TITLE
fix(meta): erdos-630 sorries 20→15 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -23,7 +23,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 20,
+    "sorries": 15,
     "erdosNumber": 630,
     "erdosUrl": "https://erdosproblems.com/630",
     "erdosProblemStatus": "solved",
@@ -56,7 +56,7 @@
     ],
     "axiomCount": 11,
     "lineCount": 246,
-    "assumptions": "11 axiom(s) and 20 sorries(s).",
+    "assumptions": "11 axiom(s) and 15 sorries(s).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 8
@@ -221,5 +221,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 20
+  "sorries": 15
 }


### PR DESCRIPTION
## Fix

Sync top-level `sorries`, `meta.sorries`, and `meta.assumptions` text in `src/data/proofs/erdos-630/meta.json` from `20 → 15` to match `leanFile.sorries` (already 15).

## Evidence

**Source-of-truth scan** of `proofs/Proofs/Erdos630Problem.lean`:

| convention | command | result |
|------------|---------|--------|
| `grep -c sorry` (raw) | `grep -c sorry Erdos630Problem.lean` | **15** |
| `leanFile.sorries` (pre-existing) | already in meta.json | 15 |

Three locations of stale `20` in the meta file before fix:

| line | field | before | after |
|------|-------|--------|-------|
| 26  | `meta.sorries`      | 20 | **15** |
| 59  | `meta.assumptions`  | "11 axiom(s) and 20 sorries(s)." | **"11 axiom(s) and 15 sorries(s)."** |
| 218 | `leanFile.sorries`  | 15 | 15 (unchanged — source of truth) |
| 224 | top-level `sorries` | 20 | **15** |

## Out of scope

- **status/badge** kept at `axiomatized/axiom` — file has 11 axioms, classification unchanged.
- **axiomCount** unchanged (11 is correct).
- **leanFile section** unchanged (already accurate).
- **Companion files** `Erdos630ProblemAristotle.lean` and `GraphCore.lean` not touched; their sorries are unrelated to main proof status.

## Test plan

- [x] `python3 -m json.tool` validates modified meta.json
- [x] `git diff --stat` shows `1 file changed, 3 insertions(+), 3 deletions(-)`
- [x] No conflicting open PR or branch on `erdos-630`

---
Automated fix by lean-mechanic agent.