### PR TITLE
fix(meta): batch sync 23 last-section endLine off-by-1 drifts (wc-l canonical)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -120,7 +120,7 @@
       "id": "summary",
       "title": "Summary Theorems",
       "startLine": 283,
-      "endLine": 307,
+      "endLine": 306,
       "summary": "large_cardinals_and_ch_summary and ch_independent_of_large_cardinals combining the main results.",
       "mathContext": "Standard large cardinals leave CH independent; MM decides ¬CH; GCH decides all continua."
     }

--- a/src/data/proofs/erdos-1161/meta.json
+++ b/src/data/proofs/erdos-1161/meta.json
@@ -112,7 +112,7 @@
       "title": "Structural Lemmas",
       "summary": "Proves structural results: for prime $p$, permutations of order $p$ in $S_p$ are exactly the $p$-cycles, so there are $(p-1)!$ of them (`permCountByOrder_prime_self`). This corrects a previous false claim for general $n$ (counterexample: $n=6$). Also proves lcmRange monotonicity and divisibility.",
       "startLine": 135,
-      "endLine": 324
+      "endLine": 323
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-123/meta.json
+++ b/src/data/proofs/erdos-123/meta.json
@@ -93,7 +93,7 @@
       "id": "structural",
       "title": "Structural Results",
       "startLine": 270,
-      "endLine": 318,
+      "endLine": 317,
       "summary": "erdos_lewin_357 (axiom), powers_2_3_special_case, antichain_singleton, dvd_iff_two_mul_dvd, antichain_double"
     }
   ],

--- a/src/data/proofs/erdos-139/meta.json
+++ b/src/data/proofs/erdos-139/meta.json
@@ -89,7 +89,7 @@
       "id": "bounds",
       "title": "Quantitative Bounds",
       "startLine": 188,
-      "endLine": 261,
+      "endLine": 260,
       "summary": "Axiomatized bounds from Kelley-Meka, Gowers, and Behrend"
     }
   ],

--- a/src/data/proofs/erdos-168/meta.json
+++ b/src/data/proofs/erdos-168/meta.json
@@ -118,7 +118,7 @@
       "id": "examples",
       "title": "Small Examples",
       "startLine": 150,
-      "endLine": 181,
+      "endLine": 180,
       "summary": "Verify {1,2} is triple-free and {1,2,3} contains a triple."
     }
   ],

--- a/src/data/proofs/erdos-172/meta.json
+++ b/src/data/proofs/erdos-172/meta.json
@@ -135,7 +135,7 @@
       "id": "examples",
       "title": "Examples",
       "startLine": 113,
-      "endLine": 145,
+      "endLine": 144,
       "summary": "Singletons and empty sets are trivially monochromatic."
     }
   ],

--- a/src/data/proofs/erdos-303/meta.json
+++ b/src/data/proofs/erdos-303/meta.json
@@ -124,7 +124,7 @@
       "id": "density",
       "title": "Connection to Density Version",
       "startLine": 190,
-      "endLine": 259,
+      "endLine": 258,
       "summary": "Relation to Erdős #302 and the general pattern"
     }
   ],

--- a/src/data/proofs/erdos-439/meta.json
+++ b/src/data/proofs/erdos-439/meta.json
@@ -143,7 +143,7 @@
       "title": "Summary Theorem",
       "summary": "Proves `erdos_439_summary` packaging three results: (1) Khalfalah-Szemerédi for all $k \\geq 1$, (2) ESS for 2 colors, (3) ESS for 3 colors. Uses `refine ⟨?_, ess_two_colors, ess_three_colors⟩` to split the conjunction.",
       "startLine": 187,
-      "endLine": 219,
+      "endLine": 218,
       "mathContext": "Proves `erdos_439_summary` packaging three results: (1) Khalfalah-Szemerédi for all $k \\geq 1$, (2) ESS for 2 colors, (3) ESS for 3 colors."
     }
   ],

--- a/src/data/proofs/erdos-485/meta.json
+++ b/src/data/proofs/erdos-485/meta.json
@@ -92,7 +92,7 @@
       "id": "related",
       "title": "Related Concepts: Sparse and Lacunary Polynomials",
       "startLine": 194,
-      "endLine": 226,
+      "endLine": 225,
       "summary": "Generalization g(k,n) for P^n, sparse polynomial definition, product density axiom, lacunary polynomial definition, and lacunary square term lower bound.",
       "mathContext": "The section connects Problem 485 to the broader theory of sparse polynomials.  A polynomial is *sparse* if $|\\text{supp}(P)| \\leq c \\log(\\deg P + 1)$, and *lacunary* if consecutive exponents have gaps $\\geq 2$.  Lacunary polynomials satisfy $\\text{termCount}(P^2) \\geq 2k - 1$ (no cancellation possible when gaps are large enough), showing that the minimum $f(k)$ must be achieved by non-lacunary, specifically engineered polynomials."
     }

