### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-01 lineCount 1498→1499 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -72,7 +72,7 @@
       "Solvable groups and the derived series"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 1498,
+    "lineCount": 1499,
     "relatedProblems": [
       {
         "id": "abel-ruffini-oq-04",
@@ -471,7 +471,7 @@
       "Polynomial"
     ],
     "namespace": "AbelRuffiniOQ04OQ01",
-    "lineCount": 1498,
+    "lineCount": 1499,
     "axiomCount": 0,
     "theoremCount": 64,
     "definitionCount": 15,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-oq-04-oq-01` with the canonical split-newline count used by `scripts/research/enrich-research.ts:174`.

## Evidence

- `wc -l proofs/Proofs/AbelRuffiniOQ04OQ01.lean` → `1498`
- `content.split('\n').length` (canonical) → `1499`
- File ends with a single trailing newline.

**Before**: `lineCount: 1498` in both `meta.lineCount` and `leanFile.lineCount`
**After**: `lineCount: 1499` in both fields

Convention matches recent mechanic syncs (e.g. #20486, #20473, #20483).

---
Automated fix by lean-mechanic agent.