### PR TITLE
audit(erdos-167): mark clean (cycle 4) — Tuza's Conjecture integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4920,12 +4920,12 @@
       ]
     },
     "erdos-167": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "#14679: phantom axioms in proofStrategy/sections (5 axioms claimed; only IsPlanar declared); lineCount 275→274; section line drift in known-results/fractional-version/summary"
       ],
-      "lastAudited": "2026-05-02T08:57:53Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T10:00:24Z",
+      "result": "clean"
     },
     "erdos-168": {
       "agentId": "auditor-agent",


### PR DESCRIPTION
## Summary
- Verified erdos-167 (Tuza's Conjecture on Triangle Covering): 0 sorries, 1 axiom (IsPlanar), 4 theorems, 7 definitions, 274 lines — all match meta.json
- Status `axiomatized`/badge `axiom` appropriate for OPEN 1981 Tuza Conjecture
- Title and description correctly mark conjecture as "remains open in general"; Haxell-Kohayakawa bound and fractional version correctly listed as docstring-only

## Test plan
- [x] Lean file counts match meta.json (sorries/axioms/theorems/definitions/lineCount)
- [x] No True stubs
- [x] No Mathlib wrapper overclaim
- [x] Title and description honestly mark problem as OPEN
- [x] originalContributions / proofStrategy accurately scoped to what's actually formalized

Cycle 4 audit of erdos-167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)