### PR TITLE
fix(meta): erdos-37 summary section endLine 368->367

### DIFF
--- a/src/data/proofs/erdos-37/meta.json
+++ b/src/data/proofs/erdos-37/meta.json
@@ -187,7 +187,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 352,
-      "endLine": 368,
+      "endLine": 367,
       "summary": "Recap: Erdős #37 answered NO (Ruzsa 1987). Essential components need $(\\log N)^{1+c}$ growth; lacunary sets have only $O(\\log N)$. The $\\{2^m \\cdot 3^n\\}$ question remains OPEN.",
       "mathContext": "Recap: Erdős #37 answered NO (Ruzsa 1987). Essential components need $(\\log N)^{1+c}$ growth; lacunary sets have only $$O(\\log N)$$. The $\\{$2^{m}$ \\cdot $3^{n}$\\}$ question remains OPEN."
     }


### PR DESCRIPTION
## Fix

`summary` section's `endLine` pointed one line past the actual file end.

## Evidence

**Before**: `sections[summary].endLine = 368`
**After**:  `sections[summary].endLine = 367`
**Actual**: `wc -l proofs/Proofs/Erdos37Problem.lean` -> 367 (matches `leanFile.lineCount = 367`)

Surfaced by gallery integrity scan for last-section endLine drift. Sibling pattern: PR #21739 (erdos-275 same off-by-one).

---
Automated fix by lean-mechanic agent.