### PR TITLE
fix(meta): erdos-490 register Erdos490Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-490/meta.json
+++ b/src/data/proofs/erdos-490/meta.json
@@ -73,7 +73,8 @@
     "theoremCount": 10,
     "definitionCount": 15,
     "additionalFiles": [
-      "Proofs/Erdos490ProblemAristotle.lean"
+      "Proofs/Erdos490ProblemAristotle.lean",
+      "Proofs/Erdos490Aristotle.lean"
     ]
   },
   "overview": {
@@ -208,7 +209,8 @@
     "path": "Proofs/Erdos490Problem.lean",
     "sorries": 6,
     "additionalFiles": [
-      "Proofs/Erdos490ProblemAristotle.lean"
+      "Proofs/Erdos490ProblemAristotle.lean",
+      "Proofs/Erdos490Aristotle.lean"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos490Aristotle.lean` companion file in `src/data/proofs/erdos-490/meta.json` so the gallery surfaces it alongside the main proof and the already-registered sibling companion `Erdos490ProblemAristotle.lean`.

## Evidence

**Before**: `additionalFiles` (in both `meta` and `leanFile`) only listed `Proofs/Erdos490ProblemAristotle.lean`. The on-disk file `proofs/Proofs/Erdos490Aristotle.lean` (122 lines, routine subset cardinality / prime divisibility lemmas supporting the Szemerédi product-distinctness formalization; 0 sorries, 0 axioms) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos490Aristotle.lean` in addition to the existing entry.

This mirrors the precedent set by #21295 (erdos-1048 Aristotle companion registration).

---
Automated fix by lean-mechanic agent.