### PR TITLE
fix(meta): erdos-1000 register Erdos1000OQ01Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "Two deep axioms: erdos_dichotomy (liminf=0 implies limsup=1, via Euler product for φ(n)/n), haight_resolution (vanishing Cesàro average exists, via highly composite construction). erdos_no_zero_limit is now PROVED from erdos_dichotomy (convergence to 0 contradicts dichotomy via frequently-vs-eventually). cassels_liminf_zero is PROVED from haight_resolution. Infrastructure: complement formula, growth bounds, multiplicity bounds, double-counting vocabulary, growth constraints from low density, deficit counting bounds.",
     "mathlib_version": "4.26.0",
     "theoremCount": 61,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "additionalFiles": [
+      "Proofs/Erdos1000OQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem originates in Cassels' 1950 work on Diophantine approximation, where he introduced the generalized totient φ_A to study the distribution of 'new' reduced denominators in increasing integer sequences. Cassels proved that for some sequences, the liminf of the Cesàro average of φ_A(k)/n_k is zero, and connected this to metric Diophantine approximation via the Khinchin-Groshev theorem. Erdős (1964) made the problem sharper: he proved that for any sequence, the individual ratio φ_A(k)/n_k cannot converge to 0, and established a remarkable dichotomy — if liminf = 0 then limsup = 1 — showing the density ratio must oscillate maximally. Erdős then asked whether the Cesàro average itself could vanish, conjecturing it could not. The lower bound φ_A(k) ≥ φ(n_k) (Euler's totient) and the fact that φ(n)/n averages to 6/π² supported his intuition. Haight's subsequent construction proved Erdős wrong: carefully chosen sequences of highly composite numbers force the average to 0 while the individual terms oscillate between 0 and 1. The problem illustrates the subtle gap between pointwise and averaged behavior of arithmetic functions.",
@@ -209,7 +212,10 @@
     "theoremCount": 61,
     "definitionCount": 12,
     "path": "Proofs/Erdos1000Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1000OQ01Aristotle.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos1000OQ01Aristotle.lean` companion file in `src/data/proofs/erdos-1000/meta.json` so the gallery surfaces the factorial-arithmetic supporting lemmas for the OQ-01 sub-problem alongside the main Erdős Problem #1000 formalization.

## Evidence

**Before**: `Erdos1000OQ01Aristotle.lean` exists on disk but was not referenced from `erdos-1000/meta.json` (scan reported it as ORPHAN). The companion exposes 3 routine factorial-sum theorem-sorries (`sum_factorials_lt`, `sum_factorials_pos`, `sum_factorials_ge_card`) suitable for Aristotle proof search.

**After**: The companion is registered in both `.meta.additionalFiles` and `.leanFile.additionalFiles`, matching the pattern established by #21295 (erdos-1048), #21328 (erdos-160), and the prior mechanic cycle.

Pre-submission gate (`def := sorry`, `axiom`, `True` stubs, `/-!` docstrings): clean.

---
Automated fix by lean-mechanic agent.