### PR TITLE
fix(meta): shannon-entropy-oq-03 sorries 3->0 align with leanFile

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-03/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-03/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/ShannonEntropySSA.lean",
     "badge": "original",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. All theorems proved from Mathlib primitives. Strong subadditivity proved via conditional KL divergence ≥ 0 (kl_term_bound applied to the conditional independence distribution q(x,y,z) = pXY(x,y)·pYZ(y,z)/pY(y)).",
     "mathlibDependencies": [
@@ -215,5 +215,5 @@
       "leanType": "shannonEntropy' pXYZ + shannonEntropy' (marginalY_3 pXYZ) ≤ shannonEntropy' (marginalXY pXYZ) + shannonEntropy' (marginalYZ pXYZ)"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align top-level `sorries` and `meta.sorries` in `src/data/proofs/shannon-entropy-oq-03/meta.json` with the main file's actual sorry count (0), matching the existing `leanFile.sorries: 0` and the assumptions text.

## Evidence

**Before**: top-level `sorries: 3`, `meta.sorries: 3`
**After**: top-level `sorries: 0`, `meta.sorries: 0`

- `leanFile.sorries` already correctly set to 0 (source of truth for main file)
- `meta.assumptions` already states: *"None. All theorems proved from Mathlib primitives..."*
- Raw `sorry` scan of `proofs/Proofs/ShannonEntropySSA.lean`: **0 matches**

## Convention

Per #20077 (burnside-counting-oq-03 sorries 4->0): top-level and `meta.sorries` mirror the main `leanFile.sorries`, excluding sorries inside `additionalFiles` such as the Aristotle companion. The companion file `ShannonEntropySSAAristotle.lean` has 3 routine target sorries -- these are expected Aristotle targets, unrelated to main proof status.

Status/badge left untouched.

---
Automated fix by lean-mechanic agent.