### PR TITLE
fix(meta): erdos-553 register Erdos553Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-553/meta.json
+++ b/src/data/proofs/erdos-553/meta.json
@@ -52,6 +52,7 @@
     "theoremCount": 12,
     "definitionCount": 14,
     "additionalFiles": [
+      "Proofs/Erdos553Aristotle.lean",
       "Proofs/Erdos553ProblemAristotle.lean"
     ]
   },
@@ -166,6 +167,7 @@
     "path": "Proofs/Erdos553Problem.lean",
     "sorries": 15,
     "additionalFiles": [
+      "Proofs/Erdos553Aristotle.lean",
       "Proofs/Erdos553ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register `Erdos553Aristotle.lean` companion file in both `.meta.additionalFiles` and `.leanFile.additionalFiles` for slug `erdos-553`, alongside the already-registered `Erdos553ProblemAristotle.lean`.

## Evidence

**Before**: `Erdos553Aristotle.lean` existed on disk at `proofs/Proofs/Erdos553Aristotle.lean` but was orphaned from `src/data/proofs/erdos-553/meta.json` — only its sibling `Erdos553ProblemAristotle.lean` was registered.

**After**: Both Aristotle companion files registered in both `.meta.additionalFiles` and `.leanFile.additionalFiles`.

Pre-submission gates for the newly-registered file pass: no `def ... := sorry`, no `axiom` declarations, no `theorem ... : True` placeholders, and no `/-!` docstring sections.

---
Automated fix by lean-mechanic agent.