### PR TITLE
fix(meta): batch sync 9 last-section endLine drifts (+3 to +103 overflow)

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02/meta.json
@@ -101,7 +101,7 @@
       "id": "concrete-examples",
       "title": "Concrete Non-Exotic Examples and the n=6 Case",
       "startLine": 179,
-      "endLine": 222,
+      "endLine": 201,
       "summary": "Proves not_exotic for 4, 8, 9, 25 (prime powers). Shows n=6 has 2 prime factors and is not exotic (via conjecture axiom). buDimFormula_six = max(buDim 2, buDim 3).",
       "mathContext": "n=6 is the smallest n with 2 distinct prime factors — the minimal case where exotic behavior would be novel. Under the conjecture, buDim(6,d) = max(buDim(2,d), buDim(3,d))."
     }

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01/meta.json
@@ -127,7 +127,7 @@
       "id": "main-theorems",
       "title": "Part V: Main Theorems",
       "startLine": 202,
-      "endLine": 217,
+      "endLine": 214,
       "summary": "retraction_construction_theorem: assembles the retraction structure. brouwer_fixed_point_explicit: Brouwer FPT without retraction_construction axiom.",
       "mathContext": "The retraction_construction_theorem provides an explicit Brouwer.Retraction n from a fixed-point-free self-map, replacing the axiom in BrouwerFixedPoint.lean."
     }

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -77,7 +77,7 @@
       "id": "main-theorem",
       "title": "Main Theorem: Sigma-Finite Riesz Representation (HARD sorry)",
       "startLine": 167,
-      "endLine": 218,
+      "endLine": 208,
       "summary": "HARD sorry (~50 lines): assembles localization + density extension to prove riesz_lp_surjective_sigma_finite. Density extension ports the parent's integral_representation.",
       "mathContext": "$(L^p(\\mu))^* \\cong L^q(\\mu)$ for sigma-finite $\\mu$, $1 < p < \\infty$, $1/p + 1/q = 1$. Proof: indicator agreement (Step A) + Lp.induction over simple functions (Step C). Removes IsFiniteMeasure from parent result."
     }

--- a/src/data/proofs/derangements-convergence/meta.json
+++ b/src/data/proofs/derangements-convergence/meta.json
@@ -89,7 +89,7 @@
       "id": "main-results",
       "title": "Main Convergence Theorems",
       "startLine": 244,
-      "endLine": 283,
+      "endLine": 272,
       "summary": "Proves derangements_convergence_rate: |D(n)/n! - e^{-1}| ≤ 1/(n+1)! by combining the identity, series representation, tail splitting, and alternating tail bound in a 3-line proof. Proves derangements_tendsto_inv_e: D(n)/n! → e^{-1} using Metric.tendsto_atTop — finds N such that 1/(N+1)! < ε via the summand tendsto_atTop_zero, then uses convergence_rate and factorial monotonicity"
     }
   ],

--- a/src/data/proofs/erdos-1012-oq-03/meta.json
+++ b/src/data/proofs/erdos-1012-oq-03/meta.json
@@ -137,7 +137,7 @@
       "id": "part-v-threshold",
       "title": "Part V: Arc Threshold + Verification",
       "startLine": 1539,
-      "endLine": 1884,
+      "endLine": 1781,
       "summary": "Defines arcCount. Proves directed_hamiltonian_threshold: (n-1)² < arcCount ∧ strongly connected → Hamiltonian cycle via probabilistic counting (hamiltonian_of_few_missing_arcs, perm_arc_bad_card_le, missing_arcs_le). Closes with #check commands verifying all four main theorems.",
       "mathContext": "`arcCount G = (Finset.univ.filter (fun p : Fin n × Fin n => G.arc p.1 p.2)).card`. `directed_hamiltonian_threshold`: if $(n-1)^2 < \\text{arcCount}(G)$ and $G$ is strongly connected, then $G$ is Hamiltonian. Proof via **probabilistic counting**: a random permutation $\\sigma$ is 'bad' (not a Hamiltonian cycle) only if some arc $(\\sigma(i), \\sigma(i+1))$ is missing. By union bound over $n$ arc positions and $n!$ total permutations: $\\Pr[\\text{bad}] \\leq n \\cdot (n!/n) \\cdot (\\text{missingArcs}/n(n-1)) < 1$ when missingArcs $< (n-1)^2/n$. Key lemma: `perm_arc_bad_card_le` bounds the number of bad permutations. This gives a polynomial-time Hamiltonicity certificate: check if $|E| > (n-1)^2$ and SC, and we're done."
     }

--- a/src/data/proofs/erdos-614/meta.json
+++ b/src/data/proofs/erdos-614/meta.json
@@ -159,7 +159,7 @@
       "id": "partial-star",
       "title": "Partial Star Construction (Proved)",
       "startLine": 449,
