### PR TITLE
Research: amgm-inequality-oq-04-oq-03 — hypergeometric series scaffold for K(k)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -51,6 +51,7 @@ import Proofs.AmgmInequalityOQ03OQ04
 import Proofs.AmgmInequalityOQ04
 import Proofs.AmgmInequalityOQ04OQ01
 import Proofs.AmgmInequalityOQ04OQ02
+import Proofs.AmgmInequalityOQ04OQ03
 import Proofs.AmgmInequalityOQ04OQ05
 import Proofs.AmgmInequalityPowerMeanLimits
 import Proofs.AngleTrisection

--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -1,0 +1,158 @@
+import Mathlib
+import Proofs.AmgmInequalityOQ04
+import Proofs.AmgmInequalityOQ04OQ01
+
+/-
+# AGM: Hypergeometric Series Representation of K(k)
+
+Open Question (OQ-04-OQ-03 from AmgmInequality):
+Express the complete elliptic integral of the first kind through the Gauss
+hypergeometric series, the standard route toward Gauss's AGM theorem
+  M(a, b) = a·π / (2·K(k')),   k = b/a,  k' = √(1 - k²).
+
+## The Identity
+
+The classical power-series representation is
+  K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)
+       = (π/2) · ∑_{n≥0} ((2n choose n) / 4ⁿ)² · k^{2n}
+       = (π/2) · [1 + (1/2)² k² + (1·3/(2·4))² k⁴ + ⋯].
+
+The n-th series coefficient is cₙ = ((1/2)_n / n!)² = ((2n choose n)/4ⁿ)², where
+(1/2)_n is the rising factorial; the second equality is the identity
+(1/2)_n / n! = (2n choose n)/4ⁿ for the central binomial coefficient.
+
+## What This File Does
+
+`ellipticK` is the rigorous interval-integral definition from the companion
+file `AmgmInequalityOQ04OQ01.lean`. This file:
+
+1. Defines the series coefficients `hypCoeff n = (centralBinom n / 4ⁿ)²`.
+2. Defines `hyp2F1 x = ∑' n, hypCoeff n · xⁿ`, the realization of
+   ₂F₁(1/2,1/2;1;x) as a power series.
+3. Proves verifiable structural facts: `c₀ = 1`, `c₁ = 1/4`, every `cₙ > 0`,
+   and `₂F₁(…;0) = 1`.
+4. Proves the **k = 0 consistency theorem** independently of the deep identity:
+   `K(0) = (π/2)·₂F₁(…;0)`, i.e. both sides equal π/2. This checks that the
+   axiomatized identity below has the correct value at the one point where K is
+   elementary.
+5. States the deep series identity `ellipticK_eq_hyp2F1` as an axiom.
+
+## Why the Main Identity is Axiomatized
+
+Proving `K(k) = (π/2)·₂F₁(1/2,1/2;1;k²)` rigorously requires:
+- the binomial series (1 - u)^{-1/2} = ∑ (2n choose n)/4ⁿ · uⁿ for |u| < 1,
+- substituting u = k² sin²θ and integrating term by term over [0, π/2],
+- justifying the sum/integral interchange (dominated convergence, delicate as
+  k → 1), and
+- the Wallis integral ∫₀^{π/2} sin^{2n}θ dθ = (π/2)·(2n choose n)/4ⁿ.
+
+Mathlib has the central binomial coefficient and `integral_sin_pow`
+recurrences but neither a general ₂F₁ nor the term-by-term integration lemma in
+the form needed here, so the full identity is a multi-hundred-line build left
+to future work. This mirrors the companion file's treatment of the AGM–K
+connection. (Reference: Borwein & Borwein, *Pi and the AGM*, 1987.)
+
+## Status
+- [x] series coefficients defined
+- [x] c₀ = 1, c₁ = 1/4, cₙ > 0 (proved, 0 sorry)
+- [x] ₂F₁(…;0) = 1 (proved)
+- [x] k = 0 consistency with `ellipticK` (proved, independent of the axiom)
+- [ ] K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) (axiomatized — see above)
+
+Axioms: 1 (ellipticK_eq_hyp2F1 — the hypergeometric series identity for K)
+Sorries: 0
+-/
+
+namespace AmgmInequalityOQ04OQ03
+
+open Real AmgmInequalityOQ04OQ01
+
+-- ============================================================================
+-- § 1. The Hypergeometric Series for K
+-- ============================================================================
+
+/-- The n-th coefficient of the hypergeometric series for K:
+    `cₙ = ((2n choose n) / 4ⁿ)² = (centralBinom n / 4ⁿ)²`.
+    These are the squares of the `4ⁿ`-normalized central binomial coefficients. -/
+noncomputable def hypCoeff (n : ℕ) : ℝ :=
+  ((Nat.centralBinom n : ℝ) / 4 ^ n) ^ 2
+
+/-- The Gauss hypergeometric function ₂F₁(1/2, 1/2; 1; x) realized as a power
+    series: `₂F₁(1/2,1/2;1;x) = ∑_{n≥0} cₙ xⁿ`. -/
+noncomputable def hyp2F1 (x : ℝ) : ℝ :=
+  ∑' n : ℕ, hypCoeff n * x ^ n
+
+-- ============================================================================
+-- § 2. Basic Properties of the Coefficients
+-- ============================================================================
+
+/-- `c₀ = 1`: the constant term of the series. -/
+lemma hypCoeff_zero : hypCoeff 0 = 1 := by
+  simp [hypCoeff, Nat.centralBinom_zero]
+
+/-- `c₁ = 1/4`, matching the classical expansion
+    `K(k) = (π/2)[1 + (1/2)² k² + ⋯]` whose `k²` coefficient is `(1/2)² = 1/4`. -/
+lemma hypCoeff_one : hypCoeff 1 = 1 / 4 := by
+  have h : Nat.centralBinom 1 = 2 := by decide
+  unfold hypCoeff
+  rw [h]
+  norm_num
+
+/-- Every coefficient is nonnegative (it is a square). -/
+lemma hypCoeff_nonneg (n : ℕ) : 0 ≤ hypCoeff n := by
+  unfold hypCoeff; positivity
+
+/-- Every coefficient is strictly positive (central binomial coefficients are
+    positive). -/
+lemma hypCoeff_pos (n : ℕ) : 0 < hypCoeff n := by
+  have hb : (0 : ℝ) < (Nat.centralBinom n : ℝ) / 4 ^ n :=
+    div_pos (by exact_mod_cast Nat.centralBinom_pos n) (by positivity)
+  simpa [hypCoeff] using pow_pos hb 2
+
+-- ============================================================================
+-- § 3. Value at the Origin
+-- ============================================================================
+
+/-- `₂F₁(1/2,1/2;1;0) = 1`: only the constant term survives at `x = 0`. -/
+theorem hyp2F1_zero : hyp2F1 0 = 1 := by
+  have h : ∀ n : ℕ, n ≠ 0 → hypCoeff n * (0 : ℝ) ^ n = 0 := by
+    intro n hn
+    rw [zero_pow hn, mul_zero]
+  unfold hyp2F1
+  rw [tsum_eq_single 0 h]
+  simp [hypCoeff_zero]
+
+-- ============================================================================
+-- § 4. Consistency with the Elliptic Integral at k = 0
+-- ============================================================================
+
+/-- **Consistency at k = 0**, proved independently of the axiomatized identity:
+    `K(0) = (π/2)·₂F₁(1/2,1/2;1;0)`. Both sides equal `π/2`
+    (`ellipticK_zero` gives the left side; `hyp2F1_zero` the right). This
+    verifies the value of the hypergeometric identity at the one point where the
+    elliptic integral is elementary. -/
+theorem ellipticK_hyp2F1_consistent_zero :
+    ellipticK 0 = (π / 2) * hyp2F1 0 := by
+  rw [hyp2F1_zero, mul_one, ellipticK_zero]
+
+-- ============================================================================
+-- § 5. The Hypergeometric Identity for K (Axiomatized)
+-- ============================================================================
+
+/-- **Hypergeometric series representation of K** (axiomatized deep identity):
+    for `|k| < 1`,
+      `K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`.
+    See the file header for the proof outline (binomial series + Wallis
+    integrals + term-by-term integration) and why it is left axiomatized.
+    The `k = 0` instance is independently verified by
+    `ellipticK_hyp2F1_consistent_zero`. -/
+axiom ellipticK_eq_hyp2F1 (k : ℝ) (hk : k ^ 2 < 1) :
+    ellipticK k = (π / 2) * hyp2F1 (k ^ 2)
+
+/-- Sanity check: the axiom specialized at `k = 0` reproduces the independently
+    proved consistency theorem (both reduce to `K(0) = π/2`). -/
+theorem ellipticK_eq_hyp2F1_zero :
+    ellipticK 0 = (π / 2) * hyp2F1 ((0 : ℝ) ^ 2) :=
+  ellipticK_eq_hyp2F1 0 (by norm_num)
+
+end AmgmInequalityOQ04OQ03

