### PR TITLE
audit(erdos-166): mark clean (cycle 4) — R(4,k) Ramsey lower bound integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4912,9 +4912,9 @@
     },
     "erdos-166": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T09:05:04Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T12:31:19Z",
+      "result": "clean",
       "issues": [
         "phantom axioms in originalContributions/proofStrategy/sections (only aks_upper_bound + mattheus_verstraete declared; spencer_lower_bound/R(3,3)/R(4,4)/R(4,5)/R(3,k) are doc-comment only); section line drift sections 4-8 (issue #14685)"
       ]


### PR DESCRIPTION
## Summary
- Cycle 4 re-audit of `erdos-166` (R(4,k) Ramsey number lower bound, Mattheus-Verstraete 2023)
- All integrity checks pass; previously flagged phantom-axiom claims already resolved upstream
- Tracker advanced from `issues-fixed` to `clean`

## Integrity Verification
| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| Sorries | 0 | 0 | ✓ |
| Axioms | 2 | 2 (`aks_upper_bound`, `mattheus_verstraete`) | ✓ |
| Theorems | 7 | 7 | ✓ |
| Definitions | 2 | 2 (`RamseyNumber`, `Erdos166Statement`) | ✓ |
| Line count | 269 | 269 | ✓ |
| True stubs | — | none | ✓ |

- `status: "axiomatized"` + badge `"axiom"` correctly reflects the 2 declared axioms encoding the historical bounds.
- `erdosProblemStatus: "solved"` accurate (Mattheus-Verstraete 2023, \$250 Erdős prize).

## Test plan
- [x] Verify sorry/axiom/theorem/definition counts match meta.json
- [x] Confirm no `True`-stub theorems
- [x] Confirm status/badge match assumption profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)