### PR TITLE
fix(meta): erdos-434 register Erdos434Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-434/meta.json
+++ b/src/data/proofs/erdos-434/meta.json
@@ -72,7 +72,10 @@
     "lineCount": 372,
     "assumptions": "4 axioms (kiss_2002, sylvester_frobenius, sylvester_count, frobenius_consecutive) and 2 sorries (nonrep_finite, topK_finite).",
     "theoremCount": 15,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "additionalFiles": [
+      "Proofs/Erdos434Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #434 is closely related to the classical Frobenius problem (also called the coin problem or money changing problem). Given a set of positive integers with gcd = 1, only finitely many integers are non-representable as sums of elements from the set.\n\nThe Frobenius number is the largest such non-representable integer. For two coprime integers a and b, Sylvester proved in 1884 that this equals ab - a - b, and the count of non-representables is (a-1)(b-1)/2.\n\nProblem #434 asks a different question: not what is the largest non-representable integer, but which k-element subset of {1, ..., n} maximizes the COUNT of non-representable integers. Kiss (2002) proved that the answer is the 'top k' set: {n-k+1, ..., n}. Intuitively, using larger numbers creates more gaps in what's representable.\n\nThe problem connects to numerical semigroup theory, where the 'genus' of a semigroup (number of gaps) is a central invariant. Problem #434 asks which generators maximize the genus. The result is also remarkable from an optimization perspective: the greedy algorithm (always pick the largest available number) produces the provably optimal solution — a rare case in combinatorial optimization where greedy is exactly optimal.\n\nRamírez-Alfonsín (2005) showed that computing the Frobenius number for sets of 3 or more elements is NP-hard, making the clean explicit solution to the extremal problem all the more surprising.",
@@ -108,7 +111,10 @@
     "theoremCount": 15,
     "definitionCount": 10,
     "path": "Proofs/Erdos434Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos434Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos434Aristotle.lean` companion file in `src/data/proofs/erdos-434/meta.json` so the gallery surfaces it alongside the main proof `Erdos434Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-434/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos434Aristotle.lean` (137 lines, 9 fully-proved theorems, 0 sorries, 0 axioms — covering `topK_card`, `zero_representable`, `mem_representable`, `add_representable`, `nonrep_finite`, `topK_5_2`, `topK_10_3`, `topK_subset`, `topK_pos`) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1446).

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos434Aristotle.lean` as the sole companion file. JSON validates.

The companion file exposes routine representability and `topK` supporting lemmas, distinct from the main Kiss (2002) extremal theorem and the four axiomatized Frobenius bounds (`kiss_2002`, `sylvester_frobenius`, `sylvester_count`, `frobenius_consecutive`) — exactly the criteria for Aristotle-ready targets.

Mirrors the precedent set by #21295 (erdos-1048) and the sibling `fix/mechanic-erdos-*-aristotle` PRs in flight.

---
Automated fix by lean-mechanic agent.