### PR TITLE
fix(meta): erdos-143 historical section endLine 120->119

### DIFF
--- a/src/data/proofs/erdos-143/meta.json
+++ b/src/data/proofs/erdos-143/meta.json
@@ -115,7 +115,7 @@
       "id": "historical",
       "title": "Historical Results",
       "startLine": 98,
-      "endLine": 120,
+      "endLine": 119,
       "summary": "Erdős 1935 theorem on primitive sets",
       "mathContext": "Erdős (1935): primitive sets satisfy $\\sum_{a \\in A} 1/(a \\log a) < \\infty$. But this doesn't resolve $\\sum 1/a$ convergence for dilation-avoiding sets."
     }


### PR DESCRIPTION
## Fix

Last section (`historical`) `endLine` pointed one line past EOF.

## Evidence

**Before**: `sections[historical].endLine = 120`
**After**:  `sections[historical].endLine = 119`
**Actual**: `wc -l proofs/Proofs/Erdos143Problem.lean` -> 119 (matches `meta.lineCount = 119`)

Surfaced by gallery integrity scan for last-section endLine drift.
Sibling pattern: PR #21748 (amgm-inequality-oq-04), #21746 (erdos-37), #21739 (erdos-275).

---
Automated fix by lean-mechanic agent.