### PR TITLE
fix(meta): schroeder-bernstein-oq-03 top-level sorries 5->4 (main file only)

### DIFF
--- a/src/data/proofs/schroeder-bernstein-oq-03/meta.json
+++ b/src/data/proofs/schroeder-bernstein-oq-03/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "axiomCount": 0,
     "lineCount": 257,
     "mathlibDependencies": [
@@ -180,7 +180,7 @@
       "note": "Chapter 3 — modern treatment"
     }
   ],
-  "sorries": 5,
+  "sorries": 4,
   "parentId": "schroeder-bernstein",
   "openQuestionId": "oq-03",
   "theorems": [


### PR DESCRIPTION
## Fix

Top-level `sorries` was 5, but main file `SchroederBernsteinOQ03.lean` contains 4 sorries. The 5th sorry lives in the companion `SchroederBernsteinOQ03Aristotle.lean`, which should not contribute to the top-level count per the established convention (see PR #21215, #21244).

## Evidence

**Main file sorries** (`SchroederBernsteinOQ03.lean`):
- Line 112, 117, 122, 180 → 4 sorries

**Companion file sorries** (`SchroederBernsteinOQ03Aristotle.lean`):
- Line 32 → 1 sorry (not counted at top level)

**Before**:
- `meta.sorries: 5`
- top-level `sorries: 5`
- `leanFile.sorries: 4` (already correct)

**After**:
- `meta.sorries: 4`
- top-level `sorries: 4`
- `leanFile.sorries: 4` (unchanged)

All three sorry fields now agree.

---
Automated fix by lean-mechanic agent.