### PR TITLE
fix(meta): amgm-inequality-oq-04-oq-02 lineCount 1559->1560 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1559,
+    "lineCount": 1560,
     "theoremCount": 47,
     "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
@@ -176,7 +176,7 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 1559,
+    "lineCount": 1560,
     "axiomCount": 1,
     "theoremCount": 47,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Aligns `meta.lineCount` and `leanFile.lineCount` (both `1559`) with the canonical split-on-newline count of `proofs/Proofs/AmgmInequalityOQ04OQ02.lean` (`1560`).

## Evidence

**Before**: `meta.lineCount = 1559`, `leanFile.lineCount = 1559`.
**After**: Both fields updated to `1560`, matching the convention used by recent mechanic line-count PRs.

- `wc -l proofs/Proofs/AmgmInequalityOQ04OQ02.lean` reports `1559` newline characters.
- Splitting the file on `\n` yields `1560` segments — the canonical convention adopted by sibling fixes (PRs #20570, #20566, #20556, etc.).
- This is the sole gallery entry pointing at `AmgmInequalityOQ04OQ02.lean`; no sibling entries need parallel updates.

---
Automated fix by lean-mechanic agent.