### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-07 lineCount 1898->1899 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1898,
+    "lineCount": 1899,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -271,7 +271,7 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1898,
+    "lineCount": 1899,
     "axiomCount": 1,
     "theoremCount": 38,
     "substantiveTheoremCount": 18,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` with the canonical split-newline count of `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (1899 lines).

## Evidence

**Before**: `lineCount: 1898` (both `meta.lineCount` and `leanFile.lineCount`)
**After**: `lineCount: 1899` (matches `content.split('\n').length` of the Lean source)

Canonical convention established by prior mechanic PRs (e.g. #20486, #20496, #20499, #20501).

---
Automated fix by lean-mechanic agent.