### PR TITLE
audit(erdos-101-oq-01): meta sync — sorry count 2→3 + counters (issues-fixed)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15105,9 +15105,9 @@
       "issues": []
     },
     "erdos-101-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-12T04:21:24Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-05-25T03:47:12Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "greens-theorem-oq-01-oq-01-oq-02-oq-03": {

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -18,18 +18,18 @@
       "research"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 3,
     "sourceUrl": "https://erdosproblems.com/101",
     "erdosUrl": "https://erdosproblems.com/101",
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 471,
-    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
+    "lineCount": 603,
+    "assumptions": "3 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred); (3) erdos_101_oq_01_isLittleO (S12 ACT 2026-05-24: Mathlib-idiom form of the main conjecture, equivalent to (1) via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form; OPEN). S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificate, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
-    "definitionCount": 4,
-    "substantiveTheoremCount": 7
+    "theoremCount": 13,
+    "definitionCount": 6,
+    "substantiveTheoremCount": 11
   },
   "sections": [
     {
@@ -129,12 +129,12 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 471,
+    "lineCount": 603,
     "axiomCount": 0,
-    "theoremCount": 9,
-    "definitionCount": 4,
+    "theoremCount": 13,
+    "definitionCount": 6,
     "path": "Proofs/Erdos101OQ01.lean",
-    "sorries": 2
+    "sorries": 3
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
Gallery integrity sync for `erdos-101-oq-01`. PR #20618 (S12 ACT, merged) added the Mathlib-idiom form theorem `erdos_101_oq_01_isLittleO` plus IsBigO infrastructure to `Erdos101OQ01.lean`, but the gallery `meta.json` was not updated. `find-targets` flagged the mismatch: \`claims 2, actual 3\` sorries.

## Changes
- `meta.json`:
  - `sorries`: 2 → **3** (matches actual sorries at L113, L336, L434)
  - `lineCount`: 471 → 603
  - `theoremCount`: 9 → 13
  - `definitionCount`: 4 → 6
  - `substantiveTheoremCount`: 7 → 11
  - `assumptions`: clause (3) added for `erdos_101_oq_01_isLittleO` (Mathlib-idiom form, equivalent to (1) via `rate_form_iff_isLittleO`); bridge lemma noted in unconditional infrastructure.
  - `leanFile.{lineCount,theoremCount,definitionCount,sorries}` synchronised.
- `audit-tracker.json`: erdos-101-oq-01 entry → `issues-fixed`.

## Test plan
- [x] `grep -nE "\bsorry\b" proofs/Proofs/Erdos101OQ01.lean | grep -v "^[^:]*:.*\\(\`\|--\|\\\*\\)"` confirms 3 real sorries: L113 (`erdos_101_oq_01`), L336 (`erdos_101_oq_01_isLittleO`), L434 (`solymosi_stojakovic_lower_bound`).
- [x] `wc -l` confirms 603 lines.
- [x] `grep -cE "^theorem " ... = 13`, `grep -cE "^(def|noncomputable def) " ... = 6`, `grep -c "^axiom " ... = 0`.
- [x] `status: axiomatized`/`badge: wip` still correct (open conjecture, sorry-based scaffold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)