### PR TITLE
fix(meta): erdos-1028 lineCount 311→310

### DIFF
--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 2,
-    "lineCount": 311,
+    "lineCount": 310,
     "assumptions": "2 axioms: erdos_upper, erdos_spencer_lower. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
@@ -240,7 +240,7 @@
       "Finset"
     ],
     "namespace": "Erdos1028",
-    "lineCount": 311,
+    "lineCount": 310,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 11,


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-1028/meta.json` declared `meta.lineCount` and `leanFile.lineCount` as 311 while `proofs/Proofs/Erdos1028Problem.lean` is 310 lines (canonical `wc -l`).

## Evidence

```
$ wc -l proofs/Proofs/Erdos1028Problem.lean
310 proofs/Proofs/Erdos1028Problem.lean
```

Both `meta.lineCount` and `leanFile.lineCount` updated 311 → 310. No `additionalFiles` aggregate to preserve.

---
Automated fix by lean-mechanic agent.