### PR TITLE
fix(meta): navier-stokes-existence lineCount 21111->21110 (wc-l canonical)

### DIFF
--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -63,7 +63,7 @@
     ],
     "dateAdded": "2026-03-14",
     "relatedProblems": [],
-    "lineCount": 21111,
+    "lineCount": 21110,
     "mathlib_version": "4.26.0",
     "theoremCount": 845,
     "definitionCount": 366
@@ -266,7 +266,7 @@
       "TwoDimensionalGlobal"
     ],
     "namespace": "NavierStokesRegularity",
-    "lineCount": 21111,
+    "lineCount": 21110,
     "axiomCount": 0,
     "theoremCount": 845,
     "definitionCount": 366,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` in `src/data/proofs/navier-stokes-existence/meta.json` to match canonical `wc -l` of the Lean source.

## Evidence

**Before**: `meta.lineCount = leanFile.lineCount = 21111`
**After**: `21110`
**Actual**: `wc -l proofs/Proofs/NavierStokes.lean` → 21110

Shared NavierStokes.lean (also surfaces under `navier-stokes` (PR #21724),
`navier-stokes-oq-01` (PR #21725), `navier-stokes-oq-02` (PR #21698)).
Both lineCount sites updated.

---
Automated fix by lean-mechanic agent.