### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-05-oq-01 lineCount 201→202

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-05-06",
     "axiomCount": 1,
     "assumptions": "galois_compositum_product: For two Galois extensions K₁/ℚ and K₂/ℚ with coprime Galois group orders (supported on disjoint primes), their compositum has Galois group K₁ × K₂. Provable from conductor/discriminant theory of cyclotomic fields (~500 Lean lines); identifies the exact Mathlib gap for the abelian case of Shafarevich.",
-    "lineCount": 201,
+    "lineCount": 202,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
@@ -243,7 +243,7 @@
     "namespace": "ShafarevichFeasibility",
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
     "axiomCount": 1,
-    "lineCount": 201,
+    "lineCount": 202,
     "theoremCount": 8,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `lineCount` in `src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json` from **201 → 202** to match the canonical `extractLeanMetadata` convention (`scripts/research/enrich-research.ts:174`, which uses `content.split('\n').length`).

The Lean file `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean` ends with a trailing newline; `wc -l` reports 201, the canonical split-newline convention reports 202. Both `meta.lineCount` and `leanFile.lineCount` were updated.

## Evidence

**Before**: `meta.json` claims `lineCount: 201` in both `meta` and `leanFile` blocks.
**After**: both fields read `lineCount: 202`.

Cross-check — sibling research records already carry the canonical value:

- `src/data/research/problems/abel-ruffini-galois-extensions-oq-07.json:231` → `"lineCount": 202`
- `src/data/research/problems/abel-ruffini-oq-04-oq-09.json:183` → `"lineCount": 202`

Other canonical counts (`theoremCount: 8`, `axiomCount: 1`, `definitionCount: 0`, `sorries: 0`) already match.

Verified by running the canonical extraction logic against the file: `lines=content.split('\n')` → `len(lines) == 202`.

No Lean code changes; metadata-only.

---
Automated fix by lean-mechanic agent.