### PR TITLE
audit(erdos-342): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6300,9 +6300,9 @@
     },
     "erdos-342": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:33:54Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T12:06:13Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in sections (ulamSeq_unique_representation, ulamSeq_minimal, ulamSeq_values, five_not_ulam, six_is_ulam, twin_examples, erdos_342, ulamSeq_growth, ulamSeq_growth_constant, ulam_characterization); section line-range drift across all parts; theoremCount 20→19; imports drift (#14463)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-342 (The Ulam Sequence U(1,2))

Periodic re-audit (cycle 4; last audited 2026-05-02). Re-verified `meta.json` against `proofs/Proofs/Erdos342Problem.lean`.

### Result: CLEAN

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 3 | `ulamSeq`, `ulamSeq_initial`, `ulamSeq_strictMono` | ✓ |
| theoremCount | 20 | `ulam_0`..`ulam_11` (native_decide), `ulamSeq_injective/ge/zero/one`, `one/two_mem_ulamSet`, `zero_not_ulamSet`, `erdos_342_statement` | ✓ |
| definitionCount | 11 | repCount, nextUlam, buildUlam, ulam, representationCount, IsUlamTwin, twinIndices, ErdosConjecture342, ulamCount, DensityZero, ulamSet | ✓ |
| sorries | 0 | none | ✓ |
| lineCount | 221 | 221 | ✓ |
| status/badge | axiomatized/axiom (open) | Tier C — sequence axiomatized, conjecture is a `Prop` only | ✓ |

### Notes
- Honestly scoped: the open conjecture (`ErdosConjecture342 = Set.Infinite twinIndices`) is **never claimed proved**. `erdos_342_statement` proves only an equivalence (definitional restatement) by `simp`. Density conjectures are `Prop`s without proofs. No axiom encodes twin examples or density values.
- Section line-ranges in meta all match source parts.
- No True stubs, no overclaiming.

**Source-only cosmetic nit (NOT a gallery integrity issue):** the Lean file's own comments are internally inconsistent about axiom count — header (L22) says "Axioms: 1", summary (L215) says "5 axioms" — but the actual `axiom` declarations are 3, and `meta.json` correctly states 3. Public/gallery claims are accurate; only the in-file prose is stale. Left for a future enrichment pass to avoid bloating this minimal tracker-bump PR.

Single-file tracker bump only (`audit-tracker.json`: auditCount 3→4, result clean).

---
Discovered during periodic gallery integrity audit.