### PR TITLE
fix(meta): erdos-307 register Erdos307Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-307/meta.json
+++ b/src/data/proofs/erdos-307/meta.json
@@ -51,7 +51,10 @@
     "lineCount": 514,
     "assumptions": "0 axiom declarations. 2 sorries: prime_sets_disjoint (P∩Q=∅ via p-adic valuation), prime_set_size_lower_bound (|P∪Q|≥60 via Mertens).",
     "theoremCount": 22,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "additionalFiles": [
+      "Proofs/Erdos307Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #307 was posed by E.J. Barbeau in 1976 in 'Computer challenge corner: Problem 477: A brute force program' (Journal of Recreational Mathematics). Barbeau framed it as a computational challenge, not suspecting the problem would resist solution for nearly 50 years.\n\nThe problem sits at the intersection of three classical threads: (1) Euler's 1737 proof that $\\sum 1/p$ diverges (establishing that prime reciprocals are arithmetically rich), (2) Egyptian fraction theory dating to the Rhind papyrus (~1650 BCE, asking when rationals can be expressed as sums of unit fractions), and (3) Mertens' 1874 theorem that $\\sum_{p \\leq x} 1/p = \\ln\\ln x + M + O(1/\\ln x)$ where $M \\approx 0.2615$ is the Meissel-Mertens constant.\n\nThe coprime relaxation was solved by Cambie, who found the elegant examples $(1 + 1/5)(1/2 + 1/3) = (6/5)(5/6) = 1$ and $(1 + 1/41)(1/2 + 1/3 + 1/7) = (42/41)(41/42) = 1$. Both exploit the pattern $1 + 1/n = (n+1)/n$ where $n+1$ is a product of small distinct primes. The prime version remains open: an AM-GM argument shows any solution requires $|P \\cup Q| \\geq 60$ primes, making the search space $\\sim 2^{60} \\approx 10^{18}$, computationally infeasible. The problem connects to the 300-310 Egyptian fraction cluster in Erdős's problem list.",
@@ -276,7 +279,10 @@
     "theoremCount": 22,
     "definitionCount": 15,
     "path": "Proofs/Erdos307Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos307Aristotle.lean"
+    ]
   },
   "sorries": 2
 }


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos307Aristotle.lean` companion file in `src/data/proofs/erdos-307/meta.json` so the gallery surfaces it alongside the main proof `Erdos307Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-307/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos307Aristotle.lean` (78 lines, 7 supporting lemmas for Erdős Problem #307 prime reciprocal products — `reciprocalProduct_comm` (commutativity), `prime_inv_pos` (positivity of 1/p in ℚ), `prime_inv_le_half` (1/p ≤ 1/2 for primes), `reciprocalSum_nonneg` (sum of reciprocals nonneg), `reciprocalSum_pos_of_prime_nonempty` (positivity for nonempty prime sets), `reciprocalProduct_factors_pos` (both factors positive when product = 1), `sum_first_58_primes_lt_two` (concrete bound for size lower bound); 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos307Aristotle.lean` as the sole companion file.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), and #21318 (erdos-678).

---
Automated fix by lean-mechanic agent.