### PR TITLE
audit(erdos-748): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9368,8 +9368,8 @@
     },
     "erdos-748": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T10:24:13Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T22:52:34Z",
       "result": "clean"
     },
     "erdos-749": {


### PR DESCRIPTION
## Audit Summary

**Proof**: erdos-748 (Cameron-Erdős Conjecture on Sum-Free Sets)
**Result**: clean
**Cycle**: 4

## Integrity Checks

- ✅ 0 sorries (matches `sorries: 0` in meta.json)
- ✅ 3 axioms (matches `axiomCount: 3`: `trivial_lower_bound`, `green_upper_bound`, `precise_asymptotic`)
- ✅ 0 True stubs
- ✅ `status: "axiomatized"` / `badge: "axiom"` — correctly reflects axiom-based proof
- ✅ `lineCount: 325` matches `proofs/Proofs/Erdos748Problem.lean`
- ✅ `assumptions` field lists all three axioms by name

No discrepancies between meta.json claims and Lean source. Tracker bumped from cycle 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)