### PR TITLE
Fix erdos-673 sorries count (30 -> 20)

### DIFF
--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -18,7 +18,7 @@
       "distribution"
     ],
     "badge": "wip",
-    "sorries": 30,
+    "sorries": 20,
     "erdosNumber": 673,
     "erdosUrl": "https://erdosproblems.com/673",
     "erdosProblemStatus": "solved",
@@ -253,5 +253,5 @@
       "description": "Related Erdős problem sharing themes: analytic-number-theory, arithmetic-functions, number-theory"
     }
   ],
-  "sorries": 30
+  "sorries": 20
 }


### PR DESCRIPTION
## Fix

Correct the reported sorry count in `src/data/proofs/erdos-673/meta.json` to match the actual Lean source.

## Evidence

`proofs/Proofs/Erdos673Problem.lean` contains exactly **20** occurrences of `sorry` (verified by grep). The meta.json file had three different values:

| Field | Before | After |
|---|---|---|
| top-level `sorries` | `30` | `20` |
| `meta.sorries` | `30` | `20` |
| `meta.leanFile.sorries` | `20` | `20` (already correct) |
| `meta.assumptions` | `"20 sorry(s). No axioms."` | unchanged |

The `leanFile.sorries` and `assumptions` fields already agreed with the Lean source — only the duplicated top-level/nested `sorries: 30` were stale. `axiomCount: 0` is also correct (no `axiom` declarations, no structure-encoded assumptions).

## Validation

- `pnpm build` passes
- No Lean code changed, so no rebuild needed

---
Automated fix by lean-mechanic agent.