### PR TITLE
research(ehrhart-cube-proven-oq-03): S7 STATE-SYNC — slug COMPLETED (build verified post-S6 ACT)

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-03/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-03/state.md
@@ -2,17 +2,33 @@
 
 ## Current State
 
-**Phase**: S6 ACT — `hypersimplex_count_k_one` discharged (Option A from S5b §3 transcribed); both reference identities now proven
+**Phase**: S7 STATE-SYNC — slug COMPLETED (hypersimplex track, Option A); both reference identities proven, build verified, meta verified+original.
 **Path**: full
-**Since**: 2026-05-16T14:30Z (researcher-8, S6 ACT — k=1 discharged; build pending — Docker daemon hung)
-**Last Updated**: 2026-05-16T14:30Z (Session 8 ACT researcher-8; iteration 6 → 7)
-**Iteration**: 7
+**Since**: 2026-05-25T08:20Z (researcher-1, S7 STATE-SYNC — pool registry catch-up post-build-verify)
+**Last Updated**: 2026-05-25T08:20Z (Session 9 STATE-SYNC researcher-1; iteration 7 → 8)
+**Iteration**: 8
 
-**Sorries**: 1 → 0 (`hypersimplex_palindrome_k_d_minus_1` proven at S4 ACT 2026-05-14; `hypersimplex_count_k_one` proven at S6 ACT 2026-05-16 via Option A from S5b §3).
+**Sorries**: 0 (`hypersimplex_palindrome_k_d_minus_1` proven at S4 ACT 2026-05-14 PR #18923; `hypersimplex_count_k_one` proven at S6 ACT 2026-05-16 PR #19639 via Option A from S5b §3).
 **Axioms**: 0 (no `axiom` declarations, no structure-encoded assumptions).
-**Build**: last clean = S4 ACT 2026-05-14 (7743 Docker jobs); S6 ACT proof body PENDING build-verify (Docker daemon hung at S6 author time — disk 6.7 Gi avail, `docker info` no Server response past 8s). Bearer pin re-verified at lake SHA `2df2f0150c2` via gh-api spot-check before transcription.
-**File**: `proofs/Proofs/EhrhartCubeProvenOQ03.lean` 169 → 210 LOC.
-**Status flip readiness**: with 0 sorries + 0 axioms, eligible for `meta.status: formalized → verified` + `meta.badge: formalized → original` once Docker build clears (auditor/mechanic flip; deferred this PR per build-pending).
+**Build**: VERIFIED GREEN. S6 ACT proof body confirmed compiling post Docker recovery; mechanic flipped `meta.status: formalized → verified` and `meta.badge: formalized → original` in PR #19751 (merged 2026-05-16 same day as S6 ACT). Meta lineCount catch-up in PR #20524.
+**File**: `proofs/Proofs/EhrhartCubeProvenOQ03.lean` 210 LOC, 6 theorems, 2 definitions.
+**Meta**: `src/data/proofs/ehrhart-cube-proven-oq-03/meta.json` → `status: verified`, `badge: original`, `sorries: 0`, `axiomCount: 0`.
+
+## S7 STATE-SYNC (researcher-1, 2026-05-25, doc-only)
+
+Pool registry catch-up. The pool entry `ehrhart-cube-proven-oq-03` ("Barvinok's algorithm for lattice point counting in fixed dimension") was still status `available` despite the on-main slug having shipped axiom-free at S6 ACT and the gallery meta being `verified/original` since PR #19751. The seeker was re-selecting a slot whose deliverable is already merged.
+
+**What S7 does:** flip pool `status: available → completed` and JSON `phase: S6_ACT → COMPLETED`, `status: in-progress → completed`. Clears the four legacy blockers (Docker hung at S6 author time; bearer audit Mathlib Ehrhart absence; slot drift from Barvinok plan to hypersimplex scaffold; status-flip deferral) — all now superseded by post-S6 reality.
+
+**What S7 does NOT do:** no `.lean` edit, no `meta.json` edit, no new sibling slug creation, no scope-decision flip. The Barvinok-track Option B (spin off as `oq-05`/`-06`) remains an *independent* scope decision for seeker/curator/human triage — it is not a blocker on **this** slug, which delivered the hypersimplex track in full.
+
+**Pool entry name vs slug reality (audit note).** The pool's `name` field still reads "Barvinok's algorithm…", which is a stale seeker artefact from the original S1 plan that S2 PREP (researcher-10, 2026-05-13) found to be incompatible with the on-main hypersimplex slot. Renaming the pool entry to match `meta.json` ("Ehrhart Polynomial of the Hypersimplex: First-Principles Scaffold") is a separate seeker/curator territory edit — left out of this PR to keep S7 scope narrow (registry-state-sync only, no metadata renames). Future seekers picking from this pool will see the slug as `completed` regardless of `name`.
+
+### S7 STATE-SYNC files modified (this PR)
+
+* `research/problems/ehrhart-cube-proven-oq-03/state.md` — this section + header refresh (phase, since, last updated, iteration, sorries, build, meta).
+* `src/data/research/problems/ehrhart-cube-proven-oq-03.json` — `currentState.{phase: COMPLETED, since, iteration: 8, focus, nextAction, attemptCounts.total: 8}`, `status: in-progress → completed`, `currentState.blockers: []`, `lastUpdate`.
+* `.lean/state/candidate-pool.json` — via `claim-problem.sh update ehrhart-cube-proven-oq-03 completed` (auto: pool entry `status: available → completed`).
 
 ## S6 ACT (researcher-8, 2026-05-16, this PR)
 

--- a/src/data/research/problems/ehrhart-cube-proven-oq-03.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "ehrhart-cube-proven-oq-03",
   "title": "Barvinok's algorithm for lattice point counting in fixed dimension",
-  "phase": "S6_ACT",
-  "status": "in-progress",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -30,19 +30,14 @@
     "goal": "Add gallery entry for Barvinok-1994 algorithm: axiomatize the polytime claim, define short rational generating function as a Lean type, prove first-principles corollary f([0,n]^d; x) = prod_i (1 - x_i^{n+1}) / (1 - x_i), bridge to ehrhart-cube-proven's (n+1)^d via x -> 1 specialization."
   },
   "currentState": {
-    "phase": "S6_ACT",
-    "since": "2026-05-16T14:30:00Z",
-    "iteration": 7,
-    "focus": "S6 ACT (researcher-8, 2026-05-16): Option A from S5b PREP §3 transcribed into proofs/Proofs/EhrhartCubeProvenOQ03.lean replacing line-75 `sorry` of `hypersimplex_count_k_one`. Body uses Sym.equivNatSumOfFintype + Sym.card_sym_eq_choose + Fintype.card_of_subtype + Nat.choose_symm_of_eq_add, with a 1-LOC `right_inv := ext i; rfl` safe substitute for S5b §4 caveat #4. File 169 → 210 LOC, sorries 1 → 0. Both reference identities now proven (palindrome at S4 ACT; k=1 at S6 ACT). Build pending — Docker daemon hung at S6 author time (docker info no Server response past 8s; disk 6.7 Gi avail). All 4 critical bearers re-verified at lake pin 2df2f0150c2 via gh-api spot-check.",
-    "blockers": [
-      "Docker daemon hung at S6 ACT author time (2026-05-16T14:16Z: `docker info` Client-only response, no Server response past 8s; root disk 6.7 Gi avail = 70% capacity). Build-verify of S6 ACT proof body deferred to deployer-side compile or to a follow-up session when host recovers.",
-      "Bearer audit S2 (2026-05-13, preserved): Mathlib has NO Ehrhart-theory toolkit (`Polytope` namespace absent, `LatticePolytope` absent, `Ehrhart` absent). Any retargeted Barvinok track must build from MvPolynomial/RatFunc/MvPowerSeries; no specialisation possible.",
-      "Slot drift S2 (2026-05-13, preserved): proofs/Proofs/EhrhartCubeProvenOQ03.lean is occupied by hypersimplex Δ(d,k) scaffold. Option B (spin off Barvinok as oq-05) still awaits seeker/curator/human triage.",
-      "Status flip to `verified` deferred (S6 ACT): meta.status remains `formalized` while build is pending; auditor/mechanic flips to `verified`+`original` once Docker build confirms 0 sorries + 0 axioms."
-    ],
-    "nextAction": "S7 (post-build-verify): if Docker build confirms 0 sorries + 0 axioms, auditor/mechanic should flip meta.json `status: formalized` → `verified` and `badge: formalized` → `original`. If build surfaces an elaboration issue, follow-up doctor/researcher session fixes (best-guess fallbacks already documented in S5b PREP §3 Option B/C: explicit `Fintype.card_of_subtype` arguments or bypass via `Finset.card_filter` decomposition). Separately: Barvinok track Option B (spin off ehrhart-cube-proven-oq-05) remains a scope-decision question for seeker/curator/human triage; both reference identities for the on-main hypersimplex track are now discharged.",
+    "phase": "COMPLETED",
+    "since": "2026-05-25T08:20:00Z",
+    "iteration": 8,
+    "focus": "S7 STATE-SYNC (researcher-1, 2026-05-25): pool registry catch-up. Slug shipped axiom-free at S6 ACT (PR #19639, 2026-05-16); mechanic flipped meta `status: formalized → verified` and `badge: formalized → original` in PR #19751 (same day); meta lineCount catch-up in PR #20524. The on-main hypersimplex track delivered both reference identities (palindrome at S4 ACT, k=1 at S6 ACT) with 0 sorries, 0 axioms, 0 structure-encoded assumptions. The four legacy blockers (Docker hung at S6 author time, Mathlib Ehrhart absence, slot drift, status-flip deferral) are all superseded by post-S6 reality. This S7 PR flips JSON phase S6_ACT → COMPLETED, status in-progress → completed, and runs `claim-problem.sh update ehrhart-cube-proven-oq-03 completed` to flip pool `status: available → completed`.",
+    "blockers": [],
+    "nextAction": "None — slug COMPLETED. Barvinok-track Option B (spin off as `ehrhart-cube-proven-oq-05`/`-06`) remains an independent scope-decision question for seeker/curator/human triage; it is NOT a blocker on this slug. If/when Option B is chosen, the S1/S2 PREP Barvinok plan (problem.md + knowledge.md sections) becomes the new sibling slug's bootstrap.",
     "attemptCounts": {
-      "total": 7,
+      "total": 8,
       "currentApproach": 5,
       "approachesTried": 1
     }
@@ -114,7 +109,8 @@
     ]
   },
   "started": "2026-05-12T20:55:00Z",
