### PR TITLE
audit(erdos-222): mark clean re-audit

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5372,12 +5372,12 @@
     },
     "erdos-222": {
       "agentId": "auditor-1777701908",
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom axioms in sections (Fermat criterion, Landau, Richards 1982, DEKKM 2022, monotonicity) + section line drift Parts II–VII (#14599)"
       ],
-      "lastAudited": "2026-05-02T06:09:26Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-30T15:30:00Z",
+      "result": "clean"
     },
     "erdos-223": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Re-audited erdos-222 (Erdős Problem #222: Gaps Between Sums of Two Squares)
- All meta.json claims verified against `Proofs/Erdos222Problem.lean`: 3 axioms, 0 sorries, 3 theorems, 5 definitions, 147 lines, status `axiomatized`, badge `axiom`.
- No issues found; updated `audit-tracker.json` from `issues-fixed` to `clean` (4th audit).

## Test plan
- [x] Verified axiom count: `nthSumTwoSquares`, `erdos_1951_lower_bound`, `bambah_chowla_upper_bound` (3)
- [x] Verified 0 sorries
- [x] Verified 3 theorems and 5 definitions
- [x] Verified line count (147)

🤖 Generated with [Claude Code](https://claude.com/claude-code)