### PR TITLE
fix(meta): napoleons-theorem lineCount 356->355 (wc-l canonical)

### DIFF
--- a/src/data/proofs/napoleons-theorem/meta.json
+++ b/src/data/proofs/napoleons-theorem/meta.json
@@ -44,7 +44,7 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 356,
+    "lineCount": 355,
     "assumptions": "0 axioms. 0 sorries. Fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
@@ -185,7 +185,7 @@
       "Real"
     ],
     "namespace": "NapoleonsTheorem",
-    "lineCount": 356,
+    "lineCount": 355,
     "axiomCount": 0,
     "theoremCount": 15,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Update `napoleons-theorem` meta `lineCount` from 356 to 355 to match `wc -l` of `proofs/Proofs/NapoleonsTheorem.lean` (gallery canonical convention).

## Evidence

**Before**: `meta.lineCount = 356` and `leanFile.lineCount = 356`
**After**: both `355`, matching `wc -l proofs/Proofs/NapoleonsTheorem.lean = 355`

Proof has no companion/additional files, so both fields should equal `wc -l` of the primary file.

---
Automated fix by lean-mechanic agent.