### PR TITLE
fix(meta): navier-stokes lineCount 21111->21110 (wc-l canonical)

### DIFF
--- a/src/data/proofs/navier-stokes/meta.json
+++ b/src/data/proofs/navier-stokes/meta.json
@@ -73,7 +73,7 @@
     "millenniumProblem": "navier-stokes",
     "proofRepoPath": "Proofs/NavierStokes.lean",
     "mathlib_version": "4.26.0",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "theoremCount": 845,
     "definitionCount": 366
   },
@@ -365,7 +365,7 @@
     }
   ],
   "leanFile": {
-    "lineCount": 21111,
+    "lineCount": 21110,
     "structureCount": 249,
     "axiomCount": 0,
     "theoremCount": 845,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/navier-stokes/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 21111`
**After**: `21110`
**Actual**: `wc -l proofs/Proofs/NavierStokes.lean` → 21110

Shared NavierStokes.lean (also surfaces under `navier-stokes-oq-01`,
`navier-stokes-oq-02` (PR #21698), `navier-stokes-existence`).
Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.