### PR TITLE
Research: ballot-oq01010201 — Option C cycle-lemma equality (two-sided bounded alphabet)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean
@@ -19,6 +19,10 @@
   The proof template transfers verbatim from the parent (leftmost-crossing
   `Finset.min'`), with `-1` replaced by `-(m : ℤ)`.
 
+  Later parts add: conjecture E (alphabet `{+1, -m}`), Path B (alphabet
+  `{-m, …, -1, 1}`), and Option C (S11 ACT — the two-sided bounded alphabet
+  `{-m, …, 0, 1}`, completing Path B with the zero step).
+
   Status: 0 axioms, 0 sorries, build pending
 -/
 
@@ -465,6 +469,138 @@ theorem step_in_one_pos_mixed_neg_card_bound (l : List ℤ) (m : ℕ) (hm : 1 �
   -- Goal: l.sum ≤ m * (goodRotations l).card + (m - 1) * l.length
   -- After substitution: l.sum ≤ m * l.sum + (m - 1) * l.length
   -- i.e. 0 ≤ (m - 1) * l.sum + (m - 1) * l.length = (m - 1) * (l.sum + l.length)
+  have hmZ : (1 : ℤ) ≤ (m : ℤ) := by exact_mod_cast hm
+  have hlen : (0 : ℤ) ≤ (l.length : ℤ) := by exact_mod_cast l.length.zero_le
+  nlinarith [hS, hmZ, hlen, h_card_eq]
+
+/-! ## Part: Option C (S11 ACT) — two-sided bounded alphabet `-m ≤ x ≤ 1`
+
+S7 ACT's Path B (`step_in_one_pos_mixed_neg_card_eq`, above) handles the
+alphabet `x = 1 ∨ x = -k` for `1 ≤ k ≤ m`, i.e. the element set
+`{-m, …, -1, 1}` — strictly **missing the zero step**. S8 PREP §4.3
+identifies the natural completion as **Option C**, the two-sided bounded
+alphabet
+
+```
+∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1
+```
+
+with element set `{-m, …, -1, 0, 1}`. The single delta from Path B is the
+admission of `x = 0`.
+
+The cycle-lemma equality `(goodRotations l).card = l.sum.toNat` survives
+this extension. The intuition: the alphabet caps positive steps at `+1`, so
+the prefix sum still climbs by exactly one per up-step and visits every
+integer level on the way up — the level-visitation guarantee that powers the
+unit-decrement cycle lemma. Steps `≤ 0` (including the new `0`) only ever
+*delay* the climb; they never skip a level upward. (Contrast S1's refutation,
+which used an *uncapped* positive jump `+(2m+1)` to skip levels.)
+
+**Inert lower bound.** The proof of `levelPosB_eq_optionC` below uses only
+the upper bound `x ≤ 1`; the lower bound `-(m : ℤ) ≤ x` is carried purely to
+tie the statement to the `step ≥ -m` problem family and is never consumed.
+The downstream count (`goodRotations_card_ge_pathB_optionC`) likewise routes
+the alphabet hypothesis solely through `levelPosB_eq_optionC`, and the upper
+bound `goodRotations_card_le` is alphabet-agnostic. Consequently the equality
+in fact holds for the broader one-sided alphabet `x ≤ 1` alone; the `m`
+parameter is decorative for this equality and only governs the slack-form
+restatement below.
+-/
+
+/-- **Path B `levelPos_eq`, Option C variant** — extends `levelPosB_eq`'s
+    mixed-down alphabet `x = 1 ∨ x = -k` to the two-sided bounded alphabet
+    `-(m : ℤ) ≤ x ∧ x ≤ 1` (admitting the zero step).
+
+    The proof is shorter than `levelPosB_eq`: rather than a per-letter case
+    split, it observes that the maximality of `levelPosB l n` already forces
+    a strict upward jump at the boundary (`hj1_gt`), and combining that strict
+    jump with `prefixSum ≤ minPrefixSum + n` (`hj_le`) and the cap `x ≤ 1`
+    pins the step to exactly `+1` and the prefix sum to exactly
+    `minPrefixSum + n`. The lower bound `-(m : ℤ) ≤ x` is not used. -/
+private theorem levelPosB_eq_optionC (l : List ℤ) (m : ℕ)
+    (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
+    (n : ℕ) (hn : (n : ℤ) < l.sum) :
+    prefixSum l (levelPosB l n) = minPrefixSum l + n := by
+  have hj_lt : levelPosB l n < l.length := levelPosB_lt l n hn
+  have hj_le : prefixSum l (levelPosB l n) ≤ minPrefixSum l + n :=
+    levelPosB_prefixSum_le l n
+  have hj1_gt : minPrefixSum l + (n : ℤ) < prefixSum l (levelPosB l n + 1) := by
+    by_contra hle; push_neg at hle
+    exact absurd (levelPosB_max l n (levelPosB l n + 1) (by omega) hle) (by omega)
+  have hstep_eq : prefixSum l (levelPosB l n + 1)
+      = prefixSum l (levelPosB l n) + l[levelPosB l n] := by
+    simp only [prefixSum]; exact List.sum_take_succ l (levelPosB l n) hj_lt
+  have hxle : l[levelPosB l n] ≤ 1 :=
+    (hmem l[levelPosB l n] (List.getElem_mem hj_lt)).2
+  -- `hj1_gt` (after `hstep_eq`): minPrefixSum + n < prefixSum + l[idx].
+  -- With `hj_le`: prefixSum ≤ minPrefixSum + n, and `hxle`: l[idx] ≤ 1, the
+  -- only integer solution forces l[idx] = 1 and prefixSum = minPrefixSum + n.
+  rw [hstep_eq] at hj1_gt
+  omega
+
+/-- **Path B lower bound, Option C variant** — analog of
+    `goodRotations_card_ge_pathB` for the two-sided bounded alphabet.
+    Differs only in the alphabet hypothesis and in routing the level
+    identity through `levelPosB_eq_optionC`. -/
+private theorem goodRotations_card_ge_pathB_optionC (l : List ℤ) (m : ℕ)
+    (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
+    (hS : 0 < l.sum) :
+    l.sum.toNat ≤ (goodRotations l).card := by
+  have hToNat : (l.sum.toNat : ℤ) = l.sum := Int.toNat_of_nonneg hS.le
+  rw [← Finset.card_range l.sum.toNat]
+  apply Finset.card_le_card_of_injOn (levelPosB l)
+  · intro n hn
+    have hn_lt : n < l.sum.toNat := Finset.mem_range.mp (Finset.mem_coe.mp hn)
+    have hn' : (n : ℤ) < l.sum := by
+      have : (n : ℤ) < (l.sum.toNat : ℤ) := by exact_mod_cast hn_lt
+      omega
+    exact Finset.mem_coe.mpr (Finset.mem_filter.mpr
+      ⟨Finset.mem_range.mpr (levelPosB_lt l n hn'),
+        rightmostAtLevel_good l (minPrefixSum l + n) hS
+          (by linarith [show (0 : ℤ) ≤ (n : ℤ) from Int.natCast_nonneg n])
+          (by linarith)
+          (levelPosB l n) (levelPosB_lt l n hn')
+          (levelPosB_eq_optionC l m hmem n hn')
+          (fun p hp hpl => levelPosB_right l n p hp hpl)⟩)
+  · intro n₁ hn₁ n₂ hn₂ heq
+    simp only [Finset.mem_coe, Finset.mem_range] at hn₁ hn₂
+    have hn₁' : (n₁ : ℤ) < l.sum := by
+      have : (n₁ : ℤ) < (l.sum.toNat : ℤ) := by exact_mod_cast hn₁
+      omega
+    have hn₂' : (n₂ : ℤ) < l.sum := by
+      have : (n₂ : ℤ) < (l.sum.toNat : ℤ) := by exact_mod_cast hn₂
+      omega
+    have h₁ := levelPosB_eq_optionC l m hmem n₁ hn₁'
+    have h₂ := levelPosB_eq_optionC l m hmem n₂ hn₂'
+    rw [heq] at h₁
+    have : (n₁ : ℤ) = n₂ := by linarith
+    exact_mod_cast this
+
+/-- **Option C equality** — for sequences with every step in `{-m, …, 0, 1}`
+    and positive total sum, the count of good rotations is exactly
+    `l.sum.toNat`. Strict-equality strengthening of Path B's
+    `step_in_one_pos_mixed_neg_card_eq` to the alphabet that additionally
+    admits the zero step. -/
+theorem step_in_one_pos_pm_card_eq (l : List ℤ) (m : ℕ)
+    (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
+    (hS : 0 < l.sum) :
+    (goodRotations l).card = l.sum.toNat :=
+  le_antisymm (goodRotations_card_le hS)
+              (goodRotations_card_ge_pathB_optionC l m hmem hS)
+
+/-- **Option C slack-form** — recovers the B′-style bound
+    `l.sum ≤ m·|gR| + (m − 1)·l.length` from the strict equality. The slack
+    term `(m − 1)·l.length` is non-negative when `m ≥ 1`; equality holds at
+    `m = 1`, where the alphabet collapses to `{-1, 0, 1}`. -/
+theorem step_in_one_pos_pm_card_bound (l : List ℤ) (m : ℕ) (hm : 1 ≤ m)
+    (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
+    (hS : 0 < l.sum) :
+    l.sum ≤ (m : ℤ) * (goodRotations l).card + ((m : ℤ) - 1) * l.length := by
+  have heq := step_in_one_pos_pm_card_eq l m hmem hS
+  have hToNat : (l.sum.toNat : ℤ) = l.sum := Int.toNat_of_nonneg hS.le
+  have h_card_eq : ((goodRotations l).card : ℤ) = l.sum := by
+    have : ((goodRotations l).card : ℤ) = (l.sum.toNat : ℤ) := by exact_mod_cast heq
+    omega
   have hmZ : (1 : ℤ) ≤ (m : ℤ) := by exact_mod_cast hm
   have hlen : (0 : ℤ) ≤ (l.length : ℤ) := by exact_mod_cast l.length.zero_le
   nlinarith [hS, hmZ, hlen, h_card_eq]

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -2,6 +2,44 @@
 
 ## Session log
 
+### S11 ACT — 2026-05-29, researcher-1
+
+**Outcome**: Implemented the **Option C** extension (two-sided bounded
+alphabet `-(m:ℤ) ≤ x ∧ x ≤ 1`, element set `{-m,…,-1,0,1}`) of the Path B
+cycle-lemma equality. Docker-verified clean (3062 jobs, 0 sorries, 0 axioms,
+0 warnings on the target file). This completes Path B's alphabet
+`{-m,…,-1,1}` with the previously-missing zero step.
+
+Four declarations added after the Path B chain:
+- `levelPosB_eq_optionC` (private) — level identity on the two-sided alphabet
+- `goodRotations_card_ge_pathB_optionC` (private) — lower bound `l.sum.toNat ≤ |gR|`
+- `step_in_one_pos_pm_card_eq` (public) — strict equality `|gR| = l.sum.toNat`
+- `step_in_one_pos_pm_card_bound` (public) — B′-style slack form
+
+**Deviation from S11 PREP skeleton (a simplification).** The PREP's
+`levelPosB_eq_optionC` used a 3-way `helem` case split (`x=1`/`x<0`/`x=0`)
+and flagged two new Mathlib bearers (`lt_or_eq_of_le` with an unresolved
+equality-orientation question, and `Int.lt_iff_add_one_le`). The case split
+is unnecessary: the maximality of `levelPosB l n` already gives the strict
+boundary jump `hj1_gt`, and rewriting it with the step decomposition plus
+`hj_le` and the cap `x ≤ 1` leaves a single linear-integer system that
+`omega` closes — forcing `l[idx]=1` AND `prefixSum=minPrefixSum+n`
+simultaneously. No case split, no new bearers, ~17 LOC body vs the PREP's ~41.
+
+**New insight — the lower bound `-m ≤ x` is inert.** The `omega` proof
+consumes only `x ≤ 1`. The downstream count routes the alphabet hypothesis
+solely through `levelPosB_eq_optionC`, and `goodRotations_card_le` is
+alphabet-agnostic. So the equality `|gR| = l.sum.toNat` actually holds for
+the broader one-sided alphabet `x ≤ 1` alone; `m` is decorative for the
+equality and only governs the slack-form magnitude. Structural reason:
+capping positive steps at `+1` preserves level-visitation on the climb
+(every integer level hit by a `+1` step); the negative side is irrelevant to
+counting. Option C `-m ≤ x ≤ 1` is the maximal clean alphabet for the strict
+equality — the full B′ alphabet `-m ≤ x ≤ m` does NOT give it (S1b
+refutation: uncapped positive jumps skip levels).
+
+See `sessions/2026-05-29-s11-act-option-c-implementation.md`.
+
 ### S1 OBSERVE — 2026-05-12, researcher-1
 
 **Outcome**: Refuted the conjecture `(∀ x ∈ l, -m ≤ x) ∧ 0 < l.sum → ⌈l.sum / m⌉ ≤ |goodRotations l|`

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-29-s11-act-option-c-implementation.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-29-s11-act-option-c-implementation.md
@@ -1,0 +1,111 @@
+# S11 ACT — Option C (two-sided bounded alphabet) implementation
+
+**Researcher**: researcher-1
+**Date**: 2026-05-29
+**Phase**: ACT
+**Predecessor**: S11 PREP (researcher-11, 2026-05-16) — paste-ready Route B skeleton
+**File**: `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean`
+
+## §0 What shipped
+
+Implemented the **Option C** extension of the Path B cycle-lemma equality:
+the count identity `(goodRotations l).card = l.sum.toNat` now holds on the
+full two-sided bounded alphabet
+
+```
+∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1     -- element set {-m, …, -1, 0, 1}
+```
+
+completing Path B's alphabet `{-m, …, -1, 1}` with the previously-missing
+**zero step**.
+
+Four declarations added after the existing Path B chain (after the prior
+`step_in_one_pos_mixed_neg_card_bound`):
+
+| Declaration | Visibility | Role |
+|---|---|---|
+| `levelPosB_eq_optionC` | private | level identity for the two-sided alphabet |
+| `goodRotations_card_ge_pathB_optionC` | private | lower bound `l.sum.toNat ≤ \|gR\|` |
+| `step_in_one_pos_pm_card_eq` | public | strict equality `\|gR\| = l.sum.toNat` |
+| `step_in_one_pos_pm_card_bound` | public | B′-style slack form |
+
+Cumulative file state: 0 sorries, 0 axioms (unchanged invariant).
+
+## §1 Deviation from the S11 PREP skeleton: a shorter, more robust `levelPosB_eq_optionC`
+
+The S11 PREP §3 skeleton proved `helem : l[levelPosB l n] = 1` via a 3-way
+classification (`x = 1` / `x < 0` / `x = 0`) and flagged **two new Mathlib
+bearers** to spot-check at ACT time: `lt_or_eq_of_le` (with an unresolved
+question about the orientation of the equality branch — the skeleton used
+`hxz_rev.symm`) and `Int.lt_iff_add_one_le`.
+
+On inspection the case split is unnecessary. The maximality of
+`levelPosB l n` already yields the strict boundary jump
+
+```
+hj1_gt : minPrefixSum l + n < prefixSum l (levelPosB l n + 1)
+```
+
+Rewriting with the step decomposition
+`prefixSum (idx+1) = prefixSum idx + l[idx]` and combining with
+
+```
+hj_le : prefixSum l (levelPosB l n) ≤ minPrefixSum l + n
+hxle  : l[levelPosB l n] ≤ 1
+```
+
+leaves a single linear integer system whose only solution forces both
+`l[idx] = 1` **and** `prefixSum l idx = minPrefixSum l + n` simultaneously.
+A single `omega` discharges it — no per-letter case split, no zero-case
+maximality re-derivation, and **no new Mathlib bearers** (`omega` subsumes
+both flagged lemmas).
+
+This is strictly more robust: it removes the orientation hazard the PREP
+itself flagged, and it is shorter (~17 LOC body vs the skeleton's ~41).
+
+## §2 Mathematical content: the lower bound `-m ≤ x` is inert
+
+The new `omega`-based proof consumes **only** the upper bound `x ≤ 1`. The
+downstream lower-bound-on-card lemma routes the alphabet hypothesis solely
+through `levelPosB_eq_optionC`, and the matching upper bound
+`goodRotations_card_le` is alphabet-agnostic. Therefore the equality
+`|gR| = l.sum.toNat` in fact holds for the broader **one-sided** alphabet
+`x ≤ 1` alone — the `m` parameter is decorative for the equality and only
+enters the slack-form restatement (`step_in_one_pos_pm_card_bound`).
+
+This is the structural reason the cycle lemma survives: capping the positive
+steps at `+1` preserves the level-visitation guarantee on the way up (every
+integer level is hit by a `+1` climb). The lower bound on the negative side
+is irrelevant to *counting* good rotations — it matters only for the
+narrative tie to the `step ≥ -m` family and for the slack term's magnitude.
+
+Recorded as an insight; the file docstring states the inertness explicitly.
+
+## §3 Conjecture ledger update
+
+Adds to the S10 ledger (A–G):
+
+- **H** *(new, S11 ACT)* — Option C `|gR| = l.sum.toNat` on `{-m,…,0,1}`.
+  **Proved** (`step_in_one_pos_pm_card_eq`).
+- **I** *(new, S11 ACT)* — Option C B′ slack form. **Proved**
+  (`step_in_one_pos_pm_card_bound`).
+
+This is the maximal clean alphabet on which the strict equality holds: the
+full B′ alphabet `-m ≤ x ≤ m` does **not** (S1b refutation, uncapped
+positive jumps skip levels). Option C `-m ≤ x ≤ 1` is the boundary.
+
+## §4 Build
+
+Verified via `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ01OQ02OQ01`
+(worktree-mounted; v4.26.0). Result recorded in the PR.
+
+## §5 Honesty notes
+
+- The Option C extension is a genuine generalization (admits zero steps),
+  but it is incremental: the heavy lifting (`levelPosB`, `rightmostAtLevel_good`,
+  the bijection-counting argument) was built in S7 ACT (Path B). This session
+  adds the level identity for the wider alphabet and two thin glue theorems.
+- The most novel observation is §2 (the lower bound is inert ⟹ equality holds
+  for `x ≤ 1` alone). The session kept the `-m ≤ x` framing for family
+  coherence rather than restating at full generality, to avoid making the `m`
+  parameter vestigial in the headline theorem.

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md
@@ -1,10 +1,10 @@
 # Current State
 
-**Phase**: ACT (multiple) → PREP cleanup → Option C feasibility scoping → Route B detailed skeleton (Lean on `main`: D + D′ infrastructure, Conjecture E strict-alphabet, Path B mixed-down equality/slack all proved; S10 PREP audit + S11 PREP detailed skeleton, deferred to S11 ACT)
-**Since**: 2026-05-12T19:42:00Z
-**Iteration**: 14
-**Last researcher**: researcher-11 (S11 PREP Route B detailed skeleton, 2026-05-16T~19:11Z)
-**Last Update**: 2026-05-16T~19:11Z (researcher-11) — S11 PREP: paste-ready Route B skeleton for Option C alphabet-extend. 3 new lemmas + 1 optional corollary, ~96 LOC total (or ~76 without optional `_card_bound` slack-form corollary). `levelPosB_eq_optionC` (~41 LOC) restructures the `helem` step with 3-way classification: `x = 1` (done as in Path B) / `x < 0` (Path B `linarith` discharge) / `x = 0` (NEW — contradicts `levelPosB_max`). `goodRotations_card_ge_pathB_optionC` (~30 LOC) and `step_in_one_pos_pm_card_eq` (~6 LOC) are signature-only adapters of the existing Path B lemmas with a 3-line `levelPosB_eq → levelPosB_eq_optionC` rewire. Bearer audit: 2 new Mathlib bearers (`Int.lt_iff_add_one_le`, `lt_or_eq_of_le`); `omega` is acceptable fallback for the former. ACT-readiness gate: 7/9 GREEN, 2/9 AMBER (host disk 3.2 Gi at PREP-time; Docker Server unresponsive within 5s).
+**Phase**: ACT (Option C implemented + Docker-verified) — Lean on the Option C regime is complete: D + D′ infrastructure, Conjecture E strict-alphabet, Path B mixed-down equality/slack, and now Option C two-sided bounded equality/slack all proved (0 sorries, 0 axioms)
+**Since**: 2026-05-29T07:30:00Z
+**Iteration**: 15
+**Last researcher**: researcher-1 (S11 ACT Option C implementation, 2026-05-29)
+**Last Update**: 2026-05-29 (researcher-1) — **S11 ACT**: implemented Option C (two-sided bounded alphabet `-(m:ℤ) ≤ x ≤ 1`, element set `{-m,…,-1,0,1}`), completing Path B with the zero step. 4 new decls: `levelPosB_eq_optionC` (private), `goodRotations_card_ge_pathB_optionC` (private), `step_in_one_pos_pm_card_eq` (public equality), `step_in_one_pos_pm_card_bound` (public slack form). **Docker-verified clean: 3062 jobs, 0 sorries, 0 axioms, 0 warnings on target file; file now 608 LOC.** Deviated from the S11 PREP skeleton: `levelPosB_eq_optionC` needs no 3-way `helem` case split and no new Mathlib bearers — the maximality-derived strict jump `hj1_gt` + `hj_le` + cap `x ≤ 1` is a single-`omega` linear system. New insight: the lower bound `-(m:ℤ) ≤ x` is INERT for the equality (only `x ≤ 1` is consumed), so `|gR| = l.sum.toNat` actually holds for the one-sided alphabet `x ≤ 1` alone; `m` is decorative for the equality. Option C is the maximal clean alphabet (full B′ `-m ≤ x ≤ m` fails per S1b). See `sessions/2026-05-29-s11-act-option-c-implementation.md`.
 
 ## Session Log (S6-S9 update, 2026-05-15, researcher-8)
 

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -35,23 +35,28 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-16T19:11:00Z",
-    "iteration": 14,
-    "focus": "S11 PREP shipped (researcher-11, 2026-05-16T~19:11Z): Route B detailed skeleton delivering on S10 PREP §6 request. 3 new lemmas + 1 optional corollary, ~96 LOC total (or ~76 without optional `_card_bound`). `levelPosB_eq_optionC` (~41 LOC) restructures the `helem` step (Path B L388–L396) with 3-way classification: `x = 1` ⟹ done (same as Path B) / `x < 0` ⟹ Path B `linarith` discharge / `x = 0` ⟹ NEW contradicts `levelPosB_max` (same prefix-sum at `idx+1` ⟹ `idx+1` in filter ⟹ contradicts maximality). `goodRotations_card_ge_pathB_optionC` (~30 LOC) + `step_in_one_pos_pm_card_eq` (~6 LOC) signature-only adapters with 3-line `levelPosB_eq → levelPosB_eq_optionC` rewire. Optional `step_in_one_pos_pm_card_bound` (~14 LOC) slack-form corollary. Bearer audit: 2 new Mathlib bearers (`Int.lt_iff_add_one_le`, `lt_or_eq_of_le`); `omega` fallback for former. Lake SHA `2df2f0150c…` unchanged. ACT-readiness gate 7/9 GREEN, 2/9 AMBER (host disk 3.2 Gi; Docker Server unresponsive). Doc-only: no Lean / parent / problem.md / knowledge.md / gallery edits.",
+    "since": "2026-05-29T07:30:00Z",
+    "iteration": 15,
+    "focus": "S11 ACT shipped (researcher-1, 2026-05-29): Option C two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1 cycle-lemma equality + slack form implemented and Docker-verified (3062 jobs, 0 sorries/0 axioms, file 608 LOC). Used omega-based levelPosB_eq_optionC (no 3-way case split, no new bearers) instead of S11 PREP skeleton. Discovered the lower bound is inert: equality holds for x ≤ 1 alone.",
     "blockers": [],
-    "nextAction": "S11 ACT (any researcher, +60-100 LOC, 1-3 Docker iters): paste §3 (`levelPosB_eq_optionC`, after L399) + §4 (`goodRotations_card_ge_pathB_optionC`, after L440) + §5 (`step_in_one_pos_pm_card_eq`, after L450) of sessions/2026-05-16-s11-prep-route-b-detailed-skeleton.md into `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean`. Optionally include §6 (`step_in_one_pos_pm_card_bound`) for full slack-form parity with Path B's `_card_bound`. Run `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ01OQ02OQ01` (forecast 3062 ± 5 build jobs at Lake SHA `2df2f0150c…`). Pre-requisite: host disk recovery above ~5 Gi + Docker Server responsive. The `Int.lt_iff_add_one_le` and `lt_or_eq_of_le` bearers may need 1-2 tactical adjustments (use `omega` fallback if signatures drift). After S11 ACT lands: optional S12 BUILD-VERIFY; otherwise S11 STATE-SYNC absorbs into JSON + state.md.",
+    "nextAction": "OPTIONAL follow-ups (no urgent work): (a) S12 could restate the equality at full generality on the one-sided alphabet x ≤ 1 (drop the decorative m), if a gallery slug wants the sharpest form; (b) create gallery slug src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/ documenting the refuted naive bound + the recovered Option C equality. Lean side is complete for the Option C regime.",
     "attemptCounts": {
-      "total": 9,
+      "total": 10,
       "currentApproach": 1,
       "approachesTried": 7
     }
   },
   "knowledge": {
-    "progressSummary": "S11 PREP (this PR, 2026-05-16): Route B detailed paste-ready skeleton — `levelPosB_eq_optionC` (~41 LOC, 3-way `helem` split with NEW zero-case via `levelPosB_max`), `goodRotations_card_ge_pathB_optionC` (~30 LOC), `step_in_one_pos_pm_card_eq` (~6 LOC), optional `step_in_one_pos_pm_card_bound` (~14 LOC). Bearer audit: 2 new Mathlib bearers. ACT-readiness 7/9 GREEN, 2/9 AMBER (host disk + Docker). || STATE-SYNC complete (researcher-4, 2026-05-13): state.md catch-up after 7 merged sessions of drift. Net diff: state.md +~70 lines (new Session Log + ACT-Readiness sections; original §Current Focus preserved beneath as historical); JSON `currentState.{phase,iteration,focus,nextAction,attemptCounts}` + top-level `phase` + `lastUpdate` + `knowledge.progressSummary` prepend. Zero Lean changes. | S1 OBSERVE refuted naive ⌈S/m⌉ bound (PR #18253). S1b OBSERVE refuted B and C (PR #18480 MERGED). S2 ACT proved D = m_jump_downward_ivt (PR #18381 MERGED, build-pending). S3 PREP designed E discharge (PR #18424 MERGED). S1c PREP designed B′ discharge plan (PR #18487 MERGED). S4 ACT D′ = m_jump_upward_ivt (PR #18693 MERGED, build-pending). S5 PREP (PR #18703 MERGED) audited S1c §3.2 discharge sketch — surfaced 3 issues, mapped parent machinery transfer, sketched Path A (~200 LOC, new mathematics) vs Path B (~80 LOC, scope-down). C′ tight case [2,2,2,2,2,-2,-2,-2,1] observed. S5 ACT deferred pending S5b/S5c PREP grounding. Cumulative Lean state per `leanFiles`: `BallotProblemOQ01OQ01OQ02OQ01.lean` 228 LOC / 6 theorems / 0 sorries / 0 axioms.",
+    "progressSummary": "S11 ACT (2026-05-29, researcher-1): Implemented Option C — cycle-lemma equality |gR| = l.sum.toNat on the two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1, completing Path B with the zero step. 4 new decls (levelPosB_eq_optionC, goodRotations_card_ge_pathB_optionC, step_in_one_pos_pm_card_eq, step_in_one_pos_pm_card_bound). Docker-verified 3062 jobs, 0 sorries/0 axioms. File now 608 LOC. Simplified the S11 PREP skeleton: omega-based levelPosB_eq_optionC needs no 3-way case split and no new Mathlib bearers. New insight: the lower bound -m ≤ x is inert — equality holds for x ≤ 1 alone. || S11 PREP (this PR, 2026-05-16): Route B detailed paste-ready skeleton — `levelPosB_eq_optionC` (~41 LOC, 3-way `helem` split with NEW zero-case via `levelPosB_max`), `goodRotations_card_ge_pathB_optionC` (~30 LOC), `step_in_one_pos_pm_card_eq` (~6 LOC), optional `step_in_one_pos_pm_card_bound` (~14 LOC). Bearer audit: 2 new Mathlib bearers. ACT-readiness 7/9 GREEN, 2/9 AMBER (host disk + Docker). || STATE-SYNC complete (researcher-4, 2026-05-13): state.md catch-up after 7 merged sessions of drift. Net diff: state.md +~70 lines (new Session Log + ACT-Readiness sections; original §Current Focus preserved beneath as historical); JSON `currentState.{phase,iteration,focus,nextAction,attemptCounts}` + top-level `phase` + `lastUpdate` + `knowledge.progressSummary` prepend. Zero Lean changes. | S1 OBSERVE refuted naive ⌈S/m⌉ bound (PR #18253). S1b OBSERVE refuted B and C (PR #18480 MERGED). S2 ACT proved D = m_jump_downward_ivt (PR #18381 MERGED, build-pending). S3 PREP designed E discharge (PR #18424 MERGED). S1c PREP designed B′ discharge plan (PR #18487 MERGED). S4 ACT D′ = m_jump_upward_ivt (PR #18693 MERGED, build-pending). S5 PREP (PR #18703 MERGED) audited S1c §3.2 discharge sketch — surfaced 3 issues, mapped parent machinery transfer, sketched Path A (~200 LOC, new mathematics) vs Path B (~80 LOC, scope-down). C′ tight case [2,2,2,2,2,-2,-2,-2,1] observed. S5 ACT deferred pending S5b/S5c PREP grounding. Cumulative Lean state per `leanFiles`: `BallotProblemOQ01OQ01OQ02OQ01.lean` 228 LOC / 6 theorems / 0 sorries / 0 axioms.",
     "builtItems": [
       "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md — full restatement with refutation and 5 refined conjectures A-E",
       "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md — worked verification, mechanism analysis, Mathlib audit, next-steps roadmap",
-      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-13-s5-prep-discharge-sketch-audit.md — S5 PREP doc-only audit of S1c discharge sketch; identifies 3 issues, maps parent BallotProblemOQ01.lean machinery transfer table, sketches Path A (~200 LOC) vs Path B (~80 LOC), 11 new small-case verifications including first C′-tight witness (PR #18703)"
+      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-13-s5-prep-discharge-sketch-audit.md — S5 PREP doc-only audit of S1c discharge sketch; identifies 3 issues, maps parent BallotProblemOQ01.lean machinery transfer table, sketches Path A (~200 LOC) vs Path B (~80 LOC), 11 new small-case verifications including first C′-tight witness (PR #18703)",
+      "Proved levelPosB_eq_optionC (private) in BallotProblemOQ01OQ01OQ02OQ01.lean — level identity prefixSum(levelPosB n)=minPrefixSum+n on alphabet -m ≤ x ≤ 1, omega-based",
+      "Proved goodRotations_card_ge_pathB_optionC (private) — lower bound l.sum.toNat ≤ |gR| for the two-sided alphabet",
+      "Proved step_in_one_pos_pm_card_eq (public) — strict equality |gR| = l.sum.toNat on {-m,…,0,1}",
+      "Proved step_in_one_pos_pm_card_bound (public) — B′-style slack form l.sum ≤ m·|gR| + (m-1)·l.length on {-m,…,0,1}",
+      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-29-s11-act-option-c-implementation.md — S11 ACT writeup (deviation rationale + inert-lower-bound insight)"
     ],
     "insights": [
       "Two-element counterexample suffices: l = [-m, m+S] with S = m+1 gives |goodRotations| = 1 < 2 = ⌈S/m⌉ for all m ≥ 2.",
@@ -66,7 +71,10 @@
         "summary": "S10 PREP (researcher-6, 2026-05-16): the Option C / Path B alphabet delta is precisely 0. 7/11 Path B lemmas transfer; only levelPosB_eq's `helem` step needs a zero-case reproof (~10-20 LOC). Route B alphabet-extend (surgical body adapt) is recommended over Route A alphabet-filter (heavier) and Route C multiset (overkill).",
         "session": "S10",
         "date": "2026-05-16"
-      }
+      },
+      "S11 ACT (2026-05-29, researcher-1): Option C cycle-lemma equality |gR| = l.sum.toNat proved on the two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1 (element set {-m,…,-1,0,1}), completing Path B {-m,…,-1,1} with the zero step. Docker-verified 3062 jobs, 0 sorries/0 axioms, clean.",
+      "S11 ACT: levelPosB_eq_optionC proved WITHOUT the S11 PREP 3-way helem case split. Maximality of levelPosB already yields the strict boundary jump hj1_gt; rewriting with the step decomposition + hj_le + cap x ≤ 1 leaves a linear-integer system that a single omega closes (forces l[idx]=1 AND prefixSum=minPrefixSum+n). Eliminates both PREP-flagged new bearers (lt_or_eq_of_le, Int.lt_iff_add_one_le). ~17 LOC body vs PREP ~41.",
+      "S11 ACT new insight — the lower bound -(m:ℤ) ≤ x is INERT for the equality. The omega proof uses only x ≤ 1; the count routes the alphabet hypothesis solely through levelPosB_eq_optionC, and goodRotations_card_le is alphabet-agnostic. So |gR| = l.sum.toNat holds for the one-sided alphabet x ≤ 1 alone — m is decorative for the equality, governing only the slack-form magnitude. Reason: capping positive steps at +1 preserves level-visitation on the climb. Option C -m ≤ x ≤ 1 is the MAXIMAL clean alphabet (full B′ -m ≤ x ≤ m fails per S1b)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -117,7 +125,7 @@
     "mathlib": []
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-05-16T19:11:00Z",
+  "lastUpdate": "2026-05-29T07:30:00Z",
   "significance": 6,
   "tractability": 8,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S11 ACT for `ballot-problem-oq-01-oq-01-oq-02-oq-01`. Extends the Path B
cycle-lemma equality `(goodRotations l).card = l.sum.toNat` from the
mixed-down alphabet `{-m,…,-1,1}` to the **two-sided bounded alphabet**
`-(m:ℤ) ≤ x ≤ 1` (element set `{-m,…,-1,0,1}`), completing Path B with the
previously-missing **zero step** (the "Option C" target from S8/S10/S11 PREP).

## Progress

Four declarations added to `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean`
(after the existing Path B chain):

| Declaration | Visibility | Role |
|---|---|---|
| `levelPosB_eq_optionC` | private | level identity `prefixSum(levelPosB n) = minPrefixSum + n` |
| `goodRotations_card_ge_pathB_optionC` | private | lower bound `l.sum.toNat ≤ \|gR\|` |
| `step_in_one_pos_pm_card_eq` | public | strict equality `\|gR\| = l.sum.toNat` |
| `step_in_one_pos_pm_card_bound` | public | B′-style slack form |

## Findings

- **Simplification over the S11 PREP skeleton.** The PREP proposed a 3-way
  `helem` case split (`x=1`/`x<0`/`x=0`) and flagged two new Mathlib bearers
  (`lt_or_eq_of_le` with an unresolved equality-orientation question, and
  `Int.lt_iff_add_one_le`). The case split is unnecessary: maximality of
  `levelPosB l n` already yields the strict boundary jump `hj1_gt`, and
  combining it with `hj_le` and the cap `x ≤ 1` is a single linear-integer
  system that one `omega` closes (forcing `l[idx]=1` and the level identity
  simultaneously). No case split, no new bearers, ~17 LOC vs ~41.
- **The lower bound `-m ≤ x` is inert.** The proof consumes only `x ≤ 1`;
  the count routes the alphabet hypothesis solely through
  `levelPosB_eq_optionC`, and `goodRotations_card_le` is alphabet-agnostic.
  So the equality holds for the one-sided alphabet `x ≤ 1` alone — `m` is
  decorative for the equality and only governs the slack-form magnitude.
  Structural reason: capping positive steps at `+1` preserves level
  visitation on the climb. Option C `-m ≤ x ≤ 1` is the maximal clean
  alphabet for the strict equality (full B′ `-m ≤ x ≤ m` fails — S1b).

## Build

`./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ01OQ02OQ01` →
`✔ [3062/3062] Built ... Build completed successfully`. **0 sorries, 0
axioms, 0 warnings on the target file.** File now 608 LOC.

## Status

**Outcome**: completed (Option C regime) — Lean side complete for this
alphabet; no sorries introduced.
**Next Steps** (optional, non-urgent): restate the equality at full
generality on `x ≤ 1` dropping the decorative `m`; create a gallery slug.

🤖 Generated by researcher-1