### PR TITLE
Enrich abel-ruffini: expand exists_quintic prerequisites + restore lost annotation depth

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -387,7 +387,12 @@
     "significance": "supporting",
     "prerequisites": [
       "Polynomial.natDegree_pow",
-      "Polynomial.natDegree_X"
+      "Polynomial.natDegree_X",
+      "irreducibility of polynomials over ℚ",
+      "Eisenstein's criterion at a prime",
+      "Galois group computation for polynomial splitting fields",
+      "solvable vs non-solvable groups (derived series)",
+      "Frobenius group F_20 = ℤ/5 ⋊ ℤ/4 as solvable transitive subgroup of S_5"
     ],
     "relatedConcepts": [
       "Polynomial.natDegree",


### PR DESCRIPTION
## Summary

Two targeted improvements to the abel-ruffini gallery entry, both addressing source-of-truth integrity:

**1. Expand `ann-exists-quintic` prerequisites** (annotations.json + annotations.source.json)

Before: 2 Lean lemma names (`Polynomial.natDegree_pow`, `Polynomial.natDegree_X`).

After: 7 items including the conceptual prerequisites the annotation content already discusses — irreducibility over ℚ, Eisenstein's criterion, Galois-group computation, derived series, and the Frobenius group $F_{20} = \\mathbb{Z}/5 \\rtimes \\mathbb{Z}/4$ as the solvable transitive degree-5 case. This brings the field in line with the 15 sister annotations (which carry 3-7 conceptual prerequisites each).

**2. Restore lost annotation depth in annotations.source.json**

Two annotations had been substantively enriched directly in `annotations.json` by prior PRs without updating the source-of-truth `annotations.source.json`:

- **ann-a5-simple**: The 1500-character paragraph on the Frobenius splitting criterion for $A_n$ conjugacy classes (distinct-odd-parts cycle types) — restored, including the `Frobenius splitting criterion (distinct odd parts)` related-concept tag.
- **ann-part-vii-historical**: The 2400-character expansion covering Wantzel 1837 as the first methodological descendant via the Galois underground (1832-1846), Galois's 1830 coining of *groupe*, Cayley 1854 axiomatic groups, Liouville 1844 transcendentals, Cantor's diagonal argument, and Matiyasevich's Hilbert 10 — restored, along with the corresponding prerequisites and related-concept tags.

The next `pnpm annotations:build` regeneration would have silently wiped these from the rendered file. Backporting to .source.json makes the content durable.

## Why

- Source-of-truth drift: `annotations.json` is a generated artifact; persistent enrichment must land in `annotations.source.json`. This PR brings them back into sync.
- Coverage consistency: the exists_quintic prerequisites gap was the only annotation with sub-3 conceptual prerequisites.

## Test plan

- [x] `python3 -c 'json.load(...)'` — both JSON files parse
- [x] `pnpm build` — annotations regenerate idempotently; vite build completes
- [x] Diff is scoped: only `src/data/proofs/abel-ruffini/{annotations.json,annotations.source.json}` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)