### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03 lineCount 187→186

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-05-04",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 187,
+    "lineCount": 186,
     "theoremCount": 3,
     "definitionCount": 1,
     "assumptions": "No sorries, no axiom declarations. All results proved from Mathlib foundations via induction. Imports AmgmInequalityOQ02 for the elemSymm definition and elemSymm_succ (variable-adding recurrence).",
@@ -204,7 +204,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean",
-    "lineCount": 187,
+    "lineCount": 186,
     "theoremCount": 3,
     "definitionCount": 1,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

Correct `lineCount` metadata for `amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03`.

## Evidence

**Before**: `meta.lineCount = 187`, `leanFile.lineCount = 187`
**After**: `meta.lineCount = 186`, `leanFile.lineCount = 186`

`wc -l proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean` reports 186. No `additionalFiles` to aggregate.

---
Automated fix by lean-mechanic agent.