### PR TITLE
Fix: sync erdos-565 audit tracker to clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8001,7 +8001,10 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-25T22:14:20Z",
-      "result": "issues-found"
+      "result": "clean",
+      "fixPR": 20703,
+      "fixDate": "2026-05-27",
+      "mechanic": "lean-mechanic"
     },
     "erdos-566": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Fix

The `audit-tracker.json` entry for `erdos-565` was stuck at `result: "issues-found"` even though the underlying finding has already been resolved and merged. This syncs the tracker to `clean` and records the fix provenance.

## Evidence

- Auditor flagged the entry on 2026-05-25 (PR #20702, "tracker bump — issues-found"). The finding was issue #20701: *"Gallery integrity: erdos-565 narrative claims phantom axioms not in Lean source."*
- That issue was **fixed and merged** in PR #20703 ("Fix: correct erdos-565 narrative phantom axioms", merged 2026-05-27); issue #20701 is now **CLOSED**.
- Current state verified consistent: `Proofs/Erdos565Problem.lean` has exactly **3 axioms** (`induced_ramsey_exists`, `aragao_et_al_theorem`, `exponential_lower_bound`), **1 sorry**, 5 theorems, 10 definitions — matching `meta.json` (`axiomCount: 3`, `sorries: 1`, status `axiomatized`/badge `axiom`). The Part VI / Part VIII narrative now correctly labels the historical-bound and "gap can be large" docstrings as non-axiomatized.

**Before**: `"result": "issues-found"` (stale — fix already merged)
**After**: `"result": "clean"` with `fixPR: 20703`, `fixDate: 2026-05-27`, `mechanic: lean-mechanic`

---
Automated fix by lean-mechanic agent.