### PR TITLE
fix(meta): amgm-inequality-oq-04 sec-elliptic endLine 307->306

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -141,7 +141,7 @@
       "id": "sec-elliptic",
       "title": "§ 7: Elliptic Integral Connection (Axiomatized)",
       "startLine": 274,
-      "endLine": 307,
+      "endLine": 306,
       "summary": "Three axioms: ellipticK : ℝ → ℝ (K(k) function, not in Mathlib), ellipticK_zero : K(0) = π/2, agm_ellipticK : M(a,b) = aπ/(2K(√(1-(b/a)²))). These are Gauss's 1799 deep theorem; the proof requires theta functions or hypergeometric series not yet in Mathlib."
     }
   ],


### PR DESCRIPTION
## Fix

`sec-elliptic` (last section) `endLine` pointed one line past the actual file end.

## Evidence

**Before**: `sections[sec-elliptic].endLine = 307`
**After**:  `sections[sec-elliptic].endLine = 306`
**Actual**: `wc -l proofs/Proofs/AmgmInequalityOQ04.lean` -> 306 (matches `leanFile.lineCount = 306`)

Surfaced by gallery integrity scan for last-section endLine drift. Sibling pattern: PR #21739 (erdos-275), PR #21746 (erdos-37).

---
Automated fix by lean-mechanic agent.