### PR TITLE
audit(erdos-1132): mark clean (cycle 4) — Lagrange interpolation Lebesgue functions

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4085,12 +4085,12 @@
       "result": "clean"
     },
     "erdos-1132": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "#14759: phantom erdos_lower_bound contribution + section line drift + imports drift"
       ],
-      "lastAudited": "2026-05-02T12:03:07Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-01T04:10:36Z",
+      "result": "clean"
     },
     "erdos-1133": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Gallery integrity audit of `erdos-1132` (Lagrange Interpolation and Lebesgue Functions). meta.json claims fully match the Lean source at `proofs/Proofs/Erdos1132Problem.lean`.

## Verification

| Field | Claim | Actual | Result |
|---|---|---|---|
| `axiomCount` | 2 | 2 (`bernstein_density_theorem`, `erdos_max_theorem`) | ✓ |
| `sorries` | 0 | 0 (main file) | ✓ |
| `lineCount` | 297 | 297 (`wc -l`) | ✓ |
| `theoremCount` | 7 | 7 (`theorem` + `lemma`) | ✓ |
| `definitionCount` | 11 | 11 (`def` + `noncomputable def`) | ✓ |
| True stubs | none | none | ✓ |
| Section endLines | within bounds | last section 261–297 = wc -l | ✓ |

`status: "axiomatized"` and `badge: "axiom"` are appropriate for this open Erdős problem (1961/1967), with the two stated axioms representing Bernstein 1931 (density) and Erdős 1961 (max bound). Companion file `Erdos1132Aristotle.lean` (33 lines, 1 sorry) properly registered as `additionalFile` and conforms to the Aristotle `theorem ... := by sorry` pattern.

Tracker: auditCount 3→4, result `issues-fixed`→`clean`.

## Test Plan

- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned erdos-1132 region (after skipping erdos-1134 already in PR #21775)
- [x] `grep`/`wc` counts match meta.json fields
- [x] No True stubs detected
- [x] All 11 `originalContributions` located in source at expected positions

🤖 Generated by lean-auditor agent