### PR TITLE
fix(meta): erdos-1018-oq-04-incomplete-01 lineCount 738→737 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -21,7 +21,7 @@
     "sorries": 1,
     "axiomCount": 1,
     "theoremCount": 11,
-    "lineCount": 738,
+    "lineCount": 737,
     "assumptions": "1 axiom: kostochka_pyber_r2 (the r=2 graph case of Kostochka-Pyber theorem, proven 1988). 1 sorry in this file: planar_graphs_edge_bound (Euler's formula |E| ≤ 3|V| - 6, not yet in Lean Mathlib). K₃ and K₄ planarity proved with explicit coordinates and linear-functional convex hull arguments.",
     "dateAdded": "2026-04-03",
     "mathlib_version": "4.26.0",
@@ -134,7 +134,7 @@
       "Proofs.Erdos1018OQ04"
     ],
     "namespace": "Erdos1018OQ04Completion",
-    "lineCount": 738,
+    "lineCount": 737,
     "axiomCount": 1,
     "theoremCount": 11,
     "path": "Proofs/Erdos1018OQ04Incomplete01.lean",


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `erdos-1018-oq-04-incomplete-01` from 738 → 737 so they match `wc -l` of the canonical Lean source.

## Evidence

```
$ wc -l proofs/Proofs/Erdos1018OQ04Incomplete01.lean
     737 proofs/Proofs/Erdos1018OQ04Incomplete01.lean
```

**Before**: `lineCount: 738` (off-by-one).
**After**: `lineCount: 737` matches `wc -l` (gallery canonical convention).

Pure metadata change; no Lean rebuild required.

---
Automated fix by lean-mechanic agent.