### PR TITLE
audit(erdos-302): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5974,13 +5974,10 @@
       "result": "clean"
     },
     "erdos-302": {
-      "agentId": "auditor-loop-1777687577",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T02:08:25Z",
-      "result": "issues-fixed",
-      "issues": [
-        "Issue #14504: phantom axioms in section narratives (doubling, summary) + 11 section line ranges drifted"
-      ]
+      "agentId": "auditor-agent-re-audit",
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T22:05:13Z",
+      "result": "clean"
     },
     "erdos-303": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
Re-audit of erdos-302 (Unit Fraction Sum-Free Sets). All checks pass.

## Audit Findings
Source matches meta exactly:
- **3 axioms** (`cambie_lower_bound`, `van_doorn_upper_bound`, `brown_rodl_coloring`) — matches `axiomCount: 3`
- **16 theorems, 10 definitions** — matches meta
- **0 sorries, 0 True stubs**
- **414 lines** — matches `lineCount: 414`
- **Status `axiomatized`, badge `axiom`** — correct for open problem with axiomatized Cambie (2023) lower bound, van Doorn (2023) upper bound, and Brown-Rödl (1991) coloring result.

## Tracker Update
Incremented `auditCount` 3 → 4, set `result: "clean"` (prior audit was `issues-fixed` for Issue #14504 phantom-axiom narratives/line-range drift — both confirmed resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)