### PR TITLE
audit(erdos-322): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6123,9 +6123,9 @@
     },
     "erdos-322": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:37:11Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T19:23:16Z",
+      "result": "clean",
       "issues": [
         "phantom originalContributions (mahler_theorem, erdos_positive_density_claim — neither axiom exists); proofStrategy + sections.positive-density falsely claim Part VII axiomatizes positive density (orphan docstring only); overview.text says '5 axioms' (actual 3) and '191-line' (actual 182); section line drift +4 from Part III onward (#14493)"
       ]


### PR DESCRIPTION
## Summary

Cycle 4 re-audit of erdos-322 (Representations as Sums of k-th Powers). All integrity checks pass:

- **status**: `axiomatized` (matches 3 axiom declarations)
- **badge**: `axiom`
- **sorries**: meta.sorries=0, leanFile.sorries=0, actual=0
- **axiomCount**: meta.axiomCount=3, leanFile.axiomCount=3, actual=3
- **trueStubCount**: 0
- **assumptions** field present, lists the 3 axioms

Previous cycle 3 (2026-05-02) was `issues-fixed` (#14493). No new drift detected.

## Test plan

- [x] meta.json status/badge/sorries/axiomCount agree with Lean source
- [x] find-targets reports no `detectedIssues`
- [x] No phantom contributions or line-count drift