### PR TITLE
fix(research): resolve claim-problem.sh repo root to main worktree

### DIFF
--- a/scripts/research/claim-problem.sh
+++ b/scripts/research/claim-problem.sh
@@ -17,8 +17,23 @@
 set -euo pipefail
 shopt -s nullglob
 
-# Find repo root
+# Find repo root.
+#
+# Claims, locks, and the gitignored candidate pool are shared coordination
+# state: every agent must reference the SAME files. When this script runs from
+# a linked worktree, an upward ".git" search resolves to the worktree, where
+# .lean/state/candidate-pool.json (gitignored) does not exist — so claim-random
+# always reports "No available problems". Resolve to the MAIN worktree root via
+# the common git dir so all agents share one pool and one claims directory.
 find_repo_root() {
+    local common_dir
+    if common_dir="$(git rev-parse --git-common-dir 2>/dev/null)" \
+        && common_dir="$(cd "$common_dir" 2>/dev/null && pwd)"; then
+        dirname "$common_dir"
+        return 0
+    fi
+
+    # Fallback: walk up looking for .git (git unavailable / not a repo)
     local dir="$PWD"
     while [[ "$dir" != "/" ]]; do
         if [[ -d "$dir/.git" ]] || [[ -f "$dir/.git" ]]; then


### PR DESCRIPTION
## Summary

`scripts/research/claim-problem.sh` derived `REPO_ROOT` with an upward `.git`
search from `$PWD`. Every researcher agent runs it from a **linked worktree**,
so that search resolved to the worktree — but the coordination state it needs
lives only in the main repo:

- `.lean/state/candidate-pool.json` is **gitignored** (`.gitignore:37-38`), so a
  fresh worktree never has it.
- `jq` reading a nonexistent pool yields zero candidates, so `claim-random`
  unconditionally printed **"No available problems"** even though the pool held
  **653 claimable** problems (111 `available` + 542 `in-progress`).

This silently blocked the entire researcher fleet — the recurring "no claims"
cycles were this bug, not an empty backlog.

## Fix

Resolve `REPO_ROOT` via `git rev-parse --git-common-dir` (→ the main worktree's
`.git`, whose parent is the main repo root) so the pool, `research/claims/`, and
`.loom/locks/` all point at the single shared main-worktree root regardless of
which worktree invokes the script. Falls back to the original upward `.git` walk
if git is unavailable.

Claims/locks/pool are cross-agent coordination state — they **must** reference
one shared location; resolving to the per-agent worktree was the defect.

## Verification

- `bash -n` syntax check passes.
- `git rev-parse --git-common-dir` → main repo root confirmed from a worktree,
  the main repo root, and a main-repo subdirectory.
- `claim-problem.sh status` run from a worktree now shows the pool
  (`available: 111`, `in-progress: 542`, …); previously the Pool Status section
  was absent because the path didn't resolve.

## Test plan

- [ ] `claim-problem.sh claim-random` from a researcher worktree returns a real
      problem instead of "No available problems".
- [ ] `status` from both the main repo and a worktree report identical pool stats.
- [ ] Claims created from different worktrees are mutually visible (shared
      `research/claims/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)