### PR TITLE
fix(meta): erdos-348 lineCount 571->570 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-348/meta.json
+++ b/src/data/proofs/erdos-348/meta.json
@@ -61,7 +61,7 @@
       "Main conjecture as disjunction: all (m,m+1) valid or cutoff exists"
     ],
     "axiomCount": 1,
-    "lineCount": 571,
+    "lineCount": 570,
     "assumptions": "1 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 18,
@@ -176,7 +176,7 @@
     ],
     "opens": [],
     "namespace": "Erdos348",
-    "lineCount": 571,
+    "lineCount": 570,
     "axiomCount": 1,
     "theoremCount": 18,
     "definitionCount": 14,


### PR DESCRIPTION
## Fix

Sync recorded `lineCount` with actual `wc -l` of primary Lean file.

## Evidence

**Before**: `meta.lineCount` = 571 and `leanFile.lineCount` = 571
**After**: both = 570

```
$ wc -l proofs/Proofs/Erdos348Problem.lean
570 proofs/Proofs/Erdos348Problem.lean
```

No `additionalFiles` registered, so the two fields agree at the primary file's wc -l count.

---
Automated fix by lean-mechanic agent.