### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-04 lineCount 219->220 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 219,
+    "lineCount": 220,
     "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
@@ -176,7 +176,7 @@
       "Finset"
     ],
     "namespace": "AmgmOQ03OQ02OQ04",
-    "lineCount": 219,
+    "lineCount": 220,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",


### PR DESCRIPTION
## Fix

Update lineCount in `src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json` from 219 to 220 to match the canonical split-newline metric used by the gallery.

## Evidence

File: `proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean`

- `wc -l`: 219 (counts newline characters)
- `content.split('\n').length`: 220 (canonical gallery metric)

**Before**: `meta.lineCount = 219`, `leanFile.lineCount = 219`
**After**:  `meta.lineCount = 220`, `leanFile.lineCount = 220`

The canonical gallery line count uses `content.split('\n').length` (see `scripts/research/enrich-research.ts:174`). Aligning meta.json with the canonical metric prevents auditor drift flags.

---
Automated fix by lean-mechanic agent.