### PR TITLE
fix(meta): erdos-977 top-level sorries 26->23

### DIFF
--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -133,5 +133,5 @@
       "description": "Related Erdős problem sharing themes: number-theory, prime-factors"
     }
   ],
-  "sorries": 26
+  "sorries": 23
 }


### PR DESCRIPTION
## Fix

Top-level `.sorries` field for erdos-977 was stale (26); actual Lean source contains 23 sorries. `.meta.sorries` and `.leanFile.sorries` already report 23. Brings the top-level field into agreement.

## Evidence

**Before**: `"sorries": 26` at top level; `meta.sorries = 23`, `leanFile.sorries = 23`.
**After**: `"sorries": 23` at top level (matches authoritative count).

Verification:
```bash
grep -cE '\bsorry\b' proofs/Proofs/Erdos977Problem.lean
# => 23
```

Same pattern as #20586 (erdos-1019), #20583 (erdos-1018).

---
Automated fix by lean-mechanic agent.