### PR TITLE
Enrich Jordan-Hölder Uniqueness (oq-04): add Schreier + Zassenhaus references

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -363,6 +363,24 @@
       "year": "1936",
       "venue": "Annals of Mathematics 37(2): 265–292",
       "note": "Establishes the Jordan-Hölder theorem for modular lattices in general — independently of (and just before) Birkhoff's *Lattice Theory*. Ore proved that in any modular lattice of finite length, all maximal chains have the same length and corresponding intervals are 'projective' (related by a chain of perspectivities). This is the result that justifies treating Jordan-Hölder as a theorem about lattices rather than about groups, modules, or rings specifically — and it underwrites the abstraction used in Mathlib's `JordanHolderLattice` framework."
+    },
+    {
+      "authors": [
+        "O. Schreier"
+      ],
+      "title": "Über den Jordan-Hölderschen Satz",
+      "year": "1928",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 6: 300–302",
+      "note": "Schreier's refinement theorem: any two normal series of a group have equivalent refinements. This sharpens Jordan-Hölder by replacing the hypothesis 'composition series' (maximal normal chain) with the weaker 'normal series' (arbitrary normal chain), then refining to recover the composition-series statement. Schreier's theorem implies Jordan-Hölder as a corollary — any two composition series, being already maximal, are equivalent to their common refinement and hence to each other. The lattice-theoretic content of Schreier's argument is exactly what `JordanHolderLattice`'s three axioms encode: `sup_eq_of_isMaximal` and `isMaximal_inf_left_of_isMaximal_sup` give the diamond closures used in the refinement, and `second_iso` gives the factor isomorphisms identified at the refinement step."
+    },
+    {
+      "authors": [
+        "H. Zassenhaus"
+      ],
+      "title": "Zum Satz von Jordan-Hölder-Schreier",
+      "year": "1934",
+      "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg 10: 106–108",
+      "note": "The *butterfly lemma* (Schmetterlingslemma): for subgroups $A_1 \\trianglelefteq A_2$ and $B_1 \\trianglelefteq B_2$ of a group, $(A_1(A_2 \\cap B_2))/(A_1(A_2 \\cap B_1)) \\simeq (B_1(A_2 \\cap B_2))/(B_1(A_1 \\cap B_2))$. This combinatorial identity gives a direct, elegant proof of Schreier's refinement theorem without requiring the chains to be composition series — the butterfly diagram is the visual mnemonic. The lemma is the technical heart of every modern proof of Jordan-Hölder via Schreier (e.g., Rotman §5.3, Lang Chapter I §3). Mathlib's `CompositionSeries.jordan_holder` proof traces this lineage: the underlying abstract argument in `JordanHolderLattice` is structurally a butterfly-style equivalence, with the `second_iso` axiom standing in for the central isomorphism step of the butterfly lemma."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for `abel-ruffini-galois-extensions-oq-04` (Jordan-Hölder Uniqueness Theorem via JordanHolderLattice).

## Gap Addressed

The entry's `historicalContext` cites Otto Schreier (1928, refinement theorem) and Hans Zassenhaus (1934, butterfly lemma) as central figures in the modern proof of Jordan-Hölder, but neither paper appeared in the `references` array. This PR closes that bibliographic gap.

## Changes

- **Schreier 1928** — *Über den Jordan-Hölderschen Satz* (Hamburger Abh. 6). Note explains how Schreier's refinement theorem implies Jordan-Hölder as a corollary, and how the `JordanHolderLattice` axioms encode the lattice-theoretic content of Schreier's argument.
- **Zassenhaus 1934** — *Zum Satz von Jordan-Hölder-Schreier* (Hamburger Abh. 10). Note states the butterfly lemma formula and traces how Mathlib's `CompositionSeries.jordan_holder` proof inherits the butterfly-style structural argument, with `second_iso` standing in for the central isomorphism step.

Both additions are bibliographically precise and connect directly to the proof technique used in this file.

## Verification

- `pnpm build` passes (JSON valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)