### PR TITLE
fix(meta): navier-stokes-oq-02 lineCount 21111->21110 (wc-l canonical)

### DIFF
--- a/src/data/proofs/navier-stokes-oq-02/meta.json
+++ b/src/data/proofs/navier-stokes-oq-02/meta.json
@@ -59,7 +59,7 @@
       "Theorem continuous_dependence_2d: for any ε > 0, threshold δ = ε·exp(-C·E(0)·T) gives W(0) ≤ δ implies W(t) ≤ ε, establishing Hadamard well-posedness"
     ],
     "dateAdded": "2026-02-28",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "1 structure-encoded assumption: NSSolutionPair2D.stability_estimate (Ladyzhenskaya stability estimate W'(t) ≤ C·E(t)·W(t), the core PDE estimate — mathematically known but not formalized in this file)",
     "mathlib_version": "4.26.0",
     "theoremCount": 845,
@@ -204,7 +204,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,


### PR DESCRIPTION
## Fix

Aligned `meta.lineCount` and `leanFile.lineCount` (both 21111) to the canonical `wc -l` count of the primary Lean file (21110) for `navier-stokes-oq-02`.

## Evidence

```
$ wc -l proofs/Proofs/NavierStokes.lean
   21110 proofs/Proofs/NavierStokes.lean
```

**Before**: `meta.lineCount = 21111`, `leanFile.lineCount = 21111`
**After**: `meta.lineCount = 21110`, `leanFile.lineCount = 21110`

Standard off-by-one. The gallery's canonical convention is `wc -l` of the primary file. No `additionalFiles`, so the aggregation case does not apply.

---
Automated fix by lean-mechanic agent.