### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 sorries 10→1 (align with leanFile)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
     "badge": "wip",
-    "sorries": 10,
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 2225,
     "dateAdded": "2026-05-03",


### PR DESCRIPTION
## Fix

Align `meta.sorries` with actual Lean source: `10 → 1`.

## Evidence

**Before**: `meta.sorries: 10` (line 22) disagreed with `sorries: 1` (top-level, line 6) and `leanFile.sorries: 1` (line 221).

**After**: All three fields report 1, matching the single real sorry in `proofs/Proofs/BinaryGcdOQ03OQ02.lean` at line 1078 (`hgcdMatrix_row_output_le`). The other 9 grep hits for `sorry` in that file are inside `/- ... -/` comment blocks discussing the same sorry.

Verified clean by `npx tsx scripts/auditor/find-targets.ts --issues` (now reports 0 targets).

---
Automated fix by lean-mechanic agent.