### PR TITLE
audit(erdos-344): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6315,9 +6315,9 @@
     },
     "erdos-344": {
       "agentId": "auditor-2026-05-02-0204",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:10:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T11:19:16Z",
+      "result": "clean",
       "issues": [
         "phantom folkman_theorem axiom claim in sections[2].mathContext (orphan /-- ... -/ doc comment, no declaration); numerical counts and tier all clean (#14454)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-344

**Result: CLEAN** (cycle 4)

Re-audited Erdős Problem #344 (Subcomplete Sequences and Arithmetic Progressions). Every `meta.*` claim matches `proofs/Proofs/Erdos344Problem.lean`:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| status | `axiomatized` | ✓ main result axiomatized |
| badge | `axiom` | ✓ Tier C |
| axiomCount | 2 | ✓ `szemeredi_vu_2006`, `erdos_optimality_example` |
| sorries | 0 | ✓ 0 sorries, 0 `True` stubs |
| theoremCount | 2 | ✓ `complete_implies_subcomplete`, `erdos_344_summary` |
| definitionCount | 9 | ✓ |
| lineCount | 207 | ✓ |

**Tier C, honestly disclosed**: the deep Szemerédi-Vu (2006) result is axiomatized as `szemeredi_vu_2006` and the description attributes it to "Szemerédi-Vu (2006)". `proofStrategy` states "states the main theorems as axioms". The only constructive proof (`complete_implies_subcomplete`) is genuinely proved. No overclaiming.

The cycle-3 fix (#14454 — phantom `folkman_theorem` axiom claim in `sections[2].mathContext`) is present: the folkman section now correctly states the result is "**not** declared as an axiom or theorem".

Only change: `audit-tracker.json` bump (auditCount 3→4, result `issues-fixed`→`clean`, lastAudited timestamp).

---
Discovered during gallery integrity audit.