### PR TITLE
Fix: erdos-57 top-level sorries 4->2 (main file only)

### DIFF
--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -18,7 +18,7 @@
       "solved"
     ],
     "badge": "axiom",
-    "sorries": 4,
+    "sorries": 2,
     "erdosNumber": 57,
     "erdosUrl": "https://erdosproblems.com/57",
     "erdosProblemStatus": "solved",
@@ -202,5 +202,5 @@
       "note": "High-girth constructions showing χ(G) = ∞ is compatible with lower density 0 for odd cycle lengths — demonstrating the reciprocal sum divergence in Problem #57 is precisely calibrated"
     }
   ],
-  "sorries": 4
+  "sorries": 2
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` (and top-level `.sorries`) with the **main-file-only** convention (PR #18127). The main proof file `Proofs/Erdos57Problem.lean` contains 2 sorries; the companion file `Proofs/Erdos57ProblemAristotle.lean` adds 2 more (chain total = 4) but companion sorries are excluded from gallery counts.

## Evidence

**Before**: `meta.sorries = 4`, top-level `.sorries = 4` (chain-aggregate)
**After**: `meta.sorries = 2`, top-level `.sorries = 2` (main file only)

Verified by direct grep:
- `Proofs/Erdos57Problem.lean`: lines 148, 153 → 2 sorries
- `Proofs/Erdos57ProblemAristotle.lean`: lines 46, 64 → 2 sorries

The existing `assumptions` field already reported "1 axiom(s) and 2 sorry(s)" — the metadata is now internally consistent.

Auditor (`scripts/auditor/find-targets.ts`) confirms 0 detected issues after the change (`claimedSorries=2`, `mainSorryCount=2`).

---
Automated fix by lean-mechanic agent.