### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-03 lineCount 243→242

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 243,
+    "lineCount": 242,
     "assumptions": "1 axiom: solvableGal_implies_solvableByRad (reverse direction, requires Kummer theory for cyclic extensions not yet in Mathlib).",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-03-27",
@@ -65,7 +65,7 @@
       "Polynomial"
     ],
     "namespace": "GaloisCriterion",
-    "lineCount": 243,
+    "lineCount": 242,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync declared `lineCount` to actual `wc -l` of `proofs/Proofs/AbelRuffiniOQ04OQ03.lean`.

## Evidence

**Before**: `meta.lineCount = 243`, `leanFile.lineCount = 243`
**After**: both `242` (matches `wc -l` output)
**File**: `proofs/Proofs/AbelRuffiniOQ04OQ03.lean` (no companion files; primary-only)

Follows the canonical `wc -l` gallery convention (96% of entries).

---
Automated fix by lean-mechanic agent.