### PR TITLE
audit(erdos-586): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8172,9 +8172,9 @@
     },
     "erdos-586": {
       "agentId": "auditor-loop-5164",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T08:30:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T14:19:28Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in originalContributions/proofStrategy: covering_implies_comparable, no_antichain_k_covering (issue #14189)"
       ]


### PR DESCRIPTION
Cycle 4 re-audit of erdos-586 (Covering Systems with Antichain Moduli). All meta.json claims match Lean source: 3 axioms (bbmst_theorem, bbmst_density_bound, antichain_not_covering), 1 theorem, 14 defs (12 def + 2 structures), 0 sorries, 0 True stubs, 165 lines. Status axiomatized/badge axiom correctly reflects 3 documented axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)