### PR TITLE
audit(erdos-597): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8262,8 +8262,8 @@
     },
     "erdos-597": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T08:51:18Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T18:05:44Z",
       "result": "clean"
     },
     "erdos-598": {


### PR DESCRIPTION
## Summary

Re-audited **erdos-597** (Partition Relations for Ordinal Powers) — gallery integrity verified.

All meta.json claims match the Lean source:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| axioms | 6 | 6 ✓ |
| theorems | 1 | 1 ✓ |
| defs/structures | 9 | 8 def + 1 structure ✓ |
| sorries | 0 | 0 ✓ |
| lines | 183 | 183 ✓ |

- status: `axiomatized` (correct for OPEN problem with axiomatized partial results)
- badge: `axiom` (correct — 6 axioms in source)

## Test plan

- [x] axiom/theorem/def/sorry counts match
- [x] status and badge appropriate for axiomatized open problem
- [x] no True stubs, no Mathlib wrapper masking

Result: **clean**.