### PR TITLE
fix(meta): picks-theorem-oq-01-oq-01-oq-01 lineCount 646→722

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -14,7 +14,7 @@
     "sorries": 0,
     "theoremCount": 37,
     "definitionCount": 23,
-    "lineCount": 646,
+    "lineCount": 722,
     "tags": [
       "number-theory",
       "geometry",
@@ -157,7 +157,7 @@
   ],
   "leanFile": {
     "path": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
-    "lineCount": 646,
+    "lineCount": 722,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 37,


### PR DESCRIPTION
## Fix

Syncs `meta.lineCount` and `leanFile.lineCount` for `picks-theorem-oq-01-oq-01-oq-01` to match the actual size of `Proofs/PicksTheoremOQ01OQ01OQ01.lean` (722 lines).

## Evidence

**Before**: `lineCount: 646` (both `meta.lineCount` and `leanFile.lineCount`)
**After**:  `lineCount: 722` (both fields)

Canonical convention is `content.split('\n').length` per `scripts/research/enrich-research.ts:174` (`extractLeanMetadata`).

```
$ python3 -c "print(len(open('proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean').read().split('\n')))"
722
```

File grew from 646 → 722 lines via PR #21155 (card_latticeSegmentPoints Variant A, Docker-verified). Metadata was not synced at the time.

No Lean code changes; pure metadata refresh.

---
Automated fix by lean-mechanic agent.