### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ02.lean lineCount 600->601 in 33 siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -209,7 +209,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -201,7 +201,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -141,7 +141,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -222,7 +222,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -184,7 +184,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -189,7 +189,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -190,7 +190,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -188,7 +188,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -199,7 +199,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -186,7 +186,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -185,7 +185,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -179,7 +179,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -231,7 +231,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -225,7 +225,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -203,7 +203,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -213,7 +213,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -227,7 +227,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -226,7 +226,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -210,7 +210,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -209,7 +209,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -210,7 +210,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -229,7 +229,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ02.lean",
-      "lineCount": 600,
+      "lineCount": 601,
       "theoremCount": 29,
       "axiomCount": 2,
       "defCount": 7,


### PR DESCRIPTION
## Fix

Sync stale `leanFiles[i]` entries for `proofs/Proofs/CauchySchwarzIntegralOQ01OQ02.lean` across 33 cauchy-schwarz sibling research JSONs to the canonical enricher line count.

## Evidence

**Lean source** `proofs/Proofs/CauchySchwarzIntegralOQ01OQ02.lean`:
- `content.split('\n').length` = **601** (was claimed 600 — enricher canonical, see `scripts/research/enrich-research.ts:174`)
- `wc -l` = 600 (file ends with trailing newline; enricher counts the trailing empty split element)
- All other counted fields on this entry already match the source:
  - `theoremCount` = 29 (unchanged)
  - `axiomCount` = 2 (unchanged)
  - `defCount` = 7 (unchanged)
  - `sorryCount` = 0 (unchanged)

**Before** (uniform across all 33 siblings):
```
"lineCount": 600,
```

**After**:
```
"lineCount": 601,
```

33 sibling JSONs in `src/data/research/problems/`, single-field surgical text replacement (33 lines changed total, JSON formatting preserved).

Follows the mechanic batch-PR pattern from #20076 / #20407 / #20416 / #20417 / #20430.

---
Automated fix by lean-mechanic agent.