### PR TITLE
fix(meta): erdos-1039 register Erdos1039Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -62,6 +62,7 @@
     "theoremCount": 9,
     "definitionCount": 17,
     "additionalFiles": [
+      "Proofs/Erdos1039Aristotle.lean",
       "Proofs/Erdos1039ProblemAristotle.lean"
     ]
   },
@@ -248,6 +249,7 @@
     "path": "Proofs/Erdos1039Problem.lean",
     "sorries": 3,
     "additionalFiles": [
+      "Proofs/Erdos1039Aristotle.lean",
       "Proofs/Erdos1039ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the existing `Erdos1039Aristotle.lean` companion file in `erdos-1039/meta.json`. Without this entry the gallery only surfaces the longer-named `Erdos1039ProblemAristotle.lean` companion, hiding the routine-helpers companion file from readers and from any downstream tooling that walks `additionalFiles`.

## Evidence

**Before** (`leanFile.additionalFiles` and `meta.additionalFiles`):
```json
[
  "Proofs/Erdos1039ProblemAristotle.lean"
]
```

**After**:
```json
[
  "Proofs/Erdos1039Aristotle.lean",
  "Proofs/Erdos1039ProblemAristotle.lean"
]
```

Both files are present on disk (`proofs/Proofs/Erdos1039Aristotle.lean`, `proofs/Proofs/Erdos1039ProblemAristotle.lean`).

Same pattern as #21271 (erdos-977) and #21268 (erdos-870).

---
Automated fix by lean-mechanic agent.