### PR TITLE
fix(meta): erdos-1100 register Aristotle companions

### DIFF
--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -25,7 +25,11 @@
     "assumptions": "3 axioms: tau_perp_lower_bound (τ⊥(n) ≥ ω(n), basic coprimality bound requiring intricate sorted-divisor reasoning), erdos_hall_max_lower_bound (max_{n<x} τ⊥(n) > exp((log log x)^(2−ε)), Erdős-Hall 1978), and erdos_simonovits_bounds (exponential bounds on g(k), Erdős-Simonovits).",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Erdos1100ProblemAristotle.lean",
+      "Proofs/Erdos1100OQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős and R. R. Hall in their 1978 paper *On some unconventional problems on the divisors of integers* (Acta Arithmetica). Hall was a specialist in multiplicative number theory at York, and this collaboration produced several problems exploring the fine structure of divisor sequences. The function $\\tau^{\\perp}(n)$ measures how often consecutive divisors in the increasing sequence $1 = d_1 < d_2 < \\cdots < d_{\\tau(n)} = n$ are coprime — a surprisingly subtle invariant. The trivial lower bound $\\tau^{\\perp}(n) \\geq \\omega(n)$ is immediate (each prime $p \\mid n$ contributes at least one coprime transition in the divisor list), and is tight infinitely often. The deeper questions concern whether $\\tau^{\\perp}(n)$ typically exceeds $\\omega(n)$ by a large factor. The exponential bounds on $g(k)$ are due to Erdős and Simonovits, who showed $\\sqrt{2}^k \\lesssim g(k) \\lesssim (2-c)^k$, revealing that the combinatorics of coprime transitions in divisor lattices is genuinely exponential but sub-maximal.",
@@ -278,7 +282,11 @@
       }
     ],
     "path": "Proofs/Erdos1100ProblemProvable.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1100ProblemAristotle.lean",
+      "Proofs/Erdos1100OQ01Aristotle.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register the two orphaned Aristotle companion files for `erdos-1100` (Coprime Consecutive Divisors) in both `meta.additionalFiles` and `leanFile.additionalFiles` of `src/data/proofs/erdos-1100/meta.json`.

## Evidence

**Before**: `Proofs/Erdos1100ProblemAristotle.lean` and `Proofs/Erdos1100OQ01Aristotle.lean` existed on disk but neither was referenced by `src/data/proofs/erdos-1100/meta.json`. The filename-grep scan (`grep -l "Proofs/Erdos1100*Aristotle.lean" src/data/proofs/*/meta.json`) returned no matches for either companion.

**After**: Both companion files are registered in `.meta.additionalFiles` (companion-style pattern used by #21295 erdos-1048, #21328 erdos-160, #21398 erdos-501, etc.) and `.leanFile.additionalFiles` (the gallery-renderer-facing list). Pre-submission gate on the two companion files (`grep -nE '^def .*:=.*sorry|^axiom |^theorem .* : True :=|/-!'`) finds nothing — both files are clean Aristotle targets (theorem-sorries only, no definition sorries, axioms, True-stubs, or `/-!` module docstrings).

---
Automated fix by lean-mechanic agent.