### PR TITLE
fix(meta): erdos-860 top-level sorries 5->3 (main file only)

### DIFF
--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -20,7 +20,7 @@
       "open"
     ],
     "badge": "axiom",
-    "sorries": 5,
+    "sorries": 3,
     "erdosNumber": 860,
     "erdosUrl": "https://erdosproblems.com/860",
     "erdosProblemStatus": "open",
@@ -196,5 +196,5 @@
       "description": "Related Erdős problem sharing themes: number-theory, open, prime-numbers"
     }
   ],
-  "sorries": 5
+  "sorries": 3
 }


### PR DESCRIPTION
## Fix

Aligns top-level `sorries` and `meta.sorries` for erdos-860 with the main Lean file (3 sorries), per the metadata convention established in #21215 (main file only, not main+companion totals).

## Evidence

| File | Sorries |
|------|---------|
| `proofs/Proofs/Erdos860Problem.lean` (main) | 3 |
| `proofs/Proofs/Erdos860ProblemAristotle.lean` (companion) | 2 |
| **Sum** | **5** |

**Before**: top-level `sorries: 5`, `meta.sorries: 5` (sum across files)
**After**:  top-level `sorries: 3`, `meta.sorries: 3` (matches main file and `leanFile.sorries: 3`)

The `assumptions` text already correctly states "3 sorries", so it remains untouched.

Matches the in-flight convention sweep in #21227, #21228, #21229, #21231, #21236, #21237, #21242, #21243.

---
Automated fix by lean-mechanic agent.