### PR TITLE
audit(erdos-599): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8274,8 +8274,8 @@
     },
     "erdos-599": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T08:47:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T17:03:30Z",
       "result": "clean"
     },
     "erdos-6": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-599

Audited **erdos-599** (Erdős Problem #599: The Erdős-Menger Conjecture) for gallery integrity. All meta.json claims verified against `proofs/Proofs/Erdos599Problem.lean`.

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`aharoni_berger_theorem`) | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 17 | 14 def + 3 struct = 17 | ✓ |
| lineCount | 230 | 230 | ✓ |
| True stubs | — | 0 | ✓ |

**Tier C (axiomatized) — correctly classified.** The deep Aharoni-Berger 2009 result is not in Mathlib and is honestly axiomatized (`axiom aharoni_berger_theorem : ErdosMengerConjecture`). Badge is `axiom`, status is `axiomatized`, and the `assumptions` field explicitly states the single axiom. No overclaiming, no axiom masking — the `originalContributions` list even names `aharoni_berger_theorem: main result axiom`.

**Result: clean.** Tracker bumped to cycle 4.

---
Discovered during autonomous gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)