### PR TITLE
audit(quadratic-reciprocity-oq-03): tracker bump — clean (cycle 2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13749,9 +13749,9 @@
       "issues": []
     },
     "quadratic-reciprocity-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-01T11:14:29Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-05-25T22:29:44Z",
+      "result": "clean",
       "issues": [
         "badge=original for proof whose reduction lemmas are 1-line Mathlib wrappers; tracked in #14250 + PR #14251"
       ]


### PR DESCRIPTION
## Summary

Cycle-2 audit of `quadratic-reciprocity-oq-03`. All meta.json claims verified against `proofs/Proofs/QuadraticReciprocityOQ03.lean`:

- `lineCount: 118` ✓
- `sorries: 0` ✓
- `axiomCount: 0` ✓
- `theoremCount: 4` ✓ (`legendreSym_mul_eq`, `legendreSym_neg_one_eq`, `reciprocity_swap`, `algorithm_descent`)
- `definitionCount: 0` ✓
- 7 `decide`-verified Legendre symbol examples ✓
- No `: True` stubs ✓

`status=verified`, `badge=mathlib` are consistent — the four reduction lemmas are 1-line wrappers around Mathlib's `legendreSym.quadratic_reciprocity'`, `legendreSym.at_neg_one`, and `map_mul`. No structure-encoded assumptions.

Tracker bump only; no source changes.

## Test plan
- [x] grep verified counts (sorries/axioms/theorems/defs/examples)
- [x] cross-checked originalContributions list against Lean theorem signatures
- [x] confirmed mathlibDependencies are real lemmas (no phantom citations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)