### PR TITLE
audit(erdos-363): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6444,9 +6444,9 @@
     },
     "erdos-363": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:05:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T11:02:01Z",
+      "result": "clean",
       "issues": [
         "phantom Bauer-Bennett/Bennett-Van Luijk axioms in originalContributions; phantom product_eq_range_prod theorem (no such name, 0 sorries); proofStrategy claims combining 3 axioms but only ulas_theorem used in disproof; section line drift Parts VIII-XII (#14451)"
       ]


### PR DESCRIPTION
## Summary
Cycle-4 gallery integrity re-audit of **erdos-363** (Square Products from Disjoint Intervals). Result: **clean**. Tracker entry bumped (auditCount 3→4, result issues-fixed→clean).

## Verification (meta.json vs `Proofs/Erdos363Problem.lean`)
- axioms: **3** (`pomerance_observation`, `ulas_theorem`, `erdos_selfridge`) ✓ axiomCount=3
- sorries: **0** ✓
- True stubs: **0** ✓
- theorems: **5** ✓ / definitions+structures: **12** ✓ / lines: **293** ✓
- status `axiomatized` / badge `axiom` — correct (axioms present)
- No structure-encoded mathematical assumptions beyond well-formedness invariants (`length_pos`, `disjoint`)

## Narrative integrity
The cycle-3 issues (#14451) are confirmed fixed: Bauer-Bennett (2007) and Bennett-Van Luijk (2012) are correctly described as docstring-only (not axiomatized, not used), and the disproof is honestly scoped to `ulas_theorem 4`. No overclaiming detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)