### PR TITLE
audit(erdos-259): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5631,9 +5631,9 @@
     },
     "erdos-259": {
       "agentId": "auditor-2026-05-02-erdos-259",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T04:38:14Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T04:33:13Z",
+      "result": "clean",
       "issues": [
         "section line drift: sections[].startLine/endLine off by ~20–90 lines; missing 'Squarefree Numbers' section (issue #14564)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-259 (Erdős Problem #259: Irrationality of Squarefree Sums); auditCount 3→4
- All meta.json counts match `proofs/Proofs/Erdos259Problem.lean`: 2 axioms, 0 sorries, 14 theorems, 4 declarations (3 def + 1 abbrev), 239 lines
- Status `axiomatized` + badge `axiom` correct: Chen-Ruzsa (1999) result depends on transcendence theory beyond current Mathlib; the two axioms (`series_summable`, `chen_ruzsa_irrationality`) faithfully encode the assumption set

## Test plan
- [x] Verified counts via grep against source
- [x] Confirmed status/badge consistency with axiom-bearing structure
- [x] No issues found; tracker entry updated to clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)