### PR TITLE
fix(meta): algebraic-numbers-countable-oq-04 lineCount 759→758

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 3,
     "assumptions": "Three independent axioms: (1) baker_homogeneous — Baker's qualitative theorem for linear forms in logarithms (Q-independent logs remain Q̄-independent); (2) baker_inhomogeneous — strengthening with algebraic constant β₀; (3) baker_wustholz_bound — Baker-Wüstholz 1993 optimal log(B) exponent. The previously-axiomatized baker_quantitative (effective lower bound |Λ| > B^{-C}) is now PROVED as a theorem from baker_homogeneous (Λ ≠ 0) plus baker_wustholz_bound (explicit log lower bound), reducing axiom count 4 → 3. All three remaining axioms encode the unformalized analytic content of Baker's proof (Siegel's lemma + auxiliary function + extrapolation).",
-    "lineCount": 759,
+    "lineCount": 758,
     "theoremCount": 13,
     "definitionCount": 0,
     "originalContributions": [
@@ -315,7 +315,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ04.lean",
-    "lineCount": 759,
+    "lineCount": 758,
     "theoremCount": 13,
     "definitionCount": 0,
     "axiomCount": 3,


### PR DESCRIPTION
## Fix

Sync both `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/algebraic-numbers-countable-oq-04/meta.json` from 759 → 758 to match `wc -l proofs/Proofs/AlgebraicNumbersCountableOQ04.lean` (758, single trailing newline, no companion files, no `additionalFiles`).

## Evidence

**Before**: `meta.lineCount = 759`, `leanFile.lineCount = 759`
**After**:  `meta.lineCount = 758`, `leanFile.lineCount = 758`

```
$ wc -l proofs/Proofs/AlgebraicNumbersCountableOQ04.lean
     758 proofs/Proofs/AlgebraicNumbersCountableOQ04.lean
```

## Root cause

Off-by-one drift consistent with the prior `content.split('\n').length` convention used by `scripts/research/enrich-research.ts:174` (research entries). The gallery convention is `wc -l` (96% of 2423 entries, verified 2026-05-31).

Single-file proof (no companions in `proofs/Proofs/AlgebraicNumbersCountable*.lean`), so no aggregate concern. Follows the wc-l alignment pattern of recent merged PRs #21540, #21543, #21549, #21551, #21554, #21560.

---
Automated fix by lean-mechanic agent.