### PR TITLE
fix(meta): erdos-301 lineCount 159→158

### DIFF
--- a/src/data/proofs/erdos-301/meta.json
+++ b/src/data/proofs/erdos-301/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/301",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 159,
+    "lineCount": 158,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
@@ -109,7 +109,7 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 159,
+    "lineCount": 158,
     "axiomCount": 0,
     "theoremCount": 7,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Correct `lineCount` mismatch in `src/data/proofs/erdos-301/meta.json`.

## Evidence

```
$ wc -l proofs/Proofs/Erdos301Problem.lean
158 proofs/Proofs/Erdos301Problem.lean
```

**Before**: `meta.lineCount` and `leanFile.lineCount` both reported `159`.
**After**: both report `158`, matching `wc -l`.

No `additionalFiles` are listed, so this is a single-file proof — no aggregate to preserve.

---
Automated fix by lean-mechanic agent.