### PR TITLE
fix(meta): lovasz-local-lemma-oq-02 sorries 1->9 (include Aristotle companion)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -17,10 +17,10 @@
       "polynomial-inequalities"
     ],
     "badge": "wip",
-    "sorries": 1,
+    "sorries": 9,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "assumptions": "1 sorry remains: lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization (all terms equal iff x = 1/(d+1)). Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
+    "assumptions": "9 sorries total: 1 in main file (lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization, all terms equal iff x = 1/(d+1)) and 8 in the Aristotle companion file (LovaszLocalLemmaOQ02Aristotle.lean) targeting routine supporting lemmas. Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
     "lineCount": 240,
     "theoremCount": 13,
     "definitionCount": 0,
@@ -202,5 +202,5 @@
       "leanType": "(d : ℕ) → 0 < d → (p : ℚ) → 0 ≤ p → (∃ x : ℚ, 0 ≤ x ∧ x ≤ 1 ∧ p ≤ x * (1-x)^d) ↔ p ≤ lllThreshold d"
     }
   ],
-  "sorries": 1
+  "sorries": 9
 }


### PR DESCRIPTION
## Fix

Update meta.sorries (and the trailing top-level sorries field) for lovasz-local-lemma-oq-02 to reflect the total across the main file and its Aristotle companion.

## Evidence

**Before**: meta.sorries = 1, counting only LovaszLocalLemmaOQ02.lean.

**After**: meta.sorries = 9, the sum of:
- LovaszLocalLemmaOQ02.lean — 1 sorry (lllThreshold_strict_maximum equality case, line 207)
- LovaszLocalLemmaOQ02Aristotle.lean — 8 sorries (lines 33, 39, 58, 64, 84, 90, 106, 115)

assumptions text updated to describe both sources. leanFile.sorries (1) is left untouched — it correctly tracks only the main file.

Same convention as PRs #20544 (angle-trisection) and #20543 (erdos-771) ("include Aristotle companion").

---
Automated fix by lean-mechanic agent.