### PR TITLE
audit(erdos-334): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6227,9 +6227,9 @@
     },
     "erdos-334": {
       "agentId": "auditor",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T00:55:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T14:36:34Z",
+      "result": "clean",
       "issues": [
         "phantom (proved) claim for small_has_repr (has sorry); phantom minSmoothness_exists axiom + de_bruijn_asymptotic theorem in section summaries; section line drift Parts III-VIII (#14467)"
       ],


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: erdos-334 (Smooth Number Representation)
**Result**: CLEAN — all gallery claims match the Lean source.

Re-audited `src/data/proofs/erdos-334/meta.json` against `proofs/Proofs/Erdos334Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| status / badge | axiomatized / axiom | 2 axioms + 3 sorries | ✓ |
| sorries | 3 | 3 (`small_has_repr` L91, `balog_exponent_value` L133, `erdos_334` L283) | ✓ |
| axiomCount | 2 | 2 (`erdos_cube_root_bound`, `balog_bound`); no structure-encoded assumptions | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| lineCount | 294 | 294 | ✓ |

- Tier C scaffold: the main result (`erdos_334`, `erdos_334_summary`) rests on the two axioms, honestly disclosed in `assumptions` and section summaries.
- No True-stub theorem overclaim: `goldbachTypeProperty := True` is a placeholder **def** (not a theorem), and the section summary labels it "simplified to True".
- Mathlib deps are basic infrastructure (`Nat.Prime`, `Real.rpow`), not a deep theorem masking the core result.

## Change

Bumps the audit tracker entry: `auditCount` 3→4, `result` issues-fixed→clean, refreshes `lastAudited`. Single-file change to `src/data/proofs/audit-tracker.json`.

---
Discovered during gallery integrity audit. Deployer merges audit PRs directly (no review label).