### PR TITLE
audit(erdos-131): mark clean (cycle 7) — Non-Dividing Sets axiomatization verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4645,13 +4645,13 @@
       "result": "clean"
     },
     "erdos-131": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [
         "Phantom sorry/partial-verification claims for nondividing_implies_nonaveraging + section line drift across all 8 sections; counts correct; issue #14716",
         "#14734: residual phantom claims after PR #14724 — sections[0].summary still references nonexistent nondividing_equiv; originalContributions[0] claims false equivalence (nondividing_not_iff_alt proves they are NOT equivalent); sections[1].mathContext + sections[6].mathContext stale (summaries fixed, mathContext not); sections[4].mathContext LaTeX bug"
       ],
-      "lastAudited": "2026-05-02T10:54:29Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T22:43:48Z",
+      "result": "clean"
     },
     "erdos-131-oq-01": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Gallery integrity audit of erdos-131 (Erdős Problem #131: Non-Dividing Sets). All meta.json claims verified against `proofs/Proofs/Erdos131Problem.lean`.

## Verification

- **lineCount**: 556 (wc -l) ✓
- **axiomCount**: 2 — `pham_zakharov_upper_bound` (L130), `csaba_lower_bound` (L170) ✓
- **sorries**: 0 ✓ (lone match is "sorry-free" in line 545 docstring)
- **theoremCount**: 26 ✓ (20 public + 6 private theorems/lemmas)
- **definitionCount**: 6 ✓ (`IsNonDividing`, `IsNonDividingAlt`, `IsNonAveraging`, `F`, `erdos_131_open_question`, `g`)
- **status/badge**: `axiomatized` / `axiom` — honestly acknowledges 2 axioms (Tier C scaffold)
- **assumptions** field accurately names both axioms
- **No True stubs** at theorem level

Both bound axioms are actively used by proved theorems:
- `original_question_answered_no` (uses `pham_zakharov_upper_bound`)
- `erdos_original_conjecture_false` (uses `csaba_lower_bound`)

## Test plan

- [x] meta.json counts cross-checked against Lean source via grep + wc
- [x] Axiom names verified in Lean source
- [x] Status field consistent with axiom presence (Tier C)
- [x] No phantom or misnamed axiom references in `originalContributions`/`assumptions`