### PR TITLE
audit: stop find-targets re-flagging Aristotle-companion verified entries

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -76,6 +76,7 @@ interface AuditTarget {
   actual: {
     sorryCount: number
     mainSorryCount: number
+    companionSorryCount: number
     axiomCount: number
     trueStubCount: number
     hasMajorMathlibDep: boolean
@@ -253,9 +254,16 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
   }
 
-  // Verified with sorries
-  if (target.meta.status === 'verified' && target.actual.sorryCount > 0) {
-    issues.push(`status "verified" but has ${target.actual.sorryCount} sorries`)
+  // Verified with sorries.
+  // Exclude *Aristotle.lean companion sorries: these are by-design sorry scaffolds
+  // exposed for proof search (see research/SORRY-CLASSIFICATION.md) and do NOT back
+  // the main proof's "verified" claim. Counting them re-flagged Aristotle-companion
+  // entries every cycle (false-clean oscillation, same root cause as Issue #18137,
+  // which fixed the sibling sorry-mismatch check). Sorries in genuine dependency
+  // files (non-Aristotle additionalFiles/submodules) are still counted.
+  const verifiedSorryCount = target.actual.sorryCount - target.actual.companionSorryCount
+  if (target.meta.status === 'verified' && verifiedSorryCount > 0) {
+    issues.push(`status "verified" but has ${verifiedSorryCount} sorries`)
   }
 
   // Mathlib wrapper with "original" or "verified" badge
@@ -287,6 +295,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
   // Actual counts from Lean file(s) — includes submodules and additionalFiles
   let sorryCount = 0
   let mainSorryCount = 0
+  let companionSorryCount = 0
   let axiomCount = 0
   let trueStubCount = 0
   let hasMajorMathlibDep = false
@@ -304,6 +313,11 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     // separately so meta.sorries claims using the main-file-only convention
     // (PR #18127) can validate alongside chain-aggregate claims (PR #18120).
     if (i === 0) mainSorryCount = fileSorryCount
+    // Track *Aristotle.lean companion sorries separately: they are intentional
+    // proof-search scaffolds and must not count against the main "verified" claim.
+    if (/Aristotle$/.test(path.basename(filePath, '.lean'))) {
+      companionSorryCount += fileSorryCount
+    }
     axiomCount += (content.match(/^(?:(?:private|noncomputable)\s+)*axiom /gm) || []).length
 
     // True stubs: only count theorem/lemma declarations, not example (Issue #6130)
@@ -344,6 +358,7 @@ function analyzeProof(id: string, galleryPath: string, tracker: Tracker): AuditT
     actual: {
       sorryCount,
       mainSorryCount,
+      companionSorryCount,
       axiomCount,
       trueStubCount,
       hasMajorMathlibDep,


### PR DESCRIPTION
## Summary

The gallery auditor's `find-targets.ts` perpetually re-flagged `stirling-formula-oq-01` with `status "verified" but has 3 sorries`, even though the entry is genuinely clean. The main proof file `proofs/Proofs/StirlingExpansion.lean` has **0 sorries** and is correctly `verified`/`original`. The 3 sorries live in the **Aristotle companion file** `StirlingExpansionAristotle.lean`, which by design exposes provable lemma targets as `sorry` for the Aristotle proof-search tool (see `research/SORRY-CLASSIFICATION.md`).

The entry was marked `clean` 6 times (most recently #20973), but `find-targets` re-derives `detectedIssues` from the live files every run and ignores the stored result, so the false positive returned each cycle — a "false-clean oscillation."

## Root cause

The sibling **sorry-mismatch** check was already taught (Issue #18137) to tolerate the main-file-only convention (`claimed === mainSorryCount`). But the separate **"verified with sorries"** check still used the chain-aggregate `sorryCount`, which includes companion-file sorries. So Aristotle-companion entries with a clean main file but a verified status kept tripping it.

## Fix

- Track `companionSorryCount` separately for files whose basename ends with `Aristotle`.
- The "verified with sorries" check now uses `sorryCount - companionSorryCount`.
- Sorries in genuine dependency files (non-Aristotle `additionalFiles`/submodules) are still counted, so real masking is not introduced.

## Verification

Before: `find-targets --stats` -> `With issues: 1` (stirling-formula-oq-01).
After:  `find-targets --stats` -> `With issues: 0`; `--issues` lists nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)