### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-03 lineCount 226->227 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 226,
+    "lineCount": 227,
     "assumptions": "1 axiom: newton_log_concavity (Newton's log-concavity of elementary symmetric polynomials, inherited from AmgmInequalityOQ02.lean). The maclaurin_step axiom is eliminated by this file — proved here as maclaurin_step_proved. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -138,7 +138,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 226,
+    "lineCount": 227,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `amgm-inequality-oq-02-oq-03` with the canonical `content.split('\n').length` convention used by `scripts/research/enrich-research.ts`.

## Evidence

**Before**: `meta.lineCount: 226`, `leanFile.lineCount: 226`
**After**: `meta.lineCount: 227`, `leanFile.lineCount: 227`

Canonical line count for `proofs/Proofs/AmgmInequalityOQ02OQ03.lean`:
```
$ python3 -c "print(len(open('proofs/Proofs/AmgmInequalityOQ02OQ03.lean').read().split(chr(10))))"
227
```

`wc -l` reports 226 (newline count), but the canonical convention adds 1 for the trailing empty element produced by `split('\n')` on a file ending in `\n`.

---
Automated fix by lean-mechanic agent.