### PR TITLE
fix(meta): erdos-12 register AlphaProof Nexus companion files

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -18,6 +18,10 @@
     ],
     "badge": "wip",
     "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos12ProblemAPNPartI.lean",
+      "Proofs/Erdos12ProblemAPNPartII.lean"
+    ],
     "erdosNumber": 12,
     "erdosUrl": "https://erdosproblems.com/12",
     "erdosProblemStatus": "open",
@@ -217,6 +221,10 @@
     "definitionCount": 29,
     "path": "Proofs/Erdos12Problem.lean",
     "companionPaths": [
+      "Proofs/Erdos12ProblemAPNPartI.lean",
+      "Proofs/Erdos12ProblemAPNPartII.lean"
+    ],
+    "additionalFiles": [
       "Proofs/Erdos12ProblemAPNPartI.lean",
       "Proofs/Erdos12ProblemAPNPartII.lean"
     ],


### PR DESCRIPTION
## Fix

Register the two AlphaProof Nexus companion files for erdos-12 in both `meta.additionalFiles` and `leanFile.additionalFiles`:

- `Proofs/Erdos12ProblemAPNPartI.lean` (1252 lines, 0 axioms, 0 sorries)
- `Proofs/Erdos12ProblemAPNPartII.lean` (810 lines, 0 axioms, 0 sorries)

## Evidence

**Before**:
- `meta.lineCount: 2355` = 293 (Erdos12Problem) + 1252 + 810 (APN companions) was already an intentional aggregate ✓
- `leanFile.companionPaths`: listed both files ✓
- `meta.additionalFiles`: missing (null) ✗
- `leanFile.additionalFiles`: missing (null) ✗

**After**: companion files registered in both auditor-readable sites; aggregate `meta.lineCount` preserved.

Background: companions added in PR #20835 (AlphaProof Nexus integration). The auditor (`scripts/auditor/find-targets.ts`) reads `proofMeta.additionalFiles` to identify cross-file deps; without it, the companion files were invisible to integrity checks. `companionPaths` is informational only and not consumed by the auditor.

Registration pattern matches PR #21534 (erdos-741) and PR #21556 (erdos-26 sibling fix).

---
Automated fix by lean-mechanic agent.