--- a/src/data/proofs/erdos-517/meta.json
+++ b/src/data/proofs/erdos-517/meta.json
@@ -123,7 +123,7 @@
       "id": "example",
       "title": "Example: Exponential Gaps and Application",
       "startLine": 151,
-      "endLine": 176,
+      "endLine": 175,
       "summary": "Verifies nₖ = 2^k has Fejér gaps (geometric series ∑1/2^k converges), then applies Biernacki's theorem to conclude any entire function f(z) = ∑ aₖz^{2^k} assumes every value infinitely often.",
       "mathContext": "$n_k = 2^k$: strictly increasing (powers of 2), and $\\sum 2^{-k} = 1 < \\infty$ (geometric series). By Biernacki: $\\forall w \\in \\mathbb{C},\\; |\\{z : f(z) = w\\}| = \\infty$ for any entire $f(z) = \\sum a_k z^{2^k}$."
     }

--- a/src/data/proofs/erdos-551/meta.json
+++ b/src/data/proofs/erdos-551/meta.json
@@ -153,7 +153,7 @@
       "title": "Main Theorem, Current Best, and Asymptotic Resolution",
       "summary": "main_theorem combining all progress (formula ↔ k ≥ SmallestValidK), current_best via KLS bound, solved_asymptotically showing formula holds for all but finitely many k per fixed n",
       "startLine": 560,
-      "endLine": 604,
+      "endLine": 603,
       "mathContext": "Conjectured: $R(C_k,K_n) = (k-1)(n-1)+1$ for $k \\\\geq n \\\\geq 3$, $(k,n) \\\\neq (3,3)$. Known thresholds: $k \\\\geq 4n+2$ (Nikiforov), $k \\\\geq C\\\\log n/\\\\log\\\\log n$ (KLS)."
     }
   ],

--- a/src/data/proofs/erdos-60/meta.json
+++ b/src/data/proofs/erdos-60/meta.json
@@ -140,7 +140,7 @@
       "title": "Aristotle-Proved Results",
       "summary": "Contains lemmas and theorems proved by Aristotle proof search, including `conjecture_implies_two_copies`, `pan_graph_no_c4`, `five_edges_implies_C4`, and `subgraph_C4_le`.",
       "startLine": 185,
-      "endLine": 386,
+      "endLine": 385,
       "mathContext": "Verified: Contains lemmas and theorems proved by Aristotle proof search, including `conjecture_implies_two_copies`, `pan_graph_no_c4`, `five_edges_implies_C4`, and `subgraph_C4_le`."
     }
   ],

--- a/src/data/proofs/erdos-604/meta.json
+++ b/src/data/proofs/erdos-604/meta.json
@@ -127,7 +127,7 @@
       "title": "Connection to Distinct Distances",
       "summary": "How pinned distances relate to all pairwise distances",
       "startLine": 115,
-      "endLine": 224
+      "endLine": 223
     }
   ],
   "conclusion": {

--- a/src/data/proofs/erdos-629/meta.json
+++ b/src/data/proofs/erdos-629/meta.json
@@ -126,7 +126,7 @@
       "title": "Complete Bipartite Graphs and Asymptotics",
       "summary": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$.",
       "startLine": 847,
-      "endLine": 912,
+      "endLine": 911,
       "mathContext": "Defines `completeBipartite m n` ($K_{m,n}$ on `Fin m ⊕ Fin n`). States `knn_list_chromatic` (sorry): $\\chi_L(K_{n,n}) \\approx \\log_2 n + 1$. States `n_exponential_growth` (sorry) and defines `ExactAsymptoticConjecture`: $n(k) = \\Theta(2^k \\cdot k^\\alpha)$."
     }
   ],

--- a/src/data/proofs/erdos-643/meta.json
+++ b/src/data/proofs/erdos-643/meta.json
@@ -120,7 +120,7 @@
       "id": "constructions",
       "title": "Sunflower Constructions",
       "startLine": 158,
-      "endLine": 1403,
+      "endLine": 1402,
       "summary": "Sunflower hypergraphs avoiding crossed pairs"
     }
   ],

--- a/src/data/proofs/erdos-846/meta.json
+++ b/src/data/proofs/erdos-846/meta.json
@@ -153,7 +153,7 @@
       "id": "conjecture",
       "title": "The Erdős–Nešetřil–Rödl Conjecture (DISPROVED 2026-05-21)",
       "startLine": 263,
