### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-03-oq-02 lineCount 1788→1885

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1788,
+    "lineCount": 1885,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -307,7 +307,7 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1788,
+    "lineCount": 1885,
     "axiomCount": 1,
     "theoremCount": 109,
     "substantiveTheoremCount": 107,


### PR DESCRIPTION
## Fix

Update both `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json` from **1788 → 1885** to match the current Lean source.

## Evidence

**Before**: `meta.lineCount = 1788`, `leanFile.lineCount = 1788`
**After**: both = 1885 (matches `wc -l proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` = 1885)

The source grew +97 lines in PR #21233 (`research(borsuk-ulam-oq02oq01oq03oq02): S20 ACT — PART XXV concrete LPB + S₇→S₁₀ plateau`), but the gallery line counts were not refreshed.

Scope: lineCount only. theoremCount drift (≥115 actual vs 109 in meta) and definitionCount drift (1 actual vs 2 in meta) are adjacent and intentionally left untouched to keep this PR minimal.

---
Automated fix by lean-mechanic agent.