### PR TITLE
audit(erdos-199): mark clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5179,9 +5179,9 @@
     },
     "erdos-199": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T07:10:40Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T00:47:47Z",
+      "result": "clean"
     },
     "erdos-2": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Audited `erdos-199` (Arithmetic Progressions in Set Complements) — cycle 4
- All meta.json counts verified against `proofs/Proofs/Erdos199Problem.lean`: 0 sorries, 1 axiom, 3 theorems, 5 definitions, 174 lines, no True stubs
- Tier C scaffold/axiomatized classification is appropriate — disproof relies on openly-declared `baumgartner_3AP_free` axiom (Hamel-basis construction requires AC)
- Status `axiomatized` and badge `axiom` correctly reflect the assumption

## Test plan
- [x] `grep` verification of sorry/axiom/theorem/def counts vs meta.json
- [x] True-stub scan — none found
- [x] Tier classification check (Tier C scaffold)
- [x] No overclaiming in originalContributions, description, or conclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)