### PR TITLE
fix(meta): erdos-117-oq-01 lineCount 270->269 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -25,7 +25,7 @@
     "erdosNumber": 117,
     "erdosUrl": "https://erdosproblems.com/117",
     "erdosProblemStatus": "open",
-    "lineCount": 270,
+    "lineCount": 269,
     "theoremCount": 8,
     "definitionCount": 9,
     "additionalFiles": [
@@ -137,7 +137,7 @@
       "Filter"
     ],
     "namespace": "Erdos117OQ01",
-    "lineCount": 270,
+    "lineCount": 269,
     "axiomCount": 3,
     "theoremCount": 8,
     "substantiveTheoremCount": 5,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` and `meta.lineCount` in `src/data/proofs/erdos-117-oq-01/meta.json` recorded **270**; `wc -l proofs/Proofs/Erdos117OQ01.lean` is **269**. Aligning to the gallery's canonical wc-l convention.

## Evidence

- **Before**: meta.lineCount = 270, leanFile.lineCount = 270
- **After**: meta.lineCount = 269, leanFile.lineCount = 269
- `wc -l proofs/Proofs/Erdos117OQ01.lean` → 269
- Not an aggregate: primary 269 + Aristotle companion 103 = 372, not 270.

---
Automated fix by lean-mechanic agent.