### PR TITLE
fix(meta): erdos-73 register Erdos73Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-73/meta.json
+++ b/src/data/proofs/erdos-73/meta.json
@@ -76,7 +76,10 @@
     "lineCount": 314,
     "assumptions": "3 axioms: reed_bound, reed_theorem, reed_bound_zero. 0 sorries. All previously sorry'd theorems (trivial_case, bipartite_deficiency_zero, strict_implies_bipartite, K3_violates_strict) are now fully proved.",
     "theoremCount": 9,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "additionalFiles": [
+      "Proofs/Erdos73Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Origins: Independence and Bipartiteness**\n\nThe connection between independence number and bipartiteness is classical: a graph $G$ is bipartite if and only if $\\alpha(G[S]) \\ge |S|/2$ for every induced subgraph $G[S]$. This follows from the odd cycle characterization — an odd cycle $C_{2m+1}$ has $\\alpha = m < (2m+1)/2$, so any non-bipartite graph violates the condition.\n\n**Erdős's Question**\n\nErdős asked a natural structural question: if we relax the condition to $\\alpha(G[S]) \\ge (|S| - k)/2$ for some fixed $k \\ge 0$, must $G$ still be 'close to bipartite'? Specifically, can $G$ be made bipartite by removing at most $f(k)$ vertices, where $f(k)$ depends only on $k$ and not on $|V(G)|$? The power of this question lies in the quantifier structure — a fixed finite bound controlling an arbitrarily large graph.\n\n**Reed's Solution (1999)**\n\nBruce Reed proved the affirmative answer in his paper 'Mangoes and Blueberries' (Combinatorica 1999). The proof uses the Erdős-Pósa theorem for odd cycles: the $k$-independence condition bounds the number of vertex-disjoint odd cycles in $G$, and bounded packing implies a bounded transversal (a set of vertices hitting all odd cycles). Reed's bound is $f(k) \\le 2^k$, but the optimal growth rate remains unknown.\n\n**Significance**\n\nThe result is a prototype for structural graph theory results showing that 'approximate' satisfaction of a property (bipartiteness) forces 'approximate' structure (few exceptional vertices). This paradigm appears throughout the Graph Minors Project of Robertson and Seymour.",
@@ -206,7 +209,10 @@
     "theoremCount": 9,
     "definitionCount": 10,
     "path": "Proofs/Erdos73Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos73Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos73Aristotle.lean` companion file in `src/data/proofs/erdos-73/meta.json` so the gallery surfaces it alongside the main proof `Erdos73Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-73/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos73Aristotle.lean` (126 lines, 8 fully-proved supporting theorems, 3 helper defs, 0 sorries, 0 axioms — covering K_3 adjacency and independence properties, the K_2 induced-subgraph bipartite witness, the K_3 1-almost-bipartite witness, and independence-arithmetic helpers for the strict condition) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos73Aristotle.lean` as the sole companion file. Gallery enrichment confirms the link: `Enriched erdos-73: 13 lean files`.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21318 (erdos-678), #21321 (erdos-307), #21325 (erdos-674), and #21326 (erdos-309).

---
Automated fix by lean-mechanic agent.