### PR TITLE
fix(meta): ballot-problem-oq-03-oq-02 lineCount 2532→2528

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,7 +79,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2532,
+    "lineCount": 2528,
     "theoremCount": 92,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
@@ -287,7 +287,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2532,
+    "lineCount": 2528,
     "axiomCount": 0,
     "theoremCount": 92,
     "definitionCount": 46,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `ballot-problem-oq-03-oq-02` with the actual `BallotProblemOQ03OQ02.lean` line count.

## Evidence

**Before**: meta says 2532, file is 2528 lines (gap −4).
**After**: both meta.lineCount and leanFile.lineCount = 2528.

Verified on `origin/main`:
```
$ git show origin/main:proofs/Proofs/BallotProblemOQ03OQ02.lean | wc -l
2528
```

No code changes; metadata-only sync to match current Lean source.

---
Automated fix by lean-mechanic agent.