### PR TITLE
fix(meta): erdos-415 register Erdos415Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-415/meta.json
+++ b/src/data/proofs/erdos-415/meta.json
@@ -77,7 +77,8 @@
     "theoremCount": 14,
     "definitionCount": 20,
     "additionalFiles": [
-      "Proofs/Erdos415ProblemAristotle.lean"
+      "Proofs/Erdos415ProblemAristotle.lean",
+      "Proofs/Erdos415Aristotle.lean"
     ]
   },
   "overview": {
@@ -234,7 +235,8 @@
     "path": "Proofs/Erdos415Problem.lean",
     "sorries": 14,
     "additionalFiles": [
-      "Proofs/Erdos415ProblemAristotle.lean"
+      "Proofs/Erdos415ProblemAristotle.lean",
+      "Proofs/Erdos415Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos415Aristotle.lean` companion file in `src/data/proofs/erdos-415/meta.json` so the gallery surfaces it alongside the main proof and the already-registered sibling companion `Erdos415ProblemAristotle.lean`.

## Evidence

**Before**: `additionalFiles` (in both `meta.meta` and `meta.leanFile`) only listed `Proofs/Erdos415ProblemAristotle.lean`. The on-disk file `proofs/Proofs/Erdos415Aristotle.lean` (35 lines, 3 supporting lemmas — `phi_2p`, `phi_consecutive_primes`, `phi_prime_succ`; routine properties of Euler's totient that follow from Mathlib's `Nat.totient` API) was orphaned from the gallery.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos415Aristotle.lean` in addition to the existing entry.

Companion file passes the pre-submission checklist:
- No `def ... := sorry` (definition sorries)
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` docstring sections (uses `/-` instead)

Mirrors the precedent set by #21295 (erdos-1048 Aristotle companion registration) and #21288 (erdos-1043).

---
Automated fix by lean-mechanic agent.