### PR TITLE
fix(meta): erdos-12 lineCount 2355->293

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -91,7 +91,7 @@
       }
     ],
     "axiomCount": 0,
-    "lineCount": 2355,
+    "lineCount": 293,
     "prerequisites": [
       "Divisibility and the divisor lattice",
       "Extremal set theory",
@@ -211,7 +211,7 @@
       "Classical"
     ],
     "namespace": "Erdos12APN_I, Erdos12APN_II (companion files)",
-    "lineCount": 2355,
+    "lineCount": 293,
     "axiomCount": 0,
     "theoremCount": 104,
     "definitionCount": 29,


### PR DESCRIPTION
## Fix

Reduce `meta.lineCount` and `leanFile.lineCount` from 2355 to 293 for erdos-12 to match the actual `Proofs/Erdos12Problem.lean` (293 lines).

## Evidence

**Before**:
- `meta.lineCount: 2355`
- `leanFile.lineCount: 2355`
- `leanFile.companionPaths` registers `Proofs/Erdos12ProblemAPNPartI.lean` (1252 lines) and `Proofs/Erdos12ProblemAPNPartII.lean` (810 lines)

```
$ wc -l proofs/Proofs/Erdos12Problem.lean proofs/Proofs/Erdos12ProblemAPNPartI.lean proofs/Proofs/Erdos12ProblemAPNPartII.lean
 293 proofs/Proofs/Erdos12Problem.lean
1252 proofs/Proofs/Erdos12ProblemAPNPartI.lean
 810 proofs/Proofs/Erdos12ProblemAPNPartII.lean
2355 total
```

293 + 1252 + 810 = 2355 confirms the prior value was the combined count across the main file and the two AlphaProof Nexus companions. Same pattern previously fixed for erdos-125 (PR #21224), erdos-846 (PR #21215), and erdos-152 (PR #21536).

**After**:
- `meta.lineCount: 293`
- `leanFile.lineCount: 293`
- Companion paths untouched

Scope: `lineCount` only on the main file's `meta` and `leanFile` blocks. Other counts (`axiomCount=0`, `theoremCount=104`, `definitionCount=29`, `sorries=0`) are out of scope — left for the auditor to recount if drift is found.

---
Automated fix by lean-mechanic agent.