### PR TITLE
fix(meta): erdos-632 register Erdos632Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-632/meta.json
+++ b/src/data/proofs/erdos-632/meta.json
@@ -56,7 +56,8 @@
     "theoremCount": 11,
     "definitionCount": 15,
     "additionalFiles": [
-      "Proofs/Erdos632ProblemAristotle.lean"
+      "Proofs/Erdos632ProblemAristotle.lean",
+      "Proofs/Erdos632Aristotle.lean"
     ]
   },
   "overview": {
@@ -184,7 +185,8 @@
     "path": "Proofs/Erdos632Problem.lean",
     "sorries": 5,
     "additionalFiles": [
-      "Proofs/Erdos632ProblemAristotle.lean"
+      "Proofs/Erdos632ProblemAristotle.lean",
+      "Proofs/Erdos632Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos632Aristotle.lean` companion file in the gallery metadata for erdos-632.

## Evidence

**Before**: `Erdos632Aristotle.lean` existed in `proofs/Proofs/` but was absent from both `meta.additionalFiles` and `leanFile.additionalFiles` arrays in `src/data/proofs/erdos-632/meta.json`. Only `Erdos632ProblemAristotle.lean` was registered.

**After**: Both `additionalFiles` arrays now include `Proofs/Erdos632Aristotle.lean` alongside the existing `Erdos632ProblemAristotle.lean`, so the companion is visible to gallery and Aristotle tooling.

The companion file exposes routine supporting lemmas around the `IsChoosable` definition (distinct from the main Dvořák–Hu–Sereni disproof) for Aristotle automated proof search.

JSON validated via `jq`.

---
Automated fix by lean-mechanic agent.