### PR TITLE
audit(erdos-449): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7100,9 +7100,9 @@
     },
     "erdos-449": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T20:22:53Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T12:04:55Z",
+      "result": "clean",
       "issues": [
         "Phantom-axiom narrative: proofStrategy claims cauchy_schwarz_divisors + problem_448_consequence are axiomatized but only docstrings exist. Line ranges drift (says Summary lines 162-174; file is 154 lines). Issue #14380."
       ]


### PR DESCRIPTION
## Summary
- Re-audit of `erdos-449` (Close Divisor Pairs, Erdős Problem #449).
- All meta.json fields match `Proofs/Erdos449Problem.lean`: 154 lines, 2 axioms, 1 theorem, 5 definitions, 0 sorries, 0 True stubs.
- `status=axiomatized` + `badge=axiom` correct (Tier C scaffold).
- `assumptions` correctly enumerates both axioms (`erdos_449_disproof`, `erdos_449_false`).
- Summary theorem combines axioms only — no independent-proof overclaim.
- `originalContributions` honestly flags that Cauchy-Schwarz and Problem-448 connection are doc-only, not Lean declarations.

## Test plan
- [x] meta.json claim counts match grep-derived counts (lines/axioms/thms/defs/sorries)
- [x] No True stubs, no hidden sorries
- [x] Status/badge consistent with axiomatized scaffold
- [x] Phantom-axiom concern from cycle 3 (#14380) confirmed resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)