### PR TITLE
fix(meta): erdos-1048 register Erdos1048Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1048/meta.json
+++ b/src/data/proofs/erdos-1048/meta.json
@@ -71,7 +71,8 @@
     "theoremCount": 12,
     "definitionCount": 14,
     "additionalFiles": [
-      "Proofs/Erdos1048ProblemAristotle.lean"
+      "Proofs/Erdos1048ProblemAristotle.lean",
+      "Proofs/Erdos1048Aristotle.lean"
     ]
   },
   "overview": {
@@ -278,7 +279,8 @@
     "path": "Proofs/Erdos1048Problem.lean",
     "sorries": 10,
     "additionalFiles": [
-      "Proofs/Erdos1048ProblemAristotle.lean"
+      "Proofs/Erdos1048ProblemAristotle.lean",
+      "Proofs/Erdos1048Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos1048Aristotle.lean` companion file in `src/data/proofs/erdos-1048/meta.json` so the gallery surfaces it alongside the main proof and the already-registered sibling companion `Erdos1048ProblemAristotle.lean`.

## Evidence

**Before**: `additionalFiles` (in both `meta.meta` and `meta.leanFile`) only listed `Proofs/Erdos1048ProblemAristotle.lean`. The on-disk file `proofs/Proofs/Erdos1048Aristotle.lean` (78 lines, 8 fully-proved supporting lemmas — polynomial sublevel set openness, monicity/degree of `X^n - C a`, absolute-value identities for roots of unity; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos1048Aristotle.lean` in addition to the existing entry.

This mirrors the precedent set by #21288 (erdos-1043 Aristotle companion registration).

---
Automated fix by lean-mechanic agent.