### PR TITLE
audit(erdos-525): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7695,9 +7695,9 @@
     },
     "erdos-525": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T16:02:08Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T04:26:45Z",
+      "result": "clean",
       "issues": [
         "Issue #14297: phantom-axiom narrative (5 phantom axioms in originalContributions: littlewood_count, has_small_value_iff_min_lt_one, konyagin_exponent_tight, konyagin_schlag_lower_tail, rudin_shapiro_bound) + section line drift across all 9 sections"
       ]


### PR DESCRIPTION
## Summary

- Auditor cycle 4 of `erdos-525`: meta.json fully matches `proofs/Proofs/Erdos525Problem.lean`
- Counts verified: 202L, 5 axioms (almost_all_small, kashin_theorem, konyagin_upper_bound, cook_nguyen_lambda, cook_nguyen_distribution), 3 theorems, 10 defs, 0 sorries
- Status `axiomatized` correct (open Erdős #525 — Littlewood polynomial conjecture)
- No True stubs, no Mathlib wrappers (mathlibDependencies are infrastructure only)
- Previous cycle 3 (2026-05-01) marked `issues-fixed` for #14297; entry now clean

## Test plan

- [x] Verified meta.json counts against Lean source
- [x] Checked axiom integrity (no structure-encoded assumptions)
- [x] Confirmed no sorries, no True stubs
- [x] No drift in lineCount/theoremCount/definitionCount/axiomCount

🤖 Generated with [Claude Code](https://claude.com/claude-code)