### PR TITLE
fix(meta): erdos-642 register Erdos642Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-642/meta.json
+++ b/src/data/proofs/erdos-642/meta.json
@@ -63,7 +63,10 @@
     "lineCount": 263,
     "assumptions": "1 axiom: dmms_2024 (DMMS 2024 result). 6 sorries.",
     "theoremCount": 12,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "additionalFiles": [
+      "Proofs/Erdos642Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Cycles with More Vertices than Diagonals: An Open Extremal Problem**\n\nA 'diagonal' (or 'chord') of a cycle $C$ in a graph $G$ is an edge of $G$ connecting two non-adjacent vertices of $C$. The condition '$|V(C)| > |\\text{diag}(C)|$' says every cycle has strictly more vertices than chords — a natural sparsity condition on how densely cycles can be chorded.\n\n**Origins**: This problem was posed by Hamburger and Szegedy and appears in Erdős's problem collections. It asks for the maximum number of edges $f(n)$ in an $n$-vertex graph satisfying this condition.\n\n**The Critical Threshold at $k = 5$**: Short cycles ($k \\le 4$) always satisfy the condition: a triangle has 0 possible diagonals, and a $C_4$ has at most 2 (both satisfying $k > \\text{diag}$). But a pentagon $C_5$ has 5 possible diagonals, and $5 \\not> 5$, so a $C_5$ with all diagonals (which is $K_5$) violates the condition. This critical transition at $k = 5$ explains why girth-5 graphs are the natural construction for the lower bound.\n\n**Progress on the Upper Bound**:\n- **Chen-Erdős-Staton (1996)**: Proved $f(n) = O(n^{3/2})$. Their argument uses neighborhood counting: in a dense graph, vertices have large neighborhoods, and the overlap of neighborhoods creates cycles with many chords. This was the state of the art for nearly 30 years.\n- **Draganić-Methuku-Munhá Correia-Sudakov (2024)**: Dramatically improved to $f(n) = O(n(\\log n)^8)$ using sublinear expander techniques. The key insight: any graph with $\\gg n(\\log n)^8$ edges contains a sublinear expander subgraph, and random walks in such expanders efficiently find cycles with many chords.\n\n**The Lower Bound**: Girth-5 graphs (no $C_3$ or $C_4$) trivially satisfy the condition (their cycles have very few diagonals). By the Kővári-Sós-Turán theorem and algebraic constructions (incidence graphs of projective planes, Reiman 1958), such graphs can have $\\Theta(n^{3/2})$ edges. This gives $f(n) = \\Omega(n^{3/2})$.\n\n**The Open Question**: Is $f(n) = o(n)$? Even $f(n) = O(n)$ is unknown. The current bounds $\\Omega(n^{3/2}) \\le f(n) \\le O(n(\\log n)^8)$ leave a gap of $(\\log n)^8/\\sqrt{n}$ in multiplicative terms, which tends to 0 — but this does not resolve the conjecture.",
@@ -199,7 +202,10 @@
     "theoremCount": 12,
     "definitionCount": 16,
     "sorries": 6,
-    "path": "Proofs/Erdos642Problem.lean"
+    "path": "Proofs/Erdos642Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos642Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos642Aristotle.lean` companion file in `src/data/proofs/erdos-642/meta.json` (`meta.additionalFiles` and `leanFile.additionalFiles`) so the gallery and deployer surface the Aristotle target file alongside the main proof.

## Evidence

**Before**: `proofs/Proofs/Erdos642Aristotle.lean` exists on disk but is not declared in `src/data/proofs/erdos-642/meta.json`, so the gallery doesn't list it.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` reference `Proofs/Erdos642Aristotle.lean`.

Mirrors the pattern used by erdos-318 (ddfc933) and erdos-1048 (#21295).

---
Automated fix by lean-mechanic agent.