### PR TITLE
deploy: re-evaluate pnpm build cap, make it a config knob

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "pnpm annotations:build && pnpm research:build && pnpm research:enrich && tsc -b && vite build",
+    "build": "export NODE_OPTIONS=\"${NODE_OPTIONS:-} --max-old-space-size=8192\" && pnpm annotations:build && pnpm research:build && pnpm research:enrich && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
     "deploy": "pnpm build && wrangler pages deploy dist --project-name=lean-genius --commit-dirty=true",

--- a/scripts/deploy/profile-build.sh
+++ b/scripts/deploy/profile-build.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+#
+# profile-build.sh - Measure per-stage wall-clock time for `pnpm build`.
+#
+# Purpose:
+#   The deploy pipeline (scripts/deploy/sync-and-deploy.sh) caps `pnpm build`
+#   at BUILD_TIMEOUT (default 20m). This script measures where the time is
+#   actually going across the five stages of the build chain so the cap can be
+#   re-evaluated mechanically rather than reactively.
+#
+# Usage:
+#   ./scripts/deploy/profile-build.sh
+#   ./scripts/deploy/profile-build.sh --json   # machine-readable output
+#
+# Output:
+#   Per-stage wall-clock seconds + total. JSON form is suitable for trend
+#   tracking (e.g., commit to research/quality-history or paste into the
+#   issue tracker).
+#
+# Reference profile (HEAD a4f83c7b055, 2026-05-27, M-series macOS):
+#   annotations:build  3.21s
+#   research:build     1.08s
+#   research:enrich    2.80s
+#   tsc -b             8.55s
+#   vite build        17.64s
+#   total             ~35s   (vs 1200s cap = ~34x headroom)
+#
+# Re-run before bumping BUILD_TIMEOUT or splitting the build into staged caps.
+
+set -euo pipefail
+
+JSON_OUTPUT=false
+if [[ "${1:-}" == "--json" ]]; then
+    JSON_OUTPUT=true
+fi
+
+# Find repo root (same logic as sync-and-deploy.sh)
+find_repo_root() {
+    local dir="$PWD"
+    while [[ "$dir" != "/" ]]; do
+        if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
+}
+
+REPO_ROOT="$(find_repo_root)"
+cd "$REPO_ROOT"
+
+export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192"
+
+# Capture wall-clock seconds for a command using bash's $SECONDS counter,
+# which is portable across macOS (BSD) and Linux (GNU) shells.
+time_stage() {
+    local label="$1"
+    shift
+    local start=$SECONDS
+    if "$@" > /tmp/profile-build-stage.log 2>&1; then
+        local elapsed=$((SECONDS - start))
+        if ! $JSON_OUTPUT; then
+            printf "  %-22s %5ds  OK\n" "$label" "$elapsed" >&2
+        fi
+        echo "$elapsed"
+    else
+        local rc=$?
+        local elapsed=$((SECONDS - start))
+        if ! $JSON_OUTPUT; then
+            printf "  %-22s %5ds  FAIL (exit %d)\n" "$label" "$elapsed" "$rc" >&2
+            echo "    --- last 20 lines of stage log ---" >&2
+            tail -20 /tmp/profile-build-stage.log | sed 's/^/    /' >&2
+        fi
+        echo "$elapsed"
+        return "$rc"
+    fi
+}
+
+if ! $JSON_OUTPUT; then
+    echo "Profiling pnpm build (per-stage wall-clock seconds)..."
+    echo "  Repo:       $REPO_ROOT"
+    echo "  HEAD:       $(git rev-parse --short HEAD) $(git log -1 --format='%s' | cut -c1-60)"
+    echo "  NODE_OPTIONS=$NODE_OPTIONS"
+    echo
+fi
+
+total_start=$SECONDS
+
+annotations_s=$(time_stage "annotations:build" pnpm annotations:build)
+research_build_s=$(time_stage "research:build" pnpm research:build)
+research_enrich_s=$(time_stage "research:enrich" pnpm research:enrich)
+tsc_s=$(time_stage "tsc -b" npx tsc -b)
+vite_s=$(time_stage "vite build" npx vite build)
+
+total_s=$((SECONDS - total_start))
+
+if $JSON_OUTPUT; then
+    cat <<EOF
+{
+  "head": "$(git rev-parse HEAD)",
+  "head_short": "$(git rev-parse --short HEAD)",
+  "node_options": "$NODE_OPTIONS",
+  "stages": {
+    "annotations:build": $annotations_s,
+    "research:build": $research_build_s,
+    "research:enrich": $research_enrich_s,
+    "tsc -b": $tsc_s,
+    "vite build": $vite_s
+  },
+  "total_seconds": $total_s,
+  "build_timeout_default_seconds": 1200,
+  "headroom_ratio": $(awk "BEGIN { printf \"%.1f\", 1200 / ($total_s > 0 ? $total_s : 1) }")
+}
+EOF
+else
+    echo
+    printf "  %-22s %5ds  TOTAL\n" "" "$total_s"
+    echo
+    # Compute headroom ratio vs default 20m cap (1200s).
+    headroom=$(awk "BEGIN { printf \"%.1fx\", 1200 / ($total_s > 0 ? $total_s : 1) }")
+    echo "  Default BUILD_TIMEOUT = 20m (1200s). Headroom: ${headroom}."
+fi

