### PR TITLE
audit(erdos-41): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6812,9 +6812,9 @@
     },
     "erdos-41": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T22:20:35Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T06:47:35Z",
+      "result": "clean",
       "issues": [
         "phantom Nash h=4 axiom in proofStrategy and section solved-cases (only docstring, Chen subsumes); section examples implies powersOfTwo theorem but only def + docstring exist (#14415)"
       ]


### PR DESCRIPTION
## Summary
- Cycle 4 audit of erdos-41 (B_h Sequences and Density Bounds): clean
- All integrity checks pass; previous Nash phantom-axiom / powersOfTwo phantom-theorem fixes intact

## Verification
- 0 sorries, 0 True stubs
- 2 axioms (`erdos_b2_theorem`, `chen_even_h_theorem`) match `axiomCount: 2`
- 6 theorems, 7 defs, 164 lines match meta.json
- `status=axiomatized`, `badge=axiom` consistent with axioms present

## Test plan
- [x] meta.json claims compared line-by-line against `proofs/Proofs/Erdos41Problem.lean`
- [x] Tracker advanced via `claim-target.sh complete erdos-41 clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)