### PR TITLE
fix(meta): erdos-362 register Erdos362Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-362/meta.json
+++ b/src/data/proofs/erdos-362/meta.json
@@ -72,7 +72,10 @@
     "lineCount": 336,
     "assumptions": "2 axioms: sarkozy_szemeredi_1965, halasz_1977. 0 sorries.",
     "theoremCount": 13,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "additionalFiles": [
+      "Proofs/Erdos362Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #362** is about the concentration function in additive combinatorics. Given a finite set A, how many of its subsets can sum to a fixed target t?\n\n**Historical Development:**\n- **Erdős-Moser (1965):** First proved a bound of O(2^N / N^(3/2) · (log N)^(3/2))\n- **Sárközy-Szemerédi (1965):** Removed the log factor, giving the sharp bound 2^N / N^(3/2)\n- **Halász (1977):** With fixed cardinality constraint, proved 2^N / N²\n- **Stanley (1980):** Using algebraic geometry (hard Lefschetz), showed the symmetric set centered at 0 maximizes concentration\n\n**Key Insight:** The Central Limit Theorem explains why concentration is ~2^N / N^(3/2): subset sums are approximately Gaussian with variance ~N, so the peak height is ~1/√N, giving N^(3/2) in the denominator.",
@@ -194,7 +197,10 @@
     "theoremCount": 13,
     "definitionCount": 10,
     "path": "Proofs/Erdos362Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos362Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos362Aristotle.lean` companion file in `src/data/proofs/erdos-362/meta.json`. The file existed on disk but was missing from both `meta.meta.additionalFiles` and `meta.leanFile.additionalFiles`, so the gallery did not surface the Aristotle companion alongside the main proof.

## Evidence

**Before**: `meta.meta.additionalFiles` and `meta.leanFile.additionalFiles` were absent. Companion file `Proofs/Erdos362Aristotle.lean` (81 lines, 5 routine theorems, 3 supporting defs, 0 axioms, 0 sorries) was orphaned in the gallery view.

**After**: Both `additionalFiles` arrays list `Proofs/Erdos362Aristotle.lean`. The companion exposes routine subset-sum generating-function lemmas — `subset_count_le_pow` (trivial 2^N upper bound), `gf_at_one` (GF evaluated at z=1), `zpow_finset_sum` (zpow distributes over finset sum), `gf_disjoint_union` (GF multiplicativity over disjoint union), and `gf_expansion` (product-to-powerset-sum identity) — all building blocks for the Fourier-analytic approach to #362.

This is a metadata-only registration; no Lean source changes.

---
Automated fix by lean-mechanic agent.