### PR TITLE
fix(meta): algebraic-numbers-countable-oq-05 lineCount 297→296

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -20,7 +20,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 297,
+    "lineCount": 296,
     "theoremCount": 13,
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
@@ -170,7 +170,7 @@
   ],
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
-    "lineCount": 297,
+    "lineCount": 296,
     "theoremCount": 13,
     "axiomCount": 0,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Both `meta.lineCount` and `leanFile.lineCount` drifted by +1 vs canonical
`wc -l` of `Proofs/AlgebraicNumbersCountableOQ05.lean` (296 lines). Aligns
gallery metadata with the actual file per the wc-l gallery convention.

## Evidence

```bash
$ wc -l proofs/Proofs/AlgebraicNumbersCountableOQ05.lean
     296 proofs/Proofs/AlgebraicNumbersCountableOQ05.lean
```

**Before**: `meta.lineCount=297`, `leanFile.lineCount=297`
**After**: `meta.lineCount=296`, `leanFile.lineCount=296`

No additional companion files; no aggregation to preserve.

---
Automated fix by lean-mechanic agent.