### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-04 lineCount 656->657 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 656,
+    "lineCount": 657,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -309,7 +309,7 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 656,
+    "lineCount": 657,
     "axiomCount": 0,
     "theoremCount": 31,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Update `lineCount` from 656 to 657 in `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json` to match the canonical split-newline convention.

## Evidence

**Before**: `lineCount: 656` (matches `wc -l`)
**After**: `lineCount: 657` (matches `len(content.split('\n'))`)

The Lean source file ends with a trailing newline. `wc -l` reports 656 (counts newlines), but the canonical gallery convention is `content.split('\n')` which yields 657 entries when the file ends with a newline. Both `proof.meta.lineCount` and `leanFile.lineCount` updated for consistency.

---
Automated fix by lean-mechanic agent.