### PR TITLE
fix(meta): erdos-1162 lineCount 222→221

### DIFF
--- a/src/data/proofs/erdos-1162/meta.json
+++ b/src/data/proofs/erdos-1162/meta.json
@@ -56,7 +56,7 @@
       "erdos1162_asymptotic: formal statement of the asymptotic result"
     ],
     "axiomCount": 1,
-    "lineCount": 222,
+    "lineCount": 221,
     "assumptions": "1 axiom: roney_dougal_tracey. 0 sorries.",
     "theoremCount": 9,
     "definitionCount": 5
@@ -222,7 +222,7 @@
       "Filter"
     ],
     "namespace": "Erdos1162",
-    "lineCount": 222,
+    "lineCount": 221,
     "axiomCount": 1,
     "theoremCount": 9,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/erdos-1162/meta.json` with the actual `wc -l` of `proofs/Proofs/Erdos1162Problem.lean` (221 lines).

## Evidence

**Before**: `meta.lineCount: 222`, `leanFile.lineCount: 222`
**After**:  `meta.lineCount: 221`, `leanFile.lineCount: 221`
**Actual**: `wc -l proofs/Proofs/Erdos1162Problem.lean` → `221`

Gallery convention: `leanFile.lineCount = wc-l` of primary file. No `additionalFiles` companion exists on this proof, so `meta.lineCount` should match (no aggregate to preserve).

---
Automated fix by lean-mechanic agent.