### PR TITLE
fix(meta): erdos-238 lineCount 345->346 (canonical split-newline)

### DIFF
--- a/src/data/proofs/erdos-238/meta.json
+++ b/src/data/proofs/erdos-238/meta.json
@@ -28,7 +28,7 @@
       "Nat.nth for prime enumeration",
       "Asymptotic analysis (big-O, little-o)"
     ],
-    "lineCount": 345,
+    "lineCount": 346,
     "assumptions": "2 axioms: erdos_partial_result, prime_number_theorem_asymptotic. See Lean source for complete statements.",
     "theoremCount": 12,
     "definitionCount": 10
@@ -226,7 +226,7 @@
       "Real"
     ],
     "namespace": "Erdos238",
-    "lineCount": 345,
+    "lineCount": 346,
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Update `lineCount` from 345 to 346 in `src/data/proofs/erdos-238/meta.json` to match the canonical split-newline convention.

## Evidence

**Before**: `lineCount: 345` (matches `wc -l`)
**After**: `lineCount: 346` (matches `len(content.split('\n'))`)

The Lean source file `proofs/Proofs/Erdos238Problem.lean` ends with a trailing newline. `wc -l` reports 345 (counts newlines), but the canonical gallery convention is `content.split('\n')` which yields 346 entries when the file ends with a newline. Both `meta.lineCount` and `leanFile.lineCount` updated for consistency.

---
Automated fix by lean-mechanic agent.