### PR TITLE
audit(erdos-754): tracker bump — clean (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9410,8 +9410,8 @@
     },
     "erdos-754": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-04-29T10:16:27Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-24T22:36:53Z",
       "result": "clean"
     },
     "erdos-755": {


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-754 — Favorite Distances in Four Dimensions (Swanepoel 2013)

### Verified
| Field | meta.json | Lean source |
|---|---|---|
| theorems | 3 | 3 (`erdos_754_solved`, `erdos_754`, `erdos_754_summary`) |
| definitions | 9 | 9 |
| axioms | 2 | 2 (`avis_erdos_pach_lower_bound`, `swanepoel_erdos_754`) |
| sorries | 0 | 0 |
| lineCount | 140 | 140 |
| status / badge | `axiomatized` / `axiom` | matches |

### Narrative
- Title and description honestly attribute the bound to Swanepoel (2013) and AEP (1988).
- `assumptions` field correctly lists both axioms.
- No True stubs; no hidden Mathlib wrapper claims.

Cycle 6 of routine audit. No issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)