### PR TITLE
fix(meta): erdos-628 register Erdos628Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos628Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos628Aristotle.lean",
       "Proofs/Erdos628ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
@@ -225,6 +226,7 @@
     "path": "Proofs/Erdos628Problem.lean",
     "sorries": 12,
     "additionalFiles": [
+      "Proofs/Erdos628Aristotle.lean",
       "Proofs/Erdos628ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ]


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos628Aristotle.lean` companion file in `src/data/proofs/erdos-628/meta.json` alongside the already-registered `Erdos628ProblemAristotle.lean`.

## Evidence

**Before**: Only `Erdos628ProblemAristotle.lean` and `GraphCore.lean` were listed in `meta.additionalFiles` and `leanFile.additionalFiles`, leaving `Erdos628Aristotle.lean` invisible to the gallery.

**After**: Both Aristotle companions are listed in both `additionalFiles` arrays so the gallery surfaces them.

---
Automated fix by lean-mechanic agent.