### PR TITLE
fix(meta): erdos-339 register Erdos339Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-339/meta.json
+++ b/src/data/proofs/erdos-339/meta.json
@@ -62,7 +62,10 @@
     "lineCount": 215,
     "assumptions": "3 axioms: hegyvari_hennecart_plagne_1, hegyvari_hennecart_plagne_2, squares_basis_of_order_4. See Lean source for complete statements.",
     "theoremCount": 7,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "additionalFiles": [
+      "Proofs/Erdos339Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #339: Additive Bases and Distinct Sums**\n\nThis problem explores the relationship between additive bases and 'restricted' representations using distinct elements.\n\n**Key History:**\n- Erdős-Graham (1980): Posed both conjectures in their monograph\n- Hegyvári-Hennecart-Plagne (2003): Proved both conjectures in J. Reine Angew. Math.\n\n**Mathematical Setting:**\nA set A ⊆ ℕ is a basis of order r if every large integer is a sum of r elements from A. The question is whether the 'restricted' sums (using r DISTINCT elements) also cover a positive fraction of integers.",
@@ -186,7 +189,10 @@
     "theoremCount": 7,
     "definitionCount": 12,
     "path": "Proofs/Erdos339Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos339Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos339Aristotle.lean` companion file in `src/data/proofs/erdos-339/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `src/data/proofs/erdos-339/meta.json` had no `additionalFiles` array in either `meta` or `leanFile`. The on-disk companion `proofs/Proofs/Erdos339Aristotle.lean` (34 lines, 1 Aristotle target: `squares_basis_of_order_4_aristotle` — Lagrange's four-squares theorem recast as `IsBasisOfOrder { n | ∃ m, n = m^2 } 4`; 0 sorries, 0 axioms, 0 `def := sorry`, no `True` placeholders, no `/-!` docstrings; `namespace Erdos339` matches main file) was orphaned from the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` now list `Proofs/Erdos339Aristotle.lean`.

Companion file checklist:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (uses `/-` only)
- [x] Namespace matches main file (`Erdos339`)
- [x] Imports `Proofs.Erdos339Problem` for shared definitions

Validation: `pnpm build` succeeded with the change.

Follows the precedent of #21295 (erdos-1048) and #21356 (erdos-337).

---
Automated fix by lean-mechanic agent.