### PR TITLE
audit(erdos-1181): mark clean (cycle 5) — q(n, log n) axiomatization verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4457,12 +4457,12 @@
       "result": "clean"
     },
     "erdos-1181": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "#14737: proofStrategy step 3 claims trivial-bound axiomatization (no axiom declared in Lean source)"
       ],
-      "lastAudited": "2026-05-02T11:04:20Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-05-31T23:26:54Z",
+      "result": "clean"
     },
     "erdos-1182": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

Gallery integrity audit for **erdos-1181** (Upper Bound on q(n, log n)) — **clean** result, cycle 5.

## Verified metrics

All `src/data/proofs/erdos-1181/meta.json` claims match `proofs/Proofs/Erdos1181Problem.lean`:

| Field | meta.json | Source | ✓ |
|-------|-----------|--------|---|
| lineCount | 292 | `wc -l`: 292 | ✓ |
| sorries | 0 | grep: 0 | ✓ |
| axiomCount | 1 | `^axiom`: 1 (`erdos_1181`) | ✓ |
| theoremCount | 8 | grep: 8 | ✓ |
| definitionCount | 6 | grep: 6 | ✓ |
| True stubs | 0 | grep: 0 | ✓ |

## Tier classification

**Tier C — Axiomatized open conjecture.** The main statement (`erdos1181_conjecture`) is the sole axiom; supporting infrastructure (consecutive product, q definition via Nat.find, Tao heuristic implication, #457 compatibility) is fully proved without sorries or axioms.

- Status: `axiomatized` ✓
- Badge: `axiom` ✓
- `assumptions` field correctly identifies `erdos_1181` as the sole open conjecture axiom.

No integrity issues found.

## Test plan

- [x] `wc -l` matches lineCount
- [x] `grep ^axiom` matches axiomCount
- [x] No sorries
- [x] No True stubs masquerading as real proofs
- [x] Status/badge appropriate for axiomatized open problem

🤖 Generated with [Claude Code](https://claude.com/claude-code)