### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02-oq-01 lineCount 92→91

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01/meta.json
@@ -40,7 +40,7 @@
     "dateAdded": "2026-04-25",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 92,
+    "lineCount": 91,
     "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "Core results obtained via Mathlib's MvPolynomial.psum_eq_mul_esymm_sub_sum and MvPolynomial.psum_one/esymm_one. The three corollaries (k=1,2,3) are derived from these Mathlib theorems. 0 sorries, 0 axiom declarations.",
@@ -193,7 +193,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean",
-    "lineCount": 92,
+    "lineCount": 91,
     "theoremCount": 3,
     "definitionCount": 0,
     "axiomCount": 0,


### PR DESCRIPTION
## Fix

`meta.lineCount` and `leanFile.lineCount` were stale at **92** while `wc -l` of `proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean` reports **91**. Updated both fields to match the canonical split-newline convention used by 96% of gallery entries.

## Evidence

**Before**: `meta.lineCount: 92`, `leanFile.lineCount: 92`
**After**:  `meta.lineCount: 91`, `leanFile.lineCount: 91`

```
$ wc -l proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
      91 proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01.lean
```

This is not an aggregate (no large diff vs. primary file); companion file `AmgmInequalityOQ02OQ01OQ02OQ01Aristotle.lean` is registered separately under `additionalFiles`.

---
Automated fix by lean-mechanic agent.