### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ03.lean lineCount 181->182 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -286,7 +286,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -278,7 +278,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -299,7 +299,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -261,7 +261,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -266,7 +266,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -267,7 +267,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -265,7 +265,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -276,7 +276,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -263,7 +263,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -256,7 +256,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -308,7 +308,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -302,7 +302,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -301,7 +301,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -280,7 +280,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -323,7 +323,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -304,7 +304,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -303,7 +303,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -287,7 +287,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -286,7 +286,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -294,7 +294,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -287,7 +287,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -293,7 +293,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -306,7 +306,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ03.lean",
       "filename": "CauchySchwarzIntegralOQ03.lean",
-      "lineCount": 181,
+      "lineCount": 182,
       "theoremCount": 20,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Fix

Update `lineCount` from 181 to 182 for `CauchySchwarzIntegralOQ03.lean` across 33 sibling research JSONs.

## Evidence

Canonical mechanic counts for `proofs/Proofs/CauchySchwarzIntegralOQ03.lean`:
- `lineCount`: `content.split('\n').length` = **182** (was 181)

This matches `scripts/research/enrich-research.ts` lines 144-174: `content.split('\n').length`.

Other fields (theoremCount=20, axiomCount=0, defCount=0, sorryCount=0) already match the actual file.

**Before**: 33 sibling JSONs report `lineCount: 181`
**After**: All siblings report `lineCount: 182`, matching the actual file

---
Automated fix by lean-mechanic agent.