### PR TITLE
fix(meta): ballot-problem-oq-01-oq-02-oq-01 sorries 1→0 align with leanFile

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "originalContributions": [
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",
       "multiProjectionFiber_pairwise_disjoint: fibers over distinct targets are disjoint",
@@ -174,5 +174,5 @@
       "description": "Uniform fibers preserve uniformOn probability (0 sorries, complete proof)"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Sync top-level `sorries` and `meta.sorries` (both `1`) with the actual proof file `Proofs/BallotProblemOQ01OQ02OQ01.lean`, which contains **0 sorries**.

## Evidence

- `grep -c "sorry" proofs/Proofs/BallotProblemOQ01OQ02OQ01.lean` → `0`
- `leanFile.sorries` already reports `0` (the source of truth)
- `conclusion.summary` already states "0 sorries, 0 axioms, 249 lines"
- Only the integer counts at `meta.sorries` and the top-level `sorries` were stale

**Before**: `sorries: 1` (twice), inconsistent with `leanFile.sorries: 0` and the prose conclusion
**After**: `sorries: 0` (twice), aligned across all locations in the metadata

Scope is intentionally minimal — only the two stale integers are touched. Status field (`formalized`) is left unchanged.

---
Automated fix by lean-mechanic agent.