### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02 lineCount 138->139 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 138,
+    "lineCount": 139,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -135,7 +135,7 @@
       "BigOperators"
     ],
     "namespace": "AMGMInequalityOQ02OQ01OQ02",
-    "lineCount": 138,
+    "lineCount": 139,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update both `meta.lineCount` and `leanFile.lineCount` from 138 to 139 in `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json` to align with the canonical gallery convention.

## Evidence

**Before**: lineCount=138 (matches `wc -l`, which counts trailing newlines)
**After**: lineCount=139 (matches `content.split('\n').length`, the canonical convention used elsewhere in the gallery — when a file ends with a trailing newline, split yields one extra empty entry)

The Lean source file is unchanged; only metadata was drifted.

---
Automated fix by lean-mechanic agent.