### PR TITLE
fix(meta): erdos-410 lineCount 372→371

### DIFF
--- a/src/data/proofs/erdos-410/meta.json
+++ b/src/data/proofs/erdos-410/meta.json
@@ -56,7 +56,7 @@
       "sigma_multiplicative theorem"
     ],
     "axiomCount": 2,
-    "lineCount": 372,
+    "lineCount": 371,
     "assumptions": "2 axiom(s): robin_inequality (equivalent to RH), average_sigma (deep analytic NT). conjecture_equiv_exp was proved from limit theory.",
     "theoremCount": 42,
     "definitionCount": 7
@@ -181,7 +181,7 @@
       "Filter"
     ],
     "namespace": "Erdos410",
-    "lineCount": 372,
+    "lineCount": 371,
     "axiomCount": 2,
     "theoremCount": 42,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Primary-file `lineCount` metadata for `erdos-410` was off by 1.

## Evidence

**Before**: `meta.lineCount = 372`, `leanFile.lineCount = 372`
**After**: both updated to `371`

`wc -l proofs/Proofs/Erdos410Problem.lean` → `371`

No `additionalFiles` listed — no aggregation needed.

---
Automated fix by lean-mechanic agent.