### PR TITLE
audit(erdos-375): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6541,9 +6541,9 @@
     },
     "erdos-375": {
       "agentId": "auditor-2026-05-02-cycle-1777679298",
-      "auditCount": 3,
-      "lastAudited": "2026-05-01T23:53:39Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T07:58:58Z",
+      "result": "clean",
       "issueUrl": "https://github.com/rjwalters/lean-genius/issues/14444"
     },
     "erdos-376": {


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-375 (Grimm's Conjecture)

**Result: CLEAN.** meta.json claims match the Lean source (`Proofs/Erdos375Problem.lean`) exactly.

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| lineCount | 354 | 354 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 2 | 2 ✓ (`ramachandra_shorey_tijdeman`, `grimm_difficulty`) |
| theoremCount | 6 | 6 ✓ |
| definitionCount | 9 | 9 ✓ |
| structures/classes | — | 0 (no hidden structure-encoded assumptions) ✓ |
| True-stubs | — | 0 ✓ |

- `status: axiomatized` / `badge: axiom` is correct for an open problem (Grimm's Conjecture) carrying 2 stated axioms.
- No overclaiming: the 2 axioms (RST partial result + Grimm→Legendre implication) are accurately documented in the `assumptions` field.

Tracker bump only — no Lean or gallery content changed.

---
Discovered during routine gallery integrity audit (rotation re-verify).