### PR TITLE
fix(meta): erdos-679 sorries 11→10 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "wip",
-    "sorries": 11,
+    "sorries": 10,
     "erdosNumber": 679,
     "erdosUrl": "https://erdosproblems.com/679",
     "erdosProblemStatus": "open",
@@ -293,5 +293,5 @@
       "Proofs/Erdos679ProblemAristotle.lean"
     ]
   },
-  "sorries": 11
+  "sorries": 10
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` and top-level `sorries` for `erdos-679` with the actual sorry count in its referenced Lean source.

## Evidence

**Before**: `meta.sorries = 11`, top-level `sorries = 11`
**After**: `meta.sorries = 10`, top-level `sorries = 10`

- `proofs/Proofs/Erdos679Problem.lean` contains 10 `sorry` occurrences (`grep -c "sorry"` = 10).
- `leanFile.sorries` is already 10 (auto-generated from the source).
- Both meta-level fields were stale at 11.

Convention matches recent mechanic syncs (e.g. #20480, #20481, #20482).

No Lean code changes; metadata-only.

---
Automated fix by lean-mechanic agent.