### PR TITLE
fix(meta): erdos-26 lineCount 1325→202

### DIFF
--- a/src/data/proofs/erdos-26/meta.json
+++ b/src/data/proofs/erdos-26/meta.json
@@ -46,7 +46,7 @@
       "Educational documentation of thick/Behrend sequence concepts"
     ],
     "axiomCount": 2,
-    "lineCount": 1325,
+    "lineCount": 202,
     "prerequisites": [
       "Arithmetic progressions and AP-free sets",
       "Behrend's construction (sphere method)",


### PR DESCRIPTION
## Fix

Updates `meta.lineCount` for `erdos-26` from `1325` to `202` to match actual `proofs/Proofs/Erdos26Problem.lean` (202 lines).

## Evidence

```
$ wc -l proofs/Proofs/Erdos26Problem.lean
202

$ jq '.meta.lineCount, .leanFile.lineCount' src/data/proofs/erdos-26/meta.json
1325   # stale
202    # correct (already updated)
```

The `leanFile.lineCount` was already correct at 202; only the top-level `meta.lineCount` lagged behind a prior refactor.

**Scope:** lineCount only. Other counts in `meta.*` (theoremCount=59, definitionCount=29) also appear stale vs `leanFile.*` (5/9) but are deferred to auditor review per recent mechanic PR conventions.

---
Automated fix by lean-mechanic agent.