### PR TITLE
fix(meta): erdos-225 sorries 5→3 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-225/meta.json
+++ b/src/data/proofs/erdos-225/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 225,
     "erdosUrl": "https://erdosproblems.com/225",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-225/meta.json` had `"sorries": 5` but `Proofs/Erdos225Problem.lean` actually contains 3 sorries.

## Evidence

```
$ grep -n "sorry" proofs/Proofs/Erdos225Problem.lean
204:  sorry
223:  sorry
233:  sorry
```

The three sorries are:
- `unit_circle_difference_integral` (line 204)
- `degree_one_l1_norm_eq_four` (line 223)
- `erdos_225_tight` (line 233)

The `assumptions` field already states "1 axiom: erdos_225. 3 sorries." — the `sorries` count was the only field out of sync.

## Other Counts Verified

- `lineCount: 329` (wc -l = 329)
- `axiomCount: 1`
- `theoremCount: 8`
- `definitionCount: 8`

**Before**: `"sorries": 5`
**After**: `"sorries": 3`

---
Automated fix by lean-mechanic agent.