### PR TITLE
fix(meta): erdos-950 lineCount 226→225

### DIFF
--- a/src/data/proofs/erdos-950/meta.json
+++ b/src/data/proofs/erdos-950/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/950",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 226,
+    "lineCount": 225,
     "assumptions": "2 axioms: de_bruijn_erdos_turan_sum, de_bruijn_erdos_turan_sum_sq. 0 sorries.",
     "theoremCount": 8,
     "definitionCount": 10
@@ -144,7 +144,7 @@
       "Real"
     ],
     "namespace": "Erdos950",
-    "lineCount": 226,
+    "lineCount": 225,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Correct `lineCount` for `erdos-950` from 226 to 225 (matches `wc -l` of primary Lean file; no companion files).

## Evidence

```
$ wc -l proofs/Proofs/Erdos950Problem.lean
     225 proofs/Proofs/Erdos950Problem.lean
```

**Before**: `meta.lineCount: 226`, `leanFile.lineCount: 226`
**After**: both `225`

`leanFile.additionalFiles` is absent, so the canonical `wc -l` convention applies directly.

---
Automated fix by lean-mechanic agent.