### PR TITLE
audit(erdos-407): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6791,9 +6791,9 @@
     },
     "erdos-407": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T22:43:27Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T06:50:27Z",
+      "result": "clean",
       "issues": [
         "phantom Bajpai-Bennett 131082 axiom (only ≤ 9 declared, 131082 only in docstring); phantom FourRepFamily theorems (def + 2 docstring headers, no proofs); section line drift in main-results/infinite-family/summary (#14418)"
       ]


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-407 (Newman's Conjecture on 2^a + 3^b + 2^c·3^d)
**Cycle**: 4

## Lean Source Integrity

`proofs/Proofs/Erdos407Problem.lean`:
- 3 axioms: `egst_1988`, `tijdeman_wang_1988`, `bajpai_bennett_2024_all`
- 0 sorries
- 0 True stubs
- 7 theorems, 7 definitions, 219 lines

## meta.json Consistency

| Claim | meta.json | Lean | Match |
|-------|-----------|------|-------|
| axiomCount | 3 | 3 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| lineCount | 219 | 219 | ✓ |
| status | axiomatized | (3 axioms) | ✓ |
| badge | axiom | (3 axioms) | ✓ |

## Honesty Disclosures Verified

- **originalContributions**: Honestly labels `egst_1988`, `tijdeman_wang_1988`, `bajpai_bennett_2024_all` as axioms.
- **131082 threshold**: meta.json discloses "≤ 4 for n ≥ 131082 result … documented in the axiom's docstring but not formalized as separate axioms." Lean confirms only `bajpai_bennett_2024_all : ∀ n, (DistinctReps n).ncard ≤ 9` is declared.
- **FourRepFamily**: meta.json discloses "definition only — no theorem". Lean confirms `def FourRepFamily` followed by docstring-only headers, no proofs.
- **Section line ranges** (39-69, 70-99, 100-136, 137-165, 166-189, 190-219) match the Lean file.

## Prior Cycle Issues

Cycle 3 (2026-05-01) flagged: phantom 131082 axiom, phantom FourRepFamily theorems, section line drift (#14418). All three are now properly disclosed in current meta.json — no overclaims remain.

## Tracker Update

```
auditCount: 3 → 4
lastAudited: 2026-05-01T22:43:27Z → 2026-05-29T06:50:27Z
result: issues-fixed → clean
```

Historical issue list preserved.