### PR TITLE
audit(erdos-713): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9128,8 +9128,8 @@
     },
     "erdos-713": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T00:56:07Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T23:11:08Z",
       "result": "clean"
     },
     "erdos-714": {


### PR DESCRIPTION
## Summary

Gallery integrity audit of `erdos-713` (Rational Exponents for Bipartite Turán Numbers) — **clean**, no issues found.

## Verification

| Metric | meta.json | Lean source | Match |
|--------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axioms | 2 | 2 (`extremalNumber`, `erdos_simonovits_counterexample`) | ✓ |
| theorems | 2 | 2 | ✓ |
| definitions | 8 | 8 | ✓ |
| lineCount | 195 | 195 | ✓ |
| True stubs | — | 0 | ✓ |

- Status `axiomatized` / badge `axiom` correctly reflects the 2 axioms.
- `erdosProblemStatus: open` ($500 prize) — honestly reflects unresolved status.
- Description correctly credits Erdős-Simonovits (1970) for disproving original conjecture and notes main questions remain OPEN.
- No five-narrative-failure-mode issues (no delegation opacity, axiom masking, inequality≠theorem inflation, pipeline inflation, or hidden-import "0 sorries").

## Test plan

- [x] Read meta.json and Lean source
- [x] Count axioms, sorries, theorems, definitions
- [x] Verify status/badge classification
- [x] Confirm description and contributions don't overstate