### PR TITLE
fix(meta): area-of-circle-oq-05-oq-01 sorries 2→0 align with leanFile + assumptions text

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05-oq-01/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/AreaOfCircleOQ05OQ01.lean",
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "Main file (AreaOfCircleOQ05OQ01.lean): 0 sorries, 0 axioms — all 10 theorems including polar_integral_factorization fully proved via Measure.restrict_prod_eq_prod_restrict + integral_prod + Integrable.comp_fst. Aristotle companion (AreaOfCircleOQ05OQ01Aristotle.lean): 2 open sorries — gaussian_product_integrable and radial_product_integrable (both routine product-measure integrability lemmas, proved inline in the main file but exposed as separate Aristotle targets).",
     "originalContributions": [
@@ -153,5 +153,5 @@
       "Connect to a formal statement that \u03c0 = area of unit disk via this polar decomposition"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align top-level `sorries` and `meta.sorries` in `src/data/proofs/area-of-circle-oq-05-oq-01/meta.json` with the main file's actual sorry count (0), matching the existing `leanFile.sorries: 0` and the assumptions text.

## Evidence

**Before**: top-level `sorries: 2`, `meta.sorries: 2`
**After**: top-level `sorries: 0`, `meta.sorries: 0`

- `leanFile.sorries` already correctly set to 0 (source of truth for main file)
- `meta.assumptions` already states: *"Main file (AreaOfCircleOQ05OQ01.lean): 0 sorries, 0 axioms"*
- Raw `\bsorry\b` scan of `proofs/Proofs/AreaOfCircleOQ05OQ01.lean`: **0 matches**

## Convention

Per #20077 (burnside-counting-oq-03 sorries 4→0): top-level and `meta.sorries` mirror the main `leanFile.sorries`, excluding sorries inside `additionalFiles` such as the Aristotle companion. The companion file `AreaOfCircleOQ05OQ01Aristotle.lean` legitimately has 2 routine target sorries (`gaussian_product_integrable`, `radial_product_integrable`) — these are expected Aristotle targets, unrelated to main proof status, and accurately described in the assumptions text.

Status/badge left untouched.

---
Automated fix by lean-mechanic agent.