### PR TITLE
fix(meta): erdos-476 register Erdos476Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-476/meta.json
+++ b/src/data/proofs/erdos-476/meta.json
@@ -58,7 +58,10 @@
     "lineCount": 384,
     "assumptions": "1 axiom: erdos_heilbronn_bound (the Erdős-Heilbronn bound). All other results (AP_restrictedSumset, AP_achieves_bound, card_two_case, etc.) are fully proved theorems. 0 sorries.",
     "theoremCount": 10,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "additionalFiles": [
+      "Proofs/Erdos476Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #476: The Erdős-Heilbronn Conjecture**\n\nThis classic conjecture in additive combinatorics concerns restricted sumsets in finite fields.\n\n**Key History:**\n- Erdős-Heilbronn (1964): Conjectured the bound |A +̂ A| ≥ min(2|A| - 3, p)\n- da Silva-Hamidoune (1994): Proved using exterior algebra (Grassmann derivatives)\n- Alon-Nathanson-Ruzsa (1995): Alternative proof via polynomial method\n\n**Mathematical Setting:**\nThe restricted sumset A +̂ A contains only sums a + b where a ≠ b, excluding diagonal elements 2a. This seemingly small change from ordinary sumsets leads to deep mathematics.",
@@ -187,7 +190,10 @@
     "theoremCount": 10,
     "definitionCount": 4,
     "path": "Proofs/Erdos476Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos476Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the existing `proofs/Proofs/Erdos476Aristotle.lean` companion file in `src/data/proofs/erdos-476/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` had no `additionalFiles` field; the companion was orphaned (present on disk, invisible in the gallery).
**After**: `additionalFiles: ["Proofs/Erdos476Aristotle.lean"]` added under both `meta` and `leanFile`.

**Companion contents** (78 lines, 0 sorries):
- `card_two_case`: for |A| = 2 in `ZMod p`, `|A +̂ A| = 1` via ZMod commutativity
- `ap_card_eq_n`: arithmetic progression of length n has cardinality n when `d ≠ 0` and `n ≤ p`, via injectivity of `i ↦ a + i·d` in the field `ZMod p`

Both lemmas are fully proved supporting facts for the Erdős-Heilbronn (#476) formalization. No definition sorries, no axioms, no `True` placeholders.

---
Automated fix by lean-mechanic agent.