### PR TITLE
audit(erdos-342): fix stale axiom/theorem counts in Lean comments

### DIFF
--- a/proofs/Proofs/Erdos342Problem.lean
+++ b/proofs/Proofs/Erdos342Problem.lean
@@ -19,8 +19,8 @@ OEIS: A002858
 
 Reference: [ErGr80, p.53]
 
-Axioms: 1 (ulamSeq — opaque sequence function)
-Proved: 15 theorems including initial values verified by native_decide
+Axioms: 3 (ulamSeq, ulamSeq_initial, ulamSeq_strictMono)
+Proved: 20 theorems including initial values verified by native_decide
 Sorries: 0
 -/
 
@@ -212,7 +212,7 @@ KNOWN:
 FORMALIZATION:
 - Computable ulam function verified against OEIS for first 12 terms
 - Opaque ulamSeq for reasoning about the infinite sequence
-- 15 theorems, 5 axioms (ulamSeq, initial agreement, strict mono, unique rep, minimality)
+- 20 theorems, 3 axioms (ulamSeq, initial agreement, strict mono)
 -/
 theorem erdos_342_statement :
     ErdosConjecture342 ↔ Set.Infinite {n : ℕ | ulamSeq (n + 1) = ulamSeq n + 2} := by


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-342 (cycle 4)

**Result**: issues-fixed (source-comment accuracy)

### Verification

Gallery `meta.json` was checked against `proofs/Proofs/Erdos342Problem.lean` and is **fully accurate**:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | yes |
| axiomCount | 3 | 3 (`ulamSeq`, `ulamSeq_initial`, `ulamSeq_strictMono`) | yes |
| theoremCount | 20 | 20 | yes |
| definitionCount | 11 | 11 | yes |
| status / badge | axiomatized / axiom | open conjecture, only stated | yes |
| True stubs | — | none | yes |

No overclaiming: description and conclusion correctly state the problem is OPEN. No Mathlib-wrapper concern (the conjecture is stated, not proved).

### Issue fixed

The only discrepancy was in the Lean file's **own internal comments**, which understated the counts:

- Header: claimed `Axioms: 1` and `Proved: 15 theorems` — actual is 3 axioms, 20 theorems. The axiom undercount (1 vs 3) is the credibility-relevant direction per the Axiom Integrity Policy.
- Part IX summary: claimed `5 axioms (ulamSeq, initial agreement, strict mono, unique rep, minimality)` — only 3 axioms exist; "unique rep" and "minimality" are orphan doc-comments, not formalized.

Both comment blocks corrected to match the source (3 axioms, 20 theorems). Comment-only change — no compilation impact. Tracker bumped to auditCount 4.

---
Discovered during gallery integrity audit.