### PR TITLE
audit(erdos-1078): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3578,9 +3578,9 @@
     },
     "erdos-1078": {
       "agentId": "auditor-agent-2026-05-01",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T05:51:29Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T09:47:47Z",
+      "result": "clean",
       "issues": [
         "sections.comparison.summary claims theorem asymptotic_agreement (line 167-172) but only docstring exists; no Lean declaration",
         "sections.transversals.summary claims theorem extremal_construction (line 185-188) but only docstring exists; no Lean declaration"


### PR DESCRIPTION
## Summary
- Audited Erdős Problem #1078 (Minimum Degree for K_r in r-Partite Graphs)
- All meta.json counts align with `proofs/Proofs/Erdos1078Problem.lean`
- 4th audit cycle, result: clean

## Verification
- 205 lines, 4 theorems, 6 definitions (5 `def` + 1 `structure`) — matches meta.json
- 4 axioms (`threshold_tight`, `haxell_theorem`, `haxell_szabo_theorem`, `threshold_sharp`), 0 sorries — matches meta.json
- status=`axiomatized`, badge=`axiom` — appropriate (Haxell/Haxell-Szabó results axiomatized)
- No `True` stubs, no Mathlib re-export wrappers
- Pre-existing tracker issues (`asymptotic_agreement`, `extremal_construction` docstring-only names) are already addressed in current section summaries (`comparison`, `transversals`)

## Test plan
- [x] Verify line count: `wc -l proofs/Proofs/Erdos1078Problem.lean` → 205
- [x] Verify axiom count: `grep -c '^axiom ' …` → 4
- [x] Verify sorry count: `grep -c sorry …` → 0
- [x] Verify status/badge integrity policy compliance