### PR TITLE
Research(fourier-series-oq-04-oq-01): S9 ACT cofinality bearer (latticeDisc_eventually_supset)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ04OQ01.lean
+++ b/proofs/Proofs/FourierSeriesOQ04OQ01.lean
@@ -274,6 +274,102 @@ theorem latticeDisc_card_le_real (R : ℝ) :
     pow_le_pow_left₀ h_nn_R h_lin 2
   linarith
 
+/-! ## S2e-cofinality — `latticeDisc R` eventually contains any fixed lattice-point set
+
+Stepping-stone for the S2e ACT discharge of `sphPartialSum_L2_norm_converge`:
+the cofinality lemma `latticeDisc_eventually_supset` says that for every
+finite set `S` of lattice points, `S ⊆ latticeDisc R` for all sufficiently
+large `R`. Combined with the eventual identification of `sphPartialSum` with
+a finset-sum projection onto the multi-Fourier basis, this turns the
+Plancherel residual `‖S_R^{sph} f - f‖₂² = ∑_{k ∉ latticeDisc R} |fk|²`
+into a tail of a convergent series — the engine of the unconditional
+L²-norm-convergence close.
+
+Pure ℝ/ℤ arithmetic — no measure-theoretic dependencies. -/
+
+/-- **Singleton-case cofinality**: every fixed lattice point `k ∈ ℤ²` is
+    eventually contained in `latticeDisc R` as `R → ∞`. Proof: for
+    `R ≥ (k 0)² + (k 1)² + 1`, both the disc condition
+    `(k 0)² + (k 1)² ≤ R²` and the bounding-box condition
+    `|k i| ≤ ⌈|R|⌉` hold. -/
+theorem latticeDisc_mem_eventually (k : Fin 2 → ℤ) :
+    ∀ᶠ R in (atTop : Filter ℝ), k ∈ latticeDisc R := by
+  refine Filter.eventually_atTop.mpr ?_
+  refine ⟨((k 0 : ℝ))^2 + ((k 1 : ℝ))^2 + 1, fun R hR => ?_⟩
+  -- Setup: nonneg facts, R ≥ 1, |R| = R, R² ≥ R
+  have h0 : (0 : ℝ) ≤ ((k 0 : ℝ))^2 := sq_nonneg _
+  have h1 : (0 : ℝ) ≤ ((k 1 : ℝ))^2 := sq_nonneg _
+  have hR1 : (1 : ℝ) ≤ R := by linarith
+  have hRnn : (0 : ℝ) ≤ R := by linarith
+  have hRabs : |R| = R := abs_of_nonneg hRnn
+  -- For R ≥ 1: R ≤ R²  (since R² - R = R(R-1) ≥ 0)
+  have hRR : R ≤ R^2 := by nlinarith
+  -- Disc condition: (k 0)² + (k 1)² ≤ R²
+  have hsum : ((k 0 : ℝ))^2 + ((k 1 : ℝ))^2 ≤ R^2 := by linarith
+  -- Component-wise squared bounds (explicit indices to avoid fin_cases atom mismatch)
+  have hbox0_sq : ((k 0 : ℝ))^2 ≤ R^2 := by linarith
+  have hbox1_sq : ((k 1 : ℝ))^2 ≤ R^2 := by linarith
+  -- Absolute-value bounds via sqrt monotonicity
+  have habs0 : |((k 0 : ℝ))| ≤ R := by
+    have := Real.sqrt_le_sqrt hbox0_sq
+    rwa [Real.sqrt_sq_eq_abs, Real.sqrt_sq hRnn] at this
+  have habs1 : |((k 1 : ℝ))| ≤ R := by
+    have := Real.sqrt_le_sqrt hbox1_sq
+    rwa [Real.sqrt_sq_eq_abs, Real.sqrt_sq hRnn] at this
+  -- ⌈|R|⌉ ≥ R: chain |R| = R with |R| ≤ ⌈|R|⌉
+  have hceil_ge : R ≤ (⌈|R|⌉ : ℝ) := by
+    have h : (|R| : ℝ) ≤ (⌈|R|⌉ : ℝ) := Int.le_ceil _
+    linarith
+  -- Per-index bounds combining |k i| ≤ R with R ≤ ⌈|R|⌉
+  have hki_le0 : (k 0 : ℝ) ≤ (⌈|R|⌉ : ℝ) :=
+    (le_abs_self _).trans habs0 |>.trans hceil_ge
+  have hki_le1 : (k 1 : ℝ) ≤ (⌈|R|⌉ : ℝ) :=
+    (le_abs_self _).trans habs1 |>.trans hceil_ge
+  have hki_ge0 : -(⌈|R|⌉ : ℝ) ≤ (k 0 : ℝ) := by
+    have : -((k 0 : ℝ)) ≤ R := (neg_le_abs _).trans habs0
+    linarith
+  have hki_ge1 : -(⌈|R|⌉ : ℝ) ≤ (k 1 : ℝ) := by
+    have : -((k 1 : ℝ)) ≤ R := (neg_le_abs _).trans habs1
+    linarith
+  -- Discharge latticeDisc membership
+  unfold latticeDisc
+  rw [Finset.mem_filter]
+  refine ⟨?_, hsum⟩
+  rw [Finset.mem_Icc]
+  refine ⟨fun i => ?_, fun i => ?_⟩
+  · -- Lower bound: -⌈|R|⌉ ≤ k i in ℤ
+    fin_cases i
+    · exact_mod_cast hki_ge0
+    · exact_mod_cast hki_ge1
+  · -- Upper bound: k i ≤ ⌈|R|⌉ in ℤ
+    fin_cases i
+    · exact_mod_cast hki_le0
+    · exact_mod_cast hki_le1
+
+/-- **Cofinality of `latticeDisc R`**: for any finite set `S ⊂ ℤ²` of lattice
+    points, `S ⊆ latticeDisc R` for all sufficiently large `R`. Direct
+    consequence of `latticeDisc_mem_eventually` by induction on `S`.
+
+    This is the cofinality bearer noted in the S2e PREP / S7 audit (`atTop`
+    cofinality of `latticeDisc`) used by the S2e ACT to discharge
+    `sphPartialSum_L2_norm_converge` via the standard Plancherel argument:
+    Bessel's inequality on the multi-Fourier basis gives
+    `‖S_R^{sph} f - f‖₂² = ∑_{k ∉ latticeDisc R} |fk|²`, and this cofinality
+    lemma converts the right-hand sum into a tail of the convergent
+    Plancherel series `∑_k |fk|² = ‖f‖₂²`. -/
+theorem latticeDisc_eventually_supset (S : Finset (Fin 2 → ℤ)) :
+    ∀ᶠ R in (atTop : Filter ℝ), S ⊆ latticeDisc R := by
+  classical
+  induction S using Finset.induction_on with
+  | empty =>
+    exact Filter.Eventually.of_forall (fun _ => Finset.empty_subset _)
+  | @insert k S _hkS ih =>
+    filter_upwards [ih, latticeDisc_mem_eventually k] with R hSR hkR
+    intro j hj
+    rcases Finset.mem_insert.mp hj with rfl | hjS
+    · exact hkR
+    · exact hSR hjS
+
 end
 
 end FourierSeriesOQ04OQ01

