### PR TITLE
fix(meta): area-of-circle-oq-01-oq-03 leanFile.lineCount 1938→1937

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -273,7 +273,7 @@
       "Topology"
     ],
     "namespace": "IsoperimetricOQ",
-    "lineCount": 1938,
+    "lineCount": 1937,
     "axiomCount": 0,
     "theoremCount": 52,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Align `leanFile.lineCount` with `meta.lineCount` in `src/data/proofs/area-of-circle-oq-01-oq-03/meta.json`.

## Evidence

| Field | Before | After |
|---|---|---|
| `meta.lineCount` (line 62) | 1937 | 1937 (unchanged) |
| `leanFile.lineCount` (line 276) | 1938 | 1937 |
| `wc -l proofs/Proofs/AreaOfCircleOQ01OQ03.lean` | — | **1937** |

**Internal inconsistency**: the two stored fields disagreed (1937 vs 1938) — `leanFile.lineCount` was bumped to 1938 by the 2026-05-23 batch sync PR #20415 using the split-newline convention, while `meta.lineCount` stayed at the `wc -l` value (1937). Recent merged fixes (e.g. #21526 borsuk-ulam) use `wc -l`, so this PR normalizes `leanFile.lineCount` down to 1937 to match.

No other counts changed.

---
Automated fix by lean-mechanic agent.