### PR TITLE
audit(erdos-101-oq-01): tracker bump — clean (cycle 3)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15096,9 +15096,9 @@
       "issues": []
     },
     "erdos-101-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-25T03:47:12Z",
-      "result": "issues-fixed",
+      "auditCount": 3,
+      "lastAudited": "2026-05-29T07:39:14Z",
+      "result": "clean",
       "issues": []
     },
     "greens-theorem-oq-01-oq-01-oq-02-oq-03": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-101-oq-01

Re-audited `erdos-101-oq-01` against `origin/main`. **Result: CLEAN.**

### Verification (origin/main)
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 3 | 3 (`erdos_101_oq_01`, `erdos_101_oq_01_isLittleO`, `solymosi_stojakovic_lower_bound`) | ✅ |
| axiomCount | 0 | 0 (no `axiom` decls, no structure-encoded assumptions) | ✅ |
| True stubs | — | 0 | ✅ |
| lineCount | 603 | 603 | ✅ |
| status/badge | axiomatized/wip | correct for open Erdős \$100 problem | ✅ |

### Why it was flagged
`find-targets --issues` recurringly reported `sorry mismatch: claims 3, actual 2`. This was a **false positive from uncommitted research-WIP edits in the shared main-repo working tree** — a `maxCountAtSize` supremum construction that derives `erdos_101_oq_01_isLittleO` from the primary conjecture, collapsing one of the three open sorries. Those edits are **not on `origin/main`**. On a clean checkout, `find-targets --issues` reports `0 total`.

### Change
Tracker bump only: `auditCount` 2→3, `result` `issues-fixed`→`clean`, `lastAudited` refreshed.

---
Discovered during gallery integrity audit.