### PR TITLE
audit(erdos-41): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6812,9 +6812,9 @@
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T22:20:35Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T06:13:15Z",
+      "result": "clean",
       "issues": [
         "phantom Nash h=4 axiom in proofStrategy and section solved-cases (only docstring, Chen subsumes); section examples implies powersOfTwo theorem but only def + docstring exist (#14415)"
       ]


### PR DESCRIPTION
## Summary

Audit cycle 4 of erdos-41: clean.

- meta.status=axiomatized, meta.badge=axiom, meta.sorries=0, meta.axiomCount=2
- Erdos41Problem.lean: 2 axioms (erdos_b2_theorem, chen_even_h_theorem), 0 sorries
- Assumptions field documents both axiomatized results
- B_h sequence density bounds: Chen 1996 even-h cases axiomatized; h=3 case noted as open with \$500 prize

Tracker entry transitioned from issues-fixed (2026-05-01, #14415) → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)