### PR TITLE
audit(erdos-476): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7295,8 +7295,8 @@
     },
     "erdos-476": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T18:54:23Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T10:47:00Z",
       "result": "clean"
     },
     "erdos-476-oq-05": {


### PR DESCRIPTION
## Summary

Erdős Problem #476 (Erdős-Heilbronn conjecture) gallery integrity audit, cycle 4.

**Result**: clean — all meta.json claims match the Lean source.

## Verification

| Field | Meta | Source (`proofs/Proofs/Erdos476Problem.lean`) |
|---|---|---|
| lineCount | 384 | 384 ✓ |
| axiomCount | 1 | 1 (`erdos_heilbronn_bound`) ✓ |
| sorries | 0 | 0 ✓ |
| theoremCount | 10 | 10 ✓ |
| definitionCount | 4 | 4 ✓ |
| status | `axiomatized` | matches (1 axiom present) ✓ |
| badge | `axiom` | matches ✓ |

No structure-encoded assumptions. Title and overview correctly disclose the axiomatized core (`erdos_heilbronn_bound`).

## Test plan
- [x] meta.json vs source counts match
- [x] No True-stub theorems
- [x] No hidden assumptions in structures