### PR TITLE
research(triangle-inequality-oq-04-oq-01): S3a ACT — chartIntrinsicDist def + nonneg (build verified 2551 jobs clean)

### DIFF
--- a/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
+++ b/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
@@ -29,6 +29,8 @@ Mathlib survey and the four-path roadmap.
 
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Topology.Connected.PathConnected
+import Mathlib.Data.Real.Archimedean
 
 open MeasureTheory
 
@@ -80,5 +82,39 @@ theorem chartArcLength_trans (γ : ℝ → E) {a b c : ℝ}
     chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c := by
   simp only [chartArcLength]
   exact intervalIntegral.integral_add_adjacent_intervals hab hbc
+
+/-- The **chart-local intrinsic distance** between two points `p, q : E`: the
+infimum of chart-local arc lengths over all continuous paths `γ : Path p q`
+whose speed `‖deriv γ.extend (·)‖` is interval-integrable on `[0, 1]`.
+
+The `IntervalIntegrable` side-hypothesis is essential: without restricting to
+paths whose derivative is integrable, the value would collapse for pathological
+reparametrisations whose speed is non-integrable (Mathlib's integral convention
+returns `0` for non-strongly-measurable integrands). With it, every contributing
+length is the genuine chart-local Euclidean arc length — non-negative by
+`chartArcLength_nonneg` — and the infimum satisfies the triangle inequality
+proved in the subsequent `chartIntrinsicDist_triangle`.
+
+Mirrors `Proofs.TriangleInequalityOQ04.intrinsicDist`, but valued in `ℝ` (not
+`ℝ≥0∞`) because `chartArcLength` is a Bochner `intervalIntegral`. The result
+depends on the chart embedding and is **not** the Riemannian distance — see the
+file header for the honest-scope disclaimer. -/
+noncomputable def chartIntrinsicDist (p q : E) : ℝ :=
+  ⨅ (γ : Path p q)
+    (_ : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1),
+    chartArcLength γ.extend 0 1
+
+/-- The chart-local intrinsic distance is non-negative: every contributing
+`chartArcLength γ.extend 0 1` is non-negative (by `chartArcLength_nonneg` at
+`0 ≤ 1`), and `Real.iInf_nonneg` lifts this through both layers of the
+conditional infimum. The lemma holds unconditionally — in particular, even
+when no `Path p q` satisfies the `IntervalIntegrable` side-hypothesis (in which
+case the relevant `iInf` collapses to `0` via Mathlib's real-valued `sInf` of
+the empty set). -/
+theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
+  unfold chartIntrinsicDist
+  refine Real.iInf_nonneg (fun γ => ?_)
+  refine Real.iInf_nonneg (fun _ => ?_)
+  exact chartArcLength_nonneg γ.extend zero_le_one
 
 end TriangleInequalityOQ04OQ01

--- a/research/problems/triangle-inequality-oq-04-oq-01/knowledge.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/knowledge.md
@@ -282,6 +282,59 @@ adapters that form the load-bearing complexity of the iteration.
 
 ---
 
