### PR TITLE
audit(erdos-330): correct density keyInsight to match Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6197,8 +6197,8 @@
     },
     "erdos-330": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:53:48Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T14:09:30Z",
       "result": "issues-fixed"
     },
     "erdos-331": {

--- a/src/data/proofs/erdos-330/meta.json
+++ b/src/data/proofs/erdos-330/meta.json
@@ -79,7 +79,7 @@
       "The question strengthens 'infinitely many' to 'positive density' of unrepresentable integers",
       "This connects the structure of individual elements to the global density of the basis",
       "A positive answer would show each element of the basis is quantitatively critical",
-      "**Axiomatized density**: Upper density is axiomatized (not computed) because computing $\\limsup$ of counting functions is noncomputable. The axioms $0 \\leq \\bar{d}(S) \\leq 1$ capture the essential properties needed for the formalization.",
+      "**Axiomatized density**: Upper density is axiomatized (not computed) because computing $\\limsup$ of counting functions is noncomputable. The single axiom declares `upperDensity` as an abstract real-valued function $\\bar{d} : \\mathrm{Set}\\,\\mathbb{N} \\to \\mathbb{R}$; the natural bounds $0 \\leq \\bar{d}(S) \\leq 1$ are noted in source comments but not enforced as axioms (no theorem in this file requires them).",
       "**Order matters**: For $h = 1$, the only basis is $A = \\mathbb{N}$ (trivially minimal and dense). The problem is interesting for $h \\geq 2$, where bases can be sparse yet minimal"
     ],
     "prerequisites": [


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-330

**Proof**: Erdős Problem #330 (Minimal Bases with Positive Density)
**Result**: issues-fixed (1 LOW-severity prose inaccuracy corrected)

## Mechanical verification (all match meta.json)

| Claim | meta.json | Erdos330Problem.lean | OK |
|-------|-----------|----------------------|----|
| lineCount | 65 | 65 | ✓ |
| axiomCount | 1 | 1 (`upperDensity`) | ✓ |
| definitionCount | 5 | 5 | ✓ |
| theoremCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| structures | — | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| status/badge | axiomatized / axiom | correct (open problem, 1 axiom, no theorems) | ✓ |

The entry is commendably honest: it repeatedly states the open question is recorded as a docstring only, with "no Lean formalization of this proposition."

## Issue fixed

A keyInsight read:

> The axioms $0 \le \bar{d}(S) \le 1$ capture the essential properties needed for the formalization.

This claims bound **axioms** exist. They do not — the file has a single axiom declaring `upperDensity` as an abstract `Set ℕ → ℝ` function. The nonneg / ≤1 properties appear only as source comments (lines 38–39), are not encoded as axioms, and no theorem requires them. Reworded to describe the single function axiom accurately.

Tracker bumped erdos-330 auditCount 3 → 4.

---
Discovered during gallery integrity audit.