### PR TITLE
fix(meta): burnside-counting-oq-03 sorries 0->4 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -21,7 +21,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 0,
+    "sorries": 4,
     "axiomCount": 0,
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
@@ -185,5 +185,5 @@
       "Proofs/BurnsideCountingOQ03Aristotle.lean"
     ]
   },
-  "sorries": 0
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Metadata mismatch: `meta.json` reported 0 total sorries for `burnside-counting-oq-03`, but the Aristotle companion file `BurnsideCountingOQ03Aristotle.lean` contributes 4 sorries.

## Evidence

| File | Actual sorries |
|------|----------------|
| `proofs/Proofs/BurnsideCountingOQ03.lean` | 0 |
| `proofs/Proofs/BurnsideCountingOQ03Aristotle.lean` | 4 (lines 37, 46, 66, 75) |
| **Total** | **4** |

**Before**: `meta.meta.sorries: 0`, top-level `sorries: 0`
**After**:  `meta.meta.sorries: 4`, top-level `sorries: 4`

`leanFile.sorries` (0) for the main file remains correct. Matches convention from PR #20543 (erdos-771) and #20503 (erdos-1018).

---
Automated fix by lean-mechanic agent.