### PR TITLE
fix(meta): erdos-892 register Erdos892Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-892/meta.json
+++ b/src/data/proofs/erdos-892/meta.json
@@ -63,7 +63,10 @@
     "assumptions": "2 axioms: (1) primitive_reciprocal_log_convergent — Erdős 1935, convergence of Σ 1/(aₙ log aₙ) for primitive sequences; (2) harmonic_log_plus2_diverges — Cauchy condensation test gives Σ 1/((n+2)·log(n+2)) → +∞ (standard analysis, not in Mathlib). The hbound step is now proved via Finset.sum_congr + cast arithmetic.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Erdos892Aristotle.lean"
+    ]
   },
   "sections": [
     {
@@ -188,7 +191,10 @@
     "theoremCount": 7,
     "definitionCount": 6,
     "path": "Proofs/Erdos892Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos892Aristotle.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register `Proofs/Erdos892Aristotle.lean` in both `.meta.additionalFiles` and `.leanFile.additionalFiles` of `src/data/proofs/erdos-892/meta.json`. Pattern B — neither array was present.

## Evidence

**Before**: companion on disk but unreferenced in either registration site.

**After**: both sites register the companion.

Pre-submission gate passes — no definition sorries, axioms, True-placeholders, or `/-!` blocks.

---
Automated fix by lean-mechanic agent.