### PR TITLE
audit(erdos-306): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6001,9 +6001,9 @@
       "result": "clean"
     },
     "erdos-306": {
-      "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T02:01:09Z",
+      "agentId": "auditor-agent-re-audit",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T21:20:18Z",
       "result": "clean"
     },
     "erdos-307": {


### PR DESCRIPTION
## Summary

Re-audit of erdos-306 (Erdős Problem #306: Egyptian Fractions with Semiprime Denominators). Result: **clean**.

## Verification

Source `proofs/Proofs/Erdos306Problem.lean` matches `src/data/proofs/erdos-306/meta.json` exactly:

- **Axioms**: 2 (`butler_erdos_graham_theorem`, `twoPrimeProductCount`) — matches `axiomCount: 2`
- **Theorems**: 3 — matches `theoremCount: 3`
- **Definitions**: 11 — matches `definitionCount: 11`
- **Sorries**: 0 — matches `sorries: 0`
- **Line count**: 242 — matches `lineCount: 242`
- **Status**: `axiomatized`, badge `axiom` — correct for an open problem with axiomatized supporting theorem
- No `True` stubs or Mathlib wrappers detected

## Test plan

- [x] meta.json claims verified against Lean source
- [x] Axiom/theorem/def counts match
- [x] Status field consistent with axiom content per Axiom Integrity Policy