### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-02 sorries 3→0 (align with leanFile)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -23,7 +23,7 @@
       "representation-theory"
     ],
     "badge": "wip",
-    "sorries": 3,
+    "sorries": 0,
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "3 open sorries (aggregate across additionalFiles): gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners) + 2 in BallotProblemOQ03OQ01OQ02Aristotle.lean. Axiom-free; all axiom declarations are 0.",
@@ -220,5 +220,5 @@
       "mathContext": "$h(\\mu,i,j) = h(\\mu^\\top,j,i)$ (arm↔leg under transpose). For N-row shapes: hook walk identity $\\sum_c \\text{hookProd}(\\mu)/\\text{hookProd}(\\mu\\setminus c) = \\sum_i a_i$ is a polynomial identity in $a_1,\\ldots,a_N$, verifiable by `ring` after computing each hook length as a linear combination of $a_i$."
     }
   ],
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Set top-level `sorries` and `meta.sorries` from `3` to `0` in `src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json` so they agree with the actual sorry count in the main `.lean` file.

## Evidence

**Before**: `sorries: 3` / `meta.sorries: 3` (aggregated sorries across `additionalFiles`).
**After**: `sorries: 0` / `meta.sorries: 0` — matches existing `leanFile.sorries: 0` and main-file convention.

Verified by stripping Lean comments and counting `\bsorry\b`:
- `proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean` — **0 sorries** (main; 7 raw matches all in doc comments)
- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Helpers.lean` — 1 sorry (`gnwProb_key`)
- `proofs/Proofs/BallotProblemOQ03OQ01OQ02Aristotle.lean` — 2 sorries (companion targets)

Per the #20466 / #18127 convention: top-level / `meta.sorries` reflect the main Lean file only; the aggregate breakdown remains described in the `assumptions` field, which is unchanged.

---
Automated fix by lean-mechanic agent.