### PR TITLE
audit(erdos-213): mark clean re-audit (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5296,9 +5296,9 @@
     },
     "erdos-213": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T06:25:46Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T17:40:30Z",
+      "result": "clean",
       "issues": [
         "Phantom axiom narrative: originalContributions/proofStrategy claim anning_erdos_finite and gip_sparsity_bound axioms that do not exist in Erdos213Problem.lean (only dangling /-- ... -/ docstrings); section line ranges drift for main-results, constructions, bounds, summary; 3 dangling docstrings in Lean source. Numerical fields (axiomCount=4, sorries=0) accurate. Issue #14608."
       ]


### PR DESCRIPTION
## Summary

Re-audited erdos-213 (Integer Distance Sets in General Position).

- 0 sorries (matches meta.json `sorries: 0`)
- 4 axioms (matches `axiomCount: 4`): `harborth_five`, `kreisel_kurz_seven`, `exists_four`, `exists_six`
- 4 theorems, 10 definitions, 0 True stubs
- Status `axiomatized` + badge `axiom` honestly reflect the axiomatized Harborth/Kreisel-Kurz constructions
- `originalContributions` scope is appropriate (formalization + axiomatization)

Previously flagged issues (phantom axiom narrative, drifted line ranges, dangling docstrings — issue #14608) are no longer present in the current meta.json / Lean source.

## Test plan

- [x] meta.json `axiomCount`, `sorries`, `theoremCount`, `definitionCount` cross-checked against `proofs/Proofs/Erdos213Problem.lean`
- [x] No True stubs / phantom axioms in source
- [x] Tier classification (C — axiomatized) consistent with badge/status

🤖 Generated with [Claude Code](https://claude.com/claude-code)