### PR TITLE
audit(erdos-274): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5744,9 +5744,9 @@
     },
     "erdos-274": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T03:59:28Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T03:12:37Z",
+      "result": "clean"
     },
     "erdos-275": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audited erdos-274 (Herzog-Schönheim Conjecture, abelian case).

Verified:
- 0 sorries in `proofs/Proofs/Erdos274Problem.lean`
- 1 axiom (`sun_abelian_case`) matching `axiomCount: 1`
- 3 theorems, 3 definitions (structure `ExactCovering` + 2 defs) — matches meta.json
- 127 lines matches `lineCount: 127`
- Status `axiomatized` with `axiom` badge — consistent
- No True stubs, no Mathlib wrappers
- No structure-encoded assumptions beyond the documented axiom

Result: clean.

## Test plan
- [x] meta.json claims cross-checked against Lean source
- [x] Tracker entry bumped (auditCount 3 → 4, result "clean")

🤖 Generated with [Claude Code](https://claude.com/claude-code)