### PR TITLE
audit(erdos-255): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5607,9 +5607,9 @@
     },
     "erdos-255": {
       "agentId": "auditor-2026-05-02T04:57:20.128138Z",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T04:56:46Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T05:29:49Z",
+      "result": "clean"
     },
     "erdos-256": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audit of Erdős Problem #255 (Discrepancy of Sequences in [0,1])
- All meta.json counts match `proofs/Proofs/Erdos255Problem.lean`
- Tracker bumped to cycle 4 (auditCount 3 → 4), result: clean

## Audit Verification

| Field | meta.json | Source | Status |
|-------|-----------|--------|--------|
| sorries | 0 | 0 | OK |
| axiomCount | 3 | 3 (schmidt_1968, schmidt_1972, van_der_corput) | OK |
| theoremCount | 2 | 2 (no_uniformly_bounded_discrepancy, erdos_255_summary) | OK |
| definitionCount | 10 | 10 | OK |
| lineCount | 163 | 163 | OK |
| status | axiomatized | 3 axioms -> axiomatized | OK |
| badge | axiom | axiom | OK |

No issues found.

## Test plan

- [x] sorry count matches
- [x] axiom count matches
- [x] No True stubs
- [x] status/badge consistent with axiom declarations

Generated with Claude Code