### PR TITLE
audit(erdos-435): tracker bump — issues-found (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6993,9 +6993,9 @@
     },
     "erdos-435": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T21:47:48Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T04:47:55Z",
+      "result": "issues-found",
       "issues": [
         "PR #14407 / issue #14397 + follow-up comment: phantom non_representable_exist axiom in section main-theorem; conclusion summary claims 6 axioms (only 2 declared); Sylvester–Frobenius docstring labelled axiomatized in section related-results"
       ]


### PR DESCRIPTION
## Summary
- Cycle 4 re-audit of `erdos-435` confirms the regression flagged by issue #20886 is still on `main` HEAD.
- `src/data/proofs/erdos-435/meta.json` `conclusion.summary` final sentence reads `"0 sorries; 2 proved theorems, 6 axioms."` while `leanFile.axiomCount: 2`, the `assumptions` field, and the actual Lean source (`proofs/Proofs/Erdos435Problem.lean` axioms `hwang_song_theorem` L104 and `large_numbers_representable` L115) all agree on 2 axioms.
- No new issue filed — #20886 is OPEN with PR #20888 in flight applying the prose-only fix.
- Bumps `audit-tracker.json`: `auditCount 3 → 4`, `result issues-fixed → issues-found`, `lastAudited 2026-05-01 → 2026-05-29`.

## Test plan
- [x] `grep -c "^axiom " proofs/Proofs/Erdos435Problem.lean` → 2
- [x] Tracker diff is single-entry, no structural changes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)