### PR TITLE
Fix(erdos-315): remove True-stub def greedyEgyptianProperty

### DIFF
--- a/proofs/Proofs/Erdos315Problem.lean
+++ b/proofs/Proofs/Erdos315Problem.lean
@@ -184,12 +184,6 @@ theorem erdos_315_solved : erdosGrahamConjecture := kamio_li_tang_2025
 ## Part VI: Why Sylvester's Sequence Is Special
 -/
 
-/-- Sylvester's sequence arises from the greedy algorithm for Egyptian fractions.
-    At each step, take the largest unit fraction not exceeding the remainder. -/
-def greedyEgyptianProperty : Prop :=
-  -- For all n: 1/u_{n+1} is the largest unit fraction ≤ 1 - Σ_{k≤n} 1/u_k
-  True
-
 /-- The double exponential growth: u_n ~ c₀^{2^n}. -/
 theorem sylvester_double_exponential :
     ∀ ε > 0, ∃ N : ℕ, ∀ n ≥ N,

--- a/src/data/proofs/erdos-315/annotations.json
+++ b/src/data/proofs/erdos-315/annotations.json
@@ -335,28 +335,6 @@
     ]
   },
   {
-    "id": "ann-e315-greedy",
-    "proofId": "erdos-315",
-    "range": {
-      "startLine": 191,
-      "endLine": 195
-    },
-    "type": "definition",
-    "title": "Greedy Egyptian Property",
-    "content": "**greedyEgyptianProperty:**\n\nSylvester's sequence arises from the greedy algorithm for Egyptian fractions: at each step, take the largest unit fraction $1/m$ not exceeding the remainder $r_n$, giving $u_{n+1} = \\lceil 1/r_n \\rceil$.\n\nCurrently defined as `True` (placeholder) since formalizing the greedy property requires reasoning about real-valued remainders and ceiling functions.",
-    "mathContext": "The greedy algorithm sets $r_0 = 1$ and $r_{n+1} = r_n - 1/u_{n+1}$ where $u_{n+1} = \\lceil 1/r_n \\rceil$. For Sylvester's sequence, $r_n = 1/\\prod_{k=0}^{n-1}(u_k - 1)$.",
-    "significance": "supporting",
-    "relatedConcepts": [
-      "Greedy algorithms",
-      "Egyptian fractions",
-      "Ceiling function"
-    ],
-    "prerequisites": [
-      "Real analysis",
-      "Egyptian fractions"
-    ]
-  },
-  {
     "id": "ann-e315-double-exp",
     "proofId": "erdos-315",
     "range": {

--- a/src/data/proofs/erdos-315/meta.json
+++ b/src/data/proofs/erdos-315/meta.json
@@ -64,10 +64,10 @@
       "Sequences and recurrences: doubly exponential growth",
       "Asymptotic analysis: growth rate comparison via n-th roots"
     ],
-    "lineCount": 258,
+    "lineCount": 252,
     "assumptions": "4 axioms: sylvester_sum_equals_one, vardiConstant_bounds, vardiConstant_is_limit, kamio_li_tang_2025. 0 sorries.",
     "theoremCount": 13,
-    "definitionCount": 12
+    "definitionCount": 11
   },
   "overview": {
     "historicalContext": "**Erdős Problem #315: Sylvester's Sequence and the Vardi Constant**\n\nSylvester's sequence (OEIS A000058) is: 2, 3, 7, 43, 1807, 3263443, ...\n\nIt arises from the greedy algorithm for Egyptian fractions and satisfies the remarkable property that Σ 1/u_n = 1. Egyptian fractions — representations of rationals as sums of distinct unit fractions — date back to the Rhind Papyrus (c. 1550 BCE), making this one of the oldest topics in number theory.\n\n**Key History:**\n- **Sylvester (1880):** James Joseph Sylvester introduced the sequence in the *American Journal of Mathematics* while studying the greedy algorithm for unit fraction decompositions. He showed the recurrence $u_{n+1} = u_n^2 - u_n + 1$ produces the unique greedy Egyptian representation of 1.\n- **Curtiss (1922):** D.R. Curtiss proved the product formula $u_n = \\lfloor E^{2^n} + 1/2 \\rfloor$ where $E \\approx 1.264$ is what would later be called the Vardi constant, establishing the doubly exponential growth rate.\n- **Erdős-Graham (1980):** In their influential monograph *Old and New Problems and Results in Combinatorial Number Theory*, Erdős and Graham conjectured that no other Egyptian sequence for 1 can match Sylvester's growth rate. This appeared as Problem #315.\n- **Vardi (1991):** Ilan Vardi studied the constant $c_0 = \\lim u_n^{1/2^n} \\approx 1.264085$ in *Computational Recreations in Mathematica*, establishing precise numerical bounds.\n- **Tang (correction):** Quanyu Tang identified that the original [ErGr80, p.41] formulation used $u_1 = 1$, which fails the unit sum condition. The correct version uses Sylvester's original $u_1 = 2$.\n- **Kamio (2025), Li-Tang (2025):** The conjecture was independently proved after 45 years. Kamio's proof (arXiv:2503.02317) and Li-Tang's proof (arXiv:2503.12277) both appeared in March 2025, using different analytic techniques to bound the growth rates of competing Egyptian sequences.",
@@ -140,33 +140,33 @@
     {
       "id": "special",
       "title": "Why Sylvester Is Special",
-      "summary": "The greedy property (each term is the greedy choice) and proved double exponential growth: $u_n \\sim c_0^{2^n}$ derived from the Vardi constant limit.",
+      "summary": "Proved double exponential growth: $u_n \\sim c_0^{2^n}$, derived from the Vardi constant limit via sylvester_double_exponential.",
       "startLine": 183,
-      "endLine": 202,
+      "endLine": 196,
       "mathContext": "$\\forall \\varepsilon > 0,\\; \\exists N : n \\geq N \\implies |u_n^{1/2^n} - c_0| < \\varepsilon$"
     },
     {
       "id": "related",
       "title": "Connection to Other Problems",
       "summary": "Links to Erdős-Straus conjecture ($4/n = 1/a + 1/b + 1/c$), odd greedy expansion, and OEIS references A000058 and A076393.",
-      "startLine": 203,
-      "endLine": 219,
+      "startLine": 197,
+      "endLine": 213,
       "mathContext": "Erdős-Straus: $\\forall n \\geq 2, \\exists a,b,c : 4/n = 1/a + 1/b + 1/c$"
     },
     {
       "id": "historical",
       "title": "Historical Note",
       "summary": "The original [ErGr80] formulation used $u_1=1, u_{n+1}=u_n(u_n+1)$, which doesn't satisfy $\\sum 1/u_n = 1$. Corrected by Quanyu Tang to the standard $u_1=2$ version.",
-      "startLine": 220,
-      "endLine": 229,
+      "startLine": 214,
+      "endLine": 223,
       "mathContext": "With $u_1=1$: $\\sum 1/u_n = 1/1 + 1/2 + 1/6 + \\cdots > 1$, violating the condition"
     },
     {
       "id": "summary",
       "title": "Summary",
       "summary": "erdos_315 and erdos_315_summary combine the solved conjecture with Vardi constant bounds $1.264 < c_0 < 1.265$. Status: SOLVED.",
-      "startLine": 230,
-      "endLine": 258,
+      "startLine": 224,
+      "endLine": 252,
       "mathContext": "$(\\text{erdosGrahamConjecture}) \\wedge (1.264 < c_0 < 1.265)$"
     }
   ],
