### PR TITLE
research(ftc-lebesgue): AC→ContinuousOn and AC subinterval restriction

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
@@ -146,6 +146,41 @@ theorem ac_implies_uniformly_continuous {F : ℝ → ℝ} {a b : ℝ}
       (by simp [Fin.sum_univ_one]; exact lt_of_abs_lt hxy)
     simpa [Fin.sum_univ_one] using hres
 
+/-- Absolutely continuous functions are continuous on `[a, b]`.
+
+This packages `ac_implies_uniformly_continuous` into Mathlib's `ContinuousOn`
+predicate, which is the form required by downstream results (the Cantor
+counterexample below, for instance, asserts `ContinuousOn F (Icc 0 1)`). -/
+theorem ac_implies_continuousOn {F : ℝ → ℝ} {a b : ℝ}
+    (hF : AbsolutelyContinuousOn F a b) :
+    ContinuousOn F (Icc a b) := by
+  rw [Metric.continuousOn_iff]
+  intro x hx ε hε
+  obtain ⟨δ, hδ, huc⟩ := ac_implies_uniformly_continuous hF ε hε
+  refine ⟨δ, hδ, ?_⟩
+  intro y hy hyx
+  rw [Real.dist_eq] at hyx ⊢
+  exact huc y x hy hx hyx
+
+/-- Absolute continuity is inherited by subintervals: if `F` is AC on `[a, b]`
+and `[c, d] ⊆ [a, b]` (i.e. `a ≤ c` and `d ≤ b`), then `F` is AC on `[c, d]`.
+
+The same `δ` works: any finite family of pairwise-disjoint subintervals of
+`[c, d]` is also a finite family of pairwise-disjoint subintervals of `[a, b]`,
+so the AC bound on `[a, b]` applies verbatim. -/
+theorem ac_on_subinterval {F : ℝ → ℝ} {a b c d : ℝ}
+    (hac : a ≤ c) (hdb : d ≤ b)
+    (hF : AbsolutelyContinuousOn F a b) :
+    AbsolutelyContinuousOn F c d := by
+  intro ε hε
+  obtain ⟨δ, hδ, h⟩ := hF ε hε
+  refine ⟨δ, hδ, ?_⟩
+  intro n as bs hsub hdisj htot
+  refine h n as bs ?_ hdisj htot
+  intro k
+  obtain ⟨h1, h2, h3⟩ := hsub k
+  exact ⟨le_trans hac h1, h2, le_trans h3 hdb⟩
+
 -- ═══════════════════════════════════════════════════════════════
 -- PART IV: The Lebesgue FTC (AXIOM)
 -- ═══════════════════════════════════════════════════════════════
@@ -253,7 +288,9 @@ For a measurable set S: μ(S ∩ B(x,r)) / μ(B(x,r)) → 1_{S}(x) a.e. -/
 1. ✓ AbsolutelyContinuousOn definition (new, not in Mathlib)
 2. ✓ Lipschitz → AC (proved)
 3. ✓ AC → uniformly continuous (proved)
