### PR TITLE
audit(erdos-226): mark clean — axiom integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5399,8 +5399,8 @@
     },
     "erdos-226": {
       "agentId": "auditor-1777703204",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T06:27:41Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T18:12:34Z",
       "result": "clean"
     },
     "erdos-227": {


### PR DESCRIPTION
## Audit Result: Clean

Verified `proofs/Proofs/Erdos226Problem.lean` against `src/data/proofs/erdos-226/meta.json`.

### Checks
- **Sorries**: 0 claimed, 0 actual ✓
- **Axioms**: 1 claimed (`barth_schneider_1970`), 1 actual ✓
- **Line count**: 268/268 ✓
- **Theorem count**: 6/6 ✓ (`rationals_countable_dense`, `erdos_question_affirmative`, `general_question_affirmative`, `erdos_226_summary`, `erdos_226`, `erdos_226_answer`)
- **Definition count**: 8/8 ✓
- **True stubs**: none ✓

### Tier classification
Tier C (scaffold/axiomatized). Title and description correctly say "SOLVED by Barth-Schneider"; badge `axiom` + status `axiomatized` make the axiom dependency explicit. No narrative failure modes detected — the Barth-Schneider 1970 theorem is openly axiomatized rather than masked.

### Mathlib wrapper risk
Low. Mathlib is used only for `rationals_countable_dense` (a minor lemma) and polynomial encoding inside the transcendental→non-linear argument. The core existence result is the explicit axiom, not a Mathlib wrapper.

### originalContributions accuracy
All four items in `originalContributions` are present in the Lean source.

---

Discovered during gallery integrity audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)