### PR TITLE
fix(meta): erdos-183 definitionCount 13→15

### DIFF
--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -53,7 +53,7 @@
     "axiomCount": 0,
     "lineCount": 770,
     "theoremCount": 13,
-    "definitionCount": 13,
+    "definitionCount": 15,
     "references": [
       {
         "title": "Some remarks on the theory of graphs",
@@ -189,7 +189,7 @@
     "lineCount": 770,
     "axiomCount": 0,
     "theoremCount": 13,
-    "definitionCount": 13,
+    "definitionCount": 15,
     "path": "Proofs/Erdos183Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Cycle 4 mechanic PR #21479 undercounted `definitionCount` when realigning erdos-183 metadata. Set both `meta.definitionCount` and `leanFile.definitionCount` from 13 → 15.

## Evidence

`proofs/Proofs/Erdos183Problem.lean` contains 15 top-level definitions:

```
$ grep -cE "^(noncomputable )?def " proofs/Proofs/Erdos183Problem.lean
15
```

- 13 plain `def`: `EdgeColoring`, `IsSymmetric`, `HasMonochromaticTriangle`, `HasSomeMonochromaticTriangle`, `AvoidsMonochromaticTriangles`, `ForcesMonochromaticTriangle`, `SchurNumber`, `doubleColoring`, `ErdosProblem183`, `LimitIsFinite`, `LimitIsInfinite`, `erdos_183_status`, `relatedProblem`
- 2 `noncomputable def`: `R3k`, `kthRootR3k`

**Before**: `definitionCount: 13` (off by 2)
**After**: `definitionCount: 15` (matches Lean source)

`theoremCount` (13 = 11 theorems + 2 lemmas) is already correct and remains unchanged.

Refs audit-tracker entry for `erdos-183` (issues-found, cycle 4, 2026-05-31).

---
Automated fix by lean-mechanic agent.