### PR TITLE
fix(meta): erdos-866 parity-pigeonhole section endLine 85->84

### DIFF
--- a/src/data/proofs/erdos-866/meta.json
+++ b/src/data/proofs/erdos-866/meta.json
@@ -118,7 +118,7 @@
       "title": "Parity Pigeonhole for Odd Sets",
       "summary": "Proves no three integers b₀, b₁, b₂ can have all three pairwise sums in oddNumbers N. Key: any pairwise sum of elements with the same parity is even, hence not in the odd set. Among 3 integers, two must share parity by pigeonhole.",
       "startLine": 68,
-      "endLine": 85,
+      "endLine": 84,
       "mathContext": "$\\forall b : \\text{Fin}\\,3 \\to \\mathbb{Z},\\; \\neg\\, \\text{HasAllPairwiseSums}(O_N, b)$. Proof: $h_{\\text{odd}}$ extracts that all pairwise sums are odd; then `simp+decide` and `grind+ring` derive parity contradiction."
     }
   ],


### PR DESCRIPTION
## Fix

`parity-pigeonhole` (last section) `endLine` pointed one line past the actual file end.

## Evidence

**Before**: `sections[parity-pigeonhole].endLine = 85`
**After**:  `sections[parity-pigeonhole].endLine = 84`
**Actual**: `wc -l proofs/Proofs/Erdos866Problem.lean` -> 84 (matches `leanFile.lineCount = 84`)

Sibling pattern: PR #21754 (erdos-624), PR #21750 (erdos-1028), PR #21748 (amgm-inequality-oq-04), PR #21746 (erdos-37), PR #21739 (erdos-275).

---
Automated fix by lean-mechanic agent.