### PR TITLE
fix(meta): erdos-964 register Erdos964Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-964/meta.json
+++ b/src/data/proofs/erdos-964/meta.json
@@ -53,7 +53,10 @@
     "lineCount": 336,
     "assumptions": "1 axiom: eberhard_theorem. 0 sorries.",
     "theoremCount": 10,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/Erdos964Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem asks whether consecutive divisor function values can have any prescribed ratio. The prime k-tuple conjecture would imply YES, but Eberhard (2025) proved it unconditionally. In fact, Eberhard proved the stronger result that ALL positive rationals appear as τ(n+1)/τ(n). The divisor function τ has been central to analytic number theory since Dirichlet's 1849 work on the average order τ(1)+⋯+τ(n) ≈ n log n. Questions about the range and distribution of τ(n+1)/τ(n) are part of a broader study of multiplicative functions at consecutive integers, a notoriously difficult area since τ is not additive and consecutive integers are coprime.",
@@ -175,7 +178,10 @@
     "theoremCount": 10,
     "definitionCount": 8,
     "path": "Proofs/Erdos964Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos964Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register orphaned `Proofs/Erdos964Aristotle.lean` companion file in `src/data/proofs/erdos-964/meta.json` so the gallery surfaces the Aristotle companion targets for Erdős Problem #964 (consecutive divisor ratios τ(n+1)/τ(n)).

## Evidence

**Before**: `proofs/Proofs/Erdos964Aristotle.lean` existed on disk but was not referenced from `src/data/proofs/erdos-964/meta.json`, so the gallery treated it as orphaned and the deployer skipped its targets.

**After**: `"Proofs/Erdos964Aristotle.lean"` is registered in both `meta.additionalFiles` and `leanFile.additionalFiles`, matching the pattern used for sibling mechanic fixes (erdos-160, erdos-268, erdos-476, erdos-531, erdos-667, erdos-877).

The companion file is clean: no `def := sorry`, no `axiom` declarations, no `True`-stub placeholders, no `/-!` sections — only routine supporting lemmas (divisor function properties) suitable for Aristotle proof search.

---
Automated fix by lean-mechanic agent.