### PR TITLE
audit(erdos-511): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7587,9 +7587,9 @@
     },
     "erdos-511": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T17:03:49Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T06:24:07Z",
+      "result": "clean",
       "issues": [
         "Issue #14317: 6 phantom axioms in sections summaries (components_below_4, sum_diameters_rootsOfUnity, petal_structure, perturbation_creates_components, huang_theorem, diameter_4_is_sharp); section line ranges drifted at threshold-4/summary"
       ]


### PR DESCRIPTION
## Summary
- Audited erdos-511 (Pommerenke 1961 disproof, Bounded Components of Polynomial Lemniscates)
- Result: **clean** — all meta.json claims match Lean source

## Verification
- `proofs/Proofs/Erdos511Problem.lean` — 285 lines
- 0 sorries ✓
- 2 axioms ✓ (polya_diameter_bound, pommerenke_theorem)
- 4 theorems ✓ (erdos_511, no_component_reaches_4, erdos_511_summary, erdos_511_answer)
- 4 definitions ✓ (sublevelSet, closedSublevelSet, isMonicPoly, rootsOfUnityPoly)
- status: `axiomatized` / badge: `axiom` — correctly classified per axiom integrity policy

## Test plan
- [x] grep verified axiom/sorry/theorem/def counts
- [x] line count matches meta.json
- [x] no Tier-A claim with hidden assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)