### PR TITLE
audit(erdos-72): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9172,9 +9172,9 @@
     },
     "erdos-72": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T01:02:25Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T23:39:37Z",
+      "result": "clean"
     },
     "erdos-720": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Routine audit-tracker bump for **erdos-72** (Erdős Problem #72: Unavoidable Cycle Lengths).

## Audit Result: clean (cycle 4)

Verified `src/data/proofs/erdos-72/meta.json` against `proofs/Proofs/Erdos72Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 3 | 3 | ✓ |
| axiomCount | 1 | 1 (`liu_montgomery_powers_of_two`) | ✓ |
| lineCount | 221 | 221 | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 17 | 17 | ✓ |
| status | axiomatized | — | consistent |
| badge | axiom | — | consistent |
| True stubs | none | 0 | ✓ |

`assumptions` field honestly notes both the 1 axiom (Liu–Montgomery) and 3 sorries (density-zero supporting facts).

No integrity issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)