### PR TITLE
fix(meta): erdos-866 register Erdos866Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -57,7 +57,10 @@
     "lineCount": 84,
     "assumptions": "0 axioms. 0 sorries. All results formalized without axioms.",
     "theoremCount": 3,
-    "definitionCount": 4
+    "definitionCount": 4,
+    "additionalFiles": [
+      "Proofs/Erdos866Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #866 originates from the work of Choi, Erdős, and Szemerédi on sumsets and additive combinatorics, building on their unpublished manuscript 'On sums and products of integers.' The problem asks: how large must a subset A of {1,...,2N} be to guarantee that some k integers have all their pairwise sums in A?\n\nThe foundational observation is the odd numbers construction: the set {1, 3, 5, ..., 2N-1} has N elements but avoids all pairwise sums (since odd + odd = even). This shows the threshold must be at least 1 above N. For k=3, the exact answer is g₃(N) = 2, proved via a complementary pairs pigeonhole argument.\n\nThe most striking feature is the phase transition as k increases: g₃ = 2 (constant), g₄ ≤ 2032 (bounded constant, van Doorn), g₅ ≍ log N (logarithmic), g₆ ≍ √N (polynomial). The general upper bound g_k(N) ≪ N^{1-2^{-k}} (Choi–Erdős–Szemerédi) shows the exponent approaches 1 geometrically, while the lower bound g_k(N) > N^{1-ε} for large k shows the threshold eventually approaches N.\n\nThis growth rate transition—from constant through logarithmic and polynomial to nearly linear—is rare in combinatorics and reflects deep structural changes in the extremal problem. The gap between upper and lower bounds for intermediate and large k remains one of the central open questions in additive combinatorics.",
@@ -149,7 +152,10 @@
     "theoremCount": 3,
     "definitionCount": 4,
     "path": "Proofs/Erdos866Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos866Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos866Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-866/meta.json`. Pattern B — neither array was present.

## Evidence

**Before**: companion on disk but unreferenced in either registration site.

**After**: both sites register the companion.

Pre-submission gate passes — no definition sorries, axioms, True-placeholders, or `/-!` blocks.

---
Automated fix by lean-mechanic agent.