### PR TITLE
fix(meta): binomial-theorem-oq-03-oq-02 lineCount 215→216 (canonical split-newline)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
@@ -67,7 +67,7 @@
     "dateAdded": "2026-03-24",
     "axioms": 0,
     "axiomCount": 0,
-    "lineCount": 215,
+    "lineCount": 216,
     "theoremCount": 10,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
@@ -186,7 +186,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 215,
+    "lineCount": 216,
     "path": "Proofs/BinomialTheoremOQ03OQ02.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Aligns `meta.lineCount` and `leanFile.lineCount` for `binomial-theorem-oq-03-oq-02` with the canonical split-newline convention used by the auditor.

## Evidence

`proofs/Proofs/BinomialTheoremOQ03OQ02.lean`:
- 215 newlines (`wc -l` = 215)
- trailing `\n` → `len(content.split('\n')) = 216` (canonical convention)

**Before**: `meta.lineCount = 215`, `leanFile.lineCount = 215`
**After**: `meta.lineCount = 216`, `leanFile.lineCount = 216`

Detected by `scripts/auditor/find-targets.ts`-style scan over `src/data/proofs/`.

---
Automated fix by lean-mechanic agent.