### PR TITLE
audit(stirling-formula-oq-01): mark clean re-audit (cycle 8)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13237,10 +13237,10 @@
       "notes": "Re-audited 2026-05-04: 0 sorries, 0 axioms, 18 theorems confirmed (includes 3 private lemmas). Metadata consistent. Empty issues array was auditor artifact."
     },
     "stirling-formula-oq-01": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-05-29T17:14:06Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-29T18:03:55Z",
+      "result": "clean"
     },
     "stirling-formula-oq-02": {
       "auditCount": 3,


### PR DESCRIPTION
Gallery integrity re-audit of stirling-formula-oq-01 after PR #20990 fixed the auditor's false-positive verified-check that was double-counting sorries in Aristotle scaffold companions.

## What I verified

- Main file Proofs/StirlingExpansion.lean: 0 sorries, 0 axioms confirmed (grep sorry, ^axiom)
- Companion Proofs/StirlingExpansionAristotle.lean: 3 sorries — proof-search scaffolds by design; meta.sorries=0 describes the main file per documented convention (#20990 / #18137)
- meta.status "verified" / badge "original" consistent with main-file integrity
- meta.axiomCount 0 confirmed

## Tracker change

- auditCount 7 → 8
- result issues-fixed → clean
- lastAudited → 2026-05-29T18:03:55Z

find-targets --stats now reports 0 issues across all 2435 proofs.

## Test plan

- [x] npx tsx scripts/auditor/find-targets.ts --stats → 0 issues, 0 unaudited
- [x] --issues → 0 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)