### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-04 lineCount 233→232

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-04/meta.json
@@ -63,7 +63,7 @@
       "Key insight: H decreasing ↔ M increasing follows from negating both sides of log(M_{α-1}) ≤ log(M_{β-1})"
     ],
     "dateAdded": "2026-04-21",
-    "lineCount": 233,
+    "lineCount": 232,
     "prerequisites": [
       "Probability distributions and Rényi entropy (information theory)",
       "Power means and AM-GM inequality (analysis)",
@@ -201,7 +201,7 @@
     ],
     "opens": [],
     "namespace": "RenyiPowerMean",
-    "lineCount": 233,
+    "lineCount": 232,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Align meta.json `lineCount` for `amgm-inequality-oq-03-oq-04` with canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = 233` and `leanFile.lineCount = 233`
**After**: both `lineCount = 232`

`wc -l proofs/Proofs/AmgmInequalityOQ03OQ04.lean` → `232`

Gallery convention is wc -l (96% of entries; see project memory `feedback_meta_linecount_canonical_split_newline`).

---
Automated fix by lean-mechanic agent.