### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-03 lineCount 227→226

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-03/meta.json
@@ -26,7 +26,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 1,
-    "lineCount": 227,
+    "lineCount": 226,
     "assumptions": "1 axiom: newton_log_concavity (Newton's log-concavity of elementary symmetric polynomials, inherited from AmgmInequalityOQ02.lean). The maclaurin_step axiom is eliminated by this file — proved here as maclaurin_step_proved. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
@@ -138,7 +138,7 @@
       "AmgmInequalityOQ02"
     ],
     "namespace": "AmgmInequalityOQ02OQ03",
-    "lineCount": 227,
+    "lineCount": 226,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Corrects `lineCount` mismatch for `amgm-inequality-oq-02-oq-03`.

## Evidence

**Before**: `.meta.lineCount = 227`, `.leanFile.lineCount = 227`
**After**: both set to `226`

`wc -l proofs/Proofs/AmgmInequalityOQ02OQ03.lean` → `226`. No companion files registered (`additionalFiles` absent), so the aggregate convention does not apply.

---
Automated fix by lean-mechanic agent.