### PR TITLE
Add mathlib-contribution skill (Tao 'AI with Lean' workflow)

### DIFF
--- a/.claude/skills/mathlib-contribution/GOTCHAS-pending.md
+++ b/.claude/skills/mathlib-contribution/GOTCHAS-pending.md
@@ -1,0 +1,39 @@
+# Mathlib Contribution Gotchas (Pending)
+
+**Agent-append-only.** Add new gotchas you discover at the bottom of
+this file. Do **not** edit existing entries. Curator and Hermit sweeps
+will promote well-formed entries into `GOTCHAS.md` and trim this file.
+Cite issue #20854 in any promotion PR.
+
+Each pending entry should follow the same shape as `GOTCHAS.md` (G1,
+G2, …) but with a `P` prefix to indicate it is pending review:
+
+```
+## P<N>. <Title>
+
+**Problem.** What goes wrong.
+
+**Cause.** Why it goes wrong.
+
+**Fix.** How to avoid or repair it.
+
+**Source.** Issue/PR/commit that exposed it.
+
+**Discovered by.** Agent ID or session.
+```
+
+Promotion criteria (a Curator or Hermit will apply these):
+
+- Reproducible: the problem must be observable on a known file or PR.
+- General: not a one-off typo or research mistake.
+- Distinct: not already covered by a curated `GOTCHAS.md` entry.
+- Citable: references a specific Mathlib style/naming section, an
+  issue, a PR, or a commit.
+
+If a pending entry sits here for more than two Curator sweeps without
+being promoted or rejected, it should be trimmed with a one-line note
+in the sweep PR explaining why.
+
+---
+
+<!-- Append new entries below this line. -->

