### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 lineCount 1420->1419 (wc-l canonical)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1420,
+    "lineCount": 1419,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1420,
+    "lineCount": 1419,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 1420`
**After**: `1419`
**Actual**: `wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` → 1419

Single-file proof. Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.