### PR TITLE
fix(meta): erdos-620 register Erdos620Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-620/meta.json
+++ b/src/data/proofs/erdos-620/meta.json
@@ -60,6 +60,7 @@
     "theoremCount": 8,
     "definitionCount": 15,
     "additionalFiles": [
+      "Proofs/Erdos620Aristotle.lean",
       "Proofs/Erdos620ProblemAristotle.lean"
     ]
   },
@@ -247,6 +248,7 @@
     "path": "Proofs/Erdos620Problem.lean",
     "sorries": 4,
     "additionalFiles": [
+      "Proofs/Erdos620Aristotle.lean",
       "Proofs/Erdos620ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned Aristotle companion `Proofs/Erdos620Aristotle.lean` (already on disk) in both `meta.additionalFiles` and `leanFile.additionalFiles` of `src/data/proofs/erdos-620/meta.json`. Sibling-completion alongside existing `Erdos620ProblemAristotle.lean`.

## Evidence

**Before**: `Erdos620Aristotle.lean` existed on disk but neither `meta.additionalFiles` nor `leanFile.additionalFiles` listed it. Only `Erdos620ProblemAristotle.lean` was registered.

**After**: Both arrays now list both companion files in alphabetical order.

Pre-submission gates pass (no `def...sorry`, `axiom`, `True`-stub, or `/-!` docstring sections in the companion file).

---
Automated fix by lean-mechanic agent.