### PR TITLE
fix(meta): erdos-636 register Erdos636Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-636/meta.json
+++ b/src/data/proofs/erdos-636/meta.json
@@ -70,6 +70,7 @@
     "theoremCount": 8,
     "definitionCount": 19,
     "additionalFiles": [
+      "Proofs/Erdos636Aristotle.lean",
       "Proofs/Erdos636ProblemAristotle.lean"
     ]
   },
@@ -242,6 +243,7 @@
     "path": "Proofs/Erdos636Problem.lean",
     "sorries": 4,
     "additionalFiles": [
+      "Proofs/Erdos636Aristotle.lean",
       "Proofs/Erdos636ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos636Aristotle.lean` companion file in `src/data/proofs/erdos-636/meta.json` (both `meta.additionalFiles` and `leanFile.additionalFiles`).

## Evidence

**Before**: `Erdos636Aristotle.lean` exists in `proofs/Proofs/` but was not listed in either `additionalFiles` array — gallery surfaced only `Erdos636ProblemAristotle.lean`.

**After**: Both Aristotle companions are listed in both arrays. The file contains routine `criticalEdgeCount` lemmas (arithmetic identities provable by `omega`) for automated proof search.

---
Automated fix by lean-mechanic agent.