### PR TITLE
audit(erdos-155): mark clean (cycle 4) — Sidon F(N) growth axiomatization integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4829,12 +4829,12 @@
       "result": "issues-fixed"
     },
     "erdos-155": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom axiom claims (Singer lower, main conjecture, strong form, F(6..18)) + section line drift; issue #14693"
       ],
-      "lastAudited": "2026-05-02T09:25:53Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T15:22:34Z",
+      "result": "clean"
     },
     "erdos-156": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Re-audited Erdős Problem #155 (Slow Growth of Maximum Sidon Subsets). Tracker bump from `issues-fixed`/2026-05-02 to `clean`/2026-05-31 (cycle 4).

## Integrity Check

| Field | meta.json | Actual (`Proofs/Erdos155Problem.lean`) | Status |
|-------|-----------|------|---|
| Line count | 199 | 199 | ✓ |
| Axiom count | 1 | 1 (`erdos_turan_upper`) | ✓ |
| Sorry count | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| Theorem count | 10 | 10 | ✓ |
| Definition count | 3 | 3 (`IsSidonSet`, `sidonSets`, `maxSidonSize`) | ✓ |
| Status / badge | `axiomatized` / `axiom` | Tier C: open conjecture, Erdős–Turán bound axiomatized | ✓ |

## Narrative Failure-Mode Scan

- **Delegation opacity**: N/A — no major Mathlib theorem powers the core result.
- **Axiom masking**: ✓ — title and description explicitly state "Status: OPEN"; `assumptions` field reads "1 axiom: erdos_turan_upper. 0 sorries."
- **Inequality ≠ theorem**: ✓ — does not claim to prove the conjecture; only proves the toolkit (monotonicity, step bound, increase-count bound, F(1..3)).
- **Pipeline inflation**: ✓ — single file, no inflation across cross-references.
- **0 sorries with hidden imports**: ✓ — 0 sorries with one acknowledged `axiom` declaration.

## Sibling Skip

Top-priority queue currently lists erdos-161, erdos-155, erdos-154, erdos-150, ... (all 2026-05-02). erdos-161's cycle 4 tracker bump is already covered by open PR #21509; this PR handles erdos-155 to avoid duplicate work.

## Test plan

- [x] Tracker JSON valid after bump
- [x] Lean source counts match meta.json
- [x] No narrative claims overstated
- [ ] Deployer merges → erdos-155 drops from priority queue

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)