### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-02 lineCount 959->960 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -34,7 +34,7 @@
       "maclaurin_step_derived: Mₖ ≥ Mₖ₊₁ where Mⱼ = (eⱼ/C(n,j))^(1/j) — the Maclaurin chain step"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 959,
+    "lineCount": 960,
     "theoremCount": 18,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -159,7 +159,7 @@
       "Proofs.NewtonInductiveStep"
     ],
     "namespace": "NewtonLogConcavity",
-    "lineCount": 959,
+    "lineCount": 960,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync `lineCount` for `amgm-inequality-oq-02-oq-02` from 959 to 960 (canonical split-newline count).

## Evidence

- **File**: `proofs/Proofs/AmgmInequalityOQ02OQ02.lean`
- **`wc -l`**: 959 (newline count)
- **Canonical**: `content.split('\n').length` = 960 (matches `scripts/research/enrich-research.ts` lineCount calculation)
- **meta.json**: both `meta.lineCount` and `leanFile.lineCount` were 959 (now 960)

No Lean source changes; only metadata sync.

---
Automated fix by lean-mechanic agent.