### PR TITLE
audit(erdos-183): cycle 4 issues-found — stale proofStrategy claims axiom that's proved

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5050,9 +5050,9 @@
     },
     "erdos-183": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T08:05:18Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T05:52:36Z",
+      "result": "issues-found",
       "issues": [
         "sections lineCount drift across all 8 sections (29-241 -> 38-613); leanFile.theoremCount 18->10, definitionCount 14->15"
       ]


### PR DESCRIPTION
## Summary

- Cycle 4 audit of erdos-183 found an internal contradiction in meta.json: `proofStrategy` and `sections[4]` claim `R3k_exponential_lower` is "a single axiom" encoding the Ageron et al. (2021) 380^{k/5} bound, but the Lean source has it as a fully proved theorem (line 686, witness c=2 via doubling).
- The `assumptions` field and `axiomCount: 0` are correct; only the narrative text is stale.
- Filed [#21358](https://github.com/rjwalters/lean-genius/issues/21358) with the specific text changes.

This PR only updates the audit tracker. The narrative fix is left to the mechanic/curator per workflow.

## Test plan
- [x] `grep -c "^axiom " proofs/Proofs/Erdos183Problem.lean` returns 0
- [x] `grep -c "sorry" proofs/Proofs/Erdos183Problem.lean` returns 0
- [x] Lean source line 686-692 confirms R3k_exponential_lower is a proved theorem
- [x] meta.json `axiomCount: 0` and `assumptions` field correctly reflect source

Generated with [Claude Code](https://claude.com/claude-code)