### PR TITLE
fix(meta): erdos-108 special-case section endLine 142->141

### DIFF
--- a/src/data/proofs/erdos-108/meta.json
+++ b/src/data/proofs/erdos-108/meta.json
@@ -106,7 +106,7 @@
       "id": "special-case",
       "title": "Rödl's Theorem (r=4)",
       "startLine": 103,
-      "endLine": 142,
+      "endLine": 141,
       "summary": "The special case for r=4: triangle-free highly chromatic subgraphs. Historical note on Mycielski's construction.",
       "mathContext": "The special case for r=4: triangle-free highly chromatic subgraphs. Historical note on Mycielski's construction."
     }


### PR DESCRIPTION
## Fix

`erdos-108` (last section, `special-case`) `endLine` pointed one line past the actual file end.

## Evidence

**Before**: `sections[special-case].endLine = 142`
**After**:  `sections[special-case].endLine = 141`
**Actual**: `wc -l proofs/Proofs/Erdos108Problem.lean` -> 141 (matches `leanFile.lineCount = 141` and `meta.lineCount = 141`)

Sibling pattern: PR #21756 (erdos-866), PR #21754 (erdos-624), PR #21750 (erdos-1028), PR #21748 (amgm-inequality-oq-04), PR #21746 (erdos-37), PR #21739 (erdos-275).

---
Automated fix by lean-mechanic agent.