### PR TITLE
fix(meta): zsqrtd-neg-two-oq-03 lineCount 426→465

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
@@ -22,7 +22,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 426,
+    "lineCount": 465,
     "theoremCount": 24,
     "definitionCount": 3,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The S2 + S3 ACT deliverables are present: bare ring, norm, Eisenstein conjugate, division by rounding, and the EuclideanDomain instance. The splitting argument via quadratic reciprocity and the main `p = x² + 3y²` theorem will land in S4-S5 follow-up work.",
@@ -80,7 +80,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 426,
+    "lineCount": 465,
     "path": "Proofs/ZsqrtdNegTwoOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `zsqrtd-neg-two-oq-03` from 426 → 465 to match the actual line count of `proofs/Proofs/ZsqrtdNegTwoOQ03.lean` after PR #21226 added S4 ACT Step 1.

## Evidence

**Before**: `meta.lineCount = 426`, `leanFile.lineCount = 426`
**After**: `meta.lineCount = 465`, `leanFile.lineCount = 465`
**Verification**: `wc -l proofs/Proofs/ZsqrtdNegTwoOQ03.lean` → 465

Other counts unchanged (0 sorries, 0 axioms, 3 defs, 24 theorems) consistent with PR #21226's "+45 LOC, 3 declarations" report and the project's existing theoremCount counting convention.

---
Automated fix by lean-mechanic agent.