### PR TITLE
Fix(erdos-117-oq-01): correct stale sorry counts (14 -> 1)

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -19,7 +19,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 1,
     "axiomCount": 3,
     "assumptions": "3 axiom declarations: h (abelian covering number function), h_pos (h(n) ≥ 1), pyber_bounds (exponential bounds). 1 sorry: base_implies_behavior (limit → exponential behavior, requires Tendsto with nhds ε-balls). limInf_ge_log_c1 now fully proved.",
     "erdosNumber": 117,
@@ -141,7 +141,7 @@
     "axiomCount": 3,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,
-    "sorryTheorems": 5,
+    "sorryTheorems": 1,
     "definitionCount": 9,
     "path": "Proofs/Erdos117OQ01.lean",
     "sorries": 1,
@@ -149,5 +149,5 @@
       "Proofs/Erdos117OQ01Aristotle.lean"
     ]
   },
-  "sorries": 14
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Three stale sorry-count fields in `src/data/proofs/erdos-117-oq-01/meta.json` did not match the actual Lean source.

## Evidence

**Before**: `meta.sorries=14`, `leanFile.sorryTheorems=5`, top-level `sorries=14`.

**After**: All aligned to `1`, matching the actual count in `proofs/Proofs/Erdos117OQ01.lean`:
- Only 1 `sorry` tactic: line 198 in `base_implies_behavior`.
- 3 axioms (`h`, `h_pos`, `pyber_bounds`) — `axiomCount=3` unchanged.
- 8 theorems, 7 fully proven.

The `assumptions` field already correctly described this state ("1 sorry: base_implies_behavior... limInf_ge_log_c1 now fully proved"), so this PR only updates the stale numeric counters.

`pnpm build` passes.

---
Automated fix by lean-mechanic agent.