### PR TITLE
Fix: erdos-1196 sorries 2→0 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-1196/meta.json
+++ b/src/data/proofs/erdos-1196/meta.json
@@ -19,7 +19,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 2,
+    "sorries": 0,
     "erdosNumber": 1196,
     "erdosUrl": "https://erdosproblems.com/1196",
     "erdosProblemStatus": "proved",
@@ -69,7 +69,7 @@
     ],
     "axiomCount": 8,
     "lineCount": 363,
-    "assumptions": "8 axiom declarations and 1 sorry. Key axioms: vonMangoldt_sum_eq_log (standard identity), subMarkov_adjoint (novel Lemma 4), erdos_sarkozy_szemeredi_conjecture (main theorem), mertens_erdos_sum (Mertens-type), sourceMass_bound, primePower_distribution_estimate, vonMangoldt_tail_estimate (standard estimates), lichtman_primitive_set_theorem (Lichtman 2023).",
+    "assumptions": "8 axiom declarations and 0 sorries in the main file (Erdos1196Problem.lean). Key axioms: vonMangoldt_sum_eq_log (standard identity), subMarkov_adjoint (novel Lemma 4), erdos_sarkozy_szemeredi_conjecture (main theorem), mertens_erdos_sum (Mertens-type), sourceMass_bound, primePower_distribution_estimate, vonMangoldt_tail_estimate (standard estimates), lichtman_primitive_set_theorem (Lichtman 2023).",
     "prerequisites": [
       "Analytic number theory (von Mangoldt function, Mertens' theorem)",
       "Markov chain theory (transition kernels, sub-Markov property)",
@@ -216,5 +216,5 @@
       "Proofs/Erdos1196Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Top-level and meta `sorries` for `erdos-1196` should match the main file count.

## Evidence

**Before**:
- `sorries: 2` (top-level)
- `meta.sorries: 2`
- `assumptions: "8 axiom declarations and 1 sorry"`

**After**:
- `sorries: 0` (top-level)
- `meta.sorries: 0`
- `assumptions: "8 axiom declarations and 0 sorries in the main file (Erdos1196Problem.lean)"`

The main proof file `Erdos1196Problem.lean` has 0 sorries (8 axioms, verified via grep). The 2 sorries live in the Aristotle companion `Erdos1196Aristotle.lean` and don't belong in the top-level headline per the PR #20077 convention (already established for the `erdos-1018-oq-04-incomplete-01` fix in #20476). `leanFile.sorries: 0` was already correct.

---
Automated fix by lean-mechanic agent.