-      "endLine": 291,
+      "endLine": 290,
       "summary": "Documents the 2026-05-21 AlphaProof Nexus refutation. The prior `axiom ErdosProblem846` has been dropped; the formal counterexample lives in `Proofs/Erdos846ProblemAPN.lean`.",
       "mathContext": "The conjecture is FALSE: DeepMind's AlphaProof Nexus exhibits an infinite (1/2)-non-trilinear subset of ℝ² that is not weakly non-trilinear (`Erdos846APN.target_false`). Construction via the Elekes parametrisation $q(i,j) = (t_i + t_j,\\, t_i^2 + t_i t_j + t_j^2)$ with $t_n = 100^{4^n}$, combined with Ramsey-for-triangles to rule out finite non-collinear partitions."
     }

--- a/src/data/proofs/erdos-941/meta.json
+++ b/src/data/proofs/erdos-941/meta.json
@@ -157,7 +157,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 217,
-      "endLine": 324,
+      "endLine": 323,
       "summary": "Three equivalent theorems: `erdos_941`, `erdos_941_main`, `erdos_941_solved`, all delegating to `heath_brown_theorem`. Confirms the problem is SOLVED: every sufficiently large integer is a sum of $\\le 3$ powerful numbers.",
       "mathContext": "Three equivalent theorems: `erdos_941`, `erdos_941_main`, `erdos_941_solved`, all delegating to `heath_brown_theorem`. Confirms the problem is SOLVED: every sufficiently large integer is a sum of $\\le 3$ powerful numbers."
     }

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
@@ -139,7 +139,7 @@
       "id": "contrast-summary",
       "title": "Part VI: Contrast and Summary",
       "startLine": 186,
-      "endLine": 215,
+      "endLine": 214,
       "summary": "Contrast theorem (finrank ℝ ℂ = 2 AND ¬Module.Finite ℚ_[p] (AlgClosure ℚ_[p])), explicit examples n=2,3,4, and summary conjunction.",
       "mathContext": "The real/p-adic dichotomy in one theorem: real algebraic closure is degree 2; p-adic algebraic closure is infinite-dimensional."
     }

--- a/src/data/proofs/hilbert-20-oq-01/meta.json
+++ b/src/data/proofs/hilbert-20-oq-01/meta.json
@@ -118,7 +118,7 @@
       "id": "special-cases",
       "title": "Special Cases: Elliptic and Real-Symbol Operators",
       "startLine": 174,
-      "endLine": 212,
+      "endLine": 211,
       "summary": "Proved theorems: `real_symbol_satisfies_psi` (operators with real principal symbol satisfy condition (Ψ) since $\\text{Im}(p_m) = 0$ always), `elliptic_satisfies_psi` (elliptic operators satisfy (Ψ) vacuously — no bicharacteristics exist), `elliptic_locally_solvable` (elliptic principal-type operators are locally solvable, combining (Ψ) with Dencker sufficiency).",
       "mathContext": "Real symbol: $p_m$ real $\\Rightarrow \\text{Im}(p_m) = 0 \\Rightarrow$ (Ψ) trivially. Elliptic: $p_m(x, \\xi) \\neq 0$ for $\\xi \\neq 0 \\Rightarrow$ no bicharacteristics $\\Rightarrow$ (Ψ) vacuously $\\Rightarrow$ locally solvable."
     }

--- a/src/data/proofs/law-of-cosines-oq-01-oq-04/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-01-oq-04/meta.json
@@ -98,7 +98,7 @@
       "id": "scaled-version",
       "title": "Scaled Version and Special Cases",
       "startLine": 169,
-      "endLine": 191,
+      "endLine": 190,
       "summary": "spherical_to_euclidean_limit and concrete verifications for right and equilateral triangles.",
       "mathContext": "The scaled version multiplies by 2: $\\lim_{t \\to 0} \\frac{2(1 - \\cos(t\\alpha)\\cos(t\\beta) - \\sin(t\\alpha)\\sin(t\\beta)\\cos C)}{t^2} = \\alpha^2 + \\beta^2 - 2\\alpha\\beta\\cos C$. Special cases: (1) Right triangle ($\\cos C = 0$, $\\alpha=3$, $\\beta=4$): limit = $(9+16)/2 = 25/2$, recovering Pythagorean theorem. (2) Equilateral ($\\alpha=\\beta$, $\\cos C = 1/2$): limit = $(\\alpha^2 + \\alpha^2 - 2\\alpha^2/2)/2 = \\alpha^2/2$."
     }

--- a/src/data/proofs/navier-stokes-existence/meta.json
+++ b/src/data/proofs/navier-stokes-existence/meta.json
@@ -215,7 +215,7 @@
       "title": "Helicity, Pressure, Liouville Theorems",
       "summary": "Parts XXXVIII-XL: Helicity conservation and Beltrami flows, pressure estimates via Calderon-Zygmund, KNSS Liouville theorem, Seregin zero theorem, Landau solution, millennium connection.",
       "startLine": 6663,
