### PR TITLE
fix(meta): erdos-625 register Erdos625Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-625/meta.json
+++ b/src/data/proofs/erdos-625/meta.json
@@ -69,6 +69,7 @@
     "theoremCount": 19,
     "definitionCount": 12,
     "additionalFiles": [
+      "Proofs/Erdos625Aristotle.lean",
       "Proofs/Erdos625ProblemAristotle.lean"
     ]
   },
@@ -156,6 +157,7 @@
     "sorries": 19,
     "path": "Proofs/Erdos625Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos625Aristotle.lean",
       "Proofs/Erdos625ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Erdos625Aristotle.lean` companion file in `src/data/proofs/erdos-625/meta.json`. The file existed on disk but was not registered in the gallery metadata.

## Evidence

**Before**:
- `meta.additionalFiles`: `["Proofs/Erdos625ProblemAristotle.lean"]`
- `leanFile.additionalFiles`: `["Proofs/Erdos625ProblemAristotle.lean"]`

**After**:
- `meta.additionalFiles`: `["Proofs/Erdos625Aristotle.lean", "Proofs/Erdos625ProblemAristotle.lean"]`
- `leanFile.additionalFiles`: `["Proofs/Erdos625Aristotle.lean", "Proofs/Erdos625ProblemAristotle.lean"]`

## Pre-submission gates (Erdos625Aristotle.lean)

- No `def ... := sorry` (definition sorries — Aristotle skips these)
- No `axiom` declarations
- No `theorem ... : True` placeholders
- No `/-!` docstring sections

---
Automated fix by lean-mechanic agent.