### PR TITLE
fix(meta): amgm-inequality-oq-02 lineCount 543->544 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
       "Real analysis (rpow, sqrt, mean inequalities)",
       "Finset combinatorics (powersetCard, sum, prod)"
     ],
-    "lineCount": 543,
+    "lineCount": 544,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
     "theoremCount": 26,
@@ -303,7 +303,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 543,
+    "lineCount": 544,
     "structureCount": 0,
     "axiomCount": 2,
     "theoremCount": 26,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` fields for `amgm-inequality-oq-02` to the canonical split-newline convention.

## Evidence

**Before**:
- `meta.lineCount`: 543
- `leanFile.lineCount`: 543

**After**:
- `meta.lineCount`: 544
- `leanFile.lineCount`: 544

Canonical line count (per `scripts/research/enrich-research.ts:174`):

content.split('\n').length = 544

`proofs/Proofs/AmgmInequalityOQ02.lean` ends with a trailing newline (543 newlines + 1 trailing empty element = 544).

Other numerics already canonical: `axiomCount: 2`, `theoremCount: 26`, `definitionCount: 3`, `sorries: 0`, `status: axiomatized`, `badge: axiom`.

---
Automated fix by lean-mechanic agent.