### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01 lineCount 134→133

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -33,7 +33,7 @@
     "dateAdded": "2026-04-26",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 134,
+    "lineCount": 133,
     "theoremCount": 4,
     "definitionCount": 0,
     "assumptions": "All results derived from Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum. 0 sorries, 0 axiom declarations.",
@@ -197,7 +197,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean",
-    "lineCount": 134,
+    "lineCount": 133,
     "theoremCount": 4,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

`wc -l` of `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean` reports **133** lines, but both `meta.lineCount` and `leanFile.lineCount` declared **134**. Realigns to the canonical gallery convention (~96% of 2423 entries use `wc -l`).

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean
     133 proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ01.lean
```

**Before**: `lineCount: 134`, `leanFile.lineCount: 134`
**After**:  `lineCount: 133`, `leanFile.lineCount: 133`

History: PR #20546 bumped 133→134 under a "split-newline" interpretation; the gallery has since standardized on `wc -l` (see PR #21549). This realigns the entry with the dominant convention.

No other meta fields touched. No code changes.

---
Automated fix by lean-mechanic agent.