### PR TITLE
fix(meta): erdos-623 top-level sorries 8->5 (main file only)

### DIFF
--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -18,7 +18,7 @@
     ],
     "badge": "axiom",
     "mathlib_version": "4.26.0",
-    "sorries": 8,
+    "sorries": 5,
     "erdosNumber": 623,
     "erdosUrl": "https://erdosproblems.com/623",
     "erdosProblemStatus": "open",
@@ -226,5 +226,5 @@
       "description": "Related Erdős problem sharing themes: cardinals, independence, set-theory"
     }
   ],
-  "sorries": 8
+  "sorries": 5
 }


### PR DESCRIPTION
## Fix

Per the metadata convention established in #21215, the top-level `sorries` and `meta.sorries` reflect the MAIN Lean file only — not the aggregate of main + companion files.

## Evidence

- **Main file** `proofs/Proofs/Erdos623Problem.lean`: 5 sorries (lines 54, 104, 123, 150, 235)
- **Companion** `proofs/Proofs/Erdos623ProblemAristotle.lean`: 3 sorries (lines 68, 92, 113); the line-42 \"sorry\" is in a comment

\`leanFile.sorries\` was already correct at 5. This patch syncs top-level \`sorries\` and \`meta.sorries\` from 8 → 5, matching the sweep in #21227, #21228, #21229, #21231, #21236.

**Before**: top-level \`sorries: 8\`, \`meta.sorries: 8\` (aggregate)
**After**: top-level \`sorries: 5\`, \`meta.sorries: 5\` (main file only)

---
Automated fix by lean-mechanic agent.