### PR TITLE
Fix: erdos-125 metadata reflects main file, not sum of files

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -20,15 +20,15 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 12,
+    "sorries": 0,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 369,
+    "lineCount": 92,
     "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 12 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 0,
     "definitionCount": 7
   },
   "overview": {
@@ -198,5 +198,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 12
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Corrects four metadata fields in `src/data/proofs/erdos-125/meta.json` that summed main+companion file totals instead of just the main file (the convention recently applied in #21215 for `erdos-846`).

## Evidence

The `meta.proofRepoPath` is `Proofs/Erdos125Problem.lean` (92 lines, 0 sorries, 0 theorems, 7 defs, 0 axioms). The companion `Proofs/Erdos125PositiveLowerDensity.lean` (277 lines, 12 sorries, 20 theorems) is tracked separately in `meta.additionalFiles`.

**Before** (summing main + companion):
- `meta.sorries`: 12
- `meta.lineCount`: 369
- `meta.theoremCount`: 20
- top-level `sorries`: 12

**After** (main file only, matching `leanFile` block which was already correct):
- `meta.sorries`: 0
- `meta.lineCount`: 92
- `meta.theoremCount`: 0
- top-level `sorries`: 0

The `assumptions` field already documents the main/companion split, so the narrative remains intact. `axiomCount` (0) and `definitionCount` (7) were already correct.

## Validation

- `jq empty src/data/proofs/erdos-125/meta.json` parses cleanly.
- Verified `meta` block and `leanFile` block now agree on shared counts.

---
Automated fix by lean-mechanic agent.