### PR TITLE
fix(meta): erdos-771 register Erdos771Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-771/meta.json
+++ b/src/data/proofs/erdos-771/meta.json
@@ -84,6 +84,7 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "additionalFiles": [
+      "Proofs/Erdos771Aristotle.lean",
       "Proofs/Erdos771ProblemAristotle.lean"
     ]
   },
@@ -219,6 +220,7 @@
     "sorries": 7,
     "path": "Proofs/Erdos771Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos771Aristotle.lean",
       "Proofs/Erdos771ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos771Aristotle.lean` companion file in `src/data/proofs/erdos-771/meta.json` alongside the already-registered `Erdos771ProblemAristotle.lean`.

## Evidence

**Before**: `Proofs/Erdos771Aristotle.lean` existed on disk but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`.

**After**: Both `additionalFiles` arrays now include the file.

Mirrors the pattern from #21328 (erdos-160), #21441 (erdos-671), etc.

---
Automated fix by lean-mechanic agent.