### PR TITLE
fix(meta): circumference-via-differentiation-oq-01 lineCount 240->241 (canonical split-newline)

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 240,
+    "lineCount": 241,
     "theoremCount": 18,
     "definitionCount": 4,
     "assumptions": "None. All theorems proved from Mathlib's power rule, Gamma_add_one, and unitBallVolume infrastructure.",
@@ -172,7 +172,7 @@
   "leanFile": {
     "path": "Proofs/CircumferenceViaDifferentiationOQ01.lean",
     "filename": "CircumferenceViaDifferentiationOQ01.lean",
-    "lineCount": 240,
+    "lineCount": 241,
     "theoremCount": 18,
     "axiomCount": 0,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/circumference-via-differentiation-oq-01/meta.json` to the canonical value used by `scripts/research/enrich-research.ts:174` (`content.split('\n').length`).

## Evidence

- File: `proofs/Proofs/CircumferenceViaDifferentiationOQ01.lean`
- `wc -l` reports **240** (no trailing newline)
- Canonical counter `content.split('\n').length` reports **241**
- meta.json had `lineCount: 240` in both `meta.lineCount` and `leanFile.lineCount`

**Before**: `lineCount: 240` (matches `wc -l`)
**After**: `lineCount: 241` (matches canonical enricher convention)

No code changes; pure metadata sync. No mathematical claims affected.

---
Automated fix by lean-mechanic agent.