### PR TITLE
fix(meta): sync ballot-problem-oq-03-oq-01-oq-01-oq-01 leanFile.lineCount 2437->2497

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-01-oq-01/meta.json
@@ -97,7 +97,7 @@
       "Finset"
     ],
     "namespace": "JacobiTrudi",
-    "lineCount": 2437,
+    "lineCount": 2497,
     "axiomCount": 0,
     "theoremCount": 62,
     "definitionCount": 12,


### PR DESCRIPTION
## Fix

Sync `meta.json.leanFile.lineCount` for `ballot-problem-oq-03-oq-01-oq-01-oq-01` to actual `wc -l` of the Lean source file.

## Evidence

**Before**: `leanFile.lineCount: 2437`
**After**: `leanFile.lineCount: 2497`

`wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ01OQ01.lean` reports `2497`. The top-level `meta.lineCount` was already updated to 2497 in earlier commits -- only the nested `leanFile.lineCount` had drifted. File grew by 60 lines via recent S31/S34/S35 rotation-infrastructure additions to the Lean source.

No Lean source changes. No build impact.

---
Automated fix by lean-mechanic agent.