### PR TITLE
fix(meta): hilbert-11 register Hilbert11OQ01OQ01Aristotle companion

### DIFF
--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -37,7 +37,8 @@
     "theoremCount": 9,
     "definitionCount": 19,
     "additionalFiles": [
-      "Proofs/Hilbert11OQ01Aristotle.lean"
+      "Proofs/Hilbert11OQ01Aristotle.lean",
+      "Proofs/Hilbert11OQ01OQ01Aristotle.lean"
     ]
   },
   "overview": {
@@ -217,7 +218,8 @@
     "path": "Proofs/Hilbert11_QuadraticForms.lean",
     "sorries": 7,
     "additionalFiles": [
-      "Proofs/Hilbert11OQ01Aristotle.lean"
+      "Proofs/Hilbert11OQ01Aristotle.lean",
+      "Proofs/Hilbert11OQ01OQ01Aristotle.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register the orphaned Aristotle companion `Proofs/Hilbert11OQ01OQ01Aristotle.lean` under `hilbert-11` in both `meta.additionalFiles` and `leanFile.additionalFiles`.

## Evidence

**Before**: `Hilbert11OQ01OQ01Aristotle.lean` (104 lines, Meyer's-theorem sign-change targets) exists on disk but is not registered in any gallery meta.json. Its parent `Hilbert11OQ01OQ01.lean` formalizes sub-question `hilbert-11-oq-01-oq-01`, for which no dedicated slug exists.

**After**: `hilbert-11/meta.json.meta.additionalFiles` and `.leanFile.additionalFiles` both now list `Hilbert11OQ01Aristotle.lean` and `Hilbert11OQ01OQ01Aristotle.lean`. Same registration precedent set by #21499 (which just merged) and #21490/#21491 (sibling continuations).

**Pre-submission gate** (companion file):
- 0 `def ... := sorry`
- 0 `axiom` declarations
- 0 `theorem ... : True :=` placeholders
- 0 `/-!` docstring sections (uses `/-` block comments)
- 2 theorem-sorries (Aristotle targets) + 1 proved helper (`baseChange_one_tmul_eq`)

---
Automated fix by lean-mechanic agent.