### PR TITLE
audit(erdos-588): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8187,12 +8187,12 @@
     },
     "erdos-588": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "originalContributions lists 11 phantom identifiers (Line, OnLine, Collinear, InKGeneralPosition, IsKRich, karteszi_lower_bound, grunbaum_lower_bound, solymosi_stojakovic, erdos_588_conjecture, problem_101, szemeredi_trotter); section k4-open summary claims axioms lower_bound_k4 and erdos_conjecture_k4 that are docstring-only (issue #14192)"
       ],
-      "lastAudited": "2026-05-01T08:11:06Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T13:14:04Z",
+      "result": "clean"
     },
     "erdos-589": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Summary

**Target**: erdos-588 (Erdős Problem #588: k-Point Lines in General Position)
**Result**: clean (cycle 4)
**Source**: proofs/Proofs/Erdos588Problem.lean

### Verification

| Metric | meta.json | Lean source | Match |
|--------|-----------|-------------|-------|
| axiomCount | 2 | 2 (`f`, `sylvester_k3`) | ✅ |
| theoremCount | 1 | 1 (`erdos_588`) | ✅ |
| definitionCount | 1 | 1 (`abbrev Point`) | ✅ |
| sorries | 0 | 0 | ✅ |
| lineCount | 87 | 87 | ✅ |

No True stubs, no Mathlib wrappers detected.

### Changes

- `src/data/proofs/audit-tracker.json`: bump erdos-588 auditCount 3 → 4, lastAudited → 2026-05-25, result → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)