### PR TITLE
audit(erdos-536): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7785,12 +7785,12 @@
     },
     "erdos-536": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom-axiom narrative + section line drift: prose claims four_elements_fail/weisenberg_construction axiomatized (only docstrings), and lcm_structure/weisenberg_dense_case as axioms (both are theorems). Filed #14286"
       ],
-      "lastAudited": "2026-05-01T15:33:04Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-27T03:14:25Z",
+      "result": "clean"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result: CLEAN (Cycle 4)

**Proof**: \`erdos-536\` (Erdős Problem #536: Equal Pairwise LCMs in Dense Sets)
**File**: \`proofs/Proofs/Erdos536Problem.lean\` (83 lines)

### Verification
- Axioms: 1 (\`erdos_536_conjecture\`) — matches \`axiomCount: 1\`
- Sorries: 0 — matches \`sorries: 0\`
- True stubs: 0
- Theorems: 2 (\`weisenberg_dense_case\`, \`lcm_structure\`) — matches \`theoremCount: 2\`
- Definitions: 2 (\`HasEqualPairwiseLCM\`, \`HasLCMTriple\`) — matches \`definitionCount: 2\`
- Status: \`axiomatized\`, Badge: \`axiom\` — correct for open conjecture
- Line count: 83 matches meta

### Notes
Prior phantom-axiom narrative fix (#14286) holds. No new issues detected. Tracker bumped 3→4.