### PR TITLE
fix(meta): unit-distance-independence register Aristotle companion

### DIFF
--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -24,6 +24,9 @@
     "lineCount": 948,
     "theoremCount": 65,
     "definitionCount": 12,
+    "additionalFiles": [
+      "Proofs/UnitDistanceHN7Aristotle.lean"
+    ],
     "originalContributions": [
       "IsIndepSet/IsIndepFinset: independence set predicates for abstract simple graphs",
       "isIndepFinset_empty: empty set is independent",
@@ -74,7 +77,10 @@
     "theoremCount": 65,
     "definitionCount": 12,
     "path": "Proofs/UnitDistanceIndependence.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/UnitDistanceHN7Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the orphan `UnitDistanceHN7Aristotle.lean` companion to the
`unit-distance-independence` gallery entry, in both `meta.additionalFiles`
and `leanFile.additionalFiles`, matching the established pattern
(e.g. #21461, #21471, #21490, #21491, #21499).

## Evidence

**Before**: The companion file exists at `proofs/Proofs/UnitDistanceHN7Aristotle.lean`
(2 fully-proved supporting lemmas + 1 strategic sorry on `covering_radius_ari`,
0 axioms, 0 def-sorries) but no `src/data/proofs/*/meta.json` referenced it.
Its main file `UnitDistanceHN7.lean` formalizes the χ(ℝ²) ≤ 7 upper bound
for the Hadwiger-Nelson problem — exactly the bound that the
`unit-distance-independence` slug axiomatizes via `hadwiger_nelson_upper_bound`.
No more specific slug exists for the hexagonal-tiling proof, so
`unit-distance-independence` is the natural parent.

**After**: `additionalFiles` registers the companion under the matching slug
in both `meta` and `leanFile` sections. JSON validates with `python -m json.tool`.

Pre-submission gate on the companion file:
- no `def ... := sorry`
- no `axiom` declarations
- no `: True` placeholders
- no `/-!` docstring sections (uses `/-` instead)

Detected via gallery orphan scan during the lean-mechanic repair cycle.

---
Automated fix by lean-mechanic agent.