### PR TITLE
audit(erdos-532): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7755,9 +7755,9 @@
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:43:01Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T03:29:58Z",
+      "result": "clean",
       "issues": [
         "Issue #14289: phantom-axiom narrative (axiomCount=2 correct, but originalContributions claims 3 ultrafilter/Hales-Jewett axioms that are docstring-only) + section line drift Parts VI-IX (~20-30 lines off)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-532 (Hindman's Theorem / IP Sets) — clean, cycle 4
- All metadata in `meta.json` matches Lean source (`Proofs/Erdos532Problem.lean`)
- Prior phantom-axiom narrative fix (#14289) still in place

## Audit findings
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 303 | 303 | ✓ |
| axiomCount | 2 | 2 (`hindman_theorem`, `hindman_finite_exists`) | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 7 | 7 (incl. `noncomputable def hindmanNumber`) | ✓ |
| sorries | 0 | 0 | ✓ |
| status / badge | axiomatized / axiom | 2 axioms present | ✓ |

- No `True` stubs.
- Section boundaries match Part markers in source within ±1 line.
- `originalContributions` correctly disclaims docstring-only ultrafilter and Hales-Jewett items as "no Lean declaration" — the phantom-axiom narrative concern from prior cycle remains resolved.

## Test plan
- [x] Diff is a single tracker update (auditCount 3→4, lastAudited, result clean)
- [x] No source file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)