### PR TITLE
fix(meta): erdos-1179-oq-01 lineCount 710→709 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-1179-oq-01/meta.json
+++ b/src/data/proofs/erdos-1179-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "theoremCount": 28,
     "definitionCount": 7,
-    "lineCount": 710,
+    "lineCount": 709,
     "erdosNumber": 1179,
     "erdosUrl": "https://erdosproblems.com/1179",
     "erdosProblemStatus": "open-question",
@@ -223,7 +223,7 @@
       "Real"
     ],
     "namespace": "Erdos1179OQ01",
-    "lineCount": 710,
+    "lineCount": 709,
     "axiomCount": 0,
     "theoremCount": 28,
     "definitionCount": 7,


### PR DESCRIPTION
## Fix

Sync `lineCount` for `erdos-1179-oq-01` with `wc -l` canonical convention (the 96% gallery norm).

## Evidence

**Before**: `meta.lineCount = 710`, `leanFile.lineCount = 710`
**After**: `meta.lineCount = 709`, `leanFile.lineCount = 709`

- `wc -l proofs/Proofs/Erdos1179OQ01.lean` → `709`
- No `additionalFiles`, so primary count == aggregate count
- Inverts the lone outlier introduced by #20250 ("S2 STATE-SYNC 709→710")

Follows the same wc-l canonicalization pattern as #21560, #21561, #21563, #21564.

---
Automated fix by lean-mechanic agent.