### PR TITLE
fix(meta): amgm-inequality-oq-02 lineCount 544→543

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -99,7 +99,7 @@
       "Real analysis (rpow, sqrt, mean inequalities)",
       "Finset combinatorics (powersetCard, sum, prod)"
     ],
-    "lineCount": 544,
+    "lineCount": 543,
     "assumptions": "2 axioms: (1) newton_log_concavity — for non-negative inputs, the normalized elementary symmetric sequence is log-concave: (eₖ/C(n,k))² ≥ (eₖ₋₁/C(n,k-1))·(eₖ₊₁/C(n,k+1)). Classical result proved by polarization + induction (Hardy-Littlewood-Pólya §2.22), not yet in Mathlib. (2) maclaurin_step — Mₖ ≥ Mₖ₊₁ where Mₖ = (eₖ/C(n,k))^(1/k). Follows from newton_log_concavity + monotonicity of t^(1/k). Note: the k=1 case of Newton's inequality (newton_k1) is proved without axioms. 0 sorries remain.(s) remain.",
     "mathlib_version": "4.26.0",
     "theoremCount": 26,
@@ -303,7 +303,7 @@
       "Real"
     ],
     "namespace": null,
-    "lineCount": 544,
+    "lineCount": 543,
     "structureCount": 0,
     "axiomCount": 2,
     "theoremCount": 26,


### PR DESCRIPTION
## Fix

`amgm-inequality-oq-02` meta.json declared `lineCount: 544` for `AmgmInequalityOQ02.lean`, but `wc -l` reports **543**.

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ02.lean
     543 proofs/Proofs/AmgmInequalityOQ02.lean
```

**Before**: `meta.lineCount = 544`, `leanFile.lineCount = 544`
**After**:  `meta.lineCount = 543`, `leanFile.lineCount = 543`

Aligns with gallery convention (`wc -l` of the primary file; 96% of 2423 entries). Companion files (`AmgmInequalityOQ02Aristotle.lean`, `AmgmInequalityOQ02Defs.lean`) are not aggregated here — both fields tracked the primary file, so this is a pure off-by-one repair.

---
Automated fix by lean-mechanic agent.