### PR TITLE
fix(meta): erdos-1019 sorries 6→1 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -17,7 +17,7 @@
       "turan-theory"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 1,
     "erdosNumber": 1019,
     "erdosUrl": "https://erdosproblems.com/1019",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-1019/meta.json` had `"sorries": 6` but `Proofs/Erdos1019Problem.lean` actually contains 1 sorry.

## Evidence

```
$ grep -n "sorry" proofs/Proofs/Erdos1019Problem.lean
267:    sorry
```

The single sorry is inside the converted `K4_saturated_planar` theorem (was an axiom). The `assumptions` field already states "K4_saturated_planar converted from axiom to theorem (1 sorry remains for edge count: C(4,2)=6 on generic 4-element type)" — only the `sorries` count field was out of sync.

## Other Counts Verified

- `lineCount: 478` (wc -l = 478)
- `axiomCount: 3` (matches 3 remaining axioms: `cyclePlus2K1_saturated_planar`, `erdos_construction_exists`, `simonovits_theorem`)
- `theoremCount: 13`
- `definitionCount: 23` (excludes `instance` declarations)

**Before**: `"sorries": 6`
**After**: `"sorries": 1`

---
Automated fix by lean-mechanic agent.