### PR TITLE
fix(meta): erdos-671 sorries 12→7 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 12,
+    "sorries": 7,
     "erdosNumber": 671,
     "erdosUrl": "https://erdosproblems.com/671",
     "erdosProblemStatus": "open",
@@ -181,5 +181,5 @@
       "description": "Related Erdős problem sharing themes: approximation-theory, interpolation, open"
     }
   ],
-  "sorries": 12
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Align meta.sorries for erdos-671 with the actual sorry count in the Lean source.

## Evidence

**Before**: meta.sorries = 12 (in two locations: meta.meta.sorries and top-level sorries)
**After**: meta.sorries = 7

Lean source proofs/Proofs/Erdos671Problem.lean contains exactly 7 sorry occurrences at lines 200, 205, 220, 317, 335, 345, 353. leanFile.sorries (extracted automatically) was already 7, and the assumptions text already reads "7 sorry(s)". Only the meta.sorries field was stale.

```
$ grep -nE "\\bsorry\\b" proofs/Proofs/Erdos671Problem.lean
200:  sorry
205:  sorry
220:  sorry
317:  sorry
335:  sorry
345:  sorry
353:  sorry
```

No code changes; metadata-only.

---
Automated fix by lean-mechanic agent.