### PR TITLE
fix(meta): erdos-260 register Erdos260Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-260/meta.json
+++ b/src/data/proofs/erdos-260/meta.json
@@ -53,7 +53,10 @@
     "lineCount": 269,
     "assumptions": "1 axiom: erdos_260_conjecture (open conjecture). 3 sorries: series_converges (convergence argument), irrational_of_gaps_to_infinity (Erdős 1974 theorem), irrational_of_superlogarithmic (number-theoretic result).",
     "theoremCount": 8,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Erdos260Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1974 work on irrationality of series [Er74b], further developed in the landmark monograph 'Old and New Problems and Results in Combinatorial Number Theory' with Graham [ErGr80]. It explores a fundamental question at the boundary of analysis and number theory: when does a lacunary (sparse) series produce an irrational sum?\n\nErdős proved that irrationality holds under the stronger condition that the gaps a_{n+1} − aₙ tend to infinity. He also showed irrationality when aₙ grows superlogarithmically, specifically when aₙ ≫ n√(log n · log log n). These partial results demonstrate that 'sufficiently fast' growth guarantees irrationality, but the full conjecture — that the mere condition aₙ/n → ∞ suffices — remains open.\n\nThe problem has an appealing simplicity: the series ∑ aₙ/2^{aₙ} converges absolutely for any increasing sequence (the terms decrease exponentially), so the question is purely about the arithmetic nature of the limit. Erdős and Graham speculated that even having limsup of the gaps being infinite might not suffice for irrationality, but no counterexample has been found. The problem connects to the theory of lacunary series, normal numbers, and the Lindemann-Weierstrass theorem.",
@@ -168,7 +171,10 @@
     "theoremCount": 8,
     "definitionCount": 9,
     "path": "Proofs/Erdos260Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos260Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos260Aristotle.lean` companion file in `src/data/proofs/erdos-260/meta.json` so the gallery surfaces it alongside the main proof `Erdos260Problem.lean`.

## Evidence

**Before**: Neither `additionalFiles` field (in `meta.meta` nor in `meta.leanFile`) existed at all. The on-disk file `proofs/Proofs/Erdos260Aristotle.lean` (112 lines, 12 fully-proved supporting lemmas — n/2^n summability, strictly-monotone telescoping, real-log / sqrt asymptotics; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos260Aristotle.lean`.

This mirrors the precedent set by #21295 (erdos-1048 Aristotle companion registration) and #21288 (erdos-1043).

---
Automated fix by lean-mechanic agent.