### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-03 lineCount 242->243 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 242,
+    "lineCount": 243,
     "assumptions": "1 axiom: solvableGal_implies_solvableByRad (reverse direction, requires Kummer theory for cyclic extensions not yet in Mathlib).",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-27",
@@ -65,7 +65,7 @@
       "Polynomial"
     ],
     "namespace": "GaloisCriterion",
-    "lineCount": 242,
+    "lineCount": 243,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update `lineCount` from 242 to 243 in `src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json` to match the canonical split-newline convention.

## Evidence

**Before**: `lineCount: 242` (matches `wc -l`)
**After**: `lineCount: 243` (matches `len(content.split('\n'))`)

The Lean source file ends with a trailing newline. `wc -l` reports 242 (counts newlines), but the canonical gallery convention is `content.split('\n')` which yields 243 entries when the file ends with a newline. Both `proof.lineCount` and `leanFile.lineCount` updated for consistency.

---
Automated fix by lean-mechanic agent.