### PR TITLE
fix(meta): brouwer-fixed-point-oq-01-oq-02 axiomCount 4→3

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02/meta.json
@@ -19,7 +19,7 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 4,
+    "axiomCount": 3,
     "mathlibDependencies": [
       {
         "theorem": "AddMonoidHom.ext",
@@ -149,7 +149,7 @@
   "leanFile": {
     "lineCount": 462,
     "path": "Proofs/BrouwerFixedPointOQ01OQ02.lean",
-    "axiomCount": 4,
+    "axiomCount": 3,
     "sorries": 0,
     "definitionCount": 3,
     "theoremCount": 14


### PR DESCRIPTION
## Fix

Realign `meta.axiomCount` and `leanFile.axiomCount` from `4` to `3` to match the actual count of axiom declarations in `proofs/Proofs/BrouwerFixedPointOQ01OQ02.lean`.

## Evidence

**Real axiom declarations** in the Lean file (verified with the auditor's own `stripLeanComments` + axiom regex from `scripts/auditor/find-targets.ts`):

| Line | Axiom |
|------|-------|
| 261 | `axiom H_n_minus_1_sphere_nonzero` |
| 287 | `axiom contractible_singularHomology_zero` |
| 351 | `axiom sphere_singularHomology_nonzero` |

**Why the previous count of 4 was wrong**: line 44 contains the text `axiom no_retraction_axiom (n : ℕ) (hn : n ≥ 1) : ¬∃ r : Retraction n, True`, but it lives inside a docstring code-block example (`-- Comparison with BrouwerFixedPoint.lean`) describing an alternative axiomatization used in a sibling file — not a real declaration. The Mechanic / Auditor's comment-stripper correctly excludes it.

**Self-consistency check**: the `assumptions` field in this very meta.json already opens with `"3 axioms."` and explicitly notes `"no_retraction_axiom appears only in a block-comment example, not as an actual axiom"`. The numeric `axiomCount` was the lone outlier.

**Before** → **After**:
- `meta.axiomCount: 4` → `3`
- `leanFile.axiomCount: 4` → `3`

All other integrity fields (`sorries: 0`, `theoremCount: 14`, `definitionCount: 3`, `lineCount: 462`, `status: axiomatized`, `badge: axiom`) verified unchanged.

---
Automated fix by lean-mechanic agent.