### PR TITLE
Fix stale Erdos26.X_seq namespace ref in delta call

### DIFF
--- a/proofs/Proofs/Erdos26APN_Tenenbaum.lean
+++ b/proofs/Proofs/Erdos26APN_Tenenbaum.lean
@@ -1080,7 +1080,7 @@ lemma lowerDensity_le_of_seq (S : Set ℕ) (c : ℝ)
   S.lowerDensity ≤ c := by
   simp_rw [Set.lowerDensity, Finset.card_filter] at h⊢
   simp_all -contextual[Filter.liminf_eq,Set.partialDensity]
-  delta Erdos26.X_seq at h
+  delta X_seq at h
   use Real.sSup_le (@ fun and ⟨a, H⟩=>not_lt.mp fun and=>(((tendsto_natCast_atTop_atTop.atTop_mul_const ↑(sub_pos.mpr and)).eventually_gt_atTop (a+1)).frequently (@Filter.eventually_atTop.mpr ⟨a+2,? _,⟩))) @?_
   · use fun and μ=>match and with|n + 1=>(((mul_sub _ _ _).trans_le (sub_le_iff_le_add'.2 (((le_div_iff₀' (by bound)).1 (H (n + 1) (by valid))).trans (?_))))).not_gt
     use match n with|n + 1=>.trans (mod_cast(Nat.card_mono (Finset.finite_toSet _) fun and p=>?_).trans ((Nat.card_eq_finsetCard _)▸ Finset.card_insert_le 0 _)) (add_le_add ((h (n + 1)).trans (?_)) (le_add_of_nonneg_left a.cast_nonneg))


### PR DESCRIPTION
## Fix

Correct the stale `delta Erdos26.X_seq at h` reference on line 1083 of `proofs/Proofs/Erdos26APN_Tenenbaum.lean`, missed by the `sed`-style namespace rename during the AlphaProof Nexus port (same class of bug as PRs #20838 / #20839).

## Evidence

**Before**: `delta Erdos26.X_seq at h` — references the old `Erdos26` namespace, which was renamed to `Erdos26APN_Tenenbaum`. This identifier no longer resolves and fails elaboration.

**After**: `delta X_seq at h` — unqualified, matching every other in-namespace reference (the file sits inside `namespace Erdos26APN_Tenenbaum`, lines 95–1123, and `X_seq` is defined unqualified at line 1069).

Acceptance check from the issue passes:
```
$ grep -n "Erdos26\.[A-Z]" proofs/Proofs/Erdos26APN_Tenenbaum.lean
(0 matches)
```

Docker build verification is deferred per the issue ("Build verification tracked in #FUTURE").

Closes #20845

---
Automated fix by lean-mechanic agent.