### PR TITLE
fix(meta): frobenius-number-oq-03 lineCount 225->226

### DIFF
--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "research",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 225,
+    "lineCount": 226,
     "theoremCount": 15,
     "definitionCount": 2,
     "assumptions": "None at this stage. The file establishes the Representable3 predicate, the frobeniusNumber3 definition (as sSup of the non-representable set), seven closure lemmas (S2), structural API for the supremum (S3a), the 2→3 generator bridge under Nat.Coprime a b with 1 ≤ a, 1 ≤ b (S3b), the loose Sylvester upper bound (a-1)(b-1) (S3c), and finiteness of the non-representable set under the same coprimality (S4). The exact Roberts-1956 closed form g(n, n+1, n+2) = ⌊(n-2)/2⌋·n + (n-1) for three consecutive integers and the general Roberts 3-AP formula are deferred to S5+.",

--- a/src/data/research/problems/frobenius-number-oq-03.json
+++ b/src/data/research/problems/frobenius-number-oq-03.json
@@ -137,7 +137,7 @@
     "leanFiles": [
         {
             "path": "proofs/Proofs/FrobeniusNumberOQ03.lean",
-            "lineCount": 225,
+            "lineCount": 226,
             "theoremCount": 15,
             "definitionCount": 2,
             "sorryCount": 0,


### PR DESCRIPTION
## Fix

Sync stale lineCount (225 -> 226) for Proofs/FrobeniusNumberOQ03.lean across the gallery meta.json and the research problem JSON.

## Evidence

**Before**:
- src/data/proofs/frobenius-number-oq-03/meta.json: meta.lineCount = 225
- src/data/research/problems/frobenius-number-oq-03.json: leanFiles[0].lineCount = 225

**After**: Both files report lineCount = 226, matching the canonical formula content.split('\n').length used by scripts/research/enrich-research.ts:174.

Other counts (theoremCount=15, definitionCount=2, sorryCount=0, axiomCount=0) already match the actual Lean file and are left untouched.

---
Automated fix by lean-mechanic agent.