### PR TITLE
fix(meta): erdos-553 sorries 17->15 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-553/meta.json
+++ b/src/data/proofs/erdos-553/meta.json
@@ -17,7 +17,7 @@
       "off-diagonal"
     ],
     "badge": "wip",
-    "sorries": 17,
+    "sorries": 15,
     "erdosNumber": 553,
     "erdosUrl": "https://erdosproblems.com/553",
     "erdosProblemStatus": "solved",
@@ -186,5 +186,5 @@
       "description": "Related Erdős problem sharing themes: graph-coloring, ramsey-theory"
     }
   ],
-  "sorries": 17
+  "sorries": 15
 }


### PR DESCRIPTION
## Fix

meta.json for erdos-553 declared sorries: 17 (both in meta.sorries and the top-level sorries), but the Lean file proofs/Proofs/Erdos553Problem.lean contains exactly **15** sorry tactics. leanFile.sorries already reports 15 and the assumptions field already reads "15 sorry(s) remain in the formalization."

## Evidence

**Before**: meta.sorries = 17, top-level sorries = 17
**After**:  meta.sorries = 15, top-level sorries = 15

Verified by:

    grep -nE "\bsorry\b" proofs/Proofs/Erdos553Problem.lean
    # 64, 83, 99, 104, 109, 113, 128, 137, 145, 155, 159, 163, 177, 181, 187 (15 lines)

No Lean code changes; metadata-only.

---
Automated fix by lean-mechanic agent.