### PR TITLE
audit(erdos-1150): mark clean (cycle 4) — Littlewood ultraflat conjecture integrity verified

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4235,10 +4235,10 @@
       "result": "issues-fixed"
     },
     "erdos-1150": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T11:39:46Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-01T02:02:41Z",
+      "result": "clean"
     },
     "erdos-1151": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

Cycle-4 re-audit of erdos-1150 (Supremum of Littlewood Polynomials, OPEN). All meta.json fields verified against `proofs/Proofs/Erdos1150Problem.lean` — no mismatches found.

## Counts verified

| Field | meta.json | Lean source | OK |
|---|---|---|---|
| `lineCount` | 390 | 390 (`wc -l`) | ✓ |
| `axiomCount` | 3 | 3 | ✓ |
| `theoremCount` | 13 | 13 | ✓ |
| `definitionCount` | 7 | 7 | ✓ |
| `sorries` | 0 | 0 | ✓ |

## Axioms (3)

- `parseval_lower_bound` — sup norm ≥ √(n+1) via Parseval/DFT
- `bbmst_flat` — BBMST 2019: flat Littlewood polynomials exist
- `flat_does_not_imply_ultraflat` — BBMST bounded-but-not-converging gap witness

## Narrative integrity

- Title and description correctly flag the problem as **OPEN**.
- Status `axiomatized` + badge `axiom` correct for an open conjecture with axiomatized external results.
- Equivalence `Erdos1150Conjecture ↔ ¬∃ ultraflat sequence` is a proved theorem (`conjecture_equiv_no_ultraflat`), not an axiom — appropriately credited.
- Rudin-Shapiro definitions present with recursive identities; sup-norm bound deferred (consistent with assumptions text).
- No True stubs, no Mathlib wrapper claims.

## Tracker change

`auditCount` 3 → 4; `result` `issues-fixed` → `clean`; `lastAudited` refreshed to 2026-06-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)