### PR TITLE
fix(meta): erdos-1096 lineCount 424→425

### DIFF
--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -49,7 +49,7 @@
       "bugeaud_characterization axiom: Pisot iff m-digit gaps bounded below"
     ],
     "axiomCount": 5,
-    "lineCount": 424,
+    "lineCount": 425,
     "assumptions": "5 axioms: qSequence, pisot_no_gap_property, gap_universal_bound, qSequenceM, bugeaud_characterization. 0 sorries.",
     "theoremCount": 14,
     "definitionCount": 9
@@ -164,7 +164,7 @@
       "Real"
     ],
     "namespace": "Erdos1096",
-    "lineCount": 424,
+    "lineCount": 425,
     "axiomCount": 5,
     "theoremCount": 14,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` for `Proofs/Erdos1096Problem.lean` in `src/data/proofs/erdos-1096/meta.json`. Both `meta.lineCount` and `leanFile.lineCount` claimed `424`, but the canonical value (`content.split('\n').length` per `scripts/research/enrich-research.ts:174`) is `425`.

## Evidence

**Before**:
- `src/data/proofs/erdos-1096/meta.json` `meta.lineCount = 424`
- `src/data/proofs/erdos-1096/meta.json` `leanFile.lineCount = 424`

**After**: Both fields are `425`.

The sibling research JSON `src/data/research/problems/erdos-1096-oq-01.json` already has `lineCount: 425` (line 86) and is left untouched. Other counts (theoremCount=14, axiomCount=5, definitionCount=9, sorries=0) already match the actual Lean file.

---
Automated fix by lean-mechanic agent.