### PR TITLE
perf(annotations): batch lastTouched() git calls (fixes #20849 regression)

### DIFF
--- a/scripts/annotations/build.ts
+++ b/scripts/annotations/build.ts
@@ -27,25 +27,85 @@ const PROOFS_SOURCE_DIR = path.join(__dirname, '../../proofs/Proofs');
 const REPO_ROOT = path.join(__dirname, '../..');
 
 /**
- * Return the most recent commit ISO timestamp touching any of the supplied
- * repo-relative paths, or undefined if the lookup fails or returns nothing.
+ * Build a single-shot map of repo-relative path -> most-recent commit ISO
+ * timestamp by running ONE `git log` over the two interesting trees instead
+ * of one subprocess per listing.
  *
- * Used to compute an "updatedAt" field for each proof listing so users can
- * sort the gallery by recently-touched proofs (data + Lean source).
+ * The map is keyed by both:
+ *   1. Each touched file path (e.g. `src/data/proofs/erdos-12/meta.json`)
+ *   2. Each ancestor directory of every touched file. This lets callers
+ *      look up by directory (e.g. `src/data/proofs/erdos-12`) and get the
+ *      latest touch under that subtree — matching the original semantics of
+ *      `git log -- <dir>`.
+ *
+ * Returns undefined when git is unavailable; lookups then fall back to
+ * undefined for every listing (same behavior as the previous per-call try/catch).
+ *
+ * Performance: trades ~2435 subprocess fork/execs for a single git log call
+ * that returns in ~1-2 seconds on a warm git cache. See issue #20850.
  */
-function lastTouched(paths: string[]): string | undefined {
-  if (paths.length === 0) return undefined;
+function buildTouchedMap(): Map<string, string> | undefined {
   try {
-    const quoted = paths.map((p) => `'${p.replace(/'/g, "'\\''")}'`).join(' ');
-    const out = execSync(`git log -1 --format=%cI -- ${quoted}`, {
-      encoding: 'utf8',
-      cwd: REPO_ROOT,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    return out || undefined;
+    const out = execSync(
+      `git log --pretty=format:'%cI%x09%H' --name-only -- 'src/data/proofs/' 'proofs/Proofs/'`,
+      {
+        encoding: 'utf8',
+        cwd: REPO_ROOT,
+        stdio: ['ignore', 'pipe', 'ignore'],
+        maxBuffer: 200 * 1024 * 1024,
+      }
+    );
+    // Parse the stream. Format per commit:
+    //   <iso>\t<sha>          <- header line
+    //   path/to/file           <- one path per following line
+    //   <blank>                <- separator before next commit
+    // git log is newest-first, so the first time we see a path it IS the latest.
+    const latest = new Map<string, string>();
+    let currentTs: string | undefined;
+    for (const line of out.split('\n')) {
+      if (!line) continue;
+      if (line.includes('\t')) {
+        // Header: capture timestamp; sha is ignored.
+        currentTs = line.split('\t', 1)[0];
+        continue;
+      }
+      if (!currentTs) continue;
+      // Record for the exact file path and every ancestor directory so that
+      // a lookup by directory (the original lastTouched call pattern) returns
+      // the latest touch anywhere under that subtree.
+      let p = line;
+      while (true) {
+        if (!latest.has(p)) latest.set(p, currentTs);
+        const slash = p.lastIndexOf('/');
+        if (slash <= 0) break;
+        p = p.slice(0, slash);
+      }
+    }
+    return latest;
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Return the most recent commit ISO timestamp touching any of the supplied
+ * repo-relative paths (files or directories), or undefined if no lookup hits.
+ *
+ * Uses the pre-built map from `buildTouchedMap()` to avoid per-call subprocesses.
+ * Preserves the original semantics: when given a directory, returns the latest
+ * commit touching anything under that subtree.
+ */
+function lastTouched(
+  paths: string[],
+  touched: Map<string, string> | undefined
+): string | undefined {
+  if (!touched || paths.length === 0) return undefined;
+  let best: string | undefined;
+  for (const p of paths) {
+    const t = touched.get(p);
+    if (t && (!best || t > best)) best = t;
+  }
+  return best;
 }
 
 interface ProofConfig {
@@ -211,6 +271,19 @@ function generateListings(proofs: ProofConfig[]): void {
 
   const listings: ProofListing[] = [];
 
+  // Pre-build the map of repo-relative path -> latest commit timestamp once,
+  // up front. This is the critical perf fix: the previous implementation
+  // spawned one `git log` per listing (~2435 subprocesses), which pushed
+  // `pnpm build` past the 20-minute deploy cap. See issue #20850.
+  const buildTouchedStart = Date.now();
+  const touched = buildTouchedMap();
+  const buildTouchedMs = Date.now() - buildTouchedStart;
+  if (touched) {
+    console.log(`   Built git touch map: ${touched.size} paths in ${buildTouchedMs}ms`);
+  } else {
+    console.log(`   Skipping git touch map (git unavailable); listings will have no updatedAt`);
+  }
+
   for (const proof of proofs) {
     const metaPath = path.join(proof.dataDir, 'meta.json');
     const annotationsPath = path.join(proof.dataDir, 'annotations.json');
@@ -236,7 +309,7 @@ function generateListings(proofs: ProofConfig[]): void {
     if (proofRepoPath) {
       trackedPaths.push(`proofs/${proofRepoPath}`);
     }
-    const updatedAt = lastTouched(trackedPaths);
+    const updatedAt = lastTouched(trackedPaths, touched);
 
     listings.push({
       id: meta.id || proof.id,


### PR DESCRIPTION
## Summary

Replaces the per-listing `git log -1 --format=%cI` subprocess pattern in `scripts/annotations/build.ts` (introduced by PR #20849) with a single `git log --name-only` traversal. Builds a `Map<path, iso_ts>` once, keyed by every touched file path AND its ancestor directories, so the original directory-prefix lookup semantics are preserved.

## Why

PR #20849 added `lastTouched()` and called it once per listing (~2435 times). Each call forked a `git log` subprocess (~200ms each on a warm cache), adding **~8-10 minutes** to `pnpm build`. That pushed total build time past the 20-minute hard cap in `scripts/deploy/sync-and-deploy.sh:570` and killed the production deploy mid-vite-transform.

Judge flagged this as non-blocking on PR #20849; the deploy failure proved it should have been blocking. Lesson captured in rjwalters/loom#3343 and rjwalters/loom#3344.

## Measured timings (this worktree, warm git cache, 2435 listings)

| Stage | Pre-fix | Post-fix |
|---|---|---|
| `pnpm annotations:build` (full) | **639.67s** (~10m 40s) | **5.06s** |
| `buildTouchedMap()` one-time cost | n/a | **1.17s** (13342 paths) |
| Net speedup | — | **~126x** |

Captured with `/usr/bin/time -p pnpm annotations:build`. Pre-fix run was timed by stashing the patch, running the script, and popping the stash. Full `pnpm build` was not re-timed because a production build is running concurrently on this host; the annotations:build delta (~634s reclaimed) is what matters for the 20-minute cap and is comfortably below it.

## Acceptance criteria

- [x] `pnpm build` runtime drops back to pre-#20849 baseline plus a small one-time traversal overhead (~1-5s observed; well under the 5-10s budget).
- [x] `listings.json` still has `updatedAt` populated on all entries — verified all 2435 entries populated.
- [x] Top-5 by `updatedAt` matches `git log --name-only` directly:
  ```
  2026-05-27T10:43:29-07:00  erdos-846   (matches git log -- src/data/proofs/erdos-846)
  2026-05-27T10:28:23-07:00  erdos-152   (matches)
  2026-05-27T10:22:33-07:00  erdos-741   (matches)
  2026-05-27T10:15:51-07:00  erdos-26    (matches)
  2026-05-27T10:02:58-07:00  erdos-138   (matches)
  ```
- [x] `npx tsc --noEmit` passes (no diagnostics).
- [x] Falls back to `undefined` on git failure (preserves original semantics).
- [ ] Full `./scripts/deploy/sync-and-deploy.sh --build` run NOT executed in this PR (a production deploy is already running in the parent worktree; running a second heavy build concurrently could OOM the host). Math: 634s saved >> 20-minute cap headroom, so this is left for the next live deploy to confirm.

## Implementation notes

- New helper `buildTouchedMap()` runs `git log --pretty=format:'%cI%x09%H' --name-only -- 'src/data/proofs/' 'proofs/Proofs/'` once at the start of `generateListings`.
- Parses the output: header lines (containing `\t`) carry the ISO timestamp; subsequent non-blank lines are file paths. Since `git log` is newest-first, first-seen wins.
- For each file path, records the timestamp at the path itself AND at every ancestor directory. This preserves the original `lastTouched(['src/data/proofs/erdos-12/'])` (directory) lookup semantics — `git log -- <dir>` returns the latest commit anywhere under that subtree.
- `lastTouched()` now takes the pre-built map as an argument; if the map is `undefined` (git unavailable / `execSync` threw) it returns `undefined`, matching the original per-call try/catch behavior.
- `maxBuffer: 200MB` on `execSync` to handle large repos; output here is ~12k lines / well under 1MB.

Closes #20850