### PR TITLE
fix(meta): erdos-378 register Erdos378Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-378/meta.json
+++ b/src/data/proofs/erdos-378/meta.json
@@ -63,7 +63,10 @@
     "lineCount": 325,
     "assumptions": "2 axioms: granville_ramare_density_exists (Granville-Ramaré density exists), complement_density (complement density for residue classes r). 4 sorries.",
     "theoremCount": 10,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "additionalFiles": [
+      "Proofs/Erdos378Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdos Problem #378**\n\nThis problem concerns the distribution of squarefree binomial coefficients in Pascal's triangle.\n\n**The Question:**\nFor a given r >= 0, does the density of integers n such that C(n,k) is squarefree for at least r values of 1 <= k < n exist? Is this density positive?\n\n**Resolution:**\nGranville and Ramare (1996) proved that the density eta_m of n having exactly 2m+2 squarefree binomial coefficients exists for each m. Aggarwal and Cambie observed that this resolves Erdos's question: the desired density is 1 - sum of eta_m for small m, which is positive.",
@@ -186,7 +189,10 @@
     "theoremCount": 10,
     "definitionCount": 10,
     "path": "Proofs/Erdos378Problem.lean",
-    "sorries": 4
+    "sorries": 4,
+    "additionalFiles": [
+      "Proofs/Erdos378Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos378Aristotle.lean` companion file in `src/data/proofs/erdos-378/meta.json` so the gallery surfaces it alongside the main proof `Erdos378Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-378/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos378Aristotle.lean` (97 lines, 12 fully-proved theorems/lemmas, 0 sorries, 0 axioms — covering squarefree facts, prime/squarefree edge cases, and binomial coefficient identities) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1376).

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos378Aristotle.lean` as the sole companion file. JSON validates.

Mirrors the precedent set by #21363 (erdos-73), #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21318 (erdos-678), #21321 (erdos-307), #21325 (erdos-674), and #21326 (erdos-309).

---
Automated fix by lean-mechanic agent.