### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02 lineCount 139→138

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -135,7 +135,7 @@
       "BigOperators"
     ],
     "namespace": "AMGMInequalityOQ02OQ01OQ02",
-    "lineCount": 139,
+    "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Gallery meta.json `lineCount` was 139; `wc -l` of the Lean source is 138.

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ02OQ01OQ02.lean
138 proofs/Proofs/AmgmInequalityOQ02OQ01OQ02.lean
```

**Before**: `meta.lineCount = 139`, `leanFile.lineCount = 139`
**After**: `meta.lineCount = 138`, `leanFile.lineCount = 138`

`additionalFiles` is empty so no aggregate handling needed (per gallery `wc -l` convention).

---
Automated fix by lean-mechanic agent.