### PR TITLE
audit(erdos-571): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8049,12 +8049,12 @@
     },
     "erdos-571": {
       "agentId": "auditor-session-1777631912",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom axioms in originalContributions / proofStrategy / sections (jiang_qiu_exponents_4_3, jiang_qiu_exponents_5_4, jiang_ma_yepremyan_exponents, conlon_janzer_near_two, bukh_conlon_families, kovari_sos_turan, bondy_simonovits_upper) — issue #14232"
       ],
-      "lastAudited": "2026-05-01T10:50:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-25T19:41:47Z",
+      "result": "clean"
     },
     "erdos-572": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of erdos-571 (Rational Turán Exponents for Bipartite Graphs). No integrity issues; tracker bumped to auditCount=4.

## Verified

- **Lean source** (`proofs/Proofs/Erdos571Problem.lean`): 3 axioms (`conlon_janzer_lee_exponents`, `jiang_qiu_low_exponents`, `exponent_7_5`), 0 sorries
- **meta.json**: `axiomCount=3`, `sorries=0`, `status=axiomatized`, `badge=axiom` — all consistent with source
- **Tier C** axiomatized open problem, correctly framed: `erdos_571_conjecture` is a `def : Prop` (not a `theorem`), preserving its open status
- **Phantom axioms** previously fixed (#14232) confirmed absent: no fabricated `jiang_qiu_exponents_4_3`, `bukh_conlon_families`, `kovari_sos_turan`, `bondy_simonovits_upper`, etc. in `originalContributions`

## Test plan
- [x] Lean source: `grep -c '^axiom ' = 3`, `grep -c 'sorry' = 0`
- [x] meta.json fields match source counts
- [x] Tracker entry updated with `result=clean` and current timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)