### PR TITLE
audit(erdos-425): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6920,9 +6920,9 @@
     },
     "erdos-425": {
       "agentId": "auditor-2026-05-01-1777671029",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T21:34:59Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T02:24:41Z",
+      "result": "clean",
       "issues": [
         "#14404: phantom axioms primes_are_sidon, log_conversion, sidon_bound in proofStrategy/sections + section line drift 5-23 lines"
       ]


### PR DESCRIPTION
## Summary

Re-audit of erdos-425 (Multiplicative Sidon Sets). All fields in `src/data/proofs/erdos-425/meta.json` match `proofs/Proofs/Erdos425Problem.lean` exactly.

| Field | meta | source |
|------|------|--------|
| lineCount | 264 | 264 |
| sorries | 0 | 0 |
| axiomCount | 2 | 2 (erdos_bounds, alexander_construction) |
| theoremCount | 1 | 1 (erdos_425_summary) |
| definitionCount | 11 | 11 (10 def + 1 noncomputable def) |

No phantom axioms, no True stubs, no Mathlib wrapper concerns. Section line ranges still align with current source. Prior issue #14404 (phantom primes_are_sidon/log_conversion/sidon_bound references) remains resolved — current `proofStrategy` / `sections` correctly mark these as docstring-only commentary.

## Test plan
- [x] Verified counts: `grep -cE '^axiom |^theorem |^def |^noncomputable def '`
- [x] Verified no sorries, no True stubs
- [x] Verified section line ranges fall within source
- [x] Tracker entry updated via `claim-target.sh complete erdos-425 clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)