### PR TITLE
fix(meta): angle-trisection-oq-01 lineCount 367→366 (wc-l canonical)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "lineCount": 367,
+    "lineCount": 366,
     "theoremCount": 44,
     "definitionCount": 3,
     "originalContributions": [
@@ -68,7 +68,7 @@
   },
   "leanFile": {
     "namespace": "AngleTrisectionOQ01",
-    "lineCount": 367,
+    "lineCount": 366,
     "axiomCount": 0,
     "theoremCount": 44,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Aligns `angle-trisection-oq-01` line count with the gallery-wide wc-l canonical.

## Evidence

```
$ wc -l proofs/Proofs/AngleTrisectionOQ01.lean
     366 proofs/Proofs/AngleTrisectionOQ01.lean
```

**Before**:
- `.meta.lineCount = 367`
- `.leanFile.lineCount = 367`

**After**:
- `.meta.lineCount = 366`
- `.leanFile.lineCount = 366`

PR #20391 previously moved this entry to 367 under the older split-newline convention; this commit returns it to wc-l, the gallery-wide canonical (96% of 2423 entries — see #21560 / #21561 / #21563 / #21564).

`proofRepoPath` is the only Lean source (no `additionalFiles`), so there is no aggregate count to preserve.

---
Automated fix by lean-mechanic agent.