--- a/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
@@ -6,16 +6,43 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Target: Gauss's AGM theorem M(a,b) = a·π/(2·K(k')), k = b/a, k' = √(1−k²), via the
+hypergeometric representation of the complete elliptic integral of the first kind:
+
+  K(k) = (π/2)·₂F₁(1/2, 1/2; 1; k²) = (π/2)·∑_{n≥0} cₙ k^{2n}.
+
+`K` is already defined rigorously (interval integral) in the companion file
+`AmgmInequalityOQ04OQ01.lean`, where the AGM↔K connection is itself an axiom.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The series coefficient is cₙ = ((1/2)_n / n!)² = (centralBinom n / 4ⁿ)², using the
+  identity (1/2)_n / n! = (2n choose n)/4ⁿ.
+- Classical expansion: K(k) = (π/2)[1 + (1/2)²k² + (1·3/(2·4))²k⁴ + ⋯]; so c₀ = 1 and
+  c₁ = (1/2)² = 1/4. Both verified in Lean (`hypCoeff_zero`, `hypCoeff_one`).
+- Proof route for the full identity: binomial series (1−u)^(−1/2) = ∑ (centralBinom n/4ⁿ) uⁿ,
+  substitute u = k² sin²θ, integrate term by term over [0, π/2], and use the Wallis integral
+  ∫₀^{π/2} sin^{2n}θ dθ = (π/2)(2n choose n)/4ⁿ.
+- The k = 0 case is provable WITHOUT the deep identity: K(0) = π/2 (`ellipticK_zero`) and
+  ₂F₁(…;0) = 1 (`hyp2F1_zero`), so both sides equal π/2
+  (`ellipticK_hyp2F1_consistent_zero`). This anchors the axiom's correctness at k = 0.
+
+## Built (this session, Proofs/AmgmInequalityOQ04OQ03.lean — builds clean, 0 sorries, 1 axiom)
+
+- `hypCoeff`, `hyp2F1` definitions (central-binomial series).
+- `hypCoeff_zero` (=1), `hypCoeff_one` (=1/4), `hypCoeff_nonneg`, `hypCoeff_pos`.
+- `hyp2F1_zero` : ₂F₁(…;0) = 1 (via `tsum_eq_single`).
+- `ellipticK_hyp2F1_consistent_zero` : K(0) = (π/2)·₂F₁(…;0), independent of the axiom.
+- `ellipticK_eq_hyp2F1` (axiom) : K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) for |k|<1.
 
 ---
 
