### PR TITLE
audit(erdos-676): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8863,12 +8863,12 @@
     },
     "erdos-676": {
       "agentId": "lean-auditor",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "section line ranges drifted: RepresentableByPrime (line 160) was in variants section instead of connections; 6 sections corrected via PR #14071"
       ],
-      "lastAudited": "2026-05-01T03:03:03Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T03:22:03Z",
+      "result": "clean"
     },
     "erdos-677": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of `erdos-676` (Representations $ap^2 + b$ with $p$ prime) — cycle 5.
- Verified Lean source ↔ meta.json alignment: 0 sorries, 1 axiom (`density_one`), 5 theorems, 225 lines. Status `axiomatized`/badge `axiom` correctly reflects open conjecture with single density axiom.
- No changes required to `meta.json` or Lean source; tracker bumped only.

## Test plan
- [x] `grep "^axiom " proofs/Proofs/Erdos676Problem.lean` → 1 match (`density_one`)
- [x] `grep "sorry" proofs/Proofs/Erdos676Problem.lean` → 0 matches
- [x] No `True`-stub theorems detected
- [x] Tracker entry updated: `auditCount` 4→5, `lastAudited` refreshed, `result: clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)