### PR TITLE
Research: minpoly-charpoly-oq-01 S8 ACT — jordanBlock semisimple/nilpotent decomp + S7 build-fix (3081 jobs)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ01.lean
@@ -233,6 +233,40 @@ theorem jordanBlock_zero_dim (R : Type*) [CommRing R] (lam : R) :
     jordanBlock R lam 0 = 0 := by
   ext i j; exact Fin.elim0 i
 
+/-! ## S8: semisimple/nilpotent decomposition of a Jordan block
+
+Every Jordan block factors as the eigenvalue acting by scalar multiplication on
+the identity plus the "nilpotent shift" — the eigenvalue-zero Jordan block of
+the same size. This is the Jordan-Chevalley decomposition specialised to a
+single block: the `λ • 1` part is semisimple (a scalar) and `jordanBlock R 0 d`
+is the strict upper-shift, which is nilpotent (its `d`-th power is zero).
+
+The lemma exposes the structural split as an entry-wise equality and so
+transfers any result proved for the eigenvalue-zero case (the OQ-01-OQ-02
+nilpotent canonical form target) to general eigenvalues. It is also the entry-
+wise version of `Module.End.exists_isNilpotent_isSemisimple` (Mathlib
+v4.26.0, `LinearAlgebra/JordanChevalley.lean`) at the block level.
+
+Pure API; no new definitions. -/
+
+/-- **S8**: a Jordan block decomposes as `λ • 1 + jordanBlock R 0 d`. The
+`λ • 1` summand is the (commuting) semisimple part — acting by `λ` on every
+basis vector — and `jordanBlock R 0 d` is the strict upper-shift, which is
+nilpotent. This is the entry-wise Jordan-Chevalley decomposition specialised
+to a single block. -/
+theorem jordanBlock_eq_lam_smul_one_add_zero_block (R : Type*) [CommRing R]
+    (lam : R) (d : Nat) :
+    jordanBlock R lam d =
+      lam • (1 : Matrix (Fin d) (Fin d) R) + jordanBlock R 0 d := by
+  ext i j
+  simp only [jordanBlock, Matrix.add_apply, Matrix.smul_apply, Matrix.one_apply,
+             smul_eq_mul, mul_ite, mul_one, mul_zero]
+  by_cases hij : i = j
+  · simp [hij]
+  · by_cases hs : (j : Nat) = (i : Nat) + 1
+    · simp [hij, hs]
+    · simp [hij, hs]
+
 /-! ## S3 candidate D: cardinality of `eigenvalueMultiset` equals `totalDim`
 
 A small but useful API lemma about `JordanBlockShape`: the cardinality of the
@@ -376,7 +410,7 @@ theorem JordanBlockShape.totalDim_eq_zero_iff_blocks_empty
     | [] => rfl
     | p :: rest =>
       exfalso
-      have hp_mem : p ∈ S.blocks := by rw [hb]; exact List.mem_cons_self _ _
+      have hp_mem : p ∈ S.blocks := by rw [hb]; exact List.mem_cons_self
       have hp_pos : 0 < p.2 := S.pos p hp_mem
       have hs : (S.blocks.map Prod.snd).sum = p.2 + (rest.map Prod.snd).sum := by
         rw [hb]; simp [List.map_cons, List.sum_cons]

--- a/research/problems/minpoly-charpoly-oq-01/state.md
+++ b/research/problems/minpoly-charpoly-oq-01/state.md
@@ -1,9 +1,71 @@
 # Current State
 
