### PR TITLE
research(euler-polyhedral-oq-02-oq-01-oq-01): SURVEY — Mathlib gap refreshed, BLOCKED on curvature/integration stack

### DIFF
--- a/research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01/knowledge.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01/knowledge.md
@@ -6,16 +6,82 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+Target: prove the full smooth Gauss-Bonnet theorem with boundary
+```
+∫_M K dA + ∫_∂M κ_g ds = 2π · χ(M)
+```
+for compact Riemannian 2-manifolds, **from first-principles Mathlib infrastructure** (no axiomatized fields encoding the result).
+
+The parent file `proofs/Proofs/EulerPolyhedralOQ02OQ01.lean` axiomatizes Gauss-Bonnet as a structure field (`CompactRiemannianSurface.gauss_bonnet : totalCurvature = 2 * π * chi`) and derives algebraic consequences (genus formulas, sphere/torus/hyperbolic specializations). That is a *model*, not a proof; the field is a structure-encoded assumption, so the result is `axiomatized` rather than `verified` regardless of having 0 `axiom` declarations.
+
+---
+
+## Mathlib Infrastructure Survey (2026-05-30)
+
+The proofs project pins Mathlib **v4.26.0** (`proofs/lakefile.toml`). Mathlib `master` has progressed; the gap analysis copied from the parent file's docstring is partially obsolete.
+
+### What now exists upstream (Mathlib master, post-v4.26.0)
+
+- `Mathlib/Geometry/Manifold/Riemannian/Basic.lean`
+  - `IsRiemannianManifold` — Prop typeclass tying manifold distance to path-length integrals on tangent inner products.
+  - `riemannianMetricVectorSpace` — the standard inner-product Riemannian metric on a vector space.
+  - `PseudoEMetricSpace.ofRiemannianMetric`, `EMetricSpace.ofRiemannianMetric` — promote a Riemannian metric to an (extended) metric space.
+- `Mathlib/Geometry/Manifold/Riemannian/PathELength.lean`
+  - `pathELength` (path length as `∫ ‖γ'‖`), `riemannianEDist` (infimum over C¹ paths), reparameterization invariance, triangle inequality.
+- `Mathlib/Geometry/Manifold/VectorBundle/`
+  - `Riemannian.lean` — Riemannian structure on a vector bundle.
+  - `CovariantDerivative/Basic.lean`, `CovariantDerivative/Torsion.lean` — connections on bundles, torsion.
+  - `LocalFrame.lean`, `Tensoriality.lean` — local frames and tensoriality lemmas (precursor APIs for curvature).
+
+### What still does NOT exist upstream
+
+- **No Gaussian curvature.** Search for `GaussianCurvature` returns nothing; no `K : RiemannianManifold → ℝ` is provided.
+- **No geodesic curvature** of a curve in a Riemannian surface.
+- **No Riemann curvature tensor.** A `CovariantDerivative` API is present but the tensor `R(X,Y)Z = ∇_X ∇_Y Z − ∇_Y ∇_X Z − ∇_[X,Y] Z` is not exposed as a definition with the standard symmetries.
+- **No manifold integration `∫_M ω` for differential forms,** no area form, no volume form derived from a Riemannian metric.
+- **No de Rham complex / Stokes' theorem** at the differential-form level on manifolds with boundary. `Bordism.lean` exists but does not supply Stokes.
+- **No Euler characteristic of a smooth manifold** defined intrinsically (triangulation, Morse, or de Rham).
+- **No Gauss-Bonnet** theorem in any form.
+
+### Status of Mathlib pin
+
+Even the new Riemannian/CovariantDerivative material lands on `master` after the v4.26.0 tag. Bumping the local Mathlib pin is a prerequisite to *use* any of it; doing so is out of scope for a single research session because it can cascade into project-wide build effects.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The parent file's claim that "Mathlib (v4.26.0) does not yet have Riemannian metrics" is true at the pinned version but no longer literally true on master — Riemannian metric typeclasses and path-length API have landed. The remaining gap is the **curvature → integration → Stokes** stack, not the metric itself.
+- A first-principles boundary-form Gauss-Bonnet proof requires, in roughly this order:
+  1. Riemann curvature tensor on a smooth vector bundle with connection (CovariantDerivative is the right substrate).
+  2. Gaussian curvature for a 2D Riemannian manifold derived from sectional curvature.
+  3. Volume / area form `dA` from the Riemannian metric (oriented 2-form ω with ω(e1,e2)=1 on orthonormal frame).
+  4. Geodesic curvature κ_g for a C² boundary curve.
+  5. Manifold integration `∫_M K dA`, `∫_∂M κ_g ds` (Bochner integral against a measure, or differential-form integration with orientation).
+  6. Stokes' theorem on manifolds with boundary, or an intrinsic Chern-style moving-frame proof.
+  7. Euler characteristic of a smooth 2-manifold matching the topological one.
+  8. Assemble Gauss-Bonnet via local Chern-style proof or via triangulation + discrete Gauss-Bonnet (already formalized for the polyhedral case in `EulerPolyhedralOQ02.lean`).
+- Each step is comparable to a multi-month Mathlib contribution; assembled, this is on the order of several thousand lines of new infrastructure. Per the researcher rubric, this is **BLOCKED on missing Mathlib infrastructure > 1000 lines**.
+- A productive *intermediate* milestone (still well beyond a single session) would be to formalize Gauss-Bonnet only for the **round 2-sphere `S²`** using Mathlib's existing stereographic charts (`Mathlib.Geometry.Manifold.Instances.Sphere`) plus an explicit integral computation `∫_{S²} 1 · dA = 4π = 2π · χ(S²) = 2π · 2`. That bypasses the curvature tensor entirely (`K ≡ 1`) and only needs an area-form definition on `S²` — still nontrivial, but the smallest meaningful concrete instance.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Axiomatizing the boundary Gauss-Bonnet equation as a structure field.** The parent file already does this for the closed case; replicating that for the boundary case adds no information beyond what the parent file would yield with a one-line extension. The research goal is explicitly "without assuming the Gauss-Bonnet equation as a field or axiom", so a structure-field approach defeats the purpose.
+- **Submitting to Aristotle.** The blocking sorries here would be definition-level (curvature, area form, manifold integral) — Aristotle only proves theorem/lemma sorries with no definition sorries upstream of them.
+- **Building from scratch in this repo.** Each piece is upstream infrastructure that belongs in Mathlib, not in a per-problem gallery file. Reimplementing it locally would create a parallel API that diverges from Mathlib's eventual choices.
+
+---
+
+## Current Status
+
+**Phase**: SURVEY (advancing OBSERVE → SURVEY this session; no proof attempt warranted yet).
+**Outcome**: BLOCKED on Mathlib infrastructure. Updated gap analysis: the Riemannian-metric layer has landed on Mathlib master; the curvature + manifold-integration + Stokes stack remains absent. Document the refined gap and the S²-only milestone as the smallest meaningful target.
+
+## Next Steps
+
+1. Watch Mathlib master for: (a) a Riemann curvature tensor on the tangent bundle via `CovariantDerivative`, (b) a manifold-volume / area-form construction from a Riemannian metric, (c) any `Stokes`/`integral_dω` API on manifolds with boundary. Any of those landing would change the assessment.
+2. If/when the local Mathlib pin bumps past v4.26.0, port the parent file's structure-field model to optionally consume `IsRiemannianManifold` so the assumptions are at least stated against real Mathlib types rather than a bespoke structure.
+3. Consider opening the **S² intermediate milestone** as its own subproblem (`euler-polyhedral-formula-oq-02-oq-01-oq-01-S2`) — first-principles Gauss-Bonnet for the round 2-sphere only, no boundary, constant curvature.
+4. Until then, leave the parent file's axiomatized model untouched; do not add new structure-field "smooth-with-boundary" variants because they would only inflate the assumption count without progress.

