### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-02 lineCount 285->286

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
       "Basic real arithmetic (division by 3, ordering)",
       "Monotonicity and antitone sequences"
     ],
-    "lineCount": 285,
+    "lineCount": 286,
     "relatedProblems": [
       {
         "id": "algebraic-numbers-countable-oq-02",
@@ -208,7 +208,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 285,
+    "lineCount": 286,
     "namespace": "CantorNestedIntervals",
     "opens": [],
     "structureCount": 0,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `algebraic-numbers-countable-oq-02-oq-02` with the canonical split-newline count of its referenced Lean source.

## Evidence

**Before**: `meta.lineCount = 285`, `leanFile.lineCount = 285`
**After**: `meta.lineCount = 286`, `leanFile.lineCount = 286`

- `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean` reports `wc -l` = 285 (trailing-newline content lines).
- Canonical split-newline count (`content.split('\n').length`) = 286.
- Convention matches recent mechanic syncs (e.g. #20453, #20454, #20459, #20460).

No Lean code changes; metadata only.

---
Automated fix by lean-mechanic agent.