### PR TITLE
fix(meta): erdos-1043 complete leanFile.additionalFiles registration

### DIFF
--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -261,7 +261,10 @@
     "theoremCount": 12,
     "definitionCount": 15,
     "sorries": 4,
-    "path": "Proofs/Erdos1043Problem.lean"
+    "path": "Proofs/Erdos1043Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos1043Aristotle.lean"
+    ]
   },
   "sorries": 4
 }


### PR DESCRIPTION
## Fix

Add `Proofs/Erdos1043Aristotle.lean` to `.leanFile.additionalFiles` in `src/data/proofs/erdos-1043/meta.json` to mirror the existing entry in `.meta.additionalFiles`.

## Evidence

**Before**: `.meta.additionalFiles` lists the companion (added in PR #21288) but `.leanFile.additionalFiles` is `null` — half-registered.

**After**: both sites list `Proofs/Erdos1043Aristotle.lean`, matching the dual-registration pattern in erdos-160 (#21328), erdos-501 (#21398), and erdos-922 (#21400).

The companion file already exists on disk (45 lines, 0 sorries, 0 axioms — routine ENNReal/iInf lemmas for the Pommerenke EHP work). No Lean file changes needed.

---
Automated fix by lean-mechanic agent.