### PR TITLE
Fix: remove True placeholder from Erdos846Problem.lean

### DIFF
--- a/proofs/Proofs/Erdos846Problem.lean
+++ b/proofs/Proofs/Erdos846Problem.lean
@@ -262,7 +262,7 @@ theorem erdos846_finite (A : Set (Fin 2 → ℝ)) (hA : Set.Finite A)
 
 -- ## The Erdős–Nešetřil–Rödl Conjecture (DISPROVED, 2026-05-21)
 
-/-- **Erdős Problem 846** (Erdős–Nešetřil–Rödl, 1992; DISPROVED 2026-05-21):
+/- **Erdős Problem 846** (Erdős–Nešetřil–Rödl, 1992; DISPROVED 2026-05-21):
     Is every infinite ε-non-trilinear subset of ℝ² weakly non-trilinear (a
     finite union of sets with no three collinear)?
 
@@ -288,4 +288,3 @@ theorem erdos846_finite (A : Set (Fin 2 → ℝ)) (hA : Set.Finite A)
     as `weaklyNonTrilinear_implies_eps`. The finite case is proved as
     `erdos846_finite`. The valid range is ε ∈ (0, 1] by
     `isEpsNonTrilinear_eps_le_one`. -/
-example : True := trivial

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -27,7 +27,7 @@
     "erdosUrl": "https://erdosproblems.com/846",
     "erdosProblemStatus": "solved",
     "axiomCount": 0,
-    "lineCount": 292,
+    "lineCount": 290,
     "assumptions": "0 axioms, 0 sorries across two Lean files. The prior `axiom ErdosProblem846` (which had asserted the conjecture) has been DROPPED: DeepMind's AlphaProof Nexus settled the conjecture NEGATIVELY on 2026-05-21 (arXiv:2605.22763v1). The refutation lives in the companion file `Proofs/Erdos846ProblemAPN.lean` (`Erdos846APN.target_false`), which constructs an explicit counterexample (the Elekes parametrisation `q(i,j) = (t i + t j, t i² + t i·t j + t j²)` with `t_seq n = 100^(4^n)`). The companion file uses Mathlib's `Collinear ℝ {x, y, z}` predicate; the gallery file uses an `AreCollinear` cross-product characterisation. Both definitions agree on `EuclideanSpace ℝ (Fin 2)` but unifying them is left as future work — for that reason, status is held at `axiomatized` rather than `verified` (no overclaim per the axiom-integrity policy), pending a successful local `docker-build.sh` run. The gallery file (`Erdos846Problem.lean`) retains all elementary proved results: converse direction (weaklyNonTrilinear_implies_eps), finite case (finite_weaklyNonTrilinear, erdos846_finite), ε bounds (isEpsNonTrilinear_eps_le_one, isEpsNonTrilinear_empty_of_eps_gt_one), collinearity symmetry, and pigeonhole principle.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
@@ -180,7 +180,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 292,
+    "lineCount": 290,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Remove the trailing `example : True := trivial` placeholder from `proofs/Proofs/Erdos846Problem.lean` and convert its now-orphan doc comment delimiter `/-- ` to a regular comment `/- ` so the documentation block continues to render as a free-floating section comment.

## Evidence

**Before**: `scripts/erdos/quality-audit.ts` flagged `src/data/proofs/erdos-846` with `placeholder-proof: Contains placeholder proof (True := trivial)`.

**After**: Re-running the audit no longer reports any `placeholder-proof` issue (only unrelated `missing-statement` items in research data remain).

## Context

The placeholder was retained when the prior `axiom ErdosProblem846` was dropped after DeepMind's AlphaProof Nexus disproof (2026-05-21, arXiv:2605.22763v1). The actual refutation lives in the companion file `proofs/Proofs/Erdos846ProblemAPN.lean` (`Erdos846APN.target_false`), and the elementary results (`weaklyNonTrilinear_implies_eps`, `erdos846_finite`, `isEpsNonTrilinear_eps_le_one`, etc.) remain in the main file.

## Changes

- `proofs/Proofs/Erdos846Problem.lean`: drop `example : True := trivial`; change `/-- ` to `/- ` on the preceding documentation block (now an unattached section comment rather than an orphan docstring).
- `src/data/proofs/erdos-846/meta.json`: `lineCount` 292 → 290 (both occurrences).

---
Automated fix by lean-mechanic agent.