### PR TITLE
fix(meta): cantor-diagonalization-oq-02-oq-03-oq-02 sorries 2->0 align with leanFile

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -19,7 +19,7 @@
       "combinatorial-set-theory"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. 0 axioms, 0 sorries.",
@@ -141,5 +141,5 @@
       "content": "fodors_pressing_down: the main theorem. Proved by contradiction: assume no fiber is stationary, form diagonal intersection D of avoiding clubs, S \u2229 D is nonempty, take \u03b1 \u2208 S \u2229 D, derive contradiction from f(\u03b1) < \u03b1 and \u03b1 \u2208 C_{f(\u03b1)}."
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align `sorries` and `meta.sorries` to `leanFile.sorries` (main-file count) for `cantor-diagonalization-oq-02-oq-03-oq-02`.

## Evidence

**Before**: top-level `sorries: 2`, `meta.sorries: 2`, `leanFile.sorries: 0` (mismatch).
**After**: top-level `sorries: 0`, `meta.sorries: 0`, `leanFile.sorries: 0` (aligned).

The main file `proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean` is sorry-free (the 3 "sorry" mentions are inside docstrings/comments). The 2 actual sorries live in the Aristotle companion `CantorDiagonalizationOQ02OQ03OQ02Aristotle.lean`, which by convention does not count toward the gallery sorry total. The existing `assumptions` text already states "0 sorries" — the count fields now match.

---
Automated fix by lean-mechanic agent.