### PR TITLE
fix(meta): erdos-162 realign stale section line ranges

### DIFF
--- a/src/data/proofs/erdos-162/meta.json
+++ b/src/data/proofs/erdos-162/meta.json
@@ -68,43 +68,43 @@
     {
       "id": "colouring",
       "title": "Edge Colouring and Balance",
-      "startLine": 32,
-      "endLine": 75,
+      "startLine": 34,
+      "endLine": 139,
       "summary": "Defines EdgeColouring (symmetric Bool on pairs), colourEdgeCount (filtered product count), colourEdgeCount_total, IsBalancedOn, IsKBalanced, and balanced_requires_le_half."
     },
     {
       "id": "function-f",
       "title": "The Function F(n, α)",
-      "startLine": 76,
-      "endLine": 103,
+      "startLine": 141,
+      "endLine": 156,
       "summary": "Axiomatizes discrepancyF with characterization spec, monotonicity in α, F(n,0)=n, and F(n,α) ≤ n."
     },
     {
       "id": "log-bounds",
       "title": "Logarithmic Bounds",
-      "startLine": 104,
-      "endLine": 129,
+      "startLine": 157,
+      "endLine": 179,
       "summary": "Axiomatizes lower and upper bounds c₁ log n < F < c₂ log n. Proves Θ(log n) sandwich theorem."
     },
     {
       "id": "derived",
       "title": "Derived Results",
-      "startLine": 130,
-      "endLine": 135,
+      "startLine": 181,
+      "endLine": 185,
       "summary": "Proves half_is_extremal: F(n,1/2) ≤ F(n,α) directly from monotonicity axiom."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
-      "startLine": 136,
-      "endLine": 149,
+      "startLine": 187,
+      "endLine": 199,
       "summary": "Defines ErdosProblem162: F(n,α)/log n → c_α via ε-δ convergence for every 0 < α ≤ 1/2."
     },
     {
       "id": "examples",
       "title": "Computational Examples",
-      "startLine": 150,
-      "endLine": 186,
+      "startLine": 201,
+      "endLine": 213,
       "summary": "Verifies C(1,2)=0, C(2,2)=1, C(4,2)=6, C(8,2)=28 via native_decide."
     }
   ],


### PR DESCRIPTION
## Fix

The six `sections[].startLine` / `endLine` values in `src/data/proofs/erdos-162/meta.json` referenced lines 32-186 from an earlier version of `Erdos162Problem.lean`. Several start/end values landed inside theorem proof bodies. The file is now 237 lines and the named sections live at different boundaries.

## Evidence

**Before** → **After** (verified against `proofs/Proofs/Erdos162Problem.lean`):

| Section | Old range | New range | Anchor |
|---|---|---|---|
| `colouring` | 32-75 | 34-139 | `-- Part I` at 34; ends at `balanced_requires_le_half` at 139 |
| `function-f` | 76-103 | 141-156 | `-- Part III` at 141; `axiom discrepancyF` at 145; `axiom ..._mono_alpha` at 151 |
| `log-bounds` | 104-129 | 157-179 | `discrepancy_lower` 160; `discrepancy_upper` 167; `discrepancy_theta_log` 174-179 |
| `derived` | 130-135 | 181-185 | `half_is_extremal` 183-185 |
| `main-conjecture` | 136-149 | 187-199 | `-- Part VII` 187; `def ErdosProblem162` 195-199 |
| `examples` | 150-186 | 201-213 | `-- Part VIII` 201; four `example` declarations at 204/207/210/213 |

All other integrity fields verified consistent:
- \`sorries: 0\` ✓
- \`axiomCount: 4\` matches 4 \`axiom\` declarations ✓
- \`theoremCount: 4\`, \`definitionCount: 5\` ✓
- \`status: axiomatized\` + \`badge: axiom\` correct for the four open-conjecture axioms ✓
- \`erdosProblemStatus: open\` correct (Erdős #162 still open) ✓

Closes #21485.

---
Automated fix by lean-mechanic agent.