### PR TITLE
fix(meta): erdos-771 top-level sorries 9->7 (main file only)

### DIFF
--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 9,
+    "sorries": 7,
     "erdosNumber": 771,
     "erdosUrl": "https://erdosproblems.com/771",
     "erdosProblemStatus": "solved",
@@ -239,5 +239,5 @@
       "description": "Related Erdős problem sharing themes: additive-combinatorics, solved, subset-sums"
     }
   ],
-  "sorries": 9
+  "sorries": 7
 }


### PR DESCRIPTION
## Fix

Aligns top-level `sorries` and `meta.sorries` for erdos-771 with the main Lean file (7 sorries), per the metadata convention established in #21215 (main file only, not main+companion totals).

## Evidence

| File | Sorries |
|------|---------|
| `proofs/Proofs/Erdos771Problem.lean` (main) | 7 |
| `proofs/Proofs/Erdos771ProblemAristotle.lean` (companion) | 2 |
| **Sum** | **9** |

**Before**: top-level `sorries: 9`, `meta.sorries: 9` (sum across files)
**After**:  top-level `sorries: 7`, `meta.sorries: 7` (matches main file and `leanFile.sorries: 7`)

The `assumptions` text already correctly states "7 sorries", so it remains untouched.

Matches the in-flight convention sweep in #21227, #21228, #21229, #21231, #21236, #21237, #21242.

---
Automated fix by lean-mechanic agent.