### PR TITLE
audit(erdos-474): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7282,8 +7282,8 @@
     },
     "erdos-474": {
       "agentId": "auditor-2026-05-01",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T19:57:50Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T10:41:39Z",
       "result": "clean"
     },
     "erdos-475": {


### PR DESCRIPTION
## Summary
- Re-audit of `erdos-474` (Erdős Problem #474: Coloring ℝ² for Uncountable Sets).
- All meta.json fields match `Proofs/Erdos474Problem.lean`: 277 lines, 3 axioms, 2 theorems, 12 definitions, 0 sorries.
- `status=axiomatized` + `badge=axiom` is correct (Tier C scaffold).
- `assumptions` correctly enumerates all 3 axioms (sierpinski_kurepa, erdos_under_ch, shelah_consistency).
- Summary theorems combine axioms only — no independent-proof overclaim.
- Mathlib deps are infrastructure (Cardinal, Set, Fin); no Mathlib-wrapper risk.

## Test plan
- [x] meta.json claim counts match grep-derived counts (lines/axioms/thms/defs/sorries)
- [x] No True stubs, no hidden sorries
- [x] Status/badge consistent with axiomatized scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)