### PR TITLE
audit(erdos-522): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7674,9 +7674,9 @@
       ]
     },
     "erdos-522": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T16:49:06Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T05:50:48Z",
+      "result": "clean",
       "issues": [
         "Issue #14311: proofStrategy claims phantom Erdős-Offord/Yakir/almost-sure-convergence axioms; root-counting section misclaimed as axiomatized; assumptions misnames axiom (KacPolynomialData → KacPolynomialData.isRademacher)"
       ]


### PR DESCRIPTION
## Audit Summary

Cycle 5 audit of erdos-522 (Random Polynomial Roots in the Unit Disk). All meta.json claims verified against `proofs/Proofs/Erdos522Problem.lean`.

## Verification

| Field | meta.json | Lean file | Match |
|-------|-----------|-----------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`KacPolynomialData.isRademacher`) | ✓ |
| theoremCount | 8 | 8 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| lineCount | 276 | 276 | ✓ |
| status | `axiomatized` | reflects 1 axiom | ✓ |
| badge | `axiom` | reflects 1 axiom | ✓ |

## Narrative Integrity

- Yakir (2021) and Erdős-Offord (1956) results documented in docstrings only — no `axiom` declarations for them.
- `originalContributions` properly scoped to Lean infrastructure (polynomial classes, unit disk definitions, KacPolynomialData with 1 axiom).
- No Mathlib wrapper inflation — proof is infrastructure-tier (D), not claiming independent proof of any deep theorem.
- Title and description correctly indicate partially-solved status.

Result: **clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)