### PR TITLE
Enrich algebraic-numbers-countable: fix lineCount metadata

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -23,7 +23,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified with 0 axioms, 0 sorries. All 18 theorems proved from Mathlib infrastructure (Algebraic.countable, cardinalMk_of_countable_of_charZero, Set.Countable.mono, Set.countable_iUnion) with no custom axioms or structure-encoded assumptions. The 4 definitions (algebraicRealsOfBoundedDegree, algebraicComplexOfBoundedDegree, algebraicRealsOfDegree, algebraicComplexOfDegree) are noncomputable due to minpoly's use of Classical.choice.",
-    "lineCount": 255,
+    "lineCount": 254,
     "theoremCount": 18,
     "definitionCount": 4,
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/AlgebraicCard.html",
@@ -361,7 +361,7 @@
       "Cardinal"
     ],
     "namespace": "AlgebraicNumbersCountable",
-    "lineCount": 255,
+    "lineCount": 254,
     "path": "Proofs/AlgebraicNumbersCountable.lean",
     "axiomCount": 0,
     "theoremCount": 18,


### PR DESCRIPTION
## Enrichment pass for `algebraic-numbers-countable`

This entry is already comprehensive and in sync — 18 cross-references, 10 key insights, 8 fully-fielded annotations, and `sections`/`annotations` line ranges that accurately cover the 254-line source. The one discrepancy found on audit:

- **lineCount 255 → 254** (verified `wc -l`) in both `meta.lineCount` and `leanFile.lineCount`. The `sections` already used 254 as the last line; only these two fields were off by one.

### Axiom integrity
`status: verified`, `badge: original`, `axiomCount: 0` — unchanged and accurate (18 theorems proved from Mathlib, no axioms or structure-encoded assumptions).

Validated via JSON parse (pure integer-field change; no structural edit).