### PR TITLE
fix(meta): erdos-840 register Erdos840Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-840/meta.json
+++ b/src/data/proofs/erdos-840/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "8 axioms (theorem sorries) and 2 definition sorries. Axioms: (1) sidon_sumset_card — classical Sidon cardinality |A+A|=C(|A|+1,2); (2) erdos_freud_lower_bound — Erdős-Freud (1991) lower bound f(N)≥(2/√3+o(1))√N; (3) construction_is_quasi_sidon — Erdős-Freud construction is quasi-Sidon; (4) erdos_freud_upper_bound — Erdős-Freud (1991) upper bound f(N)≤(2+o(1))√N; (5) pikhurko_upper_bound — Pikhurko (2006) improved bound f(N)≤(c_P+o(1))√N; (6) sidon_set_upper_bound — classical Sidon bound |A|≤√N+O(N^{1/4}); (7) sidon_set_exists — Singer construction Sidon sets of size ~√N; (8) pikhurko_constant_approx — numerical bound c_P∈(1.86,1.87). Definition sorries: f(N) and fAlt(N,δ) (axiomatized definitions). Proven: lower_bound_constant_value, bounds_gap, cilleruelo_difference_set, open_problem_gap.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "additionalFiles": [
+      "Proofs/Erdos840Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Sidon sets (also called $B_2$ sequences) were introduced by Simon Sidon in a 1932 letter to Erdős, asking for the maximum size of a subset of $\\{1, \\ldots, N\\}$ with all pairwise sums distinct. Erdős and Turán (1941) proved the upper bound $|A| \\leq \\sqrt{N} + O(N^{1/4})$, while constructions by Singer (1938, using difference sets from projective planes) and Bose–Chowla (1962) achieved $|A| \\sim \\sqrt{N}$. The quasi-Sidon relaxation, introduced by Erdős and Freud in 1991, allows a vanishing fraction of sum collisions: $|A + A| = (1 + o(1)) \\binom{|A|}{2}$. This permits larger sets — the question is how much larger. Erdős and Freud proved $(2/\\sqrt{3})\\sqrt{N} \\leq f(N) \\leq 2\\sqrt{N}$ using a reflection construction and pigeonhole arguments. Pikhurko (2006) improved the upper bound to $\\approx 1.863\\sqrt{N}$ via a connection to edge-magic graph labelings and thin additive bases. Cilleruelo (2010) resolved the analogous problem for difference sets ($A - A$ instead of $A + A$), showing the answer is simply $\\sim \\sqrt{N}$ with constant 1. The sum version remains open, with the true constant lying in the interval $[2/\\sqrt{3}, 1.863] \\approx [1.155, 1.863]$.",
@@ -108,7 +111,10 @@
     "theoremCount": 4,
     "definitionCount": 11,
     "sorries": 0,
-    "path": "Proofs/Erdos840Problem.lean"
+    "path": "Proofs/Erdos840Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos840Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos840Aristotle.lean` companion file in `src/data/proofs/erdos-840/meta.json` so the gallery surfaces it.

## Evidence

**Before**: Neither `meta.additionalFiles` nor `leanFile.additionalFiles` listed any companion file, despite `proofs/Proofs/Erdos840Aristotle.lean` existing on disk.

**After**: `Proofs/Erdos840Aristotle.lean` declared in both `meta.additionalFiles` and `leanFile.additionalFiles`.

Companion file properties:
- 193 lines, 0 axioms, 0 definition sorries, 0 True placeholders
- 14 supporting lemmas/theorems for quasi-Sidon set analysis (sumset arithmetic, sqrt-N bounds)
- Block comments only (no `/-!` docstring sections)
- Compatible with Aristotle (no `def := sorry`, no `axiom` declarations)

---
Automated fix by lean-mechanic agent.