### PR TITLE
fix(meta): de-moivre-oq-02-oq-02 — add missing definitionCount

### DIFF
--- a/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
+++ b/src/data/proofs/de-moivre-oq-02-oq-02/meta.json
@@ -27,6 +27,7 @@
     "lineCount": 216,
     "assumptions": "0 axioms, 0 sorries. Polynomial identity proved over any commutative ring R; U·U formula proved in ℝ.",
     "theoremCount": 11,
+    "definitionCount": 2,
     "originalContributions": [
       "T_mul_U_product: 2·T_m·U_n = U_{m+n} + U_{n-m} as a polynomial identity in R[X] for any CommRing R",
       "chebyshev_T_U_product_to_sum: real evaluation form of the cross-product formula",


### PR DESCRIPTION
## Fix

The `meta` sub-object for `de-moivre-oq-02-oq-02` was missing `definitionCount`. The sibling `leanFile` block already carried the correct value (`2`); this PR syncs `meta` to match.

## Evidence

**Before** (`meta` sub-object): no `definitionCount`.

**After**: `definitionCount: 2` — identical to the value already populated in the `leanFile` block.

Verified against the source file `proofs/Proofs/DeMoivreOQ02OQ02.lean`:
- `private def P (m : ℤ) : Prop := ...` (line 47)
- `private def Q (m : ℤ) : Prop := P n m ∧ P n (m - 1)` (line 51)

Other fields in `meta` (`lineCount: 216`, `theoremCount: 11`, `axiomCount: 0`, `sorries: 0`) already match `leanFile`.

Follows the precedent set by #20524 (ehrhart-cube-proven-oq-03).

---
Automated fix by lean-mechanic agent.