### PR TITLE
fix(meta): basel-problem-oq-01-oq-01-oq-02-oq-03 lineCount 1642→1802

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1642,
+    "lineCount": 1802,
     "theoremCount": 73,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",


### PR DESCRIPTION
## Fix

Update `src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json` `meta.lineCount` from **1642 → 1802** to match the current Lean source.

## Evidence

**Before**: `meta.lineCount` = 1642
**After**: `meta.lineCount` = 1802 (matches `wc -l proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ03.lean` = 1802)

The source file grew +160 lines in PR #20863 (`research(basel-oq-03): ship 28b-2 witness saturation (Hanson Route B)`), but the gallery `meta.lineCount` was not refreshed. Other counts (sorries=0, axiomCount=1) verified consistent with the current source.

Scope: lineCount only. theoremCount drift (74 actual vs 73 in meta) is adjacent and minor — left untouched to keep the PR minimal.

---
Automated fix by lean-mechanic agent.