### PR TITLE
audit(erdos-577): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8091,9 +8091,9 @@
     },
     "erdos-577": {
       "agentId": "auditor-erdos-577-2026-05-01",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T10:18:21Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T18:50:51Z",
+      "result": "clean",
       "issues": [
         "Phantom degree_bound_sharp in originalContributions; conclusion claims sharpness is proved (only docstring). See issue #14225."
       ]


### PR DESCRIPTION
## Summary

erdos-577 audit cycle 5 — clean.

**Verification** (Erdos577Problem.lean):
- 192 lines (matches meta lineCount)
- 0 sorries (matches)
- 2 axioms: wang_theorem, four_cycle_base_case (matches axiomCount)
- 2 theorems (matches theoremCount)
- 8 definitions: noncomputable def minDegree, structure FourCycle, def FourCycle.vertices, def DisjointFourCycles, def PairwiseDisjoint, def ErdosFaudreeConjecture, def erdos_577_answer, def erdos_577_status (matches definitionCount)
- status `axiomatized` / badge `axiom` is correct — Wang's theorem is asserted as `axiom`, with `erdos_577 := wang_theorem` deriving the final claim.

**Prior issue resolved**: meta.json no longer references the phantom `degree_bound_sharp` declaration; the special-cases section explicitly notes sharpness is documented only in docstring commentary.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned erdos-577
- [x] Static checks on `proofs/Proofs/Erdos577Problem.lean` (lines, sorries, axioms, theorems, defs) match `meta.json`
- [x] Tracker bumped to auditCount 4, result `clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)