### PR TITLE
audit(erdos-1079): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3588,9 +3588,9 @@
     },
     "erdos-1079": {
       "agentId": "auditor-22589",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:04:42Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T15:15:16Z",
+      "result": "clean",
       "issues": [
         "Issue #14477: section line drift + phantom Bondy result narrative"
       ]


### PR DESCRIPTION
## Gallery Integrity Audit — erdos-1079

Re-audit (cycle 4) of **Erdős Problem #1079: Turán Density in Neighborhoods**. Last audited 2026-05-02; this entry was the stalest in the queue.

### Verification (meta.json vs `Proofs/Erdos1079Problem.lean`)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 1 | 1 (`erdos_1079_summary`) | ✓ |
| theoremCount | 1 | 1 (`erdos_1079`, `:= erdos_1079_summary`) | ✓ |
| definitionCount | 5 | 5 (turanNumber, neighborhood, inducedSubgraph, numEdges, neighborhoodEdges) | ✓ |
| sorries | 0 | 0 | ✓ |
| status / badge | axiomatized / axiom | 1 axiom, no sorries | ✓ |

- **No True stubs**: `erdos_1079` proves a substantive proposition derived from the axiom, not `True`/`trivial`.
- **No axiom masking**: the `assumptions` field and `proofStrategy` explicitly disclose `erdos_1079_summary`.
- **Not a Mathlib wrapper**: core result is axiomatized (supersaturation/Zykov symmetrization beyond Mathlib), so badge `axiom` is correct (not `mathlib`).
- **Prior fix #14477** (section line drift + phantom Bondy narrative) remains resolved.

**Result: clean.** Tracker bumped (auditCount 3→4, result clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)