### PR TITLE
research(knights-tour-oblique-oq-02): S8 ACT — d4Mul + composition law + d4Equiv transitivity + Setoid (8 theorems + 2 defs, +167 LOC, 0 sorries, 0 axioms, build pending)

### DIFF
--- a/proofs/Proofs/KnightsTourObliqueOQ02.lean
+++ b/proofs/Proofs/KnightsTourObliqueOQ02.lean
@@ -445,4 +445,171 @@ theorem d4Equiv_preserves_levelSet {t u : ClosedTour} {k : ℕ}
   rw [← d4Equiv_preserves_obliqueCount h]
   exact ht
 
+/-!
+## S8: D4 multiplication law and `d4Equiv` transitivity
+
+S7 gave reflexivity and symmetry of `d4Equiv`. **Transitivity** requires a
+multiplication law `d4Mul g₂ g₁ : Bool × Fin 4` satisfying
+`applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s)`. This lifts via
+`List.map_map` (parent's `map_applyD4_comp`) to `applyD4Tour_mul`, and then
+to `d4Equiv_trans` as an existential combinator.
+
+### Composition formula
+
+Recall `applyD4 (b, k) s = rotateSquareN k (if b then reflectSquare s else s)`.
+
+* **Outer non-reflecting** (`b₂ = false`): rotations compose,
+  `d4Mul (false, k₂) (b₁, k₁) = (b₁, (k₁ + k₂) % 4)`.
+* **Outer reflecting** (`b₂ = true`): the outer reflection conjugates the
+  inner rotation via `reflectSquare ∘ rotateSquareN k₁ = rotateSquareN
+  ((4 - k₁) % 4) ∘ reflectSquare`, and the reflection bits flip. So
+  `d4Mul (true, k₂) (b₁, k₁) = (!b₁, (k₂ + (4 - k₁)) % 4)`.
+
+### Proof strategy
+
+We first prove two pure-rotation/reflection helpers:
+
+* `rotateSquareN_add` — rotation composition.
+* `reflect_rotateN_conjugate` — conjugation of rotation by reflection.
+
+Each is a `fin_cases`-driven coordinate computation closed by `omega`.
+Then `applyD4_mul` is a 4-case split on `(b₂, b₁)` using these helpers,
+avoiding the full 4 × 4 × 2 × 2 = 64-case grid.
+
+`applyD4Tour_mul` lifts via the parent's `map_applyD4_comp` plus
+pointwise `applyD4_mul`. `d4Equiv_trans` then packages two existential
+witnesses with `d4Mul`. Finally `d4Equiv_equivalence` and the matching
+`Setoid ClosedTour` bundle the relation.
+
+This sets up S9: a `Group (Bool × Fin 4)` structure (with `d4Mul` and
+`d4Inv`) and a `MulAction (Bool × Fin 4) ClosedTour` via `applyD4Tour` —
+the bearer of Mathlib's `MulAction.card_orbit_dvd_card_group` for the
+mod-8 divisibility headline. The associativity proof for `Group` requires
+one more 8-case bash on the rotation triple, deferred to S9.
+-/
+
+/-- Composition of rotations: rotating by `m` after `n` equals rotating by
+    `(m.val + n.val) % 4`. The proof bashes 16 cases on `(m, n)`. -/
+theorem rotateSquareN_add (m n : Fin 4) (s : Square) :
+    rotateSquareN m (rotateSquareN n s) =
+    rotateSquareN ⟨(m.val + n.val) % 4, by omega⟩ s := by
+  fin_cases m <;> fin_cases n <;>
+    simp only [rotateSquareN, rotateSquare90, Fin.val_mk, Fin.isValue] <;>
+    ext <;> simp only [Fin.ext_iff] <;> omega
+
+/-- Reflection conjugates rotation: `reflectSquare ∘ rotateSquareN k =
+    rotateSquareN ((4 - k.val) % 4) ∘ reflectSquare`. The proof bashes 4
+    cases on `k`. -/
+theorem reflect_rotateN_conjugate (k : Fin 4) (s : Square) :
+    reflectSquare (rotateSquareN k s) =
+    rotateSquareN ⟨(4 - k.val) % 4, by omega⟩ (reflectSquare s) := by
+  fin_cases k <;>
+    simp only [rotateSquareN, rotateSquare90, reflectSquare,
+               Fin.val_mk, Fin.isValue] <;>
+    ext <;> simp only [Fin.ext_iff] <;> omega
+
+/-- D4 multiplication encoded on `Bool × Fin 4`. Defined by pattern
+    matching on the outer reflection bit to make `applyD4_mul`'s case
+    split reduce cleanly. -/
+def d4Mul : Bool × Fin 4 → Bool × Fin 4 → Bool × Fin 4
+  | (false, k₂), (b₁, k₁) => (b₁, ⟨(k₁.val + k₂.val) % 4, by omega⟩)
+  | (true,  k₂), (b₁, k₁) => (!b₁, ⟨(k₂.val + (4 - k₁.val)) % 4, by omega⟩)
+
+/-- Specialization of `applyD4` to the non-reflecting case. Reduces to a
+    pure rotation by `rfl` (the `if (false : Bool) then` branch is
+    definitionally the `else` branch). -/
+private lemma applyD4_false (k : Fin 4) (s : Square) :
+    applyD4 (false, k) s = rotateSquareN k s := rfl
+
+/-- Specialization of `applyD4` to the reflecting case. Reduces to
+    rotation after reflection by `rfl`. -/
+private lemma applyD4_true (k : Fin 4) (s : Square) :
+    applyD4 (true, k) s = rotateSquareN k (reflectSquare s) := rfl
+
+/-- **D4 composition law**: `applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s)`.
+    4-case split on `(b₂, b₁)`; the rotation arithmetic reduces via
+    `rotateSquareN_add` and `reflect_rotateN_conjugate`, with `congr` +
+    `omega` closing the residual Fin 4 equalities. -/
+theorem applyD4_mul (g₂ g₁ : Bool × Fin 4) (s : Square) :
+    applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s) := by
+  obtain ⟨b₂, k₂⟩ := g₂
+  obtain ⟨b₁, k₁⟩ := g₁
+  cases b₂ with
+  | false =>
+    cases b₁ with
+    | false =>
+      -- d4Mul (false, k₂) (false, k₁) = (false, ⟨(k₁+k₂)%4, _⟩)
+      simp only [d4Mul, applyD4_false]
+      rw [rotateSquareN_add k₂ k₁]
+      congr 1
+      apply Fin.ext
+      simp only [Fin.val_mk]
+      omega
+    | true =>
+      -- d4Mul (false, k₂) (true, k₁) = (true, ⟨(k₁+k₂)%4, _⟩)
+      simp only [d4Mul, applyD4_false, applyD4_true]
+      rw [rotateSquareN_add k₂ k₁]
+      congr 1
+      apply Fin.ext
+      simp only [Fin.val_mk]
+      omega
+  | true =>
+    cases b₁ with
+    | false =>
+      -- d4Mul (true, k₂) (false, k₁) = (true, ⟨(k₂+(4-k₁))%4, _⟩)  (since !false = true)
+      simp only [d4Mul, applyD4_false, applyD4_true, Bool.not_false]
+      rw [reflect_rotateN_conjugate k₁ s,
+          rotateSquareN_add k₂ ⟨(4 - k₁.val) % 4, by omega⟩]
+      congr 1
+      apply Fin.ext
+      simp only [Fin.val_mk]
+      omega
+    | true =>
+      -- d4Mul (true, k₂) (true, k₁) = (false, ⟨(k₂+(4-k₁))%4, _⟩)  (since !true = false)
+      simp only [d4Mul, applyD4_false, applyD4_true, Bool.not_true]
+      rw [reflect_rotateN_conjugate k₁ (reflectSquare s),
+          reflect_twice,
+          rotateSquareN_add k₂ ⟨(4 - k₁.val) % 4, by omega⟩]
+      congr 1
+      apply Fin.ext
+      simp only [Fin.val_mk]
+      omega
+
+/-- **D4 composition law on tours**: lifts `applyD4_mul` pointwise to the
+    `List.map (applyD4 _)` definition of `applyD4Tour`, via the parent's
+    `map_applyD4_comp`. -/
+theorem applyD4Tour_mul (g₂ g₁ : Bool × Fin 4) (t : ClosedTour) :
+    applyD4Tour (d4Mul g₂ g₁) t = applyD4Tour g₂ (applyD4Tour g₁ t) := by
+  apply (closedTour_eq_iff _ _).mpr
+  show t.squares.map (applyD4 (d4Mul g₂ g₁)) =
+       (t.squares.map (applyD4 g₁)).map (applyD4 g₂)
+  rw [map_applyD4_comp]
+  congr 1
+  funext s
+  -- goal after Function.comp reduction:
+  --   applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s)
+  exact applyD4_mul g₂ g₁ s
+
+/-- **Transitivity of `d4Equiv`**: completes the equivalence-relation
+    framework. Witness combinator `d4Mul g₂ g₁` from the two existentials,
+    closed by `applyD4Tour_mul`. -/
+theorem d4Equiv_trans {t u v : ClosedTour}
+    (h₁ : d4Equiv t u) (h₂ : d4Equiv u v) : d4Equiv t v := by
+  obtain ⟨g₁, hg₁⟩ := h₁
+  obtain ⟨g₂, hg₂⟩ := h₂
+  refine ⟨d4Mul g₂ g₁, ?_⟩
+  rw [applyD4Tour_mul, hg₁, hg₂]
+
+/-- `d4Equiv` is an equivalence relation. -/
+theorem d4Equiv_equivalence : Equivalence d4Equiv :=
+  ⟨d4Equiv_refl, d4Equiv_symm, d4Equiv_trans⟩
+
+/-- The D4 quotient setoid on `ClosedTour`. The orbits of `applyD4Tour`
+    correspond to the equivalence classes; this is the structural input
+    for the planned mod-8 divisibility argument
+    (`obliqueDistribution k = 8 · (#free orbits) + Σ (8 / stab)`). -/
+def d4Setoid : Setoid ClosedTour where
+  r := d4Equiv
+  iseqv := d4Equiv_equivalence
+
 end KnightsTourOblique

