### PR TITLE
Fix: greens-theorem-oq-01x4 Mathlib v4.26.0 API drift (Docker-verified)

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean
@@ -58,7 +58,7 @@ private lemma continuous_param :
   | zero =>
     intro α _ _ _ _ a b F hF
     simp only [iteratedIntervalIntegral_zero]
-    exact hF.comp (continuous_id.prod_mk continuous_const)
+    exact hF.comp (continuous_id.prodMk continuous_const)
   | succ n ih =>
     intro α _ _ _ _ a b F hF
     simp only [iteratedIntervalIntegral_succ]
@@ -69,8 +69,13 @@ private lemma continuous_param :
           (fun rest => F (q.1, Fin.cons q.2 rest))) := by
       apply @ih (α × ℝ) _ _ _ _ (Fin.tail a) (Fin.tail b)
           (fun q : (α × ℝ) × (Fin n → ℝ) => F (q.1.1, Fin.cons q.1.2 q.2))
-      exact hF.comp ((continuous_fst.comp continuous_fst).prod_mk
-        ((continuous_snd.comp continuous_fst).finCons continuous_snd))
+      have hpair : Continuous (fun q : (α × ℝ) × (Fin n → ℝ) =>
+          ((q.1.1, Fin.cons q.1.2 q.2) : α × (Fin (n + 1) → ℝ))) := by
+        refine Continuous.prodMk (continuous_fst.comp continuous_fst) ?_
+        show Continuous (fun q : (α × ℝ) × (Fin n → ℝ) =>
+            (Fin.cons q.1.2 q.2 : Fin (n + 1) → ℝ))
+        exact Continuous.finCons (continuous_snd.comp continuous_fst) continuous_snd
+      exact hF.comp hpair
     -- Now: Continuous (fun x => ∫ t₀ in a₀..b₀, H(x, t₀) dt₀)
     -- Use continuousAt_of_dominated_interval at each x₀
     rw [continuous_iff_continuousAt]
@@ -78,24 +83,24 @@ private lemma continuous_param :
     obtain ⟨K, hK_compact, hK_nhd⟩ := exists_compact_mem_nhds x₀
     -- H is bounded on K × uIcc a₀ b₀ (compact set, image under continuous ‖H‖)
     obtain ⟨M, hM⟩ := ((hK_compact.prod isCompact_uIcc).image
-      H_cont.norm.continuousOn).bddAbove
+      H_cont.norm).bddAbove
     apply intervalIntegral.continuousAt_of_dominated_interval (bound := fun _ => M)
     · -- AEStronglyMeasurable (H(x, ·)) (vol.restrict Ι) eventually near x₀
-      apply Filter.eventually_of_forall; intro x
-      exact (H_cont.comp (continuous_const.prod_mk continuous_id)).measurable
+      apply Filter.Eventually.of_forall; intro x
+      exact (H_cont.comp (continuous_const.prodMk continuous_id)).measurable
           |>.aestronglyMeasurable
     · -- |H(x, t₀)| ≤ M for x near x₀ and t₀ ∈ Ι a₀ b₀
       -- Use compact K containing x₀ (from hK_nhd): H bounded on K × uIcc by hM
       filter_upwards [hK_nhd] with x hx
-      apply Filter.eventually_of_forall; intro t₀ ht₀
+      apply Filter.Eventually.of_forall; intro t₀ ht₀
       apply hM
       exact Set.mem_image_of_mem _
-        (Set.mk_mem_prod hx (Set.uIoc_subset_uIcc _ _ ht₀))
+        (Set.mk_mem_prod hx (Set.uIoc_subset_uIcc ht₀))
     · -- Bound is interval-integrable (constant function)
-      exact intervalIntegrable_const
+      exact intervalIntegral.intervalIntegrable_const
     · -- H(·, t₀) is continuous at x₀ for all t₀
