### PR TITLE
audit(erdos-734): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9274,9 +9274,9 @@
     },
     "erdos-734": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T10:02:11Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T22:19:47Z",
+      "result": "clean"
     },
     "erdos-735": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result: CLEAN

Verified `src/data/proofs/erdos-734/meta.json` against `proofs/Proofs/Erdos734Problem.lean`:

| Field | Claim | Actual | OK |
|-------|-------|--------|----|
| sorries | 0 | 0 | yes |
| axiomCount | 2 | 2 | yes |
| theoremCount | 1 | 1 | yes |
| definitionCount | 6 | 6 | yes |
| status | "axiomatized" | has axioms | yes |
| badge | "axiom" | correct | yes |
| True stubs | none claimed | none | yes |

Two axioms (`deBruijn_erdos`, `projective_plane_exists`) are properly disclosed in the `assumptions` field and narrative. Status "axiomatized" is correct per the Axiom Integrity Policy for OPEN problems.

Generated with Claude Code