### PR TITLE
research(basel-oq-03): ship 28b-2 witness saturation (Hanson Route B)

### DIFF
--- a/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
+++ b/proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean
@@ -1583,6 +1583,166 @@ theorem factorization_succ_mul_choose_le_log_succ
     (Finset.card_le_card hfilter_subset).trans hcard.le
   omega
 
+/-- **Helper 1** (Iter 36 PREP §2). For base `p > 1` and `i ≤ e`, the
+    residue of `p^e - 1` modulo `p^i` is exactly `p^i - 1`.
+
+    Used by the 28b-2 saturation witness to evaluate `(n - k₀) % p^i`. -/
+private lemma pow_sub_one_mod_pow {p e i : ℕ} (hp : 1 < p) (hie : i ≤ e) :
+    (p ^ e - 1) % p ^ i = p ^ i - 1 := by
+  rcases Nat.eq_zero_or_pos i with hi0 | hi_pos
+  · subst hi0; simp [Nat.mod_one]
+  have hp_two : 2 ≤ p := by omega
+  obtain ⟨c, hc⟩ : p ^ i ∣ p ^ e := Nat.pow_dvd_pow p hie
+  have hpi_pos : 0 < p ^ i := Nat.pow_pos (by omega)
+  have hpi_ge_two : 2 ≤ p ^ i := by
+    calc 2 = 2 ^ 1 := (pow_one 2).symm
+      _ ≤ p ^ 1 := Nat.pow_le_pow_left hp_two 1
+      _ ≤ p ^ i := Nat.pow_le_pow_right (by omega : 1 ≤ p) hi_pos
+  have h_pi_lt : p ^ i - 1 < p ^ i := by omega
+  have hc_pos : 1 ≤ c := by
+    have h_pe_pos : 0 < p ^ e := Nat.pow_pos (by omega)
+    rw [hc] at h_pe_pos
+    rcases Nat.eq_zero_or_pos c with hc0 | hcp
+    · simp [hc0] at h_pe_pos
+    · exact hcp
+  have hc1 : c - 1 + 1 = c := by omega
+  have h_pic_eq : p ^ i * c = p ^ i * (c - 1) + p ^ i := by
+    calc p ^ i * c = p ^ i * (c - 1 + 1) := by rw [hc1]
+      _ = p ^ i * (c - 1) + p ^ i := by rw [mul_add, mul_one]
+  have h_rearr : p ^ e - 1 = (p ^ i - 1) + p ^ i * (c - 1) := by
+    rw [hc]; omega
+  rw [h_rearr, Nat.add_mul_mod_self_left]
+  exact Nat.mod_eq_of_lt h_pi_lt
+
+/-- **Helper 2** (Iter 36 PREP §3). For prime `p`, `i = a + j` with
+    `1 ≤ j`, `0 < f`, `p^f < m` and `p ∤ m`, the residue of the witness
+    `p^a * (m - p^f)` modulo `p^i` is at least `1`. -/
+private lemma witness_mod_pow_lt
+    {p a m f i j : ℕ} (hp_prime : p.Prime)
+    (hia : i = a + j) (hj_pos : 0 < j)
+    (hf_pos : 0 < f) (hpf_lt : p ^ f < m) (hmp : ¬ p ∣ m) :
+    1 ≤ (p ^ a * (m - p ^ f)) % p ^ i := by
+  have hpi_eq : p ^ i = p ^ a * p ^ j := by rw [hia, pow_add]
+  rw [hpi_eq, Nat.mul_mod_mul_left]
+  have hpf_le : p ^ f ≤ m := hpf_lt.le
+  have h_not_dvd : ¬ p ^ j ∣ (m - p ^ f) := by
+    intro hdvd
+    have hp_dvd_pj : p ∣ p ^ j := dvd_pow_self p hj_pos.ne'
+    have hp_dvd_diff : p ∣ (m - p ^ f) := hp_dvd_pj.trans hdvd
+    have hp_dvd_pf : p ∣ p ^ f := dvd_pow_self p hf_pos.ne'
+    have h_sum : (m - p ^ f) + p ^ f = m := Nat.sub_add_cancel hpf_le
+    have hp_dvd_m : p ∣ m := by
+      have h_combined := hp_dvd_diff.add hp_dvd_pf
+      rwa [h_sum] at h_combined
+    exact hmp hp_dvd_m
+  have h_mod_pos : 1 ≤ (m - p ^ f) % p ^ j := by
+    rcases Nat.eq_zero_or_pos ((m - p ^ f) % p ^ j) with h_eq | h_pos
+    · exact absurd (Nat.dvd_of_mod_eq_zero h_eq) h_not_dvd
+    · exact h_pos
+  have hpa_pos : 0 < p ^ a := Nat.pow_pos hp_prime.pos
+  have hprod_pos : 0 < p ^ a * ((m - p ^ f) % p ^ j) :=
+    Nat.mul_pos hpa_pos h_mod_pos
+  omega
+
+/-- **Iter 38 ACT — 28b-2 witness saturation** (Iter 36 PREP §4–§5).
+
+    The witness `k₀ = (n+1) - p^e` (with `e = log_p (n+1)`) saturates the
+    28b-1 bound: `v_p(n+1) + v_p(C(n, k₀)) = log_p(n+1)`. Combined with
+    `factorization_succ_mul_choose_le_log_succ` (28b-1, the `≤` direction),
+    this certifies that the divisibility `(n+1) * C(n, k₀) ∣ lcmRange(n+1)`
+    from 28c is **tight** at `p` along the witness path.
+
+    Proof: split on whether `n+1 = p^e`. In the equality case `k₀ = 0` and
+    `C(n,0) = 1`, reducing the goal to `v_p(p^e) = e`. Otherwise `p^e < n+1`;
+    writing `n+1 = p^a * m` with `p ∤ m` and `f = e - a`, the carries-set of
+    `Nat.factorization_choose` is exactly `Ico (a+1) (e+1)` (lower bound by
+    `sum_mod_pow_lt_of_pow_dvd_succ`, upper bound by Helpers 1 and 2), of
+    cardinality `e - a`; adding back `a` gives `e`. -/
+theorem exists_witness_choose_saturates_log_succ
+    {p : ℕ} (hp : p.Prime) {n : ℕ} (hn : 1 ≤ n) :
+    ∃ k, k ≤ n ∧ (n + 1).factorization p + (Nat.choose n k).factorization p
+                  = Nat.log p (n + 1) := by
+  set e := Nat.log p (n + 1) with he_def
+  set a := (n + 1).factorization p with ha_def
+  refine ⟨(n + 1) - p ^ e, ?_, ?_⟩
+  · have hpe_pos : 1 ≤ p ^ e := Nat.one_le_pow _ _ hp.pos
+    omega
+  · set k := (n + 1) - p ^ e with hk_def
+    have hkn : k ≤ n := by
+      have hpe_pos : 1 ≤ p ^ e := Nat.one_le_pow _ _ hp.pos
+      omega
+    by_cases hCaseA : n + 1 = p ^ e
+    · -- Case A: n + 1 = p^e, so k = 0.
+      have hk_zero : k = 0 := by omega
+      rw [hk_zero, Nat.choose_zero_right, Nat.factorization_one]
+      simp only [Finsupp.coe_zero, Pi.zero_apply, Nat.add_zero]
+      rw [ha_def, hCaseA, Nat.Prime.factorization_pow hp, Finsupp.single_eq_same]
+    · -- Case B: p^e < n + 1.
+      have ha_le_e : a ≤ e := by
+        have h_dvd : p ^ a ∣ (n + 1) := Nat.ordProj_dvd (n + 1) p
+        have h_pa_le : p ^ a ≤ n + 1 := Nat.le_of_dvd (Nat.succ_pos n) h_dvd
+        exact Nat.le_log_of_pow_le hp.one_lt h_pa_le
+      set m := (n + 1) / p ^ a with hm_def
+      set f := e - a with hf_def
+      have hpa_dvd : p ^ a ∣ (n + 1) := Nat.ordProj_dvd (n + 1) p
+      have hn1_eq : n + 1 = p ^ a * m := (Nat.mul_div_cancel' hpa_dvd).symm
+      have hmp : ¬ p ∣ m := by
+        rw [hm_def]
+        exact Nat.not_dvd_ordCompl hp (Nat.succ_ne_zero n)
+      have hpe_le : p ^ e ≤ n + 1 := Nat.pow_log_le_self p (Nat.succ_ne_zero n)
+      have hCaseB : p ^ e < n + 1 := by omega
+      have h_pe_eq : p ^ e = p ^ a * p ^ f := by
+        rw [hf_def, ← pow_add]; congr 1; omega
+      have hpf_lt : p ^ f < m := by
+        by_contra hcon
+        push_neg at hcon
+        have hmul : p ^ a * m ≤ p ^ a * p ^ f := Nat.mul_le_mul (le_refl _) hcon
+        rw [← h_pe_eq, ← hn1_eq] at hmul
+        omega
+      have h_n_sub_k : n - k = p ^ e - 1 := by
+        have hpe_pos : 1 ≤ p ^ e := Nat.one_le_pow _ _ hp.pos
+        omega
+      have h_k_eq : k = p ^ a * (m - p ^ f) := by
+        have hle : p ^ f ≤ m := hpf_lt.le
+        have hm_split : m = (m - p ^ f) + p ^ f := (Nat.sub_add_cancel hle).symm
+        rw [hk_def, hn1_eq, h_pe_eq]
+        conv_lhs => rw [hm_split, mul_add]
+        rw [Nat.add_sub_cancel]
+      have hlog : Nat.log p n ≤ e := Nat.log_mono_right (Nat.le_succ n)
+      have hb : Nat.log p n < e + 1 := Nat.lt_succ_of_le hlog
+      have hfilter_eq :
+          ((Finset.Ico 1 (e + 1)).filter
+              (fun i => p ^ i ≤ k % p ^ i + (n - k) % p ^ i))
+            = Finset.Ico (a + 1) (e + 1) := by
+        apply Finset.ext
+        intro i
+        simp only [Finset.mem_filter, Finset.mem_Ico]
+        constructor
+        · rintro ⟨⟨hi1, hi_lt⟩, _hi_carry⟩
+          refine ⟨?_, hi_lt⟩
+          by_contra h_not
+          push_neg at h_not
+          have hi_le_a : i ≤ a := by omega
+          have hsum := sum_mod_pow_lt_of_pow_dvd_succ hp hkn hi1 hi_le_a
+          omega
+        · rintro ⟨hia1, hi_lt⟩
+          have hi1 : 1 ≤ i := by omega
+          refine ⟨⟨hi1, hi_lt⟩, ?_⟩
+          have hi_le_e : i ≤ e := by omega
+          have hpi_pos : 0 < p ^ i := Nat.pow_pos hp.pos
+          have h_nsubk_mod : (n - k) % p ^ i = p ^ i - 1 := by
+            rw [h_n_sub_k]; exact pow_sub_one_mod_pow hp.one_lt hi_le_e
+          have hj_pos : 0 < i - a := by omega
+          have hf_pos : 0 < f := by omega
+          have hia_eq : i = a + (i - a) := by omega
+          have h_kmod : 1 ≤ k % p ^ i := by
+            rw [h_k_eq]
+            exact witness_mod_pow_lt hp hia_eq hj_pos hf_pos hpf_lt hmp
+          rw [h_nsubk_mod]
+          omega
+      rw [Nat.factorization_choose hp hkn hb, hfilter_eq, Nat.card_Ico]
+      omega
+
 /-- **Theorem 28c** (divisibility bridge). Combining 28b-1
     (`factorization_succ_mul_choose_le_log_succ`) with the file-local
     Iter 5 lemma `prime_pow_dvd_lcmRange`, we obtain the load-bearing

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/sessions/2026-05-28-iter38-act-28b2-witness-saturation.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/sessions/2026-05-28-iter38-act-28b2-witness-saturation.md
@@ -1,0 +1,95 @@
+# Iteration 38 ACT — 28b-2 witness saturation SHIPPED (build verified)
+
+**Date**: 2026-05-28
+**Researcher**: researcher-1
+**Phase**: ACT (ships Iter 36 PREP §2–§5 paste-ready code as Lean, discharging both residual `sorry`s)
+**Branch**: `research/basel-iter38-act-28b2-*` (off `main`)
+**Lake-pinned Mathlib SHA**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (unchanged from Iter 36 PREP audit)
+
+## TL;DR
+
+Shipped the long-pending **28b-2 witness saturation** lemma, the missing `=` (tight)
+companion to Iter 34a's `factorization_succ_mul_choose_le_log_succ` (28b-1, the `≤`
+direction). Three new declarations, **0 sorries, 0 new axioms**, build verified
+3066/3066 jobs. The two residual `sorry`s that Iter 36 PREP §5 left open
+(the `k = p^a·(m − p^f)` arithmetic and the filter-equality/carry-count discharge)
+are both fully closed.
+
+| Declaration | Kind | LOC | Role |
+|---|---|---:|---|
+| `pow_sub_one_mod_pow` | private lemma | ~30 | Helper 1: `(p^e − 1) % p^i = p^i − 1` for `i ≤ e` |
+| `witness_mod_pow_lt` | private lemma | ~30 | Helper 2: `1 ≤ (p^a·(m − p^f)) % p^i` for the witness residue |
+| `exists_witness_choose_saturates_log_succ` | theorem | ~75 | Main: `∃ k ≤ n, v_p(n+1) + v_p(C(n,k)) = log_p(n+1)` |
+
+File: 1642 → **1802 LOC** (+160). Sorries: 0 → 0. Axioms: 1 → 1 (`hanson_bound`
+unchanged). theorem/lemma count: 74 → **77**.
+
+## What shipped
+
+### Helper 1 — `pow_sub_one_mod_pow {p e i} (hp : 1 < p) (hie : i ≤ e)`
+`(p ^ e - 1) % p ^ i = p ^ i - 1`. Proof: `i = 0` closes by `simp [Nat.mod_one]`;
+for `i ≥ 1`, write `p^e = p^i · c` (`Nat.pow_dvd_pow`), rearrange
+`p^e − 1 = (p^i − 1) + p^i·(c − 1)` (omega over the multiplicative identity
+`p^i·c = p^i·(c−1) + p^i`), then `Nat.add_mul_mod_self_left` + `Nat.mod_eq_of_lt`.
+
+### Helper 2 — `witness_mod_pow_lt {p a m f i j} (hp_prime) (hia : i = a+j) (hj_pos) (hf_pos) (hpf_lt : p^f < m) (hmp : ¬ p ∣ m)`
+`1 ≤ (p^a · (m − p^f)) % p^i`. Proof: `p^i = p^a·p^j` (`pow_add`),
+`Nat.mul_mod_mul_left` factors out `p^a`; then `p^j ∤ (m − p^f)` (else
+`p ∣ m` via `dvd_pow_self` + `Nat.sub_add_cancel`, contradicting `hmp`), so
+`(m − p^f) % p^j ≥ 1` and `Nat.mul_pos` finishes.
+
+**Note (cleanup vs PREP)**: the PREP's `j ≤ f` hypothesis turned out to be
+**unnecessary** — the `p ∤ m` contradiction holds for any `j ≥ 1`. Dropped it,
+making the helper strictly more general. (Caught as an unused-variable warning
+on the first verified build; removed and re-verified.)
+
+### Main — `exists_witness_choose_saturates_log_succ {p} (hp : p.Prime) {n} (hn : 1 ≤ n)`
+`∃ k, k ≤ n ∧ (n+1).factorization p + (C n k).factorization p = log_p (n+1)`.
+Witness `k₀ = (n+1) − p^e`, `e = log_p(n+1)`. Case split on `n+1 = p^e`:
+
+- **Case A** (`n+1 = p^e`): `k₀ = 0`, `C(n,0) = 1`, reduces to `v_p(p^e) = e` via
+  `Nat.Prime.factorization_pow` + `Finsupp.single_eq_same`.
+- **Case B** (`p^e < n+1`): write `n+1 = p^a·m` with `p ∤ m`
+  (`Nat.not_dvd_ordCompl`) and `f = e − a`. The carries-set of
+  `Nat.factorization_choose` is proved to equal **exactly** `Ico (a+1) (e+1)`:
+  the lower bound (`i > a`) reuses Iter 34a's `sum_mod_pow_lt_of_pow_dvd_succ`;
+  the upper bound (`i ≤ e ⇒ carry`) combines Helper 1 (the `(n−k₀) % p^i` term)
+  and Helper 2 (the `k₀ % p^i ≥ 1` term). Card `= e − a` via `Nat.card_Ico`;
+  `a + (e − a) = e`.
+
+## Significance
+
+This is the **tightness certificate** for the 28c divisibility bridge
+(`choose_mul_succ_dvd_lcmRange`, Iter 35b): together, 28b-1 (`≤`) and 28b-2 (`=`)
+show that along the witness path `k₀`, `(n+1)·C(n,k₀)` exhausts the full
+`p`-adic valuation budget `log_p(n+1)` of `lcmRange(n+1)` at each prime.
+
+What remains in the Route B chain toward discharging `axiom hanson_bound`:
+1. **28a Beta-integral identity** (Iter 29 PREP #18485 only; Mathlib lacks it in
+   rational-denominator form; ~60–100 LOC) — independent of this work.
+2. Integer-squeeze assembly once 28a lands + `n₀ ≤ 100` (numerical floor
+   `hanson_n1..hanson_n100` provides slack).
+
+## Build verification
+
+```
+./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03
+⚠ [3066/3066] Built Proofs.BaselProblemOQ01OQ01OQ02OQ03
+Build completed successfully (3066 jobs).
+```
+
+Warnings: 3 pre-existing (line 97 unused `hn`, line 270 `Finsupp.not_mem_support_iff`
+deprecation, line 650 unused `hp`) — all inherited, none introduced by this ACT.
+
+## Honesty / self-audit
+
+- **No new axioms, no sorries.** `axiom hanson_bound` is untouched; this ACT does
+  not close the parent open conjecture, only ships one of its remaining sub-lemmas.
+- Helper 1 / Helper 2 / Case A / Case B all machine-checked at the pinned SHA.
+- ACT-time fallbacks vs Iter 36 PREP: `Nat.pow_pos` takes its exponent implicitly
+  at v4.26.0 (4 call sites fixed); Helper 1's `i=0` branch needed explicit
+  `Nat.mod_one`; the PREP's `Nat.mul_le_mul_left` / `Nat.dvd_iff_mod_eq_zero`
+  risk points were sidestepped with `Nat.mul_pos` / `Nat.dvd_of_mod_eq_zero`;
+  `hmp` used `Nat.not_dvd_ordCompl` (PREP Option B) rather than the
+  `Nat.factorization_le_of_dvd` chain. Total ACT-time edits: 1 rebuild for the
+  `Nat.pow_pos`/`Nat.mod_one` fixes, 1 rebuild for the unused-hypothesis cleanup.

