### PR TITLE
audit(erdos-134): mark clean — Alon's diameter-2 axiomatization verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4676,9 +4676,9 @@
     },
     "erdos-134": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T10:01:12Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-05-31T21:10:15Z",
+      "result": "clean"
     },
     "erdos-135": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary
- Routine gallery-integrity audit of `erdos-134` (Triangle-Free Graphs with Diameter 2 — Alon)
- All meta.json counts match Lean source: lineCount 270, axioms 2, theorems 2, defs 12, sorries 0, 0 True stubs
- `status: axiomatized` + `badge: axiom` properly reflect the 2 encoded assumptions (`alon_theorem`, `alon_implies_conjecture`)
- Description honestly credits Alon for the solution; Tier C classification consistent

## Test plan
- [x] Counts grep-verified against `proofs/Proofs/Erdos134Problem.lean`
- [x] `audit-tracker.json` bumped (auditCount 3→4, result `issues-fixed`→`clean`)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>