### PR TITLE
fix(meta): cauchy-schwarz-oq-02-oq-02 lineCount 162→161 (wc-l canonical)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 162,
+    "lineCount": 161,
     "theoremCount": 10,
     "definitionCount": 0,
     "assumptions": "None. All theorems proved from Mathlib's Orthonormal.sum_inner_products_le, Orthonormal.tsum_inner_products_le, and HilbertBasis.tsum_inner_mul_inner.",
@@ -269,7 +269,7 @@
   "leanFile": {
     "path": "Proofs/CauchySchwarzOQ02OQ02.lean",
     "filename": "CauchySchwarzOQ02OQ02.lean",
-    "lineCount": 162,
+    "lineCount": 161,
     "theoremCount": 10,
     "axiomCount": 0,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync both `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/cauchy-schwarz-oq-02-oq-02/meta.json` from 162 to 161 to match the canonical `wc -l` newline count of `proofs/Proofs/CauchySchwarzOQ02OQ02.lean`.

## Evidence

```
$ wc -l proofs/Proofs/CauchySchwarzOQ02OQ02.lean
     161 proofs/Proofs/CauchySchwarzOQ02OQ02.lean
```

**Before**: `lineCount: 162` in both sites (set by merged PR #20573 under the brief "split-newline" experiment).
**After**: `lineCount: 161` (wc-l canonical, matches 96% of gallery entries).

No source code changes — metadata-only repair. Single-file proof, no additionalFiles aggregate to preserve.

---
Automated fix by lean-mechanic agent.