### PR TITLE
fix(meta): greens-theorem-oq-01x4 verified→formalized (build broken under Mathlib v4.26.0)

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Researcher-6 (2026)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Fubini%27s_theorem",
     "date": "2026",
-    "status": "verified",
+    "status": "formalized",
     "proofRepoPath": "Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean",
     "tags": [
       "analysis",
@@ -18,10 +18,10 @@
       "axiom-elimination",
       "greens-theorem"
     ],
-    "badge": "verified",
+    "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "assumptions": "None. 0 sorries, 0 axiom declarations. All theorems follow from Mathlib's Fubini theorem (MeasureTheory.integral_integral_swap) and standard measure theory. The parent module Proofs.GreensTheoremOQ01OQ01OQ01 previously declared iteratedIntervalIntegral_order_independent as an axiom; that declaration has now been retired (it was unused in the parent), since this file proves the same statement as a real theorem from first principles.",
+    "assumptions": "0 sorries, 0 axiom declarations at the source level. All theorems are intended to follow from Mathlib's Fubini theorem (MeasureTheory.integral_integral_swap) and standard measure theory. NOTE (2026-05-31, PR #21741): the file does NOT currently build against the pinned Mathlib v4.26.0 SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 — ~15 distinct compile errors from renamed/removed Mathlib symbols (Continuous.prod_mk, Filter.eventually_of_forall, Equiv.swap_symm, Equiv.swap_apply_of_ne) and tactic/unification failures. Status downgraded from \"verified\" to \"formalized\" until a Mechanic sweep repairs the API drift. See research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01/sessions/2026-05-31-audit-finding-build-broken.md.",
     "dateAdded": "2026-05-06",
     "openQuestions": [
       {


### PR DESCRIPTION
## Fix

Demote gallery `status` for `greens-theorem-oq-01-oq-01-oq-01-oq-01` from `verified` to `formalized` (and `badge` from `verified` to `original`) to reflect the audit finding from PR #21741 that the underlying Lean file does not currently build.

## Evidence

**Before** (`src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json`):
- `status: "verified"`
- `badge: "verified"`
- `assumptions: "None. 0 sorries, 0 axiom declarations…"`

**After**:
- `status: "formalized"`
- `badge: "original"`
- `assumptions` appends:
  > NOTE (2026-05-31, PR #21741): the file does NOT currently build against the pinned Mathlib v4.26.0 SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` — ~15 distinct compile errors from renamed/removed Mathlib symbols (`Continuous.prod_mk`, `Filter.eventually_of_forall`, `Equiv.swap_symm`, `Equiv.swap_apply_of_ne`) and tactic/unification failures. Status downgraded from "verified" to "formalized" until a Mechanic sweep repairs the API drift.

Source counts (`sorries: 0`, `axiomCount: 0`, `lineCount: 516`, `theoremCount: 10`) remain accurate — they describe the source-level structure, which is unchanged. The build failure is upstream API drift, not a structural assumption.

## Rationale

Per `CLAUDE.md` axiom-integrity policy:

> `verified` … Fully machine-checked, no assumptions … 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions

The "fully machine-checked" criterion is not met when the file fails to compile against the pinned Mathlib version. Per the same doc:

> When in doubt … overclaiming `"verified"` damages credibility

PR #21741 explicitly flagged the gap and noted "the verified → ? flip is an auditor's call" — this PR makes that call, choosing the least overclaiming status that still reflects that the file has 0 sorries and 0 axioms.

## Scope discipline

- **One fix per PR**: metadata only. The actual Lean repair (renamed-symbol replacements + tactic adjustments + linter.unusedSimpArgs cleanup) is a separate, larger Mechanic sweep covering 15+ errors across 8+ lines.
- **No Lean source changes** in this PR.
- **No sibling-slug changes** — the parent `greens-theorem-oq-01-oq-01-oq-01` may have parallel drift (per PR #21741's recommended follow-ups), but auditing/repairing it is out of scope here.

## References

- Audit finding: PR #21741 (merged 2026-06-01)
- Session memo: `research/problems/greens-theorem-oq-01-oq-01-oq-01-oq-01/sessions/2026-05-31-audit-finding-build-broken.md`
- Memory anchor: `feedback_g9_qualifier_masks_real_bugs` — classic G9-mask scenario, Docker-verify before trusting "verified" status

---
Automated metadata fix by lean-mechanic agent.