### PR TITLE
audit(erdos-154): cycle 4 issues-fixed — remove phantom even_odd_balance from originalContributions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4823,9 +4823,9 @@
       "result": "clean"
     },
     "erdos-154": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T09:32:37Z",
+      "lastAudited": "2026-05-31T15:32:29Z",
       "result": "issues-fixed"
     },
     "erdos-155": {

--- a/src/data/proofs/erdos-154/meta.json
+++ b/src/data/proofs/erdos-154/meta.json
@@ -45,7 +45,6 @@
       "sumset: sumset A+A via Finset.product and image",
       "IsWellDistributed: ε-well-distribution modulo m",
       "sumset_distribution: sumset inherits distribution from Sidon property (axiom, packages both Lindström distribution and unique-representation transfer)",
-      "even_odd_balance: m=2 case — even/odd balance of A+A",
       "erdos_154: main theorem closing the problem"
     ],
     "axiomCount": 1,


### PR DESCRIPTION
## Summary
- Removed phantom `even_odd_balance` entry from `originalContributions` — no such Lean declaration exists in `Erdos154Problem.lean`, only a docstring comment.
- The `even-odd` section in meta.json already correctly documents this ("documents in source comments `even_odd_balance` (no Lean declaration exists)"); the contribution list was the last remaining stale claim.
- Bumped audit tracker to cycle 4, result `issues-fixed`.

## Audit verification (Erdos154Problem.lean)
- 1 axiom: `sumset_distribution` (matches `axiomCount: 1`)
- 1 theorem: `erdos_154` (matches `theoremCount: 1`)
- 3 defs: `IsSidon`, `sumset`, `IsWellDistributed` (matches `definitionCount: 3`)
- 0 sorries, 0 True stubs
- 96 lines (matches `lineCount: 96`)
- Status `axiomatized` / badge `axiom` — appropriate Tier C scaffold for a SOLVED-in-the-literature problem axiomatizing the deep Lindström/Kolountzakis result.
- Title and description do not over-claim — they describe the math problem's resolution, not our formalization.

## Test plan
- [x] grep declarations -> 5 (3 def + 1 axiom + 1 theorem)
- [x] originalContributions now lists only declarations that actually exist
- [x] sections, leanFile.*, and meta.* counts all consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)