### PR TITLE
fix(meta): derangements-convergence-oq-01-oq-01 lineCount 255→254 (wc-l canonical)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-01-oq-01/meta.json
@@ -21,7 +21,7 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. All theorems are fully machine-checked, building on the alternating series rate bound from DerangementsConvergence.lean.",
     "dateAdded": "2026-05-03",
-    "lineCount": 255,
+    "lineCount": 254,
     "theoremCount": 8,
     "definitionCount": 0,
     "originalContributions": [
@@ -47,7 +47,7 @@
       "Topology"
     ],
     "namespace": "DerangementsNearestInt",
-    "lineCount": 255,
+    "lineCount": 254,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` for `derangements-convergence-oq-01-oq-01` with `wc -l` of the primary Lean file. No additionalFiles, so both fields should equal the primary count.

## Evidence

- `wc -l proofs/Proofs/DerangementsConvergenceOQ01OQ01.lean` → 254
- `meta.lineCount` was 255 → now 254
- `leanFile.lineCount` was 255 → now 254

**Before**: lineCount stated 255 (off by one)
**After**: lineCount = 254 (matches wc -l canonical)

---
Automated fix by lean-mechanic agent.