### PR TITLE
fix(meta): erdos-109 examples section endLine 438->437

### DIFF
--- a/src/data/proofs/erdos-109/meta.json
+++ b/src/data/proofs/erdos-109/meta.json
@@ -110,7 +110,7 @@
       "id": "examples",
       "title": "Examples",
       "startLine": 208,
-      "endLine": 438,
+      "endLine": 437,
       "summary": "Verify that ℕ has full density, define even numbers, and prove even + even ⊆ even.",
       "mathContext": "Verify that ℕ has full density, define even numbers, and prove even + even ⊆ even."
     }


### PR DESCRIPTION
## Fix

Correct the `examples` section endLine in `src/data/proofs/erdos-109/meta.json` from 438 to 437 to match the actual line count of `proofs/Proofs/Erdos109Problem.lean` (wc-l = 437).

## Evidence

**Before**: `sections[4].endLine = 438`
**After**: `sections[4].endLine = 437`

`leanFile.lineCount` already reads 437; only the section overshoot needed correction.

---
Automated fix by lean-mechanic agent.