-      "endLine": 604,
+      "endLine": 594,
       "summary": "def partialStar (n-2 edge star graph), private lemmas partialStar_zero_neighbors_card and partialStar_edgeCount and partialStar_hasPropertyP, theorem f_n_minus_2_upper_bound, and erdos_614_summary combining all main results.",
       "mathContext": "partialStar n is a star with n-2 edges (vertex 0 adjacent to vertices 1..n-2). Proved: it has Property P(1), so f(n,1) ≤ n-2. erdos_614_summary: f(n,1) = n-2 exactly (both bounds proved)."
     }

--- a/src/data/proofs/kroneckers-jugendtraum/meta.json
+++ b/src/data/proofs/kroneckers-jugendtraum/meta.json
@@ -142,7 +142,7 @@
       "id": "summary",
       "title": "Summary",
       "startLine": 352,
-      "endLine": 387,
+      "endLine": 371,
       "summary": "Documentation block recapping solved cases (ℚ, imaginary quadratic) vs open cases (real quadratic, general). Lists #check statements for key definitions.",
       "mathContext": "The file's genuine Lean content comprises three machine-checked results: (1) `cyclotomic_galois_comm` proving $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_n)/\\mathbb{Q})$ is abelian via the `autEquivPow` isomorphism to $(\\mathbb{Z}/n\\mathbb{Z})^\\times$, (2) `cyclotomic_degree` proving $[\\mathbb{Q}(\\zeta_n):\\mathbb{Q}] = \\varphi(n)$ via `IsCyclotomicExtension.finrank`, and (3) `cyclotomic_irreducible` proving $\\Phi_n$ is irreducible over $\\mathbb{Z}$. All other results -- Kronecker-Weber, CM theory, Artin reciprocity, Stark conjectures, and the general Hilbert 12th problem -- are formulated as `Prop := True` placeholders whose deep proofs lie beyond current Mathlib infrastructure."
     }

--- a/src/data/proofs/ramsey-r4k-oq-01/meta.json
+++ b/src/data/proofs/ramsey-r4k-oq-01/meta.json
@@ -117,7 +117,7 @@
       "id": "concrete-bounds",
       "title": "Concrete Classical Upper Bounds",
       "startLine": 182,
-      "endLine": 190,
+      "endLine": 187,
       "summary": "Classical binomial values C(6,3)=20, C(12,3)=220, C(22,3)=1540, C(52,3)=22100 for k=4,10,20,50 via native_decide. Also R(4,4) \u2264 20 and R(4,10) \u2264 220 from the classical bound."
     }
   ],

--- a/src/data/proofs/sylow-theorems-oq-02/meta.json
+++ b/src/data/proofs/sylow-theorems-oq-02/meta.json
@@ -140,7 +140,7 @@
       "id": "counting-and-summary",
       "title": "Counting Theorem and Verification",
       "startLine": 342,
-      "endLine": 393,
+      "endLine": 374,
       "summary": "Proves n_p is congruent to 1 mod p for finite quotients. Summary of all results: 4 axioms and 10 proved theorems. Verification via #check on all key definitions.",
       "mathContext": "Sylow counting: $n_p \\equiv 1 \\pmod{p}$. Score: 4 axioms, 10 proved theorems, 0 sorries."
     }


### PR DESCRIPTION
## Fix

Clamp the final section's `endLine` to `leanFile.lineCount` for nine gallery entries whose last section overflowed the actual file range.

Follow-up to #21785, which batched 23 simple +1 LAST-section drifts. These nine have larger overflows (+3 to +103), but the underlying fix is identical: clamp to the file's `wc -l` canonical line count.

## Evidence

Each file ends cleanly with a namespace `end` declaration well inside the section's claimed range. The drift is purely metadata, not source.

| slug | old → new | overflow |
|------|-----------|----------|
| brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01 | 217 → 214 | +3 |
| ramsey-r4k-oq-01 | 190 → 187 | +3 |
| cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01 | 218 → 208 | +10 |
| erdos-614 | 604 → 594 | +10 |
| derangements-convergence | 283 → 272 | +11 |
| kroneckers-jugendtraum | 387 → 371 | +16 |
| sylow-theorems-oq-02 | 393 → 374 | +19 |
| borsuk-ulam-oq-02-oq-01-oq-01-oq-02 | 222 → 201 | +21 |
| erdos-1012-oq-03 | 1884 → 1781 | +103 |

## Scope

- Metadata only — no Lean source touched
- One-line clamp per file
- `pnpm build` succeeds with no gallery-integrity regressions
- Sister PRs handling other variants: #21787 (mean-value duplicate sections), #21790 (elementary-quadratic +2)
- Still pending after this PR: `inverse-galois` (multiple sections with `startLine=1`, structural), `ballot-problem-oq-03-oq-01-oq-02` (4 sections with +1428 to +13235 overflows, file rewritten)

---
Automated fix by lean-mechanic agent.