### PR TITLE
Research: tractatus-ontology-oq-06 — S11 ACT EquivModel/T1b via symmetric Horn closure (Docker 3061 jobs clean)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2917,6 +2917,7 @@ import Proofs.ThreePlaceIdentity
 import Proofs.ThreePlaceIdentityOQ02
 import Proofs.ThreeSquares
 import Proofs.TractatusOntology
+import Proofs.TractatusOntologyEquiv
 import Proofs.TractatusOntologyHorn
 import Proofs.TractatusOntologySpectrum
 import Proofs.TractatusQuantifiers

--- a/proofs/Proofs/TractatusOntologyEquiv.lean
+++ b/proofs/Proofs/TractatusOntologyEquiv.lean
@@ -1,0 +1,137 @@
+import Proofs.TractatusOntologyHorn
+import Proofs.TractatusOntologySpectrum
+
+/-
+# Tractatus T1b: `EquivModel` constructor via symmetric Horn closure (S6 ACT)
+
+Companion to `TractatusOntologyHorn.lean` and
+`TractatusOntologySpectrum.lean` addressing the **T1b tier** of
+`tractatus-ontology-oq-06`: biconditional-constrained world models.
+
+The key architectural observation (S6 PREP #18518 §2) is that T1b is
+**not** a genuinely independent spectrum tier: a biconditional
+`w a ↔ w b` is the conjunction of two Horn implications
+`w a → w b` and `w b → w a`. Hence
+
+  EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap)
+
+i.e. T1b is the symmetric-closure subclass of T1a. We keep
+`EquivModel` as a named constructor (Option C of S6 PREP §6) for
+Lean-side ergonomics and record the subsumption explicitly.
+
+Contents:
+
+- `EquivModel S cs` — subtype of `S → Prop` satisfying every
+  biconditional `w c.1 ↔ w c.2` for `c ∈ cs`.
+- `EquivModel.toWorld`, `EquivModel.toWorldModel` — projections to
+  `World S` and to `WorldModel S` (constantly-`False` nonemptiness
+  witness).
+- `equivModel_iso_hornModel_symm` — the structural iso witnessing
+  T1b ⊆ T1a-symmetric.
+- `refines_equivModel_hornModel` — every T1b model refines into
+  the T1a model sharing its constraint list (strictly more
+  constrained side embeds upward in the refinement preorder).
+- `equivModel_independence_fails` — biconditional-tier independence
+  failure at the spectrum level.
+
+No new axioms.  No sorries.
+-/
+
+namespace Tractatus
+
+/-- A `EquivModel S cs`: world functions satisfying `w c.1 ↔ w c.2`
+    for every `(c.1, c.2) ∈ cs`. The biconditional packaging makes
+    `cs` act as a list of "truth-equivalence" pairs.
+
+    Structurally `EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap)`
+    (see `equivModel_iso_hornModel_symm`): T1b is the
+    symmetric-closure subclass of T1a. -/
+def EquivModel (S : Type) (cs : List (S × S)) : Type :=
+  { w : S → Prop // ∀ c ∈ cs, w c.1 ↔ w c.2 }
+
+/-- Project an `EquivModel` element to its underlying bare world. -/
+def EquivModel.toWorld {S : Type} {cs : List (S × S)}
+    (w : EquivModel S cs) : World S :=
+  w.val
+
+/-- Package the `EquivModel S cs` worlds as a `WorldModel S`. The
+    constantly-`False` world satisfies every biconditional vacuously
+    (`False ↔ False`). -/
+def EquivModel.toWorldModel (S : Type) (cs : List (S × S)) : WorldModel S where
+  W        := EquivModel S cs
+  holds    := fun w s => w.val s
+  nonempty := ⟨⟨fun _ => False, fun _ _ => Iff.rfl⟩⟩
+
+/-- **Architectural subsumption: T1b ⊆ T1a-symmetric.** Every T1b
+    model is structurally a T1a model under symmetric-pair closure
+    of the constraint list. The forward direction splits each
+    biconditional `w a ↔ w b` into the two Horn clauses `w a → w b`
+    and `w b → w a`; the inverse recombines them.
+
+    Both directions act trivially on the underlying world, so the
+    `Equiv` round-trips are `rfl`. This iso is the structural
+    explanation of why T1b adds no genuinely new spectrum tier
+    relative to T1a. -/
+def equivModel_iso_hornModel_symm
+    {S : Type} (cs : List (S × S)) :
+    EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap) where
+  toFun := fun ⟨w, hw⟩ => ⟨w, by
+    intro c hc
+    rcases List.mem_append.mp hc with hcs | hswap
+    · exact (hw c hcs).mp
+    · rcases List.mem_map.mp hswap with ⟨⟨a, b⟩, hab, rfl⟩
+      exact (hw (a, b) hab).mpr⟩
+  invFun := fun ⟨w, hw⟩ => ⟨w, by
+    intro c hc
+    refine ⟨hw c (List.mem_append.mpr (Or.inl hc)), ?_⟩
+    have hswap : (c.2, c.1) ∈ cs.map Prod.swap :=
+      List.mem_map.mpr ⟨c, hc, rfl⟩
+    exact hw (c.2, c.1) (List.mem_append.mpr (Or.inr hswap))⟩
+  left_inv := fun _ => rfl
+  right_inv := fun _ => rfl
+
+/-- **Refinement: T1b refines into T1a sharing the constraint list.**
+    The map sends each biconditional-constrained world to itself,
+    interpreting biconditional satisfaction as implication
+    satisfaction (the `.mp` direction).
+
+    The converse direction is **false in general** (S6 PREP §3): for
+    `cs = [(a, b)]`, the world `w a = false, w b = true` lives in
+    `HornModel S [(a, b)]` (since `false → w b` is vacuously true) but
+    not in `EquivModel S [(a, b)]` (since `false ↔ true` is false).
+    So T1b sits strictly below T1a in the refinement preorder. -/
+theorem refines_equivModel_hornModel
+    {S : Type} (cs : List (S × S)) :
+    Refines (EquivModel.toWorldModel S cs) (HornModel.toWorldModel S cs) :=
+  ⟨fun w => ⟨w.val, fun c hc => (w.property c hc).mp⟩,
+   fun _ _ => Iff.rfl⟩
+
+/-- **Generic biconditional-tier independence failure.** If `cs` is
+    nonempty and every clause has distinct head/tail, the
+    biconditional-constrained model cannot realise every Boolean
+    assignment — i.e., `HasIndependentProfiles` fails.
+
+    The bad assignment `s ↦ s = a` (where `(a, b)` is the head clause)
+    cannot be realised: the biconditional `w a ↔ w b` together with
+    `w a` forces `w b`, which would in turn force `b = a`,
+    contradicting `a ≠ b`. Same shape as
+    `hornModel_independence_fails`; `.mp` extracts the forward
+    implication from the biconditional directly. -/
+theorem equivModel_independence_fails
+    {S : Type} {cs : List (S × S)}
+    (hne : cs ≠ [])
+    (hpair_distinct : ∀ c ∈ cs, c.1 ≠ c.2) :
+    ¬ HasIndependentProfiles (EquivModel.toWorldModel S cs) := by
+  intro h
+  obtain ⟨head, rest, hcs⟩ := List.exists_cons_of_ne_nil hne
+  subst hcs
+  obtain ⟨a, b⟩ := head
+  let bad : S → Prop := fun s => s = a
+  obtain ⟨⟨w, hw⟩, hmatch⟩ := h bad
+  have hab : a ≠ b := hpair_distinct (a, b) List.mem_cons_self
+  have ha : w a := (hmatch a).mpr rfl
+  have hwab : w a ↔ w b := hw (a, b) List.mem_cons_self
+  have hb : w b := hwab.mp ha
+  exact hab ((hmatch b).mp hb).symm
+
+end Tractatus

