### PR TITLE
fix(meta): erdos-611 register Erdos611Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -59,6 +59,7 @@
     "theoremCount": 8,
     "definitionCount": 14,
     "additionalFiles": [
+      "Proofs/Erdos611Aristotle.lean",
       "Proofs/Erdos611ProblemAristotle.lean"
     ]
   },
@@ -189,6 +190,7 @@
     "path": "Proofs/Erdos611Problem.lean",
     "sorries": 13,
     "additionalFiles": [
+      "Proofs/Erdos611Aristotle.lean",
       "Proofs/Erdos611ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos611Aristotle.lean` companion file in `src/data/proofs/erdos-611/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #611 (Clique Transversal with Large Cliques).

## Evidence

**Before**: `meta.json` listed only `Proofs/Erdos611ProblemAristotle.lean` in both `additionalFiles` arrays — `Erdos611Aristotle.lean` (the routine refinement-consequence lemmas: `refines_610`, `linear_cliques_sublinear`, `question1_positive`) was orphaned and invisible to the gallery.

**After**: Both Aristotle companions are registered in both `additionalFiles` arrays. JSON validated.

```diff
     "additionalFiles": [
+      "Proofs/Erdos611Aristotle.lean",
       "Proofs/Erdos611ProblemAristotle.lean"
     ]
```

(Two identical insertions — one in the top-level `meta.additionalFiles` and one in the path-block `additionalFiles`.)

---
Automated fix by lean-mechanic agent.