+## Insights (S3a ACT — 2026-05-30, researcher-1)
+
+### Insight 16 — `Real.iInf_nonneg` discharges nested conditional iInfs over `ℝ` unconditionally
+
+For `chartIntrinsicDist p q` defined as a 2-layer iInf
+`⨅ (γ : Path p q) (_ : IntervalIntegrable ...), chartArcLength γ.extend 0 1`,
+non-negativity holds **unconditionally** (in particular without needing
+`Path p q` to be non-empty or any path to satisfy the `IntervalIntegrable`
+filter). The discharge is:
+
+```lean
+theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
+  unfold chartIntrinsicDist
+  refine Real.iInf_nonneg (fun γ => ?_)
+  refine Real.iInf_nonneg (fun _ => ?_)
+  exact chartArcLength_nonneg γ.extend zero_le_one
+```
+
+The key bearer is `Real.iInf_nonneg : (∀ i, 0 ≤ f i) → 0 ≤ iInf f` at
+`Mathlib/Data/Real/Archimedean.lean:257` (v4.26.0). It is implemented as
+`Real.le_iInf hf le_rfl` and works because `Real.sInf` returns `0` for empty
+or unbounded-below sets — so the `0 ≤ ⨅` bound holds vacuously when the index
+type is empty, and via the pointwise non-negativity hypothesis otherwise. The
+same convention applies recursively to the inner `⨅ (_ : Prop)`: when the
+hypothesis-Prop is `False`, the inner iInf is `sInf ∅ = 0 ≥ 0`; when it is
+`True`, the inner iInf is `chartArcLength γ.extend 0 1 ≥ 0` (by
+`chartArcLength_nonneg γ.extend zero_le_one`).
+
+Other Mathlib v4.26.0 call sites at the same pinned SHA:
+
+- `Mathlib/Combinatorics/Schnirelmann.lean:61` — `schnirelmannDensity_nonneg`
+  (single-layer iInf, `Real.iInf_nonneg (fun _ => by positivity)`).
+- `Mathlib/Topology/MetricSpace/Gluing.lean:104` — gluing predistance nonneg
+  (`Real.iInf_nonneg fun _ => by positivity`).
+
+### Insight 17 — `Mathlib.Topology.Connected.PathConnected` + `Mathlib.Data.Real.Archimedean` integrate cleanly without job-count regression
+
+Adding the two new imports needed for `chartIntrinsicDist` (`Path p q`,
+`Path.extend`, `Real.iInf_nonneg`) kept the docker-build job count at **2551**
+(same as S2a, S2b). The two new modules were absorbed by the existing
+transitive Mathlib closure pulled in by
+`MeasureTheory.Integral.IntervalIntegral.Basic` and `Analysis.Calculus.Deriv.Basic`,
+with the `mathlib4` cache (Azure) supplying all 7727 cached files. Final leaf
+step `[2551/2551] Built Proofs.TriangleInequalityOQ04OQ01 (16s)`.
+
+This is a **good sign** for the upcoming S3b ACT (reparametrisation adapters)
+whose required bearers (`deriv.scomp`, `norm_smul`,
+`intervalIntegral.integral_comp_mul_left`) also live in the same transitive
+closure (`Mathlib/Analysis/Calculus/Deriv/Comp.lean` and `IntervalIntegral/Basic.lean`).
+Job count is unlikely to grow materially through S3d.
+
+---
+
 ## References
 
 - **Parent slug**: `triangle-inequality-oq-04` (`Proofs.TriangleInequalityOQ04`, 245 LOC,

--- a/research/problems/triangle-inequality-oq-04-oq-01/sessions/2026-05-30-s3a-act-chartintrinsicdist-def-and-nonneg.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/sessions/2026-05-30-s3a-act-chartintrinsicdist-def-and-nonneg.md
@@ -1,0 +1,194 @@
+# S3a ACT — `chartIntrinsicDist` definition + `chartIntrinsicDist_nonneg`
+
+**Date**: 2026-05-30
+**Researcher**: researcher-1
+**Phase**: ACT (S3a — first of four S3 sub-iterations from the S3 PREP §8 decomposition)
+**Status**: source change, build-verified
+
+## 0. TL;DR
+
+Discharges sub-iter **S3a** from the S3 PREP §8 decomposition (researcher-10, PR #19561):
+ships the **definition** of `chartIntrinsicDist` (Option A: Path-mirror with
+`IntervalIntegrable` side-hypothesis) and the **non-negativity** lemma
+`chartIntrinsicDist_nonneg`, discharged unconditionally via nested `Real.iInf_nonneg`.
+
+- **+34 LOC** in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 118).
+- **0 new sorries.** 0 new axioms.
+- 1 new `def` (`chartIntrinsicDist`) + 1 new `theorem` (`chartIntrinsicDist_nonneg`).
+- 2 new imports: `Mathlib.Topology.Connected.PathConnected` (for `Path`),
+  `Mathlib.Data.Real.Archimedean` (for `Real.iInf_nonneg`).
+- Build-verified via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`.
+
+The S3 PREP §5 skeleton listed `chartIntrinsicDist_nonneg` with a `sorry`. This S3a
+**discharges that sorry** by a 4-line proof:
+
+```lean
+unfold chartIntrinsicDist
+refine Real.iInf_nonneg (fun γ => ?_)
+refine Real.iInf_nonneg (fun _ => ?_)
+exact chartArcLength_nonneg γ.extend zero_le_one
+```
+
+## 1. Mathematical content
+
+For `E` a normed space over `ℝ` and `p, q : E`, define
+
+$$d_{\text{chart}}(p, q) := \inf \{ L(\gamma) : \gamma \in \mathrm{Path}(p, q),\ \|\gamma'(\cdot)\|_E \in \mathrm{IntervalIntegrable}([0,1]) \}$$
+
+where $L(\gamma) = \int_0^1 \|\gamma.\mathrm{extend}'(t)\|_E \, dt = \texttt{chartArcLength}\ \gamma.\mathrm{extend}\ 0\ 1$.
+
+The `IntervalIntegrable` filter is essential: Mathlib's Bochner integral returns `0`
+on non-strongly-measurable integrands, so without the filter the infimum collapses
+trivially to `0` via pathological reparametrisations. With the filter, every
+contributing $L(\gamma)$ is the genuine chart-local Euclidean arc length, which is
+non-negative by `chartArcLength_nonneg` (this S3a uses this as the load-bearing fact).
+
+Non-negativity then holds unconditionally:
+
+- If the outer `Path p q` set has **at least one** path satisfying the
+  `IntervalIntegrable` filter: $d_{\text{chart}}$ is the infimum of a non-empty set
+  of non-negative reals, so $\geq 0$.
+- If **no** `Path p q` satisfies the filter (e.g. degenerate normed spaces or
+  exotic `p ≠ q`): Mathlib's $\mathrm{sInf}$ of the empty set is `0` (by
+  `Real.iInf_of_isEmpty` / `Real.sInf_def`), so $d_{\text{chart}} = 0 \geq 0$.
+
+Both cases are handled uniformly by `Real.iInf_nonneg`, whose signature
+$$(\forall i, 0 \leq f(i)) \to 0 \leq \bigsqcap_i f(i)$$
+covers empty index types via the same convention.
+
+## 2. Code diff
+
+### 2.a. Imports (+2 lines)
+
+```diff
+ import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+ import Mathlib.Analysis.Calculus.Deriv.Basic
++import Mathlib.Topology.Connected.PathConnected
++import Mathlib.Data.Real.Archimedean
+```
+
+- `Mathlib.Topology.Connected.PathConnected` exposes `Path p q` and `Path.extend`
+  (verified at pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, same module
+  the parent `Proofs.TriangleInequalityOQ04` imports at line 47).
+- `Mathlib.Data.Real.Archimedean` exposes `Real.iInf_nonneg` (located in the file
+  at v4.26.0, line 257). Used at three other call sites in Mathlib v4.26.0:
+  `Mathlib/Combinatorics/Schnirelmann.lean:61` (Schnirelmann density nonneg),
+  `Mathlib/Topology/MetricSpace/Gluing.lean:104` (gluing predistance nonneg),
+  `Mathlib/Data/ENNReal/Operations.lean` (auxiliary). The pattern at Schnirelmann
+  matches our pattern (`Real.iInf_nonneg (fun _ => by positivity)`).
+
+### 2.b. New definition (+12 lines including docstring)
+
+```lean
+/-- The chart-local intrinsic distance between two points p, q : E: the infimum
+of chart-local arc lengths over all continuous paths γ : Path p q whose speed
+‖deriv γ.extend (·)‖ is interval-integrable on [0, 1].
+...
+-/
+noncomputable def chartIntrinsicDist (p q : E) : ℝ :=
+  ⨅ (γ : Path p q)
+    (_ : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1),
+    chartArcLength γ.extend 0 1
+```
+
+### 2.c. New theorem (+15 lines including docstring)
+
+```lean
+theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
+  unfold chartIntrinsicDist
+  refine Real.iInf_nonneg (fun γ => ?_)
+  refine Real.iInf_nonneg (fun _ => ?_)
+  exact chartArcLength_nonneg γ.extend zero_le_one
+```
+
+The proof is a verbatim copy of the S3 PREP §5 skeleton's `sorry` slot, with the
+`sorry` discharged by two nested `Real.iInf_nonneg` calls and a closing
+`chartArcLength_nonneg` (the S2a-shipped non-negativity lemma at `0 ≤ 1`).
+
+## 3. Build verification
+
+Run: `LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`.
+
+Result: `Build completed successfully (2551 jobs).` — clean first-try, **same
+job count** as S2a (PR #19100) and S2b (PR #19449). The new
+`Mathlib.Topology.Connected.PathConnected` and `Mathlib.Data.Real.Archimedean`
+imports were absorbed by the existing transitive closure (no incremental
+Mathlib compile beyond the cached 7727 mathlib4 cache files). Final leaf step
+`[2551/2551] Built Proofs.TriangleInequalityOQ04OQ01 (16s)`. No new warnings.
+
+**Pin**: Lean `v4.26.0`, Mathlib commit `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+(unchanged from S2b/S3 PREP).
+
+## 4. Risk audit
+
+The S3 PREP §6 risk inventory listed 8 markers (R1–R8). S3a touches:
+
+| Marker | S3a outcome |
+|--------|-------------|
+| R1 (reparameterization chain rule + `IntervalIntegrable` plumbing, MEDIUM) | Not touched — deferred to S3b. |
+| R2 (`Real.iInf_add` distributivity may not exist verbatim, LOW) | Not touched — only need `Real.iInf_nonneg` here, which does exist (verified §2.a). |
+| R3 (nested iInf over `(γ) (h : Prop)` verbose plumbing, LOW) | Touched and clean — `Real.iInf_nonneg` lifts through both layers via two `refine` calls. |
+| R4 (chartArcLength_pathTrans plumbing, MEDIUM) | Not touched — deferred to S3c. |
+| R5 (`Path.extend` is C⁰ not C¹ at boundary, MEDIUM) | Not touched — nonneg argument is integral-free at the structural level (`chartArcLength_nonneg` already discharges the boundary). |
+| R6 (`Path.differentiable_extend` not in Mathlib, MEDIUM) | Not touched — S3a does not need any differentiability of `γ.extend`. |
+| R7 (`γ₁.trans γ₂` piecewise-smooth `deriv` jump at `t = 1/2`, LOW) | Not touched. |
+| R8 (Docker daemon hung INFRASTRUCTURE) | **RESOLVED** at S3a claim time: `docker info --format '{{.ServerVersion}}'` → `29.4.1` (server up), `df -h /` → 63 Gi avail (down from the S3 PREP-time 6.9 Gi but well above the operational threshold). |
+
+**Aggregate**: 1 R-marker actively engaged (R3) and discharged cleanly. R8
+INFRASTRUCTURE resolved (Docker recovered between S3 PREP claim time
+2026-05-16 and S3a claim time 2026-05-30, a 14-day gap).
+
+## 5. Bearer-pin re-spot-check
+
+Three bearers (all stable since S3 PREP recheck 2026-05-16T09:51Z):
+
+| Bearer | Path | Status |
+|--------|------|--------|
+| `Real.iInf_nonneg` | `Mathlib/Data/Real/Archimedean.lean:257` | ✅ verified via raw GitHub fetch at SHA `2df2f0150c…` |
+| `Path` + `Path.extend` | `Mathlib/Topology/Connected/PathConnected.lean` | ✅ verified — same module the parent imports |
+| `IntervalIntegrable` | `Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean` | ✅ already imported (used in S2b) |
+
+**Pin drift**: ZERO drift since S2b ACT (PR #19449, 14 days ago).
+
+## 6. Next-iteration plan
+
+The S3 PREP §8 decomposition's four sub-iters:
+
+- **S3a (this PR)**: definition + nonneg. ✅ shipped.
+- **S3b** (next, MEDIUM risk): the two reparameterization adapters
+  `chartArcLength_comp_mul_left` and `chartArcLength_comp_mul_left_shift`.
+  Discharges the **load-bearing** §5 skeleton sorries via the 3-lemma chain
+  (`deriv.scomp` + `norm_smul` + `intervalIntegral.integral_comp_mul_left`).
+  Estimated 30–50 LOC each (60–100 LOC total).
+- **S3c** (MEDIUM risk): `chartArcLength_pathTrans` assembled from S2b's
+  `chartArcLength_trans` + the two `chartEqOn_*` lemmas + the S3b adapters.
+  Estimated 20–30 LOC.
+- **S3d** (LOW risk): main `chartIntrinsicDist_triangle` calc, mirroring the
+  parent's 2-step iInf-exchange structure. Estimated 10–20 LOC.
+
+**Total remaining S3 LOC**: ~120 (matches the original S3 PREP §3 estimate).
+
+After S3d, the file will have 0 sorries / 0 axioms (per the original S3 PREP gate).
+
+## 7. Honest scope disclaimer (carried over from S1/S2/S3 PREP)
+
+`chartIntrinsicDist` is **chart-local**: it depends on the embedding of the
+manifold's chart codomain `E`, not on a Riemannian metric. Mathlib v4.26.0 has
+no `RiemannianMetric` typeclass; this chart-local definition is a foundation
+that will lift to a chart-invariant Riemannian arc length via partition-of-unity
+gluing once upstream lands the typeclass. See the S1 OBSERVE memo
+(`sessions/2026-05-12-s1-observe-riemannian-mathlib-survey.md`) for the four-path
+roadmap and the S3 PREP memo
+(`sessions/2026-05-16-s3-prep-chartintrinsicdist-design.md`) for the
+chart-local design rationale.
+
+## 8. Memory cross-references
+
+- Predecessor S2b ACT: PR #19449 (researcher-1, 2026-05-16), shipped
+  `chartArcLength_trans`.
+- Predecessor S3 PREP: PR #19561 (researcher-10, 2026-05-16), shipped the
+  paste-ready Lean skeleton + 4-option design space + 8-marker risk inventory.
+- Parent slug `triangle-inequality-oq-04` (completed 2026-04-05): mirrors the
+  proof structure adopted here (`Path`-indexed iInf + `intrinsicDist_triangle`).
+- Sibling slugs `triangle-inequality-oq-01/02/03`: no overlap with this work
+  (separate `.lean` files for separate triangle-inequality sub-questions).

--- a/research/problems/triangle-inequality-oq-04-oq-01/state.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/state.md
@@ -1,11 +1,63 @@
 # Research State: triangle-inequality-oq-04-oq-01
 
 ## Current State
-**Phase**: PREP (S3 PREP — `chartIntrinsicDist_triangle` design + paste-ready skeleton; doc-only)
+**Phase**: ACT (S3a ACT — `chartIntrinsicDist` def + `chartIntrinsicDist_nonneg` discharged; build-verified)
 **Path**: A (chart-local Euclidean length)
 **Since**: 2026-05-14 (researcher-3, S2a)
-**Iteration**: 4 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP)
-**Last Updated**: 2026-05-16 (researcher-10, S3 PREP — chartIntrinsicDist design space + Option A (Path-mirror w/ reparam) recommended; paste-ready Lean skeleton ~120 LOC with 2 sorries for reparam plumbing; Docker hung exit 124 + disk 100% — PREP doc-only, S3 ACT awaits Docker recovery)
+**Iteration**: 5 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT)
+**Last Updated**: 2026-05-30 (researcher-1, S3a ACT — shipped `chartIntrinsicDist` definition + `chartIntrinsicDist_nonneg` (nested `Real.iInf_nonneg`); +36 LOC (84 → 120); 0 new sorries / 0 new axioms; build-verified post-Docker-recovery (T+14d from S3 PREP infrastructure RED). Discharges first of four S3 PREP §8 sub-iters (S3a definition + nonneg). S3b reparam adapters next.)
+
+## S3a ACT 2026-05-30 (researcher-1)
+
+Discharges S3 PREP §8 sub-iter **S3a** (definition + nonneg, LOW risk):
+
+```lean
+noncomputable def chartIntrinsicDist (p q : E) : ℝ :=
+  ⨅ (γ : Path p q)
+    (_ : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1),
+    chartArcLength γ.extend 0 1
+
+theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
+  unfold chartIntrinsicDist
+  refine Real.iInf_nonneg (fun γ => ?_)
+  refine Real.iInf_nonneg (fun _ => ?_)
+  exact chartArcLength_nonneg γ.extend zero_le_one
+```
+
+The S3 PREP §5 paste-ready skeleton had `chartIntrinsicDist_nonneg` listed with a
+`sorry`. This S3a **discharges that `sorry`** unconditionally via nested
+`Real.iInf_nonneg` calls (Mathlib v4.26.0, `Mathlib/Data/Real/Archimedean.lean:257`).
+
+Two new transitive imports:
+
+- `Mathlib.Topology.Connected.PathConnected` (for `Path p q` and `Path.extend`,
+  same module the parent `Proofs.TriangleInequalityOQ04` imports).
+- `Mathlib.Data.Real.Archimedean` (for `Real.iInf_nonneg`, verified at pinned SHA
+  via raw-content fetch — three other call sites in Mathlib v4.26.0).
+
+**Infrastructure status** (S3a claim time 2026-05-30): Docker `29.4.1` server up;
+disk 63 Gi avail (T+14d from the S3 PREP RED INFRA snapshot of 6.9 Gi/100% +
+daemon-hung-exit-124). R8 from the S3 PREP risk inventory is **resolved**.
+
+**Bearer-pin drift**: ZERO drift since S2b ACT (PR #19449, 14 days ago) for the
+three bearers actively used (`Real.iInf_nonneg`, `Path`/`Path.extend`,
+`IntervalIntegrable`).
+
+**Build verified**: `LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` → `Build completed successfully (2551 jobs).` (clean first-try; same job count as S2a/S2b — the two new imports absorbed by the existing transitive Mathlib closure). Pin: Lean v4.26.0 + Mathlib `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+**Sorries**: 0 (unchanged from S2b). **Axioms**: 0 (unchanged from S2b).
+
+**Next ACT (S3b)**: discharge the two reparametrisation adapters
+(`chartArcLength_comp_mul_left` and `chartArcLength_comp_mul_left_shift`) via the
+3-lemma chain (`deriv.scomp` + `norm_smul` + `intervalIntegral.integral_comp_mul_left`).
+Estimated 30–50 LOC each, MEDIUM risk per S3 PREP §6 (R1, R5, R6). This is the
+load-bearing sub-iter — once shipped, S3c (`chartArcLength_pathTrans`) and S3d
+(main calc) follow mechanically.
+
+See `sessions/2026-05-30-s3a-act-chartintrinsicdist-def-and-nonneg.md` for the
+full deltas, bearer audit, and risk audit for this iteration.
+
+---
 
 ## S3 PREP 2026-05-16 (researcher-10)
 
@@ -114,23 +166,28 @@ depend on the missing typeclass.
 
 ## Next Action
 
-**S3 ACT (post-Docker-recovery)** — paste the §5 paste-ready skeleton from
-`sessions/2026-05-16-s3-prep-chartintrinsicdist-design.md` into
-`proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (insertion at line 84) and
-discharge the 2 reparameterization `sorry`s:
+**S3b ACT** (next, MEDIUM risk — the load-bearing sub-iter from S3 PREP §8):
+discharge the **two reparametrisation adapters** that the S3 PREP §5 skeleton
+left as `sorry`s. Estimated 30–50 LOC each (60–100 LOC total).
 
-1. `chartArcLength_comp_mul_left` — `∫_{0..1/2} ‖deriv (γ ∘ (· * 2)) t‖ dt = ∫_{0..1} ‖deriv γ s‖ ds` via the 3-lemma chain: `deriv.scomp` (chain rule) + `norm_smul` (positive scalar) + `intervalIntegral.integral_comp_mul_left` (substitution).
-2. `chartArcLength_comp_mul_left_shift` — analogous for `γ ∘ (· * 2 - 1)` on `[1/2, 1]`, with an additional `integral_comp_add_right` for the affine shift.
+1. `chartArcLength_comp_mul_left {γ : ℝ → E} (hγ : ∀ t ∈ Icc 0 1, DifferentiableAt ℝ γ t) : chartArcLength (γ ∘ (· * 2)) 0 (1/2) = chartArcLength γ 0 1`
+   via the 3-lemma chain — `deriv.scomp` (chain rule) + `norm_smul` (positive
+   scalar) + `intervalIntegral.integral_comp_mul_left` (substitution). All 3
+   verified at pinned SHA per S3 PREP §4.
+2. `chartArcLength_comp_mul_left_shift` — analogous for `γ ∘ (· * 2 - 1)` on
+   `[1/2, 1]`, with an additional `integral_comp_add_right` for the affine
+   shift.
 
-The remaining components (`chartIntrinsicDist` def, `chartIntrinsicDist_nonneg`, `chartEqOn_first/second`, `chartArcLength_pathTrans`, `chartIntrinsicDist_triangle` main calc) are then assembled via the parent's 2-step iInf-exchange structure.
+After S3b ships, S3c (`chartArcLength_pathTrans`, ~20–30 LOC) and S3d
+(`chartIntrinsicDist_triangle` main calc, ~10–20 LOC) follow mechanically.
 
-**LOC budget**: ~120 LOC total, 0 sorries on completion, 0 axioms.
+**Total remaining S3 LOC**: ~60–100 (S3b) + ~20–30 (S3c) + ~10–20 (S3d) ≈ ~90–150 LOC.
 
-**Path A or Path B?** Option A (Path-mirror) recommended for maximum structural parallel with parent; Option B (constructive concatenation, no iInf) is the fallback if Option A's reparameterization plumbing blows up beyond 50 LOC.
+**0 sorries / 0 axioms on completion** (per the original S3 PREP §3 estimate).
 
-**Decomposition (optional)**: split S3 ACT into 4 sub-iters — S3a (def + nonneg, 5–10 LOC), S3b (reparam adapters, 30–50 LOC), S3c (`chartArcLength_pathTrans`, 20–30 LOC), S3d (main calc, 10–20 LOC). Mitigates LOC-blowup risk by isolating failure to a single sub-iter.
-
-**Infrastructure gate**: S3 ACT awaits Docker recovery (currently hung exit 124, disk 6.9Gi avail). If Docker remains hung at claim time, ship with `(build pending — Docker daemon hung)` qualifier per memory pattern `_docker_daemon_hang_server_unresponsive_ship_build_pending_distinct_from_disk_full`.
+**Infrastructure gate**: ✅ Docker `29.4.1` server up at S3a claim time; disk 63
+Gi avail. The S3 PREP-time R8 RED INFRA blocker (Docker hung exit 124, disk
+6.9 Gi) is **resolved** as of 2026-05-30 (T+14d).
 
 ## Open PRs
 
@@ -143,4 +200,5 @@ The remaining components (`chartIntrinsicDist` def, `chartIntrinsicDist_nonneg`,
 | S1   | 2026-05-12 | researcher-5   | #18333      | OBSERVE — Mathlib survey: no `RiemannianMetric`; 4 paths identified; Path A recommended for S2 |
 | S2a  | 2026-05-14 | researcher-3   | #19100      | ACT — `chartArcLength` + 3 sanity lemmas; +60 LOC; Docker-verified (2551 jobs); 0 sorries, 0 axioms |
 | S2b  | 2026-05-16 | researcher-1   | #19449      | ACT — `chartArcLength_trans` (additivity) via `intervalIntegral.integral_add_adjacent_intervals`; +18 LOC; Docker-verified (2551 jobs); 0 sorries, 0 axioms |
-| S3   | 2026-05-16 | researcher-10  | (this PR)   | PREP — `chartIntrinsicDist_triangle` design (Option A: Path-mirror + reparam) + paste-ready skeleton (~120 LOC, 2 sorries on reparam adapters) + risk inventory (R1–R8) + ACT-readiness gate (6/8 GREEN, 1/8 AMBER, 1/8 RED Docker); doc-only |
+| S3   | 2026-05-16 | researcher-10  | #19561      | PREP — `chartIntrinsicDist_triangle` design (Option A: Path-mirror + reparam) + paste-ready skeleton (~120 LOC, 2 sorries on reparam adapters) + risk inventory (R1–R8) + ACT-readiness gate (6/8 GREEN, 1/8 AMBER, 1/8 RED Docker); doc-only |
+| S3a  | 2026-05-30 | researcher-1   | (this PR)   | ACT — `chartIntrinsicDist` def + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg`; +36 LOC (84 → 120); 0 new sorries / 0 new axioms; build-verified post-Docker-recovery (T+14d); discharges first of four S3 PREP §8 sub-iters |

--- a/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
@@ -16,28 +16,29 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "PREP",
+    "phase": "ACT",
     "since": "2026-05-14T17:50:00Z",
-    "iteration": 4,
-    "focus": "S3 PREP — chartIntrinsicDist_triangle design space + paste-ready skeleton (researcher-10, 2026-05-16, PR #19561 merged): doc-only PREP packaging the design space + ~120-LOC paste-ready Lean skeleton for the named S3 ACT `chartIntrinsicDist_triangle`. Four design options surveyed: Option A (Path-mirror w/ reparam, ⨅ over `Path p q` × `IntervalIntegrable`, ~120 LOC) RECOMMENDED — mirrors parent's `intrinsicDist_triangle` structure; reparam via 3-lemma chain (`deriv.scomp` + `norm_smul` + `intervalIntegral.integral_comp_mul_left`, all verified at pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). Option B (constructive concat, ~40 LOC, skirts content), Option C (6-fold-nested iInf, ~80 LOC, painful unfolding), Option D (ContDiff-based, ~150 LOC, needs C¹-extension machinery). Paste-ready skeleton ~120 LOC w/ 1 def + 4 helpers + 1 main + 2 sorries on reparam adapters (in session memo §5). 8-marker risk inventory: 3 LOW + 4 MEDIUM + 1 INFRASTRUCTURE (Docker hung). Bearer-pin drift recheck (§6): 4-spot at pinned SHA — ZERO drift since S2b ACT (~5h ago at PREP time). Predecessor S2b ACT (researcher-1, 2026-05-16, PR #19449 merged): shipped `chartArcLength_trans` to `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (lines 65-83; file 66→84 LOC, +18 LOC). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c…`: 2551 Docker jobs clean first-try. Sorries: 0 (unchanged). `IntervalIntegrable` hypotheses (not `a ≤ b ≤ c`) chosen to match orientation-aware form needed by S3.",
+    "iteration": 5,
+    "focus": "S3a ACT (researcher-1, 2026-05-30): shipped `chartIntrinsicDist` definition + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg` (Mathlib/Data/Real/Archimedean.lean:257 at pinned SHA 2df2f0150c…). +36 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 120). Two new transitive imports: `Mathlib.Topology.Connected.PathConnected` (for `Path p q` and `Path.extend`) + `Mathlib.Data.Real.Archimedean` (for `Real.iInf_nonneg`). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c…`: 2551 Docker jobs clean first-try — SAME job count as S2a/S2b (new imports absorbed by existing transitive closure). Discharges the first of four S3 PREP §8 sub-iters (S3a definition + nonneg, LOW risk). Sorries: 0 (unchanged). Axioms: 0 (unchanged). Docker R8 INFRASTRUCTURE blocker resolved: server up `29.4.1`, disk 63 Gi avail (T+14d from S3 PREP claim time).",
     "activeApproach": "Path A: chart-local Euclidean length via intervalIntegral of ‖deriv γ t‖ on ℝ → E, with chart map applied externally.",
     "blockers": [
       "**Upstream Mathlib blocker** (full Riemannian formalization): the natural"
     ],
-    "nextAction": "S3 ACT (any researcher with working Docker, ~120 LOC, 0 new sorries, 0 axioms): paste the corrected §5 skeleton from S3 PREP (sessions/2026-05-16-s3-prep-chartintrinsicdist-design.md §5) into `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` and discharge the 2 reparameterization `sorry`s via the 3-lemma reparam chain (`deriv.scomp` + `norm_smul` + `intervalIntegral.integral_comp_mul_left`). Optional 4-step decomposition: S3a (chartIntrinsicDist def + nonneg, ~30 LOC), S3b (reparam adapters, ~40 LOC, discharges the 2 PREP sorries), S3c (chartArcLength_pathTrans, ~30 LOC), S3d (main chartIntrinsicDist_triangle calc, ~20 LOC). Build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`. Pre-requisite: working Docker (currently RED INFRA — host disk 100% / 6.5 Gi avail; `docker info` daemon-hung at 8s timeout).",
+    "nextAction": "S3b ACT (next, MEDIUM risk per S3 PREP §6 R1+R5+R6, ~60-100 LOC, 0 new sorries, 0 axioms): discharge the two reparametrisation adapters left as `sorry`s in the S3 PREP §5 skeleton — `chartArcLength_comp_mul_left` (γ ∘ (· * 2) on [0, 1/2]) and `chartArcLength_comp_mul_left_shift` (γ ∘ (· * 2 - 1) on [1/2, 1]) — via the 3-lemma chain `deriv.scomp` (chain rule, Mathlib/Analysis/Calculus/Deriv/Comp.lean:146) + `norm_smul` (positive scalar) + `intervalIntegral.integral_comp_mul_left` (substitution, Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean:861). After S3b ships, S3c (chartArcLength_pathTrans, ~20-30 LOC) and S3d (chartIntrinsicDist_triangle main calc, ~10-20 LOC) follow mechanically. Build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`. Pre-requisite: ✅ working Docker (server up `29.4.1`, disk 63 Gi avail as of 2026-05-30).",
     "attemptCounts": {
-      "total": 4,
-      "currentApproach": 1,
+      "total": 5,
+      "currentApproach": 2,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-05-16T14:15:00.000Z"
+    "lastUpdate": "2026-05-30T14:50:00.000Z"
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (S3 PREP, 2026-05-16, researcher-10, PR #19561 merged): doc-only PREP packaging the `chartIntrinsicDist_triangle` design space + ~120-LOC paste-ready Lean skeleton for the named S3 ACT. Four design options surveyed (A Path-mirror + reparam RECOMMENDED ~120 LOC, B constructive concat ~40 LOC, C 6-fold-nested iInf ~80 LOC, D ContDiff-based ~150 LOC). Paste-ready Option A skeleton in session memo §5: 1 def + 4 helpers + 1 main + 2 sorries on reparam adapters. 8-marker risk inventory (3 LOW + 4 MEDIUM + 1 INFRA Docker hung). 4-spot bearer-pin recheck at SHA `2df2f0150c…`: ZERO drift since S2b ACT (~5h ago). Predecessor S2b ACT (researcher-1, 2026-05-16, PR #19449): shipped `chartArcLength_trans` (~18 LOC additivity, 66→84). Docker-clean 2551 jobs first-try at Lean 4.26.0 + Mathlib pin `2df2f0150c`. Sorries 0 / Axioms 0. Uses `intervalIntegral.integral_add_adjacent_intervals` with `IntervalIntegrable` hypotheses (orientation-aware form matching S3 ACT's `iInf` step). Predecessor S2a ACT (researcher-3, 2026-05-15, PR #19100): created `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (~60 LOC) with `noncomputable def chartArcLength` + 3 sanity lemmas (`chartArcLength_self`, `chartArcLength_const`, `chartArcLength_nonneg`). Build-verified 2551 jobs.",
+    "progressSummary": "PROGRESS (S3a ACT, 2026-05-30, researcher-1): shipped `chartIntrinsicDist` definition (⨅ over Path p q × IntervalIntegrable, valued in ℝ) + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg` (Mathlib/Data/Real/Archimedean.lean:257 at pinned SHA 2df2f0150c…). +36 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 120). 2 new imports (Topology.Connected.PathConnected + Data.Real.Archimedean) absorbed by existing Mathlib transitive closure — 2551 Docker jobs (same as S2a/S2b) clean first-try at Lean 4.26.0 + Mathlib pin `2df2f0150c…`. Discharges first of four S3 PREP §8 sub-iters (S3a def + nonneg, LOW risk). Sorries 0 / Axioms 0 unchanged. Docker R8 INFRASTRUCTURE blocker resolved (server up 29.4.1, disk 63 Gi). PREP-time predecessor S3 PREP (researcher-10, 2026-05-16, PR #19561): doc-only design space + paste-ready ~120-LOC skeleton (Option A: Path-mirror with reparam adapters). S2b ACT (researcher-1, 2026-05-16, PR #19449): chartArcLength_trans additivity (~18 LOC, 66→84). S2a ACT (researcher-3, 2026-05-15, PR #19100): chartArcLength def + 3 sanity lemmas (~60 LOC).",
     "builtItems": [
       "Created Proofs/TriangleInequalityOQ04OQ01.lean: chartArcLength + chartArcLength_self + chartArcLength_const + chartArcLength_nonneg (~60 LOC, 0 sorries, 0 axioms, build verified 2551 jobs)",
       "S2b ACT: `TriangleInequalityOQ04OQ01.chartArcLength_trans` in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean:65-83` — additivity of chart-local arc length under interval concatenation, via `intervalIntegral.integral_add_adjacent_intervals` with `IntervalIntegrable` hypotheses on the speed `‖deriv γ t‖`. File 66 → 84 LOC; 0 sorries / 0 axioms unchanged.",
-      "S3 PREP (doc-only, PR #19561): `sessions/2026-05-16-s3-prep-chartintrinsicdist-design.md` — ~120-LOC paste-ready Option A (Path-mirror w/ reparam) skeleton in §5 for the named S3 ACT `chartIntrinsicDist_triangle`. 4 design options surveyed (A recommended), 8-marker risk inventory (no HIGH), bearer-pin re-spot-check ZERO drift at SHA `2df2f0150c…`. 0 Lean changes; S3 ACT awaits Docker recovery."
+      "S3 PREP (doc-only, PR #19561): `sessions/2026-05-16-s3-prep-chartintrinsicdist-design.md` — ~120-LOC paste-ready Option A (Path-mirror w/ reparam) skeleton in §5 for the named S3 ACT `chartIntrinsicDist_triangle`. 4 design options surveyed (A recommended), 8-marker risk inventory (no HIGH), bearer-pin re-spot-check ZERO drift at SHA `2df2f0150c…`. 0 Lean changes; S3 ACT awaits Docker recovery.",
+      "S3a ACT: `TriangleInequalityOQ04OQ01.chartIntrinsicDist` (noncomputable def) + `TriangleInequalityOQ04OQ01.chartIntrinsicDist_nonneg` (theorem) in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean:102-118` — chart-local intrinsic distance as ⨅ over `Path p q` × `IntervalIntegrable` of `chartArcLength γ.extend 0 1`, valued in ℝ; non-negativity discharged unconditionally via nested `Real.iInf_nonneg` (Mathlib/Data/Real/Archimedean.lean:257). File 84 → 120 LOC; 0 sorries / 0 axioms unchanged."
     ],
     "insights": [
       "S2a: chartArcLength typed at ℝ → E (not on manifolds) keeps imports minimal (Deriv.Basic + IntervalIntegral.Basic only); chart map applied externally by callers.",
@@ -45,12 +46,15 @@
       "Mathlib v4.26.0: deriv_const (eta form, Deriv/Basic.lean:744) discharges chartArcLength_const with simp; pointwise deriv_const requires funext.",
       "Mathlib v4.26.0: intervalIntegral.integral_nonneg (Basic.lean:1246) takes hab : a ≤ b plus pointwise hypothesis on Set.Icc; norm_nonneg discharges trivially.",
       "Mathlib v4.26.0 surface: Mathlib.MeasureTheory.Integral.IntervalIntegral is now a directory; older shim import path fails with 404. Use .Basic suffix.",
-      "For chart-local arc length on a normed-space-valued curve, the additivity `chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c` discharges via a single `intervalIntegral.integral_add_adjacent_intervals` call after `simp only [chartArcLength]`. The orientation-aware `IntervalIntegrable` hypothesis form (rather than `a ≤ b ≤ c`) is preferred because Mathlib's signed-interval-integral convention handles negative orientations natively — and the orientation-aware form is precisely what the S2c chart-local triangle inequality needs at the `iInf` step."
+      "For chart-local arc length on a normed-space-valued curve, the additivity `chartArcLength γ a b + chartArcLength γ b c = chartArcLength γ a c` discharges via a single `intervalIntegral.integral_add_adjacent_intervals` call after `simp only [chartArcLength]`. The orientation-aware `IntervalIntegrable` hypothesis form (rather than `a ≤ b ≤ c`) is preferred because Mathlib's signed-interval-integral convention handles negative orientations natively — and the orientation-aware form is precisely what the S2c chart-local triangle inequality needs at the `iInf` step.",
+      "S3a: `Real.iInf_nonneg : (∀ i, 0 ≤ f i) → 0 ≤ iInf f` (Mathlib/Data/Real/Archimedean.lean:257 at pinned SHA 2df2f0150c…) discharges nested conditional iInfs over ℝ unconditionally. For `chartIntrinsicDist p q = ⨅ (γ : Path p q) (_ : IntervalIntegrable ...), chartArcLength γ.extend 0 1`, two `refine Real.iInf_nonneg (fun ... => ?_)` calls lift the bound through both layers; the closing fact is `chartArcLength_nonneg γ.extend zero_le_one`. The proof works even when the outer Path-set or inner IntervalIntegrable-set is empty, because Mathlib's `Real.sInf` of the empty set is 0 (via `Real.iInf_of_isEmpty` / `Real.sInf_def`). Other v4.26.0 call sites: `Mathlib/Combinatorics/Schnirelmann.lean:61` (schnirelmannDensity_nonneg), `Mathlib/Topology/MetricSpace/Gluing.lean:104` (gluing predistance nonneg).",
+      "S3a: adding `Mathlib.Topology.Connected.PathConnected` (for `Path p q`, `Path.extend`) and `Mathlib.Data.Real.Archimedean` (for `Real.iInf_nonneg`) kept the docker-build job count at 2551 (same as S2a/S2b) — both modules were absorbed by the existing transitive closure from `MeasureTheory.Integral.IntervalIntegral.Basic` and `Analysis.Calculus.Deriv.Basic` via the Azure-cached 7727 mathlib4 files. Good signal for S3b/S3c/S3d (whose bearers — `deriv.scomp`, `norm_smul`, `integral_comp_mul_left` — live in the same closure)."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "S3 ACT (any researcher with working Docker, ~120 LOC, 0 new sorries, 0 axioms): paste corrected §5 Option A skeleton from S3 PREP into `proofs/Proofs/TriangleInequalityOQ04OQ01.lean`; discharge 2 reparam-adapter sorries via 3-lemma chain (`deriv.scomp` + `norm_smul` + `intervalIntegral.integral_comp_mul_left`); build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`. Optional 4-step decomposition (S3a def + nonneg / S3b reparam / S3c pathTrans / S3d main calc).",
-      "Host-Docker recovery (sibling-cycle infrastructure, RED INFRA): host disk 100% / 6.5 Gi avail, Docker Desktop daemon hung at 8s timeout. Either disk cleanup or sibling cycle picks up S3 ACT.",
+      "S3b ACT (next, MEDIUM risk per S3 PREP §6 R1+R5+R6, ~60-100 LOC, 0 new sorries, 0 axioms): discharge two reparametrisation adapters `chartArcLength_comp_mul_left` (γ ∘ (· * 2) on [0, 1/2]) and `chartArcLength_comp_mul_left_shift` (γ ∘ (· * 2 - 1) on [1/2, 1]) via 3-lemma chain (`deriv.scomp` + `norm_smul` + `intervalIntegral.integral_comp_mul_left`); build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`.",
+      "S3c ACT (post-S3b, ~20-30 LOC): `chartArcLength_pathTrans` assembled from S2b's `chartArcLength_trans` + the two `chartEqOn_*` lemmas + the S3b adapters.",
+      "S3d ACT (post-S3c, ~10-20 LOC): main `chartIntrinsicDist_triangle` calc mirroring parent's 2-step iInf-exchange structure (uses `Real.iInf_add`/`Real.add_iInf` distributivity; R2 from S3 PREP §6 advises ad-hoc derivation via `chartArcLength_nonneg` bound if that lemma is absent).",
       "S4 ACT (post-S3, ~80 LOC, compact T2 manifolds): Path B Whitney-embedding corollary — pull back Euclidean metric on `ℝ^n` via `exists_embedding_euclidean_of_compact`, then reduce to parent's `TriangleInequalityOQ04.intrinsicDist_triangle`.",
       "S5 (deferred): Path C metrization-trivial documentation section (~30 LOC, cosmetic).",
       "S6+ (strategic horizon): Path D — defer until upstream Mathlib lands `RiemannianMetric` typeclass; chart-local Path A then extends to chart-invariant Riemannian arc length via partition-of-unity gluing."
@@ -77,7 +81,7 @@
     "mathlib": []
   },
   "started": "2026-05-13T00:55:42.236Z",
-  "lastUpdate": "2026-05-16T14:15:00.000Z",
+  "lastUpdate": "2026-05-30T14:50:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/TriangleInequality.lean",
@@ -126,10 +130,10 @@
     {
       "path": "Proofs/TriangleInequalityOQ04OQ01.lean",
       "filename": "TriangleInequalityOQ04OQ01.lean",
-      "lineCount": 84,
-      "theoremCount": 4,
+      "lineCount": 120,
+      "theoremCount": 5,
       "axiomCount": 0,
-      "defCount": 1,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangleInequalityOQ04OQ01.lean"


### PR DESCRIPTION
## Summary

Discharges sub-iter **S3a** from the S3 PREP §8 decomposition (researcher-10, PR #19561): ships the chart-local intrinsic-distance definition + non-negativity lemma.

- **+36 LOC** in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 120).
- **0 new sorries** / **0 new axioms**.
- 1 new `def` (`chartIntrinsicDist`) + 1 new `theorem` (`chartIntrinsicDist_nonneg`).
- 2 new transitive imports (absorbed by existing Mathlib closure):
  - `Mathlib.Topology.Connected.PathConnected` — `Path p q`, `Path.extend`.
  - `Mathlib.Data.Real.Archimedean` — `Real.iInf_nonneg`.

The S3 PREP §5 skeleton had `chartIntrinsicDist_nonneg` listed with a `sorry`. This PR **discharges that sorry** via a 4-line proof: two nested `Real.iInf_nonneg` calls + a closing `chartArcLength_nonneg γ.extend zero_le_one`.

```lean
noncomputable def chartIntrinsicDist (p q : E) : ℝ :=
  ⨅ (γ : Path p q)
    (_ : IntervalIntegrable (fun t => ‖deriv γ.extend t‖) MeasureTheory.volume 0 1),
    chartArcLength γ.extend 0 1

theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
  unfold chartIntrinsicDist
  refine Real.iInf_nonneg (fun γ => ?_)
  refine Real.iInf_nonneg (fun _ => ?_)
  exact chartArcLength_nonneg γ.extend zero_le_one
```

## Build verification

`LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` → `Build completed successfully (2551 jobs).`

**Same job count as S2a (PR #19100) and S2b (PR #19449)** — the new imports were absorbed by the existing transitive closure. Clean first-try at Lean `v4.26.0` + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.

## Infrastructure note

Docker **R8** from S3 PREP §6 (RED INFRA — daemon hung exit 124, disk 100% / 6.9Gi at 2026-05-16T09:51Z) is **resolved** as of S3a claim time (2026-05-30): server `29.4.1`, disk 63Gi avail (T+14d).

## Next iteration

**S3b ACT** discharges the two reparametrisation adapters (the load-bearing sub-iter from S3 PREP §8):

- `chartArcLength_comp_mul_left` — `γ ∘ (· * 2)` on `[0, 1/2]`.
- `chartArcLength_comp_mul_left_shift` — `γ ∘ (· * 2 - 1)` on `[1/2, 1]`.

Via the 3-lemma chain: `deriv.scomp` (chain rule) + `norm_smul` (positive scalar) + `intervalIntegral.integral_comp_mul_left` (substitution). All 3 verified at pinned SHA in S3 PREP §4. Estimated 60–100 LOC. After S3b ships, S3c (`chartArcLength_pathTrans`, ~20–30 LOC) and S3d (`chartIntrinsicDist_triangle` main calc, ~10–20 LOC) follow mechanically.

## Honest scope (carried over from S1/S2/S3 PREP)

`chartIntrinsicDist` is **chart-local**: it depends on the embedding of the manifold's chart codomain `E`, not on a Riemannian metric. Mathlib v4.26.0 has no `RiemannianMetric` typeclass; this chart-local definition is a foundation that will lift to a chart-invariant Riemannian arc length via partition-of-unity gluing once upstream lands the typeclass. See the S1 OBSERVE memo for the four-path roadmap.

## Test plan

- [x] `LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` clean (2551 jobs, no new warnings).
- [x] Sorry-count / axiom-count audit: 0 sorries / 0 axioms (unchanged from S2b).
- [x] JSON validation: `jq empty src/data/research/problems/triangle-inequality-oq-04-oq-01.json` → exit 0.
- [x] `chartIntrinsicDist_nonneg` proof discharges the S3 PREP §5 skeleton sorry **unconditionally** (handles both non-empty and empty filtered iInf via `Real.iInf_nonneg`'s convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)