### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02 lineCount 139→138

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json
@@ -43,7 +43,7 @@
     ],
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -135,7 +135,7 @@
       "BigOperators"
     ],
     "namespace": "AMGMInequalityOQ02OQ01OQ02",
-    "lineCount": 139,
+    "lineCount": 138,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.leanFile.lineCount` in `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02/meta.json` from 139 to 138 to match `wc -l proofs/Proofs/AmgmInequalityOQ02OQ01OQ02.lean`.

## Evidence

**Before**: meta declared `lineCount: 139` (two places)
**After**: meta declares `lineCount: 138` matching the file's actual line count

```
$ wc -l proofs/Proofs/AmgmInequalityOQ02OQ01OQ02.lean
     138 proofs/Proofs/AmgmInequalityOQ02OQ01OQ02.lean
```

Follows the gallery wc-l convention used by recent mechanic syncs (e.g. #21591, #21577, #21564).

---
Automated fix by lean-mechanic agent.