### PR TITLE
fix(meta): batch sync BezoutIdentityOQ03OQ01OQ01OQ01.lean lineCount 161->160 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -298,7 +298,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -286,7 +286,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -318,7 +318,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -293,7 +293,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -291,7 +291,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -315,7 +315,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -288,7 +288,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -329,7 +329,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -291,7 +291,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -295,7 +295,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -292,7 +292,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -292,7 +292,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -239,7 +239,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -312,7 +312,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -247,7 +247,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -313,7 +313,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -338,7 +338,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -289,7 +289,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -296,7 +296,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -315,7 +315,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -295,7 +295,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -251,7 +251,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -311,7 +311,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ01OQ01.lean",
-      "lineCount": 161,
+      "lineCount": 160,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 3,


### PR DESCRIPTION
## Fix

Syncs stale `lineCount` in the `leanFiles` entry for `Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean` across 31 bezout-identity sibling JSONs.

## Evidence

**Before**: All 31 siblings declared `lineCount: 161` for this lean file.
**After**: All 31 siblings declare `lineCount: 160` (matches `wc -l`).

Canonical mechanic counts:
- `lineCount`: `wc -l` = 160 (was 161 stale)
- `theoremCount`: 9 (unchanged)
- `axiomCount`: 0 (unchanged)
- `defCount`: 3 (unchanged)
- `sorryCount`: 0 (unchanged)

Only the `lineCount` field in the matching `leanFiles[*]` entry is modified; no other text or schema changes.

---
Automated fix by lean-mechanic agent.