### PR TITLE
fix(meta): erdos-630 register Erdos630Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos630Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos630Aristotle.lean",
       "Proofs/Erdos630ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
@@ -217,6 +218,7 @@
     "path": "Proofs/Erdos630Problem.lean",
     "sorries": 15,
     "additionalFiles": [
+      "Proofs/Erdos630Aristotle.lean",
       "Proofs/Erdos630ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ]


### PR DESCRIPTION
## Fix

Register the orphaned `Erdos630Aristotle.lean` companion file in the gallery meta so it gets picked up by the Aristotle pipeline and the build.

## Evidence

**Before**: `src/data/proofs/erdos-630/meta.json` listed only `Erdos630ProblemAristotle.lean` (and `GraphCore.lean`) in `meta.additionalFiles` and `leanFile.additionalFiles`. The sibling `proofs/Proofs/Erdos630Aristotle.lean` (5 routine list-colouring lemmas: `isKChoosable_mono`, `isListColoring_adj`, `bipartite_two_colorable`, `bipartite_chi_le_two`, `natClog_ge_one`) was not registered.

**After**: Both `Erdos630Aristotle.lean` and `Erdos630ProblemAristotle.lean` appear in both `additionalFiles` arrays. JSON validates.

Pre-submission gate on the companion file (no `def ... := sorry`, no `axiom`, no `theorem ... : True`, no `/-!`): clean.

---
Automated fix by lean-mechanic agent.