### PR TITLE
audit(erdos-583): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8151,9 +8151,9 @@
     },
     "erdos-583": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T08:18:11Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T13:38:15Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in narrative: pyber_theorem, tree_satisfies, complete_graph_satisfies, cycle_satisfies, star_needs_few_paths, bipartite_tight (issue #14195)"
       ]


### PR DESCRIPTION
## Audit Summary

**Target**: erdos-583 (Erdős-Gallai Path Partition Conjecture)
**Result**: clean (cycle 4)
**Source**: proofs/Proofs/Erdos583Problem.lean

### Verification

| Metric | meta.json | Lean source | Match |
|--------|-----------|-------------|-------|
| axiomCount | 3 | 3 (`lovasz_theorem`, `chung_theorem`, `fan_theorem`) | ✅ |
| theoremCount | 4 | 4 | ✅ |
| definitionCount | 14 | 14 (structures + defs) | ✅ |
| sorries | 0 | 0 | ✅ |
| lineCount | 232 | 232 | ✅ |

No True stubs, no Mathlib wrappers. Phantom-axiom narrative from prior cycles already resolved.

### Changes

- `src/data/proofs/audit-tracker.json`: bump erdos-583 auditCount 3 → 4, lastAudited → 2026-05-25, result → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)