### PR TITLE
fix(meta): erdos-123 lineCount 318->317 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/123",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 318,
+    "lineCount": 317,
     "assumptions": "3 axiom(s): powers23_repr, erdos_123_conjecture, erdos_lewin_357. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 22,
@@ -118,7 +118,7 @@
       "Pointwise"
     ],
     "namespace": "Erdos123",
-    "lineCount": 318,
+    "lineCount": 317,
     "axiomCount": 3,
     "theoremCount": 22,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` and `meta.lineCount` in `src/data/proofs/erdos-123/meta.json` recorded **318**; `wc -l proofs/Proofs/Erdos123Problem.lean` is **317**. Aligning to the gallery's canonical wc-l convention.

## Evidence

- **Before**: meta.lineCount = 318, leanFile.lineCount = 318
- **After**: meta.lineCount = 317, leanFile.lineCount = 317
- `wc -l proofs/Proofs/Erdos123Problem.lean` → 317
- No additionalFiles, so not an aggregate.

---
Automated fix by lean-mechanic agent.