### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03 lineCount 186->187 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-05-04",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 186,
+    "lineCount": 187,
     "theoremCount": 3,
     "definitionCount": 1,
     "assumptions": "No sorries, no axiom declarations. All results proved from Mathlib foundations via induction. Imports AmgmInequalityOQ02 for the elemSymm definition and elemSymm_succ (variable-adding recurrence).",
@@ -204,7 +204,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean",
-    "lineCount": 186,
+    "lineCount": 187,
     "theoremCount": 3,
     "definitionCount": 1,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Aligns meta.json lineCount with the canonical split-newline convention used by scripts/research/enrich-research.ts (lines.length where lines = content.split('\n')).

## Evidence

**Before**: meta.json reports lineCount: 186 in both top-level meta and leanFile.
**After**: lineCount: 187 matches content.split('\n').length for proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean (186 newlines, ends with newline → 187 split elements).

---
Automated fix by lean-mechanic agent.