### PR TITLE
audit(erdos-176): mark clean (cycle 4) — Nkl/Spencer/Erdős axiom integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4989,9 +4989,9 @@
       "result": "clean"
     },
     "erdos-176": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T08:37:29Z",
+      "lastAudited": "2026-05-31T10:12:41Z",
       "result": "clean"
     },
     "erdos-177": {


### PR DESCRIPTION
## Summary

Cycle 4 gallery integrity audit of **Erdős Problem #176** (Discrepancy of Arithmetic Progressions, N(k,ℓ)).

Verified `src/data/proofs/erdos-176/meta.json` against `proofs/Proofs/Erdos176Problem.lean`:

| Field | Claimed | Actual | Pass |
|-------|---------|--------|------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 (`satisfiesNkl_exists`, `spencer_1973`, `alpha_c_exists`) | ✓ |
| theoremCount | 6 | 6 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| lineCount | 303 | 303 | ✓ |
| status/badge | axiomatized/axiom | OPEN problem with 3 transparent axioms — correct | ✓ |

- `assumptions` field correctly enumerates all 3 axioms by name.
- No True stubs, no Mathlib wrapper masquerade — the deep results (Spencer 1973 exact formula, Erdős 1963 lower bound, existence via vdW) are encoded as axioms transparently rather than imported.
- `originalContributions` transparently flags `spencer_1973` as an axiom.
- The three open-question Props (`LinearDiscrepancyConjecture`, `Discrepancy2Conjecture`, `SqrtDiscrepancyConjecture`) are stated as `def : Prop`, not claimed as proved theorems.
- No structure-encoded assumptions.

## Test plan

- [x] Read meta.json and Erdos176Problem.lean
- [x] Count axioms / theorems / defs / lines / sorries
- [x] Confirm status/badge match assumption profile
- [x] Verify originalContributions are not overclaimed (axioms flagged, conjectures stated as Props)
- [x] Update audit-tracker (count 3→4, result clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)