### PR TITLE
audit(erdos-210): mark clean — Green-Tao ordinary lines axiom integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5278,9 +5278,9 @@
     },
     "erdos-210": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T06:39:55Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T23:07:51Z",
+      "result": "clean"
     },
     "erdos-211": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
Re-audit of erdos-210 (Ordinary Lines / Green-Tao 2013). All meta.json claims match Lean source: 9 axioms (OrdinaryLineCount, f, sylvester_gallai, motzkin_theorem, kelly_moser, csima_sawyer, green_tao_even, green_tao_odd, LiesOnCubic), 0 sorries, 196 lines, 3 proven theorems (no True stubs), 9 definitions. Status axiomatized/badge axiom — appropriate. originalContributions match. Tracker updated to auditCount 4, result clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)