### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-05-oq-01 lineCount 202→201

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -25,7 +25,7 @@
     "dateAdded": "2026-05-06",
     "axiomCount": 1,
     "assumptions": "galois_compositum_product: For two Galois extensions K₁/ℚ and K₂/ℚ with coprime Galois group orders (supported on disjoint primes), their compositum has Galois group K₁ × K₂. Provable from conductor/discriminant theory of cyclotomic fields (~500 Lean lines); identifies the exact Mathlib gap for the abelian case of Shafarevich.",
-    "lineCount": 202,
+    "lineCount": 201,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
@@ -374,7 +374,7 @@
     "namespace": "ShafarevichFeasibility",
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
     "axiomCount": 1,
-    "lineCount": 202,
+    "lineCount": 201,
     "theoremCount": 8,
     "definitionCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `lineCount` in meta.json with actual file length.

## Evidence

**Before**: `leanFile.lineCount = 202`, `meta.lineCount = 202`
**After**:  `leanFile.lineCount = 201`, `meta.lineCount = 201` (matches `wc -l proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean = 201`)

## Root cause

The Lean source last changed in PR #19454 (Sperner S2-A); the meta.lineCount was last set to 202 in PR #20461 from the enrichment script's `lines.length` (= `wc -l` + 1 when files end in newline). Recent mechanic PRs (#21540, #21549) standardize lineCount on `wc -l`, so this entry needed a -1 correction.

---
Automated fix by lean-mechanic agent.