### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05: promote solution-of-cubic & general-quartic to relatedProblems

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -91,6 +91,14 @@
       {
         "id": "abel-ruffini-oq-04-oq-02-oq-03",
         "relationship": "Proves all finite groups of order $< 60$ are solvable — quantifies the boundary where Shafarevich's axiom kicks in universally without further analysis. Every group of order $\\leq 59$ is automatically Galois-realizable over $\\mathbb{Q}$ by composing this solvability classification with Shafarevich; $A_5$ at order 60 is the first group escaping this automatic realization-via-solvability (though $A_5$ is still realizable by other means, e.g., as $\\mathrm{Gal}(x^5 - 4x + 2 / \\mathbb{Q})$ in `abel-ruffini-oq-04-oq-01`)."
+      },
+      {
+        "id": "solution-of-cubic",
+        "relationship": "Constructive companion to the abstract `s3_realizable` corollary — explicitly named in keyInsight #8 and openQuestion #2. Cardano's depressed-cubic formula (1545, Wiedijk #37) exhibits the *concrete* splitting field $L = \\mathbb{Q}(\\sqrt{\\Delta}, \\sqrt[3]{-q/2 + \\sqrt{q^2/4 + p^3/27}})$ for which $\\mathrm{Gal}(L/\\mathbb{Q}) \\cong S_3$ when the discriminant $\\Delta = -4p^3 - 27q^2$ is non-square. The two-step radical tower matches the composition series $\\{e\\} \\trianglelefteq A_3 \\trianglelefteq S_3$ step-for-step — the constructive witness to the existence statement Shafarevich asserts non-constructively. Together with `general-quartic`, fills the constructive/existential gap that this entry's keyInsight #8 identifies as the structural asymmetry between Cardano-Ferrari (explicit polynomials and formulas) and Shafarevich (existence without algorithm)."
+      },
+      {
+        "id": "general-quartic",
+        "relationship": "Constructive companion to the abstract `s4_realizable` corollary — explicitly named in keyInsight #8 and openQuestion #2. Ferrari's resolvent-cubic method (1545) exhibits the *concrete* splitting field for a generic irreducible quartic with non-square discriminant and irreducible resolvent cubic, with $\\mathrm{Gal}(L/\\mathbb{Q}) \\cong S_4$. The three-step radical tower $\\mathbb{Q} \\subset \\mathbb{Q}(\\sqrt{\\Delta}) \\subset \\mathbb{Q}(\\sqrt{\\Delta}, \\sqrt[3]{R}) \\subset L$ matches the composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$ step-for-step — Ferrari's $S_4 \\twoheadrightarrow S_3$ map on the three Lagrange resolvents $(\\alpha_a + \\alpha_b)(\\alpha_c + \\alpha_d)$ has kernel exactly the Klein four-group $V_4$, which is the *crucial normal subgroup* whose absence at degree 5 forces Abel-Ruffini. Together with `solution-of-cubic`, provides the constructive Cardano-Ferrari witnesses underlying the solvable side of the inverse-Galois problem for $n \\leq 4$."
       }
     ]
   },


### PR DESCRIPTION
## Summary

Promotes Cardano (1545) and Ferrari (1545) classical radical-formula entries to the `relatedProblems` array. Both were already present in `crossReferences`, but they are explicitly named in **keyInsight #8** ('asymmetry between Shafarevich and the converse Hilbert direction') and **openQuestion #2** ('explicit $S_3$ and $S_4$ Galois realizations in Lean') as the *constructive* companions to this entry's abstract Shafarevich corollaries `s3_realizable` and `s4_realizable`. Promoting them to `relatedProblems` surfaces that constructive/existential gap at the metadata level.

## Changes

- `relatedProblems` count: 14 → 16
- **solution-of-cubic**: two-step radical tower $\mathbb{Q} \subset \mathbb{Q}(\sqrt{\Delta}) \subset L$ matching composition series $\{e\} \trianglelefteq A_3 \trianglelefteq S_3$ — explicit witness to `s3_realizable`'s existence statement
- **general-quartic**: three-step radical tower matching $\{e\} \trianglelefteq V_4 \trianglelefteq A_4 \trianglelefteq S_4$; Ferrari's $S_4 \twoheadrightarrow S_3$ quotient via the three Lagrange resolvents has kernel $V_4$ — the crucial normal subgroup whose absence at degree 5 forces Abel-Ruffini

No changes to `keyInsights`, annotations, or other fields. Build verified via `pnpm build`.

## Test plan
- [x] JSON validity
- [x] Referenced entries exist (`solution-of-cubic/`, `general-quartic/` directories present)
- [x] `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)