### PR TITLE
audit(erdos-594): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8238,9 +8238,9 @@
     },
     "erdos-594": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T07:50:44Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T12:28:26Z",
+      "result": "clean",
       "issues": [
         "section line drift (5/8 sections shifted) + phantom contributions erdos_hajnal_aleph2 and thomassen_1983 (docstring-only, no declaration); tracked in #14183"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-594

**Result: CLEAN** (re-audit cycle 4)

Verified all `meta.json` claims against `proofs/Proofs/Erdos594Problem.lean`:

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 3 | 3 (`erdos_hajnal_shelah`, `countable_chromatic_insufficient`, `contains_all_finite_bipartite`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| lineCount | 245 | 245 | ✓ |

- No `True` stubs.
- No structure-encoded assumptions (only docstring prose mentions "structure").
- `status=axiomatized` / `badge=axiom` correctly reflects the axiomatized main result; `assumptions` field enumerates all 3 axioms.
- Prior section line-drift issue (tracked in #14183) confirmed resolved — declared section ranges contain their named declarations.

No changes needed beyond the audit-tracker bump.

---
Discovered during gallery integrity audit. Math-agent PR — deployer merges directly (no loom:review-requested).