### PR TITLE
fix(meta): arithmetic-series lineCount 181→180

### DIFF
--- a/src/data/proofs/arithmetic-series/meta.json
+++ b/src/data/proofs/arithmetic-series/meta.json
@@ -41,7 +41,7 @@
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 68,
     "axiomCount": 0,
-    "lineCount": 181,
+    "lineCount": 180,
     "relatedProblems": [
       {
         "id": "arithmetic-series-oq-02",
@@ -146,7 +146,7 @@
       "BigOperators"
     ],
     "namespace": "ArithmeticSeries",
-    "lineCount": 181,
+    "lineCount": 180,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.leanFile.lineCount` in `src/data/proofs/arithmetic-series/meta.json` from 181 to 180 to match `wc -l proofs/Proofs/ArithmeticSeries.lean`.

## Evidence

**Before**: meta declared `lineCount: 181` (two places)
**After**: meta declares `lineCount: 180` matching the file's actual line count

```
$ wc -l proofs/Proofs/ArithmeticSeries.lean
     180 proofs/Proofs/ArithmeticSeries.lean
```

Follows the gallery convention used by recent mechanic syncs:
- #21549 amgm-inequality 226→225
- #21551 area-of-circle-oq-01-oq-03 1938→1937
- #21567 erdos-200 230→229

No Lean source changes; metadata-only.

---
Automated fix by lean-mechanic agent.