### PR TITLE
audit(erdos-217): fix phantom originalContributions (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5326,9 +5326,9 @@
     },
     "erdos-217": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T06:22:03Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T18:51:54Z",
+      "result": "clean",
       "issues": [
         "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Palásti axiomatization (#14603)"
       ]

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5326,11 +5326,12 @@
     },
     "erdos-217": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-30T18:51:54Z",
-      "result": "clean",
+      "auditCount": 5,
+      "lastAudited": "2026-05-30T19:30:00Z",
+      "result": "issues-fixed",
       "issues": [
-        "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Palásti axiomatization (#14603)"
+        "phantom axioms palasti_small_n + erdos_217_conjecture (only docstrings); phantom small_cases_exist/ErdosConjecture217 in originalContributions; proofStrategy overclaims Palásti axiomatization (#14603)",
+        "originalContributions listed phantom identifiers: NoFourConcyclic, allDistances, distinctDistances, HasStaircaseMultiplicity, HasErdos217Property, Erdos217Exists. Also misnamed PointConfig as 'PointConfiguration structure' and omitted sqDist. Replaced with accurate list of actual Lean declarations."
       ]
     },
     "erdos-218": {

--- a/src/data/proofs/erdos-217/meta.json
+++ b/src/data/proofs/erdos-217/meta.json
@@ -42,12 +42,11 @@
       }
     ],
     "originalContributions": [
-      "PointConfiguration structure: n points in the plane",
-      "NoThreeCollinear, NoFourConcyclic: general position constraints",
-      "allDistances, distinctDistances: distance multiset definitions",
-      "HasStaircaseMultiplicity: the key multiplicity pattern",
-      "HasErdos217Property: full problem specification",
-      "Erdos217Exists predicate: existence for each n",
+      "PointConfig (abbrev): labeled points in ℝ² as Fin n → ℝ × ℝ",
+      "sqDist: squared Euclidean distance, avoiding square roots in computation",
+      "NoThreeCollinear: cross-product (determinant) criterion for general position ('no four concyclic' is omitted from the formalization)",
+      "HasTriangularMultiplicity: the staircase multiplicity property via Finset.filter on ordered pairs",
+      "example_n_eq_4, pomerance_n_eq_5: axiomatized existence for n = 4 (Erdős) and n = 5 (Pomerance)",
       "erdos_217 theorem: conjunction of example_n_eq_4 and pomerance_n_eq_5 (n=4 and n=5 only)",
       "Palásti's general result (4 ≤ n ≤ 8) and Erdős's conjecture appear as commentary docstrings only — not formalized as axioms"
     ],


### PR DESCRIPTION
## Summary

Re-audit of erdos-217 found 6 phantom identifiers in `originalContributions` that don't exist in `Erdos217Problem.lean`:

- `NoFourConcyclic` — the formalization correctly omits this; only `NoThreeCollinear` exists. The meta itself notes "The Lean file omits the 'no four concyclic' condition" in `problemStatement`.
- `allDistances`, `distinctDistances` — no such definitions exist; only `sqDist` is defined.
- `HasStaircaseMultiplicity` — actual name is `HasTriangularMultiplicity`.
- `HasErdos217Property`, `Erdos217Exists` — no such predicates exist.

Also misnamed `PointConfig` (an `abbrev` for `Fin n → ℝ × ℝ`) as "PointConfiguration structure", and omitted the real `sqDist` definition.

A previous audit cycle (#14603) caught analogous phantoms (`palasti_small_n`, `erdos_217_conjecture`, `small_cases_exist`, `ErdosConjecture217`) but missed these. Cycle 4 marked the proof clean without checking individual `originalContributions` entries against actual Lean declarations.

## Fix

Replaced `originalContributions` with an accurate enumeration of the actual Lean declarations: `PointConfig`, `sqDist`, `NoThreeCollinear`, `HasTriangularMultiplicity`, `example_n_eq_4`, `pomerance_n_eq_5`, and `erdos_217`.

All other meta fields verified against the Lean file:
- `axiomCount: 2` ✓ (`example_n_eq_4`, `pomerance_n_eq_5`)
- `theoremCount: 1` ✓ (`erdos_217`)
- `definitionCount: 4` ✓ (`PointConfig` abbrev, `sqDist`, `NoThreeCollinear`, `HasTriangularMultiplicity`)
- `lineCount: 91` ✓
- `sorries: 0` ✓
- `status: axiomatized`, `badge: axiom` ✓ (correctly reflects 2 axiomatic constructions)
- No True stubs ✓

## Test plan

- [x] Lean file declarations enumerated via `grep -nE "^(def|abbrev|axiom|theorem|...) "` (7 declarations match the 7 corrected entries)
- [x] `audit-tracker.json` updated: `auditCount: 5`, `result: issues-fixed`, with detailed issue note for traceability

🤖 Generated with [Claude Code](https://claude.com/claude-code)