### PR TITLE
Fix: correct inverse-galois-oq-02 sorry count (16 -> 6)

### DIFF
--- a/src/data/proofs/inverse-galois-oq-02/meta.json
+++ b/src/data/proofs/inverse-galois-oq-02/meta.json
@@ -18,7 +18,7 @@
     ],
     "proofRepoPath": "Proofs/InverseGaloisOQ02.lean",
     "badge": "axiom",
-    "sorries": 16,
+    "sorries": 6,
     "axiomCount": 3,
     "prerequisites": [
       "Galois theory (Galois groups, splitting fields)",
@@ -150,7 +150,7 @@
       "description": "Sister entry proving the solvability divide (S_n solvable iff n ≤ 4) and A₅ analysis"
     }
   ],
-  "sorries": 16,
+  "sorries": 6,
   "leanFile": {
     "path": "Proofs/InverseGaloisOQ02.lean",
     "lineCount": 388,


### PR DESCRIPTION
## Fix

Correct the displayed sorry count for `inverse-galois-oq-02` from 16 to 6 to match the actual Lean source.

## Evidence

The main file `proofs/Proofs/InverseGaloisOQ02.lean` contains **6** `sorry` tactics (lines 182, 201, 219, 269, 356, 361). A 7th occurrence on line 265 is the word "sorry" inside a block comment and is correctly excluded by the canonical `countSorries` logic in `scripts/erdos/update-badges.ts`.

Three independent signals already agree the count is 6:
- `leanFile.sorries` = 6
- `meta.assumptions` text: *"...6 sorries in this file."*
- Canonical main-file sorry count = 6

Only `meta.sorries` and the vestigial top-level `sorries` claimed 16.

**Before**: `meta.sorries = 16`, top-level `sorries = 16` (overstated; gallery displays `meta.sorries`)
**After**: both = 6, consistent with `leanFile.sorries`, the assumptions text, and the source

Status (`axiomatized`), badge (`axiom`), and `axiomCount` (3) are unchanged — this is a pure count-accuracy correction with no change to completeness claims.

Validated with `pnpm annotations:build` (passes). Pre-existing annotation line-number warnings are unrelated to this change.

---
Automated fix by lean-mechanic agent.