### PR TITLE
audit(erdos-198): mark clean (cycle 4) — Sidon-AP factorial counterexample integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5170,9 +5170,9 @@
     },
     "erdos-198": {
       "agentId": "auditor-session-1777705382",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T07:30:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T01:49:14Z",
+      "result": "clean",
       "issues": [
         "phantom Baumgartner axiom in originalContributions/proofStrategy + section title/line drift + 3 dangling docstrings (#14632)"
       ]


### PR DESCRIPTION
## Summary
- Re-audited `erdos-198` against `Proofs/Erdos198Problem.lean` (cycle 4).
- All meta.json fields match Lean source: 2 axioms, 0 sorries, 151 lines, 2 theorems, 7 definitions.
- No True stubs, no structure-encoded assumptions.
- status `axiomatized` / badge `axiom` correctly reflect AlphaProof's factorial-construction axiomatization.

## Test plan
- [x] `grep -c "^axiom "` matches `axiomCount: 2`
- [x] `grep -c sorry` matches `sorries: 0`
- [x] `wc -l` matches `lineCount: 151`
- [x] No `^structure ` / `^class ` declarations carrying hidden assumptions
- [x] No `True`-stub theorems

🤖 Generated with [Claude Code](https://claude.com/claude-code)