### PR TITLE
fix(meta): erdos-846 leanFile.additionalFiles mirror companionPaths

### DIFF
--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -188,6 +188,9 @@
     "companionPaths": [
       "Proofs/Erdos846ProblemAPN.lean"
     ],
+    "additionalFiles": [
+      "Proofs/Erdos846ProblemAPN.lean"
+    ],
     "sorries": 0
   },
   "references": [


### PR DESCRIPTION
## Fix

Add `leanFile.additionalFiles` array to `src/data/proofs/erdos-846/meta.json` to mirror the existing `leanFile.companionPaths` array.

## Evidence

**Before**: `leanFile.additionalFiles = null` despite `leanFile.companionPaths = ["Proofs/Erdos846ProblemAPN.lean"]`

**After**: `leanFile.additionalFiles = ["Proofs/Erdos846ProblemAPN.lean"]` (mirrors companionPaths)

**Convention**: Sibling APN-style entries `erdos-12` and `erdos-741` both mirror these fields:
```json
"companionPaths": ["...PartI.lean", "...PartII.lean"],
"additionalFiles": ["...PartI.lean", "...PartII.lean"]
```

Erdos-846 was the lone outlier. This brings it into alignment.

**No semantic change**: `meta.additionalFiles` (already populated correctly) drives the auditor's import-chain analysis. This PR aligns the documentation/convention-level metadata only.

---
Automated fix by lean-mechanic agent.