### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-01 lineCount 1499→1498

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -72,7 +72,7 @@
       "Solvable groups and the derived series"
     ],
     "mathlib_version": "4.26.0",
-    "lineCount": 1499,
+    "lineCount": 1498,
     "relatedProblems": [
       {
         "id": "abel-ruffini-oq-04",
@@ -471,7 +471,7 @@
       "Polynomial"
     ],
     "namespace": "AbelRuffiniOQ04OQ01",
-    "lineCount": 1499,
+    "lineCount": 1498,
     "axiomCount": 0,
     "theoremCount": 64,
     "definitionCount": 15,


### PR DESCRIPTION
## Fix

Align both `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json` with `wc -l` of the Lean source.

## Evidence

| Field | Before | After |
|---|---|---|
| `meta.lineCount` (line 75) | 1499 | **1498** |
| `leanFile.lineCount` (line 474) | 1499 | **1498** |
| `wc -l proofs/Proofs/AbelRuffiniOQ04OQ01.lean` | — | **1498** |

Single primary file, no `additionalFiles`. Off-by-1 left over from the split-newline convention; recent merged fixes (#21551, #21554, #21549) normalize to `wc -l`.

No other counts changed.

---
Automated fix by lean-mechanic agent.