### PR TITLE
fix(meta): brouwer-fixed-point-oq01x4 last section endLine 217→214

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01/meta.json
@@ -127,7 +127,7 @@
       "id": "main-theorems",
       "title": "Part V: Main Theorems",
       "startLine": 202,
-      "endLine": 217,
+      "endLine": 214,
       "summary": "retraction_construction_theorem: assembles the retraction structure. brouwer_fixed_point_explicit: Brouwer FPT without retraction_construction axiom.",
       "mathContext": "The retraction_construction_theorem provides an explicit Brouwer.Retraction n from a fixed-point-free self-map, replacing the axiom in BrouwerFixedPoint.lean."
     }


### PR DESCRIPTION
## Fix

`brouwer-fixed-point-oq-01-oq-02-oq-03-oq-01` last section (`Part V: Main Theorems`) `endLine`: 217 → 214 (wc-l canonical).

## Evidence

**Before**: `sections[4].endLine = 217`
**After**: `sections[4].endLine = 214`

`wc -l proofs/Proofs/BrouwerFixedPointOQ01OQ02OQ03OQ01.lean` → 214
`leanFile.lineCount` already 214 (consistent)
Section `Part IV` ends at 201, `Part V` starts at 202 — unchanged. The 3-line drift was the previous endLine pointing past EOF.

Companion to the section endLine drift sweep (PR #21785 batch + #21787 + #21790).

---
Automated fix by lean-mechanic agent.