### PR TITLE
audit(erdos-706): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9080,9 +9080,9 @@
     },
     "erdos-706": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T01:58:40Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T00:10:13Z",
+      "result": "clean"
     },
     "erdos-707": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-706 (Chromatic Number of Multi-Distance Graphs) — cycle 4. Result: **clean**.

All meta.json counts match `proofs/Proofs/Erdos706Problem.lean`:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| sorries | 0 | 0 ✓ |
| axiomCount | 3 | 3 ✓ |
| theoremCount | 1 | 1 ✓ |
| definitionCount | 1 | 1 ✓ |
| lineCount | 71 | 71 ✓ |

## Integrity Notes

- **Tier**: C (axiomatized) — three structural axioms encode the chromatic function `multiDistChromatic`, the Hadwiger–Nelson base case, and monotonicity.
- **Status/badge**: `axiomatized`/`axiom` — honest, no overclaiming.
- **Single proved theorem** `erdos_706_lower` correctly scoped as a trivial corollary `L(r) ≥ 5` derived from the two structural axioms.
- **No True stubs**, no Mathlib wrapper claims, no narrative inflation.
- **`assumptions` field** explicitly names the 3 axioms.

## Test plan

- [x] `wc -l` of Lean file matches lineCount
- [x] Axiom/theorem/def counts verified via grep
- [x] Status/badge consistent with axiomatization
- [x] No True stubs (`erdos_706_lower` is a real proof)

🤖 Generated with [Claude Code](https://claude.com/claude-code)