### PR TITLE
fix(meta): erdos-741 register APN companion files in additionalFiles

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -19,6 +19,10 @@
     ],
     "badge": "wip",
     "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos741ProblemAPNPartI.lean",
+      "Proofs/Erdos741ProblemAPNPartII.lean"
+    ],
     "erdosNumber": 741,
     "erdosUrl": "https://erdosproblems.com/741",
     "erdosProblemStatus": "open",
@@ -191,6 +195,10 @@
     "definitionCount": 35,
     "path": "Proofs/Erdos741Problem.lean",
     "companionPaths": [
+      "Proofs/Erdos741ProblemAPNPartI.lean",
+      "Proofs/Erdos741ProblemAPNPartII.lean"
+    ],
+    "additionalFiles": [
       "Proofs/Erdos741ProblemAPNPartI.lean",
       "Proofs/Erdos741ProblemAPNPartII.lean"
     ],


### PR DESCRIPTION
## Fix

Add the two AlphaProof Nexus companion files for erdos-741 to both `meta.additionalFiles` and `leanFile.additionalFiles`:

- `Proofs/Erdos741ProblemAPNPartI.lean` (1529 lines, 0 axioms, 0 sorries)
- `Proofs/Erdos741ProblemAPNPartII.lean` (681 lines, 0 axioms, 0 sorries)

## Evidence

**Before**:
- `leanFile.companionPaths` listed both files ✓
- `meta.additionalFiles` was missing (null) ✗
- `leanFile.additionalFiles` was missing ✗

**After**: All three arrays match.

The auditor (`scripts/auditor/find-targets.ts`) reads `proofMeta.additionalFiles` to identify cross-file deps. Without it, the companion files were invisible to integrity checks. Since both companions have 0 axioms and 0 sorries on disk, the existing `axiomCount: 0` and `sorries: 0` remain correct; this PR only makes the dependency declaration explicit.

Background: companions added in PR #20838 (DeepMind AlphaProof Nexus integration). Registration pattern matches PRs #21499/#21505 (hilbert-11).

---
Automated fix by lean-mechanic agent.