### PR TITLE
Enrich abel-ruffini-oq-09: resync stale metadata to Lean source

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-09/annotations.json
+++ b/src/data/proofs/abel-ruffini-oq-09/annotations.json
@@ -70,11 +70,11 @@
     "proofId": "abel-ruffini-oq-09",
     "range": {
       "startLine": 134,
-      "endLine": 151
+      "endLine": 163
     },
     "type": "concept",
     "title": "Liouville's Structural Theorem (Axiom)",
-    "content": "**Liouville's Integration Theorem** (1835): If f ∈ F has an elementary antiderivative g (D(g) = f), then g has the **Liouville form**:\n\n  g = v₀ + c₁·ln(v₁) + ··· + cₙ·ln(vₙ)\n\nwhere v₀, vᵢ ∈ F and cᵢ are constants of F.\n\nThis structural theorem is axiomatized here because its proof requires **Picard-Vessiot theory** — the differential analog of Galois theory. A Picard-Vessiot extension of F is the differential field analogue of a splitting field. The key result is that if an ODE system has a solution in an elementary extension, then that solution must come from a tower of algebraic/logarithmic/exponential extensions of a specific form.\n\nMathlib currently has no formalization of Picard-Vessiot theory. The gap is estimated at >1000 lines of foundational Lean code.",
+    "content": "Three opaque predicates are declared first — IsElementaryOver, IsLiouvilleForm, and IsElementaryFn — standing in for notions (membership in an elementary extension, the logarithmic-sum form, elementarity of a real function) that cannot yet be defined without differential field theory absent from Mathlib. The axiom then states:\n\n**Liouville's Integration Theorem** (1835): If f ∈ F has an elementary antiderivative g (D(g) = f), then g has the **Liouville form**:\n\n  g = v₀ + c₁·ln(v₁) + ··· + cₙ·ln(vₙ)\n\nwhere v₀, vᵢ ∈ F and cᵢ are constants of F.\n\nThis structural theorem is axiomatized here because its proof requires **Picard-Vessiot theory** — the differential analog of Galois theory. A Picard-Vessiot extension of F is the differential field analogue of a splitting field. The key result is that if an ODE system has a solution in an elementary extension, then that solution must come from a tower of algebraic/logarithmic/exponential extensions of a specific form.\n\nMathlib currently has no formalization of Picard-Vessiot theory. The gap is estimated at >1000 lines of foundational Lean code.",
     "mathContext": "**Picard-Vessiot theory** (Picard 1887, Vessiot 1891): The differential Galois group of an ODE controls whether its solutions are elementary. An ODE is solvable by elementary functions iff its Picard-Vessiot group has solvable identity component.",
     "significance": "key",
     "relatedConcepts": [
@@ -92,12 +92,12 @@
     "id": "ann-risch-criterion-axiom",
     "proofId": "abel-ruffini-oq-09",
     "range": {
-      "startLine": 156,
+      "startLine": 169,
       "endLine": 183
     },
     "type": "concept",
-    "title": "Risch Criterion and Gaussian Non-Elementarity (Axioms)",
-    "content": "Two more axioms:\n\n**risch_exp_criterion_gaussian**: ∫e^(-x²)dx is elementary iff ∃ rational Q (with nowhere-zero denominator) satisfying Q' - 2xQ = 1 pointwise.\n\nThis is the Risch criterion applied to ∫e^g where g = -x², so g' = -2x and the ODE becomes Q' + Q·(-2x) = 1, i.e., Q' - 2xQ = 1.\n\n**gaussian_not_elementary**: The antiderivative of e^(-x²) is not a rational function. This axiomatizes the conclusion of the Risch criterion applied to the polynomial case result below — the polynomial obstruction shows no polynomial Q works, and the rational case is axiomatized here.\n\nThe gap from polynomial to rational: if Q = p/q (lowest terms, q ≠ 0), partial fractions show the poles of Q' and 2xQ must cancel perfectly. Analysis of pole orders shows this forces q = 1 (Q is actually polynomial), reducing to the proved case.",
+    "title": "Risch Criterion for the Gaussian (Axiom)",
+    "content": "**risch_exp_criterion_gaussian** (the single axiom in this part): ∫e^(-x²)dx is elementary iff ∃ rational Q = p/q (with nowhere-zero denominator) satisfying Q' - 2xQ = 1 pointwise.\n\nThis is the Risch criterion applied to ∫e^g where g = -x², so g' = -2x and the ODE becomes Q' + Q·(-2x) = 1, i.e., Q' - 2xQ = 1.\n\nNote what is and is not assumed here. Only the *equivalence* (elementarity ⟺ a rational Risch solution exists) is axiomatized — this is the part needing differential Galois machinery. The actual non-elementarity conclusion, gaussian_not_elementary, is NOT axiomatized: it is proved as a theorem in the core-proof section by ruling out rational solutions directly via the iterated degree-raising operator.\n\nThe gap from polynomial to rational: if Q = p/q (lowest terms, q ≠ 0), partial fractions show the poles of Q' and 2xQ must cancel perfectly. Analysis of pole orders shows this forces q = 1 (Q is actually polynomial), reducing to the proved polynomial case.",
     "mathContext": "**Risch criterion** (1969): $\\int R(x)e^{g(x)}dx$ is elementary iff $\\exists$ rational $Q$ with $Q' + Qg' = R$. For $g = -x^2$, $g' = -2x$, giving $Q' - 2xQ = 1$.",
     "significance": "key",
     "relatedConcepts": [
@@ -114,7 +114,7 @@
     "id": "ann-risch-ode-coeff-top",
     "proofId": "abel-ruffini-oq-09",
     "range": {
-      "startLine": 208,
+      "startLine": 189,
       "endLine": 219
     },
     "type": "concept",
@@ -137,13 +137,13 @@
     "id": "ann-no-poly-risch-soln",
     "proofId": "abel-ruffini-oq-09",
     "range": {
-      "startLine": 236,
-      "endLine": 244
+      "startLine": 222,
+      "endLine": 260
     },
     "type": "concept",
     "title": "Main Theorem: No Polynomial Risch Solution",
-    "content": "**no_poly_risch_soln**: ∀ p : Polynomial ℝ, p' - C(2)·X·p ≠ 1.\n\n**Proof by contradiction**:\n1. **p = 0 case**: L[0] = 0 - 0 = 0 ≠ 1. Handled by `simp [hp] at h`.\n2. **p ≠ 0 case**: `leadingCoeff(p) ≠ 0` by `Polynomial.leadingCoeff_ne_zero`.\n   - Extract coefficient at natDeg(p)+1 from both sides of the assumed equality L[p] = 1.\n   - LHS: -2·leadingCoeff(p) (by `risch_ode_coeff_top`)\n   - RHS: 0 (by `poly_one_coeff_pos`, since natDeg+1 ≥ 1)\n   - So -2·leadingCoeff(p) = 0, hence leadingCoeff(p) = 0 — contradicts p ≠ 0.\n\nThe proof uses `congr_arg` to extract the coefficient function applied to both sides, then rewrites with the two coefficient lemmas. The final contradiction is `mul_ne_zero (by norm_num : (-2:ℝ) ≠ 0) hlc`.",
-    "mathContext": "The degree-raising argument in one line: $\\deg(p' - 2xp) = \\deg(p) + 1 > \\deg(1) = 0$ for $p \\neq 0$, so they cannot be equal.",
+    "content": "**no_poly_risch_soln**: ∀ p : Polynomial ℝ, p' - C(2)·X·p ≠ 1.\n\n**Proof by contradiction**:\n1. **p = 0 case**: L[0] = 0 - 0 = 0 ≠ 1. Handled by `simp [hp] at h`.\n2. **p ≠ 0 case**: `leadingCoeff(p) ≠ 0` by `Polynomial.leadingCoeff_ne_zero`.\n   - Extract coefficient at natDeg(p)+1 from both sides of the assumed equality L[p] = 1.\n   - LHS: -2·leadingCoeff(p) (by `risch_ode_coeff_top`)\n   - RHS: 0 (by `poly_one_coeff_pos`, since natDeg+1 ≥ 1)\n   - So -2·leadingCoeff(p) = 0, hence leadingCoeff(p) = 0 — contradicts p ≠ 0.\n\nThe proof uses `congr_arg` to extract the coefficient function applied to both sides, then rewrites with the two coefficient lemmas. The final contradiction is `mul_ne_zero (by norm_num : (-2:ℝ) ≠ 0) hlc`.\n\nThe helper **poly_one_coeff_pos** supplies the RHS fact (the constant 1 has coefficient 0 at every position ≥ 1), and **no_poly_risch_constant** generalizes the whole result: the same coefficient argument shows L[p] ≠ C(c) for EVERY nonzero constant c, so the image of L₂ avoids all nonzero constants — not just the value 1.",
+    "mathContext": "The degree-raising argument in one line: $\\deg(p' - 2xp) = \\deg(p) + 1 > \\deg(1) = 0$ for $p \\neq 0$, so they cannot be equal. More generally $L[p] \\neq C(c)$ for all $c \\neq 0$ (no_poly_risch_constant).",
     "significance": "critical",
     "relatedConcepts": [
       "proof by contradiction",
@@ -179,11 +179,37 @@
     ]
   },
   {
+    "id": "ann-gaussian-not-elementary",
+    "proofId": "abel-ruffini-oq-09",
+    "range": {
+      "startLine": 275,
+      "endLine": 376
+    },
+    "type": "insight",
+    "title": "Gaussian Non-Elementarity, Fully Proved (No Rational Antiderivative)",
+    "content": "This is the headline analytic result: **gaussian_not_elementary** proves that ∫e^(−x²)dx has no rational-function antiderivative — promoting what earlier drafts assumed as an axiom to a fully machine-checked theorem. The argument bootstraps the polynomial obstruction into a statement about real functions:\n\n- **rischOp** packages L[h] = h' − C(2)·X·h as a polynomial-to-polynomial map, and **rischOp_iter_ne_zero** uses risch_ode_raises_degree to show iterating L never produces 0 from a nonzero start (each application strictly raises degree, so it can never collapse to the zero polynomial).\n- **hasDerivAt_mul_gauss** establishes the bridge between algebra and analysis: d/dx[h(x)·e^(−x²)] = L[h](x)·e^(−x²). The Leibniz/chain-rule computation turns the −2x from differentiating e^(−x²) into exactly the −2x·h term of L.\n- **risch_iterate_eq** iterates this: the n-th derivative of h(x)·e^(−x²) equals Lⁿ(h)(x)·e^(−x²), proved by induction using HasDerivAt.unique to pin down each derivative.\n- **gaussian_not_elementary** assembles the contradiction. Suppose d/dx[p/q] = e^(−x²) with q nowhere zero. The quotient rule gives f := p'q − pq' = q²·e^(−x²) = g·e^(−x²) with g = q² ≠ 0. Differentiating n = deg(f)+1 times kills the polynomial f (Polynomial.iterate_derivative_eq_zero), so 0 = Lⁿ(g)(x)·e^(−x²) for all x. Since e^(−x²) > 0 everywhere, Lⁿ(g) vanishes pointwise, hence as a polynomial (Polynomial.funext) — contradicting rischOp_iter_ne_zero.",
+    "mathContext": "If $\\frac{d}{dx}\\frac{p}{q} = e^{-x^2}$ then $p'q - pq' = q^2 e^{-x^2}$, i.e. $f = g\\,e^{-x^2}$ with $g = q^2$. Because $\\frac{d}{dx}\\!\\left(h\\,e^{-x^2}\\right) = (h' - 2xh)e^{-x^2} = L[h]\\,e^{-x^2}$, the $n$-th derivative is $L^n(g)\\,e^{-x^2}$. Taking $n = \\deg f + 1$ forces $L^n(g) \\equiv 0$, but $L$ raises degree so $L^n(g) \\neq 0$ — contradiction. This rules out even rational antiderivatives, not just polynomial ones.",
+    "significance": "critical",
+    "relatedConcepts": [
+      "iterated derivative",
+      "quotient rule",
+      "HasDerivAt.unique",
+      "degree-raising operator",
+      "error function"
+    ],
+    "prerequisites": [
+      "risch_ode_raises_degree",
+      "Polynomial.iterate_derivative_eq_zero",
+      "HasDerivAt",
+      "Polynomial.funext"
+    ]
+  },
+  {
     "id": "ann-funext",
     "proofId": "abel-ruffini-oq-09",
     "range": {
-      "startLine": 282,
-      "endLine": 295
+      "startLine": 382,
+      "endLine": 401
     },
     "type": "concept",
     "title": "Polynomial.funext: Pointwise to Polynomial Equality",
@@ -204,8 +230,8 @@
     "id": "ann-linear-exponent-contrast",
     "proofId": "abel-ruffini-oq-09",
     "range": {
-      "startLine": 297,
-      "endLine": 346
+      "startLine": 402,
+      "endLine": 451
     },
     "type": "concept",
     "title": "The Degree-Preserving Contrast: ∫eˣ IS Elementary",
@@ -225,11 +251,35 @@
     ]
   },
   {
+    "id": "ann-linear-surjectivity",
+    "proofId": "abel-ruffini-oq-09",
+    "range": {
+      "startLine": 452,
+      "endLine": 508
+    },
+    "type": "technique",
+    "title": "L₁ is Surjective: Every Polynomial Integrand × eˣ is Elementary",
+    "content": "Part VIb sharpens the contrast from \"L₁ hits the constants\" to \"L₁ hits everything.\" The operator L₁[Q] = Q' + Q (the Risch ODE for ∫R(x)eˣdx) is proved surjective onto all of ℝ[X], so ∫p(x)eˣdx is elementary for EVERY polynomial p — the exact opposite of L₂, which misses every nonzero constant.\n\n- **risch_linear_surjective_monomial**: for each n there is a Q with Q' + Q = Xⁿ, built by the recurrence Q₀ = 1, Q_{n+1} = X^{n+1} − C(n+1)·Qₙ. The induction step verifies Q_{n+1}' + Q_{n+1} = X^{n+1} using the hypothesis Qₙ' + Qₙ = Xⁿ (closed via linear_combination).\n- **risch_linear_surjective_all**: extends from monomials to all polynomials by Polynomial.induction_on'. Linearity of L₁ (additivity, plus L₁[C(a)·Q] = C(a)·L₁[Q]) reduces every polynomial to a sum of scaled monomials.\n\nThe recurrence is exactly the finite integration-by-parts expansion: ∫p(x)eˣdx = (Σₖ (−1)ᵏ p^(k)(x))·eˣ. Degree-preservation of L₁ is what makes this terminating closed form possible — and its absence for L₂ is what makes the Gaussian non-elementary.",
+    "mathContext": "Surjectivity of $L_1[Q] = Q' + Q$: solve $Q' + Q = X^n$ by $Q_n = \\sum_{k=0}^{n} (-1)^k \\frac{n!}{(n-k)!} X^{n-k}$, equivalently the recurrence $Q_{n+1} = X^{n+1} - (n+1)Q_n$. By linearity this covers all $p \\in \\mathbb{R}[X]$, so $\\int p(x)e^x\\,dx = \\left(\\sum_k (-1)^k p^{(k)}(x)\\right)e^x$ is always elementary.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "surjectivity",
+      "degree-preserving operator",
+      "integration by parts",
+      "Polynomial.induction_on'"
+    ],
+    "prerequisites": [
+      "Polynomial.induction_on'",
+      "polynomial recurrence",
+      "linearity of derivations"
+    ]
+  },
+  {
     "id": "ann-abel-ruffini-analogy",
     "proofId": "abel-ruffini-oq-09",
     "range": {
-      "startLine": 348,
-      "endLine": 379
+      "startLine": 509,
+      "endLine": 540
     },
     "type": "concept",
     "title": "The Abel-Ruffini Analogy: Two Galois Theories",

--- a/src/data/proofs/abel-ruffini-oq-09/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-09/meta.json
@@ -23,7 +23,7 @@
     "theoremCount": 24,
     "assumptions": "5 assumptions: 3 opaque predicates (IsElementaryOver, IsLiouvilleForm, IsElementaryFn — declared opaque since formalizing elementary functions / Liouville logarithmic-sum forms requires differential field theory not yet in Mathlib) + 2 axioms: liouville_integration_theorem (structural form of elementary antiderivatives requires differential Galois/Picard-Vessiot theory not in Mathlib), risch_exp_criterion_gaussian (Risch criterion: ∫e^(-x²)dx elementary iff rational Q with Q'-2xQ=1; requires partial fraction analysis and extension from polynomial to rational case). The Gaussian non-elementarity (gaussian_not_elementary) is now fully proved as a theorem via the iterated Risch operator degree-raising argument.",
     "dateAdded": "2026-05-03",
-    "lineCount": 541,
+    "lineCount": 540,
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "risch_ode_coeff_top: coefficient identity showing L[p] = p'-C(2)·X·p has coefficient -2·leadingCoeff(p) at degree natDeg(p)+1 — the key lemma driving the degree-raising argument",
@@ -86,6 +86,21 @@
       "targetId": "liouville-theorem",
       "relationship": "related",
       "description": "The OTHER Liouville theorem (approximation/transcendence, 1844). Both are by Liouville but in different mathematical areas: the approximation theorem bounds rational approximation to algebraic numbers; this entry concerns which functions have elementary antiderivatives (1835 result)"
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions",
+      "relationship": "related",
+      "description": "Sibling extension of the Abel-Ruffini circle. That entry develops the ALGEBRAIC Galois side (Sₙ solvable iff n ≤ 4, A₅ simple as the obstruction to radical solvability); this entry is the DIFFERENTIAL Galois analog (the degree-raising Risch operator as the obstruction to elementary integration). Both reduce a Galois-theoretic impossibility to a concrete polynomial-algebra fact."
+    },
+    {
+      "targetId": "e-transcendental",
+      "relationship": "related",
+      "description": "Transcendence of e — the function e^(−x²) whose integral is shown non-elementary here is built from the exponential. Transcendence theory and the theory of elementary functions are the two pillars Liouville founded (he produced the first explicit transcendental numbers in 1844 and the integration theorem in 1835): both ask whether a quantity escapes a prescribed class — algebraic numbers there, elementary antiderivatives here."
+    },
+    {
+      "targetId": "hermite-lindemann",
+      "relationship": "related",
+      "description": "Hermite-Lindemann: e^α is transcendental for every nonzero algebraic α. Hermite is a recurring figure in this story — he proved e transcendental (1873) and earlier (1858) solved the general quintic via elliptic modular functions, the canonical example of stepping OUTSIDE radicals/elementary functions to express what Abel-Ruffini and Liouville show is otherwise inexpressible. The Gaussian e^(−x²) is the prototypical analytic function with a transcendental, non-elementary integral (the error function)."
     }
   ],
   "overview": {
@@ -128,55 +143,55 @@
     },
     {
       "id": "liouville-axiom",
-      "title": "Liouville Integration Theorem (Axiom)",
+      "title": "Liouville Integration Theorem and Risch Criterion (Axioms)",
       "startLine": 130,
-      "endLine": 183,
-      "summary": "Axiomatizes the structural Liouville theorem: if f ∈ F has an elementary antiderivative g, then g = v₀ + Σcᵢ·ln(vᵢ) with vᵢ ∈ F and cᵢ constants. Also axiomatizes the Risch criterion for ∫e^(-x²) and the Gaussian non-elementarity.",
+      "endLine": 184,
+      "summary": "Parts II–III. Declares three opaque predicates (IsElementaryOver, IsLiouvilleForm, IsElementaryFn) since elementary/Liouville-form functions need differential field theory absent from Mathlib, then axiomatizes the structural Liouville theorem (if f has an elementary antiderivative g, then g = v₀ + Σcᵢ·ln(vᵢ) with vᵢ ∈ F and cᵢ constants) and the Risch criterion for ∫e^(-x²) (elementary iff a rational Q satisfies Q' − 2xQ = 1). The Gaussian non-elementarity itself is NOT axiomatized here — it is proved as a theorem in the core-proof section.",
       "mathContext": "**Liouville (1835)**: If D(g) = f and g is elementary over F, then g = v₀ + Σcᵢ ln(vᵢ). Requires Picard-Vessiot theory (no Mathlib formalization). **Risch criterion**: ∫e^(-x²) is elementary iff ∃ rational Q/R with (Q/R)' - 2x(Q/R) = 1. **Gaussian non-elementarity**: ∫e^(-x²) is not a rational function."
     },
     {
       "id": "core-proof",
-      "title": "The Polynomial Risch Obstruction (Fully Proved)",
-      "startLine": 184,
-      "endLine": 295,
-      "summary": "The mathematical heart: proves no polynomial satisfies the Risch ODE. risch_ode_coeff_top: coefficient at natDeg+1 of L[p] equals -2·leadingCoeff(p). poly_one_coeff_pos: constant 1 has zero coefficient at position ≥1. no_poly_risch_soln: main result, by contradiction on leadingCoeff. no_poly_risch_constant: generalization to all nonzero constants. risch_ode_raises_degree: formal degree-raising statement.",
-      "mathContext": "Key identity: (p' - C(2)·X·p).coeff(natDeg p + 1) = -2·leadingCoeff(p). Proof: coeff(p', natDeg+1) = (natDeg+2)·coeff(p, natDeg+2) = 0 (above degree); coeff(C(2)·X·p, natDeg+1) = 2·coeff(p, natDeg) = 2·leadingCoeff(p). Net: 0 - 2·lc = -2·lc. If this equals 0 (as required for L[p] = 1), then lc = 0, contradicting p ≠ 0."
+      "title": "The Core Algebraic Proof — No Polynomial Risch Solution",
+      "startLine": 185,
+      "endLine": 377,
+      "summary": "Part IV, the mathematical heart. risch_ode_coeff_top: coefficient at natDeg+1 of L[p] equals -2·leadingCoeff(p). poly_one_coeff_pos: constant 1 has zero coefficient at position ≥1. no_poly_risch_soln: main polynomial obstruction, by contradiction on leadingCoeff. no_poly_risch_constant: generalization to all nonzero constants. risch_ode_raises_degree: formal degree-raising statement. The section then bootstraps the polynomial obstruction into a full analytic non-elementarity proof: rischOp (the operator L as a polynomial map), rischOp_iter_ne_zero (iterating L keeps polynomials nonzero), hasDerivAt_mul_gauss and risch_iterate_eq (the n-th derivative of h(x)·e^(−x²) equals Lⁿ(h)(x)·e^(−x²)), culminating in gaussian_not_elementary — a fully machine-checked theorem that ∫e^(−x²)dx has no rational-function antiderivative.",
+      "mathContext": "Key identity: (p' - C(2)·X·p).coeff(natDeg p + 1) = -2·leadingCoeff(p). Proof: coeff(p', natDeg+1) = (natDeg+2)·coeff(p, natDeg+2) = 0 (above degree); coeff(C(2)·X·p, natDeg+1) = 2·coeff(p, natDeg) = 2·leadingCoeff(p). Net: 0 - 2·lc = -2·lc. For gaussian_not_elementary: if d/dx[p/q] = e^(−x²) then p'q − pq' = q²·e^(−x²), i.e. f = g·e^(−x²) with g = q² ≠ 0; differentiating n = deg(f)+1 times gives 0 = Lⁿ(g)·e^(−x²), but e^(−x²) > 0 and L raises degree so Lⁿ(g) ≠ 0 — contradiction."
     },
     {
       "id": "pointwise",
       "title": "Pointwise Reformulation",
-      "startLine": 274,
-      "endLine": 296,
+      "startLine": 378,
+      "endLine": 401,
       "summary": "risch_pointwise_to_poly: converts pointwise equality (∀x, p'(x) - 2x·p(x) = 1) to polynomial identity using Polynomial.funext (density argument: two polynomials agreeing everywhere on ℝ are equal). no_poly_risch_pointwise: pointwise formulation of the main obstruction.",
       "mathContext": "**Polynomial.funext** (Mathlib): If f(x) = g(x) for all x : ℝ, then f = g as polynomials. This uses the fact that ℝ is infinite — a polynomial with infinitely many roots is identically zero."
     },
     {
       "id": "contrast",
       "title": "Elementary Contrast: The Linear Exponent Case",
-      "startLine": 297,
-      "endLine": 347,
+      "startLine": 402,
+      "endLine": 451,
       "summary": "Shows that for g = x (linear exponent), the Risch ODE Q' + Q = R IS solvable for every polynomial R: risch_g_linear_const (Q=1 solves for R=1), risch_g_linear_degree1 (Q=X-1 solves for R=X, the ∫xeˣ formula), risch_g_linear_constant_solvable (Q=C(c) solves for R=C(c)). gaussian_vs_linear_contrast packages the dichotomy as a conjunction.",
       "mathContext": "For L₁[Q] = Q' + Q: C(c)' + C(c) = 0 + C(c) = C(c) for any constant c. So L₁ maps constants to themselves — the degree-0 case is handled by Q being constant. This contrasts with L₂ where the -2xQ term forces degree to increase."
     },
     {
       "id": "surjectivity",
       "title": "L₁ is Surjective onto All Polynomials",
-      "startLine": 348,
-      "endLine": 403,
+      "startLine": 452,
+      "endLine": 508,
       "summary": "risch_linear_surjective_monomial: for each n, ∃Q with Q' + Q = X^n (induction via recurrence Q_{n+1} = X^{n+1} - C(n+1)·Q_n). risch_linear_surjective_all: L₁ is surjective onto ALL polynomials (by Polynomial.induction_on' linearity). This completes the contrast: L₁ maps onto every polynomial, while L₂ misses all nonzero constants.",
       "mathContext": "Recurrence Q_0=1; Q_{n+1}=X^{n+1}-C(n+1)·Q_n satisfies Q_{n+1}'+Q_{n+1}=X^{n+1} by induction. For the full polynomial case, linearity: L₁[C(a)·Q]=C(a)·L₁[Q] and L₁[P+Q]=L₁[P]+L₁[Q] allow reduction to monomials. Together: ∫p(x)eˣdx is elementary for EVERY polynomial p."
     },
     {
       "id": "analogy",
       "title": "Abel-Ruffini Analogy and Summary",
-      "startLine": 404,
-      "endLine": 448,
+      "startLine": 509,
+      "endLine": 540,
       "summary": "Documents the structural analogy between Abel-Ruffini (algebraic Galois theory) and Liouville (differential Galois theory). gaussian_risch_polynomial_obstruction_summary: final packaged theorem stating ¬∃p, p' - C(2)·X·p = 1.",
       "mathContext": "The pattern: Abel-Ruffini (A₅ simplicity → no radical formula for quintic) mirrors Liouville (degree-raising operator → no elementary integral for Gaussian). Both are Galois-theoretic impossibility results where the obstruction is witnessed by a polynomial algebra fact."
     }
   ],
   "conclusion": {
-    "summary": "Formalization of the polynomial obstruction to the Gaussian integral's elementarity. The main theorem (no_poly_risch_soln) is fully machine-checked: no polynomial p satisfies p' - 2xp = 1. The proof uses a clean degree-raising argument. New in this session: L₁[Q]=Q'+Q is proved surjective onto all polynomials (risch_linear_surjective_monomial + risch_linear_surjective_all), completing the contrast with L₂. Three axioms cover the full Liouville-Risch theory (structural form of elementary integrals, Risch criterion, Gaussian non-elementarity), documenting the gap requiring Picard-Vessiot theory not yet in Mathlib. Total: 24 theorems, 3 axioms, 0 sorries, 448 lines.",
+    "summary": "Formalization of the obstruction to the Gaussian integral's elementarity. The polynomial obstruction (no_poly_risch_soln) is fully machine-checked: no polynomial p satisfies p' - 2xp = 1, via a clean degree-raising argument. This is bootstrapped into gaussian_not_elementary — a fully proved theorem that ∫e^(−x²)dx has no rational-function antiderivative — by iterating the Risch operator on h(x)·e^(−x²) and using that L raises degree (so Lⁿ(g) ≠ 0 while the n-th derivative vanishes). The linear contrast is also complete: L₁[Q]=Q'+Q is proved surjective onto all polynomials (risch_linear_surjective_monomial + risch_linear_surjective_all), so ∫p(x)eˣdx is elementary for every polynomial p. Two axioms plus three opaque predicates (five assumptions total) cover the parts requiring differential Galois / Picard-Vessiot theory not yet in Mathlib: the structural Liouville form of elementary antiderivatives and the polynomial→rational extension of the Risch criterion. Total: 24 theorems/lemmas, 2 axioms + 3 opaque predicates, 0 sorries, 540 lines.",
     "implications": "**Theoretical Significance**: Liouville's integration theorem inaugurated differential algebra and the Risch decision procedure (1969), which underlies symbolic integration in all major computer algebra systems. The degree-raising operator argument is a model case of how algebraic structure (polynomial degree) witnesses transcendence. The structural analogy with Abel-Ruffini (both are Galois-theoretic impossibility results proved by polynomial algebra arguments) is formalized explicitly. The formalization also provides a clean pedagogical development of differential field basics and the Risch criterion framework.",
     "openQuestions": [
       "Reduce the axiom count: extend the polynomial obstruction to rational functions using partial fraction analysis. Key step: if Q = p/q (in lowest terms) satisfies Q' - 2xQ = 1, then poles of Q' must cancel with poles of 2xQ; analyzing the pole order at each root of q leads to a contradiction. This requires Mathlib's partial fraction decomposition.",
@@ -200,7 +215,7 @@
       "Real"
     ],
     "namespace": "AbelRuffiniOQ09",
-    "lineCount": 541,
+    "lineCount": 540,
     "axiomCount": 5,
     "theoremCount": 24,
     "definitionCount": 6,


### PR DESCRIPTION
## Enrichment pass for `abel-ruffini-oq-09` (Liouville's Theorem on Integration)

The Lean file `Proofs/AbelRuffiniOQ09.lean` had grown to 540 lines (the `gaussian_not_elementary` proof and the L₁-surjectivity lemmas were added, ~90 lines), but the gallery metadata still described the older ~448-line version. As a result the section/annotation line ranges pointed at the wrong code and the conclusion under-reported what is now proved. This pass resyncs everything to the current source.

### Correctness fixes
- **lineCount 541 → 540** (verified `wc -l`) in both `meta.lineCount` and `leanFile.lineCount`.
- **Remapped all stale `sections` ranges** to the real Part boundaries: `core-proof` [184-295]→[185-377], `pointwise` [274-296]→[378-401], `contrast` [297-347]→[402-451], `surjectivity` [348-403]→[452-508], `analogy` [404-448]→[509-540]. Refreshed the `core-proof` and `liouville-axiom` summaries.
- **Remapped 3 mismapped annotations** (`ann-funext`, `ann-linear-exponent-contrast`, `ann-abel-ruffini-analogy`) that pointed at unrelated code.
- **Fixed `ann-risch-criterion-axiom`**: `gaussian_not_elementary` is now a proved theorem, not an axiom — only `risch_exp_criterion_gaussian` is axiomatized in that part.
- **Updated `conclusion.summary`**: "448 lines"→"540 lines"; "3 axioms"→"2 axioms + 3 opaque predicates"; noted `gaussian_not_elementary` is now fully proved.

### Coverage / depth additions
- **Added `ann-gaussian-not-elementary`** (lines 275-376): the previously-uncovered headline theorem and the `rischOp` iteration machinery (`hasDerivAt_mul_gauss`, `risch_iterate_eq`) that bootstraps the polynomial obstruction into a rational-function non-elementarity proof.
- **Added `ann-linear-surjectivity`** (lines 452-508): the previously-uncovered Part VIb proving `L₁` surjective onto all polynomials (so `∫p(x)eˣdx` is always elementary). Annotation coverage now spans the full file.
- Extended `ann-risch-ode-coeff-top` and `ann-no-poly-risch-soln` to cover the coefficient-extraction docstring and the `no_poly_risch_constant` generalization.

### Cross-references (3 → 6)
Added `abel-ruffini-galois-extensions` (algebraic vs differential Galois sibling), `e-transcendental`, and `hermite-lindemann` (the transcendence / expressibility-barrier theme Liouville founded).

### Axiom integrity
`status: axiomatized`, `badge: axiom`, `axiomCount: 5` are unchanged and remain accurate: 3 opaque predicates + 2 axioms. `gaussian_not_elementary` being proved is reflected in the assumptions narrative.

`pnpm build` passes.