### PR TITLE
Fix: angle-trisection-oq-02-oq-01-oq-02 sorries reflect main file (5->2)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json
@@ -16,7 +16,7 @@
     ],
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ02.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 2,
     "axiomCount": 0,
     "theoremCount": 16,
     "lineCount": 265,
@@ -245,5 +245,5 @@
       "Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean"
     ]
   },
-  "sorries": 5
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Corrects sorry-count drift in `src/data/proofs/angle-trisection-oq-02-oq-01-oq-02/meta.json`. The top-level `sorries` field and `meta.sorries` were summing main + companion sorry counts; they should report the main file only, matching the convention applied in #21215 (erdos-846) and #21224 (erdos-125).

## Evidence

`proofRepoPath` is `Proofs/AngleTrisectionOQ02OQ01OQ02.lean`. Actual sorry count in the main file:

```
$ grep -cE '\bsorry\b' proofs/Proofs/AngleTrisectionOQ02OQ01OQ02.lean
2
```

(Lines 120 and 230 — the bridge theorem `not_constructible_of_bad_degree` and the full `wantzel_galois_iff` characterization.)

The companion `Proofs/AngleTrisectionOQ02OQ01OQ02Aristotle.lean` contributes 3 additional sorries; it is already declared separately in `meta.additionalFiles`. The `leanFile.sorries` block (2) was already correct.

**Before**:
- `meta.sorries`: 5
- top-level `sorries`: 5
- `leanFile.sorries`: 2

**After**:
- `meta.sorries`: 2
- top-level `sorries`: 2
- `leanFile.sorries`: 2 (unchanged)

## Validation

- `python3 -c "import json; json.load(open(...))"` parses cleanly
- Narrative fields (`overview.keyInsights`, `conclusion.summary`) intentionally untouched; they describe the *total* development gap (main + companion) as authored

---
Automated fix by lean-mechanic agent.