### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02-oq-02 lineCount 167->168 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -60,7 +60,7 @@
     ],
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
-    "lineCount": 167,
+    "lineCount": 168,
     "assumptions": "0 axioms, 0 sorries. Small cases via inferInstance and isSolvable_of_comm. Large cases via exact sequence: if A_n solvable then S_n solvable, but Mathlib's Equiv.Perm.not_solvable gives contradiction.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
@@ -205,7 +205,7 @@
       "Equiv"
     ],
     "namespace": "AbelRuffiniOQ04OQ02OQ02",
-    "lineCount": 167,
+    "lineCount": 168,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.json` `lineCount` for **abel-ruffini-oq-04-oq-02-oq-02** with the canonical value used by `scripts/research/enrich-research.ts:174` (`content.split('\n').length`).

## Evidence

`proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean` does not end with a trailing newline:
- `wc -l`: 167 (counts `\n` bytes)
- `content.split('\n').length`: **168** (canonical for `enrich-research.ts`)

`meta.json` declared `lineCount: 167` in both `meta.lineCount` and `leanFile.lineCount`. Both updated to **168**.

**Before**: `lineCount: 167`
**After**: `lineCount: 168`

Metadata-only fix; no code changes.

---
Automated fix by lean-mechanic agent.