### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-04 lineCount 233→232

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -63,7 +63,7 @@
       "Key insight: H decreasing ↔ M increasing follows from negating both sides of log(M_{α-1}) ≤ log(M_{β-1})"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 233,
+    "lineCount": 232,
     "prerequisites": [
       "Probability distributions and Rényi entropy (information theory)",
       "Power means and AM-GM inequality (analysis)",
@@ -201,7 +201,7 @@
     ],
     "opens": [],
     "namespace": "RenyiPowerMean",
-    "lineCount": 233,
+    "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` from 233 → 232 to match `wc -l proofs/Proofs/AmgmInequalityOQ03OQ04.lean`.

## Evidence

```
$ wc -l proofs/Proofs/AmgmInequalityOQ03OQ04.lean
     232 proofs/Proofs/AmgmInequalityOQ03OQ04.lean
```

- No `additionalFiles`, so `meta.lineCount` reflects only the primary file (not an aggregate).
- Both `meta.lineCount` and `leanFile.lineCount` were 233 — both corrected to 232.

---
Automated fix by lean-mechanic agent.