### PR TITLE
audit(erdos-13): mark clean (cycle 1) — Bedert divisibility-free axiomatization integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4625,9 +4625,9 @@
     },
     "erdos-13": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T10:15:31Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T18:59:14Z",
+      "result": "clean",
       "issues": [
         "#14718: phantom axiom claims in originalContributions and sections (5 of 6 listed axioms are not real declarations)"
       ]


### PR DESCRIPTION
## Summary

Routine audit-tracker bump for **erdos-13** (Divisibility-Free Sets, SOLVED by Bedert 2023). Verified gallery claims match Lean source.

## Verification

- 1 `axiom` declaration (`bedert_theorem`) matches `axiomCount: 1`
- 0 sorries (matches)
- 248 lines (matches `lineCount`)
- 6 theorems (`divisibilityFree_iff`, `upperThird_card`, `upperThird_achieves_bound`, `rDivisibilityFree_two`, `erdos_rsum_two`, `mem_upperThird_iff`) match `theoremCount: 6`
- 7 definitions (`IsBadTriple`, `DivisibilityFree`, `upperThird`, `RDivisibilityFree`, `upperFraction`, `ErdosRSumConjecture`, `SumFree`) match `definitionCount: 7`
- `status: axiomatized`, `badge: axiom` — correct for Bedert 2023 result axiomatized (Tier C scaffold)
- `assumptions` field accurately lists single axiom
- `erdos_rsum_two` theorem genuinely derives the r=2 case from `bedert_theorem` (real reduction, not stub)
- No True stubs
- Description honestly credits Bedert 2023 with $100 prize, notes r ≥ 3 generalization remains OPEN

## Test plan

- [x] grep `^axiom ` returns 1 match
- [x] grep `sorry` returns 0 matches
- [x] wc -l = 248
- [x] Theorem and definition counts verified via grep
- [x] No True stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)