### PR TITLE
fix(meta): erdos-667 register Erdos667Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-667/meta.json
+++ b/src/data/proofs/erdos-667/meta.json
@@ -65,7 +65,10 @@
     "assumptions": "4 axiom declarations (cpq_lower_ramsey, cpq_upper_ramsey, cpq_at_max, efrs_bound) encoding deep mathematical results. Previously 8 axioms; 4 eliminated by defining cpq via Filter.liminf and proving cpq_nonneg, cpq_le_one, cpq_mono_q from the definition.",
     "mathlib_version": "4.26.0",
     "theoremCount": 36,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Erdos667Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {
@@ -200,7 +203,10 @@
     "theoremCount": 36,
     "definitionCount": 6,
     "path": "Proofs/Erdos667Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos667Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register orphaned `Proofs/Erdos667Aristotle.lean` companion file in `src/data/proofs/erdos-667/meta.json` so the gallery surfaces the Aristotle companion targets for Erdős Problem #667 (Clique Density Exponent).

## Evidence

**Before**: `proofs/Proofs/Erdos667Aristotle.lean` existed on disk but was not referenced from `src/data/proofs/erdos-667/meta.json`, so the gallery treated it as orphaned and the deployer skipped its targets.

**After**: `"Proofs/Erdos667Aristotle.lean"` is registered in both `meta.additionalFiles` and `leanFile.additionalFiles`, matching the pattern used for sibling mechanic fixes (erdos-160, erdos-268, erdos-476, erdos-531, erdos-877).

The companion file is clean: no `def := sorry`, no `axiom` declarations, no `True`-stub placeholders, no `/-!` sections — only routine supporting lemmas for Aristotle proof search.

---
Automated fix by lean-mechanic agent.