### PR TITLE
fix(meta): erdos-893 lineCount 333->332 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-893/meta.json
+++ b/src/data/proofs/erdos-893/meta.json
@@ -65,7 +65,7 @@
       "Proved f_divisor_sum_lower: f(n) >= sum_{k=1}^n tau(k), connecting f to the divisor summatory function"
     ],
     "axiomCount": 1,
-    "lineCount": 333,
+    "lineCount": 332,
     "assumptions": "1 axiom: kovac_luca_limsup_infinite. See Lean source for the complete statement.",
     "mathlib_version": "4.26.0",
     "theoremCount": 35,
@@ -73,7 +73,7 @@
       {
         "path": "Proofs/Erdos893Problem.lean",
         "filename": "Erdos893Problem.lean",
-        "lineCount": 333,
+        "lineCount": 332,
         "theoremCount": 35,
         "axiomCount": 1,
         "defCount": 4,
@@ -213,7 +213,7 @@
       "Finset"
     ],
     "namespace": "Erdos893",
-    "lineCount": 333,
+    "lineCount": 332,
     "axiomCount": 1,
     "theoremCount": 35,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/erdos-893/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = leanFiles[0].lineCount = 333`
**After**: `332`
**Actual**: `wc -l proofs/Proofs/Erdos893Problem.lean` → 332

Single-file proof (no companion aggregate). All three lineCount sites updated.

---
Automated fix by lean-mechanic agent.