### PR TITLE
fix(meta): erdos-1028 section lower-bound endLine 311->310

### DIFF
--- a/src/data/proofs/erdos-1028/meta.json
+++ b/src/data/proofs/erdos-1028/meta.json
@@ -122,7 +122,7 @@
       "title": "Lower Bound and Special Cases",
       "summary": "large_discrepancy_exists, H_two, H_three, homogeneous_small_discrepancy",
       "startLine": 257,
-      "endLine": 311,
+      "endLine": 310,
       "mathContext": "Mathematical content: large_discrepancy_exists, H_two, H_three, homogeneous_small_discrepancy"
     }
   ],


### PR DESCRIPTION
## Fix

Update `src/data/proofs/erdos-1028/meta.json` final section `lower-bound` `endLine: 311 -> 310` to match the file's actual line count.

## Evidence

**Before**: `sections[lower-bound].endLine = 311`, while `Proofs/Erdos1028Problem.lean` has 310 lines (`wc -l`).
**After**: `sections[lower-bound].endLine = 310` — consistent with `leanFile.lineCount = 310` (set by #21627).

This is a follow-on to the lineCount fix in #21627. The lineCount was synced but the final section's endLine still pointed one past EOF.

---
Automated fix by lean-mechanic agent.