### PR TITLE
fix(meta): erdos-1095 lineCount 181→180 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -24,7 +24,7 @@
     "erdosProblemStatus": "open",
     "axiomCount": 7,
     "assumptions": "7 axioms: g (function), g_gt, g_spec, g_minimal, ees_lower_bound, ees_upper_bound, konyagin_lower_bound. 0 sorries. Concrete values g(2)=6, g(3)=7, g(4)=7, g(5)=23 are proved theorems.",
-    "lineCount": 181,
+    "lineCount": 180,
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
     "definitionCount": 6
@@ -187,7 +187,7 @@
       "BigOperators"
     ],
     "namespace": "Erdos1095",
-    "lineCount": 181,
+    "lineCount": 180,
     "axiomCount": 7,
     "theoremCount": 6,
     "definitionCount": 6,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `erdos-1095` with the canonical `wc -l` count of the primary Lean file.

## Evidence

```
$ wc -l proofs/Proofs/Erdos1095Problem.lean
180 proofs/Proofs/Erdos1095Problem.lean
```

**Before**: `lineCount: 181` (both `meta.lineCount` and `leanFile.lineCount`)
**After**: `lineCount: 180`

No companion file aggregation in this slug; both fields tracked the primary file (same value), so both move together.

---
Automated fix by lean-mechanic agent.