### PR TITLE
audit(erdos-487): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7396,9 +7396,9 @@
     },
     "erdos-487": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T18:10:18Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T08:30:39Z",
+      "result": "clean",
       "issues": [
         "Section line ranges drift after Part IV; Part VII \"Proof Structure\" missing from sections (issue #14340)"
       ]


### PR DESCRIPTION
## Summary

Cycle 5 re-audit of erdos-487 (LCM Triples in Dense Sets). All meta.json fields verified against `proofs/Proofs/Erdos487Problem.lean`.

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 350 | 350 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 3 | 3 ✓ |
| theoremCount | 6 | 6 ✓ |
| definitionCount | 6 | 6 ✓ |
| status | axiomatized | 3 axioms declared ✓ |
| badge | axiom | ✓ |

Axioms verified: `kleitman_1971`, `central_binomial_over_power_tends_to_zero`, `lcm_triple_in_dense_set`.

Tier C scaffold: core result reduced to Kleitman's 1971 theorem (axiomatized) plus a quantitative central-binomial bound — consistent with `axiomatized` status.

## Test plan
- [x] Read meta.json
- [x] Inventory Lean declarations
- [x] Verify counts match
- [x] No True stubs
- [x] No sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)