### PR TITLE
fix(deploy): 12GB heap + 2h cap to unblock deployer builds

### DIFF
--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -243,8 +243,12 @@ launch_agent() {
     # The --daemon flag ensures the deployer survives API outages indefinitely
     # Run in worktree to isolate from main repo
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    # Deploy build is memory-heavy (large vite module graph); give it a 12GB heap
+    # to avoid GC thrash that stalls vite at `transforming...`, and a 2h CLI cap so
+    # a ~40m build leaves room for merge/sync/deploy. All env-overridable. These are
+    # band-aids until #20984 moves gallery data out of the vite module graph.
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "ENHANCER_ID=deployer REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the deployer agent. Read $prompt_file for your instructions, then start the deploy loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=deployer REPO_ROOT=$WORKTREE_PATH BUILD_TIMEOUT='${BUILD_TIMEOUT:-45m}' BUILD_NODE_OPTIONS='${BUILD_NODE_OPTIONS:---max-old-space-size=12288}' CLAUDE_TIMEOUT='${CLAUDE_TIMEOUT:-7200}' $wrapper_script --daemon --prompt 'You are the deployer agent. Read $prompt_file for your instructions, then start the deploy loop.' --log '$LOG_FILE'"
 
     print_success "Launched deployer agent"
     echo ""


### PR DESCRIPTION
## Summary
- Inject `BUILD_NODE_OPTIONS=--max-old-space-size=12288` (12GB heap, up from 8GB) and `CLAUDE_TIMEOUT=7200` (2h cycle cap, up from 60m) into the deployer's spawn env in `scripts/deploy/launch-agent.sh`. Both env-overridable; `BUILD_TIMEOUT` stays 45m.
- **Band-aid** to restore deploys, which are currently blocked: vite stalls at `transforming...` near the 8GB heap as the gallery module graph grows (~2435 proofs), and the 60m wrapper cap kills the deployer mid-build (see #20984 cycles 15–16).

## Why this works (short-term)
- Cycle 14 proved a ~40m build deploys fine under a 60m budget; cycle 16 hung at the 8GB heap with zero progress. More heap → less GC thrash → build completes; more cycle headroom → merge/sync/deploy fit after the build.

## The real fix
- #20984 (architect proposal) moves gallery data out of the vite module graph entirely (emit to `public/data/`, fetch by slug), collapsing ~12K modules to a few hundred and returning the build toward its ~35s baseline. This PR is explicitly a stopgap until that lands.

## Test plan
- [ ] Merge, pull main, restart the deployer; confirm `ps eww` on the deployer PID shows `--max-old-space-size=12288` and `CLAUDE_TIMEOUT=7200`.
- [ ] Watch one deployer cycle complete a build + Cloudflare deploy without hitting the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)