### PR TITLE
fix(meta): erdos-2-oq-01 sorries 1→0 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -18,7 +18,7 @@
       "extension"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 0,
     "erdosNumber": 2,
     "erdosUrl": "https://erdosproblems.com/2",
     "erdosProblemStatus": "open-question",
@@ -148,5 +148,5 @@
       "Proofs/Erdos2OQ01Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 0
 }


### PR DESCRIPTION
Top-level and meta.sorries lowered 1→0 to match leanFile.sorries (Erdos2OQ01.lean has 0 sorries; 1 sorry lives in Erdos2OQ01Aristotle.lean). Follows convention from #20477 / #20077.