### PR TITLE
fix(meta): leibniz-pi-oq-02 sorries 14→9 (align with leanFile)

### DIFF
--- a/src/data/proofs/leibniz-pi-oq-02/meta.json
+++ b/src/data/proofs/leibniz-pi-oq-02/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/LeibnizPiOQ02.lean",
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 9,
     "mathlibDependencies": [
       {
         "theorem": "Real.tendsto_sum_pi_div_four",
@@ -209,5 +209,5 @@
       "leanType": "(s : ℝ) → s > 1 → tsum η = (1-2^{1-s}) * tsum ζ"
     }
   ],
-  "sorries": 14
+  "sorries": 9
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` (top-level and root) for `leibniz-pi-oq-02` with the actual Lean source sorry count.

## Evidence

**Before**: `meta.sorries: 14`, root `sorries: 14`
**After**: `meta.sorries: 9`, root `sorries: 9`

Lean source `proofs/Proofs/LeibnizPiOQ02.lean` has **9** sorries (verified via comment-stripped grep). The existing `leanFile.sorries: 9` and the `assumptions` text ("9 sorries for series convergence results") were already correct — only the top-level mirrors were stale.

---
Automated fix by lean-mechanic agent.