### PR TITLE
audit(erdos-168): mark clean (cycle 4) — {n,2n,3n}-free sets integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4929,9 +4929,9 @@
     },
     "erdos-168": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T09:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T10:55:34Z",
+      "result": "clean",
       "issues": [
         "phantom 0.5564 axiom claim in originalContributions; better_construction missing from proofStrategy (issue #14675)"
       ]


### PR DESCRIPTION
## Summary

- Gallery integrity audit for erdos-168 (cycle 4) — meta.json/Lean source verified
- Status: `clean`

## Verification

| Field | Claimed | Actual | Match |
|-------|---------|--------|-------|
| status/badge | axiomatized/axiom | 2 axioms declared | yes |
| sorries | 0 | 0 | yes |
| axiomCount | 2 | 2 (gsw_limit_exists, better_construction) | yes |
| theoremCount | 4 | 4 (density_bounded, F_monotone, simple_lower_bound, irrationality_open) | yes |
| definitionCount | 7 | 7 | yes |
| lineCount | 180 | 180 | yes |

No True stubs. No hidden Mathlib delegation. Open irrationality question correctly framed as `Classical.em` placeholder.

## Test plan

- [x] meta.json fields match Lean source
- [x] axiom/sorry counts verified via grep
- [x] No True-stub theorems

Generated with Claude Code