### PR TITLE
fix(meta): erdos-318 register Erdos318Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-318/meta.json
+++ b/src/data/proofs/erdos-318/meta.json
@@ -59,7 +59,10 @@
     "lineCount": 409,
     "assumptions": "5 axioms: erdos_straus_1975, sattler_odd_1975, sattler_1982, counterexample_fails_P1, squares_case_open.",
     "theoremCount": 6,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "additionalFiles": [
+      "Proofs/Erdos318Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Property P₁ and Signed Unit Fractions**\n\nThis problem traces back to Problem 387 in *Nieuw Archief voor Wiskunde*, solved independently by Erdős-Straus and Sattler in 1975.  The question belongs to the theory of Egyptian fractions — sums of distinct unit fractions $1/n$ — which has roots in the Rhind Mathematical Papyrus (c. 1650 BCE) but was revitalized by Erdős in the 20th century.\n\n**Historical Development**\n\n1. **1975 (Erdős-Straus):** Proved the natural numbers $\\mathbb{N}$ have Property $P_1$: every non-constant sign function $f : \\mathbb{N} \\to \\{\\pm 1\\}$ admits a finite subset $S$ with $\\sum_{n \\in S} f(n)/n = 0$.  Their proof uses a greedy construction: given $a$ with $f(a) = +1$ and $b$ with $f(b) = -1$, the difference $1/a - 1/b = (b-a)/(ab)$ can be decomposed into further unit fractions using the Erdős-Straus technique.\n\n2. **1975 (Sattler):** Extended $P_1$ to the odd numbers $\\{1, 3, 5, \\ldots\\}$, showing that even denominators are not required for cancellation.  This was non-trivial because restricting denominators constrains which rationals are representable.\n\n3. **1980 (Erdős-Graham):** In *Old and New Problems and Results in Combinatorial Number Theory*, Erdős and Graham posed the natural generalizations: does $P_1$ hold for arbitrary positive-density sets?  For the set of perfect squares?\n\n4. **1982 (Sattler):** Published two papers: (a) *On Erdős property $P_1$ for squarefree numbers* established $P_1$ for squarefree integers, and (b) *On Erdős property $P_1$ for arithmetical sequence* proved the definitive result that *every* infinite arithmetic progression has $P_1$.  Sattler also announced a proof for squares in the same papers, but this proof was never published.\n\n**The Counterexample**\n\nErdős observed that sets with exactly one even number fail $P_1$.  The argument is a $2$-adic valuation obstruction: if $S \\subseteq \\{\\text{odds}\\} \\cup \\{2m\\}$, any signed sum $\\sum f(n)/n$ has $v_2 = -v_2(2m) \\leq -1$ when $2m \\in S$ and $v_2 \\geq 0$ when $2m \\notin S$, so the sum is never zero.  This gives positive-density counterexamples (density $\\approx 1/2$), resolving the Erdős-Graham question negatively.\n\n**The Missing Proof for Squares**\n\nThe case of squares excluding 1 ($\\{4, 9, 16, 25, \\ldots\\}$) remains one of the tantalizing open problems in Egyptian fraction theory.  Sattler's announced but unpublished proof has led to speculation about whether a subtle error was discovered, or whether the proof was simply never written up.  The difficulty lies in the multiplicative structure of square denominators, which lack the linear regularity of arithmetic progressions.",
@@ -183,7 +186,10 @@
     "theoremCount": 6,
     "definitionCount": 14,
     "path": "Proofs/Erdos318Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos318Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `proofs/Proofs/Erdos318Aristotle.lean` companion file in `src/data/proofs/erdos-318/meta.json` under `additionalFiles` (in both `formalization` and the formalization block) so the gallery and deployer surface it alongside the main `Erdos318Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-318/meta.json` did not list `Erdos318Aristotle.lean`, but the file exists at `proofs/Proofs/Erdos318Aristotle.lean` (9.5 KB, May 29).

**After**: `additionalFiles` lists `Proofs/Erdos318Aristotle.lean` in both formalization sections, matching the registration pattern used by `erdos-1048` in #21295.

Companion file sanity-check:
- 0 `axiom` declarations
- 0 `def ... := sorry`
- 0 `: True` placeholders
- 0 `/-!` docstring sections

---
Automated fix by lean-mechanic agent.