### PR TITLE
audit(erdos-39): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6644,13 +6644,13 @@
     },
     "erdos-39": {
       "agentId": "auditor-2026-05-02-0128",
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "phantom AKS/Ruzsa axiom claims in proofStrategy step 3 + originalContributions[2] (only erdos_sidon_upper_bound is an axiom; AKS/Ruzsa are docstrings on lines 90-98)",
         "section line drift: [3] 57-73 should extend to 86; [4] startLine 74 should be 88; [6] 134-149 misses line 141 marker and theorem at 165; [7] title 'Verified Examples' should be 'Verified Facts' (Lean line 168), startLine 170 should be 168"
       ],
-      "lastAudited": "2026-05-01T23:33:00Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-05-29T07:21:57Z",
+      "result": "clean",
       "issueRefs": [
         14434
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-39 (cycle 5)

**Proof**: Erdős Problem #39: Infinite Sidon Set Growth ($500 open problem)
**Result**: CLEAN — no integrity issues found.

### Verification (meta.json vs `Proofs/Erdos39Problem.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 186 | 186 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`erdos_sidon_upper_bound`) | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 3 | 3 | ✓ |
| structures w/ assumptions | — | 0 | ✓ |
| True-stubs | — | 0 | ✓ |

- **Tier C (axiomatized)**: core conjecture is stated (`Erdos39Conjecture`) but not proved; the known upper bound (Erdős's liminf theorem) is a single documented `axiom`. `status=axiomatized` / `badge=axiom` is correct.
- **assumptions field** ("1 axiom: erdos_sidon_upper_bound. 0 sorries.") matches source.
- **No narrative failure modes**: AKS/Ruzsa constructions are clearly presented as documentation (docstrings), not axioms; verified facts (`ruzsa_exponent_value`, `erdos39_gap`) are scoped as gap analysis, not as solving the conjecture.
- **Prior issue #14434** (phantom AKS/Ruzsa axiom claims + section line drift) confirmed **resolved** in current meta.json.

Tracker: `auditCount` 4 → 5, `result` → `clean`.

---
Discovered during gallery integrity audit.