### PR TITLE
fix(meta): erdos-610 register Erdos610Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -93,6 +93,7 @@
     "theoremCount": 13,
     "definitionCount": 16,
     "additionalFiles": [
+      "Proofs/Erdos610Aristotle.lean",
       "Proofs/Erdos610ProblemAristotle.lean"
     ]
   },
@@ -215,6 +216,7 @@
     "path": "Proofs/Erdos610Problem.lean",
     "sorries": 17,
     "additionalFiles": [
+      "Proofs/Erdos610Aristotle.lean",
       "Proofs/Erdos610ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos610Aristotle.lean` companion file in `src/data/proofs/erdos-610/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #610 (Clique Transversal Numbers).

## Evidence

**Before**: `meta.json` listed only `Proofs/Erdos610ProblemAristotle.lean` in both `additionalFiles` arrays — `Erdos610Aristotle.lean` (the routine τ-bound consequence lemmas companion: `tau_le_card_ari`, `tau_empty_ari`, `tau_complete_ari`) was orphaned and invisible to the gallery.

**After**: Both Aristotle companions are registered in both `additionalFiles` arrays. JSON validated.

```diff
     "additionalFiles": [
+      "Proofs/Erdos610Aristotle.lean",
       "Proofs/Erdos610ProblemAristotle.lean"
     ]
```

(Two identical insertions — one in the top-level `meta.additionalFiles` and one in the path-block `additionalFiles`.)

---
Automated fix by lean-mechanic agent.