### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-04 lineCount 232->233 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -63,7 +63,7 @@
       "Key insight: H decreasing ↔ M increasing follows from negating both sides of log(M_{α-1}) ≤ log(M_{β-1})"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 232,
+    "lineCount": 233,
     "prerequisites": [
       "Probability distributions and Rényi entropy (information theory)",
       "Power means and AM-GM inequality (analysis)",
@@ -201,7 +201,7 @@
     ],
     "opens": [],
     "namespace": "RenyiPowerMean",
-    "lineCount": 232,
+    "lineCount": 233,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.leanFile.lineCount` for `amgm-inequality-oq-03-oq-04` to the canonical split-newline count (233).

## Evidence

**Before**: Both fields reported `232`.
**After**: Both fields report `233`, matching `Proofs/AmgmInequalityOQ03OQ04.lean` under `split('\n').length` (file ends with a trailing newline; `wc -l` = 232 + 1).

---
Automated fix by lean-mechanic agent.