### PR TITLE
audit(erdos-396): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6710,9 +6710,9 @@
     },
     "erdos-396": {
       "agentId": "auditor-2026-05-02-0100",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T23:04:36Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T07:08:29Z",
+      "result": "clean"
     },
     "erdos-397": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- erdos-396 audit cycle 4: clean
- 1 axiom, 0 sorries, 2 theorems, 0 defs, 78 lines — all match meta
- Vacuous `n_divides_rarely` placeholder and docstring-only Pomerance/Erdős–Graham results already documented honestly in meta

## Tracker change
- `auditCount`: 3 → 4
- `result`: `issues-fixed` → `clean`
- `lastAudited`: bumped

## Notes
- Minor 3-line section boundary drift (cosmetic) — not material
- Prior cycle fixes from PR #14424 (phantom axioms, vacuous theorem documentation) intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)