### PR TITLE
fix(meta): newton-inductive-step-oq-01 sorries 2→1 (align with leanFile)

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-01/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-01/meta.json
@@ -19,7 +19,7 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 1,
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -192,5 +192,5 @@
       "Proofs/NewtonInductiveStepOQ01Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` and top-level `sorries` for `newton-inductive-step-oq-01` with the actual sorry count in its Lean source.

## Evidence

**Before**: `meta.sorries = 2`, top-level `sorries = 2`
**After**: `meta.sorries = 1`, top-level `sorries = 1`

- `proofs/Proofs/NewtonInductiveStepOQ01.lean` has exactly one `sorry` tactic (line 154).
- The other 4 occurrences of the word "sorry" are inside comments/docstrings (lines 479, 573, 579, 583).
- `leanFile.sorries` already reports 1 (auto-generated, accurate).
- Both meta-level fields were stale at 2.

Convention matches recent mechanic syncs (e.g. #20480, #20481, #20482, #20487).

No Lean code changes; metadata-only.

---
Automated fix by lean-mechanic agent.