### PR TITLE
audit(erdos-191): mark clean (cycle 6)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5125,8 +5125,8 @@
     },
     "erdos-191": {
       "agentId": "auditor-agent-loop",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T07:25:14Z",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T03:50:33Z",
       "result": "clean"
     },
     "erdos-192": {


### PR DESCRIPTION
## Summary

- Audit cycle 6 for erdos-191 (Rödl/CFS monochromatic large-sum problem)
- All meta.json fields verified against Lean source — no discrepancies
- Marks tracker entry as clean

## Verification

| Field | meta.json | Actual | OK |
|-------|-----------|--------|----|
| lineCount | 357 | 357 | ✓ |
| axiomCount | 4 | 4 | ✓ |
| sorries | 1 | 1 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 13 | 13 | ✓ |
| status | axiomatized | (4 axioms + 1 sorry) | ✓ |
| badge | axiom | Tier C scaffold | ✓ |
| True stubs | none | none | ✓ |

## Test plan

- [x] grep counts match meta.json
- [x] No True stubs
- [x] Tier classification (C — axiomatized) matches badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)