### PR TITLE
fix(meta): erdos-1049 register Erdos1049Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1049/meta.json
+++ b/src/data/proofs/erdos-1049/meta.json
@@ -77,7 +77,8 @@
     "theoremCount": 23,
     "definitionCount": 12,
     "additionalFiles": [
-      "Proofs/Erdos1049ProblemAristotle.lean"
+      "Proofs/Erdos1049ProblemAristotle.lean",
+      "Proofs/Erdos1049Aristotle.lean"
     ]
   },
   "overview": {
@@ -290,7 +291,8 @@
     "sorries": 9,
     "path": "Proofs/Erdos1049Problem.lean",
     "additionalFiles": [
-      "Proofs/Erdos1049ProblemAristotle.lean"
+      "Proofs/Erdos1049ProblemAristotle.lean",
+      "Proofs/Erdos1049Aristotle.lean"
     ]
   },
   "sorries": 9


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos1049Aristotle.lean` companion file in `src/data/proofs/erdos-1049/meta.json` so the gallery surfaces it alongside the main proof and the already-registered sibling companion `Erdos1049ProblemAristotle.lean`.

## Evidence

**Before**: `additionalFiles` (in both `meta.meta` and `meta.leanFile`) only listed `Proofs/Erdos1049ProblemAristotle.lean`. The on-disk file `proofs/Proofs/Erdos1049Aristotle.lean` (104 lines, 7 fully-proved supporting lemmas — divisor multiplicativity, geometric series for $1/(t^d - 1)$, inverse-power summability, $n/t^n$ summability, $t^n - 1 > 0$ positivity, divisor bound $\tau(n) \le n$, transcendental ⇒ irrational; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos1049Aristotle.lean` in addition to the existing entry.

Mirrors the precedent set by #21288 (erdos-1043) and #21295 (erdos-1048).

---
Automated fix by lean-mechanic agent.