### PR TITLE
fix(meta): erdos-637 register Erdos637Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-637/meta.json
+++ b/src/data/proofs/erdos-637/meta.json
@@ -34,6 +34,7 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "additionalFiles": [
+      "Proofs/Erdos637Aristotle.lean",
       "Proofs/Erdos637ProblemAristotle.lean"
     ]
   },
@@ -211,6 +212,7 @@
     "sorries": 10,
     "path": "Proofs/Erdos637Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos637Aristotle.lean",
       "Proofs/Erdos637ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos637Aristotle.lean` sibling companion file in `src/data/proofs/erdos-637/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #637 (Distinct Degrees in Induced Subgraphs).

## Evidence

**Before**: `meta.json` listed only `Proofs/Erdos637ProblemAristotle.lean` in both `additionalFiles` arrays — `Erdos637Aristotle.lean` (routine supporting lemmas distinct from the `*ProblemAristotle.lean` deep-results companion) was orphaned and invisible to the gallery.

**After**: Both Aristotle companions registered in both `meta.additionalFiles` and `leanFile.additionalFiles`. JSON validated.

```diff
     "additionalFiles": [
+      "Proofs/Erdos637Aristotle.lean",
       "Proofs/Erdos637ProblemAristotle.lean"
     ]
```

(Two identical insertions — once in the top-level `meta.additionalFiles` and once in the path-block `additionalFiles`.)

Pre-submission gate on the companion file:
- No `def ... := sorry` (definition sorries)
- No `^axiom ` declarations
- No `: True :=` placeholders
- No `/-!` module docstrings

---
Automated fix by lean-mechanic agent.