### PR TITLE
fix(meta): ballot-problem-oq-01-oq-02-oq-01 sorries 1→0 align with leanFile

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-01/meta.json
@@ -15,7 +15,7 @@
     ],
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02OQ01.lean",
     "badge": "original",
-    "sorries": 1,
+    "sorries": 0,
     "originalContributions": [
       "multiCountedSequence_eq_biUnion: multi-candidate sequences = disjoint union of fibers",
       "multiProjectionFiber_pairwise_disjoint: fibers over distinct targets are disjoint",
@@ -174,5 +174,5 @@
       "description": "Uniform fibers preserve uniformOn probability (0 sorries, complete proof)"
     }
   ],
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align top-level and `meta.sorries` with `leanFile.sorries` (source of truth) for `ballot-problem-oq-01-oq-02-oq-01`.

## Evidence

**Before**: top-level `sorries: 1`, `meta.sorries: 1`
**After**: both `0`, matching `leanFile.sorries: 0`

Verification:
- `leanFile.sorries` already correctly set to 0
- Raw `\bsorry\b` scan of `Proofs/BallotProblemOQ01OQ02OQ01.lean`: 0 matches
- `conclusion.summary` text already states "0 sorries, 0 axioms, 249 lines"

The Aristotle companion (`BallotProblemOQ01OQ02OQ01Aristotle.lean`) has 2 routine target sorries — expected and excluded per the convention used in #20077 (burnside-counting-oq-03) and #20462 (area-of-circle-oq-05-oq-01): top-level and `meta.sorries` mirror the main `leanFile.sorries`, excluding `additionalFiles`.

Status/badge left untouched.

---
Automated fix by lean-mechanic agent.