### PR TITLE
audit(binary-gcd-oq-02): tracker bump — clean (cycle 2)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -958,8 +958,8 @@
       "result": "clean"
     },
     "binary-gcd-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-01T16:19:22Z",
+      "auditCount": 2,
+      "lastAudited": "2026-05-27T04:51:20Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

- Auditor cycle 2 of `binary-gcd-oq-02`: meta.json fully matches `proofs/Proofs/BinaryGcdOQ02.lean`
- Counts verified: 134L, 0 axioms, 14 theorems (incl `@[simp] theorem`), 1 def, 0 sorries
- Status `verified` and badge `original` remain consistent
- No True stubs
- `originalContributions` honestly scoped (describes itself as ℤ bridge to Mathlib's `Int.gcd` — not overclaimed)
- Previous cycle 1 (2026-05-01) also clean

## Test plan

- [x] Verified meta.json counts against Lean source
- [x] No drift in lineCount/theoremCount/definitionCount/axiomCount
- [x] No phantom axioms; no True stubs
- [x] Mathlib reliance disclosed in contributions

🤖 Generated with [Claude Code](https://claude.com/claude-code)