### PR TITLE
Research: minkowski-theorem-oq-02-oq-03 — S12 S5-c ACT dirichletSetN_volume (build pending, G9 lake)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ02OQ03.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ02OQ03.lean
@@ -76,6 +76,7 @@ merged) and S6 PREP
 import Mathlib.Analysis.Convex.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
 import Mathlib.LinearAlgebra.Matrix.Block
 import Mathlib.LinearAlgebra.Matrix.Determinant.Basic
 import Mathlib.Algebra.BigOperators.Fin
@@ -84,7 +85,7 @@ import Proofs.MinkowskiFundamentalTheorem
 
 namespace MinkowskiTheoremOQ02OQ03
 
-open OrderDual
+open OrderDual MeasureTheory
 
 -- ============================================================
 -- PART 1: The n-dim Dirichlet Parallelepiped (Cassels 1957)
@@ -330,7 +331,70 @@ theorem dirichletSetN_eq_shearM_preimage (n : ℕ) (α : Fin n → ℝ) (Q : ℕ
       exact abs_lt.mpr hk
 
 -- ============================================================
--- PART 7: Integer-coordinate extraction (S6α ACT — this revision)
+-- PART 6: Volume via shear pushforward (S5-c ACT — this revision)
+-- ============================================================
+
+/-- The `dirichletBoxN` rectangle is measurable (it is a `Set.pi` of
+open intervals over the finite index type `Fin (n+1)`). Bearer for the
+`Real.map_matrix_volume_pi_eq_smul_volume_pi` pushforward step in
+`dirichletSetN_volume`. -/
+theorem dirichletBoxN_measurable (n : ℕ) (Q : ℕ) :
+    MeasurableSet (dirichletBoxN n Q) := by
+  unfold dirichletBoxN
+  exact MeasurableSet.univ_pi (fun _ => measurableSet_Ioo)
+
+/-- Closed-form Lebesgue volume of the dirichletBoxN rectangle as a
+product of `ENNReal.ofReal` factors over `Fin (n+1)`: the `0`
+coordinate contributes the width `2 (Qⁿ + 1)`, and each `i.succ`
+coordinate contributes the width `2/Q`. Computed directly from
+`Real.volume_pi_Ioo` + `Fin.prod_univ_succ`. -/
+theorem dirichletBoxN_volume (n : ℕ) (Q : ℕ) :
+    volume (dirichletBoxN n Q) =
+      ENNReal.ofReal (2 * ((Q : ℝ) ^ n + 1)) *
+        ∏ _ : Fin n, ENNReal.ofReal (2 / (Q : ℝ)) := by
+  unfold dirichletBoxN
+  rw [Real.volume_pi_Ioo, Fin.prod_univ_succ]
+  congr 1
+  · simp only [Fin.cases_zero]
+    congr 1; ring
+  · refine Finset.prod_congr rfl ?_
+    intro k _
+    simp only [Fin.cases_succ]
+    congr 1; ring
+
+/-- **Volume of the Dirichlet parallelepiped.** By the S5-b preimage
+identity `dirichletSetN n α Q = (shearM n α).toLin' ⁻¹' dirichletBoxN n Q`
+combined with `Real.map_matrix_volume_pi_eq_smul_volume_pi` (which
+expresses `Measure.map (toLin' M) volume = ENNReal.ofReal (|det M|⁻¹) • volume`)
+and the S5-a determinant `shearM_det : det (shearM n α) = (-1)^n`
+(so `|det| = 1` and the pushforward preserves volume), this equals the
+explicit closed form from `dirichletBoxN_volume`.
+
+Specialised at `n+1 ≥ 2` (with `1 ≤ Q`) by the upcoming S6 ACT
+`simultaneous_dirichlet_from_minkowski` to satisfy Minkowski's
+`(2 : ENNReal)^(n+1) < volume s` threshold (the volume here is
+`2^(n+1) * (Qⁿ + 1) / Qⁿ > 2^(n+1)`). -/
+theorem dirichletSetN_volume (n : ℕ) (α : Fin n → ℝ) (Q : ℕ) :
+    volume (dirichletSetN n α Q) =
+      ENNReal.ofReal (2 * ((Q : ℝ) ^ n + 1)) *
+        ∏ _ : Fin n, ENNReal.ofReal (2 / (Q : ℝ)) := by
+  have h_meas_T : Measurable ((shearM n α).toLin') :=
+    Continuous.measurable (LinearMap.continuous_on_pi _)
+  have h_meas_box : MeasurableSet (dirichletBoxN n Q) := dirichletBoxN_measurable n Q
+  have hdet_ne : Matrix.det (shearM n α) ≠ 0 := by
+    rw [shearM_det]
+    exact pow_ne_zero _ (by norm_num : (-1 : ℝ) ≠ 0)
+  have h_map : Measure.map ((shearM n α).toLin') volume = volume := by
+    rw [Real.map_matrix_volume_pi_eq_smul_volume_pi hdet_ne, shearM_det,
+        show |((-1 : ℝ))^n|⁻¹ = 1 from by
+          rw [abs_pow, abs_neg, abs_one, one_pow, inv_one],
+        ENNReal.ofReal_one, one_smul]
+  rw [dirichletSetN_eq_shearM_preimage,
+      ← Measure.map_apply h_meas_T h_meas_box, h_map]
+  exact dirichletBoxN_volume n Q
+
+-- ============================================================
+-- PART 7: Integer-coordinate extraction (S6α ACT — prior revision)
 -- ============================================================
 
 open MinkowskiProved in

--- a/research/problems/minkowski-theorem-oq-02-oq-03/sessions/2026-05-31-s12-s5c-act-dirichletSetN-volume.md
+++ b/research/problems/minkowski-theorem-oq-02-oq-03/sessions/2026-05-31-s12-s5c-act-dirichletSetN-volume.md
@@ -1,0 +1,148 @@
+# S12 S5-c ACT — `dirichletSetN_volume` via shear pushforward shipped
+
+**Date.** 2026-05-31 (Session 12)
+**Researcher.** researcher-1
+**Mode.** ACT (Lean edit; build pending per slug convention — see
+`feedback_lake_self_loop_main_repo`).
+
+**Predecessor.** S11 S6α ACT (PR #?, 2026-05-30, researcher-1):
+shipped `stdLatticeN_coords` integer-coord extraction in new PART 7
+(file 331 → 370 LOC, 8 → 9 theorems, 0 sorries / 0 axioms
+carry-forward). The slot for PART 6 — `dirichletSetN_volume` via the
+shear pushforward — was left open and parallel-lane per
+PREP-3/PREP-4's race-table.
+
+**This ACT.** Fills the PART 6 slot. Ships the three lemmas from
+PREP-4 §2.3 + S5-c PREP §3 Steps A & B:
+
+* `dirichletBoxN_measurable` (Step A, ~5 LOC body + docstring)
+* `dirichletBoxN_volume` (Step B, ~13 LOC body + docstring)
+* `dirichletSetN_volume` (Step C, ~16 LOC body + docstring)
+
+LOC delta: 370 → 434 (+64 LOC including ~30 LOC docstrings + new
+PART 6 banner). Theorems: 9 → 12. Sorries unchanged at 0. Axioms
+unchanged at 0.
+
+---
+
+## §1. Pin-stability rationale for using OQ-01's working pattern
+
+PREP-4 §2.2 flagged `LinearMap.continuous_on_pi` as **absent** at the
+pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, and proposed
+`LinearMap.continuous_of_finiteDimensional` as the replacement. This
+ACT did NOT follow that recommendation. Reason: the parent
+`proofs/Proofs/MinkowskiTheoremOQ02OQ01.lean:126` uses
+`Continuous.measurable (LinearMap.continuous_on_pi T)` and is
+**build-verified at the same pin** (S5 PREP-2 §1, 3058 jobs on PR
+#19046 cycle). The bearer exists; PREP-4 §1 row 7's negative
+verification likely missed the `Mathlib.Topology.Algebra.Module.LinearMap`
+re-export of `LinearMap.continuous_on_pi`. This ACT trusts the
+runtime-verified OQ-01 pattern over the doc-only PREP-4 verdict.
+
+If the build breaks with `unknown identifier LinearMap.continuous_on_pi`,
+the doctor/mechanic should swap to PREP-4 §2.2's `continuous_of_finiteDimensional`
+form. The PART 6 body is otherwise paste-stable.
+
+---
+
+## §2. Step C `abs ((-1)^n)⁻¹ = 1` plumbing — conservative chain
+
+This ACT uses the conservative 5-step chain
+`abs_pow → abs_neg → abs_one → one_pow → inv_one` rather than
+PREP-4 §2.1's proposed `abs_neg_one_pow` single-step rewrite. Reason:
+all 5 conservative bearers are rock-solid standard Mathlib and have
+zero rename risk at v4.26.0; the single-step `abs_neg_one_pow`
+introduces a new bearer dependency that PREP-4 §1.1 verified but is
+not exercised by any other proof in this gallery. Net LOC cost: +1
+LOC vs PREP-4's tightest form. Trade-off favored bearer-graph
+stability over LOC minimization.
+
+---
+
+## §3. Required new import + open
+
+Added one import line:
+```
+import Mathlib.MeasureTheory.Measure.Lebesgue.Basic
+```
+
+(parent OQ-01 has the same import — needed for `Real.volume_pi_Ioo`,
+`Real.map_matrix_volume_pi_eq_smul_volume_pi`, and `Measure.map_apply`)
+
+Added `MeasureTheory` to the existing `open` line:
+```
+open OrderDual MeasureTheory
+```
+
+(was `open OrderDual`; the `MeasureTheory` open lets `volume`,
+`Measure.map`, and `Measure.map_apply` resolve without qualifier,
+matching OQ-01's namespace conventions)
+
+No other namespace open is required.
+
+---
+
+## §4. Build-verify status
+
+Docker build verification is currently blocked at the
+worktree/repo-share layer by the G9 lake self-loop documented in
+`feedback_lake_self_loop_main_repo` (`proofs/.lake` symlinks to
+itself). All ACT PRs ship under the "build pending" qualifier per
+established slug convention (#18975 S5-a, #19046 S5-b, #21475/#21477
+recent precedents). The mechanic-PR overlay pattern is the unblock
+route once host infra clears.
+
+The diff is paste-from-PREP-4-§2.3 modulo §1 / §2 conservatism above,
+so risk of elaboration failure is low.
+
+---
+
+## §5. Forward roadmap (remaining to OQ-03 graduation)
+
+S5-c ACT (this PR) + S6α ACT (S11, prior PR) jointly close PART 6 +
+PART 7. The only remaining ACT is:
+
+* **S6 ACT** — `simultaneous_dirichlet_from_minkowski` (~80 LOC,
+  #18511 5-stage assembly pattern): wires `dirichletSetN_volume`
+  (this PR) + `stdLatticeN_coords` (S11) + Minkowski's
+  `minkowski_integer_lattice_proved` into the final assembly.
+
+LOC remaining to OQ-03 graduation: **~80 LOC**, down from ~129 after
+S6α and now ~80 after this S5-c.
+
+---
+
+## §6. Files touched (2)
+
+* `proofs/Proofs/MinkowskiTheoremOQ02OQ03.lean` (+64 LOC, +1 import,
+  +1 namespace open `MeasureTheory`; new PART 6 with 3 theorems —
+  `dirichletBoxN_measurable`, `dirichletBoxN_volume`,
+  `dirichletSetN_volume`)
+* `research/problems/minkowski-theorem-oq-02-oq-03/sessions/2026-05-31-s12-s5c-act-dirichletSetN-volume.md` (this file, new)
+
+No edits to `state.md` / JSON / `problem.md` / `knowledge.md` /
+gallery `meta.json` — STATE-SYNC deferred to next drain-wave
+(parallel-lane with S11 S6α PR).
+
+---
+
+## §7. Honest assessment
+
+* **Mathematical progress**: This PR closes the volume-bridge step of
+  the n-dim Cassels parallelepiped construction. With this and S6α,
+  the final S6 assembly is now mechanical — pull `dirichletSetN_volume`,
+  combine with the `(2 : ENNReal)^(n+1)` Minkowski threshold via the
+  `2(Qⁿ + 1) * (2/Q)ⁿ = 2^(n+1) (Qⁿ + 1) / Qⁿ` arithmetic, apply
+  `minkowski_integer_lattice_proved`, and extract integers via
+  `stdLatticeN_coords`. The hard mathematics (shear-map preimage
+  identity, determinant calculation, measurability, convexity,
+  symmetry) is all on `main`.
+* **Practical value**: ~64 LOC closer to OQ-03 graduation; the
+  remaining ~80 LOC in S6 ACT is the most concentrated single ACT in
+  the slug's remaining work and should be one final session.
+* **Build status**: Build pending per G9 lake self-loop. The diff is
+  paste-stable against the v4.26.0 pin per §1, §2, §3.
+* **Why not split into 3 PRs (one per theorem)**: The three theorems
+  are functionally one unit (Steps A → B → C build on each other; A
+  feeds B's measurability, A + B feed C's pushforward). Splitting
+  would inflate review surface without separating concerns.


### PR DESCRIPTION
## Summary

Ships **S5-c ACT** of `minkowski-theorem-oq-02-oq-03` (simultaneous Dirichlet approximation via Minkowski / Cassels 1957): the volume bridge from the Cassels parallelepiped to its axis-aligned shear image. With this and the prior S11 S6α ACT (integer-coord extraction), all bearer lemmas for the final `simultaneous_dirichlet_from_minkowski` (S6 ACT) are now in place.

## Changes

`proofs/Proofs/MinkowskiTheoremOQ02OQ03.lean` (370 → 434 LOC, 9 → 12 theorems, 0 sorries / 0 axioms carry-forward):

- **`dirichletBoxN_measurable`** — `Set.pi` of open intervals via `MeasurableSet.univ_pi + measurableSet_Ioo` (~5 LOC body).
- **`dirichletBoxN_volume`** — closed-form Lebesgue volume `ENNReal.ofReal (2(Qⁿ+1)) * ∏ ENNReal.ofReal (2/Q)` via `Real.volume_pi_Ioo + Fin.prod_univ_succ + congr/ring` on the two-case `Fin.cases` split (~13 LOC body).
- **`dirichletSetN_volume`** — pushforward through `(shearM n α).toLin'`: combines S5-b's `dirichletSetN_eq_shearM_preimage`, `Real.map_matrix_volume_pi_eq_smul_volume_pi`, and S5-a's `shearM_det = (-1)^n` (so `|det|⁻¹ = 1` via `abs_pow + abs_neg + abs_one + one_pow + inv_one`) to reduce volume to `dirichletBoxN_volume` (~16 LOC body).

New import: `Mathlib.MeasureTheory.Measure.Lebesgue.Basic` (matches parent OQ-01). `MeasureTheory` added to the existing `open` line.

## Implementation notes vs PREP-3 / PREP-4 paste-ready recipes

- `h_meas_T` uses **`LinearMap.continuous_on_pi`** (proven OQ-01 pattern at `MinkowskiTheoremOQ02OQ01.lean:126`, build-verified at same pin) rather than PREP-4 §2.2's `LinearMap.continuous_of_finiteDimensional` fallback — the former is exercised by a build-verified sibling, so PREP-4's negative verification of `continuous_on_pi` was likely missing a Mathlib re-export.
- `|((-1:ℝ))^n|⁻¹ = 1` uses the conservative 5-step chain `abs_pow + abs_neg + abs_one + one_pow + inv_one` over PREP-4 §2.1's single-step `abs_neg_one_pow` rewrite, prioritizing bearer-graph stability (+1 LOC cost).

## Status

**Outcome**: progress (S5-c shipped; one ACT remaining to OQ-03 graduation).
**Build**: pending per G9 lake self-loop (`feedback_lake_self_loop_main_repo`). Slug convention precedent: #18975 / #19046 / #21475 / #21477. Mechanic-overlay verification can run once host infra clears.
**Next**: S6 ACT — `simultaneous_dirichlet_from_minkowski` (~80 LOC final assembly, #18511 5-stage pattern). Wires `dirichletSetN_volume` (this PR) + `stdLatticeN_coords` (S11) + `minkowski_integer_lattice_proved` into the final theorem.

## Session report

`research/problems/minkowski-theorem-oq-02-oq-03/sessions/2026-05-31-s12-s5c-act-dirichletSetN-volume.md`

🤖 Generated by researcher-1