### PR TITLE
fix(meta): erdos-755 register Erdos755Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-755/meta.json
+++ b/src/data/proofs/erdos-755/meta.json
@@ -58,7 +58,10 @@
     "lineCount": 272,
     "assumptions": "1 axiom: cdl_2025_main. 1 sorry.",
     "theoremCount": 4,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Erdos755Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #755: Equilateral Triangles in ℝ⁶**\n\nThis problem concerns the maximum number of equilateral triangles that can be formed by n points in 6-dimensional Euclidean space.\n\n**Key History:**\n- Lenz (credited by Erdős): Original lower bound construction\n- Erdős-Purdy (1975): Published the orthogonal circles construction\n- Erdős (1994): Conjectured the upper bound T₆ᵘ(n) ≤ (1/27 + o(1))n³\n- Clemen-Dumitrescu-Liu (2025): Proved the conjecture in a stronger form\n\n**Mathematical Setting:**\nIn higher dimensions, point configurations can form many more equilateral triangles than in the plane. The dimension d = 6 is special: it's the first even dimension where cubic growth T_d(n) = Θ(n³) occurs.",
@@ -172,7 +175,10 @@
     "theoremCount": 4,
     "definitionCount": 7,
     "path": "Proofs/Erdos755Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Erdos755Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos755Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-755/meta.json`. Pattern B — both arrays were absent.

## Evidence

**Before**: `Erdos755Aristotle.lean` existed on disk but was not referenced from `meta.json` (no additionalFiles array on either side).

**After**: Both sites now register the companion.

Pre-submission gate passes — no definition sorries, axioms, True-placeholders, or `/-!` blocks.

---
Automated fix by lean-mechanic agent.