### PR TITLE
fix(meta): amgm-inequality-oq-04 lineCount 307→306

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 307,
+    "lineCount": 306,
     "theoremCount": 22,
     "definitionCount": 5,
     "assumptions": "0 axioms in this parent file (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the child file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). The Gauss AGM-elliptic-integral identity remains axiomatized in the child slug oq-04-oq-01 as agm_ellipticK_connection (200+ page classical proof, requires Landen/theta-function theory not in Mathlib).",
@@ -155,7 +155,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04",
-    "lineCount": 307,
+    "lineCount": 306,
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/amgm-inequality-oq-04/meta.json` with `wc -l proofs/Proofs/AmgmInequalityOQ04.lean` (306).

## Evidence

- **Before**: `meta.lineCount: 307`, `leanFile.lineCount: 307`
- **After**: `meta.lineCount: 306`, `leanFile.lineCount: 306`
- `wc -l proofs/Proofs/AmgmInequalityOQ04.lean` → **306**

Single primary file (no `additionalFiles`), so meta.lineCount = leanFile.lineCount = wc -l per gallery convention (matches recent merges e.g. #21549, #21540).

---
Automated fix by lean-mechanic agent.