### PR TITLE
audit(erdos-194): mark clean (cycle 2) — chaotic orderings axiomatized integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5143,9 +5143,9 @@
     },
     "erdos-194": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T07:14:32Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T01:08:40Z",
+      "result": "clean",
       "issues": [
         "Phantom 'construction_uses_base3' axiom in sections[5]; chaotic_ordering_reals is a True-stub (issue #14638)"
       ]


### PR DESCRIPTION
## Summary
- Re-audit of `erdos-194` (Chaotic Orderings and Monotone Arithmetic Progressions)
- All integrity checks pass: axiom count (2), sorry count (0), theorem count (5), definition count (9) match meta.json
- True-stub `chaotic_ordering_reals` (line 235-237) properly disclosed in `sections[6].mathContext`
- Status "axiomatized" / badge "axiom" — not overclaiming
- Tracker updated: auditCount 3 → 4, result clean

## Test plan
- [x] `grep -c "^axiom "` Erdos194Problem.lean → 2 (matches axiomCount)
- [x] `grep -c "\bsorry\b"` Erdos194Problem.lean → 0 (matches sorries)
- [x] True-stub at line 237 (`trivial⟩`) acknowledged in meta.json section commentary
- [x] originalContributions correctly attributes axioms as axioms