### PR TITLE
audit(erdos-436): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7002,9 +7002,9 @@
     },
     "erdos-436": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T21:10:47Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-27T15:15:27Z",
+      "result": "clean"
     },
     "erdos-437": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Gallery integrity re-audit of `erdos-436` (Consecutive kth Power Residues): cycle 4 verification, clean result.

All meta.json claims match the Lean source at `proofs/Proofs/Erdos436Problem.lean`:
- lineCount: 686 ✓
- axiomCount: 9 ✓ (lambda_2_2..lambda_7_2, hildebrand_theorem, lambda_even_3_infinite, graham_theorem)
- sorries: 0 ✓
- theoremCount: 49 ✓ (45 public + 4 private)
- definitionCount: 8 ✓ (6 `def` + 2 `noncomputable def`)
- No True stubs, no structure-encoded assumptions

Status remains `axiomatized` / badge `axiom`. The phantom `kth_power_result` contribution flagged on 2026-05-01 (cycle 3, issues-fixed) is no longer present in `originalContributions` — fix is durable.

## Test plan

- [x] grep -c "^axiom " → 9
- [x] grep -c "sorry" → 0
- [x] wc -l → 686
- [x] theorem/def counts match
- [x] no structures/classes encoding assumptions
- [x] tracker updated to auditCount=4, result=clean