### PR TITLE
Enrich Abel-Ruffini Theorem: fix stale keyInsight #14 to #18 reference

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -116,7 +116,7 @@
       },
       {
         "id": "abel-ruffini-oq-10",
-        "relationship": "Chebotarev density theorem (1922): in a Galois extension L/ℚ with group G, primes distribute among Frobenius conjugacy classes with density |C|/|G|. The computational engine for Galois group determination — converting Abel-Ruffini's abstract impossibility into an effective procedure (factorize f mod a few hundred primes, match cycle-type distribution against transitive-subgroup cycle indices). Axiomatized in Lean with 23 derived results including all S₅ and A₅ conjugacy class sizes (verified by native_decide) and statistical detection of solvability via prime density signatures — directly addresses key insight #14 (Frobenius-Chebotarev) and the openQuestion on Chebotarev formalization"
+        "relationship": "Chebotarev density theorem (1922): in a Galois extension L/ℚ with group G, primes distribute among Frobenius conjugacy classes with density |C|/|G|. The computational engine for Galois group determination — converting Abel-Ruffini's abstract impossibility into an effective procedure (factorize f mod a few hundred primes, match cycle-type distribution against transitive-subgroup cycle indices). Axiomatized in Lean with 23 derived results including all S₅ and A₅ conjugacy class sizes (verified by native_decide) and statistical detection of solvability via prime density signatures — directly addresses key insight #18 (Frobenius-Chebotarev) and the openQuestion on Chebotarev formalization"
       },
       {
         "id": "inverse-galois-a5",


### PR DESCRIPTION
## Summary

Internal-consistency fix for the `abel-ruffini` gallery entry. The `abel-ruffini-oq-10` entry in `relatedProblems` cited **"key insight #14 (Frobenius-Chebotarev)"**, but keyInsight #14 is *"Abel-Ruffini is Radical-Specific, Not Formula-Specific."* The Frobenius-Chebotarev insight is **#18** — and is correctly referenced as such in the `burnside-counting` entry. Aligned the stale reference to #18.

Found by scanning every `#N (description)` cross-reference in `meta.json` (keyInsights, relatedProblems, conclusion.implications, openQuestions) against the actual numbered lists. All other references — keyInsight #8 / #17 / #22, implications #7 / #8 — verified correct.

No content added or removed; this is a one-character correctness fix to an already fully-enriched entry (24 keyInsights, all peer-review action items resolved, complete annotation coverage).

## Test plan

- [x] `python3 json.load` validates meta.json and annotations.json
- [x] `pnpm research:enrich` processed abel-ruffini without error
- [x] `tsc -b` passes
- [x] `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)