### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02 lineCount 154→155 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 0,
-    "lineCount": 154,
+    "lineCount": 155,
     "assumptions": "0 axioms, 0 sorries. S₂ via CommGroup instance, S₃ via decide on derived series, S₄ via native_decide. Classification theorem combines with Mathlib's Equiv.Perm.not_solvable.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -196,7 +196,7 @@
       "Equiv"
     ],
     "namespace": "AbelRuffiniOQ04OQ02",
-    "lineCount": 154,
+    "lineCount": 155,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-oq-04-oq-02` with the canonical split-newline count used by `scripts/research/enrich-research.ts:174`.

## Evidence

- `wc -l proofs/Proofs/AbelRuffiniOQ04OQ02.lean` → `154`
- `content.split('\n').length` (canonical) → `155`
- File ends with a single trailing newline.

**Before**: `lineCount: 154` in both `meta.lineCount` and `leanFile.lineCount`
**After**: `lineCount: 155` in both fields

Convention matches recent mechanic syncs (e.g. #20494, #20486, #20473, #20483).

---
Automated fix by lean-mechanic agent.