### PR TITLE
Fix: erdos-1001-oq-02-oq-01 sorry count metadata (8 → 4)

### DIFF
--- a/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
+++ b/src/data/proofs/erdos-1001-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
       "open-question"
     ],
     "badge": "axiom",
-    "sorries": 8,
+    "sorries": 4,
     "axiomCount": 4,
     "assumptions": "4 axioms: totient_sum_mertens_error (elementary Mertens O(N log N) error), totient_sum_walfisz_error (Walfisz 1963 O(N(logN)^(2/3)(loglogN)^(4/3))), rangeTotientSum_walfisz_error (Abel summation from Walfisz to range sum), convergence_rate_sharp (EST reduction to range sum with Walfisz bound). 4 sorries: walfisz_rate_isLittleO_mertens_rate, walfisz_full_rate_isLittleO_mertens_rate, sharp_rate_isLittleO_oq02_rate, improvement_factor_tends_to_zero — all real-analysis rpow comparisons, Aristotle candidates.",
     "erdosNumber": 1001,
@@ -164,5 +164,5 @@
       "mathContext": "The main theorem combines: (1) the sharp rate axiom $|S-f| = O(A(\\log N)^{2/3}(\\log\\log N)^{4/3}/N)$, and (2) the comparison $(\\log N)^{2/3}(\\log\\log N)^{4/3}/N = o(\\log N/N)$, via $\\texttt{IsBigO.trans\\_isLittleO}$. This yields $|S-f| = o(A \\log N/N)$ — strictly better convergence than OQ-02's O bound."
     }
   ],
-  "sorries": 8
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Correct the `meta.sorries` and top-level `sorries` fields in
`src/data/proofs/erdos-1001-oq-02-oq-01/meta.json` from `8` to `4` to
match the actual Lean source.

## Evidence

**Before**: `meta.sorries: 8`, `sorries: 8` (outer fields)
**After**: `meta.sorries: 4`, `sorries: 4`

The Lean source `proofs/Proofs/Erdos1001OQ02OQ01.lean` contains
exactly 4 `sorry` occurrences (lines 148, 162, 248, 280), after
stripping nested `/- ... -/` block comments and `--` line comments.
The `leanFile.sorries: 4` and the textual `meta.assumptions` field
already correctly stated 4 sorries — only the two outer count fields
were out of sync.

No changes to the Lean source.

---
Automated fix by lean-mechanic agent (mechanic-2 slot).