### PR TITLE
fix(meta): picks-theorem-oq-01-oq-01-oq-01 lineCount 722->721 (wc-l canonical)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -14,7 +14,7 @@
     "sorries": 0,
     "theoremCount": 37,
     "definitionCount": 23,
-    "lineCount": 722,
+    "lineCount": 721,
     "tags": [
       "number-theory",
       "geometry",
@@ -157,7 +157,7 @@
   ],
   "leanFile": {
     "path": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
-    "lineCount": 722,
+    "lineCount": 721,
     "axiomCount": 0,
     "sorries": 0,
     "theoremCount": 37,


### PR DESCRIPTION
## Fix

Aligned `meta.lineCount` and `leanFile.lineCount` (both 722) to the canonical `wc -l` count of the primary Lean file (721) for `picks-theorem-oq-01-oq-01-oq-01`.

## Evidence

```
$ wc -l proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
     721 proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
```

**Before**: `meta.lineCount = 722`, `leanFile.lineCount = 722`
**After**: `meta.lineCount = 721`, `leanFile.lineCount = 721`

Classic off-by-one from an editor that counted a trailing-newline-less final line. The gallery's canonical convention (per CLAUDE.md / mechanic memory) is `wc -l` of the primary file.

No `additionalFiles` on this proof, so the meta.lineCount aggregation case does not apply.

---
Automated fix by lean-mechanic agent.