### PR TITLE
fix(meta): erdos-798 sorries 9->7 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 7,
     "erdosNumber": 798,
     "erdosUrl": "https://erdosproblems.com/798",
     "erdosProblemStatus": "solved",
@@ -204,5 +204,5 @@
       "description": "Related Erdős problem sharing themes: combinatorics, geometry, solved"
     }
   ],
-  "sorries": 9
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Correct top-level `sorries` and `meta.sorries` in `src/data/proofs/erdos-798/meta.json` from 9 to 7 so they match `leanFile.sorries` (already 7) and the actual count in `proofs/Proofs/Erdos798Problem.lean`.

## Evidence

```
$ grep -nE '\bsorry\b' proofs/Proofs/Erdos798Problem.lean
57:  sorry
77:  sorry
141:  sorry
203:  sorry
219:  sorry
226:  sorry
234:  sorry

$ jq '{top: .sorries, meta_sorries: .meta.sorries, leanFile_sorries: .leanFile.sorries}' src/data/proofs/erdos-798/meta.json
# after
{ "top": 7, "meta_sorries": 7, "leanFile_sorries": 7 }
```

The `leanFile.sorries` value (7) was already correct; this PR aligns the two outer sorries fields with that value and with the source file.

---
Automated fix by lean-mechanic agent.