### PR TITLE
audit(erdos-24): mark issues-found — section line drift (#21137)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5493,9 +5493,12 @@
     },
     "erdos-24": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T05:10:38Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T08:03:13Z",
+      "result": "issues-found",
+      "issues": [
+        "Section line drift in 4 of 7 sections (main-theorem endLine +9, historical shift -9, generalization shift -16, summary shift -14). Filed #21137."
+      ]
     },
     "erdos-240": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Re-audited `erdos-24` (Pentagons in Triangle-Free Graphs)
- Found section line drift in 4 of 7 sections (main-theorem, historical, generalization, summary)
- Filed #21137 with detailed line ranges and recommended meta.json fixes
- Updated `audit-tracker.json` to `issues-found` (auditCount 3 → 4)

## Verification

- Lean source `proofs/Proofs/Erdos24Problem.lean`: 245 lines (matches `lineCount`)
- Axiom count: 4 (matches `axiomCount`)
- Sorries: 0 (matches)
- Theorem/def counts: 4/6 (match)
- Badge `axiom`, status `axiomatized` are correct
- True stubs: none

The drift is purely cosmetic (UI will scroll to wrong lines for 4 sections), severity LOW.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` still shows 2435/2435 audited
- [x] Tracker entry updated with issue reference
- [ ] Issue #21137 to be addressed in a follow-up enrichment pass