### PR TITLE
fix(meta): erdos-626 sorries 19→15 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -24,7 +24,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 19,
+    "sorries": 15,
     "erdosNumber": 626,
     "erdosUrl": "https://erdosproblems.com/626",
     "erdosProblemStatus": "open",
@@ -226,5 +226,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 19
+  "sorries": 15
 }


### PR DESCRIPTION
## Fix

Sync the top-level `sorries` and `meta.sorries` fields for `erdos-626` from 19 down to 15, matching the actual sorry count in `proofs/Proofs/Erdos626Problem.lean` (already reflected in `leanFile.sorries: 15`).

## Evidence

- `proofs/Proofs/Erdos626Problem.lean`: `grep -c "sorry"` → **15**
- `meta.leanFile.sorries`: **15** (already correct)
- `meta.sorries` (before → after): **19 → 15**
- top-level `sorries` (before → after): **19 → 15**

No code changes; `axiomCount` (7), `lineCount` (244), `theoremCount` (13), `definitionCount` (9) all already match the Lean source.

---
Automated fix by lean-mechanic agent.