### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-07 lineCount 1895->1894

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1895,
+    "lineCount": 1894,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -287,7 +287,7 @@
     ],
     "opens": [],
     "namespace": "BurnsidePQ",
-    "lineCount": 1895,
+    "lineCount": 1894,
     "axiomCount": 1,
     "theoremCount": 38,
     "substantiveTheoremCount": 18,


### PR DESCRIPTION
## Fix

Sync both `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json` from 1895 → 1894 to match `wc -l proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean` (1894, single trailing newline, no companion files, no `additionalFiles`).

## Evidence

**Before**: `lineCount = 1895` (both top-level and `leanFile`)
**After**:  `lineCount = 1894` (both top-level and `leanFile`)

```
$ wc -l proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
    1894 proofs/Proofs/AbelRuffiniGaloisExtensionsOQ07.lean
```

## Root cause

Single-line drift on the same slug after merged PR #21511 (which set 1899→1895). The file has shed one line since then.

Single-file proof (no companion files in `proofs/Proofs/AbelRuffiniGaloisExtensions*.lean`), so no aggregate concern. Follows the wc-l alignment pattern of recent merged PRs #21511 (same slug), #21540, #21543, #21551, #21554.

---
Automated fix by lean-mechanic agent.