### PR TITLE
audit(erdos-1179): mark clean — Erdős-Hall uniform subset-sum axiomatization

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4439,9 +4439,9 @@
     },
     "erdos-1179": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-02T10:47:13Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-05-31T23:48:01Z",
+      "result": "clean",
       "notes": "#14732: phantom axioms (erdos_renyi_upper, gEps_mono not declared; main_asymptotic now theorem main_asymptotic_derived; trivial_lower_bound→basic_lower_bound) in originalContributions/sections; section line drift (sections cover 1-178 of 316-line file; Parts IX, X missing); proofStrategy says 179-line file"
     },
     "erdos-1179-oq-01": {


### PR DESCRIPTION
## Summary

Re-audit of `erdos-1179` (Erdős Problem #1179: Uniform Subset Sum Representations in Abelian Groups). All integrity checks pass; tracker updated from `issues-fixed` (cycle May 2 fixes per #14732) to `clean`.

## Integrity Checks

- **status** `axiomatized` / **badge** `axiom` — correct (3-axiom file)
- **axioms** (3 declared, matches `axiomCount: 3`):
  - `gEps` (line 112)
  - `basic_lower_bound` (line 123)
  - `erdos_hall_upper` (line 144)
- **sorries** 0 (matches `grep -c sorry`)
- **lineCount** 316 matches `wc -l proofs/Proofs/Erdos1179Problem.lean`
- **theoremCount** 10, **definitionCount** 3 (`reprCount`, `expectedReprCount`, `IsEpsUniform`) — match grep
- **No True stubs**
- **No Mathlib-wrapper overclaim**: file builds infrastructure + cites Erdős-Hall as axiom

## Tracker Diff

```
- auditCount: 4
- lastAudited: 2026-05-02T10:47:13Z
- result: issues-fixed
+ auditCount: 5
+ lastAudited: 2026-05-31T23:48:01Z
+ result: clean
```

## Test plan
- [x] axiom count grep matches meta.json `axiomCount`
- [x] sorry count grep matches meta.json `sorries`
- [x] `wc -l` matches `lineCount`
- [x] No True stubs
- [x] originalContributions reference real symbols in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)