### PR TITLE
Fix(fodor-pressing-down): sync stale meta lineCount/theoremCount

### DIFF
--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -19,8 +19,8 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 568,
-    "theoremCount": 17,
+    "lineCount": 654,
+    "theoremCount": 20,
     "definitionCount": 4
   },
   "overview": {
@@ -223,10 +223,10 @@
   ],
   "leanFile": {
     "path": "Proofs/FodorPressingDown.lean",
-    "lineCount": 568,
+    "lineCount": 654,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 17,
+    "theoremCount": 20,
     "definitionCount": 4,
     "imports": [
       "import Mathlib.SetTheory.Cardinal.Ordinal",


### PR DESCRIPTION
## Fix

`meta.meta` and `meta.leanFile` both claimed `lineCount: 568` and `theoremCount: 17`. The actual file is 654 lines with 20 theorems.

## Evidence

PR #20621 (cofHead infrastructure + first Fodor application) grew the file but did not refresh `meta.json`:

- `wc -l proofs/Proofs/FodorPressingDown.lean` → 654 (meta: 568)
- `grep -c '^theorem\b'` on comment-stripped source → 20 (meta: 17)
- `^axiom\b`, `^opaque\b`, sorries: all 0 — unchanged, no other counts affected

## Diff

Both `meta.meta` and `meta.leanFile` updated in lockstep so the two blocks stay consistent:

- `lineCount`: 568 → 654 (both blocks)
- `theoremCount`: 17 → 20 (both blocks)
- All other fields unchanged (no sorries, no axioms, status remains \`verified\`)

---
Automated fix by lean-mechanic agent.