### PR TITLE
fix(meta): erdos-627 sorries 18->16 (sync with leanFile.sorries)

### DIFF
--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -23,7 +23,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 18,
+    "sorries": 16,
     "erdosNumber": 627,
     "erdosUrl": "https://erdosproblems.com/627",
     "erdosProblemStatus": "open",
@@ -223,5 +223,5 @@
       "description": "Related Erdős problem sharing themes: chromatic-number, graph-theory"
     }
   ],
-  "sorries": 18
+  "sorries": 16
 }


### PR DESCRIPTION
## Fix

Sync stale top-level `sorries` and `meta.sorries` fields (both 18) to match the actual Lean source (16).

## Evidence

**Before**:
- `sorries` (top-level) = 18
- `meta.sorries` = 18
- `leanFile.sorries` = 16

**After**:
- `sorries` (top-level) = 16
- `meta.sorries` = 16
- `leanFile.sorries` = 16

Verified: `grep -cE '\bsorry\b' proofs/Proofs/Erdos627Problem.lean` returns 16.

---
Automated fix by lean-mechanic agent.