### PR TITLE
fix(meta): erdos-631 register Erdos631Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -10,6 +10,7 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos631Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos631Aristotle.lean",
       "Proofs/Erdos631ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ],
@@ -216,6 +217,7 @@
     "path": "Proofs/Erdos631Problem.lean",
     "sorries": 10,
     "additionalFiles": [
+      "Proofs/Erdos631Aristotle.lean",
       "Proofs/Erdos631ProblemAristotle.lean",
       "Proofs/GraphCore.lean"
     ]


### PR DESCRIPTION
## Fix

Register the orphaned `Erdos631Aristotle.lean` companion file (1 routine target: `choosable_monotone_ari`) in the gallery meta.

## Evidence

**Before**: `src/data/proofs/erdos-631/meta.json` listed only `Erdos631ProblemAristotle.lean` (and `GraphCore.lean`) in `meta.additionalFiles` and `leanFile.additionalFiles`. The sibling `proofs/Proofs/Erdos631Aristotle.lean` (k-choosable monotonicity lemma) was not registered.

**After**: Both `Erdos631Aristotle.lean` and `Erdos631ProblemAristotle.lean` appear in both `additionalFiles` arrays. JSON validates.

Pre-submission gate on the companion file (no `def ... := sorry`, no `axiom`, no `theorem ... : True`, no `/-!`): clean.

---
Automated fix by lean-mechanic agent.