### PR TITLE
fix(meta): erdos-220 lineCount 228→227

### DIFF
--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -59,7 +59,7 @@
       "jacobsthal n: maximum gap function"
     ],
     "axiomCount": 4,
-    "lineCount": 228,
+    "lineCount": 227,
     "assumptions": "4 axioms: montgomery_vaughan_squared (squared gaps sum O(n²/φ(n))), montgomery_vaughan_general (γ-th power generalization), maximum_gap_bound (max gap ≤ C·n/φ(n)·(log n)²), gap_concentration (squared sum ≤ C·φ(n)·avg²). 2 sorries (sum_gaps_bound derivation; reduced_residues_count).",
     "theoremCount": 3,
     "definitionCount": 14,
@@ -142,7 +142,7 @@
     "imports": [],
     "opens": [],
     "namespace": null,
-    "lineCount": 228,
+    "lineCount": 227,
     "axiomCount": 4,
     "theoremCount": 3,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `erdos-220` to match `wc -l` of the primary Lean file.

## Evidence

```
$ wc -l proofs/Proofs/Erdos220Problem.lean
227 proofs/Proofs/Erdos220Problem.lean
```

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 228
**After**: both = 227

No Lean source changes. Companion `Proofs/Erdos220Aristotle.lean` (70 lines) is recorded separately under `additionalFiles` and is unaffected. The 228 value is not an aggregate (primary 227 + companion 70 = 297, not 228), so this is a genuine off-by-one drift.

---
Automated fix by lean-mechanic agent.