### PR TITLE
Enrich algebraic-numbers-countable: align top-level mainTheorems with leanFile (3→6)

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable/meta.json
@@ -510,6 +510,24 @@
       "type": "key",
       "description": "Algebraic reals decompose as countable union of degree strata",
       "leanType": "{x : \u211d | IsAlgebraic \u211a x} = \u22c3 d : \u2115, algebraicRealsOfDegree d"
+    },
+    {
+      "name": "algebraic_reals_countable_via_strata",
+      "type": "key",
+      "description": "Alternative countability proof: countability re-derived from the degree-stratification decomposition (countable union of countable sets is countable)",
+      "leanType": "Set.Countable {x : \u211d | IsAlgebraic \u211a x}"
+    },
+    {
+      "name": "card_algebraic_eq_card_rat",
+      "type": "key",
+      "description": "Cardinality equality: the algebraic reals and the rationals are equinumerous despite the algebraic reals being a strict superset (the 'paradox' of countable infinity)",
+      "leanType": "Cardinal.mk {x : \u211d // IsAlgebraic \u211a x} = Cardinal.mk \u211a"
+    },
+    {
+      "name": "algebraic_reals_eq_iUnion_bounded",
+      "type": "key",
+      "description": "Exhaustive bounded-degree filtration: every algebraic real lies in some algebraicRealsOfBoundedDegree d, witnessing the algebraic reals as the colimit of an ascending chain of countable layers",
+      "leanType": "{x : \u211d | IsAlgebraic \u211a x} = \u22c3 d : \u2115, algebraicRealsOfBoundedDegree d"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

The top-level \`mainTheorems\` array on \`algebraic-numbers-countable/meta.json\` listed only 3 of the 6 substantive theorems already enumerated in \`leanFile.mainTheorems\`. This PR aligns them.

**Added:**
- \`algebraic_reals_countable_via_strata\` — alternative countability proof derived from the degree-stratification decomposition (countable union of countable sets)
- \`card_algebraic_eq_card_rat\` — the cardinality-equality "paradox" that the algebraic reals are equinumerous with ℚ despite being a strict superset
- \`algebraic_reals_eq_iUnion_bounded\` — exhaustive bounded-degree filtration witnessing the algebraic reals as the colimit of an ascending chain of countable layers

Each was already present in \`leanFile.mainTheorems\` (lines 437-474) and corresponds directly to a keyInsight the entry already discusses (stratification, filtration, cardinal paradox). No annotation or other content changes.

## Why

Internal consistency: the two \`mainTheorems\` arrays should enumerate the same substantive theorems. Sister entries (e.g. \`abel-ruffini\`, 9 theorems) list the full set at the top level.

## Test plan

- [x] JSON validates
- [x] \`pnpm build\` — vite build completes
- [x] Diff scoped to a single insertion in one file

🤖 Generated with [Claude Code](https://claude.com/claude-code)