### PR TITLE
fix(meta): batch sync AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean lineCount 164->163 in 30 area-of-circle siblings

### DIFF
--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-01.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01-oq-02.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01-oq-01.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-01.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01.json
@@ -70,7 +70,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-02.json
@@ -61,7 +61,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03-oq-03.json
@@ -138,7 +138,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02-oq-03.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-02.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01-oq-03.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-01.json
@@ -142,7 +142,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03-oq-02.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-01-oq-03.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-01.json
@@ -111,7 +111,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-01.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-02-oq-04.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-02.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-01.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02-oq-01.json
@@ -112,7 +112,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02-oq-02.json
@@ -128,7 +128,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-02.json
@@ -145,7 +145,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03-oq-01.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03-oq-03.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-03.json
@@ -117,7 +117,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-04.json
@@ -115,7 +115,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-02.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-02.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-03.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-03.json
@@ -116,7 +116,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/area-of-circle-oq-05.json
+++ b/src/data/research/problems/area-of-circle-oq-05.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Syncs stale `lineCount` in the `leanFiles` entry for `Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean` across 30 area-of-circle sibling JSONs.

## Evidence

**Before**: All 30 siblings declared `lineCount: 164` for this lean file.
**After**: All 30 siblings declare `lineCount: 163` (matches `wc -l`).

Canonical mechanic counts:
- `lineCount`: `wc -l` = 163 (was 164 stale)
- `theoremCount`: 7 (unchanged)
- `axiomCount`: 0 (unchanged)
- `defCount`: 0 (unchanged)
- `sorryCount`: 0 (unchanged)

Only the `lineCount` field in the matching `leanFiles[*]` entry is modified; no other text or schema changes.

---
Automated fix by lean-mechanic agent.