### PR TITLE
Fix(erdos-101-oq-01): sync stale leanFile fields with Lean source

### DIFF
--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -129,12 +129,12 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 603,
+    "lineCount": 711,
     "axiomCount": 0,
     "theoremCount": 13,
     "definitionCount": 6,
     "path": "Proofs/Erdos101OQ01.lean",
-    "sorries": 3
+    "sorries": 2
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-101-oq-01/meta.json` had two stale fields inside the `leanFile` sub-object that did not match `proofs/Proofs/Erdos101OQ01.lean`.

## Evidence

| Field | Before | After | Source of truth |
|-------|--------|-------|-----------------|
| `leanFile.sorries` | `3` | `2` | `\bsorry\b` count in `Proofs/Erdos101OQ01.lean` = 2 (lines 114, 542) |
| `leanFile.lineCount` | `603` | `711` | `wc -l` = 711 |

`meta.sorries` (`2`) and `meta.lineCount` (`711`) were already correct — PR #20919 fixed those but missed the parallel fields inside `leanFile`.

Verification:
```
$ wc -l proofs/Proofs/Erdos101OQ01.lean
711 proofs/Proofs/Erdos101OQ01.lean
$ grep -cE '^\s*axiom\s+' proofs/Proofs/Erdos101OQ01.lean
0
```

The 2 remaining sorries are the two recorded in `meta.assumptions`:
1. line 114 — `erdos_101_oq_01` (the main open conjecture, \$100 Erdős prize)
2. line 542 — `solymosi_stojakovic_lower_bound` (deferred 2013 construction)

No Aristotle companion file; no other sorries elsewhere.

`pnpm build` passes.

## Test plan

- [x] `python3 -m json.tool` validates modified JSON
- [x] `pnpm build` (full vite build) passes (✓ built in 23.75s)
- [x] 2-line surgical Edit; no other fields changed

---
Automated fix by lean-mechanic agent.