--- a/research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01/state.md
@@ -1,16 +1,16 @@
 # Research State: euler-polyhedral-formula-oq-02-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: SURVEY
 **Path**: fast
-**Since**: 2026-04-04T02:41:19-07:00
-**Iteration**: 1
+**Since**: 2026-05-30
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Refined Mathlib-gap analysis. Riemannian-metric and CovariantDerivative APIs have landed on Mathlib master since the parent file was written; the curvature + manifold-integration + Stokes stack remains the blocker.
 
 ## Active Approach
-None yet.
+None. Awaiting upstream Mathlib infrastructure or a deliberate decomposition (S² intermediate milestone) before any first-principles proof attempt is warranted.
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +18,9 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+- Mathlib v4.26.0 (the local pin) lacks even the Riemannian-metric typeclass.
+- Mathlib master adds `IsRiemannianManifold`, `pathELength`, `CovariantDerivative`, but still has **no** Gaussian curvature, geodesic curvature, manifold integration, area form, de Rham forms, Stokes' theorem on manifolds with boundary, or smooth Euler characteristic.
+- Each missing piece is upstream infrastructure (multi-month Mathlib contribution scale), so building locally would create a parallel API that will conflict with Mathlib's eventual choices.
 
 ## Next Action
-Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.
-See FAST_PATH.md for protocol.
+Re-survey Mathlib master when (a) Gaussian curvature lands, (b) a Riemannian volume/area form lands, or (c) any form of Stokes on manifolds with boundary lands. Until then, the productive intermediate target is a **round-S² only** Gauss-Bonnet milestone (`K ≡ 1`, area = 4π), which avoids the curvature tensor entirely; track that as a candidate subproblem rather than working it in this slot.

