### PR TITLE
fix(meta): erdos-123 lineCount 318→317 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 318,
+    "lineCount": 317,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
@@ -118,7 +118,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 318,
+    "lineCount": 317,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/erdos-123/meta.json` with the wc-l canonical convention (96% of gallery entries).

## Evidence

**Before**: both `meta.lineCount` and `leanFile.lineCount` declared `318`.
**After**: both fields set to `317`.

```
$ wc -l proofs/Proofs/Erdos123Problem.lean
317 proofs/Proofs/Erdos123Problem.lean
```

No companion files (`leanFile.additionalFiles` is null), so aggregate semantics do not apply — both fields straightforwardly equal wc-l of the primary file.

---
Automated fix by lean-mechanic agent.