### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-07 lineCount 377->378 (canonical split-newline)

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 377,
+    "lineCount": 378,
     "assumptions": "Two axioms: (1) bringJerrard_reduction — the full Bring-Jerrard reduction eliminating x³ and x² terms via quadratic/cubic Tschirnhaus substitutions (requires polynomial resultant theory not in Mathlib); (2) bringRadical_not_in_radicals — the Bring radical is not expressible in radicals (follows from Abel-Ruffini but requires connecting the generic Galois group argument). The linear Tschirnhaus transform (depressed quintic) and all Bring radical properties are fully proved.",
     "dateAdded": "2026-04-03",
     "mathlibDependencies": [
@@ -205,7 +205,7 @@
       "Polynomial"
     ],
     "namespace": "BringJerrardReduction",
-    "lineCount": 377,
+    "lineCount": 378,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Update `lineCount` from 377 to 378 in `src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json` to match the canonical split-newline convention.

## Evidence

**Before**: `lineCount: 377` (matches `wc -l`)
**After**: `lineCount: 378` (matches `len(content.split('\n'))`)

The Lean source file ends with a trailing newline. `wc -l` reports 377 (counts newlines), but the canonical gallery convention is `content.split('\n')` which yields 378 entries when the file ends with a newline. Both `proof.meta.lineCount` and `leanFile.lineCount` updated for consistency.

---
Automated fix by lean-mechanic agent.