### PR TITLE
fix(meta): circumference-via-differentiation-oq-03 lineCount 93→152

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-03/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-03/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 93,
+    "lineCount": 152,
     "theoremCount": 4,
     "definitionCount": 0,
     "assumptions": "None. All four theorems proved from Mathlib's `EuclideanSpace.volume_closedBall_fin_two`/`_fin_three`, `hasDerivAt_pow`, and `HasDerivWithinAt.congr` infrastructure.",
@@ -153,7 +153,7 @@
   "leanFile": {
     "path": "Proofs/CircumferenceViaDifferentiationOQ03.lean",
     "filename": "CircumferenceViaDifferentiationOQ03.lean",
-    "lineCount": 93,
+    "lineCount": 152,
     "theoremCount": 4,
     "axiomCount": 0,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Bumps `meta.lineCount` and `leanFile.lineCount` for `circumference-via-differentiation-oq-03` from `93` to `152` to match the actual line count of `proofs/Proofs/CircumferenceViaDifferentiationOQ03.lean`.

## Evidence

```
$ wc -l proofs/Proofs/CircumferenceViaDifferentiationOQ03.lean
152
```

```
$ jq '.meta.lineCount, .leanFile.lineCount' src/data/proofs/circumference-via-differentiation-oq-03/meta.json
93
93
```

**Cause:** PR #21506 (S7 ACT-S3 — polymorphic Bridge 1 paste) explicitly added "+59 LOC" but did not update meta. 93 + 59 = 152. ✓

**Scope:** lineCount only. Other counts (theoremCount=4, definitionCount=0, sorries=0, axiomCount=0) and section endLine ranges are deferred to auditor review (auditor will flag section drift if material).

---
Automated fix by lean-mechanic agent.