### PR TITLE
audit(erdos-535): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7776,8 +7776,8 @@
     },
     "erdos-535": {
       "agentId": "auditor-64117",
-      "auditCount": 4,
-      "lastAudited": "2026-05-27T02:59:07Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-27T03:08:20Z",
       "result": "clean",
       "issues": [
         "phantom-axiom narrative + section line drift (#14284)"


### PR DESCRIPTION
## Summary

Audit cycle 5 for **erdos-535** (GCD-Free r-Subsets).

Verified meta.json claims against `proofs/Proofs/Erdos535Problem.lean`:

- **axiomCount**: 2 (`abbott_hanson_upper_bound`, `erdos_lower_bound`) — matches
- **sorries**: 0 — matches
- **theoremCount**: 2 (`exponent_improvement`, `erdos_535_summary`) — matches
- **definitionCount**: 5 (`HasNoRGCDSubset`, `HasNoGCDClique`, `IsSubsetOfInterval`, `f`, `ErdosConjecture`) — matches
- **lineCount**: 211 — matches
- **True stubs**: 0
- **status / badge**: `axiomatized` / `axiom` — appropriate (Tier C, open problem with explicit assumptions)
- **Narrative**: Honest — clearly states OPEN, quantifies the polynomial vs quasi-polynomial gap; both bounds explicitly axiomatized

Prior cycle 3 narrative fix (#14284, phantom-axiom + section line drift) holds. No new issues found.

Tracker: auditCount 4 → 5, result clean, lastAudited 2026-05-27T03:08:20Z.

## Test plan

- [x] Read meta.json against Lean source — all counts match
- [x] No True stubs, no hidden sorries, no Mathlib-wrapper masquerading as original
- [x] Tier C classification justified; narrative qualifiers present