### PR TITLE
fix(meta): erdos-57 register Erdos57Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-57/meta.json
+++ b/src/data/proofs/erdos-57/meta.json
@@ -29,6 +29,7 @@
     "theoremCount": 5,
     "definitionCount": 8,
     "additionalFiles": [
+      "Proofs/Erdos57Aristotle.lean",
       "Proofs/Erdos57ProblemAristotle.lean"
     ]
   },
@@ -169,6 +170,7 @@
     "path": "Proofs/Erdos57Problem.lean",
     "sorries": 2,
     "additionalFiles": [
+      "Proofs/Erdos57Aristotle.lean",
       "Proofs/Erdos57ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the existing `Erdos57Aristotle.lean` companion file in `src/data/proofs/erdos-57/meta.json` (`meta.additionalFiles` and `leanFile.additionalFiles`) alongside the already-listed `Erdos57ProblemAristotle.lean`, so the gallery surfaces both Aristotle target files.

## Evidence

**Before**: `proofs/Proofs/Erdos57Aristotle.lean` exists on disk (and is built via `proofs/Proofs.lean`), but is not declared in `src/data/proofs/erdos-57/meta.json`. Only the sibling `Erdos57ProblemAristotle.lean` is registered.

**After**: Both Aristotle files are listed in `meta.additionalFiles` and `leanFile.additionalFiles`.

Mirrors the dual-companion pattern already used by erdos-35, erdos-156, erdos-179, erdos-240, erdos-1039, erdos-1048, erdos-1049, erdos-1050.

---
Automated fix by lean-mechanic agent.