### PR TITLE
audit(erdos-237): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5475,9 +5475,9 @@
     },
     "erdos-237": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T05:08:05Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T07:27:44Z",
+      "result": "clean"
     },
     "erdos-238": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

Re-audit of Erdős Problem #237 (Chen-Ding 2022, Prime Plus Set Representations). All integrity checks pass.

## Findings

- **axiom count:** 1 (`chen_ding_2022`) — matches `meta.json axiomCount: 1`
- **sorries:** 0 — matches `meta.json sorries: 0`
- **lineCount:** 255 — matches meta
- **theoremCount:** 3 (`erdos_conjecture_true`, `erdos_237`, `erdos_237_summary`) — matches meta
- **definitionCount:** 8 — matches meta
- **status/badge:** `axiomatized`/`axiom` — correct for 1 stated assumption
- **No True stubs**, no structure-encoded hypotheses
- `assumptions` field accurately states "1 axiom: chen_ding_2022. 0 sorries."

## Test plan

- [x] Read meta.json and Lean source
- [x] Verified declaration counts
- [x] Verified no `:= trivial` / `: True :=` stubs
- [x] Verified no structure-encoded axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)