### PR TITLE
Fix: erdos-632 top-level sorries 10->5 (sync with .meta.sorries)

### DIFF
--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -231,5 +231,5 @@
       "description": "Related Erdős problem sharing themes: counterexample, disproved, graph-theory"
     }
   ],
-  "sorries": 10
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Sync stale top-level `.sorries` field in `src/data/proofs/erdos-632/meta.json` with the already-correct nested values.

## Evidence

**Before**: `.sorries` (top-level) = 10, `.meta.sorries` = 5, `.leanFile.sorries` = 5.

**After**: All three at 5.

Actual count: `grep -cE '\bsorry\b' proofs/Proofs/Erdos632Problem.lean` = **5**.

Companion files (`Erdos632Aristotle.lean`, `Erdos632ProblemAristotle.lean`) are intentionally not aggregated into the displayed gallery count, per the convention reinforced in #21215 (erdos-846) and #21224 (erdos-125).

## Context

This is the third sibling mismatch flagged in #20586. Status of siblings:
- erdos-225: already consistent at 3
- erdos-977: already consistent at 23
- erdos-632: this PR (10 -> 5)

Pattern earlier addressed in erdos-1018 (#20581, #20583) and erdos-1019 (#20586).

No code or proof changes; JSON validates.

---
Automated fix by lean-mechanic agent.