### PR TITLE
fix(meta): batch sync BezoutIdentityOQ03OQ01OQ02.lean lineCount 228->227 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -309,7 +309,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -297,7 +297,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -329,7 +329,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -301,7 +301,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -304,7 +304,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -302,7 +302,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -326,7 +326,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -299,7 +299,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -300,7 +300,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -340,7 +340,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -302,7 +302,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -306,7 +306,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -301,7 +301,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -303,7 +303,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -303,7 +303,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -300,7 +300,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -305,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -323,7 +323,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -305,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -324,7 +324,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -349,7 +349,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -300,7 +300,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -307,7 +307,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -305,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -326,7 +326,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -306,7 +306,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -322,7 +322,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -305,7 +305,7 @@
     {
       "path": "Proofs/BezoutIdentityOQ03OQ01OQ02.lean",
       "filename": "BezoutIdentityOQ03OQ01OQ02.lean",
-      "lineCount": 228,
+      "lineCount": 227,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `leanFiles` entry across 31 sibling JSONs for `proofs/Proofs/BezoutIdentityOQ03OQ01OQ02.lean`.

## Evidence

**Before**: `leanFiles[*].lineCount = 228` in 31 bezout-identity siblings.
**After**: `leanFiles[*].lineCount = 227` (matches `wc -l proofs/Proofs/BezoutIdentityOQ03OQ01OQ02.lean`).

Canonical mechanic counter: `wc -l` (newline count).
Other fields (`theoremCount`, `axiomCount`, `defCount`, `sorryCount`) already match actuals.

---
Automated fix by lean-mechanic agent.