### PR TITLE
audit(erdos-741): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9322,8 +9322,8 @@
     },
     "erdos-741": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-04-29T10:33:47Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T23:50:43Z",
       "result": "clean"
     },
     "erdos-742": {


### PR DESCRIPTION
## Summary

Re-audit of **erdos-741** (Splitting Sumsets with Positive Density). Cycle 4. No issues found.

## Verification

| Check | meta.json | Lean file | Match |
|-------|-----------|-----------|-------|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 `axiom` decls | ✅ |
| theoremCount | 27 | 27 | ✅ |
| definitionCount | 8 | 8 | ✅ |
| lineCount | 337 | 337 | ✅ |
| True stubs | n/a | 0 | ✅ |

- status `axiomatized` + badge `wip` appropriate for an open Erdős conjecture stated as Prop definitions
- originalContributions accurately reflect file contents (sumset algebra, partition theory, syndetic theory, density theorems, basis properties, connection theorems)
- assumptions field correctly notes `cofinite_density_one` proved in PR #16461

Previous audit: 2026-04-29 (clean). Cycle bump only.

## Test plan
- [x] Tracker JSON valid (auditCount 3→4, lastAudited updated, result `clean`)
- [x] No content changes to meta.json or Lean source