### PR TITLE
fix(meta): arithmetic-series lineCount 180->181

### DIFF
--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -41,7 +41,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
     "axiomCount": 0,
-    "lineCount": 180,
+    "lineCount": 181,
     "relatedProblems": [
       {
         "id": "arithmetic-series-oq-02",
@@ -146,7 +146,7 @@
       "BigOperators"
     ],
     "namespace": "ArithmeticSeries",
-    "lineCount": 180,
+    "lineCount": 181,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `arithmetic-series/meta.json` to the canonical value used by the enricher.

## Evidence

`scripts/research/enrich-research.ts:145,174` computes `lineCount` as `content.split('\n').length`. For `proofs/Proofs/ArithmeticSeries.lean`:

- `wc -l` reports **180** (counts trailing newlines, not lines)
- Canonical `content.split('\n').length` returns **181**

`meta.json` had two stale values (`meta.lineCount` and `leanFile.lineCount`) both set to 180. Updated both to 181 to match canonical enrichment output.

**Before**: `lineCount: 180` (stale)
**After**: `lineCount: 181` (matches enricher canonical)

---
Automated fix by lean-mechanic agent.