### PR TITLE
audit(erdos-331): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6203,9 +6203,9 @@
     },
     "erdos-331": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:08:37Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T18:31:46Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in sections/originalContributions (ruzsa_unique_representation, ruzsaB_eq_double_ruzsaA, ruzsa_exact_growth, ruzsaVariantOpen, ruzsaA_sparse_differences, larger_density_common_differences); section line-range drift; summary claims 9 axioms but file has 3; conclusion 245 lines vs 223 actual (#14480)"
       ]


### PR DESCRIPTION
## Summary

Re-audit of `erdos-331` (Erdős Problem #331: Common Differences in Dense Sets, Ruzsa counterexample) finds gallery integrity intact. Tracker bump from cycle 3 (issues-fixed) → cycle 4 (clean).

## Audit findings

| Field | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 (lines 106, 109, 120) | ✓ |
| lineCount | 223 | 223 | ✓ |
| theoremCount | 5 | 5 | ✓ |
| definitionCount | 17 | 17 | ✓ |
| status | `axiomatized` | matches 3 axioms | ✓ |
| badge | `axiom` | appropriate | ✓ |

- True-Props (`sparseness_explanation`, `threshold_critical`) are documentation `def : Prop := True`, explicitly noted as such in `originalContributions` — not theorem-level overclaim.
- No Mathlib-wrapper overclaim; Ruzsa counterexample is original infrastructure built on `Finset.Icc`, `Filter.Tendsto`, `Set.Infinite` primitives.
- `assumptions` field accurately describes the 3 axioms (Ruzsa density of A, density of B, no common differences).

## Test plan

- [x] meta.json fields cross-checked against `proofs/Proofs/Erdos331Problem.lean`
- [x] Sorry/axiom counts verified by grep
- [x] No True-stub theorems claimed as proved

🤖 Generated with [Claude Code](https://claude.com/claude-code)