### PR TITLE
audit(erdos-423): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6905,9 +6905,9 @@
     },
     "erdos-423": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T21:56:17Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T05:03:47Z",
+      "result": "clean",
       "issues": [
         "phantom axioms consSeq_is_consecutive_sum/consSeq_minimal in section consecutive-sum-predicate (only docstrings); section line ranges drift across Parts IV-XII (#14412)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-423 (Sums of Consecutive Terms Sequence) — clean
- Tracker bumped to cycle 4, result `clean`

## Findings vs. meta.json
- `axiomCount: 3` matches Lean source (3 `axiom` declarations: `excess_nondecreasing`, `excess_unbounded`, `infinitely_many_missing`)
- `sorries: 0` matches (no `sorry` in file)
- No `True` stubs, no structure-encoded assumptions
- `status: "axiomatized"` + `badge: "axiom"` correctly reflect open Erdős problem with axiomatized Bolan-Tang results
- `lineCount: 409` matches `wc -l proofs/Proofs/Erdos423Problem.lean`

## Test plan
- [x] Source/meta cross-check
- [x] No structure-encoded assumptions (`grep -E '^structure |^class '` empty)
- [x] Tracker diff scoped to single entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)