### PR TITLE
Fix auditor false positive: verified check counts Aristotle scaffold sorries

### DIFF
--- a/scripts/auditor/find-targets.ts
+++ b/scripts/auditor/find-targets.ts
@@ -253,9 +253,16 @@ function detectIssues(target: AuditTarget): string[] {
     issues.push(`axiom undercount: claims ${target.meta.claimedAxioms}, actual declarations ${target.actual.axiomCount}`)
   }
 
-  // Verified with sorries
-  if (target.meta.status === 'verified' && target.actual.sorryCount > 0) {
-    issues.push(`status "verified" but has ${target.actual.sorryCount} sorries`)
+  // Verified with sorries.
+  // "verified" status describes the gallery's main proof file. Aristotle-companion
+  // and additionalFiles scaffolds legitimately contain `sorry` (open proof-search
+  // targets) without negating a verified main proof, so flag on the main-file count
+  // (or a self-contradictory nonzero meta.sorries claim) rather than the chain-aggregate
+  // count. Using sorryCount here re-flagged verified+companion entries on every run,
+  // an oscillation mirroring the mismatch-check fix in Issue #18137.
+  const verifiedSorries = Math.max(target.actual.mainSorryCount, claimed)
+  if (target.meta.status === 'verified' && verifiedSorries > 0) {
+    issues.push(`status "verified" but has ${verifiedSorries} sorries`)
   }
 
   // Mathlib wrapper with "original" or "verified" badge

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13237,10 +13237,10 @@
       "notes": "Re-audited 2026-05-04: 0 sorries, 0 axioms, 18 theorems confirmed (includes 3 private lemmas). Metadata consistent. Empty issues array was auditor artifact."
     },
     "stirling-formula-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-29T15:40:33Z",
-      "result": "clean"
+      "lastAudited": "2026-05-29T17:14:06Z",
+      "result": "issues-fixed"
     },
     "stirling-formula-oq-02": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

The `find-targets.ts` "verified-with-sorries" check used the **chain-aggregate** sorry count (main file + `additionalFiles` + Aristotle companion). Any `verified` proof whose Aristotle proof-search companion contained `sorry` was therefore re-flagged on **every** audit run — a permanent false positive.

`stirling-formula-oq-01` oscillated through **6 audits** this way:
- `proofs/Proofs/StirlingExpansion.lean` (main proof) has **0 sorries** and fully proves all three theorems (`stirling_step_formula`, `stirling_first_correction`, `stirling_two_term_expansion`).
- `proofs/Proofs/StirlingExpansionAristotle.lean` (companion) restates those same theorems with `sorry` as proof-search targets.

`meta.json` correctly claims `status: verified`, `sorries: 0` — the public claim matches the main Lean source. The 3 sorries live only in the proof-search scaffold.

## Fix

`verified` status describes the gallery's **main proof file**, not its companion scaffolds. The sorry-*mismatch* check already accepts the main-file-only convention for Aristotle-companion entries (Issue #18137); this extends the same logic to the verified check.

Now flags on `max(mainSorryCount, claimedSorries)` instead of the chain-aggregate count. Genuine problems still flag:
- main-file sorries (`mainSorryCount > 0`)
- self-contradictory metadata (`status: verified` with `meta.sorries > 0`)

## Verification

- Before: `--issues` -> 1 (stirling-formula-oq-01 verified but 3 sorries); withIssues=1
- After: `--issues` -> 0; withIssues=0

Generated during gallery integrity audit.