### PR TITLE
fix(meta): erdos-512 register Erdos512Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-512/meta.json
+++ b/src/data/proofs/erdos-512/meta.json
@@ -69,7 +69,10 @@
     "lineCount": 368,
     "assumptions": "2 axioms: konyagin_theorem, mcgehee_pigno_smith_theorem.",
     "theoremCount": 14,
-    "definitionCount": 16
+    "definitionCount": 16,
+    "additionalFiles": [
+      "Proofs/Erdos512Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Littlewood conjectured in the 1960s that the $L^1$ norm of any exponential sum with $N$ terms is at least $c \\log N$. Specifically, if $A \\subset \\mathbb{Z}$ is a finite set with $|A| = N$, then $\\int_0^1 |\\sum_{n \\in A} e^{2\\pi i n\\theta}|\\,d\\theta \\geq c \\log N$ for an absolute constant $c > 0$. This is a fundamental question about how \"flat\" a trigonometric polynomial with unit coefficients can be.\n\nThe conjecture was independently proved in 1981 by two groups. Konyagin gave an analytic proof using character sum estimates and concentration inequalities. McGehee, Pigno, and Smith gave an elegant proof based on Hardy's inequality for power series. The MPS approach is widely considered the more beautiful: they showed that Hardy's classical inequality $\\sum_{n=1}^\\infty \\frac{1}{n}(\\sum_{k=1}^n a_k)^2 \\leq 4\\sum a_n^2$ applied to the Fourier coefficients of $|S_A|$ directly yields the logarithmic lower bound via the harmonic series $\\sum_{k=1}^N 1/k \\sim \\log N$.\n\nThe bound is tight: the Dirichlet kernel $D_N(\\theta) = \\sum_{n=0}^{N-1} e^{2\\pi i n\\theta} = \\sin(N\\pi\\theta)/\\sin(\\pi\\theta)$ has $L^1$ norm $(4/\\pi^2)\\log N + O(1)$, which is the Lebesgue constant from classical Fourier analysis. This means arithmetic progressions are essentially the worst-case sets for Littlewood's bound.\n\nThe result connects to several areas: the flat polynomial problem (can $|P(z)|$ be nearly constant on $|z|=1$ for polynomials with $\\pm 1$ coefficients?), the Rudin-Shapiro construction, equidistribution theory via Weyl's criterion, and character sum bounds in analytic number theory. Erdős included it as Problem #512, emphasizing its role as a bridge between harmonic analysis and combinatorial number theory.",
@@ -221,7 +224,10 @@
     "theoremCount": 14,
     "definitionCount": 16,
     "path": "Proofs/Erdos512Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos512Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos512Aristotle.lean` companion file in `src/data/proofs/erdos-512/meta.json` so the gallery surfaces the Aristotle companion targets for Erdős Problem #512 (Littlewood's conjecture on L¹ norms of exponential sums).

## Evidence

**Before**: `proofs/Proofs/Erdos512Aristotle.lean` existed on disk but was not referenced anywhere in `src/data/proofs/erdos-512/meta.json` — neither in `meta.additionalFiles` nor in `leanFile.additionalFiles`.

**After**: `"Proofs/Erdos512Aristotle.lean"` is registered in both `meta.additionalFiles` and `leanFile.additionalFiles`, matching the canonical pattern established by the erdos-964 / erdos-877 / erdos-268 / erdos-160 mechanic fixes.

JSON validated with `python3 -c "import json; json.load(open(...))"`.

---
Automated fix by lean-mechanic agent.