### PR TITLE
audit(erdos-616): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8410,15 +8410,10 @@
       "result": "clean"
     },
     "erdos-616": {
-      "agentId": "auditor-agent-main",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T06:44:24Z",
-      "result": "issues-fixed",
-      "issues": [
-        "sections[3]-sections[9] line ranges shifted by 2-5 lines vs actual proofs/Proofs/Erdos616Problem.lean",
-        "overview.proofStrategy claims 'only proved theorem is tau_one_iff_kernel' but coefficient_bounds and erdos_616_summary are also proved"
-      ],
-      "relatedIssue": 14157
+      "agentId": "auditor-cycle-22-erdos-616",
+      "auditCount": 5,
+      "lastAudited": "2026-05-25T10:18:52Z",
+      "result": "clean"
     },
     "erdos-617": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Audit cycle 5 of erdos-616 (Covering Numbers of Hypergraphs) — **clean**.

All meta.json claims verified against `proofs/Proofs/Erdos616Problem.lean`:

| Field | Value | Status |
|-------|-------|--------|
| lineCount | 281 | ✓ |
| sorries | 0 | ✓ |
| axiomCount | 2 (eht_lower_bound, eht_upper_bound) | ✓ |
| theoremCount | 3 (tau_one_iff_kernel, coefficient_bounds, erdos_616_summary) | ✓ |
| definitionCount | 12 (11 def + 1 structure UniformHypergraph) | ✓ |
| status | axiomatized | ✓ |
| badge | axiom | ✓ |
| erdosProblemStatus | open | ✓ |

All 10 section line ranges match the Lean source: 1-41, 42-78, 79-99, 100-117, 118-159, 160-184, 185-200, 201-227, 228-240, 241-281.

No True stubs, no Mathlib wrappers, no axiom-integrity violations.

## Cycle 5 changes

- Bump auditCount 4 → 5
- Set result: clean
- Drop stale issues array and relatedIssue: 14157 (prior cycle 4 issues are resolved; the tracker still carried them)

## Test plan

- [x] Read meta.json claims and overview
- [x] Read proofs/Proofs/Erdos616Problem.lean source
- [x] Verify axiom/theorem/def/sorry counts
- [x] Verify section line ranges match Lean source
- [x] Check for True stubs and Mathlib wrappers