### PR TITLE
fix(meta): erdos-674 register Erdos674Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-674/meta.json
+++ b/src/data/proofs/erdos-674/meta.json
@@ -27,6 +27,7 @@
     "theoremCount": 25,
     "definitionCount": 13,
     "additionalFiles": [
+      "Proofs/Erdos674Aristotle.lean",
       "Proofs/Erdos674ProblemAristotle.lean"
     ]
   },
@@ -185,6 +186,7 @@
     "sorries": 22,
     "path": "Proofs/Erdos674Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos674Aristotle.lean",
       "Proofs/Erdos674ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos674Aristotle.lean` companion file in `src/data/proofs/erdos-674/meta.json` alongside the already-registered `Erdos674ProblemAristotle.lean` so the gallery surfaces both companions for Erdős Problem #674.

## Evidence

**Before**: Both `additionalFiles` arrays (in `meta.meta` and `meta.leanFile`) listed only `Proofs/Erdos674ProblemAristotle.lean` (17 supporting lemmas in namespace `Erdos674.Aristotle`). The companion file `proofs/Proofs/Erdos674Aristotle.lean` (106 lines, namespace `Erdos674Aristotle`, 13 supporting theorems — `koX/koY/koZ_pos`, `ko_family_ratio` (4xy=z²), `ko_gcd_gt_one`, `two_dvd_koX/Y/Z`, `three_dvd_koX/Y/Z`, `gcd_gt_one_ne_one`, `exp_self_mul_comm`, `pow_succ_ge_four`, `pow_sub_one_ge_three`, `mul_pow_self`, `pos_of_sq_eq`; 0 sorries, 0 axioms) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1789).

**After**: Both `additionalFiles` arrays list both companion files in alphabetical order.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21318 (erdos-678), and #21321 (erdos-307).

---
Automated fix by lean-mechanic agent.