### PR TITLE
fix(meta): erdos-220 lineCount 227->228 (canonical split-newline)

### DIFF
--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -59,7 +59,7 @@
       "jacobsthal n: maximum gap function"
     ],
     "axiomCount": 4,
-    "lineCount": 227,
+    "lineCount": 228,
     "assumptions": "4 axioms: montgomery_vaughan_squared (squared gaps sum O(n²/φ(n))), montgomery_vaughan_general (γ-th power generalization), maximum_gap_bound (max gap ≤ C·n/φ(n)·(log n)²), gap_concentration (squared sum ≤ C·φ(n)·avg²). 2 sorries (sum_gaps_bound derivation; reduced_residues_count).",
     "theoremCount": 3,
     "definitionCount": 14,
@@ -142,7 +142,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 227,
+    "lineCount": 228,
     "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Update lineCount in src/data/proofs/erdos-220/meta.json from 227 to 228 to match the canonical split-newline metric used by the gallery.

## Evidence

File: proofs/Proofs/Erdos220Problem.lean

- wc -l: 227 (counts newline characters)
- content split newline length: 228 (canonical gallery metric)

Before: meta.lineCount = 227, leanFile.lineCount = 227
After:  meta.lineCount = 228, leanFile.lineCount = 228

The canonical gallery line count uses content split newline length (see scripts/research/enrich-research.ts:174). Aligning meta.json with the canonical metric prevents auditor drift flags.

---
Automated fix by lean-mechanic agent.