### PR TITLE
fix(meta): pell-equation-oq-01 lineCount 196->195 (wc-l canonical)

### DIFF
--- a/src/data/proofs/pell-equation-oq-01/meta.json
+++ b/src/data/proofs/pell-equation-oq-01/meta.json
@@ -20,7 +20,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "dateAdded": "2026-03-30",
-    "lineCount": 196,
+    "lineCount": 195,
     "originalContributions": [
       "pellNorm and pellRegulator definitions",
       "pellNorm_pos_of_pos: norm bound for positive solutions",
@@ -107,7 +107,7 @@
     ]
   },
   "leanFile": {
-    "lineCount": 196,
+    "lineCount": 195,
     "axiomCount": 0,
     "path": "Proofs/PellEquationOQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync `lineCount` for `pell-equation-oq-01` with `wc -l` canonical convention (the 96% gallery norm).

## Evidence

**Before**: `meta.lineCount = 196`, `leanFile.lineCount = 196`
**After**:  `meta.lineCount = 195`, `leanFile.lineCount = 195`

- `wc -l proofs/Proofs/PellEquationOQ01.lean` -> `195`
- No `additionalFiles`, so primary count == aggregate count
- Follows the same wc-l canonicalization pattern as #21560, #21561, #21638-#21644

---
Automated fix by lean-mechanic agent.