### PR TITLE
fix(meta): algebraic-numbers-countable lineCount 254->255 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified with 0 axioms, 0 sorries. All 18 theorems proved from Mathlib infrastructure (Algebraic.countable, cardinalMk_of_countable_of_charZero, Set.Countable.mono, Set.countable_iUnion) with no custom axioms or structure-encoded assumptions. The 4 definitions (algebraicRealsOfBoundedDegree, algebraicComplexOfBoundedDegree, algebraicRealsOfDegree, algebraicComplexOfDegree) are noncomputable due to minpoly's use of Classical.choice.",
-    "lineCount": 254,
+    "lineCount": 255,
     "theoremCount": 18,
     "definitionCount": 4,
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/AlgebraicCard.html",
@@ -360,7 +360,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountable",
-    "lineCount": 254,
+    "lineCount": 255,
     "path": "Proofs/AlgebraicNumbersCountable.lean",
     "axiomCount": 0,
     "theoremCount": 18,

--- a/src/data/research/problems/algebraic-numbers-countable-oq-01.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-01.json
@@ -62,7 +62,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountable.lean",
       "filename": "AlgebraicNumbersCountable.lean",
-      "lineCount": 254,
+      "lineCount": 255,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/algebraic-numbers-countable-oq-02.json
+++ b/src/data/research/problems/algebraic-numbers-countable-oq-02.json
@@ -64,7 +64,7 @@
     {
       "path": "Proofs/AlgebraicNumbersCountable.lean",
       "filename": "AlgebraicNumbersCountable.lean",
-      "lineCount": 254,
+      "lineCount": 255,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` for `Proofs/AlgebraicNumbersCountable.lean` across the gallery `meta.json` and two stale research problem JSONs.

## Evidence

**Before**:
- `src/data/proofs/algebraic-numbers-countable/meta.json`: `meta.lineCount=254`, `leanFile.lineCount=254`
- `src/data/research/problems/algebraic-numbers-countable-oq-01.json` `leanFiles[0].lineCount=254`
- `src/data/research/problems/algebraic-numbers-countable-oq-02.json` `leanFiles[0].lineCount=254`

**After**: all four fields updated to `255`, matching the canonical convention used by `scripts/research/enrich-research.ts:174`:

```
node -e "console.log(require('fs').readFileSync('proofs/Proofs/AlgebraicNumbersCountable.lean','utf-8').split('\n').length)"
# -> 255
wc -l proofs/Proofs/AlgebraicNumbersCountable.lean
# -> 254  (counts \n characters; the file ends with a newline so split sees an extra empty element)
```

Three sibling research JSONs (`algebraic-numbers-countable-oq-02-oq-03`, `-oq-04`, `-oq-05`) already use the canonical value 255 -- this PR brings the remaining two stale references and the gallery meta into alignment.

Other counts on these `leanFiles` entries (theoremCount=18, axiomCount=0, defCount=4, sorryCount=0) already match the actual Lean file and are left untouched.

---
Automated fix by lean-mechanic agent.