### PR TITLE
fix(meta): area-of-circle-oq-03-oq-02-oq-02 lineCount 205→204 (wc-l canonical)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json
@@ -56,7 +56,7 @@
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
     "assumptions": "Fully verified: 0 axioms, 0 sorries.",
-    "lineCount": 205,
+    "lineCount": 204,
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
     "definitionCount": 2
@@ -157,7 +157,7 @@
       "intervalIntegral"
     ],
     "namespace": "AreaOfCircleOQ03OQ02OQ02",
-    "lineCount": 205,
+    "lineCount": 204,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Correct `lineCount` mismatch in `src/data/proofs/area-of-circle-oq-03-oq-02-oq-02/meta.json`. Both `leanFile.lineCount` and `meta.lineCount` updated 205→204 to match canonical `wc -l` count of `proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean`.

## Evidence

```
$ wc -l proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean
204 proofs/Proofs/AreaOfCircleOQ03OQ02OQ02.lean
```

**Before**: `leanFile.lineCount: 205`, `meta.lineCount: 205`
**After**: `leanFile.lineCount: 204`, `meta.lineCount: 204`

File has a trailing newline; wc-l is the canonical gallery convention (96% of 2423 entries). Single primary file, no aggregate companion line count to preserve.

---
Automated fix by lean-mechanic agent.