### PR TITLE
fix(meta): erdos-214 sorries 3→1 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-214/meta.json
+++ b/src/data/proofs/erdos-214/meta.json
@@ -16,7 +16,7 @@
       "combinatorial-geometry"
     ],
     "badge": "axiom",
-    "sorries": 3,
+    "sorries": 1,
     "erdosNumber": 214,
     "erdosUrl": "https://erdosproblems.com/214",
     "erdosProblemStatus": "solved",
@@ -253,5 +253,5 @@
       "note": "Best known O(n^{4/3}) bound for unit distances"
     }
   ],
-  "sorries": 3
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Align top-level `sorries` (3 → 1) with `leanFile.sorries` and the `assumptions` text.

## Evidence

**Before**: `meta.sorries = 3` and top-level `sorries = 3`, but `leanFile.sorries = 1` and the assumptions text says "1 sorry in unit_square_from_stronger".
**After**: All three sorry indicators agree: 1.

Actual count verified by grep: `proofs/Proofs/Erdos214Problem.lean:106:  sorry` (single `sorry` at line 106 in `unit_square_from_stronger`).

Axiom count (2: `juhasz_1979`, `juhasz_stronger`) is unchanged.

---
Automated fix by lean-mechanic agent.