### PR TITLE
audit(erdos-531): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7746,9 +7746,9 @@
     },
     "erdos-531": {
       "agentId": "auditor-session-1777649716",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T15:51:52Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T03:53:44Z",
+      "result": "clean",
       "issues": [
         "Phantom-axiom narrative: proofStrategy claims 3 axioms (only 2 declared); F_3 phantom; F_1/F_2 still sorry-stubbed (#14295)"
       ]


### PR DESCRIPTION
## Summary

- Auditor cycle 4 of `erdos-531`: meta.json fully matches `proofs/Proofs/Erdos531Problem.lean`
- Counts verified: 171L, 2 axioms (folkman_theorem, balogh_2017), 6 theorems, 6 defs (incl noncomputable `F`), 2 sorries (F_1, F_2)
- Status `axiomatized` correct (open Erdős #531 with axioms + stub sorries)
- No True stubs, no Mathlib wrappers
- Previous cycle 3 (2026-05-01) marked `issues-fixed` for #14295; entry is now clean

## Test plan

- [x] Verified meta.json counts against Lean source
- [x] Checked axiom integrity (no structure-encoded assumptions)
- [x] Confirmed sorry locations (L103 F_1, L107 F_2)
- [x] No drift in lineCount/theoremCount/definitionCount/axiomCount

🤖 Generated with [Claude Code](https://claude.com/claude-code)