### PR TITLE
audit(erdos-391): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6662,13 +6662,11 @@
       "result": "clean"
     },
     "erdos-391": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T23:08:58Z",
-      "result": "issues-fixed",
-      "issues": [
-        "section line drift sections[3..8] (acrstuv-theorem onward) — first 3 sections aligned, drift starts at Part IV; numerical counts and tier all clean (#14427)"
-      ]
+      "agentId": "auditor-loom-cycle4",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T07:13:00Z",
+      "result": "clean",
+      "issues": []
     },
     "erdos-392": {
       "auditCount": 5,


### PR DESCRIPTION
## Summary

Re-audited erdos-391 (Factorizing n! with Large Minimum Factor). Clean cycle 4.

## Verification (proofs/Proofs/Erdos391Problem.lean)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 227 | 227 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 5 | 5 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 8 | 1 structure + 7 defs = 8 | ✓ |
| status/badge | axiomatized/axiom | — | ✓ |

Axioms present: `easy_upper_bound`, `limit_is_one_over_e`, `second_order_correction`, `upper_bound_explicit`, `lower_bound_explicit` — all 5 listed in `assumptions` and `originalContributions`.

Theorems present: `limsup_le_one_over_e`, `guy_selfridge_2_proved`, `erdos_391_summary`.

All 9 section line ranges align with Lean source headers (Part II at L75, Part III at L95, Part IV at L106, Part V at L134, Part VI at L154, Part VII at L164, Part VIII at L183, Part IX at L191). Prior section drift issue (#14427) is fully resolved.

No True stubs, no Mathlib wrappers, no phantom assumptions.

## Tracker bump

- auditCount 3 → 4
- result: issues-fixed → clean
- issues: cleared (stale section-drift note from #14427)

## Test plan

- [x] meta.json claims verified against Lean source
- [x] axiom/sorry/theorem/def counts cross-checked
- [x] section line ranges spot-checked
- [x] status field appropriate (axiomatized for axiomatized proof)