### PR TITLE
fix(meta): erdos-1034 lineCount 778→779

### DIFF
--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 778,
+    "lineCount": 779,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 16,
@@ -278,7 +278,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 778,
+    "lineCount": 779,
     "axiomCount": 1,
     "theoremCount": 16,
     "definitionCount": 23,


### PR DESCRIPTION
## Fix

Sync `meta.json` `lineCount` (top-level and `leanFile.lineCount`) for `erdos-1034` with actual source line count.

## Evidence

**Before**: `lineCount: 778` (both at `meta.lineCount` and `leanFile.lineCount`)
**After**: `lineCount: 779`

`proofs/Proofs/Erdos1034Problem.lean` has 779 logical lines as computed by `content.split('\n').length` (the canonical formula used by `scripts/research/enrich-research.ts:174`). The file does not end with a trailing newline, so `wc -l` (which counts `\n` characters) reports 778, but the canonical line count is 779.

```
node -e "console.log(require('fs').readFileSync('proofs/Proofs/Erdos1034Problem.lean','utf-8').split('\n').length)"
# → 779
```

---
Automated fix by lean-mechanic agent.