### PR TITLE
audit(erdos-442): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7051,8 +7051,8 @@
     },
     "erdos-442": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T20:55:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T14:26:53Z",
       "result": "clean",
       "notes": "2026-05-01: Verified 2 axioms (tao_counterexample, tao_construction) match declared. axiomCount=2, sorries=0, theorems=8, lineCount=255. Narrative consistent with Lean source. Section line ranges drift by 2 on Parts V/VI/VII (minor, not actionable)."
     },


### PR DESCRIPTION
## Summary
- Re-audited **erdos-442** (LCM Sums Over Dense Subsets — Tao 2024).
- All counts match meta.json: 2 axioms (`tao_counterexample`, `tao_construction`), 0 sorries, 8 theorems, 12 defs, 255 lines.
- Status `axiomatized` / badge `axiom` is correct given the 2 axiomatized assumptions.
- Tracker bumped: auditCount 3 → 4, lastAudited refreshed.

## Test plan
- [x] `grep` counts match meta.json fields
- [x] No `True` stub theorems
- [x] Status/badge consistent with axiom count

🤖 Generated with [Claude Code](https://claude.com/claude-code)