### PR TITLE
fix(meta): erdos-623 register Erdos623Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-623/meta.json
+++ b/src/data/proofs/erdos-623/meta.json
@@ -56,6 +56,7 @@
     "theoremCount": 13,
     "definitionCount": 10,
     "additionalFiles": [
+      "Proofs/Erdos623Aristotle.lean",
       "Proofs/Erdos623ProblemAristotle.lean"
     ]
   },
@@ -206,6 +207,7 @@
     "path": "Proofs/Erdos623Problem.lean",
     "sorries": 5,
     "additionalFiles": [
+      "Proofs/Erdos623Aristotle.lean",
       "Proofs/Erdos623ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos623Aristotle.lean` companion file in `src/data/proofs/erdos-623/meta.json`.

## Evidence

**Before**: `Proofs/Erdos623Aristotle.lean` exists on disk but was not referenced in either `meta.additionalFiles` or `leanFile.additionalFiles`. Only `Proofs/Erdos623ProblemAristotle.lean` was registered.

**After**: Both companion files (`Erdos623Aristotle.lean` and `Erdos623ProblemAristotle.lean`) are now registered in both arrays, matching the established pattern used for siblings like erdos-611.

---
Automated fix by lean-mechanic agent.