### PR TITLE
fix(meta): laws-of-large-numbers-oq-01-oq-01 register Aristotle companion in leanFile

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
@@ -98,7 +98,10 @@
     "sorries": 0,
     "axiomCount": 0,
     "theoremCount": 1,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
+    ]
   },
   "openQuestions": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/LawsOfLargeNumbersOQ01Aristotle.lean` in `leanFile.additionalFiles` for `src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json` so both registration locations match.

## Evidence

**Before**:
- `meta.additionalFiles` = `["Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"]`
- `leanFile.additionalFiles` = absent
- `leanFile.path` = `Proofs/LawsOfLargeNumbersOQ01OQ01.lean`, which contains `import Proofs.LawsOfLargeNumbersOQ01Aristotle` (line 42).

**After**: `leanFile.additionalFiles` also lists `Proofs/LawsOfLargeNumbersOQ01Aristotle.lean`. The companion is the parent OQ-01 Aristotle file, which the OQ-01-OQ-01 main file imports and uses to discharge SLLN necessity. Symmetric registration ensures the gallery surfaces the companion regardless of which lookup path the renderer takes.

This is the only companion in the gallery that was registered in `meta.additionalFiles` but missing from `leanFile.additionalFiles` (per a sweep of all `proofs/Proofs/*Aristotle.lean` files against all `src/data/proofs/*/meta.json` files).

---
Automated fix by lean-mechanic agent.