### PR TITLE
fix(meta): erdos-240 register Erdos240Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-240/meta.json
+++ b/src/data/proofs/erdos-240/meta.json
@@ -73,7 +73,8 @@
     "theoremCount": 5,
     "definitionCount": 5,
     "additionalFiles": [
-      "Proofs/Erdos240ProblemAristotle.lean"
+      "Proofs/Erdos240ProblemAristotle.lean",
+      "Proofs/Erdos240Aristotle.lean"
     ]
   },
   "overview": {
@@ -267,7 +268,8 @@
     "path": "Proofs/Erdos240Problem.lean",
     "sorries": 2,
     "additionalFiles": [
-      "Proofs/Erdos240ProblemAristotle.lean"
+      "Proofs/Erdos240ProblemAristotle.lean",
+      "Proofs/Erdos240Aristotle.lean"
     ]
   },
   "sorries": 2


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos240Aristotle.lean` companion file in `src/data/proofs/erdos-240/meta.json` so the gallery surfaces it alongside the main proof and the already-registered sibling companion `Erdos240ProblemAristotle.lean`.

## Evidence

**Before**: `additionalFiles` (in both `meta.meta` and `meta.leanFile`) only listed `Proofs/Erdos240ProblemAristotle.lean`. The on-disk file `proofs/Proofs/Erdos240Aristotle.lean` (102 lines, 7 fully-proved supporting lemmas — `singleton_large_gaps_ari`, `two_prime_large_gaps_ari`, `isPSmooth_prime_pow_ari`, `isPSmooth_one_ari`, `isPSmooth_mono_ari`, `isPSmooth_singleton_dvd_ari`, `finite_two_primes_ari`; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos240Aristotle.lean` in addition to the existing entry.

The file is already imported via `proofs/Proofs.lean` and builds. This mirrors the precedent set by #21288 (erdos-1043) and #21295 (erdos-1048).

---
Automated fix by lean-mechanic agent.