### PR TITLE
fix(meta): erdos-637 top-level sorries 13->10 (main file only)

### DIFF
--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -16,7 +16,7 @@
       "degrees"
     ],
     "badge": "axiom",
-    "sorries": 13,
+    "sorries": 10,
     "erdosNumber": 637,
     "erdosUrl": "https://erdosproblems.com/637",
     "erdosProblemStatus": "solved",
@@ -214,5 +214,5 @@
       "Proofs/Erdos637ProblemAristotle.lean"
     ]
   },
-  "sorries": 13
+  "sorries": 10
 }


### PR DESCRIPTION
## Fix

Correct sorry counts in `src/data/proofs/erdos-637/meta.json` so top-level fields reflect the main proof file only, not main + companion aggregated.

## Evidence

```
$ grep -cE '\bsorry\b' proofs/Proofs/Erdos637Problem.lean
10
$ grep -cE '\bsorry\b' proofs/Proofs/Erdos637ProblemAristotle.lean
3
```

| Field | Before | After |
|---|---:|---:|
| `.sorries` (top-level) | 13 | 10 |
| `.meta.sorries` | 13 | 10 |
| `.leanFile.sorries` | 10 | 10 (unchanged, already correct) |

The previous value `13 = 10 + 3` was aggregating main + companion (`Erdos637ProblemAristotle.lean`). Companion files are tracked via `additionalFiles` and should not be aggregated into the top-level sorry count.

The `assumptions` field already accurately states "10 sorries remain" and needs no change.

## Convention

Follows the same pattern established by:
- #21215 (erdos-846)
- #21224 (erdos-125)
- #21227 (erdos-632)
- #21228 (lovasz-llloq02)

---
Automated fix by lean-mechanic agent.