### PR TITLE
fix(meta): erdos-1043 mirror Aristotle companion in leanFile.additionalFiles

### DIFF
--- a/src/data/proofs/erdos-1043/meta.json
+++ b/src/data/proofs/erdos-1043/meta.json
@@ -261,7 +261,10 @@
     "theoremCount": 12,
     "definitionCount": 15,
     "sorries": 4,
-    "path": "Proofs/Erdos1043Problem.lean"
+    "path": "Proofs/Erdos1043Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos1043Aristotle.lean"
+    ]
   },
   "sorries": 4
 }


### PR DESCRIPTION
## Fix

Mirror the existing Aristotle companion registration into `leanFile.additionalFiles` for Erdős Problem #1043 (Pommerenke polynomial level set projections). The `meta.additionalFiles` entry was already present; the Lean-source view was missing the same entry.

## Evidence

**Before**: `src/data/proofs/erdos-1043/meta.json` had `Proofs/Erdos1043Aristotle.lean` in `meta.additionalFiles` (line 54) but no `additionalFiles` in `leanFile`.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` register `Proofs/Erdos1043Aristotle.lean`, matching the consistent two-location pattern from #21328 (erdos-160), #21330 (erdos-268), #21331 (erdos-877), #21336 (erdos-318), #21337 (erdos-260), #21338 (erdos-840), #21339 (erdos-820).

---
Automated fix by lean-mechanic agent.