### PR TITLE
audit(erdos-540): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7818,9 +7818,9 @@
     },
     "erdos-540": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:09:51Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T02:51:48Z",
+      "result": "clean",
       "issues": [
         "phantom-axiom narrative in proofStrategy + section line drift; fixed in PR #14280"
       ]


### PR DESCRIPTION
## Summary
- Re-audited **erdos-540** (Erdős Problem #540: Zero-Sum Subsets / Erdős-Heilbronn). Clean.
- All counts match `proofs/Proofs/Erdos540Problem.lean`: **2 axioms** (`olson_prime_case`, `szemeredi_general_case`), **0 sorries**, **160 lines**, **6 defs**, **5 theorems**.
- Section line ranges (28–160) intact; `proofStrategy` honestly attributes Olson 1968 + Szemerédi 1970 to the two axioms; status `axiomatized` / badge `axiom` consistent.

## Verification
- `grep -c "^axiom " proofs/Proofs/Erdos540Problem.lean` → 2 ✓ matches `axiomCount`
- `grep -c "\bsorry\b" proofs/Proofs/Erdos540Problem.lean` → 0 ✓
- `wc -l` → 160 ✓ matches `lineCount`
- `theoremCount=5`, `definitionCount=6` ✓

Prior cycle 3 finding (phantom-axiom narrative + section drift, fixed in PR #14280) remains resolved.

## Test plan
- [x] Lean source counts cross-checked against meta.json
- [x] Section line ranges spot-checked against actual source
- [x] No True stubs, no Mathlib wrappers
- [x] Status / badge / assumptions consistent with axiom inventory

🤖 Generated with [Claude Code](https://claude.com/claude-code)