### PR TITLE
fix(meta): erdos-415 sorries 16→14 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-415/meta.json
+++ b/src/data/proofs/erdos-415/meta.json
@@ -20,7 +20,7 @@
       "arithmetic-functions"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 14,
     "erdosNumber": 415,
     "erdosUrl": "https://erdosproblems.com/415",
     "erdosProblemStatus": "open",
@@ -284,5 +284,5 @@
       "description": "Related Erdős problem sharing themes: arithmetic-functions, number-theory, totient-function"
     }
   ],
-  "sorries": 16
+  "sorries": 14
 }


### PR DESCRIPTION
## Fix

Updates `sorries` field in `src/data/proofs/erdos-415/meta.json` from 16 → 14 to match the actual `sorry` count in `Proofs/Erdos415Problem.lean`.

## Evidence

**Before**: `meta.sorries: 16` and top-level `sorries: 16`
**After**: both = 14, matching `leanFile.sorries: 14` and the `assumptions` text ("1 axiom(s) and 14 sorry(s)")

Verified via tokenized count (block + line comments stripped) on `Proofs/Erdos415Problem.lean`: 14.

Metadata-only change.

---
Automated fix by lean-mechanic agent.