### PR TITLE
Fix(cayley-hamilton-reduction-oq-02-oq-01): status verified -> formalized

### DIFF
--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Ferdinand Georg Frobenius (1878)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Frobenius_normal_form",
     "date": "1878",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",
     "tags": [
       "linear-algebra",
@@ -41,7 +41,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 396,
-    "assumptions": "0 axioms, 0 sorries. All three key theorems fully proved: aeval_companionMatrix (orbit argument), charpoly_companionMatrix, and minpoly_companionMatrix. Uses Mathlib supporting lemmas.",
+    "assumptions": "Main file (CayleyHamiltonReductionOQ02OQ01.lean): 0 axioms, 0 sorries; all three key theorems fully proved (aeval_companionMatrix via orbit argument, charpoly_companionMatrix, minpoly_companionMatrix) using Mathlib supporting lemmas. Aristotle companion (CayleyHamiltonReductionOQ02OQ01Aristotle.lean) carries 12 routine helper-lemma stubs (minpoly_dvd_of_aeval_zero, dvd_antisymm_monic, orbit_basis_independent, etc.) staged for automated proof search; these are not imported by the main file.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Revert status from verified to formalized for cayley-hamilton-reduction-oq-02-oq-01. PR #20977 set it to verified based on the main file (0 sorries), but the auditor evaluates status against the chain-aggregate sorry count, and the Aristotle companion (declared in additionalFiles) holds 12 routine helper-lemma stubs.

## Evidence

Before (auditor):
- cayley-hamilton-reduction-oq-02-oq-01 (4x) [verified/original] status verified but has 12 sorries

After (auditor):
- (no issues for cayley-hamilton-reduction-oq-02-oq-01)

The main file Proofs/CayleyHamiltonReductionOQ02OQ01.lean remains fully proved (0 sorries, 0 axioms). Only the metadata status and assumptions fields were touched; no Lean code changed. The Aristotle companion Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean still carries 12 routine stubs, awaiting Aristotle proof search.

This pairs with the convention used by algebraic-numbers-countable (status verified only when the Aristotle companion is itself sorry-clean).

---
Automated fix by lean-mechanic agent.