### PR TITLE
audit(erdos-570): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8040,9 +8040,9 @@
     },
     "erdos-570": {
       "agentId": "auditor-agent-2026-05-01",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T10:50:04Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T19:51:49Z",
+      "result": "clean",
       "issues": [
         "sections.cases.summary claims four phantom axioms (EFRS/Sidorenko/Jayawardene/CFMPP) — only erdos_570_resolved exists in Lean; numerical fields correct — issue #14234"
       ]


### PR DESCRIPTION
## Summary

Re-audit of erdos-570 (Cycle-Graph Ramsey Numbers). No integrity issues; tracker bumped to auditCount=4.

## Verified

- **Lean source** (`proofs/Proofs/Erdos570Problem.lean`): 1 axiom (`erdos_570_resolved`), 0 sorries, 0 True stubs
- **meta.json**: `axiomCount=1`, `sorries=0`, `status=axiomatized`, `badge=axiom` — all consistent with source
- **Tier C** axiomatized open problem, correctly framed: `Erdos570Conjecture` is a `def : Prop` and the single `erdos_570_resolved` axiom is acknowledged explicitly
- **Prior phantom axiom issue** (#14234) confirmed fixed: `sections[4]` explicitly states "no per-author axioms are declared in this section"
- **originalContributions** match Lean source: `CycleGraph`, `edgeCount`, `NoIsolatedVertices`, `RamseyNumber`, `CycleRamseyNumber`, `UpperBound`, `Erdos570Conjecture`, `erdos_570_resolved` (axiom), `ceiling_formula`, `erdos_570_summary` all present

## Test plan
- [x] Lean source: `grep -c '^axiom ' = 1`, no `sorry`
- [x] meta.json fields match source counts
- [x] Phantom-axiom regression check passes (sections[4] correctly disclaims per-author axioms)
- [x] Tracker entry updated with `result=clean` and current timestamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)