### PR TITLE
Enrich Abel-Ruffini Theorem: characteristic-p radical analysis (Artin–Schreier, Witt, Abhyankar)

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -88,19 +88,26 @@
     "type": "definition",
     "title": "Solvable by Radicals and Field Variables",
     "content": "An element α is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations (+, -, ×, ÷), and radical extraction ($\\alpha \\mapsto \\alpha^{1/n}$). The intermediate field `solvableByRad F E` is the largest subfield of $E$ whose elements are all solvable by radicals over $F$.\n\nThe variable declarations introduce a universe-polymorphic framework: `F` is an arbitrary field and `E/F` is a field extension with `[Algebra F E]`. This generality means the development applies to any characteristic, though the classical Abel-Ruffini theorem is typically stated over $\\mathbb{Q}$.",
-    "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over $F$. Formally, $\\alpha \\in \\text{solvableByRad}(F, E)$ iff there exists a radical tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\beta_i)$ where $\\beta_i^{n_i} \\in K_i$.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by the tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{2}) \\subset \\mathbb{Q}(\\sqrt{2}, \\sqrt{1+\\sqrt{2}})$.",
+    "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over $F$. Formally, $\\alpha \\in \\text{solvableByRad}(F, E)$ iff there exists a radical tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\beta_i)$ where $\\beta_i^{n_i} \\in K_i$.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by the tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{2}) \\subset \\mathbb{Q}(\\sqrt{2}, \\sqrt{1+\\sqrt{2}})$.\n\n**Characteristic-dependence of the radical–solvable equivalence.** The Galois bridge `solvableByRad.isSolvable'` and its converse hold cleanly in characteristic 0; in characteristic $p > 0$ the radical concept needs supplementation. The radical step $K \\subset K(\\sqrt[n]{a})$ yields a cyclic Galois group of order dividing $n$ only when $p \\nmid n$ (the Kummer regime). For $n = p$ the polynomial $X^p - a$ is purely inseparable: if $\\alpha^p = a$ then $X^p - a = (X - \\alpha)^p$ in characteristic $p$, so $K(\\alpha)/K$ is either trivial (if $a \\in K^p$) or a purely inseparable degree-$p$ extension with trivial Galois group. The Galois-theoretic analog is the **Artin–Schreier extension**: for $K$ of characteristic $p$ and $a \\in K$, adjoining a root of the polynomial $X^p - X - a$ produces a cyclic Galois extension of degree $p$ (when $X^p - X - a$ is irreducible) — the characteristic-$p$ surrogate for $X^n - a$ in characteristic 0. The companion Lang–Steinitz theorem (Lang 1959, generalizing Witt) bidirectionally classifies *all* cyclic extensions of characteristic-$p$ fields of $p$-power degree via Witt vectors, the characteristic-$p$ analog of Kummer's $K^* / (K^*)^n$. Mathlib's `IsSolvableByRad` is the characteristic-0 / coprime-degree notion; the Abhyankar conjecture (Raynaud 1994, Harbater 1994) — referenced in this entry's openQuestion #6 — classifies which Galois groups arise from *Artin–Schreier–Witt towers* over $\\mathbb{A}^1_{\\overline{\\mathbb{F}_p}}$ and reveals that the Abel–Ruffini-style impossibility is genuinely characteristic-dependent: in characteristic 5, the $A_5$ obstruction can be bypassed via Artin–Schreier-type radicals that the characteristic-0 definition does not capture.",
     "significance": "key",
     "prerequisites": [
       "field extensions",
       "nth roots",
       "IsSolvableByRad",
-      "radical tower"
+      "radical tower",
+      "characteristic of a field",
+      "separability and purely inseparable extensions"
     ],
     "relatedConcepts": [
       "radical extension",
       "intermediate field",
       "inductive definition",
-      "Kummer theory"
+      "Kummer theory",
+      "Artin–Schreier extension",
+      "Witt vectors",
+      "Abhyankar conjecture",
+      "openQuestion #6 (positive characteristic)",
+      "purely inseparable extension"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -89,19 +89,26 @@
     "type": "definition",
     "title": "Solvable by Radicals and Field Variables",
     "content": "An element \u03b1 is 'solvable by radicals' if it can be built from the base field using field operations and nth roots. The quadratic formula is an example: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$\n\nMathlib defines this inductively via `IsSolvableByRad`, with constructors for: base field elements, arithmetic operations (+, -, \u00d7, \u00f7), and radical extraction ($\\alpha \\mapsto \\alpha^{1/n}$). The intermediate field `solvableByRad F E` is the largest subfield of $E$ whose elements are all solvable by radicals over $F$.\n\nThe variable declarations introduce a universe-polymorphic framework: `F` is an arbitrary field and `E/F` is a field extension with `[Algebra F E]`. This generality means the development applies to any characteristic, though the classical Abel-Ruffini theorem is typically stated over $\\mathbb{Q}$.",
-    "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over $F$. Formally, $\\alpha \\in \\text{solvableByRad}(F, E)$ iff there exists a radical tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\beta_i)$ where $\\beta_i^{n_i} \\in K_i$.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by the tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{2}) \\subset \\mathbb{Q}(\\sqrt{2}, \\sqrt{1+\\sqrt{2}})$.",
+    "mathContext": "`solvableByRad F E` is the intermediate field of all elements solvable by radicals over $F$. Formally, $\\alpha \\in \\text{solvableByRad}(F, E)$ iff there exists a radical tower $F = K_0 \\subset K_1 \\subset \\cdots \\subset K_m$ with $\\alpha \\in K_m$ and each $K_{i+1} = K_i(\\beta_i)$ where $\\beta_i^{n_i} \\in K_i$.\n\nExample: $\\sqrt{1 + \\sqrt{2}}$ is built by the tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{2}) \\subset \\mathbb{Q}(\\sqrt{2}, \\sqrt{1+\\sqrt{2}})$.\n\n**Characteristic-dependence of the radical–solvable equivalence.** The Galois bridge `solvableByRad.isSolvable'` and its converse hold cleanly in characteristic 0; in characteristic $p > 0$ the radical concept needs supplementation. The radical step $K \\subset K(\\sqrt[n]{a})$ yields a cyclic Galois group of order dividing $n$ only when $p \\nmid n$ (the Kummer regime). For $n = p$ the polynomial $X^p - a$ is purely inseparable: if $\\alpha^p = a$ then $X^p - a = (X - \\alpha)^p$ in characteristic $p$, so $K(\\alpha)/K$ is either trivial (if $a \\in K^p$) or a purely inseparable degree-$p$ extension with trivial Galois group. The Galois-theoretic analog is the **Artin–Schreier extension**: for $K$ of characteristic $p$ and $a \\in K$, adjoining a root of the polynomial $X^p - X - a$ produces a cyclic Galois extension of degree $p$ (when $X^p - X - a$ is irreducible) — the characteristic-$p$ surrogate for $X^n - a$ in characteristic 0. The companion Lang–Steinitz theorem (Lang 1959, generalizing Witt) bidirectionally classifies *all* cyclic extensions of characteristic-$p$ fields of $p$-power degree via Witt vectors, the characteristic-$p$ analog of Kummer's $K^* / (K^*)^n$. Mathlib's `IsSolvableByRad` is the characteristic-0 / coprime-degree notion; the Abhyankar conjecture (Raynaud 1994, Harbater 1994) — referenced in this entry's openQuestion #6 — classifies which Galois groups arise from *Artin–Schreier–Witt towers* over $\\mathbb{A}^1_{\\overline{\\mathbb{F}_p}}$ and reveals that the Abel–Ruffini-style impossibility is genuinely characteristic-dependent: in characteristic 5, the $A_5$ obstruction can be bypassed via Artin–Schreier-type radicals that the characteristic-0 definition does not capture.",
     "significance": "key",
     "relatedConcepts": [
       "radical extension",
       "intermediate field",
       "inductive definition",
-      "Kummer theory"
+      "Kummer theory",
+      "Artin–Schreier extension",
+      "Witt vectors",
+      "Abhyankar conjecture",
+      "openQuestion #6 (positive characteristic)",
+      "purely inseparable extension"
     ],
     "prerequisites": [
       "field extensions",
       "nth roots",
       "IsSolvableByRad",
-      "radical tower"
+      "radical tower",
+      "characteristic of a field",
+      "separability and purely inseparable extensions"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Single targeted enrichment to the `ann-solvable-by-rad` annotation of the Abel-Ruffini gallery entry.

The definition annotation now explicitly addresses the **characteristic-dependence** of the radical–solvable equivalence — closing a real conceptual gap that was previously only hinted at in openQuestion #6.

### What was added

- The Kummer regime: $K \\subset K(\\sqrt[n]{a})$ produces a cyclic Galois group only when $p \\nmid n$
- Purely inseparable failure when $p \\mid n$: $X^p - a = (X - \\alpha)^p$
- **Artin–Schreier extensions**: $X^p - X - a$ as the characteristic-$p$ analog of $X^n - a$
- **Witt vectors / Lang–Steinitz (1959)** as the analog of $K^* / (K^*)^n$
- **Abhyankar conjecture** (Raynaud 1994, Harbater 1994) — connecting to existing openQuestion #6

### Field updates

- `mathContext`: expanded from 456 → 2179 chars with the substantive characteristic-$p$ paragraph
- `relatedConcepts`: added Artin–Schreier extension, Witt vectors, Abhyankar conjecture, openQuestion #6, purely inseparable extension
- `prerequisites`: added characteristic of a field, separability and purely inseparable extensions

### Files

- `src/data/proofs/abel-ruffini/annotations.source.json` (source of truth — manually edited)
- `src/data/proofs/abel-ruffini/annotations.json` (regenerated by \`pnpm annotations:build\`)

## Test plan

- [x] \`pnpm annotations:build\` regenerates \`annotations.json\` cleanly (no Abel-Ruffini warnings)
- [x] \`pnpm build\` succeeds end-to-end (vite build, ~21s)
- [x] JSON validity verified (jq parses both files)
- [x] No content removed — pure addition

🤖 Generated with [Claude Code](https://claude.com/claude-code)