### PR TITLE
fix(meta): erdos-44 register Erdos44Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -55,7 +55,10 @@
     ],
     "assumptions": "1 axiom: erdos_44 (Erdős conjecture on Sidon sets). 0 sorries.",
     "theoremCount": 8,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/Erdos44Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "A **Sidon set** (or B_2 sequence) is a set of integers where all pairwise sums are distinct. These sets, named after Simon Sidon who studied them in the 1930s, appear throughout additive combinatorics.\n\nErdős Problem #44 asks whether any Sidon set can be extended to achieve near-optimal density. The famous Erdős-Turán conjecture (Problem #28) posits that Sidon sets in [1,N] have at most (1+o(1))sqrt(N) elements, and this problem asks about the reverse: can we always extend a Sidon set to approach this bound?\n\nThis file proves auxiliary undergraduate-level results from the formal-conjectures repository while the main conjecture remains open.",
@@ -143,7 +146,10 @@
     "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/Erdos44Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos44Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos44Aristotle.lean` companion file in `src/data/proofs/erdos-44/meta.json`'s `additionalFiles` arrays (both `meta.meta` and `meta.leanFile`), so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` declared `proofRepoPath: Proofs/Erdos44Problem.lean` but had no `additionalFiles` field. The on-disk file `proofs/Proofs/Erdos44Aristotle.lean` (185 lines, 8 fully-proved supporting lemmas for the Erdős-Turán Sidon construction; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `meta.meta.additionalFiles` and `meta.leanFile.additionalFiles` now list `Proofs/Erdos44Aristotle.lean`.

**Companion file integrity**:
- `grep -nE "\bsorry\b" proofs/Proofs/Erdos44Aristotle.lean` → only the in-comment token on line 10 (a hint to authors, not a tactic)
- `grep -c "^axiom " proofs/Proofs/Erdos44Aristotle.lean` → 0
- 8+ fully-proved theorems: `erdosTuran_strictMono`, `erdosTuran_injOn`, `erdosTuran_card`, `erdosTuran_pos`, `erdosTuran_le`, `sum_eq_of_sum_eq`, `rem_eq_of_sum_eq`, `dvd_prod_diff`, `factor_identity`, `sqrt_sq_le`, `sqrt_le_three` (the key algebraic/ZMod identities used to derive `p | (ab - cd)` from sum equality).
- No `/-!` docstring sections (uses `/-` — Aristotle parser-friendly).
- JSON validates.

Follows the precedent set by #21295 (erdos-1048 companion registration), adding `additionalFiles` to both `meta.meta` and `meta.leanFile`.

---
Automated fix by lean-mechanic agent.