### PR TITLE
audit(erdos-405): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6774,9 +6774,9 @@
     },
     "erdos-405": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T08:05:24Z",
+      "result": "clean",
       "issues": [
         "issue #14422: phantom \"Axiomatizes Wilson/Fermat\" in wilson-theorem section (proved via Mathlib ZMod lemmas); section line drift sections 3-9 (~25-30 line offset); minor: originalContributions[5] overstates IsPerfectPower as \"formalized generalization\""
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-405 (cycle 4)

**Proof**: Erdős Problem #405 — Factorial Plus Power Equals Prime Power
**Result**: CLEAN ✓

### Verification (meta.json vs `proofs/Proofs/Erdos405Problem.lean`)

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 (`brindza_erdos_1991`, `yu_liu_1996`, `divisible_case_analysis`) | ✓ |
| theoremCount | 15 | 15 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| status / badge | axiomatized / axiom | Tier C scaffold | ✓ |

### Tier classification
Main result `erdos_405 := ⟨brindza_erdos_1991, yu_liu_1996⟩` obtains finiteness and
the complete characterization from two stated axioms (deep results of Brindza–Erdős
1991 and Yu–Liu 1996, beyond current Mathlib). Correctly presented as
`status: axiomatized` / `badge: axiom`. The `assumptions` field names all 3 axioms.
No True-stub theorems; the `Solution` struct fields are per-instance obligations,
not global assumptions.

### Prior concerns resolved
Closed issue #14422 flagged a phantom "axiomatizes Wilson/Fermat" narrative, section
line drift, and a perfect-power overstatement. Confirmed resolved in current state:
`wilson_theorem` and `fermat_little` are proved via Mathlib `ZMod` lemmas (not axioms),
and `originalContributions` accurately scopes each claim.

---
Discovered during gallery integrity audit. Tracker bump only (no source changes).