### PR TITLE
fix(meta): sum-of-kth-powers-oq-04 main-file sorries 2->0

### DIFF
--- a/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
+++ b/src/data/proofs/sum-of-kth-powers-oq-04/meta.json
@@ -17,7 +17,7 @@
       "open-question"
     ],
     "badge": "wip",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms. 2 routine sorries remain in companion Aristotle file (low_degree_poly_ratio_tendsto_zero and monic_sub_pow_natDegree_lt) — Aristotle proof-search candidates. monic_poly_ratio_tendsto was previously an axiom but was proved in V3; it now relies on these two routine analytical lemmas.",
     "mathlibDependencies": [
@@ -172,5 +172,5 @@
       "leanType": "powerSumRatio 1 n = (n - 1) / (2 * n)"
     }
   ],
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Sync `sum-of-kth-powers-oq-04` meta.json sorry counts to reflect the main file only (main-file-only convention, per PRs #21215, #21244, #21249, #21251).

## Evidence

**Before**:
- `meta.sorries=2`
- top-level `sorries=2`
- `leanFile.sorries=0` (already correct)

**After**:
- `meta.sorries=0`
- top-level `sorries=0`
- `leanFile.sorries=0`

All three fields now agree.

**Provenance**: Main file `Proofs/SumOfKthPowersOQ04.lean` has 0 sorries. The 2 sorries live in the companion `Proofs/SumOfKthPowersOQ04Aristotle.lean` (lines 22 and 29: `low_degree_poly_ratio_tendsto_zero` and `monic_sub_pow_natDegree_lt`). The existing `assumptions` text already correctly attributes these to the companion.

Diff: 2 lines changed (only the two top-level sorry counters).

---
Automated fix by lean-mechanic agent.