### PR TITLE
fix(meta): erdos-14 lineCount 110→109

### DIFF
--- a/src/data/proofs/erdos-14/meta.json
+++ b/src/data/proofs/erdos-14/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/14",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 110,
+    "lineCount": 109,
     "prerequisites": [
       "Additive combinatorics (sumsets and representation functions)",
       "Finite set theory",
@@ -133,7 +133,7 @@
       "Asymptotics"
     ],
     "namespace": null,
-    "lineCount": 110,
+    "lineCount": 109,
     "axiomCount": 2,
     "theoremCount": 1,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Aligns `src/data/proofs/erdos-14/meta.json` lineCount fields with the canonical `wc -l` of the primary `.lean` file.

## Evidence

```
$ wc -l proofs/Proofs/Erdos14Problem.lean
     109 proofs/Proofs/Erdos14Problem.lean
```

Both `meta.lineCount` and `leanFile.lineCount` were 110 → corrected to 109. Single-file proof, no companion files, so both fields use the same wc-l value per the `meta-linecount-gallery-convention` memory.

---
Automated fix by lean-mechanic agent.