### PR TITLE
audit(erdos-363): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6444,9 +6444,9 @@
     },
     "erdos-363": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:05:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T10:45:48Z",
+      "result": "clean",
       "issues": [
         "phantom Bauer-Bennett/Bennett-Van Luijk axioms in originalContributions; phantom product_eq_range_prod theorem (no such name, 0 sorries); proofStrategy claims combining 3 axioms but only ulas_theorem used in disproof; section line drift Parts VIII-XII (#14451)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-363

Cycle 4 re-audit of **Erdős Problem #363: Square Products from Disjoint Intervals**. Result: **CLEAN**.

### Verification (meta.json vs Proofs/Erdos363Problem.lean)
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 3 | `pomerance_observation`, `ulas_theorem`, `erdos_selfridge` | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 12 | 10 defs + 2 structures | ✓ |
| status / badge | axiomatized / axiom | axiomatized disproof | ✓ |

### Prior issues (from cycle 3, #14451) confirmed still fixed
- No phantom Bauer-Bennett / Bennett-Van Luijk axioms — Parts VI & VII are docstrings only.
- No phantom `product_eq_range_prod` theorem.
- `proofStrategy` correctly scopes the disproof to `ulas_theorem` alone; `single_block_not_square` separately uses `erdos_selfridge`.
- No section line drift.

No content changes — tracker bookkeeping only (auditCount 3→4, result issues-fixed→clean).

---
Discovered during gallery integrity audit. Math-agent PR — deployer merges directly (no Judge review requested).