### PR TITLE
fix(meta): erdos-1 register Erdos1OQ03Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -55,7 +55,10 @@
       "Natural number arithmetic (powers of 2, inequalities)"
     ],
     "theoremCount": 3,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "additionalFiles": [
+      "Proofs/Erdos1OQ03Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős called this 'perhaps my first serious problem,' posing it in 1931 at age 18. A set $A \\subseteq \\{1, \\ldots, N\\}$ has distinct subset sums if the map $S \\mapsto \\sum_{a \\in S} a$ is injective on subsets of $A$. The powers of 2, $\\{1, 2, 4, \\ldots, 2^{n-1}\\}$, trivially satisfy this with $N = 2^{n-1}$, and Erdős conjectured this is essentially optimal: $N \\geq c \\cdot 2^n$ for some absolute constant $c > 0$. He offered \\$500 for a proof or disproof. The basic lower bound $N \\geq 2^{n-1}$ was known early via a counting/pigeonhole argument. Conway and Guy (1968) constructed sets with $N < 0.22002 \\cdot 2^n$, showing the constant $c$ (if it exists) is at most $0.22$. Lunnon (1988) computed optimal sets for small $n$. The best lower bound is due to Dubroff, Fox, and Xu (2021): $N \\geq \\sqrt{2/\\pi} \\cdot 2^n / \\sqrt{n}$, which still has a $1/\\sqrt{n}$ gap from the conjectured $c \\cdot 2^n$. The problem connects to Sidon sets ($B_2$ sequences), uniquely decodable codes in information theory, and the knapsack problem in computational complexity.",
@@ -227,7 +230,10 @@
     "theoremCount": 3,
     "definitionCount": 2,
     "path": "Proofs/Erdos1Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1OQ03Aristotle.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register orphaned `Proofs/Erdos1OQ03Aristotle.lean` in `src/data/proofs/erdos-1/meta.json` so the gallery surfaces the Conway-Guy supporting lemmas alongside the main formalization.

## Evidence

**Before**: `proofs/Proofs/Erdos1OQ03Aristotle.lean` exists on disk but `meta.additionalFiles` and `leanFile.additionalFiles` were both absent in `src/data/proofs/erdos-1/meta.json`, so the gallery never surfaced the companion file.

**After**: Both slots now list `Proofs/Erdos1OQ03Aristotle.lean`, matching the pattern used by prior mechanic fixes (#21328, #21330, #21331).

---
Automated fix by lean-mechanic agent.