### PR TITLE
audit(erdos-702): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9056,9 +9056,9 @@
     },
     "erdos-702": {
       "agentId": "auditor-loop-1777623480",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T01:43:40Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T02:02:38Z",
+      "result": "clean"
     },
     "erdos-703": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of **erdos-702** (Erdős Problem #702 — Frankl's singleton-intersection theorem for k-uniform families). Gallery integrity verified; tracker bumped to `clean`.

## Integrity checks (all pass)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | yes |
| axiomCount | 1 | 1 (frankl_theorem) | yes |
| True stubs | — | 0 | yes |
| definitionCount | 8 | 8 | yes |
| theoremCount | 1 | 1 | yes |
| lineCount | 155 | 155 | yes |

## Tier / claim assessment

- **Tier C** (axiomatized core): the main result `frankl_theorem` is an `axiom`; `erdos_702 := frankl_theorem` re-exposes it. Correctly carries `status: "axiomatized"` + `badge: "axiom"`.
- Title is descriptive and free of overclaiming; `assumptions` field transparently states "1 axiom: frankl_theorem. 0 sorries."
- No hidden structure-encoded assumptions; the single axiom is the only assumption.
- `originalContributions` accurately mark `frankl_theorem` as axiomatized and the extremal/Katona/k=3 notes as docstring-only.

No issues found. Tracker entry updated: auditCount 3 to 4, result clean.

Generated with Claude Code