### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02-oq-03 lineCount 105→104

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Core results obtained via Mathlib bridge: pGroup_isSolvable chains hG.isNilpotent + inferInstance; s5_not_solvable aliases Equiv.Perm.fin_5_not_solvable directly; abelian_isSolvable is inferInstance.",
-    "lineCount": 105,
+    "lineCount": 104,
     "theoremCount": 4,
     "definitionCount": 0,
     "mathlibDependencies": [
@@ -83,7 +83,7 @@
   },
   "leanFile": {
     "namespace": "AbelRuffiniOQ04OQ02OQ03",
-    "lineCount": 105,
+    "lineCount": 104,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/abel-ruffini-oq-04-oq-02-oq-03/meta.json` with the actual line count of `proofs/Proofs/AbelRuffiniOQ04OQ02OQ03.lean` (104, was 105).

## Evidence

- **Before**: `meta.lineCount: 105`, `leanFile.lineCount: 105`
- **After**: `meta.lineCount: 104`, `leanFile.lineCount: 104`
- `wc -l proofs/Proofs/AbelRuffiniOQ04OQ02OQ03.lean` → **104**

Other fields verified against source — no other drift:

| Field | Meta | Actual |
|---|---|---|
| axiomCount | 0 | 0 (`grep -c '^axiom '`) |
| theoremCount | 4 | 4 (theorems+lemmas) |
| definitionCount | 0 | 0 |
| sorries | 0 | 0 |

No companion files / `additionalFiles` (both `null`). Follows the canonical `wc -l` convention used by 96% of gallery entries (precedent: PR #21549 amgm-inequality, PR #21567 erdos-200).

---
Automated fix by lean-mechanic agent.