### PR TITLE
fix(meta): lhopital-oq-02 sorries 3→0 align with leanFile + assumptions text

### DIFF
--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -140,7 +140,7 @@
       "targetId": "lhopital"
     }
   ],
-  "sorries": 3,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib.Analysis.Calculus.LHopital",

--- a/src/data/proofs/lhopital-oq-02/meta.json
+++ b/src/data/proofs/lhopital-oq-02/meta.json
@@ -17,7 +17,7 @@
       "indeterminate-forms"
     ],
     "badge": "original",
-    "sorries": 3,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "HasDerivAt.lhopital_zero_right_on_Ioo",


### PR DESCRIPTION
## Fix

Update `src/data/proofs/lhopital-oq-02/meta.json` `sorries` field from 3 to 0 to match the Lean source file.

## Evidence

**Before**: `meta.json` declared `"sorries": 3`, while the existing `assumptions` field already stated *"0 axioms, 0 sorries. All 4 variants fully proved: right approach via Cauchy MVT, left via negation, atTop via inversion, atBot via negation of atTop."*

**After**: `"sorries": 0`, consistent with the source and the assumptions text.

Verification:
```
$ grep -c "sorry" proofs/Proofs/LHopitalOQ02.lean
0
$ grep -c "^axiom " proofs/Proofs/LHopitalOQ02.lean
0
```

`pnpm build` succeeds (exit 0, built in 3m 9s).

Minimal, single-field metadata fix; no Lean code changes.

---
Automated fix by lean-mechanic agent.