### PR TITLE
fix(meta): erdos-611 sorries 16->13 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -18,7 +18,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 13,
     "erdosNumber": 611,
     "erdosUrl": "https://erdosproblems.com/611",
     "erdosProblemStatus": "open",
@@ -275,5 +275,5 @@
       "note": "Uses probabilistic techniques for graph structure under clique constraints; the Bollobás-Erdős threshold result in #611 employs similar random graph methodology."
     }
   ],
-  "sorries": 16
+  "sorries": 13
 }


### PR DESCRIPTION
## Fix

Sync top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-611/meta.json` from `16 → 13` to match the auto-derived `leanFile.sorries` (already 13) and the existing `meta.assumptions` text which already reads *"5 axiom(s) and 13 sorries. See the Lean source for details."*

## Evidence

**Lean source** (`proofs/Proofs/Erdos611Problem.lean`):

```
$ grep -cE '\bsorry\b' proofs/Proofs/Erdos611Problem.lean
13
```

Sorry locations: lines 52, 62, 97, 112, 127, 135, 152, 181, 185, 186, 190, 191, 213.

**Before**: `sorries: 16` (overstated by 3 — likely conflated the main file with the Aristotle companion file `Proofs/Erdos611ProblemAristotle.lean`).
**After**: `sorries: 13` (matches `leanFile.sorries` and the assumptions text).

Convention (per recent mechanic PRs e.g. #19686, #19809, #19848): top-level and `meta.sorries` track the primary file count, matching `leanFile.sorries`.

`status` (`axiomatized`) and `axiomCount` (5) are unchanged — this proof carries 5 declared axioms encoding the open conjecture's stated assumptions.

---
Automated fix by lean-mechanic agent.