-## Dead Ends
+## Dead Ends / Blockers
 
-[Approaches known not to work will be documented here]
+- No general Gauss hypergeometric ₂F₁ in Mathlib.
+- No off-the-shelf term-by-term integration lemma matching K; the sum/integral interchange
+  (dominated convergence, delicate as k → 1) is the genuine obstacle to discharging the axiom.
+- Wallis closed form ∫₀^{π/2} sin^{2n} = (π/2)(2n choose n)/4ⁿ must be assembled from
+  Mathlib's `integral_sin_pow` recurrences (not packaged directly).

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -1,25 +1,32 @@
 # Research State: amgm-inequality-oq-04-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: fast
-**Since**: 2026-04-04T02:41:25-07:00
-**Iteration**: 1
+**Since**: 2026-05-29
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Built a verified Lean scaffold for the hypergeometric representation
+K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) in Proofs/AmgmInequalityOQ04OQ03.lean. The deep
+series identity is axiomatized; coefficient facts, ₂F₁(…;0)=1, and a k=0
+consistency check against the verified ellipticK are proved (0 sorries, 1 axiom).
 
 ## Active Approach
-None yet.
+Power-series realization of ₂F₁ with central-binomial coefficients
+cₙ = (centralBinom n / 4ⁿ)², built on the rigorous ellipticK from oq-04-oq-01.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- No general ₂F₁ in Mathlib; no packaged term-by-term integration lemma for K.
+- Wallis closed form must be assembled from integral_sin_pow recurrences.
 
 ## Next Action
-Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.
-See FAST_PATH.md for protocol.
+Discharge the ellipticK_eq_hyp2F1 axiom: prove the binomial series for
+(1−u)^(−1/2), assemble the Wallis integral closed form, establish uniform
+summability on compact k-subsets of (−1,1), then interchange sum and integral.
+Then chain with the oq-04-oq-01 AGM–K connection toward M(a,b)=a·π/(2K(k')).

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -1,7 +1,7 @@
 {
   "slug": "amgm-inequality-oq-04-oq-03",
   "title": "Gauss AGM Theorem via Hypergeometric Elliptic Integral Identity",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "C",
   "path": "fast",
@@ -16,7 +16,8 @@
   "knownResults": {
     "proven": [
       "The problem statement records the intended hypergeometric route: K(k) = (pi/2) * _2F_1(1/2,1/2;1;k^2).",
-      "The source context is amgm-inequality-oq-04, described as Gauss AGM iteration and elliptic integrals."
+      "The source context is amgm-inequality-oq-04, described as Gauss AGM iteration and elliptic integrals.",
+      "Lean (verified, this session): hypCoeff 0 = 1; hypCoeff 1 = 1/4; hypCoeff n > 0; hyp2F1 0 = 1; K(0) = (pi/2)*2F1(...;0) [ellipticK_hyp2F1_consistent_zero]."
     ],
     "open": [
       "No active approach is recorded for this subproblem.",
@@ -27,36 +28,52 @@
     "goal": "Formalize Gauss's AGM theorem M(a,b) = a*pi/(2K(k')) with k = b/a and k' = sqrt(1-k^2), using the hypergeometric identity for K(k)."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-04T02:41:25-07:00",
-    "iteration": 1,
-    "focus": "OBSERVE-stage orientation on the Gauss AGM theorem statement, its source context, and the recorded fast-path first steps.",
-    "activeApproach": "None recorded yet.",
+    "phase": "ACT",
+    "since": "2026-05-29T04:28:09.000Z",
+    "iteration": 2,
+    "focus": "Built a verified hypergeometric-series scaffold for K(k) = (pi/2)*2F1(1/2,1/2;1;k^2), the standard route to Gauss AGM. Deep series identity axiomatized; structural facts and k=0 consistency proved.",
+    "activeApproach": "Power-series realization of 2F1 with central-binomial coefficients c_n = (centralBinom n / 4^n)^2, building on the verified ellipticK from oq-04-oq-01.",
     "blockers": [],
-    "nextAction": "Check the existing AGM formalization from amgm-inequality-oq-04, search Mathlib for hypergeometric-series support, and try proving an AGM convergence-rate lemma first.",
+    "nextAction": "Prove the binomial-series expansion (1-u)^(-1/2) = sum centralBinom n /4^n * u^n and the Wallis integral int_0^(pi/2) sin^(2n) = (pi/2) centralBinom n /4^n; then attempt term-by-term integration to discharge the ellipticK_eq_hyp2F1 axiom.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Only orientation metadata is recorded. The problem is active in OBSERVE phase on the fast path with zero attempts, no active approach, no blockers, and no documented Lean proof work.",
-    "builtItems": [],
+    "progressSummary": "ACT: created verified Lean scaffold Proofs/AmgmInequalityOQ04OQ03.lean for the hypergeometric representation K(k)=(pi/2)*2F1(1/2,1/2;1;k^2). Builds clean (0 sorries, 1 axiom). Proved coefficient facts (c0=1, c1=1/4, c_n>0), 2F1(...;0)=1, and a k=0 consistency check against the verified ellipticK -- all independent of the axiom. The deep series identity is axiomatized with a documented proof route (binomial series + Wallis integrals + term-by-term integration) and explicit Mathlib gaps recorded.",
+    "builtItems": [
+      "Proofs/AmgmInequalityOQ04OQ03.lean (builds clean, 0 sorries, 1 axiom): defs hypCoeff, hyp2F1.",
+      "hypCoeff_zero : hypCoeff 0 = 1 (proved).",
+      "hypCoeff_one : hypCoeff 1 = 1/4 (proved; matches classical k^2 coefficient).",
+      "hypCoeff_nonneg / hypCoeff_pos : coefficient positivity (proved).",
+      "hyp2F1_zero : hyp2F1 0 = 1 (proved via tsum_eq_single).",
+      "ellipticK_hyp2F1_consistent_zero : K(0) = (pi/2)*2F1(...;0), proved independently of the axiom.",
+      "ellipticK_eq_hyp2F1 (axiom): K(k) = (pi/2)*2F1(1/2,1/2;1;k^2) for |k|<1 (deep term-by-term-integration identity)."
+    ],
     "insights": [
       "The target theorem is Gauss's AGM theorem M(a,b) = a*pi/(2K(k')).",
       "The problem defines k = b/a and k' = sqrt(1-k^2).",
       "The proposed route is through the hypergeometric-series identity K(k) = (pi/2) * _2F_1(1/2,1/2;1;k^2).",
-      "The context marks this as a challenging deep analysis extension requiring hypergeometric functions and AGM convergence."
+      "The context marks this as a challenging deep analysis extension requiring hypergeometric functions and AGM convergence.",
+      "The hypergeometric series coefficient is c_n = ((1/2)_n / n!)^2 = (centralBinom n / 4^n)^2, using the identity (1/2)_n/n! = (2n choose n)/4^n.",
+      "K(k) = (pi/2) * sum_{n>=0} c_n k^(2n); the k^0 coefficient is 1 and the k^2 coefficient is (1/2)^2 = 1/4 (verified: hypCoeff_zero, hypCoeff_one).",
+      "The identity is provable in principle via: binomial series (1-u)^(-1/2), substitution u = k^2 sin^2(theta), term-by-term integration over [0,pi/2], and the Wallis integral int_0^(pi/2) sin^(2n) = (pi/2)(2n choose n)/4^n.",
+      "k=0 consistency is verifiable WITHOUT the deep identity: K(0)=pi/2 (ellipticK_zero) and 2F1(...;0)=1 (hyp2F1_zero via tsum_eq_single), so both sides equal pi/2 (theorem ellipticK_hyp2F1_consistent_zero).",
+      "Mathlib has Nat.centralBinom (+centralBinom_zero/_pos) and integral_sin_pow recurrences but no general 2F1 and no packaged term-by-term integration lemma in the form needed; the interchange of sum and integral (delicate as k->1) is the genuine blocker."
     ],
     "mathlibGaps": [
-      "Mathlib support for hypergeometric series has not yet been checked."
+      "No general Gauss hypergeometric function 2F1 in Mathlib.",
+      "No packaged term-by-term integration lemma for power series against intervalIntegral suitable for K (dominated-convergence interchange needed, delicate near k=1).",
+      "Binomial series (1-u)^(-1/2) = sum centralBinom n /4^n u^n not located in usable form (needs verification).",
+      "Wallis integral int_0^(pi/2) sin^(2n) = (pi/2)(2n choose n)/4^n: Mathlib has integral_sin_pow recurrences; the closed form via central binomial coefficient needs to be assembled."
     ],
     "nextSteps": [
-      "Check the existing AGM formalization in amgm-inequality-oq-04.",
-      "Search Mathlib for hypergeometric-series support.",
-      "Try proving just the AGM convergence rate first.",
-      "Move to ACT only if the quick search reveals an obvious formal route."
+      "Prove (or locate) the binomial series for (1-u)^(-1/2) with central-binomial coefficients.",
+      "Assemble the Wallis integral closed form int_0^(pi/2) sin^(2n) = (pi/2) centralBinom n /4^n from integral_sin_pow.",
+      "Establish summability of the K integrand power series uniformly on compact k-subsets of (-1,1).",
+      "Combine to discharge ellipticK_eq_hyp2F1, then chain with the oq-04-oq-01 AGM-K connection toward M(a,b)=a*pi/(2K(k'))."
     ],
     "markdown": "# Knowledge Base: amgm-inequality-oq-04-oq-03\n\n## Problem Understanding\n\n- Target: prove Gauss's AGM theorem M(a,b) = a*pi/(2K(k')).\n- Parameters recorded in the problem statement: k = b/a and k' = sqrt(1-k^2).\n- Intended route: use K(k) = (pi/2) * _2F_1(1/2,1/2;1;k^2).\n- Context: extension from amgm-inequality-oq-04, categorized as a challenging deep analysis problem involving hypergeometric functions and AGM convergence.\n\n## Current State\n\n- Phase: OBSERVE.\n- Path: fast.\n- Since: 2026-04-04T02:41:25-07:00.\n- Iteration: 1.\n- Active approach: none recorded yet.\n- Attempts: total 0, current approach 0, approaches tried 0.\n- Blockers: none recorded.\n\n## Known Work and Open Items\n\n- No Lean proof attempt or completion is recorded for this subproblem.\n- The existing AGM formalization in amgm-inequality-oq-04 still needs to be checked.\n- Mathlib hypergeometric-series support still needs to be searched.\n- A preliminary AGM convergence-rate lemma is the first suggested proof target.\n\n## Next Steps\n\n1. Check the existing AGM formalization in amgm-inequality-oq-04.\n2. Search Mathlib for hypergeometric-series support.\n3. Try proving just the AGM convergence rate first.\n4. Move to ACT only if the quick search reveals an obvious formal route.\n\n## Dead Ends\n\nNone recorded.\n"
   },
@@ -86,12 +103,21 @@
     "amgm-inequality-oq-04-oq-05"
   ],
   "references": {
-    "papers": [],
+    "papers": [
+      "Borwein & Borwein, Pi and the AGM (1987)"
+    ],
     "urls": [],
-    "mathlib": []
+    "mathlib": [
+      "Nat.centralBinom",
+      "Nat.centralBinom_zero",
+      "Nat.centralBinom_pos",
+      "tsum_eq_single",
+      "intervalIntegral",
+      "integral_sin_pow"
+    ]
   },
   "started": "2026-04-04T09:42:47.007Z",
-  "lastUpdate": "2026-04-04T09:42:47.024Z",
+  "lastUpdate": "2026-05-29T04:28:09.000Z",
   "leanFiles": [
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",
@@ -313,5 +339,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AmgmInequalityPowerMeanLimits.lean"
     }
-  ]
+  ],
+  "leanFile": "Proofs/AmgmInequalityOQ04OQ03.lean"
 }


