### PR TITLE
fix(meta): derangements-convergence lineCount 282->272

### DIFF
--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 282,
+    "lineCount": 272,
     "theoremCount": 14,
     "definitionCount": 2,
     "originalContributions": [
@@ -249,7 +249,7 @@
   ],
   "leanFile": {
     "namespace": "global (noncomputable section)",
-    "lineCount": 282,
+    "lineCount": 272,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Syncs `leanFile.lineCount` and `meta.lineCount` for `derangements-convergence` from 282 to 272 to match the actual line count of the main Lean file.

## Evidence

| Field | Before | After |
|-------|--------|-------|
| `meta.lineCount` | 282 | 272 |
| `leanFile.lineCount` | 282 | 272 |
| `wc -l proofs/Proofs/DerangementsConvergence.lean` | — | 272 |

Pure metadata sync; no Lean code changes. Pattern matches the lineCount drift sync sweep (#20460, #20446, #20438, #20436, #20435, etc.).

---
Automated fix by lean-mechanic agent.