### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-03-oq-03 lineCount 67→66

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03-oq-03/meta.json
@@ -18,7 +18,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-04",
     "axiomCount": 1,
-    "lineCount": 67,
+    "lineCount": 66,
     "theoremCount": 3,
     "definitionCount": 0,
     "assumptions": "Uses `maclaurin_step` axiom from AmgmInequalityOQ02. If replaced by the proved `maclaurin_step_proved` from AmgmInequalityOQ02OQ03, all results become fully verified.",
@@ -194,7 +194,7 @@
   ],
   "leanFile": {
     "namespace": "AmgmInequalityOQ02OQ03OQ03",
-    "lineCount": 67,
+    "lineCount": 66,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

`amgm-inequality-oq-02-oq-03-oq-03` meta.json `lineCount` was 67; actual `wc -l proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean` is 66. Updated both `meta.lineCount` and `leanFile.lineCount` from 67→66 to match the gallery `wc-l` convention.

## Evidence

**Before**: `meta.lineCount=67`, `leanFile.lineCount=67`
**After**: `meta.lineCount=66`, `leanFile.lineCount=66`
**Actual `wc -l`**: 66 (`proofs/Proofs/AmgmInequalityOQ02OQ03OQ03.lean`)

`additionalFiles` is `null` for both `meta` and `leanFile`, so no aggregate handling needed.

---
Automated fix by lean-mechanic agent.