### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05: fix lineCount 215->214

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-05-04",
     "axiomCount": 1,
     "assumptions": "shafarevich_inverse_galois: Every finite solvable group G is the Galois group of some number field extension L/ℚ. Shafarevich (1954, Izv. Akad. Nauk). Proof requires class field theory, embedding problems, and Brauer group theory — not currently in Mathlib.",
-    "lineCount": 215,
+    "lineCount": 214,
     "theoremCount": 9,
     "definitionCount": 0,
     "originalContributions": [
@@ -312,7 +312,7 @@
   "leanFile": {
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05.lean",
     "axiomCount": 1,
-    "lineCount": 215,
+    "lineCount": 214,
     "theoremCount": 9,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Summary
Re-application of the lineCount fix for `abel-ruffini-galois-extensions-oq-05` (Shafarevich's theorem).

### Changes
- **lineCount fix**: `215 → 214` in both `meta.lineCount` and `leanFile.lineCount`. `wc -l proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05.lean` returns 214.

### Why a separate branch
The original PR (#20740) was created for this fix but its branch (`feature/enricher-2`) was force-pushed during the next enricher iteration, replacing the OQ-05 commit with a different lineCount fix (for the parent `abel-ruffini-galois-extensions`). This PR re-applies the OQ-05 fix on a fresh branch.

Invariants verified unchanged: `axiomCount: 1`, `theoremCount: 9`, `definitionCount: 0`, `sorries: 0`.