### PR TITLE
audit(erdos-125, erdos-846): align companion-file schema with auditor

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/125",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos125Problem.lean",
-    "additionalProofRepoPaths": [
+    "additionalFiles": [
       "Proofs/Erdos125PositiveLowerDensity.lean"
     ],
     "tags": [
@@ -20,13 +20,13 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 14,
+    "sorries": 12,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 369,
-    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 14 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
+    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 12 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
     "mathlib_version": "4.26.0",
     "theoremCount": 20,
     "definitionCount": 7

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -8,7 +8,7 @@
     "sourceUrl": "https://erdosproblems.com/846",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos846Problem.lean",
-    "additionalProofRepoPaths": [
+    "additionalFiles": [
       "Proofs/Erdos846ProblemAPN.lean"
     ],
     "tags": [


### PR DESCRIPTION
## Summary

- Rename `additionalProofRepoPaths` → `additionalFiles` in `erdos-125/meta.json` and `erdos-846/meta.json` so the auditor's `find-targets.ts` actually follows the companion Lean files when counting sorries / axioms.
- Correct erdos-125 sorries count from 14 → 12 (the script strips docstring mentions; only 12 are in code).

## Context

The auditor recognizes `additionalFiles` to follow companion Lean files. The two entries above used a non-standard `additionalProofRepoPaths` key that the script ignored:

- **erdos-125** — companion `Erdos125PositiveLowerDensity.lean` (12 sorries) was invisible, producing a false mismatch ("claims 14, actual 0"). After fix: auditor sees `claims=12, chain=12` → clean.
- **erdos-846** — companion `Erdos846ProblemAPN.lean` was invisible. Counts happen to match (both files 0/0), so no current mismatch, but the schema drift would mask future divergence.

`additionalFiles` is used by 5+ other entries (`erdos-877`, `erdos-625`, `erdos-1091`, `erdos-613`, `ballot-problem-…`). No source code or UI reads either field name (only `scripts/auditor/find-targets.ts`), so the rename is purely a meta-schema fix.

The `assumptions` text in erdos-125 was also corrected (14 → 12).

## Verification

Before:
```
erdos-125 (4x, last 2026-05-04) [axiomatized/wip] ❌ sorry mismatch: claims 14, actual 0
```

After (with the diff applied locally):
```
npx tsx scripts/auditor/find-targets.ts --issues
Top 0 audit targets (of 0 total):
```

## Test plan

- [x] `find-targets.ts --issues` returns 0 targets
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"` for both files)
- [ ] CI green

---
Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)