### PR TITLE
audit(erdos-280): mark clean re-audit (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5790,10 +5790,10 @@
       "result": "clean"
     },
     "erdos-280": {
-      "agentId": "auditor-cycle-21-issue-14552",
-      "auditCount": 4,
-      "lastAudited": "2026-05-02T04:18:24Z",
-      "result": "issues-fixed",
+      "agentId": "auditor-agent",
+      "auditCount": 5,
+      "lastAudited": "2026-05-29T00:00:00Z",
+      "result": "clean",
       "issues": [
         "phantom axiom 'cambie_only_one_avoider' in originalContributions; section summaries reference cambie_satisfies_growth/cambie_only_one_avoider/cambie_count_is_one/prime_number_theorem_approx that exist only as docstrings; section line ranges drifted — issue #14535",
         "phantom-axiom narrative in proofStrategy: claims 'growth bound, covering property, exact count, and conjecture refutation are axiomatized' but only original_conjecture_false exists; growth/covering/count are dangling docstrings (lines 78-83) — issue #14552"


### PR DESCRIPTION
## Summary
- Re-audit cycle 5 of erdos-280 (Covering Congruences and Sieve Methods)
- Verified all counts match meta.json: 0 sorries, 1 axiom, 3 theorems, 6 defs, 113 lines, 0 True stubs
- status=axiomatized correctly reflects 1 axiom (original_conjecture_false)

## Verification
| Field | meta.json | Lean source | Match |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 113 | 113 | ✓ |

Phantom-axiom narrative previously cleaned (issues #14535, #14552) remains resolved. No drift detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)