### PR TITLE
fix(meta): fourier-series-oq-02-oq-03-oq-02 sorries 8→2 align with leanFile

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json
@@ -17,7 +17,7 @@
       "sharp-constants"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 2,
     "axiomCount": 3,
     "theoremCount": 11,
     "lineCount": 427,
@@ -239,5 +239,5 @@
       "description": "Exponential Fourier decay for strip-analytic periodic functions"
     }
   ],
-  "sorries": 8
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/fourier-series-oq-02-oq-03-oq-02/meta.json` reported `sorries: 8` at both the top-level and nested `meta.sorries` fields, but the source Lean file (`proofs/Proofs/FourierSeriesOQ02OQ03OQ02.lean`) contains only 2 `sorry` placeholders. The computed `leanFile.sorries: 2` was already correct — only the two summary counts were stale.

## Evidence

**Before**: `sorries: 8` (top-level and `meta.sorries`)
**After**: `sorries: 2` (matches `leanFile.sorries`, matches actual Lean file sorry count = 2)

Actual sorries (verified with grep on the Lean source):
- Line 335: `sorry -- Standard: exponential decays faster than any polynomial`
- Line 347: `sorry -- Exponential decay beats any polynomial weight`

The `assumptions` text already correctly states "Plus 2 sorry lemmas for structural results". No code changes; metadata-only sync.

---
Automated fix by lean-mechanic agent.