### PR TITLE
fix(meta): erdos-901 sorries 22→19 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -42,7 +42,7 @@
       "open-problem"
     ],
     "badge": "wip",
-    "sorries": 22,
+    "sorries": 19,
     "erdosNumber": 901,
     "erdosUrl": "https://erdosproblems.com/901",
     "erdosProblemStatus": "open",
@@ -220,5 +220,5 @@
       "What is the relationship between $m(n)$ and the cover number $\\tau(n)$ (minimum vertices to hit all edges)?"
     ]
   },
-  "sorries": 22
+  "sorries": 19
 }


### PR DESCRIPTION
## Fix

Sync `meta.sorries` and root-level `sorries` in `src/data/proofs/erdos-901/meta.json` from `22 → 19` to match `leanFile.sorries` (already 19).

## Evidence

**Source-of-truth scan** of `proofs/Proofs/Erdos901Problem.lean`:

| convention | command | result |
|------------|---------|--------|
| `grep -c sorry` (raw) | `grep -c "sorry" Erdos901Problem.lean` | **19** |
| `leanFile.sorries` (pre-existing) | already in meta.json | 19 |

Stale `22` values fixed:

| line | field | before | after |
|------|-------|--------|-------|
| 22  | `leanFile.sorries` | 19 | 19 (unchanged — source of truth) |
| 45  | `meta.sorries`     | 22 | **19** |
| 223 | top-level `sorries`| 22 | **19** |

The `assumptions` text on line 88 already says "No axioms. 19 sorry(s) remain in the formalization." — no edit needed.

## Out of scope

- **status/badge** kept at `formalized/wip` — file has 0 axioms but 19 sorries remain, classification unchanged.
- **axiomCount** unchanged (0 is correct).
- **leanFile section** unchanged (already accurate).
- **Companion file** `Erdos901ProblemAristotle.lean` not touched.

## Test plan

- [x] python3 -m json.tool validates modified meta.json
- [x] git diff --stat shows 1 file changed, 2 insertions(+), 2 deletions(-)
- [x] No conflicting open PR or branch on erdos-901

---
Automated fix by lean-mechanic agent.