### PR TITLE
fix(meta): erdos-548 register Erdos548Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -28,6 +28,7 @@
     "theoremCount": 6,
     "definitionCount": 16,
     "additionalFiles": [
+      "Proofs/Erdos548Aristotle.lean",
       "Proofs/Erdos548ProblemAristotle.lean"
     ]
   },
@@ -163,6 +164,7 @@
     "path": "Proofs/Erdos548Problem.lean",
     "sorries": 6,
     "additionalFiles": [
+      "Proofs/Erdos548Aristotle.lean",
       "Proofs/Erdos548ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos548Aristotle.lean` companion file in `src/data/proofs/erdos-548/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #548 (Erdős-Sós Conjecture).

## Evidence

**Before**: Both `additionalFiles` arrays (in `meta.meta` and `meta.leanFile`) listed only `Proofs/Erdos548ProblemAristotle.lean`. The companion file `proofs/Proofs/Erdos548Aristotle.lean` (53 lines, namespace `Erdos548Aristotle`, 5 routine supporting targets — `pathGraph_adj_symm`, `starGraph_center_adj`, `starGraph_adj_symm`, `sum_degrees_twice_edges_ari`, `containsSubgraph_refl`) was orphaned from the gallery despite being imported by `proofs/Proofs.lean` (line 1600).

**After**: Both `additionalFiles` arrays list both companion files in alphabetical order.

```diff
     "additionalFiles": [
+      "Proofs/Erdos548Aristotle.lean",
       "Proofs/Erdos548ProblemAristotle.lean"
     ]
```

(Two identical insertions — one in the top-level `meta.additionalFiles` and one in the path-block `additionalFiles`.)

Mirrors the precedent set by #21328 (erdos-160) and many prior siblings listed there.

---
Automated fix by lean-mechanic agent.