### PR TITLE
audit(erdos-580): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8121,9 +8121,9 @@
     },
     "erdos-580": {
       "agentId": "auditor-session-1777623758",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T08:23:46Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T14:04:57Z",
+      "result": "clean",
       "issues": [
         "originalContributions: 4 phantom entries (AKS_theorem, path_case, star_case, LKS_tightness) - docstrings only",
         "proofStrategy: steps 5 and 7 claim 5 axiomatizations, only zhao_theorem is axiomatized",


### PR DESCRIPTION
## Audit Result: CLEAN

Verified `erdos-580` (Loebl-Komlós-Sós Conjecture) gallery entry matches Lean source.

## Integrity Checks

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 1 | 1 (`zhao_theorem`) | ✓ |
| theoremCount | 2 | 2 (`erdos_580`, `erdos_580_summary`) | ✓ |
| definitionCount | 11 | 11 (10 `def` + 1 `structure`) | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 236 | 236 | ✓ |
| True stubs | n/a | 0 | ✓ |

## Narrative Assessment

- Status `axiomatized`, badge `axiom` — properly labeled
- `assumptions` field explicitly states "1 axiom: zhao_theorem. 0 sorries."
- `originalContributions` correctly flags `zhao_theorem` as "the only axiom"
- Main theorem `erdos_580 := zhao_theorem` — derives from the file's own axiom, not from Mathlib
- `mathlibDependencies` are basic types (`SimpleGraph`, `neighborFinset`, `Fintype.card`, `Function.Injective`) — no Mathlib wrapper concern
- AKS, path_case, star_case, LKS_tightness correctly noted as docstring-only (no phantom axioms)

No issues found. Tracker bumped from `auditCount: 3` (cycle 3, issues-fixed) to `auditCount: 4` (cycle 4, clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)