### PR TITLE
fix(meta): erdos-531 register Erdos531Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-531/meta.json
+++ b/src/data/proofs/erdos-531/meta.json
@@ -56,7 +56,10 @@
     "lineCount": 171,
     "assumptions": "2 axioms: folkman_theorem, balogh_2017. 2 sorries.",
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Erdos531Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #531: Folkman's Theorem**\n\nThis problem asks about the quantitative aspects of Folkman's theorem, a fundamental result in Ramsey theory.\n\n**Key History:**\n- Sanders and Folkman (1960s): Proved the existence of F(k)\n- Rado's theorem (1933): Provides an alternative proof via partition regularity\n- Erdős-Spencer (1989): First non-trivial lower bound F(k) ≥ 2^{ck²/log k}\n- Balogh et al. (2017): Improved to F(k) ≥ 2^{2^{k-1}/k}\n\n**Mathematical Setting:**\nThe function F(k) is the Folkman number: the minimum N such that any 2-coloring of {1,...,N} contains a k-element subset where all 2^k - 1 non-empty subset sums are monochromatic.",
@@ -177,7 +180,10 @@
     "theoremCount": 6,
     "definitionCount": 6,
     "path": "Proofs/Erdos531Problem.lean",
-    "sorries": 2
+    "sorries": 2,
+    "additionalFiles": [
+      "Proofs/Erdos531Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register orphaned `Proofs/Erdos531Aristotle.lean` companion file in `src/data/proofs/erdos-531/meta.json` so the gallery surfaces the Aristotle companion targets for Erdős Problem #531 (Folkman's Theorem).

## Evidence

**Before**: `proofs/Proofs/Erdos531Aristotle.lean` existed on disk but was not referenced from `src/data/proofs/erdos-531/meta.json`, so the gallery treated it as orphaned and the deployer skipped its targets.

**After**: `"Proofs/Erdos531Aristotle.lean"` is registered in both `meta.additionalFiles` and `leanFile.additionalFiles`, matching the pattern used for sibling mechanic fixes (erdos-160 #21328, erdos-268 #21330, erdos-476 edfeb94, erdos-877 #21331).

The companion file is clean: no `def := sorry`, no `axiom` declarations, no `True`-stub placeholders, no `/-!` sections — only routine supporting lemmas and small-case theorems suitable for Aristotle proof search.

---
Automated fix by lean-mechanic agent.