### PR TITLE
fix(meta): erdos-1040 sorries 1→0 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -17,7 +17,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1040,
     "erdosUrl": "https://erdosproblems.com/1040",
     "erdosProblemStatus": "open",
@@ -247,5 +247,5 @@
       "Proofs/Erdos1040Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-1040/meta.json` claimed `"sorries": 1` at both top-level and `meta.sorries`, but `Proofs/Erdos1040Problem.lean` has 0 active sorries — the only `sorry` token (line 451) is inside a Lean block comment for the commented-out `transfiniteDiameter_scale` theorem.

## Evidence

```
$ grep -nE '\bsorry\b' proofs/Proofs/Erdos1040Problem.lean
451:--   sorry
```

The match is inside a commented-out theorem (`-- theorem transfiniteDiameter_scale ...`), not an active proof goal.

- `leanFile.sorries` already correctly set to `0` (source of truth)
- `meta.assumptions` text already states "0 sorries (transfiniteDiameter_scale was commented out)"

Convention (per #20077): top-level and `meta.sorries` mirror main `leanFile.sorries`, excluding sorries inside `additionalFiles` such as the Aristotle companion.

## Other Counts Verified

- `axiomCount: 4` (4 axiom declarations: `disc_diameter`, `small_diameter_disc`, `lineSegment_muPosDeg_zero`, `disc_muPosDeg_zero`)
- `status: "axiomatized"` and `badge: "axiom"` correctly reflect the 4 axiom-encoded EHP/Erdős-Netanyahu assumptions
- Main file remains 640 lines; not modified

**Before**: `"sorries": 1` (top-level and `meta.sorries`)
**After**: `"sorries": 0`

---
Automated fix by lean-mechanic agent.