### PR TITLE
audit(erdos-547): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7866,9 +7866,9 @@
     },
     "erdos-547": {
       "agentId": "auditor-erdos-547-phantom-narrative",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T14:48:12Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T02:38:37Z",
+      "result": "clean",
       "issues": [
         "phantom narrative: originalContributions/proofStrategy/sections claim IsPath/IsStar/IsCaterpillar/Chvátal bound/exact path-star Ramsey numbers/tightness theorem; Lean file has only 3 axioms + erdos_547 wrapper. Filed #14275"
       ]


### PR DESCRIPTION
## Audit summary (erdos-547, cycle 5)

**Result**: clean

### Counts verified
- `axiomCount` meta=3 vs `grep -c "^axiom "` =3 ✓ (ramseyNumber, IsTree, tree_ramsey_bound)
- `sorries` meta=0 vs Lean=0 ✓
- True stubs: 0 ✓
- Status `axiomatized` + badge `axiom` consistent with axiom-based formalization ✓

### Narrative honesty
- `originalContributions` use explicit "axiomatizes" / "outline only" language
- `proofStrategy` clearly labels each section as formalized / axiomatized / outline-only
- No phantom claims about IsPath, IsStar, Chvátal bound, or tightness theorem
- Phantom-narrative issue (cycle 3, #14275) remains fixed

Tier C reduction/axiomatization is properly presented.