### PR TITLE
audit(erdos-669): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8808,9 +8808,9 @@
     },
     "erdos-669": {
       "agentId": "auditor-loop-2026-05-01",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T03:50:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T04:53:54Z",
+      "result": "clean",
       "issues": [
         "4 phantom identifiers (burr_grunbaum_sloane, trivial_upper_bound, limit_upper, optimal_configs_exist) in section summaries; section line ranges drift; missing summary section — issue #14091"
       ]


### PR DESCRIPTION
## Summary

Re-audit of `erdos-669` (Erdős Problem #669: k-Point Lines / Orchard Problem). Tracker bump only — no Lean source or meta.json changes.

All counts in `src/data/proofs/erdos-669/meta.json` match `proofs/Proofs/Erdos669Problem.lean`:

| Field | meta.json | Lean |
|---|---|---|
| lines | 128 | 128 ✓ |
| sorries | 0 | 0 ✓ |
| axioms | 1 | 1 ✓ (`k3_limit`) |
| theorems | 3 | 3 ✓ |
| defs | 10 | 10 ✓ |

Status `axiomatized` / badge `axiom` consistent with the open problem (k=3 solved via BGS 1974, encoded as 1 axiom; general k open).

No True stubs, no `/-!` docstring parser issues, no Mathlib wrapper concerns.

## Test plan

- [x] `wc -l` and `grep` counts on Lean source
- [x] `meta.json` fields cross-checked
- [x] Status/badge consistency with axiomatized + open conjecture policy
- [x] Tracker updated via `claim-target.sh complete erdos-669 clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)