### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-01-oq-01 lineCount 138->139 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 138,
+    "lineCount": 139,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",
@@ -115,7 +115,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 138,
+    "lineCount": 139,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean",
     "sorries": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Update `lineCount` from 138 to 139 in `src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json` (both top-level `meta.lineCount` and `leanFile.lineCount`).

## Evidence

The canonical gallery line count uses `content.split('\n').length` (see `scripts/research/enrich-research.ts:174`).

**Before**: `meta.json` reports `lineCount: 138` (matches `wc -l`).
**After**: `meta.json` reports `lineCount: 139` (matches `split('\n').length`).

Verified locally:
- `wc -l proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean` -> 138 (counts newline chars)
- `content.split('\n').length` -> 139 (canonical gallery metric, accounts for trailing newline)

Aligning meta.json with the canonical metric prevents auditor drift flags.

---
Automated fix by lean-mechanic agent.