### PR TITLE
audit(erdos-233): mark clean re-audit (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5451,8 +5451,8 @@
     },
     "erdos-233": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-30T09:36:00Z",
+      "auditCount": 5,
+      "lastAudited": "2026-05-30T10:43:10Z",
       "result": "clean"
     },
     "erdos-234": {


### PR DESCRIPTION
## Summary
- Re-audited erdos-233 (Sum of Squares of Prime Gaps); meta.json claims match the Lean source exactly.
- 1 axiom (`first_prime_gaps`), 0 sorries, 147 lines, 2 theorems, 6 definitions — all consistent with `meta.json`.
- Status `axiomatized` / badge `axiom` is correct for an open conjecture carrying an axiom.

## Test plan
- [x] Verified `proofs/Proofs/Erdos233Problem.lean` axiom and sorry counts
- [x] Confirmed `src/data/proofs/erdos-233/meta.json` `axiomCount`, `sorries`, `lineCount`, `theoremCount`, `definitionCount`
- [x] No True stubs, no Mathlib wrappers, no overclaiming

Auditor cycle 5 — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)