### PR TITLE
audit(erdos-444): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7062,9 +7062,9 @@
     },
     "erdos-444": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T22:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T05:49:37Z",
+      "result": "clean",
       "issues": [
         "Phantom-axiom narrative: 5 axiom names (case_all_naturals, case_primes, highly_composite_relative, exponential_lower_bound, no_uniform_bound) referenced in assumptions/originalContributions/sections/proofStrategy are only docstring text; only erdos_graham_conjecture_true is declared. Issue #14385"
       ]


### PR DESCRIPTION
## Summary

Audit cycle 4 of erdos-444: clean.

- meta.status=axiomatized, meta.badge=axiom, meta.sorries=0, meta.axiomCount=1
- Erdos444Problem.lean: 1 axiom (erdos_graham_conjecture_true), 0 sorries
- assumptions field documents the axiomatized Erdős-Sárközy 1980 result

Tracker entry transitioned from issues-fixed (2026-05-01, #14385) → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)