### PR TITLE
fix(meta): batch sync CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean lineCount 187->188 in 33 cauchy-schwarz siblings

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-01.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -143,7 +143,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-01.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -146,7 +146,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02.json
@@ -136,7 +136,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01.json
@@ -86,7 +86,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01.json
@@ -167,7 +167,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-02.json
@@ -129,7 +129,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01.json
@@ -134,7 +134,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-02.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03-oq-01.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-03.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01.json
@@ -135,7 +135,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-01.json
@@ -103,7 +103,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02-oq-01.json
@@ -133,7 +133,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02-oq-02.json
@@ -144,7 +144,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-02.json
@@ -131,7 +131,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-03.json
@@ -130,7 +130,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-04.json
@@ -124,7 +124,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01-oq-01.json
@@ -176,7 +176,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-01.json
@@ -182,7 +182,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -169,7 +169,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-03.json
@@ -148,7 +148,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-04.json
@@ -191,7 +191,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01.json
@@ -158,7 +158,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-01.json
@@ -187,7 +187,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-01.json
@@ -154,7 +154,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03-oq-02.json
@@ -162,7 +162,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-03.json
@@ -155,7 +155,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04-oq-01.json
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,

--- a/src/data/research/problems/cauchy-schwarz-oq-04.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-04.json
@@ -174,7 +174,7 @@
     {
       "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
       "filename": "CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean",
-      "lineCount": 187,
+      "lineCount": 188,
       "theoremCount": 6,
       "axiomCount": 0,
       "defCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `leanFile.lineCount=187` to canonical `lineCount=188` across 33 cauchy-schwarz research problem JSONs that reference `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean`.

## Evidence

Canonical counter from `scripts/research/enrich-research.ts:174`:

```
content.split('\n').length = 188
```

Verified:

```
$ python3 -c "print(len(open('proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ02.lean').read().split('\n')))"
188
```

Per-file change:
- lineCount: 187 -> 188 (this fix)
- theoremCount: 6 (unchanged)
- axiomCount: 0 (unchanged)
- defCount: 4 (unchanged)
- sorryCount: 0 (unchanged)

All 33 sibling problem JSONs in src/data/research/problems/cauchy-schwarz-*.json had the same stale value.

---
Automated fix by lean-mechanic agent.