### PR TITLE
Enrich Signed CellComplex: deeper Finset.sum_involution context

### DIFF
--- a/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/annotations.json
@@ -102,8 +102,21 @@
     "type": "context",
     "title": "Forward Plan — Tucker's Lemma, Borsuk–Ulam, AlternatingFaceMapComplex",
     "content": "The signed CellComplex structure is the natural ℤ-valued substrate for two future bridges. (1) Tucker's lemma (Tucker 1946, antipodal ℤ/2-equivariant Sperner) requires an antipodal involution `ι : V → V` and a sign-respecting hypothesis on the colouring — the ℤ-valued sign field here is exactly the data needed for the equivariant counting argument. (2) Embedding into Mathlib's `AlternatingFaceMapComplex` over `ModuleCat ℤ` would tie the abstract `CellComplex` API into the standard algebraic-topology infrastructure, opening the door to spectral sequences, homology computations, and the singular-versus-simplicial comparison. Both are listed as follow-up sessions in the file's iteration plan (S2-B Mathlib bridge, S2-C Tucker scaffold, S2-D Borsuk–Ulam).",
+    "mathContext": "$\\text{AntipodalCellComplex} := \\text{SignedCellComplex} + (\\iota : V \\to V,\\ \\iota \\circ \\iota = \\mathrm{id},\\ \\iota\\ v \\neq v)$;\\ Tucker: an antipodal colouring on $\\mathrm{Sym}(\\mathbb{S}^{d-1})$ with $c(\\iota v) = -c(v)$ has a fully-coloured cell. Algebraic chain bridge: $C_\\bullet(K; \\mathbb{Z}) \\to \\text{AlternatingFaceMapComplex}\\ \\mathbb{Z}$ via $\\partial_n = \\sum_{i=0}^{n} (-1)^i\\, \\partial_i$.",
     "significance": "context",
     "relatedConcepts": ["Tucker's lemma 1946", "antipodal ℤ/2-equivariant Sperner", "AlternatingFaceMapComplex", "ModuleCat ℤ", "Borsuk–Ulam theorem", "Matoušek 2008"],
     "prerequisites": ["abstract CellComplex framework", "equivariant combinatorics intuition", "chain complex basics"]
+  },
+  {
+    "id": "ann-sum-involution-pattern",
+    "proofId": "sperner-ndim-mathlib-oq-01-oq-04",
+    "range": { "startLine": 149, "endLine": 202 },
+    "type": "technique",
+    "title": "The Four-Obligation Pattern of Finset.sum_involution",
+    "content": "Mathlib's `Finset.sum_involution` is the additive image (via `@[to_additive]`) of `Finset.prod_involution`, designed for the precise scenario at hand: a sum over a finite set where elements pair up under an involution and the paired values cancel. Invoking it requires discharging four obligations, each surfaced here as a named `case` block: (1) **cancel** — for every `p ∈ S`, `f p + f (g p hp) = 0` (here: `sign_adj`); (2) **fpf** — for every `p ∈ S` with `f p ≠ 0`, `g p hp ≠ p`, i.e., the involution has no fixed points where the summand contributes (here: `adj_ne`); (3) **gmem** — the involution preserves domain membership: `g p hp ∈ S` (here: `door_transfer_signed_one_dir` for the door predicate + `adj_symm` for the adjacency-non-`none` predicate); (4) **invol** — `g (g p hp) _ = p` (here: `adj_symm` via the extracted `signedAdjMap_invol`). Once these are dispatched, Mathlib concludes `∑ x ∈ S, f x = 0` because each pair `{p, g p}` contributes `f p + f (g p) = 0` and unpaired elements (fixed points) have `f p = 0`. The lemma's dependent-function signature `g : ∀ a ∈ s, ι` is what enables membership-aware involutions like `signedAdjMap`, where the involution's well-definedness on the source set is part of the proof obligation rather than a side condition.",
+    "mathContext": "$\\text{If } g : \\forall a \\in s,\\ \\iota,\\ \\text{ and } \\forall a\\ \\text{ha},\\ (f\\ a + f\\ (g\\ a\\ \\text{ha}) = 0)\\ \\wedge\\ (f\\ a \\neq 0 \\Rightarrow g\\ a\\ \\text{ha} \\neq a)\\ \\wedge\\ (g\\ a\\ \\text{ha} \\in s)\\ \\wedge\\ (g\\ (g\\ a\\ \\text{ha})\\ \\_ = a),\\ \\text{ then } \\sum_{x \\in s} f\\ x = 0.$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.sum_involution", "Finset.prod_involution", "@[to_additive]", "dependent function arguments", "pairing argument", "fixed-point-free involution"],
+    "prerequisites": ["Finset.sum / Finset.prod", "dependent function types in Lean 4", "involution and fixed-point-free maps"]
   }
 ]

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01-oq-04/meta.json
@@ -60,7 +60,8 @@
       "The right coherence for adjacent facets is sign(s,k) + sign(s',k') = 0 in ℤ (i.e., they are genuinely negatives), which makes ∂σ = ∑ (-1)^i ∂_i σ a meaningful boundary operator.",
       "Finset.sum_involution (additive cousin of prod_involution, derived via @[to_additive]) is the ideal Mathlib hammer: it takes a dependent involution g : ∀ a ∈ s, ι with a cancellation hypothesis f a + f (g a ha) = 0 and yields ∑ x ∈ s, f x = 0 directly.",
       "The parent's interior_doors_even proof structure (using adjMap as the involution and the three CellComplex adjacency axioms) reuses verbatim for the signed cancellation, modulo replacing the parity-of-cardinality conclusion with the additive-zero conclusion.",
