### PR TITLE
audit(erdos-314): mark clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6066,9 +6066,9 @@
     },
     "erdos-314": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T01:46:10Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T21:04:11Z",
+      "result": "clean",
       "issues": [
         "section line drift across all 8 sections; missing diophantine section in meta.json; proofStrategy step 5 references orphan docstring (#14497)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-314 (Lim-Steinerberger Harmonic Sum Error Term)
- 5 axioms, 0 sorries, 9 theorems, 5 defs — all match meta.json
- Status `axiomatized` correctly reflects 5 axiom declarations
- No structure-encoded assumptions
- Audit count incremented 3 → 4

## Verification
- `axiomCount: 5` matches (m_of_n, m_of_n_minimal, m_of_n_achieves, lim_steinerberger_theorem, lim_steinerberger_bound_tendsto)
- `sorries: 0` matches
- `theoremCount: 9` matches (incl. private lemmas)
- `definitionCount: 5` matches
- `status: axiomatized` / `badge: axiom` correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)