### PR TITLE
audit(erdos-639): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8582,9 +8582,9 @@
     },
     "erdos-639": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T06:38:51Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-25T10:09:50Z",
+      "result": "clean"
     },
     "erdos-64": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Gallery integrity audit of erdos-639 (Erdős Problem #639: Edges Not in Monochromatic Triangles) — cycle 5. All meta.json claims match the Lean source. Result: **clean**.

## Verification

| Field | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| lineCount | 202 | 202 | ✓ |
| axiomCount | 3 | 3 (ramsey_3_3, keevash_sudakov_main, keevash_sudakov_complete) | ✓ |
| theoremCount | 3 | 3 (mono_iff_red_or_blue, edge_partition, erdos_639) | ✓ |
| definitionCount | 16 | 16 (15 def + 1 structure Triangle) | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | n/a | 0 | ✓ |
| status | axiomatized | axioms present | ✓ |
| badge | axiom | axioms present | ✓ |

No integrity issues found. Tracker bumped: auditCount 4→5, result issues-fixed→clean.

## Test plan

- [x] meta.json read
- [x] Lean source read and verified
- [x] grep -c sorry → 0
- [x] grep ^axiom → 3 matches expected
- [x] No True stubs
- [x] All count fields match