### PR TITLE
audit(erdos-177): mark clean (cycle 5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4995,10 +4995,10 @@
       "result": "clean"
     },
     "erdos-177": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T08:30:12Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T10:42:19Z",
+      "result": "clean"
     },
     "erdos-177-oq-04": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Cycle 5 audit of `erdos-177` (Discrepancy of Arithmetic Progressions). All integrity fields verified against `proofs/Proofs/Erdos177Problem.lean`.

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 1 | 1 (`roth_lower_bound`) | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 163 | 163 | ✓ |
| status | axiomatized | has 1 axiom | ✓ |
| badge | axiom | has 1 axiom | ✓ |

No True stubs detected. Conclusion correctly notes that only Roth's lower bound is axiomatized; Beck's polynomial upper bound and the Cantor-Erdős-Schreiber-Straus factorial bound appear as docstring descriptions only.

## Test plan

- [x] Read meta.json
- [x] Read Erdos177Problem.lean and cross-checked counts
- [x] No True-stub theorems
- [x] No overclaiming (status/badge consistent with 1 axiom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)