### PR TITLE
fix(meta): erdos-1050 register Erdos1050Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1050/meta.json
+++ b/src/data/proofs/erdos-1050/meta.json
@@ -68,7 +68,8 @@
     "theoremCount": 27,
     "definitionCount": 9,
     "additionalFiles": [
-      "Proofs/Erdos1050ProblemAristotle.lean"
+      "Proofs/Erdos1050ProblemAristotle.lean",
+      "Proofs/Erdos1050Aristotle.lean"
     ]
   },
   "overview": {
@@ -258,7 +259,8 @@
     "path": "Proofs/Erdos1050Problem.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos1050ProblemAristotle.lean"
+      "Proofs/Erdos1050ProblemAristotle.lean",
+      "Proofs/Erdos1050Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the unregistered Aristotle companion `Erdos1050Aristotle.lean` in `src/data/proofs/erdos-1050/meta.json` so the gallery surfaces it alongside `Erdos1050ProblemAristotle.lean`.

## Evidence

**Before**: `additionalFiles` listed only `Proofs/Erdos1050ProblemAristotle.lean` (in both the `meta` and inner `path` sections). The companion file `proofs/Proofs/Erdos1050Aristotle.lean` (104 lines, 6 proved theorems, 0 sorries, 0 axioms) was present on disk but invisible to the gallery.

**After**: Both `Proofs/Erdos1050ProblemAristotle.lean` and `Proofs/Erdos1050Aristotle.lean` are declared in `additionalFiles`.

Contents of the newly-registered companion:
- `denom_nonzero`: 2^n − 3 ≠ 0 for n ≥ 2
- `denom_sequence`: OEIS A331372 equals 2^n − 3
- `denom_growth`: 2^n − 3 > 2^(n−1) for n ≥ 3
- `S_eq_sumTwoMinusThree`: definitional equality of S variants
- `T_eq_S_1049`: T(q, −1) = S_1049(q)
- `transcendence_implies_irrationality`: transcendental ⇒ irrational

Same pattern as #21289 (erdos-660) and #21295 (erdos-1048).

---
Automated fix by lean-mechanic agent.