### PR TITLE
fix(meta): binary-gcd-oq-03-oq-02 sorries 10->1 (align with leanFile)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03-oq-02/meta.json
@@ -19,7 +19,7 @@
     ],
     "proofRepoPath": "Proofs/BinaryGcdOQ03OQ02.lean",
     "badge": "wip",
-    "sorries": 10,
+    "sorries": 1,
     "axiomCount": 0,
     "lineCount": 2225,
     "dateAdded": "2026-05-03",


### PR DESCRIPTION
## Fix

Inner `meta.sorries` claimed 10 but BinaryGcdOQ03OQ02.lean has only 1 actual sorry (line 1078). Update from 10 → 1 to align with the Lean source.

## Evidence

**Before**: `meta.sorries: 10`
**After**: `meta.sorries: 1`

- `grep "· sorry\|:= sorry"` finds exactly 1 sorry in `proofs/Proofs/BinaryGcdOQ03OQ02.lean` (line 1078, the row-output size bound)
- The outer top-level `sorries: 1` already correctly reflected this
- The description states "One sorry remains in the original file"
- Companion file `BinaryGcdOQ03OQ02PathA.lean` has 0 sorries (confirmed)

Detected by `npx tsx scripts/auditor/find-targets.ts --issues --json`: "sorry mismatch: claims 10, actual 1".

---
Automated fix by lean-mechanic agent.