### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-01-oq-01 lineCount 139→138

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -18,7 +18,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "mathlibDependencies": [
       {
         "theorem": "Real.geom_mean_le_arith_mean_weighted",
@@ -115,7 +115,7 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 139,
+    "lineCount": 138,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean",
     "sorries": 0,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Correct `meta.lineCount` and `leanFile.lineCount` for `amgm-inequality-oq-03-oq-02-oq-01-oq-01`: `139 → 138` to match `wc -l` of the primary Lean file.

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean
138
```

**Before**: both fields = 139  
**After**: both fields = 138

No companion / `additionalFiles` to aggregate. Mechanic minimal-diff metadata fix.

---
Automated fix by lean-mechanic agent.