### PR TITLE
fix(meta): binomial-theorem-oq-02-oq-01-oq-01 sorries 5->4 (main file only)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01/meta.json
@@ -16,7 +16,7 @@
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01.lean",
     "badge": "wip",
-    "sorries": 5,
+    "sorries": 4,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "lineCount": 292,
@@ -196,5 +196,5 @@
       "leanType": "covariance_sum = -n*pi*pj"
     }
   ],
-  "sorries": 5
+  "sorries": 4
 }


### PR DESCRIPTION
## Fix

Aligns top-level `sorries` and `meta.sorries` for binomial-theorem-oq-02-oq-01-oq-01 with the main Lean file (4 sorries), per the metadata convention established in #21215 (main file only, not main+companion totals).

## Evidence

| File | Sorries |
|------|---------|
| `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01.lean` (main) | 4 (lines 164, 185, 200, 213) |
| `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01Aristotle.lean` (companion) | 1 (line 67) |
| **Sum** | **5** |

**Before**: top-level `sorries: 5`, `meta.sorries: 5` (sum across files)
**After**:  top-level `sorries: 4`, `meta.sorries: 4` (matches main file and `leanFile.sorries: 4`)

The `assumptions` text already enumerates "4 in main file ... + 1 in BinomialTheoremOQ02OQ01OQ01Aristotle.lean", so it remains accurate and is left unchanged.

Matches the in-flight convention sweep in #21227, #21228, #21229, #21231, #21236, #21237, #21242, #21243, #21244, #21248, #21249, #21251, #21254, #21256.

Auditor (\`scripts/auditor/find-targets.ts --issues\`) reports 0 detected issues after the change.

---
Automated fix by lean-mechanic agent.