### PR TITLE
audit(erdos-479): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7321,9 +7321,9 @@
     },
     "erdos-479": {
       "agentId": "auditor-loom",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T18:29:13Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T09:49:20Z",
+      "result": "clean",
       "issues": [
         "Issue #14351: phantom k=-1 axiom narrative — originalContributions, proofStrategy, sections[partial-results], and erdos_479_summary docstring all claim a Graham-Lehmer-Lehmer k=-1 axiom that does not exist in the Lean source; only solution_set_one_finite and powers_of_two_infinite are declared. Numerical fields (axiomCount=2, sorries=0, lineCount=230) are correct."
       ]


### PR DESCRIPTION
## Audit Summary

Re-audited **erdos-479** (Powers of 2 Modulo n / Graham's conjecture) during the gallery integrity loop. **Result: clean.**

All integrity-critical claims in `meta.json` match `proofs/Proofs/Erdos479Problem.lean`:

| Claim | meta.json | Lean source |
|-------|-----------|-------------|
| sorries | 0 | 0 |
| axiomCount | 2 | 2 (`solution_set_one_finite`, `powers_of_two_infinite`) |
| structure-encoded assumptions | — | none |
| True-stubs | — | 0 |
| theoremCount | 4 | 4 |
| definitionCount | 2 | 2 |
| lineCount | 230 | 230 |

- Badge `axiom` / status `axiomatized` correctly reflect the axiomatized open conjecture — no overclaiming.
- Narrative honestly labels the problem OPEN; both axioms are disclosed in the `assumptions` field.
- The prior #14351 phantom k=-1 axiom remediation has held: k=-1 now appears only as historical context, and the Lean source explicitly notes that case is "not formalized in this file".

Tracker bumped to cycle 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)