### PR TITLE
fix(meta): burnside-counting-oq-03 main-file sorries 4->0

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -21,7 +21,7 @@
       "open-problem"
     ],
     "badge": "mathlib",
-    "sorries": 4,
+    "sorries": 0,
     "axiomCount": 0,
     "assumptions": "No sorries, no axioms. Uses Mathlib's ZMod.addOrderOf_coe for the orbit size formula (addOrderOf r = n / gcd(n, r.val)) and references MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (Burnside's lemma). The core theorem polya_cyclic_fixed_count is independently proved via explicit bijection; the general necklace formula is stated conditionally with Burnside as a hypothesis.",
     "dateAdded": "2026-04-04",
@@ -185,5 +185,5 @@
       "Proofs/BurnsideCountingOQ03Aristotle.lean"
     ]
   },
-  "sorries": 4
+  "sorries": 0
 }


### PR DESCRIPTION
## Fix

Reconciles `sorries: 4` in `src/data/proofs/burnside-counting-oq-03/meta.json` with the actual main Lean file content (0 sorries). The stale count was double-counting the Aristotle companion's 4 sorries.

## Evidence

**Before**:
- `.meta.sorries`: 4
- `.sorries` (top-level): 4
- `.leanFile.sorries`: 0 (already correct)
- `.meta.assumptions`: "No sorries, no axioms. ..." (internally inconsistent with `.meta.sorries: 4`)

**After**:
- `.meta.sorries`: 0
- `.sorries` (top-level): 0
- All three counts now agree, and the assumptions narrative matches the numeric fields.

**Verification** (word-boundary match, comments stripped — same algorithm as `scripts/erdos/update-badges.ts`):

```
proofs/Proofs/BurnsideCountingOQ03.lean             → 0 sorry, 0 axiom
proofs/Proofs/BurnsideCountingOQ03Aristotle.lean    → 4 sorry, 0 axiom
```

The 4 companion sorries remain in the companion file (correct destination for Aristotle targets) and are referenced via `meta.additionalFiles`.

## Why this matters

Per precedent commit `1e74e6996` ("erdos-846 metadata reflects main file, not main+companion totals"), `meta.json.sorries` reports the main file only. The companion contributes to gallery-wide Aristotle backlog but should not inflate the proof page's WIP indicator.

The `mathlib` badge + 0 sorries + 0 axioms is internally consistent — no badge/status change required by this fix.

---
Automated fix by lean-mechanic agent.