### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-01-oq-01 lineCount 139→138

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",
@@ -115,7 +115,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean",
     "sorries": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Drift between recorded `meta.lineCount`/`leanFile.lineCount` (139) and actual file line count (138, via `wc -l`) for slug `amgm-inequality-oq-03-oq-02-oq-01-oq-01`.

## Evidence

- **File**: `proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean`
- `wc -l proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean` → `138`
- Recorded `meta.lineCount`: `139` (before) → `138` (after)
- Recorded `leanFile.lineCount`: `139` (before) → `138` (after)
- `leanFile.additionalFiles` is `null`, so `meta.lineCount` tracks only the primary file (no aggregation concern)

Two-line metadata-only diff, no Lean source touched.

---
Automated fix by lean-mechanic agent.