### PR TITLE
Enrich Abel-Ruffini Galois Theory Extensions: Bring (1786) and Jerrard (1859) references

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -454,6 +454,24 @@
     },
     {
       "authors": [
+        "E. S. Bring"
+      ],
+      "title": "Meletemata quaedam mathematica circa transformationem aequationum algebraicarum",
+      "year": "1786",
+      "venue": "Promotionsschrift, Lund University (Sweden)",
+      "note": "Erland Samuel Bring's 1786 doctoral dissertation establishing the **Bring reduction**: any general quintic $x^5 + a_4 x^4 + \\cdots + a_1 x + a_0 = 0$ can be transformed by a Tschirnhaus substitution of degree $\\leq 4$ into the *Bring normal form* $y^5 + py + q = 0$ — a one-parameter family (since $p$ can be absorbed by rescaling $y$, leaving a single essential parameter). The Tschirnhaus substitution $y = c_4 x^4 + c_3 x^3 + c_2 x^2 + c_1 x + c_0$ has 5 free coefficients $c_0, \\ldots, c_4$, and Bring showed that solving the auxiliary equations for these coefficients to eliminate the quartic, cubic, and quadratic terms in $y$ requires only operations of degree $\\leq 4$ — i.e. is itself solvable by radicals (since the auxiliary system has Galois group inside $S_4$). Bring's work was lost in the Lund archives until 1864 when Sylvester discovered and publicized it, by which time Jerrard (1859, below) had independently rediscovered the result. The Bring reduction is the *algebraic preprocessing* step that makes Hermite's 1858 modular-function solution of the quintic possible: Hermite solves the Bring form $y^5 - y + t = 0$ in theta constants, and the Bring reduction supplies the preprocessing from the general quintic to this one-parameter form. This places the depth-of-radical-tower for the *Tschirnhaus-reducible part* of the quintic squarely inside the solvable $S_4$-regime classified in this file — the irreducible non-solvable part is then exactly the one-parameter Bring quintic, which requires the escape to modular functions of keyInsight #11. The dual algorithm (Bring's algebraic reduction + Hermite's modular solution) gives a constructive proof that *every* quintic over $\\mathbb{Q}$ is solvable in Bring-Jerrard normal form by elliptic-modular functions — not by radicals, exactly as Abel-Ruffini proves here. Cited in keyInsight #11."
+    },
+    {
+      "authors": [
+        "G. B. Jerrard"
+      ],
+      "title": "An Essay on the Resolution of Equations",
+      "year": "1859",
+      "venue": "Taylor and Francis, London (xii + 110 pp.)",
+      "note": "George Birch Jerrard's independent rediscovery (1832 preliminary, 1859 final) of the Bring reduction (entry above), now standardly called the **Bring-Jerrard normal form**. Jerrard extended Bring's result by attempting to push the Tschirnhaus reduction beyond degree 5 to higher-degree equations, conjecturing (incorrectly) that every degree-$n$ equation could be reduced to a normal form with only $\\lfloor n/2 \\rfloor$ or fewer parameters. Hamilton (1836) showed Jerrard's general claim was wrong — only the quintic admits the one-parameter reduction — but the $n = 5$ case stands as the key algebraic preprocessing step in the Hermite-Brioschi-Kronecker solution of the quintic in modular functions (Hermite 1858, reference above). The historical name 'Bring-Jerrard' acknowledges both Bring's 1786 priority (lost in Swedish archives until 1864) and Jerrard's 1859 independent rediscovery and dissemination — the standard accepted convention since Sylvester (1864). Jerrard's *Essay* is the most widely-read primary source for the reduction method in 19th-century English-language algebra; the technique appears in modern textbooks (e.g., King 1996, *Beyond the Quartic Equation*) as the bridge between purely algebraic quintic theory and the modular-function escape. Cited together with Bring (1786) in keyInsight #11."
+    },
+    {
+      "authors": [
         "H. Umemura"
       ],
       "title": "Resolution of algebraic equations by theta constants",


### PR DESCRIPTION
## Summary

Pass-5 enrichment for `abel-ruffini-galois-extensions`. The entry is already at quality 100 with 14 keyInsights, 9 openQuestions, and 25+ references — this pass adds two primary-source citations referenced but not previously cited.

## Quality improvement

KeyInsight #11 (Hermite's modular escape) discusses the Bring-Jerrard reduction as the algebraic preprocessing step that bridges the solvable $S_4$ regime (this file's positive classification) with the modular-function escape needed for the irreducible $S_5$-non-solvable quintic. The primary sources were referenced in the prose but not cited as references entries.

Two reference additions:

- **Bring (1786)** — *Meletemata quaedam mathematica circa transformationem aequationum algebraicarum* — Erland Samuel Bring's Lund dissertation establishing the one-parameter Bring normal form $y^5 + py + q = 0$. The Tschirnhaus substitution required is itself solvable by radicals (Galois group inside $S_4$), placing the algebraic preprocessing squarely in the solvable regime classified here. Lost in Swedish archives until Sylvester rediscovered them in 1864.

- **Jerrard (1859)** — *An Essay on the Resolution of Equations* — independent rediscovery establishing the standard 19th-century English-language exposition. The dual algorithm (Bring's algebraic reduction + Hermite's modular solution) gives the constructive proof that every quintic is solvable in Bring-Jerrard normal form by elliptic-modular functions — not by radicals, exactly as Abel-Ruffini proves.

## Test plan

- [x] JSON validity verified via `node JSON.parse`
- [x] No structural changes (only added two reference entries to existing array)
- [x] Anchors keyInsight #11 with proper primary-source citations

> Note: this PR's commit history was rewritten by enricher-2's worktree reset workflow between iterations. The current commit reflects the Bring-Jerrard enrichment for the parent `abel-ruffini-galois-extensions` entry. A separate prior iteration enriched `abel-ruffini-galois-extensions-oq-04` (Jordan-Hölder Uniqueness) with `subgroupOf`-Galois-insertion and noncomputability keyInsights and the Eilenberg-MacLane reference; those changes are not present in this PR's current branch state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)