### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-03 lineCount 66→65

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 66,
+    "lineCount": 65,
     "theoremCount": 2,
     "definitionCount": 1
   },
@@ -157,7 +157,7 @@
   "leanFile": {
     "namespace": "AmgmOQ03OQ03",
     "axiomCount": 0,
-    "lineCount": 66,
+    "lineCount": 65,
     "path": "Proofs/AmgmInequalityOQ03OQ03.lean",
     "sorries": 0,
     "theoremCount": 2,


### PR DESCRIPTION
## Fix

Aligns recorded lineCount with actual wc -l of the Lean source file.

## Evidence

**Before**: `meta.lineCount = 66`, `leanFile.lineCount = 66`
**After**: `meta.lineCount = 65`, `leanFile.lineCount = 65`

Verification:
```
$ wc -l proofs/Proofs/AmgmInequalityOQ03OQ03.lean
65
```

No companion files for this slug, so the top-level `meta.lineCount` is not an aggregate — both fields should equal wc -l of the primary file (gallery convention, 96% of entries).

---
Automated fix by lean-mechanic agent.