### PR TITLE
fix(meta): erdos-337 register Erdos337Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-337/meta.json
+++ b/src/data/proofs/erdos-337/meta.json
@@ -72,7 +72,10 @@
     "lineCount": 298,
     "assumptions": "3 axioms: turjanyi_counterexample (Turjányi counterexample), ruzsa_turjanyi_generalization (Ruzsa-Turjányi generalization for h ≥ 2), scaled_conjecture_open (scaled version remains open). 0 sorries.",
     "theoremCount": 4,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "additionalFiles": [
+      "Proofs/Erdos337Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Additive bases are sets $A \\subseteq \\mathbb{N}$ such that every sufficiently large integer is a sum of $h$ elements from $A$ (for some fixed $h$). Classical examples include the squares (Lagrange's four-square theorem, $h=4$) and the primes (Goldbach-type results). The study of sumsets $A+A = \\{a+b : a,b \\in A\\}$ is central to additive combinatorics, with Freiman's theorem (1966) and the Plünnecke-Ruzsa inequality providing structural control when $|A+A|$ is small relative to $|A|$.\n\nErdős and Graham [ErGr80, ErGr80b] posed Problem #337: for a sparse additive basis $A$ (meaning $|A \\cap [1,N]| = o(N)$), must the sumset grow faster than $A$ itself? Specifically, is $|A+A \\cap [1,N]|/|A \\cap [1,N]| \\to \\infty$? The natural intuition says yes—if $A$ is thin, the sumset should be much richer. But Turjányi (1984) [Tu84] constructed a stunning counterexample: a sparse additive basis where the ratio $|A+A \\cap [1,N]|/|A \\cap [1,N]|$ stays bounded. Imre Z. Ruzsa and Turjányi (1985) [RT85] generalized this to all $h$-fold sumsets $hA$, while proving the positive result that $|3A \\cap [1,3N]|/|A \\cap [1,N]| \\to \\infty$. The scaled conjecture for $|2A \\cap [1,2N]|/|A \\cap [1,N]|$ remains open.",
@@ -229,7 +232,10 @@
     "theoremCount": 4,
     "definitionCount": 11,
     "path": "Proofs/Erdos337Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos337Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos337Aristotle.lean` companion file in `src/data/proofs/erdos-337/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `src/data/proofs/erdos-337/meta.json` had no `additionalFiles` array in either `meta` or `leanFile`. The on-disk companion `proofs/Proofs/Erdos337Aristotle.lean` (46 lines, 1 Aristotle target: `squares_basis_of_order_4_erdos337` — Lagrange's four-square theorem that the perfect squares form an additive basis of order 4; 0 axioms, 0 `def := sorry`, no `True` placeholders, no `/-!` docstrings) was orphaned from the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` now list `Proofs/Erdos337Aristotle.lean`.

Companion file checklist:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (uses `/-` only)
- [x] Target is a routine supporting lemma, not the main open conjecture

Follows the precedent of #21295 (erdos-1048 Aristotle companion registration) and the recent batch of similar registrations.

---
Automated fix by lean-mechanic agent.