### PR TITLE
fix(meta): angle-trisection-cos-20-gal-oq-01-oq-01 lineCount 183→182 (wc-l canonical)

### DIFF
--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-01/meta.json
@@ -22,7 +22,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 183,
+    "lineCount": 182,
     "assumptions": "No axioms, no sorries. Imports AngleTrisectionCos20Gal and AngleTrisectionCos20GalOQ01; all key theorems reduce to those parent results via case-splitting.",
     "mathlib_version": "4.26.0",
     "historicalContext": "This entry answers the natural question raised by two near-identical proofs in the gallery: both AngleTrisectionCos20Gal (8X³−6X−1, the minimal polynomial of cos(20°)) and AngleTrisectionCos20GalOQ01 (8X³−4X²−4X+1, the minimal polynomial of cos(π/7)) have Galois groups of order 3, but each proof uses a different Eisenstein prime (p=2 vs p=7). The parameterized unification reveals the common structure: both belong to a family of cyclic cubics over ℚ reducible to Eisenstein form by a suitable linear substitution. The CyclicCubicData typeclass captures the common interface, providing a template extensible to other angles whose minimal polynomials are cyclic cubics.",
@@ -104,7 +104,7 @@
       "Proofs.AngleTrisectionCos20GalOQ01"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ01",
-    "lineCount": 183,
+    "lineCount": 182,
     "axiomCount": 0,
     "theoremCount": 11,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync `lineCount` for `angle-trisection-cos-20-gal-oq-01-oq-01` with `wc -l` canonical convention (the 96% gallery norm).

## Evidence

**Before**: `meta.lineCount = 183`, `leanFile.lineCount = 183`
**After**: `meta.lineCount = 182`, `leanFile.lineCount = 182`

- `wc -l proofs/Proofs/AngleTrisectionCos20GalOQ01OQ01.lean` → `182`
- No `additionalFiles`, so primary count == aggregate count
- Reverts the lone outlier introduced by #20568 ("canonical split-newline")

Follows the same wc-l canonicalization pattern as #21560, #21561, #21563, #21564.

---
Automated fix by lean-mechanic agent.