### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ02.lean lineCount 263->264 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -242,7 +242,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -234,7 +234,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -174,7 +174,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -255,7 +255,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -217,7 +217,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -222,7 +222,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -223,7 +223,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -221,7 +221,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -232,7 +232,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -219,7 +219,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -218,7 +218,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -212,7 +212,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -264,7 +264,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -258,7 +258,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -236,7 +236,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -279,7 +279,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -260,7 +260,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -259,7 +259,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -242,7 +242,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -250,7 +250,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -243,7 +243,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -249,7 +249,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -262,7 +262,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ02.lean",
       "filename": "CauchySchwarzIntegralOQ02.lean",
-      "lineCount": 263,
+      "lineCount": 264,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,


### PR DESCRIPTION
## Summary

Bumps `leanFiles[].lineCount` 263→264 on the `Proofs/CauchySchwarzIntegralOQ02.lean` entry in **33 sibling research-problem JSONs** under `src/data/research/problems/` (cauchy-schwarz and cauchy-schwarz-integral families).

## Canonical lineCount semantic

`proofs/Proofs/CauchySchwarzIntegralOQ02.lean`:

```
wc -l → 263 (newline char count)
trailing_newline → True
content.split('\n').length → 264 (canonical)
```

The gallery's enrichment script `scripts/research/enrich-research.ts` uses:

```ts
const lines = content.split('\n')
lineCount: lines.length,
```

`content.split('\n')` on a file ending in `\n` returns one extra empty trailing element → 264. Pre-existing values (263) reflected `wc -l` (newline count) and were off by one. Same off-by-one pattern as PR #20389 (`CauchySchwarzIntegral.lean` 117→118) and PR #20444 (`CauchySchwarzIntegralOQ03.lean` 181→182).

## Scope discipline

- Only the `lineCount` field is touched.
- Only the `Proofs/CauchySchwarzIntegralOQ02.lean` entry within `leanFiles[]` is touched.
- All other `leanFiles[]` entries and all other JSON fields are left intact.
- `theoremCount: 9`, `axiomCount: 0`, `defCount: 0`, `sorryCount: 0` already match canonical counts — no edits needed there.

## Verification

- 33 sibling JSONs modified, 1 line edit each: `git diff --stat` → 33 files changed, 33 insertions(+), 33 deletions(-).
- `git diff -U0 | grep ^[+-]` yields only `lineCount: 263/264` rows — no other deltas.
- All 33 files revalidate as parseable JSON via `json.load` (1916 ok / 0 bad across the full directory).
- Independent recompute via the canonical regex (`scripts/research/enrich-research.ts:143-182`) confirms `{lineCount:264, theoremCount:9, axiomCount:0, defCount:0, sorryCount:0}`.

## Test plan

- [x] `git diff --stat` shows exactly 33 files, 33 line edits
- [x] No edits to non-lineCount numerics
- [x] No edits to non-CauchySchwarzIntegralOQ02.lean entries
- [x] All edited files remain valid JSON

---
Automated fix by lean-mechanic agent.