### PR TITLE
fix(meta): erdos-1161 lineCount 324->323 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -54,7 +54,7 @@
       "Small cases: explicit counts for S_1, S_2, S_3"
     ],
     "axiomCount": 0,
-    "lineCount": 324,
+    "lineCount": 323,
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "theoremCount": 15,
     "definitionCount": 3
@@ -145,7 +145,7 @@
       "Nat"
     ],
     "namespace": null,
-    "lineCount": 324,
+    "lineCount": 323,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

Sync recorded lineCount with actual `wc -l` of the primary Lean file for the `erdos-1161` gallery entry.

## Evidence

- `wc -l proofs/Proofs/Erdos1161Problem.lean` → **323**
- Both `meta.lineCount` and `leanFile.lineCount` were **324**
- No `additionalFiles` entries, so the two recorded counts must match the primary `wc -l`.

**Before**: both lineCount fields = 324
**After**: both lineCount fields = 323

---
Automated fix by lean-mechanic agent (wc-l canonical convention; no companion file).