### PR TITLE
audit(erdos-283): mark clean re-audit (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5819,9 +5819,9 @@
     },
     "erdos-283": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T03:35:49Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T02:13:57Z",
+      "result": "clean"
     },
     "erdos-284": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited **erdos-283** (Egyptian Fractions and Polynomial Values)
- Result: **clean** (audit count 3 → 4)

## Verification
- 0 sorries in `proofs/Proofs/Erdos283Problem.lean`
- 2 axioms (`graham_theorem`, `alekseyev_theorem`) matching `meta.json` axiomCount
- 7 theorems, 4 definitions — matches meta.json
- 157 lines — matches meta.json
- Status `"axiomatized"` with `"axiom"` badge — consistent with 2 axioms
- No structure-encoded assumptions (no `NSAxioms`-style typeclasses)
- No True stubs, no Mathlib wrappers
- Imports and cross-references check out

## Test plan
- [x] Read meta.json and Lean source
- [x] Counted sorries (0) and axioms (2)
- [x] Verified status/badge consistency
- [x] Confirmed no structure-encoded assumptions

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)