### PR TITLE
fix(meta): cauchy-schwarz-integral equality section endLine 118->117

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral/meta.json
@@ -107,7 +107,7 @@
       "title": "Equality Characterization",
       "summary": "Proves equality holds iff $f$ and $g$ are linearly dependent in $L^2$: $|\\langle f, g \\rangle| = \\|f\\|\\|g\\| \\iff \\exists c: f = c \\cdot g$, using `norm_inner_eq_norm_iff`.",
       "startLine": 95,
-      "endLine": 118,
+      "endLine": 117,
       "mathContext": "Equality $|\\langle f, g \\rangle| = \\|f\\| \\cdot \\|g\\|$ holds iff $f = cg$ a.e. for some $c \\in \\mathbb{R}$. Geometrically, this means the 'angle' between $f$ and $g$ in $L^2$ is $0$ or $\\pi$ — they point in the same or opposite directions. The proof uses the standard Hilbert space fact: $\\|u - tv\\|^2 = 0$ for some $t$ iff $u$ and $v$ are proportional. In probability, equality means $Y = aX + b$ a.s. (perfect linear correlation $|\\rho| = 1$)."
     }
   ],


### PR DESCRIPTION
## Fix

Last annotation section (`equality`) had `endLine = 118`, overrunning the file by one line.

## Evidence

**Before**: `sections[equality].endLine = 118`
**After**: `117`
**Actual**: `wc -l proofs/Proofs/CauchySchwarzIntegral.lean` -> 117 (matches `leanFile.lineCount = 117`)

Surfaced by gallery integrity scan for last-section endLine overruns (sections claiming lines past the actual file end). Follows the same wc-l canonical pattern as #21739, #21746.

---
Automated fix by lean-mechanic agent.