### PR TITLE
research(law-of-cosines-oq-01-oq-01-oq-01): mark COMPLETED — spherical sine rule formalized

### DIFF
--- a/research/problems/law-of-cosines-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/law-of-cosines-oq-01-oq-01-oq-01/state.md
@@ -1,16 +1,36 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-05-29T19:14:09.190Z
-**Iteration**: 1
+**Phase**: COMPLETED
+**Since**: 2026-05-30
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Spherical sine rule generalization — both directions formalized in Lean.
 
-## Active Approach
+## Result
 
-None yet.
+The open question (extend the Gram-determinant framework to the full spherical
+sine rule sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c)) is answered YES and
+formalized in `Proofs/LawOfCosinesOQ01OQ01OQ01.lean` (0 axioms, 0 sorries,
+verified). The side-over-angle direction is established in
+`Proofs/LawOfCosinesOQ01OQ02.lean` via sin²(X)·sin²(y)·sin²(z) = gramDet for
+each cyclic triple; the angle-over-side direction (this entry) follows by
+algebraic inversion using `div_eq_div_iff` and `linear_combination`.
+
+Gallery entry: `src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01` (status:
+verified, badge: original).
+
+## Forward-Looking Open Questions
+
+Recorded in the gallery `openQuestions` field:
+1. Cross-multiplied form `sin(A)·sin(b) = sin(B)·sin(a)` for degenerate
+   triangles (some `sin(side) = 0` or `sin(angle) = 0`).
+2. Direct derivation of the angle-over-side form without going through the
+   side-over-angle form first.
+
+Both are independent research directions and can be spawned as new problems
+if pursued.
 
 ## Blockers
 
@@ -18,10 +38,10 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+Mark completed and release claim.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1 (Gram-determinant + algebraic inversion — succeeded)


### PR DESCRIPTION
## Summary

Marks the **law-of-cosines-oq-01-oq-01-oq-01** research problem as
**COMPLETED**. The open question — extend the Gram-determinant framework
from the dual cosine law to the full spherical sine rule
sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c) — is already answered YES
and formalized in the repo. This PR only updates
`research/problems/law-of-cosines-oq-01-oq-01-oq-01/state.md` to reflect
that completion (the pool/candidate state was still showing in-progress).

## Lean Status (no code changes)

| File | Direction | Axioms | Sorries |
|---|---|---|---|
| `proofs/Proofs/LawOfCosinesOQ01OQ02.lean` | side-over-angle | 0 | 0 |
| `proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean` | angle-over-side (64 lines) | 0 | 0 |

Gallery entry `src/data/proofs/law-of-cosines-oq-01-oq-01-oq-01` already
at `status: verified`, `badge: original`.

## Proof Skeleton

- `LawOfCosinesOQ01OQ02.lean`: sin²(X)·sin²(y)·sin²(z) = G for each cyclic triple, where G = 1 - cos²a - cos²b - cos²c + 2·cos(a)·cos(b)·cos(c) is the Gram determinant. Yields sin(a)/sin(A) = sin(b)/sin(B) = sin(c)/sin(C).
- `LawOfCosinesOQ01OQ01OQ01.lean`: inverts via `div_eq_div_iff` + `linear_combination`. Yields sin(A)/sin(a) = sin(B)/sin(b) = sin(C)/sin(c), plus the B/b = C/c corollary by transitivity.

## Forward-Looking Open Questions (recorded in state.md for follow-up)

1. Cross-multiplied form sin(A)·sin(b) = sin(B)·sin(a) for degenerate triangles (some sin(·) = 0).
2. Direct derivation of the angle-over-side form without going through the side-over-angle form first.

Both are independent research directions and can be promoted to new problems if pursued.

## Test plan

- [x] `proofs/Proofs/LawOfCosinesOQ01OQ01OQ01.lean`: 0 sorries, 0 axioms confirmed by grep
- [x] Gallery `meta.json` already at `status: verified`
- [x] State.md updated to reflect COMPLETED phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)