### PR TITLE
fix(meta): erdos-353 register Erdos353Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-353/meta.json
+++ b/src/data/proofs/erdos-353/meta.json
@@ -55,7 +55,10 @@
     "lineCount": 445,
     "assumptions": "4 axiom(s): Koizumi's three main theorems (isosceles trapezoid, isosceles triangle, right triangle) and Kovač-Predojević cyclic quadrilateral theorem are stated as axioms.",
     "theoremCount": 8,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "additionalFiles": [
+      "Proofs/Erdos353Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #353**\n\nThis problem explores what geometric configurations must appear in sets of infinite measure in the plane.\n\n**Key History:**\n- Erdős-Mauldin (unpublished): Claimed true for trapezoids\n- Kovač (2023): Proved trapezoids work; showed parallelograms can fail\n- Kovač-Predojević (2024): Proved cyclic quadrilaterals; congruent sides counterexample\n- Koizumi (2025): Complete resolution for isosceles trapezoids, triangles, and right triangles\n\n**Mathematical Setting:**\nThe problem connects geometric measure theory with combinatorial geometry. Infinite measure ensures sufficient point density to guarantee configurations.",
@@ -183,7 +186,10 @@
     "theoremCount": 8,
     "definitionCount": 14,
     "path": "Proofs/Erdos353Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos353Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos353Aristotle.lean` companion file in `src/data/proofs/erdos-353/meta.json`'s `additionalFiles` arrays (both `meta.additionalFiles` and `leanFile.additionalFiles`), so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` declared `proofRepoPath: Proofs/Erdos353Problem.lean` but had no `additionalFiles` field. The on-disk file `proofs/Proofs/Erdos353Aristotle.lean` (40 lines, fully-proved supporting lemma `volume_preimage_smul_eq_top` for the Lebesgue measure scaling identity used in the area-1 geometric configurations infrastructure; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` now list `Proofs/Erdos353Aristotle.lean`.

**Companion file integrity**:
- `grep -cE "\bsorry\b" proofs/Proofs/Erdos353Aristotle.lean` → 0
- `grep -c "^axiom " proofs/Proofs/Erdos353Aristotle.lean` → 0
- 1 fully-proved theorem: `volume_preimage_smul_eq_top` (preimage of an ∞-measure set under non-zero scaling has ∞ measure, via `Measure.addHaar_smul` and the 2D Euclidean Lebesgue measure).
- No `/-!` docstring sections (uses `/-` — Aristotle parser-friendly).
- JSON validates.
- `pnpm build` succeeds.

Follows the precedent set by #21295 (erdos-1048) and #21337 (erdos-260) — adding `additionalFiles` arrays to both the `meta` and `leanFile` blocks.

---
Automated fix by lean-mechanic agent.