### PR TITLE
fix(meta): erdos-559 register Erdos559Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -25,7 +25,10 @@
     "assumptions": "No axioms. 10 sorries(s) remain in the formalization.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "additionalFiles": [
+      "Proofs/Erdos559Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Beck posed this problem in 1983, motivated by his proof that the size Ramsey number of paths is linear: R̂(P_n) = O(n). He conjectured that the same linearity holds for all bounded-degree graphs: R̂(G) ≤ c_d · n when Δ(G) ≤ d. The conjecture was supported by positive results for increasingly general graph classes: Friedman and Pippenger (1987) proved it for all trees using expander graphs, and Haxell, Kohayakawa, and Luczak (1995) proved it for cycles, completing the picture for Δ ≤ 2. However, Rödl and Szemerédi (2000) dramatically disproved the conjecture for d = 3, constructing degree-3 graphs with R̂(G) ≥ cn(log n)^c using a probabilistic argument involving random 3-regular graphs. Tikhomirov (2022) strengthened this to R̂(G) ≥ cn · exp(c√(log n)), a bound that is superlinear but subpolynomial (n^{1+o(1)}). On the upper bound side, a sequence of improvements — Kohayakawa et al. (n^{5/3+o(1)}), Conlon-Nenadov-Trujić (n^{8/5}), and Draganić-Petrova (2022, n^{3/2+o(1)}) — has steadily reduced the exponent but a substantial gap remains between the lower bound n^{1+o(1)} and the upper bound n^{3/2+o(1)}.",
@@ -133,7 +136,10 @@
     "theoremCount": 9,
     "definitionCount": 11,
     "path": "Proofs/Erdos559Problem.lean",
-    "sorries": 10
+    "sorries": 10,
+    "additionalFiles": [
+      "Proofs/Erdos559Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing Aristotle companion file `proofs/Proofs/Erdos559Aristotle.lean` in `src/data/proofs/erdos-559/meta.json` so build and audit tooling treat erdos-559 as a multi-file entry.

## Evidence

**Before**:
- `proofs/Proofs/Erdos559Aristotle.lean` exists (72 LOC, 5 sorries, well-formed Aristotle companion).
- `meta.additionalFiles` and `leanFile.additionalFiles` both absent / null.
- The companion is invisible to gallery tooling and audit pipelines.

**After**:
- Both `meta.additionalFiles` and `leanFile.additionalFiles` reference `["Proofs/Erdos559Aristotle.lean"]`, matching the convention used by other companion-bearing entries (erdos-415, erdos-625, erdos-628).

No changes to sorry / axiom counts: companion files carry supplementary Aristotle proof-search targets and are tracked but not aggregated into main-file totals (per the main-file-only convention).

JSON validity confirmed; listings.json regeneration via pnpm annotations:build preserves erdos-559's sorries: 10 value.

---
Automated fix by lean-mechanic agent.