### PR TITLE
fix(kroneckers-jugendtraum): remove 3 True-stub theorems (batch 12)

### DIFF
--- a/proofs/Proofs/KroneckersJugendtraum.lean
+++ b/proofs/Proofs/KroneckersJugendtraum.lean
@@ -284,25 +284,9 @@ def Hilberts12thProblem : Prop :=
       True -- Full statement is not formalizable without specifying
            -- what "explicit analytic function" means
 
-/-- The problem is solved for imaginary quadratic fields (by CM theory) -/
-theorem hilbert12_solved_for_imaginary_quadratic :
-    ∀ (K : Type*) [Field K] [Algebra ℚ K],
-      IsImaginaryQuadratic K → CMSolution K := by
-  intro K _ _ hK
-  intro _
-  intro L _ _ _ _
-  trivial
-
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART VI: KNOWN PARTIAL RESULTS AND EXAMPLES
 ═══════════════════════════════════════════════════════════════════════════════ -/
-
-/-- Roots of unity generate cyclotomic extensions -/
-theorem root_of_unity_generates_cyclotomic (n : ℕ) (hn : n ≠ 0) (ζ : ℂ)
-    (hζ : ζ ^ n = 1) (hprim : ∀ m : ℕ, m < n → m ≠ 0 → ζ ^ m ≠ 1) :
-    -- ℚ(ζ) is a cyclotomic field
-    True := by
-  trivial
 
 /-- The n-th cyclotomic polynomial is irreducible over ℚ -/
 theorem cyclotomic_irreducible (n : ℕ+) :
@@ -348,7 +332,8 @@ def StarkConjecture : Prop :=
 PART VIII: SUMMARY
 ═══════════════════════════════════════════════════════════════════════════════ -/
 
-/-- Summary of Hilbert's 12th Problem:
+/-!
+### Summary of Hilbert's 12th Problem
 
 1. **The Problem**: Find explicit generators for all abelian extensions of any number field K
 
@@ -376,7 +361,6 @@ PART VIII: SUMMARY
    - Foundation of modern arithmetic geometry
    - Deep relations to the Langlands program
 -/
-theorem hilbert12_summary : (1 : ℕ) + 1 = 2 := rfl
 
 #check KroneckerWeberTheorem
 #check cyclotomic_galois_abelian

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -49,8 +49,8 @@
     "assumptions": "4 placeholder axioms defined as Prop := True: (1) KroneckerWeberTheorem — every abelian extension of ℚ is cyclotomic (requires local class field theory to prove), (2) CMSolution — CM theory for imaginary quadratic fields (deep result in arithmetic geometry), (3) ArtinReciprocity — Artin reciprocity map isomorphism (central theorem of class field theory), (4) StarkConjecture — Stark's conjectures on L-function values (open conjecture). One genuine proof: cyclotomic_galois_comm (Galois group of cyclotomic extensions is abelian, via Mathlib's autEquivPow). Two Mathlib applications: cyclotomic degree = totient, cyclotomic polynomial irreducibility.",
     "proofRepoPath": "Proofs/KroneckersJugendtraum.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 387,
-    "theoremCount": 6,
+    "lineCount": 371,
+    "theoremCount": 3,
     "definitionCount": 10
   },
   "overview": {
@@ -119,7 +119,7 @@
       "title": "Open Cases",
       "startLine": 255,
       "endLine": 300,
-      "summary": "States Hilberts12thProblem for general K. Proves hilbert12_solved_for_rationals and hilbert12_solved_for_imaginary_quadratic (both reduce to trivial via placeholders).",
+      "summary": "States Hilberts12thProblem for general K as a placeholder proposition (the deep statement is not formalizable without specifying \"explicit analytic function\").",
       "mathContext": "The general `Hilberts12thProblem` asks for a set of generators in $\\mathbb{C}$ that are special values of explicit analytic functions and generate all abelian extensions of any number field $K$. The file proves `hilbert12_solved_for_rationals` (reducing to `KroneckerWeberTheorem \\to \\mathrm{True}$) and `hilbert12_solved_for_imaginary_quadratic` (reducing via `CMSolution`). Both proofs are trivial since the deep content is in the axiomatized premises. For real quadratic fields $\\mathbb{Q}(\\sqrt{d})$, no analogue of CM exists; the Stark conjectures and the Langlands program represent the main avenues of current research."
     },
     {
@@ -143,7 +143,7 @@
       "title": "Summary",
       "startLine": 352,
       "endLine": 387,
-      "summary": "hilbert12_summary theorem. Recaps solved cases (ℚ, imaginary quadratic) vs open cases (real quadratic, general). Lists #check statements for key definitions.",
+      "summary": "Documentation block recapping solved cases (ℚ, imaginary quadratic) vs open cases (real quadratic, general). Lists #check statements for key definitions.",
       "mathContext": "The file's genuine Lean content comprises three machine-checked results: (1) `cyclotomic_galois_comm` proving $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ is abelian via the `autEquivPow` isomorphism to $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, (2) `cyclotomic_degree` proving $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ via `IsCyclotomicExtension.finrank`, and (3) `cyclotomic_irreducible` proving $\\Phi_n$ is irreducible over $\\mathbb{Z}$. All other results -- Kronecker-Weber, CM theory, Artin reciprocity, Stark conjectures, and the general Hilbert 12th problem -- are formulated as `Prop := True` placeholders whose deep proofs lie beyond current Mathlib infrastructure."
     }
   ],
@@ -271,11 +271,11 @@
       "scoped"
     ],
     "namespace": "KroneckersJugendtraum",
-    "lineCount": 387,
+    "lineCount": 371,
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 10,
-    "theoremCount": 6
+    "theoremCount": 3
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Removes three remaining vacuous `True`-proving theorems from `KroneckersJugendtraum.lean`, continuing the cleanup started in #10192 (batch 10).

## Evidence

**Before**: Three theorems whose bodies are `trivial` or `rfl` and whose conclusions reduce to `True`:
- `hilbert12_solved_for_imaginary_quadratic` — `CMSolution K` is defined as `Prop := True`, so the proof is vacuous
- `root_of_unity_generates_cyclotomic` — concludes `True` after taking hypothesis arguments it never uses
- `hilbert12_summary` — proves `(1 : ℕ) + 1 = 2` with no connection to Hilbert 12

These were flagged as "filler" findings in `src/data/proofs/kroneckers-jugendtraum/review.json` (peer review action item `ai-2`).

**After**: The three theorems are removed. The `hilbert12_summary` docstring (a useful narrative recap) is preserved as a `/-! ... -/` documentation block.

## Meta sync

- `meta.theoremCount`: 6 → 3 (and `leanFile.theoremCount`)
- `meta.lineCount`: 387 → 371 (and `leanFile.lineCount`)
- Two `sections[].summary` strings updated to drop references to removed theorems

`pnpm build` succeeds with the updated gallery data.

Closes peer review action item `ai-2` for `kroneckers-jugendtraum` (the resolution previously read "Deferred to builder/researcher").

---
Automated repair by lean-mechanic agent.