### PR TITLE
fix(meta): central-limit-theorem-oq-02 sorries 6->3

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-02/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-02/meta.json
@@ -19,7 +19,7 @@
       "dependent-variables"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "dateAdded": "2026-04-02",
     "axiomCount": 1,
     "assumptions": "1 axiom: martingale_clt (McLeish 1974, Brown 1971) \u2014 the martingale CLT itself, stating that MDA satisfying Lindeberg condition and conditional variance convergence has row sums converging in distribution to Gaussian. Requires characteristic function methods and deep martingale theory not yet formalized in Mathlib. 3 sorries: (1) nested ciSup of zeros = 0 for independent sequences, (2) i.i.d. Lindeberg condition via dominated convergence for truncated moments, (3) i.i.d. Lyapunov condition via rpow moment decay.",
@@ -169,5 +169,5 @@
       "mathContext": "$(X_1+\\cdots+X_n)/\\sqrt{n} \\xrightarrow{d} N(0,\\sigma^2)$; sorry: $\\mathbb{E}[X^2 \\cdot \\mathbf{1}_{|X|>\\varepsilon\\sqrt{n}}] \\xrightarrow{\\text{DCT}} 0$; $\\Lambda_n(\\delta) = \\mathbb{E}[|X|^{2+\\delta}]/n^{\\delta/2} \\to 0$"
     }
   ],
-  "sorries": 6
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Align top-level `sorries` (and `meta.sorries`) with the actual sorry count in `Proofs/CentralLimitTheoremOQ02.lean`.

## Evidence

**Before**: `meta.sorries = 6`, `sorries = 6`
**After**: `meta.sorries = 3`, `sorries = 3`

- `leanFile.sorries` already reports 3 (canonical mechanic count).
- Actual sorry tactic count in `proofs/Proofs/CentralLimitTheoremOQ02.lean` is 3:
  - line 499 (`sorry`)
  - line 532 (`sorry -- requires dominated convergence...`)
  - line 549 (`sorry -- requires moment computation + rpow decay`)
  - line 699 contains the word `sorry` inside a `/- ... -/` Part XI summary block (not a tactic).
- `description`, `meta.assumptions`, and `conclusion.summary` already state "3 sorries" — only the two numeric fields were stale.

No code changes; metadata only.

---
Automated fix by lean-mechanic agent.