### PR TITLE
fix(meta): yang-mills-lattice-oq-01 lineCount 580→579

### DIFF
--- a/src/data/proofs/yang-mills-lattice-oq-01/meta.json
+++ b/src/data/proofs/yang-mills-lattice-oq-01/meta.json
@@ -22,7 +22,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "assumptions": "2 axioms: (1) os_reconstruction — the GNS construction from reflection-positive lattice OS data producing a WightmanQFT; this is mathematically proven (Osterwalder-Schrader 1973, Osterwalder-Seiler 1978) but requires functional analysis (Bochner's theorem, GNS construction) beyond current Mathlib. (2) os_mass_gap_transfer — that exponential decay of Schwinger functions implies a spectral gap in the reconstructed Hilbert space via the Kallen-Lehmann representation; similarly proven but requires the full OS machinery. The 2D results (Migdal formula, string tension, SU(2) computation) are fully proved with 0 axioms.",
-    "lineCount": 580,
+    "lineCount": 579,
     "mathlibDependencies": [
       {
         "theorem": "Real.log_neg",
@@ -153,7 +153,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 580,
+    "lineCount": 579,
     "structureCount": 7,
     "axiomCount": 2,
     "theoremCount": 28,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.leanFile.lineCount` in `src/data/proofs/yang-mills-lattice-oq-01/meta.json` from 580 to 579 to match `wc -l proofs/Proofs/YangMillsLatticeOQ01.lean`.

## Evidence

**Before**: meta declared `lineCount: 580` (two places)
**After**: meta declares `lineCount: 579` matching the file's actual line count

```
$ wc -l proofs/Proofs/YangMillsLatticeOQ01.lean
     579 proofs/Proofs/YangMillsLatticeOQ01.lean
```

Follows the gallery wc-l convention used by recent mechanic syncs (e.g. #21602, #21591, #21577).

---
Automated fix by lean-mechanic agent.