### PR TITLE
Enrich Moulton plane (Desargues OQ01-OQ01): 3 new annotations

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/annotations.json
@@ -1,5 +1,30 @@
 [
   {
+    "id": "ann-file-header",
+    "proofId": "desargues-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 46
+    },
+    "type": "context",
+    "title": "File Overview: The Moulton Plane Construction in 297 Lines",
+    "content": "The file's docstring header (lines 4-42) and namespace declaration (line 44) frame the entire formalization. The construction is the Moulton plane (Moulton 1902): points are $\\mathbb{R}^2$ and lines are ordinary Cartesian lines *except* for positive-slope lines, which are 'bent' at the y-axis so the right half-plane has slope halved. All affine plane axioms (two-points-determine-a-line, two-non-parallel-lines-meet, parallel postulate) remain satisfied, but Desargues's theorem fails for an explicit rational-coordinate counterexample. The header lists the full counterexample data: center of perspectivity $O = (0,0)$; triangles $A=(-2,3), B=(3,1), C=(0,-1)$ and $A'=(-4,6), B'=(9,3), C'=(0,-4)$; intersection points $P=(-17,9), Q=(27,17), R=(-6,11)$. The crucial observation noted at line 40-41: P, Q, R *are* Euclidean-collinear (classical Desargues holds in $\\mathbb{R}^2$) — only the Moulton plane's bent lines reveal the failure. The `open Classical` at line 46 enables decidable case analysis on $m \\leq 0$ vs $m > 0$ in the piecewise definition.",
+    "mathContext": "Moulton's bending rule: $\\text{line}(m, b) = \\{(x,y) : y = mx + b\\}$ for $m \\leq 0$, but for $m > 0$, $\\text{line}(m, b) = \\{(x,y) : y = mx + b \\text{ if } x \\leq 0, \\ y = \\tfrac{m}{2}x + b \\text{ if } x > 0\\}$. The bend preserves continuity at $x=0$ (both pieces give $y=b$). Counterexample: $A' = 2A$, $B' = 3B$, $C' = 4C$ (scalar multiples from $O$), so the perspectivity hypothesis is satisfied along rays through $O$; the failure of Desargues is exhibited by computing $P, Q, R$ and checking that no Moulton line contains all three.",
+    "significance": "context",
+    "prerequisites": [
+      "affine plane axioms",
+      "real coordinates",
+      "Lean 4 docstring conventions",
+      "namespace and Classical opens"
+    ],
+    "relatedConcepts": [
+      "Moulton plane (1902)",
+      "non-Desarguesian affine plane",
+      "Hilbert's Grundlagen der Geometrie (1899)",
+      "rational counterexamples in affine geometry"
+    ]
+  },
+  {
     "id": "ann-moulton-line-def",
     "proofId": "desargues-theorem-oq-01-oq-01",
     "range": {
@@ -93,6 +118,30 @@
     ]
   },
   {
+    "id": "ann-q-bent-incidence",
+    "proofId": "desargues-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 162,
+      "endLine": 186
+    },
+    "type": "technique",
+    "title": "Q on Bent Moulton Lines: The Asymmetric Test at x = 27",
+    "content": "This sub-block (lemmas $Q$_on_BC, $Q$_on_B'C', $B$_on_BC, $C$_on_BC, $B'$_on_B'C', $C'$_on_B'C') is where the Moulton bending becomes operationally visible. Side $BC$ has left-slope $4/3 > 0$ (right-slope $2/3$), and side $B'C'$ has left-slope $14/9 > 0$ (right-slope $7/9$). Q lives at $x = 27 > 0$, so Q is tested against the *right* branch of the bent line via `onML_pos_right`. But the endpoints split: $C = (0, -1)$ and $C' = (0, -4)$ lie at $x = 0$ (the seam), tested via `onML_pos_left` — at $x = 0$ both branches agree ($y = b$). Meanwhile $B = (3,1)$ and $B' = (9, 3)$ are at $x > 0$, tested via `onML_pos_right`. The asymmetry — same line, three different helper lemmas depending on each endpoint's half-plane — is the operational signature of Moulton bending. Crucially, *the Moulton bending shows up only here*: P and R lie on ordinary negative-slope lines (`onML_neg_slope` throughout), so the failure of Desargues is detectable precisely because Q's bent verification produces the slope-mismatch that the contradiction in `desargues_fails` exploits.",
+    "mathContext": "Side $BC$: left-slope $m = \\frac{4}{3}$, intercept $b = -1$. At $C = (0, -1)$: left branch, $-1 = \\frac{4}{3} \\cdot 0 + (-1)$. ✓. At $B = (3, 1)$: right branch with right-slope $\\frac{m}{2} = \\frac{2}{3}$, $1 = \\frac{2}{3} \\cdot 3 + (-1)$. ✓. At $Q = (27, 17)$: right branch, $17 = \\frac{2}{3} \\cdot 27 + (-1) = 18 - 1 = 17$. ✓. Side $B'C'$: left-slope $m = \\frac{14}{9}$, intercept $b = -4$, right-slope $\\frac{7}{9}$. At $Q$: $\\frac{7}{9} \\cdot 27 - 4 = 21 - 4 = 17$. ✓. The right-slope arithmetic is what blocks the Euclidean-collinearity computation: an ordinary line through $B$ and $C$ with slope $\\frac{4}{3}$ would give $y = \\frac{4}{3} \\cdot 27 - 1 = 35$ at $x = 27$, not $17$.",
+    "significance": "key",
+    "prerequisites": [
+      "onML_pos_left and onML_pos_right helper lemmas",
+      "case-splitting on x-sign at endpoints",
+      "norm_num for arithmetic at concrete rationals"
+    ],
+    "relatedConcepts": [
+      "Moulton plane bending at x = 0",
+      "left-half vs right-half slope",
+      "operational signature of non-Desarguesian planes",
+      "seam behavior at the y-axis"
+    ]
+  },
+  {
     "id": "ann-desargues-fails",
     "proofId": "desargues-theorem-oq-01-oq-01",
     "range": {
@@ -115,6 +164,31 @@
       "linear_combination tactic in Lean 4",
       "contradiction by linear system",
       "linarith for numeric contradictions"
+    ]
+  },
+  {
+    "id": "ann-linear-combination-tactic",
+    "proofId": "desargues-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 256,
+      "endLine": 261
+    },
+    "type": "technique",
+    "title": "linear_combination: Extracting $m$ from Two Different Linear Pairs",
+    "content": "The contradiction hinges on two applications of the `linear_combination` tactic (introduced in Mathlib 4, generalising Lean 3's `linarith` for equalities expressible as integer-coefficient combinations of given hypotheses). Step 1: `linear_combination hP' - hR'` proves $11m = 2$ by computing $(\\text{hP'}) - (\\text{hR'}) = (9 - m(-17) - b) - (11 - m(-6) - b) = -11m + 2$, which equals $0$, hence $11m = 2$. Step 2: `linear_combination 2 * hP' - 2 * hQ'` proves $61m = 16$ by computing $2(9 - m(-17) - b) - 2(17 - \\frac{m}{2}(27) - b) = -16 + (34 + 27)m = 61m - 16$, which equals $0$, hence $61m = 16$. The user does not need to write the algebraic manipulation — `linear_combination` mechanically expands the linear combination and discharges the resulting `= 0` goal by `ring`. The final `linarith` then closes $11 \\cdot 16 = 176 \\neq 122 = 2 \\cdot 61$, exhibiting the inconsistency. This three-line tactic pipeline ($h_1, h_2$, `linarith`) is the entire algebraic core of the Moulton counterexample.",
+    "mathContext": "From $h_P: 9 = m(-17) + b$, $h_Q: 17 = \\tfrac{m}{2}(27) + b$, $h_R: 11 = m(-6) + b$. Pair 1 ($P$ vs $R$, both left-half): subtracting eliminates $b$ and gives $9 - 11 = m(-17) - m(-6) = -11m$, i.e. $m = \\tfrac{2}{11}$. Pair 2 ($P$ vs $Q$, left vs right): $9 \\cdot 2 - 17 \\cdot 2 = m(-34) - m(27) = -61m$ (after using $\\frac{m}{2} \\cdot 27 \\cdot 2 = 27m$), i.e. $-16 = -61m$, so $m = \\tfrac{16}{61}$. The slope $m$ would have to be *both* $\\tfrac{2}{11}$ and $\\tfrac{16}{61}$ — but $2 \\cdot 61 = 122 \\neq 176 = 11 \\cdot 16$, so no real $m$ exists. The Moulton bend on the right half (the factor of $\\tfrac{1}{2}$) is the unique reason the two slopes disagree: in the ordinary Euclidean plane, both pairs would yield the same slope $\\tfrac{2}{11}$ and Desargues would hold.",
+    "significance": "critical",
+    "prerequisites": [
+      "linear_combination tactic in Mathlib 4",
+      "ring tactic for commutative ring equalities",
+      "linarith for inequality contradictions",
+      "elimination of variables in linear systems"
+    ],
+    "relatedConcepts": [
+      "Mathlib linear_combination tactic",
+      "Gaussian elimination in two unknowns",
+      "tactic-driven contradiction proofs",
+      "the half-slope factor as the failure witness"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Enrichment pass for `desargues-theorem-oq-01-oq-01` (Moulton plane non-Desarguesian counterexample). Adds three new annotations filling real coverage gaps:

- **`ann-file-header`** (lines 1–46): file docstring + namespace + construction summary; previously uncovered. Frames the bending rule, counterexample data, and the `open Classical` setup.
- **`ann-q-bent-incidence`** (lines 162–186): isolates the sub-block where the Moulton bending becomes *operationally* visible — Q at $x=27>0$ uses `onML_pos_right`, while the seam-points $C, C'$ at $x=0$ use `onML_pos_left`. The asymmetric helper-lemma dispatch is the operational signature of the non-Desarguesian behaviour.
- **`ann-linear-combination-tactic`** (lines 256–261): technique annotation on the `linear_combination` tactic uses that derive $11m = 2$ and $61m = 16$ from two different point-pairs, with the slope mismatch closed by `linarith`.

Annotations: 6 → 9. All new annotations include `mathContext` (LaTeX), `significance`, `prerequisites`, and `relatedConcepts`. Existing six annotations are preserved unchanged; no content removed.

## Test plan

- [x] `pnpm build` succeeds (1m 49s, all proof JSON validated)
- [x] All three new annotation ranges lie inside the actual Lean file (lines 1–46, 162–186, 256–261 of `proofs/Proofs/DesarguesTheoremOQ01OQ01.lean`)
- [x] Math content cross-checked against the Lean source (slopes, intercepts, helper-lemma signatures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)