### PR TITLE
fix(meta): erdos-933 register Erdos933Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-933/meta.json
+++ b/src/data/proofs/erdos-933/meta.json
@@ -61,6 +61,7 @@
     "theoremCount": 9,
     "definitionCount": 12,
     "additionalFiles": [
+      "Proofs/Erdos933Aristotle.lean",
       "Proofs/Erdos933ProblemAristotle.lean"
     ]
   },
@@ -195,6 +196,7 @@
     "path": "Proofs/Erdos933Problem.lean",
     "sorries": 3,
     "additionalFiles": [
+      "Proofs/Erdos933Aristotle.lean",
       "Proofs/Erdos933ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos933Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-933/meta.json`.

## Evidence

**Before**: `Erdos933Aristotle.lean` existed on disk but had count=0 in both arrays. Sibling `Erdos933ProblemAristotle.lean` was registered.

**After**: Both companions now listed in both registration sites.

Pre-submission gate passes — no definition sorries, axioms, True-placeholders, or `/-!` blocks.

---
Automated fix by lean-mechanic agent.