### PR TITLE
audit(erdos-535): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7776,9 +7776,9 @@
     },
     "erdos-535": {
       "agentId": "auditor-64117",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:24:33Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T02:59:07Z",
+      "result": "clean",
       "issues": [
         "phantom-axiom narrative + section line drift (#14284)"
       ]


### PR DESCRIPTION
## Summary

Audit cycle 4 for **erdos-535** (GCD-Free r-Subsets).

Verified meta.json claims against `proofs/Proofs/Erdos535Problem.lean`:

- **axiomCount**: 2 (`abbott_hanson_upper_bound`, `erdos_lower_bound`) — matches
- **sorries**: 0 — matches
- **theoremCount**: 2 (`exponent_improvement`, `erdos_535_summary`) — matches
- **definitionCount**: 5 — matches
- **lineCount**: 211 — matches
- **status**: `axiomatized` / **badge**: `axiom` — appropriate (Tier C, open problem)
- **Narrative**: Honest — clearly states OPEN with quantified polynomial vs quasi-polynomial gap; both bounds explicitly axiomatized

Prior cycle (3) was `issues-fixed` (#14284, phantom-axiom narrative + section line drift). That fix holds.

Tracker bumped: auditCount 3 → 4, result clean, lastAudited 2026-05-27.

## Test plan

- [x] Read meta.json against Lean source — all counts match
- [x] No True stubs, no hidden sorries, no Mathlib-wrapper masquerading as original
- [x] Tier C classification justified; narrative qualifiers present