### PR TITLE
fix(meta): fourier-series-oq-02-incomplete-01 sorries 5->0

### DIFF
--- a/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json
@@ -48,7 +48,7 @@
       "infrastructure"
     ],
     "badge": "original",
-    "sorries": 5,
+    "sorries": 0,
     "dateAdded": "2026-04-05",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -179,5 +179,5 @@
       "url": "https://en.wikipedia.org/wiki/Harmonic_analysis"
     }
   ],
-  "sorries": 5
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` and top-level `sorries` (5 → 0) with `leanFile.sorries: 0` in `src/data/proofs/fourier-series-oq-02-incomplete-01/meta.json`.

## Evidence

**Before**: `meta.sorries = 5`, top-level `sorries = 5`, but `leanFile.sorries = 0` and `assumptions: "0 axioms, 0 sorries. All theorems fully proved..."`

**After**: All three sorries fields consistent at `0`.

Verified `proofs/Proofs/FourierSeriesOQ02Incomplete01.lean` contains 0 actual `sorry` tactics. The one "sorry" string match in the file is a comment reference to a sorry in a sibling proof (`FourierSeriesOQ02.lean`).

Scope: count alignment only. `status: "formalized"` and `badge: "original"` left unchanged.

---
Automated fix by lean-mechanic agent.