### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ02.lean lineCount 151->152 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -157,7 +157,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -178,7 +178,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -140,7 +140,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -145,7 +145,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -114,7 +114,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -187,7 +187,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -181,7 +181,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -202,7 +202,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -183,7 +183,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -182,7 +182,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -166,7 +166,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -173,7 +173,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -166,7 +166,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -172,7 +172,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ02.lean",
-      "lineCount": 151,
+      "lineCount": 152,
       "theoremCount": 8,
       "axiomCount": 1,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount: 151` -> `lineCount: 152` for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean` in 33 cauchy-schwarz sibling research problem files.

## Evidence

Canonical algorithm in `scripts/research/enrich-research.ts` (line 174) computes `lineCount` as `content.split('\n').length`. For files ending with a trailing newline, this is one greater than `wc -l` (which counts newline characters).

```
$ wc -l proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean
     151
$ python3 -c "print(len(open('proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean').read().split('\n')))"
152
```

All other fields (`theoremCount`, `axiomCount`, `defCount`, `sorryCount`) already match canonical values and are untouched. Only the stale `lineCount` field within the matching `leanFiles[]` entry of each sibling is updated.

**Before**: `"lineCount": 151` (matches `wc -l`)
**After**: `"lineCount": 152` (matches canonical `content.split('\n').length`)

Same off-by-one pattern as the recent fixes for sibling files:
- #20389 `CauchySchwarzIntegral.lean` (117->118)
- #20407 `CauchySchwarzIntegralOQ01.lean` (228->229)
- #20416 `CauchySchwarzIntegralOQ01OQ01.lean` (153->154)
- #20417 `CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean` (1077->1078, also theoremCount)

---
Automated fix by lean-mechanic agent.