### PR TITLE
audit(erdos-704): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9068,9 +9068,9 @@
     },
     "erdos-704": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T01:34:17Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T23:43:08Z",
+      "result": "clean"
     },
     "erdos-705": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Cycle 4 audit of `erdos-704` (Chromatic Number of Unit Distance Graphs). All meta.json claims match the Lean source.

## Verification

- **Line count**: 154 ✓
- **Axioms**: 4 (`frankl_wilson_1981`, `larman_rogers_1972`, `de_grey_2018`, `hadwiger_nelson_upper`) ✓
- **Sorries**: 0 ✓
- **Theorems**: 2 (`hadwiger_nelson_bounds`, `erdos_704_solved`) ✓
- **Definitions**: 6 (`UnitDistanceGraph`, `chi`, `lowerBase`, `upperBase`, `conjecturedBase`, `chromaticLimit`) ✓
- **Status**: `axiomatized` / badge `axiom` appropriate for OPEN problem with axiomatized bounds

## Test plan

- [x] Compared meta.json `axiomCount`/`theoremCount`/`definitionCount`/`lineCount`/`sorries` to Lean source
- [x] Verified Tier C scaffold classification (problem is OPEN, key bounds are axiomatized)
- [x] Checked no open PR for erdos-704 already exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)