### PR TITLE
fix(meta): erdos-715 register Erdos715Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -87,6 +87,7 @@
     "theoremCount": 13,
     "definitionCount": 11,
     "additionalFiles": [
+      "Proofs/Erdos715Aristotle.lean",
       "Proofs/Erdos715ProblemAristotle.lean"
     ]
   },
@@ -196,6 +197,7 @@
     "path": "Proofs/Erdos715Problem.lean",
     "sorries": 15,
     "additionalFiles": [
+      "Proofs/Erdos715Aristotle.lean",
       "Proofs/Erdos715ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos715Aristotle.lean` companion file in `src/data/proofs/erdos-715/meta.json` alongside the already-registered `Erdos715ProblemAristotle.lean`.

## Evidence

**Before**: `Proofs/Erdos715Aristotle.lean` existed on disk but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`, so the gallery silently dropped it.

**After**: Both `additionalFiles` arrays now include the file.

Mirrors the pattern from #21328 (erdos-160), #21441 (erdos-671), #21442 (erdos-679), etc.

---
Automated fix by lean-mechanic agent.