### PR TITLE
audit(erdos-526): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7710,8 +7710,8 @@
     },
     "erdos-526": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-27T05:09:48Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-27T05:19:31Z",
       "result": "clean"
     },
     "erdos-527": {


### PR DESCRIPTION
## Summary
- Re-audited `erdos-526` (Erdős #526: Circle Coverage by Random Arcs / Dvoretzky's Problem)
- All meta.json claims match Lean source `proofs/Proofs/Erdos526Problem.lean`
- Result: **clean** (cycle 5)

## Verification
- lineCount: 242 ✓
- axiomCount: 4 ✓ (`CoversWithProbOne`, `shepp_1972`, `criticalSeq`, `erdos_critical`)
- sorries: 0 ✓
- theoremCount: 2 ✓ (`erdos_526_solved`, `erdos_526_summary`)
- definitionCount: 5 ✓ (4 defs + 1 structure `ArcSequence`)
- status: `axiomatized`, badge: `axiom` ✓ (consistent with 4 axioms)

## Test plan
- [x] Verified Lean source metrics with grep
- [x] meta.json fields consistent with Lean file
- [x] No structural drift in cycle 5