### PR TITLE
audit(erdos-489): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7411,8 +7411,8 @@
     },
     "erdos-489": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-27T09:33:29Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-27T09:39:00Z",
       "result": "clean",
       "issues": [
         "14338"


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-489

Independent audit of **Erdős Problem #489: Gaps Between B-Free Numbers**.

### Verification (meta.json vs `proofs/Proofs/Erdos489Problem.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | yes |
| axiomCount | 2 | 2 (`nthElement`, `erdos_squarefree_limit`) | yes |
| definitionCount | 12 | 12 | yes |
| theoremCount | 2 | 2 | yes |
| True-stubs | — | 0 | yes |
| lineCount | 190 | 190 | yes |

### Tier / claim assessment
- **Tier C (axiomatized)** — `status=axiomatized`, `badge=axiom` is correct.
- Open problem honestly presented: squarefree case axiomatized via `erdos_squarefree_limit`, general case OPEN. No overclaiming.
- `assumptions` field accurate ("2 axioms: nthElement, erdos_squarefree_limit. 0 sorries").
- No structure-encoded assumptions. No narrative failure modes detected.

**Result: clean.** No issues found. Tracker bumped to auditCount 5.

---
Discovered during gallery integrity audit.