### PR TITLE
fix(meta): erdos-456 register Erdos456Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -111,7 +111,10 @@
     "lineCount": 271,
     "assumptions": "0 axioms, 0 sorries. All infrastructure fully verified. The 'axiomatized' status reflects that the three main conjectures (Parts 1-3) are open problems stated as Prop definitions, not theorems. The surrounding infrastructure (definitions, properties, relationships, van Doorn's result) is completely proved.",
     "theoremCount": 16,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Erdos456Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #456 compares two natural arithmetic functions of n. The first, pₙ, is the smallest prime congruent to 1 modulo n — guaranteed to exist by Dirichlet's theorem (1837) on primes in arithmetic progressions. The second, mₙ, is the smallest positive integer m such that n divides Euler's totient φ(m).\n\nPeter Gustav Lejeune Dirichlet (1805-1859) proved in 1837 that every arithmetic progression a, a+d, a+2d, ... with gcd(a,d) = 1 contains infinitely many primes. This landmark result — one of the great achievements of 19th-century number theory — ensures pₙ is well-defined. Yuri Vladimirovich Linnik (1915-1972) proved in 1944 that the smallest such prime satisfies pₙ ≤ n^L for some absolute constant L, now called Linnik's constant. The best known bound, L ≤ 5.18, was established by Triantafyllos Xylouris in his 2011 Bonn thesis, improving earlier work by Heath-Brown (L ≤ 5.5, 1992).\n\nThe trivial inequality mₙ ≤ pₙ holds because φ(pₙ) = pₙ - 1 is divisible by n (since pₙ ≡ 1 mod n), making pₙ a candidate for mₙ. Equality mₙ = pₙ occurs when n = q - 1 for a prime q: then mₙ must be at least q (since φ(m) divisible by q - 1 requires m to have a prime factor ≡ 1 mod (q-1), and q is the smallest such prime).\n\nVan Doorn observed that for n = 2^{2k+1}, we have φ(2n) = φ(2^{2k+2}) = 2^{2k+1} = n, so mₙ ≤ 2n. Since pₙ grows polynomially by Linnik's theorem, this gives explicit families where mₙ < pₙ. Erdős proved that mₙ < pₙ for infinitely many n and that mₙ/n → ∞ for almost all n.\n\nThe three open questions ask progressively stronger statements: (1) is mₙ < pₙ for almost all n (density 1), (2) does pₙ/mₙ → ∞ (the gap widens), and (3) are there infinitely many 'rigid' primes p where p - 1 is the unique n with mₙ = p?",
@@ -205,7 +208,10 @@
     "theoremCount": 16,
     "definitionCount": 6,
     "path": "Proofs/Erdos456Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos456Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos456Aristotle.lean` companion file in `src/data/proofs/erdos-456/meta.json` so the gallery surfaces it.

## Evidence

**Before**: `proofs/Proofs/Erdos456Aristotle.lean` exists on disk (82 lines, 0 sorries, 0 axioms — fully proved supporting lemmas), but neither `meta.additionalFiles` nor `leanFile.additionalFiles` declared it.

**After**: both arrays list `"Proofs/Erdos456Aristotle.lean"`, matching the established pattern (cf. #21328 erdos-160, #21330 erdos-268, #21371 erdos-490).

The companion provides `totient_two_pow_succ` (van Doorn's φ(2^(m+1)) = 2^m) and basic power arithmetic helpers supporting the `smallestPrimeMod1` / `smallestTotientDiv` machinery in the main `Erdos456Problem.lean` formalization.

---
Automated fix by lean-mechanic agent.