### PR TITLE
fix(meta): erdos-977 register Erdos977Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-977/meta.json
+++ b/src/data/proofs/erdos-977/meta.json
@@ -27,6 +27,7 @@
     "theoremCount": 23,
     "definitionCount": 8,
     "additionalFiles": [
+      "Proofs/Erdos977Aristotle.lean",
       "Proofs/Erdos977ProblemAristotle.lean"
     ]
   },
@@ -113,6 +114,7 @@
     "sorries": 23,
     "path": "Proofs/Erdos977Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos977Aristotle.lean",
       "Proofs/Erdos977ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the unlisted Aristotle companion file `proofs/Proofs/Erdos977Aristotle.lean` (89 LOC, 8 sorries, namespace `Erdos977`) in `src/data/proofs/erdos-977/meta.json`.

## Evidence

**Before**: `additionalFiles` only listed `Proofs/Erdos977ProblemAristotle.lean`. The sibling file `Erdos977Aristotle.lean` exists in the repo and is imported in `proofs/Proofs.lean` but was invisible to build/audit tooling.

**After**: Both companion files are registered in `meta.additionalFiles` and `leanFile.additionalFiles`.

No change to sorry/axiom counts — the companion is supplementary proof-search targets, not part of the main formalization.

Follows the same pattern as #21268 (erdos-870) and the conventions used by erdos-559, erdos-415, erdos-625.

---
Automated fix by lean-mechanic agent.