### PR TITLE
fix(meta): erdos-1161 lineCount 323→324 (canonical split-newline)

### DIFF
--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 323,
+    "lineCount": 324,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "theoremCount": 15,
     "definitionCount": 3
@@ -145,7 +145,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 323,
+    "lineCount": 324,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync `meta.json` `lineCount` for **erdos-1161** with the canonical value used by `scripts/research/enrich-research.ts` (`content.split('\n').length`).

## Evidence

`proofs/Proofs/Erdos1161Problem.lean` does not end with a trailing newline:
- `wc -l`: 323 (counts `\n` bytes)
- `content.split('\n').length`: **324** (canonical for `enrich-research.ts`)
- `content.splitlines().length`: 324

`meta.json` declared `lineCount: 323` in both occurrences (`meta.lineCount` and `leanFile.lineCount`). Both updated to **324**.

**Before**: `lineCount: 323`
**After**: `lineCount: 324`

No code changes; metadata-only fix.

---
Automated fix by lean-mechanic agent.