### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01 lineCount 88→89 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Works in any CommRing R.",
-    "lineCount": 88,
+    "lineCount": 89,
     "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
@@ -49,7 +49,7 @@
     ]
   },
   "conclusion": {
-    "summary": "Newton-Girard p₂ = e₁² - 2e₂ via double sum decomposition into diagonal and off-diagonal parts. Works in any CommRing over any Finset. 5 theorems, 0 axioms, 88 lines.",
+    "summary": "Newton-Girard p₂ = e₁² - 2e₂ via double sum decomposition into diagonal and off-diagonal parts. Works in any CommRing over any Finset. 5 theorems, 0 axioms, 89 lines.",
     "implications": "This algebraic identity is the foundation of AM-GM for n variables and Newton's power sum method for symmetric polynomials. The Finset-based proof applies to sums over any finite index set, making it reusable for combinatorial applications.",
     "openQuestions": [
       "Prove the full Newton-Girard recurrence: p_k = Σ_{i=1}^k (-1)^{i-1} eᵢ p_{k-i}",
@@ -58,7 +58,7 @@
   },
   "leanFile": {
     "namespace": "AMGMInequalityOQ02OQ01",
-    "lineCount": 88,
+    "lineCount": 89,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Align `amgm-inequality-oq-02-oq-01/meta.json` `lineCount` with the canonical split-newline convention used by `scripts/research/enrich-research.ts:174` (`content.split('\n').length`).

## Evidence

- **Before**: `meta.lineCount: 88`, `leanFile.lineCount: 88`, summary text "88 lines"
- **After**: `meta.lineCount: 89`, `leanFile.lineCount: 89`, summary text "89 lines"

`AMGMInequalityOQ02OQ01.lean` has a trailing newline: `wc -l` reports 88 newlines, but `split('\n').length` (the enrichment pipeline's convention) is 89. Same off-by-one pattern as recent mechanic fixes (e.g. #20534, #20533, #20530, #20525, #20527).

No Lean source changes; metadata only.

---
Automated fix by lean-mechanic agent.