### PR TITLE
fix(meta): erdos-798 register Erdos798Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-798/meta.json
+++ b/src/data/proofs/erdos-798/meta.json
@@ -66,6 +66,7 @@
     "theoremCount": 11,
     "definitionCount": 7,
     "additionalFiles": [
+      "Proofs/Erdos798Aristotle.lean",
       "Proofs/Erdos798ProblemAristotle.lean"
     ]
   },
@@ -184,6 +185,7 @@
     "sorries": 7,
     "path": "Proofs/Erdos798Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos798Aristotle.lean",
       "Proofs/Erdos798ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos798Aristotle.lean` companion file in `src/data/proofs/erdos-798/meta.json` alongside the already-registered `Erdos798ProblemAristotle.lean`.

## Evidence

**Before**: `Proofs/Erdos798Aristotle.lean` existed on disk but was missing from both `meta.additionalFiles` and `leanFile.additionalFiles`.

**After**: Both `additionalFiles` arrays now include the file.

Mirrors the pattern from #21328 (erdos-160), #21441 (erdos-671), etc.

---
Automated fix by lean-mechanic agent.