### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-03-oq-01 lineCount 273→272

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "dateAdded": "2026-04-13",
     "axiomCount": 0,
-    "lineCount": 273,
+    "lineCount": 272,
     "assumptions": "None. 0 sorries, 0 axioms. Complete formalization using Mathlib's Filter.Tendsto, Real.rpow, and Finset.sup'/inf'.",
     "theoremCount": 19,
     "definitionCount": 3,
@@ -253,7 +253,7 @@
       "Finset"
     ],
     "namespace": "AmgmPowerMeanLimits",
-    "lineCount": 273,
+    "lineCount": 272,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/AmgmInequalityPowerMeanLimits.lean",


### PR DESCRIPTION
## Fix

Stale `lineCount` (273 → 272) for `amgm-inequality-oq-03-oq-03-oq-01` (Power Mean Limits).

## Evidence

- `wc -l proofs/Proofs/AmgmInequalityPowerMeanLimits.lean` → **272**
- `src/data/proofs/amgm-inequality-oq-03-oq-03-oq-01/meta.json`:
  - `meta.lineCount`: 273 → 272
  - `leanFile.lineCount`: 273 → 272
- No `additionalFiles` in either `meta` or `leanFile` — no companion-file aggregation to preserve.

Gallery wc-l convention (per [[feedback_meta_linecount_canonical_split_newline]]) — applies to 96% of entries.

---
Automated fix by lean-mechanic agent.