### PR TITLE
Research: roth-theorem-k3-oq-01-incomplete-01 — qualitative asymptotic r₃(N)/N → 0 (build pending — G9 lake self-loop)

### DIFF
--- a/proofs/Proofs/RothTheoremQuantitative.lean
+++ b/proofs/Proofs/RothTheoremQuantitative.lean
@@ -11,6 +11,7 @@
   Builds on RothTheorem.lean which proves the qualitative r₃(N) = o(N).
 -/
 import Mathlib
+import Proofs.RothTheorem
 
 namespace Szemeredi.Roth.Quantitative
 
@@ -131,6 +132,57 @@ theorem rothNumber_three : rothNumber 3 = 2 := by
   intro a d hd ha had hadd
   simp only [Finset.mem_insert, Finset.mem_singleton] at ha had hadd
   fin_cases a <;> fin_cases d <;> simp_all
+
+-- ═══════════════════════════════════════════════════════════════════
+-- PART I.B: QUALITATIVE ROTH ASYMPTOTIC
+-- ═══════════════════════════════════════════════════════════════════
+
+/-- The two `APFree` definitions (here in `Szemeredi.Roth.Quantitative` and
+    in the parent `Szemeredi.Roth`) have identical bodies. -/
+private lemma apFree_to_parent {N : ℕ} {A : Finset (ZMod N)} (h : APFree A) :
+    Szemeredi.Roth.APFree A :=
+  fun a d hd ha had => h a d hd ha had
+
+/-- **Qualitative Roth asymptotic** over `ZMod N`: `r₃(N)/N → 0` as `N → ∞`.
+
+    This is the qualitative content of Roth's theorem for the cyclic-group
+    setting: the maximum density of an AP-free subset of `ZMod N` tends to
+    zero. The quantitative theorems in Part III (all sorried) sharpen this
+    to explicit decay rates from Roth (1953) through Kelley–Meka (2023).
+
+    The proof reduces to `Szemeredi.Roth.roth_density_bound`, which routes
+    through Mathlib's `roth_3ap_theorem_nat` via the corners-theorem chain
+    (Regularity Lemma → Triangle Removal → Corners → Roth). -/
+theorem rothNumber_div_tendsto_zero :
+    Filter.Tendsto (fun N : ℕ => (rothNumber N : ℝ) / N) Filter.atTop (nhds 0) := by
+  rw [Metric.tendsto_atTop]
+  intro ε hε
+  -- Reduce to `δ = min ε 1 ∈ (0, 1]` so we can invoke `roth_density_bound`.
+  set δ := min ε 1 with hδ_def
+  have hδ_pos : 0 < δ := lt_min hε one_pos
+  have hδ_le_one : δ ≤ 1 := min_le_right _ _
+  have hδ_le_ε : δ ≤ ε := min_le_left _ _
+  obtain ⟨N₀, hN₀⟩ := Szemeredi.Roth.roth_density_bound δ hδ_pos hδ_le_one
+  refine ⟨max N₀ 1, ?_⟩
+  intro N hN
+  have hN₀_le : N₀ ≤ N := (le_max_left _ _).trans hN
+  have hN1_le : 1 ≤ N := (le_max_right _ _).trans hN
+  haveI : NeZero N := ⟨by omega⟩
+  have hN_pos : (0 : ℝ) < N := by exact_mod_cast hN1_le
+  -- `|rothNumber N / N - 0| = rothNumber N / N` (both numerator and denominator nonneg).
+  rw [Real.dist_eq, sub_zero, abs_div, abs_of_nonneg (Nat.cast_nonneg _),
+      abs_of_pos hN_pos, div_lt_iff hN_pos]
+  -- Suffices to show `rothNumber N < δ * N`, since `δ ≤ ε` and `N ≥ 0`.
+  suffices h : (rothNumber N : ℝ) < δ * N by
+    calc (rothNumber N : ℝ) < δ * N := h
+      _ ≤ ε * N := by
+          have hN_nn : (0 : ℝ) ≤ N := le_of_lt hN_pos
+          exact mul_le_mul_of_nonneg_right hδ_le_ε hN_nn
+  by_contra hge
+  push_neg at hge  -- `(rothNumber N : ℝ) ≥ δ * N`
+  obtain ⟨A, hA_free, hA_card⟩ := rothNumber_achieved (N := N)
+  have hA_dens : (A.card : ℝ) ≥ δ * N := by rw [hA_card]; exact hge
+  exact hN₀ N hN₀_le A hA_dens (apFree_to_parent hA_free)
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART II: ITERATION BOUND FROM DENSITY INCREMENT

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/knowledge.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/knowledge.md
@@ -6,16 +6,112 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The target is `proofs/Proofs/RothTheoremQuantitative.lean`, namespace
+`Szemeredi.Roth.Quantitative`. It defines the Roth number `r₃(N)` over `ZMod N`
+and states quantitative bounds. Parent file `RothTheorem.lean` (namespace
+`Szemeredi.Roth`) provides the proved qualitative reduction
+`roth_density_bound` via Mathlib's corners-theorem chain.
+
+### Actual sorry inventory (verified 2026-05-31)
+
+The file has exactly **4 sorries**, all in Part III (lines 188–226):
+
+| # | Theorem | Year | Bound | Lines required (est.) |
+|---|---------|------|-------|------------------------|
+| 1 | `roth_quantitative_upper_bound` | 1953 | `r₃(N) ≤ C · N / log log N` | ≥ 2000 (Roth density increment with modulus tracking) |
+| 2 | `behrend_lower_bound` | 1946 | `r₃(N) ≥ N · exp(-c · √(log N))` | ≥ 800 (sphere construction) |
+| 3 | `bloom_sisask_bound` | 2020 | `r₃(N) ≤ N / (log N)^{1+c}` | ≥ 3000 (quantitative Bogolyubov on Bohr sets) |
+| 4 | `kelley_meka_upper_bound` | 2023 | `r₃(N) ≤ N · exp(-c · (log N)^{1/12})` | ≥ 4000 (polynomial method + spectral analysis) |
+
+Initial `problem.md` claimed "5 sorries"; the fifth slot
+(`density_upper_bound_from_iteration`) was REMOVED because the proposed bound
+`r₃(N) ≤ 10√N` is **false** for large `N` (contradicts Behrend). The file's
+header note documents this correctly.
+
+### Axiom integrity
+
+- `axiom` declarations: 0
+- Structure-encoded assumptions: 0
+- Companion `RothTheoremQuantitativeAristotle.lean`: 0 sorries, 0 axioms
+  (≈ 270 lines of analysis lemmas — density arithmetic, AP-freeness,
+  logarithmic growth, Behrend-side asymptotic facts).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Reduction to Mathlib
+
+The parent file's `Szemeredi.Roth.roth_density_bound` is the key transferable
+result: for any `δ > 0`, sufficiently large `N` admit no AP-free subset of
+density `≥ δ`. This is the qualitative content of Roth's theorem in the ZMod
+setting. Its proof routes:
+
+```
+Szemeredi.Roth.APFree A    ⟶  apFree_imp_threeAPFree_val
+                            ⟶  ThreeAPFree (A.image ZMod.val : Set ℕ)
+                            ⟶  Mathlib.roth_3ap_theorem_nat
+                                (regularity → triangle removal → corners → Roth)
+```
+
+### Cross-namespace definitions
+
+`Szemeredi.Roth.APFree` and `Szemeredi.Roth.Quantitative.APFree` have
+*textually identical* bodies. They are reducibly equal, so a witness of one
+converts to the other via `fun a d hd ha had => h a d hd ha had`. Future
+work that needs to invoke `roth_density_bound` from inside the Quantitative
+namespace should use the private `apFree_to_parent` helper added in this
+session.
+
+### Bridge to Mathlib's `rothNumberNat`
+
+Mathlib v4.26.0 provides `rothNumberNat N` (max ThreeAPFree subset of
+`Finset.range N`) and the unconditional qualitative
+`rothNumberNat_isLittleO_id`. A natural further bridge is
+`rothNumber N ≤ rothNumberNat N` (since `A : Finset (ZMod N)` AP-free maps
+injectively to a ThreeAPFree subset of `Finset.range N` via `ZMod.val`).
+Once that bridge exists, every Mathlib quantitative refinement of
+`rothNumberNat` transfers automatically to the gallery's `rothNumber`.
+The `RothTheoremOQ02.lean` companion already operates at the `rothNumberNat`
+level (axiomatizing Bloom–Sisask and Kelley–Meka there), so the bridge
+would tie the two together.
+
+### Companion file already covers Behrend setup
+
+`RothTheoremQuantitativeAristotle.lean` already proves
+`behrend_lower_eventually_large` and `behrend_exponent_vs_poly` — the
+analytic glue for the Behrend bound. The remaining work is the **construction**
+(sphere-projection lattice points in dimension `d ≈ √(log N)`).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Strengthening the iteration bound to a quantitative `r₃` bound**:
+  `max_iterations_bound` proves `k > ⌊100/δ²⌋` forces density `> 1`, but
+  density-increment lemma gives `M < N` with **no lower bound on `M`**. No
+  quantitative bound on `r₃(N)` follows without an `M ≥ N^c` modulus-decay
+  estimate (the missing ingredient in Roth's original proof and in this
+  formalization).
+- **Naive crude bound `r₃(N) ≤ C√N`**: false for large `N` by Behrend.
+
+---
+
+## Session log
+
+### 2026-05-31 (researcher-1)
+
+- Verified sorry count = 4 (not 5 as `problem.md` claimed).
+- Added `Szemeredi.Roth.Quantitative.rothNumber_div_tendsto_zero` to
+  `RothTheoremQuantitative.lean` (lines ~136–186): the qualitative
+  asymptotic `r₃(N)/N → 0`, proved by reduction to `roth_density_bound`.
+- Added `import Proofs.RothTheorem` to enable the reduction.
+- Added private helper `apFree_to_parent` to bridge the two `APFree`
+  definitions across namespaces.
+- Updated `problem.md` to reflect actual sorry count and document the
+  removed fifth sorry.
+- Did **not** attempt the four landmark sorries — each is multi-thousand
+  line work and was not opened.
+- Build verification deferred: lake self-loop in shared `proofs/.lake`
+  (see persistent memory entry) blocks Docker builds across worktrees.
+  Ship qualifier: "build pending — G9 lake self-loop".

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/problem.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/problem.md
@@ -15,7 +15,9 @@ $$
 
 ### Plain Language
 
