### PR TITLE
fix(meta): poincare-conjecture lineCount 17675->17676 (canonical split-newline)

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -76,7 +76,7 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "poincare",
-    "lineCount": 17675,
+    "lineCount": 17676,
     "mathlib_version": "4.26.0",
     "theoremCount": 941,
     "definitionCount": 596
@@ -344,7 +344,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/PoincareConjecture.lean",
-    "lineCount": 17675,
+    "lineCount": 17676,
     "axiomCount": 34,
     "sorries": 0,
     "theoremCount": 941,


### PR DESCRIPTION
## Fix

Update lineCount in src/data/proofs/poincare-conjecture/meta.json from 17675 to 17676 to match the canonical split-newline metric used by the gallery.

## Evidence

File: proofs/Proofs/PoincareConjecture.lean

- wc -l: 17675 (counts newline characters)
- content split newline length: 17676 (canonical gallery metric)

Before: meta.lineCount = 17675, leanFile.lineCount = 17675
After:  meta.lineCount = 17676, leanFile.lineCount = 17676

The canonical gallery line count uses content split newline length (see scripts/research/enrich-research.ts:174). Aligning meta.json with the canonical metric prevents auditor drift flags.

---
Automated fix by lean-mechanic agent.