### PR TITLE
fix(meta): erdos-695 register Erdos695Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -8,6 +8,9 @@
     "sourceUrl": "https://erdosproblems.com/695",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/Erdos695Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos695Aristotle.lean"
+    ],
     "tags": [
       "erdos",
       "number-theory",
@@ -186,6 +189,9 @@
     "theoremCount": 8,
     "definitionCount": 10,
     "path": "Proofs/Erdos695Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos695Aristotle.lean"
+    ],
     "sorries": 1
   },
   "sorries": 1


### PR DESCRIPTION
## Fix

Register the existing `proofs/Proofs/Erdos695Aristotle.lean` companion file in `src/data/proofs/erdos-695/meta.json`.

## Evidence

**Before**: The companion file existed on disk but was not referenced in either `meta.additionalFiles` or `leanFile.additionalFiles`.

**After**: Both fields list `Proofs/Erdos695Aristotle.lean` so the gallery shows it and Aristotle ingestion finds it.

---
Automated fix by lean-mechanic agent.