### PR TITLE
fix(meta): erdos-877 register Erdos877Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-877/meta.json
+++ b/src/data/proofs/erdos-877/meta.json
@@ -45,7 +45,8 @@
     "theoremCount": 9,
     "definitionCount": 6,
     "additionalFiles": [
-      "Proofs/Erdos877ProblemAristotle.lean"
+      "Proofs/Erdos877ProblemAristotle.lean",
+      "Proofs/Erdos877Aristotle.lean"
     ]
   },
   "crossReferences": [
@@ -191,7 +192,8 @@
     "path": "Proofs/Erdos877Problem.lean",
     "sorries": 4,
     "additionalFiles": [
-      "Proofs/Erdos877ProblemAristotle.lean"
+      "Proofs/Erdos877ProblemAristotle.lean",
+      "Proofs/Erdos877Aristotle.lean"
     ]
   },
   "sorries": 4


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos877Aristotle.lean` companion file in
`src/data/proofs/erdos-877/meta.json` so the gallery surfaces it
alongside the already-registered `Erdos877ProblemAristotle.lean` sibling.

## Evidence

**Before**: `additionalFiles` listed only `Erdos877ProblemAristotle.lean`.
**After**: Both companion files are declared in both `meta.additionalFiles`
and `proof.additionalFiles`.

Companion file properties:
- 128 lines, 0 sorries, 0 axioms
- 8 fully-proved supporting lemmas
- Topics: odd parity arithmetic, sum-free odd filter (cardinality >= n/2),
  maximal-criterion helpers (insert-breaks-sum-free triple extraction)
- Compatible with Aristotle (block comments only, no def := sorry,
  no axiom declarations, no True placeholders)

---
Automated fix by lean-mechanic agent.