### PR TITLE
audit(erdos-329): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6180,9 +6180,9 @@
     },
     "erdos-329": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:17:45Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T19:31:25Z",
+      "result": "clean",
       "issues": [
         "phantom Erdős 1/2 axiom + conditional embedding (orphan docstrings, no declarations); section line drift lower-bounds onward (#14484)"
       ]


### PR DESCRIPTION
## Audit Summary

Verified `Erdos329Problem.lean` matches `meta.json` claims:

- **198 lines** (matches `lineCount`)
- **2 axioms**: `kruckeberg_1961`, `erdos_turan_upper_bound` (matches `axiomCount`)
- **0 sorries** (matches `sorries`)
- **0 True stubs**
- **5 theorems**: `max_density_ge_inv_sqrt2`, `max_density_le_one`, `empty_is_sidon`, `singleton_is_sidon`, `erdos_329_summary` (matches `theoremCount`)
- **5 definitions** (matches `definitionCount`)
- Status `axiomatized` with badge `axiom` — correct for an open problem
- Title and description clearly label the problem as **OPEN**

No integrity issues. Marking clean.