-**Phase**: ACT (S7 this PR — adds `JordanBlockShape.totalDim_eq_zero_iff_blocks_empty` API lemma, +1 theorem, +31 LOC). Pure additive API, no def or sorry change. INFRA recovered: G7+G8 GREEN, G9 still RED (Docker bypasses).
-**Since**: 2026-05-12 (S1 OBSERVE by researcher-12; S2 ACT by researcher-6; S3 ACT by researcher-4; S4-E ACT by researcher-9 MERGED [#19123](https://github.com/rjwalters/lean-genius/pull/19123) 2026-05-15T22:58:16Z; S5 STATE-SYNC by researcher-1 MERGED [#19781](https://github.com/rjwalters/lean-genius/pull/19781) 2026-05-16T12:19:55Z; S6 STATE-SYNC by researcher-11 2026-05-17)
-**Iteration**: 7
-**Last Updated**: 2026-05-30T18:50:00Z (S7 ACT, researcher-1)
+**Phase**: ACT (S8 this PR — adds `jordanBlock_eq_lam_smul_one_add_zero_block` API lemma, +1 theorem, ~+34 LOC; ALSO fixes S7 PR #21220 v4.26.0 build break — `List.mem_cons_self _ _` → `List.mem_cons_self`). Pure additive API + 1-line S7 fix, no def or sorry change. Exposes the entry-wise Jordan-Chevalley split `λ • 1 + jordanBlock R 0 d` of a Jordan block. **Docker build-verified: 3081/3081 jobs**.
+**Since**: 2026-05-12 (S1 OBSERVE by researcher-12; S2 ACT by researcher-6; S3 ACT by researcher-4; S4-E ACT by researcher-9 MERGED [#19123](https://github.com/rjwalters/lean-genius/pull/19123) 2026-05-15T22:58:16Z; S5 STATE-SYNC by researcher-1 MERGED [#19781](https://github.com/rjwalters/lean-genius/pull/19781) 2026-05-16T12:19:55Z; S6 STATE-SYNC by researcher-11 MERGED [#20027](https://github.com/rjwalters/lean-genius/pull/20027) 2026-05-17T02:23:09Z; S7 ACT by researcher-1 MERGED [#21220](https://github.com/rjwalters/lean-genius/pull/21220) 2026-05-31T00:36:40Z)
+**Iteration**: 8
+**Last Updated**: 2026-05-31T22:10:00Z (S8 ACT, researcher-1)
+
+## S8 ACT Summary (2026-05-31, researcher-1)
+
+**Mode**: ACT (small focused API addition — entry-wise Jordan-Chevalley decomposition of a single block).
+
+### Deliverable
+
+Augmented `proofs/Proofs/MinpolyCharpolyOQ01.lean` with one public theorem:
+
+**`jordanBlock_eq_lam_smul_one_add_zero_block`** — `jordanBlock R λ d = λ • 1 + jordanBlock R 0 d` for any commutative ring `R`, scalar `λ`, and dimension `d`. The `λ • 1` summand is the semisimple part (a scalar acting on the identity); `jordanBlock R 0 d` is the strict upper-shift, which is nilpotent (its `d`-th power vanishes). This is the entry-wise version of Mathlib's `Module.End.exists_isNilpotent_isSemisimple` (`LinearAlgebra/JordanChevalley.lean`) specialised to a single Jordan block.
+
+### Why this matters
+
+Any future eigenvalue-zero result (the OQ-01-OQ-02 nilpotent canonical form target) lifts to general eigenvalues by adding `λ • 1`. The lemma is the structural API surface for that transfer, and removes the need to repeat eigenvalue-shifting arguments at each downstream use site.
+
+### Design choices
+
+* **`λ • 1 + jordanBlock R 0 d`, not `jordanBlock R λ d - λ • 1 = jordanBlock R 0 d`.** Both forms are equivalent, but the additive form is more natural for downstream `rw` users who want to *replace* `jordanBlock R λ d` with its decomposition.
+* **`Matrix.add_apply`/`Matrix.smul_apply`/`Matrix.one_apply` + `smul_eq_mul`/`mul_ite`.** The proof uses an `ext` reduction followed by entry-wise case-analysis on `i = j` and `(j : Nat) = (i : Nat) + 1`, identical structure to the S1/S2 entry-wise lemmas. The `simp only` set keeps the proof inspectable rather than collapsing to a black-box `simp`.
+* **No new defs.** Pure API addition on the existing `jordanBlock`. Definition count stable at 3 since S2.
+
+### File deltas
+
+* `proofs/Proofs/MinpolyCharpolyOQ01.lean`: 387 → 421 lines (+34, of which ~+15 are the new lemma and ~+19 are the section docstring).
+* Sorries: 5 (raw count; 1 tactic at line 342 + 4 commentary mentions — unchanged).
+* Axioms: 0 (unchanged).
+* Theorems: 11 → 12 (added `jordanBlock_eq_lam_smul_one_add_zero_block`).
+* Definitions: 3 (unchanged).
+
+### Build status
+
+**Docker build-verified: 3081/3081 jobs, 7.1s for the target file.** Build log: `/tmp/research-builds/minpoly-charpoly-oq-01-s8-retry.log`. The only warning is the expected `declaration uses 'sorry'` on the load-bearing `jordan_normal_form_exists` at line 366 (now-shifted from line 342 due to S8 additions). Per memory `project_lake_self_loop_main_repo` (G9 self-symlink inert for Docker), the Docker `-v` mount overrides the symlink; build path was unaffected.
+
+### S7 build-bug discovered and fixed (this PR)
+
+PR [#21220](https://github.com/rjwalters/lean-genius/pull/21220) (S7 ACT, researcher-1, merged 2026-05-31T00:36:40Z) shipped with "Not run in this session" build status. The S8 Docker build of the post-merge file revealed a Mathlib v4.26.0 API drift in the S7 proof body at the (then) line 413:
+
+```
+error: Proofs/MinpolyCharpolyOQ01.lean:413:54: Function expected at
+  List.mem_cons_self
+but this term has type
+  ?m.48 ∈ ?m.48 :: ?m.49
+```
+
+In Lean core v4.26.0 (`~/.elan/toolchains/leanprover--lean4---v4.26.0/src/lean/Init/Data/List/Lemmas.lean:350`), `List.mem_cons_self` is `{a : α} {l : List α} : a ∈ a :: l := .head ..` — implicit args, not a function with explicit args. The S7 proof used the older form `exact List.mem_cons_self _ _`, which Lean parses as "apply the term to two values", producing the function-expected error.
+
+**Fix (this PR)**: replace `exact List.mem_cons_self _ _` with `exact List.mem_cons_self`. The post-fix file builds cleanly (verified above).
+
+This is the **same class of regression** as S2's `List.not_mem_nil` drift-fix (the S1 author shipped with "build pending" and S2 discovered the breakage). Confirms the memory note `feedback_g9_qualifier_masks_real_bugs`: "G9 qualifier masks real bugs — ALWAYS Docker-verify". The S7 PR should not have been merged without a Docker build.
+
+### S7 absorbed (post-merge fact-check)
+
+PR #21220 added `JordanBlockShape.totalDim_eq_zero_iff_blocks_empty` (+1 theorem, +31 LOC, file 356 → 387, theorem count 10 → 11). The S8 Docker build implicitly re-verifies the (now-fixed) S7 lemma as a side effect of compiling the file.
+
+### Anti-scope
+
+* No child OQ slug creation (S5 candidate A) — defer to a session that opens that scaffold deliberately.
+* No `jnfMatrix` def / strong-form statement upgrade (S5 candidate B) — block-diagonal assembly is non-trivial; needs its own ACT slot.
+* No sibling JSON edits (slug-local file only).
+* No `MinpolyCharpoly.lean` (parent) edits.
+
+---
 
 ## S7 ACT Summary (2026-05-30, researcher-1)
 

--- a/src/data/research/problems/minpoly-charpoly-oq-01.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-01.json
@@ -32,20 +32,20 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-30T18:50:00Z",
-    "iteration": 7,
-    "focus": "S7 ACT (this PR) — adds JordanBlockShape.totalDim_eq_zero_iff_blocks_empty API lemma (+1 theorem, +31 LOC). Connects totalDim with the underlying blocks list using the structures pos invariant. Companion of S1 totalDim_empty on the iff side (handles arbitrary JordanBlockShape S, not just the explicit empty-list constructor). Pure additive API, no def or sorry change. INFRA improved since S6: G7 GREEN (disk 61Gi up from 3.4Gi, +57.6Gi), G8 GREEN (Docker 29.4.1 running, was hung), G9 still RED (.lake self-symlink — Docker bypasses). Build-verification recommended (Docker available); deferred this session for scope. Mathlib pin 2df2f0150c... (v4.26.0) unchanged. leanFiles[0] line drift 247→246 already absorbed in current JSON (mechanic batch must have run since S6).",
+    "since": "2026-05-31T22:10:00.000Z",
+    "iteration": 8,
+    "focus": "S8 ACT — adds jordanBlock_eq_lam_smul_one_add_zero_block API lemma (+1 theorem, +34 LOC) AND fixes v4.26.0 build break in S7 lemma (List.mem_cons_self _ _ → List.mem_cons_self). Docker build-verified 3081/3081 jobs.",
     "blockers": [],
     "nextAction": "S8 picker matrix: (a) build-verify this S7 PR via ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ01 (Docker GREEN; ~45min cold). (b) S5 candidate A — open child OQ minpoly-charpoly-oq-01-oq-01 + scaffold MinpolyCharpolyOQ01OQ01.lean with jordanBlock.charpoly = (X - C λ)^d identity (~80 LOC, fully dischargable; INFRA now permits NEW slug creation). (c) S5 candidate B — upgrade jordan_normal_form_exists to strong form (∃ invertible P), requires jnfMatrix : JordanBlockShape K → Matrix def first. (d) S5 candidate C — begin OQ-01-OQ-02 (nilpotent canonical form, ~400 LOC, load-bearing). (e) Mathlib gap re-audit at current pin.",
     "attemptCounts": {
-      "total": 5,
+      "total": 6,
       "currentApproach": 3,
-      "approachesTried": 1,
+      "approachesTried": 2,
       "S4": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S7 ACT (this PR) — adds JordanBlockShape.totalDim_eq_zero_iff_blocks_empty API lemma (+1 theorem, +31 LOC, file 356→387 LOC, theorems 10→11). Uses the structures pos invariant for forward direction; backward is the unfolded def on []. S1 OBSERVE (PR #18045) + S2 ACT (PR #18106, entry-wise jordanBlock API + drift-fix) + S3 ACT (PR #18134, eigenvalueMultiset_card_eq_totalDim) + S4-E ACT (PR #19123, toFinset.card ≤ totalDim + iff-Nodup) + S5 STATE-SYNC (PR #19781) + S6 STATE-SYNC. Build-verified at v4.26.0 (3081 jobs) per S4-E baseline; S7 addition is pure additive standard-Mathlib tactics (unfold/match/simp/omega). 11 theorems, 0 axioms, 1 tactic sorry (jordan_normal_form_exists, load-bearing, deferred to OQ-01-OQ-04). Defs stable at 3 since S2. INFRA recovered: G7 GREEN (disk 61Gi), G8 GREEN (Docker 29.4.1), G9 still RED (.lake self-loop, Docker bypasses).",
+    "progressSummary": "S8 ACT (this PR) — adds jordanBlock_eq_lam_smul_one_add_zero_block API lemma (+1 theorem, +34 LOC, file 387→421 LOC, theorems 11→12), the entry-wise Jordan-Chevalley decomposition λ • 1 + jordanBlock R 0 d. Also fixes a v4.26.0 build break in the merged S7 lemma (PR #21220): exact List.mem_cons_self _ _ → exact List.mem_cons_self (Lean core API has implicit args, not explicit). Docker build-verified: 3081/3081 jobs, only expected sorry warning on jordan_normal_form_exists. Same regression class as S2's List.not_mem_nil drift-fix; confirms feedback_g9_qualifier_masks_real_bugs.",
     "builtItems": [
       "JordanBlockShape K (structure): bundles `blocks : List (K × Nat)` and positivity-of-block-sizes proof as a first-class JNF descriptor.",
       "JordanBlockShape.totalDim (def): the sum of all block sizes — the total dimension of the Jordan-form matrix.",
@@ -69,13 +69,16 @@
       "**Structure-encoded shape**: bundling the multiset of (eigenvalue, block size) pairs as a single `JordanBlockShape` structure makes downstream statements concise (the strong-form statement is one line of similarity, not one line per eigenvalue).",
       "**Weak vs strong JNF**: S1 asserts only existence of a `JordanBlockShape` of the correct total dimension. The strong form (existence of an invertible similarity transform P) is the target of OQ-01-OQ-04 and is a ~5-line statement edit on top of S1's weak form.",
       "S4-E API closes the JNF cardinality/distinctness surface: `Multiset.card eigenvalueMultiset = totalDim` (S3) + `toFinset.card ≤ totalDim` (S4-E bound) + `toFinset.card = totalDim ↔ Nodup` (S4-E equality). The equality case characterises the diagonalisable simple-spectrum boundary (every block size 1 AND all eigenvalues distinct), which is the natural shape predicate the OQ-01-OQ-03 per-eigenspace assembly will consume.",
-      "The JordanBlockShape pos invariant (every block has positive size) is what makes totalDim = 0 detect emptiness. Without pos, a zero-size block would give a non-empty list with totalDim = 0. This is a small but important point — the structure encoding (forcing pos at construction time, not as a separate hypothesis) is what makes downstream API clean."
+      "The JordanBlockShape pos invariant (every block has positive size) is what makes totalDim = 0 detect emptiness. Without pos, a zero-size block would give a non-empty list with totalDim = 0. This is a small but important point — the structure encoding (forcing pos at construction time, not as a separate hypothesis) is what makes downstream API clean.",
+      "S8 (2026-05-31, researcher-1): jordanBlock_eq_lam_smul_one_add_zero_block exposes the entry-wise λ • 1 + jordanBlock R 0 d decomposition as a public API lemma. Foundational for OQ-01-OQ-02 (nilpotent canonical form): any eigenvalue-zero result transfers to general eigenvalues by adding λ • 1, without per-call-site eigenvalue-shifting boilerplate. Docker build-verified before ship.",
+      "S8 (2026-05-31, researcher-1) — Docker build of post-S7-merge file revealed Mathlib v4.26.0 API drift: Lean core's List.mem_cons_self has implicit args ({a : α} {l : List α} : a ∈ a :: l := .head ..). S7 used the older List.mem_cons_self _ _ form. Fix: drop the _ _. Same pattern as the S2 drift-fix of List.not_mem_nil. Build-verified 3081 jobs after fix."
     ],
     "mathlibGaps": [
       "Nilpotent canonical form (Jordan basis for nilpotent operators) — no `jordanBlock` definition and no nilpotent-shift-basis theorem in Mathlib v4.26.0. This is the load-bearing OQ-01-OQ-02 (~400 lines). Standard textbook construction (Axler §8.D) — cyclic-vector chains + linear-independence + dimension count.",
       "(Optional / further work) Uniqueness of the JordanBlockShape up to permutation. Follows from existence + dimension count of generalized-kernel filtrations."
     ],
     "nextSteps": [
+      "S9 candidates: (A) jordanBlock charpoly identity (charpoly = (X - C λ)^d) — uses S8 decomposition; ~25 LOC. (B) open child slug minpoly-charpoly-oq-01-oq-01 with the jordanBlock charpoly/minpoly identities as the scaffold target. (C) define jnfMatrix : JordanBlockShape K → Matrix (Fin S.totalDim) ... (block-diagonal assembly, the S5-B candidate). Recommend (A) or (B); (C) is larger scope and benefits from a dedicated session.",
       "**S8 candidate (recommended next)**: build-verify this S7 PR via ./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ01 now that Docker is GREEN (~45 min cold). Retires the (build-verified) claim from S4-E with a current-pin baseline.",
       "S8 candidate A: open child OQ minpoly-charpoly-oq-01-oq-01 and scaffold MinpolyCharpolyOQ01OQ01.lean with the jordanBlock API — charpoly identity (jordanBlock R λ d).charpoly = (X - C λ)^d, minpoly identity, nilpotent-shift identity (jordanBlock R 0 d)^d = 0. ~80 lines, fully dischargable (no sorry). INFRA permits NEW slug creation.",
       "S8 candidate B: upgrade S1 weak-form jordan_normal_form_exists to the strong form with similarity transform P. Requires jnfMatrix : JordanBlockShape K → Matrix def first (block-diagonal assembly). ~30-50 LOC for the def + ~5 LOC statement edit.",
@@ -124,7 +127,7 @@
     ]
   },
   "started": "2026-05-12T10:00:00Z",
-  "lastUpdate": "2026-05-17T02:00:00Z",
+  "lastUpdate": "2026-05-31T22:10:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
@@ -142,8 +145,8 @@
     {
       "path": "Proofs/MinpolyCharpolyOQ01.lean",
       "filename": "MinpolyCharpolyOQ01.lean",
-      "lineCount": 387,
-      "theoremCount": 11,
+      "lineCount": 421,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 5,


### PR DESCRIPTION
## Summary

Research S8 ACT for `minpoly-charpoly-oq-01` (Jordan Normal Form). Adds one API lemma exposing the entry-wise Jordan-Chevalley split of a single Jordan block, AND fixes a v4.26.0 build break in the merged S7 PR ([#21220](https://github.com/rjwalters/lean-genius/pull/21220)) that Docker-verify discovered.

**Docker build-verified: 3081/3081 jobs.**

## Progress

### New lemma (S8 ACT)

**`jordanBlock_eq_lam_smul_one_add_zero_block`** — for any `CommRing R`, scalar `λ`, and dimension `d`:

```
jordanBlock R λ d = λ • (1 : Matrix (Fin d) (Fin d) R) + jordanBlock R 0 d
```

The `λ • 1` summand is the (commuting) semisimple part; `jordanBlock R 0 d` is the strict upper-shift, nilpotent of degree `d`. This is the entry-wise version of `Module.End.exists_isNilpotent_isSemisimple` (Mathlib v4.26.0, `LinearAlgebra/JordanChevalley.lean`) specialised to a single Jordan block. Foundational for OQ-01-OQ-02: any eigenvalue-zero result transfers to general eigenvalues by adding `λ • 1`, without per-call-site eigenvalue-shifting boilerplate.

Proof is entry-wise `ext` + `by_cases` on `i = j` and `(j : Nat) = (i : Nat) + 1`, identical pattern to S1/S2 entry-wise lemmas.

### S7 build-fix

Docker build-verify of the post-S7-merge file revealed a Mathlib v4.26.0 API drift in PR #21220:

```
error: Proofs/MinpolyCharpolyOQ01.lean:413: Function expected at
  List.mem_cons_self
but this term has type
  ?m.48 ∈ ?m.48 :: ?m.49
```

Lean core v4.26.0 (`~/.elan/toolchains/leanprover--lean4---v4.26.0/src/lean/Init/Data/List/Lemmas.lean:350`):

```
theorem mem_cons_self {a : α} {l : List α} : a ∈ a :: l := .head ..
```

Implicit args, not a function with explicit args. The S7 proof used the older `List.mem_cons_self _ _` form. **Fix**: drop the `_ _`. Identical regression class to S2's `List.not_mem_nil` drift-fix.

S7 shipped with "Not run in this session" build status — confirms `feedback_g9_qualifier_masks_real_bugs.md`: always Docker-verify ACTs before shipping.

## Findings

- The Jordan-Chevalley decomposition factors cleanly at the entry-wise level: `jordanBlock R λ d - λ • 1 = jordanBlock R 0 d` (equivalent form). The additive form `λ • 1 + jordanBlock R 0 d` is more `rw`-friendly downstream.
- A bug existed in the merged S7 lemma; Docker-verify caught it. This is the second `List.*` API drift in this file (S2 fixed `List.not_mem_nil`).

## Files modified

- `proofs/Proofs/MinpolyCharpolyOQ01.lean` (+36, -2): adds S8 lemma + section docstring; fixes S7 `List.mem_cons_self _ _` → `List.mem_cons_self`. Final stats: 421 lines, 12 theorems, 0 axioms, 5 sorries raw (1 tactic + 4 commentary; the load-bearing `jordan_normal_form_exists` is unchanged).
- `research/problems/minpoly-charpoly-oq-01/state.md` (+70, -3): S8 ACT summary, S7 build-fix narrative, iteration 7 → 8, last-updated 2026-05-31.
- `src/data/research/problems/minpoly-charpoly-oq-01.json`: iteration → 8, lineCount → 421, theoremCount → 12, focus + progressSummary + new insight.

## Build status

```
⚠ [3081/3081] Built Proofs.MinpolyCharpolyOQ01 (7.1s)
warning: Proofs/MinpolyCharpolyOQ01.lean:366:8: declaration uses 'sorry'
Build completed successfully (3081 jobs).
```

The single warning is the expected `sorry` on the load-bearing `jordan_normal_form_exists` (line 366, shifted from 342 due to S8 additions). Full log: `/tmp/research-builds/minpoly-charpoly-oq-01-s8-retry.log` on the researcher-1 host.

## Status

**Outcome**: progress (Docker build-verified, 1 new lemma, 1 latent S7 bug fixed)
**Next Steps (S9 candidates)**:
- **A** — `jordanBlock R λ d` characteristic polynomial identity `(X - C λ)^d` using the S8 decomposition; ~25 LOC, pure proof.
- **B** — Open child slug `minpoly-charpoly-oq-01-oq-01` with the jordanBlock charpoly/minpoly identities as scaffold.
- **C** — Define `jnfMatrix : JordanBlockShape K → Matrix (Fin S.totalDim) ... K` block-diagonal assembly (the S5-B candidate; larger scope).

🤖 Generated by researcher-1