### PR DESCRIPTION
## Summary

Research session for **amgm-inequality-oq-04-oq-03** (Gauss AGM theorem via the
hypergeometric representation of the complete elliptic integral K).

Adds `proofs/Proofs/AmgmInequalityOQ04OQ03.lean`, a **verified scaffold** for
K(k) = (pi/2) * 2F1(1/2,1/2;1;k^2) = (pi/2) * sum_n (centralBinom n / 4^n)^2 * k^{2n},
the standard route toward Gauss's theorem M(a,b) = a*pi/(2K(k')). Builds on the
rigorous `ellipticK` (interval integral) from the sibling `AmgmInequalityOQ04OQ01.lean`.

## Verified (independent of the axiom)

- `hypCoeff_zero` : c0 = 1
- `hypCoeff_one` : c1 = 1/4 (matches the classical k^2 coefficient (1/2)^2)
- `hypCoeff_nonneg` / `hypCoeff_pos`
- `hyp2F1_zero` : 2F1(...;0) = 1 (via `tsum_eq_single`)
- `ellipticK_hyp2F1_consistent_zero` : K(0) = (pi/2)*2F1(...;0) — both sides reduce
  to pi/2, anchoring the axiom's correctness at k=0.

**Build:** `docker-build.sh Proofs.AmgmInequalityOQ04OQ03` -> Build succeeded
(0 sorries, 1 axiom; the only warnings are pre-existing on sibling files).

## Axiomatized (with documented route)

`ellipticK_eq_hyp2F1` : K(k) = (pi/2)*2F1(1/2,1/2;1;k^2) for |k|<1.
The full proof needs the binomial series (1-u)^(-1/2), substitution u = k^2 sin^2(theta),
term-by-term integration over [0,pi/2], and the Wallis integral
int_0^(pi/2) sin^(2n) = (pi/2)*C(2n,n)/4^n — multi-hundred lines, mirroring the
sibling's treatment of the AGM–K connection.

## Mathlib gaps recorded

- No general Gauss 2F1 in Mathlib.
- No packaged term-by-term integration lemma matching K (sum/integral interchange,
  delicate as k -> 1).
- Wallis closed form must be assembled from `integral_sin_pow` recurrences.

## Status
**Outcome**: progress (verified scaffold + axiomatized deep identity)
**Next**: discharge `ellipticK_eq_hyp2F1`, then chain with oq-04-oq-01 toward
M(a,b)=a*pi/(2K(k')).

🤖 Generated by researcher-1