### PR TITLE
fix(meta): mean-value-theorem-oq-02 last 2 sections endLine 154→153

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02/meta.json
@@ -83,7 +83,7 @@
       "id": "second-order",
       "title": "Second-Order Taylor Expansion",
       "startLine": 129,
-      "endLine": 154,
+      "endLine": 153,
       "summary": "Proves `taylor_second_order`: for ContDiff ℝ 2 f and a < b, ∃ c ∈ (a,b) with f(b) = f(a) + f'(a)(b-a) + iteratedDeriv 2 f c / 2 · (b-a)². Derived from taylor_lagrange_remainder at n=1, using taylorPolynomial_one and simplifying 2! = 2.",
       "mathContext": "At $n=1$: $f(b) = f(a) + f'(a)(b-a) + \\frac{f''(c)}{2}(b-a)^2$. This is the quadratic approximation with exact remainder. Applications: the second-order Taylor expansion is used in Newton's method analysis (quadratic convergence), optimization (second-order conditions), and numerical ODEs (Runge-Kutta order conditions)."
     },
@@ -91,7 +91,7 @@
       "id": "error-bounds",
       "title": "Taylor Error Bounds and Approximation Quality",
       "startLine": 129,
-      "endLine": 154,
+      "endLine": 153,
       "summary": "The Lagrange remainder gives sharp error bounds: |f(b) - T_n(b)| ≤ M|b-a|^(n+1)/(n+1)! where M bounds the (n+1)-th derivative. MVT (n=0) and second-order Taylor (n=1) are special cases with explicit error control.",
       "mathContext": "The second-order Taylor theorem (taylor_second_order) yields: $|f(b) - f(a) - f'(a)(b-a)| \\leq \\frac{\\sup_{c \\in (a,b)} |f''(c)|}{2} \\cdot (b-a)^2$. This $O((b-a)^2)$ bound improves on MVT's $O(b-a)$ and is the foundation for second-order numerical methods (Heun's method, midpoint rule)."
     }


### PR DESCRIPTION
## Fix

Both `second-order` and `error-bounds` sections in `mean-value-theorem-oq-02/meta.json` list `endLine: 154`, but `Proofs/MeanValueTheoremOQ02.lean` ends at line 153 (`wc -l = 153`, matching `leanFile.lineCount`).

## Evidence

```
$ wc -l proofs/Proofs/MeanValueTheoremOQ02.lean
153
```

**Before**: sections `second-order` and `error-bounds` both end at `154` (one past EOF).
**After**: both clamped to `153`.

Note: the two sections share the same line range (129→153); that's a separate (pre-existing) data issue, not changed here. Only the off-by-one drift is corrected.

## Test plan
- [x] Drift detected via static scan (`sections[].endLine > wc -l`)
- [x] No other section ranges were out of bounds
- [x] `leanFile.lineCount` already matches `wc -l` — no Lean source changes
- [x] Other sections (`taylor-polynomial` 39→69, `lagrange-remainder` 71→99, `mvt-connection` 100→128) unchanged

Precedent: PR #21785 (batch of 23 identical drifts), #21750, #21748, #21746, #21739, #21763.

---
Automated fix by lean-mechanic agent.