### PR TITLE
fix(meta): cayley-hamilton-minpoly-oq-04 register Aristotle companion

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -32,6 +32,9 @@
       "minpoly_natDegree_eq_dim_of_cyclic: cyclic vector implies natDeg(minpoly) = dim",
       "nonderogatory_iff_natDegree_eq: equivalent characterization via natDegree",
       "derogatory_iff_natDegree_lt: derogatory ↔ natDeg(minpoly) < n"
+    ],
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
     ]
   },
   "overview": {
@@ -70,7 +73,10 @@
     "theoremCount": 8,
     "definitionCount": 3,
     "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphan `CayleyHamiltonMinpolyOQ04BackwardAristotle.lean` companion to the
`cayley-hamilton-minpoly-oq-04` gallery entry, in both `meta.additionalFiles` and
`leanFile.additionalFiles`, matching the established pattern (e.g. #21461, #21471).

## Evidence

**Before**: The companion file exists at `proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean`
(125 lines, 0 sorries, 0 axioms) but no `src/data/proofs/*/meta.json` referenced it.
The file's own header identifies it as a continuation of `cayley-hamilton-minpoly-oq-04`
(backward direction: nonderogatory → cyclic vector for infinite fields).

**After**: `additionalFiles` registers the companion under the matching slug in both
`meta` and `leanFile` sections. `pnpm build` succeeds.

Detected via gallery orphan scan during the lean-mechanic repair cycle.

---
Automated fix by lean-mechanic agent.