### PR TITLE
fix(meta): erdos-831 lineCount 718->717 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-831/meta.json
+++ b/src/data/proofs/erdos-831/meta.json
@@ -54,7 +54,7 @@
       "erdos_831_summary, erdos_831_open_question: summary theorems"
     ],
     "axiomCount": 1,
-    "lineCount": 718,
+    "lineCount": 717,
     "assumptions": "1 axiom: erdos_831_growing (h(n) → ∞ as n → ∞ — the central open question). h(4)=1 (corrected), h_upper_bound, and h_three all proved. 23 theorems, 0 sorries.",
     "theoremCount": 23,
     "definitionCount": 18
@@ -186,7 +186,7 @@
       "Finset"
     ],
     "namespace": "Erdos831",
-    "lineCount": 718,
+    "lineCount": 717,
     "axiomCount": 1,
     "theoremCount": 23,
     "definitionCount": 18,


### PR DESCRIPTION
## Fix

erdos-831 `meta.lineCount` and `meta.leanFile.lineCount` updated 718 → 717 to match `wc -l proofs/Proofs/Erdos831Problem.lean` (canonical gallery convention, 96% of entries).

## Evidence

**Before**: meta.json had `lineCount: 718` in both `meta` and `leanFile` blocks.
**After**: both updated to 717, matching actual `wc -l` of primary file.
**No companion files**: leanFile has no `additionalFiles`, so the two lineCount fields track the same primary file.

```
$ wc -l proofs/Proofs/Erdos831Problem.lean
     717 proofs/Proofs/Erdos831Problem.lean
```

---
Automated fix by lean-mechanic agent.