### PR TITLE
audit(erdos-532): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7755,9 +7755,9 @@
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:43:01Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T03:38:01Z",
+      "result": "clean",
       "issues": [
         "Issue #14289: phantom-axiom narrative (axiomCount=2 correct, but originalContributions claims 3 ultrafilter/Hales-Jewett axioms that are docstring-only) + section line drift Parts VI-IX (~20-30 lines off)"
       ]


### PR DESCRIPTION
## Audit Result: CLEAN (cycle 4)

Re-audited **Erdős Problem #532: Hindman's Theorem (IP Sets)**.

### Verification

| Field | Meta | Lean source | Status |
|-------|------|-------------|--------|
| `lineCount` | 303 | 303 | ✓ |
| `axiomCount` | 2 | 2 (`hindman_theorem`, `hindman_finite_exists`) | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `theoremCount` | 6 | 6 | ✓ |
| `definitionCount` | 7 | 7 | ✓ |
| `status` | axiomatized | axioms present | ✓ |
| `badge` | axiom | matches status | ✓ |

- No True stubs
- No structure-encoded assumptions (no `structure`/`class` declarations)
- Docstring-only items in `originalContributions` properly qualified ("no Lean declaration")
- Section line bounds align with current Lean source

### History

Prior fix from cycle 3 (#14289 — phantom-axiom narrative claiming 3 ultrafilter/Hales-Jewett axioms that were docstring-only, plus section line drift) holds across this re-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)