### PR TITLE
audit(erdos-596): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8253,9 +8253,9 @@
     },
     "erdos-596": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T07:44:52Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T12:23:14Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in narrative: section summaries claim Axiom erdos_596 (Part IV) and Axiom erdos_595_k4_k3 (Part V) — neither declared in Lean file; only nesetril_rodl_c4_c6 and erdos_hajnal_c4_trees exist — issue #14179"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-596 (cycle 4)

Re-audited **Erdős Problem #596: Graph Coloring Dichotomy for Forbidden Subgraphs**.

### Result: CLEAN

All meta.json claims match the Lean source (`proofs/Proofs/Erdos596Problem.lean`):

| Field | meta.json | Lean actual | Match |
|-------|-----------|-------------|-------|
| axiomCount | 2 | 2 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 142 | 142 | ✓ |
| True-stubs | — | 0 | ✓ |

- **Status/badge**: `axiomatized`/`axiom` — correct. The two deep external theorems (Nešetřil-Rödl, Erdős-Hajnal) are honestly axiomatized and explicitly credited; only the `(C₄, C₆)` dichotomy is derived from them. No overclaiming.
- **Prior fix held**: The phantom-axiom narrative issue (#14179) — section summaries previously claiming undeclared axioms for Parts IV/V — remains correctly resolved; current narrative states "no axiom is declared" for those parts.

Tracker bump only; no source or narrative changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)