### PR TITLE
Enrich Higher-Order Stirling Expansion: fix stale verified status + full re-annotation

### DIFF
--- a/src/data/proofs/stirling-formula-oq-01/annotations.json
+++ b/src/data/proofs/stirling-formula-oq-01/annotations.json
@@ -1,21 +1,44 @@
 [
   {
+    "id": "ann-module-overview",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 27
+    },
+    "type": "context",
+    "title": "Goal: The First Stirling Correction, Axiom-Free",
+    "content": "This file refines the bare Stirling approximation n! ~ √(2πn)(n/e)^n by formalizing the first correction factor (1 + 1/(12n) + O(1/n²)) and using it to discharge an error-bound axiom in the companion file StirlingFormula.lean. The classical coefficients of the Stirling series arise from the Euler-Maclaurin summation formula applied to log(n!) = Σ_{k=1}^n log(k), giving the k-th coefficient B_{2k}/(2k(2k−1)) in terms of Bernoulli numbers. Mathlib, however, builds stirlingSeq from the Wallis product rather than Euler-Maclaurin, so this file develops a self-contained telescoping argument that avoids Bernoulli-number infrastructure entirely. The entire development is machine-checked with 0 sorries and 0 axioms.",
+    "mathContext": "$n! \\sim \\sqrt{2\\pi n}\\left(\\frac{n}{e}\\right)^n\\left(1 + \\frac{1}{12n} + \\frac{1}{288n^2} - \\frac{139}{51840 n^3} + \\cdots\\right)$",
+    "significance": "context",
+    "relatedConcepts": [
+      "asymptotic expansion",
+      "Euler-Maclaurin formula",
+      "Wallis product",
+      "Bernoulli numbers"
+    ],
+    "prerequisites": [
+      "asymptotic analysis",
+      "factorials"
+    ]
+  },
+  {
     "id": "ann-coefficients",
     "proofId": "stirling-formula-oq-01",
     "range": {
-      "startLine": 44,
+      "startLine": 36,
       "endLine": 53
     },
     "type": "definition",
     "title": "Stirling Series Coefficients from Bernoulli Numbers",
-    "content": "The Stirling series coefficients a_0=1, a_1=1/12, a_2=1/288, a_3=−139/51840 are defined by cases. These arise from the Euler-Maclaurin formula applied to log(n!): the k-th coefficient involves the Bernoulli number B_{2k} via the formula a_k = B_{2k}/(2k(2k−1)). For k=1: B_2 = 1/6, so a_1 = (1/6)/(2·1) = 1/12. Higher coefficients follow from B_4 = −1/30. The pattern is not entirely captured by the explicit definition (which defaults to 0 for k ≥ 4), but the first four terms are sufficient for all applications in this file.",
-    "mathContext": "$a_k = \\frac{B_{2k}}{2k(2k-1)}$; $a_1 = \\frac{B_2}{2} = \\frac{1/6}{2} = \\frac{1}{12}$; $a_2 = \\frac{B_4}{12} = \\frac{-1/30}{12} = \\frac{1}{288}$",
+    "content": "The Stirling series coefficients a_0=1, a_1=1/12, a_2=1/288, a_3=−139/51840 are defined by cases (defaulting to 0 for k ≥ 4, since only the first few are needed here). They arise from the Euler-Maclaurin formula applied to log(n!): the k-th coefficient involves the Bernoulli number B_{2k} via a_k = B_{2k}/(2k(2k−1)). For k=1: B_2 = 1/6, so a_1 = (1/6)/2 = 1/12; for k=2: B_4 = −1/30 enters a higher-order combination giving the positive 1/288. The three theorems stirlingCoeff_zero/one/two confirm the values hold definitionally (rfl).",
+    "mathContext": "$a_k = \\frac{B_{2k}}{2k(2k-1)}$; $a_1 = \\frac{B_2}{2} = \\frac{1/6}{2} = \\frac{1}{12}$",
     "significance": "key",
     "relatedConcepts": [
       "Bernoulli numbers",
       "Euler-Maclaurin formula",
       "asymptotic series",
-      "Zeta function"
+      "Riemann zeta function"
     ],
     "prerequisites": [
       "Bernoulli numbers B_{2k}",
@@ -26,13 +49,13 @@
     "id": "ann-partial-expansion",
     "proofId": "stirling-formula-oq-01",
     "range": {
-      "startLine": 65,
+      "startLine": 59,
       "endLine": 76
     },
     "type": "definition",
     "title": "Truncated Stirling Series: stirlingPartial",
-    "content": "stirlingPartial k n = Σ_{i=0}^{k-1} a_i / n^i is the truncated expansion at k terms. For k=1: constant 1 (the Stirling approximation itself). For k=2: 1 + 1/(12n) (the first correction). The simp lemma stirlingPartial_two is proved by unfolding the Finset.sum and rewriting. The pow_one step handling n^1 = n is the main algebraic manipulation. This truncation structure is the standard way to state O(1/n^k) asymptotics in terms of explicit rational approximations.",
-    "mathContext": "$S_k(n) = \\sum_{i=0}^{k-1} \\frac{a_i}{n^i}$; $S_2(n) = 1 + \\frac{1}{12n}$",
+    "content": "stirlingPartial k n = Σ_{i=0}^{k-1} a_i / n^i is the expansion truncated at k terms. For k=1 it is the constant 1 (the bare Stirling approximation); for k=2 it is 1 + 1/(12n) (the first correction). stirlingPartial_one and stirlingPartial_two are proved by unfolding Finset.sum via Finset.sum_range_succ and closing with ring. This truncation is the standard way to phrase an O(1/n^k) asymptotic as an explicit rational approximant.",
+    "mathContext": "$S_k(n) = \\sum_{i=0}^{k-1} \\frac{a_i}{n^i}$; $S_1(n) = 1$, $S_2(n) = 1 + \\frac{1}{12n}$",
     "significance": "supporting",
     "relatedConcepts": [
       "asymptotic expansion",
@@ -46,46 +69,134 @@
     ]
   },
   {
-    "id": "ann-first-correction",
+    "id": "ann-log-cubic",
     "proofId": "stirling-formula-oq-01",
     "range": {
-      "startLine": 91,
-      "endLine": 94
+      "startLine": 77,
+      "endLine": 149
     },
-    "type": "insight",
-    "title": "The First Correction Theorem (sorry: requires Euler-Maclaurin)",
-    "content": "stirling_first_correction states that |stirlingSeq(n)/√π − (1 + 1/(12n))| ≤ C/n² for some constant C and all n ≥ 2. This is the most important unproved theorem in the file. The difficulty: Mathlib's stirlingSeq is defined via the Wallis product (n!²·4^n/(n·((2n)!)²) → π), not via Euler-Maclaurin. Connecting the Wallis-product definition to the Bernoulli number expansion requires analyzing the rate of convergence of the Wallis product, which involves the Gamma function and is non-trivial. The three known approaches are (1) Euler-Maclaurin for log(k) sum, (2) Gamma function asymptotics from log-gamma expansion, or (3) direct telescoping product analysis.",
-    "mathContext": "$\\left|\\frac{\\text{stirlingSeq}(n)}{\\sqrt{\\pi}} - 1 - \\frac{1}{12n}\\right| \\leq \\frac{C}{n^2}$",
+    "type": "technique",
+    "title": "Sharp Log Bound (Cubic) via Derivative Monotonicity",
+    "content": "log_one_plus_le_cubic proves log(1+x) ≤ x − x²/2 + x³/3 for x > 0, the third-order truncation of the alternating Mercator series. The proof is the workhorse technique reused throughout the file: set g(t) = (polynomial) − log(1+t), show g(0) = 0, compute g'(t) = 1 − t + t² − 1/(1+t) = t³/(1+t) ≥ 0 using HasDerivAt for each summand, conclude g is MonotoneOn [0,∞) via monotoneOn_of_deriv_nonneg, hence g(x) ≥ g(0) = 0. The algebraic identity 1 − t + t² − 1/(1+t) = t³/(1+t) (closed by field_simp; ring) is what makes the derivative manifestly nonnegative.",
+    "mathContext": "$g(t)=t-\\tfrac{t^2}{2}+\\tfrac{t^3}{3}-\\log(1+t),\\quad g'(t)=\\frac{t^3}{1+t}\\ge 0$",
     "significance": "key",
     "relatedConcepts": [
-      "Euler-Maclaurin formula",
-      "Wallis product",
-      "Gamma function asymptotics",
-      "log-gamma expansion"
+      "Mercator series",
+      "derivative monotonicity",
+      "HasDerivAt",
+      "monotoneOn_of_deriv_nonneg"
     ],
     "prerequisites": [
-      "Stirling.stirlingSeq",
-      "Stirling.tendsto_stirlingSeq_sqrt_pi"
+      "differentiation of log",
+      "monotonicity from nonnegative derivative"
     ]
   },
   {
-    "id": "ann-error-bound",
+    "id": "ann-log-quartic",
     "proofId": "stirling-formula-oq-01",
     "range": {
-      "startLine": 121,
-      "endLine": 142
+      "startLine": 151,
+      "endLine": 214
     },
-    "type": "concept",
-    "title": "Error Bound from First Correction: Algebraic Argument",
-    "content": "The theorem error_bound_from_correction is the fully proved part of the file. Assuming the first correction (as a hypothesis h), it derives the error bound stirlingSeq(n)/√π − 1 ≤ 1/n. The key algebraic step: decompose the LHS as (stirlingSeq(n)/√π − (1 + 1/(12n))) + 1/(12n). The first summand is bounded by 1/n² (from h), so the total is ≤ 1/n² + 1/(12n). The final calc block shows 1/n − (1/n² + 1/(12n)) = (11n − 12)/(12n²) ≥ 0 for n ≥ 2 (since 11·2 − 12 = 10 > 0). This is a purely algebraic chain: ring + nlinarith close everything.",
-    "mathContext": "$\\frac{1}{n} - \\left(\\frac{1}{n^2} + \\frac{1}{12n}\\right) = \\frac{11n - 12}{12n^2} \\geq 0$ for $n \\geq 2$",
+    "type": "technique",
+    "title": "Sharp Log Bound (Quartic Lower Bound)",
+    "content": "log_one_plus_ge_quartic proves x − x²/2 + x³/3 − x⁴/4 ≤ log(1+x) for x > 0 — the fourth-order truncation, which bounds log from below (truncating the alternating series after an even-power term undershoots). Same recipe as the cubic bound: f(t) = log(1+t) − (polynomial), f(0) = 0, and f'(t) = 1/(1+t) − (1 − t + t² − t³) = t⁴/(1+t) ≥ 0. Pairing the cubic upper bound with this quartic lower bound sandwiches log(1+1/k) tightly enough to pin the leading 1/(12k²) behaviour of the Stirling step.",
+    "mathContext": "$f(t)=\\log(1+t)-\\left(t-\\tfrac{t^2}{2}+\\tfrac{t^3}{3}-\\tfrac{t^4}{4}\\right),\\quad f'(t)=\\frac{t^4}{1+t}\\ge 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "alternating series bounds",
+      "derivative monotonicity",
+      "two-sided estimate"
+    ],
+    "prerequisites": [
+      "differentiation of log",
+      "monotonicity from nonnegative derivative"
+    ]
+  },
+  {
+    "id": "ann-log-quintic",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 215,
+      "endLine": 300
+    },
+    "type": "technique",
+    "title": "Sharp Log Bound (Quintic) — Toolkit for the Next Correction",
+    "content": "log_one_plus_le_quintic proves log(1+x) ≤ x − x²/2 + x³/3 − x⁴/4 + x⁵/5 for x > 0, the fifth-order upper bound (added in iteration 5). It follows the identical derivative-monotonicity pattern, powered by the algebraic identity 1 − t + t² − t³ + t⁴ = (1+t⁵)/(1+t), which makes g'(t) = t⁵/(1+t) ≥ 0. This bound is not needed for the 1/(12n) correction proved here; it is infrastructure for a future iteration targeting the second Stirling coefficient 1/(288n²), where a finer step estimate d_k = 1/(12k²) + 1/(120k⁴) + (lower order) is required.",
+    "mathContext": "$1 - t + t^2 - t^3 + t^4 = \\frac{1+t^5}{1+t}\\implies g'(t)=\\frac{t^5}{1+t}\\ge 0$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "alternating series bounds",
+      "second Stirling correction",
+      "geometric series identity"
+    ],
+    "prerequisites": [
+      "differentiation of log",
+      "polynomial identities"
+    ]
+  },
+  {
+    "id": "ann-step-formula",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 301,
+      "endLine": 374
+    },
+    "type": "insight",
+    "title": "The Telescoping Step d_k = (k + 1/2)·log(1 + 1/k) − 1",
+    "content": "stirling_step_formula is the structural heart of the proof. It rewrites the consecutive difference d_k = log(stirlingSeq k) − log(stirlingSeq(k+1)) into the closed form (k + 1/2)·log(1 + 1/k) − 1. The proof unfolds stirlingSeq k = k!/[√(2k)·(k/e)^k], expands its log via log_div, log_mul, log_sqrt, log_pow, log_exp into log(k!) − (1/2)log(2k) − k(log k − 1), does the same for k+1, and cancels using log((k+1)!) = log(k!) + log(k+1) and log(1+1/k) = log(k+1) − log(k). After all cancellations both sides reduce to (k+1/2)(log(k+1) − log k) − 1, closed by ring. This converts the global limit log(stirlingSeq n) − log √π into a telescoping series Σ_{k≥n} d_k.",
+    "mathContext": "$d_k = \\log(\\mathrm{stirlingSeq}\\,k) - \\log(\\mathrm{stirlingSeq}(k{+}1)) = \\left(k + \\tfrac12\\right)\\log\\!\\left(1 + \\tfrac1k\\right) - 1$",
     "significance": "key",
     "relatedConcepts": [
-      "error bound",
-      "ring tactic",
+      "telescoping series",
+      "logarithm arithmetic",
+      "stirlingSeq",
+      "Wallis product"
+    ],
+    "prerequisites": [
+      "Real.log_mul / log_div / log_pow",
+      "factorial recurrence"
+    ]
+  },
+  {
+    "id": "ann-step-bounds",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 376,
+      "endLine": 411
+    },
+    "type": "technique",
+    "title": "Sandwiching the Step: 1/(12k²) ± Lower Order",
+    "content": "stirling_step_upper and stirling_step_lower feed the log bounds into the step formula. Substituting x = 1/k into log_one_plus_le_cubic gives the upper bound d_k ≤ 1/(12k²) + 1/(6k³); substituting into log_one_plus_ge_quartic gives the lower bound 1/(12k²) − 1/(12k³) − 1/(8k⁴) ≤ d_k. The leading term 1/(12k²) is the source of the 1/(12n) correction once summed. Each bound is established by multiplying the log estimate by (k + 1/2) ≥ 0 (mul_le_mul_of_nonneg_left) and simplifying the rational expression with field_simp; ring.",
+    "mathContext": "$\\frac{1}{12k^2} - \\frac{1}{12k^3} - \\frac{1}{8k^4} \\le d_k \\le \\frac{1}{12k^2} + \\frac{1}{6k^3}$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "two-sided bound",
+      "monotone multiplication",
+      "leading-order asymptotics"
+    ],
+    "prerequisites": [
+      "mul_le_mul_of_nonneg_left",
+      "field_simp"
+    ]
+  },
+  {
+    "id": "ann-telescoping-lemmas",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 413,
+      "endLine": 494
+    },
+    "type": "technique",
+    "title": "Telescoping Arithmetic Lemmas",
+    "content": "Five elementary rational inequalities convert the per-step bounds into differences of a 'potential' function so the partial sums telescope. For example inv_sq_le_telescope shows 1/(12k²) ≤ 1/(12(k−1)) − 1/(12k) (equivalently k(k−1) ≤ k²), and inv_quad_le_telescope shows 1/(8k⁴) ≤ 1/(24(k−1)³) − 1/(24k³) using the identity k⁴ − (k+3)(k−1)³ = 6k² − 8k + 3 = (2k−1)² + 2(k−1)² ≥ 0. Each is reduced to nonnegativity of an explicit polynomial numerator via field_simp and discharged with nlinarith/positivity. These are the gears that make the next section's induction collapse to a closed form.",
+    "mathContext": "$\\frac{1}{12k^2} \\le \\frac{1}{12(k-1)} - \\frac{1}{12k},\\qquad \\frac{1}{8k^4} \\le \\frac{1}{24(k-1)^3} - \\frac{1}{24k^3}$",
+    "significance": "technical",
+    "relatedConcepts": [
+      "telescoping sums",
+      "potential function",
       "nlinarith",
-      "calc block",
-      "axiom elimination"
+      "rational inequalities"
     ],
     "prerequisites": [
       "field_simp",
@@ -94,21 +205,114 @@
     ]
   },
   {
-    "id": "ann-numerical",
+    "id": "ann-partial-sums",
     "proofId": "stirling-formula-oq-01",
     "range": {
-      "startLine": 149,
-      "endLine": 154
+      "startLine": 496,
+      "endLine": 555
     },
-    "type": "concept",
-    "title": "Numerical Verification of the First Correction Term",
-    "content": "Two norm_num examples verify the first correction at n=10 and n=100: 1 + 1/120 = 121/120 and 1 + 1/1200 = 1201/1200. These are trivial rationally but serve as concrete reference points. For n=10, the actual ratio 10!/[√(20π)·(10/e)^10] ≈ 1.00834, matching 1 + 1/120 ≈ 1.00833 to within 10^{-5} — the O(1/n²) correction is about 3.5 × 10^{-6}. These examples illustrate the practical accuracy of the first correction for modest n.",
-    "mathContext": "$n=10: 1 + \\frac{1}{12\\cdot 10} = \\frac{121}{120} \\approx 1.00833$; actual: $1.00834...$",
+    "type": "technique",
+    "title": "Closed-Form Partial Sum Bounds by Induction",
+    "content": "log_stirlingSeq_partial_upper and log_stirlingSeq_partial_lower bound the finite telescoped sum log(stirlingSeq n) − log(stirlingSeq(n+L)) for all L, by induction on L. The upper bound is the telescoping potential F(k) = 1/(12(k−1)) + 1/(12(k−1)²) evaluated at the endpoints: the sum ≤ F(n) − F(n+L). The lower bound uses G(k) = 1/(12k) − 1/(24(k−1)²) − 1/(24(k−1)³). The inductive step splits off the last term d_{n+L}, bounds it via the step inequalities, and folds in the telescoping lemmas; push_cast and add_assoc normalization align the Nat/Real casts so linarith can close each step.",
+    "mathContext": "$\\log\\frac{\\mathrm{stirlingSeq}\\,n}{\\mathrm{stirlingSeq}(n{+}L)} \\le \\frac{1}{12(n-1)} + \\frac{1}{12(n-1)^2} - F(n{+}L)$",
     "significance": "supporting",
     "relatedConcepts": [
-      "norm_num",
-      "Stirling's approximation accuracy",
-      "relative error"
+      "mathematical induction",
+      "telescoping",
+      "partial sums"
+    ],
+    "prerequisites": [
+      "induction on ℕ",
+      "push_cast"
+    ]
+  },
+  {
+    "id": "ann-first-correction",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 557,
+      "endLine": 802
+    },
+    "type": "insight",
+    "title": "Main Theorem: Stirling's First Correction (fully proved, C = 2)",
+    "content": "stirling_first_correction proves |stirlingSeq(n)/√π − (1 + 1/(12n))| ≤ 2/n² for all n ≥ 2 — fully machine-checked, with no remaining sorry. Earlier annotations of this entry described it as an unproved theorem 'requiring Euler-Maclaurin'; that is now obsolete. The proof takes L = log(stirlingSeq n) − log √π ≥ 0 and observes L = Σ_{k≥n} d_k via the telescoping step and the limit stirlingSeq(n+M) → √π (tendsto_stirlingSeq_sqrt_pi). Taking limits of the partial-sum bounds (le_of_tendsto', with each residual tail driven to 0 by Tendsto.div_atTop) sandwiches L between explicit rational functions of n. Since exp(L) = stirlingSeq n / √π, the result follows from Real.exp_bound at degree 2 — |exp L − (1+L)| ≤ 3L²/4 when |L| ≤ 1 — combined with L² ≤ 1/n² (from 0 ≤ L ≤ 1/n) and the algebraic comparison L − 1/(12n) ≤ 1/(2n²), giving the total bound 5/(4n²) ≤ 2/n².",
+    "mathContext": "$\\left|\\frac{\\mathrm{stirlingSeq}(n)}{\\sqrt{\\pi}} - \\left(1 + \\frac{1}{12n}\\right)\\right| \\le \\frac{2}{n^2},\\quad n \\ge 2$",
+    "significance": "key",
+    "relatedConcepts": [
+      "telescoping series",
+      "Real.exp_bound",
+      "le_of_tendsto'",
+      "Tendsto.div_atTop",
+      "Taylor remainder"
+    ],
+    "prerequisites": [
+      "Stirling.tendsto_stirlingSeq_sqrt_pi",
+      "limits of sequences",
+      "exp/log inverse"
+    ]
+  },
+  {
+    "id": "ann-two-term",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 804,
+      "endLine": 839
+    },
+    "type": "concept",
+    "title": "Two-Term Expansion of n! Directly",
+    "content": "stirling_two_term_expansion restates the first correction for n! itself: |n!/[√(2πn)·(n/e)^n] − (1 + 1/(12n))| ≤ C/n² for n ≥ 2. It is derived from stirling_first_correction by the single identity n!/[√(2πn)·(n/e)^n] = stirlingSeq(n)/√π, which follows from the factorization √(2πn) = √(2n)·√π (Real.sqrt_mul) and rearranging the division. This is the reader-facing form of the result, expressed in the classical Stirling variables rather than Mathlib's normalized stirlingSeq.",
+    "mathContext": "$\\sqrt{2\\pi n} = \\sqrt{2n}\\cdot\\sqrt{\\pi}\\;\\Longrightarrow\\; \\frac{n!}{\\sqrt{2\\pi n}(n/e)^n} = \\frac{\\mathrm{stirlingSeq}(n)}{\\sqrt{\\pi}}$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Stirling's approximation",
+      "Real.sqrt_mul",
+      "normalization"
+    ],
+    "prerequisites": [
+      "Real.sqrt_mul",
+      "algebraic rearrangement"
+    ]
+  },
+  {
+    "id": "ann-error-bound",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 841,
+      "endLine": 869
+    },
+    "type": "concept",
+    "title": "Error Bound that Replaces an Axiom",
+    "content": "error_bound_from_correction shows stirlingSeq(n)/√π − 1 ≤ 1/n for n ≥ 2, which is the statement axiomatized as stirling_error_bound_ge_2 in StirlingFormula.lean. Given the first correction, decompose the LHS as (stirlingSeq(n)/√π − (1 + 1/(12n))) + 1/(12n); the first summand is ≤ 1/n² and the residual reduces to showing 1/n − (1/n² + 1/(12n)) = (11n − 12)/(12n²) ≥ 0 for n ≥ 2 — a purely algebraic fact closed by field_simp, ring and nlinarith. This is the payoff: the correction term turns a previously assumed bound into a theorem.",
+    "mathContext": "$\\frac{1}{n} - \\left(\\frac{1}{n^2} + \\frac{1}{12n}\\right) = \\frac{11n - 12}{12n^2} \\ge 0 \\text{ for } n \\ge 2$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "axiom elimination",
+      "error bound",
+      "nlinarith",
+      "proof-by-assuming pattern"
+    ],
+    "prerequisites": [
+      "field_simp",
+      "nlinarith",
+      "positivity"
+    ]
+  },
+  {
+    "id": "ann-numerical-summary",
+    "proofId": "stirling-formula-oq-01",
+    "range": {
+      "startLine": 871,
+      "endLine": 915
+    },
+    "type": "context",
+    "title": "Numerical Checks and Development Notes",
+    "content": "Two norm_num examples anchor the correction numerically: at n=10, 1 + 1/120 = 121/120 ≈ 1.00833 (the true ratio is ≈ 1.00834, so the O(1/n²) error is ≈ 3.5×10⁻⁶); at n=100, 1 + 1/1200 = 1201/1200. The closing comment block records the development history — session 2026-05-06 reached 0 sorries by discharging the upper-half Taylor bound via Real.exp_bound, and iteration 5 (2026-05-08) added the quintic log bound as scaffolding for the future 1/(288n²) term. The file as a whole stands at 0 sorries, 0 axioms.",
+    "mathContext": "$n=10:\\; 1 + \\tfrac{1}{120} = \\tfrac{121}{120} \\approx 1.00833;\\quad \\text{true} \\approx 1.00834$",
+    "significance": "context",
+    "relatedConcepts": [
+      "numerical verification",
+      "relative error",
+      "norm_num"
     ],
     "prerequisites": [
       "norm_num"

--- a/src/data/proofs/stirling-formula-oq-01/meta.json
+++ b/src/data/proofs/stirling-formula-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Stirling (1730), de Moivre (1733)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Stirling%27s_approximation#Speed_of_convergence_and_error_estimates",
     "date": "1730",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/StirlingExpansion.lean",
     "tags": [
       "analysis",
@@ -17,7 +17,7 @@
       "bernoulli-numbers"
     ],
     "badge": "original",
-    "sorries": 3,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "None. 0 axioms, 0 sorries. The full chain {log_one_plus_le_cubic, log_one_plus_ge_quartic, stirling_step_formula, stirling_step_upper, stirling_step_lower, telescoping helpers (inv_sq_le_telescope, inv_cube_le_telescope, inv_harmonic_le_sq, inv_cube_le_telescope2, inv_quad_le_telescope), partial-sum bounds (log_stirlingSeq_partial_upper/lower), stirling_first_correction, stirling_two_term_expansion, error_bound_from_correction} is fully proved. The final upper-half exp-Taylor bound is discharged via Real.exp_bound at degree n=2 (|L|≤1 → |exp L − (1+L)| ≤ 3·L²/4), combined with L² ≤ 1/n² (from 0 ≤ L ≤ 1/n) and the algebraic identity L − 1/(12n) ≤ 1/(2n²) (from L ≤ 1/(12(n−1)) + 1/(12(n−1)²)).",
     "dateAdded": "2026-03-29",
@@ -60,54 +60,105 @@
     "historicalContext": "James Stirling published 'Methodus Differentialis' in 1730, giving the asymptotic formula n! ~ \u221a(2\u03c0n)(n/e)^n and the full asymptotic series with Bernoulli number coefficients. Abraham de Moivre independently arrived at the same formula in 1733, and the constant \u221a(2\u03c0) was supplied by de Moivre (Stirling had initially left it implicit). The higher-order terms n! ~ \u221a(2\u03c0n)(n/e)^n \u00b7 (1 + 1/(12n) + 1/(288n\u00b2) \u2212 139/(51840n\u00b3) + ...) were known to both Stirling and de Moivre. The coefficients are given by the Euler-Maclaurin formula: applying the summation formula to \u03a3_{k=1}^n log(k) = log(n!) yields the asymptotic series, with the k-th correction coefficient a_k = B_{2k}/(2k(2k\u22121)n^k) involving Bernoulli numbers B_{2k}. Leonhard Euler's contributions to the Maclaurin-Euler formula (1730s) provided the systematic tool for deriving these coefficients. In the 20th century, the Stirling series was understood as the asymptotic expansion of the log-Gamma function: log \u0393(z) ~ (z\u22121/2)log(z) \u2212 z + (1/2)log(2\u03c0) + \u03a3 B_{2k}/[2k(2k\u22121)z^{2k-1}]. Mathlib's formalization uses the Wallis product as the entry point for Stirling's formula, making the connection to Bernoulli numbers indirect.",
     "problemStatement": "Formalize the higher-order terms in the Stirling expansion and use them to eliminate the error bound axiom in StirlingFormula.lean.",
     "text": "Formalizes the Stirling series coefficients and the first correction term 1/(12n), showing it implies the axiomatized error bound.",
-    "proofStrategy": "1. Define the Stirling series coefficients from Bernoulli numbers\n2. State the first correction: stirlingSeq(n)/\u221a\u03c0 = 1 + 1/(12n) + O(1/n\u00b2)\n3. Derive the error bound from the first correction\n4. The first correction proof requires Euler-Maclaurin or Wallis product analysis",
+    "proofStrategy": "Rather than invoke Euler-Maclaurin (which would require Bernoulli-number infrastructure absent from Mathlib), the file proves the first correction by a self-contained telescoping argument:\n1. Define the Stirling series coefficients and the truncated partial sums.\n2. Prove sharp polynomial bounds for log(1+x) (cubic upper, quartic lower, quintic upper) by the derivative-monotonicity method.\n3. Rewrite the consecutive difference d_k = log(stirlingSeq k) \u2212 log(stirlingSeq(k+1)) into the closed form (k+1/2)\u00b7log(1+1/k) \u2212 1, and sandwich it as 1/(12k\u00b2) \u00b1 lower-order using the log bounds.\n4. Telescope the per-step bounds (via elementary rational inequalities) and pass to the limit stirlingSeq(n+M) \u2192 \u221a\u03c0, sandwiching L = log(stirlingSeq n / \u221a\u03c0) between explicit rational functions of n.\n5. Since exp(L) = stirlingSeq(n)/\u221a\u03c0, finish with Real.exp_bound at degree 2 to convert the bound on L into the bound |stirlingSeq(n)/\u221a\u03c0 \u2212 (1 + 1/(12n))| \u2264 2/n\u00b2.\n6. Derive the two-term expansion of n! and the error bound (replacing an axiom in StirlingFormula.lean) as corollaries. The whole development is machine-checked: 0 sorries, 0 axioms.",
     "keyInsights": [
-      "The error bound proof (error_bound_from_correction) is fully proved without the first correction: assuming the correction as a hypothesis, it reduces to (11n \u2212 12)/(12n\u00b2) \u2265 0 for n \u2265 2, a purely algebraic fact closed by ring + nlinarith",
-      "The first correction proof (sorry) is hard because Mathlib defines stirlingSeq via the Wallis product, not via Euler-Maclaurin \u2014 connecting the Wallis convergence rate to Bernoulli number coefficients requires non-trivial analysis not currently in Mathlib",
-      "The Bernoulli number formula a_k = B_{2k}/(2k(2k\u22121)) gives a_1 = 1/12 from B_2 = 1/6 \u2014 this connection to Bernoulli numbers explains why the sign of the third term is negative (B_4 = \u22121/30) but a_2 is positive (higher-order polynomial in B_4 > 0)",
-      "The file splits into two tiers: the 'hard' theorems with sorry (stirling_first_correction, stirling_two_term_expansion) and the 'easy' theorem (error_bound_from_correction) that is fully proved given the correction as a hypothesis \u2014 a useful proof-by-assuming pattern",
-      "The practical accuracy of the 1/(12n) correction is remarkable: for n \u2265 2 the relative error is < 1/n\u00b2, and for n = 10 the correction gives 4 correct decimal digits of n!/[\u221a(2\u03c0n)(n/e)^n]"
+      "The first correction is proved without Euler-Maclaurin. Mathlib defines stirlingSeq via the Wallis product, so instead of connecting Wallis convergence to Bernoulli coefficients, the file telescopes the consecutive differences d_k = (k+1/2)\u00b7log(1+1/k) \u2212 1 directly \u2014 a fully elementary route that needs no Bernoulli-number infrastructure.",
+      "The derivative-monotonicity lemmas for log(1+x) are the reusable engine: each bound g(t) = (polynomial) \u2212 log(1+t) has g(0) = 0 and a derivative that simplifies to t^m/(1+t) \u2265 0, so g is monotone and nonnegative. The same three lines of reasoning give the cubic, quartic, and quintic bounds.",
+      "Reducing the global limit to a telescoping series is the structural pivot: log(stirlingSeq n / \u221a\u03c0) = \u03a3_{k\u2265n} d_k, so a sharp per-step estimate d_k \u2248 1/(12k\u00b2) sums (via 1/(12k\u00b2) telescoping against 1/(12(k\u22121)) \u2212 1/(12k)) to the leading 1/(12n) correction with an O(1/n\u00b2) remainder.",
+      "The final exp/log bridge is handled by Real.exp_bound at degree 2: because |L| \u2264 1/n \u2264 1, the Taylor remainder satisfies |exp L \u2212 (1+L)| \u2264 3L\u00b2/4 \u2264 3/(4n\u00b2), which combines with L \u2212 1/(12n) \u2264 1/(2n\u00b2) to yield the clean constant C = 2.",
+      "The Bernoulli formula a_k = B_{2k}/(2k(2k\u22121)) gives a_1 = 1/12 from B_2 = 1/6 and explains the sign pattern of the series (the negative third term reflects B_4 = \u22121/30), even though the proof itself never needs Bernoulli numbers.",
+      "The practical accuracy of the 1/(12n) correction is remarkable: for n \u2265 2 the relative error is < 1/n\u00b2, and at n = 10 the correction 1 + 1/120 \u2248 1.00833 already matches the true ratio 1.00834 to about four decimal digits.",
+      "The error bound that replaces the axiom stirling_error_bound_ge_2 collapses to a single algebraic inequality once the correction is in hand: (11n \u2212 12)/(12n\u00b2) \u2265 0 for n \u2265 2, closed by ring + nlinarith \u2014 illustrating how one quantitative theorem can retire a previously assumed bound."
     ]
   },
   "sections": [
     {
+      "id": "module-overview",
+      "title": "Module Overview",
+      "startLine": 1,
+      "endLine": 30,
+      "summary": "Docstring, imports, and namespace. States the goal \u2014 formalize the first Stirling correction 1/(12n) and use it to eliminate an error-bound axiom \u2014 and notes the coefficients' Euler-Maclaurin origin.",
+      "mathContext": "$n! \\sim \\sqrt{2\\pi n}(n/e)^n\\left(1 + \\tfrac{1}{12n} + \\tfrac{1}{288n^2} - \\cdots\\right)$"
+    },
+    {
       "id": "coefficients",
       "title": "Part I: Stirling Series Coefficients",
-      "startLine": 1,
-      "endLine": 28,
-      "summary": "Defines stirlingCoeff with first 4 coefficients. Proves values match. 0 sorries.",
-      "mathContext": "$a_0 = 1,\\; a_1 = \\frac{1}{12},\\; a_2 = \\frac{1}{288},\\; a_3 = -\\frac{139}{51840}$"
+      "startLine": 32,
+      "endLine": 53,
+      "summary": "Defines stirlingCoeff with the first four coefficients (a_0=1, a_1=1/12, a_2=1/288, a_3=\u2212139/51840) and proves the values hold by rfl.",
+      "mathContext": "$a_k = \\frac{B_{2k}}{2k(2k-1)},\\quad a_1 = \\frac{1}{12},\\ a_2 = \\frac{1}{288}$"
     },
     {
-      "id": "section-29",
-      "title": "Part I: Stirling Series Coefficients (continued)",
-      "startLine": 29,
-      "endLine": 55,
-      "summary": "Continuation of Part I: Stirling Series Coefficients."
+      "id": "partial-series",
+      "title": "Part II: Truncated Stirling Series",
+      "startLine": 55,
+      "endLine": 75,
+      "summary": "Defines stirlingPartial k n = \u03a3_{i<k} a_i/n^i and proves S_1(n)=1 and S_2(n)=1+1/(12n).",
+      "mathContext": "$S_k(n) = \\sum_{i=0}^{k-1}\\frac{a_i}{n^i}$"
     },
     {
-      "id": "expansion",
-      "title": "Parts II-III: First Correction and Main Expansion",
-      "startLine": 56,
-      "endLine": 110,
-      "summary": "Defines stirlingPartial and states the first correction theorem. 2 sorries.",
-      "mathContext": "$\\frac{n!}{\\sqrt{2\\pi n}(n/e)^n} = 1 + \\frac{1}{12n} + O(n^{-2})$"
+      "id": "log-bounds",
+      "title": "Part IIIa: Sharp Polynomial Bounds for log(1+x)",
+      "startLine": 77,
+      "endLine": 300,
+      "summary": "Three sharp bounds \u2014 cubic upper, quartic lower, quintic upper \u2014 each proved by the derivative-monotonicity method: g(t)=(polynomial)\u2212log(1+t) has g(0)=0 and g'(t)=t^m/(1+t)\u22650.",
+      "mathContext": "$x - \\tfrac{x^2}{2} + \\tfrac{x^3}{3} - \\tfrac{x^4}{4} \\le \\log(1+x) \\le x - \\tfrac{x^2}{2} + \\tfrac{x^3}{3}$"
+    },
+    {
+      "id": "step-formula",
+      "title": "Part IIIa (cont.): The Stirling Step and Its Bounds",
+      "startLine": 301,
+      "endLine": 411,
+      "summary": "stirling_step_formula rewrites d_k = log(stirlingSeq k) \u2212 log(stirlingSeq(k+1)) as (k+1/2)\u00b7log(1+1/k)\u22121; stirling_step_upper/lower sandwich it as 1/(12k\u00b2) \u00b1 lower-order via the log bounds.",
+      "mathContext": "$d_k = (k+\\tfrac12)\\log(1+\\tfrac1k) - 1 \\in \\left[\\tfrac{1}{12k^2} - \\cdots,\\ \\tfrac{1}{12k^2} + \\tfrac{1}{6k^3}\\right]$"
+    },
+    {
+      "id": "telescoping",
+      "title": "Part IIIb: Telescoping Arithmetic Lemmas",
+      "startLine": 413,
+      "endLine": 494,
+      "summary": "Five elementary rational inequalities expressing each per-step bound as a difference of a potential function, so the partial sums telescope. Each reduces to nonnegativity of a polynomial numerator via field_simp + nlinarith.",
+      "mathContext": "$\\frac{1}{12k^2} \\le \\frac{1}{12(k-1)} - \\frac{1}{12k}$"
+    },
+    {
+      "id": "partial-sums",
+      "title": "Part IIIc: Closed-Form Partial Sum Bounds",
+      "startLine": 496,
+      "endLine": 555,
+      "summary": "By induction on L, log(stirlingSeq n) \u2212 log(stirlingSeq(n+L)) is bounded above and below by telescoping potentials evaluated at the endpoints n and n+L.",
+      "mathContext": "$\\log\\frac{\\mathrm{stirlingSeq}\\,n}{\\mathrm{stirlingSeq}(n+L)} \\le F(n) - F(n+L)$"
+    },
+    {
+      "id": "main-theorem",
+      "title": "Part III: Main Theorem \u2014 Stirling's First Correction",
+      "startLine": 557,
+      "endLine": 802,
+      "summary": "stirling_first_correction proves |stirlingSeq(n)/\u221a\u03c0 \u2212 (1 + 1/(12n))| \u2264 2/n\u00b2 for n \u2265 2. Takes L = log(stirlingSeq n/\u221a\u03c0) = \u03a3_{k\u2265n} d_k, sandwiches L via the partial-sum bounds and the limit stirlingSeq(n+M)\u2192\u221a\u03c0, then converts to the ratio bound with Real.exp_bound. Fully proved, C = 2.",
+      "mathContext": "$\\left|\\frac{\\mathrm{stirlingSeq}(n)}{\\sqrt\\pi} - \\left(1 + \\tfrac{1}{12n}\\right)\\right| \\le \\frac{2}{n^2}$"
+    },
+    {
+      "id": "two-term",
+      "title": "Two-Term Expansion of n!",
+      "startLine": 804,
+      "endLine": 839,
+      "summary": "stirling_two_term_expansion restates the correction for n! itself, derived from the main theorem via the factorization \u221a(2\u03c0n) = \u221a(2n)\u00b7\u221a\u03c0.",
+      "mathContext": "$\\left|\\frac{n!}{\\sqrt{2\\pi n}(n/e)^n} - \\left(1 + \\tfrac{1}{12n}\\right)\\right| \\le \\frac{C}{n^2}$"
     },
     {
       "id": "error-bound",
-      "title": "Part IV: Error Bound (Axiom Replacement)",
-      "startLine": 111,
-      "endLine": 145,
-      "summary": "Shows first correction implies the axiomatized error bound. Fully proved (0 sorries). Key step: (11n \u2212 12)/(12n\u00b2) \u2265 0 for n \u2265 2.",
-      "mathContext": "$\\frac{\\text{stirlingSeq}(n)}{\\sqrt{\\pi}} - 1 \\leq \\frac{1}{n}$ for $n \\geq 2$ via $\\frac{1}{n} - \\frac{1}{n^2} - \\frac{1}{12n} = \\frac{11n-12}{12n^2} \\geq 0$"
+      "title": "Part IV: Error Bound (Replaces Axiom)",
+      "startLine": 841,
+      "endLine": 869,
+      "summary": "error_bound_from_correction derives stirlingSeq(n)/\u221a\u03c0 \u2212 1 \u2264 1/n for n \u2265 2 \u2014 the statement axiomatized in StirlingFormula.lean. Reduces to (11n \u2212 12)/(12n\u00b2) \u2265 0, closed by ring + nlinarith.",
+      "mathContext": "$\\frac{1}{n} - \\left(\\frac{1}{n^2} + \\frac{1}{12n}\\right) = \\frac{11n-12}{12n^2} \\ge 0$"
     },
     {
       "id": "numerical",
-      "title": "Part V: Numerical Examples and Summary",
-      "startLine": 144,
-      "endLine": 176,
-      "summary": "Two norm_num examples verify the first correction at n=10 (1 + 1/120) and n=100 (1 + 1/1200). Summary block explains the three paths to proving stirling_first_correction: Euler-Maclaurin, telescoping product analysis, or Gamma function asymptotics.",
-      "mathContext": "$n = 10: 1 + \\frac{1}{120} \\approx 1.00833$; error from true value $< 10^{-5}$"
+      "title": "Part V: Numerical Verification and Notes",
+      "startLine": 871,
+      "endLine": 915,
+      "summary": "Two norm_num checks anchor the correction at n=10 (1+1/120) and n=100 (1+1/1200), followed by development notes recording the path to 0 sorries and the iteration-5 addition of the quintic log bound.",
+      "mathContext": "$n = 10:\\ 1 + \\frac{1}{120} \\approx 1.00833;\\ \\text{true} \\approx 1.00834$"
     }
   ],
   "crossReferences": [
@@ -120,6 +171,16 @@
       "targetId": "stirling-formula-oq-02",
       "relationship": "related",
       "description": "The Gamma function extension also benefits from improved error bounds"
+    },
+    {
+      "targetId": "central-limit-theorem",
+      "relationship": "application",
+      "description": "The 1/(12n) correction sharpens the factorial estimates behind binomial-coefficient asymptotics, the analytic core of the de Moivre–Laplace local central limit theorem"
+    },
+    {
+      "targetId": "basel-problem",
+      "relationship": "related",
+      "description": "The leading Stirling coefficient 1/12 comes from the Bernoulli number B_2 = 1/6 — the same constant that produces ζ(2) = π²/6 in the Basel problem"
     }
   ],
   "conclusion": {
@@ -154,5 +215,5 @@
       "Proofs/StirlingExpansionAristotle.lean"
     ]
   },
