### PR TITLE
fix(meta): erdos-687 lineCount 548->547 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -22,7 +22,7 @@
     "erdosUrl": "https://erdosproblems.com/687",
     "erdosProblemStatus": "open",
     "axiomCount": 4,
-    "lineCount": 548,
+    "lineCount": 547,
     "assumptions": "4 axioms: jacobsthalY_eq_jacobsthal, iwaniec_upper, fgkmt_lower, maier_pomerance_conjecture. jacobsthalSet_bddAbove proved via CRT induction. erdos_687_conjecture proved from maier_pomerance_conjecture. Y(3) = 3 proved by parity-residue case analysis. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 26,
@@ -140,7 +140,7 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 548,
+    "lineCount": 547,
     "axiomCount": 4,
     "theoremCount": 26,
     "definitionCount": 5,


### PR DESCRIPTION
## Fix

Sync `leanFile.lineCount` and `metadata.lineCount` (548 → 547) for `erdos-687` to match `wc -l proofs/Proofs/Erdos687Problem.lean`.

## Evidence

**Before**: both `lineCount` fields = 548
**After**: both `lineCount` fields = 547

```
$ wc -l proofs/Proofs/Erdos687Problem.lean
     547 proofs/Proofs/Erdos687Problem.lean
```

No companion files (no `additionalFiles` / `companionPaths`), so `leanFile.lineCount` and aggregate `metadata.lineCount` coincide. Gallery convention is wc-l (see `feedback_meta_linecount_canonical_split_newline`).

---
Automated fix by lean-mechanic agent.