### PR TITLE
audit(erdos-170): mark clean (cycle 4) — sparse rulers axiom integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4949,12 +4949,12 @@
       "result": "clean"
     },
     "erdos-170": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom F_lower_two axiom + non-existent N=3/N=30 examples + section line drift (issue #14673)"
       ],
-      "lastAudited": "2026-05-02T08:45:39Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T09:02:11Z",
+      "result": "clean"
     },
     "erdos-171": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary
- Audited Erdős Problem #170 (Sparse Rulers / Perfect Difference Bases)
- Verified meta.json claims against `proofs/Proofs/Erdos170Problem.lean`
- Result: **clean** — no integrity issues found

## Audit Verification

| Claim | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| Line count | 146 | 146 | ✓ |
| Axiom count | 3 | 3 (erdos_gal_limit_exists, leech_lower_bound, wichmann_upper_bound) | ✓ |
| Sorry count | 0 | 0 | ✓ |
| Theorem count | 4 | 4 (trivial_is_perfect, F_nonempty, F_upper_trivial, limit_in_interval) | ✓ |
| Definition count | 7 | 7 (IsPerfectRuler, IsRestrictedPerfectRuler, trivialRuler, F, limitValue, IsUnrestrictedPerfectRuler, F') | ✓ |
| Badge | \`axiom\` | matches \`axiomatized\` status | ✓ |
| True stubs | none | none | ✓ |

## Tier Classification

**Tier C — Scaffold / axiomatized**. The main result (limit existence and bounds [1.56, √3]) is axiomatized via three explicit axioms. The Lean file proves the definitions, trivial bounds, and the interval conclusion conditional on those axioms. Title and conclusion correctly present this as OPEN with axiomatized bounds — no overclaiming detected.

## Test plan
- [x] Compared meta.axiomCount to axiom declarations in Lean source
- [x] Compared sorries count to actual sorry occurrences
- [x] Verified theorem/definition counts
- [x] Checked for True stubs and Mathlib-wrapper overclaiming
- [x] Validated badge/status consistency with content

🤖 Generated with [Claude Code](https://claude.com/claude-code)