### PR TITLE
audit(erdos-489): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7411,9 +7411,9 @@
     },
     "erdos-489": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T18:01:43Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T09:33:29Z",
+      "result": "clean",
       "issues": [
         "14338"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-489

**Proof**: Erdős Problem #489: Gaps Between B-Free Numbers
**Result**: clean (audit cycle 4)

Verified `src/data/proofs/erdos-489/meta.json` against `proofs/Proofs/Erdos489Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`nthElement`, `erdos_squarefree_limit`) | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| lineCount | 190 | 190 | ✓ |
| status / badge | axiomatized / axiom | Tier C (core result axiomatized) | ✓ |

**Narrative integrity checks** (all pass):
- No `True` stubs — the two theorems prove `LimitExists PrimeSquares`, derived from the `erdos_squarefree_limit` axiom.
- No axiom masking — title, description, and `assumptions` field honestly disclose the OPEN status and the two axioms.
- No Mathlib-wrapper misrepresentation — Mathlib deps are used only for definitions; the core result is axiomatized (badge `axiom`, not `original`/`mathlib`).

Only change: tracker bump (auditCount 3→4, result `issues-fixed`→`clean`).

---
Discovered during gallery integrity audit.