### PR TITLE
audit(erdos-225): fix top-level sorries count (5 → 3)

### DIFF
--- a/src/data/proofs/erdos-225/meta.json
+++ b/src/data/proofs/erdos-225/meta.json
@@ -162,5 +162,5 @@
       "description": "Related Erdős problem sharing themes: analysis, solved"
     }
   ],
-  "sorries": 5
+  "sorries": 3
 }


### PR DESCRIPTION
## Summary

The top-level `sorries` field in `src/data/proofs/erdos-225/meta.json` reported `5`, but:
- `meta.sorries`: 3
- `leanFile.sorries`: 3
- `proofs/Proofs/Erdos225Problem.lean`: 3 `sorry` occurrences (lines 204, 223, 233)

Synced top-level field to match the actual count.

## Test plan
- [x] Verified Lean source has exactly 3 sorries
- [x] No other fields require changes (meta.sorries and leanFile.sorries already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)