### PR TITLE
audit(erdos-999): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11095,9 +11095,9 @@
     },
     "erdos-999": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T04:10:52Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T08:23:16Z",
+      "result": "clean"
     },
     "erdos-ko-rado": {
       "auditCount": 3,


### PR DESCRIPTION
## Audit Result: CLEAN (cycle 4)

Audited `erdos-999` (Duffin-Schaeffer Conjecture). All integrity claims match the Lean source.

### Verified
| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`koukoulopoulos_maynard_2020`, `zero_one_law`) | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| lineCount | 147 | 147 | ✓ |
| True stubs | none claimed | 0 | ✓ |
| status / badge | axiomatized / axiom | matches (has axioms) | ✓ |

### Narrative integrity
- Title and description correctly credit Koukoulopoulos-Maynard (2020).
- `originalContributions` transparently labels both axioms.
- No Mathlib wrapper masking; the file states the conjecture and uses Mathlib only for measure-theoretic primitives.

Tracker `auditCount` 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)