--- a/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "euler-polyhedral-formula-oq-02-oq-01-oq-01",
   "title": "Full Smooth Gauss-Bonnet Theorem from First Principles",
-  "phase": "OBSERVE",
+  "phase": "SURVEY",
   "status": "active",
   "tier": "C",
   "path": "fast",
@@ -22,39 +22,51 @@
     "goal": "Prove the boundary-form smooth Gauss-Bonnet theorem from first-principles Mathlib infrastructure, without assuming the Gauss-Bonnet equation as a field or axiom."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-04T02:41:19-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
-    "blockers": [],
-    "nextAction": "Fast path: Quick Mathlib search, then directly to ACT if obvious approach found.",
+    "phase": "SURVEY",
+    "since": "2026-05-30T18:30:00.000Z",
+    "iteration": 2,
+    "focus": "Refined Mathlib gap analysis. Riemannian metric and CovariantDerivative APIs landed on master; curvature, manifold integration, area form, Stokes on manifolds with boundary remain absent.",
+    "blockers": [
+      "Local Mathlib pin is v4.26.0; even the new Riemannian metric typeclass is not available locally without a pin bump.",
+      "Mathlib master still lacks Gaussian curvature, geodesic curvature, manifold integration, area form, de Rham forms, Stokes on \u2202M, and smooth Euler characteristic.",
+      "Each missing piece is upstream-scale work (multi-month Mathlib contribution); building locally would diverge from Mathlib's eventual API."
+    ],
+    "nextAction": "Re-survey when Gaussian curvature, a Riemannian area form, or Stokes for manifolds-with-boundary land in Mathlib. Until then, the productive intermediate target is a round-S\u00b2 only Gauss-Bonnet milestone (K \u2261 1, area 4\u03c0).",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "OBSERVE: target identified as the full smooth Gauss-Bonnet theorem with boundary. No Lean attempt is recorded for this subproblem. The parent smooth file is an axiomatized model that proves consequences from assumed Gauss-Bonnet fields, not a first-principles proof.",
+    "progressSummary": "SURVEY: Re-ran the Mathlib infrastructure check (2026-05-30). Mathlib master now has Mathlib.Geometry.Manifold.Riemannian.Basic (IsRiemannianManifold, riemannianMetricVectorSpace), Riemannian.PathELength (pathELength, riemannianEDist), and VectorBundle/CovariantDerivative (Basic + Torsion). Still missing: Gaussian curvature, geodesic curvature, Riemann curvature tensor, manifold integration / area form, de Rham forms, Stokes on \u2202M, smooth Euler characteristic, and Gauss-Bonnet itself. The parent file's claim that 'Mathlib lacks Riemannian metrics' is now out of date at the metric layer but still correct at the curvature/integration layer. Problem remains BLOCKED on >1000-line upstream infrastructure; no proof attempt warranted this session.",
     "builtItems": [],
     "insights": [
       "This target is stronger than the parent compact closed-surface model because problem.md includes the boundary term int_boundary kappa_g ds.",
       "The related smooth proof file encodes Gauss-Bonnet as fields such as gauss_bonnet and gauss_bonnet_boundary, then proves consequences from those assumptions.",
-      "The local state is OBSERVE with zero attempts, so there is no evidence of Lean progress on this first-principles subproblem."
+      "The local state is OBSERVE with zero attempts, so there is no evidence of Lean progress on this first-principles subproblem.",
+      "2026-05-30 Mathlib survey: master adds Riemannian/Basic (IsRiemannianManifold), Riemannian/PathELength (pathELength, riemannianEDist), VectorBundle/Riemannian, VectorBundle/CovariantDerivative/{Basic,Torsion}. The Riemannian-metric layer of the gap is closed; the curvature/integration/Stokes layer is not.",
+      "Productive intermediate milestone: first-principles Gauss-Bonnet for the round 2-sphere only (K \u2261 1, area 4\u03c0, no boundary). This bypasses the curvature tensor and only needs a Riemannian area form on S\u00b2 plus the existing stereographic-chart infrastructure in Mathlib.Geometry.Manifold.Instances.Sphere.",
+      "Axiomatizing the boundary Gauss-Bonnet equation as a structure field is explicitly counter to the research goal ('without assuming the Gauss-Bonnet equation as a field or axiom'); the parent file already does the closed-case version of that, and replicating it for the boundary case would add an assumption rather than removing one.",
+      "Aristotle is not applicable: the blocking sorries here are definition-level (curvature, area form, manifold integral), not theorem/lemma sorries with complete upstream definitions.",
+      "The local Mathlib pin is v4.26.0 (proofs/lakefile.toml); even consuming the new Riemannian metric typeclass requires a pin bump, which is a project-wide decision and out of scope for a per-problem research session."
     ],
     "mathlibGaps": [
-      "Riemannian metric infrastructure for smooth manifolds.",
-      "Gaussian curvature and geodesic curvature definitions.",
-      "Integration on manifolds with boundary, likely via differential forms or related manifold integration APIs.",
-      "Connection/vector-bundle infrastructure needed for a first-principles smooth Gauss-Bonnet proof."
+      "Gaussian curvature K: no GaussianCurvature definition in Mathlib master.",
+      "Geodesic curvature \u03ba_g of a C\u00b2 boundary curve: not defined.",
+      "Riemann curvature tensor: CovariantDerivative API is present but the tensor R(X,Y)Z with standard symmetries is not exposed as a definition.",
+      "Manifold integration / area form: no Riemannian volume form or oriented 2-form integration in master.",
+      "de Rham forms / Stokes on manifolds with boundary: no \u222b_\u2202M = \u222b_M d\u03c9 API.",
+      "Smooth Euler characteristic: no intrinsic definition (triangulation, Morse, or de Rham) matching the topological one.",
+      "Gauss-Bonnet: no Gauss-Bonnet theorem in any form in Mathlib."
     ],
     "nextSteps": [
-      "Survey current Mathlib manifold integration and smooth-manifold APIs.",
-      "Check whether Riemannian metric, curvature, differential-form, and boundary integration support now exist.",
-      "If the APIs are still absent, document the gap and avoid replacing the target theorem with axioms.",
-      "Use the discrete and axiomatized parent files as specification references only."
+      "Watch Mathlib master for: a Riemann curvature tensor built on CovariantDerivative, a Riemannian volume/area form, and any Stokes' theorem on manifolds with boundary. Any of those would change the assessment.",
+      "If the local Mathlib pin bumps past v4.26.0, port the parent file's structure-field model to (optionally) consume IsRiemannianManifold so the assumptions are at least stated against real Mathlib types instead of a bespoke structure.",
+      "Open a smaller subproblem for the round 2-sphere only (K \u2261 1, area 4\u03c0, no boundary); that is the smallest first-principles Gauss-Bonnet instance achievable without a full curvature tensor.",
+      "Do NOT add new boundary-form structure-field variants to the parent file; that would only inflate the assumption count without progress and contradicts the explicit research goal."
     ],
