### PR TITLE
fix(meta): erdos-35 register Erdos35Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-35/meta.json
+++ b/src/data/proofs/erdos-35/meta.json
@@ -36,6 +36,7 @@
     "theoremCount": 10,
     "definitionCount": 9,
     "additionalFiles": [
+      "Proofs/Erdos35Aristotle.lean",
       "Proofs/Erdos35ProblemAristotle.lean"
     ]
   },
@@ -152,6 +153,7 @@
     "path": "Proofs/Erdos35Problem.lean",
     "sorries": 0,
     "additionalFiles": [
+      "Proofs/Erdos35Aristotle.lean",
       "Proofs/Erdos35ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos35Aristotle.lean` companion file in `src/data/proofs/erdos-35/meta.json` alongside the already-registered `Erdos35ProblemAristotle.lean` so the gallery surfaces both companions for Erdős Problem #35.

## Evidence

**Before**: Both `additionalFiles` arrays (in `meta.meta` and `meta.leanFile`) listed only `Proofs/Erdos35ProblemAristotle.lean`. The companion file `proofs/Proofs/Erdos35Aristotle.lean` (96 lines, namespace `Erdos35Aristotle`, 12 supporting theorems on Finset/Schnirelmann-density combinatorics — `range2_sdiff_zero`, `filter_singleton_card_le`, `mem_sumset_of_zero_mem`, `counting_mono`, `counting_le_N`, `power_bound_k1`, `power_bound_alpha_zero`, `power_bound_alpha_one`, `iInf_nonneg_of_nonneg`, `ratio_le_one_of_card_le`, etc.; 0 sorries, 0 axioms) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1337).

**After**: Both `additionalFiles` arrays list both companion files in alphabetical order.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21318 (erdos-678), #21321 (erdos-307), #21324 (erdos-338), and #21325 (erdos-674).

---
Automated fix by lean-mechanic agent.