### PR TITLE
fix(meta): erdos-454 register Erdos454Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-454/meta.json
+++ b/src/data/proofs/erdos-454/meta.json
@@ -108,6 +108,7 @@
     "theoremCount": 16,
     "definitionCount": 14,
     "additionalFiles": [
+      "Proofs/Erdos454Aristotle.lean",
       "Proofs/Erdos454ProblemAristotle.lean"
     ]
   },
@@ -257,6 +258,7 @@
     "path": "Proofs/Erdos454Problem.lean",
     "sorries": 3,
     "additionalFiles": [
+      "Proofs/Erdos454Aristotle.lean",
       "Proofs/Erdos454ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos454Aristotle.lean` companion file in `src/data/proofs/erdos-454/meta.json` alongside the already-registered `Erdos454ProblemAristotle.lean` so the gallery surfaces both companions for Erdős Problem #454.

## Evidence

**Before**: Both `additionalFiles` arrays (in `meta.meta` and `meta.leanFile`) listed only `Proofs/Erdos454ProblemAristotle.lean`. The companion file `proofs/Proofs/Erdos454Aristotle.lean` (131 lines, namespace `Erdos454Aristotle`, 9 supporting theorems on Nat.nth Prime / limsup / prime gap routine results — `nthPrime_strictMono`, `nthPrime_prime`, `symmetric_sum_at_zero`, `f_le_twice_nthPrime`, `f_eq_f'`, `conjecture_iff_not_negation`, `infinitely_many_deviation_ge_2`, `large_prime_gaps_exist`, `asymmetric_behavior`; 2 sorries — Aristotle targets) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1476).

**After**: Both `additionalFiles` arrays list both companion files in alphabetical order.

Mirrors the precedent set by #21288 (erdos-1043), #21295 (erdos-1048), #21309 (erdos-1049), #21316 (erdos-179), #21318 (erdos-678), #21321 (erdos-307), #21324 (erdos-338), #21325 (erdos-674), #21327 (erdos-35), and many later siblings.

---
Automated fix by lean-mechanic agent.