### PR TITLE
fix(meta): erdos-375 register Erdos375Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-375/meta.json
+++ b/src/data/proofs/erdos-375/meta.json
@@ -62,7 +62,10 @@
     "lineCount": 354,
     "assumptions": "2 axioms: (1) ramachandra_shorey_tijdeman — Ramachandra-Shorey-Tijdeman (1975) partial result for k << (log n / log log n)^3; (2) grimm_difficulty — the known mathematical implication Grimm conjecture → Legendre conjecture (via prime gap bounds p_{n+1}-p_n ≪ p_n^{1/2-ε}), requiring analytic number theory not yet in Mathlib.",
     "theoremCount": 6,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Erdos375Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdos Problem #375: Grimm's Conjecture**\n\nThis conjecture was originally posed by C.A. Grimm in 1969 in the American Mathematical Monthly. It connects prime factorization with combinatorial matching theory.\n\n**The Core Question:**\nGiven any interval of k consecutive composite numbers (a 'prime gap'), can we always assign a distinct prime divisor to each composite?\n\n**Historical Progress:**\n- 1969: Grimm poses conjecture, proves k << log n / log log n\n- 1970s: Erdos-Selfridge extend to k <= (1+o(1)) log n\n- 1975: Ramachandra-Shorey-Tijdeman prove k << (log n / log log n)^3\n\n**Significance:**\nThis is listed as problem B32 in Guy's Unsolved Problems in Number Theory. It remains one of the most intriguing open problems connecting prime gaps to matching theory.",
@@ -186,7 +189,10 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos375Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos375Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Erdos375Aristotle.lean` companion file in `src/data/proofs/erdos-375/meta.json`.

## Evidence

**Before**: `meta.additionalFiles` and `leanFile.additionalFiles` fields absent — the existing companion file `proofs/Proofs/Erdos375Aristotle.lean` was not declared in the gallery metadata.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` list `Proofs/Erdos375Aristotle.lean`.

## Companion content

The companion file (Erdős Problem #375, Grimm's Conjecture) contains routine supporting lemmas suitable for Aristotle proof search:
- Concrete compositeness facts (`composite_24`, ..., `composite_95`)
- Consecutive composite block examples (`block_23_3`, `block_89_6`)
- Prime divisibility facts (`two_dvd_24`, `five_dvd_25`, `thirteen_dvd_26`)
- k=1 support lemmas (`composite_has_prime_dvd`, `consecutive_coprime`, `coprime_disjoint_primes`)

Not Grimm's conjecture itself — that remains open in the main file.

Pre-submission checklist:
- [x] No `def ... := sorry`
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (uses `/-`)
- [x] No open conjectures

---
Automated fix by lean-mechanic agent.