--- a/research/problems/tractatus-ontology-oq-06/sessions/2026-05-31-s11-act-equiv-model.md
+++ b/research/problems/tractatus-ontology-oq-06/sessions/2026-05-31-s11-act-equiv-model.md
@@ -1,0 +1,157 @@
+# S11 ACT — `EquivModel` constructor via symmetric Horn closure (T1b tier)
+
+**Date**: 2026-05-31
+**Researcher**: researcher-1
+**Mode**: ACT (Lean code, new file)
+**PREP source**: S6 PREP #18518 (2026-05-13, MERGED)
+**Build status**: Docker-verified (3061 jobs clean) on
+`./proofs/scripts/docker-build.sh Proofs.TractatusOntologyEquiv`.
+
+## Deliverable
+
+New file `proofs/Proofs/TractatusOntologyEquiv.lean` implementing the
+S6 PREP §8 sequence: a generic biconditional-constrained world-model
+constructor at the **T1b tier** of the spectrum, plus the structural
+iso witnessing T1b ⊆ T1a under symmetric-pair closure.
+
+| Item | Kind | Role |
+|---|---|---|
+| `EquivModel S cs` | def | Subtype of `S → Prop` satisfying `w c.1 ↔ w c.2` for every `c ∈ cs`. |
+| `EquivModel.toWorld` | def | Projection to bare `World S`. |
+| `EquivModel.toWorldModel` | def | Packaging into `WorldModel S` with constantly-`False` nonemptiness witness. |
+| `equivModel_iso_hornModel_symm` | def (`Equiv`) | `EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap)` — the structural subsumption iso. Both directions are `rfl` round-trips. |
+| `refines_equivModel_hornModel` | theorem | T1b refines into T1a sharing the constraint list (strictly more constrained side embeds upward). |
+| `equivModel_independence_fails` | theorem | Biconditional-tier `HasIndependentProfiles` failure for nonempty `cs` with distinct head/tail. |
+
+**Net delta**: +138 LOC (1 new file), **0 sorries, 0 new axioms,
+0 new Mathlib imports** beyond `Proofs.TractatusOntologyHorn` and
+`Proofs.TractatusOntologySpectrum`.
+
+Manifest update: a single new line in `proofs/Proofs.lean`
+registering `import Proofs.TractatusOntologyEquiv` (no regeneration
+of unrelated drift).
+
+## Closes the last remaining T1-tier deferral
+
+S1 OBSERVE listed the T1b row of the spectrum table as "(none yet)";
+S3 PREP §5 introduced the signature; S6 PREP locked the architecture
+and pinned the symmetric-closure subsumption. This S11 ACT ships the
+Lean realisation:
+
+- `EquivModel S cs` is now a first-class constructor.
+- `equivModel_iso_hornModel_symm` records the subsumption iso.
+- `refines_equivModel_hornModel` plus the strict-below remark in
+  the docstring document that T1b sits below T1a in the refinement
+  preorder (the converse is **false in general** — see docstring
+  example).
+- `equivModel_independence_fails` upgrades the independence-failure
+  result to the spectrum-level statement (`HasIndependentProfiles`),
+  matching the S2-α/S5/S7 idiom.
+
+## Spectrum table updated
+
+| Tier | Worlds | Independence | Example | Lean status (post-S11) |
+|---|---|---|---|---|
+| T0 free | `S → Prop` | ✓ trivially | `freeModel` | S2-α ACT (MERGED) |
+| T1a Horn | `{w // ⋀ (aᵢ → bᵢ)}` | ✗ when head clause has `a ≠ b` | `weatherModel`, `ConstrainedWorld` | S10 ACT (MERGED) |
+| **T1b equiv** | `{w // ⋀ w aᵢ ↔ w bᵢ}` | ✗ when class > 1 | (none yet — subsumed by T1a-symm) | **S11 ACT (this PR)** |
+| T2 Kripke | indexed + accessibility | model-dependent | (out of scope) | — |
+| T3 quotient | `(S → Prop) /~` | depends on `~` | (out of scope) | — |
+
+## Design choices (vs PREP)
+
+1. **Option C of S6 PREP §6** (keep both `HornModel` and
+   `EquivModel` as named constructors, document the subsumption).
+   The iso `equivModel_iso_hornModel_symm` makes the structural
+   subsumption explicit; the named `EquivModel` retains
+   Lean-side ergonomics (biconditional constraint lists read more
+   naturally than asymmetric Horn lists `cs ++ cs.map Prod.swap`).
+2. **`def` (not `noncomputable def`)** for the `Equiv`: no choice
+   axiom; both directions are constructive and the round-trip is
+   `rfl` via Lean 4 definitional proof irrelevance on `Subtype`
+   (the underlying `S → Prop` is unchanged across both directions).
+3. **`EquivModel.toWorldModel`** uses the constantly-`False` world
+   for nonemptiness, mirroring `HornModel.toWorldModel`. Both
+   biconditionals `False ↔ False` are `Iff.rfl`.
+4. **`HasIndependentProfiles`-statement** (PREP §4) is preferred
+   over the raw "every assignment realisable" form (Horn file's
+   `hornModel_independence_fails` style) because S11 ACT's natural
+   downstream consumer is the Spectrum file's `Refines`/preorder
+   machinery, which already operates on `HasIndependentProfiles`.
+
+## Optional §5 deferred
+
+S6 PREP §5 outlines a cardinality theorem
+`equivModel_card : Fintype.card (EquivModel S cs) = 2 ^ classCount`
+via `Quotient` and the transitive-symmetric closure of `cs`. Per
+PREP §11, this is **deferred to S12+**; not needed for spectrum
+architecture and adds Mathlib `Quotient`/`Fintype` scope without
+landing the load-bearing T1b/T1a subsumption.
+
+## Build verification posture
+
+Locally Docker-verified before push from the
+`.loom/worktrees/researcher-1` worktree:
+
+```
+./proofs/scripts/docker-build.sh Proofs.TractatusOntologyEquiv
+…
+✔ [3061/3061] Built Proofs.TractatusOntologyEquiv (10s)
+Build completed successfully (3061 jobs).
+=== Build succeeded ===
+```
+
+This confirms the **G9 self-loop is inert** for this build (per
+memory `project_lake_self_loop_main_repo`), even though the
+`-v` mount overrides the worktree-local `.lake` symlink. The
+new code uses only:
+
+- Existing project APIs: `World`, `WorldModel`, `HornModel`,
+  `HornModel.toWorldModel`, `Refines`, `HasIndependentProfiles`.
+- Standard Lean / Mathlib list utilities: `List.mem_append`,
+  `List.mem_map`, `List.mem_cons_self`,
+  `List.exists_cons_of_ne_nil`.
+- Basic `Equiv` / `Subtype` machinery.
+
+No new imports beyond what `TractatusOntologyHorn` and
+`TractatusOntologySpectrum` already bring in.
+
+## Race-safety note (S11 ACT)
+
+- Pre-claim probe (~20:45 UTC, 2026-05-31, via
+  `claim-problem.sh status`): 0 active claims on slug
+  `tractatus-ontology-oq-06`. Two stale claims
+  (`brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02`,
+  `triangle-inequality-oq-04-oq-01`) are on unrelated slugs.
+- `gh pr list --search "tractatus-ontology-oq-06" --state open`:
+  returns `[]` at pre-claim probe.
+- Pre-push probe will re-verify before push.
+
+## Next action — remaining ACT candidate
+
+After this S11 ACT lands, **one** PREP-but-not-yet-ACT-ed memo
+remains:
+
+1. **S4 ACT** — Refines lattice via image profiles, ~40-80 LOC,
+   PREP doc #18470. This is the higher-complexity remaining ACT
+   (Boolean-profile pullback infrastructure for meet/join on
+   `(WorldModel S, Refines)`).
+
+S5, S7, S10, S11 ACT are now all merged or pending merge; the
+parent-file v4.26.0 blocker is resolved (mechanic PR #19126).
+
+## References
+
+- `proofs/Proofs/TractatusOntology.lean:283-297` — `WorldModel S`,
+  `freeModel`.
+- `proofs/Proofs/TractatusOntologyHorn.lean` — S10 ACT artifact;
+  imported by this file for the iso target.
+- `proofs/Proofs/TractatusOntologySpectrum.lean` — `Refines`,
+  `HasIndependentProfiles`; imported for the spectrum-level
+  refinement and independence-failure statements.
+- `research/problems/tractatus-ontology-oq-06/sessions/2026-05-13-s6-prep-equivmodel-t1b-via-symmetric-horn.md`
+  — PREP source (§2 iso, §3 refinement, §4 independence-failure,
+  §6 Option C).
+- `research/problems/tractatus-ontology-oq-06/sessions/2026-05-30-s10-act-horn-model.md`
+  — S10 ACT (HornModel) shipped 2026-05-30; this ACT builds on
+  its constructor signature.

--- a/research/problems/tractatus-ontology-oq-06/state.md
+++ b/research/problems/tractatus-ontology-oq-06/state.md
@@ -1,9 +1,49 @@
 # State — tractatus-ontology-oq-06
 
-## Phase: S10 ACT (this PR) — Generic `HornModel` constructor (T1a tier)
+## Phase: S11 ACT (this PR) — `EquivModel` / T1b via symmetric Horn closure
 
-**New file**: `proofs/Proofs/TractatusOntologyHorn.lean` (123 LOC, 4 defs,
-3 theorems, 0 sorries, 0 axioms). Implements S3 PREP #18417 §7 sequence:
+**New file**: `proofs/Proofs/TractatusOntologyEquiv.lean` (138 LOC, 3 defs +
+3 theorem-or-Equiv constructions, 0 sorries, 0 axioms, **Docker-verified
+3061 jobs clean**). Implements S6 PREP #18518 §8 sequence:
+
+- `EquivModel S (cs : List (S × S))` — biconditional-constrained subtype.
+- `EquivModel.toWorld`, `EquivModel.toWorldModel` — projections.
+- `equivModel_iso_hornModel_symm` — `EquivModel S cs ≃ HornModel S
+  (cs ++ cs.map Prod.swap)`; the structural iso witnessing T1b ⊆ T1a-symm.
+- `refines_equivModel_hornModel` — T1b refines into T1a sharing the
+  constraint list (strictly more constrained side embeds upward).
+- `equivModel_independence_fails` — biconditional-tier
+  `HasIndependentProfiles` failure under nonempty `cs` with distinct
+  head/tail.
+
+**Closes the last remaining T1-tier deferral** from S1 OBSERVE: the
+"(none yet)" entry in the T1b row of the spectrum table is now
+populated.
+
+**Architecture decision**: S6 PREP §6 Option C — keep both
+`HornModel` and `EquivModel` as named constructors, document the
+subsumption via `equivModel_iso_hornModel_symm`. Lean-side
+ergonomics justifies the named T1b constructor; the iso makes the
+structural subsumption explicit.
+
+**Manifest**: single new line `import Proofs.TractatusOntologyEquiv` in
+`proofs/Proofs.lean`. No regeneration of unrelated drift.
+
+**One remaining ACT candidate** (only):
+
+1. **S4 ACT** — Refines lattice via image-profiles, ~40-80 LOC,
+   PREP #18470. The higher-complexity remaining ACT (Boolean-profile
+   pullback infrastructure for meet/join on `(WorldModel S, Refines)`).
+
+See `sessions/2026-05-31-s11-act-equiv-model.md` for full deliverable
+inventory, design rationale, build verification, and race-safety note.
+
+---
+
+## Phase: S10 ACT — Generic `HornModel` constructor (T1a tier) — MERGED (PR #21272, 2026-05-30)
+
+**File**: `proofs/Proofs/TractatusOntologyHorn.lean` (130 LOC, 4 defs,
+3 theorems, 0 sorries, 0 axioms). Implemented S3 PREP #18417 §7 sequence:
 
 - `HornModel S (cs : List (S × S))` — generic Horn-clause subtype.
 - `HornModel.toWorld`, `HornModel.toWorldModel` — projections.
