### PR TITLE
fix(meta): inverse-galois sharp-threshold endLine 1881→534

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -217,7 +217,7 @@
       "id": "sharp-threshold",
       "title": "Sharp Threshold: S_n Solvable iff n ≤ 4",
       "startLine": 158,
-      "endLine": 1881,
+      "endLine": 534,
       "summary": "In AbelRuffiniGaloisExtensions.lean: S_n is solvable iff n ≤ 4. Uses Equiv.Perm.not_solvable for n ≥ 5. This is the fundamental threshold in the Abel-Ruffini theorem. 59 theorems, all fully proved.",
       "file": "Proofs/AbelRuffiniGaloisExtensions.lean",
       "mathContext": "Sharp solvability threshold: $S_n$ is solvable $\\iff n \\leq 4$. For $n \\geq 5$, the commutator series $S_n \\supset A_n \\supset \\{e\\}$ fails since $A_n$ is simple and non-abelian. This is the group-theoretic core of Abel-Ruffini."


### PR DESCRIPTION
## Fix

Section 8 (`sharp-threshold`) of `inverse-galois/meta.json` references `Proofs/AbelRuffiniGaloisExtensions.lean` but had `endLine: 1881` — grossly exceeding that file's 534 lines (+1347 overflow). Clamp to file length.

## Evidence

```
$ wc -l proofs/Proofs/AbelRuffiniGaloisExtensions.lean
     534 proofs/Proofs/AbelRuffiniGaloisExtensions.lean
```

**Before**:
```json
{
  "id": "sharp-threshold",
  "startLine": 158,
  "endLine": 1881,
  "file": "Proofs/AbelRuffiniGaloisExtensions.lean"
}
```

**After**: `endLine: 534` (file's canonical wc -l).

The previous 1881 appears to be a leftover from when this section was indexed against `InverseGalois.lean` (1877 lines, file path later changed to the companion). Now matches the referenced file.

This is the pattern flagged in memory `feedback_section_endline_drift_unflagged`: `find-targets.ts` does not check `sections[].endLine` against the referenced file's wc -l, so cross-file overshoots slip through silently. Continues the cleanup begun in #21785 and #21797.

---
Automated fix by lean-mechanic agent.