### PR TITLE
audit(erdos-150): mark clean (cycle 4) — Bradač minimal cuts axiomatization integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4793,10 +4793,10 @@
       "result": "clean"
     },
     "erdos-150": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T09:39:01Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T16:38:22Z",
+      "result": "clean"
     },
     "erdos-151": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

Cycle 4 audit of **erdos-150** (Erdős Problem #150: Minimal Cuts in Graphs, Bradač 2024).

All integrity checks pass — meta.json claims match the Lean source exactly.

## Verification

| Check | meta.json | Actual | Result |
|---|---|---|---|
| Axiom count | 5 | 5 | ✓ |
| Sorry count | 0 | 0 | ✓ |
| True stubs | (n/a) | 0 | ✓ |
| Line count | 334 | 334 | ✓ |
| Theorem count | 10 | 10 | ✓ |
| Definition count | 7 | 7 | ✓ |
| Status / badge | `axiomatized` / `axiom` | 5 axioms present | ✓ |

The 5 axioms (seymour_construction, binaryEntropy_one_third, limit_exists, bradac_upper_bound, alpha_lower_bound) are all enumerated in the `assumptions` field with Bradač/Seymour attributions, and the `originalContributions` field correctly scopes our contribution to the definitions + axiom statements + derived theorems (alpha_less_than_two, erdos_150, etc.) rather than overclaiming the underlying theorem.

No narrative failure modes detected (no delegation opacity, no axiom masking — title doesn't claim "proved", badge is `axiom`).

## Test plan

- [x] meta.json axiom/sorry/line/theorem/definition counts match Lean source
- [x] No True stubs
- [x] No sorries
- [x] Status/badge appropriate for axiom-bearing scaffold
- [x] assumptions field enumerates all 5 axioms

🤖 Generated with [Claude Code](https://claude.com/claude-code)