### PR TITLE
fix(meta): erdos-5 lineCount 658->657 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -21,7 +21,7 @@
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
     "axiomCount": 3,
-    "lineCount": 658,
+    "lineCount": 657,
     "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 26 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density), frequently_near_of_isLimitPoint and erdos_5_iff_dense_at_every_point (forward density direction giving the iff characterization), and unconditional oscillation lemmas frequently_normalizedGap_lt and frequently_normalizedGap_gt.",
     "mathlib_version": "4.26.0",
     "theoremCount": 33,
@@ -164,7 +164,7 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 658,
+    "lineCount": 657,
     "axiomCount": 3,
     "theoremCount": 33,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/erdos-5/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 658`
**After**: `657`
**Actual**: `wc -l proofs/Proofs/Erdos5PrimeGaps.lean` → 657

Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.