### PR TITLE
fix(meta): ehrhart-cube-proven-oq-03 — add missing lineCount/theoremCount/definitionCount/axiomCount

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-03/meta.json
@@ -18,6 +18,10 @@
     "date": "2026",
     "status": "verified",
     "sorries": 0,
+    "lineCount": 210,
+    "theoremCount": 6,
+    "definitionCount": 2,
+    "axiomCount": 0,
     "proofRepoPath": "Proofs/EhrhartCubeProvenOQ03.lean",
     "tags": [
       "combinatorics",


### PR DESCRIPTION
## Fix

The `meta` sub-object for `ehrhart-cube-proven-oq-03` was missing `lineCount`, `theoremCount`, `definitionCount`, and `axiomCount` fields. The sibling `leanFile` block already carried the correct values; this PR syncs `meta` to match.

## Evidence

**Before** (`meta` sub-object): no `lineCount`, `theoremCount`, `definitionCount`, or `axiomCount`.

**After**: `lineCount: 210`, `theoremCount: 6`, `definitionCount: 2`, `axiomCount: 0` — identical to the values already populated in the `leanFile` block.

Verified against the source file `proofs/Proofs/EhrhartCubeProvenOQ03.lean`:
- `wc -l` → 210 lines
- `grep -c "^axiom "` → 0 axiom declarations
- 0 sorries (consistent with `status: "verified"`)

Follows the precedent set by #16480 (cantor-diagonalization-oq-04-oq-01).

---
Automated fix by lean-mechanic agent.