-  "lastUpdate": "2026-05-16T14:30:00Z",
+  "lastUpdate": "2026-05-25T08:20:00Z",
+  "completed": "2026-05-25T08:20:00Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S7 STATE-SYNC for `ehrhart-cube-proven-oq-03` — pool registry catch-up. The on-main hypersimplex slug shipped axiom-free at S6 ACT (PR #19639, 2026-05-16); mechanic flipped meta `status: formalized → verified` and `badge: formalized → original` in PR #19751 the same day; meta lineCount catch-up in PR #20524. But the research tracking JSON (`src/data/research/problems/ehrhart-cube-proven-oq-03.json`) and the slug `state.md` still claimed `phase: S6_ACT` / `status: in-progress` with four obsolete blockers (Docker hung at S6 author time, Mathlib Ehrhart absence, slot drift, status-flip deferral). The seeker was re-selecting a slot whose deliverable is already merged.

This PR flips the JSON to COMPLETED, clears blockers, refreshes state.md, and runs `claim-problem.sh update ehrhart-cube-proven-oq-03 completed` to flip the pool registry (`.lean/state/candidate-pool.json` — gitignored).

## What's COMPLETED

Both reference identities of the hypersimplex track proven, file 210 LOC, 0 sorries, 0 axioms, 0 structure-encoded assumptions:

- `hypersimplex_palindrome_k_d_minus_1` — S4 ACT PR #18923 (researcher-3, 2026-05-14)
- `hypersimplex_count_k_one` — S6 ACT PR #19639 (researcher-8, 2026-05-16) via Option A from S5b §3
- Meta flipped to `verified` + `original` — PR #19751 (mechanic, 2026-05-16)
- Meta lineCount catch-up — PR #20524

## What's still open (independent scope)

Barvinok-track Option B (spin off as `ehrhart-cube-proven-oq-05`/`-06`) remains a scope-decision question for seeker/curator/human triage. It is NOT a blocker on **this** slug; both reference identities are discharged.

## Files changed

- `research/problems/ehrhart-cube-proven-oq-03/state.md` — header refresh + S7 STATE-SYNC section.
- `src/data/research/problems/ehrhart-cube-proven-oq-03.json` — `phase: S6_ACT → COMPLETED`, `status: in-progress → completed`, blockers cleared.

Pool registry (`.lean/state/candidate-pool.json`, gitignored): `ehrhart-cube-proven-oq-03 status: available → completed`.

## Test plan

- [x] JSON valid
- [x] Pool entry status flipped to `completed`
- [x] No `.lean` edits, no `meta.json` edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)