### PR TITLE
fix(meta): erdos-309 register Erdos309Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -68,7 +68,10 @@
     "lineCount": 339,
     "assumptions": "1 axiom: yokota_lower_bound_1997. 3 sorries.",
     "theoremCount": 12,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Erdos309Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Egyptian Fractions and Erdős's Question**\n\nThis problem concerns a fundamental question about **Egyptian fractions** - sums of distinct unit fractions 1/n. The ancient Egyptians represented all fractions this way.\n\n**The Question:** Given denominators from {1, ..., N}, how many integers can be represented as such sums? Specifically, is this count o(log N) (sublogarithmic)?\n\n**The Answer:** NO. The count F(N) grows like log N + γ, where γ ≈ 0.5772 is the Euler-Mascheroni constant.\n\n**Key Contributors:**\n- Yokota (1997): First logarithmic lower bound\n- Croot (1999): Exact threshold for representability\n- Yokota (2002): Refined bounds with (log log N)² correction\n\n**The harmonic number H_N = 1 + 1/2 + ... + 1/N ~ log N + γ** is central to understanding this problem, as representable integers are bounded by H_N.",
@@ -229,7 +232,10 @@
     "theoremCount": 12,
     "definitionCount": 7,
     "path": "Proofs/Erdos309Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos309Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos309Aristotle.lean` companion file in `src/data/proofs/erdos-309/meta.json` so the gallery surfaces it alongside the main `Erdos309Problem.lean` proof.

## Evidence

**Before**: `src/data/proofs/erdos-309/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos309Aristotle.lean` (135 lines, 11 supporting lemmas for Erdős Problem #309 on integers as sums of distinct unit fractions; **0 sorries, 0 axioms**) was orphaned from the gallery.

Lemmas in the companion:
- `denominatorRange_card` — cardinality of {1..N}
- `mem_denominatorRange` — membership characterization
- `unitFraction_pos`, `unitFraction_one`, `unitFraction_anti` — basic positivity / monotonicity
- `sumUnitFractions_empty`, `sumUnitFractions_insert` — sum manipulation
- `harmonicNumber_one` — H_1 = 1
- `zero_representable`, `one_representable` — trivial representability
- `max_representable_le_harmonic` — bound k ≤ H_N for representable k

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos309Aristotle.lean` as the sole companion file.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21318 (erdos-678), and #21321 (erdos-307).

---
Automated fix by lean-mechanic agent.