### PR TITLE
fix(meta): erdos-1018 sorries 22->7 align with leanFile + assumptions text

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -17,7 +17,7 @@
       "extremal-combinatorics"
     ],
     "badge": "axiom",
-    "sorries": 22,
+    "sorries": 7,
     "erdosNumber": 1018,
     "erdosUrl": "https://erdosproblems.com/1018",
     "erdosProblemStatus": "solved",


### PR DESCRIPTION
## Fix

meta.json declared `sorries: 22` but the Lean source has 7 sorries, and the existing `assumptions` text already states "7 sorries". Updates the count to match reality.

## Evidence

**Before**: `meta.sorries = 22`
**After**: `meta.sorries = 7`

Verified:
- `grep -cE '\bsorry\b' proofs/Proofs/Erdos1018Problem.lean` → 7
- `grep -cE '^axiom ' proofs/Proofs/Erdos1018Problem.lean` → 7 (matches `axiomCount: 7`)
- `assumptions` field already says "7 sorries (incomplete topological and density definitions)"

The nested `leanFile.sorries` (a per-file scan field elsewhere in this meta.json) already reads 7, confirming the source of truth.

---
Automated fix by lean-mechanic agent.