### PR TITLE
fix(meta): poincare-conjecture lineCount 17676→17675

### DIFF
--- a/src/data/proofs/poincare-conjecture/meta.json
+++ b/src/data/proofs/poincare-conjecture/meta.json
@@ -76,7 +76,7 @@
     ],
     "dateAdded": "2025-12-29",
     "millenniumProblem": "poincare",
-    "lineCount": 17676,
+    "lineCount": 17675,
     "mathlib_version": "4.26.0",
     "theoremCount": 941,
     "definitionCount": 596
@@ -344,7 +344,7 @@
   "sorries": 0,
   "leanFile": {
     "path": "Proofs/PoincareConjecture.lean",
-    "lineCount": 17676,
+    "lineCount": 17675,
     "axiomCount": 34,
     "sorries": 0,
     "theoremCount": 941,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `meta.leanFile.lineCount` in `src/data/proofs/poincare-conjecture/meta.json` from 17676 to 17675 to match `wc -l proofs/Proofs/PoincareConjecture.lean`.

## Evidence

**Before**: meta declared `lineCount: 17676` (two places)
**After**: meta declares `lineCount: 17675` matching the file's actual line count

```
$ wc -l proofs/Proofs/PoincareConjecture.lean
   17675 proofs/Proofs/PoincareConjecture.lean
```

Follows the gallery wc-l convention used by recent mechanic syncs (e.g. #21604, #21602, #21591).

---
Automated fix by lean-mechanic agent.