### PR TITLE
Enrich abel-ruffini-oq-04-oq-02-oq-02: seed leanFile.mainTheorems

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -212,6 +212,44 @@
     "axiomCount": 0,
     "theoremCount": 14,
     "definitionCount": 0,
+    "mainTheorems": [
+      {
+        "name": "alternating_solvable_iff",
+        "type": "core",
+        "description": "The full bidirectional classification: $A_n$ is solvable if and only if $n \\leq 4$. Forward direction by contradiction via `an_not_solvable_of_ge_five`; backward direction by `interval_cases n` enumerating $n = 0, 1, 2, 3, 4$.",
+        "leanType": "(n : ℕ) → IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4"
+      },
+      {
+        "name": "an_not_solvable_of_ge_five",
+        "type": "key",
+        "description": "$A_n$ is not solvable for $n \\geq 5$. Proof: assume $A_n$ solvable; the sign exact sequence $1 \\to A_n \\to S_n \\to \\{\\pm 1\\} \\to 1$ gives $S_n$ solvable, contradicting Mathlib's `Equiv.Perm.not_solvable`.",
+        "leanType": "{n : ℕ} → 5 ≤ n → ¬IsSolvable (alternatingGroup (Fin n))"
+      },
+      {
+        "name": "a4_solvable",
+        "type": "key",
+        "description": "$A_4$ is solvable. The largest solvable alternating group; its solvability rests on the Klein four-group $V_4 \\trianglelefteq A_4$ with composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4$ having abelian factors $(\\mathbb{Z}/2\\mathbb{Z})^2$ and $\\mathbb{Z}/3\\mathbb{Z}$.",
+        "leanType": "IsSolvable (alternatingGroup (Fin 4))"
+      },
+      {
+        "name": "a3_solvable",
+        "type": "supporting",
+        "description": "$A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ is solvable (abelian). Proved via `isSolvable_of_comm` plus `decide` on the commutativity check.",
+        "leanType": "IsSolvable (alternatingGroup (Fin 3))"
+      },
+      {
+        "name": "sharp_threshold",
+        "type": "key",
+        "description": "Witnesses the sharp dichotomy: $A_4$ is solvable AND $A_5$ is not. A single quotable conjunction making the transition at $n = 5$ a one-line corollary.",
+        "leanType": "IsSolvable (alternatingGroup (Fin 4)) ∧ ¬IsSolvable (alternatingGroup (Fin 5))"
+      },
+      {
+        "name": "a5_not_solvable",
+        "type": "specialization",
+        "description": "$A_5$ is not solvable. Direct application of `an_not_solvable_of_ge_five` with $n = 5$. Illustrates the smallest non-solvable alternating group.",
+        "leanType": "¬IsSolvable (alternatingGroup (Fin 5))"
+      }
+    ],
     "path": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Seeds `leanFile.mainTheorems` (previously empty) with the 6 entries already present in top-level `mainTheorems`, per the alignment rule from #21735 (algebraic-numbers-countable) and #21795 (abel-ruffini).

## What's seeded

| name | type | role |
|------|------|------|
| alternating_solvable_iff | core | Aₙ solvable iff n ≤ 4 biconditional |
| an_not_solvable_of_ge_five | key | sign-exact-sequence contradiction |
| a4_solvable | key | Klein-four composition series |
| a3_solvable | supporting | A₃ ≅ ℤ/3ℤ abelian discharge |
| sharp_threshold | key | conjunction witnessing the n = 5 jump |
| a5_not_solvable | specialization | direct n = 5 application |

Entries copied verbatim from top-level; types match the existing top-level taxonomy.

## Verification

- JSON validates
- `tsc --noEmit` passes
- No other content touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)