### PR TITLE
fix(meta): circumference-via-differentiation-oq-01 lineCount 241→240 (wc-l canonical)

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 241,
+    "lineCount": 240,
     "theoremCount": 18,
     "definitionCount": 4,
     "assumptions": "None. All theorems proved from Mathlib's power rule, Gamma_add_one, and unitBallVolume infrastructure.",
@@ -172,7 +172,7 @@
   "leanFile": {
     "path": "Proofs/CircumferenceViaDifferentiationOQ01.lean",
     "filename": "CircumferenceViaDifferentiationOQ01.lean",
-    "lineCount": 241,
+    "lineCount": 240,
     "theoremCount": 18,
     "axiomCount": 0,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Update lineCount from 241 to 240 in both `leanFile.lineCount` and `meta.lineCount` to match the canonical `wc -l` count of the Lean source file.

## Evidence

- **File**: `proofs/Proofs/CircumferenceViaDifferentiationOQ01.lean`
- **`wc -l`**: 240 (canonical gallery convention — used by 96% of 2423 entries)
- **Before**: `lineCount: 241` (split-newline drift)
- **After**: `lineCount: 240`

No companion files; both meta fields point to the same primary file.

---
Automated fix by lean-mechanic agent.