### PR TITLE
audit(erdos-233): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5451,9 +5451,9 @@
     },
     "erdos-233": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T05:24:15Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T09:36:00Z",
+      "result": "clean"
     },
     "erdos-234": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Summary

Re-audit of erdos-233 (Erdős Problem #233: Sum of Squares of Prime Gaps).

**Result**: clean

## Verification

Verified meta.json claims against `proofs/Proofs/Erdos233Problem.lean`:

| Field | meta.json | Source | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`first_prime_gaps`) | ✓ |
| theoremCount | 2 | 2 (`erdos_233_open`, `summary_erdos_233`) | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 147 | 147 | ✓ |
| status | axiomatized | open conjecture | ✓ |
| badge | axiom | correct tier | ✓ |

- `erdos_233_open := Classical.em _` is correctly documented as a trivial decidability statement in `proofStrategy` (no false claim of proving the conjecture).
- No True-stubs claiming verification.
- No Mathlib wrapper inflation — `originalContributions` appropriately scoped to statement-level work.

## Test plan
- [x] meta.json fields match Lean source
- [x] Status and badge tier correctly reflect "axiomatized" (open conjecture)
- [x] No narrative failure modes detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)