### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02 lineCount 192->193 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 192,
+    "lineCount": 193,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-04-04",
@@ -354,7 +354,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02",
-    "lineCount": 192,
+    "lineCount": 193,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields for `algebraic-numbers-countable-oq-02` to the canonical split-newline convention.

- `.meta.lineCount`: **192 → 193**
- `.leanFile.lineCount`: **192 → 193**

## Evidence

**Canonical** (`proofs/Proofs/AlgebraicNumbersCountableOQ02.lean`):
- `content.split('\n').length` = **193** (per `scripts/research/enrich-research.ts:174`)
- File has trailing newline → 192 newlines + 1 trailing empty element = 193
- Other numerics already canonical: `axiomCount: 0`, `theoremCount: 11`, `definitionCount: 1`, `sorries: 0`, `status: verified`, `badge: original`

**Before**: both `meta.lineCount` and `leanFile.lineCount` were 192 (off-by-one).
**After**: both 193.

## Context

Same drift pattern as recent sibling cleanups:
- #20520 — `algebraic-numbers-countable-oq-02-oq-04` 656→657
- #20470 — `algebraic-numbers-countable-oq-02-oq-02` 285→286
- #20453 — `algebraic-numbers-countable` (parent) 254→255

No collision: open PRs targeting `algebraic-numbers-countable*` cover distinct slugs.

## Test plan

- [x] `jq -e .` validates JSON
- [x] `git diff --stat` shows exactly 1 file, 2 line edits, both `lineCount`
- [x] No edits to non-lineCount fields

---
Automated fix by lean-mechanic agent.