### PR TITLE
fix(meta): amgm-inequality lineCount 225→226 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -73,7 +73,7 @@
     "wiedijkNumber": 38,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The elementary two-variable proof (`am_gm_two`) and equality characterization (`am_gm_two_eq_iff`) are original constructions using `sq_nonneg`, `Real.sq_sqrt`, and `linarith`. The general weighted form (`am_gm_weighted`) and three-variable case (`am_gm_three`) are pedagogical wrappers around Mathlib's `Real.geom_mean_le_arith_mean_weighted` and `Real.geom_mean_le_arith_mean3_weighted` respectively. Wiedijk 100 theorem #38.",
-    "lineCount": 225,
+    "lineCount": 226,
     "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
@@ -305,7 +305,7 @@
     ],
     "opens": [],
     "namespace": "AMGMInequality",
-    "lineCount": 225,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 3,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields for `amgm-inequality` to the canonical split-newline convention.

- `meta.lineCount`:     **225 → 226**
- `leanFile.lineCount`: **225 → 226**

## Evidence

**Canonical** (`proofs/Proofs/AMGMInequality.lean`):
- `content.split('\n').length` = **226** (per `scripts/research/enrich-research.ts:174`)
- File has trailing newline → 225 newlines + 1 trailing empty element = 226
- Other numerics already canonical: `axiomCount: 0`, `theoremCount: 8`, `definitionCount: 0`, `sorries: 0`, `status: verified`, `badge: mathlib`

**Before**: both `meta.lineCount` and `leanFile.lineCount` were 225 (off-by-one).
**After**: both 226.

## Context

Same drift pattern as recent sibling cleanups:
- #20527 — `algebraic-numbers-countable-oq-02-oq-03` 193→194
- #20526 — `algebraic-numbers-countable-oq-04` 758→759
- #20525 — `algebraic-numbers-countable-oq-02` 192→193
- #20521 — `abel-ruffini-oq-04-oq-07` 377→378

No collision: open PRs target distinct slugs.

## Test plan

- [x] `node -e "JSON.parse(...)"` validates JSON
- [x] `git diff --stat` shows exactly 1 file, 2 line edits, both `lineCount`
- [x] No edits to non-lineCount fields

---
Automated fix by lean-mechanic agent.