-  "sorries": 3
+  "sorries": 0
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `stirling-formula-oq-01` (Higher-Order Stirling Expansion). This entry was **stale and internally contradictory**: the Lean file `Proofs/StirlingExpansion.lean` had grown to 915 lines and reached **0 sorries / 0 axioms**, but the gallery metadata still described an incomplete, sorry-bearing proof and its annotations covered only the first ~176 lines (≈6% of the file).

## What was wrong

- `meta.status: "formalized"`, `meta.sorries: 3`, and top-level `sorries: 3` **contradicted** `leanFile.sorries: 0`, the `assumptions` block ("0 sorries, fully proved"), `originalContributions` ("fully proved"), and the `conclusion` ("0 axioms, 0 sorries").
- `overview.keyInsights` and `proofStrategy` still described `stirling_first_correction` as an unproved theorem "requiring Euler-Maclaurin".
- 3 of 5 annotations had line ranges pointing at unrelated code (e.g. an annotation titled "First Correction Theorem (sorry…)" landed on the cubic log-bound statement).
- `sections` stopped at line 176 with summaries claiming "2 sorries".

## Changes

- **Accuracy** (confirmed by a docker build — `Build succeeded`, 3083 jobs, no sorry/axiom warnings): `status` formalized→**verified**; `meta.sorries` and top-level `sorries` 3→**0**.
- Rewrote `overview.proofStrategy` and `keyInsights` to describe the actual **telescoping** proof (avoids Euler-Maclaurin; uses the step formula `d_k = (k+1/2)·log(1+1/k) − 1`, derivative-monotonicity log bounds, and `Real.exp_bound`).
- Rewrote `sections` (5→**11**) to cover all 915 lines with accurate summaries.
- Rewrote `annotations` (5→**14**, coverage **6%→97%**), fixing the 3 stale ranges and adding `mathContext`/`significance`/`relatedConcepts`/`prerequisites` for the cubic/quartic/quintic log bounds, the step formula, the telescoping lemmas, the partial-sum induction, the main theorem, the two-term expansion, and the error bound.
- Added 2 cross-references: `central-limit-theorem` (the 1/(12n) correction sharpens the binomial estimates behind de Moivre–Laplace) and `basel-problem` (the 1/12 coefficient comes from B₂=1/6, the constant behind ζ(2)=π²/6).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.StirlingExpansion` → **Build succeeded** (0 sorries, 0 axioms confirmed).
- `pnpm build` → ✓ built (JSON valid, gallery typechecks and compiles).

## Test plan

- [x] Lean proof builds with 0 sorries / 0 axioms (docker)
- [x] `pnpm build` succeeds
- [x] meta.json / annotations.json are valid JSON; all annotations carry full fields
- [x] Annotation ranges realigned to the current 915-line file (97% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)