### PR TITLE
fix(meta): erdos-898 register Erdos898Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -52,7 +52,10 @@
     "assumptions": "11 axiom(s) and 8 sorries(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "additionalFiles": [
+      "Proofs/Erdos898Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdos proposed this inequality in 1935 in the American Mathematical Monthly (Problem 3740). Louis Mordell proved it in 1937 in the Mathematical Gazette using trigonometric identities and AM-GM. David Barrow independently gave a more elementary proof in the same year in the American Mathematical Monthly. Since then, many alternative proofs have appeared: Kazarinoff (1957) used the law of cosines, Bankoff (1958) gave a particularly elegant simplification, and Avez (1993) found a proof using only the triangle inequality. The result is now considered one of the most beautiful inequalities in plane geometry, appearing in Bottema's 'Geometric Inequalities' (1969) and Mitrinovic's 'Recent Advances in Geometric Inequalities' (1989). The constant 2 is optimal, attained for equilateral triangles with $P$ at the center.",
@@ -192,7 +195,10 @@
     "theoremCount": 2,
     "definitionCount": 17,
     "path": "Proofs/Erdos898Problem.lean",
-    "sorries": 8
+    "sorries": 8,
+    "additionalFiles": [
+      "Proofs/Erdos898Aristotle.lean"
+    ]
   },
   "sorries": 8
 }


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos898Aristotle.lean` companion file in `src/data/proofs/erdos-898/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `Erdos898Aristotle.lean` lives on disk (63 lines, 5 routine Aristotle-target theorems, 0 axioms) but neither `meta.meta.additionalFiles` nor `meta.leanFile.additionalFiles` declared it.

**After**: Both `additionalFiles` arrays list `Proofs/Erdos898Aristotle.lean`, mirroring the pattern established for erdos-260 (commit 7c6d51cbba8) and erdos-1048 (#21295).

### Companion file contents

Routine supporting lemmas for the Erdős-Mordell inequality (vertex distance setup), all Aristotle-eligible (theorem statements with `by sorry`, no definition sorries, no axioms):

- `dist_nonneg : dist P Q ≥ 0`
- `dist_self : dist P P = 0`
- `dist_comm : dist P Q = dist Q P`
- `isEquilateral_swap12 : IsEquilateral A B C → IsEquilateral B A C`
- `vertexDistanceSum_nonneg : vertexDistanceSum P A B C ≥ 0`

Main proof `Erdos898Problem.lean` (with its 11 axioms / 8 definition sorries for the open conjecture statement and pedal-triangle infrastructure) is unchanged.

---
Automated fix by lean-mechanic agent.