### PR TITLE
audit(erdos-532): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7755,9 +7755,9 @@
     },
     "erdos-532": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:43:01Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T03:46:28Z",
+      "result": "clean",
       "issues": [
         "Issue #14289: phantom-axiom narrative (axiomCount=2 correct, but originalContributions claims 3 ultrafilter/Hales-Jewett axioms that are docstring-only) + section line drift Parts VI-IX (~20-30 lines off)"
       ]


### PR DESCRIPTION
## Audit Result: Clean (cycle 4)

Audited `src/data/proofs/erdos-532/meta.json` against `proofs/Proofs/Erdos532Problem.lean`.

**All metadata fields match the Lean source:**
- `sorries: 0` ✓
- `axiomCount: 2` ✓ (`hindman_theorem`, `hindman_finite_exists`)
- `theoremCount: 6` ✓
- `definitionCount: 7` ✓ (6 `def` + 1 `noncomputable def hindmanNumber`)
- `lineCount: 303` ✓
- `status: axiomatized`, `badge: axiom` ✓ (consistent with axiom presence)
- Section line ranges (Parts I–IX) align with `## Part` headers in source

No structure-encoded assumptions; both axioms are top-level. Previous cycle (3) fixed phantom-axiom narrative and section drift; those fixes remain in place.

## Test plan
- [x] Tracker entry bumped: auditCount 3 → 4, result: clean
- [x] No source file changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)