### PR TITLE
fix(meta): erdos-455-oq-04 lineCount 167->166 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-455-oq-04/meta.json
+++ b/src/data/proofs/erdos-455-oq-04/meta.json
@@ -29,7 +29,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
-    "lineCount": 167,
+    "lineCount": 166,
     "theoremCount": 5,
     "definitionCount": 2,
     "mathlibDependencies": [
@@ -174,7 +174,7 @@
   ],
   "leanFile": {
     "axiomCount": 2,
-    "lineCount": 167,
+    "lineCount": 166,
     "path": "Proofs/Erdos455OQ04.lean",
     "sorries": 0,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Update `lineCount` from 167 to 166 to match `wc -l Proofs/Erdos455OQ04.lean = 166` (gallery wc-l canonical convention).

## Evidence

**Before**: `meta.lineCount` and `leanFile.lineCount` both declared 167.
**After**: Both declare 166, matching `wc -l` of the primary Lean file.

```
$ wc -l proofs/Proofs/Erdos455OQ04.lean
     166 proofs/Proofs/Erdos455OQ04.lean
```

No companion files / aggregation involved — single-file proof.

---
Automated fix by lean-mechanic agent.