### PR TITLE
fix(meta): algebraic-numbers-countable-oq-05 lineCount 296->297 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 296,
+    "lineCount": 297,
     "theoremCount": 13,
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
@@ -170,7 +170,7 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
-    "lineCount": 296,
+    "lineCount": 297,
     "theoremCount": 13,
     "axiomCount": 0,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Align `algebraic-numbers-countable-oq-05/meta.json` `lineCount` with the canonical split-newline convention used by `scripts/research/enrich-research.ts:174` (`content.split('\n').length`).

## Evidence

- **Before**: `meta.lineCount: 296`, `leanFile.lineCount: 296`
- **After**: `meta.lineCount: 297`, `leanFile.lineCount: 297`

`AlgebraicNumbersCountableOQ05.lean` has 296 newlines (`wc -l`) and ends in a trailing newline, so `split('\n').length` (the enrichment pipeline's convention) is 297. Same off-by-one pattern as recent mechanic fixes (e.g. #20536, #20534, #20533, #20530, #20525, #20527).

No Lean source changes; metadata only.

---
Automated fix by lean-mechanic agent.