### PR TITLE
audit(erdos-275): mark clean re-audit (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5750,9 +5750,9 @@
     },
     "erdos-275": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T04:06:14Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T03:22:03Z",
+      "result": "clean"
     },
     "erdos-276": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-275 (Covering Congruences) for cycle 6
- All integrity checks pass — meta.json claims match Lean source exactly

## Audit Findings (clean)
- **axiomCount: 2** matches `erdos_275_theorem` + `not_covered_2r_minus_1`
- **sorries: 0** matches Lean source
- **lineCount: 171** matches
- **theoremCount: 1, definitionCount: 9** matches
- **Status:** `axiomatized` with badge `axiom` — correct per axiom-integrity policy
- **assumptions field** names both axioms correctly
- No True stubs, no Mathlib wrappers

## Test plan
- [x] Tracker updated to `result: clean`, `auditCount: 4`
- [x] No code changes; meta.json + Lean source unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)