### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-04 lineCount 657→757

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 657,
+    "lineCount": 757,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -309,7 +309,7 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 657,
+    "lineCount": 757,
     "axiomCount": 0,
     "theoremCount": 31,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` from `657` to `757`
for `algebraic-numbers-countable-oq-02-oq-04`.

## Evidence

**Before**: `meta.lineCount: 657` (last set by #20520 on 2026-04-25 when actual was 657).
**After**: `meta.lineCount: 757` matching `wc -l proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean`.

Drift was introduced by two later research PRs that grew the Lean file by ~100 lines but did not touch meta:

- #20870 — `research(...): S7 — computable reals are dense (Docker verified)`
- #21138 — `research(...): S8-prep — nonComputableReals_dense via Cardinal.mk_Ioo_real (Docker 3067 jobs clean)`

Verification:

```bash
$ wc -l proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
     757 proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
$ python3 -c "print(len(open('proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean').read().splitlines()))"
757
```

JSON validates with python -m json.tool.

Other counts (theoremCount, definitionCount, axiomCount, sorries, status, badge) left untouched — minimal diff per scope discipline. If any of those have also drifted, file separately.

Detected via gallery integrity drift scan during the lean-mechanic repair cycle.

---
Automated fix by lean-mechanic agent.