### PR TITLE
fix(meta): batch sync BezoutIdentity.lean lineCount 237->238 in 31 bezout-identity siblings

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-01.json
@@ -77,7 +77,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-01.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01-oq-02.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01-oq-01.json
@@ -84,7 +84,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-01.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-02.json
@@ -95,7 +95,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02-oq-03.json
@@ -79,7 +79,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-02.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02-oq-03.json
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01-oq-02.json
@@ -82,7 +82,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01-oq-01.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02-oq-01.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-02.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-02-oq-03.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-02.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01-oq-01.json
@@ -30,7 +30,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01-oq-02.json
@@ -38,7 +38,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-01.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-02.json
@@ -104,7 +104,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-03.json
@@ -96,7 +96,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04-oq-01.json
@@ -80,7 +80,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-03.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-01.json
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01-oq-03.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -42,7 +42,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-02.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/bezout-identity-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-04.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/BezoutIdentity.lean",
       "filename": "BezoutIdentity.lean",
-      "lineCount": 237,
+      "lineCount": 238,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` field for `Proofs/BezoutIdentity.lean` across 31 sibling research problem JSONs.

## Evidence

**Before**: All 31 siblings stored `lineCount: 237` for the `BezoutIdentity.lean` `leanFiles` entry.

**After**: `lineCount: 238`, matching the canonical convention used by `scripts/research/enrich-research.ts:174`:

```
content.split('\n').length = 238
wc -l                      = 237  (counts newline characters)
```

Other fields on this entry (theoremCount=8, axiomCount=0, defCount=0, sorryCount=0) already match the actual Lean file and are left untouched. Only the `lineCount` field within the matched `leanFiles` entry is changed; other `leanFiles` entries in each sibling are untouched.

Same off-by-one pattern as previous bezout-identity syncs (e.g., PRs #20431, #20433, #20438).

---
Automated fix by lean-mechanic agent.