### PR TITLE
Update erdos-90: cite OpenAI 2026-05-20 reported disproof of unit-distance conjecture

### DIFF
--- a/proofs/Proofs/Erdos90Problem.lean
+++ b/proofs/Proofs/Erdos90Problem.lean
@@ -8,10 +8,19 @@ Known results:
 - Upper bound: u(n) = O(n^{4/3}) (Spencer–Szemerédi–Trotter 1984)
 - Lower bound: u(n) ≥ n^{1+c/log log n} for some c > 0 (lattice constructions)
 - The upper bound cannot be improved by methods that work in general metrics (Valtr)
+- On 2026-05-20, OpenAI announced a construction (rings of integers in number fields
+  with infinite class field towers, via Golod–Shafarevich) reportedly disproving the
+  conjectured exponent — peer review pending. The Spencer–Szemerédi–Trotter O(n^{4/3})
+  upper bound is unaffected, and the true asymptotic order of u(n) remains open.
 
 $500 prize offered by Erdős.
 
-Reference: https://erdosproblems.com/90
+References:
+- https://erdosproblems.com/90
+- OpenAI announcement (2026-05-20):
+    https://openai.com/index/model-disproves-discrete-geometry-conjecture/
+- OpenAI technical note:
+    https://cdn.openai.com/pdf/74c24085-19b0-4534-9c90-465b8e29ad73/unit-distance-remarks.pdf
 -/
 
 import Mathlib.Analysis.InnerProductSpace.Basic
@@ -49,14 +58,21 @@ noncomputable def maxUnitDistances (n : ℕ) : ℕ :=
 
 /-- There exist n-point configurations with n^{1+c/log log n} unit distances
     for some constant c > 0, achieved by lattice-point constructions -/
-/- ## The Erdős Conjecture -/
+/- ## Erdős's 1946 Conjecture (reportedly disproved by OpenAI 2026-05-20,
+       peer review pending) -/
 
-/-- Erdős Problem 90: u(n) = n^{1+O(1/log log n)}, i.e. the maximum number of
-    unit distances among n points in ℝ² is at most n^{1+O(1/log log n)}.
-    This would match the lattice lower bound up to the constant in the exponent.
-    $500 prize. Open since 1946. -/
-/-- Stronger form: u(n) = n^{1+o(1)}, meaning the exponent approaches 1.
-    Erdős offered $300 (later $250) for this weaker conjecture. -/
+/-- Erdős's 1946 conjecture (now reportedly false, peer review pending):
+    u(n) = n^{1+O(1/log log n)}, i.e. the maximum number of unit distances
+    among n points in ℝ² is at most n^{1+O(1/log log n)}. This would have
+    matched the lattice lower bound up to the constant in the exponent.
+    $500 prize. Posed 1946. On 2026-05-20, OpenAI announced a construction
+    via number fields with infinite class field towers (Golod–Shafarevich)
+    reportedly giving a polynomial improvement over the lattice lower bound,
+    disproving the conjectured exponent — peer review pending. -/
+/-- Stronger (now also in doubt) form: u(n) = n^{1+o(1)}, meaning the exponent
+    approaches 1. Erdős offered $300 (later $250) for this weaker conjecture.
+    Status of this weak form under the OpenAI 2026 construction depends on the
+    precise exponent achieved (peer review pending). -/
 /- ## Valtr's Obstruction -/
 
 /-- Valtr showed that there exists a metric on ℝ² (not Euclidean) where

