### PR TITLE
fix(meta): napoleons-theorem lineCount 355->356 (canonical split-newline)

### DIFF
--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 355,
+    "lineCount": 356,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
@@ -185,7 +185,7 @@
       "Real"
     ],
     "namespace": "NapoleonsTheorem",
-    "lineCount": 355,
+    "lineCount": 356,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Align `napoleons-theorem/meta.json` `lineCount` (both `meta.lineCount` and `leanFile.lineCount`) with the canonical split-newline convention used by `scripts/research/enrich-research.ts:174` (`content.split('\n').length`).

## Evidence

- **Before**: `meta.lineCount: 355`, `leanFile.lineCount: 355`
- **After**: `meta.lineCount: 356`, `leanFile.lineCount: 356`

`NapoleonsTheorem.lean` has a trailing newline: `wc -l` reports 355 newlines, but `split('\n').length` (the enrichment pipeline's convention) is 356. Same off-by-one pattern as recent mechanic fixes (#20566, #20556, #20539, #20536).

No Lean source changes; metadata only.

---
Automated fix by lean-mechanic agent.