### PR TITLE
Research(gauss-wilson-non-cyclic-oq-01): S14 ACT — L112 Hermit fix (1-token, build-verified)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean
@@ -109,7 +109,7 @@ theorem prod_eq_neg_one_of_isCyclic_aux {n : ℕ} (hn : n ≥ 3) [NeZero n]
   have h_one_mem : (1 : (ZMod n)ˣ) ∈ S := by
     simp [hS_def, mem_filter]
   have h_neg_mem : (-1 : (ZMod n)ˣ) ∈ S := by
-    simp [hS_def, mem_filter, neg_one_sq]
+    simp [hS_def, mem_filter]
   have h_pair_sub : ({1, -1} : Finset (ZMod n)ˣ) ⊆ S := by
     intro x hx
     rcases Finset.mem_insert.mp hx with rfl | hx

--- a/research/problems/gauss-wilson-non-cyclic-oq-01/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-01/state.md
@@ -2,7 +2,20 @@
 
 ## Current phase
 
-**S13 PREP shipped (2026-05-16, this PR).** Doc-only post-completion
+**S14 ACT shipped (2026-05-30, this PR).** Disk-recovered execution of
+S13 PREP's paste-ready 1-token L112 Hermit fix: removes `neg_one_sq`
+from the `simp [hS_def, mem_filter, neg_one_sq]` arg list in
+`prod_eq_neg_one_of_isCyclic_aux` (Phase C cyclic-direction proof).
+Build-verified clean at Mathlib v4.26.0:
+`✔ [3066/3066] Built Proofs.GaussWilsonNonCyclicOQ01 (8.3s)`. **The
+pre-existing linter warning at `GaussWilsonNonCyclicOQ01.lean:112` is
+gone.** Slug-wide remains `0 sorries / 0 axioms / 0 structure-encoded
+assumptions` across Phases A + B + C. Net Lean diff: −1 token (`,
+neg_one_sq`) on line 112. No `meta.json` / `knowledge.md` /
+`problem.md` edits. Disk is now 62 Gi free / 16% used (vs S13 PREP's
+7.2 Gi / 100% — the planned recovery window arrived).
+
+**S13 PREP shipped (2026-05-16).** Doc-only post-completion
 housekeeping ~4h after S12 ACT merge (#19440 at 04:39:24Z): (i)
 corrects LOC drift in the Phase chain snapshot table below
 (`256 → 265` for Phase C and `243 → 244` for Phase B core, both


### PR DESCRIPTION
## Summary

- **Disk-recovered execution of S13 PREP's paste-ready L112 Hermit fix**: removes `neg_one_sq` from `simp [hS_def, mem_filter, neg_one_sq]` at `GaussWilsonNonCyclicOQ01.lean:112` (inside `prod_eq_neg_one_of_isCyclic_aux`, the Phase C cyclic-direction proof).
- **Build-verified clean** at Mathlib v4.26.0: `✔ [3066/3066] Built Proofs.GaussWilsonNonCyclicOQ01 (8.3s)`. The `This simp argument is unused: neg_one_sq` linter warning that S12 ACT (#19440) flagged is **gone**.
- **Slug-wide remains 0/0/0** (sorries / axioms / structure-encoded assumptions) across Phases A + B + C.
- Net Lean diff: **−1 token** (drops `, neg_one_sq`). The remaining `simp [hS_def, mem_filter]` closes the goal because Mathlib's default simp set discharges `(-1 : (ZMod n)ˣ)^2 = 1` via stable Units / ZMod normalization.
- Disk recovery: 62 Gi free / 16% used (S13 PREP had deferred at 100% / 7.2 Gi).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ01` → `✔ [3066/3066] Built Proofs.GaussWilsonNonCyclicOQ01 (8.3s)` → `Build succeeded`
- [x] No `This simp argument is unused` warnings in build output
- [x] Slug-wide: 0 sorries (no `\\bsorry\\b` matches outside docstrings), 0 axioms across all four `GaussWilsonNonCyclic*.lean` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)