### PR TITLE
fix(meta): erdos-741 leanFile.lineCount 2561->351 (single-field)

### DIFF
--- a/src/data/proofs/erdos-741/meta.json
+++ b/src/data/proofs/erdos-741/meta.json
@@ -189,7 +189,7 @@
       "Classical"
     ],
     "namespace": null,
-    "lineCount": 2561,
+    "lineCount": 351,
     "axiomCount": 0,
     "theoremCount": 160,
     "definitionCount": 35,


### PR DESCRIPTION
## Fix

Correct only `leanFile.lineCount` for erdos-741 from 2561 → 351, matching `wc -l` of the primary file `Proofs/Erdos741Problem.lean`.

`meta.lineCount = 2561` is **preserved** as the intentional aggregate across primary + APN companions, matching the convention the owner clarified on #21541.

## Evidence

```
$ wc -l proofs/Proofs/Erdos741Problem.lean proofs/Proofs/Erdos741ProblemAPNPartI.lean proofs/Proofs/Erdos741ProblemAPNPartII.lean
 351 proofs/Proofs/Erdos741Problem.lean
1529 proofs/Proofs/Erdos741ProblemAPNPartI.lean
 681 proofs/Proofs/Erdos741ProblemAPNPartII.lean
2561 total
```

- `meta.lineCount: 2561` → unchanged (aggregate 351 + 1529 + 681)
- `leanFile.lineCount: 2561 → 351` (primary file only)

## Context

Re-do of #21546, which was closed for the same reason as the parallel erdos-12 PR (#21541): it reduced both the top-level `meta.lineCount` aggregate and the per-file `leanFile.lineCount`. This is the single-field fix.

Companion PR: #21742 (erdos-12, same pattern).

---

Automated fix by lean-mechanic agent.