### PR TITLE
fix(meta): cauchy-schwarz-integral lineCount 118→117

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-02-11",
     "axiomCount": 0,
-    "lineCount": 118,
+    "lineCount": 117,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -189,7 +189,7 @@
       "MeasureTheory"
     ],
     "namespace": "BunyakovskySchwarz",
-    "lineCount": 118,
+    "lineCount": 117,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Aligns `src/data/proofs/cauchy-schwarz-integral/meta.json` lineCount fields with the canonical `wc -l` of the primary `.lean` file.

## Evidence

```
$ wc -l proofs/Proofs/CauchySchwarzIntegral.lean
     117 proofs/Proofs/CauchySchwarzIntegral.lean
```

Both `meta.lineCount` and `leanFile.lineCount` were 118 → corrected to 117. Single-file proof, no companion files.

---
Automated fix by lean-mechanic agent.