### PR TITLE
audit(erdos-1130): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4065,12 +4065,12 @@
       "result": "clean"
     },
     "erdos-1130": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom axiom narrative: sections sqrt-bound and de-boor-pinkus claim Axiomatizes when only logarithmic_bound is declared; section line drift on main-result (claims 87-95, actually 126-154); proofStrategy overclaims \"All deep results are axiomatized\" (only 1 of 3). Issue #14763."
       ],
-      "lastAudited": "2026-05-02T00:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-29T10:25:21Z",
+      "result": "clean"
     },
     "erdos-1131": {
       "auditCount": 3,


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1130 (cycle 4)

Re-audit of **Erdős Problem #1130: Lagrange Basis Function Sums**.

### Result: CLEAN ✅

All `meta.json` claims verified against `proofs/Proofs/Erdos1130Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 154 | 154 | ✅ |
| sorries | 0 | 0 | ✅ |
| axiomCount | 1 | 1 (`logarithmic_bound`) | ✅ |
| theoremCount | 5 | 5 | ✅ |
| definitionCount | 6 | 5 def + 1 structure | ✅ |
| True-stubs | — | 0 | ✅ |

- `status: "axiomatized"` / `badge: "axiom"` correctly reflect the single axiom.
- The main theorem `erdosProblem1130` is genuinely **proved from** `logarithmic_bound` (the reduction is real, not a stub).
- `mathlibDependencies` are basic constants (`Real.log`, `Real.pi`, `Real.sqrt`) — not core-result theorems, so `axiom` badge (not `mathlib`) is correct.
- The `assumptions` field honestly names the axiom and what is reduced from it.

### Prior issue resolved
Issue #14763 (phantom-axiom narrative + section line drift) is **CLOSED** and confirmed fixed in current meta.json:
- sqrt-bound and de-boor-pinkus sections now state "no axiom is declared — background context only"
- proofStrategy correctly states "Only the logarithmic bound is axiomatized"
- main-result section is now 122–154 (was the stale 87–95)

Tracker bump only: `auditCount` 3→4, `result` issues-fixed→clean.

---
Discovered during autonomous gallery integrity audit.