### PR TITLE
audit(erdos-382): tracker bump — clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6596,9 +6596,9 @@
     },
     "erdos-382": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-01T23:37:09Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-05-29T07:29:50Z",
+      "result": "clean"
     },
     "erdos-383": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-382 (cycle 5)

**Result: CLEAN** — meta.json claims match the Lean source exactly.

### Verification against `proofs/Proofs/Erdos382Problem.lean`

| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|----|
| lineCount | 659 | 659 | yes |
| sorries | 0 | 0 | yes |
| axiomCount | 1 | 1 (`ramachandra_bound`, L294) | yes |
| theoremCount | 18 | 18 (11 top-level + 7 private) | yes |
| definitionCount | 9 | 9 | yes |
| status / badge | axiomatized / axiom | correct (open problem, 1 axiom) | yes |

### Integrity checks
- **True-stub detection**: none. `erdos_382_summary` uses `trivial` only for a `True` conjunct, not as a standalone stub.
- **Structure-encoded assumptions**: none (no `structure`/`class` declarations) — so `axiomCount: 1` reflects all assumptions.
- **Axiom masking**: `ramachandra_bound` is explicitly listed in `assumptions` and `originalContributions`; description marks the problem OPEN.
- **Delegation opacity**: Mathlib's Bertrand postulate supports the structural theorem `no_prime_in_upper_half`, not the open core questions; no overclaim.

Tracker: auditCount 4 -> 5, result `clean`.

---
Discovered during gallery integrity audit. Tracker-only change.