### PR TITLE
fix(meta): cauchy-schwarz-oq-02-oq-02 lineCount 161->162 (canonical split-newline)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 161,
+    "lineCount": 162,
     "theoremCount": 10,
     "definitionCount": 0,
     "assumptions": "None. All theorems proved from Mathlib's Orthonormal.sum_inner_products_le, Orthonormal.tsum_inner_products_le, and HilbertBasis.tsum_inner_mul_inner.",
@@ -269,7 +269,7 @@
   "leanFile": {
     "path": "Proofs/CauchySchwarzOQ02OQ02.lean",
     "filename": "CauchySchwarzOQ02OQ02.lean",
-    "lineCount": 161,
+    "lineCount": 162,
     "theoremCount": 10,
     "axiomCount": 0,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update lineCount in src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json from 161 to 162 to match the canonical split-newline metric used by the gallery.

## Evidence

File: proofs/Proofs/CauchySchwarzOQ02OQ02.lean

- wc -l: 161 (counts newline characters)
- content split newline length: 162 (canonical gallery metric)

Before: meta.lineCount = 161, leanFile.lineCount = 161
After:  meta.lineCount = 162, leanFile.lineCount = 162

The canonical gallery line count uses content split newline length (see scripts/research/enrich-research.ts:174). Aligning meta.json with the canonical metric prevents auditor drift flags.

---
Automated fix by lean-mechanic agent.