### PR TITLE
audit(erdos-636): fix sorry count 7->4 (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8555,8 +8555,8 @@
     },
     "erdos-636": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T07:20:00Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-25T12:05:00Z",
       "result": "issues-fixed",
       "issues": [
         "phantom axioms in narrative: assumptions field claims 7 former axioms (ramsey_graphs_exist, erdos_faudree_sos, ks_probabilistic_method, signature_distribution, non_ramsey_smaller_bound, ramsey_forces_complexity, induced_path_count) which are absent from the file; sections efs/ramsey/techniques/ramsey-theory and originalContributions/proofStrategy reference axioms that do not exist — issue #14136",

--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -17,7 +17,7 @@
       "counting"
     ],
     "badge": "axiom",
-    "sorries": 7,
+    "sorries": 4,
     "erdosNumber": 636,
     "erdosUrl": "https://erdosproblems.com/636",
     "erdosProblemStatus": "solved",
@@ -267,5 +267,5 @@
       "type": "paper"
     }
   ],
-  "sorries": 7
+  "sorries": 4
 }


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-636 (Distinct Induced Subgraphs in Ramsey Graphs)
**Severity**: HIGH (sorry count mismatch)
**Cycle**: 5

## Problem

`meta.json` stated `sorries: 7` in two places (top-level field and `meta.sorries`), but `Proofs/Erdos636Problem.lean` contains exactly **4** sorries:

- `edge_count_range` (line 186)
- `clique_few_signatures` (line 198)
- `empty_few_signatures` (line 203)
- `CountDistinctIsomorphismTypes` (line 214)

This count already agreed with `leanFile.sorries: 4` and the `assumptions` field, which explicitly names the 4 sorries — so the two `7` fields were stale drift.

## Fix

- `meta.sorries`: 7 -> 4
- top-level `sorries`: 7 -> 4
- Audit tracker bumped (cycle 5, `issues-fixed`)

## Other checks (all clean)

- `axiomCount: 2` matches 2 axiom declarations (`kwan_sudakov`, `signature_upper_bound`)
- `status: axiomatized` / `badge: axiom` correct (axioms + sorries present)
- `theoremCount: 8`, `definitionCount: 19`, `lineCount: 261` all match source
- Section line ranges cover their declarations (prior cycle-4 drift resolved)
- No phantom axioms in narrative (prior cycle-4 issue resolved)
- 0 True-stub theorems

---
Discovered during gallery integrity audit.