### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-04 lineCount 220→219

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-04/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-05",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 220,
+    "lineCount": 219,
     "theoremCount": 6,
     "definitionCount": 1,
     "originalContributions": [
@@ -176,7 +176,7 @@
       "Finset"
     ],
     "namespace": "AmgmOQ03OQ02OQ04",
-    "lineCount": 220,
+    "lineCount": 219,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ04.lean",


### PR DESCRIPTION
## Fix

Both `meta.lineCount` and `leanFile.lineCount` were 220 but the actual
file `proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean` is 219 lines (`wc -l`).

## Evidence

- `wc -l proofs/Proofs/AmgmInequalityOQ03OQ02OQ04.lean` → 219
- `meta.meta.lineCount` was 220, now 219
- `meta.leanFile.lineCount` was 220, now 219
- No `additionalFiles` registered, so `meta.lineCount` tracks the primary file only.

Aligns the gallery meta with the wc-l convention used by 96% of entries.

---
Automated fix by lean-mechanic agent.