### PR TITLE
fix(meta): erdos-1043 register Erdos1043Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -50,7 +50,10 @@
     "lineCount": 272,
     "assumptions": "2 axioms: pommerenke_counterexample (Pommerenke — monic poly s.t. every projection of level set has measure ≥ 2.386), pommerenke_upper_bound (measure 3.3 is achievable as upper bound). 4 sorries remain in complex-analysis supporting lemmas (disk_projection_measure, monomial_projection, levelSet_connected_iff, levelSet_compact).",
     "theoremCount": 12,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "additionalFiles": [
+      "Proofs/Erdos1043Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Origins in Polynomial Geometry (1958)**\n\nErdős, Herzog, and Piranian posed this problem in their 1958 paper 'Metric properties of polynomials' (J. Analyse Math. 6, 125–148), studying how the level set $L_f = \\{z \\in \\mathbb{C} : |f(z)| \\le 1\\}$ of a monic polynomial spreads in the complex plane. For $f(z) = z^n$, the level set is the closed unit disk $\\overline{B}(0,1)$, whose projection onto any line has length exactly 2 (the diameter). They conjectured this measure of 2 might be universally achievable.\n\n**The Level Set Tradition**: These sets are **lemniscates**, named after the figure-eight curve $|z^2 - 1| = c$ studied by Jakob Bernoulli (1694). The arc length integral for Bernoulli's lemniscate was a catalyst for Euler's and Gauss's work on elliptic integrals. In potential theory, level sets of monic polynomials have logarithmic capacity 1, a normalization due to Fekete's transfinite diameter theorem (1923).\n\n**Pommerenke's Resolution (1961)**: Christian Pommerenke, in 'Über die analytische Kapazität' (Math. Ann. 144, 285–296), proved the conjecture **FALSE**: there exist monic polynomials where every projection has measure $\\ge 2.386$, so no direction achieves the disk's measure of 2. He also proved the positive result that every monic polynomial has some projection $\\le 3.3$. The exact value of the **Pommerenke constant** $\\mathcal{P} = \\sup_f \\inf_u \\mu(\\pi_u(L_f)) \\in [2.386, 3.3]$ remains unknown.",


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos1043Aristotle.lean` companion file in `src/data/proofs/erdos-1043/meta.json`'s `additionalFiles` field, so the gallery correctly surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` listed `proofRepoPath: Proofs/Erdos1043Problem.lean` but `additionalFiles` was absent — the companion at `proofs/Proofs/Erdos1043Aristotle.lean` (8 fully-proved routine lemmas: ENNReal arithmetic, `iInf` / `iSup` bounds) was undocumented in metadata.

**After**: `additionalFiles: ["Proofs/Erdos1043Aristotle.lean"]` is declared, matching the convention used by other registered companions (e.g., `erdos-545`).

**Companion file integrity**:
- 0 sorries (`grep -c sorry proofs/Proofs/Erdos1043Aristotle.lean` → 0)
- 0 axioms (`grep -c '^axiom ' proofs/Proofs/Erdos1043Aristotle.lean` → 0)
- All 8 theorems closed via `norm_num` / `le_trans`

---
Automated fix by lean-mechanic agent.