--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03/state.md
@@ -1,13 +1,25 @@
 # Research State: basel-problem-oq-01-oq-01-oq-02-oq-03
 
 ## Current State
-**Phase**: PREP (Iter 37 INFRA-SIGNAL — Docker gate RED→GREEN; Iter 35a/36+ ACT now infrastructure-unblocked)
+**Phase**: ACT (Iter 38 — 28b-2 witness saturation SHIPPED, build verified; remaining Route B work: 28a Beta-integral)
 **Path**: full
 **Since**: 2026-05-15 (Iter 34a ACT merge; prior since-2026-05-07 superseded)
-**Last Updated**: 2026-05-25 (Iter 37 INFRA-SIGNAL — Docker recovered, ACT-readiness 7/8 GREEN + 1/8 AMBER, researcher-1)
-**Iteration**: 38
+**Last Updated**: 2026-05-28 (Iter 38 ACT — 28b-2 shipped, 3 decls, 1642→1802 LOC, 0 sorries, build verified 3066/3066, researcher-1)
+**Iteration**: 39
 
-## Iter 37 INFRA-SIGNAL (this iteration — 2026-05-25, researcher-1) — Docker gate RED→GREEN (doc-only)
+## Iter 38 ACT (this iteration — 2026-05-28, researcher-1) — 28b-2 witness saturation SHIPPED
+
+Ships Iter 36 PREP §2–§5 paste-ready code as Lean, discharging **both** residual `sorry`s. Three new declarations in `BaselProblemOQ01OQ01OQ02OQ03.lean`:
+
+- `pow_sub_one_mod_pow` (Helper 1, private): `(p^e − 1) % p^i = p^i − 1` for `i ≤ e`, `1 < p`.
+- `witness_mod_pow_lt` (Helper 2, private): `1 ≤ (p^a·(m − p^f)) % p^i` for the saturation-witness residue. The PREP's `j ≤ f` hypothesis was found **unnecessary** (the `p ∤ m` contradiction holds for any `j ≥ 1`) and dropped, making the helper strictly more general.
+- `exists_witness_choose_saturates_log_succ` (Theorem 28b-2): `∃ k ≤ n, v_p(n+1) + v_p(C(n,k)) = log_p(n+1)`. Witness `k₀ = (n+1) − p^e`. Case A (`n+1 = p^e`, so `k₀ = 0`) trivial via `Nat.Prime.factorization_pow`; Case B proves the `Nat.factorization_choose` carries-set equals **exactly** `Ico (a+1) (e+1)` (lower bound via Iter 34a `sum_mod_pow_lt_of_pow_dvd_succ`, upper bound via Helpers 1+2), card `e − a`, giving `a + (e − a) = e`.
+
+**File state**: 1642 → 1802 LOC (+160). Sorries: 0 → 0. Axioms: 1 → 1 (`hanson_bound` unchanged). theorem/lemma count 74 → 77. **Build verified**: 3066/3066 jobs (3 pre-existing warnings inherited, none introduced). Session log: `sessions/2026-05-28-iter38-act-28b2-witness-saturation.md`.
+
+**Net effect**: 28b-2 is the tightness (`=`) certificate complementing 28b-1's `≤` bound (`factorization_succ_mul_choose_le_log_succ`, Iter 34a); together with 28c (`choose_mul_succ_dvd_lcmRange`, Iter 35b) they show `(n+1)·C(n,k₀) ∣ lcmRange(n+1)` saturates the `p`-adic valuation budget `log_p(n+1)` at the witness `k₀`. Remaining Route B work toward `axiom hanson_bound`: **28a Beta-integral identity** (Iter 29 PREP #18485 only, Mathlib lacks rational-denominator form, ~60–100 LOC, independent) + integer-squeeze assembly once 28a lands and `n₀ ≤ 100` (numerical floor `hanson_n1..hanson_n100` provides slack).
+
+## Iter 37 INFRA-SIGNAL (2026-05-25, researcher-1) — Docker gate RED→GREEN (doc-only)
 
 Iter 36 PREP gated ACT on a single RED infrastructure signal: `docker ps` timeout at 10s under host disk pressure (7.1Gi free of 926Gi, 100% capacity). At 2026-05-25T08:08Z verification:
 

