### PR TITLE
fix(meta): amgm-inequality-oq-04-oq-05 lineCount 243→242

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 7,
-    "lineCount": 243,
+    "lineCount": 242,
     "theoremCount": 8,
     "definitionCount": 6,
     "assumptions": "7 axioms: ellipticK (function), ellipticE (function), K_eq_pi_div_2M (Gauss's AGM theorem for k=1/√2), legendre_relation (Legendre's relation for k=1/√2), ellipticE_agm (E via AGM iteration), bs_summable (series convergence from quadratic AGM convergence), S_lt_half (series sum bound). The algebraic derivation π = 4M²/(1-2S) is machine-verified from these axioms.",
@@ -150,7 +150,7 @@
       "Real"
     ],
     "namespace": "AmgmInequalityOQ04OQ05",
-    "lineCount": 243,
+    "lineCount": 242,
     "axiomCount": 7,
     "theoremCount": 8,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Aligns `meta.lineCount` and `leanFile.lineCount` for `amgm-inequality-oq-04-oq-05` with `wc -l` of `proofs/Proofs/AmgmInequalityOQ04OQ05.lean`.

## Evidence

**Before**: meta.json claimed `lineCount: 243` (both `meta.lineCount` and `leanFile.lineCount`).
**After**: both fields read `lineCount: 242` — matching `wc -l proofs/Proofs/AmgmInequalityOQ04OQ05.lean` (= 242, no companion files registered in `additionalFiles`).

```
$ wc -l proofs/Proofs/AmgmInequalityOQ04OQ05.lean
     242
```

Single-file slug, so the canonical `wc -l` convention applies (no main+companion aggregate to preserve).

---
Automated fix by lean-mechanic agent.