### PR TITLE
audit(erdos-569): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8025,9 +8025,9 @@
     },
     "erdos-569": {
       "agentId": "auditor-session-1777632838",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T10:59:06Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T19:55:24Z",
+      "result": "clean",
       "issues": [
         "Phantom axioms in narrative: pentagon case + lower bounds in proofStrategy; vertex-bound axiom in section summary; pentagon axiom claimed in known-results section — issue #14242"
       ]


### PR DESCRIPTION
## Summary
- Re-audited **erdos-569** (Odd Cycle Ramsey Numbers Linear in Edges, OPEN).
- Lean source verifies: 167 lines, 3 axioms (R_cycle_graph, triangle_constant_bound, efrs_upper_bound), 0 sorries, 3 defs, 3 theorems — all match `meta.json`.
- Narrative integrity holds: pentagon case (c_2 ≤ 5) and lower-bound (c_k ≥ 2) appear in docstrings only, no phantom-axiom claims. Phantom-axiom fix from #14242 remains intact.
- Status `axiomatized` / badge `axiom` correct for this open problem.
- Cycle 4 result: `issues-fixed` → `clean`.

## Test plan
- [x] `meta.axiomCount` == `grep -c '^axiom ' Erdos569Problem.lean` == 3
- [x] `meta.sorries` == 0; no `sorry` in Lean source
- [x] `meta.lineCount` == file line count (167)
- [x] `originalContributions` enumerate the 3 axioms + 3 theorems + 3 defs visible in source
- [x] No `True` stub theorems, no Mathlib wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)