### PR TITLE
audit(erdos-698): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9014,9 +9014,9 @@
     },
     "erdos-698": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T02:44:34Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T00:19:15Z",
+      "result": "clean"
     },
     "erdos-699": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Cycle 4 audit of **erdos-698** (Erdős Problem #698: GCDs of Binomial Coefficients) — **clean**.

## Verified Against Lean Source

| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|----|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`erdos_szekeres_exponential`, `min_gcd_growth`) | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 293 | 293 | ✓ |
| status | axiomatized | has axioms | ✓ |
| badge | axiom | reflects axiomatized core | ✓ |

## Narrative Checks

- No True stubs.
- Title and description correctly frame the result as "axiomatized" (Bergman 2011) with explicit named axioms.
- `assumptions` field names both axioms verbatim.
- `originalContributions` accurately lists axioms vs theorems vs definitions.

No issues. Bumping tracker `auditCount` 3→4 and `result` to `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)