### PR TITLE
fix(meta): erdos-627 register Erdos627Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -11,6 +11,7 @@
     "proofRepoPath": "Proofs/Erdos627Problem.lean",
     "additionalFiles": [
       "Proofs/Erdos627ProblemAristotle.lean",
+      "Proofs/Erdos627Aristotle.lean",
       "Proofs/GraphCore.lean"
     ],
     "tags": [
@@ -203,6 +204,7 @@
     "sorries": 16,
     "additionalFiles": [
       "Proofs/Erdos627ProblemAristotle.lean",
+      "Proofs/Erdos627Aristotle.lean",
       "Proofs/GraphCore.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos627Aristotle.lean` companion in `src/data/proofs/erdos-627/meta.json` so the gallery and Aristotle pipeline can see it.

## Evidence

**Before**: `meta.additionalFiles` and `leanFile.additionalFiles` listed only `Erdos627ProblemAristotle.lean` and `GraphCore.lean`. `Proofs/Erdos627Aristotle.lean` exists on disk (routine `limit_bounds_numerical_ari`, `chi_ge_omega_ari`, `ratio_ge_one_ari` lemmas) but was not registered.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos627Aristotle.lean` in addition to the previous entries.

---
Automated fix by lean-mechanic agent.