### PR TITLE
audit(erdos-290): mark clean re-audit (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5884,9 +5884,9 @@
     },
     "erdos-290": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T02:52:57Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T00:11:44Z",
+      "result": "clean",
       "issues": [
         "phantom axiom narrative + section drift: proofStrategy claims '6 axioms, 2 sorries' (actual 2/0); 5 section summaries claim axioms that are only block comments (van_doorn_lower_bound, van_doorn_explicit, van_doorn_infinitely_many_small, denom_divides_lcm, oeis_values, ratio_bounds); originalContributions overstates van_doorn axioms; section line ranges off by ~1-2 (#14518)"
       ]


### PR DESCRIPTION
## Summary
- Re-audited erdos-290 (Denominator Non-Monotonicity in Harmonic Sums, van Doorn 2024)
- All meta.json claims verified against `proofs/Proofs/Erdos290Problem.lean`
- 0 sorries, 2 axioms (`van_doorn_main`, `van_doorn_upper_bound`), 7 theorems, 21 definitions, 263 lines — all match
- Status `axiomatized` / badge `axiom` correctly reflects assumed van Doorn results
- No True stubs, no Mathlib wrappers
- Section ranges and narrative consistent with file

Bumps `auditCount` 3 → 4 and flips `result` to `clean` in audit-tracker.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)