### PR TITLE
fix(meta): erdos-820 register Erdos820Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -64,7 +64,10 @@
     "lineCount": 284,
     "assumptions": "3 axiom(s) and 6 sorries. See the Lean source for details.",
     "theoremCount": 5,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "additionalFiles": [
+      "Proofs/Erdos820Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**The GCD Problem for Exponential Sequences**\n\nThis problem originates from Erdős's 1974 paper \"Remarks on some problems in number theory\" in Mathematica Balkanica. The core question studies when powers of different bases minus one are coprime.\n\n**The Function H(n)**\n\nDefine H(n) as the smallest l such that there exists k < l with gcd(k^n - 1, l^n - 1) = 1. This measures how \"rare\" coprimality is among these exponential expressions.\n\n**Computed Values**\n\nFor small n: H(1)=3, H(2)=3, H(3)=3, H(4)=6, H(5)=3, H(6)=18, H(7)=3, H(8)=6, H(9)=3, H(10)=12. The value H(n)=3 occurs frequently, corresponding to gcd(2^n-1, 3^n-1)=1.\n\n**Progress**\n\n1. **Erdős (1974):** Proved H(n) > exp(n^{c/(log log n)²}) for infinitely many n\n2. **van Doorn:** Improved to H(n) > exp(n^{c/log log n}) infinitely often\n3. **OEIS A263647:** Catalogues n where gcd(2^n-1, 3^n-1)=1\n\nThe main conjectures remain OPEN.",
@@ -206,7 +209,10 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "path": "Proofs/Erdos820Problem.lean",
-    "sorries": 6
+    "sorries": 6,
+    "additionalFiles": [
+      "Proofs/Erdos820Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos820Aristotle.lean` companion file in `src/data/proofs/erdos-820/meta.json` (`meta.additionalFiles` and `leanFile.additionalFiles`) so the gallery and deployer surface the Aristotle target file alongside the main proof.

## Evidence

**Before**: `proofs/Proofs/Erdos820Aristotle.lean` exists on disk but is not declared in `src/data/proofs/erdos-820/meta.json`, so the gallery doesn't list it.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` reference `Proofs/Erdos820Aristotle.lean`.

Mirrors the pattern used by erdos-318 (ddfc933) and erdos-1048 (#21295).

---
Automated fix by lean-mechanic agent.