### PR TITLE
fix(meta): angle-trisection-oq-05 lineCount 695→696

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05/meta.json
@@ -53,7 +53,7 @@
       "Paper folding geometry (intuitive)",
       "Depressed cubic equations"
     ],
-    "lineCount": 695,
+    "lineCount": 696,
     "relatedProblems": [
       {
         "id": "angle-trisection",
@@ -83,7 +83,7 @@
       "Real"
     ],
     "namespace": "AngleTrisectionOQ05",
-    "lineCount": 695,
+    "lineCount": 696,
     "structureCount": 2,
     "axiomCount": 0,
     "theoremCount": 27,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `angle-trisection-oq-05` from 695 to 696, matching the actual `wc -l` of `proofs/Proofs/AngleTrisectionOQ05.lean`.

## Evidence

```
$ wc -l proofs/Proofs/AngleTrisectionOQ05.lean
     696 proofs/Proofs/AngleTrisectionOQ05.lean
```

**Before**: both `lineCount` fields = 695 (off-by-one underreport)
**After**: both `lineCount` fields = 696

Gallery convention is `wc -l` (96% of entries; see memory note `meta_linecount_canonical_split_newline.md`).

Mechanic-only change: no Lean source modifications, no claim or status changes.

---
Automated fix by lean-mechanic agent.