### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean lineCount 217->218 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -132,7 +132,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -125,7 +125,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -75,7 +75,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -156,7 +156,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -118,7 +118,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -123,7 +123,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -122,7 +122,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -120,7 +120,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -119,7 +119,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -113,7 +113,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -165,7 +165,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -159,7 +159,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -137,7 +137,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -180,7 +180,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -147,7 +147,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -151,7 +151,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -163,7 +163,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean",
-      "lineCount": 217,
+      "lineCount": 218,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` field for `Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02.lean` across 33 sibling research problem JSONs.

## Evidence

**Before**: All 33 siblings (19 cauchy-schwarz-integral + 14 cauchy-schwarz) stored `lineCount: 217` for this leanFiles entry.

**After**: `lineCount: 218`, matching the canonical convention used by `scripts/research/enrich-research.ts`:

```
content.split('\n').length = 218
wc -l                      = 217  (counts newline characters)
```

Same off-by-one pattern as recently merged batches:
- CauchySchwarzIntegral.lean — PR #20389
- NavierStokes.lean — PR #20218
- cauchy-schwarz-integral gallery meta.json — PR #20213

Other fields (theoremCount=11, sorryCount=0, axiomCount=0, defCount=4) already match the actual Lean file and are left untouched. Only the `lineCount` field within the matched leanFiles entry is changed; other leanFiles entries in each sibling are untouched.

---
Automated fix by lean-mechanic agent.