### PR TITLE
fix(meta): erdos-608 register Erdos608Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-608/meta.json
+++ b/src/data/proofs/erdos-608/meta.json
@@ -65,6 +65,7 @@
     "theoremCount": 14,
     "definitionCount": 15,
     "additionalFiles": [
+      "Proofs/Erdos608Aristotle.lean",
       "Proofs/Erdos608ProblemAristotle.lean"
     ]
   },
@@ -214,6 +215,7 @@
     "sorries": 13,
     "path": "Proofs/Erdos608Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos608Aristotle.lean",
       "Proofs/Erdos608ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos608Aristotle.lean` companion file in `src/data/proofs/erdos-608/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #608 (Füredi-Maleki C₅-Saturated Graphs).

## Evidence

**Before**: `meta.json` listed only `Proofs/Erdos608ProblemAristotle.lean` in both `additionalFiles` arrays — `Erdos608Aristotle.lean` (the routine √2/Turán-edges consequence lemmas companion) was orphaned and invisible to the gallery.

**After**: Both Aristotle companions are registered in both `additionalFiles` arrays. JSON validated.

```diff
     "additionalFiles": [
+      "Proofs/Erdos608Aristotle.lean",
       "Proofs/Erdos608ProblemAristotle.lean"
     ]
```

(Two identical insertions — one in the top-level `meta.additionalFiles` and one in the path-block `additionalFiles`.)

---
Automated fix by lean-mechanic agent.