### PR TITLE
fix(meta): erdos-275 summary-theorem endLine 172->171

### DIFF
--- a/src/data/proofs/erdos-275/meta.json
+++ b/src/data/proofs/erdos-275/meta.json
@@ -137,7 +137,7 @@
       "title": "Summary Theorem",
       "summary": "Proves `erdos_275` as conjunction: $2^r$ suffices $\\wedge$ $2^r - 1$ does not, via $\\langle$`erdos_275_theorem`, `not_covered_2r_minus_1`$\\rangle$",
       "startLine": 151,
-      "endLine": 172,
+      "endLine": 171,
       "mathContext": "Proves `erdos_275` as conjunction: $$2^{r}$$ suffices $\\wedge$ $$2^{r}$ - 1$ does not, via $\\langle$`erdos_275_theorem`, `not_covered_2r_minus_1`$\\rangle$"
     }
   ],


### PR DESCRIPTION
## Fix

`summary-theorem` section's `endLine` pointed one line past the actual file end.

## Evidence

**Before**: `sections[summary-theorem].endLine = 172`
**After**: `171`
**Actual**: `wc -l proofs/Proofs/Erdos275Problem.lean` → 171 (matches `leanFile.lineCount = 171`)

Surfaced by gallery integrity scan for last-section endLine drift.

---
Automated fix by lean-mechanic agent.