### PR TITLE
fix(meta): erdos-501 register Erdos501Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "0 axioms, 3 sorries. CH is defined as a Prop (not axiom), used as hypothesis to Hechler's theorem. Gladysz proved from NPS.",
     "mathlib_version": "4.26.0",
     "theoremCount": 10,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "additionalFiles": [
+      "Proofs/Erdos501Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős and Hajnal posed this problem around 1960, connecting combinatorial independence with measure theory and set-theoretic foundations. Their 1960 theorem that arbitrarily large finite independent sets exist uses a probabilistic/measure-theoretic argument: since each $A_x$ has outer measure $< 1$, the 'forbidden region' for any finite set of points has total measure less than the length of the interval, leaving room for an additional independent point. Gladysz (1962) showed that for closed families, even size-2 independent sets exist — a non-trivial fact since closedness provides topological structure. The dramatic set-theoretic turn came with Hechler (1972), who constructed under the Continuum Hypothesis a bounded outer measure family with no infinite independent set. This used a CH-powered diagonalization: well-ordering the reals in type $\\omega_1$ and building each $A_x$ to prevent infinite independence. The positive resolution for closed sets came from Newelski, Pawlikowski, and Seredyński (1987), who proved in ZFC alone that closed measure families always admit infinite independent sets. This is one of the cleanest examples in mathematics where the answer to a natural analytic question depends on set-theoretic axioms.",
@@ -141,7 +144,10 @@
     "theoremCount": 10,
     "definitionCount": 12,
     "path": "Proofs/Erdos501Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos501Aristotle.lean"
+    ]
   },
   "references": [
     "Erdős & Hajnal (1960): finite independent sets exist",


### PR DESCRIPTION
## Fix

Register the existing `proofs/Proofs/Erdos501Aristotle.lean` companion file in `src/data/proofs/erdos-501/meta.json` so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: `meta.json` had no `additionalFiles` field; the companion was orphaned (present on disk, invisible in the gallery).
**After**: `additionalFiles: ["Proofs/Erdos501Aristotle.lean"]` added under both `meta` and `leanFile`.

**Companion contents** (158 lines, 0 sorries, 0 axioms):
- `bounded_empty`, `bounded_subset`, `bounded_union`, `bounded_inter_Icc` — boundedness lemmas for the family domain
- `outerMeasure_mono`, `outerMeasure_inter_le`, `outerMeasure_union_le` — Lebesgue outer-measure monotonicity and subadditivity
- `exists_not_mem_of_outerMeasure_lt_Icc`, `measure_compl_Icc_pos` — extraction lemmas used by the Erdős-Hajnal forbidden-region argument
- `isClosed_measurableSet`, `closed_outerMeasure_eq_measure` — interface lemmas for the closed-family branch
- `independent_size_zero`, `independent_size_one` — base cases for size-n independence

All routine supporting lemmas for the Erdős-Hajnal (1960) finite-independence theorem. No definition sorries, no axiom declarations, no `True` placeholders, no `/-!` docstring sections.

---
Automated fix by lean-mechanic agent.