### PR TITLE
Enrich Abel-Ruffini: correct lineCount metadata

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -143,7 +143,7 @@
         "relationship": "Cantor's 1874 theorem that the algebraic closure ℚ̄ is countable (|ℚ̄| = ℵ₀) via degree-by-degree enumeration of ℚ[X], each polynomial having finitely many roots. Sits one tier above Abel-Ruffini in the algebraic-vs-radical-vs-transcendental hierarchy: ℚ̄ is countable, but the *radically expressible* sub-subset is a strict (still countable) subset, and Abel-Ruffini exhibits explicit elements of ℚ̄ (roots of x⁵ − 4x + 2) that escape it. Combined with |ℝ| = 2^ℵ₀, Cantor's countability gives the existence of transcendentals (cf. `liouville-theorem`); Abel-Ruffini delivers a parallel impossibility one tier down — algebraic non-radicals exist among the countable ℚ̄. The implications section's 'impossibility paradigm' (#7) and 'transcendence hierarchy' (#8) place both results on the same Galois-(1832)–Cantor-(1874)–Lindemann-(1882) lineage of cardinality- and expressibility-based barriers."
       }
     ],
-    "lineCount": 188,
+    "lineCount": 187,
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
     "definitionCount": 0
@@ -265,7 +265,7 @@
     ],
     "opens": [],
     "namespace": "AbelRuffini",
-    "lineCount": 188,
+    "lineCount": 187,
     "axiomCount": 0,
     "theoremCount": 9,
     "substantiveTheoremCount": 3,


### PR DESCRIPTION
## Enrichment pass for `abel-ruffini`

This entry is already exceptionally comprehensive (quality 100, 6 prior passes): 16 fully-populated annotations, 20 key insights, 10 open questions, 70 valid cross-references, 40 references, and all peer-review action items resolved. Rather than padding mature content, this pass corrects the one concrete, verifiable inconsistency found during audit.

### Change
- **`meta.lineCount` and `leanFile.lineCount`: 188 -> 187.** Verified via `wc -l proofs/Proofs/AbelRuffini.lean` (187 lines). The `description` field and all `sections` line ranges (which end at 187) already used the correct count; only these two metadata fields were stale.

### Audit findings (no change needed)
- **Annotations:** 16/16 have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`; line coverage spans 1-185 with no meaningful gaps.
- **Cross-references:** all 70 `targetId`s resolve to existing gallery proof directories; every sub-entry discussed in prose (21 of them) is also present in the structured array.
- **Sections:** all 7 ranges accurately match the Lean source parts.
- **review.json:** all three enricher-targeted action items confirmed already resolved in the current files.
- **Axiom integrity:** `status: verified`, `badge: mathlib`, `axiomCount: 0`, `sorries: 0` -- consistent with the source (0 axioms, 0 sorries, no structure-encoded assumptions; a Mathlib wrapper).

`pnpm build` passes.