### PR TITLE
[codex] Backfill discrete analysis metadata (rebase of #20313)

### DIFF
--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-03.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-03.json
@@ -167,10 +167,34 @@
     "chinese-remainder-non-coprime-oq-03-oq-02",
     "chinese-remainder-non-coprime-oq-04"
   ],
-  "tags": [],
+  "tags": [
+    "number-theory",
+    "chinese-remainder-theorem",
+    "non-coprime-moduli",
+    "euclidean-domains",
+    "gcd",
+    "lcm",
+    "completed"
+  ],
   "problemStatement": {
-    "formal": "",
-    "plain": "Formal mathematical investigation: chinese-remainder-non-coprime-oq-03.",
-    "whyMatters": []
+    "formal": "For three moduli m1,m2,m3 over a Euclidean domain, pairwise congruence compatibility modulo gcd(mi,mj) is equivalent to solvability of the simultaneous non-coprime CRT system, with uniqueness modulo lcm(m1,m2,m3).",
+    "plain": "Extends the non-coprime Chinese remainder theorem from two moduli to three. The proof packages the exact compatibility conditions, shows they are sufficient for a common solution, proves the iff form, and records uniqueness modulo the combined lcm.",
+    "whyMatters": [
+      "The ordinary CRT assumes coprime moduli; practical congruence systems often have overlapping moduli.",
+      "The three-moduli case is the first place where pairwise gcd/lcm compatibility has to be managed carefully.",
+      "This file supplies reusable algebra for building larger finite CRT systems over Euclidean domains."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "`ed_crt_three_sufficient` proves the pairwise gcd compatibility conditions imply existence of a common solution.",
+      "`ed_crt_three_iff` packages the three-moduli non-coprime CRT as an iff.",
+      "`ed_crt_three_unique` proves any two solutions are congruent modulo the lcm of the three moduli.",
+      "The file documents the gcd/lcm decomposition needed to bridge pairwise compatibility to the combined modulus."
+    ],
+    "open": [
+      "General list-length non-coprime CRT automation is handled by sibling entries; this entry is intentionally scoped to the three-moduli theorem."
+    ],
+    "goal": "Make the three-moduli non-coprime CRT evidence discoverable without editing proof-health counts."
   }
 }

