### PR TITLE
fix(meta): erdos-410 lineCount 371->372 (canonical split-newline)

### DIFF
--- a/src/data/proofs/erdos-410/meta.json
+++ b/src/data/proofs/erdos-410/meta.json
@@ -56,7 +56,7 @@
       "sigma_multiplicative theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 371,
+    "lineCount": 372,
     "assumptions": "2 axiom(s): robin_inequality (equivalent to RH), average_sigma (deep analytic NT). conjecture_equiv_exp was proved from limit theory.",
     "theoremCount": 42,
     "definitionCount": 7
@@ -181,7 +181,7 @@
       "Filter"
     ],
     "namespace": "Erdos410",
-    "lineCount": 371,
+    "lineCount": 372,
     "axiomCount": 2,
     "theoremCount": 42,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Aligns `lineCount` in `src/data/proofs/erdos-410/meta.json` with the canonical
gallery metric `content.split('\n').length` (see `scripts/research/enrich-research.ts:174`).

## Evidence

**Before**: `lineCount: 371` (matches `wc -l` newline count)
**After**: `lineCount: 372` (matches canonical split-newline count, accounts for trailing newline)

Both `meta.lineCount` (top-level) and `meta.leanFile.lineCount` updated.

Verified locally:
- `wc -l proofs/Proofs/Erdos410Problem.lean` -> 371
- `python3 -c "print(len(open(...).read().split('\n')))"` -> 372

---
Automated fix by lean-mechanic agent.