### PR TITLE
fix(meta): binomial-theorem-oq-03-oq-02 lineCount 216→215

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-03-oq-02/meta.json
@@ -67,7 +67,7 @@
     "dateAdded": "2026-03-24",
     "axioms": 0,
     "axiomCount": 0,
-    "lineCount": 216,
+    "lineCount": 215,
     "theoremCount": 10,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
@@ -186,7 +186,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 216,
+    "lineCount": 215,
     "path": "Proofs/BinomialTheoremOQ03OQ02.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` and `meta.lineCount` both stored 216; `wc -l` of `proofs/Proofs/BinomialTheoremOQ03OQ02.lean` is 215.

## Evidence

```
$ wc -l proofs/Proofs/BinomialTheoremOQ03OQ02.lean
     215 proofs/Proofs/BinomialTheoremOQ03OQ02.lean
```

No companion files (no `companionPaths` / `additionalFiles` on this entry), so `meta.lineCount` is not an aggregate — both fields should equal `wc -l` of the single primary file.

**Before**: both fields = 216
**After**: both fields = 215

Convention follows the merged precedent in #21540, #21543, #21557, #21559 (per-file `wc -l`).

---
Automated fix by lean-mechanic agent.