### PR TITLE
Enrich abel-ruffini-galois-extensions: fix lineCount 535->534

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
-    "lineCount": 535,
+    "lineCount": 534,
     "theoremCount": 57,
     "definitionCount": 0,
     "mathlibDependencies": [
@@ -96,7 +96,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniGaloisExtensions",
-    "lineCount": 535,
+    "lineCount": 534,
     "axiomCount": 0,
     "theoremCount": 57,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary
Enrichment pass for `abel-ruffini-galois-extensions` (parent file: solvability classification of symmetric groups).

### Changes
- **lineCount fix**: `535 → 534` in both `meta.lineCount` and `leanFile.lineCount`. `wc -l proofs/Proofs/AbelRuffiniGaloisExtensions.lean` returns 534.

### Notes
Invariants verified unchanged: `axiomCount: 0`, `theoremCount: 57`, `definitionCount: 0`, `sorries: 0`.

### Note on history rewrite
This branch was force-pushed during enricher workflow iteration; the previous PR content (lineCount fix for `abel-ruffini-galois-extensions-oq-05`, original 215→214) was overwritten. That OQ-05 fix needs to be re-applied in a separate PR.