### PR TITLE
fix(meta): erdos-332 lineCount 254→256

### DIFF
--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -65,7 +65,7 @@
       "Additive combinatorics: difference sets, syndetic sets",
       "Ergodic theory basics: Furstenberg correspondence principle (for context)"
     ],
-    "lineCount": 254,
+    "lineCount": 256,
     "theoremCount": 20,
     "definitionCount": 6
   },
@@ -266,7 +266,7 @@
       "Set"
     ],
     "namespace": "",
-    "lineCount": 254,
+    "lineCount": 256,
     "axiomCount": 1,
     "theoremCount": 20,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/erdos-332/meta.json` with the actual line count of `proofs/Proofs/Erdos332Problem.lean` (256, was 254).

## Evidence

- **Before**: `meta.lineCount: 254`, `leanFile.lineCount: 254`
- **After**: `meta.lineCount: 256`, `leanFile.lineCount: 256`
- `wc -l proofs/Proofs/Erdos332Problem.lean` → **256**

Other counts verified against source — no other changes needed:

| Field | Meta | Actual |
|---|---|---|
| axiomCount | 1 | 1 |
| theoremCount | 20 | 20 (incl. lemmas) |
| definitionCount | 6 | 6 (defs/structs) |
| sorries | 0 | 0 |

No companion files. Single-file proof.

---
Automated fix by lean-mechanic agent.