### PR TITLE
fix(meta): erdos-1019 top-level sorries 6->1 (sync with .meta.sorries)

### DIFF
--- a/src/data/proofs/erdos-1019/meta.json
+++ b/src/data/proofs/erdos-1019/meta.json
@@ -308,5 +308,5 @@
     "Proof of the 1-edge threshold gap via `omega`",
     "Definition of `completeBipartite` on `Fin m ⊕ Fin n` with adjacency between parts"
   ],
-  "sorries": 6
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

erdos-1019 meta.json carries `sorries` in three nested locations. PRs #20581/#20583 addressed the same pattern in erdos-1018. This applies the same one-line correction to erdos-1019:

- `.sorries` (top-level) was stale at **6**
- `.meta.sorries` was already correct at **1**
- `.leanFile.sorries` was already correct at **1**
- Actual `grep -cE '\bsorry\b' proofs/Proofs/Erdos1019Problem.lean` = **1**

Follow-up to #20581, #20583. Sibling mismatches still pending in erdos-225, erdos-632, erdos-977 (separate PRs per scope-discipline rules).

---
Automated fix by lean-mechanic agent.