### PR TITLE
audit(erdos-591): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8217,9 +8217,9 @@
     },
     "erdos-591": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T07:54:15Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T13:01:41Z",
+      "result": "clean",
       "issues": [
         "Phantom axiom narrative: originalContributions/proofStrategy/sections claim formalizations of Specker and Chang theorems that exist only as docstrings (issue #14186)"
       ]


### PR DESCRIPTION
## Summary
- Audited `erdos-591` (Ordinal Ramsey Theory for ω^(ω²))
- All counts in meta.json match Lean source: 2 axioms, 6 theorems, 0 defs, 0 sorries, 175 lines
- Status `axiomatized` + badge `axiom` correct (Schipperus-Darby and OrdinalRamseyProperty axioms)
- No integrity issues; tracker-only update

🤖 Generated with [Claude Code](https://claude.com/claude-code)