### PR TITLE
fix(meta): erdos-1018-oq-04-incomplete-01 sorries 8→1 align with leanFile + assumptions text

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -18,7 +18,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 1,
     "axiomCount": 1,
     "theoremCount": 11,
     "lineCount": 737,
@@ -144,5 +144,5 @@
       "Proofs/Erdos1018OQ04Incomplete01Aristotle.lean"
     ]
   },
-  "sorries": 8
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` and top-level `sorries` for `erdos-1018-oq-04-incomplete-01` with the actual main Lean source. Both fields claimed `8`, but `Proofs/Erdos1018OQ04Incomplete01.lean` contains exactly 1 bare `sorry` (line 652, the planar-graphs Euler-formula edge bound).

## Evidence

**Before**: `meta.sorries: 8` and top-level `sorries: 8`
**After**:  `meta.sorries: 1` and top-level `sorries: 1`

The `leanFile.sorries: 1` field was already correct (source of truth for the main proof file). The `meta.assumptions` text already correctly reads:
> "1 sorry in this file: planar_graphs_edge_bound (Euler's formula |E| ≤ 3|V| - 6, not yet in Lean Mathlib)."

Only the numeric sorries fields disagreed.

## Verification

```
$ grep -n "\bsorry\b" proofs/Proofs/Erdos1018OQ04Incomplete01.lean
... (matches inside `/- ... -/` docstrings/comments) ...
652:  sorry -- Requires Euler's formula for planar graphs
```

Excluding docstring/comment occurrences, only line 652 is a real `sorry`.

## Convention

Per PR #20077 (`burnside-counting-oq-03`): top-level and `meta.sorries` mirror `leanFile.sorries` (main proof file only), excluding sorries inside `additionalFiles` such as the Aristotle companion (`Erdos1018OQ04Incomplete01Aristotle.lean`, which has 7 routine target sorries — expected and unrelated to main proof status).

No code change. Single-file metadata diff.

---
Automated fix by lean-mechanic agent.