### PR TITLE
audit(erdos-426): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6929,8 +6929,8 @@
     },
     "erdos-426": {
       "agentId": "auditor-36921",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T21:41:59Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T03:34:49Z",
       "result": "clean"
     },
     "erdos-427": {


### PR DESCRIPTION
## Summary

Audit cycle 4 of erdos-426 (Unique Subgraphs, Bradač-Christoph 2024). Tracker bump only — no integrity issues found.

## Verification

| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| status | axiomatized | axiom decls present | ✓ |
| badge | axiom | axiom decls present | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 4 | 4 | ✓ |
| True stubs | n/a | 0 | ✓ |

**Axioms**: CountUniqueSubgraphs, brouwer_1975, bradac_christoph_2024, original_question_false (all match assumptions field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)