### PR TITLE
fix(meta): erdos-876 sorries 7->2 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-876/meta.json
+++ b/src/data/proofs/erdos-876/meta.json
@@ -17,7 +17,7 @@
       "partially-solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 2,
     "erdosNumber": 876,
     "erdosUrl": "https://erdosproblems.com/876",
     "erdosProblemStatus": "open",
@@ -189,5 +189,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, partially-solved"
     }
   ],
-  "sorries": 7
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

meta.json for erdos-876 declared sorries: 7 (both in meta.sorries and the top-level sorries), but the Lean file proofs/Proofs/Erdos876Problem.lean contains exactly **2** sorries (lines 76 and 206).

## Evidence

**Before**: meta.sorries = 7, top-level sorries = 7
**After**:  meta.sorries = 2, top-level sorries = 2

The leanFile.sorries field was already 2 and the assumptions text already read "1 axiom: graham_result. 2 sorries.", so this change brings the structured count into agreement with the rest of the metadata and the source file.

Verified by:

    grep -n "sorry" proofs/Proofs/Erdos876Problem.lean
    # 76:  sorry -- Technical: construct the witnessing subset
    # 206:  sorry

No Lean code changes; metadata-only.

---
Automated fix by lean-mechanic agent.