### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02 lineCount 317→316

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json
@@ -69,7 +69,7 @@
       "Filter.Tendsto and nhdsWithin for limit formalization",
       "Weighted AM-GM inequality (Mathlib)"
     ],
-    "lineCount": 317,
+    "lineCount": 316,
     "mathlib_version": "4.26.0",
     "relatedProblems": [
       {
@@ -234,7 +234,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 317,
+    "lineCount": 316,
     "structureCount": 0,
     "axiomCount": 0,
     "theoremCount": 10,


### PR DESCRIPTION
## Fix

Update `lineCount` in `src/data/proofs/amgm-inequality-oq-03-oq-02/meta.json` from 317 to 316 to match actual `wc -l` of the referenced Lean file.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 317`
**After**:  `meta.lineCount = leanFile.lineCount = 316`

```
$ wc -l proofs/Proofs/PowerMeanLimitOQ.lean
     316 proofs/Proofs/PowerMeanLimitOQ.lean
```

The slug `amgm-inequality-oq-03-oq-02` is the sole gallery entry referencing `PowerMeanLimitOQ.lean` (verified via grep over `src/data/proofs/`). Sibling slugs `amgm-inequality-oq-03` and `amgm-inequality-oq-03-oq-01` point at a different file (`AmgmInequalityOQ03.lean`, 374 lines, matching declared).

Single primary file, no `additionalFiles` to aggregate — straight wc-l fix per the gallery convention.

---
Automated fix by lean-mechanic agent.