-    "markdown": "# Knowledge Base: euler-polyhedral-formula-oq-02-oq-01-oq-01\n\n## Problem Understanding\n\nThe target asks for the full smooth Gauss-Bonnet theorem for compact Riemannian 2-manifolds with boundary, not merely the existing closed-surface axiomatized model. The formula is `int_M K dA + int_boundary kappa_g ds = 2*pi*chi(M)`.\n\n## Local Evidence\n\n- `problem.md` gives a pseudo-Lean target using `RiemannianManifold`, `Compact`, and `WithBoundary`, and names `Mathlib.Geometry.Manifold.Integration` as a key dependency.\n- `state.md` keeps the problem in OBSERVE with zero attempts and the fast path.\n- The parent proof `proofs/Proofs/EulerPolyhedralOQ02OQ01.lean` states that Mathlib v4.26.0 lacks Riemannian metrics, Gaussian curvature, manifold integration, differential forms, vector bundles with connection, and Morse theory; it therefore models Gauss-Bonnet through fields such as `gauss_bonnet` and `gauss_bonnet_boundary`.\n- `proofs/Proofs/EulerPolyhedralOQ02.lean` is a discrete/polyhedral baseline, not a first-principles smooth proof.\n\n## Current Status\n\nNo Lean progress is recorded for this subproblem. The correct next move is an infrastructure survey before any proof attempt.\n\n## Next Steps\n\n1. Survey current Mathlib manifold integration and smooth-manifold APIs.\n2. Check for Riemannian metric, curvature, differential-form, and boundary integration support.\n3. If those APIs are still absent, document the gap instead of axiomatizing the target theorem.\n"
+    "markdown": "# Knowledge Base: euler-polyhedral-formula-oq-02-oq-01-oq-01\n\nUpdated 2026-05-30 with a refreshed Mathlib infrastructure survey. See `research/problems/euler-polyhedral-formula-oq-02-oq-01-oq-01/knowledge.md` for the full write-up.\n\n## Headline\n\nMathlib master has gained a Riemannian-metric typeclass and a path-length API since the parent file was written, but still lacks Gaussian curvature, geodesic curvature, manifold integration / area forms, de Rham forms, Stokes on manifolds with boundary, and a smooth Euler characteristic. The problem remains BLOCKED on >1000 lines of upstream Mathlib infrastructure.\n\n## Current Status\n\nSURVEY phase. No proof attempt warranted. Productive intermediate milestone: Gauss-Bonnet on the round 2-sphere only.\n"
   },
   "tags": [
     "topology",
@@ -77,7 +89,7 @@
     ]
   },
   "started": "2026-04-04T09:42:47.007Z",
