### PR TITLE
fix(meta): picks-theorem-oq-03 cross-polytope endLine 710->695 (wc-l canonical)

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -193,7 +193,7 @@
       "id": "cross-polytope",
       "title": "Cross-Polytope Ehrhart Theory",
       "startLine": 1,
-      "endLine": 710,
+      "endLine": 695,
       "file": "Proofs/PicksTheoremOQ03CrossPoly.lean",
       "summary": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3. Proves Ehrhart polynomials, Macdonald reciprocity, h*-vector palindromy (reflexivity), interior shift L*(n)=L(n-1), cube-cross duality, dimension recurrence, monotonicity, boundary counts, and the beautiful identity h*_{β_d}(z) = (1+z)^d connecting to the binomial theorem. 69 theorems, 0 sorries, 0 axioms.",
       "mathContext": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3."


### PR DESCRIPTION
## Fix

Align `cross-polytope` section endLine to canonical wc-l of its referenced companion file.

## Evidence

- **File**: `proofs/Proofs/PicksTheoremOQ03CrossPoly.lean`
- **wc -l**: 695
- **Before**: `endLine: 710` (overruns file by 15 lines)
- **After**: `endLine: 695`

```diff
       "id": "cross-polytope",
       "title": "Cross-Polytope Ehrhart Theory",
       "startLine": 1,
-      "endLine": 710,
+      "endLine": 695,
       "file": "Proofs/PicksTheoremOQ03CrossPoly.lean",
```

Consistent with the wc-l canonical convention used across the gallery (PRs #21549, #21785, #21797).

---
Automated fix by lean-mechanic agent.