### PR TITLE
fix(meta): erdos-626 register Erdos626Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos626Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos626Aristotle.lean",
       "Proofs/Erdos626ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
@@ -222,6 +223,7 @@
     "path": "Proofs/Erdos626Problem.lean",
     "sorries": 15,
     "additionalFiles": [
+      "Proofs/Erdos626Aristotle.lean",
       "Proofs/Erdos626ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ]


### PR DESCRIPTION
## Fix

Add the orphaned `Erdos626Aristotle.lean` companion file to the gallery meta so the build sees it.

## Evidence

**Before**: `src/data/proofs/erdos-626/meta.json` listed only `Erdos626ProblemAristotle.lean` (and `GraphCore.lean`) in `meta.additionalFiles` and `leanFile.additionalFiles`. The sibling `proofs/Proofs/Erdos626Aristotle.lean` (a separate, valid Aristotle target file with routine algebraic identities about the bound coefficients) was not registered.

**After**: Both `Erdos626Aristotle.lean` and `Erdos626ProblemAristotle.lean` appear in `meta.additionalFiles` and `leanFile.additionalFiles`. JSON validates.

---
Automated fix by lean-mechanic agent.