### PR TITLE
audit(erdos-714): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9133,9 +9133,9 @@
       "result": "clean"
     },
     "erdos-714": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T01:37:03Z",
+      "agentId": "auditor-agent-20260524",
+      "auditCount": 4,
+      "lastAudited": "2026-05-24T22:34:00Z",
       "result": "clean"
     },
     "erdos-715": {


### PR DESCRIPTION
## Audit Summary

**Proof**: erdos-714 (Zarankiewicz Problem for K_{r,r})
**Cycle**: 4 (was 3, last 2026-05-01)
**Result**: clean

## Integrity Checks

| Check | Expected | Actual | Status |
|-------|----------|--------|--------|
| sorries | 0 | 0 | ok |
| axiomCount | 3 | 3 (kovari_sos_turan, zarankiewicz_r2, brown_theorem) | ok |
| theoremCount | 5 | 5 | ok |
| definitionCount | 6 | 6 | ok |
| lineCount | 259 | 259 | ok |
| status | axiomatized | axiomatized | ok |
| badge | axiom | axiom | ok |
| True stubs | 0 | 0 | ok |

## Narrative Review

- Title "Erdős Problem #714: The Zarankiewicz Problem for K_{r,r}" — appropriately scoped, no overclaim.
- Description and conclusion clearly state "Proved for r=2,3; open for r >= 4."
- `proofStrategy` explicitly documents "Why Axioms?" (constructions outside Mathlib).
- `assumptions` field accurately lists the 3 axioms.
- `originalContributions` distinguishes definitions, axioms, and derived theorems.
- Mathlib dependencies are limited to SimpleGraph/Finset infrastructure (no delegation of main result).

No risk indicators (Tier C reduction-to-axioms, correctly labeled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)