### PR TITLE
fix(meta): erdos-238 lineCount 346→345 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-238/meta.json
+++ b/src/data/proofs/erdos-238/meta.json
@@ -28,7 +28,7 @@
       "Nat.nth for prime enumeration",
       "Asymptotic analysis (big-O, little-o)"
     ],
-    "lineCount": 346,
+    "lineCount": 345,
     "assumptions": "2 axioms: erdos_partial_result, prime_number_theorem_asymptotic. See Lean source for complete statements.",
     "theoremCount": 12,
     "definitionCount": 10
@@ -226,7 +226,7 @@
       "Real"
     ],
     "namespace": "Erdos238",
-    "lineCount": 346,
+    "lineCount": 345,
     "axiomCount": 2,
     "theoremCount": 12,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Align `erdos-238` meta.json `lineCount` fields with the canonical `wc -l` convention.

## Evidence

**Before**: `meta.lineCount = 346` and `leanFile.lineCount = 346`
**After**: `meta.lineCount = 345` and `leanFile.lineCount = 345`
**Actual**: `wc -l proofs/Proofs/Erdos238Problem.lean` → 345

No companion files / aggregates to preserve. Gallery convention is `wc -l` (96% of 2423 entries — see prior fixes #21638, #21639, #21640).

---
Automated fix by lean-mechanic agent.