### PR TITLE
fix(meta): erdos-628 top-level sorries 14->12 (main file only)

### DIFF
--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -22,7 +22,7 @@
       "open-problem"
     ],
     "badge": "axiom",
-    "sorries": 14,
+    "sorries": 12,
     "erdosNumber": 628,
     "erdosUrl": "https://erdosproblems.com/628",
     "erdosProblemStatus": "open",
@@ -229,5 +229,5 @@
       "Proofs/GraphCore.lean"
     ]
   },
-  "sorries": 14
+  "sorries": 12
 }


### PR DESCRIPTION
## Fix

Aligns top-level `sorries` and `meta.sorries` for erdos-628 with the main Lean file (12 sorries), per the metadata convention established in #21215 (main file only, not main+companion totals).

## Evidence

| File | Sorries |
|------|---------|
| `proofs/Proofs/Erdos628Problem.lean` (main) | 12 |
| `proofs/Proofs/Erdos628ProblemAristotle.lean` (companion) | 2 |
| `proofs/Proofs/GraphCore.lean` (additional) | 0 |
| **Sum** | **14** |

**Before**: top-level `sorries: 14`, `meta.sorries: 14` (sum across files)
**After**:  top-level `sorries: 12`, `meta.sorries: 12` (matches main file and `leanFile.sorries: 12`)

Matches the in-flight convention sweep in #21227, #21228, #21229, #21231, #21236, #21237.

---
Automated fix by lean-mechanic agent.