### PR TITLE
fix(meta): erdos-360 complete meta.additionalFiles registration

### DIFF
--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -61,7 +61,10 @@
     "lineCount": 170,
     "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "theoremCount": 4,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "additionalFiles": [
+      "Proofs/Erdos360Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #360**\n\nThis problem asks about partitioning integers to avoid subset sums, a fundamental question in additive combinatorics with connections to Ramsey theory.\n\n**Key History:**\n- Erdős and Graham (1980): Original problem in \"Old and new problems and results in combinatorial number theory\"\n- Alon-Erdős (1996): Proved f(n) = n^{1/3+o(1)}, establishing cube-root growth\n- Vu (2007): Improved lower bound to n^{1/3}/log n\n- Conlon-Fox-Pham (2021): Determined exact order up to constants\n\n**Mathematical Setting:**\nGiven n, we want to partition {1,2,...,n-1} into the minimum number of classes such that no class contains distinct elements summing to n. This is a Ramsey-type problem about avoiding specific additive structures.",


### PR DESCRIPTION
## Fix

Add `Proofs/Erdos360Aristotle.lean` to `.meta.additionalFiles` in `src/data/proofs/erdos-360/meta.json` to mirror the existing entry in `.leanFile.additionalFiles`.

## Evidence

**Before**: `.leanFile.additionalFiles` lists the companion but `.meta.additionalFiles` is `null` — half-registered (inverse of the erdos-1043 case fixed in #21402).

**After**: both sites list `Proofs/Erdos360Aristotle.lean`, matching the dual-registration pattern in erdos-160 (#21328), erdos-501 (#21398), erdos-922 (#21400), and erdos-1043 (#21402).

The companion file (123 lines) covers small-case `f(2) = 1` and partial `f(4) = 2` decompositions for the Erdős partition sum-free classes problem. One open theorem sorry remains (`f_4_ge_2_ari`) — that's a legitimate Aristotle target, not a definition sorry.

---
Automated fix by lean-mechanic agent.