-      "The parent's door_transfer lemma is private, so the signed file re-proves a one-dir variant (door_transfer_signed_one_dir, 8 LOC) directly from the public adj_vertices axiom. No parent surgery is needed."
+      "The parent's door_transfer lemma is private, so the signed file re-proves a one-dir variant (door_transfer_signed_one_dir, 8 LOC) directly from the public adj_vertices axiom. No parent surgery is needed.",
+      "Two pragmatic engineering shifts emerged in implementation: (a) `signedAdjMap` is exposed as a public top-level definition (rather than reusing the parent's `private adjMap`), and (b) `signedAdjMap_invol` is extracted as a standalone lemma to dodge a dependent-type `generalize` failure that occurs when its proof is inlined inside the main theorem's `invol` case. Both choices preserve the proof's mathematical content but reflect the Lean-4 reality that tactic-level limitations sometimes force structural decomposition that is invisible from a paper proof."
     ],
     "prerequisites": [
       "SpernerNDimMathlib (abstract CellComplex with adj_symm, adj_vertices, adj_ne axioms)",
@@ -99,8 +100,15 @@
       "id": "main-theorem",
       "title": "Signed Interior Doors Sum to Zero",
       "startLine": 101,
-      "endLine": 200,
+      "endLine": 203,
       "summary": "signed_interior_doors_sum_zero: the central cancellation theorem. Applies Finset.sum_involution with the four obligations dispatched in case blocks (cancel/fpf/gmem/invol). The proof closely mirrors the parent's interior_doors_even structure but yields an additive-zero conclusion in ℤ instead of an even-cardinality conclusion."
+    },
+    {
+      "id": "namespace-close",
+      "title": "Namespace Closures",
+      "startLine": 204,
+      "endLine": 207,
+      "summary": "Close the nested namespaces SignedCellComplex, Signed, and SpernerAbstract. Definitions in this file are accessed externally as SpernerAbstract.Signed.SignedCellComplex.* (mirroring the parent's SpernerAbstract namespace for the unsigned CellComplex)."
     }
   ],
   "conclusion": {
@@ -132,6 +140,11 @@
       "proofId": "borsuk-ulam",
       "relationship": "supports",
       "description": "The signed CellComplex structure here is the natural ℤ-valued substrate for an equivariant Sperner argument; Tucker's lemma (the ℤ/2-equivariant Sperner statement) is the combinatorial heart of Borsuk–Ulam. This file delivers the foundational cancellation theorem; the Tucker/Borsuk–Ulam bridges remain follow-up work."
+    },
+    {
+      "proofId": "sperner-mathlib",
+      "relationship": "background",
+      "description": "Mathlib's standard Sperner formalisation. The abstract-CellComplex line (parent SpernerNDimMathlib and this signed OQ-04 extension) is a complementary, lighter-weight framework: where Mathlib uses explicit triangulations, the abstract CellComplex captures only the adjacency axioms needed for the door-counting argument. The ℤ-valued signed extension here is the natural orientation enrichment of that abstract approach."
     }
   ],
   "mainTheorems": [

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-01-oq-04.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-01-oq-04.json
@@ -66,10 +66,12 @@
     ]
   },
   "relatedProofs": [
+    "borsuk-ulam",
+    "sperner-ndim",
     "sperner-ndim-mathlib",
     "sperner-ndim-mathlib-oq-01",
-    "sperner-ndim-mathlib-oq-02",
-    "borsuk-ulam"
+    "sperner-ndim-mathlib-oq-01-oq-04",
+    "sperner-ndim-mathlib-oq-02"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary

Enrichment pass on `sperner-ndim-mathlib-oq-01-oq-04` (ℤ-Valued Signed CellComplex with interior-door cancellation).

## Improvements

**annotations.json (new + filled):**
- New `ann-sum-involution-pattern` annotation (key/technique) explaining the four-obligation pattern of `Finset.sum_involution` (cancel/fpf/gmem/invol) — surfaces the dependent-argument pairing structure as a reusable Mathlib technique with full `mathContext`, `relatedConcepts`, `prerequisites`.
- Added missing `mathContext` to `ann-future-tucker-bridge`: AntipodalCellComplex structure sketch + standard signed boundary formula $\partial_n = \sum_i (-1)^i \partial_i$.

**meta.json:**
- Added 5th `keyInsight` documenting two pragmatic Lean engineering shifts in implementation (public `signedAdjMap` vs reusing parent's `private adjMap`; extracted `signedAdjMap_invol` to dodge a dependent-type `generalize` failure).
- Extended `sections` coverage to the full Lean file (was endLine 200; file is 207 lines). Added `namespace-close` section for lines 204–207.
- Added cross-reference to `sperner-mathlib` (background) framing the abstract-CellComplex line as complementary to Mathlib's explicit triangulation approach.

## Quality

- Build: `pnpm build` (tsc -b + vite build) passes clean
- JSON: valid
- 0 sorries, 0 axioms (verified)
- Annotations now: 10 (was 9); all carry `mathContext`, `significance`, `relatedConcepts`, `prerequisites`

🤖 Generated with [Claude Code](https://claude.com/claude-code)