### PR TITLE
fix(meta): erdos-901 register Erdos901Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -23,6 +23,7 @@
     "definitionCount": 10,
     "theoremCount": 19,
     "additionalFiles": [
+      "Proofs/Erdos901Aristotle.lean",
       "Proofs/Erdos901ProblemAristotle.lean"
     ]
   },
@@ -90,6 +91,7 @@
     "theoremCount": 19,
     "definitionCount": 10,
     "additionalFiles": [
+      "Proofs/Erdos901Aristotle.lean",
       "Proofs/Erdos901ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Registers `Proofs/Erdos901Aristotle.lean` in `src/data/proofs/erdos-901/meta.json` under both `.meta.additionalFiles` and `.leanFile.additionalFiles`.

## Evidence

**Before**: meta listed only `Erdos901ProblemAristotle.lean`. The sibling companion `Erdos901Aristotle.lean` existed on disk (since 2026-04-27) but was orphaned — invisible to the gallery and Aristotle pipeline.

**After**: both Aristotle companion files are now registered in both sites.

Aristotle pre-submission gate verified clean on `Erdos901Aristotle.lean`:
- No `def ... := sorry`
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` module docstrings

Pattern established by #21295, #21328, #21330, #21331, #21398, #21400, #21402, #21403.

---
Automated fix by lean-mechanic agent.