### PR TITLE
fix(meta): erdos-381 sorries 6→3 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-381/meta.json
+++ b/src/data/proofs/erdos-381/meta.json
@@ -18,7 +18,7 @@
       "disproved"
     ],
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 3,
     "erdosNumber": 381,
     "erdosUrl": "https://erdosproblems.com/381",
     "erdosProblemStatus": "disproved",
@@ -202,5 +202,5 @@
       "description": "Related Erdős problem sharing themes: divisor-functions, number-theory"
     }
   ],
-  "sorries": 6
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` and top-level `sorries` (both 6) with `leanFile.sorries` (3) and actual tactic count in `Proofs/Erdos381Problem.lean` (3, after stripping comments).

## Evidence

**Before**:
- `meta.sorries`: 6
- `sorries` (top-level): 6
- `leanFile.sorries`: 3
- Actual sorry tactic count in Lean file: 3
- `assumptions` text already states "3 sorries"

**After**: all three fields agree at 3, consistent with the Lean source and the human-written assumptions text.

Metadata-only change.

---
Automated fix by lean-mechanic agent.