### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01 lineCount 133->134 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -33,7 +33,7 @@
     "dateAdded": "2026-04-26",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 133,
+    "lineCount": 134,
     "theoremCount": 4,
     "definitionCount": 0,
     "assumptions": "All results derived from Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum. 0 sorries, 0 axiom declarations.",
@@ -197,7 +197,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean",
-    "lineCount": 133,
+    "lineCount": 134,
     "theoremCount": 4,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Update both `meta.lineCount` and `leanFile.lineCount` from 133 to 134 in `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json` to align with the canonical gallery convention.

## Evidence

**Before**: lineCount=133 (matches `wc -l`, which counts trailing newlines)
**After**: lineCount=134 (matches `content.split('\n').length`, the canonical convention used elsewhere in the gallery — when a file ends with a trailing newline, split yields one extra empty entry)

The Lean source file (`proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean`) is unchanged; only metadata was drifted.

---
Automated fix by lean-mechanic agent.