### PR TITLE
fix(research): honor exported REPO_ROOT in claim-problem.sh

### DIFF
--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -31,7 +31,11 @@ find_repo_root() {
     return 1
 }
 
-REPO_ROOT="$(find_repo_root)"
+# Honor REPO_ROOT exported by the launcher. When run from an agent worktree,
+# find_repo_root would stop at the worktree, but the shared candidate pool
+# (.lean/state/candidate-pool.json) is gitignored and exists only in the main
+# repo. The daemon exports REPO_ROOT=<main repo> for exactly this reason.
+REPO_ROOT="${REPO_ROOT:-$(find_repo_root)}"
 CLAIMS_DIR="$REPO_ROOT/research/claims"
 POOL_FILE="$REPO_ROOT/.lean/state/candidate-pool.json"
 PROBLEMS_DIR="$REPO_ROOT/src/data/research/problems"


### PR DESCRIPTION
## Summary

`claim-problem.sh claim-random` has been reporting **"No available problems to claim"** to every researcher agent for many cycles, even though the candidate pool has 100+ available (and 500+ in-progress) problems. This is a path-resolution bug, not an empty pool.

### Root cause
- The script set `REPO_ROOT="$(find_repo_root)"`, which walks up to the nearest `.git`. Run from an agent worktree (`.loom/worktrees/researcher-N`), that resolves to the **worktree**, not the main repo.
- `POOL_FILE="$REPO_ROOT/.lean/state/candidate-pool.json"`, but `.lean/state/` is **gitignored** — the pool exists only in the main repo working tree, never in a worktree checkout.
- So from a worktree the script read a missing pool -> `jq` produced nothing -> `available[]` empty -> "No available problems to claim".
- The daemon launcher (`scripts/lean/launch.sh`) already **exports `REPO_ROOT=<main repo>`** in each agent session for exactly this reason, and other scripts (`launch-seeker.sh`, `synthesize-knowledge.sh`) use `$REPO_ROOT` from the environment. `claim-problem.sh` was the outlier that ignored it.

### Fix
`REPO_ROOT="${REPO_ROOT:-$(find_repo_root)}"` — honor the exported value when present, fall back to `find_repo_root()` for standalone use. This also makes `CLAIMS_DIR` / `LOCKS_DIR` / `PROBLEMS_DIR` resolve to the shared canonical locations instead of per-worktree paths.

### Verification
With `REPO_ROOT` exported (as the daemon does) and CWD inside a worktree, the resolved `POOL_FILE` now points at the existing main-repo pool and the claim filter matches **656** candidates (was 0). `bash -n` passes.

## Test plan
- [ ] From a researcher worktree with `REPO_ROOT` exported, `claim-problem.sh claim-random` selects and claims a problem instead of reporting "No available problems".
- [ ] Standalone invocation from the main repo (no `REPO_ROOT` exported) still resolves correctly via `find_repo_root()`.
- [ ] `release` / `update` / `status` subcommands operate on the shared `research/claims` dir as before.

## Notes
Labeled `loom:review-requested` intentionally: this is shared infra used by all researchers + the deployer, so it should go through Judge review rather than deployer auto-merge.

Generated with Claude Code