### PR TITLE
fix(meta): erdos-338 register Erdos338Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-338/meta.json
+++ b/src/data/proofs/erdos-338/meta.json
@@ -66,7 +66,10 @@
     "lineCount": 363,
     "assumptions": "11 axiom(s) and 0 sorry(s). All theorems genuinely proved; axioms encode deep classical results (Bateman, Kelly, Hennecart, Lagrange, Pall, Gauss, Schinzel, HHP).",
     "theoremCount": 10,
-    "definitionCount": 15
+    "definitionCount": 15,
+    "additionalFiles": [
+      "Proofs/Erdos338Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #338: Restricted Order of Additive Bases**\n\nThe concept of an additive basis goes back to Waring's problem (1770): Waring conjectured that for each $k$, every positive integer is a sum of a fixed number of $k$-th powers. Hilbert proved this in 1909, establishing that the set of $k$-th powers is a basis of finite order $g(k)$. The order of a basis $A$ is the minimum $h$ such that every sufficiently large integer can be written as $x_1 + x_2 + \\cdots + x_k$ with $x_i \\in A$ and $k \\le h$, allowing repetitions.\n\nThe **restricted order** adds a crucial constraint: the summands must be **distinct**. This seemingly small change — replacing Multiset representations with Finset representations — has profound consequences. Bateman observed that for $h \\ge 3$, the set $A = \\{1\\} \\cup \\{x > 0 : h \\mid x\\}$ is a basis of order $h$ but has no finite restricted order at all, because distinct multiples of $h$ grow quadratically: the sum of the first $t$ multiples is $h \\cdot t(t+1)/2$, requiring $t \\gtrsim \\sqrt{2n/h} \\to \\infty$.\n\n**Kelly (1957)** initiated the systematic study by proving the remarkable result that every basis of order 2 has restricted order at most 4 — a pigeonhole argument exploiting the richness of order-2 representations. Kelly conjectured the sharp bound should be 3. This conjecture stood for nearly 50 years before **Hennecart (2005)** constructed an explicit order-2 basis with restricted order exactly 4, disproving Kelly.\n\nThe most striking result came from **Hegyvári, Hennecart, and Plagne (HHP, 2007)**: for order $k \\ge 2$, there exist bases whose restricted order is at least $2^{k-2} + k - 1$. This exponential lower bound shows the gap between order and restricted order can be enormous — for order 10, the restricted order can be at least 265.\n\nTwo classical examples illuminate the landscape: **squares** have order 4 (Lagrange's four-squares theorem, 1770) but restricted order 5 (Pall, 1933) — the gap of 1 arises because representations like $4 = 2^2$ need repetition. **Triangular numbers** are the rare case where order equals restricted order: both are 3, by Gauss's Eureka theorem (1796) and Schinzel (1954). The problem remains **OPEN**: all four of Erdős's questions about characterizing when restricted order exists, bounding it, determining when it equals order, and whether robustness implies restricted order, are unsolved.",
@@ -188,7 +191,10 @@
     "theoremCount": 10,
     "definitionCount": 15,
     "path": "Proofs/Erdos338Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos338Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos338Aristotle.lean` companion file in `src/data/proofs/erdos-338/meta.json` so the gallery surfaces it alongside `Erdos338Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-338/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos338Aristotle.lean` (42 lines, 3 supporting theorems — `mul_self_mem_squares`, `sq_mem_squares`, `squares_order_four_aristotle`; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos338Aristotle.lean` as the sole companion file.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21317 (erdos-240), #21318 (erdos-678), and #21321 (erdos-307).

---
Automated fix by lean-mechanic agent.