### PR TITLE
audit(erdos-684): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8920,13 +8920,13 @@
     },
     "erdos-684": {
       "agentId": "auditor-foreground",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "phantom identifiers in section summaries: tang_bound, rh_conditional_bound, heuristic_conjecture, erdos_684_status (issue #14084)",
         "phantom identifiers in section summaries: tang_bound, rh_conditional_bound (Modern Bounds), heuristic_conjecture (Heuristic), erdos_684_status (Status); all removed (closes #14084)"
       ],
-      "lastAudited": "2026-05-01T03:54:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T07:05:32Z",
+      "result": "clean"
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Gallery integrity re-audit of **Erdős Problem #684** (Smooth Parts of Binomial Coefficients). Tracker bump only — no source/metadata changes required.

## Findings (meta.json vs `proofs/Proofs/Erdos684Problem.lean`)

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| status | `axiomatized` | 2 axioms present | ✅ |
| badge | `axiom` | 2 axiom declarations | ✅ |
| sorries | 0 | 0 | ✅ |
| axiomCount | 2 | `f_domain_large`, `mahler_ineffective` (no structure-encoded assumptions) | ✅ |
| lineCount | 451 | 451 | ✅ |
| theoremCount | 20 | 20 | ✅ |
| definitionCount | 11 | 11 | ✅ |

- No `True` stubs; main statement `erdos_684_statement` is a genuine non-vacuous theorem proved via `f_property` + the domain axiom.
- Open problem properly disclosed (status/badge/assumptions all honest).
- Mathlib-derived lemmas (`kummer_theorem`, Legendre exponent) honestly credited in `originalContributions`.
- Prior issues (#14084 phantom section identifiers) confirmed fixed.

**Result: clean.** Tracker entry updated (auditCount 4→5, result `issues-fixed`→`clean`).

## Test plan

- [x] Verified sorry/axiom/True-stub counts directly against source
- [x] Confirmed no structure-encoded assumptions
- [x] Tracker diff scoped to single erdos-684 entry