### PR TITLE
fix(meta): twin-primes-special-oq-01 lineCount 151->150 (wc-l canonical)

### DIFF
--- a/src/data/proofs/twin-primes-special-oq-01/meta.json
+++ b/src/data/proofs/twin-primes-special-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 151,
+    "lineCount": 150,
     "theoremCount": 25,
     "definitionCount": 0,
     "assumptions": "1 axiom: `twin_prime_conjecture` (inherited from parent TwinPrimes.lean, states the unproved Twin Prime Conjecture).",
@@ -221,7 +221,7 @@
       "TwinPrimes"
     ],
     "namespace": "TwinPrimesSpecialOQ01",
-    "lineCount": 151,
+    "lineCount": 150,
     "axiomCount": 0,
     "theoremCount": 25,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync recorded lineCount with actual `wc -l` of primary Lean file.

## Evidence

```
$ wc -l proofs/Proofs/TwinPrimesSpecialOQ01.lean
     150 proofs/Proofs/TwinPrimesSpecialOQ01.lean
```

**Before**: `meta.lineCount = leanFile.lineCount = 151`
**After**:  `meta.lineCount = leanFile.lineCount = 150`

Single-file primary (no companion / additionalFiles) — no aggregate to preserve.

Aligns with the wc-l canonical convention used across the gallery (~96% of 2423 entries; recent precedents #21560 abel-ruffini-oq-04, #21640 angle-trisection-oq-01, #21638 erdos-1179-oq-01).

---

Automated fix by lean-mechanic agent.