### PR TITLE
audit(erdos-564): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7992,9 +7992,9 @@
     },
     "erdos-564": {
       "agentId": "auditor-loop-1777634217",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T11:22:23Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-25T22:33:21Z",
+      "result": "clean",
       "issues": [
         "Phantom-axiom narrative — originalContributions 6/7/8, proofStrategy steps 7/8, sections small-values/comparison/four-colour describe docstring placeholders, not Lean declarations (axiomCount 3, sorries 1 are correct) — issue #14254"
       ]


### PR DESCRIPTION
## Summary

Cycle 4 audit of `erdos-564` (Hypergraph Ramsey Numbers, open Erdős problem with $500 prize). All gallery integrity checks pass.

## Verification

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| status | `axiomatized` | open problem, axiomatized | ✓ |
| badge | `axiom` | 3 axioms present | ✓ |
| axiomCount | 3 | `R`, `erdos_hajnal_rado_upper`, `erdos_hajnal_rado_lower` | ✓ |
| sorries | 1 | `bounds_gap_enormous` (line 205) | ✓ |
| theoremCount | 6 | tower_{zero,one,two,pos}, bounds_summary, bounds_gap_enormous | ✓ |
| definitionCount | 5 | UniformHypergraph, TwoColouring, HasHypergraphRamseyProperty, erdos_564_conjecture, tower | ✓ |
| lineCount | 207 | 207 | ✓ |
| assumptions | "3 axioms: R, erdos_hajnal_rado_upper, erdos_hajnal_rado_lower. 1 sorry." | matches | ✓ |

No True stubs. No Mathlib wrapper masking (axiomatized open problem, badge correctly axiom). Cycle 3 phantom-axiom narrative issue (#14254) was previously fixed and remains resolved.

## Test plan
- [x] Tracker entry shows auditCount: 4, result: clean, current timestamp
- [x] No changes outside src/data/proofs/audit-tracker.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)