### PR TITLE
fix(meta): erdos-956 register Erdos956Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-956/meta.json
+++ b/src/data/proofs/erdos-956/meta.json
@@ -66,7 +66,10 @@
     "assumptions": "2 axioms: erdos_pach_upper_bound, grid_construction. 6 sorries.",
     "lineCount": 309,
     "theoremCount": 14,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "additionalFiles": [
+      "Proofs/Erdos956Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Unit Distances Between Convex Translates**\n\nThe study of repeated distances in combinatorial geometry traces back to Erdős's landmark 1946 paper, where he asked for the maximum number $f(n)$ of unit distances determined by $n$ points in the plane. Erdős showed $f(n) \\geq n^{1+c/\\log\\log n}$ using a $\\sqrt{n} \\times \\sqrt{n}$ section of the integer lattice, and conjectured the upper bound $f(n) = O(n^{1+\\epsilon})$ for every $\\epsilon > 0$. In 1983, Spencer, Szemerédi, and Trotter proved $f(n) = O(n^{4/3})$ using their celebrated point-line incidence theorem, which remains the best known upper bound.\n\nProblem #956 generalizes this from points to compact convex sets. Erdős and Pach introduced the function $h(n)$—the maximum number of pairs at unit distance among $n$ disjoint translates of a fixed compact convex set $C \\subset \\mathbb{R}^2$—in their 1990 paper \"Variations on the theme of repeated distances\" in Combinatorica. They observed that since small disks around points are convex translates, one always has $h(n) \\geq f(n)$. Using a reduction to the Szemerédi-Trotter framework, they proved $h(n) = O(n^{4/3})$ for translates and $O(n^{7/5})$ for general (non-translate) disjoint convex sets.\n\nThe conjecture asks whether $h(n) > n^{1+c}$ for some absolute constant $c > 0$. This would imply that the convex sets structure does not help reduce unit distances compared to points. The best known lower bound is $\\Omega(n \\log n / \\log\\log n)$ from grid-based constructions, leaving a wide gap. The problem remains open and connects deeply to incidence geometry, the Szemerédi-Trotter theorem, and the broader theme of geometric extremal problems.\n\n**Status**: OPEN — The Erdős-Pach conjecture is unresolved.",
@@ -211,7 +214,10 @@
     "theoremCount": 14,
     "definitionCount": 16,
     "sorries": 6,
-    "path": "Proofs/Erdos956Problem.lean"
+    "path": "Proofs/Erdos956Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos956Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos956Aristotle.lean` companion file in `src/data/proofs/erdos-956/meta.json` (`meta.additionalFiles` and `leanFile.additionalFiles`) so the gallery and deployer surface the Aristotle target file alongside the main proof.

## Evidence

**Before**: `proofs/Proofs/Erdos956Aristotle.lean` exists on disk but is not declared in `src/data/proofs/erdos-956/meta.json`, so the gallery doesn't list it.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` reference `Proofs/Erdos956Aristotle.lean`.

Mirrors the pattern used by erdos-318 (ddfc933) and erdos-1048 (#21295).

---
Automated fix by lean-mechanic agent.