--- a/research/problems/fourier-series-oq-04-oq-01/sessions/2026-05-29-s9-act-cofinality.md
+++ b/research/problems/fourier-series-oq-04-oq-01/sessions/2026-05-29-s9-act-cofinality.md
@@ -1,0 +1,145 @@
+# S9 ACT — Cofinality bearer landed (step 3 of S7 audit §4 recipe)
+
+**Researcher**: researcher-1
+**Date**: 2026-05-29
+**Mode**: ACT (sorry-free / axiom-free Lean delta; not STATE-SYNC)
+**Phase delta**: Iteration 7 → 8; phase header unchanged (still ACT)
+**Worktree HEAD**: branch `feature/researcher-1` off main `25e69ba357e`
+**Mathlib pin**: unchanged
+
+---
+
+## §1 — Trigger
+
+S7 audit's §4 recipe (carried by S8 STATE-SYNC #19385) specifies a 6-step
+S2e ACT close of `sphPartialSum_L2_norm_converge`:
+
+1. Setup (3-5 LOC)
+2. Drop in `coeFn_finset_sum` helper (8-10 LOC)
+3. **Cofinality `latticeDisc_eventually_supset` in `∀ᶠ` form (15-25 LOC)** ← this iteration
+4. Bridge `sphPartialSum` → Lp finset-sum (15-25 LOC)
+5. Cite `hasSum_mFourier_series_L2` (5-10 LOC)
+6. Close `eLpNorm`-form via `Lp.norm_def` (5-10 LOC)
+
+Step 3 is independent of all other steps (pure ℝ/ℤ arithmetic — no Lp /
+volume / haarT2 dependencies). Landing it standalone shrinks the future
+ACT scope without taking on the risky measure-theoretic bridge work.
+
+---
+
+## §2 — Deliverables
+
+Two new sorry-free, axiom-free public theorems in
+`proofs/Proofs/FourierSeriesOQ04OQ01.lean` (in a new `S2e-cofinality`
+section after `latticeDisc_card_le_real`):
+
+### §2.1 `latticeDisc_mem_eventually` (singleton case)
+
+```lean
+theorem latticeDisc_mem_eventually (k : Fin 2 → ℤ) :
+    ∀ᶠ R in (atTop : Filter ℝ), k ∈ latticeDisc R
+```
+
+**Witness**: `R₀ = (k 0 : ℝ)² + (k 1 : ℝ)² + 1`.
+
+**Proof outline**: For `R ≥ R₀`:
+- Nonneg sums give `R ≥ 1`, hence `|R| = R` and `R ≤ R²` (via `nlinarith`).
+- Disc condition: `(k 0)² + (k 1)² ≤ R²` by `linarith` from `R ≤ R² ∧ R ≥ R₀`.
+- Bounding-box condition: from `(k i)² ≤ R²` (chained from the disc bound + nonneg of the other component) get `|k i| ≤ R` via `Real.sqrt_le_sqrt` + `Real.sqrt_sq_eq_abs` + `Real.sqrt_sq hRnn`. Then `R ≤ ⌈|R|⌉` via `Int.le_ceil`, giving `|k i| ≤ ⌈|R|⌉`. The lower/upper conjuncts of `Finset.mem_Icc` follow by `exact_mod_cast` after a `linarith` chain through `le_abs_self` / `neg_abs_le`.
+
+LOC: ~50 (proof body), 5 (signature + docstring).
+
+### §2.2 `latticeDisc_eventually_supset` (full cofinality)
+
+```lean
+theorem latticeDisc_eventually_supset (S : Finset (Fin 2 → ℤ)) :
+    ∀ᶠ R in (atTop : Filter ℝ), S ⊆ latticeDisc R
+```
+
+**Proof**: `Finset.induction_on`:
+- Empty case: `Filter.Eventually.of_forall ∘ Finset.empty_subset`.
+- Insert case: `filter_upwards [ih, latticeDisc_mem_eventually k]`, then split membership of `j ∈ insert k S` via `Finset.mem_insert.mp` and dispatch each case.
+
+LOC: ~15 (proof body), 12 (signature + docstring).
+
+**Total new LOC**: ~85 (theorems + section header docstring).
+
+---
+
+## §3 — Why this is safe to ship standalone
+
+| Property | Status | Notes |
+|---|---|---|
+| Sorry-free | ✅ | No `sorry` in either new theorem |
+| Axiom-free | ✅ | No new `axiom` declarations |
+| Measure-theory-free | ✅ | Pure ℝ/ℤ arithmetic; no `Lp`, `volume`, `haarT2`, `MemLp` |
+| Mathlib-stable | ✅ | Uses only `Real.sqrt_*`, `Int.le_ceil`, `Filter.eventually_atTop`, `Finset.induction_on`, `Finset.mem_filter`, `Finset.mem_Icc`, `Finset.mem_insert` — all in v4.26.0 |
+| Standalone | ✅ | Independent of S2e ACT's remaining steps 1+2+4+5+6 |
+| Publicly useful | ✅ | Marked as `theorem` (not `private`); can be cited by downstream slug consumers |
+| Composable | ✅ | The `∀ᶠ` form composes via `filter_upwards` with future bridge steps |
+
+The lemma is the cofinality bearer for any Plancherel-style argument that
+identifies `‖S_R^{sph} f - f‖₂²` with a tail of the convergent series
+`∑_k |fk|²`. The future step 4 (bridge) will produce an a.e. identification
+`(S_R^{sph} f - f)(x) = ∑_{k ∉ latticeDisc R} fk · e_k(x)`; this lemma is
+what reduces the right-hand `tsum` to the convergent tail.
+
+---
+
+## §4 — Build verification
+
+Docker build via `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ04OQ01`
+(per CLAUDE.md's mandatory wrapper for `lake build` — direct invocation is
+unsafe). Build result: ✅ **7743 jobs replayed cleanly**, single expected
+warning `Proofs/FourierSeriesOQ04OQ01.lean:148:8: declaration uses 'sorry'`
+(the pre-existing `sphPartialSum_L2_norm_converge` sorry, unchanged). No
+new warnings from the cofinality addition.
+
+---
+
+## §5 — Gallery sync
+
+`src/data/proofs/fourier-series-oq-04-oq-01/meta.json`:
+- `lineCount`: 279 → 366 (synced in both top-level `leanFile` and inner `meta` blocks)
+- `theoremCount`: 8 → 10
+- `sorries`: 1 (unchanged)
+- `axiomCount`: 1 (unchanged)
+- `originalContributions`: extended with 1 entry for the cofinality
+  pair + 1 entry for the S2-Gauss-real real-form bound (missed in prior
+  meta-sync — corrects an `originalContributions` drift from the
+  S2-Gauss-real session).
+- `sections`: new `lattice-disc-cofinality` entry with `startLine: 277`,
+  `endLine: 362`.
+
+---
+
+## §6 — S2e ACT scope reduction
+
+| Step | Pre-S9 budget | Post-S9 budget | Status |
+|---|---|---|---|
+| 1 — Setup (haarT2/volume) | 3-5 LOC + 3-5 LOC contingency | unchanged | pending |
+| 2 — `coeFn_finset_sum` helper | 8-10 LOC | unchanged | pending |
+| 3 — Cofinality | 15-25 LOC | **0 LOC (DONE this iter)** | ✅ |
+| 4 — Bridge `sphPartialSum` → Lp | 15-25 LOC | unchanged | pending |
+| 5 — Cite engine | 5-10 LOC | unchanged | pending |
+| 6 — Close `eLpNorm`-form | 5-10 LOC | unchanged | pending |
+| **Total** | **53-90 LOC** | **38-65 LOC** | scope reduction ~30% |
+
+The remaining S2e ACT close is now a 38-65 LOC single-iteration target
+(plus 2-3 Docker iterations) — closer to a true one-shot ACT.
+
+---
+
+## §7 — Honest-status block
+
+- **Mathematical progress this iteration**: 2 new theorems
+  (`latticeDisc_mem_eventually`, `latticeDisc_eventually_supset`). Both
+  sorry-free, axiom-free, build-verified. The cofinality bearer for the
+  Plancherel-tail engine is now in place.
+- **Build-verification status**: ✅ Docker-built clean at HEAD (7743 jobs,
+  single expected pre-existing sorry at line 148).
+- **Race disclosure**: 0 open PRs touching
+  `proofs/Proofs/FourierSeriesOQ04OQ01.lean` at iteration pickup.
+- **Open conjecture status**: unchanged (Carleson L²-pointwise
+  convergence for 2D spherical-Fourier sums remains open;
+  `carleson_2d_sph` axiom unchanged at line 132).

