### PR TITLE
fix(meta): erdos-629 register Erdos629Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "7 sorry(s). No axioms.",
     "mathlib_version": "4.26.0",
     "theoremCount": 37,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "additionalFiles": [
+      "Proofs/Erdos629Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős, Rubin, and Taylor introduced the concept of list coloring (choosability) in their landmark 1979/1980 paper, which revealed a fundamental surprise: bipartite graphs, though 2-colorable, can have arbitrarily large list chromatic number. They proved the first bounds $2^{k-1} < n(k) < k^2 \\cdot 2^{k+2}$ and computed $n(2) = 6$ using $K_{3,3}$ with a clever adversarial list assignment. Hanson, MacGillivray, and Toft (1996) determined $n(3) = 14$ through exhaustive case analysis and gave the recursive bound $n(k) \\leq k \\cdot n(k-2) + 2^k$. Radhakrishnan and Srinivasan (2000) improved the lower bound to $n(k) \\geq c \\cdot 2^k \\sqrt{k/\\ln k}$ using an entropy-based refinement of the probabilistic method. Galvin's 1995 theorem that $\\chi_L(K_{n,n}) = \\lceil\\log_2 n\\rceil + 1$, proved via the kernel method, provides the key structural result for complete bipartite graphs. The problem connects to Property B (Erdős Problem #901) via the sandwich inequality $m(k) \\leq n(k) \\leq m(k+1)$, linking list coloring to hypergraph 2-coloring theory.",
@@ -182,7 +185,10 @@
     "theoremCount": 37,
     "definitionCount": 14,
     "sorries": 7,
-    "path": "Proofs/Erdos629Problem.lean"
+    "path": "Proofs/Erdos629Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos629Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos629Aristotle.lean` companion file in `src/data/proofs/erdos-629/meta.json` (`meta.additionalFiles` and `leanFile.additionalFiles`) so the gallery and deployer surface the Aristotle target file alongside the main proof.

## Evidence

**Before**: `proofs/Proofs/Erdos629Aristotle.lean` exists on disk but is not declared in `src/data/proofs/erdos-629/meta.json`, so the gallery doesn't list it.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` reference `Proofs/Erdos629Aristotle.lean`.

Mirrors the pattern used by erdos-318 (ddfc933) and erdos-1048 (#21295).

---
Automated fix by lean-mechanic agent.