### PR TITLE
audit(erdos-743): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9334,8 +9334,8 @@
     },
     "erdos-743": {
       "agentId": "auditor-agent-20260524",
-      "auditCount": 4,
-      "lastAudited": "2026-05-24T22:00:08Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-24T22:04:07Z",
       "result": "clean"
     },
     "erdos-744": {


### PR DESCRIPTION
## Summary
- Re-audited `erdos-743` (Tree Packing Conjecture); meta.json claims match `proofs/Proofs/Erdos743Problem.lean`
- Bump `auditCount` 4 → 5, result `clean`

## Findings
- 8 axioms claimed → 8 axiom declarations in source ✓
- 0 sorries claimed → 0 sorries ✓
- `status: axiomatized` + `badge: axiom` consistent (open problem with 8 axioms)
- No `True` stubs
- `lineCount` 162 matches; 3 theorems, 5 definitions match

## Test plan
- [x] `grep -c "^axiom " proofs/Proofs/Erdos743Problem.lean` → 8
- [x] `grep -c "\bsorry\b" proofs/Proofs/Erdos743Problem.lean` → 0
- [x] No `:= trivial` or `: True` matches in Lean source