### PR TITLE
audit(erdos-665): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8773,9 +8773,9 @@
     },
     "erdos-665": {
       "agentId": "auditor-erdos-665-1777620272",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T07:25:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-25T12:18:59Z",
+      "result": "clean",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14171",
       "issues": [
         "Section line ranges drift 1-5 lines in middle sections (II/III/IV/V) — endpoints cross axiom/def boundaries; proofStrategy credits Shrikhande-Singhi embedding theorem and Cramér conjecture as axiomatized but they are docstring-only — issue #14171"


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-665

**Result: CLEAN** (cycle 5)

Audited `src/data/proofs/erdos-665/meta.json` against Lean source `proofs/Proofs/Erdos665Problem.lean`. All public claims match the source:

| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| axiomCount | 5 | 5 axiom decls | ✓ |
| sorries (all 3 fields) | 0 | 0 | ✓ |
| True stubs | none | 0 | ✓ |
| theoremCount | 1 | 1 | ✓ |
| definitionCount | 6 | 5 def + 1 struct | ✓ |
| lineCount | 170 | 170 | ✓ |
| status / badge | axiomatized / axiom | open problem, 5 axioms | ✓ |

**Narrative integrity (Tier C):** The `assumptions` field names all 5 axioms (`h`, `erdos_larson_bound`, `prime_power_planes_implies_unbounded`, `largestPrimeGap`, `h_correlates_with_prime_gap`). The `proofStrategy` honestly notes that the Shrikhande-Singhi embedding theorem and Cramér's conjecture appear only in docstrings, not as Lean axioms. Title and description correctly present the conditional ("conditionally no") result. No axiom masking, no delegation opacity, no overclaiming.

This PR only bumps the audit tracker (auditCount 4→5, result issues-fixed→clean). No content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)