### PR TITLE
fix(meta): greens-theorem-oq-01x4 lineCount 516→537 + last section endLine

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json
@@ -59,7 +59,7 @@
       "Inductive proof structure: decomposition into inner-permutation + adjacent-swap building blocks",
       "Eliminates the axiom iteratedIntervalIntegral_order_independent from greens-theorem-oq-01-oq-01-oq-01"
     ],
-    "lineCount": 516,
+    "lineCount": 537,
     "theoremCount": 10,
     "definitionCount": 0,
     "mathlib_version": "4.26.0"
@@ -77,7 +77,7 @@
       "Topology"
     ],
     "namespace": "GreensTheoremOQ01OQ01OQ01OQ01",
-    "lineCount": 516,
+    "lineCount": 537,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 0,
@@ -138,7 +138,7 @@
       "id": "main-and-verified",
       "title": "Main Theorem and Small-Dimension Verifications",
       "startLine": 423,
-      "endLine": 516,
+      "endLine": 537,
       "summary": "`iteratedIntervalIntegral_order_independent` is proved by `Equiv.Perm.swap_induction_on σ`: the identity case is immediate, and the transposition case is supplied by `iter_integral_swap_any` (B3). The verified small cases `order_independent_2d` (enumerating $\\text{Equiv.Perm}(\\text{Fin}\\,2) = \\{\\text{id}, \\text{swap}\\,0\\,1\\}$) and `order_independent_3d_swap01` provide pedagogical entry points and direct proofs that bypass the full induction for the most physically common dimensions $n = 2, 3$."
     }
   ],


### PR DESCRIPTION
## Fix

`Proofs/GreensTheoremOQ01OQ01OQ01OQ01.lean` is **537 lines** (`wc -l`), but
`src/data/proofs/greens-theorem-oq-01-oq-01-oq-01-oq-01/meta.json` still
claims `lineCount = 516` in both `meta.lineCount` and `leanFile.lineCount`,
and the last section `"Main Theorem and Small-Dimension Verifications"`
stops at `endLine = 516`.

The extra 21 lines (517–537) are a `/- ... -/` docstring summarising which
sorries remain in the broader Green's-theorem chain plus the closing
`end GreensTheoremOQ01OQ01OQ01OQ01` declaration — they belong inside
section 7.

## Evidence

**Before**
- `meta.lineCount`        : 516
- `leanFile.lineCount`    : 516
- `sections[7].endLine`   : 516
- `wc -l`                 : 537

**After**
- `meta.lineCount`        : 537
- `leanFile.lineCount`    : 537
- `sections[7].endLine`   : 537

Verified:
- `jq empty meta.json` parses
- `wc -l` matches
- No `sorry` count change (file still 0 sorries)
- No code changes; the broken-build status from PR #21780 is untouched

## Scope discipline

Metadata-only. Does not touch the Mathlib-v4.26.0 API drift documented in
the `meta.assumptions` field; that's a separate compile-error sweep.

---
Automated fix by lean-mechanic agent.