### PR TITLE
fix(meta): erdos-441 register Erdos441Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-441/meta.json
+++ b/src/data/proofs/erdos-441/meta.json
@@ -59,7 +59,10 @@
     "assumptions": "3 axioms: chen_1998 (Chen 1998 — asymptotic formula), chen_dai_2007 (Chen-Dai 2007 — refined upper bound), chen_dai_2006 (Chen-Dai 2006 — construction is not optimal infinitely often). 2 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "additionalFiles": [
+      "Proofs/Erdos441Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**LCM-Bounded Subsets: From Erdős to Chen-Dai**\n\nErdős proposed this problem in 1951, asking: given N, what is the largest set A ⊆ {1,...,N} such that every pair has lcm(a,b) ≤ N? He offered a specific two-part construction and asked whether it is always optimal.\n\n**The Construction**\n\nErdős' construction takes all integers up to ⌊√(N/2)⌋ (where any pair has lcm ≤ product ≤ N/2 < N) together with all even integers in [√(N/2), √(2N)] (where any pair 2k, 2l has lcm ≤ 2kl ≤ N since both factors are at most √(2N)/√2). The total size is approximately √(N/2) + (1/2)(√(2N) - √(N/2)) = 3√N/(2√2) = √(9N/8).\n\n**Early Progress**\n\nChoi (1972) studied the problem and obtained partial results on the structure of optimal sets. The breakthrough came from Yong-Gao Chen, who in 1998 established the definitive asymptotic g(N) ~ √(9N/8), confirming that Erdős' construction captures the correct leading term.\n\n**The Resolution (Chen-Dai 2006-2007)**\n\nChen and Dai proved two complementary results:\n\n1. **Upper bound** (2007): g(N) ≤ √(9N/8) + O(√(N/log N) · log log N). The error term is o(√N) but ω(1), leaving room for the construction to be suboptimal.\n\n2. **Non-optimality** (2006): For infinitely many N, g(N) > |ErdősConstruction(N)|. The proof identifies specific N values where highly composite numbers create additional elements that can be added to any LCM-bounded set — elements with favorable GCD structure that the rigid two-part partition misses.\n\nThis definitively answered Erdős' question: NO, the construction is not always optimal. The gap arises because the construction treats all integers uniformly within each part, while optimal sets exploit the detailed divisibility structure of specific integers.",
@@ -191,7 +194,10 @@
     "theoremCount": 6,
     "definitionCount": 13,
     "path": "Proofs/Erdos441Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos441Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos441Aristotle.lean` companion file in `src/data/proofs/erdos-441/meta.json` so the gallery surfaces it alongside the main proof `Erdos441Problem.lean`.

## Evidence

**Before**: `src/data/proofs/erdos-441/meta.json` had no `additionalFiles` arrays in either `meta.meta` or `meta.leanFile`. The on-disk file `proofs/Proofs/Erdos441Aristotle.lean` (131 lines, with theorems covering `erdos_question_answer_proof`, `mem_erdosFirstPart_iff`, `erdosFirstPart_ge_one`, `erdosFirstPart_le_sqrt`, `mem_erdosSecondPart_iff`, `erdosSecondPart_even`, `erdosSecondPart_le_sqrt2N`, `sqrt_half_le_sqrt`, `lcm_self_eq`, `erdosFirstPart_le_N`) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1457).

**After**: Both `additionalFiles` arrays now list `Proofs/Erdos441Aristotle.lean` as the sole companion file. JSON validates.

The companion file exposes routine membership, bound, and LCM supporting lemmas for the Erdős/Chen-Dai LCM-bounded subsets problem — distinct from the three axiomatized deep results (`chen_1998`, `chen_dai_2007`, `chen_dai_2006`) and the main Lean theorem `erdos_question_disproved`. Excludes the deeper `construction_gives_lower_bound`, Chen-Dai upper bound, and asymptotic formula per Aristotle-readiness criteria documented in the companion's header comment.

Mirrors the precedent set by #21295 (erdos-1048) and the sibling `fix/mechanic-erdos-*-aristotle` PRs in flight.

---
Automated fix by lean-mechanic agent.