--- a/research/problems/fourier-series-oq-04-oq-01/state.md
+++ b/research/problems/fourier-series-oq-04-oq-01/state.md
@@ -2,11 +2,55 @@
 
 ## Current State
 **Phase**: ACT
-**Since**: 2026-05-16 (S8 STATE-SYNC absorbs S7 audit)
-**Iteration**: 7
-**Last Update**: 2026-05-16 (researcher-9) — S8 STATE-SYNC absorbs S7 audit-at-pick-time (PR #19411, researcher-12, MERGED 03:26:54Z); gate-4 AMBER→GREEN; all 6 ACT-readiness gates GREEN; S2e ACT fully unblocked at next iteration
+**Since**: 2026-05-29 (S9 ACT — cofinality bearer landed)
+**Iteration**: 8
+**Last Update**: 2026-05-29 (researcher-1) — **S9 ACT cofinality**: `latticeDisc_mem_eventually` + `latticeDisc_eventually_supset` landed as sorry-free / axiom-free public theorems (~85 LOC). Discharges step 3 of the S7 audit §4 recipe (cofinality bearer). The remaining S2e ACT scope shrinks to ~35-60 LOC (steps 1+2+4+5+6); the eLpNorm-form close is unblocked.
 
 ## Current Focus
+
+S9 ACT cofinality (researcher-1, 2026-05-29) — **ACT mini-task delivering
+the cofinality bearer** of the S7 audit §4 recipe (step 3, 15-25 LOC
+budgeted; actual ~85 LOC including the singleton helper). Adds two
+sorry-free, axiom-free, public theorems:
+
+- `latticeDisc_mem_eventually (k : Fin 2 → ℤ) : ∀ᶠ R in (atTop : Filter ℝ), k ∈ latticeDisc R`
+  — singleton-case cofinality. For `R ≥ (k 0)² + (k 1)² + 1`, the
+  cardinality condition `(k 0)² + (k 1)² ≤ R²` (via `R ≥ 1 ⇒ R ≤ R²`)
+  and the bounding-box condition `|k i| ≤ ⌈|R|⌉` (via `Real.sqrt_sq_eq_abs`
+  + `Int.le_ceil`) both hold.
+- `latticeDisc_eventually_supset (S : Finset (Fin 2 → ℤ)) : ∀ᶠ R in (atTop : Filter ℝ), S ⊆ latticeDisc R`
+  — the full cofinality lemma. By `Finset.induction_on` from
+  `latticeDisc_mem_eventually`, combining the per-point witnesses via
+  `Filter.filter_upwards`.
+
+The lemmas are **pure ℝ/ℤ arithmetic** — they use no measure-theoretic
+APIs, no `Lp`, no `volume`/`haarT2` disambiguation. Tactics: `linarith`,
+`nlinarith`, `Real.sqrt_le_sqrt`, `Real.sqrt_sq_eq_abs`, `Int.le_ceil`,
+`Finset.mem_filter`, `Finset.mem_Icc`, `Finset.induction_on`,
+`Filter.eventually_atTop`. No new sorries, no new axioms.
+
+**S2e ACT scope after this iteration**: step 3 (cofinality) ✅ done.
+Remaining recipe = steps 1 (Setup, 3-5 LOC) + 2 (drop-in `coeFn_finset_sum`
+helper, 8-10 LOC) + 4 (Bridge `sphPartialSum` → Lp finset-sum, 15-25 LOC) +
+5 (cite `hasSum_mFourier_series_L2`, 5-10 LOC) + 6 (close `eLpNorm`-form
+via `Lp.norm_def`, 5-10 LOC) = 36-60 LOC + 3-5 LOC haarT2/volume contingency.
+A future single-iteration close is now genuinely tractable.
+
+**Build status**: Docker-built and verified (researcher-1, 2026-05-29,
+7743 jobs, only the pre-existing `sphPartialSum_L2_norm_converge` sorry
+warning at line 148; no new warnings from the cofinality addition).
+Updated Lean file: `proofs/Proofs/FourierSeriesOQ04OQ01.lean` (279 → 366
+lines, 8 → 10 theorems; +2 sorry-free public theorems in a new
+"S2e-cofinality" section after `latticeDisc_card_le_real`). Gallery
+meta-json line/theorem counts synced; new `lattice-disc-cofinality`
+section added with `startLine: 277`, `endLine: 362`; `originalContributions`
+extended.
+
+Full forensics in `sessions/2026-05-29-s9-act-cofinality.md`.
+
+---
+
+## Previous Focus — S8 STATE-SYNC (2026-05-16, researcher-9, MERGED)
 
 S8 STATE-SYNC (researcher-9, 2026-05-16) — **doc-only absorption of
 the S7 audit-at-pick-time merge**. PR #19411 (researcher-12, MERGED

--- a/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
@@ -5,14 +5,21 @@
   "description": "Axiomatizes the 2D Carleson conjecture on T² = (R/Z)²: for f ∈ L²(T²), the spherical partial Fourier sum S_R^sph f converges to f for almost every x as R → ∞. This is the L²-endpoint of the Bochner-Riesz / spherical-summation family and the natural higher-dimensional analogue of the 1D Carleson theorem (1966). Open in mathematics; no improvement on Fefferman's 1971 ball-multiplier barrier. Companion unconditional theorem (L² norm convergence by Plancherel) stated with sorry pending the Plancherel-on-T² lemma (Mathlib gap).",
   "leanFile": {
     "path": "Proofs/FourierSeriesOQ04OQ01.lean",
-    "imports": ["Mathlib"],
-    "opens": ["MeasureTheory", "Complex", "Filter", "Topology"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "MeasureTheory",
+      "Complex",
+      "Filter",
+      "Topology"
+    ],
     "namespace": "FourierSeriesOQ04OQ01",
-    "lineCount": 279,
+    "lineCount": 375,
     "axiomCount": 1,
     "sorries": 1,
     "definitionCount": 5,
-    "theoremCount": 8
+    "theoremCount": 10
   },
   "meta": {
     "author": "Open in mathematics (Stein 1971 ICM; Tao 2002 survey). Formalized statement: Lean Genius contributors.",
@@ -33,8 +40,8 @@
     "sorries": 1,
     "dateAdded": "2026-05-12",
     "axiomCount": 1,
-    "lineCount": 279,
-    "theoremCount": 8,
+    "lineCount": 375,
+    "theoremCount": 10,
     "definitionCount": 5,
     "assumptions": "1 axiom: `carleson_2d_sph` — the open 2D Carleson spherical-summation conjecture on T². 1 sorry: `sphPartialSum_L2_norm_converge` — the unconditional L²-norm convergence statement; provable from Plancherel on T² (Mathlib gap; the orthonormal basis tensor-product structure is implicit but not exposed as a named identity). No other assumptions.",
     "mathlibDependencies": [
@@ -79,7 +86,9 @@
       "sphPartialSum_L2_norm_converge: unconditional L²-norm convergence statement (Plancherel-direct; sorried)",
       "multiFourierCoeff_zero, sphPartialSum_zero: sanity-check lemmas (zero function in / zero coefficient out)",
       "latticeDisc_subset_bbox, latticeDisc_card_le_bbox (S2c): trivial pre-Gauss bounding-box cardinality bound for the lattice disc",
-      "bbox_card, latticeDisc_card_le_explicit (S2d): explicit bounding-box cardinality (2⌈|R|⌉+1)² via Pi.card_Icc + Int.card_Icc, yielding the closed-form O(R²) Gauss-circle upper bound for the lattice disc"
+      "bbox_card, latticeDisc_card_le_explicit (S2d): explicit bounding-box cardinality (2⌈|R|⌉+1)² via Pi.card_Icc + Int.card_Icc, yielding the closed-form O(R²) Gauss-circle upper bound for the lattice disc",
+      "latticeDisc_card_le_real (S2-Gauss-real): Real-form qualitative Gauss-circle bound ((latticeDisc R).card : ℝ) ≤ (2|R|+3)² suitable for ℓ¹-majorisation of sphPartialSum",
+      "latticeDisc_mem_eventually, latticeDisc_eventually_supset (S2e-cofinality, iter 8): atTop cofinality of latticeDisc — every fixed finite set of lattice points is eventually contained in latticeDisc R as R → ∞; stepping-stone for the Plancherel-tail engine that closes sphPartialSum_L2_norm_converge"
     ]
   },
   "overview": {
@@ -149,6 +158,14 @@
       "endLine": 230,
       "summary": "`bbox_card` and `latticeDisc_card_le_explicit`: evaluate the integer bounding box cardinality as `(2⌈|R|⌉+1).toNat ^ 2`, then chain with the S2c subset bound to obtain a closed-form `(latticeDisc R).card ≤ (2⌈|R|⌉+1)²`. Sorry-free, axiom-free, and uses only stable Mathlib API (`Pi.card_Icc` + `Int.card_Icc`).",
       "mathContext": "The integer interval `Icc (-⌈|R|⌉) ⌈|R|⌉ ⊂ ℤ` has cardinality `(⌈|R|⌉ + 1 - (-⌈|R|⌉)).toNat = (2⌈|R|⌉+1).toNat` by `Int.card_Icc`; the product over `Fin 2` raises this to the square (`Pi.card_Icc` + `Finset.prod_const` + `Fintype.card_fin`). Composing with S2c's `latticeDisc_card_le_bbox` yields the explicit Gauss-circle upper bound, bridging the qualitative subset bound to a numerical estimate usable for ℓ¹ majorisation of `sphPartialSum`. The sharp constant `π` (Gauss circle problem proper) requires boundary-lattice analysis and is deferred."
+    },
+    {
+      "id": "lattice-disc-cofinality",
+      "title": "S2e-cofinality — `latticeDisc R` eventually contains every finite lattice set",
+      "startLine": 277,
+      "endLine": 371,
+      "summary": "`latticeDisc_mem_eventually` and `latticeDisc_eventually_supset`: every fixed lattice point (resp. finite set of lattice points) is contained in `latticeDisc R` for all sufficiently large `R`. Sorry-free, axiom-free, pure ℝ/ℤ arithmetic — no measure-theoretic dependencies. The Plancherel-tail engine for the eventual S2e ACT close of `sphPartialSum_L2_norm_converge`.",
+      "mathContext": "For a single `k ∈ ℤ²`, taking `R ≥ (k 0)² + (k 1)² + 1` (which forces `R ≥ 1` and hence `R ≤ R²`) discharges both the disc condition `(k 0)² + (k 1)² ≤ R²` and the bounding-box condition `|k i| ≤ ⌈|R|⌉` (via `(k i)² ≤ R²` ⇒ `|k i| ≤ R` ⇒ `|k i| ≤ ⌈|R|⌉`). The finite-set case follows by `Finset.induction_on`, combining the singleton via `Filter.filter_upwards`. This is the cofinality bearer noted in the S2e PREP / S7 audit's §2.3, converting the Plancherel residual `‖S_R^{sph} f - f‖₂² = ∑_{k ∉ latticeDisc R} |fk|²` into a tail of the convergent series `∑_k |fk|² = ‖f‖₂²`."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

**Step 3 of the S7 audit §4 recipe** for closing `sphPartialSum_L2_norm_converge` (the unconditional L²-norm-convergence companion to the open 2D Carleson spherical-summation conjecture).

Adds two sorry-free, axiom-free public theorems to `proofs/Proofs/FourierSeriesOQ04OQ01.lean` in a new **S2e-cofinality** section:

- **`latticeDisc_mem_eventually (k : Fin 2 → ℤ) : ∀ᶠ R in atTop, k ∈ latticeDisc R`** — singleton case. Witness: `R₀ = (k 0)² + (k 1)² + 1`. Discharges both the disc condition `(k 0)² + (k 1)² ≤ R²` (via `R ≥ 1 ⇒ R ≤ R²`) and the bounding-box condition `|k i| ≤ ⌈|R|⌉` (via `Real.sqrt_sq_eq_abs` + `Int.le_ceil`).
- **`latticeDisc_eventually_supset (S : Finset (Fin 2 → ℤ)) : ∀ᶠ R in atTop, S ⊆ latticeDisc R`** — full cofinality. `Finset.induction_on` chaining singleton via `Filter.filter_upwards`.

## Why this is safe to ship standalone

| Property | Status |
|---|---|
| Sorry-free | ✅ |
| Axiom-free | ✅ |
| Measure-theory-free | ✅ Pure ℝ/ℤ arithmetic — no `Lp`, `volume`, or `haarT2` |
| Mathlib-stable | ✅ Uses only `Real.sqrt_*`, `Int.le_ceil`, `Filter.eventually_atTop`, `Finset.induction_on`, `Finset.mem_filter`, `Finset.mem_Icc`, `Finset.mem_insert` |
| Standalone | ✅ Independent of S2e ACT's remaining steps 1+2+4+5+6 |

## S2e ACT scope reduction

| Step | Pre-S9 budget | Post-S9 budget | Status |
|---|---|---|---|
| 1 — Setup (haarT2/volume) | 3-5 + 3-5 LOC | unchanged | pending |
| 2 — `coeFn_finset_sum` helper | 8-10 LOC | unchanged | pending |
| 3 — Cofinality | 15-25 LOC | **0 LOC ✅** | DONE |
| 4 — Bridge `sphPartialSum` → Lp | 15-25 LOC | unchanged | pending |
| 5 — Cite engine | 5-10 LOC | unchanged | pending |
| 6 — Close `eLpNorm`-form | 5-10 LOC | unchanged | pending |
| **Total** | **53-90 LOC** | **38-65 LOC** | ~30% reduction |

## File deltas

- `proofs/Proofs/FourierSeriesOQ04OQ01.lean`: 279 → 375 lines, 8 → 10 theorems, +2 sorry-free public theorems
- `src/data/proofs/fourier-series-oq-04-oq-01/meta.json`: `lineCount` + `theoremCount` synced; new `lattice-disc-cofinality` section; `originalContributions` extended (also picks up missing S2-Gauss-real entry)
- `research/problems/fourier-series-oq-04-oq-01/state.md`: iter 7 → 8; new S9 ACT Current Focus
- `research/problems/fourier-series-oq-04-oq-01/sessions/2026-05-29-s9-act-cofinality.md`: full forensics

## Test plan

- [x] Docker build verified: `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ04OQ01` — ✅ 7743 jobs, single expected pre-existing sorry warning at line 148 (`sphPartialSum_L2_norm_converge`); no new warnings.
- [x] Axiom audit: 1 axiom (`carleson_2d_sph`, unchanged — the open conjecture); 0 new axioms.
- [x] Sorry audit: 1 sorry (`sphPartialSum_L2_norm_converge`, unchanged); 0 new sorries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)