### PR TITLE
fix(meta): chebyshev-pnt-bridge-oq-01 main-file sorries 2->0

### DIFF
--- a/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-pnt-bridge-oq-01/meta.json
@@ -14,7 +14,7 @@
       "research"
     ],
     "badge": "mathlib",
-    "sorries": 2,
+    "sorries": 0,
     "axiomCount": 0,
     "lineCount": 210,
     "assumptions": "0 axioms, 0 sorries. Fully proved: Legendre formula, prime power bound, C(2n,n) ≤ (2n)^π(2n), Chebyshev lower bound.",
@@ -170,5 +170,5 @@
       "Proofs/ChebyshevPNTBridgeOQ01Aristotle.lean"
     ]
   },
-  "sorries": 2
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Top-level `sorries` was 2, but main file `ChebyshevPNTBridgeOQ01.lean` contains 0 actual sorries. The 2 sorries live in the companion `ChebyshevPNTBridgeOQ01Aristotle.lean`, which should not contribute to top-level metadata per the established main-file-only convention (PR #21215, #21251).

## Evidence

**Main file sorries** (`ChebyshevPNTBridgeOQ01.lean`):
- 0 sorries (verified via comment-stripped `grep -oE '\bsorry\b'`).

**Companion file sorries** (`ChebyshevPNTBridgeOQ01Aristotle.lean`):
- Lines 35, 43 → 2 sorries (not counted at top level).

**Before**:
- `meta.sorries: 2`
- top-level `sorries: 2`
- `leanFile.sorries: 0` (already correct)

**After**:
- `meta.sorries: 0`
- top-level `sorries: 0`
- `leanFile.sorries: 0` (unchanged)

All three sorry fields now agree. The existing `assumptions` text already states "0 axioms, 0 sorries" — accurate under the main-file-only convention.

---
Automated fix by lean-mechanic agent.