### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-07 lineCount 378→377

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -22,7 +22,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 378,
+    "lineCount": 377,
     "assumptions": "Two axioms: (1) bringJerrard_reduction — the full Bring-Jerrard reduction eliminating x³ and x² terms via quadratic/cubic Tschirnhaus substitutions (requires polynomial resultant theory not in Mathlib); (2) bringRadical_not_in_radicals — the Bring radical is not expressible in radicals (follows from Abel-Ruffini but requires connecting the generic Galois group argument). The linear Tschirnhaus transform (depressed quintic) and all Bring radical properties are fully proved.",
     "dateAdded": "2026-04-03",
     "mathlibDependencies": [
@@ -205,7 +205,7 @@
       "Polynomial"
     ],
     "namespace": "BringJerrardReduction",
-    "lineCount": 378,
+    "lineCount": 377,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` from 378 → 377 to match `wc -l proofs/Proofs/AbelRuffiniOQ04OQ07.lean`.

## Evidence

```
$ wc -l proofs/Proofs/AbelRuffiniOQ04OQ07.lean
     377 proofs/Proofs/AbelRuffiniOQ04OQ07.lean
```

Both `meta.lineCount` and `leanFile.lineCount` claimed 378. No `additionalFiles` listed, so both fields should equal the main-file count (canonical `wc -l` convention).

**Before**: meta.lineCount = 378, leanFile.lineCount = 378
**After**: meta.lineCount = 377, leanFile.lineCount = 377

---
Automated fix by lean-mechanic agent.