### PR TITLE
audit(erdos-239): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5487,9 +5487,9 @@
     },
     "erdos-239": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T05:03:16Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T06:31:29Z",
+      "result": "clean"
     },
     "erdos-24": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audit of erdos-239 (Wirsing/Halász mean values of multiplicative ±1 functions)
- meta.json matches Lean source exactly: 275 lines, 6 axioms, 0 sorries, 10 theorems, 13 defs
- All 6 named axioms verified present in Lean source
- Status `axiomatized` and badge `axiom` honestly reflect that Wirsing's theorem is axiomatized rather than proved

## Test plan
- [x] meta.json claims match Lean source
- [x] Tier classification (Tier C — Scaffold/axiomatized) is correct
- [x] No True stubs, no Mathlib wrapper masking, no axiom masking
- [x] Audit tracker incremented (3 → 4 audits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)