### PR TITLE
fix(meta): erdos-552 register Erdos552Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "No axioms. 12 sorry(s) remain in the formalization.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "additionalFiles": [
+      "Proofs/Erdos552Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This $100 Erdős problem was posed by Burr, Erdős, Faudree, Rousseau, and Schelp in 1989. It asks for the precise asymptotic behavior of R(C₄, Sₙ), the Ramsey number of the 4-cycle versus the star graph K_{1,n}. Parsons (1975) established the upper bound R(C₄, Sₙ) ≤ n + ⌈√n⌉ + 1 using the Kővári-Sós-Turán theorem, which bounds the number of edges in C₄-free graphs. Parsons also determined exact values when n is related to prime powers: R(C₄, S_{q²+1}) = n + q using the polarity graph of the projective plane PG(2,q), a remarkable C₄-free extremal graph with q²+q+1 vertices. BEFRS (1989) proved the lower bound R(C₄, Sₙ) ≥ n + √n - 6n^{11/40}, where the exponent 11/40 comes from Huxley's prime gap bound. The problem is deeply connected to analytic number theory: the exact value of R(C₄, Sₙ) depends on how close n is to q² for a prime power q, and finding such q requires prime gap estimates. Under Cramér's conjecture on prime gaps, the lower bound would improve to n + √n - n^{o(1)}, nearly closing the gap. All known exact values lie in {n + ⌈√n⌉, n + ⌈√n⌉ + 1}, a remarkably narrow range. The $100 prize question asks: for any c > 0, are there infinitely many n with R(C₄, Sₙ) ≤ n + √n - c?",
@@ -159,7 +162,10 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "path": "Proofs/Erdos552Problem.lean",
-    "sorries": 12
+    "sorries": 12,
+    "additionalFiles": [
+      "Proofs/Erdos552Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos552Aristotle.lean` companion file in `src/data/proofs/erdos-552/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` had no `additionalFiles` field in either the `meta` or `leanFile` block, even though `proofs/Proofs/Erdos552Aristotle.lean` exists on disk (117 lines, 7 Aristotle target lemmas — Parsons upper bound, BEFRS lower bound, three exact-value identities at prime-power parameters, projective-plane construction witness, and the min-degree implies C_4 lemma). The companion file was added in #12427 but never registered in metadata.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` list `Proofs/Erdos552Aristotle.lean`, matching the registration pattern established by #21295 (erdos-1048) and #21328 (erdos-160).

## Validation

- `jq .` parses the updated meta.json.
- `jq '.meta.additionalFiles, .leanFile.additionalFiles'` shows the new entry in both locations.
- Companion file passes Aristotle pre-submission checks: 0 `def ... := sorry`, 0 `axiom`, no `True`-stub theorems, no `/-!` docstring sections.

---
Automated fix by lean-mechanic agent.