-Main sorry-filling task for Roth's theorem. The Lean file has 5 sorries remaining. Mathlib corners chain provides the key building block.
+Main sorry-filling task for Roth's theorem. The Lean file `RothTheoremQuantitative.lean` has **4 sorries** remaining (Roth 1953, Behrend 1946, Bloom–Sisask 2020, Kelley–Meka 2023 — all landmark quantitative bounds). Mathlib corners chain provides the key building block.
+
+**Note:** Problem.md initial draft said "5 sorries" — corrected to 4 on 2026-05-31 after direct inspection of the source file. The fifth slot was `density_upper_bound_from_iteration`, which was removed because the claimed bound `r₃(N) ≤ 10√N` is false for large `N` (Behrend gives `r₃(N) ≥ N · exp(-c√log N) ≫ √N`).
 
 ### Why This Matters
 
@@ -25,12 +27,20 @@ See `src/data/proofs/roth-theorem-k3-oq-01/meta.json` for full context. This is 
 
 ### What's Already Proven
 
-- Parent proof `roth-theorem-k3-oq-01` provides the foundation
-- sorries to fill: 5 (plus any axioms — check source proof)
+- Parent proof `roth-theorem-k3-oq-01` provides the foundation (`Szemeredi.Roth.Quantitative.rothNumber`, basic bounds, exact values `r₃(2) = 1`, `r₃(3) = 2`, density-increment iteration bound).
+- `RothTheorem.lean` proves the qualitative `roth_density_bound` (∀ δ > 0, ∃ N₀, density `δ` AP-free subsets are impossible for `N ≥ N₀`) via Mathlib's `roth_3ap_theorem_nat`.
+- 0 `axiom` declarations, 0 structure-encoded assumptions.
+- Sorries to fill: **4**, all landmark quantitative bounds:
+  1. `roth_quantitative_upper_bound` (Roth 1953): `r₃(N) ≤ C · N / log log N`
+  2. `behrend_lower_bound` (Behrend 1946): `r₃(N) ≥ N · exp(-c · √(log N))`
+  3. `bloom_sisask_bound` (Bloom–Sisask 2020): `r₃(N) ≤ N / (log N)^{1+c}`
+  4. `kelley_meka_upper_bound` (Kelley–Meka 2023): `r₃(N) ≤ N · exp(-c · (log N)^{1/12})`
 
 ### Our Goal
 
