### PR TITLE
fix(meta): erdos-29 lineCount 523→524

### DIFF
--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 523,
+    "lineCount": 524,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",
@@ -173,7 +173,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 523,
+    "lineCount": 524,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Sync `erdos-29` `lineCount` metadata 523 → 524 to match `Erdos29Problem.lean`.

## Evidence

**Before**:
- `meta.lineCount: 523`
- `leanFile.lineCount: 523`

**After**:
- `meta.lineCount: 524`
- `leanFile.lineCount: 524`

Canonical line count convention: `content.split('\n').length`. `Erdos29Problem.lean` has 524 elements (file does not end with a trailing newline), matching the recent precedent set in #20357, #20359, #20361, etc.

---
Automated fix by lean-mechanic agent.