### PR TITLE
fix(meta): erdos-551 sorries 25→22 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -16,7 +16,7 @@
       "cycles"
     ],
     "badge": "wip",
-    "sorries": 25,
+    "sorries": 22,
     "erdosNumber": 551,
     "erdosUrl": "https://erdosproblems.com/551",
     "erdosProblemStatus": "solved",
@@ -225,5 +225,5 @@
     "Erdős, P.; Faudree, R.J.; Rousseau, C.C.; Schelp, R.H. (1978): The Ramsey number for the pair complete graph-cycle",
     "https://erdosproblems.com/551"
   ],
-  "sorries": 25
+  "sorries": 22
 }


### PR DESCRIPTION
## Fix

Sync top-level `meta.sorries` and root-level `sorries` in `src/data/proofs/erdos-551/meta.json` from `25 → 22` to match `leanFile.sorries` (already 22).

## Evidence

**Source-of-truth scan** of `proofs/Proofs/Erdos551Problem.lean`:

| convention | command | result |
|------------|---------|--------|
| `grep -c sorry` (raw) | `grep -c "sorry" Erdos551Problem.lean` | **22** |
| `leanFile.sorries` (pre-existing) | already in meta.json | 22 |

Stale `25` values fixed:

| line | field | before | after |
|------|-------|--------|-------|
| 19  | `meta.sorries`     | 25 | **22** |
| 187 | `leanFile.sorries` | 22 | 22 (unchanged — source of truth) |
| 228 | top-level `sorries`| 25 | **22** |

The `assumptions` text already says "22 sorry(s) remain in the formalization." — no edit needed.

## Out of scope

- **status/badge** kept at `formalized/wip` — file has 0 axioms but 22 sorries remain, classification unchanged.
- **axiomCount** unchanged (0 is correct).
- **leanFile section** unchanged (already accurate).
- **Companion file** `Erdos551ProblemAristotle.lean` not touched.

## Test plan

- [x] python3 -m json.tool validates modified meta.json
- [x] git diff --stat shows 1 file changed, 2 insertions(+), 2 deletions(-)
- [x] No conflicting open PR or branch on erdos-551

---
Automated fix by lean-mechanic agent.