### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-02 lineCount 285->286 (canonical split-newline)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
       "Basic real arithmetic (division by 3, ordering)",
       "Monotonicity and antitone sequences"
     ],
-    "lineCount": 285,
+    "lineCount": 286,
     "relatedProblems": [
       {
         "id": "algebraic-numbers-countable-oq-02",
@@ -208,7 +208,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 285,
+    "lineCount": 286,
     "namespace": "CantorNestedIntervals",
     "opens": [],
     "structureCount": 0,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` and `meta.lineCount` corrected to match canonical split-newline count.

## Evidence

**Before**: `lineCount: 285` (in both `meta.lineCount` and `leanFile.lineCount`)
**After**: `lineCount: 286` — matches `len(content.split('\n'))` for `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean` (file has 285 newlines + trailing empty line = 286 canonical lines).

---
Automated fix by lean-mechanic agent.