@@ -210,10 +210,10 @@
       "Filter"
     ],
     "namespace": "Erdos315",
-    "lineCount": 258,
+    "lineCount": 252,
     "axiomCount": 4,
     "theoremCount": 13,
-    "definitionCount": 12,
+    "definitionCount": 11,
     "path": "Proofs/Erdos315Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Removes the vacuous `greedyEgyptianProperty : Prop := True` definition from `proofs/Proofs/Erdos315Problem.lean` and syncs the gallery metadata.

## Evidence

**Before**: `Erdos315Problem.lean:189-191` defined `greedyEgyptianProperty := True` — a vacuous stub. The `meta.json` "special" section and an annotation advertised the greedy-choice property as formalized content, but the def carried no mathematical statement.

**After**:
- `greedyEgyptianProperty := True` removed (no other references in the proof).
- `meta.json`: `definitionCount` 12→11, `lineCount` 258→252 (both `meta` and `leanFile` blocks).
- Section line ranges re-anchored after the 6-line removal: `special` 183–196, `related` 197–213, `historical` 214–223, `summary` 224–252.
- "special" section summary no longer claims a "greedy property" is formalized; now describes only the proved double-exponential growth.
- Removed the orphaned `ann-e315-greedy` annotation (which stated the def was "defined as `True` (placeholder)").

All other audited fields (4 axioms, 0 sorries, 13 theorems) are unchanged and remain correct.

Closes #21027

---
Automated fix by lean-mechanic agent.