--- a/src/data/proofs/erdos-90/annotations.json
+++ b/src/data/proofs/erdos-90/annotations.json
@@ -18,8 +18,8 @@
       "EuclideanSpace definition"
     ],
     "range": {
-      "startLine": 17,
-      "endLine": 22
+      "startLine": 26,
+      "endLine": 31
     }
   },
   {
@@ -41,8 +41,8 @@
       "EuclideanSpace metric"
     ],
     "range": {
-      "startLine": 26,
-      "endLine": 28
+      "startLine": 35,
+      "endLine": 37
     }
   },
   {
@@ -63,8 +63,8 @@
       "set-builder notation in Lean"
     ],
     "range": {
-      "startLine": 30,
-      "endLine": 33
+      "startLine": 39,
+      "endLine": 42
     }
   },
   {
@@ -85,8 +85,8 @@
       "BddAbove"
     ],
     "range": {
-      "startLine": 35,
-      "endLine": 37
+      "startLine": 44,
+      "endLine": 46
     }
   },
   {
@@ -107,8 +107,8 @@
       "Finset.card"
     ],
     "range": {
-      "startLine": 43,
-      "endLine": 44
+      "startLine": 50,
+      "endLine": 51
     }
   },
   {
@@ -130,8 +130,8 @@
       "incidence bounds"
     ],
     "range": {
-      "startLine": 48,
-      "endLine": 54
+      "startLine": 54,
+      "endLine": 56
     }
   },
   {
@@ -154,8 +154,34 @@
       "Real.log"
     ],
     "range": {
-      "startLine": 58,
-      "endLine": 63
+      "startLine": 59,
+      "endLine": 60
+    }
+  },
+  {
+    "id": "openai-2026-disproof",
+    "proofId": "erdos-90",
+    "type": "concept",
+    "title": "OpenAI 2026 Construction (Reported Disproof of Erdős's Exponent)",
+    "content": "On 2026-05-20 OpenAI announced an AI-assisted construction reportedly disproving the conjectured exponent in u(n). The construction replaces the Gaussian integer lattice with rings of integers in number fields admitting infinite class field towers, whose unit groups generate substantially more unit-length differences than ℤ². Peer review is pending; the Spencer–Szemerédi–Trotter O(n^{4/3}) upper bound is unaffected.",
+    "significance": "key",
+    "mathContext": "Erdős (1946) conjectured $u(n) = n^{1+O(1/\\log\\log n)}$, i.e. the $\\sqrt{n} \\times \\sqrt{n}$ integer lattice (achieving $n \\cdot \\exp(c \\log n / \\log\\log n)$) is essentially optimal. OpenAI's construction (announced 2026-05-20) reportedly produces an infinite family of point sets in $\\mathbb{R}^2$ yielding a **polynomial improvement** over Erdős's lower bound. The mechanism: pick an algebraic number field $K$ whose ring of integers $\\mathcal{O}_K$ admits an **infinite class field tower**, guaranteed to exist by the **Golod–Shafarevich theorem** when the $\\ell$-rank of the class group of $K$ is sufficiently large relative to $\\sqrt{[K : \\mathbb{Q}]}$. The unit group $\\mathcal{O}_K^\\times$ then provides exponentially many algebraic relations of norm 1, which (after embedding $\\mathcal{O}_K$ into $\\mathbb{C} \\cong \\mathbb{R}^2$) translate to many unit-length differences.\n\n**Status (peer review pending).** This disproves the conjectured upper bound on the *exponent* of $u(n)$; it does not disprove the SST $O(n^{4/3})$ upper bound, which is unaffected. The true asymptotic order of $u(n)$ remains an open problem. Until the OpenAI write-up is peer-reviewed and erdosproblems.com#90 is reclassified, this gallery entry retains `status: axiomatized`, `badge: wip`, and `erdosProblemStatus: open`.",
+    "relatedConcepts": [
+      "class field tower",
+      "Golod–Shafarevich theorem",
+      "ring of integers",
+      "unit group",
+      "number field embeddings",
+      "AI-assisted mathematics"
+    ],
+    "prerequisites": [
+      "algebraic number theory",
+      "class field theory",
+      "unit theorem (Dirichlet)"
+    ],
+    "range": {
+      "startLine": 52,
+      "endLine": 65
     }
   }
 ]

--- a/src/data/proofs/erdos-90/meta.json
+++ b/src/data/proofs/erdos-90/meta.json
@@ -2,7 +2,7 @@
   "id": "erdos-90",
   "title": "Erdős Problem #90: The Unit Distance Problem",
   "slug": "erdos-90",
