### PR TITLE
audit(erdos-535): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7776,9 +7776,9 @@
     },
     "erdos-535": {
       "agentId": "auditor-64117",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:24:33Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T03:03:35Z",
+      "result": "clean",
       "issues": [
         "phantom-axiom narrative + section line drift (#14284)"
       ]


### PR DESCRIPTION
## Summary

Re-audit cycle 4 of **erdos-535** (GCD-Free r-Subsets, OPEN problem). Result: **clean**.

## Verification

Metadata matches Lean source (`proofs/Proofs/Erdos535Problem.lean`):
- Line count: 211 ✓
- Axioms: 2 (`abbott_hanson_upper_bound`, `erdos_lower_bound`) ✓
- Theorems: 2 (`exponent_improvement`, `erdos_535_summary`) ✓
- Definitions: 5 (`HasNoRGCDSubset`, `HasNoGCDClique`, `IsSubsetOfInterval`, `f`, `ErdosConjecture`) ✓
- Sorries: 0 ✓
- Status: `axiomatized` ✓ (open problem, 2 stated assumptions)
- Badge: `axiom` ✓
- Cross-references valid (erdos-302, erdos-534, erdos-539)

No structure-encoded assumptions; all `def`s are computational. Status correctly reflects axiomatized state per Axiom Integrity Policy.

## Test plan
- [x] Lean source line count matches meta
- [x] axiom count matches (grep `^axiom`)
- [x] theorem/definition counts match
- [x] Status field correct for OPEN problem
- [x] Cross-referenced proofs exist in gallery

🤖 Generated with [Claude Code](https://claude.com/claude-code)