### PR TITLE
fix(meta): erdos-660 register Erdos660Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-660/meta.json
+++ b/src/data/proofs/erdos-660/meta.json
@@ -63,7 +63,8 @@
     "theoremCount": 10,
     "definitionCount": 10,
     "additionalFiles": [
-      "Proofs/Erdos660ProblemAristotle.lean"
+      "Proofs/Erdos660ProblemAristotle.lean",
+      "Proofs/Erdos660Aristotle.lean"
     ]
   },
   "overview": {
@@ -148,7 +149,8 @@
     "sorries": 10,
     "path": "Proofs/Erdos660Problem.lean",
     "additionalFiles": [
-      "Proofs/Erdos660ProblemAristotle.lean"
+      "Proofs/Erdos660ProblemAristotle.lean",
+      "Proofs/Erdos660Aristotle.lean"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Register `proofs/Proofs/Erdos660Aristotle.lean` in `src/data/proofs/erdos-660/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**On disk** (worktree HEAD = `origin/main`):
- `proofs/Proofs/Erdos660Problem.lean` (main, 6884 bytes) — registered as `proofRepoPath`
- `proofs/Proofs/Erdos660ProblemAristotle.lean` (2447 bytes) — already in `additionalFiles`
- `proofs/Proofs/Erdos660Aristotle.lean` (9022 bytes, **246 lines, 30 proved lemmas, 0 sorries, 0 axioms**) — **MISSING from additionalFiles**

The larger Erdos660Aristotle.lean covers basic distance properties (`dist_pos_of_ne`, `dist_comm'`, etc.), Finset/cardinality helpers, and pairwiseDistances structure lemmas. All 30 lemmas are fully proved (no sorries, no axioms).

**Before**:
```json
"additionalFiles": [
  "Proofs/Erdos660ProblemAristotle.lean"
]
```

**After**:
```json
"additionalFiles": [
  "Proofs/Erdos660ProblemAristotle.lean",
  "Proofs/Erdos660Aristotle.lean"
]
```

Applied to both `meta.additionalFiles` and `leanFile.additionalFiles` (both fields exist).

No other meta.json fields changed; no Lean source changes.

---
Automated fix by lean-mechanic agent (mechanic-3).