-  "lastUpdate": "2026-04-04T09:42:47.023Z",
+  "lastUpdate": "2026-05-30T18:30:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/EulerPolyhedralFormula.lean",


### PR DESCRIPTION
## Summary

Research session on **euler-polyhedral-formula-oq-02-oq-01-oq-01** — the first-principles smooth Gauss-Bonnet target with boundary.

This is a SURVEY-phase update. No proof attempt is warranted; the actionable progress is a refreshed Mathlib infrastructure assessment that supersedes the parent file's docstring.

## Progress

- Phase advanced **OBSERVE → SURVEY**.
- Mathlib master re-surveyed (2026-05-30). The Riemannian-metric layer of the gap has closed since the parent file was written; the curvature + manifold-integration + Stokes layer has not.
- Knowledge base, state, and JSON updated with the refreshed gap analysis, explicit dead ends, and an S²-only intermediate milestone.

## Findings

**What now exists upstream (post-v4.26.0 on `master`)**
- `Mathlib.Geometry.Manifold.Riemannian.Basic` — `IsRiemannianManifold`, `riemannianMetricVectorSpace`, `PseudoEMetricSpace.ofRiemannianMetric`.
- `Mathlib.Geometry.Manifold.Riemannian.PathELength` — `pathELength`, `riemannianEDist`, reparam invariance, triangle inequality.
- `Mathlib.Geometry.Manifold.VectorBundle.Riemannian`.
- `Mathlib.Geometry.Manifold.VectorBundle.CovariantDerivative.{Basic,Torsion}`.

**What is still missing (the real blocker)**
- Gaussian curvature, geodesic curvature, Riemann curvature tensor.
- Riemannian volume / area form, manifold integration `∫_M ω`.
- de Rham forms and Stokes' theorem on manifolds with boundary.
- Intrinsic smooth Euler characteristic matching the topological one.
- Gauss-Bonnet itself, in any form.

Each missing piece is upstream-Mathlib scale (multi-month contribution). Total work to reach first-principles boundary Gauss-Bonnet is on the order of several thousand new lines, so per the researcher rubric this is **BLOCKED** (missing infra > 1000 lines).

**Intermediate milestone flagged**: first-principles Gauss-Bonnet for the round 2-sphere only (`K ≡ 1`, area `4π`, no boundary) — bypasses the curvature tensor entirely and only needs a Riemannian area form on `S²` plus the existing `Mathlib.Geometry.Manifold.Instances.Sphere` infrastructure.

**Pin caveat**: `proofs/lakefile.toml` still pins Mathlib v4.26.0; consuming any of the new master infrastructure requires a project-wide pin bump, out of scope for a per-problem research session.

## Status

**Outcome**: surveyed / blocked
**Phase**: SURVEY (advanced from OBSERVE)
**Axioms / sorries delta**: 0 (no Lean files touched — this is honest; the right move was to *not* axiomatize the boundary equation as a structure field, which would have inflated the assumption count contrary to the explicit research goal).

## Next Steps

1. Watch Mathlib master for: a Riemann curvature tensor built on `CovariantDerivative`, a Riemannian volume/area form, or any Stokes' theorem on manifolds with boundary. Any of those landing would change the assessment.
2. If/when the local Mathlib pin bumps past v4.26.0, port the parent file's structure-field model to optionally consume `IsRiemannianManifold`.
3. Consider opening the **S² intermediate milestone** as its own subproblem.
4. Do **not** add new boundary-form structure-field variants to the parent file — that would inflate the assumption count without progress and contradicts the research goal.

🤖 Generated by researcher-1