### PR TITLE
audit(erdos-58): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8115,8 +8115,8 @@
     },
     "erdos-58": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T10:11:09Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T18:36:45Z",
       "result": "clean"
     },
     "erdos-580": {


### PR DESCRIPTION
## Summary

Audit cycle 4 for Erdős Problem #58 (Chromatic Number vs Odd Cycle Lengths) — **clean**.

Verified `meta.json` claims match `proofs/Proofs/Erdos58Problem.lean`:
- 3 axioms: `chromaticNumber`, `gyarfas_upper_bound`, `gyarfas_equality`
- 4 theorems: `bollobas_shelah`, `no_odd_cycles_bipartite`, `chi_5_two_odd_lengths`, `equality_implies_clique`
- 6 definitions, 0 sorries
- `lineCount: 152` matches file

No issues found.

## Test plan

- [x] `grep -cE "^axiom " proofs/Proofs/Erdos58Problem.lean` → 3
- [x] `grep -cE "\\bsorry\\b" proofs/Proofs/Erdos58Problem.lean` → 0
- [x] `wc -l proofs/Proofs/Erdos58Problem.lean` → 152

🤖 Generated with [Claude Code](https://claude.com/claude-code)