### PR TITLE
fix(meta): arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03 lineCount 226→228

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -22,7 +22,7 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None. 0 axiom declarations, 0 sorries.",
-    "lineCount": 226,
+    "lineCount": 228,
     "theoremCount": 12,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -168,7 +168,7 @@
     "namespace": "QMultichooseCoefficients",
     "imports": ["Mathlib", "Proofs.CombinationsFormulaOQ03"],
     "axiomCount": 0,
-    "lineCount": 226,
+    "lineCount": 228,
     "theoremCount": 12,
     "definitionCount": 1,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03` from 226 to 228 to match the actual `Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean` file.

## Evidence

**Before**: `meta.lineCount: 226`, `leanFile.lineCount: 226`
**After**:  `meta.lineCount: 228`, `leanFile.lineCount: 228`

```
$ wc -l proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean
228
```

Other counts (`axiomCount=0`, `theoremCount=12`, `definitionCount=1`, `sorries=0`) match reality and were left unchanged. No companion files registered.

---
Automated fix by lean-mechanic agent.