### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-02 lineCount 960→959

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -34,7 +34,7 @@
       "maclaurin_step_derived: Mₖ ≥ Mₖ₊₁ where Mⱼ = (eⱼ/C(n,j))^(1/j) — the Maclaurin chain step"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 960,
+    "lineCount": 959,
     "theoremCount": 18,
     "definitionCount": 1,
     "mathlib_version": "4.26.0"
@@ -159,7 +159,7 @@
       "Proofs.NewtonInductiveStep"
     ],
     "namespace": "NewtonLogConcavity",
-    "lineCount": 960,
+    "lineCount": 959,
     "axiomCount": 0,
     "theoremCount": 18,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

`amgm-inequality-oq-02-oq-02` meta.json declared `lineCount: 960` for `AmgmInequalityOQ02OQ02.lean`, but `wc -l` reports **959**.

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ02OQ02.lean
     959 proofs/Proofs/AmgmInequalityOQ02OQ02.lean
```

**Before**: `meta.lineCount = 960`, `leanFile.lineCount = 960`
**After**:  `meta.lineCount = 959`, `leanFile.lineCount = 959`

No `additionalFiles` registered, so both fields tracked the primary file. Pure off-by-one repair aligned with the gallery `wc -l` convention.

---
Automated fix by lean-mechanic agent.