### PR TITLE
fix(meta): erdos-741 lineCount 2561→351

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -74,7 +74,7 @@
       "Erdos741APN_II.cassels_set + 25 supporting lemmas: Cassels-style basis with not_syndetic_of_large_gaps obstruction (657-line port)"
     ],
     "axiomCount": 0,
-    "lineCount": 2561,
+    "lineCount": 351,
     "assumptions": "0 axioms, 0 sorries (combined across the three files: Erdos741Problem.lean, Erdos741ProblemAPNPartI.lean, Erdos741ProblemAPNPartII.lean). cofinite_density_one proved as a theorem in PR #16461. AlphaProof Nexus companion files (parts i and ii, 2026-05-21) port Apache-2.0 DeepMind Lean output verbatim against Mathlib; build not yet locally verified (see PR caveat).",
     "theoremCount": 160,
     "definitionCount": 35,
@@ -189,7 +189,7 @@
       "Classical"
     ],
     "namespace": null,
-    "lineCount": 2561,
+    "lineCount": 351,
     "axiomCount": 0,
     "theoremCount": 160,
     "definitionCount": 35,


### PR DESCRIPTION
## Fix

`meta.lineCount` and `leanFile.lineCount` for `erdos-741` both said **2561** — the pre-split aggregate of main + APN companion parts I/II. After PR #21534 registered the AlphaProof Nexus companions in `additionalFiles`, the main-file lineCount fields were never reduced.

## Evidence

```
$ wc -l proofs/Proofs/Erdos741Problem.lean \
        proofs/Proofs/Erdos741ProblemAPNPartI.lean \
        proofs/Proofs/Erdos741ProblemAPNPartII.lean
 351 proofs/Proofs/Erdos741Problem.lean
1529 proofs/Proofs/Erdos741ProblemAPNPartI.lean
 681 proofs/Proofs/Erdos741ProblemAPNPartII.lean
2561 total
```

**Before:** `lineCount: 2561` (aggregate sum)
**After:** `lineCount: 351` (main file at `leanFile.path` only)

## Convention

Matches PR #21536 (erdos-152 1031→493) and the hilbert-11 baseline: `leanFile.lineCount` reflects only the file at `leanFile.path`. Aggregates live in narrative fields (`assumptions`, `summary`) and in per-file blocks (`companionFiles` / `additionalFiles`).

## Scope

`lineCount` on `meta` and `leanFile` only. `axiomCount=0`, `sorries=0`, `theoremCount=160`, `definitionCount=35` are intentionally aggregated across the three files (per the `assumptions` prose) and remain unchanged. The `summary`'s narrative "across 2561 lines" describes the combined corpus and is left intact.

---
Automated fix by lean-mechanic agent.