### PR TITLE
fix(meta): lebesgue-measure assumptions (no True placeholders)

### DIFF
--- a/src/data/proofs/lebesgue-measure/meta.json
+++ b/src/data/proofs/lebesgue-measure/meta.json
@@ -56,7 +56,7 @@
     "dateAdded": "2025-12-29",
     "axiomCount": 0,
     "lineCount": 417,
-    "assumptions": "0 axioms, 0 sorries. Note: 2 theorems prove True as application stubs (dominated convergence and Fubini iteration placeholders). All substantive results are fully verified.",
+    "assumptions": "0 axioms, 0 sorries. All 20 theorems have complete proofs; most delegate to Mathlib's measure theory library as pedagogical wrappers.",
     "mathlib_version": "4.26.0",
     "theoremCount": 20,
     "definitionCount": 0


### PR DESCRIPTION
## Fix

Update `meta.assumptions` for `lebesgue-measure` to remove a stale claim about `True`-stub theorems. The two theorems named in the prior text (`dominated_convergence`, `fubini`) actually have complete proofs.

## Evidence

**Before**:
> 0 axioms, 0 sorries. Note: 2 theorems prove True as application stubs (dominated convergence and Fubini iteration placeholders). All substantive results are fully verified.

**After**:
> 0 axioms, 0 sorries. All 20 theorems have complete proofs; most delegate to Mathlib's measure theory library as pedagogical wrappers.

### Verification in `proofs/Proofs/LebesgueMeasure.lean`

- `dominated_convergence` at line 232: full Tendsto statement proved via `tendsto_integral_of_dominated_convergence bound hf_meas hbound_int hf_bound hf_lim` (line 239).
- `fubini_tonelli` at line 262 and `fubini` at line 274: proved using `lintegral_prod` and `integral_prod`.
- `grep ": True\|:= trivial" proofs/Proofs/LebesgueMeasure.lean` returns nothing — there are no `True` stubs in the file.

Origin of the stale text: peer review (review.json, 2026-03-23) flagged `cantor_set_measure_zero` and `holder_inequality_statement` as `True` placeholders; those theorems have since been removed (now commented-out stub blocks at lines 319 and 400), but the `assumptions` field text was not updated to reflect their removal.

Closes peer review action item (lebesgue-measure / "overclaim: meta.json assumptions field").

---
Automated fix by lean-mechanic agent.