### PR TITLE
audit(erdos-126): mark clean — Erdős-Turán pairwise-sum prime factors integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4598,9 +4598,9 @@
     },
     "erdos-126": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T10:30:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T19:55:41Z",
+      "result": "clean",
       "issues": [
         "#14722: phantom axiom claims for erdos_126, erdos_126_littleo, trivial_upper_bound, f_monotone, conjecture_implies_not_O_log in sections/proofStrategy + section line drift"
       ]


### PR DESCRIPTION
## Summary

Audit verification of `erdos-126` (Distinct Prime Factors of Pairwise Sums).

All integrity checks pass:
- `lineCount: 152` ✓ matches `wc -l Erdos126Problem.lean`
- `axiomCount: 2` ✓ matches `erdos_turan_lower`, `erdos_turan_upper`
- `sorries: 0` ✓ no `sorry` in file
- `theoremCount: 1` ✓ matches `erdos_turan_bounds`
- `definitionCount: 2` ✓ matches `IsMaximalAddFactorsCard`, `ErdosConjecture126`
- No `True` stubs

Badge `axiom` with status `axiomatized` appropriately reflects:
- Erdős-Turán (1934) lower/upper bounds `log(n) ≪ f(n) ≪ n/log(n)` axiomatized
- Main conjecture `f(n)/log(n) → ∞` honestly framed as OPEN ($250 prize)
- No over-claiming of independent proof; framing matches Tier C scaffold/reduction

## Test plan
- [x] `wc -l proofs/Proofs/Erdos126Problem.lean` → 152
- [x] axiom/sorry/theorem/def counts verified via grep
- [x] No True stub theorems
- [x] Cross-checked meta.json claims against Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)