-      "endLine": 21111,
+      "endLine": 21110,
       "mathContext": "Helicity: $H(t) = \\int u \\cdot \\omega\\,dx$ conserved for inviscid flow. Beltrami: $\\omega = \\lambda u$ (eigenvectors of curl). Pressure: $-\\Delta p = \\partial_i \\partial_j (u_i u_j)$, with $\\|p\\|_{L^{3/2}} \\leq C\\|u\\|_{L^3}^2$ via Calderon-Zygmund. KNSS Liouville: bounded ancient solutions in $L^{9/2}$ are zero."
     }
   ],

--- a/src/data/proofs/perfect-numbers-oq-03/meta.json
+++ b/src/data/proofs/perfect-numbers-oq-03/meta.json
@@ -124,7 +124,7 @@
       "id": "sec-small-cases",
       "title": "Parts V-VI: Composite Criterion and Known Values",
       "startLine": 201,
-      "endLine": 260,
+      "endLine": 259,
       "summary": "Proves composite_exp_implies_composite (converse: n composite, n≥2 → M(n) composite via mersenne_dvd_of_dvd), mersenne_equiv (M(n) prime ↔ n prime ∧ M(n) prime), first_four_mersenne_prime_exponents (exponents 2,3,5,7), first_four_mersenne_primes (3,7,31,127 all prime), M_eleven_composite (2047=23×89 not prime via decide).",
       "mathContext": "$M(11) = 2047 = 23 \\times 89$; the factor $23 \\equiv 1 \\pmod{11}$ confirms the Lucas congruence."
     }

--- a/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-02-oq-03/meta.json
@@ -129,7 +129,7 @@
       "id": "main-theorem",
       "title": "Channel Coding Converse (Asymptotic)",
       "startLine": 131,
-      "endLine": 163,
+      "endLine": 162,
       "description": "The main theorem: for R > C, the gap δ = (R-C)/(2R) is positive and any code with rate ≥ R and block length n ≥ ⌈2/(R-C)⌉ has error probability ≥ δ.",
       "summary": "Main result: P_e ≥ (R-C)/(2R) for sufficiently long codes at rates above capacity.",
       "mathContext": "$\\forall n \\geq \\lceil 2/(R-C) \\rceil,\\; \\text{rate} \\geq R \\implies P_e \\geq \\frac{R-C}{2R}$"


### PR DESCRIPTION
## Fix

Batch sync of 23 gallery `meta.json` files where the final `sections[].endLine` was off-by-one above the actual line count (a leftover from trailing-newline trimming that updated `lineCount` but missed the section range).

## Evidence

For each slug, `leanFile.lineCount` is already correct (`wc -l` canonical, per existing gallery convention). Only the last section's `endLine` was stale.

| Slug | Section | Before | After |
|---|---|---|---|
| cantor-diagonalization-oq-01-oq-02 | summary | 307 | 306 |
| erdos-1161 | structural-lemmas | 324 | 323 |
| erdos-123 | structural | 318 | 317 |
| erdos-139 | bounds | 261 | 260 |
| erdos-168 | examples | 181 | 180 |
| erdos-172 | examples | 145 | 144 |
| erdos-303 | density | 259 | 258 |
| erdos-439 | summary | 219 | 218 |
| erdos-485 | related | 226 | 225 |
| erdos-517 | example | 176 | 175 |
| erdos-551 | summary | 604 | 603 |
| erdos-60 | aristotle-proofs | 386 | 385 |
| erdos-604 | connection | 224 | 223 |
| erdos-629 | constructions | 912 | 911 |
| erdos-643 | constructions | 1403 | 1402 |
| erdos-846 | conjecture | 291 | 290 |
| erdos-941 | summary | 324 | 323 |
| fundamental-theorem-algebra-oq-04-oq-04 | contrast-summary | 215 | 214 |
| hilbert-20-oq-01 | special-cases | 212 | 211 |
| law-of-cosines-oq-01-oq-04 | scaled-version | 191 | 190 |
| navier-stokes-existence | helicity-pressure-liouville | 21111 | 21110 |
| perfect-numbers-oq-03 | sec-small-cases | 260 | 259 |
| shannon-channel-coding-oq-02-oq-03 | main-theorem | 163 | 162 |

`pnpm build` passes.

## Test plan
- [x] Drift detected via static scan (`sections[].endLine > wc -l`)
- [x] All other section ranges within file remain valid (only the LAST section was clamped; no other section was touched)
- [x] `leanFile.lineCount` already matches `wc -l` for each slug — no Lean source changes
- [x] `pnpm build` succeeds

Precedent: PRs #6703, #9643, #9645, #19622 (batch section/lineCount drift sync).

---
Automated fix by lean-mechanic agent.