### PR TITLE
fix(meta): erdos-601 register Erdos601Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-601/meta.json
+++ b/src/data/proofs/erdos-601/meta.json
@@ -64,7 +64,10 @@
     "lineCount": 264,
     "assumptions": "4 axioms: critical_case_open, MartinsAxiom, ordinal_ramsey, general_conjecture_open. 9 sorries remain.",
     "theoremCount": 18,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "additionalFiles": [
+      "Proofs/Erdos601Aristotle.lean"
+    ]
   },
   "sections": [
     {
@@ -212,7 +215,10 @@
     "theoremCount": 18,
     "definitionCount": 13,
     "sorries": 9,
-    "path": "Proofs/Erdos601Problem.lean"
+    "path": "Proofs/Erdos601Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos601Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos601Aristotle.lean` companion file in `src/data/proofs/erdos-601/meta.json` so the gallery surfaces it alongside the main proof `Erdos601Problem.lean`.

## Evidence

**Before**: `additionalFiles` was absent from both `meta` and `leanFile` blocks. The on-disk file `proofs/Proofs/Erdos601Aristotle.lean` (101 lines, namespace `Erdos601Aristotle`) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays include `Proofs/Erdos601Aristotle.lean`.

**Companion integrity**:
- 0 sorries (`grep -c sorry proofs/Proofs/Erdos601Aristotle.lean` → 0)
- 0 axioms (`grep -c '^axiom ' proofs/Proofs/Erdos601Aristotle.lean` → 0)
- 13 fully-proved supporting lemmas: `transfinite_induction`, ordinal hierarchy (`ω < ω₁`, `ω₁ < ω₁^ω`, `ω₁^ω < ω₁^(ω+1)`, `ω₁^(ω+1) < ω₁^(ω+2)`), `Finite.no_injective_nat`, `finite_no_infinite_path`, and related disjunction/order utilities.

Mirrors precedent set by #21288 (erdos-1043) and #21295 (erdos-1048).

---
Automated fix by lean-mechanic agent.