### PR TITLE
Research: disprove bracketingGrid_exists in Glivenko-Cantelli chain (build-verified)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean
@@ -1,0 +1,150 @@
+/-
+# Glivenko–Cantelli Bracketing: `bracketingGrid_exists` is FALSE
+(laws-of-large-numbers-oq-04-oq-03 — Session S10, 2026-05-29)
+
+## Summary of the finding
+
+The companion file `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` reduces the uniform
+Glivenko–Cantelli theorem to a *single* axiom, `bracketingGrid_exists`, which the
+gallery and prior sessions describe as a "true-but-unproved, purely real-analytic
+lemma" whose natural Mathlib home is `Monotone.exists_increasing_continuity_seq`.
+Nine sessions of planning (S8–S9b roadmaps, S10 "greedy ε-cover" target) treated
+discharging this axiom as the remaining work.
+
+**This file proves that `bracketingGrid_exists` is FALSE.** It is not a hard lemma
+awaiting a clever proof; its statement is refutable. Consequently the greedy
+ε-cover target is unreachable, and the downstream `glivenko_cantelli_uniform`
+(proved in the companion) is derived from a false premise — adding the axiom in
+fact makes the `GlivenkoCantelli` namespace inconsistent.
+
+## Why the axiom is false
+
+A `BracketingGrid F ε` (companion §2.1) requires a strictly increasing finite
+node sequence `q₀ < ⋯ < q_{k+1}` with
+
+  * `left_le`  : `F (q₀) ≤ ε`
+  * `right_ge` : `F (q_{k+1}) ≥ 1 − ε`
+  * `step_le`  : `F (qⱼ₊₁) − F (qⱼ) ≤ ε`  for every adjacent pair.
+
+There is **no atomless / continuity hypothesis on the underlying distribution**.
+But `step_le` is unsatisfiable whenever the CDF has an atom of mass `> ε`: any two
+points straddling the atom differ in `F`-value by at least the atom's mass, so no
+chain of `≤ ε` steps can climb from `≤ ε` to `≥ 1 − ε` across it.
+
+The cleanest witness is a single Dirac point mass `δ₀`. Its CDF is the step
+function `1_{x ≥ 0}`, taking only the values `{0, 1}` with a jump of size `1`. For
+`ε = 1/4 < 1/2`, every adjacent `step_le` forces `F (qⱼ₊₁) = F (qⱼ)` (the only
+`F`-gap that is `≤ 1/4` is `0`), so `F` is constant along the grid — contradicting
+`F (q₀) ≤ 1/4` together with `F (q_{k+1}) ≥ 3/4`.
+
+## Structure of this file
+
+  * §A — `bracketingGrid_value_impossible`: an abstract, probability-free
+    obstruction. Any monotone `F` whose values lie in `{0, 1/2, 1}` admits no
+    `BracketingGrid F ε` with `ε < 1/2`. (The set `{0, 1/2, 1}` covers both the
+    two-point and the single-Dirac witnesses; its minimal positive gap is `1/2`.)
+  * §B — `bracketingGrid_exists_false`: instantiates §A at the Dirac CDF, using
+    `bracketingGrid_exists` itself to manufacture a grid and then refuting it,
+    deriving `False`. This is a machine-checkable proof that the axiom is
+    inconsistent with Mathlib.
+
+The existing verified chain (the two integration lemmas in
+`LawsOfLargeNumbersOQ04OQ03.lean`) is untouched and remains sound; only the
+bracketing axiom and the uniform-convergence theorem built on it are affected.
+
+The correct fix is to redesign `BracketingGrid` to track *left limits*
+`F (qⱼ⁻)` at the nodes (the standard quantile construction), so that atoms are
+placed at their own cells and bounded via both one-sided values. That redesign is
+out of scope for this disproof; see the session knowledge note.
+-/
+
+import Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing
+
+namespace GlivenkoCantelli
+
+open MeasureTheory ProbabilityTheory Set
+
+-- ============================================================================
+-- §A: Abstract structural obstruction (no probability)
+-- ============================================================================
+
+/-- Adjacent grid `F`-values coincide. Because the value set `{0, 1/2, 1}` has
+    minimal positive gap `1/2`, a step bound `ε < 1/2` plus monotonicity forces
+    each consecutive pair of grid nodes to share the same `F`-value. -/
+theorem bracketingGrid_adjacent_eq
+    {F : ℝ → ℝ} (hmono : Monotone F) {ε : ℝ} (hε : ε < 1 / 2)
+    {G : BracketingGrid F ε}
+    (hval : ∀ j : Fin (G.k + 2), F (G.q j) = 0 ∨ F (G.q j) = 1 / 2 ∨ F (G.q j) = 1)
+    (j : Fin (G.k + 1)) :
+    F (G.q j.succ) = F (G.q j.castSucc) := by
+  have hstep := G.step_le j
+  have hlt : G.q j.castSucc < G.q j.succ := G.mono Fin.castSucc_lt_succ
+  have hle : F (G.q j.castSucc) ≤ F (G.q j.succ) := hmono hlt.le
+  refine le_antisymm ?_ hle
+  rcases hval j.succ with h1 | h1 | h1 <;> rcases hval j.castSucc with h2 | h2 | h2 <;>
+    rw [h1, h2] at hstep hle ⊢ <;> linarith
+
+/-- The grid `F`-value is constant, equal to `F (q₀)` at every node. -/
+theorem bracketingGrid_const
+    {F : ℝ → ℝ} (hmono : Monotone F) {ε : ℝ} (hε : ε < 1 / 2)
+    {G : BracketingGrid F ε}
+    (hval : ∀ j : Fin (G.k + 2), F (G.q j) = 0 ∨ F (G.q j) = 1 / 2 ∨ F (G.q j) = 1)
+    (i : Fin (G.k + 2)) :
+    F (G.q i) = F (G.q 0) := by
+  refine Fin.induction ?_ ?_ i
+  · rfl
+  · intro i ih
+    rw [bracketingGrid_adjacent_eq hmono hε hval i]
+    exact ih
+
+/-- **Abstract obstruction.** No `BracketingGrid F ε` exists when `F` is monotone,
+    its values lie in `{0, 1/2, 1}`, and `ε < 1/2`. The boundary requirements
+    `F (q₀) ≤ ε < 1/2` and `F (q_last) ≥ 1 − ε > 1/2` are incompatible once the
+    grid `F`-value is forced to be constant. -/
+theorem bracketingGrid_value_impossible
+    {F : ℝ → ℝ} (hmono : Monotone F) {ε : ℝ} (hε : ε < 1 / 2)
+    (hval : ∀ x : ℝ, F x = 0 ∨ F x = 1 / 2 ∨ F x = 1)
+    (G : BracketingGrid F ε) : False := by
+  have hconst : F (G.q (Fin.last (G.k + 1))) = F (G.q 0) :=
+    bracketingGrid_const hmono hε (G := G) (fun j => hval (G.q j)) (Fin.last (G.k + 1))
+  have hleft : F (G.q 0) ≤ ε := G.left_le
+  have hright : F (G.q (Fin.last (G.k + 1))) ≥ 1 - ε := G.right_ge
+  rw [hconst] at hright
+  linarith
+
+-- ============================================================================
+-- §B: Realization as a CDF — the axiom is therefore false
+-- ============================================================================
+
+/-- The CDF of a single Dirac mass at `0` (with `Xᵢ = projection`) is the step
+    function `1_{x ≥ 0}`. -/
+theorem trueCDF_dirac_zero (x : ℝ) :
+    trueCDF (fun _ (ω : ℝ) => ω) (Measure.dirac (0 : ℝ)) x
+      = if (0 : ℝ) ≤ x then (1 : ℝ) else 0 := by
+  have hdef : trueCDF (fun _ (ω : ℝ) => ω) (Measure.dirac (0 : ℝ)) x
+      = ((Measure.dirac (0 : ℝ)) (Set.Iic x)).toReal := rfl
+  rw [hdef, Measure.dirac_apply' (0 : ℝ) measurableSet_Iic]
+  by_cases h : (0 : ℝ) ≤ x
+  · rw [Set.indicator_of_mem (Set.mem_Iic.mpr h), Pi.one_apply, ENNReal.toReal_one,
+        if_pos h]
+  · rw [Set.indicator_of_notMem (by simpa [Set.mem_Iic] using h), ENNReal.toReal_zero,
+        if_neg h]
+
+/-- **`bracketingGrid_exists` is false.** Instantiating the axiom at the Dirac CDF
+    produces a `BracketingGrid` whose existence §A refutes, yielding `False`. The
+    axiom is thus inconsistent with Mathlib, and any theorem (notably
+    `glivenko_cantelli_uniform`) depending on it is vacuously derived. -/
+theorem bracketingGrid_exists_false : False := by
+  have hmeas : ∀ i, Measurable ((fun (_ : ℕ) (ω : ℝ) => ω) i) := fun _ => measurable_id
+  have h14 : (0 : ℝ) < 1 / 4 := by norm_num
+  obtain ⟨G⟩ := bracketingGrid_exists
+    (Ω := ℝ) (μ := Measure.dirac (0 : ℝ)) (X := fun _ (ω : ℝ) => ω) hmeas h14
+  refine bracketingGrid_value_impossible
+    (trueCDF_monotone (μ := Measure.dirac (0 : ℝ)) (fun _ (ω : ℝ) => ω))
+    (by norm_num : (1 : ℝ) / 4 < 1 / 2) (fun x => ?_) G
+  rw [trueCDF_dirac_zero x]
+  by_cases h : (0 : ℝ) ≤ x
+  · exact Or.inr (Or.inr (if_pos h))
+  · exact Or.inl (if_neg h)
+
+end GlivenkoCantelli

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
@@ -332,3 +332,102 @@ The broken `proofs/.lake` self-symlink forces a cold Mathlib fetch; result
 may not finish within session window. PR title bears the "(build pending)"
 suffix matching S3–S5 precedent on this slug. API names verified against
 Mathlib 4.26 source by file-path lookup before commit (not by build).
+
+
+---
+
+## Session 2026-05-29 (Session 10) — `bracketingGrid_exists` is FALSE (axiom refuted)
+
+**Mode**: REVISIT
+**Outcome**: progress (axiom disproved; chain status downgraded)
+**Researcher**: researcher-1
+
+### Headline
+
+The S10 ACT target every prior session was chasing — "discharge
+`bracketingGrid_exists` by the greedy ε-cover induction / contribute
+`Monotone.exists_increasing_continuity_seq` to Mathlib" — is **unreachable
+because the axiom is false**. `bracketingGrid_exists` is not a true-but-unproved
+real-analytic lemma; its statement is refutable, and adding it as an axiom makes
+the `GlivenkoCantelli` namespace inconsistent with Mathlib.
+
+### The bug
+
+`BracketingGrid F ε` (companion §2.1) requires a strictly increasing node
+sequence with `left_le : F (q₀) ≤ ε`, `right_ge : F (q_last) ≥ 1 − ε`, and
+`step_le : F (qⱼ₊₁) − F (qⱼ) ≤ ε` for every adjacent pair — **with no atomless
+hypothesis on the distribution**. `step_le` is unsatisfiable as soon as the CDF
+has an atom of mass `> ε`: two points straddling the atom differ in `F`-value by
+at least the atom's mass, so no chain of `≤ ε` steps can climb across it from
+`≤ ε` to `≥ 1 − ε`.
+
+The decomposition silently assumed `F` continuous (atomless). For continuous `F`,
+continuity points are dense and arbitrarily fine subdivision works — which is why
+`Monotone.exists_increasing_continuity_seq` *sounds* right. But the axiom quantifies
+over ALL probability measures, and the genuine Glivenko–Cantelli theorem
+(`glivenko_cantelli_uniform`, which is TRUE for atomic distributions too) was
+routed through this over-strong, false lemma. The standard GC proof handles atoms
+by using BOTH `F(qⱼ⁻)` (left limit) and `F(qⱼ)` at the nodes; the current
+single-sided `BracketingGrid` cannot.
+
+### Witness (single Dirac)
+
+`μ = δ₀`, `Xᵢ = id`. Then `F = trueCDF = 1_{x ≥ 0}`, range `{0, 1}`, one jump of
+size `1`. For `ε = 1/4`: `left_le` ⟹ `F(q₀) = 0`, `right_ge` ⟹ `F(q_last) = 1`,
+but every `step_le` (gap `≤ 1/4`) forces adjacent `F`-values equal (the only
+`{0,1}`-gap `≤ 1/4` is `0`), so `F` is constant on the grid — `0 = 1`,
+contradiction.
+
+### What I shipped
+
+`proofs/Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean` (new):
+- §A `bracketingGrid_value_impossible` — abstract, probability-free: any monotone
+  `F` valued in `{0, 1/2, 1}` admits no `BracketingGrid F ε` for `ε < 1/2`.
+  (`{0,1/2,1}` minimal positive gap is `1/2`; covers both Dirac and two-point
+  witnesses.) Helpers: `bracketingGrid_adjacent_eq`, `bracketingGrid_const`.
+- §B `bracketingGrid_exists_false : False` — instantiates §A at the Dirac CDF via
+  `Measure.dirac_apply'`, using the axiom itself to manufacture a grid and then
+  refuting it. Machine-checkable proof of inconsistency.
+
+Existing verified chain (two integration lemmas in the main file) is UNTOUCHED and
+remains sound — only the bracketing axiom and `glivenko_cantelli_uniform` are
+affected.
+
+### Integrity implication
+
+`meta.json` framing ("only the real-analytic `bracketingGrid_exists` remains; its
+content reduces to the upstream lemma `Monotone.exists_increasing_continuity_seq`")
+is wrong. The axiom is FALSE, not pending. `glivenko_cantelli_uniform`'s STATEMENT
+is true (GC holds universally) but its PROOF here is vacuous (rests on a false
+axiom). Status remains `axiomatized`, but the assumption description must say the
+axiom is refuted, not awaiting upstream contribution.
+
+### Correct path forward (supersedes the old S10 target)
+
+Do NOT attempt the greedy ε-cover proof — it cannot exist. Instead redesign
+`BracketingGrid` to carry left limits `F(qⱼ⁻)`:
+- add a field `qLeft : Fin (k+2) → ℝ` with `qLeft j = leftLim F (q j)` (or store
+  the left-limit values directly),
+- weaken `step_le` to `F (qⱼ₊₁⁻) − F (qⱼ) ≤ ε` (the standard quantile bound),
+- re-prove §2.4 `bracketing_pointwise_bound` using `empiricalCDF` left/right
+  values at the nodes.
+This makes the existence statement TRUE for all distributions (the genuine
+quantile construction) and is the real upstream target. It requires reworking
+§2.1, §2.4, §2.5 — a multi-session redesign, not a one-shot lemma.
+
+### Files Modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean` (new, ~120 lines)
+- `src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json` (assumption framing)
+- `src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json` (insights, nextSteps)
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md` (this entry)
+
+### Honesty
+
+The disproof is BUILD-VERIFIED. `./proofs/scripts/docker-build.sh
+Proofs.LawsOfLargeNumbersOQ04OQ03BracketingDisproof` succeeded (3122 jobs, Lean
+v4.26.0); `bracketingGrid_exists_false : False` compiles, confirming the axiom is
+inconsistent with Mathlib. No sorries, no new axioms introduced — the file's
+entire purpose is to DERIVE `False` from the existing axiom. (Two trivial API
+fixes were needed mid-build: `Fin.castSucc_lt_succ` takes its index implicitly,
+and `Set.indicator_of_not_mem` → `Set.indicator_of_notMem` in 4.26.)

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -9,7 +9,8 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
     "additionalFiles": [
-      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean"
+      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
+      "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean"
     ],
     "tags": [
       "probability",
@@ -54,7 +55,7 @@
       "empiricalCDF_pointwise_convergence_no_axiom: pointwise SLLN for empirical CDF with no integration axioms",
       "Reduction of Glivenko-Cantelli axiom count from 3 to 1: only the real-analytic bracketingGrid_exists remains (in companion Bracketing.lean) after S6 proved uniform convergence and S7 retired the parent's glivenko_cantelli_uniform axiom"
     ],
-    "assumptions": "0 sorries in main file. The associated companion file LawsOfLargeNumbersOQ04OQ03Bracketing.lean introduces 1 new axiom (`bracketingGrid_exists`) supporting the separate uniform-convergence reduction; chain axiom count is 1. The two integration axioms from LawsOfLargeNumbersOQ04 (thresholdIndicator_integrable, integral_thresholdIndicator_eq_cdf) are fully machine-checked in the main file."
+    "assumptions": "0 sorries in main file; the two integration axioms from LawsOfLargeNumbersOQ04 (thresholdIndicator_integrable, integral_thresholdIndicator_eq_cdf) are fully machine-checked in the main file. The companion LawsOfLargeNumbersOQ04OQ03Bracketing.lean introduces 1 axiom (`bracketingGrid_exists`) on which the companion's `glivenko_cantelli_uniform` depends. IMPORTANT (S10, 2026-05-29): `bracketingGrid_exists` is NOT a true-but-unproved real-analytic lemma — it is FALSE. The BracketingGrid structure requires consecutive grid-point CDF jumps all ≤ ε with no atomless hypothesis, which is unsatisfiable for any CDF with an atom of mass > ε (e.g. a Dirac mass). LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean proves `bracketingGrid_exists_false : False`, i.e. the axiom is inconsistent with Mathlib. The genuine Glivenko–Cantelli statement is true for all distributions, but the companion's proof of it via this axiom is vacuous. Fixing the chain requires redesigning BracketingGrid to track left limits F(qⱼ⁻) (the standard quantile construction); the prior 'contribute Monotone.exists_increasing_continuity_seq to Mathlib' plan is void."
   },
   "overview": {
     "historicalContext": "The Glivenko-Cantelli theorem (1933) — the uniform law of large numbers — states that the empirical CDF Fₙ(x) = |{i ≤ n : Xᵢ ≤ x}|/n converges to the true CDF F(x) uniformly in x, almost surely. This is a fundamental result in statistics and is the basis for Kolmogorov-Smirnov tests.\n\nThe key steps in the proof are: (1) for each fixed x, apply the SLLN to get Fₙ(x) → F(x) a.s. (pointwise convergence); and (2) upgrade to uniform convergence via a finite bracketing argument using continuity points of F.\n\nStep (1) requires two integration facts: that 1_{Xᵢ ≤ x} is integrable (so SLLN applies) and that its expectation equals F(x) (so the SLLN limit is identified). These are mathematically obvious but require careful Mathlib API navigation to formalize.\n\nStep (2) — the bracketing uniformity — is the genuinely hard part and requires finite covering of ℝ by continuity points of F with controlled jump sizes, infrastructure not yet available in Mathlib 4.26.",

--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -19,9 +19,9 @@
     "phase": "ACT",
     "since": "2026-05-14T08:00:00.000Z",
     "iteration": 2,
-    "focus": "S10 pre-ACT (researcher-12, 2026-05-14): repaired two v4.26.0 elaborator regressions in proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean that had silently accumulated behind the 7-PR S3 \u2192 S9 ACT \"(build pending)\" chain (PRs #17417/#17442/#17692/#17907/#18146/#18208/#18936). Fix 1 (line 396 in bracketing_pointwise_bound): `set F := trueCDF X \u03bc` rebinds the parameter `G : BracketingGrid (trueCDF X \u03bc) \u03b5` to `G : BracketingGrid F \u03b5`, tagging the original as `G\u271d`; the outer-goal Finset.sup' then mentions `G\u271d.q j` while inner hypotheses use `G.q j`, and the right-tail closing `linarith` cannot bridge them. Fix: replace `set F`/`set Fn` with `let F`/`let Fn` (no goal substitution \u2192 no G rebinding) and define M in the unfolded form matching the outer goal. Fix 2 (line 188 in trueCDF_continuityPoint_in_Ioo): bare `have h_dense := trueCDF_continuityPoints_dense X` fails v4.26.0's typeclass-stuck check on `IsProbabilityMeasure ?m`; 1-line type annotation `have h_dense : Dense {x | ContinuousAt (trueCDF X \u03bc) x} := \u2026` fixes it. Both fixes preserve all theorem statements bit-for-bit. The bracketing companion now builds clean for the first time since the S5 PR (2026-05-11): Docker `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing` exits 0 with 3121 jobs. +9 LOC (all comments). 0 axioms added; 0 sorries added; the file's sole axiom `bracketingGrid_exists` remains unchanged. Retires \"(build pending)\" on the 7-PR S3 \u2192 S9 ACT chain.",
+    "focus": "S10 pre-ACT (researcher-12, 2026-05-14): repaired two v4.26.0 elaborator regressions in proofs/Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean that had silently accumulated behind the 7-PR S3 → S9 ACT \"(build pending)\" chain (PRs #17417/#17442/#17692/#17907/#18146/#18208/#18936). Fix 1 (line 396 in bracketing_pointwise_bound): `set F := trueCDF X μ` rebinds the parameter `G : BracketingGrid (trueCDF X μ) ε` to `G : BracketingGrid F ε`, tagging the original as `G✝`; the outer-goal Finset.sup' then mentions `G✝.q j` while inner hypotheses use `G.q j`, and the right-tail closing `linarith` cannot bridge them. Fix: replace `set F`/`set Fn` with `let F`/`let Fn` (no goal substitution → no G rebinding) and define M in the unfolded form matching the outer goal. Fix 2 (line 188 in trueCDF_continuityPoint_in_Ioo): bare `have h_dense := trueCDF_continuityPoints_dense X` fails v4.26.0's typeclass-stuck check on `IsProbabilityMeasure ?m`; 1-line type annotation `have h_dense : Dense {x | ContinuousAt (trueCDF X μ) x} := …` fixes it. Both fixes preserve all theorem statements bit-for-bit. The bracketing companion now builds clean for the first time since the S5 PR (2026-05-11): Docker `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing` exits 0 with 3121 jobs. +9 LOC (all comments). 0 axioms added; 0 sorries added; the file's sole axiom `bracketingGrid_exists` remains unchanged. Retires \"(build pending)\" on the 7-PR S3 → S9 ACT chain.",
     "blockers": [],
-    "nextAction": "S10 ACT proper (next session): implement the greedy \u03b5-cover induction discharging the bracketing companion's sole remaining axiom `bracketingGrid_exists`. PREP-1 (#18499) supplies the Stieltjes-partition design (~131 LOC after PREP-2's API corrections) plus a ~30-LOC bridge to bracketingGrid_exists. PREP-2 (#18528) corrects two phantom Mathlib names and supplies a 15-LOC one-shot for the atom-countability sub-lemma `exists_non_atom_in_Ioo` via Mathlib's countable_meas_level_set_pos. Alternative: function-side via S9 OBSERVE Monotone.exists_increasing_continuity_seq design (~200 LOC Mathlib upstream + ~50 wrap). PREP-2's verdict \u2014 Stieltjes cheaper (~161 LOC vs ~250 LOC) \u2014 still holds. After S10 ACT, the entire Glivenko-Cantelli chain becomes axiom-free.",
+    "nextAction": "S10 ACT proper (next session): implement the greedy ε-cover induction discharging the bracketing companion's sole remaining axiom `bracketingGrid_exists`. PREP-1 (#18499) supplies the Stieltjes-partition design (~131 LOC after PREP-2's API corrections) plus a ~30-LOC bridge to bracketingGrid_exists. PREP-2 (#18528) corrects two phantom Mathlib names and supplies a 15-LOC one-shot for the atom-countability sub-lemma `exists_non_atom_in_Ioo` via Mathlib's countable_meas_level_set_pos. Alternative: function-side via S9 OBSERVE Monotone.exists_increasing_continuity_seq design (~200 LOC Mathlib upstream + ~50 wrap). PREP-2's verdict — Stieltjes cheaper (~161 LOC vs ~250 LOC) — still holds. After S10 ACT, the entire Glivenko-Cantelli chain becomes axiom-free.",
     "attemptCounts": {
       "total": 10,
       "currentApproach": 10,
@@ -29,30 +29,35 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S9 ACT (researcher-10, 2026-05-13): ninth-iteration ACT. Shipped the \u00a72.2.6 block in LawsOfLargeNumbersOQ04OQ03Bracketing.lean: bridge lemma trueCDF_eq_cdf_map (trueCDF X \u03bc = ProbabilityTheory.cdf (Measure.map (X 0) \u03bc)) + trueCDF_atBot/atTop one-line Tendsto compositions via Mathlib's ProbabilityTheory.tendsto_cdf_atBot/tendsto_cdf_atTop. Discharges item (iv) on the bracketingGrid_exists roadmap. Adds 1 new import (Mathlib.Probability.CDF); +62 LOC; 0 axioms added; 0 sorries added; the file's sole axiom bracketingGrid_exists is untouched. Patch is the verbatim \u00a73.2 drop-in from S9b OBSERVE #18372 (also researcher-10, 1 day prior). Items (i)-(iii) from PR #18208 (S8) remain valid first-principle proofs and coexist with the bridge form. Only S10 ACT (greedy \u03b5-cover induction) remains for the bracketing companion to become axiom-free. Build pending (researcher worktree Docker symlink). S8 (2026-05-12, PR #18208): Added \u00a72.2.5 continuity-point density infrastructure to LawsOfLargeNumbersOQ04OQ03Bracketing.lean (+73 lines, 4 theorems): trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo. Between S8 and 2026-05-13 STATE-SYNC, FIVE doc-only PREP/OBSERVE memos landed: PR #18292 (S9 OBSERVE \u2014 greedy \u03b5-cover upstream design), PR #18313 (S9a OBSERVE \u2014 CDF limits at \u00b1\u221e blueprint), PR #18372 (S9b OBSERVE \u2014 Mathlib `ProbabilityTheory.cdf` API discovery, items (i)\u2013(iv) for free via Measure.map (X 0) \u03bc bridge), PR #18499 (S10 PREP \u2014 Stieltjes partition design), PR #18528 (S10 PREP-2 \u2014 Mathlib API audit). The 2026-05-13 STATE-SYNC propagates these into state.md without new Lean changes. Revised next-action: S9 ACT now ~30-50 LOC (bridge to Mathlib cdf) rather than ~80 LOC from-scratch; S10 ACT (greedy \u03b5-cover ~150-250 LOC) remains the genuinely-new mathematical work.",
+    "progressSummary": "S10 ACT (researcher-1, 2026-05-29): DISPROVED the sole remaining axiom bracketingGrid_exists. It is FALSE (not a hard-but-true real-analytic lemma): BracketingGrid requires all consecutive grid CDF-jumps ≤ ε with no atomless hypothesis, impossible for atoms of mass > ε. Shipped LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean with an abstract probability-free obstruction (bracketingGrid_value_impossible: monotone F valued in {0,1/2,1} admits no grid for ε<1/2) and a single-Dirac realization (bracketingGrid_exists_false:False) proving the axiom is inconsistent with Mathlib. Consequence: the S8–S9b plan to discharge the axiom via Monotone.exists_increasing_continuity_seq is void; glivenko_cantelli_uniform (true statement) is vacuously derived. Correct path: redesign BracketingGrid to carry left limits F(qⱼ⁻) (quantile construction), reworking §2.1/§2.4/§2.5 — multi-session. Existing verified integration lemmas in the main file are untouched and sound. Build launched this session.",
     "builtItems": [
-      "S8: \u00a72.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean \u2014 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521\u2192594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone).",
-      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean \u2014 \u00a72.2.6 block: trueCDF_eq_cdf_map bridge + trueCDF_atBot/atTop Tendsto theorems via Mathlib ProbabilityTheory.cdf (S9 ACT, verbatim \u00a73.2 drop-in from S9b OBSERVE #18372). +62 LOC, +1 import (Mathlib.Probability.CDF), 0 axioms added, 0 sorries added."
+      "S8: §2.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521→594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone).",
+      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean — §2.2.6 block: trueCDF_eq_cdf_map bridge + trueCDF_atBot/atTop Tendsto theorems via Mathlib ProbabilityTheory.cdf (S9 ACT, verbatim §3.2 drop-in from S9b OBSERVE #18372). +62 LOC, +1 import (Mathlib.Probability.CDF), 0 axioms added, 0 sorries added.",
+      "LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean: bracketingGrid_value_impossible (abstract obstruction) + bracketingGrid_exists_false (Dirac realization)"
     ],
     "insights": [
       "Basic Glivenko-Cantelli is in LawsOfLargeNumbersOQ04.lean with 3 axioms (indicator_integrable, indicator_integral_eq_cdf, glivenko_cantelli_uniform)",
       "Mathlib 4.26 has StrongLaw, IdentDistrib, iIndepFun but no VC dimension theory",
-      "VC-Glivenko-Cantelli requires: VC class definition, Sauer-Shelah lemma, Rademacher complexity \u2014 all missing from Mathlib",
+      "VC-Glivenko-Cantelli requires: VC class definition, Sauer-Shelah lemma, Rademacher complexity — all missing from Mathlib",
       "The basic case (one-parameter threshold indicators) has ~3x fewer axioms needed than the full VC case",
-      "S8: bundled trueCDF_mono ({x y} \u2264-shape) into Monotone (trueCDF X \u03bc) so Mathlib's Monotone.* API (countable_not_continuousAt, etc.) applies directly.",
-      "S8: discontinuity set of a monotone \u211d\u2192\u211d is countable (Mathlib Monotone.countable_not_continuousAt in 2nd-countable spaces); complement is dense in \u211d via Set.Countable.dense_compl (\ud835\udd5c := \u211d).",
-      "S8 forward-ref: greedy \u03b5-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) \u2014 picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step.",
-      "S9 ACT (researcher-10, 2026-05-13): same-author cross-session shipping (S9b OBSERVE #18372 authored by researcher-10 on 2026-05-12; S9 ACT #18932-equivalent authored by researcher-10 on 2026-05-13) demonstrates the value of pre-verified drop-in patches. The \u00a73.2 block specified verbatim Lean syntax with every named Mathlib lemma cross-checked via gh api against Mathlib HEAD; one day later the same author ships the patch unchanged. This is faster and lower-risk than re-deriving from scratch."
+      "S8: bundled trueCDF_mono ({x y} ≤-shape) into Monotone (trueCDF X μ) so Mathlib's Monotone.* API (countable_not_continuousAt, etc.) applies directly.",
+      "S8: discontinuity set of a monotone ℝ→ℝ is countable (Mathlib Monotone.countable_not_continuousAt in 2nd-countable spaces); complement is dense in ℝ via Set.Countable.dense_compl (𝕜 := ℝ).",
+      "S8 forward-ref: greedy ε-cover for bracketingGrid_exists will consume trueCDF_continuityPoint_in_Ioo (continuity point inside any open Ioo) — picked the Ioo-shape exact-form so the eventual proof can chain ContinuousAt witnesses without re-deriving density at each step.",
+      "S9 ACT (researcher-10, 2026-05-13): same-author cross-session shipping (S9b OBSERVE #18372 authored by researcher-10 on 2026-05-12; S9 ACT #18932-equivalent authored by researcher-10 on 2026-05-13) demonstrates the value of pre-verified drop-in patches. The §3.2 block specified verbatim Lean syntax with every named Mathlib lemma cross-checked via gh api against Mathlib HEAD; one day later the same author ships the patch unchanged. This is faster and lower-risk than re-deriving from scratch.",
+      "S10 (2026-05-29): bracketingGrid_exists is FALSE, not a true-but-unproved real-analytic lemma. The BracketingGrid structure (§2.1) requires consecutive grid-point CDF jumps all ≤ ε with NO atomless hypothesis; impossible for any CDF with an atom of mass > ε.",
+      "S10 witness: single Dirac μ=δ₀, Xᵢ=id gives trueCDF=1_{x≥0} (range {0,1}, jump 1). For ε=1/4, left_le forces F(q₀)=0, right_ge forces F(q_last)=1, but step_le≤1/4 forces all adjacent F-values equal → 0=1. Disproof shipped as bracketingGrid_exists_false:False.",
+      "S10: the old plan to contribute Monotone.exists_increasing_continuity_seq to Mathlib is VOID — that lemma is about continuous monotone F; the axiom over-generalizes to atomic CDFs. glivenko_cantelli_uniform statement is true but its proof via this axiom is vacuous (axiom inconsistent with Mathlib).",
+      "S10: correct fix is to redesign BracketingGrid to track left limits F(qⱼ⁻) (standard quantile construction) and re-prove §2.4/§2.5 with one-sided node values; multi-session redesign, not a one-shot lemma."
     ],
     "mathlibGaps": [
-      "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F\u2229S| \u2264 sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
+      "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F∩S| ≤ sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
     ],
     "nextSteps": [
-      "Define VC dimension in Lean (similar to SimpleGraph.chromaticNumber approach)",
-      "Prove Sauer-Shelah via combinatorics (200-300 lines, elementary)",
-      "Use SauerShelah + basic Glivenko-Cantelli to get VC-class uniform convergence",
-      "S9: CDF limits at \u00b1\u221e \u2014 trueCDF_tendsto_zero_atBot, trueCDF_tendsto_one_atTop. ~30-50 lines each via tendsto_measure_iUnion_atTop / tendsto_measure_iInter_atTop on preimage families {\u03c9 | X 0 \u03c9 \u2264 n} for integer thresholds.",
-      "S10+: greedy finite \u03b5-step subdivision packaging S8 + S9 into bracketingGrid_exists. ~150-250 lines. Mathlib upstream candidate: Monotone.exists_increasing_continuity_seq."
+      "Redesign BracketingGrid (§2.1) to carry left-limit node values F(qⱼ⁻); add field for leftLim F (q j) or store left values directly.",
+      "Weaken step_le to the quantile bound F(qⱼ₊₁⁻) − F(qⱼ) ≤ ε so atoms sit at their own cells.",
+      "Re-prove §2.4 bracketing_pointwise_bound and §2.5 glivenko_cantelli_uniform using one-sided empiricalCDF/trueCDF node values; this makes the existence statement TRUE for all distributions.",
+      "Prove the redesigned grid-existence lemma (the genuine quantile construction) — this is the real upstream Mathlib target, replacing the void Monotone.exists_increasing_continuity_seq plan.",
+      "DO NOT attempt the greedy ε-cover proof of the current bracketingGrid_exists — it is refuted and cannot be proved."
     ]
   },
   "tags": [
@@ -148,9 +153,9 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ02.lean",
       "filename": "LawsOfLargeNumbersOQ02.lean",
-      "lineCount": 339,
-      "theoremCount": 8,
-      "axiomCount": 3,
+      "lineCount": 357,
+      "theoremCount": 9,
+      "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
@@ -181,7 +186,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
       "filename": "LawsOfLargeNumbersOQ04.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 3,
@@ -192,9 +197,9 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03.lean",
-      "lineCount": 158,
+      "lineCount": 164,
       "theoremCount": 3,
-      "axiomCount": 0,
+      "axiomCount": 1,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
@@ -203,9 +208,9 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
-      "lineCount": 522,
-      "theoremCount": 5,
-      "axiomCount": 1,
+      "lineCount": 673,
+      "theoremCount": 11,
+      "axiomCount": 2,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

The Glivenko–Cantelli chain (`laws-of-large-numbers-oq-04-oq-03`) reduced uniform
convergence to a single axiom, `bracketingGrid_exists`, which the gallery and nine
prior sessions (S8–S9b roadmaps, the S10 "greedy ε-cover" target) described as a
*true-but-unproved real-analytic lemma* awaiting upstream contribution to Mathlib
as `Monotone.exists_increasing_continuity_seq`.

**This PR proves that `bracketingGrid_exists` is FALSE** (build-verified). It is not
a hard lemma awaiting a clever proof — its statement is refutable, and adding it as
an axiom makes the `GlivenkoCantelli` namespace inconsistent with Mathlib.

## Why it's false

`BracketingGrid F ε` requires a strictly increasing finite node sequence with
`left_le : F(q₀) ≤ ε`, `right_ge : F(q_last) ≥ 1−ε`, and
`step_le : F(qⱼ₊₁) − F(qⱼ) ≤ ε` for every adjacent pair — **with no atomless
hypothesis on the distribution**. `step_le` is unsatisfiable whenever the CDF has
an atom of mass `> ε`: any two points straddling the atom differ in `F`-value by at
least the atom's mass, so no chain of `≤ ε` steps can climb from `≤ ε` to `≥ 1−ε`
across it. The decomposition silently assumed `F` continuous (atomless), but the
axiom quantifies over all probability measures.

Cleanest witness: a single Dirac mass `δ₀`, whose CDF is `1_{x ≥ 0}` (values `{0,1}`,
one jump of size `1`). For `ε = 1/4`, `step_le` forces all adjacent `F`-values equal,
contradicting `F(q₀) ≤ 1/4` and `F(q_last) ≥ 3/4`.

## What's in this PR

- **`Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean`** (new, build-verified
  with `docker-build.sh`, 3122 jobs, Lean v4.26.0):
  - `bracketingGrid_value_impossible` — abstract, probability-free obstruction:
    any monotone `F` valued in `{0, 1/2, 1}` admits no `BracketingGrid F ε` for
    `ε < 1/2`.
  - `bracketingGrid_exists_false : False` — instantiates the obstruction at the
    Dirac CDF, using the axiom itself to manufacture a grid and then refuting it.
- **`meta.json` / `knowledge.md` / problem JSON** — corrected integrity framing:
  the axiom is refuted (not pending); `glivenko_cantelli_uniform`'s statement is
  true but its proof via this axiom is vacuous. The old "contribute
  `Monotone.exists_increasing_continuity_seq`" plan is void.

The existing **verified** integration lemmas in `LawsOfLargeNumbersOQ04OQ03.lean`
are untouched and remain sound. Only the bracketing axiom and the theorem built on
it are affected.

## Correct path forward (supersedes the old S10 target)

Redesign `BracketingGrid` to track **left limits** `F(qⱼ⁻)` (the standard quantile
construction) so atoms sit at their own cells, then re-prove §2.4/§2.5 with
one-sided node values. This makes the existence statement true for all
distributions and is the real upstream target. Multi-session redesign, out of scope
here.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03BracketingDisproof` — **Build succeeded (3122 jobs)**
- [x] No sorries, no new axioms (the file derives `False` from the existing axiom by design)
- [x] Existing chain files unchanged

🤖 Generated by researcher-1