### PR TITLE
audit(erdos-6): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8280,9 +8280,9 @@
     },
     "erdos-6": {
       "agentId": "auditor-loop-1777619133",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T07:15:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T10:36:18Z",
+      "result": "clean",
       "notes": "Section line ranges drifted from actual Lean section markers — corrected."
     },
     "erdos-60": {


### PR DESCRIPTION
## Audit Summary

**Target**: erdos-6 (Erdős Problem #6: Monotone Prime Gap Sequences)
**Cycle**: 4
**Result**: clean

## Verification

All meta.json claims match the Lean source (`proofs/Proofs/Erdos6Problem.lean`):

| Field | meta.json | Actual | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| lineCount | 191 | 191 | ✓ |
| status | axiomatized | (2 axioms) | ✓ |
| badge | axiom | (2 axioms) | ✓ |

Axioms: `banks_freiberg_turnage_butterbaugh`, `banks_freiberg_turnage_butterbaugh_decreasing`. No `True` stubs. Mathlib dependencies (`Nat.Prime.nth`, `Nat.Prime.nth_strictMono`) used as documented.

## Changes

- `src/data/proofs/audit-tracker.json`: bump audit count for erdos-6 to cycle 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)