### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-03-oq-03 lineCount 66->67 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 1,
-    "lineCount": 66,
+    "lineCount": 67,
     "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "Uses `maclaurin_step` axiom from AmgmInequalityOQ02. If replaced by the proved `maclaurin_step_proved` from AmgmInequalityOQ02OQ03, all results become fully verified.",
@@ -194,7 +194,7 @@
   ],
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
-    "lineCount": 66,
+    "lineCount": 67,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `amgm-inequality-oq-02-oq-03-oq-03` with the canonical `content.split('\n').length` convention used by `scripts/research/enrich-research.ts`.

## Evidence

**Before**: `meta.lineCount: 66`, `leanFile.lineCount: 66`
**After**: `meta.lineCount: 67`, `leanFile.lineCount: 67`

Canonical line count for `proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean`:
```
$ python3 -c "print(len(open('proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean').read().split(chr(10))))"
67
```

`wc -l` reports 66 (newline count), but the canonical convention adds 1 for the trailing empty element produced by `split('\n')` on a file ending in `\n`.

---
Automated fix by lean-mechanic agent.