### PR TITLE
fix(meta): erdos-117-oq-01 sorries 1->14 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 1,
+    "sorries": 14,
     "axiomCount": 3,
     "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 1 sorry: base_implies_behavior (limit → exponential behavior, requires Tendsto with nhds ε-balls). limInf_ge_log_c1 now fully proved.",
     "erdosNumber": 117,
@@ -149,5 +149,5 @@
       "Proofs/Erdos117OQ01Aristotle.lean"
     ]
   },
-  "sorries": 1
+  "sorries": 14
 }


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 1 total sorry for `erdos-117-oq-01`, but the actual total across the main file + Aristotle companion is 14.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/Erdos117OQ01.lean` | 1 |
| `proofs/Proofs/Erdos117OQ01Aristotle.lean` | 13 |
| **Total** | **14** |

**Before**: `meta.meta.sorries: 1`, top-level `sorries: 1`
**After**:  `meta.meta.sorries: 14`, top-level `sorries: 14`

`leanFile.sorries` (1) for the main file remains correct. The `assumptions` text describes the main file's 1 sorry and is left untouched (matches convention from #20503 / erdos-1018).

---
Automated fix by lean-mechanic agent.