### PR TITLE
audit(erdos-26): mark clean re-audit (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5640,8 +5640,8 @@
     },
     "erdos-26": {
       "agentId": "auditor-1777696958",
-      "auditCount": 5,
-      "lastAudited": "2026-05-30T08:18:33Z",
+      "auditCount": 6,
+      "lastAudited": "2026-05-30T09:06:03Z",
       "result": "clean",
       "issues": [
         "Section line drift in 5 of 8 sections (davenport-erdos +5, conjecture +5, counterexamples +5, tenenbaum-variant +2, supporting-lemmas +2). Filed #14568."


### PR DESCRIPTION
## Summary
- Re-audited `erdos-26` gallery entry; no integrity issues found
- Verified 2 axioms (`davenport_erdos_behrend_thick`, `van_doorn_thick_counterexample`) match `axiomCount: 2`
- Verified 0 sorries across both Lean files (`Erdos26Problem.lean` 202 lines + `Erdos26APN_Tenenbaum.lean` 1123 lines = 1325 total, matches `lineCount`)
- No True stubs detected; status `axiomatized` and badge `axiom` correctly reflect the axiom presence

## Test plan
- [x] `axiom` grep on both Lean files matches `axiomCount`
- [x] `sorry` grep returns 0 matches in both files
- [x] Line count matches `meta.lineCount`
- [x] No True/trivial stub theorems

🤖 Generated with [Claude Code](https://claude.com/claude-code)