### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02-oq-02 lineCount 168→167

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -60,7 +60,7 @@
     ],
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
-    "lineCount": 168,
+    "lineCount": 167,
     "assumptions": "0 axioms, 0 sorries. Small cases via inferInstance and isSolvable_of_comm. Large cases via exact sequence: if A_n solvable then S_n solvable, but Mathlib's Equiv.Perm.not_solvable gives contradiction.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
@@ -208,7 +208,7 @@
       "Equiv"
     ],
     "namespace": "AbelRuffiniOQ04OQ02OQ02",
-    "lineCount": 168,
+    "lineCount": 167,
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Both `meta.lineCount` and `leanFile.lineCount` for `abel-ruffini-oq-04-oq-02-oq-02` claimed 168 lines, but the Lean source `proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean` is 167 lines (`wc -l`).

## Evidence

- **Before**: `lineCount: 168` (both top-level and `leanFile.lineCount`)
- **After**: `lineCount: 167`
- `wc -l proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean` → 167
- No companion files; single-file aggregate matches primary.

Aligns metadata with the canonical wc-l convention used by 96% of gallery entries.

---
Automated fix by lean-mechanic agent.