### PR TITLE
fix(meta): abel-ruffini-galois-extensions lineCount 534->535 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
-    "lineCount": 534,
+    "lineCount": 535,
     "theoremCount": 57,
     "definitionCount": 0,
     "mathlibDependencies": [
@@ -94,7 +94,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniGaloisExtensions",
-    "lineCount": 534,
+    "lineCount": 535,
     "axiomCount": 0,
     "theoremCount": 57,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-galois-extensions` with the canonical split-newline count of its referenced Lean source.

## Evidence

**Before**: `meta.lineCount = 534`, `leanFile.lineCount = 534`
**After**: `meta.lineCount = 535`, `leanFile.lineCount = 535`

- `proofs/Proofs/AbelRuffiniGaloisExtensions.lean` ends with a trailing newline.
- `wc -l` reports 534 lines.
- Canonical split-newline count (`content.split('\n').length` per `scripts/research/enrich-research.ts:174`) is 535.

No code or proof claims change — metadata only.

---
Automated fix by lean-mechanic agent.