### PR TITLE
fix(meta): erdos-268 register Erdos268Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-268/meta.json
+++ b/src/data/proofs/erdos-268/meta.json
@@ -64,6 +64,7 @@
     "assumptions": "2 axioms: erdos_268_solved (main interior result for all dimensions), harmonicPointSet_path_connected_large (path-connectedness for d ≥ 2, Kovač-Tao structural analysis). 0 sorries. Proved: shifted_summable (decomposition at n=0), harmonicPointSet_nonempty (powers-of-2 witness), harmonicPointSet_dense_somewhere (directly from interior axiom), coordinate_decreasing (tsum_lt_tsum; requires 0 ∉ A), first_coordinate_largest (from coordinate_decreasing), squares_convergent (bijection + p-series), powers_convergent (bijection + geometric series), harmonicPointSet_one_eq (X₁ = positive half-line via greedy construction), harmonicSubseriesSum_surjective_on_pos (every s > 0 is achievable).",
     "definitionCount": 17,
     "additionalFiles": [
+      "Proofs/Erdos268Aristotle.lean",
       "Proofs/Erdos268ProblemAristotle.lean"
     ]
   },
@@ -221,6 +222,7 @@
     "sorries": 0,
     "path": "Proofs/Erdos268Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos268Aristotle.lean",
       "Proofs/Erdos268ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos268Aristotle.lean` companion file in
`src/data/proofs/erdos-268/meta.json` alongside the already-registered
`Erdos268ProblemAristotle.lean` so the gallery surfaces both companions
for Erdős Problem #268.

## Evidence

**Before**: `Erdos268Aristotle.lean` exists on disk but is absent from both
`meta.additionalFiles` and `leanFile.additionalFiles`.

**After**: Both `additionalFiles` arrays list both `Erdos268Aristotle.lean`
and `Erdos268ProblemAristotle.lean` (sorted alphabetically).

```
proofs/Proofs/Erdos268Aristotle.lean         # on disk, now registered
proofs/Proofs/Erdos268ProblemAristotle.lean  # on disk, already registered
proofs/Proofs/Erdos268Problem.lean           # main file
```

Pattern matches PRs #21327 (erdos-35), #21318 (erdos-678), and other recent
mechanic Aristotle-companion registrations.

---
Automated fix by lean-mechanic agent.