### PR TITLE
fix(meta): erdos-817 register Erdos817Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-817/meta.json
+++ b/src/data/proofs/erdos-817/meta.json
@@ -65,7 +65,10 @@
     "lineCount": 580,
     "assumptions": "No axioms, 0 sorries. The main open conjecture (g₃(n) ≫ 3ⁿ) is stated as a def, not proved. Proved: g_k(n) ≥ n and g_3(n) ≤ 3ⁿ.",
     "theoremCount": 16,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/Erdos817Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem combines two fundamental concepts in additive combinatorics: subset sums and arithmetic progression avoidance. The subset sum set ⟨A⟩ of a finite set A is the collection of all possible sums formed by selecting subsets of A. This structure appears throughout number theory and combinatorics.\n\nErdős and Sárközy studied the function g_k(n): the minimal N such that {1,...,N} contains some n-element set A whose subset sums avoid non-trivial k-term arithmetic progressions. They proved that g₃(n) ≫ 3ⁿ/n^{O(1)}, establishing exponential growth up to polynomial factors.\n\nThe main conjecture asks whether the polynomial factor is necessary: is g₃(n) truly ≫ 3ⁿ? This remains open and connects to deep questions about the structure of subset sum sets and Szemerédi-type theorems.",
@@ -213,7 +216,10 @@
     "theoremCount": 16,
     "definitionCount": 8,
     "path": "Proofs/Erdos817Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos817Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Erdos817Aristotle.lean` companion file in `src/data/proofs/erdos-817/meta.json`.

## Evidence

**Before**:
- `proofs/Proofs/Erdos817Aristotle.lean` exists on disk
- `.meta.additionalFiles` = `null`
- `.leanFile.additionalFiles` = `null`

**After**:
- Both `.meta.additionalFiles` and `.leanFile.additionalFiles` contain `["Proofs/Erdos817Aristotle.lean"]`

Pre-submission gate on the companion file (no defn-sorries / axioms / True-stubs / `/-!` blocks) passes.

Closes part of the orphaned Aristotle companion registration backlog tracked in mechanic memory.

---
Automated fix by lean-mechanic agent.