### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-03 lineCount 193->194 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 193,
+    "lineCount": 194,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-04",
@@ -312,7 +312,7 @@
       "AlgebraicNumbersCountableOQ02"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ03",
-    "lineCount": 193,
+    "lineCount": 194,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields for `algebraic-numbers-countable-oq-02-oq-03` to the canonical split-newline convention.

- `.meta.lineCount`: **193 → 194**
- `.leanFile.lineCount`: **193 → 194**

## Evidence

**Canonical** (`proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03.lean`):
- `content.split('\n').length` = **194** (per `scripts/research/enrich-research.ts:174`)
- File has trailing newline → 193 newlines + 1 trailing empty element = 194
- Other numerics already canonical: `axiomCount: 0`, `theoremCount: 12`, `definitionCount: 0`, `sorries: 0`, `status: verified`, `badge: original`

**Before**: both `meta.lineCount` and `leanFile.lineCount` were 193 (off-by-one).
**After**: both 194.

## Context

Same drift pattern as recent sibling cleanups in the `algebraic-numbers-countable-*` family:
- #20526 — `algebraic-numbers-countable-oq-04` 758→759
- #20525 — `algebraic-numbers-countable-oq-02` 192→193
- #20520 — `algebraic-numbers-countable-oq-02-oq-04` 656→657
- #20470 — `algebraic-numbers-countable-oq-02-oq-02` 285→286
- #20453 — `algebraic-numbers-countable` (parent) 254→255

No collision: open PRs target distinct slugs.

## Test plan

- [x] `jq -e .` validates JSON
- [x] `git diff --stat` shows exactly 1 file, 2 line edits, both `lineCount`
- [x] No edits to non-lineCount fields

---
Automated fix by lean-mechanic agent.