-      apply Filter.eventually_of_forall; intro t₀ _
-      exact (H_cont.comp (continuous_id.prod_mk continuous_const)).continuousAt
+      apply Filter.Eventually.of_forall; intro t₀ _
+      exact (H_cont.comp (continuous_id.prodMk continuous_const)).continuousAt
 
 -- ═══════════════════════════════════════════════════
 -- Section 1: Integrability for the Fubini Swap
@@ -118,9 +123,15 @@ private lemma integrable_swap_pair {n : ℕ} {a b : Fin (n + 2) → ℝ}
         (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
         (fun rest => f (Fin.cons p.1 (Fin.cons p.2 rest)))) := by
     apply continuous_param n (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
-    -- F q = f (Fin.cons q.1.1 (Fin.cons q.1.2 q.2)) : continuous by finCons compositions
-    exact hf.comp ((continuous_fst.comp continuous_fst).finCons
-      ((continuous_snd.comp continuous_fst).finCons continuous_snd))
+        (F := fun q : (ℝ × ℝ) × (Fin n → ℝ) =>
+          f (Fin.cons q.1.1 (Fin.cons q.1.2 q.2)))
+    have hcons : Continuous (fun q : (ℝ × ℝ) × (Fin n → ℝ) =>
+        (Fin.cons q.1.1 (Fin.cons q.1.2 q.2) : Fin (n + 2) → ℝ)) := by
+      refine Continuous.finCons (continuous_fst.comp continuous_fst) ?_
+      show Continuous (fun q : (ℝ × ℝ) × (Fin n → ℝ) =>
+          (Fin.cons q.1.2 q.2 : Fin (n + 1) → ℝ))
+      exact Continuous.finCons (continuous_snd.comp continuous_fst) continuous_snd
+    exact hf.comp hcons
   have hint : IntegrableOn
       (fun p : ℝ × ℝ =>
         iteratedIntervalIntegral (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
@@ -135,7 +146,7 @@ private lemma integrable_swap_pair {n : ℕ} {a b : Fin (n + 2) → ℝ}
       (Ioc (a 0) (b 0) ×ˢ Ioc (a 1) (b 1))
       (volume.prod volume) :=
     hint.mono_set (Set.prod_mono Ioc_subset_Icc_self Ioc_subset_Icc_self)
-  rw [← Measure.prod_restrict]
+  rw [Measure.prod_restrict]
   exact hint_ioc
 
 -- ═══════════════════════════════════════════════════
@@ -146,20 +157,21 @@ private lemma integrable_swap_pair {n : ℕ} {a b : Fin (n + 2) → ℝ}
 private lemma swap01_cons_eq {n : ℕ} {f : (Fin (n + 2) → ℝ) → ℝ}
     (x₀ x₁ : ℝ) (rest : Fin n → ℝ) :
     let σ := Equiv.swap (0 : Fin (n + 2)) 1
-    (fun x => f (fun i => x (σ.symm i))) (Fin.cons x₁ (Fin.cons x₀ rest)) =
+    (fun x : Fin (n + 2) → ℝ => f (fun i => x (σ.symm i)))
+        (Fin.cons x₁ (Fin.cons x₀ rest)) =
     f (Fin.cons x₀ (Fin.cons x₁ rest)) := by
   intro σ
-  simp only [σ, Equiv.swap_symm]
+  simp only [σ, Equiv.symm_swap]
   congr 1
   ext i
   refine Fin.cases ?_ (fun j => ?_) i
-  · simp [Equiv.swap_apply_left, Fin.cons_zero, Fin.cons_succ]
+  · simp [Equiv.swap_apply_left, Fin.cons_zero]
   · refine Fin.cases ?_ (fun k => ?_) j
-    · simp [Equiv.swap_apply_right, Fin.cons_zero, Fin.cons_succ]
+    · simp [Equiv.swap_apply_right, Fin.cons_zero]
     · have hne0 : k.succ.succ ≠ (0 : Fin (n + 2)) := Fin.succ_ne_zero _
       have hne1 : k.succ.succ ≠ (1 : Fin (n + 2)) := by
-        intro h; have hv := congr_arg Fin.val h; simp [Fin.val_succ] at hv; omega
-      simp [Equiv.swap_apply_of_ne hne0 hne1, Fin.cons_zero, Fin.cons_succ]
+        intro h; have hv := congr_arg Fin.val h; simp [Fin.val_succ] at hv
+      simp [Equiv.swap_apply_of_ne_of_ne hne0 hne1, Fin.cons_succ]
 
 -- ═══════════════════════════════════════════════════
 -- Section 3: Swapping Positions 0 and 1
@@ -177,7 +189,7 @@ theorem swap_outer_two {n : ℕ} {a b : Fin (n + 2) → ℝ}
         iteratedIntervalIntegral
           (Fin.tail (Fin.tail a)) (Fin.tail (Fin.tail b))
           (fun rest => f (Fin.cons x₀ (Fin.cons x₁ rest))) := by
-    simp only [iteratedIntervalIntegral_succ, Fin.tail]
+    simp only [iteratedIntervalIntegral_succ, Fin.tail, Fin.succ_zero_eq_one]
   have fubini_step :
       ∫ x₀ in (a 0)..(b 0), ∫ x₁ in (a 1)..(b 1),
         iteratedIntervalIntegral
@@ -197,7 +209,7 @@ theorem swap_outer_two {n : ℕ} {a b : Fin (n + 2) → ℝ}
           (fun rest => f (Fin.cons x₀ (Fin.cons x₁ rest))) := by
     simp only [iteratedIntervalIntegral_succ, σ, Function.comp, Equiv.swap_apply_left]
     congr 1; ext x₁
-    simp only [iteratedIntervalIntegral_succ, Fin.tail, σ, Function.comp, Equiv.swap_apply_right]
+    simp only [Fin.tail, Function.comp]
     congr 1; ext x₀
     congr 1; ext rest
     exact swap01_cons_eq x₀ x₁ rest
@@ -251,16 +263,17 @@ private lemma iteratedIntervalIntegral_perm_tail {n : ℕ} {a b : Fin (n + 1) �
   rw [iteratedIntervalIntegral_succ, iteratedIntervalIntegral_succ, h0a, h0b]
   apply intervalIntegral.integral_congr
   intro x₀ _
+  -- Beta-reduced equation: rewriting inside the iterated integral.
   have hfun : ∀ x' : Fin n → ℝ,
-      (fun x => f (fun i => x (σ.symm i))) (Fin.cons x₀ x') =
-      (fun y' => f (Fin.cons x₀ y')) (fun i => x' (σ'.symm i)) := by
+      f (fun i => (Fin.cons x₀ x' : Fin (n + 1) → ℝ) (σ.symm i)) =
+      f (Fin.cons x₀ (fun i => x' (σ'.symm i))) := by
     intro x'
-    simp only []
     congr 1; ext i
     refine Fin.cases ?_ (fun j => ?_) i
     · simp [hσ_symm_0, Fin.cons_zero]
     · simp [hsucc_symm j, Fin.cons_succ]
-  rw [htail_a, htail_b, funext hfun]
+  rw [htail_a, htail_b]
+  simp_rw [hfun]
   exact ih (Fin.tail a) (Fin.tail b)
     (fun y' => f (Fin.cons x₀ y'))
     (hf.comp (continuous_const.finCons continuous_id))
@@ -294,7 +307,7 @@ private lemma iter_integral_swap_zero {n : ℕ}
   induction m with
   | zero =>
     intro hm a b hab f hf
-    simp [Equiv.swap_self, Function.comp]
+    simp [Equiv.swap_self]
   | succ m ihm =>
     intro hm a b hab f hf
     -- k = ⟨m+1, hm⟩, k₀ = ⟨m, lt_of_succ_lt hm⟩... no wait
@@ -308,12 +321,11 @@ private lemma iter_integral_swap_zero {n : ℕ}
       -- The types: Fin(n+1) with n ≥ 1, so we have Fin(n'+2) for n' = n-1
       -- Use swap_outer_two after matching n = n'+1
       obtain ⟨n', rfl⟩ := Nat.exists_eq_succ_of_ne_zero (Nat.one_le_iff_ne_zero.mp hn)
-      -- Now n+1 = n'+2, and the lemma swap_outer_two applies
+      -- Now n+1 = n'+2, and the lemma swap_outer_two applies directly
+      -- (⟨0+1, _⟩ : Fin (n'+2)) is definitionally 1.
       simp only
-      convert @swap_outer_two n' a b hab f hf using 1
-      · rfl
-      · simp [Equiv.swap_comm]
-    | succ m' =>
+      exact swap_outer_two hab hf
+    | m' + 1 =>
       -- k = ⟨m'+2, hm⟩, k₀ = ⟨m'+1, hm0⟩
       have hm0 : m' + 1 < n + 1 := Nat.lt_of_succ_lt hm
       let k₀ : Fin (n + 1) := ⟨m' + 1, hm0⟩
@@ -322,18 +334,27 @@ private lemma iter_integral_swap_zero {n : ℕ}
       have hk₀_ne_0 : k₀ ≠ (0 : Fin (n + 1)) := by simp [k₀, Fin.ext_iff]
       have hk_ne_0  : k  ≠ (0 : Fin (n + 1)) := by simp [k, Fin.ext_iff]
       have hk₀_ne_k : k₀ ≠ k := by simp [k₀, k, Fin.ext_iff]
-      -- Pointwise identity: swap(0,k₀)(swap(k₀,k)(swap(0,k₀) i)) = swap(0,k) i
-      -- This is the function form of swap(k₀,k)*swap(0,k₀)*swap(k₀,k) = swap(0,k)
+      -- Pointwise identity: conjugating swap(k₀,k) by swap(0,k₀) yields swap(0,k).
+      -- Proven via Equiv.swap_apply_apply (swap conjugation lemma).
+      have h_sk0 : Equiv.swap 0 k₀ k₀ = (0 : Fin (n + 1)) :=
+        Equiv.swap_apply_right 0 k₀
+      have h_sk : Equiv.swap 0 k₀ k = k :=
+        Equiv.swap_apply_of_ne_of_ne hk_ne_0 (Ne.symm hk₀_ne_k)
+      have heq : Equiv.swap (0 : Fin (n + 1)) k =
+          Equiv.swap 0 k₀ * Equiv.swap k₀ k * Equiv.swap 0 k₀ := by
+        conv_lhs => rw [show (0 : Fin (n + 1)) = Equiv.swap 0 k₀ k₀ from h_sk0.symm,
+                        show k = Equiv.swap 0 k₀ k from h_sk.symm,
+                        Equiv.swap_apply_apply, Equiv.swap_inv]
       have hcomp : ∀ i : Fin (n + 1),
           Equiv.swap 0 k₀ (Equiv.swap k₀ k (Equiv.swap 0 k₀ i)) = Equiv.swap 0 k i := by
         intro i
-        simp only [Equiv.swap_apply_def, k₀, k, Fin.mk.injEq]
-        split_ifs <;> simp_all [Fin.ext_iff] <;> omega
+        have := congr_fun (congr_arg DFunLike.coe heq.symm) i
+        simpa [Equiv.Perm.mul_apply] using this
       -- Step 1: apply IH for k₀
       have step1 := ihm hm0 hab hf
       -- Step 2: apply perm_tail for swap(k₀,k) (fixes 0)
       have hfixes0 : Equiv.swap k₀ k (0 : Fin (n+1)) = 0 :=
-        Equiv.swap_apply_of_ne (Ne.symm hk₀_ne_0) (Ne.symm hk_ne_0)
+        Equiv.swap_apply_of_ne_of_ne (Ne.symm hk₀_ne_0) (Ne.symm hk_ne_0)
       have hab₁ : ∀ i, (a ∘ Equiv.swap 0 k₀) i ≤ (b ∘ Equiv.swap 0 k₀) i :=
         fun i => hab _
       have hf₁ : Continuous (fun v : Fin (n+1) → ℝ =>
@@ -369,8 +390,8 @@ private lemma iter_integral_swap_zero {n : ℕ}
                   ((Equiv.swap k₀ k).symm ((Equiv.swap 0 k₀).symm i))))) =
             fun v => f (fun i => v ((Equiv.swap 0 k).symm i)) := by
         ext v; congr 1; ext i
-        simp only [Equiv.swap_symm]
-        exact hcomp i
+        simp only [Equiv.symm_swap]
+        exact congr_arg v (hcomp i)
       rw [chain, ha_eq, hb_eq, hf_eq]
 
 -- ═══════════════════════════════════════════════════
@@ -394,7 +415,7 @@ private lemma iter_integral_swap_any {n : ℕ}
     iteratedIntervalIntegral (a ∘ Equiv.swap x y) (b ∘ Equiv.swap x y)
       (fun v => f (fun i => v ((Equiv.swap x y).symm i))) := by
   rcases eq_or_ne x y with rfl | hxy
-  · simp [Equiv.swap_self, Function.comp]
+  · simp [Equiv.swap_self]
   · -- Case: x ≠ y
     rcases eq_or_ne x 0 with rfl | hx0
     · -- x = 0: use iter_integral_swap_zero
@@ -405,7 +426,7 @@ private lemma iter_integral_swap_any {n : ℕ}
         exact iter_integral_swap_zero ih x.val x.isLt hab hf
       · -- x ≠ 0, y ≠ 0: swap(x,y) fixes 0, use perm_tail
         have hfixes0 : (Equiv.swap x y) 0 = 0 := by
-          rw [Equiv.swap_apply_of_ne hx0.symm hy0.symm]
+          rw [Equiv.swap_apply_of_ne_of_ne hx0.symm hy0.symm]
         exact iteratedIntervalIntegral_perm_tail hab hf (Equiv.swap x y) hfixes0 ih
 
 -- ═══════════════════════════════════════════════════
@@ -428,7 +449,7 @@ theorem iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → �
   induction n with
   | zero =>
     have : σ = Equiv.refl (Fin 0) := Subsingleton.elim _ _
-    subst this; simp [iteratedIntervalIntegral, Function.comp]
+    subst this; simp [iteratedIntervalIntegral]
   | succ n ih =>
     have ih' : ∀ (a' b' : Fin n → ℝ) (g : (Fin n → ℝ) → ℝ),
         Continuous g → (∀ i, a' i ≤ b' i) →
@@ -436,33 +457,33 @@ theorem iteratedIntervalIntegral_order_independent {n : ℕ} {a b : Fin n → �
         iteratedIntervalIntegral a' b' g =
         iteratedIntervalIntegral (a' ∘ τ) (b' ∘ τ) (fun x => g (fun i => x (τ.symm i))) :=
       fun a' b' g hg hab' τ => ih hab' hg τ
-    -- Prove by swap induction on σ
+    -- Prove by swap induction on σ.
     -- P(σ) = ∀ a b hab f hf, integral a b f = integral (a∘σ) (b∘σ) (f∘σ.symm)
-    -- We prove the SPECIFIC instance with our a, b, f by using induction on σ
-    -- via swap_induction_on (reduces to P(1) and P(swap(x,y) * τ) from P(τ))
-    induction σ using Equiv.Perm.swap_induction_on with
+    -- We use swap_induction_on' (right-multiplication form): reduces to P(1) and
+    -- P(τ * swap(x,y)) from P(τ). This matches the convention `(σ * τ) i = σ (τ i)`
+    -- so that `a ∘ (τ * swap) = (a ∘ τ) ∘ swap` pointwise.
+    induction σ using Equiv.Perm.swap_induction_on' with
     | one =>
-      simp [Function.comp]
-    | swap_mul τ x y hxy hPτ =>
+      simp
+    | mul_swap τ x y hxy hPτ =>
       -- hPτ : integral a b f = integral (a∘τ) (b∘τ) (fun v => f(v∘τ.symm))
-      -- Goal: integral a b f = integral (a∘(swap*τ)) (b∘(swap*τ)) (fun v => f(v∘(swap*τ).symm))
+      -- Goal: integral a b f = integral (a∘(τ*swap)) (b∘(τ*swap)) (fun v => f(v∘(τ*swap).symm))
       have hab_τ : ∀ i, (a ∘ τ) i ≤ (b ∘ τ) i := fun i => hab _
       have hf_τ : Continuous (fun v : Fin (n + 1) → ℝ => f (fun i => v (τ.symm i))) :=
         hf.comp (continuous_pi_iff.mpr fun i => continuous_apply (τ.symm i))
       -- Chain: a b f = a∘τ b∘τ f∘τ.symm  [hPτ]
-      --            = a∘τ∘swap b∘τ∘swap (f∘τ.symm)∘swap.symm [iter_integral_swap_any]
-      --            = a∘(swap*τ) b∘(swap*τ) f∘(swap*τ).symm  [simplification]
+      --            = (a∘τ)∘swap (b∘τ)∘swap (f∘τ.symm)∘swap.symm  [iter_integral_swap_any]
+      --            = a∘(τ*swap) b∘(τ*swap) f∘(τ*swap).symm  [(τ*swap)(i) = τ(swap i)]
       rw [hPτ, iter_integral_swap_any ih' hab_τ hf_τ x y]
       -- Show bounds and function match
       have hbnd : ∀ (c : Fin (n + 1) → ℝ),
-          c ∘ τ ∘ Equiv.swap x y = c ∘ (Equiv.swap x y * τ) :=
-        fun c => funext fun i => by simp [Function.comp, Equiv.Perm.mul_apply]
+          (c ∘ τ) ∘ Equiv.swap x y = c ∘ (τ * Equiv.swap x y) :=
+        fun _ => rfl
       rw [hbnd a, hbnd b]
-      congr 1; ext v; congr 1; ext i
-      -- (fun j => v(swap.symm j))(τ.symm i) = v((swap*τ).symm i)
-      -- LHS = v(swap.symm(τ.symm i)) = v(swap(τ.symm i))  [swap self-inverse]
-      -- RHS = v((τ.symm * swap.symm) i) = v(swap.symm(τ.symm i)) [mul_inv_rev]
-      simp [Equiv.swap_symm, mul_inv_rev, Equiv.Perm.mul_apply]
+      -- After the bound rewrites, the function parts coincide via congr.
+      -- LHS fn at v, i: v(swap.symm(τ.symm i)) = v(swap(τ.symm i))  [swap self-inverse]
+      -- RHS fn at v, i: v((τ*swap).symm i) = v(swap(τ.symm i))      [mul_inv_rev]
+      congr 1
 
 -- ═══════════════════════════════════════════════════
 -- Section 8: Verified Special Cases (0 sorries)
@@ -501,7 +522,7 @@ theorem order_independent_3d_swap01 {a b : Fin 3 → ℝ}
 1. `continuous_param` (succ step, h_bound): Compact bound for dominated convergence.
    Fix: Use hM (from IsCompact.bddAbove on compact K × uIcc) + hK_nhd filter_upwards
    to show ∀ᶠ x in 𝓝 x₀, ∀ᵐ t₀, ‖H(x,t₀)‖ ≤ M.
-   Concretely: `filter_upwards [hK_nhd] with x hx; apply Filter.eventually_of_forall;
+   Concretely: `filter_upwards [hK_nhd] with x hx; apply Filter.Eventually.of_forall;
    intro t ht; exact hM (mem_image_of_mem _ (mk_mem_prod hx (uIoc_subset_uIcc ht)))`
 
 2. `iter_integral_swap_zero` (succ step, m'+2 case): Decompose swap(0,k) into


### PR DESCRIPTION
## Fix

Repair `proofs/Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` (gallery slug `greens-theorem-oq-01-oq-01-oq-01-oq-01`) which failed Docker-verify with 15+ Mathlib v4.26.0 API-drift errors. The lake cache had been masking these errors; the gallery `status: "verified"` claim was stale until now.

## Evidence

**Before**: `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ01OQ01` fails with 15+ distinct errors (renamed symbols `Continuous.prod_mk`, `Filter.eventually_of_forall`, `Equiv.swap_symm`, `Equiv.swap_apply_of_ne`; tactic/unification failures the lake cache masked). Discovered 2026-05-31 — see PR #21741.

**After**: Docker-verify succeeds — 7745 jobs build cleanly. Only pre-existing unused-variable warnings in the parent chain remain (in `GreensTheoremOQ01OQ01.lean`, `GreensTheoremOQ01OQ01OQ01.lean`, and the file itself). 0 sorries, 0 `axiom` declarations preserved → gallery `verified` claim is now actually backed by a buildable file.

## API-drift summary (Mathlib v4.26.0)

| Old symbol / pattern | New symbol / pattern |
|---|---|
| `Continuous.prod_mk` | `Continuous.prodMk` |
| `Filter.eventually_of_forall` | `Filter.Eventually.of_forall` |
| `Equiv.swap_symm` | `Equiv.symm_swap` |
| `Equiv.swap_apply_of_ne` | `Equiv.swap_apply_of_ne_of_ne` |
| `intervalIntegrable_const` | `intervalIntegral.intervalIntegrable_const` |
| `Equiv.Perm.swap_induction_on` (left-mul) | `Equiv.Perm.swap_induction_on'` (right-mul, matches `(σ*τ) i = σ (τ i)`) |
| `Set.uIoc_subset_uIcc _ _ ht` | `Set.uIoc_subset_uIcc ht` |
| `(_.norm.continuousOn).bddAbove` on compact | `_.norm.bddAbove` (already continuous) |
| `← Measure.prod_restrict` | `Measure.prod_restrict` (forward direction) |

## Notable tactic rewrites

- **Swap conjugation identity** `swap(0,k₀) ∘ swap(k₀,k) ∘ swap(0,k₀) = swap(0,k)` is now proven cleanly via `Equiv.swap_apply_apply` + `Equiv.swap_inv` instead of brittle `split_ifs <;> simp_all <;> omega` over `Equiv.swap_apply_def`.
- **`continuous_param` succ step**: replaced `IsCompact.image H_cont.norm.continuousOn` with direct `H_cont.norm` (the function is `Continuous`, not just `ContinuousOn`).
- **`integral_swap_zero` m'+2 case**: simplified the `convert ... using 1` with `Equiv.swap_comm` to a direct `exact swap_outer_two hab hf` (the `⟨0+1, _⟩` is definitionally `(1 : Fin (n'+2))`).
- **`iteratedIntervalIntegral_perm_tail`**: rewrote the `funext hfun` ▸ `iter ih` step using `simp_rw [hfun]` against a beta-reduced equality, avoiding a unification failure with the dependent integrand.

Closes the audit failure reported in PR #21741 (which preserved the docstring-cleanup work but documented that the file did not build).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.GreensTheoremOQ01OQ01OQ01OQ01` succeeds
- [x] 0 `sorry` in the proof body (only docstring mention)
- [x] 0 `axiom` declarations preserved
- [x] No new warnings beyond the pre-existing unused-variable lints in the parent chain

---
Automated fix by lean-mechanic agent.