### PR TITLE
fix(meta): erdos-735 axiomCount 7→5, theoremCount 3→5

### DIFF
--- a/src/data/proofs/erdos-735/meta.json
+++ b/src/data/proofs/erdos-735/meta.json
@@ -21,11 +21,11 @@
     "erdosNumber": 735,
     "erdosUrl": "https://erdosproblems.com/735",
     "erdosProblemStatus": "solved",
-    "axiomCount": 7,
+    "axiomCount": 5,
     "lineCount": 247,
-    "assumptions": "7 axioms: collinear_is_magic, general_position_is_magic, magic_classification, three_collinear_card, three_collinear_collinear, triangle_card, triangle_general_position. 0 sorries.",
+    "assumptions": "5 axioms: collinear_is_magic, general_position_is_magic, magic_classification, three_collinear_collinear, triangle_general_position. 0 sorries. (three_collinear_card and triangle_card are proved as theorems, not axioms.)",
     "mathlib_version": "4.26.0",
-    "theoremCount": 3,
+    "theoremCount": 5,
     "definitionCount": 16
   },
   "overview": {
@@ -148,8 +148,8 @@
     "opens": ["Classical"],
     "namespace": "Erdos735",
     "lineCount": 247,
-    "axiomCount": 7,
-    "theoremCount": 3,
+    "axiomCount": 5,
+    "theoremCount": 5,
     "definitionCount": 16,
     "path": "Proofs/Erdos735Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`three_collinear_card` and `triangle_card` are listed in `meta.assumptions` as axioms, but they are proved theorems in `proofs/Proofs/Erdos735Problem.lean`.

## Evidence

After stripping block comments (`/- ... -/`), grep on the source file gives:

| Declaration | Kind | Line |
|---|---|---|
| `collinear_is_magic` | axiom | 50 |
| `general_position_is_magic` | axiom | 60 |
| `magic_classification` | axiom | 106 |
| `not_magic_outside_classes` | theorem | 120 |
| `three_collinear_card` | **theorem** (proved `by`) | 134 |
| `three_collinear_collinear` | axiom | 147 |
| `three_collinear_is_magic` | theorem | 149 |
| `triangle_card` | **theorem** (proved `by`) | 158 |
| `triangle_general_position` | axiom | 171 |
| `triangle_is_magic` | theorem | 173 |

Totals: 5 axioms, 5 theorems, 16 definitions.

## Changes

| Field | Before | After |
|---|---|---|
| `meta.axiomCount` | 7 | 5 |
| `meta.theoremCount` | 3 | 5 |
| `leanFile.axiomCount` | 7 | 5 |
| `leanFile.theoremCount` | 3 | 5 |
| `meta.assumptions` | lists `three_collinear_card` and `triangle_card` as axioms | removes them, adds note |

`status: "axiomatized"` and `badge: "axiom"` are unchanged — 5 axioms still encode the Ackerman-Buchin-Knauer-Pinchasi-Rote 2008 magic classification.

`pnpm build` passes.

---
Automated fix by lean-mechanic agent.