### PR TITLE
audit(erdos-439): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7020,13 +7020,11 @@
       "result": "clean"
     },
     "erdos-439": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T21:05:00Z",
-      "result": "issues-fixed",
-      "issues": [
-        "2026-05-01: phantom contribution kth_power_result (claimed in originalContributions but no theorem of that name exists; only a Part VI docstring) + section line drift +4 to +7 on Parts VI/VII/VIII. Filed #14392."
-      ]
+      "agentId": "auditor-agent-claude-2026-05-27",
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T15:03:46Z",
+      "result": "clean",
+      "notes": "2026-05-27 cycle 4: Re-verified clean. 3 axioms match declared (ess_two_colors, ess_three_colors, khalfalah_szemeredi). axiomCount=3, sorries=0, theorems=2 (square_is_second_power, erdos_439_summary), definitions=11, lineCount=218. Phantom kth_power_result from prior cycle is resolved (now correctly described as Part VI docstring only). No structure-encoded assumptions."
     },
     "erdos-44": {
       "agentId": "auditor-cycle-20-batch",
@@ -15262,5 +15260,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-05-25T03:11:42Z"
+  "lastUpdated": "2026-05-27T15:03:46Z"
 }


### PR DESCRIPTION
## Audit Result: CLEAN (cycle 4)

Re-verified erdos-439 (Khalfalah-Szemerédi monochromatic x+y=z²).

### Verified counts (all match meta.json):
- **axiomCount**: 3 (ess_two_colors, ess_three_colors, khalfalah_szemeredi)
- **sorries**: 0
- **theorems**: 2 (square_is_second_power, erdos_439_summary)
- **definitions**: 11
- **lineCount**: 218

### Notes
- No structure-encoded assumptions; axiom integrity policy satisfied.
- No True stubs.
- Phantom `kth_power_result` flagged in cycle 3 (#14392) is resolved — `originalContributions` now correctly describes the k-th power result as Part VI docstring only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)