### PR TITLE
Enrich Eulerian Paths in Directed Graphs: trail-support trilogy + Hierholzer/BEST cross-refs

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/annotations.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/annotations.json
@@ -243,6 +243,32 @@
     ]
   },
   {
+    "id": "ann-koe02-maxtrail-support-trilogy",
+    "proofId": "konigsberg-oq-01-oq-02",
+    "range": {
+      "startLine": 734,
+      "endLine": 915
+    },
+    "type": "technique",
+    "title": "Trail-Support Trilogy: Exhaustion, Step-Membership, Step-Distinctness by Strong Induction on |E|",
+    "content": "Three private lemmas form the bridge between maxTrail's recursive definition and its use in the balance-contradiction proof. All three share the same induction skeleton: `Nat.strong_rec_on` on `E.card`, case-split on whether `(E.filter (fun e => e.1 = v)).Nonempty`, and in the recursive case unfold `maxTrail E v = v :: maxTrail (E.erase c) c.2` where `c = hout.choose`.\n\n**maxTrail_last_exhausted** (734–792): every outgoing edge of the trail's last vertex was consumed. Strong-induction lets the inner trail `maxTrail (E.erase c) c.2` share the same last vertex as the outer trail (`List.getLast_cons`), so the IH applied at `E.erase c` directly handles edges other than `c`; the case `e = c` uses step 0 of the outer trail (the edge `c` itself).\n\n**maxTrail_steps_in_E** (794–829): every consecutive walk-pair is an actual graph edge. Step 0 is `(v, c.2)` which equals `c ∈ E` (using `hinner_start : maxTrail (E.erase c) c.2)[0] = c.2`); step `i+1` reduces to the inner-trail IH and lifts back to `E` via `Finset.mem_of_mem_erase`.\n\n**maxTrail_steps_distinct** (831–915): no edge appears at two positions. Four-way case analysis on `i, j ∈ {0, succ}`: cases `(0, 0)` and `(succ, succ)` are immediate / inner-IH; the two mixed cases use the fact that step 0 produces edge `c` while any step `j' + 1` produces an edge in `E.erase c`, and `Finset.not_mem_erase c E` rules out the collision. This distinctness is exactly what `Finset.card_bij` needs for the injection from outgoing edges to source-positions of the last vertex in STEP B of maxTrail_closed.",
+    "mathContext": "Three claims about $\\text{maxTrail}(E, v)$ proved by strong induction on $|E|$: (1) **exhaustion**: $\\forall e \\in E,\\ e.1 = \\text{last\\_v} \\Rightarrow \\exists i,\\ \\text{step}(i) = e$; (2) **step-membership**: $\\forall i,\\ \\text{step}(i) \\in E$; (3) **distinctness**: $i \\neq j \\Rightarrow \\text{step}(i) \\neq \\text{step}(j)$. Inductive structure: write $\\text{maxTrail}(E, v) = v :: \\text{maxTrail}(E \\setminus \\{c\\}, c.2)$ where $c$ is the chosen outgoing edge. The IH at $E \\setminus \\{c\\}$ (with cardinality $|E| - 1$) handles all inner-trail steps; the base step (step 0) is identified with $c$ via $\\text{hinner\\_start}$ and Prod.mk.inj. Distinctness across step 0 / step $j+1$ uses $c \\notin E \\setminus \\{c\\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Nat.strong_rec_on: strong induction over natural numbers",
+      "Finset.card_erase_lt_of_mem: |E.erase e| < |E| when e ∈ E",
+      "Finset.not_mem_erase / Finset.mem_of_mem_erase",
+      "List.getLast_cons: last of (v :: t) equals last of t when t ≠ []",
+      "Classical.choose / Finset.Nonempty.choose pattern for selecting an outgoing edge"
+    ],
+    "prerequisites": [
+      "maxTrail recursive definition: greedy edge-consumption with Finset.erase",
+      "maxTrail_head' and maxTrail_nonempty': trail starts at v, is non-empty",
+      "Prod.mk.inj_iff: ordered-pair equality componentwise",
+      "Finset.Nonempty.choose / choose_spec: select witness from nonempty Finset"
+    ]
+  },
+  {
     "id": "ann-koe02-maxtrail-closed-proof",
     "proofId": "konigsberg-oq-01-oq-02",
     "range": {

--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -156,6 +156,16 @@
       "targetId": "konigsberg",
       "relationship": "ancestor",
       "description": "Original Königsberg bridges problem — Euler 1736; the undirected Eulerian theorem whose directed analogue is formalized here."
+    },
+    {
+      "targetId": "konigsberg-oq-02-oq-01",
+      "relationship": "successor",
+      "description": "Hierholzer's Algorithm — Directed Eulerian Circuit (Corrected). This file leaves Hierholzer sufficiency as an axiom (directed_eulerian_iff); konigsberg-oq-02-oq-01 takes up the constructive discharge of that axiom by formalizing Hierholzer's splicing recursion on top of the maxTrail / circuit_exists infrastructure proved here."
+    },
+    {
+      "targetId": "konigsberg-oq-04",
+      "relationship": "extension",
+      "description": "Counting Eulerian Circuits: the BEST Theorem (van Aardenne-Ehrenfest, de Bruijn 1951; Smith, Tutte 1941–48). Once existence is established by directed_eulerian_iff (this file), the BEST theorem gives the exact count via arborescences and the Matrix-Tree theorem — the quantitative refinement of the qualitative result here."
     }
   ],
   "sorries": 1


### PR DESCRIPTION
## Summary

Enrichment pass for `konigsberg-oq-01-oq-02` (Eulerian Paths in Directed Graphs).

### Annotation depth
- **New annotation**: `ann-koe02-maxtrail-support-trilogy` covers lines 734–915 — the three private strong-induction lemmas (`maxTrail_last_exhausted`, `maxTrail_steps_in_E`, `maxTrail_steps_distinct`) that were previously sandwiched between the `maxTrail` definition and `maxTrail_closed` without focused commentary. The annotation explains the shared `Nat.strong_rec_on` skeleton, the `maxTrail E v = v :: maxTrail (E.erase c) c.2` unfolding, the role of `List.getLast_cons` in transporting the IH's last-vertex claim, and how step-distinctness via `Finset.not_mem_erase` later enables `Finset.card_bij` in STEP B of the balance-contradiction proof.

### Cross-references
- **`konigsberg-oq-02-oq-01`** (successor) — Hierholzer's Algorithm — Directed Eulerian Circuit (Corrected). The natural follow-up that takes the `maxTrail` / `circuit_exists` infrastructure proved here and uses it to discharge the `directed_eulerian_iff` axiom via Hierholzer's splicing recursion.
- **`konigsberg-oq-04`** (extension) — Counting Eulerian Circuits: the BEST theorem. The quantitative refinement (arborescences × ∏ (out-deg − 1)!) that becomes accessible once existence is established.

### Verified
- `jq empty` on both JSON files
- `pnpm build` ✓ (only touched the target directory)