### PR TITLE
audit(erdos-618): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8427,10 +8427,10 @@
       "result": "clean"
     },
     "erdos-618": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T06:24:41Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-cycle-21-erdos-618",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T09:58:56Z",
+      "result": "clean"
     },
     "erdos-619": {
       "agentId": "auditor-loop-1777618251",


### PR DESCRIPTION
## Summary

Audit of **erdos-618** (Decreasing Diameter of Triangle-Free Graphs, Alon) — **clean**, cycle 4.

All meta.json claims verified against `proofs/Proofs/Erdos618Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 250 | 250 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`main_conjecture_proved`, `threshold_is_sharp`) | ✓ |
| theoremCount | 2 | 2 (`h₂_nonneg`, `erdos_618`) | ✓ |
| definitionCount | 11 | 11 | ✓ |
| status | axiomatized | (has 2 axioms) | ✓ |
| badge | axiom | (has 2 axioms) | ✓ |

`assumptions` field accurately describes both axioms. No True stubs. No Mathlib-wrapper masking.

## Test plan
- [x] Counts cross-checked via `grep -cE "^axiom "`, `grep -c sorry`, `wc -l`
- [x] No True-stub theorems
- [x] Status/badge consistent with axiom presence
- [x] Tracker entry updated: auditCount 3→4, result issues-fixed→clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)