### PR TITLE
fix(meta): erdos-624 lineCount 218→219

### DIFF
--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 218,
+    "lineCount": 219,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
@@ -174,7 +174,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 218,
+    "lineCount": 219,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Align `erdos-624` meta.json `lineCount` (both `meta.lineCount` and `leanFile.lineCount`) with the actual line count of `Proofs/Erdos624Problem.lean`.

## Evidence

**Before**: `lineCount: 218`
**After**: `lineCount: 219`

Computed using the same method as `scripts/research/enrich-research.ts:174` (`content.split('\n').length`):

```
$ node -e "console.log(require('fs').readFileSync('proofs/Proofs/Erdos624Problem.lean','utf-8').split('\n').length)"
219
```

Other `leanFile` fields (theoremCount=4, axiomCount=5, definitionCount=5, sorries=0) already match the Lean source.

---
Automated fix by lean-mechanic agent.