### PR TITLE
fix(meta): erdos-870 register Erdos870Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-870/meta.json
+++ b/src/data/proofs/erdos-870/meta.json
@@ -66,7 +66,10 @@
     "lineCount": 303,
     "assumptions": "2 axioms: hartter_nathanson_existence, erdos_nathanson_k2. 2 sorries.",
     "theoremCount": 4,
-    "definitionCount": 19
+    "definitionCount": 19,
+    "additionalFiles": [
+      "Proofs/Erdos870Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem asks about additive bases — sets A ⊆ N where every large integer is a sum of at most k elements from A. A minimal basis has no proper subset that is also a basis. Erdős and Nathanson (1979) proved that for k = 2, if representations grow logarithmically, the basis contains a minimal basis. Härtter (1956) and Nathanson (1974) showed that without growth conditions, bases may contain no minimal bases. The theory of additive bases originates with Waring's problem (1770) and Goldbach's conjecture (1742); Lagrange's four-square theorem (1770) shows the squares form a basis of order 4. The distinction between bases and minimal bases captures a fundamental redundancy phenomenon: most natural bases (squares, cubes, primes) are far from minimal.",
@@ -213,7 +216,10 @@
     "theoremCount": 4,
     "definitionCount": 19,
     "path": "Proofs/Erdos870Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos870Aristotle.lean"
+    ]
   },
   "sorries": 2
 }


### PR DESCRIPTION
## Fix

Register the existing `proofs/Proofs/Erdos870Aristotle.lean` companion file in `src/data/proofs/erdos-870/meta.json` so build/audit tooling treats erdos-870 as a multi-file entry.

## Evidence

**Before**: `meta.additionalFiles` absent; `leanFile.additionalFiles` absent. Companion file (46 LOC, 4 sorries) sits unreferenced; main file `Erdos870Problem.lean` does not import it, so import-walking cannot find it.

**After**: both reference `["Proofs/Erdos870Aristotle.lean"]`, matching the convention used by erdos-559 (#21261), erdos-415, erdos-625, and other companion-bearing entries.

No change to sorry/axiom counts (companion file holds supplementary proof-search targets, not the main formalization).

---
Automated fix by lean-mechanic agent.