### PR TITLE
audit(erdos-342): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6300,9 +6300,9 @@
     },
     "erdos-342": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:33:54Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T12:43:52Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in sections (ulamSeq_unique_representation, ulamSeq_minimal, ulamSeq_values, five_not_ulam, six_is_ulam, twin_examples, erdos_342, ulamSeq_growth, ulamSeq_growth_constant, ulam_characterization); section line-range drift across all parts; theoremCount 20→19; imports drift (#14463)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-342 (cycle 4)

Re-audited **Erdős Problem #342: The Ulam Sequence U(1,2)**. Verified `meta.json` claims against `proofs/Proofs/Erdos342Problem.lean`.

### Verification

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 3 | 3 (`ulamSeq`, `ulamSeq_initial`, `ulamSeq_strictMono`) | OK |
| sorries | 0 | 0 | OK |
| theoremCount | 20 | 20 | OK |
| definitionCount | 11 | 11 | OK |
| lineCount | 221 | 221 | OK |
| status / badge | axiomatized / axiom | open conjecture left as unproved `Prop`; 3 axioms present | OK |
| True stubs | — | 0 | OK |

- No Mathlib-wrapper overclaim: `ErdosConjecture342` is an unproved `Prop`; proved theorems are elementary (injectivity from `StrictMono`, growth lower bound, membership facts).
- The cycle-3 issues (phantom section axioms, section line-range drift, `theoremCount`, imports drift) fixed in #14463 are confirmed resolved.

### Result
**CLEAN** — `auditCount` 3 -> 4, `result` `issues-fixed` -> `clean`.

Note: stale internal code comments in the `.lean` file (header says "1 axiom"; Part IX summary says "5 axioms, 15 theorems") disagree with reality (3 axioms, 20 theorems), but these are non-public comments and do not affect gallery claims. Left as-is.

---
Discovered during gallery integrity audit.