### PR TITLE
fix(erdos-24): correct section line ranges after content reorg (#21137)

### DIFF
--- a/src/data/proofs/erdos-24/meta.json
+++ b/src/data/proofs/erdos-24/meta.json
@@ -105,27 +105,27 @@
       "id": "main-theorem",
       "title": "The Main Theorem",
       "startLine": 133,
-      "endLine": 172,
+      "endLine": 163,
       "summary": "Grzesik-Hatami pentagon theorem and uniqueness of extremal."
     },
     {
       "id": "historical",
       "title": "Historical Progress",
-      "startLine": 173,
-      "endLine": 190,
+      "startLine": 164,
+      "endLine": 174,
       "summary": "Győri's earlier 1.03n^5 bound."
     },
     {
       "id": "generalization",
       "title": "Erdős's Generalization",
-      "startLine": 191,
-      "endLine": 223,
+      "startLine": 175,
+      "endLine": 209,
       "summary": "General conjecture for odd r-cycles (open for r > 5)."
     },
     {
       "id": "summary",
       "title": "Summary",
-      "startLine": 224,
+      "startLine": 210,
       "endLine": 245,
       "summary": "Main theorem statement and extremal existence."
     }


### PR DESCRIPTION
## Summary
- Fix `sections[].startLine`/`endLine` drift in `src/data/proofs/erdos-24/meta.json`
- Aligns 4 sections to actual `/-` opener locations in `proofs/Proofs/Erdos24Problem.lean`

| Section          | Before     | After      |
|------------------|------------|------------|
| `main-theorem`   | 133–172    | 133–163    |
| `historical`     | 173–190    | 164–174    |
| `generalization` | 191–223    | 175–209    |
| `summary`        | 224–245    | 210–245    |

Verified actual opener positions:
- main-theorem at line 133, historical at 164, generalization at 175, summary at 210.
- File total: 245 lines (already matches `lineCount`).

## Test plan
- [x] Grep for `^/-` openers in Lean file matches new ranges
- [x] No Lean code or axiom changes; counts (4 axioms, 4 theorems, 6 defs) unchanged
- [ ] UI scroll-to-section behavior (cosmetic, not blocking)

Closes #21137