### PR TITLE
fix(meta): sqrt2-plus-sqrt3-irrational-oq-03 sorries 3→0 (align with leanFile)

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json
@@ -16,7 +16,7 @@
       "square-roots"
     ],
     "badge": "mathlib",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-22",
     "axiomCount": 0,
     "assumptions": "None. Fully proved: 0 sorries, 0 axioms. Irreducibility is proved over \u2124[X] via case analysis, then transferred to \u211a[X] via Gauss's lemma (Mathlib's IsPrimitive.Int.irreducible_iff_irreducible_map_cast).",
@@ -129,5 +129,5 @@
       "summary": "adjoin_sqrt2_plus_sqrt3_finrank: [\u211a(\u221a2+\u221a3):\u211a]=4 via adjoin.finrank and natDegree computation. sqrt2_plus_sqrt3_irrational: fully proved by direct algebra \u2014 if \u221a2+\u221a3=q then (q\u00b2-5)/2=\u221a6, contradicting irrationality of \u221a6."
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

`src/data/proofs/sqrt2-plus-sqrt3-irrational-oq-03/meta.json` had stale sorry counts: both `meta.sorries` (line 19) and the top-level `sorries` (line 132) claimed 3, but the Lean file contains zero `sorry` tokens. `leanFile.sorries` already reported 0, and the `assumptions` text already said "0 sorries, 0 axioms" — only the numeric fields were stale.

## Evidence

**Before**:
```
"meta.sorries": 3
"sorries": 3            (top-level)
"leanFile.sorries": 0
"assumptions": "...Fully proved: 0 sorries, 0 axioms..."
```

**After**: both numeric fields set to 0.

`grep -nE '\bsorry\b' proofs/Proofs/Sqrt2PlusSqrt3IrrationalOQ03.lean` returns no matches.

## Scope

Two-line metadata fix. No Lean code, no status/badge/assumptions text changes.

---
Automated fix by lean-mechanic agent.