--- a/scripts/deploy/sync-and-deploy.sh
+++ b/scripts/deploy/sync-and-deploy.sh
@@ -11,10 +11,19 @@
 #   ./sync-and-deploy.sh --dry-run    Show what would be done
 #
 # Environment:
-#   SKIP_MERGE=1    Skip PR merging
-#   SKIP_SYNC=1     Skip data syncing
-#   SKIP_BUILD=1    Skip building
-#   SKIP_DEPLOY=1   Skip deployment
+#   SKIP_MERGE=1            Skip PR merging
+#   SKIP_SYNC=1             Skip data syncing
+#   SKIP_BUILD=1            Skip building
+#   SKIP_DEPLOY=1           Skip deployment
+#   BUILD_TIMEOUT=20m       Hard cap for `pnpm build` (timeout(1) duration syntax).
+#                           Default 20m. As of 2026-05-27 at HEAD a4f83c7b055 a
+#                           clean build measures ~35s wall-clock total
+#                           (annotations 3s, research:build 1s, research:enrich
+#                           3s, tsc 9s, vite 18s) -- ~34x headroom. Re-profile
+#                           with scripts/deploy/profile-build.sh before bumping.
+#   BUILD_NODE_OPTIONS=...  Extra Node options for the build. Defaults to
+#                           "--max-old-space-size=8192" so vite does not OOM on
+#                           the current bundle.
 
 set -euo pipefail
 
