### PR TITLE
fix(meta): erdos-859 register Erdos859Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-859/meta.json
+++ b/src/data/proofs/erdos-859/meta.json
@@ -54,6 +54,7 @@
     "theoremCount": 13,
     "definitionCount": 9,
     "additionalFiles": [
+      "Proofs/Erdos859Aristotle.lean",
       "Proofs/Erdos859ProblemAristotle.lean"
     ]
   },
@@ -210,6 +211,7 @@
     "path": "Proofs/Erdos859Problem.lean",
     "sorries": 3,
     "additionalFiles": [
+      "Proofs/Erdos859Aristotle.lean",
       "Proofs/Erdos859ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos859Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-859/meta.json`.

## Evidence

**Before**: `Erdos859Aristotle.lean` existed on disk but was not referenced from `meta.json` (count=0 in both arrays). The sibling `Erdos859ProblemAristotle.lean` was registered.

**After**: Both companions now listed in both registration sites.

Pre-submission gate (`^def .*:=.*sorry|^axiom |^theorem .* : True :=|/-!`) passes — file has no definition sorries, no axioms, no True-placeholders, no `/-!` blocks.

---
Automated fix by lean-mechanic agent.