### PR TITLE
fix(meta): batch sync AmgmInequalityOQ02Aristotle.lean lineCount 353->352 in 29 amgm-inequality siblings

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-01.json
@@ -78,7 +78,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01.json
@@ -97,7 +97,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03.json
@@ -102,7 +102,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02-oq-01.json
@@ -35,7 +35,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01.json
@@ -53,7 +53,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-01.json
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-01.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03-oq-02.json
@@ -85,7 +85,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03-oq-03.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-03.json
@@ -92,7 +92,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-02.json
@@ -76,7 +76,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01-oq-03.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-01.json
@@ -101,7 +101,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01-oq-01.json
@@ -93,7 +93,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-01.json
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02-oq-04.json
@@ -83,7 +83,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-02.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03-oq-01.json
@@ -49,7 +49,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-03.json
@@ -31,7 +31,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-03-oq-04.json
@@ -100,7 +100,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-03.json
@@ -88,7 +88,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-01.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-04.json
@@ -81,7 +81,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-05.json
@@ -107,7 +107,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,

--- a/src/data/research/problems/amgm-inequality-oq-04.json
+++ b/src/data/research/problems/amgm-inequality-oq-04.json
@@ -109,7 +109,7 @@
     {
       "path": "Proofs/AmgmInequalityOQ02Aristotle.lean",
       "filename": "AmgmInequalityOQ02Aristotle.lean",
-      "lineCount": 353,
+      "lineCount": 352,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 2,


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount=353` to canonical `wc -l = 352` across 29 amgm-inequality research problem JSONs that reference `proofs/Proofs/AmgmInequalityOQ02Aristotle.lean`.

## Evidence

Canonical mechanic counts for `proofs/Proofs/AmgmInequalityOQ02Aristotle.lean`:

```
wc -l proofs/Proofs/AmgmInequalityOQ02Aristotle.lean
     352 proofs/Proofs/AmgmInequalityOQ02Aristotle.lean
```

- lineCount: 353 -> 352 (this fix)
- theoremCount: 6 (unchanged)
- axiomCount: 0 (unchanged)
- defCount: 2 (unchanged)
- sorryCount: 1 (unchanged, Aristotle target sorry)

All 29 sibling problem JSONs in src/data/research/problems/amgm-inequality-*.json had the same stale value.

---
Automated fix by lean-mechanic agent.