### PR TITLE
audit(erdos-697): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9007,9 +9007,9 @@
       "result": "clean"
     },
     "erdos-697": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T02:56:01Z",
+      "agentId": "auditor-agent-cycle-4",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T03:11:42Z",
       "result": "clean"
     },
     "erdos-698": {
@@ -15268,5 +15268,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-16T03:24:09Z"
+  "lastUpdated": "2026-05-25T03:11:42Z"
 }


### PR DESCRIPTION
## Summary

Re-audit of erdos-697 (Density of Integers Divisible by d ≡ 1 (mod m)) — cycle 4. Result: **clean**.

All meta.json counts match `proofs/Proofs/Erdos697Problem.lean`:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| sorries | 0 | 0 ✓ |
| axiomCount | 1 | 1 ✓ |
| theoremCount | 6 | 6 ✓ |
| definitionCount | 8 | 8 ✓ |
| lineCount | 226 | 226 ✓ |

## Integrity Notes

- **Tier**: C (axiomatized) — Hall's 1992 sharp-threshold theorem is the single structural axiom (`hall_theorem`); the final `erdos_697_*` theorems are honest corollaries of that axiom.
- **Status/badge**: `axiomatized`/`axiom` — honest, no overclaiming. Description and conclusion both label the result as Hall (1992) with the axiomatization explicit.
- **`assumptions` field** explicitly names the 1 axiom (`hall_theorem`).
- **No True stubs**: `:= trivial`, `: True :=`, `: True$` all return zero matches.
- **Mathlib dependencies** (`Real.log`, `Real.exp`, `Filter.Tendsto`) are used only as ambient infrastructure for the threshold statement, not as a wrapper for the proof — appropriate for `axiom` badge rather than `mathlib`.

## Test plan

- [x] `wc -l` of Lean file matches lineCount (226)
- [x] `grep -c '^axiom '` → 1 (matches axiomCount)
- [x] `grep -c 'sorry'` → 0 (matches sorries)
- [x] Theorem/def counts verified via grep including `noncomputable def`
- [x] No True stubs
- [x] Status/badge consistent with axiomatization

🤖 Generated with [Claude Code](https://claude.com/claude-code)