### PR TITLE
fix(meta): continuum-hypothesis-oq-02 definitionCount 7→6

### DIFF
--- a/src/data/proofs/continuum-hypothesis-oq-02/meta.json
+++ b/src/data/proofs/continuum-hypothesis-oq-02/meta.json
@@ -74,7 +74,7 @@
     "assumptions": "3 assumptions: 2 axioms (bounding_number_uncountable, MA_implies_b_eq_continuum) + 1 opaque constant (MartinsAxiom — declared opaque since the full forcing-axiom statement is not formalized). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 32,
-    "definitionCount": 7
+    "definitionCount": 6
   },
   "overview": {
     "historicalContext": "After Cohen's 1963 forcing proof showed the independence of CH, a natural question emerged: what values CAN 2^aleph_0 take? Konig (1905) had already shown a cofinality constraint: cf(2^kappa) > kappa, ruling out singular cardinals. Easton (1970) proved the dramatic result that for regular cardinals, the continuum function is essentially unconstrained by ZFC. Meanwhile, the bounding and dominating numbers (b and d) emerged in the 1970s-80s as intermediate cardinal invariants between aleph_1 and 2^aleph_0, leading to the rich combinatorial study of Cichon's diagram.",
@@ -184,7 +184,7 @@
     "lineCount": 584,
     "axiomCount": 3,
     "theoremCount": 32,
-    "definitionCount": 7,
+    "definitionCount": 6,
     "path": "Proofs/ContinuumHypothesisOQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `continuum-hypothesis-oq-02` meta.json `definitionCount` from stale `7` to actual `6`. Updated in both `meta.definitionCount` and `leanFile.definitionCount`.

## Evidence

**Before**: `meta.definitionCount: 7`, `leanFile.definitionCount: 7`.

**After**: Both set to `6`. The Lean file `Proofs/ContinuumHypothesisOQ02.lean` contains exactly 6 strict definitions:

| # | Line | Declaration |
|---|---|---|
| 1 | 201 | `def IsPossibleContinuumValue` |
| 2 | 285 | `def eventuallyDominates` |
| 3 | 290 | `def IsUnbounded` |
| 4 | 295 | `def IsDominating` |
| 5 | 300 | `noncomputable def boundingNumber` |
| 6 | 305 | `noncomputable def dominatingNumber` |

No `structure`, `inductive`, `class`, or `abbrev` declarations. The drift is likely a leftover from PR #8688 (True-stub theorem cleanup), which earlier removed a now-redundant definition without re-syncing the counts.

Other counts remain correct:
- `axiomCount`: 3 ✓
- `theoremCount`: 32 ✓
- `sorries`: 0 ✓
- `lineCount`: 584 = `wc -l` ✓

Auditor previously logged this exact drift as "minor LOW: definitionCount 7 vs actual 6 (not credibility-affecting)" but the underlying mismatch persisted.

## Test plan
- [x] Strict regex count `^(noncomputable\s+|private\s+)?(def|abbrev|structure|inductive|class)\b` returns 6
- [x] JSON parses successfully
- [x] No narrative references to "7 definitions" in meta.json

---
Automated fix by lean-mechanic agent.