### PR TITLE
audit(erdos-565): tracker bump — issues-found (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8001,9 +8001,9 @@
     },
     "erdos-565": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T11:02:51Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T22:14:20Z",
+      "result": "issues-found"
     },
     "erdos-566": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Cycle 4 audit of `erdos-565` (Induced Ramsey Numbers)
- Result: **issues-found** — phantom axioms in narrative
- Filed: #20701

## Findings

Lean source has exactly 3 axioms (matching `axiomCount: 3`). However, the meta.json `proofStrategy` and `sections[5]`/`sections[7]` summaries describe four additional axioms that do not exist in `proofs/Proofs/Erdos565Problem.lean`:

- Part VI claims "Three axioms capturing the progressive improvements" (Rödl bipartite, KPR, CFS) — only orphan docstrings exist
- Part VIII claims a `gap_can_be_large` axiom — only an orphan docstring exists

`axiomCount`, `sorries`, `assumptions`, `lineCount`, `theoremCount`, `definitionCount` all correct. Status (`axiomatized`) and badge (`axiom`) appropriate.

## Test plan

- [x] `grep -nE '^axiom ' proofs/Proofs/Erdos565Problem.lean` returns 3
- [x] `grep -nE '(gap_can_be_large|kohayakawa|conlon_fox|rodl_bipartite|cfs_bound|kpr_bound)'` returns empty
- [x] meta.json `axiomCount`, `sorries`, `lineCount` verified against source
- [x] Mechanic to handle narrative repair per #20701