### PR TITLE
audit(erdos-67): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8817,12 +8817,12 @@
     },
     "erdos-67": {
       "agentId": "auditor-agent",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "section line ranges drift across 3 sections (complex-variant, stronger-conjecture, multiplicative) — issue #14099"
       ],
-      "lastAudited": "2026-05-01T05:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T09:17:50Z",
+      "result": "clean"
     },
     "erdos-670": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
## Summary

Re-audit of `erdos-67` (Erdős Discrepancy Problem, Tao 2015) — **clean**, cycle 5.

## Verification

- 1 `axiom` declaration: `erdosDiscrepancy` (line 84) — matches `axiomCount: 1`
- 0 sorries — matches `sorries: 0`
- 0 True-stub theorems
- Theorems `noBoundedDiscrepancy` (line 91) and `no_discrepancy_2_sequence` (line 182) honestly derive from the stated axiom
- `status: axiomatized` / `badge: axiom` correctly reflect the axiomatized main result (Tao's theorem)
- `assumptions` field accurate: "1 axiom: erdosDiscrepancy. 0 sorries."
- `theoremCount: 2`, `definitionCount: 7`, `lineCount: 187` all verified against source
- `originalContributions` transparently lists "Statement of Tao's theorem as an axiom"

## Test plan

- [x] Confirmed axiom count matches Lean source
- [x] Confirmed 0 sorries, 0 True-stub theorems
- [x] Badge/status match Lean reality
- [x] Definition/theorem/line counts verified
- [x] No new integrity issues detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)