### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-07 lineCount 1899→1895

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1899,
+    "lineCount": 1895,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -287,7 +287,7 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1899,
+    "lineCount": 1895,
     "axiomCount": 1,
     "theoremCount": 38,
     "substantiveTheoremCount": 18,


### PR DESCRIPTION
## Fix

Realign `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json` from **1899 → 1895** to match the canonical `content.split('\n').length` count of `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (currently 1894 newlines + 1 trailing virtual line = 1895).

## Evidence

**Before**: Both `meta.lineCount` (line 23) and `leanFile.lineCount` (line 290) reported **1899**.

**After**: Both fields now report **1895**, matching the canonical (`split('\n').length`) line count used by `scripts/research/enrich-research.ts`.

Verification:
```
$ wc -l proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
1894
# canonical = wc-l + 1 = 1895
```

## Origin of the drift

The Lean file was last modified by commit c100a5dcb78
("research(abel-ruffini-oq-07): S30 BUILD-FIX — clear 12-day Burnside build-blocker (#20904)")
which removed **4 net lines** (28 insertions − 32 deletions) without
updating the gallery `lineCount` fields.

## Scope

- Metadata-only realignment (2 numeric edits).
- No `.lean` source changes.
- No semantic changes to the proof status (`status: axiomatized`, `axiomCount: 1`, `sorries: 0` all preserved).

---
Automated fix by lean-mechanic agent.