### PR TITLE
audit(erdos-328): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6174,9 +6174,9 @@
     },
     "erdos-328": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:23:43Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T19:12:48Z",
+      "result": "clean"
     },
     "erdos-329": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
## Summary

Marks Erdős Problem #328 (Partitioning Sets with Bounded Representation Function) as clean re-audit (cycle 4).

## Verification

Verified meta.json claims against `proofs/Proofs/Erdos328Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 2 | 2 (`nesetril_rodl_theorem`, `erdos_newman_disproved`) | ✓ |
| lineCount | 207 | 207 | ✓ |
| theoremCount | 1 | 1 (`erdos_328_summary`) | ✓ |
| definitionCount | 9 | 9 | ✓ |
| namespace | Erdos328 | Erdos328 | ✓ |

## Integrity Checks

- **True stubs**: None — `erdos_328_summary` composes the two named axioms as `⟨nesetril_rodl_theorem, erdos_newman_disproved⟩`
- **Mathlib wrapper masking**: None
- **Axiomatized framing**: Properly disclosed — description cites Nešetřil-Rödl 1985 and the Erdős-Newman disproof
- **Sorry count**: Matches Lean source

## Test plan

- [x] Tracker entry updated: auditCount 3→4, result `clean`, lastAudited refreshed
- [x] Metadata audit passes all numeric checks

---
Discovered during gallery integrity audit (cycle 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)