### PR TITLE
fix(meta): cayley-hamilton-reduction-oq-02-oq-01 sorries 0->12 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -16,7 +16,7 @@
       "rational-canonical-form"
     ],
     "badge": "original",
-    "sorries": 0,
+    "sorries": 12,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 0,
+  "sorries": 12,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 0 total sorries for `cayley-hamilton-reduction-oq-02-oq-01`, but the actual total across the main file + Aristotle companion is 12.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean` | 0 |
| `proofs/Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean` | 12 |
| **Total** | **12** |

**Before**: `meta.meta.sorries: 0`, top-level `sorries: 0`
**After**:  `meta.meta.sorries: 12`, top-level `sorries: 12`

`leanFile.sorries` (0) for the main file is correct and remains unchanged. The `assumptions` text correctly describes the main file's state ("0 axioms, 0 sorries") and is left untouched (matches convention used in similar fixes, e.g. erdos-1018, erdos-117-oq-01).

---
Automated fix by lean-mechanic agent.