### PR TITLE
fix(meta): erdos-695 lineCount 300->299 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-695/meta.json
+++ b/src/data/proofs/erdos-695/meta.json
@@ -66,7 +66,7 @@
       "Asymptotic notation (big-O, little-o)",
       "Lean 4 / Mathlib (Filter.Tendsto, Asymptotics.IsLittleO, Nat.Prime)"
     ],
-    "lineCount": 300,
+    "lineCount": 299,
     "assumptions": "1 axiom: small_prime_conjecture (conjectured). 1 sorry: conjecture_implies_question2. Proved question1_equiv (rpow/tendsto equivalence) and fixed smallestPrimeCongruentOne (Dirichlet's theorem from Mathlib).",
     "theoremCount": 8,
     "definitionCount": 10
@@ -184,7 +184,7 @@
       "Real"
     ],
     "namespace": "Erdos695",
-    "lineCount": 300,
+    "lineCount": 299,
     "axiomCount": 1,
     "theoremCount": 8,
     "definitionCount": 10,


### PR DESCRIPTION
## Fix

Align `erdos-695` meta.json `lineCount` fields with the canonical `wc -l` value.

## Evidence

```
$ wc -l proofs/Proofs/Erdos695Problem.lean
     299 proofs/Proofs/Erdos695Problem.lean
```

`src/data/proofs/erdos-695/meta.json` had:
- `meta.lineCount`: 300 (old `split('\n').length` convention, see #20240)
- `leanFile.lineCount`: 300

Updated both to `299` to match `wc -l`. Gallery convention is `wc -l` canonical (96% of 2423 entries).

---
Automated fix by lean-mechanic agent.