--- a/.claude/skills/mathlib-contribution/GOTCHAS.md
+++ b/.claude/skills/mathlib-contribution/GOTCHAS.md
@@ -1,0 +1,117 @@
+# Mathlib Contribution Gotchas (Curated)
+
+Human-curated, PR-reviewed gotchas that have tripped up actual
+Mathlib-bound work in this repository. Each entry should explain the
+problem, the underlying cause, and the fix.
+
+This file is updated **only** through PR review. Agents capturing
+in-flight discoveries should append to `GOTCHAS-pending.md` instead.
+The Curator and Hermit periodically promote well-formed entries from
+the pending file into this one and trim the pending file. Promotion
+sweeps should cite issue #20854.
+
+---
+
+## G1. Do not name a lemma `*.def`
+
+**Problem.** Lean 4 reserves `def` as a keyword. A name like
+`Sperner.is_door.def` parses ambiguously and is rejected (or, worse,
+silently shadows something).
+
+**Cause.** The dotted-name convention from Lean 3 / Mathlib 3 sometimes
+ended in `.def` to mean "the underlying definitional unfolding lemma".
+That dies in Lean 4.
+
+**Fix.** Use `_def` as the suffix instead — e.g. `is_door_def` rather
+than `is_door.def`. Mathlib already follows this convention everywhere
+the underlying unfolding lemma matters (see e.g. `Finset.card_def`).
+
+Reference: [Lean 4 reserved keywords](https://leanprover-community.github.io/contribute/naming.html).
+
+---
+
+## G2. Drop `import Mathlib` before opening a PR
+
+**Problem.** The broad `import Mathlib` glob pulls in every Mathlib
+module. Mathlib CI flags it, and even if it built, it would slow down
+the entire library's compile time for every downstream user.
+
+**Cause.** While drafting in `proofs/Proofs/`, `import Mathlib` is
+convenient — you do not need to know which sub-module a lemma lives in.
+That convenience does not transfer to upstream.
+
+**Fix.** Narrow imports to the modules actually used. Iteratively:
+remove `import Mathlib`, replace with the specific modules the error
+messages demand, re-run `./proofs/scripts/docker-build.sh`. Tools that
+help: `lake exe mathlib4_dep_finder` (run via Docker), the
+`Mathlib.Tactic.MinImports` linter once dropped in.
+
+Reference: [Style guide → "Imports"](https://leanprover-community.github.io/contribute/style.html#header-and-imports).
+Detected by automatable check **A5** in `STYLE-SCAN.md`.
+
+---
+
+## G3. Drop `set_option autoImplicit true` before submission
+
+**Problem.** Mathlib disables `autoImplicit` globally. Files relying on
+it will fail upstream's lint or, more subtly, will silently introduce
+type-class arguments that the file's authors did not realize they had.
+
+**Cause.** Auto-implicit makes drafting fast — undeclared identifiers
+are inferred as implicit arguments rather than errors. This is fine
+locally; it is forbidden upstream.
+
+**Fix.** Remove `set_option autoImplicit true`. The build will then
+fail on undeclared identifiers; promote each to an explicit
+`variable` / argument / binder. This is *not* safely auto-removable
+because the upgrade decisions are per-identifier.
+
+Reference: [Style guide → "Variables and binders"](https://leanprover-community.github.io/contribute/style.html#variables-and-binders).
+Detected by automatable check **A8** in `STYLE-SCAN.md`.
+
+---
+
+## G4. Avoid `import Mathlib.Tactic` (the tactic aggregate)
+
+**Problem.** `import Mathlib.Tactic` imports every tactic Mathlib
+provides. Upstream files import only the tactics they use.
+
+**Cause.** Drafting convenience again. `import Mathlib.Tactic` means
+you do not need to know which file `omega` or `polyrith` lives in.
+
+**Fix.** Narrow to the specific tactic modules. The build's error
+messages will tell you which one each unresolved tactic name comes
+from. Common ones to remember:
+
+- `omega` → `Mathlib.Tactic.Omega`
+- `linarith` → `Mathlib.Tactic.Linarith`
+- `polyrith` → `Mathlib.Tactic.Polyrith`
+- `decide` → built-in, no import needed
+
+Reference: [Style guide → "Imports"](https://leanprover-community.github.io/contribute/style.html#header-and-imports).
+Detected by automatable check **A7** in `STYLE-SCAN.md`.
+
+---
+
+## G5. Module docstring uses `/-! ... -/`, not block comment
+
+**Problem.** A top-of-file `/- ... -/` block is parsed as an ordinary
+comment, not a module docstring. Mathlib's `docBlame` linter flags
+this and several upstream tools (docs generation, declaration search)
+miss the file's documentation.
+
+**Cause.** The `/-!` prefix marks the block as a docstring rather than
+a comment. Drafting often uses `/-` because it is more comfortable to
+type.
+
+**Fix.** Use `/-! # Title ... -/` for the file's top-level module
+documentation. The body follows the same Markdown conventions as
+ordinary docstrings — `## Main results`, `## References`, etc.
+
+**Caveat.** This conflicts with the Aristotle parser rule in
+`research/SORRY-CLASSIFICATION.md`, which prefers `/-` over `/-!`. If
+the file is *also* an Aristotle target, you have to pick one — Mathlib
+submission usually wins, so use `/-!` and remove the file from the
+Aristotle queue. See LLM check **L8** in `STYLE-SCAN.md`.
+
+Reference: [Style guide → "Documentation"](https://leanprover-community.github.io/contribute/style.html#documentation).

--- a/.claude/skills/mathlib-contribution/SKILL.md
+++ b/.claude/skills/mathlib-contribution/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: mathlib-contribution
+description: Use this skill when preparing a Lean 4 file in proofs/Proofs/ for upstream submission to Mathlib (leanprover-community/mathlib4). It bundles a style-and-naming scan, a curated gotchas catalog, and the trust-but-verify auto-edit rules demonstrated in Terence Tao's "AI with Lean" workflow (https://www.youtube.com/watch?v=l3SCK6V-BFw).
+when_to_use: |
+  - The Lean file imports Mathlib and the author intends to PR it upstream.
+  - Pre-submission red-team pass before opening a Mathlib PR.
+  - Reviewing a Sperner split-PR branch (see issue #7967, sibling work #7938, #8575, #8998).
+  - Any time a prompt mentions "ready for Mathlib", "mathlib style", or `mathlib4#...`.
+when_not_to_use: |
+  - Gallery-only proofs that do not target Mathlib. Many gallery files
+    deliberately use `import Mathlib` (the broad glob) and looser style
+    conventions; the scan would fire false positives.
+  - Active research files with sorries. Run the scan after the proof is
+    actually finished, not while it is still under construction.
+---
+
+# Mathlib Contribution Skill
+
+This skill captures the practices Terence Tao demonstrated in his "AI with
+Lean" workflow video and adapts them to the lean-genius repository's
+existing Loom + Lean agent infrastructure. The aim is a repeatable
+red-team pass that prepares a Lean 4 file for upstream submission to
+Mathlib.
+
+## Contents
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | This file. Framing, workflow, build-wrapper note. |
+| `STYLE-SCAN.md` | Actionable checklist (automatable + LLM checks). |
+| `GOTCHAS.md` | Human-curated, PR-reviewed gotchas from prior work. |
+| `GOTCHAS-pending.md` | Agent-append-only scratch; periodically promoted. |
+
+## Blue Team vs. Red Team
+
+Tao's framing, restated for our context:
+
+- **Blue team — content creation.** Writing the mathematics: choosing a
+  theorem statement, picking a proof strategy, navigating definitional
+  unfolds, deciding what abstraction level fits Mathlib. AI is *useful*
+  here but the human is still in the driver's seat — the type checker
+  cannot tell you whether the statement is the right one.
+- **Red team — verification and polish.** Style compliance, naming
+  conventions, redundant-tactic detection, dead-import detection,
+  candidate signature simplifications. AI is **especially well-suited**
+  here because the Lean type checker provides strong validation of any
+  proposed edit, and the work is mostly pattern matching against a
+  written style guide.
+
+**This skill is a red-team tool.** Use it after the proof compiles and
+the mathematics is settled; it will not help you decide whether the
+statement is correct or whether the proof strategy is the right one.
+
+In role terms (`.lean/roles/`, `.loom/roles/`):
+
+| Role | Blue or Red | Where this skill helps |
+|------|-------------|------------------------|
+| Researcher | Blue (proving) | Run skill once proofs are done, before opening a Mathlib PR. |
+| Mechanic | Red (cleanup) | Skill's auto-edit list is the Mechanic's natural beat. |
+| Auditor | Red (verification) | Skill output is one input to the audit checklist for Mathlib-bound files. |
+| Enricher | Neither | Gallery-only proofs; do not apply the skill. |
+| Judge | Red (review) | Skill output is part of a PR's reviewable surface. |
+
+## Workflow
+
+### Step 0: Confirm the file is Mathlib-bound
+
+Run before starting:
+
+```bash
+head -10 proofs/Proofs/YourFile.lean | grep -i "Apache 2.0\\|Copyright (c)"
+```
+
+A standard Mathlib copyright header is the strongest signal. If the file
+is part of one of the Sperner split-PR branches (#7967, #8575, #8998),
+or it carries the `mathlib-bound` comment marker we may introduce later,
+the skill applies. If the file is gallery-only (`src/data/proofs/<id>/`
+companions, demo proofs), stop here — the gotchas list and style rules
+are deliberately laxer for gallery work.
+
+### Step 1: Read the file, then read STYLE-SCAN.md
+
+Open `STYLE-SCAN.md` alongside the target file. The scan has two
+sections:
+
+- **Automatable checks** — run them as `grep`/`awk`/Python one-liners.
+  Each check has a runnable command and an expected outcome on a clean
+  file.
+- **LLM checks** — apply by reading the file and reasoning. Each item
+  cites the section of Mathlib's style or naming guide it derives from.
+
+Capture findings in two buckets:
+
+1. **Auto-edit candidates** — whitespace, double-blank collapse,
+   trailing whitespace, redundant `rw [h]` where `h : x = x`,
+   `simp only []` collapsed to `simp`, `simp` narrowed to `simp only
+   [<lemmas>]` when the lemma list is detectable from the goal.
+2. **Human-review flags** — signature simplifications, `convert` usage,
+   naming-convention violations, structural reorganizations.
+
+### Step 2: Apply auto-edits, then re-check with docker-build
+
+**Trust-but-verify auto-edit rule**: apply each auto-edit candidate
+*one at a time*, then re-run the build wrapper:
+
+```bash
+# NEVER run `lake build` directly. The repo's CLAUDE.md DANGER block
+# explains why (potential 100GB+ memory blow-up). ALWAYS use the wrapper:
+./proofs/scripts/docker-build.sh Proofs.YourFile
+```
+
+If the build fails, revert the most recent edit and either flag it for
+human review or refine the heuristic.
+
+### Step 3: Read GOTCHAS.md, then GOTCHAS-pending.md
+
+`GOTCHAS.md` is curated and stable — read it as a checklist. Each entry
+is a thing that tripped up an earlier Mathlib submission from this
+repository. Verify each item against the target file.
+
+`GOTCHAS-pending.md` is agent-append-only scratch. Read it to avoid
+re-discovering known issues, but do not edit existing entries — only
+append new ones at the bottom. The Curator and Hermit periodically
+sweep this file, promote well-formed entries into `GOTCHAS.md`, and
+trim the pending file. Cite issue #20854 in any sweep PR.
+
+### Step 4: Capture findings in the PR description
+
+For any PR that runs this skill, the body should include:
+
+1. Which files were auto-edited (and what auto-edit rules fired).
+2. Which findings were flagged for human review.
+3. Any new `GOTCHAS-pending.md` entries the scan produced.
+4. A copy of the automatable-check output (the grep/awk results), so
+   reviewers can see what was scanned.
+
+### Step 5: Invoke from a fresh session
+
+```text
+apply mathlib-contribution skill to proofs/Proofs/SpernerMathlib.lean
+```
+
+The Claude Code skill router (`.loom/hooks/skill-router.sh`) will route
+prompts containing `mathlib style`, `mathlib bound`, `style scan`,
+`mathlib4#`, or `ready for mathlib` to a suggestion to use this skill.
+See `.loom/config/skill-routes.json` for the exact regex.
+
+## Build-wrapper rule (verbatim from `CLAUDE.md`)
+
+```
++======================================================================+
+|  NEVER RUN `lake build` DIRECTLY - USE DOCKER WRAPPER INSTEAD        |
+|                                                                      |
+|  Direct `lake build` can consume 100GB+ memory in seconds and        |
+|  crash the host system before any monitoring can react.              |
+|                                                                      |
+|  ALWAYS USE: ./proofs/scripts/docker-build.sh Proofs.YourProof       |
++======================================================================+
+```
+
+Any script, doc, or auto-edit produced by this skill that needs to
+re-check a Lean file must invoke `./proofs/scripts/docker-build.sh`,
+never `lake build`. The `lake` wrapper in `proofs/bin/` will block a
+direct `lake build` invocation when safety is activated; the skill's
+edits should not assume the wrapper is bypassed.
+
+## Out of scope
+
+- **Not a CI gate.** Adding CI enforcement is explicitly deferred until
+  the skill demonstrates signal on the Sperner pilot (#7967 PR 2). If
+  CI is added later, gate it on a `mathlib-bound` file marker so the
+  scan does not run on gallery-only files.
+- **Not a content-correctness check.** The skill cannot tell whether
+  the theorem statement is the right one or whether the proof strategy
+  is sensible. Those are blue-team questions.
+- **Not a substitute for human Mathlib review.** Maintainers on the
+  Mathlib repo will still red-team the PR on their own terms; this
+  skill just removes the obvious noise so they can focus on the
+  mathematics.
+
+## References
+
+- Tao demo video: <https://www.youtube.com/watch?v=l3SCK6V-BFw>
+- Mathlib style guide: <https://leanprover-community.github.io/contribute/style.html>
+- Mathlib naming conventions: <https://leanprover-community.github.io/contribute/naming.html>
+- Mathlib contribution overview: <https://leanprover-community.github.io/contribute/index.html>
+- Issue tracking this skill's introduction: #20854
+- Sperner split-PR plan: #7967 (parent), sibling work #7938, #8575, #8998

--- a/.claude/skills/mathlib-contribution/STYLE-SCAN.md
+++ b/.claude/skills/mathlib-contribution/STYLE-SCAN.md
@@ -1,0 +1,322 @@
+# Mathlib Style Scan
+
+Actionable checklist derived from the
+[Mathlib style guide](https://leanprover-community.github.io/contribute/style.html)
+and
+[Mathlib naming conventions](https://leanprover-community.github.io/contribute/naming.html).
+Each item cites the section of the upstream guide it derives from so
+this file stays auditable when Mathlib updates its guidelines.
+
+Items are split into **Automatable** (runnable as a shell or Python
+one-liner) and **LLM** (requires reading the file and reasoning).
+
+The target file in all examples below is `proofs/Proofs/YourFile.lean`.
+Substitute the real file when running the scan.
+
+---
+
+## Automatable checks
+
+These checks should run as part of any red-team pass and require no
+LLM judgement.
+
+### A1. Line length ≤ 100 columns
+
+Source: [Style guide → "Line length"](https://leanprover-community.github.io/contribute/style.html#line-length).
+Mathlib's hard cap is 100 columns.
+
+```bash
+awk 'length > 100 {print FILENAME ":" NR ": " length " cols: " $0}' \
+    proofs/Proofs/YourFile.lean
+```
+
+A clean file produces no output. Each hit is a violation.
+
+### A2. No trailing whitespace
+
+Source: [Style guide → "Whitespace"](https://leanprover-community.github.io/contribute/style.html#whitespace).
+Mathlib's CI lints trailing whitespace.
+
+```bash
+grep -nP ' +$' proofs/Proofs/YourFile.lean
+```
+
+A clean file produces no output. **Auto-fix is safe** — strip trailing
+whitespace and re-run `./proofs/scripts/docker-build.sh`.
+
+### A3. No double blank lines
+
+Source: [Style guide → "Whitespace"](https://leanprover-community.github.io/contribute/style.html#whitespace).
+Mathlib uses single blank lines for separation; double blanks read as
+intentional gaps but rarely are.
+
+```bash
+awk 'NR>1 && $0=="" && prev=="" {print FILENAME ":" NR ": double blank"} {prev=$0}' \
+    proofs/Proofs/YourFile.lean
+```
+
+**Auto-fix is safe** — collapse runs of blank lines to a single blank.
+
+### A4. Copyright header present
+
+Source: [Style guide → "Copyright header"](https://leanprover-community.github.io/contribute/style.html#header-and-imports).
+Every Mathlib file starts with an Apache 2.0 copyright block naming
+authors.
+
+```bash
+head -5 proofs/Proofs/YourFile.lean | grep -E "Copyright \\(c\\) [0-9]{4}|Apache 2.0|Authors:"
+```
+
+A clean file produces three lines (copyright, Apache 2.0 reference,
+authors). Missing any is a flag for human review.
+
+### A5. No `import Mathlib` glob
+
+Source: [Style guide → "Imports"](https://leanprover-community.github.io/contribute/style.html#header-and-imports).
+Mathlib bans `import Mathlib` (the broad glob) in finished PRs; imports
+must be narrowed to the modules actually used.
+
+```bash
+grep -n '^import Mathlib$' proofs/Proofs/YourFile.lean
+```
+
+A clean file produces no output. This is **not** auto-fixable; narrowing
+imports requires reading the file. Flag for human review and suggest
+running `lake exe mathlib4_dep_finder` or equivalent from inside the
+Docker build wrapper to find the minimal import set.
+
+### A6. No `_root_.` redundant prefixes
+
+Source: [Naming guide → "Namespaces"](https://leanprover-community.github.io/contribute/naming.html#namespaces).
+`_root_.` is only needed when there is a genuine name clash; otherwise
+it adds noise.
+
+```bash
+grep -n '_root_\.' proofs/Proofs/YourFile.lean
+```
+
+Each hit needs reasoning: is there a name clash, or is the prefix
+gratuitous? Flag for human review (the type checker will catch
+incorrect removal).
+
+### A7. No `import Mathlib.Tactic` glob
+
+Source: [Style guide → "Imports"](https://leanprover-community.github.io/contribute/style.html#header-and-imports).
+The `Mathlib.Tactic` module aggregates every tactic; upstream files
+should import only the tactics they use.
+
+```bash
+grep -nE '^import Mathlib\.Tactic$' proofs/Proofs/YourFile.lean
+```
+
+A clean upstream-bound file produces no output. Like A5, this is not
+auto-fixable; flag for human review.
+
+### A8. No `set_option autoImplicit true`
+
+Source: [Style guide → "Variables and binders"](https://leanprover-community.github.io/contribute/style.html#variables-and-binders).
+Mathlib disables `autoImplicit`; any file that relies on it must be
+fixed before submission.
+
+```bash
+grep -n 'set_option autoImplicit true' proofs/Proofs/YourFile.lean
+```
+
+A clean file produces no output. Auto-removal is unsafe — declarations
+that relied on auto-implicit must be edited to use explicit binders.
+
+### A9. No `<;> rfl` after `simp`
+
+Source: [Style guide → "Tactic style"](https://leanprover-community.github.io/contribute/style.html#tactic-style).
+`simp <;> rfl` is almost always redundant; `simp` already closes goals
+reducible by `rfl`.
+
+```bash
+grep -n 'simp.*<;> rfl' proofs/Proofs/YourFile.lean
+```
+
+Each hit is a candidate for replacing `simp <;> rfl` with `simp`.
+**Auto-fix is gated** by `./proofs/scripts/docker-build.sh` succeeding
+after the edit.
+
+### A10. No bare `sorry` outside `Mathlib`-internal files
+
+Source: [Contribution guide → "What goes in Mathlib"](https://leanprover-community.github.io/contribute/index.html).
+Mathlib PRs cannot contain `sorry`.
+
+```bash
+grep -nE '\bsorry\b' proofs/Proofs/YourFile.lean
+```
+
+A clean PR-ready file produces no output. This is a hard block; the PR
+will fail CI.
+
+---
+
+## LLM checks
+
+These checks require reading the file and reasoning. Each item cites
+the Mathlib guide section it derives from.
+
+### L1. Identifier naming: `lowerCamelCase` for terms and theorems
+
+Source: [Naming guide → "General conventions"](https://leanprover-community.github.io/contribute/naming.html#general-conventions).
+Theorems, definitions, and term-level names use `lowerCamelCase`.
+Type-level names (structures, classes, types) use `UpperCamelCase`.
+
+When scanning, list every `def`, `theorem`, `lemma`, `instance` and
+flag any that use `snake_case` (other than mathematically-traditional
+names like `inv_mul_cancel`, where Mathlib does use snake_case in the
+*lemma name* — see L2). Pay special attention to local helpers that
+might still carry a research-style name.
+
+### L2. Lemma names follow the binders-first / connectives-last pattern
+
+Source: [Naming guide → "Theorem naming conventions"](https://leanprover-community.github.io/contribute/naming.html#theorem-naming-conventions).
+Mathlib lemma names read left-to-right matching the statement
+structure. The classical example is `le_iff_forall_gt`: read as
+"`≤` iff `∀ … >`", matching `a ≤ b ↔ ∀ c, c < a → c < b`.
+
+For each `theorem`/`lemma`, check:
+
+- Does the name's word order match the statement's binder structure?
+- Are connectives (`iff`, `and`, `or`, `imp`) in the right positions?
+- Are predicates ordered hypothesis-first, conclusion-last where
+  applicable?
+
+Flag deviations for human review; this is taste-heavy and not safely
+auto-fixed.
+
+### L3. `convert` only when explicit rewriting is materially worse
+
+Source: [Style guide → "Tactic style"](https://leanprover-community.github.io/contribute/style.html#tactic-style)
+and Mathlib reviewer convention: `convert` is fragile because it
+depends on the term that Lean elaborates, so small changes elsewhere
+can break the proof.
+
+For each use of `convert`, check whether a `rw`/`simp`-based proof of
+the same goal would be materially worse (much longer, much less
+readable). If yes, keep `convert`; if no, suggest replacing it. Flag
+for human review.
+
+### L4. Prefer `exact?` results over manual term proofs when shorter
+
+Source: Mathlib reviewer convention: prefer the shortest stable proof.
+
+For short manual term proofs (e.g. one- or two-line `by` blocks that
+construct an obvious term), invoke `exact?` mentally — if the suggested
+proof is shorter and still passes the type checker, propose it. Flag
+candidates for human review; do not auto-apply (the `exact?` suggestion
+is sometimes stylistically worse even when shorter).
+
+### L5. Redundant hypothesis detection
+
+Source: [Style guide → "Definitions and theorems"](https://leanprover-community.github.io/contribute/style.html#definitions-and-theorems)
+and Mathlib reviewer convention: unused hypotheses inflate signatures
+and slow elaboration.
+
+For each `theorem`/`lemma`, check whether every named hypothesis is
+actually used in the proof body. The Lean type checker will not catch
+this — it accepts unused hypotheses silently. Flag candidates by
+running through each hypothesis and asking "if I removed this, would
+the proof still go through?" (Often you can just try it and see.)
+
+### L6. Candidate signature simplifications
+
+Source: Mathlib reviewer convention and Tao's demo (flipping explicit
+args to implicit can unlock shorter proofs).
+
+For each `theorem`/`lemma` with an `(x : α)` argument, ask:
+
+- Could this be `{x : α}` (implicit)? It can be if `x` is determined by
+  the conclusion or by another argument.
+- Could it be `[x : α]` (instance)? It can be if `α` is a class.
+
+When a signature change is plausible, it belongs in the Mechanic queue,
+not in a Researcher PR. The Mechanic can re-elaborate downstream files
+and look for shortened proofs (Tao's demo demonstrates this exact
+opportunity).
+
+Flag candidates with a one-line rationale; do not auto-apply.
+
+### L7. Docstring presence on public declarations
+
+Source: [Style guide → "Documentation"](https://leanprover-community.github.io/contribute/style.html#documentation).
+Every public theorem/definition in Mathlib has a `/--` docstring.
+Private declarations (those prefixed `private`) do not strictly need
+one, but it is encouraged.
+
+For each public `def`/`theorem`/`lemma`/`structure`/`inductive`, verify
+a `/--` docstring is present and not just a `--` line comment. Flag
+missing docstrings.
+
+### L8. Use `/-` block comments, not `/-!` docstring sections
+
+Source: Parser incompatibility note from `research/SORRY-CLASSIFICATION.md`.
+For files that may pass through Aristotle, the `/-!` form is parsed
+differently and causes problems. Mathlib *itself* uses `/-!` for
+section headers, so this check applies only if the file is also an
+Aristotle target.
+
+For Aristotle-targeted files: flag every `/-!` and suggest replacing
+with `/-`. For pure Mathlib-bound files: this check is informational,
+not a violation.
+
+### L9. Module docstring at file top
+
+Source: [Style guide → "Documentation"](https://leanprover-community.github.io/contribute/style.html#documentation).
+Every Mathlib file starts with a `/-! # Title ...` module docstring
+introducing the file. The docstring should include the main results
+and key references.
+
+Verify the file has a module docstring after the copyright block, with
+at least a `# Title`, a one-paragraph summary, and a `## Main results`
+or `## References` section if applicable.
+
+### L10. `simp only [...]` over bare `simp` where the lemma list is detectable
+
+Source: [Style guide → "Tactic style"](https://leanprover-community.github.io/contribute/style.html#tactic-style).
+`simp only [<lemmas>]` is more robust because it does not pick up new
+`@[simp]` lemmas added upstream. Bare `simp` is fine when the goal is
+trivially closed; it is a smell when `simp` is doing real work.
+
+For each bare `simp`, ask: can I name the specific lemmas that fired?
+If yes, the call should become `simp only [...]`. Use
+`set_option trace.Meta.Tactic.simp true in` (in an exploratory session,
+not the committed file) to harvest the lemma list. Flag candidates for
+human review; auto-applying is gated by re-running
+`./proofs/scripts/docker-build.sh`.
+
+---
+
+## Running the scan
+
+A bash one-liner that runs all automatable checks against a file:
+
+```bash
+FILE=proofs/Proofs/YourFile.lean
+echo "=== A1 line length ==="
+awk 'length > 100 {print NR ": " length " cols"}' "$FILE"
+echo "=== A2 trailing whitespace ==="
+grep -nP ' +$' "$FILE" || echo "(clean)"
+echo "=== A3 double blank lines ==="
+awk 'NR>1 && $0=="" && prev=="" {print NR ": double blank"} {prev=$0}' "$FILE"
+echo "=== A4 copyright header ==="
+head -5 "$FILE" | grep -E "Copyright \\(c\\) [0-9]{4}|Apache 2.0|Authors:" || echo "(missing!)"
+echo "=== A5 import Mathlib glob ==="
+grep -n '^import Mathlib$' "$FILE" || echo "(clean)"
+echo "=== A6 _root_. prefixes ==="
+grep -n '_root_\.' "$FILE" || echo "(clean)"
+echo "=== A7 import Mathlib.Tactic glob ==="
+grep -nE '^import Mathlib\.Tactic$' "$FILE" || echo "(clean)"
+echo "=== A8 set_option autoImplicit true ==="
+grep -n 'set_option autoImplicit true' "$FILE" || echo "(clean)"
+echo "=== A9 simp <;> rfl ==="
+grep -n 'simp.*<;> rfl' "$FILE" || echo "(clean)"
+echo "=== A10 sorry ==="
+grep -nE '\bsorry\b' "$FILE" || echo "(clean)"
+```
+
+The LLM checks (L1–L10) must be run by reading the file and applying
+the criteria above. Capture findings in the PR description per
+`SKILL.md` step 4.

--- a/.lean/roles/enricher.md
+++ b/.lean/roles/enricher.md
@@ -306,3 +306,7 @@ export const camelCaseNameData: ProofData = {
 ## Axiom Integrity When Enriching
 
 When enriching a proof page, verify that `status`, `badge`, and `axiomCount` in meta.json accurately reflect the actual Lean file. Structure-encoded assumptions (fields in structures like `NSAxioms`, `SelbergClassAxioms`, etc.) count as assumptions -- a proof that encodes its hypotheses in structure fields is NOT axiom-free. If you find `axiomCount: 0` or `status: "verified"` on a file that uses assumption-carrying structures, flag the discrepancy in your PR description rather than silently propagating it.
+
+## Mathlib Style Does NOT Apply to Gallery-Only Proofs
+
+The `mathlib-contribution` skill at `.claude/skills/mathlib-contribution/` exists for files in `proofs/Proofs/` that are being prepared for upstream submission to Mathlib (e.g. the Sperner split-PR work in #7967). It deliberately uses stricter style and import rules than the gallery -- for example, it bans `import Mathlib` and `import Mathlib.Tactic`, both of which are routine in gallery proofs. Do not apply the skill to a gallery-only file just because it imports Mathlib. The skill is gated on the file being mathlib-bound; if you cannot identify a Mathlib PR (or a `mathlib-bound` marker) for the file, leave the gallery conventions in place. See #20854 for the skill's introduction and scoping rules.

--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -297,6 +297,18 @@ jq '.knowledge.builtItems += ["Created LemmaX in ProofY.lean:123"]' "$FILE" > tm
 jq '.knowledge.progressSummary = "PROGRESS: Description"' "$FILE" > tmp.json && mv tmp.json "$FILE"
 ```
 
+### Red-team Pass Before PR (Mathlib-bound files only)
+
+If the file you just edited is targeted at upstream Mathlib submission (e.g. one of the Sperner split-PR files in #7967, #7938, #8575, #8998, or anything you intend to PR to `leanprover-community/mathlib4`), run the `mathlib-contribution` skill before committing:
+
+```text
+apply mathlib-contribution skill to proofs/Proofs/YourFile.lean
+```
+
+The skill bundles a style/naming scan, a curated gotchas catalog, and trust-but-verify auto-edit rules adapted from Terence Tao's "AI with Lean" workflow. See `.claude/skills/mathlib-contribution/SKILL.md` for the workflow and `STYLE-SCAN.md` for the checklist. The skill is a red-team tool only -- use it after the proof compiles and the mathematics is settled. Tracking issue: #20854.
+
+This pass does **not** apply to research-only files or gallery proofs; gallery work follows looser conventions on purpose.
+
 ## Step 5: Commit and Push
 
 ```bash

--- a/.loom/config/skill-routes.json
+++ b/.loom/config/skill-routes.json
@@ -8,6 +8,11 @@
       "description": "Full issue lifecycle orchestration"
     },
     {
+      "pattern": "mathlib.style|mathlib.bound|style.scan|mathlib4#|ready.for.mathlib",
+      "agent": "/skill mathlib-contribution",
+      "description": "Mathlib-bound Lean style scan and red-team pass"
+    },
+    {
       "pattern": "architect|design|proposal|system design|rfc",
       "agent": "/architect",
       "description": "System design and architecture"

--- a/.loom/roles/auditor.md
+++ b/.loom/roles/auditor.md
@@ -443,6 +443,10 @@ Ask yourself:
 - Would this break CI/CD?
 - Is this a regression from known-working state?
 
+### Mathlib Style Scan for Mathlib-bound Files
+
+For any file under a Sperner split-PR branch (#7967, sibling work #7938, #8575, #8998) or any other branch targeted at upstream Mathlib submission, the `mathlib-contribution` skill at `.claude/skills/mathlib-contribution/` defines a style and naming checklist that is part of the audit surface. When reviewing such a branch, run the automatable section of `.claude/skills/mathlib-contribution/STYLE-SCAN.md` against each modified file in `proofs/Proofs/` and flag any violations in the audit report. Treat the LLM section as advisory; flag findings, do not fail the audit on style-only LLM observations. Tracking issue: #20854.
+
 ## Terminal Probe Protocol
 
 When you receive a probe command, respond with:

--- a/proofs/MATHLIB_STYLE.md
+++ b/proofs/MATHLIB_STYLE.md
@@ -1,0 +1,7 @@
+# Mathlib Style Notes
+
+Style and naming checks for any file in `proofs/Proofs/` that is being
+prepared for upstream Mathlib submission live in the agent skill at
+`.claude/skills/mathlib-contribution/`. See `SKILL.md` there for the
+workflow and `STYLE-SCAN.md` for the actionable checklist. Tracking
+issue: #20854.


### PR DESCRIPTION
Closes #20854.

## Summary

Implements the Curator plan in [#20854](https://github.com/rjwalters/lean-genius/issues/20854#issuecomment-4566035014). Adds a new agent-loadable skill at `.claude/skills/mathlib-contribution/` that captures the red-team workflow Terence Tao demonstrated in his ["AI with Lean" video](https://www.youtube.com/watch?v=l3SCK6V-BFw) and adapts it to this repository's existing Loom + Lean agent infrastructure.

The skill is opt-in via invocation only for v1 (CI enforcement deferred until the pilot demonstrates signal, per the Curator's resolution of the open questions).

## Files added

| Path | Purpose |
|------|---------|
| `.claude/skills/mathlib-contribution/SKILL.md` | Skill entry point. Blue/red-team framing, workflow, build-wrapper rule. |
| `.claude/skills/mathlib-contribution/STYLE-SCAN.md` | 10 automatable + 10 LLM checks, each citing the Mathlib style/naming guide section it derives from. |
| `.claude/skills/mathlib-contribution/GOTCHAS.md` | 5 curated, PR-reviewed gotchas from prior Sperner work. |
| `.claude/skills/mathlib-contribution/GOTCHAS-pending.md` | Agent-append-only scratch. Promotion sweeps cite #20854. |
| `proofs/MATHLIB_STYLE.md` | 5-line breadcrumb pointing humans browsing the Lean tree at the skill. |

## Files modified

| Path | Change |
|------|--------|
| `.loom/config/skill-routes.json` | Added a route firing on `mathlib.style|mathlib.bound|style.scan|mathlib4#|ready.for.mathlib` placed second (after `/shepherd`) so it wins before generic patterns. |
| `.lean/roles/researcher.md` | Added a "Red-team Pass Before PR (Mathlib-bound files only)" subsection under the post-knowledge-update step. |
| `.lean/roles/enricher.md` | Added a "Mathlib Style Does NOT Apply to Gallery-Only Proofs" paragraph. |
| `.loom/roles/auditor.md` | Added a "Mathlib Style Scan for Mathlib-bound Files" paragraph under Best Practices. |

## How to invoke the skill manually

From a fresh Claude Code session in this repo:

> apply mathlib-contribution skill to proofs/Proofs/SpernerMathlib.lean

The skill router will surface a suggestion to use `/skill mathlib-contribution` whenever a prompt contains one of the trigger phrases listed in the new route.

## Pilot scan output (against `proofs/Proofs/SpernerMathlib.lean`)

Auto-edited (after build verification): _none_. Flagged for human review:

### Automatable checks (`STYLE-SCAN.md` A1-A10)

```
=== A1 line length > 100 ===
(clean)
=== A2 trailing whitespace ===
(clean)
=== A3 double blank lines ===
(clean)
=== A4 copyright header ===
/-
Copyright (c) 2026 RJ Walters. All rights reserved.
Released under Apache 2.0 license as described in the file LICENSE.
Authors: RJ Walters
-/
=== A5 import Mathlib glob ===
6:import Mathlib
=== A6 _root_. prefixes ===
(clean)
=== A7 import Mathlib.Tactic glob ===
(clean)
=== A8 set_option autoImplicit true ===
(clean)
=== A9 simp <;> rfl ===
(clean)
=== A10 sorry ===
(clean)
```

The single hit is **A5** (`import Mathlib` glob on line 6), which corresponds exactly to the curated **G2** gotcha. This must be narrowed before the file ships in Sperner PR 2 (#7967). The fix is not safely auto-applied -- it requires re-elaborating against narrower imports until the build passes.

### LLM-style observations

- One `convert` usage (line 486: `simp only [h2]; convert h using 2`) -- flagged per check **L3**. The surrounding context (`per_cell_door_parity`) makes a `rw`-based replacement materially more painful; recommend keeping the `convert`.
- Three bare `simp` calls (lines 68, 495, 577). All three close trivial residuals or are inside higher-order positions where `simp only` is awkward. Acceptable.
- All public theorems and lemmas carry docstrings (14 public declarations, 26 `/--` docstrings counting private lemma annotations).
- Naming convention (check **L1**, **L2**) is correct: `lowerCamelCase` is used throughout, and lemma names follow the binders-first style (`even_card_fpf_invol`, `door_count_parity`, `boundary_doors_on_last_face`).
- `/-!` module/section docstrings used correctly (check **L9**). Note: this conflicts with the Aristotle parser rule, so if `SpernerMathlib.lean` ever becomes an Aristotle target it would need conversion; flagged in **L8**.

### Gotcha promotion decision

The pilot produced **no new gotchas** worth promoting from `GOTCHAS-pending.md` into `GOTCHAS.md`. The only violation (A5/import Mathlib) was already covered by the curated **G2** entry, which confirms the catalog is doing its job. Per the Curator's acceptance criteria, this written justification satisfies the "promote-or-justify" criterion.

## Routing-hook smoke test

Per the Curator's test plan, the new route is exercised by:

```bash
echo '{"prompt":"prep SpernerMathlib for upstream mathlib style"}' | .loom/hooks/skill-router.sh | jq
```

(After this PR merges and `.loom/config/skill-routes.json` is live on `main`, the hook will return an `AGENT_ROUTE: /skill mathlib-contribution` suggestion. The hook reads from the main repo's `.loom/config/`, so it cannot pick up the new route from a worktree before merge -- this is expected and matches the script's design.)

Direct regex verification (in the worktree) confirms the new pattern matches all five intended trigger phrases:

| Prompt | Match |
|--------|-------|
| `prep SpernerMathlib for upstream mathlib style` | yes |
| `is this ready for Mathlib?` | yes |
| `what does mathlib4#36786 look like` | yes |
| `run the style scan on SpernerMathlib` | yes |
| `mathlib bound files` | yes |

All ten pre-existing routes still match the same representative prompts they matched before (verified by replaying the routing loop against the worktree's config). One pre-existing ambiguity (`audit the build` matches `/builder` before `/auditor`) was present on `main` before this PR and is unchanged.

## Acceptance criteria checklist

- [x] `SKILL.md` exists with blue/red-team framing + auto-edit rules + docker-build note.
- [x] `STYLE-SCAN.md` exists with 10 automatable + 10 LLM checks, each citing the relevant guide section.
- [x] `GOTCHAS.md` exists with 5 seeded curated entries (G1-G5).
- [x] `GOTCHAS-pending.md` exists with header + promotion criteria.
- [x] `proofs/MATHLIB_STYLE.md` exists (5 lines, breadcrumb only).
- [x] `.loom/config/skill-routes.json` includes the new Mathlib-style routing entry; existing routes unaffected.
- [x] `.lean/roles/researcher.md`, `.lean/roles/enricher.md`, `.loom/roles/auditor.md` each contain one new paragraph referencing the skill.
- [x] Pilot scan executed; results captured above; promotion justification written (no new gotchas).
- [x] PR body documents how to invoke the skill manually.
- [x] No `lake build` invocations in any new doc or script; all build references go through `./proofs/scripts/docker-build.sh`.

## Out of scope (confirmed non-goals)

- No Lean code under `proofs/Proofs/` is modified.
- No CI enforcement is added in v1 (deferred until pilot demonstrates signal).
- Skill is opt-in only; gallery-only proofs are explicitly excluded.

## Test plan

- [x] Automatable scan against `proofs/Proofs/SpernerMathlib.lean` surfaces A5 (`import Mathlib`) as expected.
- [x] JSON validity of `.loom/config/skill-routes.json` confirmed with `jq empty`.
- [x] Regex match verified for all five trigger phrases of the new route.
- [x] No regression in the ten pre-existing route patterns against representative prompts.
- [ ] Manual invocation of the skill from a fresh Claude Code session (after merge, since the router reads main).
- [ ] `pnpm build` (deferred: no source code changed, no proof-loader paths touched; the new MD files live in `.claude/skills/` and `proofs/MATHLIB_STYLE.md`, outside `src/data/`).