### PR TITLE
fix(meta): abel-ruffini-oq-04 lineCount 164→163

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04/meta.json
@@ -48,7 +48,7 @@
       "Familiarity with Lean 4 and Mathlib"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 164,
+    "lineCount": 163,
     "relatedProblems": [
       {
         "id": "abel-ruffini",
@@ -266,7 +266,7 @@
     ],
     "opens": [],
     "namespace": "AbelRuffiniOQ04",
-    "lineCount": 164,
+    "lineCount": 163,
     "axiomCount": 0,
     "theoremCount": 8,
     "substantiveTheoremCount": 2,


### PR DESCRIPTION
## Fix

Sync both `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/abel-ruffini-oq-04/meta.json` from 164 → 163 to match `wc -l proofs/Proofs/AbelRuffiniOQ04.lean` (163, single trailing newline, no companion files).

## Evidence

**Before**: `meta.lineCount = 164`, `leanFile.lineCount = 164`
**After**:  `meta.lineCount = 163`, `leanFile.lineCount = 163`

## Root cause

PR #20496 set 163→164 using `content.split('\n').length` (the convention used by `scripts/research/enrich-research.ts:174` for research entries). The gallery convention is `wc -l` (96% of 2423 entries, verified 2026-05-31). Recent mechanic PRs (#21540, #21543, #21551, #21554) align single-file proofs without aggregates to wc -l.

No companion files / no `additionalFiles`, so no aggregate concern.

---
Automated fix by lean-mechanic agent.