### PR TITLE
fix(meta): shannon-channel-coding-oq-03 sorries 4->0 (align with leanFile)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "original",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Finset.le_sup'",
@@ -225,5 +225,5 @@
       "note": "Chapter 7: Fano's inequality and its application to channel coding converse"
     }
   ],
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` and top-level `sorries` for `shannon-channel-coding-oq-03` with the actual count in `Proofs/ShannonChannelCodingOQ03.lean`.

## Evidence

**Before**: `meta.sorries: 4`, top-level `sorries: 4`
**After**: `meta.sorries: 0`, top-level `sorries: 0`

Verified:
- `grep -c '\bsorry\b' proofs/Proofs/ShannonChannelCodingOQ03.lean` → 0
- `leanFile.sorries` was already `0`
- `assumptions` field already states "0 axioms, 0 sorries in main file"
- `conclusion.summary` already states "Complete formalization ... with 0 sorries and 0 axioms"

The 4 sorries referenced in the stale metadata are in the Aristotle companion file (`ShannonChannelCodingOQ03Aristotle.lean`), which is correctly tracked separately.

---
Automated fix by lean-mechanic agent.