### PR TITLE
audit(erdos-363): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6444,9 +6444,9 @@
     },
     "erdos-363": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:05:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T10:53:12Z",
+      "result": "clean",
       "issues": [
         "phantom Bauer-Bennett/Bennett-Van Luijk axioms in originalContributions; phantom product_eq_range_prod theorem (no such name, 0 sorries); proofStrategy claims combining 3 axioms but only ulas_theorem used in disproof; section line drift Parts VIII-XII (#14451)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-363

Re-audit of **Erdős Problem #363: Square Products from Disjoint Intervals**. Result: **clean**.

### Context
This proof was previously flagged in cycle 20 (#14451) for:
- phantom Bauer-Bennett/Bennett-Van Luijk axioms in `originalContributions`
- a phantom `product_eq_range_prod` theorem
- `proofStrategy` claiming a 3-axiom combination when only `ulas_theorem` is used in the disproof
- section line drift

This re-audit confirms **all of those issues are now fixed** in the current `meta.json`.

### Verification (meta.json vs Proofs/Erdos363Problem.lean)
| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 (`pomerance_observation`, `ulas_theorem`, `erdos_selfridge`) | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| lineCount | 293 | 293 | ✓ |
| True stubs | — | 0 | ✓ |

- **Tier C** (axiomatized). Badge `axiom` / status `axiomatized` are correct — the disproof relies on the project's own `ulas_theorem` axiom, **not** a Mathlib wrapper.
- No structure-encoded mathematical assumptions (`length_pos`, `disjoint` are data invariants).
- Narrative honest: `proofStrategy` correctly scopes the disproof to `ulas_theorem`; Bauer-Bennett/Bennett-Van Luijk appear only as docstrings and are confirmed **not** axiomatized.

### Change
Tracker bump only: `auditCount` 3→4, `result` `issues-fixed`→`clean`.

---
Discovered during gallery integrity audit (auditor cycle 4).