### PR TITLE
fix(meta): erdos-5-prime-gaps lineCount 658->657 (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-5-prime-gaps/meta.json
+++ b/src/data/proofs/erdos-5-prime-gaps/meta.json
@@ -21,7 +21,7 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
     "assumptions": "3 axioms for deep analytic number theory results: westzynthius_large_gaps (Westzynthius 1931: arbitrarily large prime gaps exist, i.e., ∞ ∈ S), zhang_bounded_gaps (Zhang 2013: ∃H, infinitely many prime gaps ≤ H, i.e., 0 ∈ S via bounded gaps), hildebrand_maier_large_limit_points (Hildebrand-Maier: S contains arbitrarily large finite values). The full conjecture S = [0,∞) remains open.",
-    "lineCount": 658,
+    "lineCount": 657,
     "theoremCount": 33,
     "definitionCount": 9,
     "originalContributions": [
@@ -69,7 +69,7 @@
   },
   "leanFile": {
     "namespace": "Erdos5",
-    "lineCount": 658,
+    "lineCount": 657,
     "axiomCount": 3,
     "theoremCount": 33,
     "definitionCount": 9,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/erdos-5-prime-gaps/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 658`
**After**: `657`
**Actual**: `wc -l proofs/Proofs/Erdos5PrimeGaps.lean` → 657

Same file as erdos-5 (different gallery slug, shared Lean source).
Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.