### PR TITLE
fix(meta): birthday-problem-oq-03-oq-01-oq-02 definitionCount 7→8

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-02/meta.json
@@ -26,7 +26,7 @@
     "dateAdded": "2026-04-04",
     "lineCount": 2263,
     "theoremCount": 59,
-    "definitionCount": 7,
+    "definitionCount": 8,
     "originalContributions": [
       "asympThreshold: exact definition (6d² ln 2)^{1/3} using Real.rpow",
       "asympThreshold_cubed: (asympThreshold d)³ = 6d² ln 2 (PROVED)",
@@ -147,7 +147,7 @@
     "sorries": 0,
     "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
     "theoremCount": 59,
-    "definitionCount": 7
+    "definitionCount": 8
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Sync `birthday-problem-oq-03-oq-01-oq-02` meta.json `definitionCount` from stale `7` to actual `8`. Updated in both `meta.definitionCount` and `leanFile.definitionCount`.

## Evidence

**Before**: `meta.definitionCount: 7`, `leanFile.definitionCount: 7`.

**After**: Both set to `8`. The Lean file `Proofs/BirthdayProblemOQ03OQ01OQ02.lean` (comment-stripped) contains exactly 8 strict definitions:

| # | Line | Declaration |
|---|---|---|
| 1 | 140 | `noncomputable def expectedTriples` |
| 2 | 161 | `noncomputable def asympThreshold` |
| 3 | 480 | `noncomputable def k2Threshold` |
| 4 | 651 | `def tripleCount` |
| 5 | 1298 | `def strictTriples` |
| 6 | 1305 | `private def tripleCountFinset` |
| 7 | 1406 | `def tripleSet` |
| 8 | 1521 | `def overlapPattern` |

No `structure`, `inductive`, `class`, or `abbrev` declarations.

Other counts remain correct:
- `axiomCount`: 1 ✓
- `theoremCount`: 59 ✓
- `sorries`: 0 ✓
- `lineCount`: 2263 = `wc -l` ✓

## Test plan
- [x] Strict regex count `^(?:(?:noncomputable|private|protected)\s+)*(?:def|abbrev|structure|inductive|class)\b` returns 8 (auditor-style comment-stripped)
- [x] JSON parses successfully
- [x] No narrative references to "7 definitions" in meta.json

---
Automated fix by lean-mechanic agent.