### PR TITLE
fix(meta): angle-trisection-oq-02-oq-01-oq-02 sorries 2->5 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 5,
     "axiomCount": 0,
     "theoremCount": 16,
     "lineCount": 265,
@@ -245,5 +245,5 @@
       "Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 2 total sorries for `angle-trisection-oq-02-oq-01-oq-02`, but the actual total across the main file + Aristotle companion in `additionalFiles` is 5.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02.lean` | 2 |
| `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean` | 3 |
| **Total** | **5** |

**Before**: `meta.meta.sorries: 2`, top-level `sorries: 2`
**After**:  `meta.meta.sorries: 5`, top-level `sorries: 5`

`leanFile.sorries` (2) for the main file remains correct. Matches convention from PR #20503 (erdos-1018) and #20512 (inverse-galois-oq-02).

---
Automated fix by lean-mechanic agent.