### PR TITLE
fix(meta): erdos-644 sorries 19→16 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -19,7 +19,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 19,
+    "sorries": 16,
     "erdosNumber": 644,
     "erdosUrl": "https://erdosproblems.com/644",
     "erdosProblemStatus": "open",
@@ -200,5 +200,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, open"
     }
   ],
-  "sorries": 19
+  "sorries": 16
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-644/meta.json` reported 19 sorries at both the top-level `sorries` and nested `meta.sorries` fields, but the source Lean file (`proofs/Proofs/Erdos644Problem.lean`) contains only 16 `sorry` placeholders. The `leanFile.sorries: 16` (computed) and `meta.assumptions: "3 axiom(s) and 16 sorry(s). See the Lean source for details."` were already correct — only the two summary counts were stale.

## Evidence

**Before**: `sorries: 19` (top-level and `meta.sorries`)
**After**: `sorries: 16` (matches `leanFile.sorries`, matches `grep -cE "\\bsorry\\b" proofs/Proofs/Erdos644Problem.lean` = 16, matches `meta.assumptions` text)

No code changes; metadata-only sync.

---
Automated fix by lean-mechanic agent.