### PR TITLE
audit(erdos-174): mark clean (cycle 4) — Euclidean Ramsey sets integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4975,12 +4975,12 @@
       "result": "clean"
     },
     "erdos-174": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "section line drift in 5/9 sections (Parts V-IX); known-ramsey endLine 160→158, examples 161-187→159-178, non-ramsey 188-206→179-197, characterization 207-221→198-212, summary 222-247→213-247; not_spherical_not_ramsey at L182 falls outside its claimed section by line; counts/axioms/narrative all accurate (#14671)"
       ],
-      "lastAudited": "2026-05-02T08:42:30Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T07:58:44Z",
+      "result": "clean"
     },
     "erdos-175": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Cycle 4 audit of erdos-174 (Euclidean Ramsey Sets) — **CLEAN**.

**Counts verified against `proofs/Proofs/Erdos174Problem.lean`:**
- 5 axioms (ramsey_implies_spherical, rectangle_is_ramsey, simplex_is_ramsey, trapezoid_is_ramsey, collinear_not_spherical)
- 5 theorems (not_spherical_not_ramsey, collinear_not_ramsey, characterization_exists, erdos_174, erdos_174_summary)
- 18 definitions
- 0 sorries
- 247 lines

**Integrity:**
- Status `axiomatized`/badge `axiom` appropriate for OPEN problem
- Section line ranges (all 9 sections) align correctly — prior cycle's drift issue resolved
- `originalContributions` clearly distinguishes proved theorems from axioms
- Title and description explicitly mark problem as OPEN
- No True stubs, no Mathlib wrapper inflation

## Test plan
- [x] Tracker file updated via `claim-target.sh complete erdos-174 clean`
- [x] All meta.json counts cross-checked against Lean source
- [x] Section ranges manually verified