### PR TITLE
audit(erdos-221): mark clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5363,9 +5363,9 @@
     },
     "erdos-221": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T06:00:57Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T14:50:12Z",
+      "result": "clean",
       "issues": [
         "Phantom axioms in originalContributions/proofStrategy: lorentz_1954, two_primitive_root_mod_five_power, generalization_to_any_base, sumset_covering, additive_basis_order_two are listed but not declared in source (only dangling docstrings). Stale lineCount 274 in proofStrategy (file is 239 lines). Issue #14597 filed."
       ]


### PR DESCRIPTION
## Summary
- Re-audit of erdos-221 (additive complements with powers of 2, Ruzsa 1972)
- All meta.json claims match the Lean source: 239 lines, 0 sorries, 4 axioms, 6 theorems, 13 defs
- Status `axiomatized` + badge `axiom` correctly reflect the 4 stated assumptions
- Previous phantom-axiom issue (#14597) is resolved — meta now correctly distinguishes Lean declarations from documentation-only items

## Test plan
- [x] Sorry count matches (0 = 0)
- [x] Axiom count matches (4 = 4)
- [x] Theorem/def counts match
- [x] No overclaim — status correctly reflects axiomatized