### PR TITLE
audit(erdos-642): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8606,9 +8606,9 @@
     },
     "erdos-642": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T05:35:40Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T09:42:54Z",
+      "result": "clean"
     },
     "erdos-643": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Audited Erdős Problem #642 (Cycles with More Vertices than Diagonals)
- All meta.json counts align with `proofs/Proofs/Erdos642Problem.lean`
- 4th audit cycle, result: clean

## Verification
- 263 lines, 12 theorems, 16 definitions (def + abbrev + structure + noncomputable def) — matches meta.json
- 1 axiom (`dmms_2024`), 6 sorries — matches meta.json
- status=`axiomatized`, badge=`axiom` — appropriate for OPEN problem
- No `True` stubs, no Mathlib re-export wrappers

## Test plan
- [x] Verify line count: `wc -l proofs/Proofs/Erdos642Problem.lean` → 263
- [x] Verify axiom count: `grep -c '^axiom ' …` → 1
- [x] Verify sorry count: `grep -c sorry …` → 6
- [x] Verify status/badge integrity policy compliance