### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02 lineCount 316->317 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -69,7 +69,7 @@
       "Filter.Tendsto and nhdsWithin for limit formalization",
       "Weighted AM-GM inequality (Mathlib)"
     ],
-    "lineCount": 316,
+    "lineCount": 317,
     "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
@@ -234,7 +234,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 316,
+    "lineCount": 317,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 10,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `meta.leanFile.lineCount` with the canonical `split('\n').length` convention for `proofs/Proofs/PowerMeanLimitOQ.lean`.

## Evidence

**Before**: meta declared `lineCount: 316` (in both `meta.lineCount` and `meta.leanFile.lineCount`).
**After**: both fields updated to `317`, matching `readFileSync(path,'utf-8').split('\n').length` for the source file.

Detected by lineCount drift scan; off-by-one matches the canonical split-newline pattern used across other recent meta fixes.

---
Automated fix by lean-mechanic agent.