### PR TITLE
fix(meta): erdos-152 lineCount 1031->493

### DIFF
--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/152",
     "erdosProblemStatus": "partially-solved",
     "axiomCount": 0,
-    "lineCount": 1031,
+    "lineCount": 493,
     "assumptions": "Fully verified (0 axioms, 0 sorries) across two Lean files. The companion file `Erdos152ProblemAPN.lean` is a verbatim port of the DeepMind AlphaProof Nexus proof (517 source lines) establishing `16 * num_isolated A + 100*n + 16 ≥ n*n` for any Sidon set of size n, and concluding `Tendsto f atTop atTop` — the weak form of Erdős #152. The gallery file `Erdos152Problem.lean` retains the original verified definitions (`IsSidonFinset`, `sumsetFinset`, `IsIsolated`, `isolatedCount`) and supporting lemmas (`sidon_sumset_size`, `sidon_set_range_lower_bound`, `gap_existence_pigeonhole` for |A|≥5). The strong form `ErdosProblem152Strong` (universal constant c>0 with I(A) ≥ c|A|² for all Sidon A) and `ErdosProblem152Infinite` are stated but remain open as Lean propositions; the DeepMind bound implies asymptotic f(n) ≫ n² but does not directly furnish the universally-quantified constant for small Sidon sets.",
     "mathlib_version": "4.26.0",
     "theoremCount": 56,
@@ -136,7 +136,7 @@
       "Filter"
     ],
     "namespace": "Erdos152APN",
-    "lineCount": 1031,
+    "lineCount": 493,
     "axiomCount": 0,
     "theoremCount": 56,
     "definitionCount": 26,


### PR DESCRIPTION
## Fix

Reduce `meta.lineCount` and `leanFile.lineCount` from 1031 to 493 for erdos-152 to match the actual `Proofs/Erdos152Problem.lean` (493 lines), now that the file has been split.

## Evidence

**Before**:
- `meta.lineCount: 1031`
- `leanFile.lineCount: 1031`
- `leanFile.companionFiles[0]` already registers `Proofs/Erdos152ProblemAPN.lean` with `lineCount: 538` (correct)

**After**:
- `meta.lineCount: 493`
- `leanFile.lineCount: 493`
- Companion entry untouched

493 + 538 = 1031 confirms the prior value was the pre-split combined count. PR #20838 (DeepMind AlphaProof Nexus integration) split `Erdos152Problem.lean` into main (493) + companion `Erdos152ProblemAPN.lean` (538). The companion was registered separately at the time, but the main file's `lineCount` fields were never reduced.

Scope: `lineCount` only on the main file's `meta` and `leanFile` blocks. Other counts (`axiomCount=0`, `theoremCount=56`, `definitionCount=26`, `sorries=0`) are out of scope — left for auditor to recount if drift is found.

---
Automated fix by lean-mechanic agent.