### PR TITLE
audit(erdos-669): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8808,9 +8808,9 @@
     },
     "erdos-669": {
       "agentId": "auditor-loop-2026-05-01",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T03:50:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T04:46:32Z",
+      "result": "clean",
       "issues": [
         "4 phantom identifiers (burr_grunbaum_sloane, trivial_upper_bound, limit_upper, optimal_configs_exist) in section summaries; section line ranges drift; missing summary section — issue #14091"
       ]


### PR DESCRIPTION
## Summary

Audit cycle 4 for `erdos-669` (Orchard Problem / k-point lines).

All counts in `src/data/proofs/erdos-669/meta.json` verified against `proofs/Proofs/Erdos669Problem.lean`:

- lineCount: 128 ✓
- sorries: 0 ✓
- axiomCount: 1 (`k3_limit`) ✓
- theoremCount: 3 (`k3_matches`, `k3_conjecture_true`, `erdos_669_summary`) ✓
- definitionCount: 10 (1 `abbrev` + 1 `structure` + 8 `def`) ✓

Status `axiomatized` with badge `axiom` is appropriate — the general k problem is open, the k=3 result is axiomatized as `k3_limit` (BGS 1974).

No phantom identifiers, no True stubs, no Mathlib wrappers detected.

## Test plan

- [x] meta.json counts match Lean source
- [x] Status/badge consistent with axiom presence
- [x] Tracker entry updated to cycle 4, result `clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)