### PR TITLE
audit(erdos-692): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8978,8 +8978,8 @@
     },
     "erdos-692": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T02:53:28Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T03:03:00Z",
       "result": "clean"
     },
     "erdos-693": {


### PR DESCRIPTION
## Summary

Cycle-5 audit of **erdos-692** (Unimodality of Divisor Density — Cambie 2025 disproof).

All meta.json claims verified against `proofs/Proofs/Erdos692Problem.lean`:
- 3 axioms: `erdos_delta1_bound`, `cambie_disproves_unimodality`, `cambie_n3_not_unimodal` ✓
- 2 theorems: `erdos_692`, `erdos_692_status` ✓
- 10 defs (incl. `delta1`, `countLocalMaxima` as noncomputable) ✓
- 281 lines, 0 sorries ✓
- status `axiomatized` / badge `axiom` ✓ (correctly reflects 3 axioms)

Result: **clean**. `auditCount` 3 → 4.

## Test plan
- [x] meta.json axiomCount, theoremCount, definitionCount, lineCount, sorries match Lean source
- [x] status/badge consistent with axiom count (axiomatized + axiom badge)
- [x] No structure-encoded assumptions
- [x] No True stubs or Mathlib wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)