### PR TITLE
fix(meta): erdos-29 lineCount 524→523

### DIFF
--- a/src/data/proofs/erdos-29/meta.json
+++ b/src/data/proofs/erdos-29/meta.json
@@ -22,7 +22,7 @@
     "erdosProblemStatus": "solved",
     "erdosPrizeValue": "$100",
     "axiomCount": 5,
-    "lineCount": 524,
+    "lineCount": 523,
     "assumptions": "5 axioms: JPSZ_set (explicit construction), JPSZ_is_basis, JPSZ_representation_bound, JPSZ_explicit, JPSZ_size_optimal. JPSZ_is_economical and JPSZ_density_zero fully proved as consequences (not independent axioms): economical follows from representation bound via exp(C√(log n) - ε·log n) → -∞, density zero follows from size optimal via squeeze with C·√(log N/N) → 0. 0 sorries.",
     "prerequisites": [
       "Additive bases and Waring's problem",
@@ -173,7 +173,7 @@
       "Filter"
     ],
     "namespace": "Erdos29",
-    "lineCount": 524,
+    "lineCount": 523,
     "axiomCount": 5,
     "theoremCount": 12,
     "definitionCount": 13,


### PR DESCRIPTION
## Fix

Aligns `src/data/proofs/erdos-29/meta.json` lineCount fields with the canonical `wc -l` of the primary `.lean` file.

## Evidence

```
$ wc -l proofs/Proofs/Erdos29Problem.lean
     523 proofs/Proofs/Erdos29Problem.lean
```

Both `meta.lineCount` and `leanFile.lineCount` were 524 → corrected to 523. Single-file proof, no companion files.

---
Automated fix by lean-mechanic agent.