### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01 lineCount 89→88

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified. Works in any CommRing R.",
-    "lineCount": 89,
+    "lineCount": 88,
     "theoremCount": 5,
     "definitionCount": 0,
     "originalContributions": [
@@ -60,7 +60,7 @@
   },
   "leanFile": {
     "namespace": "AMGMInequalityOQ02OQ01",
-    "lineCount": 89,
+    "lineCount": 88,
     "axiomCount": 0,
     "theoremCount": 5,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

`amgm-inequality-oq-02-oq-01` meta.json declared `lineCount: 89` for `AMGMInequalityOQ02OQ01.lean`, but `wc -l` reports **88**.

## Evidence

```
$ wc -l proofs/Proofs/AMGMInequalityOQ02OQ01.lean
      88 proofs/Proofs/AMGMInequalityOQ02OQ01.lean
```

**Before**: `meta.lineCount = 89`, `leanFile.lineCount = 89`
**After**:  `meta.lineCount = 88`, `leanFile.lineCount = 88`

No `additionalFiles` registered, so both fields tracked the primary file. Pure off-by-one repair aligned with the gallery `wc -l` convention.

---
Automated fix by lean-mechanic agent.