### PR TITLE
fix(meta): divisibility-truncation-general-oq-03 lineCount 222→221

### DIFF
--- a/src/data/proofs/divisibility-truncation-general-oq-03/meta.json
+++ b/src/data/proofs/divisibility-truncation-general-oq-03/meta.json
@@ -20,7 +20,7 @@
     "dateAdded": "2026-04-24",
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using only Mathlib.",
-    "lineCount": 222,
+    "lineCount": 221,
     "theoremCount": 21,
     "definitionCount": 1,
     "originalContributions": [
@@ -111,7 +111,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 222,
+    "lineCount": 221,
     "path": "Proofs/DivisibilityTruncationGeneralOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `divisibility-truncation-general-oq-03` to actual `wc -l` of the primary Lean source.

## Evidence

- `wc -l proofs/Proofs/DivisibilityTruncationGeneralOQ03.lean` → **221**
- meta.json stored `meta.lineCount = 222` and `leanFile.lineCount = 222`
- No `leanFile.additionalFiles` — both counters track the primary file alone, so both should equal wc -l (no aggregate)

**Before**: meta=222, leanFile=222, actual=221
**After**: meta=221, leanFile=221, actual=221

Drift likely introduced after PR #20234 (which bumped 221→222). File has since been trimmed by one line; this PR re-syncs.

---
Automated fix by lean-mechanic agent.