### PR TITLE
audit(erdos-296): mark clean re-audit (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5926,9 +5926,9 @@
     },
     "erdos-296": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T02:18:11Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-29T23:10:44Z",
+      "result": "clean"
     },
     "erdos-297": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit cycle 5 for erdos-296 (Disjoint Unit Fraction Partitions)
- All meta.json fields match Lean source: 0 sorries, 2 axioms (hunter_sawhney_lower, erdos_296_main), 6 definitions, 2 theorems, 160 lines
- Status "axiomatized" + badge "axiom" correctly reflects the 2 axiom declarations
- Proved theorems (k_not_sublogarithmic, k_infinitely_often_large) are genuine derivations, not stubs

## Test plan
- [x] Verified sorry count = 0
- [x] Verified axiom count = 2 (matches declared assumptions)
- [x] Verified no True stubs
- [x] Verified Mathlib dependencies properly disclosed

🤖 Generated with [Claude Code](https://claude.com/claude-code)