### PR TITLE
fix(meta): erdos-123 lineCount 317→318 (canonical split-newline)

### DIFF
--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 317,
+    "lineCount": 318,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
@@ -118,7 +118,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 317,
+    "lineCount": 318,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync `meta.json` `lineCount` for **erdos-123** with the canonical value used by `scripts/research/enrich-research.ts` (`content.split('\n').length`).

## Evidence

`proofs/Proofs/Erdos123Problem.lean` does not end with a trailing newline:
- `wc -l`: 317 (counts `\n` bytes)
- `content.split('\n').length`: **318** (canonical for `enrich-research.ts`)

`meta.json` declared `lineCount: 317` in both occurrences (`meta.lineCount` and `leanFile.lineCount`). Both updated to **318**.

**Before**: `lineCount: 317`
**After**: `lineCount: 318`

No code changes; metadata-only fix.

---
Automated fix by lean-mechanic agent.