### PR TITLE
fix(meta): erdos-548 sorries 9->6 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -17,7 +17,7 @@
       "erdos"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 6,
     "erdosNumber": 548,
     "erdosUrl": "https://erdosproblems.com/548",
     "erdosProblemStatus": "open",
@@ -183,5 +183,5 @@
       "description": "Related Erdős problem sharing themes: extremal-graph-theory, graph-theory"
     }
   ],
-  "sorries": 9
+  "sorries": 6
 }


### PR DESCRIPTION
## Fix

Correct top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-548/meta.json` from 9 to 6 so they match `leanFile.sorries` (which already reports the true count in `proofs/Proofs/Erdos548Problem.lean`).

## Evidence

```
$ grep -c -E '\bsorry\b' proofs/Proofs/Erdos548Problem.lean
6

$ jq '{top: .sorries, meta_sorries: .meta.sorries, leanFile_sorries: .leanFile.sorries}' src/data/proofs/erdos-548/meta.json
# before
{ "top": 9, "meta_sorries": 9, "leanFile_sorries": 6 }
# after
{ "top": 6, "meta_sorries": 6, "leanFile_sorries": 6 }
```

`assumptions` text already says `"9 axiom(s) and 6 sorries(s)"`, so no other field was out of sync.

---
Automated fix by lean-mechanic agent.