### PR TITLE
audit(erdos-684): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8920,13 +8920,13 @@
     },
     "erdos-684": {
       "agentId": "auditor-foreground",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "phantom identifiers in section summaries: tang_bound, rh_conditional_bound, heuristic_conjecture, erdos_684_status (issue #14084)",
         "phantom identifiers in section summaries: tang_bound, rh_conditional_bound (Modern Bounds), heuristic_conjecture (Heuristic), erdos_684_status (Status); all removed (closes #14084)"
       ],
-      "lastAudited": "2026-05-01T03:54:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T07:12:56Z",
+      "result": "clean"
     },
     "erdos-685": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Gallery integrity re-audit of **erdos-684** (Smooth Parts of Binomial Coefficients). Result: **clean**.

## Verification
All meta.json claims match `proofs/Proofs/Erdos684Problem.lean`:
- **sorries**: 0
- **axioms**: 2 — `f_domain_large`, `mahler_ineffective` (both listed in `assumptions`)
- **True stubs**: none
- **theorems**: 20 · **defs**: 11 · **lines**: 451 (all match meta)
- **status/badge**: `axiomatized`/`axiom` — correct for an open problem with 2 axioms
- No structure-encoded assumptions; Mathlib deps are basic primitives, `kummer_theorem` credited as "proved from Mathlib"
- Previously-fixed phantom identifiers (#14084) confirmed resolved — section summaries reference real identifiers (`tang_exponent`, `rh_exponent`, `heuristic_bound`, `erdos_684_statement`)

## Changes
- `src/data/proofs/audit-tracker.json`: erdos-684 auditCount 4→5, result issues-fixed→clean, lastAudited bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)