### PR TITLE
fix(meta): abel-ruffini-oq-10 lineCount 369->370

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-10/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-10/meta.json
@@ -24,7 +24,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 2,
     "assumptions": "chebotarev_density: For a Galois extension L/ℚ with group G and conjugacy class C ⊆ G, the natural density of primes with Frobenius in C is |C|/|G|. Chebotarev (1922). Proof requires Dedekind domain theory, Frobenius elements, and L-function analytic continuation — not in Mathlib. | dirichlet_density: For gcd(a,n)=1, primes p ≡ a (mod n) have density 1/φ(n). Dirichlet (1837). Provable from chebotarev_density via cyclotomic fields; stated separately for clarity.",
-    "lineCount": 369,
+    "lineCount": 370,
     "theoremCount": 23,
     "definitionCount": 1,
     "originalContributions": [
@@ -289,7 +289,7 @@
     ],
     "opens": ["AbelRuffiniGaloisExtensions", "Finset"],
     "namespace": "AbelRuffiniOQ10",
-    "lineCount": 369,
+    "lineCount": 370,
     "axiomCount": 2,
     "theoremCount": 23,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-oq-10` with the canonical split-newline count of its referenced Lean source.

## Evidence

**Before**: `meta.lineCount = 369`, `leanFile.lineCount = 369`
**After**: `meta.lineCount = 370`, `leanFile.lineCount = 370`

- `proofs/Proofs/AbelRuffiniOQ10.lean` ends with a trailing newline.
- `wc -l` reports 369 lines.
- Canonical split-newline count (`content.split('\n').length` per `scripts/research/enrich-research.ts:174`) is 370.
- All other counts (`theoremCount: 23`, `axiomCount: 2`, `definitionCount: 1`, `sorries: 0`) already match the actual file.

Convention matches recent mechanic syncs (e.g. #20461, #20470).

No Lean code changes; metadata-only.

---
Automated fix by lean-mechanic agent.