### PR TITLE
fix(meta): erdos-200 lineCount 230->229

### DIFF
--- a/src/data/proofs/erdos-200/meta.json
+++ b/src/data/proofs/erdos-200/meta.json
@@ -74,7 +74,7 @@
     "dateAdded": "2026-01-19",
     "axiomCount": 3,
     "theoremCount": 11,
-    "lineCount": 230,
+    "lineCount": 229,
     "assumptions": "3 axioms: prime_ap_pnt_upper (PNT upper bound), green_tao (Green-Tao 2008), erdos_200 (open conjecture). 0 sorries.",
     "mathlib_version": "4.26.0",
     "definitionCount": 3
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 230,
+    "lineCount": 229,
     "axiomCount": 3,
     "theoremCount": 11,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/erdos-200/meta.json` with the actual line count of `proofs/Proofs/Erdos200Problem.lean` (229, was 230).

## Evidence

- **Before**: `meta.lineCount: 230`, `leanFile.lineCount: 230`
- **After**: `meta.lineCount: 229`, `leanFile.lineCount: 229`
- `wc -l proofs/Proofs/Erdos200Problem.lean` → **229**

Other fields verified against source — no other drift:

| Field | Meta | Actual |
|---|---|---|
| axiomCount | 3 | 3 (`grep -c '^axiom '`) |
| theoremCount | 11 | 11 (theorems+lemmas) |
| definitionCount | 3 | 3 |
| sorries | 0 | 0 |

No companion files / `additionalFiles` (both `null`). No top-level `lineCount` aggregate. Follows the canonical `wc -l` convention used by 96% of gallery entries (precedent: PR #21549 merged today for `amgm-inequality`).

---
Automated fix by lean-mechanic agent.