### PR TITLE
fix(meta): erdos-360 register Erdos360Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -175,7 +175,10 @@
     "theoremCount": 4,
     "definitionCount": 4,
     "path": "Proofs/Erdos360Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos360Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos360Aristotle.lean` companion file in `src/data/proofs/erdos-360/meta.json`'s `leanFile.additionalFiles`.

## Evidence

**Before**: `meta.json` had no `additionalFiles` field — the companion was invisible to the gallery.

**After**: `additionalFiles` lists `Proofs/Erdos360Aristotle.lean` (123 lines, 9 supporting lemmas covering concrete `f(2)=1` and `f(4)=2` cases via sum-free witness partitions and decidable subset-sum checks; 1 sorry on `f_4_ge_2_ari`, 0 axioms).

The companion file deliberately excludes the main open growth-rate result (Conlon-Fox-Pham 2021, axiomatized) and other deep axioms; it surfaces only Aristotle-eligible small-case witnesses.

Pattern mirrors recently-merged PR #21295 (erdos-1048 registration).

---
Automated fix by lean-mechanic agent.