### PR TITLE
fix(meta): amgm-inequality-oq-03 lineCount 373->374 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03/meta.json
@@ -57,7 +57,7 @@
       "Real power function (rpow) arithmetic and monotonicity",
       "Finset product and sum operations"
     ],
-    "lineCount": 373,
+    "lineCount": 374,
     "assumptions": "0 axioms, 0 sorries. Core building blocks (AM-GM, Jensen, AM ≤ M_p) from Mathlib; original proofs for HM ≤ GM, power mean monotonicity (positive and negative exponents), and duality identity.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
@@ -228,7 +228,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 373,
+    "lineCount": 374,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Update `lineCount` from 373 to 374 in `src/data/proofs/amgm-inequality-oq-03/meta.json` (both top-level and `leanFile.lineCount`).

## Evidence

The canonical gallery line count uses `content.split('\n').length` (see `scripts/research/enrich-research.ts:174`).

**Before**: `meta.json` reports `lineCount: 373` (matches `wc -l`).
**After**: `meta.json` reports `lineCount: 374` (matches `split('\n').length`).

Verified locally:
- `wc -l proofs/Proofs/AmgmInequalityOQ03.lean` → 373 (counts newline chars)
- `content.split('\n').length` → 374 (canonical gallery metric, accounts for trailing newline)

Aligning meta.json with the canonical metric prevents auditor drift flags.

---
Automated fix by lean-mechanic agent.