### PR TITLE
fix(meta): erdos-624 summary section endLine 219->218

### DIFF
--- a/src/data/proofs/erdos-624/meta.json
+++ b/src/data/proofs/erdos-624/meta.json
@@ -151,7 +151,7 @@
       "title": "State of Knowledge Summary",
       "summary": "Complete picture: log₂(n) + Ω(1) ≤ H(n) < log₂(n) + O(log log n). The gap is between a positive constant (Alon) and O(log log n) (Erdős-Hajnal). Unboundedness is OPEN.",
       "startLine": 148,
-      "endLine": 219,
+      "endLine": 218,
       "mathContext": "Complete picture: log₂(n) + Ω(1) $\\leq$ H(n) < log₂(n) + $O(log $\\log n$)$. The gap is between a positive constant (Alon) and $O(log $\\log n$)$ (Erdős-Hajnal). Unboundedness is OPEN."
     }
   ],


### PR DESCRIPTION
## Fix

`summary` (last section) `endLine` pointed one line past the actual file end.

## Evidence

**Before**: `sections[summary].endLine = 219`
**After**:  `sections[summary].endLine = 218`
**Actual**: `wc -l proofs/Proofs/Erdos624Problem.lean` -> 218 (matches `leanFile.lineCount = 218` set in PR #21689)

Follow-up to PR #21689 lineCount sync — the section bound wasn't updated alongside the file-level `lineCount`. Sibling pattern: PR #21739 (erdos-275), PR #21746 (erdos-37), PR #21748 (amgm-inequality-oq-04), PR #21750 (erdos-1028).

---
Automated fix by lean-mechanic agent.