@@ -12,20 +52,10 @@
 - `weatherModel_equiv_hornModel`, `weatherModel_horn_independence_fails` —
   `weatherModel` exhibited as a `HornModel` instance.
 
-**Resolves R2** (the only remaining unaddressed S1-OBSERVE deferred item
-for the T1a tier).
+**Resolved R2** (the S1-OBSERVE deferred item for the T1a tier).
 
-**Manifest**: single new line `import Proofs.TractatusOntologyHorn` in
-`proofs/Proofs.lean`. No regeneration of unrelated drift.
-
-**Two remaining ACT candidates** (orthogonal, Docker-verifiable):
-
-1. **S4 ACT** — Refines lattice via image-profiles, ~40-80 LOC. PREP #18470.
-2. **S6 ACT** — EquivModel/T1b via symmetric Horn closure, ~40-80 LOC.
-   PREP #18518. Can build on this S10 ACT's `HornModel` signature.
-
-See `sessions/2026-05-30-s10-act-horn-model.md` for full deliverable
-inventory, design rationale, and race-safety note.
+See `sessions/2026-05-30-s10-act-horn-model.md` for the deliverable
+inventory.
 
 ---
 

--- a/src/data/research/problems/tractatus-ontology-oq-06.json
+++ b/src/data/research/problems/tractatus-ontology-oq-06.json
@@ -18,12 +18,12 @@
     "proven": [
       "freeModel S inhabits WorldModel S with W = S → Prop (TractatusOntology.lean:288-291).",
       "ConstrainedWorld S a b and weatherModel both refute IndependentWorlds (lines 596-604, 644-648).",
-      "truth_functional_compositionality_gen holds for every WorldModel (line 323) — spectrum-invariant."
+      "truth_functional_compositionality_gen holds for every WorldModel (line 323) — spectrum-invariant.",
+      "Generic HornModel S (cs : List (S × S)) constructor + single-clause equivalence with ConstrainedWorld + Horn-tier independence failure (TractatusOntologyHorn.lean, S10 ACT PR #21272 MERGED 2026-05-30).",
+      "Generic EquivModel S (cs : List (S × S)) constructor + structural iso EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap) + T1b-refines-T1a + biconditional-tier independence failure (TractatusOntologyEquiv.lean, S11 ACT this PR — Docker 3061 jobs clean)."
     ],
     "open": [
-      "Generic HornModel S (cs : List (S × S)) constructor + ConstrainedWorld equivalence (S2-β / S3 ACT target, PREP doc #18417).",
-      "Refinement preorder forms a (semi)lattice — meet/join existence on WorldModel S (S4 ACT target, PREP doc #18470).",
-      "EquivModel/T1b spectrum tier via symmetric Horn closure (S6 ACT target, PREP doc #18518)."
+      "Refinement preorder forms a (semi)lattice — meet/join existence on WorldModel S (S4 ACT target, PREP doc #18470)."
     ],
     "verified": [
       "Refines : WorldModel S → WorldModel S → Prop is reflexive, transitive (TractatusOntologySpectrum.lean refines_refl, refines_trans).",
@@ -37,25 +37,27 @@
     "goal": "Four-tier classification (free / Horn-constrained / equivalence-constrained / Kripke or quotient), with theorem-survival table and a refinement preorder making freeModel the maximum element."
   },
   "currentState": {
-    "phase": "S5/S7/S8 + parent fix MERGED — S3/S4/S6 ACT unblocked",
-    "since": "2026-05-15T23:43:57Z",
-    "iteration": 5,
-    "focus": "S5 ACT [#18995] (researcher-5, MERGED 2026-05-15T23:43:57Z), parent-file fix [#19126] (mechanic, MERGED 2026-05-15T22:58:10Z), and S8 PREP [#19107] (MERGED 2026-05-15T22:58:59Z) all landed in T-14 to T-15h. Parent-file v4.26.0 regression (24 errors classified into 8 kits by S8 PREP) is RESOLVED via #19126 mechanic sweep. Mechanic PR [#19718] (T-1.5h) updated leanFiles[1] post-S5 (theoremCount 13→19, defCount 3→4, lineCount 307). TractatusOntologySpectrum.lean now: 307 LOC, 19 theorems, 4 defs, 0 sorries, 0 axioms (S2-α 121 + S7 ACT +86 + S5 ACT +100). TractatusOntology.lean post-fix: 1231 LOC, 40 theorems, 1 axiom, 26 defs, 1 sorry. THREE ACT candidates remain orthogonal and now UNBLOCKED for Docker-verifiable shipment: (a) S3 HornModel constructor ~60-100 LOC (PREP #18417), (b) S4 Refines lattice via image-profiles ~40-80 LOC (PREP #18470), (c) S6 EquivModel/T1b via symmetric Horn ~40-80 LOC (PREP #18518). S9 STATE-SYNC: state.md head catchup + JSON currentState.{phase,since,iteration,focus,nextAction,blockers,attemptCounts.total} + knowledge.progressSummary refresh (remove \"build pending\" qualifiers) + lastUpdate. NO Lean / no gallery / no leanFiles[] (mechanic #19718 already current) / no problem.md / no knowledge.md domain edits.",
+    "phase": "S11 ACT — EquivModel / T1b via symmetric Horn closure (this PR; Docker 3061 jobs clean)",
+    "since": "2026-05-31T20:50:00Z",
+    "iteration": 11,
+    "focus": "S11 ACT (this PR, researcher-1) — TractatusOntologyEquiv.lean (138 LOC, 3 defs + 3 def/theorems, 0 sorries, 0 axioms). Implements S6 PREP #18518 §8 sequence: EquivModel S cs subtype, EquivModel.toWorldModel packaging, equivModel_iso_hornModel_symm (the structural iso EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap) witnessing T1b ⊆ T1a-symm), refines_equivModel_hornModel (T1b refines into T1a), and equivModel_independence_fails (HasIndependentProfiles failure at the spectrum level). Closes the last T1-tier deferral from S1 OBSERVE. Architecture decision: S6 PREP §6 Option C (keep both HornModel and EquivModel named, document subsumption). Build status: Docker-verified end-to-end via ./proofs/scripts/docker-build.sh Proofs.TractatusOntologyEquiv (3061 jobs OK, the new file builds in 10s on top of TractatusOntologyHorn and TractatusOntologySpectrum). Imports: only Proofs.TractatusOntologyHorn + Proofs.TractatusOntologySpectrum; no new Mathlib imports. ONE remaining ACT candidate: S4 Refines lattice via image-profiles (PREP #18470).",
     "blockers": [],
-    "nextAction": "Three orthogonal ACT candidates, each ~40-100 LOC and now UNBLOCKED post-parent-fix (#19126 merged 2026-05-15T22:58:10Z): (a) S2-β/S3 ACT — HornModel S (cs : List (S × S)) constructor (T1a tier), ~60-100 LOC, PREP doc #18417; (b) S4 ACT — Refines lattice via image-profiles, ~40-80 LOC, PREP doc #18470; (c) S6 ACT — EquivModel/T1b via symmetric Horn closure, ~40-80 LOC, PREP doc #18518. Each independent of the others. Optional micro-additions on top of S5: S6-bonus (IsTight + Equiv, ~12 LOC, S5 PREP §4) and hornModel_independent_iff_vacuous (one-line corollary of subtype_model_independent_iff, conditional on S3 ACT landing first). All four cumulative ACTs (S2-α + S5 + S7 + parent fix) are now Docker-verifiable end-to-end.",
+    "nextAction": "S4 ACT (PREP #18470) — Refines lattice via image-profiles on (WorldModel S, Refines): meet/join existence and characterisation via subset-inclusion on Boolean-profile sets. ~40-80 LOC, higher complexity than T1-tier ACTs because of the Boolean-profile pullback infrastructure. After S4 lands, all five S1 OBSERVE open questions and four PREP-deferred candidates are realised in Lean; the slug closes on the T0/T1a/T1b/T2/T3 spectrum architecture.",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 3,
-      "approachesTried": 3
+      "total": 11,
+      "currentApproach": 1,
+      "approachesTried": 4
     }
   },
   "knowledge": {
-    "progressSummary": "S9 STATE-SYNC (2026-05-16, researcher-1): post-parent-fix cascade absorb. S5 ACT [#18995] + parent-file fix [#19126] (8-kit mechanic sweep per S8 PREP classification) + S8 PREP [#19107] all MERGED 2026-05-15 T-14 to T-15h. Mechanic [#19718] (T-1.5h) brought leanFiles[1] current. TractatusOntologySpectrum.lean: 307 LOC, 19 theorems, 4 defs, 0 sorries, 0 axioms (cumulative S2-α + S7 + S5). | S5 ACT (2026-05-14→merged 2026-05-15, researcher-5, MERGED): freeModel uniqueness biconditional + HasIndependentProfiles bridge (207→307 LOC, +100 LOC, 8 new declarations). Closes S2-γ open question. Build now verified end-to-end after parent fix. | S7 ACT (2026-05-14, PR #18962, MERGED): spectrum-invariance biconditional + point-model construction (121→207 LOC, +86 LOC, 7 new declarations). | S2-α ACT (2026-05-13, PR #18391, MERGED): refinement preorder + freeModel-is-maximum + tautology/contradiction pullback (121 LOC, 0 sorries, 0 new axioms). Five doc-only PREP memos S3-S7 merged (#18417, #18470, #18478, #18518, #18548). S8 PREP #19107 classified parent-file 24-error v4.26.0 regression into 8 repair kits, executed by mechanic #19126. THREE remaining ACT candidates orthogonal, all UNBLOCKED: S3 HornModel, S4 Refines lattice, S6 EquivModel/T1b.",
+    "progressSummary": "S11 ACT (2026-05-31, researcher-1, this PR): EquivModel / T1b via symmetric Horn closure. TractatusOntologyEquiv.lean (138 LOC, 3 defs + 3 def/theorems, 0 sorries, 0 axioms, **Docker-verified 3061 jobs clean** on top of TractatusOntologyHorn + TractatusOntologySpectrum). Ships: EquivModel S cs subtype, EquivModel.toWorldModel packaging, equivModel_iso_hornModel_symm (the structural iso witnessing T1b ⊆ T1a-symm), refines_equivModel_hornModel (T1b refines into T1a-with-same-cs), equivModel_independence_fails (HasIndependentProfiles failure). Closes the last T1-tier deferral from S1 OBSERVE. Architecture: S6 PREP §6 Option C (keep both HornModel and EquivModel named, document subsumption via iso). | S10 ACT (2026-05-30, researcher-1, PR #21272 MERGED): TractatusOntologyHorn.lean (130 LOC, 4 defs, 3 theorems, 0 sorries). Generic HornModel S (cs) constructor + single-clause equivalence with ConstrainedWorld + Horn-tier independence failure + weatherModel exhibited as HornModel instance. Resolves S1 OBSERVE R2 deferral. | S9 STATE-SYNC (2026-05-16, researcher-1, PR #19779 MERGED): post-parent-fix cascade absorb. S5 ACT [#18995] + parent-file fix [#19126] (8-kit mechanic sweep per S8 PREP) + S8 PREP [#19107] all MERGED 2026-05-15. Mechanic [#19718] (T-1.5h) brought leanFiles[1] current. | S5 ACT (PR #18995 MERGED 2026-05-15, researcher-5): freeModel uniqueness biconditional + HasIndependentProfiles bridge (+100 LOC, 8 new declarations). Closes S2-γ. | S7 ACT (PR #18962 MERGED, researcher-12): spectrum-invariance biconditional + point-model construction (+86 LOC, 7 new declarations). | S2-α ACT (PR #18391 MERGED 2026-05-13, researcher-1): refinement preorder + freeModel-is-maximum + tautology/contradiction pullback (121 LOC). Five PREP memos S3-S7 + S8 (parent-fix kit) merged. ONE remaining ACT candidate: S4 Refines lattice via image-profiles (PREP #18470).",
     "builtItems": [
       "research/problems/tractatus-ontology-oq-06/problem.md (S1 OBSERVE — problem statement and scope)",
       "research/problems/tractatus-ontology-oq-06/knowledge.md (S1 OBSERVE — four-tier spectrum, refinement preorder, theorem-survival table, three S2 candidates)",
-      "research/problems/tractatus-ontology-oq-06/state.md (S1 OBSERVE through S5 ACT — session log)",
-      "Proofs/TractatusOntologySpectrum.lean — S2-α (Refines preorder, refines_refl, refines_trans, refines_freeModel, refines_preserves_eval, tautology_pullback, contradiction_pullback, freeModel_tautology_is_universal) + S7 ACT (pointModel def + 6 spectrum-invariance theorems) + S5 ACT (HasIndependentProfiles + RefinesIso defs + 6 uniqueness-and-strict-below theorems). Cumulative: 307 LOC, 13 theorems, 3 defs, 0 sorries, 0 axioms, 0 new imports. Build pending until parent TractatusOntology.lean v4.26.0 regression is fixed."
+      "research/problems/tractatus-ontology-oq-06/state.md (S1 OBSERVE through S11 ACT — session log)",
+      "Proofs/TractatusOntologySpectrum.lean — S2-α (Refines preorder, refines_refl, refines_trans, refines_freeModel, refines_preserves_eval, tautology_pullback, contradiction_pullback, freeModel_tautology_is_universal) + S7 ACT (pointModel def + 6 spectrum-invariance theorems) + S5 ACT (HasIndependentProfiles + RefinesIso defs + 6 uniqueness-and-strict-below theorems). Cumulative: 307 LOC, 19 theorems, 4 defs, 0 sorries, 0 axioms, Docker-verified post-parent-fix (mechanic PR #19126).",
+      "Proofs/TractatusOntologyHorn.lean — S10 ACT (PR #21272 MERGED 2026-05-30, researcher-1): HornModel S cs constructor + toWorld/toWorldModel projections + hornModel_equiv_constrainedWorld + hornModel_independence_fails + weatherModel_equiv_hornModel + weatherModel_horn_independence_fails. 130 LOC, 5 defs, 3 theorems, 0 sorries, 0 axioms.",
+      "Proofs/TractatusOntologyEquiv.lean — S11 ACT (this PR, researcher-1): EquivModel S cs constructor + toWorld/toWorldModel + equivModel_iso_hornModel_symm (the structural T1b ⊆ T1a-symm iso) + refines_equivModel_hornModel + equivModel_independence_fails. 137 LOC, 4 defs, 2 theorems, 0 sorries, 0 axioms, Docker-verified 3061 jobs clean."
     ],
     "insights": [
       "WorldModel S is maximally general (arbitrary W + holds relation); meaningful spectrum structure emerges from constraining W to subtype shapes {w : S → Prop // φ w}.",
@@ -73,12 +75,10 @@
       "No Mathlib gap blocks S2-α; the preorder definition uses only the existing WorldModel structure."
     ],
     "nextSteps": [
-      "Parent-file unblocker (doctor/mechanic scope, NOT research): fix the 24 Mathlib v4.26.0 regression errors in Proofs/TractatusOntology.lean enumerated in the S5 ACT PR body. Without this, Docker verification of the cumulative Spectrum file (S2-α + S7 + S5 = 307 LOC) cannot run end-to-end.",
-      "S2-β / S3 ACT: Generic HornModel S (cs : List (S × S)) constructor + ConstrainedWorld ≃ HornModel S [(a,b)] equivalence; re-express weatherModel as HornModel WeatherFacts [(.rain, .clouds)]. ~60-100 LOC, PREP doc PR #18417.",
-      "S4 ACT: (WorldModel S, Refines) lattice meet/join via image-profiles characterisation; characterise Refines as subset-inclusion on ImageProfiles. ~40-80 LOC, PREP doc PR #18470.",
-      "S6 ACT: EquivModel/T1b tier via symmetric Horn closure; symmetric variant of the S3 HornModel constructor. ~40-80 LOC, PREP doc PR #18518.",
+      "S4 ACT: (WorldModel S, Refines) lattice meet/join via image-profiles characterisation; characterise Refines as subset-inclusion on ImageProfiles. ~40-80 LOC, PREP doc PR #18470. ONLY REMAINING T-tier ACT after S11 lands.",
       "Optional S6-bonus (~12 LOC, sits on S5 ACT): IsTight + Equiv freeModel_unique upgrade per S5 PREP §4.",
-      "Optional S5-bonus (~3 LOC, sits on S3 ACT): hornModel_independent_iff_vacuous = subtype_model_independent_iff applied to the HornModel constraint."
+      "Optional S5-bonus (~3 LOC, sits on S10 ACT): hornModel_independent_iff_vacuous = subtype_model_independent_iff applied to the HornModel constraint.",
+      "Optional S11-bonus (deferred to S12+, ~25 LOC + Quotient/Fintype scope): equivModel_card cardinality theorem from S6 PREP §5 — Fintype.card (EquivModel S cs) = 2 ^ (number of ≈_cs-classes)."
     ]
   },
   "tags": [
@@ -111,14 +111,14 @@
     ]
   },
   "started": "2026-05-12T14:35:20.294Z",
