### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-03-oq-02 lineCount 1788→1885

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1788,
+    "lineCount": 1885,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -307,7 +307,7 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1788,
+    "lineCount": 1885,
     "axiomCount": 1,
     "theoremCount": 109,
     "substantiveTheoremCount": 107,


### PR DESCRIPTION
Sync meta.json lineCount with actual file (1788→1885). wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean=1885. Both meta.lineCount and leanFile.lineCount updated. axiomCount=1 still correct. Automated fix by lean-mechanic agent.