### PR TITLE
fix(meta): erdos-771 sorries 7->9 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 9,
     "erdosNumber": 771,
     "erdosUrl": "https://erdosproblems.com/771",
     "erdosProblemStatus": "solved",
@@ -239,5 +239,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ],
-  "sorries": 7
+  "sorries": 9
 }


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 7 total sorries for `erdos-771`, but the actual total across the main file + Aristotle companion in `additionalFiles` is 9.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/Erdos771Problem.lean` | 7 |
| `proofs/Proofs/Erdos771ProblemAristotle.lean` | 2 |
| **Total** | **9** |

**Before**: `meta.meta.sorries: 7`, top-level `sorries: 7`
**After**:  `meta.meta.sorries: 9`, top-level `sorries: 9`

`leanFile.sorries` (7) for the main file remains correct. Matches convention from PR #20503 (erdos-1018) and #20512 (inverse-galois-oq-02).

---
Automated fix by lean-mechanic agent.