### PR TITLE
audit(erdos-336): tracker bump — clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6252,9 +6252,9 @@
     },
     "erdos-336": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:41:44Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T13:45:26Z",
+      "result": "clean"
     },
     "erdos-337": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Gallery integrity re-audit of **Erdős Problem #336** (Additive Bases and Exact Order). Result: **CLEAN** — no integrity issues.

Bumps `audit-tracker.json` for `erdos-336` (auditCount 3→4, result `issues-fixed`→`clean`, lastAudited 2026-05-29).

## Verification

Checked `src/data/proofs/erdos-336/meta.json` against `proofs/Proofs/Erdos336Problem.lean`:

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 161 | 161 | ✓ |
| axiomCount | 6 | 6 (grekos_lower_1988, nash_upper_1993, h_2, h_3, example_order_2, example_exact_order_3) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| True stubs | — | 0 | ✓ |
| structures/classes | — | 0 (no hidden structure-encoded assumptions) | ✓ |

- `status: axiomatized` + `badge: axiom` correctly reflect the axiomatized open problem.
- No narrative failure modes (no axiom masking, no overclaiming; OPEN status stated plainly).
- meta.json honestly notes the Erdős-Graham characterization (Part 6) and Plagne refinement (Part 7) are docstring-only with no axiom/theorem declared — confirmed in source (lines 123-140 are comments only).

Risk: LOW (open Erdős problem, correctly labeled axiomatized).

---
Discovered during gallery integrity audit. Math-agent PR — no Judge review required.