### PR TITLE
fix(meta): erdos-190 correct H_pos label (theorem, not axiom) + add Part XI section

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5116,8 +5116,8 @@
     },
     "erdos-190": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T07:19:59Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T01:15:39Z",
       "result": "issues-fixed",
       "issues": [
         "proofStrategy/keyInsight reverse H(k)≤W(k) (Lean proves W(k)≤H(k) at line 177); section line drift in 6/10 sections; filed #14641"

--- a/src/data/proofs/erdos-190/meta.json
+++ b/src/data/proofs/erdos-190/meta.json
@@ -123,8 +123,16 @@
       "title": "Part 10: Summary",
       "startLine": 299,
       "endLine": 348,
-      "summary": "H_pos axiom, summary theorem combining H(k) > 0 and H(k)^{1/k} → ∞. Status: OPEN.",
-      "mathContext": "H_pos axiom, summary theorem combining H(k) > 0 and H(k)^{1/k} $\\to$ ∞. Status: OPEN."
+      "summary": "H_pos theorem (proved from H_spec on empty Fin 0 codomain), erdos_190_summary theorem combining H_pos, H_root_to_infinity, and W_le_H. Status: OPEN.",
+      "mathContext": "H_pos theorem (proved, not axiomatized) and erdos_190_summary theorem combining H(k) > 0, H(k)^{1/k} $\\to$ ∞, and W(k) $\\leq$ H(k). Status: OPEN."
+    },
+    {
+      "id": "subset-helpers",
+      "title": "Part 11: Subset Helpers and Conjecture Strength",
+      "startLine": 348,
+      "endLine": 398,
+      "summary": "isMonochromatic_subset and isRainbow_subset (color predicates preserved under subsets). erdos190Conjecture_implies_root_to_infinity (conjecture is strictly stronger than the known result).",
+      "mathContext": "Proved theorems: isMonochromatic_subset, isRainbow_subset (subset preservation), and erdos190Conjecture_implies_root_to_infinity (showing the open conjecture H(k)^{1/k}/k $\\to$ ∞ implies the known H(k)^{1/k} $\\to$ ∞)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- meta.json section 10 ("Part 10: Summary") incorrectly labeled `H_pos` as an axiom; it is a proved theorem at `proofs/Proofs/Erdos190Problem.lean:308`.
- The 3 actual axioms remain `exists_canonical_threshold` (line 110), `vanDerWaerden_exists` (line 167), and `H_root_to_infinity` (line 241) — `axiomCount: 3` is correct.
- Sections array previously omitted Part XI (lines 348-398) which contains three proved theorems: `isMonochromatic_subset`, `isRainbow_subset`, and `erdos190Conjecture_implies_root_to_infinity`. Added as new section `subset-helpers`.
- Audit-tracker bumped: cycle 4, result `issues-fixed`.

## Why this matters
The "H_pos axiom" mislabel in gallery commentary would misleadingly inflate the perceived assumption surface (4 axioms instead of 3) and conflate proved theorems with stated assumptions. Catching this kind of axiom-vs-theorem confusion is core auditor work — see the Axiom Integrity Policy in CLAUDE.md.

## Test plan
- [x] `grep -nE "^(theorem|axiom)" Erdos190Problem.lean` confirms `H_pos` is `theorem`, not `axiom`
- [x] Axiom count `grep -c "^axiom "` = 3 (matches `axiomCount`)
- [x] Theorem count `grep -c "^theorem "` = 9 (matches `theoremCount`)
- [x] `node -e "JSON.parse(require('fs').readFileSync('src/data/proofs/erdos-190/meta.json','utf8'))"` passes
- [x] Part XI section line range `348-398` matches Lean file boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)