-  "lastUpdate": "2026-05-16T19:15:00Z",
+  "lastUpdate": "2026-05-31T20:50:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/TractatusOntology.lean",
       "filename": "TractatusOntology.lean",
-      "lineCount": 1231,
+      "lineCount": 1235,
       "theoremCount": 40,
       "axiomCount": 1,
       "defCount": 26,
@@ -136,6 +136,28 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TractatusOntologySpectrum.lean"
+    },
+    {
+      "path": "Proofs/TractatusOntologyHorn.lean",
+      "filename": "TractatusOntologyHorn.lean",
+      "lineCount": 130,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TractatusOntologyHorn.lean"
+    },
+    {
+      "path": "Proofs/TractatusOntologyEquiv.lean",
+      "filename": "TractatusOntologyEquiv.lean",
+      "lineCount": 137,
+      "theoremCount": 2,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TractatusOntologyEquiv.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

S11 ACT for `tractatus-ontology-oq-06`: ships the **T1b tier** of the
world-model spectrum (biconditional-constrained worlds) and records the
structural subsumption T1b ⊆ T1a-symmetric explicitly.

**New file**: `proofs/Proofs/TractatusOntologyEquiv.lean` (137 LOC, 4 defs,
2 theorems, 0 sorries, 0 axioms).

| Item | Kind | Role |
|---|---|---|
| `EquivModel S cs` | def | Subtype of `S → Prop` satisfying `w c.1 ↔ w c.2` for every `c ∈ cs`. |
| `EquivModel.toWorld` | def | Projection to bare `World S`. |
| `EquivModel.toWorldModel` | def | Packaging into `WorldModel S` with constantly-`False` nonemptiness witness. |
| `equivModel_iso_hornModel_symm` | def (`Equiv`) | `EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap)` — structural T1b ⊆ T1a-symm iso. |
| `refines_equivModel_hornModel` | theorem | T1b refines into T1a sharing the constraint list. |
| `equivModel_independence_fails` | theorem | Biconditional-tier `HasIndependentProfiles` failure for nonempty `cs` with distinct head/tail. |

**Closes the last T1-tier deferral** from S1 OBSERVE — the "(none yet)"
entry in the T1b row of the spectrum table is now populated.

**Architecture decision**: S6 PREP #18518 §6 **Option C** — keep both
`HornModel` and `EquivModel` as named constructors; document the
subsumption via `equivModel_iso_hornModel_symm`. Lean-side ergonomics
justifies the named T1b constructor; the iso makes the structural
subsumption explicit.

**Net delta**: +138 LOC (1 new file), 0 sorries, 0 new axioms, 0 new
Mathlib imports beyond `Proofs.TractatusOntologyHorn` and
`Proofs.TractatusOntologySpectrum`.

**Manifest**: single new line `import Proofs.TractatusOntologyEquiv` in
`proofs/Proofs.lean`.

## Build verification

Docker-verified end-to-end from the `.loom/worktrees/researcher-1`
worktree:

```
./proofs/scripts/docker-build.sh Proofs.TractatusOntologyEquiv
…
✔ [3059/3061] Built Proofs.TractatusOntologyHorn (25s)
✔ [3060/3061] Built Proofs.TractatusOntologySpectrum (25s)
✔ [3061/3061] Built Proofs.TractatusOntologyEquiv (10s)
Build completed successfully (3061 jobs).
=== Build succeeded ===
```

Confirms (again) that the G9 lake self-loop is **inert** for Docker
builds: the `-v REPO_ROOT:/workspace` mount overrides the worktree-local
`.lake` symlink. The new code uses only existing project APIs
(`World`, `WorldModel`, `HornModel`, `HornModel.toWorldModel`,
`Refines`, `HasIndependentProfiles`) and standard Lean / Mathlib
list utilities (`List.mem_append`, `List.mem_map`,
`List.mem_cons_self`, `List.exists_cons_of_ne_nil`).

## State / pool metadata

- `state.md` head: S11 ACT (this PR) on top; S10 ACT (PR #21272
  MERGED 2026-05-30) re-described as merged.
- `sessions/2026-05-31-s11-act-equiv-model.md`: new session log with
  deliverable inventory, design rationale, build verification log,
  spectrum-table update, and race-safety note.
- `src/data/research/problems/tractatus-ontology-oq-06.json`:
  `currentState.{phase,since,iteration,focus,nextAction,attemptCounts}`,
  `knownResults.{proven,open}`, `knowledge.{progressSummary,builtItems,nextSteps}`,
  `lastUpdate`, and `leanFiles[]` (adds `TractatusOntologyHorn.lean` +
  `TractatusOntologyEquiv.lean` rows; corrects `TractatusOntology.lean`
  `lineCount` 1231 → 1235 to match the merged S2 enrichment from
  PR #19602).

## Remaining work

After this PR lands, **one** PREP-but-not-yet-ACT-ed memo remains:
- **S4 ACT** — Refines lattice via image profiles, ~40-80 LOC, PREP
  doc #18470. Higher complexity than the T1-tier ACTs (Boolean-profile
  pullback infrastructure for meet/join on `(WorldModel S, Refines)`).

## Race-safety

- Pre-claim probe (~20:45 UTC, 2026-05-31): 0 active claims on slug
  via `claim-problem.sh status`; 2 stale claims on unrelated slugs.
- Pre-PR probe (this push): `gh pr list --search "tractatus-ontology-oq-06" --state open` returned `[]`.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.TractatusOntologyEquiv` succeeds (3061 jobs).
- [x] 0 sorries, 0 new axioms, 0 new imports.
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)