### PR TITLE
fix(meta): erdos-545 register Erdos545Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-545/meta.json
+++ b/src/data/proofs/erdos-545/meta.json
@@ -24,7 +24,10 @@
     "assumptions": "2 axiom(s) and 12 sorries(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "additionalFiles": [
+      "Proofs/Erdos545Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in 1975 [ErGr75, p.526], asking whether the 'most complete' graph with $m$ edges maximizes the Ramsey number. Given $m = \\binom{n}{2} + t$ with $0 \\leq t < n$, the maximally complete graph $H_m$ is $K_n$ augmented with a new vertex connected to $t$ vertices of $K_n$. The conjecture states $R(G) \\leq R(H_m)$ for any $m$-edge graph $G$ without isolated vertices. Surprisingly, the conjecture fails for small values: $m \\in \\{2, 3, 4, 5, 7, 8, 9\\}$ are all counterexamples. The notable gap at $m = 6 = \\binom{4}{2}$ (where $H_m = K_4$) suggests the conjecture may hold when the maximally complete graph is itself complete. The asymptotic version — that the conjecture holds for all sufficiently large $m$ — remains wide open. In 2011, Benny Sudakov proved the weaker universal bound $R(G) \\leq 2^{C\\sqrt{m}}$ using dependent random choice (related to Problem #546), which gives the right order of magnitude for dense graphs but does not identify the extremal graph. The problem connects to the broader question of which graph structures are hardest for Ramsey theory: complete graphs, dense bipartite graphs, or something else entirely. Classical Ramsey theory provides exact values $R(3) = 6$ (Ramsey 1930) and $R(4) = 18$ (Greenwood-Gleason 1955), while Erdős's 1947 probabilistic lower bound $R(k) \\geq 2^{k/2}$ and the pigeonhole upper bound $R(k) \\leq 4^k$ frame the growth rate.",
@@ -145,7 +148,10 @@
     "theoremCount": 9,
     "definitionCount": 11,
     "path": "Proofs/Erdos545Problem.lean",
-    "sorries": 12
+    "sorries": 12,
+    "additionalFiles": [
+      "Proofs/Erdos545Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos545Aristotle.lean` companion file in `src/data/proofs/erdos-545/meta.json` so gallery/audit tooling surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` had no `additionalFiles` array. `proofs/Proofs/Erdos545Aristotle.lean` (48 LOC, 5 routine theorem sorries, `namespace Erdos545Aristotle`) exists on disk and is imported by `proofs/Proofs.lean:1582`, but the gallery data did not reference it.

**After**: `additionalFiles: ["Proofs/Erdos545Aristotle.lean"]` added to both `meta` and `leanFile` sections, matching the convention used by erdos-977 (#21271), erdos-870 (#21268), erdos-1039 (#21276), erdos-559 (#21261).

No change to sorry/axiom counts (companion is supplementary proof-search targets, not part of main formalization).

---
Automated fix by lean-mechanic agent.