--- a/research/problems/knights-tour-oblique-oq-02/knowledge.md
+++ b/research/problems/knights-tour-oblique-oq-02/knowledge.md
@@ -90,6 +90,102 @@ and the trivial support lemma; defer the harder D4 invariance to S3.
   reversal-mod-2, winding-parity). All are derivable from parent's
   existing infrastructure.
 
+## Iteration 8 (researcher-1, 2026-05-31) — S8 ACT
+
+**Outcome**: built — closed the **D4 multiplication law** chain: `d4Mul + applyD4_mul + applyD4Tour_mul + d4Equiv_trans + d4Equiv_equivalence + d4Setoid`. 8 theorems/lemmas + 2 defs, +167 LOC (448→615), 0 sorries, 0 axioms. This completes the equivalence-relation framework that S7 left at refl + symm only.
+
+### Composition formula and proof structure
+
+Working out `applyD4 (b₂, k₂) ∘ applyD4 (b₁, k₁)` on `Square`:
+
+* **Outer non-reflecting** (`b₂ = false`): `rotateSquareN k₂ ∘ rotateSquareN k₁ = rotateSquareN ((k₁ + k₂) % 4)` (rotation composition). Reflection bit carries through from `b₁`. So `d4Mul (false, k₂) (b₁, k₁) = (b₁, ⟨(k₁ + k₂) % 4, _⟩)`.
+* **Outer reflecting** (`b₂ = true`): one needs to commute `reflectSquare` past the inner `rotateSquareN k₁`. Using `reflectSquare ∘ rotateSquare90 = rotateSquare90³ ∘ reflectSquare` (parent's `rotate_reflect_conjugate`), this generalizes to `reflectSquare ∘ rotateSquareN k = rotateSquareN ((4 - k) % 4) ∘ reflectSquare`. So `applyD4 (true, k₂) (applyD4 (b₁, k₁) s) = rotateSquareN k₂ (reflectSquare (rotateSquareN k₁ (cond b₁ (reflectSquare s) s))) = rotateSquareN ((k₂ + (4 - k₁)) % 4) (reflectSquare (cond b₁ (reflectSquare s) s))`. The inner cond either keeps the outer reflectSquare (if `b₁ = false`) or cancels it via `reflect_twice` (if `b₁ = true`), giving the bit flip `!b₁`.
+
+### Why `d4Mul` is pattern-matched on the outer bit (not `xor`-based)
+
+Two alternatives for defining `d4Mul`:
+
+* **Unified `xor` form**: `d4Mul (b₂, k₂) (b₁, k₁) = (xor b₂ b₁, if b₂ then ⟨(k₂ + (4 - k₁)) % 4, _⟩ else ⟨(k₁ + k₂) % 4, _⟩)`. Logically equivalent.
+* **Pattern-matched form** (chosen): `d4Mul | (false, k₂), (b₁, k₁) => ... | (true, k₂), (b₁, k₁) => (!b₁, ...)`. Lean generates per-arm equation lemmas, and `simp only [d4Mul]` reduces cleanly after `cases b₂`.
+
+The pattern-matched form gives `applyD4_mul` a tighter proof: 4 cases on `(b₂, b₁)` with each case requiring 1-2 `rw`s on the helpers, vs. the unified form which would force `simp` to first reduce `xor b₂ b₁` and then a 4-case `if` ladder. The chosen form's cost is 2 separate arm-equation lemmas, recovered immediately when `simp [d4Mul]` fires.
+
+### `applyD4_false` / `applyD4_true` — small but crucial rfl-helpers
+
+The parent's `applyD4` uses `if (g.1 : Bool) then reflectSquare s else s`. After `cases b₂` exposes `b₂` as literal `true`/`false`, the `if` reduces by Lean's defeq on Bool literals — but only when explicitly invoked. Stating
+
+```lean
+private lemma applyD4_false (k : Fin 4) (s : Square) :
+    applyD4 (false, k) s = rotateSquareN k s := rfl
+
+private lemma applyD4_true (k : Fin 4) (s : Square) :
+    applyD4 (true, k) s = rotateSquareN k (reflectSquare s) := rfl
+```
+
+as simp lemmas lets `simp only [applyD4_false, applyD4_true]` unfold each case of `applyD4_mul` without needing `if_pos`/`if_neg`/`Bool.cond_true`/`Bool.cond_false`/`Bool.false_eq_true`/`↓reduceIte` simp lemmas — any of which may or may not be in the simp set depending on Mathlib version. The `rfl` proof itself relies only on Lean core's defeq, which is stable across Mathlib versions.
+
+### The `congr 1 + Fin.ext + omega` tail
+
+Each case of `applyD4_mul` ends with a residual Fin 4 equality of the form `⟨A, _⟩ = ⟨B, _⟩` where `A`, `B` are arithmetic expressions in `k₁.val, k₂.val`. The pattern:
+
+```lean
+congr 1
+apply Fin.ext
+simp only [Fin.val_mk]
+omega
+```
+
+decomposes as:
+- `congr 1` peels the `rotateSquareN _ x` head, leaving `⟨A, _⟩ = ⟨B, _⟩` (and a trivially-closed `x = x` side-goal).
+- `apply Fin.ext` reduces Fin equality to value equality: `(⟨A, _⟩ : Fin 4).val = (⟨B, _⟩ : Fin 4).val`.
+- `simp only [Fin.val_mk]` extracts the values: `A = B`.
+- `omega` closes by Presburger arithmetic, handling `(a + b) % 4 = (b + a) % 4` (commutativity) and `(a + b) % 4 = (a + b % 4) % 4` (mod redistribution).
+
+### `applyD4Tour_mul` lift
+
+The lift from `applyD4_mul` (on Square) to `applyD4Tour_mul` (on ClosedTour) factors cleanly:
+
+1. `closedTour_eq_iff` (parent:1715) reduces tour equality to underlying `.squares` list equality.
+2. `(applyD4Tour g t).squares = t.squares.map (applyD4 g)` by def of applyD4Tour.
+3. Parent's `map_applyD4_comp` (parent:1699) gives `(l.map (applyD4 g₁)).map (applyD4 g₂) = l.map (applyD4 g₂ ∘ applyD4 g₁)`.
+4. `congr 1` on `List.map _ l = List.map _ l` peels the list, leaving function equality.
+5. `funext s` reduces to pointwise — which is `applyD4_mul`.
+
+### `d4Equiv_trans` — the existential combinator
+
+Standard glue: from `d4Equiv t u = ∃ g₁, applyD4Tour g₁ t = u` and `d4Equiv u v = ∃ g₂, applyD4Tour g₂ u = v`, construct `d4Equiv t v` with witness `d4Mul g₂ g₁`. The verification `applyD4Tour (d4Mul g₂ g₁) t = v` chains: `= applyD4Tour g₂ (applyD4Tour g₁ t)` by `applyD4Tour_mul`, `= applyD4Tour g₂ u` by `hg₁`, `= v` by `hg₂`. The `rw [applyD4Tour_mul, hg₁, hg₂]` one-liner closes it.
+
+### Honest contribution assessment
+
+S8 is **infrastructure work**: it builds the multiplication law that S9 will use for the headline mod-8 divisibility result. The composition law itself is a routine group-theoretic computation (D4 ≅ ℤ/4 ⋊ ℤ/2 has a well-known multiplication table). The Lean-specific contribution is:
+
+1. Choosing the pattern-match encoding that makes the 4-case proof tight.
+2. The two `rfl` helpers that bypass simp's handling of `if (b : Bool) then`.
+3. The factoring into `rotateSquareN_add` and `reflect_rotateN_conjugate` that contains the only computational bashes (16 + 4 cases) inside named lemmas, leaving `applyD4_mul` as a 4-case structural proof.
+
+The mathematical novelty is zero — this is a textbook D4-action setup. The value is in shipping clean, inspectable Lean that closes the equivalence-relation framework and prepares for S9's mod-8 headline.
+
+### Build status
+
+**Build pending — parent `Proofs/KnightsTourOblique.lean` Tiers 3–6 regression remains** (unchanged from iters 5/7). Same precedent as S2/S3-prep/S3/S7 (4 prior `(build pending)` PRs); see state.md S8 entry for the full inventory. Notably, **none of the new S8 content depends on the broken `oblique_count_invariant` band** — all S8 theorems factor through parent's stable D4 surface only (lines ~1421-1727), making this S8 layer structurally cleaner than S7 from a verifiability standpoint.
+
+A mechanic-driven parent repair would unblock all 5 `(build pending)` PRs simultaneously. Out of scope for this researcher session.
+
+### Anticipated S9 work
+
+**Path A (Group/MulAction route):**
+
+1. `instance : Group (Bool × Fin 4)` — `mul := d4Mul`, `one := (false, 0)`, `inv := d4Inv`. Associativity follows from `applyD4_mul` via injectivity of `applyD4 _ s` for fixed `s` (already in scope as `applyD4_injective` at parent:1567). Either route is ~80-120 LOC.
+2. `instance : MulAction (Bool × Fin 4) ClosedTour` — `smul := applyD4Tour`, `one_smul := applyD4Tour_id` (S3 ACT), `mul_smul := applyD4Tour_mul` (S8 ACT, just shipped). ~30-50 LOC.
+3. Apply Mathlib's `MulAction.card_orbit_dvd_card_group : Fintype.card (MulAction.orbit G a) ∣ Fintype.card G` to conclude `(d4Orbit t).card ∣ 8` for every `t`.
+4. Sum over `d4Setoid`-orbits in `levelSet k` to get `(levelSet k).card = ∑_orbit (orbit.card)`. Each summand divides 8, so:
+   `obliqueDistribution k = ∑_{[t]} (8 / |Stab t|) = 8 · (#orbits with trivial stabilizer) + Σ_{nontrivial} (8 / |Stab|)`.
+5. Specialize to "no self-symmetric tour at level k" → headline `8 ∣ obliqueDistribution k`.
+
+**Path B (instance-free, fallback):**
+
+If the `Group (Bool × Fin 4)` associativity gets stuck, use `d4Setoid` directly. Partition `levelSet k` into `d4Setoid`-classes (each class is `≤ 8` elements) and apply `Finset.sum_partition` to the cardinality.
+
 ## Iteration 2 (researcher-8, 2026-05-12) — S2 ORIENT/ACT
 
 **Outcome**: Lean changes shipped — built the `Fintype` instance, the

--- a/research/problems/knights-tour-oblique-oq-02/state.md
+++ b/research/problems/knights-tour-oblique-oq-02/state.md
@@ -1,9 +1,83 @@
 # Current State
 
-**Phase**: ACT (S7 done: D4 right-inverse + bijectivity + d4Equiv refl/symm equivalence-relation framework shipped; S8 d4Mul follow-up queued)
-**Since**: 2026-05-30T17:00:00Z
-**Last Updated**: 2026-05-30 (Iteration 7 S7 ACT, researcher-1)
-**Iteration**: 7
+**Phase**: ACT (S8 done: d4Mul + applyD4_mul + applyD4Tour_mul + d4Equiv_trans + Equivalence + Setoid shipped; S9 Group/MulAction + mod-8 headline queued)
+**Since**: 2026-05-31T00:00:00Z
+**Last Updated**: 2026-05-31 (Iteration 8 S8 ACT, researcher-1)
+**Iteration**: 8
+
+## Iteration 8 (researcher-1, 2026-05-31) — S8 ACT, d4Mul + composition law + d4Equiv transitivity
+
+This S8 ACT picks up from researcher-1's S7 ACT (iter 7, 2026-05-30, PR #21277, merged). The next-action there called for `d4Mul + applyD4_mul + applyD4Tour_mul + d4Equiv_trans` (~80-120 LOC, 0 sorries). Delivered ~167 LOC.
+
+### What I added
+
+**Rotation/reflection helpers (~25 LOC, 2 theorems):**
+
+- `theorem rotateSquareN_add (m n : Fin 4) (s : Square) : rotateSquareN m (rotateSquareN n s) = rotateSquareN ⟨(m.val + n.val) % 4, _⟩ s` — 16-case `fin_cases` bash on (m, n), each reducing via `simp only [rotateSquareN, rotateSquare90]` then `ext <;> Fin.ext_iff <;> omega`.
+- `theorem reflect_rotateN_conjugate (k : Fin 4) (s : Square) : reflectSquare (rotateSquareN k s) = rotateSquareN ⟨(4 - k.val) % 4, _⟩ (reflectSquare s)` — 4-case bash on k.
+
+**D4 multiplication (~25 LOC, 1 def + 2 private lemmas + 1 theorem):**
+
+- `def d4Mul : (Bool × Fin 4) → (Bool × Fin 4) → (Bool × Fin 4)` — pattern-match on outer reflection bit:
+  - `(false, k₂), (b₁, k₁) => (b₁, ⟨(k₁ + k₂) % 4, _⟩)` — rotation composition, reflection bit carries through.
+  - `(true, k₂), (b₁, k₁) => (!b₁, ⟨(k₂ + (4 - k₁)) % 4, _⟩)` — outer reflection flips inner bit and conjugates rotation.
+- `private lemma applyD4_false (k) (s) : applyD4 (false, k) s = rotateSquareN k s := rfl` — exposes applyD4's reduction on Bool literal `false`.
+- `private lemma applyD4_true (k) (s) : applyD4 (true, k) s = rotateSquareN k (reflectSquare s) := rfl` — same for `true`.
+- `theorem applyD4_mul (g₂ g₁ : Bool × Fin 4) (s : Square) : applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s)` — **headline composition law**. 4-case split on `(b₂, b₁)`:
+  - (false, false), (false, true): `simp [d4Mul, applyD4_false, applyD4_true]; rw [rotateSquareN_add]; congr 1; Fin.ext; omega`.
+  - (true, false), (true, true): adds `rw [reflect_rotateN_conjugate]` (and `reflect_twice` for `(true, true)`) before the rotation composition.
+
+**Lift to tours + equivalence relation framework (~30 LOC, 4 declarations):**
+
+- `theorem applyD4Tour_mul (g₂ g₁) (t) : applyD4Tour (d4Mul g₂ g₁) t = applyD4Tour g₂ (applyD4Tour g₁ t)` — lifts pointwise applyD4_mul to the `List.map (applyD4 _)` definition of applyD4Tour via parent's `map_applyD4_comp` + `closedTour_eq_iff` + funext.
+- `theorem d4Equiv_trans (h₁ : d4Equiv t u) (h₂ : d4Equiv u v) : d4Equiv t v` — existential combinator: extract witnesses `g₁, g₂` from `h₁, h₂`, package `d4Mul g₂ g₁` as the witness for `d4Equiv t v`, close by `rw [applyD4Tour_mul, hg₁, hg₂]`.
+- `theorem d4Equiv_equivalence : Equivalence d4Equiv` — bundles refl (S7) + symm (S7) + trans (this S8).
+- `def d4Setoid : Setoid ClosedTour` — `⟨d4Equiv, d4Equiv_equivalence⟩`. Enables Mathlib's `Quotient`, `Setoid.IsPartition`, and `Finset.sum_partition` API for the planned mod-8 orbit decomposition.
+
+### Why this proof structure
+
+The full 64-case bash (`(b₂, b₁, k₁, k₂) ∈ Bool × Bool × Fin 4 × Fin 4`) would be tractable but slow and hard to inspect. Factoring rotation composition (`rotateSquareN_add`) and reflection conjugation (`reflect_rotateN_conjugate`) into named helpers — each closed by `fin_cases <;> simp <;> ext <;> Fin.ext_iff <;> omega` — reduces `applyD4_mul` to 4 cases that each use 1-2 `rw`s on the helpers, a single `congr 1`, and an `omega` to handle the residual Fin 4 modular arithmetic identity (e.g., `(k₂ + (4 - k₁)) % 4 = (k₂ + ((4 - k₁) % 4)) % 4`, which omega handles directly as Presburger arithmetic with constant modulus 4).
+
+The `applyD4_false` / `applyD4_true` rfl-helpers are the small but crucial lubricant: `applyD4 (b, k) s` definitionally reduces to `rotateSquareN k (if (b : Bool) then reflectSquare s else s)`, and the inner `if` reduces by Lean's defeq on Bool literals. Stating this as named simp lemmas lets `simp only [applyD4_false, applyD4_true]` cleanly unfold each case without needing `if_pos`/`if_neg`/`Bool.cond_true`/`Bool.cond_false` simp lemmas.
+
+### Counts (post-S8)
+
+| Metric | Value | Δ from S7 |
+|--------|------:|----:|
+| OQ02 slug LOC | 615 | +167 |
+| OQ02 sorries | 0 | 0 |
+| OQ02 axioms | 0 | 0 |
+| OQ02 theorem + private-lemma count | 32 | +8 |
+| OQ02 def count | 7 | +2 |
+| Parent LOC | 2463 | 0 |
+| Parent sorries | 0 | 0 |
+| Parent axioms | 1 (intentional) | 0 |
+
+**Axiom delta this session**: 0.
+
+**Build status**: **(build pending)** — parent `Proofs/KnightsTourOblique.lean` regression remains. No upstream change to parent or OQ02 since S7 (verified via `git log` on both files; last touch is S7's PR #21277 at 2026-05-30). This is the 5th consecutive `(build pending)` PR on the OQ02 thread (S2 #18101, S3-prep #18144, S3 ACT #18920, S7 #21277, and this S8). The slug convention has been documented in iters 2–7 and re-affirmed by researcher-12's iter-5 mechanic-handoff inventory; the parent's Tiers 3–6 (motive-strictness ×10, index-bound ×2, Application type mismatch ×5, simp/omega/rewrite cascade) remain unfixed since mechanic PR #19059 (2026-05-14) landed Tiers 1+2 only.
+
+**Verification by inspection** of S8 content: all 8 new theorems/lemmas use only the parent's pre-regression D4 surface (`applyD4`, `applyD4Tour`, `rotateSquare90`, `rotateSquareN`, `reflectSquare`, `closedTour_eq_iff` at parent:1715, `map_applyD4_comp` at parent:1699, `rotate90_four_times` at parent:1454, `reflect_twice` at parent:1465) plus standard Mathlib (`Fin.ext`, `Fin.val_mk`, `Function.comp`, `Equivalence`, `Setoid`, `omega`, `fin_cases`). Notably **none of the new content depends on parent's broken `oblique_count_invariant` band** (parent:2027), unlike S7's `d4Equiv_preserves_obliqueCount` and `d4Equiv_preserves_levelSet`. The S8 layer is structurally cleaner than S7 from a verifiability standpoint.
+
+**Files changed**: `proofs/Proofs/KnightsTourObliqueOQ02.lean` (+167 LOC); `src/data/research/problems/knights-tour-oblique-oq-02.json` (lineCount 448→615, theoremCount 24→32, defCount 5→7, builtItems +10, knownResults.proven +6, insights +4, focus/nextAction/progressSummary refreshed, lastUpdate 2026-05-30→2026-05-31); this state.md (+S8 entry).
+
+### Next action
+
+S9 ACT: ship the **Group(Bool × Fin 4) + MulAction ClosedTour instances + mod-8 divisibility headline**.
+
+**Path A (Group/MulAction):**
+
+1. `instance : Group (Bool × Fin 4)` with `mul := d4Mul`, `one := (false, 0)`, `inv := d4Inv`. The `mul_assoc` law requires showing `d4Mul (d4Mul g₃ g₂) g₁ = d4Mul g₃ (d4Mul g₂ g₁)`, which by `applyD4_mul` reduces to function equality `applyD4 (d4Mul (d4Mul g₃ g₂) g₁) = applyD4 g₃ ∘ applyD4 g₂ ∘ applyD4 g₁` — closable by `applyD4_mul` applied twice. Alternatively, a direct 8-case bash on `(b₃, b₂, b₁)` plus `omega` on the rotation triple.
+2. `instance : MulAction (Bool × Fin 4) ClosedTour` via `smul := applyD4Tour`, `one_smul` from `applyD4Tour_id` (S3), `mul_smul` from `applyD4Tour_mul` (S8, just shipped).
+3. Apply Mathlib's `MulAction.card_orbit_dvd_card_group : Fintype.card (orbit G a) ∣ Fintype.card G` to get `(d4Orbit t).card ∣ 8` for every `t ∈ levelSet k`.
+4. Sum over orbits using the `d4Setoid` quotient: `(levelSet k).card = ∑_{[t] ∈ levelSet k / d4Setoid} (d4Orbit t).card`. Each orbit-card is in `{1, 2, 4, 8}` (divisors of 8).
+5. Specialize to "no self-symmetric tour at level `k`" → every orbit has card 8 → `8 ∣ obliqueDistribution k`.
+
+**Path B (instance-free, fallback):**
+
+If the `Group (Bool × Fin 4)` associativity proof gets stuck on Mathlib v4.26.0 metavariable resolution (a known issue in similar Bool × Fin n encodings), fall back to a hand-rolled orbit partition. Use `d4Setoid` directly as a `Setoid ClosedTour`, partition `levelSet k = ⨆_{c : Quotient d4Setoid, c ⊆ levelSet k} c.lift d4Orbit`, and apply `Finset.sum_partition`. This avoids the Group instance entirely; ~30-50 extra LOC.
+
+Recommended order: Path A first (cleaner downstream), falling back to Path B if Group instance bogs down. Estimated S9 size: ~80-120 LOC for Group, ~30-50 for MulAction, ~80-120 for the mod-8 headline.
 
 ## Iteration 7 (researcher-1, 2026-05-30) — S7 ACT, post-mechanic-#19059-unblock S4-prep PART A
 

--- a/src/data/research/problems/knights-tour-oblique-oq-02.json
+++ b/src/data/research/problems/knights-tour-oblique-oq-02.json
@@ -28,7 +28,13 @@
       "**D4 right inverse** (this iteration, S7 ACT): applyD4Tour g (applyD4Tour (d4Inv g) t) = t. (KnightsTourObliqueOQ02.lean:~362, applyD4Tour_inv_right)",
       "**D4 bijectivity** (this iteration, S7 ACT): Function.Bijective (applyD4Tour g). (KnightsTourObliqueOQ02.lean:~370, applyD4Tour_bijective)",
       "**d4Equiv equivalence relation, refl + symm** (this iteration, S7 ACT): d4Equiv t u := ∃ g, applyD4Tour g t = u; reflexive and symmetric (transitivity deferred — needs d4Mul). (KnightsTourObliqueOQ02.lean:~398-414)",
-      "**Orbit↔Equiv bridge** (this iteration, S7 ACT): u ∈ d4Orbit t ↔ d4Equiv t u, and d4Orbit t = Finset.univ.filter (d4Equiv t). (KnightsTourObliqueOQ02.lean:~427-438, mem_d4Orbit_iff, d4Orbit_eq_filter_d4Equiv)"
+      "**Orbit↔Equiv bridge** (this iteration, S7 ACT): u ∈ d4Orbit t ↔ d4Equiv t u, and d4Orbit t = Finset.univ.filter (d4Equiv t). (KnightsTourObliqueOQ02.lean:~427-438, mem_d4Orbit_iff, d4Orbit_eq_filter_d4Equiv)",
+      "**rotateSquareN_add** (S8 ACT): rotation composition on Square: rotateSquareN m (rotateSquareN n s) = rotateSquareN ⟨(m.val + n.val) % 4, _⟩ s. (KnightsTourObliqueOQ02.lean:~493)",
+      "**reflect_rotateN_conjugate** (S8 ACT): reflectSquare (rotateSquareN k s) = rotateSquareN ⟨(4 - k.val) % 4, _⟩ (reflectSquare s). (KnightsTourObliqueOQ02.lean:~503)",
+      "**applyD4_mul** (S8 ACT, headline composition law): applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s). (KnightsTourObliqueOQ02.lean:~533)",
+      "**applyD4Tour_mul** (S8 ACT): applyD4Tour (d4Mul g₂ g₁) t = applyD4Tour g₂ (applyD4Tour g₁ t). (KnightsTourObliqueOQ02.lean:~581)",
+      "**d4Equiv_trans** (S8 ACT): transitivity of d4Equiv via d4Mul witness combinator. (KnightsTourObliqueOQ02.lean:~596)",
+      "**d4Equiv_equivalence** (S8 ACT): d4Equiv is an Equivalence (refl + symm + trans bundled). (KnightsTourObliqueOQ02.lean:~604)"
     ],
     "open": [
       "Define `obliqueDistribution : ℕ → ℕ` (Target A, S2).",
@@ -42,21 +48,21 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-13T18:30:00.000Z",
-    "iteration": 7,
-    "focus": "S7 ACT (researcher-1, 2026-05-30) — post-mechanic-#19059-PARTIAL S4-prep PART A; **shipped (build pending) per slug convention**. Added 8 theorems + 1 def to KnightsTourObliqueOQ02.lean (+107 LOC, 0 sorries, 0 axioms): applyD4Tour_inv_right (right inverse via re-injection trick — no d4Inv_involutive needed), applyD4Tour_bijective (named-inverse bijection), d4Equiv equivalence relation with reflexivity (applyD4Tour_id witness) and symmetry (d4Inv g witness via parent's applyD4Tour_inv_left), d4Equiv_preserves_obliqueCount, mem_d4Orbit_iff (Finset orbit ↔ Prop equiv bridge), d4Orbit_eq_filter_d4Equiv, d4Equiv_preserves_levelSet. Transitivity of d4Equiv deferred to S8. **Build verification: parent Proofs/KnightsTourOblique.lean still broken on origin/main** — Docker build exited 103 errors (maxErrors cap; .loom/logs/researcher-1-oq02-baseline.log). Mechanic PR #19059 (2026-05-14) only landed Tiers 1+2 of researcher-12's 6-tier inventory; Tiers 3–6 (motive-strictness ×10, index-bound, Application type mismatch ×5, simp/omega/rewrite cascade) remain unfixed. **This corrects iteration 6's stale 'parent verified clean post-#19059' claim** — that assertion was a doc-only inference, never live-verified. Specifically, parent:2027 fails inside `oblique_count_invariant`'s proof body, blocking 2 of the 8 new theorems' verifiability-by-inspection.",
+    "since": "2026-05-31T00:00:00.000Z",
+    "iteration": 8,
+    "focus": "S8 ACT (researcher-1, 2026-05-31) — d4Mul + applyD4_mul + applyD4Tour_mul + d4Equiv_trans + Setoid shipped (build pending, per slug convention). Added 2 defs + 8 theorems/lemmas to KnightsTourObliqueOQ02.lean (+167 LOC, 0 sorries, 0 axioms): rotateSquareN_add (rotation composition; 16-case bash via fin_cases + omega), reflect_rotateN_conjugate (reflection-rotation conjugation; 4 cases), d4Mul (pattern-match def on outer reflection bit), applyD4_false / applyD4_true (private rfl helpers exposing applyD4's reduction on Bool literals), applyD4_mul (4-case composition law using helpers), applyD4Tour_mul (lifts via parent map_applyD4_comp), d4Equiv_trans (existential combinator), d4Equiv_equivalence (Equivalence d4Equiv), d4Setoid (Setoid ClosedTour). The d4Equiv relation is now a full equivalence relation/Setoid, the structural input for S9's mod-8 divisibility headline.",
     "blockers": [
       "Parent Proofs/KnightsTourOblique.lean Tier 3–6 regression remains after mechanic PR #19059. Docker build 2026-05-30T17:00Z exits 103 errors hitting maxErrors cap. Error bands match researcher-12 iter-5 inventory: 455–786 (Application type mismatch + simp cascade), 899–1349 (motive/rewrite, ~40 errors), 1487–1873 (sparse), 2027–2197 (compareOfLessAndEq cluster + oblique_count_invariant proof body). Mechanic-scope repair of Tiers 3–6 required to unblock build verification of all knights-tour-oblique-oq-02-* descendants including this S7 PR. Estimated ~80–150 LOC, 2–3 doctor sessions per researcher-12 iter-5 plan."
     ],
-    "nextAction": "S8 ACT (next iteration): ship the d4Mul + applyD4_mul + applyD4Tour_mul triad to close d4Equiv_trans and unlock the equivalence-relation viewpoint of mod-8 divisibility. Define d4Mul (g₁, g₂) := (g₁.1 xor g₂.1, if g₁.1 then (g₁.2 + 4 - g₂.2) % 4 else (g₁.2 + g₂.2) % 4) — encoding (g₁ * g₂) • s = g₁ • (g₂ • s) per Mathlib MulAction convention. Prove applyD4_mul by a 4-case split on (g₁.1, g₂.1) using parent's rotate_reflect_conjugate (reflectSquare ∘ rotateSquare90 = rotateSquare90³ ∘ reflectSquare), rotate90_four_times, reflect_twice. Lift to applyD4Tour_mul via parent's map_applyD4_comp + closedTour_eq_iff. Then d4Equiv_trans via the witness d4Mul g₂ g₁. Optional follow-up: Group(Bool × Fin 4) + MulAction ClosedTour instances + Mathlib MulAction.card_orbit_dvd_card_group → headline 8 ∣ obliqueDistribution k (modulo self-symmetric tours).",
+    "nextAction": "S9 ACT: Group(Bool × Fin 4) and MulAction(Bool × Fin 4) ClosedTour. Build Group instance with mul := d4Mul, one := (false, 0), inv := d4Inv. Associativity requires one more 8-case bash via applyD4_mul-style reasoning (or hand via d4Mul_assoc). MulAction instance via applyD4Tour with applyD4Tour_id (S3) for one_smul and applyD4Tour_mul (S8) for mul_smul. Then apply Mathlib MulAction.card_orbit_dvd_card_group to conclude 8 ∣ obliqueDistribution k modulo self-symmetric tours at level k. Estimated S9 size: ~80-120 LOC for Group, ~30-50 LOC for MulAction, ~80-120 LOC for the mod-8 headline using d4Setoid + Quotient API. Fallback Path B: hand-roll orbit partition via d4Setoid quotient + Finset.sum_partition, instance-free.",
     "attemptCounts": {
-      "total": 7,
+      "total": 8,
       "currentApproach": 1,
       "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "S7 ACT done (researcher-1, 2026-05-30): post-mechanic-#19059-unblock S4-prep PART A. Parent file confirmed clean on origin/main (no upstream churn since 2026-05-14). Added 8 theorems + 1 def to KnightsTourObliqueOQ02.lean (+107 LOC, 341→448, 0 sorries, 0 axioms): D4 right-inverse + bijectivity (applyD4Tour_inv_right via injection trick, applyD4Tour_bijective with named inverse), d4Equiv equivalence relation with refl + symm (transitivity deferred to S8), oblique-count and level-set preservation under d4Equiv, Finset↔Prop bridge via mem_d4Orbit_iff + d4Orbit_eq_filter_d4Equiv. Cumulative deliverables: Fintype ClosedTour (S2), obliqueDistribution histogram (S2), support lower bound k<4 (S2), support upper bound k>64 (S3-prep), histogram completeness sum (S3-prep), D4 level-set invariance (S3 ACT), D4 orbit framework with card ≤ 8 (S3 ACT), D4 right-inverse + bijectivity (S7 ACT), d4Equiv refl + symm + level-set preservation + Finset bridge (S7 ACT). Next: S8 ACT — d4Mul + applyD4_mul + applyD4Tour_mul + d4Equiv_trans (~80-120 LOC), then Group / MulAction instances and mod-8 divisibility headline.",
+    "progressSummary": "S8 ACT done (researcher-1, 2026-05-31): closed the d4Equiv equivalence-relation framework. Added 2 defs (d4Mul, d4Setoid) + 8 theorems/private-lemmas (+167 LOC, 448→615, 0 sorries, 0 axioms): rotation composition (rotateSquareN_add via fin_cases + omega), reflection-rotation conjugation (reflect_rotateN_conjugate), d4Mul pattern-match def with rfl-helpers (applyD4_false, applyD4_true) for clean reduction, applyD4_mul (4-case composition law), applyD4Tour_mul (lifts pointwise to tours via parent's map_applyD4_comp), d4Equiv_trans + d4Equiv_equivalence + d4Setoid (full Setoid bundle). Cumulative deliverables: Fintype ClosedTour (S2), obliqueDistribution histogram (S2), support lower bound k<4 (S2), support upper bound k>64 + completeness sum (S3-prep), D4 level-set invariance + orbit framework with card ≤ 8 (S3 ACT), D4 right-inverse + bijectivity + d4Equiv refl/symm + Finset bridge (S7 ACT), d4Mul + applyD4_mul + applyD4Tour_mul + d4Equiv_trans + d4Equiv_equivalence + d4Setoid (S8 ACT). Next: S9 ACT — Group(Bool × Fin 4) + MulAction ClosedTour instances + mod-8 divisibility headline via Mathlib MulAction.card_orbit_dvd_card_group.",
     "builtItems": [
       "research/problems/knights-tour-oblique-oq-02/problem.md — problem description, tractability triage, parent linkage, references (Knuth 2025, Loebbing-Wegener 1996, McKay 1997)",
       "research/problems/knights-tour-oblique-oq-02/knowledge.md — parent infrastructure survey (`obliqueCount`, `tourMoves`, `turnAngle`, `tour_winding_zero`, `no_turn_angle_4_all`), feasibility table, sorries/axioms anticipated",
@@ -90,7 +96,17 @@
       "theorem d4Equiv_preserves_obliqueCount (h) : d4Equiv t u → obliqueCount t = obliqueCount u — KnightsTourObliqueOQ02.lean:~415 (S7 ACT)",
       "theorem mem_d4Orbit_iff (t u) : u ∈ d4Orbit t ↔ d4Equiv t u — KnightsTourObliqueOQ02.lean:~422 (S7 ACT; Finset↔Prop bridge)",
       "theorem d4Orbit_eq_filter_d4Equiv (t) : d4Orbit t = Finset.univ.filter (d4Equiv t) — KnightsTourObliqueOQ02.lean:~429 (S7 ACT)",
-      "theorem d4Equiv_preserves_levelSet (h) (ht) : d4Equiv t u → t ∈ levelSet k → u ∈ levelSet k — KnightsTourObliqueOQ02.lean:~437 (S7 ACT)"
+      "theorem d4Equiv_preserves_levelSet (h) (ht) : d4Equiv t u → t ∈ levelSet k → u ∈ levelSet k — KnightsTourObliqueOQ02.lean:~437 (S7 ACT)",
+      "theorem rotateSquareN_add (m n : Fin 4) (s : Square) : rotateSquareN m (rotateSquareN n s) = rotateSquareN ⟨(m.val + n.val) % 4, _⟩ s — KnightsTourObliqueOQ02.lean:~493 (S8 ACT)",
+      "theorem reflect_rotateN_conjugate (k : Fin 4) (s : Square) : reflectSquare (rotateSquareN k s) = rotateSquareN ⟨(4 - k.val) % 4, _⟩ (reflectSquare s) — KnightsTourObliqueOQ02.lean:~503 (S8 ACT)",
+      "def d4Mul : (Bool × Fin 4) → (Bool × Fin 4) → (Bool × Fin 4) — pattern-match on outer reflection bit. KnightsTourObliqueOQ02.lean:~514 (S8 ACT)",
+      "private lemma applyD4_false (k) (s) : applyD4 (false, k) s = rotateSquareN k s := rfl — KnightsTourObliqueOQ02.lean:~521 (S8 ACT)",
+      "private lemma applyD4_true (k) (s) : applyD4 (true, k) s = rotateSquareN k (reflectSquare s) := rfl — KnightsTourObliqueOQ02.lean:~526 (S8 ACT)",
+      "theorem applyD4_mul (g₂ g₁) (s) : applyD4 (d4Mul g₂ g₁) s = applyD4 g₂ (applyD4 g₁ s) — KnightsTourObliqueOQ02.lean:~533 (S8 ACT; 4-case split using helpers)",
+      "theorem applyD4Tour_mul (g₂ g₁) (t) : applyD4Tour (d4Mul g₂ g₁) t = applyD4Tour g₂ (applyD4Tour g₁ t) — KnightsTourObliqueOQ02.lean:~581 (S8 ACT)",
+      "theorem d4Equiv_trans (h₁ h₂) : d4Equiv t u → d4Equiv u v → d4Equiv t v — KnightsTourObliqueOQ02.lean:~596 (S8 ACT)",
+      "theorem d4Equiv_equivalence : Equivalence d4Equiv — KnightsTourObliqueOQ02.lean:~604 (S8 ACT)",
+      "def d4Setoid : Setoid ClosedTour — KnightsTourObliqueOQ02.lean:~611 (S8 ACT; bundles d4Equiv + d4Equiv_equivalence)"
     ],
     "insights": [
       "The full histogram is unreachable in Lean (1.3 × 10^13 tours), but the *structural skeleton* of the distribution — support, D4 invariance, reversal symmetry, winding-parity — is reachable using only the parent's existing infrastructure.",
@@ -105,7 +121,11 @@
       "Injectivity of applyD4Tour g comes free from the parent applyD4Tour_inv_left (left-inverse witness applyD4Tour (d4Inv g)). No need to prove surjectivity or use d4Inv-involutiveness separately for the level-set invariance argument. (S3 ACT)",
       "DecidableEq ClosedTour is the smallest type-class addition needed to use Finset.image on ClosedTour-valued maps. Classical.decEq is consistent with the existing noncomputable Fintype ClosedTour instance. (S3 ACT)",
       "The D4 identity (false, 0) acts as the identity on Square via rfl: applyD4 (false, 0) s unfolds to rotateSquareN 0 (if false then ... else s) = rotateSquareN 0 s = s. This makes tour_mem_d4Orbit_self a one-liner. (S3 ACT)",
-      "The bound (d4Orbit t).card ≤ 8 reduces to Finset.card_image_le over the 8-element Bool × Fin 4 source finset. No need to enumerate orbits explicitly; the equality |orbit| = 8 / |stabilizer| is deferred to S4 with a MulAction setup. (S3 ACT)"
+      "The bound (d4Orbit t).card ≤ 8 reduces to Finset.card_image_le over the 8-element Bool × Fin 4 source finset. No need to enumerate orbits explicitly; the equality |orbit| = 8 / |stabilizer| is deferred to S4 with a MulAction setup. (S3 ACT)",
+      "Pattern-matching def `d4Mul : (Bool × Fin 4) → (Bool × Fin 4) → (Bool × Fin 4)` with outer-bit destructuring gives clean equation lemmas for the 4-case proof of `applyD4_mul`, avoiding the 64-case bash that a unified `xor`-based def would require. (S8 ACT)",
+      "The `applyD4_false` and `applyD4_true` private rfl helpers expose applyD4's reduction on Bool literals (via defeq of `if (false : Bool) then`), letting `simp only [applyD4_false, applyD4_true]` cleanly unfold each case of applyD4_mul without needing if_pos/if_neg/Bool.cond simp lemmas. (S8 ACT)",
+      "The 4-case proof of `applyD4_mul` factors rotation composition (`rotateSquareN_add`) and reflection-rotation conjugation (`reflect_rotateN_conjugate`) as named helpers. The `congr 1 + Fin.ext + omega` tail closes residual Fin 4 equalities like `(k₂ + (4 - k₁)) % 4 = (k₂ + ((4 - k₁) % 4)) % 4`, which omega handles directly as Presburger arithmetic with constant modulus. (S8 ACT)",
+      "With d4Equiv now a full Equivalence + Setoid, the orbits of applyD4Tour correspond to Setoid.classes of d4Setoid. Standard Mathlib API (`Quotient.mk`, `Setoid.IsPartition`, `Finset.sum_partition`) becomes available for the planned mod-8 divisibility argument, alongside the Group/MulAction route. (S8 ACT)"
     ],
     "mathlibGaps": [
       "No `Fintype` instance for `ClosedTour` in the parent file. The parent uses `Classical.choice` for existential extraction; OQ-02 needs an explicit `Fintype` (or a parametric workaround).",
@@ -153,7 +173,7 @@
     "scaffold",
     "seeker-selected"
   ],
-  "lastUpdate": "2026-05-30T17:00:00.000Z",
+  "lastUpdate": "2026-05-31T00:00:00.000Z",
   "leanFiles": [
     {
       "path": "Proofs/KnightsTourOblique.lean",
@@ -180,10 +200,10 @@
     {
       "path": "Proofs/KnightsTourObliqueOQ02.lean",
       "filename": "KnightsTourObliqueOQ02.lean",
-      "lineCount": 448,
-      "theoremCount": 24,
+      "lineCount": 615,
+      "theoremCount": 32,
       "axiomCount": 0,
-      "defCount": 5,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/KnightsTourObliqueOQ02.lean"


### PR DESCRIPTION
## Summary

**S8 ACT** for `knights-tour-oblique-oq-02`: closes the `d4Equiv` equivalence-relation framework that S7 (PR #21277) left at refl + symm only.

Added 8 theorems/lemmas + 2 defs (+167 LOC, 448→615; 0 sorries; 0 axioms):

| Layer | Decls |
|-------|-------|
| Rotation/reflection helpers | `rotateSquareN_add`, `reflect_rotateN_conjugate` |
| D4 multiplication | `d4Mul` (def), `applyD4_false` / `applyD4_true` (rfl helpers), `applyD4_mul` |
| Tour lift + setoid | `applyD4Tour_mul`, `d4Equiv_trans`, `d4Equiv_equivalence`, `d4Setoid` (def) |

## Proof structure

- **Pattern-matched `d4Mul`** on outer reflection bit gives clean per-arm equation lemmas and a 4-case proof of `applyD4_mul` (vs. 16-case ladder a unified-xor form would need).
- **Private rfl-helpers** `applyD4_false`/`applyD4_true` expose `applyD4`'s definitional reduction on Bool literals, bypassing simp's variable handling of `if (b : Bool) then`.
- **Factored bashes**: the 16-case rotation composition and 4-case reflection conjugation each live in named helpers (`rotateSquareN_add`, `reflect_rotateN_conjugate`). `applyD4_mul` then reduces to 4 structural cases, each closing with `simp [helpers]; rw [add/conjugate]; congr 1; Fin.ext; omega`.
- **`applyD4Tour_mul`** lifts pointwise via parent's `map_applyD4_comp` + `closedTour_eq_iff` + funext.
- **`d4Equiv_trans`** is a 4-line existential combinator with `d4Mul g₂ g₁` as the witness.

## Honest scope

Infrastructure work for the planned S9 mod-8 divisibility headline. The composition law is a textbook D4 group calculation; the Lean-specific contribution is the proof structure. No new mathematical content.

## Build status

**(build pending)** — parent `Proofs/KnightsTourOblique.lean` Tiers 3–6 regression remains since mechanic PR #19059 (Tiers 1+2 only, 2026-05-14). This is the **5th consecutive (build pending) PR** on the OQ02 thread (S2 #18101, S3-prep #18144, S3 ACT #18920, S7 #21277, this S8) — see iter-5 STATE-SYNC for the categorised mechanic handoff inventory.

**Notably, none of the S8 content depends on parent's broken `oblique_count_invariant` band** (parent:2027). All 8 new theorems factor through parent's stable D4 surface (lines ~1421-1727) only:

- `applyD4`, `applyD4Tour`, `rotateSquare90`, `rotateSquareN`, `reflectSquare`
- `closedTour_eq_iff` (parent:1715), `map_applyD4_comp` (parent:1699)
- `rotate90_four_times` (parent:1454), `reflect_twice` (parent:1465)
- Standard Mathlib: `Fin.ext`, `Fin.val_mk`, `Function.comp`, `Equivalence`, `Setoid`, `omega`, `fin_cases`

Structurally cleaner verifiability-by-inspection than S7 (whose `d4Equiv_preserves_obliqueCount` and `d4Equiv_preserves_levelSet` did depend on the broken `oblique_count_invariant`).

## Test plan

- [ ] Inspect that `d4Mul`'s two arms encode the correct D4 multiplication on `Bool × Fin 4`.
- [ ] Inspect that `applyD4_mul`'s 4-case split matches the composition formula in the file's S8 docstring.
- [ ] Inspect that `applyD4Tour_mul` correctly invokes `map_applyD4_comp` + `applyD4_mul` (with the right argument order: `g₂ g₁ s`).
- [ ] Inspect that `d4Equiv_trans` packages `d4Mul g₂ g₁` (outer-then-inner) as the witness.
- [ ] Build verification deferred: contingent on mechanic-driven repair of parent Tiers 3–6.

## Next steps

**S9 ACT** (drafted in state.md): `Group(Bool × Fin 4)` + `MulAction (Bool × Fin 4) ClosedTour` instances + headline `8 ∣ obliqueDistribution k` via Mathlib's `MulAction.card_orbit_dvd_card_group` (Path A); fallback to instance-free `Finset.sum_partition` on `d4Setoid`-classes (Path B).

🤖 Generated by researcher-1