### PR TITLE
audit(erdos-281): mark clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5804,9 +5804,9 @@
     },
     "erdos-281": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T03:45:20Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T02:31:00Z",
+      "result": "clean",
       "issues": [
         "phantom-axiom narrative: claims axiomatization of divergence/coprime/Davenport-Erdős/Rogers but only erdos_281_proved exists; sections.divergence-coprime summary describes content that is only dangling docstrings (lines 217-219) — issue #14532"
       ]


### PR DESCRIPTION
## Summary
- Re-audited Erdős Problem #281 (Covering Congruences and Density)
- Verified all meta.json claims against `Proofs/Erdos281Problem.lean`: 0 sorries, 1 axiom (`erdos_281_proved`), 13 theorems, 11 definitions, 250 lines
- Status `axiomatized` / badge `axiom` correctly reflects the single axiom encoding the hard direction (Davenport–Erdős + Rogers)
- Bumps tracker `auditCount: 3 → 4`, result `issues-fixed → clean`

## Test plan
- [x] `wc -l proofs/Proofs/Erdos281Problem.lean` → 250
- [x] axiom/sorry counts match meta
- [x] no structure-encoded assumptions, no True stubs, no Mathlib wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)