### PR TITLE
Enrich Moulton plane (desargues-theorem-oq-01-oq-01): add 2 cross-references

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -130,6 +130,14 @@
         {
             "proofId": "desargues-theorem-oq-04",
             "relationship": "sibling — formalizes the self-duality of Desargues's theorem: collinearity and concurrence are the same predicate in homogeneous coordinates, so the dual statement (triangles perspective from a line $\\Rightarrow$ perspective from a point) is identical to the primal. The Moulton counterexample in this entry refutes both the primal (perspectivity from a point $O$ but $P, Q, R$ not collinear) and, by duality, the dual statement in any Moulton-style non-Desarguesian plane — confirming that the failure is structural rather than direction-specific"
+        },
+        {
+            "proofId": "desargues-theorem-oq-02",
+            "relationship": "sibling — an independent formalization of the same Moulton plane counterexample. Both entries construct the bent-line affine plane over $\\mathbb{R}$ (positive-slope lines halved on the right half-plane) and exhibit explicit rational-coordinate triangles in perspective from a point whose corresponding-side intersections fail to be Moulton-collinear. The parallel developments cross-validate the counterexample, confirming that the failure of Desargues in the Moulton plane is robust to the specific choice of witness triangles and proof structure"
+        },
+        {
+            "proofId": "pappus-theorem-oq-02",
+            "relationship": "related — Pappus's hexagon theorem, proved in the gallery over any commutative ring via the same cross-product / homogeneous-coordinate framework used for Desargues. By Hessenberg's theorem (1905; see keyInsight #6), Pappus implies Desargues, so every Pappian plane is Desarguesian; the Moulton plane, being non-Desarguesian, is a fortiori non-Pappian. This entry and `pappus-theorem-oq-02` therefore sit at opposite poles of the Hilbert-Hall coordinatization hierarchy: pappus-theorem-oq-02 establishes the strongest classical incidence theorem (Pappian $\\Leftrightarrow$ coordinatization by a commutative field), while this Moulton counterexample refutes even the weaker Desargues property (Desarguesian $\\Leftrightarrow$ coordinatization by a skew field), exhibiting the strict containment Pappian $\\subsetneq$ Desarguesian $\\subsetneq$ all planes"
         }
     ],
     "references": [


### PR DESCRIPTION
## Summary

Enrichment pass for **desargues-theorem-oq-01-oq-01** (Non-Desarguesian Planes: The Moulton Plane Counterexample). Adds two genuinely-relevant gallery cross-references, growing the set from 3 → 5. Both targets verified to exist.

- **`pappus-theorem-oq-02`** — The entry's keyInsight #6 is entirely about Hessenberg's theorem (1905: Pappus ⟹ Desargues) and explicitly notes the Moulton plane must also be non-Pappian, yet the entry did not cross-link the gallery's Pappus formalization. The new reference situates this counterexample at the bottom of the Hilbert–Hall coordinatization hierarchy: Pappian (commutative field) ⊊ Desarguesian (skew field) ⊊ all planes.
- **`desargues-theorem-oq-02`** — An independent formalization of the *same* Moulton plane counterexample. Linking it cross-validates the construction via parallel Lean developments.

## Context

This entry was audited as part of an enrichment pass. By the active quality scorer (`scripts/enricher/find-targets.ts`) it already scores 100/100 (6 fully-populated annotations, 10 keyInsights, >500-char historicalContext, full conclusion, 6 sections) — the tracker's stale `26` predates the meta.json buildout. The only genuine, non-padding improvement available was the missing cross-references, which the entry's own keyInsights already discuss.

The sibling entry **abel-ruffini** was also examined and found saturated (quality 100, all 3 peer-review action items resolved and verified, 74 valid cross-references, axiom integrity accurate) — no honest enrichment available there, so it was released rather than padded.

## Validation

- `jq` confirms valid JSON; `crossReferences.length == 5`; all 5 target directories exist.
- `pnpm annotations:build` runs clean for this entry (0 errors mentioning it).
- `tsc -b`/`vite build` could not run in this fresh worktree (native `better-sqlite3` fails to compile under node v26) — unrelated to this pure-JSON data change; `index.ts` is untouched.

## Test plan

- [ ] Verify the Moulton plane page renders the two new cross-reference cards linking to `pappus-theorem-oq-02` and `desargues-theorem-oq-02`.