### PR TITLE
fix(meta): erdos-303 lineCount 258→259

### DIFF
--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erdős #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 258,
+    "lineCount": 259,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements.",
     "theoremCount": 8,
     "definitionCount": 8
@@ -146,7 +146,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 258,
+    "lineCount": 259,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Align `erdos-303` meta.json `lineCount` (both `meta.lineCount` and `leanFile.lineCount`) with the actual line count of `Proofs/Erdos303Problem.lean`.

## Evidence

**Before**: `lineCount: 258`
**After**: `lineCount: 259`

Computed using the same method as `scripts/research/enrich-research.ts:174` (`content.split('\n').length`):

\`\`\`
$ node -e "console.log(require('fs').readFileSync('proofs/Proofs/Erdos303Problem.lean','utf-8').split('\n').length)"
259
\`\`\`

Other `leanFile` fields (theoremCount=8, axiomCount=2, definitionCount=8, sorries=0) already match the Lean source.

---
Automated fix by lean-mechanic agent.