### PR TITLE
Fix: cayley-hamilton-reduction-oq-02-oq-01 stale sorries/status metadata

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -16,7 +16,7 @@
       "rational-canonical-form"
     ],
     "badge": "original",
-    "sorries": 12,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "Matrix.aeval_self_charpoly",
@@ -52,7 +52,7 @@
   "overview": {
     "historicalContext": "The companion matrix appears implicitly in Arthur Cayley's 1858 work on linear transformations, and was codified by Ferdinand Frobenius in his 1878 paper 'Über lineare Substitutionen und bilineare Formen', where the rational canonical form (Frobenius normal form) was established. Unlike the Jordan canonical form (Jordan 1870), which requires the characteristic polynomial to split into linear factors over the base field, the rational canonical form works over any field: it is the canonical block-diagonal decomposition using invariant factors rather than eigenvalues. The companion matrix C(p) is the matrix representation of multiplication by x on the quotient module F[X]/(p), making it the elementary algebraic object from which all F[X]-modules are built (via the primary decomposition theorem for modules over PIDs). The orbit argument — that {e₀, Ce₀, ..., C^{d-1}e₀} is the standard basis — is the key fact, and was known to Frobenius. The full RCF formalization in a proof assistant has been completed in Coq by Cano-Dénès (2012) and in Isabelle/HOL by Divasón-Thiemann (2016); a Lean 4 formalization is an active gap in Mathlib.",
     "problemStatement": "Define the companion matrix $C(p)$ for a monic polynomial $p$ of degree $d$ and prove: (1) the orbit $\\{e_0, C(p)e_0, \\ldots, C(p)^{d-1}e_0\\}$ is the standard basis; (2) $p(C(p)) = 0$; (3) $\\mathrm{charpoly}(C(p)) = p$; (4) $\\mathrm{minpoly}(C(p)) = p$.",
-    "proofStrategy": "Five parts: explicit entry-formula definition, three entry-characterization lemmas, orbit argument (C(p)ᵏ·e₀ = eₖ proved by induction), three key theorems (sorry: annihilation, charpoly, minpoly), and the linear-polynomial base case C(x−c) = [c]. A final roadmap assesses the ~1800-line gap for the full RCF theorem.",
+    "proofStrategy": "Five parts: explicit entry-formula definition, three entry-characterization lemmas, orbit argument (C(p)ᵏ·e₀ = eₖ proved by induction), three key theorems (proved: annihilation, charpoly, minpoly), and the linear-polynomial base case C(x−c) = [c]. A final roadmap assesses the ~1800-line gap for the full RCF theorem.",
     "keyInsights": [
       "The companion matrix C(p) is the canonical matrix representation of multiplication by x on F[X]/(p): the orbit {e₀, C(p)e₀, ..., C(p)^{d-1}e₀} = standard basis confirms the isomorphism F^d ≅ F[X]/(p) as F[X]-modules",
       "Companion matrices are non-derogatory: minpoly = charpoly = p, making them the unique matrix type (up to similarity) with a given characteristic polynomial of full degree",
@@ -164,7 +164,7 @@
       "description": "Sibling entry in the reduction series: OQ-01 proves the Cayley-Hamilton theorem for block upper triangular matrices via the trace formula. Together with this OQ-02-OQ-01, they form the infrastructure for the rational canonical form."
     }
   ],
-  "sorries": 12,
+  "sorries": 0,
   "leanFile": {
     "imports": [
       "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",


### PR DESCRIPTION
## Fix

`src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json` reported 12 sorries and `status: "formalized"`, but the Lean source file `proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean` actually has **0 sorries and 0 axioms** (396 lines, fully verified).

## Evidence

**Before**:
- `meta.status`: `"formalized"`
- `meta.sorries`: `12`
- top-level `sorries`: `12`
- `proofStrategy`: refers to `"(sorry: annihilation, charpoly, minpoly)"`

**After**:
- `meta.status`: `"verified"` (matches 0 sorries + 0 axioms per CLAUDE.md Status Field Definitions)
- `meta.sorries`: `0`
- top-level `sorries`: `0`
- `proofStrategy`: now reads `"(proved: annihilation, charpoly, minpoly)"`

The embedded `leanFile.sorries = 0`, `meta.axiomCount = 0`, and `meta.assumptions: "0 axioms, 0 sorries. All three key theorems fully proved"` were already correct — confirming the stale fields were a metadata-only drift.

Verification:
```
$ python3 count_real_sorries.py proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean
0
$ grep -cE '^\s*axiom\s+' proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean
0
$ wc -l proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean
396
```

---
Automated fix by lean-mechanic agent.