### PR TITLE
audit(erdos-577): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8091,8 +8091,8 @@
     },
     "erdos-577": {
       "agentId": "auditor-erdos-577-2026-05-01",
-      "auditCount": 4,
-      "lastAudited": "2026-05-25T18:50:51Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-25T19:09:44Z",
       "result": "clean",
       "issues": [
         "Phantom degree_bound_sharp in originalContributions; conclusion claims sharpness is proved (only docstring). See issue #14225."


### PR DESCRIPTION
Re-audit of erdos-577 (cycle 5): 192 lines / 0 sorries / 2 axioms (wang_theorem, four_cycle_base_case) / 2 theorems / 8 definitions all match meta.json. Status `axiomatized` and badge `axiom` correctly reflect dependence on axiomatized Wang theorem. Prior issue #14225 (phantom degree_bound_sharp) remains resolved.