### PR TITLE
Enrich abel-ruffini & abel-ruffini-galois-extensions: derived-series prerequisites

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -89,7 +89,8 @@
       "Galois theory: Galois group, radical extensions, Kummer theory; specifically that $\\alpha$ is solvable by radicals iff $\\text{Gal}(f_\\alpha/F)$ is solvable",
       "Lean 4 / Mathlib typeclasses: `IsSolvable`, `IsSimpleGroup`, `IsGalois` — solvability and simplicity are typeclass predicates whose instances Lean derives automatically via `inferInstance`",
       "Decision procedures in Lean 4: `decide` (kernel evaluator, used here for groups up to $|S_5| = 120$ and $|A_5| = 60$) vs `native_decide` (compiles to native code, used from $|A_6| = 360$ and $|S_6| = 720$ upward, including $|S_7| = 5040$ and $|S_8| = 40320$)",
-      "Klein four-group $V_4 \\cong (\\mathbb{Z}/2\\mathbb{Z})^2$: the unique proper non-trivial normal subgroup of $A_4$ giving the composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$ with abelian factors"
+      "Klein four-group $V_4 \\cong (\\mathbb{Z}/2\\mathbb{Z})^2$: the unique proper non-trivial normal subgroup of $A_4$ giving the composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$ with abelian factors",
+      "Derived series and commutator subgroups: $G^{(0)} = G$, $G^{(k+1)} = [G^{(k)}, G^{(k)}]$ as the canonical solvability witness — Mathlib's `Group.derivedSeries` enumerates this iterated commutator chain via `commutator G`, and `IsSolvable` is precisely the predicate $\\exists n,\\, G^{(n)} = 1$. Every `inferInstance` proof in this file ultimately discharges against this derived-series termination."
     ]
   },
   "conclusion": {

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -52,7 +52,8 @@
       "Galois theory and field extensions",
       "Group theory (symmetric groups, solvability)",
       "Polynomial rings and splitting fields",
-      "Radical extensions and root expressions"
+      "Radical extensions and root expressions",
+      "Derived series and the `IsSolvable` typeclass: $G^{(0)} = G$, $G^{(k+1)} = [G^{(k)}, G^{(k)}]$ — Mathlib's `IsSolvable G` is the predicate $\\exists n,\\, G^{(n)} = 1$, exposed via `Group.derivedSeries` and discharged by `inferInstance` whenever the kernel and quotient of a short exact sequence are solvable (the splicing lemma `solvable_of_ker_le_range` used by `symmetric_group_not_solvable`)"
     ],
     "wiedijkNumber": 16,
     "axiomCount": 0,


### PR DESCRIPTION
## Summary

Adds one prerequisite item to each of two related entries explicitly tying Lean's `IsSolvable` typeclass to the derived series $G^{(k+1)} = [G^{(k)}, G^{(k)}]$ — closing the operational gap between `inferInstance`/`solvable_of_ker_le_range` invocations and the underlying group-theoretic definition.

## Changes (2 commits)

1. **`abel-ruffini-galois-extensions/meta.json`**: prerequisites 6 → 7
   - Adds derived-series + commutator-subgroups prerequisite citing Mathlib's `Group.derivedSeries`

2. **`abel-ruffini/meta.json`**: prerequisites 4 → 5
   - Adds a parallel derived-series prerequisite, explicitly mentioning the `solvable_of_ker_le_range` splicing lemma used by `symmetric_group_not_solvable`

## Why this matters

Both entries' existing prerequisites cover Lean typeclasses (`IsSolvable`, `IsSimpleGroup`, `IsGalois`) but did not explicitly state the *derived series definition* of solvability that Mathlib's typeclass mechanism relies on. The annotations and section summaries repeatedly invoke `inferInstance` without naming the underlying derived-series chain — these prerequisites close that conceptual gap for readers unfamiliar with Mathlib's `Group.derivedSeries` API.

## Test plan
- [x] JSON parses for both files
- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] No structural changes — single string append to each prerequisites array

🤖 Generated with [Claude Code](https://claude.com/claude-code)