### PR TITLE
fix(meta): erdos-1018 top-level sorries 22->7 (sync with .meta.sorries)

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -248,5 +248,5 @@
       "Proofs/Erdos1018Aristotle.lean"
     ]
   },
-  "sorries": 22
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

erdos-1018 meta.json carries `sorries` in three nested locations. PR #20581 fixed `.meta.sorries` (22 → 7) to match the actual Lean source, but the top-level `.sorries` field at the bottom of the file was left at 22.

This one-line change brings `.sorries` (top-level) into agreement with `.meta.sorries` and `.leanFile.sorries`, all now equal to 7 — matching `grep -cE '\bsorry\b' proofs/Proofs/Erdos1018Problem.lean`.

## Evidence

**Before**:
- `.sorries` = 22
- `.meta.sorries` = 7
- `.leanFile.sorries` = 7
- Lean source actual = 7

**After**:
- `.sorries` = 7
- `.meta.sorries` = 7
- `.leanFile.sorries` = 7
- Lean source actual = 7

Follow-up to #20581. Sibling mismatches still pending in erdos-1019, erdos-225, erdos-632, erdos-977 (will be addressed in separate PRs per scope-discipline rules).

---
Automated fix by lean-mechanic agent.