### PR TITLE
fix(meta): erdos-905 definitionCount 9→10 (Graph structure undercounted)

### DIFF
--- a/src/data/proofs/erdos-905/meta.json
+++ b/src/data/proofs/erdos-905/meta.json
@@ -32,12 +32,12 @@
     "assumptions": "1 axiom: bollobas_erdos_theorem. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 10
   },
   "overview": {
     "historicalContext": "Bollobás and Erdős conjectured this result about edge-triangle multiplicity. It was independently proved by Edwards (unpublished) and Hadziivanov-Nikiforov in 1979. The problem connects to Turán's classical theorem on triangle-free graphs. Turán's theorem (1941) established that the complete bipartite graph K_{⌊n/2⌋,⌈n/2⌉} is the unique triangle-free graph on n vertices maximizing the number of edges, at exactly ⌊n²/4⌋. The question posed by Bollobás and Erdős pushed beyond mere existence of triangles to ask about their concentration: once the Turán bound is exceeded, must some edge bear a disproportionate share of the triangle count? The answer n/6 is tight, achieved by graphs close to the balanced complete bipartite graph with a small clique added. Nikiforov subsequently extended these ideas into a broader program on the distribution of cliques above Turán thresholds.",
     "problemStatement": "Every graph with n vertices and more than n²/4 edges contains an edge which is in at least n/6 triangles.",
-    "text": "A 190-line formalization of Erdős Problem #905 (SOLVED) with 1 proved theorem, 9 definitions, and 1 axiom. Defines a custom `Graph` structure with symmetric irreflexive edge sets, `IsTriangle` (three pairwise adjacent vertices), `triangleCountEdge` (number of triangles containing a given edge), and `maxTriangleMultiplicity` (maximum over all edges). The Turán threshold `turanNumber n = n^2/4` and `AboveTuran` predicate are defined. The main result `bollobas_erdos_theorem` is axiomatized: any graph with $> n^2/4$ edges has an edge in $\\geq n/6$ triangles. Turán graph properties and a triangle count lower bound are documented in comments.",
+    "text": "A 190-line formalization of Erdős Problem #905 (SOLVED) with 1 proved theorem, 10 definitions (1 structure + 9 def), and 1 axiom. Defines a custom `Graph` structure with symmetric irreflexive edge sets, `IsTriangle` (three pairwise adjacent vertices), `triangleCountEdge` (number of triangles containing a given edge), and `maxTriangleMultiplicity` (maximum over all edges). The Turán threshold `turanNumber n = n^2/4` and `AboveTuran` predicate are defined. The main result `bollobas_erdos_theorem` is axiomatized: any graph with $> n^2/4$ edges has an edge in $\\geq n/6$ triangles. Turán graph properties and a triangle count lower bound are documented in comments.",
     "proofStrategy": "**Part I**: Custom `Graph` structure with `adj : Fin n → Fin n → Prop`, symmetric and irreflexive. `edgeCount` counts unordered pairs.\n\n**Part II**: `IsTriangle G a b c` requires all three edges. `triangleCountEdge G u v` counts vertices $w$ forming a triangle with $(u,v)$. `maxTriangleMultiplicity G` is the maximum over all edges.\n\n**Part III**: `turanNumber n = n^2/4` defines the Turán threshold. `AboveTuran G` means `edgeCount G > turanNumber n`. Turán's theorem (triangle-free $\\Rightarrow e(G) \\leq n^2/4$) is stated only in a docstring comment; the file's sole axiom is `bollobas_erdos_theorem`.\n\n**Part IV**: `BollobasErdosConjecture` states the main result. `bollobas_erdos_theorem` axiomatizes it as proved.\n\n**Part V-VII**: `IsTuranGraph` defined as the balanced bipartite structure. Tightness of n/6 and the triangle count lemma $T(G) \\geq (e(G) - n^2/4) \\cdot n/6$ are stated in docstring comments only; no additional axioms.",
     "keyInsights": [
       "n²/4 is the Turán threshold for triangle-free graphs",
@@ -168,7 +168,7 @@
     "lineCount": 190,
     "axiomCount": 1,
     "theoremCount": 1,
-    "definitionCount": 9,
+    "definitionCount": 10,
     "path": "Proofs/Erdos905Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Sync `erdos-905` meta.json `definitionCount` from stale `9` to actual `10`. Updated in three locations: `meta.definitionCount`, `leanFile.definitionCount`, and the `overview.text` narrative ("9 definitions" → "10 definitions (1 structure + 9 def)").

## Evidence

**Before**: `meta.definitionCount: 9`, `leanFile.definitionCount: 9`, narrative text claims "9 definitions".

**After**: All three set to `10`. The Lean file `Proofs/Erdos905Problem.lean` contains exactly 10 strict definitions:

| # | Line | Declaration |
|---|---|---|
| 1 | 49 | `structure Graph` |
| 2 | 58 | `noncomputable def edgeCount` |
| 3 | 65 | `def Adj` |
| 4 | 76 | `def IsTriangle` |
| 5 | 84 | `noncomputable def triangleCountEdge` |
| 6 | 91 | `noncomputable def maxTriangleMultiplicity` |
| 7 | 103 | `def turanNumber` |
| 8 | 109 | `def AboveTuran` |
| 9 | 125 | `def BollobasErdosConjecture` |
| 10 | 153 | `def IsTuranGraph` |

The drift is due to the `structure Graph` not being counted toward the original total. The narrative already mentions "a custom `Graph` structure", confirming the structure is canonical.

Other counts remain correct:
- `axiomCount`: 1 ✓ (`bollobas_erdos_theorem`)
- `theoremCount`: 1 ✓
- `sorries`: 0 ✓
- `lineCount`: 190 = `wc -l` ✓

## Test plan
- [x] Strict regex `^(?:(?:noncomputable|private|protected)\s+)*(?:def|abbrev|structure|inductive|class)\b` (comment-stripped) returns 10
- [x] JSON parses successfully
- [x] Narrative "9 definitions" updated to "10 definitions (1 structure + 9 def)"

---
Automated fix by lean-mechanic agent.