@@ -557,17 +566,23 @@ build_website() {
         return 0
     fi
 
-    print_info "Running pnpm build..."
+    # Cap node heap at 8 GB so OOMs surface as deterministic exits rather than
+    # thrashing the host, and bound the whole chain at BUILD_TIMEOUT so a hung
+    # step can't accumulate zombie pnpm/vite processes across cycles. The cap
+    # is configurable via env (BUILD_TIMEOUT, BUILD_NODE_OPTIONS) so future
+    # adjustments don't require code changes. A profiler is available at
+    # scripts/deploy/profile-build.sh -- re-run before tightening or loosening
+    # the default.
+    local build_timeout="${BUILD_TIMEOUT:-20m}"
+    local build_node_options="${BUILD_NODE_OPTIONS:---max-old-space-size=8192}"
+    print_info "Running pnpm build (cap ${build_timeout}, NODE_OPTIONS=${build_node_options})..."
     # Capture full log so failures aren't masked by `| tail -5` (which forces
-    # the pipe's exit status to tail's, always 0). Cap node heap at 8 GB so
-    # OOMs surface as deterministic exits rather than thrashing the host, and
-    # bound the whole chain at 20 minutes so a hung step can't accumulate
-    # zombie pnpm/vite processes across cycles.
+    # the pipe's exit status to tail's, always 0).
     local build_log
     build_log=$(mktemp)
     local build_status=0
-    NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=8192" \
-        timeout --kill-after=30 20m pnpm build > "$build_log" 2>&1 \
+    NODE_OPTIONS="${NODE_OPTIONS:-} ${build_node_options}" \
+        timeout --kill-after=30 "$build_timeout" pnpm build > "$build_log" 2>&1 \
         || build_status=$?
     tail -20 "$build_log"
     case $build_status in
@@ -576,7 +591,7 @@ build_website() {
             rm -f "$build_log"
             ;;
         124|137)
-            print_error "Build timed out after 20m (status $build_status); see full log at $build_log"
+            print_error "Build timed out after ${build_timeout} (status $build_status); see full log at $build_log"
             return 1
             ;;
         *)


### PR DESCRIPTION
## Summary

Per the recommendation in #20851, profiled per-stage build time first and then decided on the cap.

**Findings** on a clean tree at HEAD `a4f83c7b055` (2026-05-27), post #20852:

| Stage              | Wall (s) |
|--------------------|---------:|
| annotations:build  |        3 |
| research:build     |        1 |
| research:enrich    |        3 |
| tsc -b             |        8 |
| vite build         |       18 |
| **TOTAL**          |  **~35** |

20m cap = 1200s, so ~34x headroom. The cap is no longer the constraint that motivated the issue; #20852 already removed the regression.

## Decision

`config_knob` — keep the 20m default (massive headroom) but make it a config knob so future bumps don't require code changes.

## Changes

- **`scripts/deploy/sync-and-deploy.sh`**: introduce `BUILD_TIMEOUT` and `BUILD_NODE_OPTIONS` env knobs. Defaults stay at `20m` and `--max-old-space-size=8192`. Header doc and call-site comment quote the current profile and point at the new profiler so future re-evals are mechanical.
- **`scripts/deploy/profile-build.sh`** (new, executable): wraps the five stages of `pnpm build`, prints a table by default or `--json` for trend tracking. Re-run before changing `BUILD_TIMEOUT`.
- **`package.json`**: bake `NODE_OPTIONS=--max-old-space-size=8192` into the `build` script via `export ... && ...` so anyone running `pnpm build` outside the deploy wrapper gets the same heap limit (vite OOMs without it on the current bundle — confirmed empirically today).

## Verification

End-to-end `pnpm build` with the new hardened script: 31s wall-clock.

`./scripts/deploy/profile-build.sh` output:

```
  annotations:build          3s  OK
  research:build             1s  OK
  research:enrich            3s  OK
  tsc -b                     8s  OK
  vite build                17s  OK

                            32s  TOTAL

  Default BUILD_TIMEOUT = 20m (1200s). Headroom: 37.5x.
```

## Future signals to re-bump

Re-run `scripts/deploy/profile-build.sh` when:
- Total build time crosses ~5m (still 4x headroom, but trajectory matters).
- Any single stage dominates (>70% of total) — that's a sign to split into staged caps per option (4).
- A deploy timeout reoccurs in `sync-and-deploy.sh` after this change.

## Test plan

- [x] `bash -n scripts/deploy/sync-and-deploy.sh` syntax check
- [x] `./scripts/deploy/profile-build.sh` runs to completion and prints all 5 stages
- [x] `./scripts/deploy/profile-build.sh --json` produces valid JSON
- [x] `pnpm build` succeeds end-to-end with new `NODE_OPTIONS` in package.json (31s wall)
- [ ] Deployer's next cycle exercises the env-driven cap (no change in default behavior expected)

Closes #20851