### PR TITLE
audit(erdos-751): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9392,8 +9392,8 @@
     },
     "erdos-751": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T10:43:31Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T23:17:45Z",
       "result": "clean"
     },
     "erdos-752": {


### PR DESCRIPTION
## Audit Summary

**Proof**: erdos-751 (Cycle Lengths in 4-Chromatic Graphs — Bondy-Vince 1998)
**Result**: clean
**Cycle**: 4

## Integrity Checks

- ✅ 2 sorries (matches `sorries: 2` in meta.json) — at lines 85, 178
  (`minCycleLengthGap` definition and gap-bound argument in `erdos_751`)
- ✅ 5 axioms (matches `axiomCount: 5`): `chromaticNumber`, `girth`, `cycleLengths`, `four_chromatic_minDeg`, `bondy_vince_theorem`
- ✅ 0 True stubs
- ✅ 6 theorems, 3 definitions — match meta.json (`theoremCount`, `definitionCount`)
- ✅ `lineCount: 235` matches `proofs/Proofs/Erdos751Problem.lean`
- ✅ `status: "axiomatized"` / `badge: "axiom"` — appropriate for axiom-bearing reduction
- ✅ `erdosProblemStatus: "solved"` — honestly reflects math status; formalization is correctly presented as reduction to Bondy-Vince theorem (axiomatized)
- ✅ `assumptions` field lists all 5 axioms by name

No discrepancies between meta.json claims and Lean source. Tracker bumped from cycle 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)