### PR TITLE
Research: derangements-convergence — restore Mathlib v4.26.0 build

### DIFF
--- a/proofs/Proofs/DerangementsConvergence.lean
+++ b/proofs/Proofs/DerangementsConvergence.lean
@@ -59,7 +59,7 @@ theorem numDerangements_eq_factorial_mul_altSum (n : ℕ) :
   | _ n ih =>
   match n with
   | 0 => simp [altFactPartialSum, altFactTerm]
-  | 1 => simp [altFactPartialSum, altFactTerm, Finset.sum_range_succ]; ring
+  | 1 => simp [altFactPartialSum, altFactTerm, Finset.sum_range_succ]
   | n + 2 =>
     rw [numDerangements_add_two]
     push_cast
@@ -67,6 +67,7 @@ theorem numDerangements_eq_factorial_mul_altSum (n : ℕ) :
     rw [altFactPartialSum_succ (n + 1), altFactPartialSum_succ n]
     simp only [altFactTerm, Nat.factorial_succ]
     push_cast
+    field_simp
     ring
 
 theorem derangements_div_factorial (n : ℕ) :
@@ -87,8 +88,7 @@ theorem exp_neg_one_eq_tsum_alt :
   have : rexp (-1) = NormedSpace.exp ℝ (-1 : ℝ) := by
     rw [Real.exp_eq_exp_ℝ]
   rw [this, NormedSpace.exp_eq_tsum (𝕂 := ℝ) (𝔸 := ℝ)]
-  congr 1
-  funext k
+  refine tsum_congr fun k => ?_
   simp only [altFactTerm, smul_eq_mul]
   ring
 
@@ -96,23 +96,11 @@ theorem exp_neg_one_eq_tsum_alt :
 
 lemma tsum_eq_partial_sum_add_tail (n : ℕ) :
     ∑' k, altFactTerm k = altFactPartialSum n + ∑' k, altFactTerm (n + 1 + k) := by
