### PR TITLE
fix(meta): ballot-problem-oq-03-oq-01-oq-02 lineCount 399→398 (wc-l canonical)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01-oq-02/meta.json
@@ -27,7 +27,7 @@
     "dateAdded": "2026-04-21",
     "axiomCount": 0,
     "assumptions": "3 open sorries (aggregate across additionalFiles): gnwProb_key (GNW 1979 probabilistic exchange argument for ≥2 corners) + 2 in BallotProblemOQ03OQ01OQ02Aristotle.lean. Axiom-free; all axiom declarations are 0.",
-    "lineCount": 399,
+    "lineCount": 398,
     "theoremCount": 16,
     "definitionCount": 1,
     "originalContributions": [
@@ -95,7 +95,7 @@
       "LGV"
     ],
     "namespace": "HookLengthFormula",
-    "lineCount": 399,
+    "lineCount": 398,
     "axiomCount": 0,
     "sorries": 0,
     "path": "Proofs/BallotProblemOQ03OQ01OQ02.lean",


### PR DESCRIPTION
## Fix

Update `meta.lineCount` and `leanFile.lineCount` for `ballot-problem-oq-03-oq-01-oq-02` from 399 → 398 to match the gallery's wc-l canonical convention.

## Evidence

```
$ wc -l proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
     398 proofs/Proofs/BallotProblemOQ03OQ01OQ02.lean
```

**Before**: `meta.lineCount = 399`, `leanFile.lineCount = 399` (split-newline counting).
**After**: both = 398 (wc-l canonical, primary file only — `additionalFiles` line counts not aggregated for this entry).

Per the gallery convention (96% of 2423 entries on wc-l), `leanFile.lineCount` reflects wc-l of the primary file declared at `meta.proofRepoPath`. The companion files in `additionalFiles` keep their own per-file counts elsewhere.

---
Automated fix by lean-mechanic agent.