### PR TITLE
fix(meta): fundamental-theorem-calculus-oq-02 sorries 3→0 align with leanFile

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-02/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusStokes.lean",
     "badge": "original",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries in main file. d^2=0 in 2D (Clairaut's theorem) now proved via ContDiff.contDiffAt.isSymmSndFDerivAt; Green's theorem in Stokes form proved via GreensTheoremOQ01.greens_theorem_concrete.",
     "mathlibDependencies": [
@@ -254,5 +254,5 @@
       "leanType": "Continuous f -> exists F, extDeriv1D F = f"
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Top-level and `meta.sorries` lowered 3 → 0 to match `leanFile.sorries`.

## Evidence

**Before**: top-level `sorries: 3`, `meta.sorries: 3`
**After**: both `sorries: 0`, matching `leanFile.sorries: 0`

- `FundamentalTheoremCalculusStokes.lean` has **0 sorries** (verified via `grep -c "sorry"`).
- `meta.assumptions` already states "0 axioms, 0 sorries in main file".
- Follows convention from #20478 / #20477 (top-level matches `leanFile.sorries`, not the Aristotle companion).

---
Automated fix by lean-mechanic agent.