### PR TITLE
audit(erdos-229): mark clean re-audit (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5417,9 +5417,9 @@
     },
     "erdos-229": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T05:43:06Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-30T11:27:22Z",
+      "result": "clean",
       "issues": [
         "Section line drift for 4 sections + 2 sections missing from meta.json. Filed issue #14587"
       ]


### PR DESCRIPTION
## Summary
- Re-audited erdos-229 (Zeros of Derivatives of Entire Functions, Barth-Schneider 1972)
- Tracker updated: result "issues-fixed" → "clean", auditCount 3 → 5

## Verification
- Line count: 137 ✓
- Sorries: 0 ✓
- Axioms: 1 (`barth_schneider_theorem`) ✓
- Theorems: 2 (`erdos_229_answer`, `summary_erdos_229`) ✓
- Definitions: 4 (`HasNoFiniteLimitPoint`, `IsEntireFunction`, `IsTranscendental`, `Erdos229Question`) ✓
- No True stubs
- Status `axiomatized`, badge `axiom` — appropriate
- `originalContributions` properly acknowledges axiomatization (no overclaim)

## Test plan
- [x] Verified meta.json vs Lean source
- [x] No new integrity issues found