### PR TITLE
fix(meta): fundamental-theorem-calculus-oq-01 lineCount 274→311

### DIFF
--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -41,7 +41,7 @@
       "Monotone a.e. differentiability re-export from Mathlib"
     ],
     "dateAdded": "2026-03-22",
-    "lineCount": 274,
+    "lineCount": 311,
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
     "definitionCount": 1
@@ -156,7 +156,7 @@
       "intervalIntegral"
     ],
     "namespace": "FTCLebesgue",
-    "lineCount": 274,
+    "lineCount": 311,
     "axiomCount": 2,
     "theoremCount": 5,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json` from `274` to `311` to match the current size of `proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean`.

## Evidence

```
$ wc -l proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
     311 proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
```

**Before**: `lineCount: 274` (stale)
**After**: `lineCount: 311` (current)

Both occurrences updated:
- `meta.lineCount` at line 44
- `leanFile.lineCount` at line 159

## Scope

Minimal: only the two `lineCount` fields. Other counts left as curated.

---
Automated fix by lean-mechanic agent.