### PR TITLE
fix(meta): platonic-solids-oq-01 lineCount 629->628 (wc-l canonical)

### DIFF
--- a/src/data/proofs/platonic-solids-oq-01/meta.json
+++ b/src/data/proofs/platonic-solids-oq-01/meta.json
@@ -23,7 +23,7 @@
     "axiomCount": 0,
     "theoremCount": 53,
     "defCount": 28,
-    "lineCount": 629,
+    "lineCount": 628,
     "mathlibDependencies": [
       {
         "theorem": "native_decide",
@@ -166,7 +166,7 @@
     ],
     "opens": [],
     "namespace": "RegularPolytopes",
-    "lineCount": 629,
+    "lineCount": 628,
     "axiomCount": 0,
     "theoremCount": 53,
     "definitionCount": 31,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/platonic-solids-oq-01/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 629`
**After**: `628`
**Actual**: `wc -l proofs/Proofs/PlatonicSolidsOQ01.lean` → 628

Single-file proof. Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.