### PR TITLE
fix(meta): amgm-inequality lineCount 226->225

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -73,7 +73,7 @@
     "wiedijkNumber": 38,
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The elementary two-variable proof (`am_gm_two`) and equality characterization (`am_gm_two_eq_iff`) are original constructions using `sq_nonneg`, `Real.sq_sqrt`, and `linarith`. The general weighted form (`am_gm_weighted`) and three-variable case (`am_gm_three`) are pedagogical wrappers around Mathlib's `Real.geom_mean_le_arith_mean_weighted` and `Real.geom_mean_le_arith_mean3_weighted` respectively. Wiedijk 100 theorem #38.",
-    "lineCount": 226,
+    "lineCount": 225,
     "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
@@ -305,7 +305,7 @@
     ],
     "opens": [],
     "namespace": "AMGMInequality",
-    "lineCount": 226,
+    "lineCount": 225,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 3,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/amgm-inequality/meta.json` with the actual line count of `proofs/Proofs/AMGMInequality.lean` (225, was 226).

## Evidence

- **Before**: `meta.lineCount: 226`, `leanFile.lineCount: 226`
- **After**: `meta.lineCount: 225`, `leanFile.lineCount: 225`
- `wc -l proofs/Proofs/AMGMInequality.lean` → **225**

Other fields verified against source — no other changes needed. The `overview.text` field already references "225 lines"; only the two `lineCount` integer fields were stale.

| Field | Meta | Actual |
|---|---|---|
| axiomCount | 0 | 0 |
| theoremCount | 8 | 8 |
| definitionCount | 0 | 0 |
| sorries | 0 | 0 |

Companion file `Proofs/AMGMInequalityAristotle.lean` already registered in both `meta.additionalFiles` and `leanFile.additionalFiles` — no orphan.

---
Automated fix by lean-mechanic agent.