### PR TITLE
audit(erdos-653): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8690,9 +8690,9 @@
     },
     "erdos-653": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T04:48:53Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T08:51:30Z",
+      "result": "clean"
     },
     "erdos-654": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of `erdos-653` (Distinct Distance Counts in the Plane) — **clean**, cycle 4.

## Verification

- 3 `axiom` declarations: `csizmadia_bound` (line 111), `upper_bound` (119), `g_le_n` (147) — match `axiomCount: 3`
- 0 sorries — matches `sorries: 0`
- 0 True-stub theorems
- Theorems `erdos_653_summary` / `erdos_653` honestly assemble the conjecture conjunction from the three stated axioms
- `status: axiomatized` / `badge: axiom` correctly reflect the axiomatized main result
- `assumptions` field accurate: "3 axioms: csizmadia_bound, upper_bound, g_le_n. 0 sorries."
- `originalContributions` transparently lists each axiom

## Test plan

- [x] Confirmed axiom count matches Lean source
- [x] Confirmed 0 sorries, 0 True-stub theorems
- [x] Badge/status match Lean reality
- [x] No new integrity issues detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)