### PR TITLE
fix(meta): erdos-818 register Erdos818Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-818/meta.json
+++ b/src/data/proofs/erdos-818/meta.json
@@ -64,7 +64,10 @@
     "lineCount": 294,
     "assumptions": "1 axiom(s) and 3 sorry(s). See the Lean source for details.",
     "theoremCount": 5,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Erdos818Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem is part of the sum-product phenomenon, a central topic in additive combinatorics. Erdős-Szemerédi conjectured that finite sets cannot have both small sumsets AND small product sets. This problem explores a conditional version: if the sumset is small, how large must the product set be? Solymosi's 2009 paper resolved this completely. The sum-product conjecture (1983) was proved in quantitative forms by Elekes (1997) using the Szemerédi-Trotter incidence theorem, and by Solymosi and others achieving exponent 4/3. The conditional question asks whether small additive structure forces large multiplicative structure, refining the unconditional sum-product estimates.",
@@ -275,7 +278,10 @@
     "theoremCount": 5,
     "definitionCount": 7,
     "path": "Proofs/Erdos818Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos818Aristotle.lean"
+    ]
   },
   "sorries": 3
 }


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos818Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-818/meta.json`. Pattern B — neither array was present.

## Evidence

**Before**: companion on disk but unreferenced in either registration site.

**After**: both sites register the companion.

Pre-submission gate passes — no definition sorries, axioms, True-placeholders, or `/-!` blocks.

---
Automated fix by lean-mechanic agent.