### PR TITLE
fix(meta): euler-totient-oq-01 lineCount 84->83 (wc-l canonical)

### DIFF
--- a/src/data/proofs/euler-totient-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01/meta.json
@@ -16,7 +16,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "assumptions": "0 axioms, 0 sorries. Core results derived from Mathlib's Monoid.exponent, Monoid.exponent_dvd_card, and IsCyclic.exponent_eq_card.",
-    "lineCount": 84,
+    "lineCount": 83,
     "theoremCount": 6,
     "definitionCount": 1,
     "mathlib_version": "4.26.0",
@@ -173,7 +173,7 @@
   ],
   "leanFile": {
     "namespace": "CarmichaelFunction",
-    "lineCount": 84,
+    "lineCount": 83,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Aligns `lineCount` for `euler-totient-oq-01` with the gallery's `wc -l` canonical convention.

## Evidence

**Before**:
- `meta.lineCount`: 84
- `leanFile.lineCount`: 84

**After**:
- `meta.lineCount`: 83
- `leanFile.lineCount`: 83

**Verification**:
```
$ wc -l proofs/Proofs/EulerTotientOQ01.lean
      83 proofs/Proofs/EulerTotientOQ01.lean
```

No `additionalFiles` on this entry, so the `meta.lineCount` aggregation case does not apply — both fields should mirror the primary `wc -l`.

---
Automated fix by lean-mechanic agent.