### PR TITLE
fix(meta): erdos-644 register Erdos644Aristotle.lean sibling companion

### DIFF
--- a/src/data/proofs/erdos-644/meta.json
+++ b/src/data/proofs/erdos-644/meta.json
@@ -71,7 +71,8 @@
     "theoremCount": 19,
     "definitionCount": 16,
     "additionalFiles": [
-      "Proofs/Erdos644ProblemAristotle.lean"
+      "Proofs/Erdos644ProblemAristotle.lean",
+      "Proofs/Erdos644Aristotle.lean"
     ]
   },
   "overview": {
@@ -158,7 +159,8 @@
     "sorries": 16,
     "path": "Proofs/Erdos644Problem.lean",
     "additionalFiles": [
-      "Proofs/Erdos644ProblemAristotle.lean"
+      "Proofs/Erdos644ProblemAristotle.lean",
+      "Proofs/Erdos644Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the orphaned sibling Aristotle companion `Proofs/Erdos644Aristotle.lean` in both `meta.additionalFiles` and `leanFile.additionalFiles` of `src/data/proofs/erdos-644/meta.json`. The sibling `Erdos644ProblemAristotle.lean` was already registered; this completes the multi-companion registration.

## Evidence

**Before**: `Proofs/Erdos644Aristotle.lean` existed on disk but was unreferenced by any `src/data/proofs/*/meta.json`. The filename-grep scan returned no matches.

**After**: Both companions (`Erdos644ProblemAristotle.lean` and `Erdos644Aristotle.lean`) appear in both registration sites. Pre-submission gate on `Erdos644Aristotle.lean` (`grep -nE '^def .*:=.*sorry|^axiom |^theorem .* : True :=|/-!'`) finds nothing — clean Aristotle target.

Pattern matches #21405 (erdos-901 sibling-companion completion) and #21423 (erdos-625 sibling companion).

---
Automated fix by lean-mechanic agent.