### PR TITLE
audit(erdos-284): fix assumptions text ('minimum function' → 'maximum first denominator')

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5825,11 +5825,11 @@
     },
     "erdos-284": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom theorems harmonic_interval/croot_2001/f_asymptotic claimed in originalContributions/mainTheorems but only docstrings, never declared; section line drift (examples L147–157 actually contains Part VI Summary header) — issue #14526"
       ],
-      "lastAudited": "2026-05-02T03:33:16Z",
+      "lastAudited": "2026-05-30T01:44:22Z",
       "result": "issues-fixed"
     },
     "erdos-285": {

--- a/src/data/proofs/erdos-284/meta.json
+++ b/src/data/proofs/erdos-284/meta.json
@@ -62,7 +62,7 @@
     ],
     "axiomCount": 3,
     "lineCount": 183,
-    "assumptions": "3 axioms: f (minimum function — axiomatized), f_upper_bound (upper bound on f), f_lower_bound (lower bound on f). 0 sorries.",
+    "assumptions": "3 axioms: f (maximum first denominator function — axiomatized), f_upper_bound (upper bound on f), f_lower_bound (lower bound on f). 0 sorries.",
     "dateUpdated": "2026-03-27",
     "theoremCount": 3,
     "definitionCount": 4


### PR DESCRIPTION
## Summary

Re-audit of erdos-284 (Croot 2001 / Erdős Problem #284). Result: **issues-fixed**.

**Issue found and fixed:** The `assumptions` field in `meta.json` described axiom `f` as a *"minimum function"*, but both the Lean source docstring and the entry `description` define `f(k)` as the **maximum first denominator** in a k-term Egyptian fraction representation of 1.

Source (`proofs/Proofs/Erdos284Problem.lean` line 70):
```
f(k) = max{n₁ : ∃ n₁ < ... < nₖ with 1 = Σ 1/nᵢ}
```

**Fix:** `"f (minimum function — axiomatized)"` → `"f (maximum first denominator function — axiomatized)"`.

## Other audit findings (clean)

- 0 sorries (matches `sorries: 0`)
- 3 axioms: `f`, `f_upper_bound`, `f_lower_bound` (matches `axiomCount: 3`)
- 183 lines (matches `lineCount: 183`)
- 3 theorems, 4 definitions (matches `theoremCount`/`definitionCount`)
- No True stubs, no structure-encoded assumptions
- `status: "axiomatized"`, `badge: "axiom"` — correct per Axiom Integrity Policy
- `originalContributions` already describes `f` accurately as "maximum first denominator function"

## Test plan

- [x] Verified sorry count → 0
- [x] Verified axiom count → 3, names match
- [x] Verified line count → 183
- [x] Verified the corrected text agrees with source docstring and entry description

Generated with Claude Code