### PR TITLE
audit(erdos-1158): mark clean (cycle 4) — hypergraph Turán bound integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4301,12 +4301,12 @@
       "result": "clean"
     },
     "erdos-1158": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "#14745 phantom \"axiomatize\" claims for upper bound, lower bound, stepping-up + section line drift"
       ],
-      "lastAudited": "2026-05-02T11:31:08Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-01T01:47:00Z",
+      "result": "clean"
     },
     "erdos-1159": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Cycle 4 gallery integrity audit for erdos-1158 (Hypergraph Turán Lower Bound for $K_t(r)$).

All meta.json claims match the Lean source `proofs/Proofs/Erdos1158Problem.lean`:

| Field | meta.json | Actual | Status |
|-------|-----------|--------|--------|
| lineCount | 306 | 306 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | 0 | 0 | ✓ |
| theoremCount | 7 | 7 | ✓ |
| definitionCount | 7 | 7 (structure + 6 defs) | ✓ |

Axioms (Tier C scaffold, badge `axiom` correct):
- `conjecture_t2_r2` — Zarankiewicz $K_{2,2}$ case (projective planes)
- `conjecture_t2_r3` — $K_{3,3}$ case (Brown 1966, Erdős-Rényi-Sós 1966)

Status `axiomatized` + badge `axiom` consistent with 2 axioms / 0 sorries.

## Test plan

- [x] meta.json field counts match Lean source
- [x] No True stubs claimed as verified
- [x] No overstatement of contributions (open conjecture properly framed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)