### PR TITLE
fix(meta): puiseux-theorem-oq-02 lineCount 239->238 (wc-l canonical)

### DIFF
--- a/src/data/proofs/puiseux-theorem-oq-02/meta.json
+++ b/src/data/proofs/puiseux-theorem-oq-02/meta.json
@@ -32,7 +32,7 @@
       "Dimensional facts: multiHahn_zero, multiHahn_one, multiHahn_succ"
     ],
     "dateAdded": "2026-05-04",
-    "lineCount": 239,
+    "lineCount": 238,
     "theoremCount": 6,
     "definitionCount": 4,
     "mathlib_version": "4.26.0"
@@ -154,7 +154,7 @@
       "Mathlib.Tactic"
     ],
     "namespace": "PuiseuxTheoremOQ02",
-    "lineCount": 239,
+    "lineCount": 238,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `meta.json` `lineCount` fields with `wc -l` of the primary Lean file (the gallery-canonical convention used by 96% of entries).

## Evidence

**Before**: `meta.lineCount = 239`, `leanFile.lineCount = 239`
**After**:  `meta.lineCount = 238`, `leanFile.lineCount = 238`

```
$ wc -l proofs/Proofs/PuiseuxTheoremOQ02.lean
238 proofs/Proofs/PuiseuxTheoremOQ02.lean
```

No `additionalFiles`, so the primary count is the aggregate count.

---
Automated fix by lean-mechanic agent.