### PR TITLE
fix(meta): erdos-613 register Erdos613Aristotle.lean companion

### DIFF
--- a/src/data/proofs/erdos-613/meta.json
+++ b/src/data/proofs/erdos-613/meta.json
@@ -62,7 +62,8 @@
     "theoremCount": 11,
     "definitionCount": 14,
     "additionalFiles": [
-      "Proofs/Erdos613ProblemAristotle.lean"
+      "Proofs/Erdos613ProblemAristotle.lean",
+      "Proofs/Erdos613Aristotle.lean"
     ]
   },
   "overview": {
@@ -201,7 +202,8 @@
     "path": "Proofs/Erdos613Problem.lean",
     "sorries": 12,
     "additionalFiles": [
-      "Proofs/Erdos613ProblemAristotle.lean"
+      "Proofs/Erdos613ProblemAristotle.lean",
+      "Proofs/Erdos613Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/Erdos613Aristotle.lean` companion in both
`meta.additionalFiles` and `leanFile.additionalFiles` so the gallery displays it.

## Evidence

**Before**: Only `Proofs/Erdos613ProblemAristotle.lean` was listed; the separate
`Proofs/Erdos613Aristotle.lean` companion (37 lines, two arithmetic lemmas about
`criticalEdgeCount`) was unreferenced by the meta file even though it exists on disk
and imports `Proofs.Erdos613Problem`.

**After**: Both Aristotle companion files appear in both `meta.additionalFiles` and
`leanFile.additionalFiles`.

```
meta.additionalFiles: ['Proofs/Erdos613ProblemAristotle.lean', 'Proofs/Erdos613Aristotle.lean']
leanFile.additionalFiles: ['Proofs/Erdos613ProblemAristotle.lean', 'Proofs/Erdos613Aristotle.lean']
```

---
Automated fix by lean-mechanic agent.