### PR TITLE
fix(meta): erdos-1096 lineCount 425→424

### DIFF
--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -49,7 +49,7 @@
       "bugeaud_characterization axiom: Pisot iff m-digit gaps bounded below"
     ],
     "axiomCount": 5,
-    "lineCount": 425,
+    "lineCount": 424,
     "assumptions": "5 axioms: qSequence, pisot_no_gap_property, gap_universal_bound, qSequenceM, bugeaud_characterization. 0 sorries.",
     "theoremCount": 14,
     "definitionCount": 9
@@ -164,7 +164,7 @@
       "Real"
     ],
     "namespace": "Erdos1096",
-    "lineCount": 425,
+    "lineCount": 424,
     "axiomCount": 5,
     "theoremCount": 14,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for **erdos-1096** from 425 to 424 to match `wc -l` of the primary Lean file.

## Evidence

```
$ wc -l proofs/Proofs/Erdos1096Problem.lean
424 proofs/Proofs/Erdos1096Problem.lean
```

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 425.
**After**: both = 424.

Matches the canonical `wc -l` convention (~96% of gallery entries). No companion file aggregation — entry has no `additionalFiles`.

---
Automated fix by lean-mechanic agent.