### PR TITLE
fix(meta): lovasz-local-lemma-oq-02 top-level sorries 9->1 (main file only)

### DIFF
--- a/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
+++ b/src/data/proofs/lovasz-local-lemma-oq-02/meta.json
@@ -17,7 +17,7 @@
       "polynomial-inequalities"
     ],
     "badge": "wip",
-    "sorries": 9,
+    "sorries": 1,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
     "assumptions": "9 sorries total: 1 in main file (lllThreshold_strict_maximum equality case — requires the AM-GM equality characterization, all terms equal iff x = 1/(d+1)) and 8 in the Aristotle companion file (LovaszLocalLemmaOQ02Aristotle.lean) targeting routine supporting lemmas. Proved: lllThreshold_is_maximum (general d) via Real.geom_mean_le_arith_mean2_weighted + rpow monotonicity (PR #11084).",
@@ -202,5 +202,5 @@
       "leanType": "(d : ℕ) → 0 < d → (p : ℚ) → 0 ≤ p → (∃ x : ℚ, 0 ≤ x ∧ x ≤ 1 ∧ p ≤ x * (1-x)^d) ↔ p ≤ lllThreshold d"
     }
   ],
-  "sorries": 9
+  "sorries": 1
 }


### PR DESCRIPTION
## Fix

Sync top-level `.sorries` and `.meta.sorries` for `lovasz-local-lemma-oq-02` to reflect the main file only (1 sorry), not the main+companion sum (9).

## Evidence

**Before**:
- `.sorries`: 9
- `.meta.sorries`: 9
- `.leanFile.sorries`: 1 (correct)

**After**:
- `.sorries`: 1
- `.meta.sorries`: 1
- `.leanFile.sorries`: 1

Actual count:

```
grep -cE '\bsorry\b' proofs/Proofs/LovaszLocalLemmaOQ02.lean = 1
```

Companion file `Proofs/LovaszLocalLemmaOQ02Aristotle.lean` contains 8 routine sorry placeholders tracked separately via `additionalFiles`; per convention (#21215 erdos-846, #21224 erdos-125, #21227 erdos-632) these are not aggregated into top-level metadata.

The descriptive `assumptions` field (which narrates the 1+8 split in prose) is intentionally left untouched.

---
Automated fix by lean-mechanic agent.