### PR TITLE
audit(erdos-1175): mark clean (cycle 4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4412,9 +4412,9 @@
     },
     "erdos-1175": {
       "agentId": "auditor-loop-1777720421",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T11:17:28Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T01:06:05Z",
+      "result": "clean",
       "issues": [
         "#14741: phantom axiom claims for Mycielski / finite case / Erdős 1959 in proofStrategy + sections (only docstrings; no declarations)"
       ]


### PR DESCRIPTION
## Summary

Audited `erdos-1175` (Triangle-Free Subgraphs with Large Chromatic Number) — clean.

All meta.json counts match Lean source:
- lineCount: 186 (wc-l)
- axiomCount: 2 (`cardinalChromaticNumber`, `shelah_consistency`)
- theoremCount: 2, definitionCount: 10, sorries: 0
- status: `axiomatized`, badge: `axiom` (correct for open problem)

`assumptions` field correctly documents both axioms. Previous issue #14741 (phantom axiom claims) verified resolved — Mycielski / finite case / Erdős 1959 are only docstrings, no declarations follow.

## Test plan
- [x] meta.json counts match `wc -l` and grep counts for axiom/theorem/def/sorry
- [x] No True stubs (no `:= trivial` patterns)
- [x] Status/badge consistent with open-problem axiomatization policy
- [x] audit-tracker.json updated to `clean`, cycle 4