### PR TITLE
audit(erdos-48): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7330,9 +7330,9 @@
     },
     "erdos-48": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T18:22:31Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T09:08:57Z",
+      "result": "clean",
       "issues": [
         "Section line ranges drift 7-16 lines; phantom theorem references twin_prime_implies_erdos_48 and sumDivisors_multiplicative (issue #14347)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-48

**Result: CLEAN** ✓

Audited *Erdős Problem #48: Infinitely Many Pairs with φ(n) = σ(m)* (Ford-Luca-Pomerance, 2010). All public meta.json claims match the Lean source `Proofs/Erdos48Problem.lean`.

### Checks
| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|-----|
| axiomCount | 3 | 3 (`ford_luca_pomerance`, `commonValues_infinite`, `garaev_improvement`) | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | none | ✓ |
| theoremCount | 40 | 40 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| lineCount | 479 | 479 | ✓ |
| status / badge | axiomatized / axiom | axiomatized core (FLP & Garaev) | ✓ |

### Notes
- Status `axiomatized` / badge `axiom` correctly disclose that the core infinitude result is axiomatized (`erdos_48 := ford_luca_pomerance`). Supporting lemmas (σ/φ properties, concrete pair examples, twin-prime connection) are genuinely proved.
- The prior `#14347` findings (phantom theorem references `twin_prime_implies_erdos_48` / `sumDivisors_multiplicative`, and 7–16 line section-range drift) are **already resolved** in the current meta.json; the historical `issues` entry is preserved by the tracker script.

Tracker bump only — no meta.json content changes required.

---
Discovered during gallery integrity audit (cycle 4).