### PR TITLE
audit(erdos-33): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6188,12 +6188,12 @@
       ]
     },
     "erdos-33": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "Phantom axiomatizations in proofStrategy/sections (Moser, Van Doorn) + section line drift +7 to +9; headline counts correct (issue #14482)"
       ],
-      "lastAudited": "2026-05-02T01:13:18Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-29T18:20:07Z",
+      "result": "clean"
     },
     "erdos-330": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-33 (Additive Complements of Squares). All meta.json counts match the Lean source.

## Verification
- 1 axiom (cilleruelo_habsieger_lower_bound) — matches axiomCount: 1
- 4 theorems — matches theoremCount: 4
- 8 definitions — matches definitionCount: 8
- 0 sorries — matches sorries: 0
- 172 lines — matches lineCount: 172
- Status axiomatized / badge axiom correct
- assumptions field accurately enumerates the single axiom

Prior issue #14482 (phantom axiomatizations, section line drift) was already closed; current state is clean.

## Test plan
- [ ] Tracker entry for erdos-33 shows auditCount: 4, result: clean
- [ ] No meta.json or Lean source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)