### PR TITLE
audit(erdos-277): mark clean re-audit (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5762,9 +5762,9 @@
     },
     "erdos-277": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T03:55:51Z",
-      "result": "issues-fixed",
+      "auditCount": 6,
+      "lastAudited": "2026-05-30T02:56:27Z",
+      "result": "clean",
       "issues": [
         "Phantom sorries/placeholders in sections[] narrative + openQuestions; numerical fields correct (#14537)"
       ]


### PR DESCRIPTION
## Summary
Re-audited **erdos-277** (Covering Systems and Abundancy / Haight 1979).

## Verified
- 0 sorries in `proofs/Proofs/Erdos277Problem.lean`
- 1 `axiom` declaration (`haight_theorem`) matching `meta.json` `axiomCount: 1`
- 12 theorems, 18 definitions (matches `meta.json`)
- 275 lines (matches `meta.json`)
- Status `axiomatized` with `axiom` badge — consistent
- No structure-encoded assumptions
- No `True` stubs, no trivial Mathlib wrappers
- Imports, cross-references, and section ranges check out

## Result
clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)