### PR TITLE
fix(meta): erdos-79 register Erdos79Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-79/meta.json
+++ b/src/data/proofs/erdos-79/meta.json
@@ -38,7 +38,8 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "additionalFiles": [
-      "Proofs/Erdos79ProblemAristotle.lean"
+      "Proofs/Erdos79ProblemAristotle.lean",
+      "Proofs/Erdos79Aristotle.lean"
     ]
   },
   "overview": {
@@ -186,7 +187,8 @@
     "path": "Proofs/Erdos79Problem.lean",
     "sorries": 1,
     "additionalFiles": [
-      "Proofs/Erdos79ProblemAristotle.lean"
+      "Proofs/Erdos79ProblemAristotle.lean",
+      "Proofs/Erdos79Aristotle.lean"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Register the existing `Proofs/Erdos79Aristotle.lean` companion file in `src/data/proofs/erdos-79/meta.json`'s `additionalFiles` arrays so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `Erdos79Aristotle.lean` exists on disk (68 lines, 8 routine supporting lemmas with sorries: K2/K3/K4 edge counts, vertex counts, complete-graph edge-count formula, and choose(n,2) helpers — all sized for the Ramsey-size-linearity context) but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`. Only the sibling `Erdos79ProblemAristotle.lean` was declared.

**After**: Both companions are registered in both arrays. The gallery now surfaces `Erdos79Aristotle.lean` alongside `Erdos79Problem.lean` and `Erdos79ProblemAristotle.lean`.

This is a metadata-only fix; the Lean file content is unchanged. Same pattern as #21331 (erdos-877), #21328 (erdos-160), #21330 (erdos-268).

---
Automated fix by lean-mechanic agent.