### PR TITLE
fix(meta): erdos-69 irrationality section endLine 189->188

### DIFF
--- a/src/data/proofs/erdos-69/meta.json
+++ b/src/data/proofs/erdos-69/meta.json
@@ -114,7 +114,7 @@
       "id": "irrationality",
       "title": "Irrationality and Main Theorem",
       "startLine": 165,
-      "endLine": 189,
+      "endLine": 188,
       "summary": "`primeSum_irrational : Irrational primeSum` is the deep analytic result (sorry — Tao-Teräväinen 2025, beyond current Mathlib). `erdos_69 : Irrational omegaSum` combines `tao_identity` and `primeSum_irrational` in a two-line proof: rewrite via the identity, then apply irrationality.",
       "mathContext": "The final proof: `rw [tao_identity]; exact primeSum_irrational`. This two-line argument is the entire reduction of Problem 69 to Problem 257 — the combinatorial identity does all the work, and the deep analytic number theory is encapsulated in the single sorry."
     }


### PR DESCRIPTION
## Fix

Correct the `Irrationality and Main Theorem` section endLine in `src/data/proofs/erdos-69/meta.json` from 189 to 188 to match the actual line count of `proofs/Proofs/Erdos69Problem.lean` (wc-l = 188).

## Evidence

**Before**: `sections[4].endLine = 189`
**After**: `sections[4].endLine = 188`

`leanFile.lineCount` already reads 188; only the section overshoot needed correction.

---
Automated fix by lean-mechanic agent.