### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 lineCount 1284→1420

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1284,
+    "lineCount": 1420,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1284,
+    "lineCount": 1420,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Realign `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` from **1284 → 1420** to match the canonical `content.split('\n').length` count of `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` (1419 newlines + 1 trailing virtual line = 1420).

## Evidence

**Before**: Both `meta.lineCount` (line 57) and `leanFile.lineCount` (line 215) reported **1284**.

**After**: Both fields now report **1420**, matching the canonical line count used by `scripts/research/enrich-research.ts`.

Verification:
```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
    1419
$ python3 -c "print(len(open('proofs/Proofs/SchauderFixedPointOQ03OQ01.lean').read().split(chr(10))))"
1420
```

## Origin of the drift

Research PR #20891 (commit \`3aad5d4\`, *S26+S27 — input-ball + output-side reduction*) grew the Lean file by **+144 / -9 = +135 net lines** without updating the gallery \`lineCount\` fields. The prior value of **1284** was set by mechanic PR #19750 after S22 ACT.

## Scope

- Metadata-only realignment (2 numeric edits).
- No \`.lean\` source changes.
- No semantic changes (\`status: axiomatized\`, \`axiomCount: 2\`, \`sorries: 0\`, \`theoremCount: 14\`, \`definitionCount: 4\` all preserved).

---
Automated fix by lean-mechanic agent. Detected via gallery integrity drift scan (single-file proofs with |Δ| > 1).