### PR TITLE
audit(stirling-formula-oq-01): mark clean re-audit (cycle 7)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13237,9 +13237,9 @@
       "notes": "Re-audited 2026-05-04: 0 sorries, 0 axioms, 18 theorems confirmed (includes 3 private lemmas). Metadata consistent. Empty issues array was auditor artifact."
     },
     "stirling-formula-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-29T15:40:33Z",
+      "lastAudited": "2026-05-29T17:41:29Z",
       "result": "clean"
     },
     "stirling-formula-oq-02": {


### PR DESCRIPTION
## Summary

Routine audit-tracker update: marks `stirling-formula-oq-01` as cleanly re-audited (cycle 7).

The find-targets tool continues to flag this entry as `"status verified but has 3 sorries"`. Re-confirmed: those 3 sorries are in the Aristotle companion file (`proofs/Proofs/StirlingExpansionAristotle.lean`), not the main proof (`StirlingExpansion.lean` has 0 sorries). Tooling fixes already in flight:

- #20978 — exempt Aristotle companion sorries from verified-with-sorries check
- #20981 — stop find-targets re-flagging Aristotle-companion verified entries
- #20990 — fix auditor false positive (verified check counts Aristotle scaffold sorries)

Follows the precedent of #20973 (cycle 6).

## Test plan

- [x] Verified main Lean file has 0 sorries
- [x] Verified 3 sorries are in companion file only
- [x] Diff is bookkeeping-only (auditCount and lastAudited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)