### PR TITLE
audit(erdos-582): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8142,9 +8142,9 @@
     },
     "erdos-582": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T09:24:45Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T18:15:02Z",
+      "result": "clean",
       "issues": [
         "Inconsistent axioms: folkmanNumber_2_3_4 := 0 (def) with axiom folkman_lower_bound : ≥ 19 — issue #14212"
       ]


### PR DESCRIPTION
## Summary

Gallery integrity audit (cycle 4) for **erdos-582** (Folkman Number Problem).

## Audit Results

**Status: CLEAN** — meta.json claims match Lean source.

| Metric | meta.json | Lean source | Match |
|--------|-----------|-------------|-------|
| lineCount | 315 | 315 | ✓ |
| axiomCount | 5 | 3 axioms + 2 opaques | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 11 | 9 def/structure + 2 opaque | ✓ |
| sorries | 0 | 0 | ✓ |
| status | axiomatized | (3 axioms + 2 opaques) | ✓ |
| badge | axiom | (assumption-bearing) | ✓ |

Assumptions field correctly documents: 2 opaque constants (folkmanNumber_2_3_4, folkmanNumber) + 3 axioms (folkman_existence, folkman_lower_bound, folkman_upper_bound).

No true-stub theorems (`grep ":= trivial\|: True :=\|: True\b"` = 0).
Historic issue noted in tracker (`issue #14212`) was previously fixed; current state is clean.

## Test plan
- [x] Compared meta.json fields against `proofs/Proofs/Erdos582Problem.lean`
- [x] Ran true-stub detection grep
- [x] Verified status/badge consistent with axiom presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)