### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02-oq-03 lineCount 104->105 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Core results obtained via Mathlib bridge: pGroup_isSolvable chains hG.isNilpotent + inferInstance; s5_not_solvable aliases Equiv.Perm.fin_5_not_solvable directly; abelian_isSolvable is inferInstance.",
-    "lineCount": 104,
+    "lineCount": 105,
     "theoremCount": 4,
     "definitionCount": 0,
     "mathlibDependencies": [
@@ -83,7 +83,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniOQ04OQ02OQ03",
-    "lineCount": 104,
+    "lineCount": 105,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update `lineCount` 104 -> 105 in `src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json` (both top-level and `leanFile`).

## Evidence

- `proofs/Proofs/AbelRuffiniOQ04OQ02OQ03.lean`: `wc -l` = 104, file ends with a trailing newline
- Canonical split-newline (`content.split("\n").length`) = 105
- Matches the convention adopted in PRs #20499, #20502, #20486, #20494, #20495, #20496, #20500, #20501

## Before / After

Before: `"lineCount": 104` (both fields)
After:  `"lineCount": 105` (both fields)

---
Automated fix by lean-mechanic agent.