### PR TITLE
audit(erdos-600): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8293,9 +8293,9 @@
     },
     "erdos-600": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T07:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T10:33:54Z",
+      "result": "clean",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14163"
     },
     "erdos-601": {


### PR DESCRIPTION
## Summary

Gallery integrity audit of `erdos-600` (Erdős Problem #600: Edge-Triangle Containment Thresholds) — all meta.json claims match Lean source.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 3 | 3 (`ruzsa_szemeredi`, `e_monotone_r`, `e_monotone_n`) | ✓ |
| lineCount | 167 | 167 | ✓ |
| sorries | 0 | 0 | ✓ |
| assumptions list | 3 entries | matches 3 axioms | ✓ |
| status | axiomatized | (has 3 axioms) | ✓ |
| badge | axiom | (has 3 axioms) | ✓ |

No True stubs detected. No Mathlib wrapper masking. Status/badge correctly reflect axiomatized formalization.

## Test plan
- [x] meta.json values match `grep -cE "^axiom "` and `wc -l` of Lean source
- [x] No sorries, no True stubs
- [x] audit-tracker.json bumped: cycle 4, result `clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)