### PR TITLE
fix(meta): erdos-1049 sorries 14→9 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 9,
     "erdosNumber": 1049,
     "erdosUrl": "https://erdosproblems.com/1049",
     "erdosProblemStatus": "open",
@@ -293,5 +293,5 @@
       "Proofs/Erdos1049ProblemAristotle.lean"
     ]
   },
-  "sorries": 14
+  "sorries": 9
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-1049/meta.json` reported 14 sorries at both the top-level `sorries` and nested `meta.sorries` fields, but the source Lean file (`proofs/Proofs/Erdos1049Problem.lean`) contains only 9 `sorry` placeholders. The computed `leanFile.sorries: 9` was already correct — only the two summary counts were stale.

## Evidence

**Before**: `sorries: 14` (top-level and `meta.sorries`)
**After**: `sorries: 9` (matches `leanFile.sorries`, matches actual Lean file sorry count = 9)

No code changes; metadata-only sync.

---
Automated fix by lean-mechanic agent.