### PR TITLE
audit(erdos-381): mark clean re-audit (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6587,9 +6587,9 @@
     },
     "erdos-381": {
       "agentId": "auditor-cycle-2026-05-02",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:45:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T19:45:00Z",
+      "result": "clean",
       "issues": [
         "phantom HC_exponent_decreasing/ramanujan_characterization/HC_sparser_than_primes theorems in originalContributions; 4 dangling doc-comments; section line drift Parts VI–IX (#14438)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-381 (Counting Highly Composite Numbers); marked clean.
- Verified meta.json matches Lean source: 3 sorries, 2 axioms, axiomatized/axiom status+badge, no True stubs.

## Test plan
- [x] grep sorry count → 3 (matches `sorries: 3`)
- [x] grep `^axiom ` → 2 declarations (erdos_lower_bound, nicolas_upper_bound) matching `axiomCount: 2`
- [x] Status `axiomatized` / badge `axiom` consistent
- [x] No True stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)