### PR TITLE
fix(meta): erdos-240 sorries 3→2 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 2,
     "erdosNumber": 240,
     "erdosUrl": "https://erdosproblems.com/240",
     "erdosProblemStatus": "solved",
@@ -270,5 +270,5 @@
       "Proofs/Erdos240ProblemAristotle.lean"
     ]
   },
-  "sorries": 3
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Top-level and `meta.sorries` lowered 3→2 to align with `leanFile.sorries=2` (main file only) and the existing `assumptions` text.

## Evidence

`Erdos240Problem.lean` (main file) has 2 sorries (lines 174, 203). The 3rd sorry lives in the companion `Erdos240ProblemAristotle.lean`, which per convention does not count toward the top-level headline.

**Before**:
- `sorries: 3` (top-level)
- `meta.sorries: 3`
- `leanFile.sorries: 2`
- `assumptions: "3 axioms ... 2 sorries."`

**After**:
- `sorries: 2` (top-level)
- `meta.sorries: 2`
- `leanFile.sorries: 2` (unchanged)
- `assumptions` text already correct (2 sorries)

Follows convention from #20477 / #20479 / #20077.

---
Automated fix by lean-mechanic agent.