### PR TITLE
audit(erdos-536): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7785,12 +7785,12 @@
     },
     "erdos-536": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom-axiom narrative + section line drift: prose claims four_elements_fail/weisenberg_construction axiomatized (only docstrings), and lcm_structure/weisenberg_dense_case as axioms (both are theorems). Filed #14286"
       ],
-      "lastAudited": "2026-05-01T15:33:04Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-27T03:21:34Z",
+      "result": "clean"
     },
     "erdos-537": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit cycle 4 of erdos-536: **clean**
- meta.json claims (1 axiom, 0 sorries, 2 theorems, 2 defs, status `axiomatized`, badge `axiom`) match Lean source exactly
- Prior phantom-axiom fix (#14286) holds

## Audit details
- `proofs/Proofs/Erdos536Problem.lean`: 1 axiom (`erdos_536_conjecture`), 2 theorems (`weisenberg_dense_case`, `lcm_structure`), 2 defs (`HasEqualPairwiseLCM`, `HasLCMTriple`), 0 sorries, 0 True stubs
- Tracker: auditCount 3 → 4, result `issues-fixed` → `clean`, lastAudited bumped

## Test plan
- [x] meta.json axiomCount/theoremCount/definitionCount/sorries verified against Lean source
- [x] No phantom-axiom narrative drift in section summaries

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>