### PR TITLE
fix(meta): inverse-galois-oq-02 sorries 6→16 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
     "badge": "axiom",
-    "sorries": 6,
+    "sorries": 16,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",
@@ -150,7 +150,7 @@
       "description": "Sister entry proving the solvability divide (S_n solvable iff n ≤ 4) and A₅ analysis"
     }
   ],
-  "sorries": 6,
+  "sorries": 16,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ02.lean",
     "lineCount": 388,


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 6 total sorries for `inverse-galois-oq-02`, but the actual total across the main file + Aristotle companion is 16.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/InverseGaloisOQ02.lean` | 6 |
| `proofs/Proofs/InverseGaloisOQ02Aristotle.lean` | 10 |
| **Total** | **16** |

**Before**: `meta.meta.sorries: 6`, top-level `sorries: 6`
**After**:  `meta.meta.sorries: 16`, top-level `sorries: 16`

`leanFile.sorries` (6) for the main file remains correct. The `assumptions` text describes the main file's 6 sorries and is left untouched (matches convention used in PR #20503 for erdos-1018).

---
Automated fix by lean-mechanic agent.