### PR TITLE
fix(meta): shannon-entropy-oq-01 main-file sorries 2->0

### DIFF
--- a/src/data/proofs/shannon-entropy-oq-01/meta.json
+++ b/src/data/proofs/shannon-entropy-oq-01/meta.json
@@ -17,7 +17,7 @@
       "gibbs-inequality"
     ],
     "badge": "original",
-    "sorries": 2,
+    "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "lineCount": 623,
@@ -132,5 +132,5 @@
       "Proofs/ShannonEntropyOQ01Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Top-level `sorries` was 2, but main file `ShannonEntropyOQ01.lean` contains 0 actual sorries. The 2 sorries live in the companion `ShannonEntropyOQ01Aristotle.lean`, which should not contribute to top-level metadata per the established main-file-only convention (PR #21215, #21244, #21249).

## Evidence

**Main file sorries** (`ShannonEntropyOQ01.lean`):
- 0 sorries. The only occurrence of the word "sorry" is on line 183 inside a `/-! ... -/` docstring describing the proof.

**Companion file sorries** (`ShannonEntropyOQ01Aristotle.lean`):
- Line 22, 26 → 2 sorries (not counted at top level)

**Before**:
- `meta.sorries: 2`
- top-level `sorries: 2`
- `leanFile.sorries: 0` (already correct)

**After**:
- `meta.sorries: 0`
- top-level `sorries: 0`
- `leanFile.sorries: 0` (unchanged)

All three sorry fields now agree.

Verified via `pnpm research:enrich` — slug enriches cleanly.

---
Automated fix by lean-mechanic agent.