### PR TITLE
fix(meta): erdos-678 register Erdos678Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-678/meta.json
+++ b/src/data/proofs/erdos-678/meta.json
@@ -68,7 +68,10 @@
     "assumptions": "0 axiom(s) and 4 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "additionalFiles": [
+      "Proofs/Erdos678Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1979, asking a counterintuitive question: can a shorter interval of consecutive integers have a larger LCM than a longer interval starting further along?\n\nThe referee of the 1979 paper (later identified as John Selfridge) immediately found examples: M(96,7) > M(104,8). The full answer—infinitely many such comparisons—was proved by Stijn Cambie in 2024, with a Lean-verified proof showing that for all sufficiently large k, such pairs exist. The phenomenon is driven by the distribution of prime powers: the LCM of an interval is essentially determined by which prime powers it contains, and an interval that captures a large prime power (such as 2^7 = 128) can have a much larger LCM than a slightly longer interval that misses it. Chebyshev's classical estimates show log M(n,k) ≈ k, making the precise combinatorics of prime power placement critical.",
@@ -173,7 +176,10 @@
     "theoremCount": 18,
     "definitionCount": 4,
     "sorries": 4,
-    "path": "Proofs/Erdos678Problem.lean"
+    "path": "Proofs/Erdos678Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos678Aristotle.lean"
+    ]
   },
   "sorries": 4
 }


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos678Aristotle.lean` companion file in `src/data/proofs/erdos-678/meta.json` so the gallery surfaces it alongside `Erdos678Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-678/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos678Aristotle.lean` (76 lines, 4 supporting lemmas — `intervalLcm_eq_intervalLcm'`, `dvd_intervalLcm`, `intervalLcm_mono_right`, `prime_power_divides_intervalLcm`; 0 sorries, 0 axioms — each delegating to the already-proved theorems in `Erdos678Problem.lean`) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos678Aristotle.lean` as the sole companion file.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), and #21316 (erdos-179).

---
Automated fix by lean-mechanic agent.