### PR TITLE
Enrich amgm-inequality-oq-02-oq-01: mark resolved openQuestion

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
@@ -55,7 +55,7 @@
     "implications": "This algebraic identity is the foundation of AM-GM for n variables and Newton's power sum method for symmetric polynomials. The Finset-based proof applies to sums over any finite index set, making it reusable for combinatorial applications.",
     "openQuestions": [
       "Prove the full Newton-Girard recurrence: p_k = Σ_{i=1}^k (-1)^{i-1} eᵢ p_{k-i}",
-      "Connect to the off-diagonal symmetry: show Σ_{i≠j} xᵢxⱼ = 2·Σ_{i<j} xᵢxⱼ"
+      "**[Addressed in `amgm-inequality-oq-02-oq-01-oq-02`]** Connect to the off-diagonal symmetry: show Σ_{i≠j} xᵢxⱼ = 2·Σ_{i<j} xᵢxⱼ. The companion sub-entry formalizes this via the Prod.swap bijection between lower and upper triangular pairs, requiring a LinearOrder on ι that the parent CommRing-only file deliberately avoids."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary

Mark a stale openQuestion as resolved.

## Change

The `amgm-inequality-oq-02-oq-01` entry's openQuestions listed:

> Connect to the off-diagonal symmetry: show Σ_{i≠j} xᵢxⱼ = 2·Σ_{i<j} xᵢxⱼ

But this is already formalized in the child sub-entry \`amgm-inequality-oq-02-oq-01-oq-02\` (per the existing crossReference on this entry, which says: *\"Completes the off-diagonal symmetry step left open here\"*).

Updated the openQuestion to:
- Tag as `[Addressed in \`amgm-inequality-oq-02-oq-01-oq-02\`]`
- Briefly summarize the resolution mechanism (Prod.swap bijection)

This keeps the openQuestions list accurate without removing the historical breadcrumb.

## Test plan
- [x] JSON validates
- [x] Only the one stale openQuestion modified