### PR TITLE
fix(meta): abel-ruffini-oq-04 lineCount 163→164 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -48,7 +48,7 @@
       "Familiarity with Lean 4 and Mathlib"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 163,
+    "lineCount": 164,
     "relatedProblems": [
       {
         "id": "abel-ruffini",
@@ -261,7 +261,7 @@
     ],
     "opens": [],
     "namespace": "AbelRuffiniOQ04",
-    "lineCount": 163,
+    "lineCount": 164,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 2,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-oq-04` with the canonical split-newline count used by `scripts/research/enrich-research.ts:174`.

## Evidence

- `wc -l proofs/Proofs/AbelRuffiniOQ04.lean` → `163`
- `content.split('\n').length` (canonical) → `164`
- File ends with a single trailing newline.

**Before**: `lineCount: 163` in both `meta.lineCount` and `leanFile.lineCount`
**After**: `lineCount: 164` in both fields

Convention matches recent mechanic syncs (e.g. #20495, #20494, #20486, #20483).

---
Automated fix by lean-mechanic agent.