### PR TITLE
audit(erdos-178): mark clean (cycle 4) — Beck discrepancy bounds

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5007,10 +5007,10 @@
       "result": "clean"
     },
     "erdos-178": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T08:24:53Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T06:33:50Z",
+      "result": "clean"
     },
     "erdos-179": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Cycle 4 audit of erdos-178 (Balancing Infinite Collections of Integer Sequences): **CLEAN**.

All meta.json fields verified against `proofs/Proofs/Erdos178Problem.lean`:

| Field | Meta | Source | Match |
|-------|------|--------|-------|
| lineCount | 165 | 165 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 3 | 3 (theorem+lemma) | ✓ |
| definitionCount | 11 | 11 (def + noncomputable def) | ✓ |
| status | axiomatized | (has 2 axioms) | ✓ |
| badge | axiom | (axiomatized) | ✓ |

Axiom inventory matches `assumptions` field:
- `beck_1981` (existence of bounded signing for any family — Beck 1981)
- `beck_2017` (quantitative bound K·d^(4+ε) — Beck 2017)

`erdos_178` and `erdos_178_answer` are direct consequences of the axioms. `non_uniform_trivial` is a verified minor lemma derived from `beck_1981`. No True stubs, no Mathlib wrapper inflation; correctly classified as Tier C (axiomatized).

## Test plan

- [x] grep axioms = 2 matches axiomCount
- [x] grep sorry = 0 matches sorries
- [x] wc -l = 165 matches lineCount
- [x] No True stubs or trivial proofs of nontrivial claims
- [x] Status/badge consistent with axiomatized core

🤖 Generated with [Claude Code](https://claude.com/claude-code)