### PR TITLE
fix(meta): erdos-610 sorries 20→17 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 20,
+    "sorries": 17,
     "erdosNumber": 610,
     "erdosUrl": "https://erdosproblems.com/610",
     "erdosProblemStatus": "open",
@@ -255,5 +255,5 @@
       "description": "Foundational Ramsey theory (2-complete sets): the Ramsey-theoretic framework underpinning Kim's theorem R(3,k) = Θ(k²/log k)"
     }
   ],
-  "sorries": 20
+  "sorries": 17
 }


### PR DESCRIPTION
## Fix

Sync `meta.sorries` and root-level `sorries` in `src/data/proofs/erdos-610/meta.json` from `20 → 17` to match `leanFile.sorries` (already 17).

## Evidence

**Source-of-truth scan** of `proofs/Proofs/Erdos610Problem.lean`:

| convention | command | result |
|------------|---------|--------|
| `grep -c sorry` (raw) | 17 |
| `leanFile.sorries` (pre-existing) | 17 |

Stale `20` values fixed:

| line | field | before | after |
|------|-------|--------|-------|
| 21  | `meta.sorries`     | 20 | **17** |
| 216 | `leanFile.sorries` | 17 | 17 (unchanged — source of truth) |
| 258 | top-level `sorries`| 20 | **17** |

The `assumptions` text on line 92 already says "1 axiom(s) and 17 sorries." — no edit needed.

## Out of scope

- **status/badge** kept (axiomatized/axiom is correct — 1 axiom present).
- **axiomCount** unchanged.
- **leanFile section** unchanged (already accurate).

## Test plan

- [x] python3 -m json.tool validates modified meta.json
- [x] git diff --stat shows 1 file changed, 2 insertions(+), 2 deletions(-)
- [x] No conflicting open PR or branch on erdos-610

---
Automated fix by lean-mechanic agent.