### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-03-oq-01 lineCount 272->273 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 272,
+    "lineCount": 273,
     "assumptions": "None. 0 sorries, 0 axioms. Complete formalization using Mathlib's Filter.Tendsto, Real.rpow, and Finset.sup'/inf'.",
     "theoremCount": 19,
     "definitionCount": 3,
@@ -253,7 +253,7 @@
       "Finset"
     ],
     "namespace": "AmgmPowerMeanLimits",
-    "lineCount": 272,
+    "lineCount": 273,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",


### PR DESCRIPTION
## Fix

Aligns `meta.lineCount` and `leanFile.lineCount` (both `272`) with the canonical split-on-newline count of `Proofs/AmgmInequalityPowerMeanLimits.lean` (`273`).

## Evidence

**Before**: `meta.lineCount = 272`, `leanFile.lineCount = 272`.
**After**: Both fields updated to `273`, matching the convention used by recent mechanic line-count PRs.

`proofs/Proofs/AmgmInequalityPowerMeanLimits.lean` has 272 `\n` characters (`wc -l`) and 273 segments when split on `\n` (the convention adopted by sibling fixes such as PR #20556 and #20553).

This is the sole gallery entry pointing at `AmgmInequalityPowerMeanLimits.lean`; siblings sharing the file were already synced in PR #19734.

---
Automated fix by lean-mechanic agent.