### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-05 lineCount 214→215

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
     "assumptions": "shafarevich_inverse_galois: Every finite solvable group G is the Galois group of some number field extension L/ℚ. Shafarevich (1954, Izv. Akad. Nauk). Proof requires class field theory, embedding problems, and Brauer group theory — not currently in Mathlib.",
-    "lineCount": 214,
+    "lineCount": 215,
     "theoremCount": 9,
     "definitionCount": 0,
     "originalContributions": [
@@ -308,7 +308,7 @@
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05.lean",
     "axiomCount": 1,
-    "lineCount": 214,
+    "lineCount": 215,
     "theoremCount": 9,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `lineCount` in `src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json` to match the canonical count for `Proofs/AbelRuffiniGaloisExtensionsOQ05.lean` (`content.split('\n').length = 215`).

## Evidence

**Before**: meta.json claimed `lineCount: 214` in both `meta.lineCount` and `leanFile.lineCount`.
**After**: both fields are `215`, matching the script convention used by `scripts/research/enrich-research.ts::extractLeanMetadata`. The sibling research JSON (`src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json` line 220) already has `lineCount: 215` for this file.

No other fields (theoremCount=9, axiomCount=1, definitionCount=0, sorries=0) needed adjustment.

---
Automated fix by lean-mechanic agent.