### PR TITLE
fix(meta): erdos-303 lineCount 259->258 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -54,7 +54,7 @@
       "Connection to density version (Erdős #302)"
     ],
     "axiomCount": 2,
-    "lineCount": 259,
+    "lineCount": 258,
     "assumptions": "2 axioms: brownRodl_theorem, erdos303_true. See Lean source for complete statements.",
     "theoremCount": 8,
     "definitionCount": 8
@@ -146,7 +146,7 @@
       "Set"
     ],
     "namespace": "Erdos303",
-    "lineCount": 259,
+    "lineCount": 258,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Align `meta.lineCount` and `leanFile.lineCount` for `erdos-303` to the wc-l canonical count.

## Evidence

`wc -l proofs/Proofs/Erdos303Problem.lean` = `258` (final line has no trailing newline).

**Before**: `lineCount: 259` (both at `meta.lineCount` and `leanFile.lineCount`)
**After**:  `lineCount: 258`

No companion / additional files registered for this proof, so no aggregate to preserve.

---
Automated fix by lean-mechanic agent.