-  "description": "What is the maximum number u(n) of unit-distance pairs among n points in ℝ²? Erdős conjectured u(n) = n^{1+O(1/log log n)}. Best upper bound is O(n^{4/3}) by Spencer–Szemerédi–Trotter. $500 prize.",
+  "description": "What is the maximum number u(n) of unit-distance pairs among n points in ℝ²? Erdős (1946) conjectured u(n) = n^{1+O(1/log log n)}. The best published upper bound is O(n^{4/3}) by Spencer–Szemerédi–Trotter. On 2026-05-20, OpenAI announced a construction (via number fields with infinite class field towers / Golod–Shafarevich) reportedly giving a polynomial improvement over the lattice lower bound, disproving the conjectured exponent — peer review pending. $500 prize.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/90",
@@ -63,17 +63,17 @@
       "Documented Valtr's obstruction informally: a non-Euclidean semimetric achieving Θ(n^{4/3}) unit distances exists, showing SST alone cannot beat n^{4/3} (stated in comments, not as a Lean axiom)"
     ],
     "axiomCount": 0,
-    "lineCount": 65,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "lineCount": 81,
+    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean. Status note: on 2026-05-20 OpenAI announced a reported disproof of the conjectured exponent (peer review pending); status remains 'axiomatized' and erdosProblemStatus remains 'open' until the disproof is peer-reviewed and erdosproblems.com#90 is reclassified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
     "definitionCount": 3
   },
   "overview": {
-    "historicalContext": "Erdős posed Problem 90 in 1946, making it one of the oldest open problems in combinatorial geometry. The unit distance problem asks: given $n$ points in $\\mathbb{R}^2$, what is the maximum number $u(n)$ of pairs at Euclidean distance exactly 1? Erdős himself showed the trivial bound $u(n) \\leq \\binom{n}{2}$ and constructed lattice examples achieving $u(n) \\geq n^{1+c/\\log\\log n}$ for a constant $c > 0$, exploiting the number-theoretic fact that $\\lfloor\\sqrt{n}\\rfloor \\times \\lfloor\\sqrt{n}\\rfloor$ integer lattice points have many representations as sums of two squares. In 1984, Spencer, Szemerédi, and Trotter proved $u(n) = O(n^{4/3})$ using the celebrated Szemerédi–Trotter incidence theorem, which bounds the number of incidences between $n$ points and $m$ lines (or circles). This $n^{4/3}$ bound has stood for over 40 years. In 2005, Valtr constructed a non-Euclidean metric on $\\mathbb{R}^2$ achieving $\\Theta(n^{4/3})$ unit distances, proving that any improvement must exploit specific properties of the Euclidean metric. Erdős offered $\\$500$ for the full resolution and $\\$250$–$300$ for even the weaker form $u(n) = n^{1+o(1)}$. The problem connects to the Erdős distinct distances problem (solved by Guth–Katz in 2015 using algebraic methods), but the unit distance conjecture remains stubbornly open.",
-    "problemStatement": "Let $u(n)$ denote the maximum number of unordered pairs at Euclidean distance 1 among $n$ points in $\\mathbb{R}^2$. Is $u(n) = n^{1+O(1/\\log\\log n)}$?",
-    "text": "What is the maximum number u(n) of unit-distance pairs among n points in ℝ²? Erdős conjectured u(n) = n^{1+O(1/log log n)}. Best upper bound is O(n^{4/3}) by Spencer–Szemerédi–Trotter. $500 prize.",
-    "proofStrategy": "The formalization defines $u(n)$ constructively: `unitDistancePairsCount` filters `Finset.offDiag` for pairs at `dist = 1` and divides by 2 for unordered pairs; `maxUnitDistances` takes the `sSup` over all $n$-point configurations. The key results (SST upper bound, lattice lower bound, Valtr's obstruction, main conjecture, weak form) are documented as informal Lean comments — no `axiom` declarations remain in the source. The file has 0 axioms and 0 sorries; `status: axiomatized` reflects that the main open conjecture is not yet formally proved.",
+    "historicalContext": "Erdős posed Problem 90 in 1946, making it one of the oldest open problems in combinatorial geometry. The unit distance problem asks: given $n$ points in $\\mathbb{R}^2$, what is the maximum number $u(n)$ of pairs at Euclidean distance exactly 1? Erdős himself showed the trivial bound $u(n) \\leq \\binom{n}{2}$ and constructed lattice examples achieving $u(n) \\geq n^{1+c/\\log\\log n}$ for a constant $c > 0$, exploiting the number-theoretic fact that $\\lfloor\\sqrt{n}\\rfloor \\times \\lfloor\\sqrt{n}\\rfloor$ integer lattice points have many representations as sums of two squares. In 1984, Spencer, Szemerédi, and Trotter proved $u(n) = O(n^{4/3})$ using the celebrated Szemerédi–Trotter incidence theorem, which bounds the number of incidences between $n$ points and $m$ lines (or circles). This $n^{4/3}$ bound has stood for over 40 years. In 2005, Valtr constructed a non-Euclidean metric on $\\mathbb{R}^2$ achieving $\\Theta(n^{4/3})$ unit distances, proving that any improvement must exploit specific properties of the Euclidean metric. Erdős offered $\\$500$ for the full resolution and $\\$250$–$300$ for even the weaker form $u(n) = n^{1+o(1)}$.\n\nOn **2026-05-20**, OpenAI announced that an internal reasoning model produced a construction reportedly disproving the conjectured exponent. The construction replaces the Gaussian-integer lattice with rings of integers in number fields admitting **infinite class field towers** (via the Golod–Shafarevich theorem); the corresponding unit groups generate many more unit-length differences than the integer lattice, yielding an infinite family of point sets with a polynomial improvement over Erdős's lower bound (see OpenAI's announcement and accompanying technical note). This is a disproof of the conjectured upper bound on the exponent in $u(n)$, not of the Spencer–Szemerédi–Trotter $O(n^{4/3})$ upper bound, which is unaffected. As of this writing the OpenAI write-up has not been peer-reviewed; the true asymptotic order of $u(n)$ also remains unknown. The problem connects to the Erdős distinct distances problem (solved by Guth–Katz in 2015 using algebraic methods).",
+    "problemStatement": "Let $u(n)$ denote the maximum number of unordered pairs at Euclidean distance 1 among $n$ points in $\\mathbb{R}^2$. Erdős (1946) conjectured $u(n) = n^{1+O(1/\\log\\log n)}$; on 2026-05-20 OpenAI announced a reported disproof of this exponent bound (peer review pending), so the true asymptotic order of $u(n)$ remains an open problem.",
+    "text": "What is the maximum number u(n) of unit-distance pairs among n points in ℝ²? Erdős (1946) conjectured u(n) = n^{1+O(1/log log n)}. The best published upper bound is O(n^{4/3}) by Spencer–Szemerédi–Trotter. On 2026-05-20, OpenAI announced a construction reportedly disproving the conjectured exponent (peer review pending). $500 prize.",
+    "proofStrategy": "The formalization defines $u(n)$ constructively: `unitDistancePairsCount` filters `Finset.offDiag` for pairs at `dist = 1` and divides by 2 for unordered pairs; `maxUnitDistances` takes the `sSup` over all $n$-point configurations. The key results (SST upper bound, lattice lower bound, Valtr's obstruction, Erdős's 1946 conjecture, weak form, and a note on the OpenAI 2026 reported disproof of the conjectured exponent) are documented as informal Lean comments — no `axiom` declarations remain in the source. The file has 0 axioms and 0 sorries; `status: axiomatized` reflects that no asymptotic statement is yet formally proved in Lean.",
     "keyInsights": [
       "The **Szemerédi–Trotter incidence theorem** gives $u(n) = O(n^{4/3})$ by viewing unit distances as incidences between points and unit circles: each point $p$ contributes a unit circle $\\{q : |p - q| = 1\\}$, and the SST theorem bounds point-curve incidences",
       "**Lattice constructions** achieve $n^{1+c/\\log\\log n}$: in a $\\sqrt{n} \\times \\sqrt{n}$ integer lattice, the number of representations of an integer as a sum of two squares is controlled by its prime factorization, and integers with many small prime factors yield many unit distance pairs",
@@ -93,53 +93,54 @@
       "id": "imports",
       "title": "Imports and Setup",
       "startLine": 1,
-      "endLine": 23,
+      "endLine": 31,
       "summary": "Imports Mathlib modules for inner product spaces (`EuclideanSpace`), metric spaces (`dist`), finite sets (`Finset.offDiag`, `Finset.card`), filters (`Filter.atTop`), and general tactics. These provide the $\\mathbb{R}^2$ ambient space, Euclidean distance, and the asymptotic filter framework."
     },
     {
       "id": "counting",
       "title": "Unit Distance Counting Definitions",
-      "startLine": 24,
-      "endLine": 38,
+      "startLine": 33,
+      "endLine": 46,
       "summary": "Defines three core objects: `unitDistancePairsCount` counts unordered pairs at distance 1 via `offDiag` filtering and division by 2; `unitDistanceCounts(n)` is the set of achievable counts for $n$-point configurations; `maxUnitDistances(n) = \\mathrm{sSup}(\\text{unitDistanceCounts}(n))$ is the extremal function $u(n)$."
     },
     {
       "id": "trivial-bound",
       "title": "Trivial Upper Bound",
-      "startLine": 39,
-      "endLine": 45,
+      "startLine": 48,
+      "endLine": 51,
       "summary": "Comments on the trivial bound: the set of achievable unit distance counts is bounded above by $\\binom{n}{2}$, ensuring the `sSup` defining $u(n)$ is finite. Stated informally in Lean comments; no `axiom` declaration in source."
     },
     {
       "id": "upper-bound",
       "title": "Spencer–Szemerédi–Trotter Upper Bound",
-      "startLine": 46,
-      "endLine": 55,
+      "startLine": 52,
+      "endLine": 56,
       "summary": "States $u(n) \\leq C \\cdot n^{4/3}$ for a constant $C > 0$ and all $n \\geq 1$. This 1984 result applies the Szemerédi–Trotter incidence theorem to unit circles: each point generates a unit circle, and bounding point-circle incidences gives the $n^{4/3}$ bound."
     },
     {
       "id": "lower-bound",
       "title": "Lattice Lower Bound",
-      "startLine": 56,
-      "endLine": 64,
+      "startLine": 57,
+      "endLine": 60,
       "summary": "States that for some $c > 0$, eventually $u(n) \\geq n^{1+c/\\log\\log n}$. This is achieved by integer lattice configurations exploiting the arithmetic of sums of two squares. The double-logarithmic factor arises from the Ramanujan–Hardy estimate for highly composite numbers."
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture and Weak Form",
-      "startLine": 65,
-      "endLine": 65,
-      "summary": "States the main conjecture (`ErdosProblem90`): $u(n) \\leq n^{1+C/\\log\\log n}$ eventually, matching the lattice lower bound up to the constant $C$. Also states the weak form (`erdos_90_weak`): $u(n) \\leq n^{1+\\varepsilon}$ for every $\\varepsilon > 0$ and large $n$."
+      "startLine": 61,
+      "endLine": 75,
+      "summary": "States the main conjecture (`ErdosProblem90`): $u(n) \\leq n^{1+C/\\log\\log n}$ eventually, matching the lattice lower bound up to the constant $C$. Also states the weak form (`erdos_90_weak`): $u(n) \\leq n^{1+\\varepsilon}$ for every $\\varepsilon > 0$ and large $n$. On 2026-05-20 OpenAI announced a reported disproof of the conjectured exponent via class field tower constructions (peer review pending); the file's comments are updated to reflect this status."
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #90 defines the extremal function u(n) via offDiag filtering and sSup, then documents the key results informally as Lean comments: the Spencer–Szemerédi–Trotter O(n^{4/3}) upper bound (1984), the lattice lower bound n^{1+c/log log n}, the main conjecture (with $500 prize), the weak form ($250–300 prize), and Valtr's fundamental obstruction. The file has 0 sorries and 0 axioms; results are informal pending full formalization.",
-    "implications": "**Theoretical Significance**: Resolution would transform combinatorial geometry.\n\nThe unit distance problem is intimately connected to the Erdős distinct distances problem (solved by Guth–Katz 2015), Kakeya-type problems, and the algebraic structure of Euclidean distance. Valtr's obstruction shows that purely topological or incidence-theoretic methods are insufficient; progress requires exploiting the algebraic nature of circles in the Euclidean plane, perhaps via polynomial methods as in the distinct distances solution.",
+    "summary": "Erdős Problem #90 defines the extremal function u(n) via offDiag filtering and sSup, then documents the key results informally as Lean comments: the Spencer–Szemerédi–Trotter O(n^{4/3}) upper bound (1984), the lattice lower bound n^{1+c/log log n}, Erdős's 1946 conjecture ($500 prize), the weak form ($250–300 prize), Valtr's fundamental obstruction, and a note on the OpenAI 2026-05-20 reported disproof of the conjectured exponent (peer review pending). The file has 0 sorries and 0 axioms; results are informal pending full formalization.",
+    "implications": "**Theoretical Significance**: The asymptotic order of $u(n)$ remains an open problem, but the landscape changed substantially on 2026-05-20 when OpenAI announced an AI-assisted construction reportedly disproving Erdős's conjectured exponent. The construction replaces the Gaussian integer lattice with rings of integers in number fields admitting infinite class field towers (via Golod–Shafarevich), yielding a polynomial improvement over the lattice lower bound. The Spencer–Szemerédi–Trotter $O(n^{4/3})$ upper bound is unaffected; closing the gap between the new lower bound and SST remains open.\n\nThe unit distance problem is intimately connected to the Erdős distinct distances problem (solved by Guth–Katz 2015), Kakeya-type problems, and the algebraic structure of Euclidean distance. Valtr's obstruction shows that purely topological or incidence-theoretic methods are insufficient on the upper-bound side; progress requires exploiting the algebraic nature of circles in the Euclidean plane.",
     "openQuestions": [
       "Can the O(n^{4/3}) upper bound be improved at all, even to O(n^{4/3 - ε}) for some ε > 0?",
-      "What specific property of Euclidean distance (beyond convexity of unit circles) would enable progress?",
+      "What is the true asymptotic order of u(n), given the OpenAI 2026-05-20 lower bound exceeds n^{1+c/log log n}?",
+      "Will the OpenAI construction survive peer review, and what is the precise exponent it achieves?",
+      "What specific property of Euclidean distance (beyond convexity of unit circles) would enable matching upper-bound progress?",
       "Can polynomial partitioning methods (successful for distinct distances) be adapted for unit distances?",
-      "What is the exact constant c in the lattice lower bound n^{1+c/log log n}?",
       "Does the problem have fundamentally different behavior in dimensions d ≥ 3?"
     ]
   },
@@ -166,7 +167,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 65,
+    "lineCount": 81,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 3,
@@ -198,6 +199,16 @@
       "year": "1984",
       "pages": "293-303",
       "note": "Best known upper bound O(n^{4/3}) for unit distances in the plane"
+    },
+    {
+      "key": "OpenAI26",
+      "authors": [
+        "OpenAI"
+      ],
+      "title": "Remarks on the Disproof of the Unit Distance Conjecture",
+      "venue": "OpenAI technical note (announcement: https://openai.com/index/model-disproves-discrete-geometry-conjecture/ ; PDF: https://cdn.openai.com/pdf/74c24085-19b0-4534-9c90-465b8e29ad73/unit-distance-remarks.pdf)",
+      "year": "2026",
+      "note": "Announced 2026-05-20: AI-assisted construction reportedly disproving the conjectured exponent in u(n) via number fields with infinite class field towers (Golod–Shafarevich); peer review pending."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

Records the **OpenAI 2026-05-20 announcement** that an AI-assisted construction reportedly disproves the conjectured exponent in `u(n)` for Erdős Problem #90 (the unit-distance problem). Updates the `erdos-90` gallery entry's metadata, annotations, and Lean docstrings to cite the development with consistent hedging ("peer review pending"). Status fields are deliberately **unchanged**: `status: axiomatized`, `badge: wip`, `erdosProblemStatus: open` — they will be revised only when the disproof is peer-reviewed and erdosproblems.com#90 is reclassified.

References:
- Announcement: https://openai.com/index/model-disproves-discrete-geometry-conjecture/
- Technical note: https://cdn.openai.com/pdf/74c24085-19b0-4534-9c90-465b8e29ad73/unit-distance-remarks.pdf

## Changes

- `src/data/proofs/erdos-90/meta.json`:
  - `description`, `overview.text`, `overview.historicalContext` (appended 2026-05-20 paragraph), `overview.problemStatement`, `overview.proofStrategy`, `meta.assumptions` updated with hedged wording.
  - `conclusion.summary` and `conclusion.implications` updated; `openQuestions` expanded with two new entries about the OpenAI development.
  - `sections[id=conjecture].summary` updated; `sections` line ranges updated to match the new Lean file length (81 lines, up from 65).
  - `meta.lineCount` and `leanFile.lineCount`: `65` → `81`.
  - New entry added to `references[]` (key `OpenAI26`) citing the announcement and PDF.
- `src/data/proofs/erdos-90/annotations.json`:
  - Added a new `openai-2026-disproof` annotation (`type: concept`, `significance: key`) with a ~2-paragraph plain-language summary of the class-field-tower / Golod–Shafarevich mechanism and the "peer review pending" status note.
  - `range` line numbers for the existing 7 annotations updated to match the new Lean line numbers.
- `proofs/Proofs/Erdos90Problem.lean`:
  - Header docstring (lines 1–24) updated to add a fourth "Known results" bullet noting the OpenAI 2026 reported disproof; references block expanded with the announcement and PDF URLs.
  - Conjecture-section comments (now lines 61–75) updated to label Erdős's 1946 conjecture as "reportedly disproved (peer review pending)" and note that the weak form's status under the new construction is also in doubt.
  - **No code, axiom, theorem, or sorry changes.** File still has 0 axioms and 0 sorries.

## Acceptance Criteria Verification

| Criterion | Status | Notes |
|---|---|---|
| 1. `meta.json` accurately reflects 2026-05-20 development with citation, no overclaiming | yes | All updated fields use "peer review pending" hedging; status fields unchanged. |
| 2. `annotations.json` has 1–2 paragraph summary of OpenAI construction | yes | New `openai-2026-disproof` annotation covers class field towers + Golod–Shafarevich, with explicit "peer review pending" status note. |
| 3. `Erdos90Problem.lean` no longer asserts the disproved exponent bound | yes | The file never asserted it as `axiom`/`theorem` (only in block comments). Comments now label it "reportedly disproved (peer review pending)". |
| 4. Follow-up issues opened | yes | #20576 (Lean formalization), #20577 (Mathlib prerequisites scoping for class field towers / Golod–Shafarevich). |
| 5. No regressions in `unit-distance-independence` or other entries that reference `u(n)` | yes | `unit-distance-independence` is about Hadwiger–Nelson `χ(ℝ²)` and makes no claim about `u(n)` or the SST upper bound. Six other entries cross-reference erdos-90; none assert the now-disproved exponent bound. erdos-1085 mentions the weak form `f_2(n) = n^{1+o(1)}` as open — left unchanged for now since the weak form's status under the OpenAI construction is itself peer-review-pending. |

## Test Plan

- [x] `meta.json` valid JSON (`python3 -m json.tool`).
- [x] `annotations.json` valid JSON.
- [x] `pnpm annotations:build` succeeds and regenerates `src/data/proofs/listings.json` with the updated `description` and `annotationCount: 8` (was 7) for `erdos-90`.
- [x] No new `axiom` or `theorem` declarations added to `Erdos90Problem.lean`.
- [x] `grep -rn "u(n)\|n\^{4/3}" src/data/proofs/unit-distance-independence/` returns no hits.
- [ ] (Manual, recommended for reviewer): open the `erdos-90` page locally (`pnpm dev`) and confirm the OpenAI link renders and the updated description displays.
- [ ] (Optional, recommended): Docker Lean build of `Erdos90Problem.lean`: `./proofs/scripts/docker-build.sh Proofs.Erdos90Problem`. The change is comments-only inside `/- ... -/` blocks; semantics unchanged.

## Notes for reviewer

- `src/data/proofs/listings.json` is gitignored (auto-regenerated build artifact); not included in the diff but verified to regenerate cleanly.
- `pnpm annotations:build` also normalizes ~40 other `annotations.json` files (changes `"type": "concept"` → `"type": "context"` and adds trailing newlines). Those changes were reverted from this PR to keep scope focused.

Closes #20516

🤖 Generated with [Claude Code](https://claude.com/claude-code)