### PR TITLE
audit(erdos-573): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8064,9 +8064,9 @@
     },
     "erdos-573": {
       "agentId": "auditor-agent-tracker",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T10:25:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T19:18:23Z",
+      "result": "clean",
       "issues": [
         "Phantom KST/Erdős-Simonovits bound axioms in narrative (counts correct); lineCount 152→177; section line drift — issue #14227"
       ]


### PR DESCRIPTION
## Audit Result: CLEAN

Gallery integrity audit of `erdos-573` (Erdős Problem #573: Extremal Numbers for {C₃, C₄}-free Graphs).

### Verification

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| axiomCount | 5 | 5 | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 177 | 177 | ✓ |
| True stubs | — | 0 | ✓ |

### Narrative integrity

- `status: "axiomatized"` and `badge: "axiom"` — correct for an OPEN problem with 5 axioms.
- `erdosProblemStatus: "open"` — accurate.
- Title and description explicitly mark the problem as open and asymptotic; no overclaim.
- `originalContributions` correctly scope work to infrastructure (predicates, definitions, extremal-function axiomatization, conjecture formalization). They do not claim the conjecture is proved.
- Main "theorem" `erdos_573` is `Classical.em` of the conjecture — a tautology, not a proof; not presented otherwise in the gallery copy.
- Mathlib dependencies (`SimpleGraph`, `Real`, `Nat.Basic`) are infrastructure only; not a wrapper around a deep theorem.

No issues found. Tracker bumped to record audit completion.