### PR TITLE
fix(meta): erdos-1018 lineCount 261→260

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -26,7 +26,7 @@
       "erdos-945"
     ],
     "axiomCount": 7,
-    "lineCount": 261,
+    "lineCount": 260,
     "assumptions": "7 axioms: K5_nonplanar (K₅ is non-planar), K33_nonplanar (K₃,₃ is non-planar), kuratowski_theorem (non-planar iff contains K₅ or K₃,₃ subdivision), kostochka_pyber (ε-dense graphs contain K₅ subdivisions on ≤ C(ε) vertices, 1988), constant_grows (C(ε) → ∞ as ε → 0), planar_linear_bound (planar graphs have ≤ 3n−6 edges), kostochka_pyber_explicit (polynomial bound in 1/ε). 7 sorries (incomplete topological and density definitions).",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
@@ -238,7 +238,7 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos1018",
-    "lineCount": 261,
+    "lineCount": 260,
     "axiomCount": 7,
     "theoremCount": 4,
     "definitionCount": 15,


### PR DESCRIPTION
## Fix

Primary-file `lineCount` metadata for `erdos-1018` was off by 1.

## Evidence

**Before**: `meta.lineCount = 261`, `leanFile.lineCount = 261`
**After**: both updated to `260`

`wc -l proofs/Proofs/Erdos1018Problem.lean` → `260`

Companion `Proofs/Erdos1018Aristotle.lean` (in `additionalFiles`) is unaffected — no aggregation in this slug's `meta.lineCount`.

---
Automated fix by lean-mechanic agent.