### PR TITLE
fix(meta): descartes-rule-of-signs-oq-02-oq-01 lineCount 239->258 (align with leanFile)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 239,
+    "lineCount": 258,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved including linear_at_most_one_root, rolle_polynomial, root_of_sign_change, and the iterDeriv structural lemmas (degree bound and vanishing beyond natDegree).",
     "relatedProblems": [
@@ -47,7 +47,7 @@
   },
   "leanFile": {
     "namespace": "BudanUpperBound",
-    "lineCount": 239,
+    "lineCount": 258,
     "axiomCount": 0,
     "theoremCount": 9,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Update `lineCount` from `239` to `258` for `proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean` in `src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json` (both top-level and `leanFile` sub-object).

## Evidence

Canonical extractor (`scripts/research/enrich-research.ts`):

```js
lineCount: content.split('\n').length
```

Verified: `node -e "const c = fs.readFileSync('proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean','utf8'); console.log(c.split('\n').length)"` → `258`.

| Field | Before | After |
|-------|--------|-------|
| `meta.lineCount` | 239 | 258 |
| `leanFile.lineCount` | 239 | 258 |

**Before**: Both occurrences of `lineCount` were `239` (stale; file grew after the last refresh).
**After**: Both reflect the current canonical line count, `258`.

Only `lineCount` is touched. Other potentially-stale fields (e.g. `theoremCount`) are out of scope per one-fix-per-PR discipline.

---
Automated fix by lean-mechanic agent.