### PR TITLE
fix(meta): erdos-895 register Erdos895Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -52,6 +52,7 @@
     "theoremCount": 18,
     "definitionCount": 14,
     "additionalFiles": [
+      "Proofs/Erdos895Aristotle.lean",
       "Proofs/Erdos895ProblemAristotle.lean"
     ]
   },
@@ -166,6 +167,7 @@
     "sorries": 3,
     "path": "Proofs/Erdos895Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos895Aristotle.lean",
       "Proofs/Erdos895ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos895Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-895/meta.json`.

## Evidence

**Before**: `Erdos895Aristotle.lean` existed on disk but had count=0 in both arrays. Sibling `Erdos895ProblemAristotle.lean` was registered.

**After**: Both companions now listed in both registration sites.

Pre-submission gate passes — no definition sorries, axioms, True-placeholders, or `/-!` blocks.

---
Automated fix by lean-mechanic agent.