### PR TITLE
fix(meta): erdos-922 register Erdos922Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 4 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Erdos922Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Hajnal in 1967 as they studied connections between local graph properties and chromatic number. The condition that every subgraph has a large independent set is a strong structural constraint. Surprisingly, they could not prove even the k=1 case, though k=0 is trivial (it implies bipartiteness). Jon Folkman proved the general result in 1970, establishing that the chromatic bound k+2 always holds. This is a beautiful example of how local constraints (subgraph structure) control global properties (chromatic number).",
@@ -154,7 +157,10 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos922Problem.lean",
-    "sorries": 4
+    "sorries": 4,
+    "additionalFiles": [
+      "Proofs/Erdos922Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `proofs/Proofs/Erdos922Aristotle.lean` companion file in `src/data/proofs/erdos-922/meta.json` (both `meta.additionalFiles` and `leanFile.additionalFiles`) so the gallery surfaces it alongside the main proof.

## Evidence

**Before**: companion file exists on disk but `.meta.additionalFiles` and `.leanFile.additionalFiles` are both `null` — the gallery does not surface the Aristotle companion.

**After**: both fields list `Proofs/Erdos922Aristotle.lean`, matching the pattern established by #21295 (erdos-1048), #21328 (erdos-160), and #21398 (erdos-501).

Companion contents (45 lines, 0 sorries, 0 axioms):
- bipartite_chromatic_le_two: IsBipartite ⇒ chromaticNumber ≤ 2
- ratio_ge_of_two_card_bound: rational arithmetic for Folkman density bound

Pre-submission gates pass: no def-sorries, no axioms, no True placeholders, no /-! docstring sections.

---
Automated fix by lean-mechanic agent.