### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-01-oq-01 lineCount 139→138

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",
@@ -115,7 +115,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean",
     "sorries": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Correct `lineCount` for `amgm-inequality-oq-03-oq-02-oq-01-oq-01` from 139 to 138 (matches `wc -l` of primary Lean file; no companion files).

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean
     138 proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean
```

**Before**: `meta.lineCount: 139`, `leanFile.lineCount: 139`
**After**: both `138`

`leanFile.additionalFiles` is absent, so the canonical `wc -l` convention applies directly.

---
Automated fix by lean-mechanic agent.