### PR TITLE
audit(erdos-541): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7827,9 +7827,9 @@
     },
     "erdos-541": {
       "agentId": "lean-auditor",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T17:15:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T06:27:23Z",
+      "result": "clean",
       "issues": [
         "Issue #14282: phantom-axiom narrative (axiomCount=1 correct, but assumptions list 3, sections claim EGZ/Erdős-Szemerédi axiomatized, proofStrategy says graham_conjecture is sorry — it is proved)"
       ]


### PR DESCRIPTION
## Summary
- Cycle 4 audit of erdos-541 (Graham's Conjecture on Zero-Sum Subsequences)
- All claimed counts match Lean source: 0 sorries, 1 axiom (gao_hamidoune_wang)
- No True stubs, no structure-encoded assumptions
- status: axiomatized, badge: axiom — correctly classified

## Tracker change
- auditCount: 3 → 4
- result: issues-fixed → clean
- lastAudited: 2026-05-01 → 2026-05-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)