### PR TITLE
Add 'recently updated' sort option to gallery

### DIFF
--- a/scripts/annotations/build.ts
+++ b/scripts/annotations/build.ts
@@ -14,6 +14,7 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { execSync } from 'node:child_process';
 import { fileURLToPath } from 'url';
 import { resolveAnnotations, resolveSections, validateLineAnnotations } from './resolver.js';
 import type { SourceAnnotation, SourceSection, ResolvedAnnotation, ResolvedSection } from './types.js';
@@ -23,6 +24,29 @@ const __dirname = path.dirname(__filename);
 
 const PROOFS_DATA_DIR = path.join(__dirname, '../../src/data/proofs');
 const PROOFS_SOURCE_DIR = path.join(__dirname, '../../proofs/Proofs');
+const REPO_ROOT = path.join(__dirname, '../..');
+
+/**
+ * Return the most recent commit ISO timestamp touching any of the supplied
+ * repo-relative paths, or undefined if the lookup fails or returns nothing.
+ *
+ * Used to compute an "updatedAt" field for each proof listing so users can
+ * sort the gallery by recently-touched proofs (data + Lean source).
+ */
+function lastTouched(paths: string[]): string | undefined {
+  if (paths.length === 0) return undefined;
+  try {
+    const quoted = paths.map((p) => `'${p.replace(/'/g, "'\\''")}'`).join(' ');
+    const out = execSync(`git log -1 --format=%cI -- ${quoted}`, {
+      encoding: 'utf8',
+      cwd: REPO_ROOT,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+    return out || undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 interface ProofConfig {
   id: string;
@@ -175,6 +199,7 @@ function generateListings(proofs: ProofConfig[]): void {
     badge?: string;
     tags: string[];
     dateAdded?: string;
+    updatedAt?: string;
     wiedijkNumber?: number;
     hilbertNumber?: number;
     millenniumProblem?: string;
@@ -201,6 +226,18 @@ function generateListings(proofs: ProofConfig[]): void {
       annotationCount = Array.isArray(annotations) ? annotations.length : 0;
     }
 
+    // Compute updatedAt: most recent commit touching either the proof's
+    // data directory or its Lean source file. Both paths are repo-relative
+    // and passed in a single git log invocation. Falls back to undefined if
+    // git is unavailable or the proof was never committed.
+    const dataDirRel = path.relative(REPO_ROOT, proof.dataDir);
+    const trackedPaths: string[] = [dataDirRel];
+    const proofRepoPath: string | undefined = meta.meta?.proofRepoPath;
+    if (proofRepoPath) {
+      trackedPaths.push(`proofs/${proofRepoPath}`);
+    }
+    const updatedAt = lastTouched(trackedPaths);
+
     listings.push({
       id: meta.id || proof.id,
       title: meta.title || proof.id,
@@ -210,6 +247,7 @@ function generateListings(proofs: ProofConfig[]): void {
       badge: meta.meta?.badge,
       tags: meta.meta?.tags || [],
       dateAdded: meta.meta?.dateAdded,
+      updatedAt,
       wiedijkNumber: meta.meta?.wiedijkNumber,
       hilbertNumber: meta.meta?.hilbertNumber,
       millenniumProblem: meta.meta?.millenniumProblem,

--- a/src/pages/ErdosPage.tsx
+++ b/src/pages/ErdosPage.tsx
@@ -10,7 +10,7 @@ import { ArrowRight, Clock, CheckCircle, AlertCircle, Plus, Filter, ArrowUpDown,
 import { useDebouncedUrlState, useUrlState, serializers } from '@/hooks'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
-type SortOption = 'problem-number' | 'newest' | 'alphabetical'
+type SortOption = 'problem-number' | 'newest' | 'updated' | 'alphabetical'
 
 // Parse MM/DD/YY to Date object
 function parseDateAdded(dateStr?: string): Date {
@@ -50,7 +50,7 @@ export function ErdosPage() {
   const [sortBy, setSortBy] = useUrlState<SortOption>(
     'sort',
     'problem-number',
-    serializers.enum('problem-number', ['problem-number', 'newest', 'alphabetical'])
+    serializers.enum('problem-number', ['problem-number', 'newest', 'updated', 'alphabetical'])
   )
   const [showAiSolvedOnly, setShowAiSolvedOnly] = useUrlState('ai', false, serializers.boolean)
 
@@ -97,6 +97,14 @@ export function ErdosPage() {
           return parseDateAdded(b.dateAdded).getTime() - parseDateAdded(a.dateAdded).getTime()
         case 'alphabetical':
           return a.title.localeCompare(b.title)
+        case 'updated': {
+          // Sort by git-derived updatedAt (ISO) descending. Fall back to
+          // dateAdded for any entry missing the field so the list stays
+          // stable on pre-rebuild data.
+          const aUpdated = a.updatedAt ? new Date(a.updatedAt).getTime() : parseDateAdded(a.dateAdded).getTime()
+          const bUpdated = b.updatedAt ? new Date(b.updatedAt).getTime() : parseDateAdded(b.dateAdded).getTime()
+          return bUpdated - aUpdated
+        }
         default:
           return 0
       }
@@ -301,6 +309,7 @@ export function ErdosPage() {
               >
                 <option value="problem-number">By Number</option>
                 <option value="newest">Newest</option>
+                <option value="updated">Recently updated</option>
                 <option value="alphabetical">A-Z</option>
               </select>
             </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import { BookOpen, ArrowRight, Clock, CheckCircle, AlertCircle, Plus, Filter, Ar
 import { useDebouncedUrlState, useUrlState, serializers } from '@/hooks'
 import type { ProofBadge as ProofBadgeType, ProofListing } from '@/types/proof'
 
-type SortOption = 'newest' | 'oldest' | 'alphabetical'
+type SortOption = 'newest' | 'oldest' | 'alphabetical' | 'updated'
 
 // Parse MM/DD/YY to Date object
 function parseDateAdded(dateStr?: string): Date {
@@ -38,7 +38,7 @@ export function HomePage() {
   const [sortBy, setSortBy] = useUrlState<SortOption>(
     'sort',
     'newest',
-    serializers.enum('newest', ['newest', 'oldest', 'alphabetical'])
+    serializers.enum('newest', ['newest', 'oldest', 'alphabetical', 'updated'])
   )
   const [showWiedijkOnly, setShowWiedijkOnly] = useUrlState('wiedijk', false, serializers.boolean)
   const [showHilbertOnly, setShowHilbertOnly] = useUrlState('hilbert', false, serializers.boolean)
@@ -107,6 +107,14 @@ export function HomePage() {
           return parseDateAdded(a.dateAdded).getTime() - parseDateAdded(b.dateAdded).getTime()
         case 'alphabetical':
           return a.title.localeCompare(b.title)
+        case 'updated': {
+          // Sort by git-derived updatedAt (ISO) descending. Fall back to
+          // dateAdded for any entry missing the field so the list stays
+          // stable on pre-rebuild data.
+          const aUpdated = a.updatedAt ? new Date(a.updatedAt).getTime() : parseDateAdded(a.dateAdded).getTime()
+          const bUpdated = b.updatedAt ? new Date(b.updatedAt).getTime() : parseDateAdded(b.dateAdded).getTime()
+          return bUpdated - aUpdated
+        }
         default:
           return 0
       }
@@ -238,6 +246,7 @@ export function HomePage() {
               >
                 <option value="newest">Newest</option>
                 <option value="oldest">Oldest</option>
+                <option value="updated">Recently updated</option>
                 <option value="alphabetical">A-Z</option>
               </select>
             </div>

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -441,6 +441,8 @@ export interface ProofListing {
   badge?: ProofBadge
   tags: string[]
   dateAdded?: string
+  /** ISO timestamp of the most recent git commit touching the proof's data dir or Lean source. */
+  updatedAt?: string
   wiedijkNumber?: number
   hilbertNumber?: number
   millenniumProblem?: MillenniumProblem


### PR DESCRIPTION
## Summary

- Adds a **Recently updated** sort option to both the front page (`/`) and Erdős page (`/erdos`) galleries.
- Computes an `updatedAt` ISO timestamp per proof at build time from a single `git log -1 --format=%cI` call covering both the proof's data directory and its Lean source file (resolved from `meta.meta.proofRepoPath`).
- The new option is URL-state-serializable (`?sort=updated`) and falls back to `dateAdded` for any entry missing the field so behavior stays stable on pre-rebuild data.

## Changes

- **`scripts/annotations/build.ts`** — adds a `lastTouched(paths: string[])` helper using `execSync` with `cwd: REPO_ROOT`, and populates `updatedAt` on each listing.
- **`src/types/proof.ts`** — adds `updatedAt?: string` to the `ProofListing` interface.
- **`src/pages/HomePage.tsx`** — extends `SortOption`, the `serializers.enum` whitelist, the sort switch (new `case 'updated':` with `dateAdded` fallback), and the dropdown.
- **`src/pages/ErdosPage.tsx`** — mirrors the same three edits in the parallel sort block.

## Verification

- `pnpm annotations:build` — emits `listings.json` with 2435/2435 entries carrying ISO `updatedAt`, e.g. `2026-05-27T10:43:29-07:00`.
- `npx tsc -b` — passes cleanly.
- `npx vite build` — succeeds (16s). The built `HomePage` and `ErdosPage` chunks contain the new `"Recently updated"` label.
- Sort sanity-check: top-5 by `updatedAt` desc are the proofs that received commits earliest today (`erdos-846`, `erdos-152`, `erdos-741`, `erdos-26`, `erdos-138`) — matching expectation for proofs touched by recent merges.
- Browser smoke test was not run (build pipeline only); manual verification via dev server is recommended before merge.

## Notes

- `listings.json` is gitignored — `updatedAt` is regenerated on every build, so it self-maintains without committing derived data.
- `hasActiveFilters` already gates on `sortBy !== 'newest'` / `sortBy !== 'problem-number'`, so the share/clear UI surfaces correctly for `'updated'` without extra changes.
- Per-card "updated X ago" chips are explicitly out of scope (follow-up).

Closes #20848

## Test plan

- [ ] `pnpm build` succeeds locally.
- [ ] Visit `/` → sort dropdown shows "Recently updated".
- [ ] Selecting "Recently updated" reorders the gallery with recently-touched proofs first.
- [ ] `?sort=updated` survives a page reload.
- [ ] Existing `newest` / `oldest` / `alphabetical` orderings unchanged.
- [ ] Same checks on `/erdos`.

Generated with [Claude Code](https://claude.com/claude-code)