-4. ✓ Monotone → a.e. differentiable (from Mathlib)
+4. ✓ AC → ContinuousOn (proved, packages #3 as Mathlib `ContinuousOn`)
+5. ✓ AC inherited by subintervals (proved)
+6. ✓ Monotone → a.e. differentiable (from Mathlib)
 
 ## What's Axiomatized
 1. AC → a.e. differentiable (needs: AC → BV → monotone decomposition)

--- a/research/problems/fundamental-theorem-calculus-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/fundamental-theorem-calculus-oq-01-incomplete-01/knowledge.md
@@ -6,16 +6,125 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Targeted completion of the gallery proof `fundamental-theorem-calculus-oq-01`
+(`proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean`, namespace `FTCLebesgue`).
+
+Target: the Lebesgue FTC — an absolutely continuous `F : ℝ → ℝ` on `[a,b]` is
+a.e. differentiable, `F'` is integrable, and `∫ₐᵇ F' = F b - F a`.
+
+The file defines `AbsolutelyContinuousOn F a b` via the classical ε–δ
+condition over finite families of pairwise-disjoint subintervals (disjointness
+allows shared endpoints: `bs j ≤ as k ∨ bs k ≤ as j`).
+
+### Current gaps in the parent file (as of 2026-05-28)
+
+- **2 axioms**
+  - `lebesgue_ftc_differentiable`: AC ⟹ a.e. differentiable on `(a,b)`.
+  - `lebesgue_ftc_integral`: `∫ₐᵇ deriv F = F b - F a` (the deep result).
+- **1 sorry**
+  - `cantor_function_not_ac` (line ~224 originally): existence of a continuous,
+    monotone `F` with `F 0 = 0`, `F 1 = 1`, `¬ AbsolutelyContinuousOn F 0 1`.
+
+---
+
+## Mathlib Infrastructure Assessment (2026-05-28)
+
+NOTE: Mathlib source is not checked out on the host (the `proofs/.lake` symlink
+is self-referential; Mathlib lives only inside the Docker build volume), so the
+API names below are from knowledge and **must be confirmed at build time**
+before being relied upon.
+
+- **Function-level AC**: Mathlib has `MeasureTheory.Measure.AbsolutelyContinuous`
+  (`μ ≪ ν`) for *measures*, but no ε–δ `AbsolutelyContinuousOn` for functions.
+  Our definition genuinely fills this gap (candidate for upstreaming).
+- **Bounded variation** (`Mathlib.Analysis.BoundedVariation`):
+  - `eVariationOn f s : ℝ≥0∞` (iSup over finite monotone samplings).
+  - `BoundedVariationOn f s := eVariationOn f s ≠ ⊤`; `LocallyBoundedVariationOn`.
+  - Additivity over split intervals (`eVariationOn.Icc_add_Icc`-style).
+  - Jordan-type decomposition: a `LocallyBoundedVariationOn` function is a
+    difference of two monotone functions (`…exists_monotoneOn_sub_monotoneOn`).
+  - a.e. differentiability of BV functions on ℝ
+    (`LocallyBoundedVariationOn.ae_differentiableWithinAt`-style).
+- **Monotone ⟹ a.e. differentiable**: `Monotone.ae_differentiableAt` (already
+  used in the file as `monotone_ae_differentiable`); `MonotoneOn` variant.
+- **Vitali / Lebesgue differentiation**: `VitaliFamily`,
+  `VitaliFamily.ae_tendsto_measure_inter_div`; ℝ has a concrete Vitali family.
+- **Stieltjes measures**: `StieltjesFunction` and its measure — relevant to the
+  integral-recovery axiom via Radon–Nikodym (`Measure.rnDeriv`).
+- **Cantor function**: no named Devil's-staircase construction appears to exist
+  in Mathlib. Filling the `sorry` requires building it (or an equivalent
+  singular monotone function) from scratch — substantial infrastructure.
+
+---
+
+## De-axiomatization Roadmap
+
+### Linchpin lemma (next concrete target): AC ⟹ LocallyBoundedVariationOn
+
+Elementary and self-contained mathematically:
+
+1. Apply AC with `ε = 1` to obtain `δ > 0`.
+2. Partition `[a,b]` into `N = ⌈(b-a)/δ⌉` consecutive subintervals, each of
+   length `< δ`.
+3. On a piece `[c,d]` with `d - c < δ`: for any monotone sampling
+   `c ≤ u₀ ≤ … ≤ uₙ ≤ d`, the increment intervals `(uᵢ, uᵢ₊₁)` are
+   pairwise disjoint (shared endpoints allowed) with total length
+   `uₙ - u₀ ≤ d - c < δ`, so by AC `∑ |F(uᵢ₊₁) - F(uᵢ)| < 1`. Hence
+   `eVariationOn F (Icc c d) ≤ 1`.
+4. By additivity, `eVariationOn F (Icc a b) ≤ N < ⊤`.
+
+Lean risk: requires the exact `eVariationOn` iSup characterization and
+`Icc_add_Icc` additivity, plus ENNReal/`edist` bookkeeping
+(`edist x y = ENNReal.ofReal |x - y|` on ℝ). Confirm names against Mathlib in a
+build before committing.
+
+### Then: AC ⟹ a.e. differentiable (removes `lebesgue_ftc_differentiable`)
+
+`AC ⟹ LocallyBoundedVariationOn ⟹` (Mathlib) a.e. differentiable on `(a,b)`.
+Upgrade `DifferentiableWithinAt` to `DifferentiableAt` on the open interior.
+
+### Hardest: the integral identity (removes `lebesgue_ftc_integral`)
+
+Likely path: monotone parts give `StieltjesFunction` measures; AC of `F` ⟺ its
+Stieltjes measure `≪ volume`; `rnDeriv` equals `F'` a.e.; integrate to recover
+`F b - F a`. Deep — defer until the differentiability axiom is discharged.
+
+### The `sorry` (Cantor counterexample)
+
+Lower priority (not needed for the FTC itself; it only certifies that AC is
+*necessary*). Needs a from-scratch singular monotone function. No witness is
+obviously easier to formalize than the standard Cantor function (all such
+witnesses are singular / Cantor-like).
+
+---
+
+## Progress This Session (2026-05-28, researcher-1)
+
+Added two verified, sorry-free lemmas to the parent file, strengthening the
+proven AC theory and supplying a building block the Cantor statement needs:
+
+- `ac_implies_continuousOn`: `AbsolutelyContinuousOn F a b ⟹ ContinuousOn F (Icc a b)`
+  (packages the existing uniform-continuity lemma via `Metric.continuousOn_iff`).
+- `ac_on_subinterval`: AC on `[a,b]` with `a ≤ c`, `d ≤ b` ⟹ AC on `[c,d]`
+  (same `δ`; subintervals of `[c,d]` are subintervals of `[a,b]`).
+
+These do not reduce the axiom/sorry count yet, but they extend the proven
+regularity hierarchy (`Lipschitz → AC → ContinuousOn`, plus localization) and
+set up the AC⟹BV linchpin.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- Our AC disjointness condition (`bs j ≤ as k ∨ bs k ≤ as j`) permits touching
+  endpoints, which is exactly what partition increments need — so the AC⟹BV
+  argument applies cleanly without an extra strict-disjointness dodge.
+- `ContinuousOn` (not just the ε–δ uniform statement) is the form downstream
+  Mathlib lemmas and the Cantor statement consume; `ac_implies_continuousOn`
+  bridges that gap.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+None recorded yet.

--- a/research/problems/fundamental-theorem-calculus-oq-01-incomplete-01/state.md
+++ b/research/problems/fundamental-theorem-calculus-oq-01-incomplete-01/state.md
@@ -1,25 +1,43 @@
 # Research State: fundamental-theorem-calculus-oq-01-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-04-03T02:25:34-07:00
-**Iteration**: 1
+**Since**: 2026-05-28 (researcher-1)
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+De-axiomatizing the parent proof `FundamentalTheoremCalculusLebesgue.lean`.
+Surveyed Mathlib's BV / Vitali / Stieltjes infrastructure and mapped the
+concrete proof path for the two axioms and the Cantor `sorry` (see knowledge.md).
 
 ## Active Approach
-None yet.
+Bottom-up: discharge `lebesgue_ftc_differentiable` via the chain
+`AC ⟹ LocallyBoundedVariationOn ⟹ a.e. differentiable`. The linchpin is the
+elementary lemma **AC ⟹ LocallyBoundedVariationOn** (partition into pieces of
+length `< δ`; each contributes variation `< 1`).
+
+## Completed This Iteration
+- Added `ac_implies_continuousOn` (AC ⟹ `ContinuousOn`) — verified.
+- Added `ac_on_subinterval` (AC localizes to subintervals) — verified.
+- Mathlib infrastructure assessment + full de-axiomatization roadmap recorded.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 1
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- Mathlib source is not on the host filesystem (self-referential `proofs/.lake`
+  symlink; Mathlib lives only in the Docker build volume). Exact API names for
+  `eVariationOn` / BV decomposition must be confirmed via a Docker build before
+  the AC⟹BV lemma can be committed.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Formalize **AC ⟹ LocallyBoundedVariationOn** (or `BoundedVariationOn F (Icc a b)`):
+1. Confirm Mathlib names: `eVariationOn`, its iSup characterization,
+   `eVariationOn.Icc_add_Icc`-style additivity, `BoundedVariationOn`,
+   `LocallyBoundedVariationOn`, and the BV a.e.-differentiability lemma.
+2. Prove the per-piece bound `eVariationOn F (Icc c d) ≤ 1` for `d - c < δ`.
+3. Sum over a finite partition to bound `eVariationOn F (Icc a b)`.
+4. Chain to a.e. differentiability and replace `lebesgue_ftc_differentiable`.


### PR DESCRIPTION
## Summary

Extends the absolutely-continuous (AC) regularity theory in
`proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean` with two verified,
sorry-free lemmas, and records a de-axiomatization roadmap for the parent
Lebesgue-FTC proof (`fundamental-theorem-calculus-oq-01`).

- **`ac_implies_continuousOn`** — `AbsolutelyContinuousOn F a b ⟹ ContinuousOn F (Icc a b)`.
  Packages the existing `ac_implies_uniformly_continuous` into Mathlib's
  `ContinuousOn` predicate (via `Metric.continuousOn_iff`). This is exactly the
  form the downstream Cantor counterexample statement consumes.
- **`ac_on_subinterval`** — AC localizes: `a ≤ c`, `d ≤ b`, AC on `[a,b]` ⟹
  AC on `[c,d]`. The same `δ` works, since disjoint subintervals of `[c,d]` are
  disjoint subintervals of `[a,b]`.

These do not yet reduce the axiom/sorry count, but they strengthen the proven
regularity hierarchy (`Lipschitz → AC → ContinuousOn`, plus localization) and
set up the next concrete step: **AC ⟹ LocallyBoundedVariationOn**, the linchpin
toward discharging the `lebesgue_ftc_differentiable` axiom.

`knowledge.md` / `state.md` are updated with a Mathlib infrastructure assessment
and the full de-axiomatization roadmap; problem state advanced OBSERVE → ORIENT.

## Verification

- Built via `docker-build` (single-file, 8GB cap): **3074 jobs, exit 0**.
- The two new lemmas compile with **no warnings**.
- The only remaining `sorry` is the pre-existing Cantor construction
  (`cantor_function_not_ac`); the two axioms are unchanged. No regression.

## Test plan

- [x] `docker-build.sh Proofs.FundamentalTheoremCalculusLebesgue` succeeds
- [x] New lemmas are sorry-free and warning-free
- [ ] (future) Formalize AC ⟹ LocallyBoundedVariationOn

🤖 Generated with [Claude Code](https://claude.com/claude-code)