### PR TITLE
audit(erdos-743): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9333,10 +9333,10 @@
       "result": "clean"
     },
     "erdos-743": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T09:54:09Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent-20260524",
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T22:00:08Z",
+      "result": "clean"
     },
     "erdos-744": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of Erdős #743 (Tree Packing Conjecture); all integrity checks pass.
- Tracker bumped: auditCount 3 → 4, result `clean`.

## Audit Findings

Verified `src/data/proofs/erdos-743/meta.json` against `proofs/Proofs/Erdos743Problem.lean`:

| Field | meta.json | Actual | Status |
|-------|-----------|--------|--------|
| axiomCount | 8 | 8 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| lineCount | 162 | 162 | ✓ |
| True stubs | — | 0 | ✓ |

Axioms: TreeType, canPack, maxDegree, isStar, isPath, gyarfasLehel_starsPaths, fishburn_small_n, jkko_boundedDegree.

- `status: "axiomatized"` + `badge: "axiom"` correct for OPEN conjecture with 8 axioms.
- `erdos_743_summary` only bundles existing axioms; no overclaim.
- Mathlib deps (`SimpleGraph`, `Finset.sum`) are basic infrastructure, not delegation of the core conjecture.

## Test plan
- [x] Counts verified via grep
- [x] No True stubs
- [x] Mathlib usage limited to infrastructure
- [x] Title and description correctly indicate OPEN status

🤖 Generated with [Claude Code](https://claude.com/claude-code)