### PR TITLE
audit(erdos-516): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7625,9 +7625,9 @@
     },
     "erdos-516": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T16:56:28Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T06:06:21Z",
+      "result": "clean",
       "issues": [
         "Issue #14314: originalContributions claims 3 phantom Statement-of-theorem items (Wiman 1914, Erdős-Macintyre 1954, Kovári 1965) that exist only as doc-comments; numerical fields (axiomCount=1, sorries=1, lineCount=196) are correct"
       ]


### PR DESCRIPTION
## Summary

Re-audit cycle 4 for erdos-516. All numerical claims in meta.json verified against `proofs/Proofs/Erdos516Problem.lean`.

- `sorries`: 1 actual, 1 claimed
- `axiomCount`: 1 actual (`fabryGapFuchsTheorem`), 1 claimed
- `theoremCount`: 2 actual, 2 claimed
- `definitionCount`: 8 actual, 8 claimed
- `lineCount`: 196 actual, 196 claimed
- No `True` stubs
- Status `axiomatized` and badge `axiom` correctly reflect 1 axiom + 1 sorry

Previously-flagged phantom `originalContributions` items (Issue #14314, closed) now carry explicit "no Lean axiom; doc-comment only" disclaimers, so the contributions list is no longer misleading.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --json` reports 0 detected issues for erdos-516
- [x] Numerical fields cross-checked with grep against the Lean source