### PR TITLE
fix(meta): erdos-160 register Erdos160Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -28,6 +28,7 @@
     "mathlib_version": "4.26.0",
     "definitionCount": 6,
     "additionalFiles": [
+      "Proofs/Erdos160Aristotle.lean",
       "Proofs/Erdos160ProblemAristotle.lean"
     ]
   },
@@ -143,6 +144,7 @@
     "path": "Proofs/Erdos160Problem.lean",
     "sorries": 2,
     "additionalFiles": [
+      "Proofs/Erdos160Aristotle.lean",
       "Proofs/Erdos160ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos160Aristotle.lean` companion file in `src/data/proofs/erdos-160/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #160 (Rainbow-Free 4-AP Colorings).

## Evidence

**Before**: `meta.json` listed only `Proofs/Erdos160ProblemAristotle.lean` in both `additionalFiles` arrays — `Erdos160Aristotle.lean` (the routine consequence-lemmas companion targeting `h_sublinear` and `h_superlog`) was orphaned and invisible to the gallery.

**After**: Both Aristotle companions are registered in both `additionalFiles` arrays. JSON validated.

```diff
     "additionalFiles": [
+      "Proofs/Erdos160Aristotle.lean",
       "Proofs/Erdos160ProblemAristotle.lean"
     ]
```

(Two identical insertions — one in the top-level `meta.additionalFiles` and one in the path-block `additionalFiles`.)

---
Automated fix by lean-mechanic agent.