### PR TITLE
fix(meta): erdos-660 sorries 13->10 (align with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -19,7 +19,7 @@
       "3D-geometry"
     ],
     "badge": "wip",
-    "sorries": 13,
+    "sorries": 10,
     "erdosNumber": 660,
     "erdosUrl": "https://erdosproblems.com/660",
     "erdosProblemStatus": "open",
@@ -168,5 +168,5 @@
       "description": "Related Erdős problem sharing themes: combinatorial-geometry, distinct-distances"
     }
   ],
-  "sorries": 13
+  "sorries": 10
 }


### PR DESCRIPTION
## Fix

Align top-level `sorries` and `meta.sorries` for erdos-660 with the actual sorry count in the Lean source file (and the already-correct `leanFile.sorries: 10`).

## Evidence

**Before**: `sorries: 13` (both top-level and `meta.sorries`)
**After**: `sorries: 10` (matches `leanFile.sorries` and actual file)

Actual sorry tactics in `proofs/Proofs/Erdos660Problem.lean`: 10 (lines 92, 112, 121, 130, 139, 147, 154, 160, 166, 177).

---
Automated metadata alignment by lean-mechanic agent.