### PR TITLE
Enrich Irrationality of √2+√3: fix broken cross-refs, deepen sections

### DIFF
--- a/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
+++ b/src/data/proofs/sqrt2-plus-sqrt3-irrational/meta.json
@@ -71,14 +71,29 @@
       "description": "Companion irrationality result using a different technique (minimal polynomial / p-adic valuation for cube roots vs squaring trick for sum of square roots)."
     },
     {
-      "targetId": "irrational-sqrt-2",
-      "relationship": "parent",
-      "description": "Irrationality of √2 — the classical Pythagorean result that provides the foundation. The irrationality of √2+√3 requires √6 ∉ ℚ as an intermediate step, which uses the same non-perfect-square criterion."
+      "targetId": "sqrt2-irrational",
+      "relationship": "foundational",
+      "description": "Irrationality of square roots (√2, √3, √6, …) via the non-perfect-square criterion. This is the classical Pythagorean result that grounds the present proof: the contradiction step hinges on √6 ∉ ℚ, which is exactly an instance of `irrational_sqrt_natCast_iff` (Irrational √n ↔ ¬IsSquare n)."
     },
     {
-      "targetId": "algebraic-numbers",
+      "targetId": "algebraic-numbers-countable",
       "relationship": "related",
-      "description": "Algebraic numbers over ℚ: √2+√3 is algebraic of degree 4 with minimal polynomial x⁴-10x²+1. Irrationality is equivalent to this polynomial having degree > 1."
+      "description": "Countability of the algebraic numbers. √2+√3 is algebraic of degree 4 (root of x⁴-10x²+1), hence one of the countably many algebraic reals; its irrationality is the statement that this minimal polynomial has degree > 1."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational-oq-03",
+      "relationship": "extension",
+      "description": "Minimal polynomial of √2+√3 over ℚ. Strengthens the present result from 'irrational' to '[ℚ(√2+√3):ℚ] = 4' by establishing that x⁴-10x²+1 is the minimal polynomial — the field-theoretic refinement noted in this entry's third open question."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-plus-sqrt5-irrational",
+      "relationship": "extension",
+      "description": "Three-radical generalization. Applying the squaring reduction once leaves cross terms √6, √10, √15, requiring a second squaring; this realizes the first open question of the present entry and is a stepping stone toward Besicovitch's independence theorem."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "Irrationality of nth roots of non-perfect-powers. The √6 ∉ ℚ step used here is the n=2 case: √k is irrational exactly when k is not a perfect square, the same number-theoretic criterion generalized to arbitrary roots."
     }
   ],
   "sections": [
@@ -108,14 +123,14 @@
       "title": "Main Theorem: √2+√3 is Irrational",
       "startLine": 36,
       "endLine": 44,
-      "summary": "irrational_sqrt2_plus_sqrt3: Irrational (sqrt 2 + sqrt 3). Proof by contradiction: intro ⟨r, hr⟩ gives r:ℚ with hr:(r:ℝ)=√2+√3. Squaring via sqrt2_plus_sqrt3_sq gives hsq:(r:ℝ)²=5+2√6. linarith gives h6:√6=(r²-5)/2. Constructs rational witness q=(r²-5)/2 with cast computation, then exact irrational_sqrt_six ⟨q, ...⟩."
+      "summary": "irrational_sqrt2_plus_sqrt3: Irrational (sqrt 2 + sqrt 3). Sets up the proof by contradiction: `intro ⟨r, hr⟩` unfolds Irrational (a negated existential) into a rational witness r:ℚ with hr:(r:ℝ)=√2+√3. Squaring both sides via sqrt2_plus_sqrt3_sq produces hsq:(r:ℝ)²=5+2√6, transporting the question to the rationality of √6. The contradiction is then closed in the following section."
     },
     {
-      "id": "section-45",
-      "title": "Main Theorem: √2+√3 is Irrational (continued)",
+      "id": "sec-contradiction",
+      "title": "Closing the Contradiction: √6 Forced Rational",
       "startLine": 45,
-      "endLine": 53,
-      "summary": "Continuation: remaining proofs and definitions in this section."
+      "endLine": 54,
+      "summary": "The second half of irrational_sqrt2_plus_sqrt3. From hsq : (r:ℝ)² = 5 + 2√6, `linarith` isolates h6 : √6 = ((r:ℝ)² - 5)/2. The witness hrat : ∃ q : ℚ, (q:ℝ) = √6 is built with q = (r²-5)/2, using `simp only [Rat.cast_div, Rat.cast_sub, Rat.cast_pow, Rat.cast_natCast]` to align ℚ→ℝ casts with h6.symm. Then `exact irrational_sqrt_six hrat` feeds the rational witness into the auxiliary lemma, contradicting Irrational (√6) and discharging the goal. Line 54 closes the namespace."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `sqrt2-plus-sqrt3-irrational`.

## Cross-reference integrity (the main fix)
Two cross-references pointed at non-existent gallery entries — dead links on the live site:
- `irrational-sqrt-2` → **`sqrt2-irrational`** ("Irrationality of Square Roots")
- `algebraic-numbers` → **`algebraic-numbers-countable`** ("Countability of Algebraic Numbers")

Added three valid, genuinely-related cross-refs (two of which directly realize this entry's own open questions):
- `sqrt2-plus-sqrt3-irrational-oq-03` — minimal polynomial $x^4-10x^2+1$, the degree-4 refinement (open question 3)
- `sqrt2-plus-sqrt3-plus-sqrt5-irrational` — three-radical generalization (open question 1)
- `nth-root-irrational` — the $\sqrt 6 \notin \mathbb Q$ step generalized to arbitrary roots

## Sections
- Replaced the placeholder section (`section-45`, summary "Continuation: remaining proofs and definitions") with a real section `sec-contradiction` describing the contradiction-closing phase (lines 45–54).
- Trimmed `sec-main-theorem` (36–44) so its summary matches its actual span. Sections now tile the full 54-line file with no overlap.

## Verification
- `jq empty` on meta.json/annotations.json: valid
- All 6 cross-reference targets resolve to existing directories
- `pnpm build`: passes

## Note for Auditor/Mechanic
A gallery-wide scan turned up **36 broken `crossReferences` targetIds across ~34 entries** (e.g. `cayley-hamilton-oq-01` → jordan-normal-form/rational-canonical-form, `erdos-70-oq-01` → ramsey-theorem [should be `ramseys-theorem`], `euler-polyhedral-oq-02-oq-01` → euler-polyhedral [should be `euler-polyhedral-formula`], plus many broken `-oq` siblings). This PR fixes only the two in the claimed entry; the rest are a good candidate for a dedicated integrity-repair sweep.