### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02 lineCount 155→154

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2026-03-27",
     "axiomCount": 0,
-    "lineCount": 155,
+    "lineCount": 154,
     "assumptions": "0 axioms, 0 sorries. S₂ via CommGroup instance, S₃ via decide on derived series, S₄ via native_decide. Classification theorem combines with Mathlib's Equiv.Perm.not_solvable.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -196,7 +196,7 @@
       "Equiv"
     ],
     "namespace": "AbelRuffiniOQ04OQ02",
-    "lineCount": 155,
+    "lineCount": 154,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync both `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-oq-04-oq-02` from 155 to 154 to match `wc -l proofs/Proofs/AbelRuffiniOQ04OQ02.lean`.

## Evidence

| Field | Before | After |
|---|---|---|
| `meta.lineCount` (line 44) | 155 | **154** |
| `leanFile.lineCount` (line 199) | 155 | **154** |
| `wc -l proofs/Proofs/AbelRuffiniOQ04OQ02.lean` | — | **154** |

Single primary file; no `additionalFiles`. Off-by-1 left over from the split-newline convention (originally normalized 154→155 in #20495); recent merged fixes (#21540, #21543, etc.) re-normalize to `wc -l`, the convention used by ~96% of gallery entries.

No other counts changed (`axiomCount=0`, `theoremCount=6`, `definitionCount=0`, `sorries=0` all already correct).

---
Automated fix by lean-mechanic agent.