### PR TITLE
fix(meta): erdos-1151 register Erdos1151OQ04Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-1151/meta.json
+++ b/src/data/proofs/erdos-1151/meta.json
@@ -50,7 +50,10 @@
       "Point-set topology (closed sets, limit points)"
     ],
     "theoremCount": 7,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/Erdos1151OQ04Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Lagrange interpolation has a troubled history: Runge (1901) famously showed that interpolation at equally-spaced nodes for f(x) = 1/(1+25x²) diverges as n → ∞, despite f being analytic. Chebyshev nodes were introduced precisely to avoid this: by placing nodes at the roots of the Chebyshev polynomials, the interpolation error for smooth functions is dramatically reduced. Chebyshev (1854) showed these nodes minimize the ∞-norm of the Lebesgue function among all choices of n nodes. However, Erdős (1941) proved something deeper and disturbing: even at Chebyshev nodes, Lagrange interpolation can diverge for continuous (not just analytic) functions. Specifically, for x = cos(πp/q) with odd p, q, there exists a continuous f whose interpolation values diverge to ∞. Erdős (1943) then claimed — without proof — that the limit-point behavior is completely flexible: any closed subset of [−1, 1] can arise as the set of limit points of 𝓛ⁿf(x) for some continuous f. This conjecture was listed as open by Vértesi in his 1999 problem compilation [Va99, Problem 2.41]. As of 2026, it remains unresolved.",
@@ -159,7 +162,10 @@
     "theoremCount": 7,
     "definitionCount": 8,
     "path": "Proofs/Erdos1151Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1151OQ04Aristotle.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos1151OQ04Aristotle.lean` companion file in `src/data/proofs/erdos-1151/meta.json` so the gallery surfaces the Chebyshev-node supporting lemmas (cosine root identities, Chebyshev node injectivity) alongside the main Erdős Problem #1151 formalization on Lagrange interpolation.

## Evidence

**Before**: `Erdos1151OQ04Aristotle.lean` exists on disk but was not referenced from `erdos-1151/meta.json` (scan reported it as ORPHAN). The companion contains seven fully proved theorems about Chebyshev nodes (`n_mul_chebyshevAngle`, `chebyshevAngle_pos`, `chebyshevAngle_lt_pi`, `chebyshevAngle_mem_Ioo`, `chebyshevAngle_ne_of_ne`, `cos_odd_half_pi`, `chebyshevNode_is_root`, `chebyshevNode_injective`).

**After**: The companion is registered in both `.meta.additionalFiles` and `.leanFile.additionalFiles`, matching the pattern established by #21295 (erdos-1048), #21328 (erdos-160), and the prior mechanic cycle.

Pre-submission gate (`def := sorry`, `axiom`, `True` stubs, `/-!` docstrings): clean.

---
Automated fix by lean-mechanic agent.