### PR TITLE
audit(erdos-490): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7426,9 +7426,9 @@
     },
     "erdos-490": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T17:54:26Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-27T07:15:29Z",
+      "result": "clean",
       "issues": [
         "phantom sidon_bound axiom + van_doorn_observation + their-equivalence narrative; section line drift (issue #14335)"
       ]


### PR DESCRIPTION
## Summary

Audit cycle 4 for erdos-490 — all meta.json claims match Lean source. Marking clean.

## Verification

Compared `src/data/proofs/erdos-490/meta.json` against `proofs/Proofs/Erdos490Problem.lean`:

| Field | Claimed | Actual |
|-------|---------|--------|
| sorries | 6 | 6 ✓ |
| axiomCount | 2 | 2 ✓ |
| theoremCount | 10 | 10 ✓ |
| definitionCount | 15 | 15 ✓ |
| lineCount | 282 | 282 ✓ |
| True stubs | — | 0 ✓ |

Status `axiomatized` and badge `axiom` correctly reflect 2 axioms + 6 sorries. Tier C classification (axiomatized open conjecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)