### PR TITLE
audit(binary-gcd-oq-02): tracker bump — clean (cycle 3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -958,8 +958,8 @@
       "result": "clean"
     },
     "binary-gcd-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-27T04:51:20Z",
+      "auditCount": 3,
+      "lastAudited": "2026-05-27T04:57:56Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- Re-audit of `binary-gcd-oq-02`. All meta.json claims verified against `proofs/Proofs/BinaryGcdOQ02.lean`.

## Findings
- 0 sorries, 0 axioms, 134 lines, 14 theorems, 1 def — all match meta.
- Tier A. Core bridge `binaryGcdInt_eq_intGcd` proved internally via `binaryGcd_eq_gcd`; Mathlib `Int.gcd_*` usage is standard utility, disclosed in `mathlibDependencies` and `originalContributions`.
- Badge "original" is justified.

Result: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)