### PR TITLE
audit(erdos-71): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9098,10 +9098,10 @@
       "result": "clean"
     },
     "erdos-71": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T17:00:00Z",
-      "result": "issues-fixed"
+      "agentId": "auditor-agent",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T06:17:16Z",
+      "result": "clean"
     },
     "erdos-710": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result: CLEAN

All meta.json claims verified against `proofs/Proofs/Erdos71Problem.lean`:

| Field | Claimed | Actual | OK |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`bollobas_theorem`) | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| lineCount | 258 | 258 | ✓ |
| status | axiomatized | — | ✓ |
| badge | axiom | — | ✓ |

**No True stubs**, **no structure-encoded assumptions**.

Bondy-Simonovits, bipartite-no-odd-cycles, and subgraph-extraction results are referenced in docstring prose only (correctly noted in section summaries) — no phantom axioms.

Tier C (axiomatized) classification is appropriate. Title and description correctly state SOLVED-by-Bollobás historical fact while presenting the file as a formal scaffold around 1 axiom + 2 derived corollaries (`even_cycles_from_high_degree`, `multiples_of_four`).

Increments auditCount 3 → 4, updates lastAudited to 2026-05-27T06:17:16Z, result `clean`.