### PR TITLE
audit(erdos-264): mark clean re-audit (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5673,9 +5673,9 @@
     },
     "erdos-264": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T04:14:26Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T04:24:12Z",
+      "result": "clean",
       "issues": [
         "phantom-axiom narrative: originalContributions/proofStrategy/sections claim formal statements for Kovač-Tao negative/positive criteria and 2^(2ⁿ) example that exist only as docstrings (issue #14549)"
       ]


### PR DESCRIPTION
## Summary
- Re-audited erdos-264 (Irrationality Sequences, Kovač-Tao 2024).
- Counts verified against Lean source: 1 axiom, 1 theorem, 1 def, 137 lines, 0 sorries, 0 True stubs.
- Prior phantom-axiom narrative (#14549) is properly remediated in meta.json — docstring-only Kovač-Tao criteria and 2^(2ⁿ) example are explicitly disclaimed.
- Status \`axiomatized\` / badge \`axiom\` correctly reflects 1 axiom (\`powers_of_two_not_irrationality_seq\`).

## Test plan
- [x] Lean source counts match meta.json claims
- [x] No structure-encoded assumptions
- [x] Prior issue disclaimers present in proofStrategy and sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)