### PR TITLE
audit(erdos-146): fix opens field — strip docstring tokens from leanFile.opens

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4761,11 +4761,11 @@
       "result": "issues-fixed"
     },
     "erdos-146": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom axioms in originalContributions/proofStrategy/sections (#14705) + section line drift"
       ],
-      "lastAudited": "2026-05-02T09:45:33Z",
+      "lastAudited": "2026-05-31T16:48:01Z",
       "result": "issues-fixed"
     },
     "erdos-147": {

--- a/src/data/proofs/erdos-146/meta.json
+++ b/src/data/proofs/erdos-146/meta.json
@@ -147,20 +147,7 @@
     ],
     "opens": [
       "Nat",
-      "Real",
-      "problem",
-      "in",
-      "extremal",
-      "graph",
-      "theory.",
-      "Even",
-      "the",
-      "simplest",
-      "case",
-      "r",
-      "=",
-      "2",
-      "remains"
+      "Real"
     ],
     "namespace": "Erdos146",
     "lineCount": 215,


### PR DESCRIPTION
## Summary

- Strip 13 garbage tokens (problem, in, extremal, graph, theory., Even, the, simplest, case, r, =, 2, remains) from `leanFile.opens` in `src/data/proofs/erdos-146/meta.json`
- Tokens were parsed from inside a `/- ... -/` comment block at `proofs/Proofs/Erdos146Problem.lean:201` ("open problem in extremal graph theory. Even the simplest case r = 2 remains")
- Actual Lean directive at line 36 is `open Nat Real`

## Audit Verification (clean otherwise)

| Field | Claimed | Actual | Status |
|-------|---------|--------|--------|
| lineCount | 215 | 215 | ✓ |
| axiomCount | 1 (turanNumber) | 1 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | 0 | 0 | ✓ |
| status/badge | axiomatized/axiom | matches Tier C open-problem classification | ✓ |
| opens | 15 entries (13 garbage) | `Nat`, `Real` | **fixed** |

Severity: LOW (cosmetic metadata bug). Possible upstream root cause: opens extractor not respecting multi-line `/- ... -/` comment blocks. Did not investigate the extractor itself in this PR.

## Test plan

- [x] meta.json parses (JSON valid after edit)
- [x] Lean file unchanged
- [x] audit-tracker.json marks erdos-146 as issues-fixed for cycle 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)