### PR TITLE
fix(meta): erdos-334 register Erdos334Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-334/meta.json
+++ b/src/data/proofs/erdos-334/meta.json
@@ -56,7 +56,10 @@
     "assumptions": "2 axioms: erdos_cube_root_bound, balog_bound. 3 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Erdos334Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The concept of smooth numbers — integers whose prime factors are all bounded — goes back to Ramanujan and was systematically studied by de Bruijn (1951), who introduced the Dickman function $\\rho(u)$ governing the density of $y$-smooth numbers up to $x$ (where $u = \\log x / \\log y$). This function satisfies the delay differential equation $u\\rho'(u) = -\\rho(u-1)$.\n\nErdős originally asked (circa 1980, [ErGr80]) whether $f(n) \\leq n^{1/3}$ holds, where $f(n)$ is the minimal smoothness bound needed to write $n = a + b$ with both summands $f(n)$-smooth. This was answered positively, and Balog (1989) obtained the current best bound $f(n) \\ll n^{4/(9\\sqrt{e})+\\varepsilon} \\approx n^{0.2695}$ using the Selberg-Delange method from analytic number theory.\n\nThe problem connects to Goldbach-type questions about additive representations and to cryptographic applications where smooth numbers play a crucial role (e.g., the number field sieve and Lenstra's ECM factoring algorithm).",
@@ -190,7 +193,10 @@
     "theoremCount": 10,
     "definitionCount": 9,
     "path": "Proofs/Erdos334Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos334Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos334Aristotle.lean` companion file in `src/data/proofs/erdos-334/meta.json`. The file existed on disk but was missing from both `meta.meta.additionalFiles` and `meta.leanFile.additionalFiles`, so the gallery did not surface the Aristotle companion alongside the main proof.

## Evidence

**Before**: `meta.meta.additionalFiles` and `meta.leanFile.additionalFiles` were absent. Companion file `Proofs/Erdos334Aristotle.lean` (48 lines, 7 routine theorems, 0 axioms) was orphaned in the gallery view.

**After**: Both `additionalFiles` arrays list `Proofs/Erdos334Aristotle.lean`. The companion's 7 Aristotle-target theorems (sqrt_exp_one_pos, nine_sqrt_exp_pos, balog_exponent_pos, exp_one_gt_271, exp_one_gt_sq_1646, sqrt_exp_one_gt_1646, balog_exponent_value) — all routine `Real`-analytic positivity / numeric-bound facts used to justify Balog's smooth-representation exponent 4/(9√e) — are now surfaced.

This is a metadata-only registration; no Lean source changes.

---
Automated fix by lean-mechanic agent.