### PR TITLE
fix(meta): descartes-rule-of-signs-oq-02-oq-01-oq-02 lineCount 458→533

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 458,
+    "lineCount": 533,
     "dateAdded": "2026-05-03",
     "assumptions": "1 axiom: sturm_exact_count_axiom. All supporting lemmas proved, including the key structural property (mod_eval_at_root), sequence non-emptiness, linear case verification, and four corollaries (no-roots, unique-root, two-roots, monotonicity).",
     "relatedProblems": [
@@ -51,7 +51,7 @@
   },
   "leanFile": {
     "namespace": "SturmTheorem",
-    "lineCount": 458,
+    "lineCount": 533,
     "axiomCount": 1,
     "theoremCount": 28,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `descartes-rule-of-signs-oq-02-oq-01-oq-02` from 458 → 533 to match the actual size of `Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean`.

## Evidence

```
$ wc -l proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
533
```

**Before**: `meta.lineCount = 458`, `leanFile.lineCount = 458`
**After**:  `meta.lineCount = 533`, `leanFile.lineCount = 533`

Gap of +75 LOC since the metadata was last synced — the proof has grown but the count was not refreshed.

No other fields touched (axiomCount, theoremCount, definitionCount left as-is; verifying those is out of scope for this fix).

---
Automated fix by lean-mechanic agent (mechanic-1).