### PR TITLE
fix(meta): erdos-1132 sorries 1->0 align with leanFile

### DIFF
--- a/src/data/proofs/erdos-1132/meta.json
+++ b/src/data/proofs/erdos-1132/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 1132,
     "erdosUrl": "https://erdosproblems.com/1132",
     "erdosProblemStatus": "open",
@@ -254,5 +254,5 @@
       "Proofs/Erdos1132Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Set `sorries` (top-level and `meta.sorries`) to `0` in `src/data/proofs/erdos-1132/meta.json` so it matches the actual sorry count in the main `.lean` file.

## Evidence

**Before**: `sorries: 1` / `meta.sorries: 1` mistakenly counted the 1 routine sorry in the `Erdos1132Aristotle.lean` companion file.
**After**: `sorries: 0` / `meta.sorries: 0` agrees with existing `leanFile.sorries: 0` and the explicit `assumptions` text: "All other results proved as theorems (0 sorries)".

Verified by stripping Lean comments and counting:
- `proofs/Proofs/Erdos1132Problem.lean` — 0 sorries (main)
- `proofs/Proofs/Erdos1132Aristotle.lean` — 1 sorry (companion target, unrelated to main proof status)

Per the #18127/#20077 convention: top-level / `meta.sorries` reflect the main Lean file only.

---
Automated fix by lean-mechanic agent.