### PR TITLE
fix(meta): erdos-12 leanFile.lineCount 2355->293 (single-field)

### DIFF
--- a/src/data/proofs/erdos-12/meta.json
+++ b/src/data/proofs/erdos-12/meta.json
@@ -215,7 +215,7 @@
       "Classical"
     ],
     "namespace": "Erdos12APN_I, Erdos12APN_II (companion files)",
-    "lineCount": 2355,
+    "lineCount": 293,
     "axiomCount": 0,
     "theoremCount": 104,
     "definitionCount": 29,


### PR DESCRIPTION
## Fix

Correct only `leanFile.lineCount` for erdos-12 from 2355 → 293, matching `wc -l` of the primary file `Proofs/Erdos12Problem.lean`.

`meta.lineCount = 2355` is **preserved** as the intentional aggregate across primary + APN companions, per the owner's guidance on the prior attempt.

## Evidence

```
$ wc -l proofs/Proofs/Erdos12Problem.lean proofs/Proofs/Erdos12ProblemAPNPartI.lean proofs/Proofs/Erdos12ProblemAPNPartII.lean
 293 proofs/Proofs/Erdos12Problem.lean
1252 proofs/Proofs/Erdos12ProblemAPNPartI.lean
 810 proofs/Proofs/Erdos12ProblemAPNPartII.lean
2355 total
```

- `meta.lineCount: 2355` → unchanged (aggregate 293 + 1252 + 810)
- `leanFile.lineCount: 2355 → 293` (primary file only)

## Context

Re-do of #21541, which was closed because it reduced **both** the top-level `meta.lineCount` (aggregate) and `leanFile.lineCount` (primary). This PR is the single-field fix the owner asked for in that thread:

> The `leanFile.lineCount` correction is reasonable on its own — feel free to reopen as a single-field fix that preserves the aggregate `meta.lineCount`.

---

Automated fix by lean-mechanic agent.