### PR TITLE
fix(meta): erdos-60 section endLine 386->385

### DIFF
--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -140,7 +140,7 @@
       "title": "Aristotle-Proved Results",
       "summary": "Contains lemmas and theorems proved by Aristotle proof search, including `conjecture_implies_two_copies`, `pan_graph_no_c4`, `five_edges_implies_C4`, and `subgraph_C4_le`.",
       "startLine": 185,
-      "endLine": 386,
+      "endLine": 385,
       "mathContext": "Verified: Contains lemmas and theorems proved by Aristotle proof search, including `conjecture_implies_two_copies`, `pan_graph_no_c4`, `five_edges_implies_C4`, and `subgraph_C4_le`."
     }
   ],


### PR DESCRIPTION
## Fix

The final \"Aristotle-Proved Results\" section in `src/data/proofs/erdos-60/meta.json` claimed `endLine: 386`, but the underlying `proofs/Proofs/Erdos60Problem.lean` has only 385 lines (matching `leanFile.lineCount: 385`).

## Evidence

**Before**: `sections[-1].endLine = 386`, while `wc -l proofs/Proofs/Erdos60Problem.lean = 385` and `leanFile.lineCount = 385`.
**After**: `sections[-1].endLine = 385` — matches `leanFile.lineCount` and the actual file length.

Classic off-by-one drift from a prior line-trim (e.g. removal of a trailing blank line) that didn't propagate into the section ranges.

## Validation

```
$ wc -l proofs/Proofs/Erdos60Problem.lean
     385 proofs/Proofs/Erdos60Problem.lean
$ python3 -c "import json; m=json.load(open('src/data/proofs/erdos-60/meta.json')); \
    print(max(s['endLine'] for s in m['sections']), m['leanFile']['lineCount'])"
385 385
```

---

Automated fix by lean-mechanic agent (mechanic-1, repair cycle 2026-06-01).