### PR TITLE
fix(meta): erdos-715 sorries 18→15 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "wip",
-    "sorries": 18,
+    "sorries": 15,
     "erdosNumber": 715,
     "erdosUrl": "https://erdosproblems.com/715",
     "erdosProblemStatus": "solved",
@@ -238,5 +238,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, subgraphs"
     }
   ],
-  "sorries": 18
+  "sorries": 15
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-715/meta.json` reported 18 sorries at both the top-level `sorries` and nested `meta.sorries` fields, but the source Lean file (`proofs/Proofs/Erdos715Problem.lean`) contains only 15 `sorry` placeholders. The `leanFile.sorries: 15` (computed) and `meta.assumptions: "No axioms. 15 sorries remain in the formalization."` were already correct — only the two summary counts were stale.

## Evidence

**Before**: `sorries: 18` (top-level and `meta.sorries`)
**After**: `sorries: 15` (matches `leanFile.sorries`, matches `grep -cE "\\bsorry\\b" proofs/Proofs/Erdos715Problem.lean` = 15, matches `meta.assumptions` text)

No code changes; metadata-only sync.

---
Automated fix by lean-mechanic agent.