### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-01 lineCount 373->374 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-01/meta.json
@@ -53,7 +53,7 @@
     ],
     "dateAdded": "2026-03-21",
     "axiomCount": 0,
-    "lineCount": 373,
+    "lineCount": 374,
     "focusedRange": {
       "startLine": 220,
       "endLine": 343
@@ -151,7 +151,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 373,
+    "lineCount": 374,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 12,


### PR DESCRIPTION
## Fix

Aligns `meta.lineCount` and `leanFile.lineCount` (both `373`) with the canonical split-on-newline count of `Proofs/AmgmInequalityOQ03.lean` (`374`).

## Evidence

**Before**: `meta.lineCount = 373`, `leanFile.lineCount = 373`.
**After**: Both fields updated to `374`, matching the convention used by recent mechanic line-count PRs.

`proofs/Proofs/AmgmInequalityOQ03.lean` has 373 `\n` characters (`wc -l`) and 374 segments when split on `\n` (the convention adopted by sibling fixes).

Sibling `amgm-inequality-oq-03` (the parent entry sharing the same Lean file) received the same fix in PR #20551.

---
Automated fix by lean-mechanic agent.