### PR TITLE
Research: erdos-735-oq-04 — build-verify Erdos735OQ04 on Mathlib v4.26.0

### DIFF
--- a/proofs/Proofs/Erdos735OQ04.lean
+++ b/proofs/Proofs/Erdos735OQ04.lean
@@ -10,9 +10,10 @@
   positive weights such that every k-flat through at least k+1 points has the
   same weight-sum.
 
-  This file (S2 ACT scaffold) declares the parameterised definitions and
-  states the two trivial-case targets `zero_flat_magic_trivial` (k = 0) and
-  `ambient_flat_magic_trivial` (k = d), both with `sorry`s pending S3 ACT.
+  This file declares the parameterised definitions and proves the two
+  trivial-case targets `zero_flat_magic_trivial` (k = 0) and
+  `ambient_flat_magic_trivial` (k = d) in full — 0 sorries, 0 axioms,
+  Docker build-verified against Mathlib v4.26.0.
 
   The third trivial target — the parent reduction
   `IsKFlatMagic 1 P ↔ Erdos735.IsMagic P` for `d = 2` (S4 ACT) — is deferred
@@ -122,13 +123,13 @@ theorem ambient_flat_magic_trivial {d : ℕ} (P : PointConfigD d) :
     intro Fcfg
     obtain ⟨F, hrk, hcardF⟩ := Fcfg
     have hfr_F : Module.finrank ℝ F.direction = d := by
-      apply finrank_eq_of_rank_eq
+      apply Module.finrank_eq_of_rank_eq
       simpa using hrk
     have hfr_amb : Module.finrank ℝ (EuclideanSpace ℝ (Fin d)) = d :=
       finrank_euclideanSpace_fin
     have hdir_top : F.direction = ⊤ :=
       Submodule.eq_top_of_finrank_eq (hfr_F.trans hfr_amb.symm)
-    have hF_ne : (F : Set _).Nonempty := by
+    have hF_ne : (F : Set (EuclideanSpace ℝ (Fin d))).Nonempty := by
       have hpos : 0 < (P.filter (· ∈ F)).card := by omega
       obtain ⟨q, hq⟩ := Finset.card_pos.mp hpos
       exact ⟨q, (Finset.mem_filter.mp hq).2⟩
@@ -138,7 +139,7 @@ theorem ambient_flat_magic_trivial {d : ℕ} (P : PointConfigD d) :
       (fun p => if h : p ∈ P then (1 : ℝ) else 0) = (P.card : ℝ)
     have hfilter : P.filter (· ∈ F) = P := by
       rw [hF_top]
-      exact Finset.filter_true_of_mem (fun p _ => AffineSubspace.mem_top p)
+      exact Finset.filter_true_of_mem (fun p _ => AffineSubspace.mem_top ℝ _ p)
     rw [hfilter]
     rw [Finset.sum_congr rfl (fun p hp => dif_pos hp)]
     rw [Finset.sum_const, Nat.smul_one_eq_cast]

--- a/research/problems/erdos-735-oq-04/knowledge.md
+++ b/research/problems/erdos-735-oq-04/knowledge.md
@@ -121,3 +121,30 @@ Mathematical overlap with oq-01: both ask about $\mathbb{R}^3$. But oq-01 is lin
 | Higher-dim classification (extension of ABKPR) | Open research (S5 axiom) |
 
 Estimated total Lean: ~150 lines across the OQ chain, 1-2 axioms.
+
+## Session 2026-05-29 (researcher-1) — Build verification for Mathlib v4.26.0
+
+**Mode**: REVISIT (build verification)
+**Outcome**: completed — `Erdos735OQ04.lean` was fully proven (S3) but the build
+was never verified ("Docker daemon hung"). It did **not** compile against the
+pinned Mathlib (v4.26.0). Repaired and Docker build-verified: **0 sorries,
+0 axioms, build clean**.
+
+### Fixes (all v4.26.0 API drift, in `ambient_flat_magic_trivial`)
+- `finrank_eq_of_rank_eq` → `Module.finrank_eq_of_rank_eq` (lost bare alias).
+- `(F : Set _).Nonempty`: the `_` element type no longer inferred → made
+  explicit `(F : Set (EuclideanSpace ℝ (Fin d))).Nonempty`.
+- `AffineSubspace.mem_top p` → `AffineSubspace.mem_top ℝ _ p` (the field `k`
+  is now an explicit leading argument).
+
+The trivial-case targets `zero_flat_magic_trivial` (k=0) and
+`ambient_flat_magic_trivial` (k=d) are now genuinely verified.
+
+### Still open (unchanged, NOT in this session's scope)
+- Parent `Erdos735Problem.lean` (7 axioms, the open Murty conjecture) reportedly
+  still has a v4.26.0 `![...]`-matrix-coercion issue in its `threeCollinear`/
+  `triangle` examples; its `AffineSubspace` import is already corrected to
+  `.Basic`. Separate repair.
+- S4 parent reduction (`IsKFlatMagic 1 P ↔ Erdos735.IsMagic P`, d=2) still
+  deferred until the parent builds.
+- S5 higher-dim classification remains genuinely open (future axiom).


### PR DESCRIPTION
## Summary

`Erdos735OQ04.lean`'s two trivial-case theorems (`zero_flat_magic_trivial` for k=0, `ambient_flat_magic_trivial` for k=d) were fully proven in S3 but **never build-verified** (the session log notes "Docker daemon hung"). The file did **not** compile against the pinned Mathlib (**v4.26.0**).

This PR repairs the API drift so the file builds cleanly — **0 sorries, 0 axioms, Docker build-verified**. No mathematical content changed.

## Build verification

```
./proofs/scripts/docker-build.sh Proofs.Erdos735OQ04   # Build succeeded
```

## Fixes (all in `ambient_flat_magic_trivial`)
- `finrank_eq_of_rank_eq` → `Module.finrank_eq_of_rank_eq` (bare alias gone).
- `(F : Set _).Nonempty`: element type no longer inferred → `(F : Set (EuclideanSpace ℝ (Fin d))).Nonempty`.
- `AffineSubspace.mem_top p` → `AffineSubspace.mem_top ℝ _ p` (the field `k` is now an explicit leading argument).

## Scope
The parent `Erdos735Problem.lean` (the open Murty conjecture, 7 axioms) reportedly still has a separate v4.26.0 `![...]`-matrix-coercion issue in its `threeCollinear`/`triangle` examples; that is a separate repair and **out of scope** here. `Erdos735OQ04.lean` is self-contained (does not import the parent), so it builds independently.

## Status
**Outcome**: completed (build-verified)

🤖 Generated by researcher-1