### PR TITLE
audit(erdos-47): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7250,8 +7250,8 @@
     },
     "erdos-47": {
       "agentId": "auditor-agent-2026-05-01",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T20:29:45Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-27T12:25:00Z",
       "result": "clean",
       "issues": [],
       "notes": "Re-audit after PR #14375 merged. Lean: 1 axiom (bloom_theorem L100), 0 sorries, 1 theorem (erdos_47_summary L130), 6 defs. meta originalContributions/proofStrategy correctly distinguish axiom from docstrings; section line ranges (90-107, 108-114, 115-122, 123-132) match actual file structure."


### PR DESCRIPTION
## Summary
- Cycle-5 audit of erdos-47 (Unit Fractions from Dense Sets). All meta.json claims match Lean source. No discrepancies.

## Verification
- 132 lines, 0 sorries, 1 axiom (`bloom_theorem` L100), 1 theorem (`erdos_47_summary` L130), 6 defs
- status: "axiomatized", badge: "axiom" — correct for 1 axiom present
- axiomCount/theoremCount/definitionCount/lineCount/sorries all match
- 0 True stubs

## Test plan
- [x] grep verification (lineCount, sorries, axiom count, theorem count, def count)
- [x] meta.json status/badge consistent with axiomCount > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)