### PR TITLE
fix(meta): erdos-160 sorries 4→2 align with leanFile + assumptions text

### DIFF
--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -12,7 +12,7 @@
     "erdosUrl": "https://erdosproblems.com/160",
     "erdosProblemStatus": "open",
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "tags": [
       "erdos",
       "additive-combinatorics",
@@ -181,5 +181,5 @@
       "note": "Survey of rainbow-free colorings and anti-Ramsey problems in arithmetic settings"
     }
   ],
-  "sorries": 4
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Top-level `sorries` and `meta.sorries` claimed 4, but only 2 sorries exist in the main proof file.

## Evidence

**Before**: `meta.sorries: 4`, top-level `sorries: 4`
**After**: `meta.sorries: 2`, top-level `sorries: 2`

- `leanFile.sorries` already correctly set to 2 (source of truth)
- `meta.assumptions` text states "2 sorries (h_sublinear, h_superlog)"
- Raw `\bsorry\b` scan of `Proofs/Erdos160Problem.lean`: 2 matches (lines 213, 220)

Convention (per #20077): top-level and `meta.sorries` mirror the main
`leanFile.sorries`, excluding sorries inside `additionalFiles` such as
the Aristotle companion (`Erdos160ProblemAristotle.lean`, which has 2
routine target sorries — expected and unrelated to main proof status).

Status/badge `axiomatized/axiom` left untouched: the 3 axioms encode the
known bounds for h(N) (upper_bound_two_thirds, upper_bound_hunter,
lower_bound_exp), and the 2 remaining sorries are routine analytic
bridges (h_sublinear, h_superlog) — consistent with the stated "open"
Erdős problem status.

---
Automated fix by lean-mechanic agent.