### PR TITLE
fix(meta): erdos-26 register Erdos26APN_Tenenbaum.lean companion

### DIFF
--- a/src/data/proofs/erdos-26/meta.json
+++ b/src/data/proofs/erdos-26/meta.json
@@ -19,6 +19,9 @@
     ],
     "badge": "axiom",
     "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos26APN_Tenenbaum.lean"
+    ],
     "erdosNumber": 26,
     "erdosUrl": "https://erdosproblems.com/26",
     "erdosProblemStatus": "disproved",
@@ -170,6 +173,9 @@
     "theoremCount": 5,
     "definitionCount": 9,
     "path": "Proofs/Erdos26Problem.lean",
+    "additionalFiles": [
+      "Proofs/Erdos26APN_Tenenbaum.lean"
+    ],
     "sorries": 0
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

Register the AlphaProof Nexus Tenenbaum-variant companion file for erdos-26 in both `meta.additionalFiles` and `leanFile.additionalFiles`:

- `Proofs/Erdos26APN_Tenenbaum.lean` (1123 lines, 0 axioms, 0 sorries)

## Evidence

**Before**:
- `meta.lineCount: 1325` = 202 (Erdos26Problem) + 1123 (Erdos26APN_Tenenbaum) was already an intentional aggregate ✓
- `meta.additionalFiles`: missing (null) ✗
- `leanFile.additionalFiles`: missing (null) ✗

**After**: companion file registered in both sites; aggregate `meta.lineCount` preserved.

Background: companion added in PR #20837 (AlphaProof Nexus integration, 2026-05-21). The auditor (`scripts/auditor/find-targets.ts`) reads `proofMeta.additionalFiles` to identify cross-file deps; without it, the companion was invisible to integrity checks.

Registration pattern matches PR #21534 (erdos-741 APN companions registered same way).

---
Automated fix by lean-mechanic agent.