### PR TITLE
audit(erdos-342): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6300,9 +6300,9 @@
     },
     "erdos-342": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:33:54Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T12:49:36Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in sections (ulamSeq_unique_representation, ulamSeq_minimal, ulamSeq_values, five_not_ulam, six_is_ulam, twin_examples, erdos_342, ulamSeq_growth, ulamSeq_growth_constant, ulam_characterization); section line-range drift across all parts; theoremCount 20→19; imports drift (#14463)"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-342 (cycle 4)

**Result: CLEAN** — meta.json claims match the Lean source exactly.

### Verified against `proofs/Proofs/Erdos342Problem.lean`

| Claim (meta.json) | Lean source | Status |
|---|---|---|
| `axiomCount: 3` | 3 `axiom` decls (`ulamSeq`, `ulamSeq_initial`, `ulamSeq_strictMono`) | ✓ |
| `sorries: 0` | 0 sorries | ✓ |
| True stubs | 0 | ✓ |
| `theoremCount: 20` | 20 theorems | ✓ |
| `definitionCount: 11` | 11 definitions | ✓ |
| structure-encoded assumptions | 0 structures | ✓ |
| `lineCount: 221` | 221 lines | ✓ |
| `status: axiomatized` / `badge: axiom` | OPEN conjecture, 3 axioms | ✓ |

### Notes
- `ErdosConjecture342` is an unproved `Prop`; `erdos_342_statement` only proves a trivial restatement iff (`simp`), not the conjecture itself — no overclaiming.
- Prior cycle issues (phantom axioms in sections, section line-range drift, theoremCount drift, imports drift; ref #14463) are resolved in the current data.
- Minor (non-blocking, not a gallery claim): stale internal Lean comments contradict the actual axiom count — the top doc-comment says "Axioms: 1" and the Part IX summary says "5 axioms", while the actual count is 3. The public `meta.json` is accurate, so gallery integrity is intact.

Tracker bump only: `auditCount` 3→4, `result` issues-fixed→clean.

---
Discovered during gallery integrity audit.