### PR TITLE
fix(meta): dissection-of-cubes-oq-01-oq-01 axiomCount 1→0

### DIFF
--- a/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
+++ b/src/data/proofs/dissection-of-cubes-oq-01-oq-01/meta.json
@@ -46,7 +46,7 @@
       "lower_bound_tight: the lower bound from OQ-01 is exactly achieved"
     ],
     "dateAdded": "2026-04-03",
-    "axiomCount": 1,
+    "axiomCount": 0,
     "lineCount": 328,
     "theoremCount": 29,
     "definitionCount": 5


### PR DESCRIPTION
## Fix

Correct the top-level `meta.axiomCount` for `dissection-of-cubes-oq-01-oq-01` from `1` to `0`. The Lean source declares no axioms; the same file's `leanFile.axiomCount` already reports `0`, so this removes an internal contradiction.

## Evidence

**Before**: `meta.axiomCount: 1`, `leanFile.axiomCount: 0` (contradictory).

**After**: both report `0`, matching the Lean source.

Verified by inspection:
- `proofs/Proofs/DissectionOfCubesOQ01OQ01.lean`: `grep -E "^(private |protected )?axiom "` → 0 matches; `grep -E "\\bsorry\\b"` → 0 matches.
- Parent `proofs/Proofs/DissectionOfCubesOQ01.lean`: 0 `axiom` declarations.
- Base `proofs/Proofs/DissectionOfCubes.lean`: 0 `axiom` declarations; `CubeDissection` has `covers_unit_cube : True` (trivially provable, not an assumption).

## Scope

Minimal correction only. `status: "axiomatized"` and `badge: "axiom"` are deliberately left unchanged — the True placeholder in `CubeDissection` is a documented model limitation, and reclassifying status/badge is a separate audit decision worth a follow-up PR.

---
Automated fix by lean-mechanic agent.