### PR TITLE
fix(meta): erdos-613 register Erdos613Aristotle.lean sibling companion

### DIFF
--- a/src/data/proofs/erdos-613/meta.json
+++ b/src/data/proofs/erdos-613/meta.json
@@ -62,6 +62,7 @@
     "theoremCount": 11,
     "definitionCount": 14,
     "additionalFiles": [
+      "Proofs/Erdos613Aristotle.lean",
       "Proofs/Erdos613ProblemAristotle.lean"
     ]
   },
@@ -201,6 +202,7 @@
     "path": "Proofs/Erdos613Problem.lean",
     "sorries": 12,
     "additionalFiles": [
+      "Proofs/Erdos613Aristotle.lean",
       "Proofs/Erdos613ProblemAristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos613Aristotle.lean` companion file in `src/data/proofs/erdos-613/meta.json` alongside the already-registered `Erdos613ProblemAristotle.lean`, so the gallery surfaces both Aristotle companions for Erdős Problem #613.

## Evidence

**Before**: `meta.additionalFiles` and `leanFile.additionalFiles` each listed only `Proofs/Erdos613ProblemAristotle.lean` — the sibling `Erdos613Aristotle.lean` (37 lines, present on disk) was orphaned.

**After**: Both arrays now list both companions in alphabetical order.

The added companion targets routine arithmetic identities about `criticalEdgeCount` (theorem-level sorries suitable for automated proof search) and contains 0 axioms, 0 def-sorries, no `True` placeholders, and no module docstrings — passes the standard pre-submission gate.

---
Automated fix by lean-mechanic agent.