### PR TITLE
fix(meta): erdos-795 register Erdos795Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -28,6 +28,7 @@
     "theoremCount": 13,
     "definitionCount": 7,
     "additionalFiles": [
+      "Proofs/Erdos795Aristotle.lean",
       "Proofs/Erdos795ProblemAristotle.lean"
     ]
   },
@@ -179,6 +180,7 @@
     "path": "Proofs/Erdos795Problem.lean",
     "sorries": 14,
     "additionalFiles": [
+      "Proofs/Erdos795Aristotle.lean",
       "Proofs/Erdos795ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos795Aristotle.lean` companion file in `src/data/proofs/erdos-795/meta.json` alongside the already-registered `Erdos795ProblemAristotle.lean`.

## Evidence

**Before**: `Proofs/Erdos795Aristotle.lean` existed on disk but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`.

**After**: Both `additionalFiles` arrays now include the file.

Mirrors the pattern from #21328 (erdos-160), #21441 (erdos-671), etc.

---
Automated fix by lean-mechanic agent.