### PR TITLE
audit(erdos-578): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8100,9 +8100,9 @@
     },
     "erdos-578": {
       "agentId": "auditor-session-1777628135",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T09:50:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T18:30:29Z",
+      "result": "clean",
       "issues": [
         "section line drift fixed: riordan, threshold-distribution, properties, summary all shifted to match actual Part V-VIII positions"
       ]


### PR DESCRIPTION
## Summary

Cycle 4 audit of `erdos-578` (Erdős Problem #578: Hypercube Subgraphs of Random Graphs).

**Result**: clean

**Verification**:
- Lines: 151 ✓ matches meta
- Axioms: 2 (`erdos_bollobas_proved`, `threshold_at_quarter`) ✓ matches meta
- Theorems: 2 ✓ matches meta
- Definitions: 9 `def` + 2 `structure` (Hypercube, RandomGraph) = 11 ✓ matches meta
- Sorries: 0 ✓ matches meta
- Status: `axiomatized`, badge: `axiom` — consistent
- Structure fields (`hp_nonneg`, `hp_le_one`) are concrete constraints proved at construction sites (`norm_num` / `linarith`), not assumption-carrying

No issues found. Tracker bumped to auditCount=4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)