### PR TITLE
fix(meta): erdos-1018 sorries 7->22 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 22,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",
@@ -248,5 +248,5 @@
       "Proofs/Erdos1018Aristotle.lean"
     ]
   },
-  "sorries": 7
+  "sorries": 22
 }


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 7 total sorries for `erdos-1018`, but the actual total across the main file + Aristotle companion is 22.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/Erdos1018Problem.lean` | 7 |
| `proofs/Proofs/Erdos1018Aristotle.lean` | 15 |
| **Total** | **22** |

**Before**: `meta.meta.sorries: 7`, top-level `sorries: 7`
**After**:  `meta.meta.sorries: 22`, top-level `sorries: 22`

`leanFile.sorries` (7) for the main file remains correct. The `assumptions` text describes the main file's 7 sorries and is left untouched (matches convention used elsewhere, e.g. erdos-977).

---
Automated fix by lean-mechanic agent.