### PR TITLE
fix(meta): hilbert-11 register Aristotle companion

### DIFF
--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -35,7 +35,10 @@
     "assumptions": "3 axiom declarations: diagonalForm (existence of diagonal quadratic forms), sylvester_law_of_inertia (real classification by signature), selmer_curve_no_rational_points (Selmer's counterexample to Hasse for cubics). Two former axioms (hasse_minkowski_alt, rational_classification_complete) are now placeholder theorems with sorry, since their conclusions reduce to True ↔ True via True-placeholder definitions; converting to sorry makes the gap visible to #check_sorry instead of asserting a vacuous axiom. Five additional placeholder theorems carry sorry: weak_hasse_principle, ternary_representation, witt_cancellation, dimension_five_always_isotropic, hilbert_reciprocity (their formal statements depend on tensor products with R/Q_p that are not yet formalized). Three definitions still use True as a placeholder body (RepresentsZeroOverReals, RepresentsZeroOverPadic, HasseMinkowskiNumberField), and HilbertSymbol is hardcoded to 1. Only four_squares_connection is fully proved (via Mathlib's Nat.sum_four_squares).",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 19
+    "definitionCount": 19,
+    "additionalFiles": [
+      "Proofs/Hilbert11OQ01Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Hilbert's 11th Problem, posed in his famous 1900 address at the International Congress of Mathematicians in Paris, asks for the classification of quadratic forms $Q(x_1, \\ldots, x_n) = \\sum a_{ij} x_i x_j$ with coefficients in algebraic number fields. The roots of this question trace to Gauss's *Disquisitiones Arithmeticae* (1801), which classified binary quadratic forms over $\\mathbb{Z}$ using genera and class numbers. Hermann Minkowski, Hilbert's close friend and colleague at Gottingen, proved the local-global principle for ternary quadratic forms in 1890 using his geometry of numbers. Helmut Hasse, a student of Kurt Hensel (inventor of $p$-adic numbers), extended this in his 1923 dissertation to all dimensions, establishing the full Hasse-Minkowski theorem: a quadratic form over $\\mathbb{Q}$ represents zero nontrivially if and only if it does so over $\\mathbb{R}$ and over $\\mathbb{Q}_p$ for every prime $p$. Ernst Witt developed the algebraic theory of quadratic forms in 1937, introducing the Witt ring $W(F)$ and proving Witt cancellation. James Sylvester's law of inertia (1852) had earlier provided the classification over $\\mathbb{R}$ via the signature $(p,q)$. The discovery by Ernst Selmer in 1951 that the cubic curve $3x^3 + 4y^3 + 5z^3 = 0$ violates the Hasse principle showed this beautiful local-global approach is special to quadratic forms. Yuri Manin's introduction of the Brauer-Manin obstruction (1970) provided a systematic explanation for such failures.",
@@ -212,7 +215,10 @@
     "theoremCount": 9,
     "definitionCount": 19,
     "path": "Proofs/Hilbert11_QuadraticForms.lean",
-    "sorries": 7
+    "sorries": 7,
+    "additionalFiles": [
+      "Proofs/Hilbert11OQ01Aristotle.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the orphan `Hilbert11OQ01Aristotle.lean` companion to the
`hilbert-11` gallery entry, in both `meta.additionalFiles` and
`leanFile.additionalFiles`, matching the established pattern (e.g.
#21461, #21471, #21490, #21491).

## Evidence

**Before**: The companion file exists at `proofs/Proofs/Hilbert11OQ01Aristotle.lean`
(0 axioms, 0 sorries, 2 routine tensor-product injectivity lemmas for ℝ and ℚ_[p]) but
no `src/data/proofs/*/meta.json` referenced it. Its main file
(`Hilbert11OQ01.lean`) explicitly identifies itself as continuation of
`Hilbert11_QuadraticForms.lean` — the docstring states it formalizes
local isotropy conditions "replacing the `True` placeholders in
`Hilbert11_QuadraticForms.lean`". No `hilbert-11-oq-01` slug exists,
so `hilbert-11` is the natural parent.

**After**: `additionalFiles` registers the companion under the matching slug in both
`meta` and `leanFile` sections. JSON validates with `python -m json.tool`.

Pre-submission gate on the companion file: no def-sorries, no `axiom`
declarations, no `True`-placeholder theorems, no `/-!` docstrings — clean.

Detected via gallery orphan scan during the lean-mechanic repair cycle.

---
Automated fix by lean-mechanic agent.