### PR TITLE
audit(erdos-440): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7036,9 +7036,9 @@
     },
     "erdos-440": {
       "agentId": "auditor-2026-05-01-session",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T20:40:12Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T14:21:26Z",
+      "result": "clean",
       "issues": [
         "PR #14387: phantom axiom erdos_szemeredi_liminf_bound in originalContributions/proofStrategy/section-3 — only tao_elementary_proof and van_doorn_sharp_bound declared in Lean"
       ]


### PR DESCRIPTION
## Summary

Cycle-4 re-audit of [Erdős Problem #440](https://erdosproblems.com/440) (LCM of Consecutive Sequence Elements). Tracker bumped to `clean`.

## Verification

Cross-checked `src/data/proofs/erdos-440/meta.json` against `proofs/Proofs/Erdos440Problem.lean`:

- **Axioms (2):** `tao_elementary_proof`, `van_doorn_sharp_bound` — matches `axiomCount: 2`.
- **Sorries:** 0 — matches `sorries: 0`.
- **True stubs / Mathlib wrappers:** none.
- **Structures:** `IncreasingSeq` — `strictly_increasing` field is a definitional property, not an encoded assumption.
- **Counts:** `theoremCount=3`, `definitionCount=7`, `lineCount=200` — all consistent.
- **Status / badge:** `axiomatized` / `axiom` — appropriate.

No discrepancies.

## Test plan

- [x] meta.json vs Lean source consistency
- [x] axiom enumeration (no structure-encoded hidden assumptions)
- [x] sorry / True-stub scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)