### PR TITLE
audit(erdos-1177): mark clean — 3-uniform hypergraph forbidden subgraph conjectures verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4427,9 +4427,9 @@
     },
     "erdos-1177": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T11:12:05Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T00:09:40Z",
+      "result": "clean"
     },
     "erdos-1178": {
       "auditCount": 3,


### PR DESCRIPTION
## Audit Summary

Integrity audit of `erdos-1177` (Erdős-Galvin-Hajnal three conjectures about F_G(κ) = 3-uniform hypergraphs with chromatic number κ avoiding G).

**Result:** clean ✅

## Verification Details

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `lineCount` | 206 | `wc -l` = 206 | ✓ |
| `sorries` | 0 | 0 | ✓ |
| `axiomCount` | 5 | 5 `axiom` decls | ✓ |
| True stubs | (n/a) | 0 | ✓ |
| `theoremCount` | 7 | 7 | ✓ |
| `definitionCount` | 6 | 6 | ✓ |
| `status` / `badge` | `axiomatized` / `axiom` | matches open-problem axiomatization | ✓ |

## Tier Classification

**Tier C** — Scaffold / axiomatized. Three open conjectures stated formally; abstract `Hypergraph3` type with 4 operations is axiomatized. Cardinal lemmas (ℵ₀ < ℵ₁, ℵ₁ uncountable, ℵ₁ ≤ 2^(2^ℵ₀)) are *proved* from Mathlib's `Cardinal` API (no Cardinal axioms). Two relational theorems and antimonotonicity lemmas are real proofs.

No overclaiming detected:
- Public status correctly states `axiomatized` for an open Erdős problem
- `assumptions` field documents 5 axioms
- No `sorry` masquerading as `verified`

## Tracker Update

`erdos-1177` auditCount 3 → 4, result `issues-fixed` → `clean`, lastAudited bumped to 2026-06-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)