### PR TITLE
fix(meta): erdos-1034 lineCount 779→778 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-1034/meta.json
+++ b/src/data/proofs/erdos-1034/meta.json
@@ -26,7 +26,7 @@
       "erdos-1033"
     ],
     "axiomCount": 1,
-    "lineCount": 779,
+    "lineCount": 778,
     "assumptions": "1 axiom: maTang_counterexample. 3 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 16,
@@ -278,7 +278,7 @@
       "Finset"
     ],
     "namespace": "Erdos1034",
-    "lineCount": 779,
+    "lineCount": 778,
     "axiomCount": 1,
     "theoremCount": 16,
     "definitionCount": 23,


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `erdos-1034` from 779 → 778 so they match `wc -l` of the canonical Lean source.

## Evidence

```
$ wc -l proofs/Proofs/Erdos1034Problem.lean
     778 proofs/Proofs/Erdos1034Problem.lean
```

**Before**: `lineCount: 779` (off-by-one).
**After**: `lineCount: 778` matches `wc -l` (gallery canonical convention).

Pure metadata change; no Lean rebuild required.

---
Automated fix by lean-mechanic agent.