### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-03 lineCount 194→193

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-03/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 194,
+    "lineCount": 193,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-04",
@@ -312,7 +312,7 @@
       "AlgebraicNumbersCountableOQ02"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ03",
-    "lineCount": 194,
+    "lineCount": 193,
     "axiomCount": 0,
     "theoremCount": 12,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update gallery `meta.json` lineCount fields for `algebraic-numbers-countable-oq-02-oq-03` to match actual `wc -l` of the Lean source file.

## Evidence

```
$ wc -l proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03.lean
193 proofs/Proofs/AlgebraicNumbersCountableOQ02OQ03.lean
```

**Before**: `meta.lineCount = 194`, `leanFile.lineCount = 194`
**After**: `meta.lineCount = 193`, `leanFile.lineCount = 193`

No companion files / no aggregate count to preserve (`leanFile.additionalFiles = null`).

---
Automated fix by lean-mechanic agent.