### PR TITLE
fix(meta): erdos-125 register Erdos125PositiveLowerDensityAristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -9,7 +9,8 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos125Problem.lean",
     "additionalFiles": [
-      "Proofs/Erdos125PositiveLowerDensity.lean"
+      "Proofs/Erdos125PositiveLowerDensity.lean",
+      "Proofs/Erdos125PositiveLowerDensityAristotle.lean"
     ],
     "tags": [
       "erdos",
@@ -142,7 +143,11 @@
     "theoremCount": 0,
     "definitionCount": 7,
     "path": "Proofs/Erdos125Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos125PositiveLowerDensity.lean",
+      "Proofs/Erdos125PositiveLowerDensityAristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos125PositiveLowerDensityAristotle.lean` companion in `src/data/proofs/erdos-125/meta.json` and mirror the entries into `leanFile.additionalFiles` (previously absent).

## Evidence

**Before**: `meta.additionalFiles` listed only `Proofs/Erdos125PositiveLowerDensity.lean`; the Aristotle companion (`Proofs/Erdos125PositiveLowerDensityAristotle.lean`, present on disk and well-formed — see its header "See Erdos125PositiveLowerDensity.lean for the main formalization") was orphaned. `leanFile.additionalFiles` did not exist.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` list both companion files (`Proofs/Erdos125PositiveLowerDensity.lean` and `Proofs/Erdos125PositiveLowerDensityAristotle.lean`), matching the consistent two-location pattern from #21328, #21330, #21331, #21336, #21337, #21338, #21339.

---
Automated fix by lean-mechanic agent.