### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-01 drop stale closure_cycle_swap_eq_top mainTheorem

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-01/meta.json
@@ -482,11 +482,6 @@
         "description": "x^5 - 4x + 2 is irreducible over Q (Eisenstein at p=2)"
       },
       {
-        "name": "closure_cycle_swap_eq_top",
-        "type": "proved",
-        "description": "5-cycle + transposition generates all of S_5"
-      },
-      {
         "name": "no_subgroup_order_15",
         "type": "proved",
         "description": "No subgroup of S_5 has order 15 (Sylow theory)"


### PR DESCRIPTION
## Fix

`leanFile.mainTheorems[1]` listed `closure_cycle_swap_eq_top` (5-cycle + transposition generates S₅), but that lemma was removed from `proofs/Proofs/AbelRuffiniOQ04OQ01.lean` in #9848 ("fix(filler): remove 7 vestigial lemmas"). Drop the stale entry — 10 → 9.

## Evidence

```
$ grep -nE "(theorem|lemma|def)\s+closure_cycle_swap_eq_top" proofs/Proofs/AbelRuffiniOQ04OQ01.lean
$ git log --all --oneline -S "closure_cycle_swap_eq_top" proofs/Proofs/AbelRuffiniOQ04OQ01.lean
5e16e16259c Research: abel-ruffini-oq-04-oq-01 — prove group theory bridge for S₅ generation (#6584)
195a265541c Research: abel-ruffini-oq-04-oq-01 — prove |Gal|=120 as theorem via axiom decomposition (#6618)
cbfafabdab3 fix(filler): remove 7 vestigial lemmas from AbelRuffiniOQ04OQ01 (#9848)
```

Re-verified the remaining 9 mainTheorem names — each resolves to an actual top-level `theorem` declaration:

| Name | Lean line |
|---|---|
| `p_irreducible` | 175 |
| `no_subgroup_order_15` | 346 |
| `no_subgroup_order_30` | 457 |
| `three_dvd_gal_card` | 1210 |
| `gal_has_odd_perm` | 803 |
| `gal_card_eq_120` | 1349 |
| `gal_iso_s5` | 1386 |
| `roots_not_solvable_by_rad` | 1455 |
| `s5_realizable` | 1472 |

## Diff

```
-      {
-        "name": "closure_cycle_swap_eq_top",
-        "type": "proved",
-        "description": "5-cycle + transposition generates all of S_5"
-      },
```

5 lines removed, `meta.json` only — no Lean source changes.

---
Automated fix by lean-mechanic agent.