### PR TITLE
fix(meta): erdos-922 register Erdos922Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-922/meta.json
+++ b/src/data/proofs/erdos-922/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "2 axioms: folkman_theorem, folkman_bound_tight. 4 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Erdos922Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and Hajnal in 1967 as they studied connections between local graph properties and chromatic number. The condition that every subgraph has a large independent set is a strong structural constraint. Surprisingly, they could not prove even the k=1 case, though k=0 is trivial (it implies bipartiteness). Jon Folkman proved the general result in 1970, establishing that the chromatic bound k+2 always holds. This is a beautiful example of how local constraints (subgraph structure) control global properties (chromatic number).",
@@ -154,7 +157,10 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos922Problem.lean",
-    "sorries": 4
+    "sorries": 4,
+    "additionalFiles": [
+      "Proofs/Erdos922Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos922Aristotle.lean` companion file in `src/data/proofs/erdos-922/meta.json` so the gallery surfaces both the problem file and its Aristotle companion for Folkman's chromatic-number bound (Erdős Problem #922).

## Evidence

**Before**: `src/data/proofs/erdos-922/meta.json` had no `additionalFiles` entry in either `meta` or `leanFile`. `proofs/Proofs/Erdos922Aristotle.lean` (45 lines, well-formed companion targeting `bipartite_chromatic_le_two` and a routine ratio lemma) existed on disk but was invisible to the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` list `Proofs/Erdos922Aristotle.lean`, matching the registration pattern from #21328 (erdos-160), #21330 (erdos-268), #21331 (erdos-877), #21336 (erdos-318), #21337 (erdos-260), #21338 (erdos-840), #21339 (erdos-820).

---
Automated fix by lean-mechanic agent.