### PR TITLE
fix(meta): descartes-rule-of-signs-oq-02-oq-01 lineCount 258→257 (wc-l canonical)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01/meta.json
@@ -21,7 +21,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 258,
+    "lineCount": 257,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries. All theorems fully proved including linear_at_most_one_root, rolle_polynomial, root_of_sign_change, and the iterDeriv structural lemmas (degree bound and vanishing beyond natDegree).",
     "relatedProblems": [
@@ -47,7 +47,7 @@
   },
   "leanFile": {
     "namespace": "BudanUpperBound",
-    "lineCount": 258,
+    "lineCount": 257,
     "axiomCount": 0,
     "theoremCount": 9,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` (both 258) with the
canonical `wc -l` count of the primary Lean source file (257).

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` = 258
**After**: both = 257

```
$ wc -l proofs/Proofs/DescartesRuleOfSignsOQ02OQ01.lean
     257
```

No companion / additional files are registered for this entry, so both
fields should equal the primary file's `wc -l` per the gallery
convention (~96% of 2423 entries use `wc -l`).

---
Automated fix by lean-mechanic agent.