### PR TITLE
Fix: taylor-sincos-convergence-oq-03 sorries 6->3 (align with leanFile)

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-03/meta.json
@@ -17,7 +17,7 @@
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ03.lean",
     "badge": "wip",
-    "sorries": 6,
+    "sorries": 3,
     "axiomCount": 0,
     "assumptions": "0 axioms. 3 sorries: alternating tail bound, alternating remainder for sin, alternating remainder for cos. Partial sum bounds fully proved by induction on paired terms.",
     "originalContributions": [
@@ -127,5 +127,5 @@
       "Quantitative sharpness: at x = 1, the alternating bound for n = 5 is 1/5040 \u2248 0.0002, while the actual error is much smaller. Is the alternating bound itself tight, or can it be further improved for specific values of x?"
     ]
   },
-  "sorries": 6
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Correct `sorries` count in `src/data/proofs/taylor-sincos-convergence-oq-03/meta.json` from 6 -> 3 to align with the actual count in `proofs/Proofs/TaylorSinCosConvergenceOQ03.lean`.

## Evidence

**Before**: `meta.sorries` and top-level `sorries` both reported 6.
**After**: Both report 3, matching `leanFile.sorries` and the `assumptions` text which already read "0 axioms. 3 sorries: alternating tail bound, alternating remainder for sin, alternating remainder for cos."

Verified: `grep -c "sorry" proofs/Proofs/TaylorSinCosConvergenceOQ03.lean` returns 3.

---
Automated fix by lean-mechanic agent.