### PR TITLE
fix(meta): amgm-inequality-oq-04-oq-02 lineCount 1560→1559

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1560,
+    "lineCount": 1559,
     "theoremCount": 47,
     "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
@@ -176,7 +176,7 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 1560,
+    "lineCount": 1559,
     "axiomCount": 1,
     "theoremCount": 47,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Correct `lineCount` from 1560 to 1559 in `src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json` to match `wc -l` of the primary Lean file.

## Evidence

- `wc -l proofs/Proofs/AmgmInequalityOQ04OQ02.lean` → **1559**
- File ends with trailing newline (verified via `tail -c 1`)
- Both `meta.lineCount` and `leanFile.lineCount` were **1560** — off by 1
- No `additionalFiles`/companion file — value is not an aggregate
- Per gallery convention (96% of 2423 entries use `wc -l`), corrected to 1559

---
Automated fix by lean-mechanic agent.