### PR TITLE
fix(meta): erdos-72 register Erdos72Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-72/meta.json
+++ b/src/data/proofs/erdos-72/meta.json
@@ -74,7 +74,10 @@
     "lineCount": 221,
     "assumptions": "1 axiom: liu_montgomery_powers_of_two. 3 sorries.",
     "theoremCount": 6,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "additionalFiles": [
+      "Proofs/Erdos72Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**The Quest for Unavoidable Cycle Lengths**\n\nErdős posed this $100 problem asking whether there exists a 'sparse' set A ⊂ ℕ (density 0) such that any sufficiently dense graph must contain a cycle with length in A. This connects extremal graph theory to number-theoretic properties of cycle length sets.\n\n**Key Historical Developments:**\n\n- **1977**: Bollobás proved the result for infinite arithmetic progressions containing even numbers\n- **2005**: Verstraëte gave a non-constructive existence proof for such a set A\n- **2020**: Liu and Montgomery proved the surprising result that A can be the powers of 2, directly contradicting Erdős's stated belief\n\n**Why Erdős Was Wrong**: Erdős was 'almost certain' that powers of 2 would not work, expecting that forcing specific cycle lengths would require average degree growing with graph size. Liu and Montgomery showed a constant threshold suffices.",
@@ -277,7 +280,10 @@
     "theoremCount": 6,
     "definitionCount": 17,
     "path": "Proofs/Erdos72Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos72Aristotle.lean"
+    ]
   },
   "sorries": 3
 }


### PR DESCRIPTION
## Fix

Register the existing `Erdos72Aristotle.lean` companion file in `src/data/proofs/erdos-72/meta.json` (`meta.additionalFiles` and `leanFile.additionalFiles`) so the gallery and deployer surface the Aristotle target file alongside the main proof.

## Evidence

**Before**: `proofs/Proofs/Erdos72Aristotle.lean` exists on disk (68 lines, density-zero / cycle-length lemmas) but is not declared in `src/data/proofs/erdos-72/meta.json`, so the gallery doesn't list it.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` reference `Proofs/Erdos72Aristotle.lean`.

Mirrors the pattern used by erdos-318 (ddfc933), erdos-956 (#21344), erdos-1048 (#21295).

---
Automated fix by lean-mechanic agent.