### PR TITLE
fix(meta): taylor-sincos-convergence-oq-02 main-file sorries 2->0

### DIFF
--- a/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
+++ b/src/data/proofs/taylor-sincos-convergence-oq-02/meta.json
@@ -18,9 +18,9 @@
     ],
     "proofRepoPath": "Proofs/TaylorSinCosConvergenceOQ02.lean",
     "badge": "mathlib",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries via Mathlib bridge. The core step uses Mathlib's NormedSpace.expSeries_div_hasSum_exp for the exp series; all 16 theorems including the bonus bridge lemmas are proved with 0 sorries.",
+    "assumptions": "None for the main file: 0 axioms and 0 sorries via Mathlib bridge. The core step uses Mathlib's NormedSpace.expSeries_div_hasSum_exp for the exp series; all 16 main-file theorems including the bonus bridge lemmas are proved with 0 sorries. The companion file TaylorSinCosConvergenceOQ02Aristotle.lean carries 2 routine sorries (Aristotle proof-search targets).",
     "originalContributions": [
       "Explicit real-to-complex summability transfer for sin/cos Taylor series",
       "Complex tsum identification via I-cancellation (mul_right_cancel\u2080 Complex.I_ne_zero)",
@@ -148,5 +148,5 @@
       "Generalize: can this approach prove the power series identity for cosh/sinh (replacing ix with x), giving cosh x = \u2211 x^{2k}/(2k)! and sinh x = \u2211 x^{2k+1}/(2k+1)!?"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Align `meta.sorries` (and top-level convenience `sorries`) for `taylor-sincos-convergence-oq-02` with the main-file-only convention.

## Evidence

- Main file `proofs/Proofs/TaylorSinCosConvergenceOQ02.lean`: **0 sorries** (matches `leanFile.sorries: 0`).
- Companion file `proofs/Proofs/TaylorSinCosConvergenceOQ02Aristotle.lean`: 2 sorries at lines 104, 111.
- Previously, `meta.sorries` and the top-level `sorries` field both reported `2`, mixing chain-aggregate convention with the canonical main-file-only convention used in PR #21215, #21244, #21249, #21251, #21254.
- The pre-existing `assumptions` text already claimed "0 axioms and 0 sorries" — the new wording preserves that claim and explicitly attributes the 2 routine sorries to the companion file.

**Before**: `meta.sorries=2`, top-level `sorries=2`, `leanFile.sorries=0`
**After**:  `meta.sorries=0`, top-level `sorries=0`, `leanFile.sorries=0`

All three sorry fields now agree on the main-file count.

---
Automated fix by lean-mechanic agent.