### PR TITLE
audit(erdos-215): mark clean — axiom integrity verified (cycle 11)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5311,9 +5311,9 @@
     },
     "erdos-215": {
       "agentId": "auditor-session-1777703363",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T06:35:11Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-30T23:37:18Z",
+      "result": "clean",
       "issues": [
         "phantom axiom narrative (isCongruent_symm, steinhaus_set_unbounded, steinhaus_set_measure_pathological, jackson_mauldin_general) + section line drift Parts II-VI + 209-line claim contradicts 187-line file (#14613)"
       ]


### PR DESCRIPTION
## Summary
- Re-audited erdos-215 (Steinhaus Lattice Point Problem) for cycle 11
- All gallery integrity checks pass
- Updated audit-tracker.json with clean result

## Audit Results
- **Line count**: 187 (matches meta)
- **Sorries**: 0 (no `sorry` in source)
- **AxiomCount**: 1 (`jackson_mauldin_theorem` at line 121)
- **TheoremCount**: 5 (lines 50, 77, 129, 160, 166)
- **DefinitionCount**: 8 (lines 43, 47, 72, 93, 97, 148, 154, 180)
- Status `axiomatized` + badge `axiom` correctly reflect the 1 axiom
- No hidden structure-encoded assumptions
- Main result not a Mathlib wrapper — `erdos_215_answer` derives from local axiom
- All 11 originalContributions exist in source
- `ConstructiveSteinhausQuestion := True` is a placeholder def for the open ZF-without-AC question, explicitly disclosed in meta + source comments

## Test plan
- [x] Verified meta.json counts against `proofs/Proofs/Erdos215Problem.lean`
- [x] Confirmed no `sorry` declarations in source
- [x] Verified all listed originalContributions correspond to actual identifiers
- [x] Confirmed axiom + status + badge alignment per axiom integrity policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)