### PR TITLE
fix(meta): newton-inductive-step-oq-02 lineCount 612->611 (wc-l canonical)

### DIFF
--- a/src/data/proofs/newton-inductive-step-oq-02/meta.json
+++ b/src/data/proofs/newton-inductive-step-oq-02/meta.json
@@ -44,7 +44,7 @@
     ],
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
-    "lineCount": 612,
+    "lineCount": 611,
     "theoremCount": 6,
     "definitionCount": 0,
     "prerequisites": [
@@ -153,7 +153,7 @@
       "Nat"
     ],
     "namespace": "NewtonInductiveStepOQ02",
-    "lineCount": 612,
+    "lineCount": 611,
     "axiomCount": 0,
     "theoremCount": 6,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/newton-inductive-step-oq-02/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 612`
**After**: `611`
**Actual**: `wc -l proofs/Proofs/NewtonInductiveStepOQ02.lean` → 611

Single-file proof. Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.