### PR TITLE
Enrich abel-ruffini-galois-extensions: fix theoremCount 57→59, definitionCount 0→1

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -21,8 +21,8 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
     "lineCount": 534,
-    "theoremCount": 57,
-    "definitionCount": 0,
+    "theoremCount": 59,
+    "definitionCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "Equiv.Perm.not_solvable",
@@ -98,8 +98,8 @@
     "namespace": "AbelRuffiniGaloisExtensions",
     "lineCount": 534,
     "axiomCount": 0,
-    "theoremCount": 57,
-    "definitionCount": 0,
+    "theoremCount": 59,
+    "definitionCount": 1,
     "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary
- Corrects stale `theoremCount` (57 → 59) and `definitionCount` (0 → 1) in both `meta` and `leanFile` blocks of `src/data/proofs/abel-ruffini-galois-extensions/meta.json`
- The Lean source `proofs/Proofs/AbelRuffiniGaloisExtensions.lean` actually contains 59 theorems and 1 definition (the private `klein_four` subgroup)
- The entry description already correctly states "59 theorems, 1 definition, 0 axioms" — only the structured fields were out of sync

## Verification
```
$ grep -c '^theorem\|^private theorem' proofs/Proofs/AbelRuffiniGaloisExtensions.lean
59
$ grep -c '^def\|^private def' proofs/Proofs/AbelRuffiniGaloisExtensions.lean
1
```

The single definition is `private def klein_four : Subgroup (alternatingGroup (Fin 4))` at line 107 — the Klein four-group $V_4 = \{e, (12)(34), (13)(24), (14)(23)\}$ used to prove $A_4$ solvable.

## Test plan
- [x] JSON validity confirmed via `python3 json.load`
- [x] Full `pnpm build` passes (gallery integrity unchanged, 1662/1912 problems enriched)
- [x] No content removed; existing rich annotations, key insights, cross-references preserved