### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-03 lineCount 65->66 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 65,
+    "lineCount": 66,
     "theoremCount": 2,
     "definitionCount": 1
   },
@@ -157,7 +157,7 @@
   "leanFile": {
     "namespace": "AmgmOQ03OQ03",
     "axiomCount": 0,
-    "lineCount": 65,
+    "lineCount": 66,
     "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
     "sorries": 0,
     "theoremCount": 2,


### PR DESCRIPTION
## Fix

Align `amgm-inequality-oq-03-oq-03/meta.json` `lineCount` with the canonical split-newline convention used by `scripts/research/enrich-research.ts:174` (`content.split('\n').length`).

## Evidence

- **Before**: `meta.lineCount: 65`, `leanFile.lineCount: 65`
- **After**: `meta.lineCount: 66`, `leanFile.lineCount: 66`

`AmgmInequalityOQ03OQ03.lean` has a trailing newline: `wc -l` reports 65 newlines, but `split('\n').length` (the enrichment pipeline's convention) is 66. Same off-by-one pattern as recent mechanic fixes (e.g. #20556, #20539, #20536).

No Lean source changes; metadata only.

---
Automated fix by lean-mechanic agent.