### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-02 lineCount 286→285

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -58,7 +58,7 @@
       "Basic real arithmetic (division by 3, ordering)",
       "Monotonicity and antitone sequences"
     ],
-    "lineCount": 286,
+    "lineCount": 285,
     "relatedProblems": [
       {
         "id": "algebraic-numbers-countable-oq-02",
@@ -208,7 +208,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 286,
+    "lineCount": 285,
     "namespace": "CantorNestedIntervals",
     "opens": [],
     "structureCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` from 286 → 285 to match `wc -l proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean`.

## Evidence

```
$ wc -l proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean
     285 proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02.lean
```

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 286
**After**: both = 285

No companion files registered (no aggregate); single-file alignment to the established `wc -l` convention.

## Related

Sibling lineCount fixes in flight today:
- #21582 abel-ruffini-oq-04-oq-07 (378→377)
- #21549 amgm-inequality (226→225, merged 2026-05-31)
- #21275 derangements-convergence (282→272, merged 2026-05-31)

---
Automated fix by lean-mechanic agent.