### PR TITLE
fix(docstring): lebesgue-measure status checklist (0 sorries)

### DIFF
--- a/proofs/Proofs/LebesgueMeasure.lean
+++ b/proofs/Proofs/LebesgueMeasure.lean
@@ -37,11 +37,11 @@ fundamental convergence theorems:
   and integrals.
 
 ## Status
-- [ ] Complete proof
+- [x] Complete proof
 - [x] Uses Mathlib for main result
 - [ ] Proves extensions/corollaries
 - [ ] Pedagogical example
-- [x] Incomplete (has sorries)
+- [ ] Incomplete (has sorries)
 
 ## Mathlib Dependencies
 - `MeasureTheory.Measure.volume` : Lebesgue measure on ℝⁿ


### PR DESCRIPTION
## Fix

Update the `LebesgueMeasure.lean` in-file status checklist (lines 40-44) to reflect that the file has 0 sorries.

## Evidence

**Before** (lines 40, 44):
```
- [ ] Complete proof
...
- [x] Incomplete (has sorries)
```

**After**:
```
- [x] Complete proof
...
- [ ] Incomplete (has sorries)
```

`grep -cE '\bsorry\b' proofs/Proofs/LebesgueMeasure.lean` returns `0` — the file has no sorries, and `meta.json` correctly marks `status: verified`, `sorries: 0`. The in-file checklist was the last stale claim of incompleteness.

Closes peer review action item (`src/data/proofs/lebesgue-measure/review.json` — minor finding "Lean source docstring lines 40-44 self-description inconsistency").

---
Automated fix by lean-mechanic agent.