### PR TITLE
audit(erdos-562): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7977,9 +7977,9 @@
     },
     "erdos-562": {
       "agentId": "auditor-loom",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T11:07:37Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T22:22:40Z",
+      "result": "clean",
       "issues": [
         "phantom-axiom narrative: proofStrategy/sections claim Erdős–Rado, Erdős–Hajnal, general lower, and main conjecture as axioms but they are docstring-only (issue #14247)"
       ]


### PR DESCRIPTION
## Summary

Re-audited erdos-562 (Hypergraph Ramsey Number Tower Growth) — clean.

Verified against `proofs/Proofs/Erdos562Problem.lean`:
- 2 axioms (`erdos_szekeres_lower`, `erdos_szekeres_upper`) — matches `meta.json` axiomCount: 2
- 0 sorries
- 3 theorems, 2 definitions, 85 lines — all match meta
- Status `axiomatized` / badge `axiom` correct (open Erdős–Hajnal–Rado conjecture)
- Narrative correctly labels stepping-up, r3-lower, general-lower, main-conjecture sections as docstring placeholders (no phantom axioms)

Cycle 3 had flagged phantom-axiom narrative; that was resolved in issue #14247. Current state is clean.

## Test plan

- [x] grep counts match meta (axioms=2, sorries=0, theorems=3, defs=2)
- [x] line count = 85
- [x] no phantom axiom claims in narrative
- [x] status/badge consistent with axiom presence

🤖 Generated with [Claude Code](https://claude.com/claude-code)