### PR TITLE
audit(erdos-315): mark clean re-audit (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6075,8 +6075,8 @@
     },
     "erdos-315": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 5,
-      "lastAudited": "2026-05-29T19:58:09Z",
+      "auditCount": 6,
+      "lastAudited": "2026-05-29T20:08:04Z",
       "result": "clean"
     },
     "erdos-316": {


### PR DESCRIPTION
## Summary

- Re-audit of erdos-315 (Sylvester's sequence / Vardi constant)
- 0 sorries, 4 axioms (matches meta.json), 13 theorems, 11 definitions
- status=axiomatized / badge=axiom correct
- No True stubs, no Mathlib wrapper inflation

## Test plan

- [x] Verified axiom count: sylvester_sum_equals_one, vardiConstant_bounds, vardiConstant_is_limit, kamio_li_tang_2025
- [x] Verified 0 sorries
- [x] Verified status/badge consistency with axiomatized state

Generated with Claude Code