### PR TITLE
fix(meta): erdos-1048 sorries 14→10 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 10,
     "erdosNumber": 1048,
     "erdosUrl": "https://erdosproblems.com/1048",
     "erdosProblemStatus": "disproved",
@@ -303,5 +303,5 @@
       "type": "book"
     }
   ],
-  "sorries": 14
+  "sorries": 10
 }


### PR DESCRIPTION
## Fix

\`src/data/proofs/erdos-1048/meta.json\` reported 14 sorries at both the top-level \`sorries\` and nested \`meta.sorries\` fields, but the source Lean file (\`proofs/Proofs/Erdos1048Problem.lean\`) contains only 10 \`sorry\` placeholders. The \`leanFile.sorries: 10\` and \`leanFile.sorryTheorems: 10\` (computed) were already correct — only the two summary counts were stale.

## Evidence

**Before**: \`sorries: 14\` (top-level and \`meta.sorries\`)
**After**: \`sorries: 10\` (matches \`leanFile.sorries\`, matches actual Lean file sorry count = 10, matches \`leanFile.sorryTheorems\`)

No code changes; metadata-only sync.

---
Automated fix by lean-mechanic agent.