### PR TITLE
fix(meta): erdos-454 sorries 5->3 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-454/meta.json
+++ b/src/data/proofs/erdos-454/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 454,
     "erdosUrl": "https://erdosproblems.com/454",
     "erdosProblemStatus": "open",
@@ -300,5 +300,5 @@
       "description": "Both concern the fine distribution of primes beyond PNT: bounded prime gaps (Maynard-Tao) shows primes cluster more than average, while #454 studies how prime sums deviate from their expected values — complementary perspectives on prime irregularity"
     }
   ],
-  "sorries": 5
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Correct top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-454/meta.json` from 5 to 3 so they match `leanFile.sorries` (already 3) and the actual count in `proofs/Proofs/Erdos454Problem.lean`.

## Evidence

```
$ grep -nE '\bsorry\b' proofs/Proofs/Erdos454Problem.lean
234:  sorry
243:  sorry
252:  sorry

$ jq '{top: .sorries, meta_sorries: .meta.sorries, leanFile_sorries: .leanFile.sorries}' src/data/proofs/erdos-454/meta.json
# before
{ "top": 5, "meta_sorries": 5, "leanFile_sorries": 3 }
# after
{ "top": 3, "meta_sorries": 3, "leanFile_sorries": 3 }
```

The leanFile.sorries value (3) was already correct; this PR aligns the two outer sorries fields with that value and with the source file.

---
Automated fix by lean-mechanic agent.