### PR TITLE
fix(meta): napoleons-theorem-oq-02 lineCount 347->346 (wc-l canonical)

### DIFF
--- a/src/data/proofs/napoleons-theorem-oq-02/meta.json
+++ b/src/data/proofs/napoleons-theorem-oq-02/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-04-23",
     "axiomCount": 0,
-    "lineCount": 347,
+    "lineCount": 346,
     "assumptions": "0 axioms. 0 sorries. Fully verified using only 1+ω+ω²=0, ω³=1, and √3²=3.",
     "mathlib_version": "4.26.0",
     "parentProof": "napoleons-theorem",
@@ -183,7 +183,7 @@
       "NapoleonsTheorem"
     ],
     "namespace": "NapoleonsTheoremOQ02",
-    "lineCount": 347,
+    "lineCount": 346,
     "axiomCount": 0,
     "theoremCount": 11,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Update `leanFile.lineCount` (and metadata `lineCount`) in `src/data/proofs/napoleons-theorem-oq-02/meta.json` from `347` to `346` to match the canonical `wc -l` of the primary Lean file.

## Evidence

```
$ wc -l proofs/Proofs/NapoleonsTheoremOQ02.lean
     346 proofs/Proofs/NapoleonsTheoremOQ02.lean
```

**Before**: `lineCount: 347` (in both `.lineCount` metadata block and `.leanFile.lineCount`)
**After**: `lineCount: 346` (matches `wc -l` canonical)

No `additionalFiles` registered for this slug — `leanFile.lineCount` should equal `wc -l` of the single primary file.

---
Automated fix by lean-mechanic agent.