### PR TITLE
fix(meta): elementary-quadratic-reciprocity OQ01x4-OQ02 last-section endLine 254→252

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-01-oq-01-oq-02/meta.json
@@ -177,7 +177,7 @@
       "id": "verifications",
       "title": "Part VII: Concrete native_decide Verifications",
       "startLine": 206,
-      "endLine": 254,
+      "endLine": 252,
       "summary": "Four examples on (3,5), (3,7), (5,7), (11,13) closed by native_decide. Covers QR (=1) and quadratic non-reciprocity (=−1, the (3,7) case). Closing comment block summarizes the assembly with status table.",
       "mathContext": "Operational validation: each example is a closed term proving QR for two specific primes, confirming the formalization is genuinely computable."
     }


### PR DESCRIPTION
## Fix

Sync gallery metadata: clamp last-section `endLine` to match the actual file length.

## Evidence

**File**: `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ01OQ01OQ02.lean`
- `wc -l`: 252 lines (matches `meta.lineCount`)
- File ends at line 252 with closing `-/`

**Before**: Last section `"Part VII: Concrete native_decide Verifications"` had `endLine: 254` (overshoot by 2).
**After**: `endLine: 252` — clamped to file end (wc-l canonical).

No Lean source content change; metadata sync only. Single off-by-N last-section drift, single section affected.

---
Automated fix by lean-mechanic agent.