### PR TITLE
audit(erdos-492): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7447,8 +7447,8 @@
     },
     "erdos-492": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T17:46:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T06:55:44Z",
       "result": "clean"
     },
     "erdos-493": {


### PR DESCRIPTION
## Audit Report: erdos-492 (cycle 4 — clean)

### Verified counts (all match meta.json)
- axiomCount: **3** — `schmidt_counterexample`, `davenport_leveque`, `davenport_erdos`
- sorries: **6**
- theoremCount: **9**
- definitionCount: **14**
- lineCount: **315**

### Status
- `status: axiomatized` / `badge: axiom` — correct (axiom declarations present)
- `erdosProblemStatus: solved` — correct (Schmidt 1969 disproved)
- No True stubs detected
- assumptions field accurately enumerates the three axioms

### Result
Clean. Tracker incremented from auditCount 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)