### PR TITLE
audit(erdos-334): fix "Verified" overclaim on sorried main theorem

### DIFF
--- a/src/data/proofs/erdos-334/meta.json
+++ b/src/data/proofs/erdos-334/meta.json
@@ -142,7 +142,7 @@
       "summary": "erdos_334_summary, erdos_334 main theorem, openQuestion",
       "startLine": 253,
       "endLine": 294,
-      "mathContext": "Verified: erdos_334_summary, erdos_334 main theorem, openQuestion"
+      "mathContext": "erdos_334_summary is proved modulo the axioms erdos_cube_root_bound and balog_bound; erdos_334 (main theorem) is reduced to a single remaining sorry closing the 0.27 vs balogExponent ≈ 0.2695 gap; openQuestion is stated as a definition (Prop), not proved."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Gallery Integrity Fix

**Proof**: erdos-334 (Erdős Problem #334: Smooth Number Representation)

### Problem
The "Part VIII: Main Results Summary" section in `meta.json` had:

> `"mathContext": "Verified: erdos_334_summary, erdos_334 main theorem, openQuestion"`

This overclaims. In `proofs/Proofs/Erdos334Problem.lean`:
- **`erdos_334` (main theorem, line 276)** ends in `sorry` (line 283) — it is *not* verified.
- **`erdos_334_summary` (line 257)** is proved only *modulo* the axioms `erdos_cube_root_bound` and `balog_bound`.
- **`openQuestion` (line 290)** is a `def` (Prop), not a proved theorem.

### Evidence
```
$ grep -nE 'sorry' proofs/Proofs/Erdos334Problem.lean
91:  sorry        # small_has_repr
133:  sorry       # balog_exponent_value
283:    sorry     # erdos_334  <- MAIN THEOREM
```
Counts otherwise verified: 294 lines, 9 defs, 2 axioms, 10 theorems, 3 sorries, 0 True stubs, 0 structures.

### Fix
Rewrote the section `mathContext` to state the actual formalization status (summary proved modulo axioms; main theorem reduced to a remaining sorry; open question stated as a definition).

Headline fields were already accurate and are unchanged: `status=axiomatized`, `badge=axiom`, `sorries=3`, `axiomCount=2`. The `assumptions` field already disclosed "2 axioms ... 3 sorries". This corrects the per-section narrative only.

---
Discovered during gallery integrity audit (re-audit cycle).