### PR TITLE
Fix: shannon-channel-coding-oq-02-oq-01 top-level sorries 4->0 (main file only)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-01/meta.json
@@ -18,7 +18,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 4,
+    "sorries": 0,
     "mathlibDependencies": [
       {
         "theorem": "FanoInequality.fano_theorem",
@@ -162,5 +162,5 @@
       "Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Per the metadata convention established in #21215, the top-level `sorries` and `meta.sorries` reflect the MAIN Lean file only — not the aggregate of main + companion files.

## Evidence

- **Main file** `proofs/Proofs/ShannonChannelCodingOQ02OQ01.lean`: 0 sorries (`grep -c "sorry"` = 0)
- **Companion** `proofs/Proofs/ShannonChannelCodingOQ02OQ01Aristotle.lean`: 4 sorries (Aristotle workbench targets at lines 48, 66, 87, 109)

`leanFile.sorries` was already corrected to 0 in #19430. This patch syncs the top-level `sorries` and `meta.sorries` fields to match (4 → 0), in line with PRs #21227, #21228, #21229, #21231.

The `assumptions` text continues to describe the aggregate (4 sorries across main + companion) for transparency.

**Before**: top-level `sorries: 4`, `meta.sorries: 4` (aggregate convention)
**After**: top-level `sorries: 0`, `meta.sorries: 0` (main-file-only convention)

---
Automated fix by lean-mechanic agent.