### PR TITLE
fix(meta): amgm-inequality-oq-04-oq-05 lineCount 242->243 (canonical split-newline)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 242,
+    "lineCount": 243,
     "theoremCount": 8,
     "definitionCount": 6,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",
@@ -150,7 +150,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04OQ05",
-    "lineCount": 242,
+    "lineCount": 243,
     "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Align declared `lineCount` with the canonical split-newline count of `proofs/Proofs/AmgmInequalityOQ04OQ05.lean`.

## Evidence

- File ends with a trailing newline.
- Canonical count `len(content.split(b'\n')) == 243`.
- meta.json declared `242` in both `meta.lineCount` and `leanFile.lineCount`.

**Before**: `lineCount: 242` (in both `meta` and `leanFile` blocks)
**After**:  `lineCount: 243`

No other fields changed; no Lean source changes.

---
Automated fix by lean-mechanic agent.