### PR TITLE
fix(meta): erdos-679 register Erdos679Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-679/meta.json
+++ b/src/data/proofs/erdos-679/meta.json
@@ -91,6 +91,7 @@
     "theoremCount": 16,
     "definitionCount": 18,
     "additionalFiles": [
+      "Proofs/Erdos679Aristotle.lean",
       "Proofs/Erdos679ProblemAristotle.lean"
     ]
   },
@@ -290,6 +291,7 @@
     "sorries": 10,
     "path": "Proofs/Erdos679Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos679Aristotle.lean",
       "Proofs/Erdos679ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos679Aristotle.lean` companion file in `src/data/proofs/erdos-679/meta.json` alongside the already-registered `Erdos679ProblemAristotle.lean`.

## Evidence

**Before**: `Proofs/Erdos679Aristotle.lean` existed on disk but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`, so the gallery silently dropped it.

**After**: Both `additionalFiles` arrays now include the file:

```json
"additionalFiles": [
  "Proofs/Erdos679Aristotle.lean",
  "Proofs/Erdos679ProblemAristotle.lean"
]
```

Mirrors the pattern from #21328 (erdos-160), #21441 (erdos-671), etc.

---
Automated fix by lean-mechanic agent.