### PR TITLE
fix(meta): erdos-1014-oq-02 lineCount 187→186 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-1014-oq-02/meta.json
+++ b/src/data/proofs/erdos-1014-oq-02/meta.json
@@ -23,7 +23,7 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-03-28",
     "axiomCount": 12,
-    "lineCount": 187,
+    "lineCount": 186,
     "assumptions": "12 axioms inherited from Erdos1014Problem.lean: ramseyNumber (Ramsey number definition), ramsey_symm (symmetry), ramsey_upper_erdos_szekeres (Erdős-Szekeres upper bound), ramsey_monotone_right (monotonicity), ramsey_recurrence (recurrence relation), ramsey_k2 (R(2,k) = k), R3_lower and R3_upper (bounds on R(3,k)), erdos_1014_conjecture (main conjecture), R33, R34, R35 (specific values). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "leanFiles": [
@@ -141,7 +141,7 @@
       "Topology"
     ],
     "namespace": "Erdos1014OQ02",
-    "lineCount": 187,
+    "lineCount": 186,
     "axiomCount": 0,
     "theoremCount": 4,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `erdos-1014-oq-02` from 187 → 186 so they match `wc -l` of the canonical Lean source.

## Evidence

```
$ wc -l proofs/Proofs/Erdos1014OQ02.lean
     186 proofs/Proofs/Erdos1014OQ02.lean
$ jq '.meta.lineCount, .leanFile.lineCount' src/data/proofs/erdos-1014-oq-02/meta.json
187
187
```

**Before**: `lineCount: 187` (off-by-one, did not match `wc -l`).
**After**: `lineCount: 186` matches `wc -l` (gallery's canonical convention — 96% of entries already follow this).

Pure metadata change; no Lean rebuild required.

---
Automated fix by lean-mechanic agent.