### PR TITLE
audit(erdos-547): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7866,8 +7866,8 @@
     },
     "erdos-547": {
       "agentId": "auditor-erdos-547-phantom-narrative",
-      "auditCount": 4,
-      "lastAudited": "2026-05-27T02:38:37Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-27T02:42:49Z",
       "result": "clean",
       "issues": [
         "phantom narrative: originalContributions/proofStrategy/sections claim IsPath/IsStar/IsCaterpillar/Chvátal bound/exact path-star Ramsey numbers/tightness theorem; Lean file has only 3 axioms + erdos_547 wrapper. Filed #14275"


### PR DESCRIPTION
## Summary

Re-verified erdos-547 (Tree Ramsey Numbers) gallery integrity.

**Counts verified against Lean source:**
- 3 axioms (ramseyNumber, IsTree, tree_ramsey_bound) match axiomCount: 3
- 2 defs match definitionCount: 2
- 1 theorem (erdos_547 wrapper) matches theoremCount: 1
- 0 sorries, 0 True stubs, 132 lines

**Narrative honesty:** Phantom-narrative fix from PR #20701 holds. originalContributions/proofStrategy/sections honestly note that IsPath/IsStar/IsCaterpillar/Chvátal bound/exact Ramsey values are docstring outlines only. Status remains axiomatized with badge axiom.

Bumps auditCount 4 to 5, updates lastAudited timestamp.

## Test plan

- [x] Counts match meta.json
- [x] Status field matches actual axiom state
- [x] Narrative does not overclaim

🤖 Generated with [Claude Code](https://claude.com/claude-code)