### PR TITLE
fix(meta): erdos-982 register Erdos982Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-982/meta.json
+++ b/src/data/proofs/erdos-982/meta.json
@@ -66,7 +66,10 @@
     "lineCount": 333,
     "assumptions": "4 axioms: moser_bound, nppz_bound, regular_polygon_distances, stronger_conjecture_is_false. 3 sorries.",
     "theoremCount": 6,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Erdos982Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdos Problem #982** is a fundamental question in discrete geometry about the structure of convex polygons.\n\n**Historical Development:**\n- **1946**: Erdos posed the original problem in \"On sets of distances of n points\"\n- **1952**: Moser proved the first lower bound f(n) >= ceil(n/3)\n- **1994**: Erdos and Fishburn improved this to f(n) >= floor(n/3 + 1)\n- **2006**: Dumitrescu pushed the bound to approximately 0.361n\n- **2013**: Nivasch, Pach, Pinchasi, and Zerbib achieved f(n) >= (13/36 + 1/22701)n - O(1)\n\n**Related Conjectures:**\nErdos originally conjectured something stronger: that every convex polygon has a vertex with no three equidistant vertices. This was disproved (see Problem #97). He also conjectured a continuous version for convex curves, which Barany and Roldan-Pensado showed is false as stated (acute triangle boundaries are counterexamples).",
@@ -195,7 +198,10 @@
     "theoremCount": 6,
     "definitionCount": 9,
     "path": "Proofs/Erdos982Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Erdos982Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register `proofs/Proofs/Erdos982Aristotle.lean` in `src/data/proofs/erdos-982/meta.json` (both `meta.additionalFiles` and `leanFile.additionalFiles`).

## Evidence

**Before**: The companion file existed on disk but was not referenced by any gallery entry — neither `meta.additionalFiles` nor `leanFile.additionalFiles` listed it. The gallery surfaced only `Erdos982Problem.lean`.

**After**: Both registration sites list `Proofs/Erdos982Aristotle.lean`, matching the canonical pattern used by `erdos-922`, `erdos-1043`, and the other Aristotle-companion gallery entries.

## Scope

Single metadata-only change. No Lean source edits.

---
Automated fix by lean-mechanic agent.