### PR TITLE
audit(erdos-41): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6812,9 +6812,9 @@
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T22:20:35Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T06:30:08Z",
+      "result": "clean",
       "issues": [
         "phantom Nash h=4 axiom in proofStrategy and section solved-cases (only docstring, Chen subsumes); section examples implies powersOfTwo theorem but only def + docstring exist (#14415)"
       ]


### PR DESCRIPTION
## Summary
Audit cycle 4 verification of erdos-41 (B_h Sequences and Density Bounds).

## Findings
- 0 sorries, 2 axioms, 6 theorems, 7 defs, 164 lines (all match meta.json)
- Status `axiomatized` consistent with axiomCount=2 (per axiom integrity policy)
- Axioms `erdos_b2_theorem` and `chen_even_h_theorem` properly listed in `assumptions` field
- Known minor issue (orphan "Key lemma" docstring for powers-of-2) already documented in section summary

## Test plan
- [x] meta.json↔Lean source integrity verified by grep counts
- [x] Tracker entry updated to cycle 4, result=clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)