### PR TITLE
audit(erdos-619): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8434,9 +8434,9 @@
     },
     "erdos-619": {
       "agentId": "auditor-loop-1777618251",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T06:54:15Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T10:25:57Z",
+      "result": "clean"
     },
     "erdos-62": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Summary

Audited **erdos-619** (Decreasing Diameter of Triangle-Free Graphs). All meta.json claims match Lean source.

### Verification

| Field | Meta | Actual |
|-------|------|--------|
| axioms | 2 | 2 (`h3_upper_bound`, `h5_upper_bound`) |
| theorems | 1 | 1 (`erdos_619_partial_results`) |
| definitions | 11 | 11 |
| sorries | 0 | 0 |
| True stubs | — | 0 |
| lineCount | 209 | 209 |
| status | axiomatized | ✓ (axioms present) |
| badge | axiom | ✓ |

### Tier Classification

**Tier C — Scaffold / axiomatized.** Core EGR 1998 bounds (h₃ ≤ n, h₅ ≤ (n-1)/2) are axiomatized; the open h₄ question is stated as a proposition. Title and description appropriately mark it OPEN. `erdos_619_partial_results` correctly combines the two axioms without overclaiming.

No integrity issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)