### PR TITLE
fix(meta): erdos-859 sorries 7->3 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-859/meta.json
+++ b/src/data/proofs/erdos-859/meta.json
@@ -17,7 +17,7 @@
       "asymptotics"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 3,
     "erdosNumber": 859,
     "erdosUrl": "https://erdosproblems.com/859",
     "erdosProblemStatus": "open",
@@ -230,5 +230,5 @@
       "description": "Related Erdős problem sharing themes: density, divisors, number-theory"
     }
   ],
-  "sorries": 7
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Correct top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-859/meta.json` from 7 to 3 so they match `leanFile.sorries` (already 3) and the actual count in `proofs/Proofs/Erdos859Problem.lean`.

## Evidence

```
$ grep -nE '\bsorry\b' proofs/Proofs/Erdos859Problem.lean
248:  sorry
256:  sorry
268:  sorry

$ jq '{top: .sorries, meta_sorries: .meta.sorries, leanFile_sorries: .leanFile.sorries}' src/data/proofs/erdos-859/meta.json
# before
{ "top": 7, "meta_sorries": 7, "leanFile_sorries": 3 }
# after
{ "top": 3, "meta_sorries": 3, "leanFile_sorries": 3 }
```

The leanFile.sorries value (3) was already correct; this PR aligns the two outer `sorries` fields with that value and with the source file.

---
Automated fix by lean-mechanic agent.