### PR TITLE
fix(meta): algebraic-numbers-countable-oq-04 lineCount 758->759 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 3,
     "assumptions": "Three independent axioms: (1) baker_homogeneous — Baker's qualitative theorem for linear forms in logarithms (Q-independent logs remain Q̄-independent); (2) baker_inhomogeneous — strengthening with algebraic constant β₀; (3) baker_wustholz_bound — Baker-Wüstholz 1993 optimal log(B) exponent. The previously-axiomatized baker_quantitative (effective lower bound |Λ| > B^{-C}) is now PROVED as a theorem from baker_homogeneous (Λ ≠ 0) plus baker_wustholz_bound (explicit log lower bound), reducing axiom count 4 → 3. All three remaining axioms encode the unformalized analytic content of Baker's proof (Siegel's lemma + auxiliary function + extrapolation).",
-    "lineCount": 758,
+    "lineCount": 759,
     "theoremCount": 13,
     "definitionCount": 0,
     "originalContributions": [
@@ -315,7 +315,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ04.lean",
-    "lineCount": 758,
+    "lineCount": 759,
     "theoremCount": 13,
     "definitionCount": 0,
     "axiomCount": 3,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields for `algebraic-numbers-countable-oq-04` to the canonical split-newline convention.

- `.meta.lineCount`: **758 → 759**
- `.leanFile.lineCount`: **758 → 759**

## Evidence

**Canonical** (`proofs/Proofs/AlgebraicNumbersCountableOQ04.lean`):
- `content.split('\n').length` = **759** (per `scripts/research/enrich-research.ts:174`)
- File has trailing newline → 758 newlines + 1 trailing empty element = 759
- Other numerics already canonical: `axiomCount: 3`, `theoremCount: 13`, `definitionCount: 0`, `sorries: 0`, `status: axiomatized`, `badge: axiom`

**Before**: both `meta.lineCount` and `leanFile.lineCount` were 758 (off-by-one).
**After**: both 759.

## Context

Same drift pattern as recent sibling cleanups:
- #20525 — `algebraic-numbers-countable-oq-02` 192→193
- #20520 — `algebraic-numbers-countable-oq-02-oq-04` 656→657
- #20470 — `algebraic-numbers-countable-oq-02-oq-02` 285→286
- #20453 — `algebraic-numbers-countable` (parent) 254→255

No collision: open PRs touching `algebraic-numbers-countable-*` target distinct slugs.

## Test plan

- [x] `jq -e .` validates JSON
- [x] `git diff --stat` shows exactly 1 file, 2 line edits, both `lineCount`
- [x] No edits to non-lineCount fields (assumptions/axiomCount/status/etc. untouched)

---
Automated fix by lean-mechanic agent.