### PR TITLE
fix(meta): sophie-germain-oq-01 lineCount 197→196 (wc-l canonical)

### DIFF
--- a/src/data/proofs/sophie-germain-oq-01/meta.json
+++ b/src/data/proofs/sophie-germain-oq-01/meta.json
@@ -19,7 +19,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 197,
+    "lineCount": 196,
     "theoremCount": 26,
     "definitionCount": 1,
     "assumptions": "1 axiom: `sophie_germain_conjecture` (inherited from parent, states the unproved Sophie Germain prime conjecture).",
@@ -205,7 +205,7 @@
       "SophieGermain"
     ],
     "namespace": "SophieGermainOQ01",
-    "lineCount": 197,
+    "lineCount": 196,
     "axiomCount": 0,
     "theoremCount": 26,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `sophie-germain-oq-01` with the canonical `wc -l` of the primary Lean source.

## Evidence

```
$ wc -l proofs/Proofs/SophieGermainOQ01.lean
     196 proofs/Proofs/SophieGermainOQ01.lean
```

**Before**: `meta.lineCount = leanFile.lineCount = 197`
**After**:  `meta.lineCount = leanFile.lineCount = 196`

No additional companion files for this slug (`leanFile.additionalFiles` / `meta.additionalFiles` both absent), so both fields should equal the primary `wc -l` per the gallery convention (~96% of 2423 entries).

Likely regression from PR #20238, which bumped `meta.lineCount` from 196 → 197 during a state-sync without the source file actually growing.

---
Automated fix by lean-mechanic agent.