### PR TITLE
audit(erdos-309): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6026,9 +6026,9 @@
     },
     "erdos-309": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:56:43Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T20:49:17Z",
+      "result": "clean",
       "issues": [
         "phantom axiom narrative: sections claim croot_threshold_1999 axiom and yokota_refined_2002 axiom that are not declared (only docstrings); section line drift around line 213 (#14501)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-309 (Yokota integers-as-unit-fraction-sums theorem). All integrity checks pass.
- audit-tracker.json: cycle 3 -> 4, result \`issues-fixed\` -> \`clean\`.

## Integrity checks
- 3 sorries (matches meta.json sorries: 3)
- 1 axiom (\`yokota_lower_bound_1997\`) matches axiomCount: 1
- 12 theorems match theoremCount: 12
- 7 definitions match definitionCount: 7
- Line count 339 matches lineCount: 339
- No True stubs
- Status \`axiomatized\` with badge \`axiom\` correctly reflects Tier C scaffold with mixed axiom + sorry state
- \`assumptions\` field honestly reports both: "1 axiom: yokota_lower_bound_1997. 3 sorries."

## Test plan
- [x] Sorry/axiom/theorem/def counts verified by grep
- [x] No True stubs or assumption-encoding structures
- [x] Status/badge match assumptions field

🤖 Generated with [Claude Code](https://claude.com/claude-code)