### PR TITLE
fix(meta): erdos-624 lineCount 219->218 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -57,7 +57,7 @@
     ],
     "dateAdded": "2025-12-27",
     "axiomCount": 5,
-    "lineCount": 219,
+    "lineCount": 218,
     "assumptions": "5 axioms: erdos_hajnal_upper_bound, erdos_624_open, weaker_conjecture_open, and 2 more. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
@@ -174,7 +174,7 @@
       "Set"
     ],
     "namespace": "Erdos624",
-    "lineCount": 219,
+    "lineCount": 218,
     "axiomCount": 5,
     "theoremCount": 4,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/erdos-624/meta.json` lineCount fields with `wc -l` of the primary Lean file (gallery-canonical convention, 96% of entries).

## Evidence

```
$ wc -l proofs/Proofs/Erdos624Problem.lean
218 proofs/Proofs/Erdos624Problem.lean
```

**Before**: `meta.lineCount: 219`, `leanFile.lineCount: 219`
**After**:  `meta.lineCount: 218`, `leanFile.lineCount: 218`

No `additionalFiles`, so primary count == aggregate count. Both fields move together.

---
Automated fix by lean-mechanic agent.