-  have hs := summable_altFactTerm
-  have hshift : HasSum (fun k => altFactTerm (n + 1 + k))
-      (∑' k, altFactTerm k - ∑ k ∈ range (n + 1), altFactTerm k) := by
-    have hfull := hs.hasSum
-    rw [Finset.hasSum_compl_iff (s := range (n + 1)) hs] at hfull
-    rw [← (Function.Injective.hasSum_iff
-      (f := fun (x : ↥(↑(range (n + 1)))ᶜ) => altFactTerm ↑x)
-      (i := fun k => ⟨n + 1 + k, by
-        simp only [Set.mem_compl_iff, Finset.mem_coe, Finset.mem_range, not_lt]; omega⟩)
-      ?_ ?_)] at hfull
-    · exact hfull
-    · intro a b h; simp only [Subtype.mk.injEq] at h; omega
-    · intro ⟨b, hb⟩
-      simp only [Set.mem_compl_iff, Finset.mem_coe, Finset.mem_range, not_lt] at hb
-      exact ⟨b - (n + 1), by simp only [Subtype.mk.injEq]; omega⟩
-  rw [hshift.tsum_eq, altFactPartialSum]
-  ring
+  rw [altFactPartialSum, ← summable_altFactTerm.sum_add_tsum_nat_add (n + 1)]
+  congr 1
+  refine tsum_congr fun k => ?_
+  congr 1
+  omega
 
 /- ## Alternating series estimation -/
 
@@ -122,7 +110,7 @@ lemma alt_partial_sum_nonneg (m : ℕ) (N : ℕ) :
   | _ N ih =>
   match N with
   | 0 => simp
-  | 1 => simp; exact div_nonneg one_pos.le (factorial_cast_pos' m).le
+  | 1 => simp
   | N' + 2 =>
     have hsplit : ∑ k ∈ range (N' + 2), ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) =
         ∑ k ∈ range N', ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) +
@@ -135,34 +123,32 @@ lemma alt_partial_sum_nonneg (m : ℕ) (N : ℕ) :
     · obtain ⟨k, rfl⟩ := hN'
       have hpair : 0 ≤ (-1 : ℝ) ^ (2 * k) / ((m + (2 * k)).factorial : ℝ) +
           (-1 : ℝ) ^ (2 * k + 1) / ((m + (2 * k + 1)).factorial : ℝ) := by
-        simp only [pow_succ, pow_mul, neg_one_sq, one_pow, one_mul, neg_one_mul, neg_div]
-        linarith [div_le_div_of_nonneg_left one_pos (factorial_cast_pos' (m + (2 * k)))
-          (show ((m + (2 * k)).factorial : ℝ) ≤ ((m + (2 * k + 1)).factorial : ℝ) from by
-            push_cast; exact_mod_cast Nat.factorial_le (by omega))]
+        have hle : (1 : ℝ) / ((m + (2 * k + 1)).factorial : ℝ) ≤
+            1 / ((m + (2 * k)).factorial : ℝ) := by
+          gcongr
+          omega
+        rw [show (-1 : ℝ) ^ (2 * k) = 1 from by rw [pow_mul]; simp,
+            show (-1 : ℝ) ^ (2 * k + 1) = -1 from by rw [pow_add, pow_mul]; simp, neg_div]
+        linarith
+      simp only [two_mul] at hpair
       linarith
     · rw [Nat.not_even_iff_odd] at hN'
       obtain ⟨k, rfl⟩ := hN'
       have hprev2 := ih (2 * k) (by omega)
       have hpair : 0 ≤ (-1 : ℝ) ^ (2 * k) / ((m + (2 * k)).factorial : ℝ) +
           (-1 : ℝ) ^ (2 * k + 1) / ((m + (2 * k + 1)).factorial : ℝ) := by
-        simp only [pow_succ, pow_mul, neg_one_sq, one_pow, one_mul, neg_one_mul, neg_div]
-        linarith [div_le_div_of_nonneg_left one_pos (factorial_cast_pos' (m + (2 * k)))
-          (show ((m + (2 * k)).factorial : ℝ) ≤ ((m + (2 * k + 1)).factorial : ℝ) from by
-            push_cast; exact_mod_cast Nat.factorial_le (by omega))]
-      have hlast : 0 ≤ (-1 : ℝ) ^ (2 * k + 2) / ((m + (2 * k + 2)).factorial : ℝ) := by
-        apply div_nonneg
-        · simp [pow_succ, pow_mul]
-        · exact (factorial_cast_pos' _).le
-      have hsplit2 : ∑ i ∈ range (2 * k + 1 + 2),
-          ((-1 : ℝ) ^ i / ((m + i).factorial : ℝ)) =
-          ∑ i ∈ range (2 * k), ((-1 : ℝ) ^ i / ((m + i).factorial : ℝ)) +
-          ((-1 : ℝ) ^ (2 * k) / ((m + (2 * k)).factorial : ℝ) +
-           (-1 : ℝ) ^ (2 * k + 1) / ((m + (2 * k + 1)).factorial : ℝ)) +
-          (-1 : ℝ) ^ (2 * k + 2) / ((m + (2 * k + 2)).factorial : ℝ) := by
-        rw [show 2 * k + 1 + 2 = (2 * k + 2) + 1 from by omega]
-        rw [Finset.sum_range_succ, Finset.sum_range_succ, Finset.sum_range_succ]
-        ring
-      rw [hsplit2]
+        have hle : (1 : ℝ) / ((m + (2 * k + 1)).factorial : ℝ) ≤
+            1 / ((m + (2 * k)).factorial : ℝ) := by
+          gcongr
+          omega
+        rw [show (-1 : ℝ) ^ (2 * k) = 1 from by rw [pow_mul]; simp,
+            show (-1 : ℝ) ^ (2 * k + 1) = -1 from by rw [pow_add, pow_mul]; simp, neg_div]
+        linarith
+      have hlast : 0 ≤ (-1 : ℝ) ^ (2 * k + 1 + 1) / ((m + (2 * k + 1 + 1)).factorial : ℝ) := by
+        rw [show (-1 : ℝ) ^ (2 * k + 1 + 1) = 1 from by
+          rw [show 2 * k + 1 + 1 = 2 * (k + 1) by ring, pow_mul]; simp]
+        positivity
+      rw [Finset.sum_range_succ]
       linarith
 
 lemma alt_partial_sum_le_first (m : ℕ) (N : ℕ) :
@@ -171,8 +157,8 @@ lemma alt_partial_sum_le_first (m : ℕ) (N : ℕ) :
   induction N using Nat.strong_induction_on with
   | _ N ih =>
   match N with
-  | 0 => simp; exact div_nonneg one_pos.le (factorial_cast_pos' m).le
-  | 1 => simp; exact le_refl _
+  | 0 => simp
+  | 1 => simp
   | N' + 2 =>
     have hsplit : ∑ k ∈ range (N' + 2), ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) =
         ∑ k ∈ range N', ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) +
@@ -185,7 +171,7 @@ lemma alt_partial_sum_le_first (m : ℕ) (N : ℕ) :
       have hneg : (-1 : ℝ) ^ (N' + 1) / ((m + (N' + 1)).factorial : ℝ) ≤ 0 := by
         obtain ⟨k, rfl⟩ := hN'
         apply div_nonpos_of_nonpos_of_nonneg
-        · simp [pow_succ, pow_mul]; ring_nf; norm_num
+        · simp [pow_succ, pow_mul]
         · exact (factorial_cast_pos' _).le
       have hrewrite : ∑ k ∈ range N', ((-1 : ℝ) ^ k / ((m + k).factorial : ℝ)) +
           ((-1 : ℝ) ^ N' / ((m + N').factorial : ℝ) +
@@ -199,11 +185,15 @@ lemma alt_partial_sum_le_first (m : ℕ) (N : ℕ) :
       obtain ⟨k, rfl⟩ := hN'
       have hprev := ih (2 * k + 1) (by omega)
       have hpair : (-1 : ℝ) ^ (2 * k + 1) / ((m + (2 * k + 1)).factorial : ℝ) +
-          (-1 : ℝ) ^ (2 * k + 2) / ((m + (2 * k + 2)).factorial : ℝ) ≤ 0 := by
-        simp only [pow_succ, pow_mul, neg_one_sq, one_pow, one_mul, neg_one_mul, neg_div]
-        linarith [div_le_div_of_nonneg_left one_pos (factorial_cast_pos' (m + (2 * k + 1)))
-          (show ((m + (2 * k + 1)).factorial : ℝ) ≤ ((m + (2 * k + 2)).factorial : ℝ) from by
-            push_cast; exact_mod_cast Nat.factorial_le (by omega))]
+          (-1 : ℝ) ^ (2 * k + 1 + 1) / ((m + (2 * k + 1 + 1)).factorial : ℝ) ≤ 0 := by
+        have hle : (1 : ℝ) / ((m + (2 * k + 1 + 1)).factorial : ℝ) ≤
+            1 / ((m + (2 * k + 1)).factorial : ℝ) := by
+          gcongr
+          omega
+        rw [show (-1 : ℝ) ^ (2 * k + 1) = -1 from by rw [pow_add, pow_mul]; simp,
+            show (-1 : ℝ) ^ (2 * k + 1 + 1) = 1 from by
+              rw [show 2 * k + 1 + 1 = 2 * (k + 1) by ring, pow_mul]; simp, neg_div]
+        linarith
       linarith
 
 theorem alternating_tail_bound (n : ℕ) :
@@ -219,11 +209,11 @@ theorem alternating_tail_bound (n : ℕ) :
   have hc_summable : Summable c := by
     have hbnd_summable : Summable (fun k => (1 : ℝ) / ((m + k).factorial : ℝ)) := by
       have h1 : Summable (fun (k : ℕ) => (1 : ℝ) / (k.factorial : ℝ)) := by
-        have := summable_pow_div_factorial (1 : ℝ)
-        simp [one_pow, one_div] at this; exact this
+        simpa only [one_pow] using summable_pow_div_factorial (1 : ℝ)
       exact h1.comp_injective (fun ⦃a b⦄ (h : m + a = m + b) => by omega)
     exact Summable.of_norm_bounded_eventually hbnd_summable (by
       filter_upwards with k
+      apply le_of_eq
       simp only [c, norm_eq_abs, abs_div, abs_pow, abs_neg, abs_one, one_pow, Nat.abs_cast])
 
   have hlower : 0 ≤ ∑' k, c k := by

--- a/proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean
+++ b/proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean
@@ -42,7 +42,7 @@ theorem derangements_rate_scaled (n : ℕ) :
   -- D(n) - n!/e = n! * (D(n)/n! - 1/e)
   have hrw : (numDerangements n : ℝ) - (n.factorial : ℝ) / rexp 1 =
              (n.factorial : ℝ) * ((numDerangements n : ℝ) / n.factorial - 1 / rexp 1) := by
-    field_simp; ring
+    field_simp
   rw [hrw, abs_mul, abs_of_pos hn_pos]
   -- n! * |D(n)/n! - 1/e| ≤ n! / (n+1)! = 1/(n+1)
   calc (n.factorial : ℝ) * |(numDerangements n : ℝ) / n.factorial - 1 / rexp 1|
@@ -74,12 +74,12 @@ theorem derangements_nearest_integer_n1 :
     |(numDerangements 1 : ℝ) - ((1 : ℕ).factorial : ℝ) / rexp 1| < 1 / 2 := by
   have hD1 : (numDerangements 1 : ℝ) = 0 := by
     norm_cast
-    decide
   have hf1 : ((1 : ℕ).factorial : ℝ) = 1 := by norm_num
   rw [hD1, hf1, zero_sub, abs_neg, abs_of_pos (by positivity)]
   -- Goal: 1 / rexp 1 < 1 / 2, i.e., 2 < rexp 1
-  rw [div_lt_div_iff (Real.exp_pos 1) two_pos]
-  linarith [Real.add_one_lt_exp (show (1 : ℝ) ≠ 0 from one_ne_zero)]
+  have he2 : (2 : ℝ) < rexp 1 := by
+    linarith [Real.add_one_lt_exp (show (1 : ℝ) ≠ 0 from one_ne_zero)]
+  exact one_div_lt_one_div_of_lt (by norm_num) he2
 
 /-- **All n ≥ 1**: D(n) is the nearest integer to n!/e. -/
 theorem derangements_nearest_all (n : ℕ) (hn : 1 ≤ n) :
@@ -107,7 +107,7 @@ theorem derangements_unique_nearest (n : ℕ) (hn : 1 ≤ n) (m : ℕ)
     rw [hrw]
     calc |(m : ℝ) - n.factorial / rexp 1 + (n.factorial / rexp 1 - numDerangements n)|
         ≤ |(m : ℝ) - n.factorial / rexp 1| + |n.factorial / rexp 1 - numDerangements n| :=
-          abs_add _ _
+          abs_add_le _ _
       _ < 1 / 2 + 1 / 2 := by
           have : |n.factorial / rexp 1 - (numDerangements n : ℝ)| < 1 / 2 := by
             rw [abs_sub_comm]; exact hd
@@ -180,10 +180,9 @@ theorem derangements_error_sign (n : ℕ) :
   set f : ℕ → ℝ := fun k => (-1 : ℝ) ^ k / ((n + 1 + k).factorial : ℝ) with hf_def
   -- Step A: f is summable. Bound |f k| ≤ 1/k! and 1/k! is summable.
   have hf_summable : Summable f := by
-    apply Summable.of_norm_bounded (fun k : ℕ => (1 : ℝ) / (k.factorial : ℝ))
+    apply Summable.of_norm_bounded (g := fun k : ℕ => (1 : ℝ) / (k.factorial : ℝ))
     · -- ∑ 1/k! is summable (special case of summable_pow_div_factorial 1).
-      have := summable_pow_div_factorial (1 : ℝ)
-      simpa [one_pow] using this
+      simpa only [one_pow] using summable_pow_div_factorial (1 : ℝ)
     · -- |f k| = 1/(n+1+k)! ≤ 1/k!.
       intro k
       simp only [hf_def, norm_eq_abs, abs_div, abs_pow, abs_neg, abs_one, one_pow]
@@ -220,7 +219,7 @@ theorem derangements_error_sign (n : ℕ) :
     have h_exp_full :
         rexp (-1) = altFactPartialSum n + (-1 : ℝ) ^ (n + 1) * ∑' k, f k := by
       rw [hexp, htail, h_tail_factored]
-    have h_exp_neg : rexp (-1) = 1 / rexp 1 := by rw [Real.exp_neg]
+    have h_exp_neg : rexp (-1) = 1 / rexp 1 := by rw [Real.exp_neg, one_div]
     -- D(n)/n! - rexp(-1) = -((-1)^(n+1) · ∑' f).
     have hkey : (numDerangements n : ℝ) / (n.factorial : ℝ) - rexp (-1) =
                 -((-1 : ℝ) ^ (n + 1) * ∑' k, f k) := by

--- a/research/problems/derangements-convergence-oq-01-oq-01/knowledge.md
+++ b/research/problems/derangements-convergence-oq-01-oq-01/knowledge.md
@@ -212,3 +212,59 @@ n!/e in the parity-determined direction).
 - **Axiom count**: 0 (unchanged)
 - **Sorry count**: 0 (unchanged)
 - **Phase**: COMPLETED + parity-sign theorem added
+
+## Session 2026-05-29 (Session 4) — Build repair for Mathlib v4.26.0 (researcher-1)
+
+**Mode**: REVISIT (build verification)
+**Outcome**: completed — the entire derangements-convergence family now compiles
+against the pinned Mathlib (v4.26.0). Both this file and its parent
+`DerangementsConvergence.lean` were marked `verified` but did **not** build:
+the S3 parity-sign addition was explicitly never build-verified, and a Mathlib
+bump (to v4.26.0) had broken the parent after it was last checked.
+
+### What I Did
+
+Docker-verified `Proofs.DerangementsConvergenceOQ01OQ01` (which imports the
+parent) and repaired all API-drift errors in both files. Build now clean
+(0 errors, 0 sorries, 0 axioms in both files).
+
+**Parent `DerangementsConvergence.lean` (15 error sites):**
+- `tsum_eq_partial_sum_add_tail`: replaced a manual `Finset.hasSum_compl_iff`
+  derivation (lemma gone) with `Summable.sum_add_tsum_nat_add`.
+- `exp_neg_one_eq_tsum_alt`: `congr 1; funext` → `tsum_congr`.
+- Internal alternating-series `hpair` proofs: the old
+  `simp [pow_succ, pow_mul, neg_one_sq, …]` no longer reduces `(-1)^(2k)`
+  (in v4.26.0 `pow_succ` decomposes `(-1)^2` before `neg_one_sq` can fire,
+  leaving `((-1)^0*-1*-1)^k`). Replaced with explicit
+  `rw [show (-1)^(2k) = 1 …, show (-1)^(2k+1) = -1 …, neg_div]` — the `neg_div`
+  is essential because `linarith` treats `-1/x` and `1/x` as *unrelated atoms*.
+- Factorial-ratio bounds: `div_le_div_of_nonneg_left … (one_pos)` → `gcongr; omega`
+  (gcongr peels `m+·` and factorial monotonicity down to a raw `2k ≤ 2k+1`).
+- `Even`-branch index mismatch: `Even N'` destructures to `k+k`, not `2*k`;
+  added `simp only [two_mul] at hpair` so the final `linarith` atoms align.
+- Odd-branch `2*k+1+1` vs `2*k+2` syntactic mismatch: aligned indices.
+- `numDerangements_eq_factorial_mul_altSum` n+2 arm: `ring` could not equate
+  inverses of *expanded* factorial polynomials; added `field_simp` before `ring`.
+
+**This file `DerangementsConvergenceOQ01OQ01.lean` (10 error sites):**
+- `div_lt_div_iff` (renamed/removed) → `one_div_lt_one_div_of_lt`.
+- `abs_add` → `abs_add_le`.
+- `Summable.of_norm_bounded`: bounding function `g` is now implicit — pass `(g := …)`.
+- `simpa [one_pow]` → `simpa only [one_pow]` (full simp rewrote `1/n!` to `(n!)⁻¹`).
+- `Real.exp_neg` rewrite left `(rexp 1)⁻¹ = 1/rexp 1`; added `one_div`.
+- Several `simp;tac` / `norm_cast;decide` where the first tactic now closes the goal.
+
+### Key Findings
+- **A `verified` gallery badge is only as good as the last build against the
+  current Mathlib pin.** Two entries in this family claimed `verified` but were
+  broken by a Mathlib bump + an unverified S3 addition. Build verification on
+  the pinned toolchain is the ground truth.
+- Recurring v4.26.0 drift patterns: `simp`/`norm_cast` got stronger (trailing
+  tactics hit "no goals"); `pow_succ` over-eagerly decomposes literal powers in
+  `simp`; `linarith` cannot relate `c/x` atoms with different numerators (use
+  `neg_div`); `gcongr` is far more robust than the renamed `div_le_div_*` lemmas.
+
+### Status
+- **Axiom count**: 0 (both files, unchanged)
+- **Sorry count**: 0 (both files, unchanged)
+- **Phase**: COMPLETED — Docker build-verified on Mathlib v4.26.0 (researcher-1)


### PR DESCRIPTION
## Summary

The `derangements-convergence` gallery family was marked **verified** but no longer compiled against the pinned Mathlib (**v4.26.0**):

- `DerangementsConvergence.lean` (parent, slug `derangements-convergence`) was broken by a Mathlib bump after it was last verified (15 error sites).
- `DerangementsConvergenceOQ01OQ01.lean` (slug `derangements-convergence-oq-01-oq-01`) had its own drift — the S3 parity-sign theorem (`derangements_error_sign`) was explicitly committed **"build NOT verified"** (10 error sites).

This PR repairs all API-drift errors so the whole chain builds cleanly. **No mathematical content changed** — only proofs were updated for the current Mathlib API. Both files remain **0 sorries / 0 axioms**.

## Build verification (Docker, pinned Mathlib v4.26.0)

```
./proofs/scripts/docker-build.sh Proofs.DerangementsConvergence            # Build succeeded
./proofs/scripts/docker-build.sh Proofs.DerangementsConvergenceOQ01OQ01    # Build succeeded
```

## Representative fixes

**Parent (`DerangementsConvergence.lean`)**
- `Finset.hasSum_compl_iff` (gone) → `Summable.sum_add_tsum_nat_add`.
- `congr 1; funext` → `tsum_congr`.
- Fragile `simp [pow_succ, neg_one_sq, …]` no longer reduces `(-1)^(2k)` (v4.26.0 `pow_succ` decomposes `(-1)^2` before `neg_one_sq`) → explicit `pow_mul`/`pow_add` rewrites + `neg_div` (`linarith` treats `-1/x` and `1/x` as distinct atoms).
- `div_le_div_of_nonneg_left … one_pos` → `gcongr; omega`.
- `Even N'` destructures to `k + k` (not `2*k`) → `simp only [two_mul]` to align `linarith` atoms; `2*k+1+1` vs `2*k+2` index alignment.
- `numDerangements` `n+2` arm: `field_simp` before `ring` to clear factorial denominators.

**`DerangementsConvergenceOQ01OQ01.lean`**
- `div_lt_div_iff` (renamed/removed) → `one_div_lt_one_div_of_lt`.
- `abs_add` → `abs_add_le`.
- `Summable.of_norm_bounded`: bounding function now implicit → `(g := …)`.
- `simpa [one_pow]` → `simpa only [one_pow]`; `Real.exp_neg` + `one_div`; dropped redundant trailing tactics where `simp`/`norm_cast` now close the goal.

## Status
**Outcome**: completed (build-verified)
**Next steps**: an enricher pass will refresh the research-JSON `leanFiles` line/theorem counts (parent 282→272; OQ01OQ01 147→254, 7→8 theorems).

🤖 Generated by researcher-1