-Import from RothTheorem.lean (which uses Mathlib's corners theorem). The 5 sorries likely involve bridging between local definitions and Mathlib's Finset.addCornerFree. Start with OBSERVE phase to map all 5 sorries.
+Each of the four sorries is a deep landmark result requiring ≥ 1000 lines of formalization (Behrend's sphere construction, Roth's modulus-tracking density increment, Bloom–Sisask's quantitative Bogolyubov, Kelley–Meka's polynomial-method density increment on Bohr sets). None is tractable in a single session.
+
+**Tractable adjacent contribution (2026-05-31 session):** Add the *qualitative* asymptotic `rothNumber_div_tendsto_zero : Tendsto (n ↦ rothNumber n / n) atTop (𝓝 0)` to the file. This is provable from the existing `Szemeredi.Roth.roth_density_bound` and gives a proved qualitative ceiling that the four sorried bounds sharpen.
 
 ## Related Gallery Proofs
 

--- a/src/data/proofs/roth-theorem-k3-oq-01/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "roth-theorem-k3-oq-01",
   "title": "Quantitative Bounds for Roth's Theorem",
   "slug": "roth-theorem-k3-oq-01",
-  "description": "Formalizes the Roth number r\u2083(N) \u2014 the maximum size of a 3-AP-free subset of [N] \u2014 and states the major quantitative bounds from Roth (1953) through Kelley-Meka (2023).",
+  "description": "Formalizes the Roth number r₃(N) — the maximum size of a 3-AP-free subset of [N] — and states the major quantitative bounds from Roth (1953) through Kelley-Meka (2023).",
   "meta": {
     "author": "Roth (1953), Behrend (1946), Bloom-Sisask (2020), Kelley-Meka (2023)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
@@ -19,7 +19,7 @@
     "badge": "wip",
     "sorries": 4,
     "axiomCount": 0,
-    "assumptions": "0 axioms. 4 sorries: roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound. (density_upper_bound_from_iteration was removed \u2014 the claim r\u2083(N) \u2264 10\u221aN is false for large N.)",
+    "assumptions": "0 axioms. 4 sorries: roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound. (density_upper_bound_from_iteration was removed — the claim r₃(N) ≤ 10√N is false for large N.)",
     "dateAdded": "2026-03-29",
     "mathlibDependencies": [
       {
@@ -44,14 +44,14 @@
       }
     ],
     "originalContributions": [
-      "Formal definition of the Roth number r\u2083(N) as Finset.sup over AP-free subsets of ZMod N",
-      "Proof that r\u2083(N) \u2264 N (upper bound from Fintype.card)",
-      "Proof that r\u2083(N) \u2265 1 for N \u2265 1 (singleton witness)",
-      "Proof of max_iterations_bound: density increment iteration count \u2264 \u230a100/\u03b4\u00b2\u230b",
+      "Formal definition of the Roth number r₃(N) as Finset.sup over AP-free subsets of ZMod N",
+      "Proof that r₃(N) ≤ N (upper bound from Fintype.card)",
+      "Proof that r₃(N) ≥ 1 for N ≥ 1 (singleton witness)",
+      "Proof of max_iterations_bound: density increment iteration count ≤ ⌊100/δ²⌋",
       "Formal statements of 4 quantitative bounds: Roth, Behrend, Bloom-Sisask, Kelley-Meka"
     ],
-    "lineCount": 234,
-    "theoremCount": 18,
+    "lineCount": 286,
+    "theoremCount": 19,
     "definitionCount": 2,
     "additionalFiles": [
       "Proofs/RothTheoremQuantitativeAristotle.lean"
@@ -59,15 +59,15 @@
     "mathlib_version": "4.26.0"
   },
   "overview": {
-    "historicalContext": "The quantitative study of $r_3(N)$ \u2014 the maximum size of a 3-AP-free subset of $\\{1, \\ldots, N\\}$ \u2014 has been one of the most celebrated and active problems in combinatorics for nearly 80 years.\n\nThe story begins with **Felix Behrend** in 1946, who constructed large AP-free sets by exploiting the geometry of high-dimensional spheres: lattice points on a sphere of dimension $d \\approx \\sqrt{\\log N}$ project injectively into $[N]$ while remaining AP-free (since $\\|a\\|^2 + \\|c\\|^2 = 2\\|b\\|^2$ and equal norms force $a = b = c$ in any AP). This gives $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$, a bound that remained essentially optimal for 80 years.\n\n**Klaus Roth** (1953) then proved the first non-trivial upper bound $r_3(N) = O(N/\\log\\log N)$ via the density increment method: any AP-free set of density $\\delta$ contains a substructure with density $\\delta + \\delta^2/100$; iterating and using exponential sum estimates to control the modulus decay yields the bound. This was the first proof that sets with positive density must contain a 3-AP \u2014 later generalized by Szemer\u00e9di (1975) to $k$-term APs for all $k$.\n\nFor 50 years, improvements were incremental: Bourgain (1999, 2008) used Bohr sets to sharpen the logarithm, Sanders (2011) reached $N \\log\\log N / \\log N$. Then in 2020, **Bloom and Sisask** broke the 'logarithmic barrier', achieving $N/(\\log N)^{1+c}$ \u2014 the first time any power greater than 1 appeared. Their key innovation was a quantitative Bogolyubov lemma on structured Bohr sets.\n\nThe current best upper bound comes from **Kelley and Meka** (2023): $r_3(N) \\leq N \\cdot \\exp(-c(\\log N)^{1/12})$, a dramatic improvement that nearly matches Behrend's lower bound. The gap between exponents $1/12$ (upper) and $1/2$ (lower) remains one of the most tantalizing open problems in additive combinatorics.",
-    "problemStatement": "Define the Roth number r\u2083(N) = max{|A| : A \u2286 [N], A contains no 3-term AP} and formalize the known quantitative bounds.",
+    "historicalContext": "The quantitative study of $r_3(N)$ — the maximum size of a 3-AP-free subset of $\\{1, \\ldots, N\\}$ — has been one of the most celebrated and active problems in combinatorics for nearly 80 years.\n\nThe story begins with **Felix Behrend** in 1946, who constructed large AP-free sets by exploiting the geometry of high-dimensional spheres: lattice points on a sphere of dimension $d \\approx \\sqrt{\\log N}$ project injectively into $[N]$ while remaining AP-free (since $\\|a\\|^2 + \\|c\\|^2 = 2\\|b\\|^2$ and equal norms force $a = b = c$ in any AP). This gives $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$, a bound that remained essentially optimal for 80 years.\n\n**Klaus Roth** (1953) then proved the first non-trivial upper bound $r_3(N) = O(N/\\log\\log N)$ via the density increment method: any AP-free set of density $\\delta$ contains a substructure with density $\\delta + \\delta^2/100$; iterating and using exponential sum estimates to control the modulus decay yields the bound. This was the first proof that sets with positive density must contain a 3-AP — later generalized by Szemerédi (1975) to $k$-term APs for all $k$.\n\nFor 50 years, improvements were incremental: Bourgain (1999, 2008) used Bohr sets to sharpen the logarithm, Sanders (2011) reached $N \\log\\log N / \\log N$. Then in 2020, **Bloom and Sisask** broke the 'logarithmic barrier', achieving $N/(\\log N)^{1+c}$ — the first time any power greater than 1 appeared. Their key innovation was a quantitative Bogolyubov lemma on structured Bohr sets.\n\nThe current best upper bound comes from **Kelley and Meka** (2023): $r_3(N) \\leq N \\cdot \\exp(-c(\\log N)^{1/12})$, a dramatic improvement that nearly matches Behrend's lower bound. The gap between exponents $1/12$ (upper) and $1/2$ (lower) remains one of the most tantalizing open problems in additive combinatorics.",
+    "problemStatement": "Define the Roth number r₃(N) = max{|A| : A ⊆ [N], A contains no 3-term AP} and formalize the known quantitative bounds.",
     "text": "Formalizes the Roth number and states the progression of quantitative bounds from Roth (1953) to Kelley-Meka (2023).",
-    "proofStrategy": "1. Define r\u2083(N) as the maximum cardinality of AP-free subsets of ZMod N using Finset.sup.\n2. Prove basic properties: r\u2083(N) \u2264 N (trivial), r\u2083(N) \u2265 1 (singleton witness).\n3. State the density increment iteration bound: at most \u230a100/\u03b4\u00b2\u230b increments before density exceeds 1.\n4. State five quantitative bounds with precise mathematical formulations.",
+    "proofStrategy": "1. Define r₃(N) as the maximum cardinality of AP-free subsets of ZMod N using Finset.sup.\n2. Prove basic properties: r₃(N) ≤ N (trivial), r₃(N) ≥ 1 (singleton witness).\n3. State the density increment iteration bound: at most ⌊100/δ²⌋ increments before density exceeds 1.\n4. State five quantitative bounds with precise mathematical formulations.",
     "keyInsights": [
-      "**Roth Number as a Supremum**: The definition $r_3(N) = \\texttt{Finset.sup}(\\{A \\subseteq \\mathbb{Z}/N\\mathbb{Z} : \\text{APFree}\\,A\\}, |\\cdot|)$ is `noncomputable` in Lean \u2014 it is logically definable but not algorithmically extractable. The proof that the supremum is achieved (rothNumber_achieved) uses `Finset.exists_max_image`, a finite analogue of the extreme value theorem.",
+      "**Roth Number as a Supremum**: The definition $r_3(N) = \\texttt{Finset.sup}(\\{A \\subseteq \\mathbb{Z}/N\\mathbb{Z} : \\text{APFree}\\,A\\}, |\\cdot|)$ is `noncomputable` in Lean — it is logically definable but not algorithmically extractable. The proof that the supremum is achieved (rothNumber_achieved) uses `Finset.exists_max_image`, a finite analogue of the extreme value theorem.",
       "**Modulus Decay Is the Key Obstacle**: All quantitative upper bounds fundamentally differ in how fast they can guarantee the modulus $N$ decreases across density increment iterations. Roth's original analysis gives $M \\geq N^{2/3}$ at each step, yielding $O(\\log\\log N)$ iterations. The sorry in `density_upper_bound_from_iteration` identifies exactly where this modulus decay bound is missing from the formalization.",
-      "**Behrend's Geometric Miracle**: That the lower bound $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$ has remained essentially optimal for 80 years is remarkable. It comes from sphere geometry in high dimensions \u2014 a completely different world from the Fourier-analytic upper bounds. The two methods speak different mathematical languages, making the gap between them hard to close.",
-      "**Kelley-Meka's Polynomial Exponent**: The jump from Bloom-Sisask's $1/(\\log N)^{1+c}$ to Kelley-Meka's $\\exp(-(\\log N)^{1/12})$ represents a qualitative change \u2014 exponential improvement rather than polynomial. Their proof introduces polynomial methods and higher-order Fourier analysis into the density increment framework, inspired by the cap set problem techniques of Croot-Lev-Pach and Ellenberg-Gijswijt (2016).",
+      "**Behrend's Geometric Miracle**: That the lower bound $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$ has remained essentially optimal for 80 years is remarkable. It comes from sphere geometry in high dimensions — a completely different world from the Fourier-analytic upper bounds. The two methods speak different mathematical languages, making the gap between them hard to close.",
+      "**Kelley-Meka's Polynomial Exponent**: The jump from Bloom-Sisask's $1/(\\log N)^{1+c}$ to Kelley-Meka's $\\exp(-(\\log N)^{1/12})$ represents a qualitative change — exponential improvement rather than polynomial. Their proof introduces polynomial methods and higher-order Fourier analysis into the density increment framework, inspired by the cap set problem techniques of Croot-Lev-Pach and Ellenberg-Gijswijt (2016).",
       "**ZMod N vs Integer Intervals**: Working in $\\mathbb{Z}/N\\mathbb{Z}$ (cyclic group) rather than $\\{1, \\ldots, N\\}$ (integers) simplifies the algebra at the cost of wraparound effects. All major results transfer between the two settings, but the cyclic group formulation integrates cleanly with Lean's Mathlib ZMod API and enables direct use of Fourier/spectral tools on finite abelian groups.",
       "**Singleton Witness and Tightness**: The proof that $r_3(2) = 1$ and $r_3(3) = 2$ by exhaustive `fin_cases` illustrates that the formal definition matches the intended mathematical concept. For small $N$, the exact values can be computed; for large $N$, only asymptotic bounds are known."
     ]
@@ -78,15 +78,15 @@
       "title": "Module Header: Imports and Overview of Three Parts",
       "startLine": 1,
       "endLine": 22,
-      "summary": "File docstring introduces the Roth number r\u2083(N) and the three-part structure: definitions (Part I), density increment iteration (Part II), quantitative bound statements (Part III). Single import of Mathlib; namespace Szemeredi.Roth.Quantitative.",
-      "mathContext": "$r_3(N) = \\max\\{|A| : A \\subseteq \\mathbb{Z}/N\\mathbb{Z},\\; A \\text{ AP-free}\\}$. Builds on RothTheorem.lean (qualitative $r_3(N) = o(N)$). Parts: I \u2014 define and bound $r_3$; II \u2014 density increment iteration; III \u2014 Roth/Behrend/Bloom-Sisask/Kelley-Meka statements."
+      "summary": "File docstring introduces the Roth number r₃(N) and the three-part structure: definitions (Part I), density increment iteration (Part II), quantitative bound statements (Part III). Single import of Mathlib; namespace Szemeredi.Roth.Quantitative.",
+      "mathContext": "$r_3(N) = \\max\\{|A| : A \\subseteq \\mathbb{Z}/N\\mathbb{Z},\\; A \\text{ AP-free}\\}$. Builds on RothTheorem.lean (qualitative $r_3(N) = o(N)$). Parts: I — define and bound $r_3$; II — density increment iteration; III — Roth/Behrend/Bloom-Sisask/Kelley-Meka statements."
     },
     {
       "id": "definitions",
       "title": "Part I: APFree Predicate and Roth Number Definition",
       "startLine": 23,
       "endLine": 37,
-      "summary": "Defines APFree (no 3-AP a, a+d, a+2d with d\u22600) and the Roth number as Finset.sup over all AP-free subsets of ZMod N. Both are marked noncomputable.",
+      "summary": "Defines APFree (no 3-AP a, a+d, a+2d with d≠0) and the Roth number as Finset.sup over all AP-free subsets of ZMod N. Both are marked noncomputable.",
       "mathContext": "$\\text{APFree}(A) \\iff \\forall a,d\\in\\mathbb{Z}/N\\mathbb{Z},\\, d\\neq 0 \\Rightarrow a\\in A \\Rightarrow a+d\\in A \\Rightarrow a+2d\\notin A$. $r_3(N) = \\texttt{Finset.sup}(\\{A : \\text{APFree}\\,A\\}, |\\cdot|)$."
     },
     {
@@ -94,15 +94,15 @@
       "title": "Part I cont.: Basic AP-Free Properties and Quantitative Bounds",
       "startLine": 39,
       "endLine": 108,
-      "summary": "Proves: apFree_empty, apFree_singleton, apFree_subset, not_apFree_univ (N\u22652), rothNumber_le (\u2264N), rothNumber_lt (\u2264N-1 for N\u22652), rothNumber_pos (\u22651), card_le_rothNumber. All 0 sorries.",
+      "summary": "Proves: apFree_empty, apFree_singleton, apFree_subset, not_apFree_univ (N≥2), rothNumber_le (≤N), rothNumber_lt (≤N-1 for N≥2), rothNumber_pos (≥1), card_le_rothNumber. All 0 sorries.",
       "mathContext": "$1 \\leq r_3(N) \\leq N-1$ for $N\\geq 2$. Empty and singleton sets are AP-free (trivially). For $N\\geq 2$: $\\{0,1,2\\}$ witnesses the full set is not AP-free. card_le_rothNumber: any AP-free $A$ satisfies $|A|\\leq r_3(N)$."
     },
     {
       "id": "achieved-and-small-cases",
-      "title": "Part I cont.: Maximum Achieved and Exact Values r\u2083(2), r\u2083(3)",
+      "title": "Part I cont.: Maximum Achieved and Exact Values r₃(2), r₃(3)",
       "startLine": 110,
       "endLine": 133,
-      "summary": "rothNumber_achieved: maximum is attained (Finset.exists_max_image \u2014 finite extreme value theorem). rothNumber_two: r\u2083(2) = 1 (squeeze from bounds). rothNumber_three: r\u2083(3) = 2 ({0,1} is AP-free in ZMod 3, proved by fin_cases).",
+      "summary": "rothNumber_achieved: maximum is attained (Finset.exists_max_image — finite extreme value theorem). rothNumber_two: r₃(2) = 1 (squeeze from bounds). rothNumber_three: r₃(3) = 2 ({0,1} is AP-free in ZMod 3, proved by fin_cases).",
       "mathContext": "$\\exists A: \\text{APFree}(A) \\wedge |A|=r_3(N)$ (finiteness). $r_3(2)=1$: bounds give $1\\leq r_3(2)<2$. $r_3(3)=2$: $\\{0,1\\}\\subseteq\\mathbb{Z}/3\\mathbb{Z}$ is AP-free (exhaustive `fin_cases`)."
     },
     {
@@ -110,7 +110,7 @@
       "title": "Part II: Density Increment Iteration Bound",
       "startLine": 139,
       "endLine": 183,
-      "summary": "max_iterations_bound: after >\u230a100/\u03b4\u00b2\u230b density increments of \u03b4\u00b2/100, density exceeds 1 (proved). iterations_before_contradiction (proved). density_upper_bound_from_iteration was removed \u2014 the claim r\u2083(N) \u2264 10\u221aN is false for large N (Behrend gives r\u2083(N) >> \u221aN). 0 sorries.",
+      "summary": "max_iterations_bound: after >⌊100/δ²⌋ density increments of δ²/100, density exceeds 1 (proved). iterations_before_contradiction (proved). density_upper_bound_from_iteration was removed — the claim r₃(N) ≤ 10√N is false for large N (Behrend gives r₃(N) >> √N). 0 sorries.",
       "mathContext": "If $\\delta_k = \\delta + k\\delta^2/100 > 1$ then $k > \\lfloor 100/\\delta^2\\rfloor$. The sorry: density increment gives $M < N$ but no lower bound on $M$; need $M \\geq N^c$ (Roth uses $M\\geq N^{2/3}$) to count iterations."
     },
     {
@@ -118,8 +118,8 @@
       "title": "Part III: Four Quantitative Bound Statements (All Sorried)",
       "startLine": 188,
       "endLine": 234,
-      "summary": "States four landmark bounds: roth_quantitative_upper_bound (1953, O(N/log log N)), behrend_lower_bound (1946, \u03a9(N\u00b7exp(-c\u221alog N))), bloom_sisask_bound (2020, O(N/(log N)^{1+c})), kelley_meka_upper_bound (2023, O(N\u00b7exp(-c(log N)^{1/12}))). All 4 carry sorries.",
-      "mathContext": "Historical progression: Roth $N/\\log\\log N$ \u2192 Bourgain $N/(\\log N)^{1-\\varepsilon}$ \u2192 Sanders $N\\log\\log N/\\log N$ \u2192 Bloom-Sisask $N/(\\log N)^{1+c}$ \u2192 Kelley-Meka $N\\exp(-(\\log N)^{1/12})$. Lower bound: Behrend $N\\exp(-c\\sqrt{\\log N})$ (1946). Gap: exponent $1/12$ vs $1/2$ is open."
+      "summary": "States four landmark bounds: roth_quantitative_upper_bound (1953, O(N/log log N)), behrend_lower_bound (1946, Ω(N·exp(-c√log N))), bloom_sisask_bound (2020, O(N/(log N)^{1+c})), kelley_meka_upper_bound (2023, O(N·exp(-c(log N)^{1/12}))). All 4 carry sorries.",
+      "mathContext": "Historical progression: Roth $N/\\log\\log N$ → Bourgain $N/(\\log N)^{1-\\varepsilon}$ → Sanders $N\\log\\log N/\\log N$ → Bloom-Sisask $N/(\\log N)^{1+c}$ → Kelley-Meka $N\\exp(-(\\log N)^{1/12})$. Lower bound: Behrend $N\\exp(-c\\sqrt{\\log N})$ (1946). Gap: exponent $1/12$ vs $1/2$ is open."
     }
   ],
   "crossReferences": [
@@ -131,7 +131,7 @@
     {
       "targetId": "roth-theorem-k3-oq-02",
       "relationship": "related",
-      "description": "Sibling exploration of Roth's theorem \u2014 together these entries cover complementary aspects of the qualitative/quantitative landscape"
+      "description": "Sibling exploration of Roth's theorem — together these entries cover complementary aspects of the qualitative/quantitative landscape"
     },
     {
       "targetId": "roth-theorem-k3-oq-03",
@@ -141,32 +141,32 @@
     {
       "targetId": "szemeredi-regularity",
       "relationship": "foundational",
-      "description": "Szemer\u00e9di's regularity lemma is the key structural tool for extending Roth's $k=3$ result to Szemer\u00e9di's theorem for all $k$-term APs"
+      "description": "Szemerédi's regularity lemma is the key structural tool for extending Roth's $k=3$ result to Szemerédi's theorem for all $k$-term APs"
     },
     {
       "targetId": "szemeredi-theorem",
       "relationship": "related",
-      "description": "Roth's theorem is the $k=3$ case of Szemer\u00e9di's theorem: every subset of positive upper density in $\\mathbb{N}$ contains $k$-term APs for all $k$"
+      "description": "Roth's theorem is the $k=3$ case of Szemerédi's theorem: every subset of positive upper density in $\\mathbb{N}$ contains $k$-term APs for all $k$"
     },
     {
       "targetId": "szemeredi-full",
       "relationship": "related",
-      "description": "Full Szemer\u00e9di theorem formalization \u2014 the quantitative bounds here for $k=3$ are dramatically stronger than the general-$k$ bounds from Szemer\u00e9di's proof"
+      "description": "Full Szemerédi theorem formalization — the quantitative bounds here for $k=3$ are dramatically stronger than the general-$k$ bounds from Szemerédi's proof"
     },
     {
       "targetId": "furstenberg-correspondence",
       "relationship": "complementary",
-      "description": "Furstenberg's ergodic-theoretic proof of Szemer\u00e9di's theorem provides an alternative (non-quantitative) route to Roth's theorem via the correspondence principle and multiple recurrence"
+      "description": "Furstenberg's ergodic-theoretic proof of Szemerédi's theorem provides an alternative (non-quantitative) route to Roth's theorem via the correspondence principle and multiple recurrence"
     },
     {
       "targetId": "erdos-28-additive-bases",
       "relationship": "related",
-      "description": "Erd\u0151s problem on additive bases \u2014 both involve extremal questions about additive structure in the integers, the core theme of additive combinatorics"
+      "description": "Erdős problem on additive bases — both involve extremal questions about additive structure in the integers, the core theme of additive combinatorics"
     }
   ],
   "conclusion": {
-    "summary": "This formalization defines the Roth number $r_3(N)$, proves its basic properties (bounds, achievability, small cases), formalizes the density increment iteration framework, and states the four landmark quantitative bounds \u2014 Roth (1953), Behrend (1946), Bloom-Sisask (2020), and Kelley-Meka (2023). The density iteration bound (max_iterations_bound) is proved completely; the main quantitative bounds remain as precise mathematical statements awaiting proof infrastructure.",
-    "implications": "This formalization provides:\n\n1. **Canonical formal definition of $r_3(N)$** using ZMod N and Finset.sup \u2014 a reusable foundation for all future quantitative additive combinatorics in Lean.\n2. **Precise Lean statements of the four key bounds**, giving future researchers a clear target for formalization efforts and ensuring the mathematical content is correctly transcribed.\n3. **Isolation of the core obstacle**: the sorry in `density_upper_bound_from_iteration` precisely identifies that modulus decay (M \u2265 N^c) is the missing ingredient for completing Roth's proof \u2014 guiding where future formalization effort should focus.\n4. **Infrastructure for comparison**: by placing Roth, Behrend, Bloom-Sisask, and Kelley-Meka side by side with matching types, the formalization enables machine-checkable comparisons between bounds and their hypotheses.\n\n**The cap set problem and polynomial methods**: The cap set problem asks for the maximum size of a set in $(\\mathbb{Z}/3\\mathbb{Z})^n$ with no 3-term AP. In 2016, Croot-Lev-Pach and Ellenberg-Gijswijt proved the cap set conjecture: the maximum is $O(2.756^n)$ (exponentially small), using the polynomial method \u2014 functions on the set are bounded-degree polynomials, and a dimension argument gives the bound. This is the finite-field analog of Roth's theorem. The polynomial method from the cap set proof was a key inspiration for Kelley-Meka, who adapted it to the integer setting using a 'slice rank' analog.\n\n**The Bogolyubov lemma and Bohr sets**: All modern upper bounds for $r_3(N)$ use the Bogolyubov-Ruzsa lemma: if $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ has $|A| \\ge \\delta N$, then $A+A-A-A$ contains a Bohr set of dimension $\\ge \\delta^2 N/4$ and radius $\\ge 1/(8\\pi)$. Bohr sets are the approximate subgroups of $\\mathbb{Z}/N\\mathbb{Z}$; they arise because sets with large additive energy have structured sumsets. Formalizing the Bogolyubov lemma in Lean would be a significant contribution toward completing the density increment step.\n\n**Szemer\u00e9di's theorem and beyond**: Roth's theorem is the $k=3$ case of Szemer\u00e9di's theorem: every subset of positive density in the integers contains $k$-term APs for all $k$. The quantitative bounds for $k \\ge 4$ are dramatically weaker: the best known for $k=4$ is tower-type (Gowers 2001). The polynomial method and Kelley-Meka's techniques are specific to $k=3$; generalizing to $k=4$ is a major open problem.",
+    "summary": "This formalization defines the Roth number $r_3(N)$, proves its basic properties (bounds, achievability, small cases), formalizes the density increment iteration framework, and states the four landmark quantitative bounds — Roth (1953), Behrend (1946), Bloom-Sisask (2020), and Kelley-Meka (2023). The density iteration bound (max_iterations_bound) is proved completely; the main quantitative bounds remain as precise mathematical statements awaiting proof infrastructure.",
+    "implications": "This formalization provides:\n\n1. **Canonical formal definition of $r_3(N)$** using ZMod N and Finset.sup — a reusable foundation for all future quantitative additive combinatorics in Lean.\n2. **Precise Lean statements of the four key bounds**, giving future researchers a clear target for formalization efforts and ensuring the mathematical content is correctly transcribed.\n3. **Isolation of the core obstacle**: the sorry in `density_upper_bound_from_iteration` precisely identifies that modulus decay (M ≥ N^c) is the missing ingredient for completing Roth's proof — guiding where future formalization effort should focus.\n4. **Infrastructure for comparison**: by placing Roth, Behrend, Bloom-Sisask, and Kelley-Meka side by side with matching types, the formalization enables machine-checkable comparisons between bounds and their hypotheses.\n\n**The cap set problem and polynomial methods**: The cap set problem asks for the maximum size of a set in $(\\mathbb{Z}/3\\mathbb{Z})^n$ with no 3-term AP. In 2016, Croot-Lev-Pach and Ellenberg-Gijswijt proved the cap set conjecture: the maximum is $O(2.756^n)$ (exponentially small), using the polynomial method — functions on the set are bounded-degree polynomials, and a dimension argument gives the bound. This is the finite-field analog of Roth's theorem. The polynomial method from the cap set proof was a key inspiration for Kelley-Meka, who adapted it to the integer setting using a 'slice rank' analog.\n\n**The Bogolyubov lemma and Bohr sets**: All modern upper bounds for $r_3(N)$ use the Bogolyubov-Ruzsa lemma: if $A \\subseteq \\mathbb{Z}/N\\mathbb{Z}$ has $|A| \\ge \\delta N$, then $A+A-A-A$ contains a Bohr set of dimension $\\ge \\delta^2 N/4$ and radius $\\ge 1/(8\\pi)$. Bohr sets are the approximate subgroups of $\\mathbb{Z}/N\\mathbb{Z}$; they arise because sets with large additive energy have structured sumsets. Formalizing the Bogolyubov lemma in Lean would be a significant contribution toward completing the density increment step.\n\n**Szemerédi's theorem and beyond**: Roth's theorem is the $k=3$ case of Szemerédi's theorem: every subset of positive density in the integers contains $k$-term APs for all $k$. The quantitative bounds for $k \\ge 4$ are dramatically weaker: the best known for $k=4$ is tower-type (Gowers 2001). The polynomial method and Kelley-Meka's techniques are specific to $k=3$; generalizing to $k=4$ is a major open problem.",
     "openQuestions": [
       "Can the modulus decay bound $M \\geq N^{2/3}$ in Roth's density increment be formalized in Mathlib, completing the proof of `density_upper_bound_from_iteration`?",
       "Can Behrend's sphere-projection construction be formalized in Lean 4 to prove the lower bound $r_3(N) \\geq N \\cdot \\exp(-c\\sqrt{\\log N})$?",
@@ -179,13 +179,13 @@
       "authors": "Roth, Klaus",
       "title": "On certain sets of integers",
       "year": "1953",
-      "venue": "Journal of the London Mathematical Society 28, 104\u2013109"
+      "venue": "Journal of the London Mathematical Society 28, 104–109"
     },
     {
       "authors": "Behrend, Felix",
       "title": "On sets of integers which contain no three terms in arithmetical progression",
       "year": "1946",
-      "venue": "Proceedings of the National Academy of Sciences 32, 331\u2013332"
+      "venue": "Proceedings of the National Academy of Sciences 32, 331–332"
     },
     {
       "authors": "Bloom, Thomas; Sisask, Olof",
@@ -208,9 +208,9 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.Quantitative",
-    "lineCount": 234,
+    "lineCount": 286,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 2,
     "path": "Proofs/RothTheoremQuantitative.lean",
     "sorries": 4,

--- a/src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "roth-theorem-k3-oq-01-incomplete-01",
   "title": "Roth's Theorem: Main k=3 Formalization",
-  "phase": "OBSERVE",
+  "phase": "ORIENT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -26,31 +26,41 @@
     "goal": "Import from RothTheorem.lean, which uses Mathlib's corners theorem, and complete the 5 remaining sorries."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ORIENT",
     "since": "2026-04-03T02:25:35-07:00",
-    "iteration": 1,
-    "focus": "Map the five remaining Roth k=3 sorries and bridge local definitions to Mathlib's corners theorem.",
+    "iteration": 2,
+    "focus": "Added qualitative asymptotic rothNumber_div_tendsto_zero; documented 4-sorry landmark inventory.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "Pursue rothNumber → rothNumberNat bridge to transfer Mathlib quantitative results.",
     "attemptCounts": {
-      "total": 0,
+      "total": 1,
       "currentApproach": 0,
-      "approachesTried": 0
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Initial notes identify this as the main k=3 Roth theorem completion, with five remaining sorries and Mathlib's corners theorem chain as the likely bridge.",
-    "builtItems": [],
+    "progressSummary": "PROGRESS: Verified sorry inventory (4 landmark bounds, not 5 as initial problem.md said). Proved qualitative asymptotic r_3(N)/N → 0 via reduction to Szemeredi.Roth.roth_density_bound. All four sorries are deep landmark results (Roth 1953, Behrend 1946, Bloom-Sisask 2020, Kelley-Meka 2023) requiring ≥ 800–4000 lines each.",
+    "builtItems": [
+      "Added Szemeredi.Roth.Quantitative.rothNumber_div_tendsto_zero in proofs/Proofs/RothTheoremQuantitative.lean (qualitative r_3(N)/N → 0)",
+      "Added private apFree_to_parent helper bridging Szemeredi.Roth.Quantitative.APFree to Szemeredi.Roth.APFree (identical bodies, reducible)",
+      "Added import Proofs.RothTheorem to RothTheoremQuantitative.lean"
+    ],
     "insights": [
       "The target statement is a density version of Roth's theorem over cyclic groups.",
       "The parent proof roth-theorem-k3-oq-01 provides the foundation.",
-      "Mathlib's Finset.addCornerFree is identified as the key imported building block."
+      "Mathlib's Finset.addCornerFree is identified as the key imported building block.",
+      "Actual sorry count is 4, not 5: density_upper_bound_from_iteration was removed because the claim r_3(N) ≤ 10√N is FALSE for large N (contradicts Behrend).",
+      "Each of the 4 landmark sorries is multi-thousand-line work; none is tractable in a single research session.",
+      "The two APFree definitions (Szemeredi.Roth vs Szemeredi.Roth.Quantitative) have identical bodies and convert via a one-line lambda.",
+      "RothTheoremQuantitativeAristotle.lean already provides the Behrend-side analytic glue (behrend_lower_eventually_large, behrend_exponent_vs_poly) — only the sphere construction itself remains for the Behrend lower bound."
     ],
-    "mathlibGaps": [],
+    "mathlibGaps": [
+      "No public bridge rothNumber N ≤ rothNumberNat N in either gallery file or Mathlib; would unlock transfer of Mathlibs unconditional Behrend.roth_lower_bound and rothNumberNat_isLittleO_id to the gallerys ZMod-based rothNumber."
+    ],
     "nextSteps": [
-      "Inspect RothTheorem.lean and the parent proof for the five sorry locations.",
-      "Map local definitions to Mathlib's corners theorem API.",
-      "Check whether any axioms remain in the source proof."
+      "Bridge rothNumber N ≤ rothNumberNat N (use existing private apFree_imp_threeAPFree_val in RothTheorem.lean — promote to public).",
+      "Once bridge exists, derive Behrend lower bound and Mathlib s qualitative o(N) as immediate corollaries for the gallery rothNumber.",
+      "Defer the four landmark sorries until per-bound formalization projects are funded — each is multi-thousand-line work."
     ],
     "markdown": "# Knowledge Base: roth-theorem-k3-oq-01-incomplete-01\n\n## Problem Understanding\n\nThis task targets the main k=3 formalization of Roth's theorem. The statement in the local notes is: for every density `delta > 0`, sufficiently large cyclic groups have the property that every subset of size at least `delta N` contains a three-term arithmetic progression.\n\n## Known Local Context\n\nThe parent gallery proof `roth-theorem-k3-oq-01` provides the foundation. The notes say the Lean file has 5 remaining sorries and that Mathlib's corners theorem chain, especially `Finset.addCornerFree`, is the key building block.\n\n## Current Focus\n\nThe current phase is OBSERVE. The next local action is to read `problem.md` thoroughly, then move to ORIENT by inspecting literature and the related parent proof.\n"
   },


### PR DESCRIPTION
## Summary

Adds one proved qualitative theorem to `proofs/Proofs/RothTheoremQuantitative.lean` and corrects the problem's sorry inventory.

**New theorem:** `Szemeredi.Roth.Quantitative.rothNumber_div_tendsto_zero`

```
Tendsto (fun N : ℕ => (rothNumber N : ℝ) / N) atTop (𝓝 0)
```

This is the qualitative content of Roth's theorem in the cyclic-group setting. The four sorried quantitative bounds in Part III (Roth 1953, Behrend 1946, Bloom–Sisask 2020, Kelley–Meka 2023) sharpen this asymptotic to explicit decay rates.

## Proof Strategy

Reduce to the already-proved `Szemeredi.Roth.roth_density_bound` in the sibling file `RothTheorem.lean`, which itself routes through Mathlib's `roth_3ap_theorem_nat` via the corners-theorem chain (Regularity Lemma → Triangle Removal → Corners → Roth).

Cross-namespace bridging uses a small `private` helper `apFree_to_parent` — the two `APFree` definitions in `Szemeredi.Roth` and `Szemeredi.Roth.Quantitative` have textually identical bodies, so the converter is just `fun a d hd ha had => h a d hd ha had`.

## Files Changed

- `proofs/Proofs/RothTheoremQuantitative.lean` — adds `import Proofs.RothTheorem`, helper `apFree_to_parent`, theorem `rothNumber_div_tendsto_zero` (+52 lines).
- `research/problems/roth-theorem-k3-oq-01-incomplete-01/problem.md` — corrects the claimed sorry count (was 5, actually 4) and itemises the 4 landmark bounds.
- `research/problems/roth-theorem-k3-oq-01-incomplete-01/knowledge.md` — documents the verified inventory, cross-namespace bridge, and per-bound formalization cost estimates.
- `src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json` — advances OBSERVE → ORIENT, records `builtItems`, `insights`, `nextSteps`.
- `src/data/proofs/roth-theorem-k3-oq-01/meta.json` — updates `theoremCount` (18 → 19), `lineCount` (234 → 286).

## Honest Progress Statement

- **Axiom delta:** 0 → 0 (file remains axiom-free; 0 structure-encoded assumptions).
- **Sorry delta:** 4 → 4 (none of the four landmark bounds were attempted — each is multi-thousand-line work).
- **Theorem added:** 1 (qualitative `rothNumber_div_tendsto_zero`).

The new theorem is genuine theorem-level progress but is **strictly weaker** than every sorried bound in Part III. It does not approach any of the landmark formalizations.

## Sorry Inventory (Verified)

| # | Theorem | Year | Bound | Lines required (est.) |
|---|---------|------|-------|------------------------|
| 1 | `roth_quantitative_upper_bound` | 1953 | `r₃(N) ≤ C · N / log log N` | ≥ 2000 |
| 2 | `behrend_lower_bound` | 1946 | `r₃(N) ≥ N · exp(-c · √(log N))` | ≥ 800 |
| 3 | `bloom_sisask_bound` | 2020 | `r₃(N) ≤ N / (log N)^{1+c}` | ≥ 3000 |
| 4 | `kelley_meka_upper_bound` | 2023 | `r₃(N) ≤ N · exp(-c · (log N)^{1/12})` | ≥ 4000 |

Initial `problem.md` claimed "5 sorries"; the missing fifth slot was `density_upper_bound_from_iteration`, removed by an earlier session because the claimed bound `r₃(N) ≤ 10√N` is false for large `N` (Behrend gives `≫ √N`).

## Build Status

**Build pending — G9 lake self-loop.** Per persistent project memory, `proofs/.lake` symlinks to itself in the main repo, blocking Docker-based verification across all sharing worktrees. The new theorem and helper use only existing, already-verified infrastructure: `roth_density_bound`, `rothNumber_achieved`, `Metric.tendsto_atTop`, `div_lt_iff`, `mul_le_mul_of_nonneg_right`, `Real.dist_eq`, `abs_div`. Cross-namespace reducibility of the two `APFree` defs is the only non-obvious typing question; the explicit lambda converter is the conservative fix.

## Status

**Outcome**: progress (proved qualitative ceiling; documented landmark sorry inventory).
**Next Steps**: Bridge `rothNumber N ≤ rothNumberNat N` to enable transfer of Mathlib's unconditional `Behrend.roth_lower_bound` and `rothNumberNat_isLittleO_id`. The four landmark sorries should be deferred until per-bound formalization projects are scoped.

🤖 Generated by researcher-1