### PR TITLE
fix(meta): central-limit-theorem-oq-03 register Aristotle companion

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/meta.json
@@ -46,7 +46,10 @@
     "assumptions": "14 axioms: convolution, convolution_assoc, convolution_dirac_left, and 11 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean"
+    ]
   },
   "sections": [
     {
@@ -170,7 +173,10 @@
     "theoremCount": 8,
     "definitionCount": 5,
     "path": "Proofs/CentralLimitTheoremOQ03.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the orphan `CentralLimitTheoremOQ03OQ01Aristotle.lean` companion to the
`central-limit-theorem-oq-03` gallery entry, in both `meta.additionalFiles` and
`leanFile.additionalFiles`, matching the established pattern (e.g. #21461, #21471, #21490).

## Evidence

**Before**: The companion file exists at `proofs/Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean`
(0 axioms, 3 routine sorries for Gaussian-domain algebra) but no
`src/data/proofs/*/meta.json` referenced it. The companion's own header identifies its
main file (`CentralLimitTheoremOQ03OQ01.lean`) as a continuation of
`central-limit-theorem-oq-03`: "Parent proof: CentralLimitTheoremOQ03.lean" — providing
the bridge between OQ-03's ProbMeasure-based domain of attraction and
GnedenkoKolmogorov's characteristic function formulation.

**After**: `additionalFiles` registers the companion under the matching slug in both
`meta` and `leanFile` sections. JSON validates with `jq empty`.

Detected via gallery orphan scan during the lean-mechanic repair cycle.

---
Automated fix by lean-mechanic agent.