### PR TITLE
fix(meta): navier-stokes-oq-01 lineCount 21111->21110 (wc-l canonical)

### DIFF
--- a/src/data/proofs/navier-stokes-oq-01/meta.json
+++ b/src/data/proofs/navier-stokes-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Theorem total_dissipation_bound: ∫₀ᵀ 2νP(t) dt ≤ E(0), total dissipation bounded by initial enstrophy"
     ],
     "dateAdded": "2026-02-26",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "assumptions": "None. Formalized with 0 axioms and 0 sorries remain.",
     "relatedProblems": [
       {
@@ -183,7 +183,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/navier-stokes-oq-01/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 21111`
**After**: `21110`
**Actual**: `wc -l proofs/Proofs/NavierStokes.lean` → 21110

Shared NavierStokes.lean (also surfaces under `navier-stokes` (PR #21724),
`navier-stokes-oq-02` (PR #21698), `navier-stokes-existence`).
Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.