### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04: fix lineCount 235->234

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "",
-    "lineCount": 235,
+    "lineCount": 234,
     "theoremCount": 3,
     "definitionCount": 2,
     "originalContributions": [
@@ -76,7 +76,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniGaloisExtensionsOQ04",
-    "lineCount": 235,
+    "lineCount": 234,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 2,


### PR DESCRIPTION
## Summary
- Updates `meta.lineCount` and `leanFile.lineCount` from 235 to 234 to match the actual Lean file length (`AbelRuffiniGaloisExtensionsOQ04.lean` ends at line 234 with `end AbelRuffiniGaloisExtensionsOQ04`).

## Context
Quality score for this entry is already 100 — annotations, key insights, conclusion, cross-references, and sections are all richly populated. The remaining gap was the line-count discrepancy, matching the same pattern fixed recently in #20740 (535->534) and #20741 (215->214).

## Test plan
- [x] `meta.json` and `annotations.json` parse as valid JSON
- [x] `awk 'END{print NR}'` confirms 234 lines in the Lean source