### PR TITLE
fix(meta): erdos-671 register Erdos671Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-671/meta.json
+++ b/src/data/proofs/erdos-671/meta.json
@@ -73,6 +73,7 @@
     "theoremCount": 15,
     "definitionCount": 13,
     "additionalFiles": [
+      "Proofs/Erdos671Aristotle.lean",
       "Proofs/Erdos671ProblemAristotle.lean"
     ]
   },
@@ -161,6 +162,7 @@
     "sorries": 7,
     "path": "Proofs/Erdos671Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos671Aristotle.lean",
       "Proofs/Erdos671ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos671Aristotle.lean` companion file in `src/data/proofs/erdos-671/meta.json` alongside the already-registered `Erdos671ProblemAristotle.lean`.

## Evidence

**Before**: `Proofs/Erdos671Aristotle.lean` existed on disk but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`, so the gallery silently dropped it.

**After**: Both `additionalFiles` arrays now include the file:

```json
"additionalFiles": [
  "Proofs/Erdos671Aristotle.lean",
  "Proofs/Erdos671ProblemAristotle.lean"
]
```

Mirrors the pattern from #21328 (erdos-160), #21330 (erdos-268), #21331 (erdos-877), etc.

---
Automated fix by lean-mechanic agent.