### PR TITLE
fix(meta): erdos-632 sorries 10→5 align with leanFile + assumptions text

### DIFF
--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 10,
+    "sorries": 5,
     "erdosNumber": 632,
     "erdosUrl": "https://erdosproblems.com/632",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

Align `meta.sorries` for `erdos-632` with the actual Lean source. Field claimed `10`, but `Proofs/Erdos632Problem.lean` contains exactly 5 bare `sorry`s.

## Evidence

**Before**: `"sorries": 10`
**After**: `"sorries": 5`

Verification (in repo root):
```
$ grep -n "sorry" proofs/Proofs/Erdos632Problem.lean
94:  sorry
105:  sorry
110:  sorry
115:  sorry
120:  sorry
```

The `assumptions` text already correctly read "1 axiom … 5 sorries (supporting conjectures on ERT for intermediate parameter values)" — only the numeric `sorries` field disagreed.

No code change. Single-file metadata diff.

---
Automated fix by lean-mechanic agent.