### PR TITLE
fix(meta): cramers-rule-oq-03 lineCount 176→175 (wc-l canonical)

### DIFF
--- a/src/data/proofs/cramers-rule-oq-03/meta.json
+++ b/src/data/proofs/cramers-rule-oq-03/meta.json
@@ -18,7 +18,7 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 176,
+    "lineCount": 175,
     "assumptions": "None. Fully verified over any DivisionRing D.",
     "originalContributions": [
       "Defined quasidet₀₀ and quasidet₁₁: Gelfand-Retakh quasideterminants for 2×2 matrices",
@@ -147,7 +147,7 @@
       "Finset"
     ],
     "namespace": "CramersRuleOQ03",
-    "lineCount": 176,
+    "lineCount": 175,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/cramers-rule-oq-03/meta.json` with the wc-l canonical convention (96% of gallery entries).

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` declared `176`.
**After**: both fields set to `175`.

```
$ wc -l proofs/Proofs/CramersRuleOQ03.lean
175 proofs/Proofs/CramersRuleOQ03.lean
```

No companion files (`leanFile.additionalFiles` is null), so aggregate semantics do not apply — both fields straightforwardly equal wc-l of the primary file.

---
Automated fix by lean-mechanic agent.