### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): S8-prep — nonComputableReals dense (Docker 3067 jobs clean)

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
@@ -1,5 +1,6 @@
 import Mathlib.SetTheory.Cardinal.Basic
 import Mathlib.SetTheory.Cardinal.Continuum
+import Mathlib.Analysis.Real.Cardinality
 import Mathlib.Data.Real.Basic
 import Mathlib.Data.Set.Countable
 import Mathlib.Data.Rat.Cardinal
@@ -691,5 +692,66 @@ theorem computable_reals_dense : Dense {r : ℝ | IsComputable r} := by
 theorem closure_computable_reals_eq_univ :
     closure {r : ℝ | IsComputable r} = Set.univ :=
   computable_reals_dense.closure_eq
+
+/-! ## S8-prep — Topological complement: the non-computable reals are also dense
+
+S7 showed `{r | IsComputable r}` is a countable dense subset of `ℝ`. Its complement
+`nonComputableReals` is uncountable (S4, `nonComputableReals_uncountable`), yet a
+priori one might still ask whether it is *topologically* visible — does it meet
+every nonempty open set, or could it sit on a thin closed subset of `ℝ`?
+
+The answer is that **the non-computable reals are dense too**. The argument is
+purely cardinality-vs-countability:
+
+* Every nonempty open `U ⊆ ℝ` contains an open interval `Ioo a b` with `a < b`
+  (`IsOpen.exists_Ioo_subset`).
+* `Ioo a b` has cardinality `𝔠` (`Cardinal.mk_Ioo_real`).
+* If `U` missed `nonComputableReals` entirely then `U ⊆ {r | IsComputable r}`, so
+  the interval `Ioo a b` would inherit countability from S3, forcing
+  `𝔠 ≤ ℵ₀` — a contradiction with `Cardinal.aleph0_lt_continuum`.
+
+Combined with S7, this exhibits `ℝ` as the disjoint union of two **simultaneously
+dense** sets: the countable dense set of computable reals and the uncountable
+dense set of non-computable reals. Topologically, computability is a
+"measure-zero/dense" predicate: countably many points, but everywhere.
+
+* `nonComputableReals_dense` — `Dense nonComputableReals`.
+* `closure_nonComputableReals_eq_univ` — closure-form restatement.
+-/
+
+/-- **S8-prep — the non-computable reals are dense in `ℝ`**.
+
+    Every nonempty open `U ⊆ ℝ` meets `nonComputableReals`. Proof by contradiction:
+    if `U ∩ nonComputableReals = ∅`, then `U ⊆ {r | IsComputable r}`. Pick an
+    open interval `Ioo a b ⊆ U` with `a < b` via `IsOpen.exists_Ioo_subset`. The
+    interval is then countable (subset of a countable set), but
+    `Cardinal.mk_Ioo_real` gives cardinality `𝔠 > ℵ₀`, contradiction. -/
+theorem nonComputableReals_dense : Dense nonComputableReals := by
+  rw [dense_iff_inter_open]
+  intro U hU_open hU_ne
+  obtain ⟨a, b, hab, hsub⟩ := hU_open.exists_Ioo_subset hU_ne
+  by_contra h
+  rw [Set.not_nonempty_iff_eq_empty] at h
+  have hU_sub : U ⊆ {r : ℝ | IsComputable r} := by
+    intro x hx
+    by_contra hxn
+    have hmem : x ∈ U ∩ nonComputableReals := ⟨hx, hxn⟩
+    rw [h] at hmem
+    exact hmem.elim
+  have hIoo_sub : Set.Ioo a b ⊆ {r : ℝ | IsComputable r} := hsub.trans hU_sub
+  have hIoo_count : (Set.Ioo a b).Countable := computable_reals_countable.mono hIoo_sub
+  have hIoo_card_le : (#(↑(Set.Ioo a b) : Set ℝ) : Cardinal) ≤ ℵ₀ :=
+    le_aleph0_iff_set_countable.mpr hIoo_count
+  rw [Cardinal.mk_Ioo_real hab] at hIoo_card_le
+  exact absurd hIoo_card_le (not_le.mpr Cardinal.aleph0_lt_continuum)
+
+/-- **S8-prep — closure form**: the topological closure of the non-computable
+    reals is all of `ℝ`. Direct restatement of `nonComputableReals_dense` via
+    `Dense.closure_eq`. Together with S7's `closure_computable_reals_eq_univ`,
+    this says both sides of the computable/non-computable partition are
+    topologically maximal. -/
+theorem closure_nonComputableReals_eq_univ :
+    closure nonComputableReals = Set.univ :=
+  nonComputableReals_dense.closure_eq
 
 end AlgebraicNumbersCountableOQ02OQ04

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-05-30-s8-prep-noncomputable-dense.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-05-30-s8-prep-noncomputable-dense.md
@@ -1,0 +1,180 @@
+# S8-prep ACT — non-computable reals are dense
+
+- **Date**: 2026-05-30
+- **Session**: 9 (S8-prep)
+- **Phase**: ACT — topological complement of S7
+- **Researcher**: researcher-1
+- **Base**: `origin/main` post S7 (Docker 3067/3067 verified)
+- **Branch**: `research/algebraic-numbers-countable-oq-02-oq-04-s8-prep-noncomp-dense`
+
+## 1. TL;DR
+
+S7 proved `{r | IsComputable r}` is dense in `ℝ` (it contains the rationals).
+The natural symmetric question — is the complement `nonComputableReals` also
+dense? — is settled affirmatively here by a pure cardinality-vs-countability
+argument: any nonempty open contains an interval `Ioo a b` of cardinality `𝔠`,
+which cannot embed into the countable set of computable reals.
+
+Two new theorems, +62 LOC (incl. section docstring), 0 sorries, 0 axioms,
+1 new import.
+
+## 2. Mathematical content
+
+The partition
+```
+ℝ = {r | IsComputable r} ⊔ nonComputableReals
+```
+sends a countable set against an uncountable one (S4: cardinality `𝔠`). S7
+showed the countable side is dense. This session shows the uncountable side
+is *also* dense.
+
+The proof reuses no arithmetic infrastructure on `IsComputable` (no `.add`,
+`.neg`, etc.). Instead it leans on three facts already in the file or in
+Mathlib:
+
+1. **S3**: `computable_reals_countable : Set.Countable {r | IsComputable r}`.
+2. **Order topology**: any nonempty open `U ⊆ ℝ` contains an open interval
+   `Ioo a b` with `a < b` (`IsOpen.exists_Ioo_subset` from
+   `Mathlib.Topology.Order.Basic`, works in any Nontrivial linearly ordered
+   topology).
+3. **Cardinality**: `#(Set.Ioo a b) = 𝔠` for `a < b` in `ℝ`
+   (`Cardinal.mk_Ioo_real` from `Mathlib.Analysis.Real.Cardinality`).
+
+The argument is: if `U ⊆ ℝ` is open and misses `nonComputableReals`, then
+`U ⊆ {r | IsComputable r}`. Pick `Ioo a b ⊆ U`; then `Ioo a b` inherits
+countability from S3, so `#(Ioo a b) ≤ ℵ₀` via
+`le_aleph0_iff_set_countable`. But `Cardinal.mk_Ioo_real hab` gives
+`#(Ioo a b) = 𝔠`, contradicting `Cardinal.aleph0_lt_continuum`.
+
+## 3. The proof in Lean
+
+```lean
+theorem nonComputableReals_dense : Dense nonComputableReals := by
+  rw [dense_iff_inter_open]
+  intro U hU_open hU_ne
+  obtain ⟨a, b, hab, hsub⟩ := hU_open.exists_Ioo_subset hU_ne
+  by_contra h
+  rw [Set.not_nonempty_iff_eq_empty] at h
+  have hU_sub : U ⊆ {r : ℝ | IsComputable r} := by
+    intro x hx
+    by_contra hxn
+    have hmem : x ∈ U ∩ nonComputableReals := ⟨hx, hxn⟩
+    rw [h] at hmem
+    exact hmem.elim
+  have hIoo_sub : Set.Ioo a b ⊆ {r : ℝ | IsComputable r} := hsub.trans hU_sub
+  have hIoo_count : (Set.Ioo a b).Countable :=
+    computable_reals_countable.mono hIoo_sub
+  have hIoo_card_le : (#(↑(Set.Ioo a b) : Set ℝ) : Cardinal) ≤ ℵ₀ :=
+    le_aleph0_iff_set_countable.mpr hIoo_count
+  rw [Cardinal.mk_Ioo_real hab] at hIoo_card_le
+  exact absurd hIoo_card_le (not_le.mpr Cardinal.aleph0_lt_continuum)
+
+theorem closure_nonComputableReals_eq_univ :
+    closure nonComputableReals = Set.univ :=
+  nonComputableReals_dense.closure_eq
+```
+
+The cast `(#(↑(Set.Ioo a b) : Set ℝ) : Cardinal)` mirrors the existing usage
+at line 644 inside `nonComputableReals_uncountable`, which is the proof
+pattern this lemma generalizes (singleton-vs-open).
+
+## 4. Mathlib API verification
+
+All four Mathlib lemmas verified via `gh api` source-fetch against
+`leanprover-community/mathlib4` at session-start SHA:
+
+| Lemma | Module | Signature (verified) |
+|---|---|---|
+| `IsOpen.exists_Ioo_subset` | `Topology.Order.Basic` | `[Nontrivial α] {s : Set α} (hs : IsOpen s) (h : s.Nonempty) : ∃ a b, a < b ∧ Ioo a b ⊆ s` |
+| `Cardinal.mk_Ioo_real` | `Analysis.Real.Cardinality` | `{a b : ℝ} (h : a < b) : #(Ioo a b) = 𝔠` |
+| `le_aleph0_iff_set_countable` | `SetTheory.Cardinal.Basic:430` | `s.Countable ↔ # s ≤ ℵ₀` (re-pinned at S6f §3) |
+| `Cardinal.aleph0_lt_continuum` | `SetTheory.Cardinal.Continuum:65` | `ℵ₀ < 𝔠` (re-pinned at S6f §3) |
+
+The first two are new to this file (S7 baseline used neither). The last two
+were already exercised by `nonComputableReals_uncountable` (line 642).
+
+## 5. Import deltas
+
+```diff
+ import Mathlib.SetTheory.Cardinal.Basic
+ import Mathlib.SetTheory.Cardinal.Continuum
++import Mathlib.Analysis.Real.Cardinality
+ import Mathlib.Data.Real.Basic
+```
+
+`Mathlib.Analysis.Real.Cardinality` is the canonical home for
+`Cardinal.mk_Ioo_real` (and siblings `mk_Icc_real`, `mk_Ico_real`, `mk_Ioc_real`,
+`mk_Ioi_real`, `mk_Iio_real`, `mk_Ici_real`, `mk_Iic_real`, `mk_real`,
+`mk_univ_real`, `not_countable_real`). It transitively imports
+`Mathlib.Analysis.SpecificLimits.Basic` and
+`Mathlib.Algebra.Order.Group.Pointwise.Interval`; both are far below the
+file's existing topology footprint.
+
+`IsOpen.exists_Ioo_subset` comes via `Mathlib.Topology.Order.Basic`, which is
+already transitively imported by `Mathlib.Topology.Instances.Real.Lemmas` (in
+the file imports). No new import needed for it.
+
+## 6. Why this is independent of S8-true (`IsComputable e`)
+
+The recommended next ACT (S6f §5 priority tree, repeated in state.md head)
+is to ship `IsComputable e` (or `π`) as a concrete computable transcendental,
+sharpening the strict inclusion `algebraic ⊊ computable` beyond pure
+cardinality.
+
+This S8-prep session is on a fundamentally different axis: it adds
+*topological* (not arithmetic) structure to the complement side. The two
+sessions touch disjoint Mathlib API:
+
+| Axis | S8-prep (this) | S8 (e-witness, future) |
+|---|---|---|
+| Mathlib home | `Analysis.Real.Cardinality`, `Topology.Order.Basic` | `Analysis.SpecialFunctions.Exp`, `Computability.Primrec` rat-arith |
+| Output | `Dense nonComputableReals` | `IsComputable (Real.exp 1)` |
+| LOC | +62 | ~80-150 estimated |
+| Risk | Low (closed-form 1-step proof) | Medium (factorial computability + series convergence) |
+
+S8-prep and S8 can be shipped in either order; neither blocks the other.
+
+## 7. Next-picker priority refresh
+
+After this session:
+
+* **Topological picture**: complete on both sides
+  - `computable_reals_dense` (S7) + `closure_computable_reals_eq_univ`
+  - `nonComputableReals_dense` (S8-prep) + `closure_nonComputableReals_eq_univ`
+* **Cardinality picture**: complete (S2-S6)
+* **Computable arithmetic**: NOT YET STARTED. Open: `IsComputable.add`,
+  `.neg`, `.sub`, `.mul`, `.inv`. Each is a small lemma but depends on
+  Primrec / Computable on `ℚ` arithmetic — see Mathlib
+  `Computability.Primrec/List` and `Computability.Partrec` for the relevant
+  encoded infrastructure.
+* **Computable transcendental witness**: NOT YET STARTED. `Real.exp 1 = e` via
+  `Real.exp_eq_tsum`, finite-partial-sum sequence, factorial computability.
+  Estimated ~80-150 LOC.
+* **algebraic ⊆ computable**: NOT YET STARTED. Sturm's theorem + bisection.
+  Estimated heavy (~300+ LOC; depends on Mathlib's Sturm chain API).
+
+The S8-true witness path is still the recommended next ACT.
+
+## 8. Build / verification status
+
+**Docker build: ✔ VERIFIED clean (3067/3067 jobs, 11s file compile).**
+
+```
+./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ04
+...
+✔ [3067/3067] Built Proofs.AlgebraicNumbersCountableOQ02OQ04 (11s)
+Build completed successfully (3067 jobs).
+=== Build succeeded ===
+```
+
+The S7 baseline (same file minus S8-prep additions) was verified Docker
+`3067/3067` clean at 2026-05-28. The S8-prep version (this PR) compiles to
+the same `3067/3067` job count — the new theorems `nonComputableReals_dense`
+and `closure_nonComputableReals_eq_univ` along with the
+`Mathlib.Analysis.Real.Cardinality` import added no new build targets at the
+session/cache layer used by Lake, only `+62` LOC of file content. The file
+compiles in 11 seconds (vs. 8.1s at S7), confirming the new import is light.
+
+Per repository convention (CLAUDE.md "DANGER: Never Run lake build Directly"),
+the build was run via the Docker wrapper with `LEAN_MEMORY_LIMIT=32768MB` and
+`LEAN_BUILD_TIMEOUT=60m`. Build output: `/tmp/researcher-1-s8-prep-build-v2.log`.

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
@@ -2,35 +2,36 @@
 
 ## Current Status
 
-**Phase**: S7 ACT — topological structure (computable reals are dense), Docker build verified
-**Owner**: researcher-1 (S7 ACT, 2026-05-28); prior S6f STATE-SYNC owner: researcher-5 (2026-05-16)
-**Iteration**: 8 (S1 + S2 + S3 + S4 + S5 + S6 + mechanic #19054 + S6f STATE-SYNC + S7)
-**Last Updated**: 2026-05-28Z (S7 ACT; density + closure-form theorems, Docker `3067/3067` clean)
-**Branch (this PR)**: `research/algebraic-numbers-countable-oq-02-oq-04-s7-dense`
+**Phase**: S8-prep ACT — topological complement (non-computable reals are dense)
+**Owner**: researcher-1 (S8-prep ACT, 2026-05-30); prior S7 owner: researcher-1 (2026-05-28)
+**Iteration**: 9 (S1 + S2 + S3 + S4 + S5 + S6 + mechanic #19054 + S6f STATE-SYNC + S7 + S8-prep)
+**Last Updated**: 2026-05-30Z (S8-prep ACT; nonComputableReals_dense + closure-form, Docker `3067/3067` clean)
+**Branch (this PR)**: `research/algebraic-numbers-countable-oq-02-oq-04-s8-prep-noncomp-dense`
 
-## Lean file inventory (at base `b97b863990d`, S7 verified)
+## Lean file inventory (at base `origin/main`, S8-prep Docker-verified)
 
 ```
 File:        proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
-Lines:       695 (was 110 at S1; +585 across S2-S7)
-Theorems:    33 (S7 adds computable_reals_dense + closure_computable_reals_eq_univ)
+Lines:       757 (was 695 at S7; +62 in S8-prep including section docstring)
+Theorems:    35 (S8-prep adds nonComputableReals_dense + closure_nonComputableReals_eq_univ)
 Definitions: 3 (IsComputable, decodeReal, nonComputableReals)
-Sorries:     0 (S3 discharged the S1 sorry; S4-S7 added no new)
+Sorries:     0 (S3 discharged the S1 sorry; S4-S8-prep added no new)
 Axioms:      0
-Build:       ✔ VERIFIED S7 (Docker 3067/3067 jobs clean, 2026-05-28)
+Build:       ✔ VERIFIED S8-prep (Docker 3067/3067 jobs clean, 11s file compile, 2026-05-30)
+Imports:     +1 (Mathlib.Analysis.Real.Cardinality for Cardinal.mk_Ioo_real)
 ```
 
-3 critical Mathlib bearers re-verified at SHA `2df2f015...`
-(S6f §3 — 0 drift):
-- `Nat.Partrec.Code.exists_code` at `Mathlib/Computability/PartrecCode.lean:550`
-- `le_aleph0_iff_set_countable` at `Mathlib/SetTheory/Cardinal/Basic.lean:430`
-- `Cardinal.aleph0_lt_continuum` at `Mathlib/SetTheory/Cardinal/Continuum.lean:65`
+4 critical Mathlib bearers used in S8-prep proof:
+- `IsOpen.exists_Ioo_subset` (Topology.Order.Basic) — gets `Ioo a b ⊆ U` from nonempty open
+- `Cardinal.mk_Ioo_real` (Analysis.Real.Cardinality) — `#(Ioo a b) = 𝔠` for `a < b`
+- `le_aleph0_iff_set_countable` (SetTheory.Cardinal.Basic:430) — countable ↔ ≤ ℵ₀
+- `Cardinal.aleph0_lt_continuum` (SetTheory.Cardinal.Continuum:65) — `ℵ₀ < 𝔠`
 
-**Next-picker priority (S8+)**: S7 took the *topological* branch (density)
-rather than the computable-transcendental-witness branch, which remains
-open. Recommended next ACT: ship `IsComputable e` (or `π`) as the explicit
-computable transcendental witness sharpening the strict inclusion
-`algebraic ⊊ computable` beyond the pure-cardinality argument of S4.
+**Next-picker priority (S9+)**: With both S7 (computable dense) and S8-prep
+(non-computable dense) now in place, the topological picture is complete on
+both sides of the partition. The remaining headline next step remains
+shipping `IsComputable e` (or `π`) as the explicit computable transcendental
+witness sharpening `algebraic ⊊ computable` beyond pure cardinality.
 Path A (e via partial sums of `1/n!`) is the cleaner-skeleton candidate
 at v4.26.0; ~80-150 LOC estimate. See S6f §5 for the full priority tree
 (witness → algebraic⊆computable via Sturm/bisection → real-closed-subfield
@@ -207,6 +208,30 @@ infrastructure + strategy + 1 file + 1 module-doc + 4 annotations).
   `knowledge.md`, or `meta.json` changes. See
   `sessions/2026-05-16-s6f-statesync-postmechanic-buildverified.md`
   for the full memo (~360 LOC, 8 sections).
+- **2026-05-30 (S8-prep ACT, researcher-1)**: TOPOLOGICAL COMPLEMENT —
+  non-computable reals are dense (Docker `3067/3067` jobs clean, 11s file compile).
+  Two new theorems, no new defs/axioms/sorries:
+  - `nonComputableReals_dense : Dense nonComputableReals` — proof: any nonempty
+    open `U ⊆ ℝ` contains an open interval `Ioo a b` with `a < b`
+    (`IsOpen.exists_Ioo_subset`); if `U` missed `nonComputableReals`, then
+    `Ioo a b ⊆ {r | IsComputable r}` would be countable via S3, but
+    `Cardinal.mk_Ioo_real` gives cardinality `𝔠`, contradicting
+    `Cardinal.aleph0_lt_continuum`.
+  - `closure_nonComputableReals_eq_univ : closure nonComputableReals = Set.univ`
+    — closure-form restatement via `Dense.closure_eq`.
+  Mathematical content: complements S7's `computable_reals_dense` by showing
+  that the partition `ℝ = computable ⊔ non-computable` is into two
+  *simultaneously dense* sets. Computability is a "countable yet dense"
+  predicate (S3+S7), and non-computability is a "uncountable and dense"
+  predicate (S4+S8-prep). Topologically neither side hides on a thin closed
+  subset.
+  New Mathlib bearers used: `IsOpen.exists_Ioo_subset`, `Cardinal.mk_Ioo_real`,
+  `Set.not_nonempty_iff_eq_empty`. New import:
+  `Mathlib.Analysis.Real.Cardinality` (for `Cardinal.mk_Ioo_real`). Lean file
+  695 → 757 LOC, 0 sorries → 0 sorries, 0 axioms → 0 axioms, theorem count
+  33 → 35. See `sessions/2026-05-30-s8-prep-noncomputable-dense.md` for the
+  full memo.
+
 - **2026-05-28 (S7 ACT, researcher-1)**: TOPOLOGICAL STRUCTURE —
   computable reals are dense (Docker build verified, not "build pending").
   Two new theorems, no new defs/axioms/sorries:


### PR DESCRIPTION
## Summary

S8-prep complements S7 (`computable_reals_dense`) by showing that the complement is also dense in `ℝ`. Adds 2 theorems (+62 LOC, 0 new sorries, 0 axioms, 1 new import).

- `nonComputableReals_dense : Dense nonComputableReals`
- `closure_nonComputableReals_eq_univ : closure nonComputableReals = Set.univ`

**Proof strategy** (cardinality-vs-countability, no new arithmetic API on `IsComputable`):
1. Any nonempty open `U ⊆ ℝ` contains an open interval `Ioo a b` with `a < b` (`IsOpen.exists_Ioo_subset`).
2. `#(Ioo a b) = 𝔠` (`Cardinal.mk_Ioo_real`).
3. If `U ∩ nonComputableReals = ∅` then `Ioo a b ⊆ {r | IsComputable r}` would be countable (S3), forcing `𝔠 ≤ ℵ₀`, contradicting `Cardinal.aleph0_lt_continuum`.

**Mathematical content**: combined with S7, this exhibits `ℝ` as the disjoint union of two *simultaneously dense* sets: the countable dense set of computable reals and the uncountable dense set of non-computable reals. Topologically, computability is a "countable yet dense" predicate (S3+S7), and non-computability is a "uncountable and dense" predicate (S4+S8-prep). Neither side hides on a thin closed subset.

**Import delta**: +1 (`Mathlib.Analysis.Real.Cardinality`, canonical home for `Cardinal.mk_Ioo_real`).

**File stats**: 695 → 757 LOC, 33 → 35 theorems, 0 → 0 sorries, 0 → 0 axioms.

## Test plan

- [x] All Mathlib API names verified pre-write via `gh api` source-fetch (4 lemma signatures confirmed at session-start SHA).
- [x] Docker build verified: `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ04` → **3067/3067 jobs clean (11s file compile)**.
- [x] No sorries introduced, no axioms introduced.
- [x] Sibling slug API patterns (e.g., `nonComputableReals_uncountable` at file line 642) reused for cast/coercion shape.

## Independent of S8-true (`IsComputable e`)

The recommended S8 ACT — shipping `IsComputable e` (or `π`) as an explicit computable transcendental — remains the priority path. This S8-prep session is on the *topological* axis (Mathlib `Analysis.Real.Cardinality` + `Topology.Order.Basic`) and touches disjoint API from the future arithmetic/exp work (Mathlib `Analysis.SpecialFunctions.Exp` + `Computability.Primrec`). The two can ship in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)