### PR TITLE
audit(erdos-186): mark clean (cycle 4) — non-averaging sets integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5075,9 +5075,9 @@
     },
     "erdos-186": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T07:52:20Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T07:25:07Z",
+      "result": "clean"
     },
     "erdos-187": {
       "agentId": "auditor-1777707734",


### PR DESCRIPTION
## Summary

Audit of Erdős Problem #186 (Non-Averaging Sets) — cycle 4. Marked clean.

## Verification

Verified `src/data/proofs/erdos-186/meta.json` matches `proofs/Proofs/Erdos186Problem.lean`:

- **Sorries**: 0 claimed, 0 actual ✓
- **Axioms**: 2 claimed (`lower_bound_quarter`, `pham_zakharov_upper_bound_2024`), 2 actual ✓
- **Theorems**: 6 (empty/singleton/pair_is_nonAveraging, erdos_186_bounds, nonAveraging_subset, nonAveraging_no_centered_AP) ✓
- **Definitions**: 3 (IsNonAveraging, IsNonAveraging', F) ✓
- **Line count**: 243/243 ✓
- **Status**: `axiomatized` with badge `axiom` — correct for deep combinatorial bounds (Bosznay 1989, Pham-Zakharov 2024)
- No True stubs, no Mathlib wrapper masking
- `originalContributions` accurately scope what's verified vs axiomatized

## Test plan

- [x] Compared meta.json field counts against Lean source
- [x] Confirmed axioms are honestly labeled in `originalContributions`
- [x] Confirmed Tier C classification (axiomatized scaffold) — title and description correctly attribute deep bounds to external work

🤖 Generated with [Claude Code](https://claude.com/claude-code)