### PR TITLE
audit(erdos-670): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8826,8 +8826,8 @@
     },
     "erdos-670": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T03:35:26Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T04:30:56Z",
       "result": "clean"
     },
     "erdos-671": {


### PR DESCRIPTION
## Summary
Re-audited erdos-670 (Diameter of Sets with Distinct Distances). All meta.json counts match Lean source.

## Verification

- **Lean file**: `proofs/Proofs/Erdos670Problem.lean` (157 lines)
- **Axioms**: 2 (`trivial_gives_half`, `erdos_1997_d1`) ✓
- **Theorems**: 1 (`erdos_670_summary`) ✓
- **Definitions**: 15 ✓
- **Sorries**: 0 ✓
- **Status**: `axiomatized` with badge `axiom` ✓

No discrepancies found. Tracker bumped (cycle 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)