### PR TITLE
fix(meta): erdos-156 register Erdos156Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-156/meta.json
+++ b/src/data/proofs/erdos-156/meta.json
@@ -72,7 +72,8 @@
     "theoremCount": 19,
     "definitionCount": 12,
     "additionalFiles": [
-      "Proofs/Erdos156ProblemAristotle.lean"
+      "Proofs/Erdos156ProblemAristotle.lean",
+      "Proofs/Erdos156Aristotle.lean"
     ]
   },
   "overview": {
@@ -190,7 +191,8 @@
     "path": "Proofs/Erdos156Problem.lean",
     "sorries": 3,
     "additionalFiles": [
-      "Proofs/Erdos156ProblemAristotle.lean"
+      "Proofs/Erdos156ProblemAristotle.lean",
+      "Proofs/Erdos156Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the unregistered Aristotle companion `Erdos156Aristotle.lean` in `src/data/proofs/erdos-156/meta.json` so the gallery surfaces it alongside `Erdos156ProblemAristotle.lean`.

## Evidence

**Before**: Both `meta.additionalFiles` and `leanFile.additionalFiles` listed only `Proofs/Erdos156ProblemAristotle.lean`. The companion file `proofs/Proofs/Erdos156Aristotle.lean` (98 lines, 12 sorry lemmas, 0 axioms, 0 definition sorries — originally added in #9245) was present on disk but invisible to the gallery.

**After**: Both lists declare `Proofs/Erdos156ProblemAristotle.lean` and `Proofs/Erdos156Aristotle.lean`.

Contents of the newly-registered companion (`namespace Erdos156.Aristotle`):
- `sidon_sumset_ncard`, `sidon_unique_pair`: Sidon set sumset bound + uniqueness
- `ncard_union_le`, `ncard_union3_le`, `ncard_le_of_subset`: ncard union/subset helpers
- `fiber_ncard_le_sumset`: diffShadow fiber size bound
- `cube_bound_ineq`, `cube_root_lower_bound`, `triangular_le_sq`, `cubic_bound`: cube lower-bound arithmetic
- `Icc_ncard`, `diffShadow_finite`: Set.ncard / finiteness helpers

Companion passes Aristotle pre-submission checklist: no `def ... := sorry`, no `axiom`, no `: True` placeholders, no `/-!` sections.

Same pattern as #21289 (erdos-660), #21295 (erdos-1048), #21304 (erdos-1050).

---
Automated fix by lean-mechanic agent.