### PR TITLE
Fix: sync stale root sorries count in erdos-125 meta.json

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -198,5 +198,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 0
+  "sorries": 12
 }


### PR DESCRIPTION
## Fix

The root-level `sorries: 0` in `src/data/proofs/erdos-125/meta.json` was stale; it now reads `12`, matching the canonical `meta.sorries: 12` and the actual count in `proofs/Proofs/Erdos125PositiveLowerDensity.lean` (declared via `meta.additionalFiles`).

## Evidence

**Before**:
- `meta.sorries: 12`
- `sorries: 0` (root-level — stale)
- `leanFile.sorries: 0` (correct: counts only `Proofs/Erdos125Problem.lean`, which has 0 sorries)

**After**:
- `meta.sorries: 12`
- `sorries: 12` (root-level — now matches canonical)
- `leanFile.sorries: 0` (unchanged; still correct for the primary file)

Verification:
\`\`\`
$ grep -c "sorry" proofs/Proofs/Erdos125PositiveLowerDensity.lean
14   # 2 are docstring mentions, 12 are tactics
$ grep -c "sorry" proofs/Proofs/Erdos125Problem.lean
0
\`\`\`

\`pnpm build\` passes.

Refs #20842 — does not close; the 14-sorry-discharge work in that issue remains for the research/enricher pass.

---
Automated fix by lean-mechanic agent.