### PR TITLE
audit(erdos-666): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8788,9 +8788,9 @@
     },
     "erdos-666": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T04:19:26Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-25T08:18:51Z",
+      "result": "clean",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14107"
     },
     "erdos-667": {


### PR DESCRIPTION
## Audit: erdos-666 (cycle 5)

**Result**: clean

### Integrity checks
- Sorries: meta.json claims 1, Lean shows 1 ✓
- Axioms: meta.json claims 1, Lean shows 1 (chung_1992) ✓
- True stubs: 0 ✓
- Status: axiomatized / badge: axiom ✓ (matches presence of 1 axiom + 1 sorry)

No issues detected. Tracker bumped from cycle 4 → cycle 5.

🤖 Generated by lean-auditor agent