--- a/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-03.json
@@ -29,14 +29,13 @@
     "goal": "Replace `axiom hanson_bound` and `axiom lcm_hanson_bound` (parent file) with a fully proved Lean theorem."
   },
   "currentState": {
-    "phase": "PREP (Iter 37 INFRA-SIGNAL — Docker gate RED→GREEN; Iter 35a ACT-ready paste from Iter 36 PREP §2-§5, parallel-ready with Iter 36+ ACT 28a Beta-integral)",
+    "phase": "ACT (Iter 38 — 28b-2 witness saturation SHIPPED build-verified; remaining Route B: 28a Beta-integral identity)",
     "since": "2026-05-16T05:00:00Z",
-    "iteration": 38,
-    "focus": "Iter 37 INFRA-SIGNAL (researcher-1, 2026-05-25, doc-only): flips the single RED ACT-readiness gate from Iter 36 PREP (Docker availability) to GREEN. Verification at 2026-05-25T08:08Z: `docker ps` returns instantly (vs 10s timeout at Iter 36); `docker info` returns 29.4.1 | 8GB | aarch64 instantly; host root disk 97Gi free (vs 7.1Gi at Iter 36, 90Gi released); filesystem unchanged (/dev/disk3s1s1 926Gi). ACT-readiness gate update: 6/8 GREEN, 1/8 AMBER, 1/8 RED → **7/8 GREEN, 1/8 AMBER, 0/8 RED**. Remaining AMBER (Case B 2 nested sorries) is documented acceptable per Iter 34b PREP #19258 Option A audit — discharge during ACT, not a blocker. Net effect: Iter 35a ACT (28b-2 witness saturation, 127 LOC paste-ready from Iter 36 PREP §2-§5) AND Iter 36+ ACT (28a Beta-integral identity, 60-100 LOC from Iter 29 PREP #18485) are both parallel-ready and infrastructure-unblocked. Insertion point for 28b-2: immediately before 28c docstring (now ~line 1589 post-Iter-35b shipping). Session log: `sessions/2026-05-25-iter37-infra-signal-docker-recovered.md`. Memory trap: `_infra_signal_doc_only_when_red_gate_lifts` (inverse of `_act_pivot_to_prep_when_host_docker_corrupt`). 0 Lean edits, 0 meta.json edits, 0 new theorems/axioms/sorries — strictly doc-only, conflict-free with any in-flight paste.",
+    "iteration": 39,
+    "focus": "Iter 38 ACT (researcher-1, 2026-05-28): shipped Iter 36 PREP §2-§5 paste-ready code as Lean, discharging BOTH residual sorries. Three new declarations: pow_sub_one_mod_pow (Helper 1, private; (p^e-1)%p^i = p^i-1 for i≤e), witness_mod_pow_lt (Helper 2, private; 1 ≤ (p^a·(m-p^f))%p^i — PREP's j≤f hypothesis found unnecessary and dropped), and exists_witness_choose_saturates_log_succ (Theorem 28b-2; ∃ k≤n, v_p(n+1)+v_p(C(n,k)) = log_p(n+1)). Witness k₀=(n+1)-p^e; Case A (n+1=p^e) trivial, Case B proves the factorization_choose carries-set equals exactly Ico(a+1)(e+1) via Iter 34a sum_mod_pow_lt_of_pow_dvd_succ (lower) + Helpers 1+2 (upper). File 1642→1802 LOC (+160), 0 sorries, 1 axiom unchanged (hanson_bound), theorem/lemma 74→77. Build verified 3066/3066 jobs (3 pre-existing warnings inherited, none introduced). ACT-time fallbacks vs PREP: Nat.pow_pos exponent implicit at v4.26.0 (4 sites); Helper 1 i=0 needs explicit Nat.mod_one; hmp via Nat.not_dvd_ordCompl (PREP Option B); Nat.mul_pos/Nat.dvd_of_mod_eq_zero sidestepped PREP risk points. Session log: sessions/2026-05-28-iter38-act-28b2-witness-saturation.md.",
     "blockers": [
-      "28a Beta-integral identity: Iter 29 PREP #18485 only — no Lean shipping yet; Mathlib lacks Beta-integral identity in rational-denominator form. Largest remaining standalone Lean LOC commitment in Route B chain (60-100 LOC per Iter 31 §4).",
-      "28b-2 witness saturation ACT pending: Iter 32 PREP §4 skeleton + Iter 34b PREP #19258 Option A audit corrections; ~50-57 LOC Lean (0 sorries reachable). Independent of 28c (now shipped).",
-      "Integer-squeeze closure of hanson_bound: needs 28a + 28b-2 landed (28c shipped Iter 35b) AND integer-squeeze threshold n_0 <= 100 (numerical floor hanson_n1..hanson_n100 provides slack budget).",
+      "28a Beta-integral identity: Iter 29 PREP #18485 only — no Lean shipping yet; Mathlib lacks Beta-integral identity in rational-denominator form. Largest remaining standalone Lean LOC commitment in Route B chain (60-100 LOC per Iter 31 §4). Now the SOLE remaining Lean-shipping blocker after 28b-2 shipped (Iter 38).",
+      "Integer-squeeze closure of hanson_bound: needs 28a landed (28b-1 shipped Iter 34a, 28b-2 shipped Iter 38, 28c shipped Iter 35b) AND integer-squeeze threshold n_0 <= 100 (numerical floor hanson_n1..hanson_n100 provides slack budget).",
       "Iter 25 envelope (4^n * (n/2)^sqrt(n)) is strictly weaker than Hanson 3^n target; closing requires Route B Beta-integral approach or primorial-vs-correction cancellation (PNT-equivalent)."
     ],
     "attemptCounts": {
@@ -44,10 +43,10 @@
       "currentApproach": 12,
       "approachesTried": 2
     },
-    "nextAction": "Iter 38 ACT (next researcher): pick up Iter 35a ACT (28b-2 witness saturation) from Iter 36 PREP §2-§5 paste-ready code (127 LOC). Insertion point: immediately before 28c docstring (~line 1589, re-pin post-Iter-35b). Estimated 3-5 Docker iters for Case B residual filter-equality 2-nested-sorry discharge. Parallel-ready with Iter 36+ ACT (28a Beta-integral identity, 60-100 LOC from Iter 29 PREP #18485, self-contained atop build-verified file)."
+    "nextAction": "Iter 39+ (next researcher): 28b-2 is now shipped (Iter 38), so the sole remaining Lean-shipping ACT in Route B is 28a Beta-integral identity (Iter 29 PREP #18485 only; Mathlib lacks rational-denominator form; ~60-100 LOC; self-contained atop the build-verified file). After 28a lands, the integer-squeeze assembly closes hanson_bound once n_0 ≤ 100 is established (numerical floor hanson_n1..hanson_n100 provides slack). Consider a PREP iteration first to pin the Beta-integral Mathlib bearers at the current SHA before attempting the 28a ACT."
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (iter 36, 28b-1 + 28c shipped build-verified). Iter 34a (#19208 merged 2026-05-15T18:06Z): shipped 28b-1 bridge bound + Lemma A (122 LOC, build verified). Iter 35b (THIS ITER, researcher-11): shipped Theorem 28c choose_mul_succ_dvd_lcmRange (26 LOC, build verified). Lean file 1469 → 1642 LOC (+173 across 28b-1 + Lemma A + 28c). 1 axiom hanson_bound, 0 sorries throughout. Remaining ACTs in Route B chain: 28b-2 witness saturation (Iter 35a, ~50-57 LOC, audit-corrected #19258 Option A) + 28a Beta-integral identity (Iter 36+, 60-100 LOC, Iter 29 PREP #18485 only). Both independent and parallel-ready. Integer-squeeze closure of hanson_bound follows once both ship + n₀ ≤ 100 (existing numerical floor hanson_n1..hanson_n100 provides slack budget).",
+    "progressSummary": "PROGRESS (iter 38, 28b-1 + 28b-2 + 28c all shipped build-verified). Iter 34a (#19208): 28b-1 bridge bound + Lemma A. Iter 35b (#19372): Theorem 28c choose_mul_succ_dvd_lcmRange. Iter 38 (THIS ITER, researcher-1): shipped 28b-2 witness saturation — exists_witness_choose_saturates_log_succ + Helpers pow_sub_one_mod_pow, witness_mod_pow_lt (+160 LOC), build verified 3066/3066. Lean file 1469 → 1802 LOC. 1 axiom hanson_bound, 0 sorries throughout. The Route B divisibility/saturation numerator side is now COMPLETE: 28b-1 (≤) + 28b-2 (=) + 28c together certify (n+1)·C(n,k₀) ∣ lcmRange(n+1) is tight at the witness k₀. SOLE remaining Lean-shipping ACT: 28a Beta-integral identity (60-100 LOC, Iter 29 PREP #18485 only, Mathlib lacks rational-denominator form). Integer-squeeze closure of hanson_bound follows once 28a ships + n₀ ≤ 100 (existing numerical floor hanson_n1..hanson_n100 provides slack budget).",
     "builtItems": [
       "lcmRange (def): lcm(1,...,n) at BaselProblemOQ01OQ01OQ02OQ03.lean:80",
       "lcmRange_zero/one/pos: basic facts at BaselProblemOQ01OQ01OQ02OQ03.lean:87-98",
@@ -75,7 +74,10 @@
       "prod_prime_pow_pred_small_le_pow_sqrt (theorem, Iter 23): BaselProblemOQ01OQ01OQ02OQ03.lean:1103 — chained envelope, ∏_{p² ≤ n} p^(Nat.log p n - 1) ≤ (n/2)^√n under 2 ≤ n. LHS half of the Hanson bridge, orthogonal to PR #17619.",
       "Iter 24 (researcher-1, this PR): prod_prime_pow_pred_eq_small in BaselProblemOQ01OQ01OQ02OQ03.lean — support-reduction equality between the full prime filter and the small-prime filter (p² ≤ n) on the correction-factor product. Direct in-file analogue of #17619's lcmRange_correction_supported_on_small_primes.",
       "Iter 24 (researcher-1, this PR): prod_prime_pow_pred_le_pow_sqrt in BaselProblemOQ01OQ01OQ02OQ03.lean — FULL correction-factor envelope ∏_{p prime, p ≤ n+1} p^(Nat.log p n - 1) ≤ (n/2)^√n under 2 ≤ n. Combines Iter 24 support-reduction with Iter 23's small-prime envelope.",
-      "Iter 35b (this PR, researcher-11): choose_mul_succ_dvd_lcmRange in BaselProblemOQ01OQ01OQ02OQ03.lean:1586 — Theorem 28c divisibility bridge `(n + 1) * Nat.choose n k ∣ lcmRange (n + 1)` for k ≤ n. Tactic body chains Iter 34a 28b-1 (file line 1545) + Iter 5 prime_pow_dvd_lcmRange (file line 134) via Nat.factorization_prime_le_iff_dvd. ~12 LOC body, no sorry, no axiom. Build verified 3066/3066 jobs. Implements Iter 35 PREP #19293 §4.1 drop-in body verbatim."
+      "Iter 35b (this PR, researcher-11): choose_mul_succ_dvd_lcmRange in BaselProblemOQ01OQ01OQ02OQ03.lean:1586 — Theorem 28c divisibility bridge `(n + 1) * Nat.choose n k ∣ lcmRange (n + 1)` for k ≤ n. Tactic body chains Iter 34a 28b-1 (file line 1545) + Iter 5 prime_pow_dvd_lcmRange (file line 134) via Nat.factorization_prime_le_iff_dvd. ~12 LOC body, no sorry, no axiom. Build verified 3066/3066 jobs. Implements Iter 35 PREP #19293 §4.1 drop-in body verbatim.",
+      "Iter 38 (this PR, researcher-1): pow_sub_one_mod_pow (Helper 1, private) in BaselProblemOQ01OQ01OQ02OQ03.lean — `(p^e - 1) % p^i = p^i - 1` for `1 < p`, `i ≤ e`. Proof: i=0 by simp [Nat.mod_one]; i≥1 writes p^e = p^i·c, rearranges p^e-1 = (p^i-1) + p^i·(c-1) via omega, then Nat.add_mul_mod_self_left + Nat.mod_eq_of_lt. No sorry, no axiom.",
+      "Iter 38 (this PR, researcher-1): witness_mod_pow_lt (Helper 2, private) in BaselProblemOQ01OQ01OQ02OQ03.lean — `1 ≤ (p^a·(m-p^f)) % p^i` for prime p, i=a+j, 0<j, 0<f, p^f<m, ¬p∣m. Proof: p^i=p^a·p^j (pow_add) + Nat.mul_mod_mul_left factors p^a; p^j∤(m-p^f) (else p∣m, contra hmp), so residue ≥1, Nat.mul_pos closes. PREP's j≤f hypothesis dropped as unnecessary (contradiction holds for any j≥1) — strictly more general. No sorry, no axiom.",
+      "Iter 38 (this PR, researcher-1): exists_witness_choose_saturates_log_succ (Theorem 28b-2) in BaselProblemOQ01OQ01OQ02OQ03.lean — `∃ k ≤ n, (n+1).factorization p + (Nat.choose n k).factorization p = Nat.log p (n+1)`. The tightness (=) companion to 28b-1's ≤ bound. Witness k₀=(n+1)-p^e; Case A (n+1=p^e ⇒ k₀=0) via Nat.Prime.factorization_pow; Case B (p^e<n+1) writes n+1=p^a·m with p∤m (Nat.not_dvd_ordCompl), proves the Nat.factorization_choose carries-set equals EXACTLY Finset.Ico (a+1) (e+1) (lower bound via Iter 34a sum_mod_pow_lt_of_pow_dvd_succ, upper via Helpers 1+2), card e-a, giving a+(e-a)=e. ~75 LOC, no sorry, no axiom. Build verified 3066/3066 jobs."
     ],
     "insights": [
       "Apéry's proof of ζ(3) irrationality requires the exact constant 3 (threshold c ≈ 3.245); the easier 4^n is insufficient.",
@@ -151,15 +153,15 @@
     ]
   },
   "started": "2026-04-26T08:56:57.649Z",
-  "lastUpdate": "2026-05-25T08:10:00.000Z",
+  "lastUpdate": "2026-05-28T00:00:00.000Z",
   "significance": 7,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean",
       "filename": "BaselProblemOQ01OQ01OQ02OQ03.lean",
-      "lineCount": 1642,
-      "theoremCount": 73,
+      "lineCount": 1802,
+      "theoremCount": 77,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Iter 38 ACT for `basel-problem-oq-01-oq-01-oq-02-oq-03` (**Hanson's bound** `lcm(1..n) ≤ 3^n`, the explicit constant used in Apéry's ζ(3) irrationality proof).

Ships the long-pending **28b-2 witness saturation** lemma — the tight (`=`) companion to Iter 34a's `factorization_succ_mul_choose_le_log_succ` (28b-1, the `≤` bound) — discharging **both** residual `sorry`s left by Iter 36 PREP §5.

Three new declarations in `BaselProblemOQ01OQ01OQ02OQ03.lean` (1642 → 1802 LOC):

| Declaration | Statement |
|---|---|
| `pow_sub_one_mod_pow` (Helper 1, private) | `(p^e - 1) % p^i = p^i - 1` for `i ≤ e`, `1 < p` |
| `witness_mod_pow_lt` (Helper 2, private) | `1 ≤ (p^a·(m - p^f)) % p^i` for the saturation-witness residue |
| `exists_witness_choose_saturates_log_succ` (Theorem 28b-2) | `∃ k ≤ n, v_p(n+1) + v_p(C(n,k)) = log_p(n+1)` |

The witness is `k₀ = (n+1) - p^e` with `e = log_p(n+1)`. Case A (`n+1 = p^e`) is trivial; Case B proves the `Nat.factorization_choose` carries-set equals **exactly** `Finset.Ico (a+1) (e+1)` (lower bound via Iter 34a `sum_mod_pow_lt_of_pow_dvd_succ`, upper bound via Helpers 1 + 2), of cardinality `e - a`.

Together with 28c (`choose_mul_succ_dvd_lcmRange`, Iter 35b), this certifies that `(n+1)·C(n,k₀) ∣ lcmRange(n+1)` saturates the `p`-adic valuation budget `log_p(n+1)` at the witness `k₀`. The **sole remaining** Route B Lean-shipping work toward discharging `axiom hanson_bound` is the 28a Beta-integral identity.

- **0 sorries**, **1 axiom unchanged** (`hanson_bound`), theorem/lemma count 74 → 77.
- Helper 2's PREP `j ≤ f` hypothesis was found unnecessary and dropped (more general).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.BaselProblemOQ01OQ01OQ02OQ03` → **Build completed successfully (3066/3066 jobs)**
- [x] 0 sorries, 1 axiom (`hanson_bound`) unchanged
- [x] No new warnings (only 3 pre-existing inherited warnings remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)