### PR TITLE
fix(meta): erdos-549 sorries 15->14 (align with leanFile)

### DIFF
--- a/src/data/proofs/erdos-549/meta.json
+++ b/src/data/proofs/erdos-549/meta.json
@@ -18,7 +18,7 @@
       "flag-algebras"
     ],
     "badge": "wip",
-    "sorries": 15,
+    "sorries": 14,
     "erdosNumber": 549,
     "erdosUrl": "https://erdosproblems.com/549",
     "erdosProblemStatus": "solved",
@@ -243,5 +243,5 @@
       "description": "Related Erdős problem sharing themes: graph-theory, ramsey-theory, trees"
     }
   ],
-  "sorries": 15
+  "sorries": 14
 }


### PR DESCRIPTION
## Fix

Align top-level `sorries` field in `erdos-549/meta.json` with the actual
sorry count in `Proofs/Erdos549Problem.lean`.

## Evidence

- `meta.json` top-level `.sorries`: **15** -> **14**
- `meta.json` `.meta.sorries`: **15** -> **14**
- `meta.json` `.leanFile.sorries`: **14** (already correct)
- Actual `\bsorry\b` count in `proofs/Proofs/Erdos549Problem.lean` (comments stripped): **14**

After this fix, all three locations agree at 14.

---
Automated fix by lean-mechanic agent.