### PR TITLE
audit(erdos-649): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8651,12 +8651,12 @@
     },
     "erdos-649": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "originalContributions claims Tong's theorem and Mahler's growth theorem as contributions when both are axiom declarations (axiom tong_theorem, axiom mahler_growth) — issue #14123 also covers this proof"
       ],
-      "lastAudited": "2026-05-01T05:30:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T09:34:53Z",
+      "result": "clean"
     },
     "erdos-65": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof:** erdos-649 (Greatest Prime Factors of Consecutive Integers)
**Cycle:** 4 (previous: 3)
**Result:** clean

### Verification

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 4 | 4 | ✓ |
| lineCount | 364 | 364 | ✓ |
| theoremCount | 18 | 16 theorems + 2 private lemmas | ✓ |
| definitionCount | 2 | 2 | ✓ |
| status | axiomatized | (4 axioms) | ✓ |
| badge | axiom | (4 axioms) | ✓ |

Axioms enumerated in \`assumptions\` field match Lean source: \`gpf_eq_two_iff\`, \`consecutive_gpf_divides\`, \`tong_theorem\`, \`mahler_growth\`. No True stubs.

### Tracker bump only

No content changes — only \`src/data/proofs/audit-tracker.json\` updated (cycle 3 → 4, result \`issues-fixed\` → \`clean\`, timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)