### PR TITLE
fix(meta): arithmetic-series-oq-02-oq-01-oq-01 lineCount 218→217 (wc-l canonical)

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-04",
     "axiomCount": 0,
     "assumptions": "None. Axiom-free and sorry-free.",
-    "lineCount": 218,
+    "lineCount": 217,
     "theoremCount": 6,
     "definitionCount": 0,
     "originalContributions": [
@@ -66,7 +66,7 @@
       "GaussianBinomial"
     ],
     "namespace": "qVandermondeProof",
-    "lineCount": 218,
+    "lineCount": 217,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean",


### PR DESCRIPTION
## Fix

Both `leanFile.lineCount` and `meta.lineCount` updated from 218 → 217 to match `wc -l proofs/Proofs/ArithmeticSeriesOQ02OQ01OQ01.lean`.

## Evidence

**Before**: `lineCount: 218` (set by PR #20232 using split-newline convention)
**After**: `lineCount: 217` (matches `wc -l` canonical convention used by 96% of 2423 gallery entries)

Reverts the split-newline drift from PR #20232 back to the wc-l convention. The file ends with a trailing newline; wc-l counts newline characters and yields 217.

---
Automated fix by lean-mechanic agent.