--- a/src/data/research/problems/combinations-formula-oq-02.json
+++ b/src/data/research/problems/combinations-formula-oq-02.json
@@ -6,14 +6,25 @@
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in combinatorics: Combinations Formula: Connections to Catalan Numbers and Combinatorial Sequences.",
-    "whyMatters": []
+    "formal": "C_n = (1/(n+1)) * binomial(2*n,n), with Catalan recurrence and central-binomial bounds formalized for n in N.",
+    "plain": "Develops the Catalan-number side of the combinations formula project. The Lean file defines Catalan numbers from central binomial coefficients, verifies the first values, proves positivity and growth bounds, and records the convolution recurrence used across Catalan-counting arguments.",
+    "whyMatters": [
+      "Catalan numbers connect binomial coefficients to trees, paths, parenthesizations, and many other counting problems.",
+      "The entry turns the combinations formula into reusable Catalan and central-binomial infrastructure rather than a single isolated identity.",
+      "Verified tables and bounds make the result useful for downstream combinatorics entries that need small values or asymptotic estimates."
+    ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "Defines `catalan n` as `Nat.centralBinom n / (n + 1)` and proves the initial values C_0 through C_5.",
+      "Proves `catalan_mul_succ`, `catalan_pos`, and monotonicity for positive indices.",
+      "Establishes central-binomial bounds including `centralBinom_le_four_pow` and `centralBinom_ge_two_pow`.",
+      "Proves the Catalan convolution recurrence in `catalan_convolution` for the verified Catalan sequence."
+    ],
+    "open": [
+      "The Aristotle companion file still contains exploratory sorry placeholders; the main `CombinationsFormulaOQ02.lean` evidence is the completed file used for this metadata entry."
+    ],
+    "goal": "Document the completed Catalan-number and central-binomial toolkit attached to the combinations formula family."
   },
   "currentState": {
     "phase": "COMPLETED",
@@ -59,7 +70,11 @@
   "tags": [
     "seeker-selected",
     "combinatorics",
-    "catalan-numbers"
+    "catalan-numbers",
+    "binomial-coefficients",
+    "central-binomial-coefficients",
+    "recurrences",
+    "completed"
   ],
   "relatedProofs": [
     "combinations-formula",

--- a/src/data/research/problems/dissection-of-cubes-oq-02.json
+++ b/src/data/research/problems/dissection-of-cubes-oq-02.json
@@ -163,10 +163,33 @@
     "dissection-of-cubes-oq-03",
     "dissection-of-cubes-oq-04"
   ],
-  "tags": [],
+  "tags": [
+    "geometry",
+    "hilberts-third-problem",
+    "dehn-invariant",
+    "scissors-congruence",
+    "irrational-angles",
+    "completed"
+  ],
   "problemStatement": {
-    "formal": "",
-    "plain": "Formalizes the Dehn invariant approach to Hilbert's Third Problem: proves the cube has zero Dehn invariant (rational angles) while the tetrahedron has nonzero invariant (irrational angle), showing they cannot be scissors congruent.",
-    "whyMatters": []
+    "formal": "Using the Dehn invariant, show a cube and a regular tetrahedron are not scissors congruent, giving the Hilbert third problem obstruction.",
+    "plain": "Formalizes the Dehn-invariant obstruction behind Hilbert's third problem. The entry proves the tetrahedron angle is irrational relative to pi, records the cube/tetrahedron invariant mismatch, and derives the non-dissection conclusion.",
+    "whyMatters": [
+      "Hilbert's third problem shows that equal volume is not enough for polyhedral scissors congruence.",
+      "The Dehn invariant is the central algebraic obstruction separating three-dimensional dissection from the planar case.",
+      "A Lean version gives the geometry gallery a concrete example where angle arithmetic drives an impossibility theorem."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "`tetrahedron_angle_irrational_pi` captures the irrational angle input for the regular tetrahedron.",
+      "`hilbert_third_problem` states the cube and tetrahedron obstruction through the Dehn invariant.",
+      "`dehn_obstruction` packages the invariant mismatch into the scissors-congruence obstruction.",
+      "The OQ02 proof file is recorded with zero axioms and zero sorries in the current research JSON."
+    ],
+    "open": [
+      "Sibling dissection entries explore broader geometric covering and extended dissection infrastructure; this entry stays on the classical Dehn-invariant obstruction."
+    ],
+    "goal": "Document the completed Hilbert third problem / Dehn invariant formalization."
   }
 }


### PR DESCRIPTION
Rebase of #20313 onto current main.

Summary:
- Backfills `problemStatement`, `knownResults`, and `tags` for three proof-backed research metadata entries that still had stub content on main:
  - `chinese-remainder-non-coprime-oq-03.json`
  - `combinations-formula-oq-02.json`
  - `dissection-of-cubes-oq-02.json`

Resolution notes (the original PR touched 6 files; 3 were dropped during rebase because main already has equivalent or richer content):
- `birthday-problem-oq-02.json`: main has more detailed, evidence-aware metadata; took main's version.
- `fundamental-theorem-calculus-oq-01.json`: main has the more honest "partial / still-axiomatized" framing; took main's version.
- `prob-method-expectation-oq-01.json`: main already has populated `problemStatement`, `knownResults`, and `tags`; the PR was appending duplicate keys. Took main's version.

Original PR body:
> Backfills `problemStatement`, `knownResults`, and `tags` for six proof-backed research metadata entries. Covers Catalan/combinations infrastructure, three-moduli non-coprime CRT, birthday collision bounds, the Dehn-invariant obstruction for Hilbert's third problem, the Lebesgue FTC bridge, and the measure-theoretic expectation bridge. Metadata-only: no Lean proof edits, proof-health counts, or generated artifacts.