### PR TITLE
audit(erdos-287): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5847,9 +5847,9 @@
     },
     "erdos-287": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T03:16:47Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T01:42:39Z",
+      "result": "clean",
       "issues": [
         "phantom axiom narrative + dangling docstrings: 2 phantom axioms (example_2_3_6, erdos_287_conjecture) listed in assumptions/originalContributions/proofStrategy/sections but never declared; proofStrategy claims '3 axioms, 91 lines' (actual 1/85); section line drift on example/conjecture (#14521)"
       ]


### PR DESCRIPTION
## Summary

Re-audit of erdos-287 (Erdős Problem #287). Result: **clean**.

- 0 sorries
- 1 axiom: `no_consecutive_reciprocals` (Erdős 1932 theorem on consecutive integer reciprocals)
- 1 theorem (`erdos_287`), 2 definitions (`IsUnitFractionDecomp`, `maxGap`)
- `lineCount: 85` in meta.json matches actual file (85 lines)
- `status: "axiomatized"`, `badge: "axiom"` — correctly reflect the single axiom
- `originalContributions` transparently lists the axiom
- No True stubs, no structure-encoded assumptions
- No phantom-axiom narrative remains (prior issue resolved in #14521)

## Test plan

- [x] Verified sorry count: `grep -cE '^\s*sorry$|:= by sorry|:= sorry' Erdos287Problem.lean` → 0
- [x] Verified axiom count: `grep -cE '^axiom ' Erdos287Problem.lean` → 1
- [x] Verified line count matches lineCount in meta.json (85)
- [x] Verified status/badge match Axiom Integrity Policy for axiomatized proofs

Generated with Claude Code