### PR TITLE
fix(meta): frobenius-number-oq-03 lineCount 226->225 (wc-l canonical)

### DIFF
--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -19,7 +19,7 @@
     "badge": "research",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 226,
+    "lineCount": 225,
     "theoremCount": 15,
     "definitionCount": 2,
     "assumptions": "None at this stage. The file establishes the Representable3 predicate, the frobeniusNumber3 definition (as sSup of the non-representable set), seven closure lemmas (S2), structural API for the supremum (S3a), the 2→3 generator bridge under Nat.Coprime a b with 1 ≤ a, 1 ≤ b (S3b), the loose Sylvester upper bound (a-1)(b-1) (S3c), and finiteness of the non-representable set under the same coprimality (S4). The exact Roberts-1956 closed form g(n, n+1, n+2) = ⌊(n-2)/2⌋·n + (n-1) for three consecutive integers and the general Roberts 3-AP formula are deferred to S5+.",


### PR DESCRIPTION
## Fix

Update `meta.lineCount` for `frobenius-number-oq-03` from 226 to 225 to match `wc -l` of the primary Lean source.

## Evidence

- **File**: `proofs/Proofs/FrobeniusNumberOQ03.lean`
- **Before**: `meta.lineCount = 226`
- **After**: `meta.lineCount = 225`
- **Verification**: `wc -l proofs/Proofs/FrobeniusNumberOQ03.lean → 225`
- Single-file proof (no companion files); wc-l canonical applies directly per gallery convention.

---
Automated fix by lean-mechanic agent.