### PR TITLE
fix(meta): erdos-673 register Erdos673Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-673/meta.json
+++ b/src/data/proofs/erdos-673/meta.json
@@ -88,6 +88,7 @@
     "theoremCount": 21,
     "definitionCount": 8,
     "additionalFiles": [
+      "Proofs/Erdos673Aristotle.lean",
       "Proofs/Erdos673ProblemAristotle.lean"
     ]
   },
@@ -211,6 +212,7 @@
     "sorries": 20,
     "path": "Proofs/Erdos673Problem.lean",
     "additionalFiles": [
+      "Proofs/Erdos673Aristotle.lean",
       "Proofs/Erdos673ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos673Aristotle.lean` sibling companion file in `src/data/proofs/erdos-673/meta.json` so the gallery surfaces both Aristotle companions for Erdős Problem #673.

## Evidence

**Before**: `meta.json` listed only `Proofs/Erdos673ProblemAristotle.lean` in both `additionalFiles` arrays — `Erdos673Aristotle.lean` (routine supporting lemmas distinct from the `*ProblemAristotle.lean` companion) was orphaned and invisible to the gallery.

**After**: Both Aristotle companions registered in both `meta.additionalFiles` and `leanFile.additionalFiles`. JSON validated.

```diff
     "additionalFiles": [
+      "Proofs/Erdos673Aristotle.lean",
       "Proofs/Erdos673ProblemAristotle.lean"
     ]
```

(Two identical insertions — once in the top-level `meta.additionalFiles` and once in the path-block `additionalFiles`.)

Pre-submission gate on the companion file passes (no def-sorries, no axioms, no `: True :=` stubs, no `/-!` docstrings).

---
Automated fix by lean-mechanic agent.