### PR TITLE
audit(erdos-645): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8624,12 +8624,12 @@
     },
     "erdos-645": {
       "agentId": "auditor-loop-2026-05-01",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "Section main-theorem claims phantom axiomatized theorem; status overstated (Tier C narrative on Tier D content); see #14118"
       ],
-      "lastAudited": "2026-05-01T05:10:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T09:29:38Z",
+      "result": "clean"
     },
     "erdos-646": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of **erdos-645** (Erdős Problem #645, monochromatic 3-AP with d > x). All meta.json claims match the Lean source.

## Audit Findings

| Metric | meta.json | Lean source | Match |
|---|---|---|---|
| Sorries | 0 | 0 | ✓ |
| Axioms | 1 | 1 (`erdos645_threshold`) | ✓ |
| True stubs | 0 | 0 | ✓ |
| Line count | 251 | 251 | ✓ |
| Theorems | 3 | 3 | ✓ |
| Definitions | 12 | 12 | ✓ |
| Status | `axiomatized` | 1 axiom present | ✓ |
| Badge | `axiom` | matches status | ✓ |

The single axiom `erdos645_threshold : ℕ` is a constant placeholder for N₀ (the threshold guaranteed by the combinatorial literature), **not** an assertion that the conjecture holds. The `assumptions` field documents this correctly.

The file proves three auxiliary results — `monochromatic_iff`, `erdos_645_equiv`, and `erdos_645_implies_vdw` (Erdős #645 implies the 2-coloring 3-AP case of van der Waerden) — but does not prove the conjecture itself.

## Issue #14118 Resolution

The previously logged issue (Section main-theorem claims phantom axiomatized theorem) has been resolved. The Main Theorem section summary now correctly states: *"The main conjecture erdos_645_statement is defined but not axiomatized or proved in this file."*

## Tracker Diff

```
auditCount: 3 → 4
lastAudited: 2026-05-01T05:10:00Z → 2026-05-25T09:29:38Z
result: issues-fixed → clean
```

## Test plan

- [x] Verified Lean source counts (sorries, axioms, True stubs, theorems, defs, lines) match meta.json
- [x] Verified axiom classification matches stated status (axiomatized) and badge (axiom)
- [x] Verified Main Theorem section text no longer overstates the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)