### PR TITLE
Enrich abel-ruffini-galois-extensions: surface 2 originalContributions

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -50,7 +50,9 @@
       "Complete biconditional packaging: symmetric_solvable_iff and alternating_solvable_iff combining Mathlib results into explicit iff statements",
       "sign_kernel_is_alternating: formal verification that ker(sign) = A_n",
       "solvable_small_has_abelian_factors: joint solvability packaging for S_n and A_n (n ≤ 4)",
-      "not_solvable_by_rad_of_not_solvable_galois: contrapositive of Galois's theorem as a standalone named theorem"
+      "not_solvable_by_rad_of_not_solvable_galois: contrapositive of Galois's theorem as a standalone named theorem",
+      "Non-commutativity witness suite (Part XIII, lines 431–461): five named theorems s3_not_comm, s4_not_comm, s5_not_comm, a4_not_comm, a5_not_comm verifying the absence of commutativity in S_n (n ≥ 3) and A_n (n ≥ 4) via `push_neg; decide` (S_3, S_4) and `push_neg; native_decide` (S_5, A_4, A_5) — provides explicit non-commutativity certificates as standalone named theorems beyond Mathlib's general `Equiv.Perm.not_commutative` instance, making the failure of abelianness directly citable in downstream proofs without instance search",
+      "Computational verification of higher-cardinality group orders (Part XIV, lines 470–480): four named theorems card_s7, card_s8, card_a7, card_a8 proving |S_7|=5040, |S_8|=40320, |A_7|=2520, |A_8|=20160 via `native_decide` — extends the standard Mathlib `Fintype.card_perm` (which gives a formula) to *explicit numerical equalities* that `decide` cannot handle (cardinalities ≥ 720 exceed the kernel evaluator's practical threshold), demonstrating the `native_decide` boundary for permutation-group cardinality verification"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary
Enrichment pass for `abel-ruffini-galois-extensions`. The entry was already at saturation (quality 100, 4 prior passes, 20 keyInsights, 11 multi-paragraph openQuestions, 35 crossReferences, 20 fully-fielded annotations, 47 references). This pass makes a single targeted improvement: surfacing 2 `originalContributions` that are clearly present in the Lean file but were missing from the meta list.

## Changes
`src/data/proofs/abel-ruffini-galois-extensions/meta.json`:
- **+ Non-commutativity witness suite (Part XIII, lines 431–461)**: five named theorems `s3_not_comm`, `s4_not_comm`, `s5_not_comm`, `a4_not_comm`, `a5_not_comm` verifying the absence of commutativity in S_n (n ≥ 3) and A_n (n ≥ 4) via `push_neg; decide` / `push_neg; native_decide`, providing explicit non-commutativity certificates as standalone named theorems beyond Mathlib's general instance.
- **+ Computational verification of higher-cardinality group orders (Part XIV, lines 470–480)**: four named theorems `card_s7`, `card_s8`, `card_a7`, `card_a8` proving |S_7|=5040, |S_8|=40320, |A_7|=2520, |A_8|=20160 via `native_decide`, documenting the `decide` → `native_decide` boundary for permutation cardinalities (kernel evaluator becomes impractical for cardinalities ≥ 720).

`originalContributions` count: 5 → 7.

## Test plan
- [x] JSON validates (python json.load)
- [x] Enrichment script processes the entry without error (1722/1982 enriched in pnpm build pipeline)
- [x] No structural changes; only additions to existing array

> **Note**: This PR's branch was force-reset; previous PR title/body referred to an earlier iteration (abel-ruffini keyInsight #35) and have been updated to match the current single-commit diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)