### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04: split Part I/II sections, +2 cross-refs

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -118,20 +118,36 @@
     },
     {
       "id": "sec-predicates",
-      "title": "Part I: Core Predicates and Normalizer Lemma",
+      "title": "Part I: Core Predicates (IsMaxNorm and GroupQuotIso)",
       "startLine": 38,
-      "endLine": 66,
-      "summary": "Three building blocks for the JordanHolderLattice instance. `IsMaxNorm H K` (lines 48–51): H is a maximal normal subgroup of K — strict containment, relative normality via `subgroupOf`, and no intermediate normal-in-K subgroups. `GroupQuotIso` (lines 54–57): quotient isomorphism K₁/H₁ ≃* K₂/H₂ packaged with explicit Normal witnesses to avoid typeclass synthesis failures. `le_normalizer_of_normal_in_sup` (lines 64–66): bridge lemma — if H is relatively normal in H⊔K then K ≤ H.normalizer — used in both isMaximal_inf and second_iso proofs.",
-      "mathContext": "`IsMaxNorm` avoids `IsSimpleGroup (K ⧸ H)` to sidestep the typeclass dependency where the `Normal` instance for the quotient depends on the syntactic form of the subgroup expression. `GroupQuotIso` packages Normal evidence as existential witnesses `hn1, hn2`, enabling `haveI` introduction before constructing `MulEquiv`. The normalizer lemma chains `le_sup_right : K \\leq H \\vee K` with `normal_subgroupOf_iff_le_normalizer` to convert relative normality $H \\trianglelefteq_{H \\vee K}$ into the normalizer containment $K \\leq N_G(H)$.",
+      "endLine": 57,
+      "summary": "The two predicates carrying the proof's design decisions. `IsMaxNorm H K` (lines 48–51): H is a maximal normal subgroup of K — strict containment, relative normality via `subgroupOf`, and no intermediate normal-in-K subgroups (an unfolded surrogate for `IsSimpleGroup (K ⧸ H.subgroupOf K)` that avoids the quotient-typeclass issues described in keyInsight #13). `GroupQuotIso` (lines 54–57): quotient isomorphism K₁/H₁ ≃* K₂/H₂ packaged with explicit Normal witnesses `hn1, hn2` (existentials) plus a `Nonempty (MulEquiv …)` payload — the canonical Lean idiom for Prop-valued storage of data-bearing isomorphisms.",
+      "mathContext": "`IsMaxNorm` keeps every conjunct inside the lattice $(\\text{Subgroup}\\,G, \\leq, \\sqcup, \\sqcap)$, sidestepping the synthesis chain that breaks `rw [sup_comm]` and similar quotient-type rewrites (a recurring Lean 4 fragility documented across the file's three axiom proofs). `GroupQuotIso` packages Normal evidence as existential witnesses, enabling `haveI` introduction before constructing `MulEquiv`. The `letI := hn1; letI := hn2` inside the definition body ensures the `Nonempty` payload is itself well-formed at definition time.",
       "relatedConcepts": [
         "IsMaxNorm",
         "GroupQuotIso",
         "subgroupOf",
-        "normalizer",
         "relative normality",
         "Nonempty",
         "MulEquiv",
-        "haveI pattern"
+        "haveI pattern",
+        "Prop/data divide"
+      ]
+    },
+    {
+      "id": "sec-normalizer-lemma",
+      "title": "Part II: Key Normalizer Lemma",
+      "startLine": 59,
+      "endLine": 66,
+      "summary": "A one-line bridge lemma `le_normalizer_of_normal_in_sup`: if H is relatively normal in $H \\sqcup K$, then $K \\leq H.\\text{normalizer}$. The proof chains `le_sup_right : K \\leq H \\sqcup K` with `normal_subgroupOf_iff_le_normalizer le_sup_left` to convert the relative-normality hypothesis into the absolute normalizer containment. This lemma is invoked twice downstream — in `isMaximal_inf_left_of_isMaximal_sup` (showing x normalizes y in their join) and at the start of `second_iso` (extracting that y ≤ x.normalizer from the maximality hypothesis).",
+      "mathContext": "The lemma abstracts the observation that *relative normality lifts to absolute normalizer when one conjunct equals the subgroup being normalized*: if $H \\trianglelefteq_{H \\vee K} H \\vee K$, then every element of $K \\subseteq H \\vee K$ normalizes $H$, giving $K \\leq N_G(H)$. Factoring this as a separate lemma is structurally important — it concentrates the only use of `normal_subgroupOf_iff_le_normalizer` in the file, so the two downstream axiom proofs can treat 'relative normality $\\Rightarrow$ normalizer bound' as a black box rather than re-doing the conversion each time.",
+      "relatedConcepts": [
+        "normalizer",
+        "normal_subgroupOf_iff_le_normalizer",
+        "relative normality",
+        "subgroupOf",
+        "le_sup_right",
+        "lemma factoring"
       ]
     },
     {
@@ -326,6 +342,16 @@
       "targetId": "inverse-galois-d4",
       "relationship": "complementary",
       "description": "Concrete realization of the dihedral group $D_4$ as $\\text{Gal}(X^4 - 2/\\mathbb{Q})$ with $|D_4| = 8$, formalized with 27 theorems, 0 sorries, 0 axioms. **A solvable composition-series exemplar governed by Jordan-Hölder uniqueness (this entry's main theorem).** Where the sibling cross-reference `inverse-galois-a5` exhibits the *non-solvable* obstruction (the $A_5$ composition factor that Jordan-Hölder forces to appear in every decomposition of $\\text{Gal}(x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5/\\mathbb{Q})$), `inverse-galois-d4` exhibits the *solvable* side of the same uniqueness story: $D_4$ has the unique composition series $D_4 \\trianglerighteq \\langle r \\rangle \\cong \\mathbb{Z}/4 \\trianglerighteq \\langle r^2 \\rangle \\cong \\mathbb{Z}/2 \\trianglerighteq \\{e\\}$ with composition factors $(\\mathbb{Z}/2, \\mathbb{Z}/2, \\mathbb{Z}/2)$ — three copies of the prime-cyclic group, in agreement with Jordan-Hölder's uniqueness assertion that *every* refinement to a composition series yields this same multiset of simple quotients (up to reordering). The concrete connection to the larger Abel-Ruffini story: $X^4 - 2$ has $D_4$ as Galois group, $D_4$ is solvable (every composition factor is $\\mathbb{Z}/2$, abelian), hence — by `not_solvable_by_rad_of_not_solvable_gal`'s contrapositive — $X^4 - 2$ is solvable by radicals, with explicit radical witness $\\sqrt[4]{2}$. This is the *positive* converse of the Abel-Ruffini chain: solvable composition series ⇒ solvable Galois group ⇒ radical expressibility. Jordan-Hölder uniqueness ensures this verdict is *invariant* under choice of normal series: any refinement of $D_4 \\trianglerighteq \\{e\\}$ produces the same three composition factors, hence the same solvable judgment. The parallel with `inverse-galois-f20` (composition factors $(\\mathbb{Z}/5, \\mathbb{Z}/4)$, also solvable, also a degree-5 polynomial $X^5 - 2$ solvable by radicals) and `inverse-galois-a5` (composition factor $A_5$, non-abelian simple, non-solvable, polynomial $x^5 - 5x^4 + 10x^3 - 10x^2 + 25x - 5$ NOT solvable by radicals) makes the Jordan-Hölder dichotomy concrete across the gallery's degree-4 and degree-5 inventory: the solvability fate of every realized Galois group is read off the multiset of composition factors that Jordan-Hölder makes a group invariant."
+    },
+    {
+      "targetId": "abel-ruffini-oq-04-oq-01",
+      "relationship": "complementary",
+      "description": "**The concrete polynomial witness.** Realizes $\\text{Gal}(x^5 - 4x + 2/\\mathbb{Q}) \\cong S_5$ explicitly (Eisenstein irreducibility at $p = 2$; $|\\text{Gal}| = 120$ via Vandermonde-discriminant ruling out $\\text{Gal} \\subseteq A_5$, complex-conjugation transposition, and Sylow theory eliminating subgroup orders 5, 10, 15, 20, 30, 40, 60). This is the *concrete instance* on which Jordan-Hölder uniqueness (proved here) bites: by uniqueness, the composition series of $S_5 = \\text{Gal}(x^5 - 4x + 2/\\mathbb{Q})$ is forced to be $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ with composition factors $\\{A_5, \\mathbb{Z}/2\\mathbb{Z}\\}$, and the non-abelian simple factor $A_5$ cannot be avoided by *any* alternative decomposition. Galois's solvability criterion (`abel-ruffini-oq-04-oq-03`) then reads 'not solvable by radicals' off this factor multiset. Without Jordan-Hölder uniqueness, the unsolvability of $x^5 - 4x + 2$ would be tied to a specific decomposition rather than being a structural invariant of $S_5$ — the uniqueness clause is what makes the verdict *intrinsic to the polynomial* rather than an artifact of analysis."
+    },
+    {
+      "targetId": "abel-ruffini-galois-extensions-oq-05",
+      "relationship": "complementary",
+      "description": "**Shafarevich's theorem (1954)**: every finite *solvable* group is realizable as $\\text{Gal}(L/\\mathbb{Q})$ for some Galois extension $L/\\mathbb{Q}$. This entry's relationship to Jordan-Hölder is precise: Shafarevich's hypothesis ('solvable group') is *exactly* 'every composition factor is cyclic of prime order' — a statement about the Jordan-Hölder factor multiset (which this file makes a well-defined invariant). The two theorems together close one half of the inverse-Galois landscape: Jordan-Hölder identifies *which* simple groups appear as the indecomposable factors of a finite group; Shafarevich shows that when those factors are all cyclic-of-prime-order (i.e., the group is solvable), the group is realizable over $\\mathbb{Q}$. The complementary open problem — realizing groups whose Jordan-Hölder multiset contains non-abelian simple factors (CFSG-frontier groups like $M_{23}$, cross-referenced via `inverse-galois-oq-02`) — remains the active edge of the inverse-Galois problem, governed precisely by the factors Jordan-Hölder makes invariant here."
     },
     {
       "targetId": "kroneckers-jugendtraum",


### PR DESCRIPTION
## Summary

Enrichment pass for `abel-ruffini-galois-extensions-oq-04` (Jordan-Hölder uniqueness via JordanHolderLattice).

- **Section accuracy**: split the merged `sec-predicates` (Part I + Part II glossed together) into two sections matching the Lean file's PART I / PART II headers — `sec-predicates` (lines 38-57: `IsMaxNorm` + `GroupQuotIso`) and new `sec-normalizer-lemma` (lines 59-66: `le_normalizer_of_normal_in_sup` bridge).
- **Cross-references (+2)**:
  - `abel-ruffini-oq-04-oq-01` — the concrete polynomial witness $\text{Gal}(x^5 - 4x + 2/\mathbb{Q}) \cong S_5$. Jordan-Hölder uniqueness (proved here) forces the unique series $\{e\} \triangleleft A_5 \triangleleft S_5$ on this polynomial's Galois group, making unsolvability a structural invariant rather than an artifact of any chosen decomposition.
  - `abel-ruffini-galois-extensions-oq-05` — Shafarevich's theorem. Closes one half of the inverse-Galois landscape: Jordan-Hölder identifies the composition factors (this file); Shafarevich realizes solvable factor multisets over $\mathbb{Q}$. The CFSG frontier (e.g. $M_{23}$ via `inverse-galois-oq-02`) remains the open edge.

## Test plan

- [x] `pnpm build` succeeds — JSON parses, schema validates, page bundles.