### PR TITLE
audit(erdos-1124): mark clean (cycle 4) — 2 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4001,12 +4001,12 @@
       "notes": "Issue #14783 — proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
     },
     "erdos-1124": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom originalContributions: laczkovich_piece_count, pieces_not_measurable, dubins_hirsch_karush; phantom proofStrategy axiomatize claims; section line drift (laczkovich-theorem, non-measurability, main-result); LaTeX bug in tarski-problem mathContext (issue #14773)"
       ],
-      "lastAudited": "2026-05-02T12:28:16Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-01T05:10:00Z",
+      "result": "clean"
     },
     "erdos-1124-oq-01": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Cycle 4 re-audit of erdos-1124 (Tarski's Circle-Squaring Problem). All meta.json claims match Erdos1124Problem.lean source.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 190 | 190 (wc -l) | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 16 | 16 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |

Axioms in source: `laczkovich_theorem`, `translation_implies_isometry` — both match `assumptions` field text.

Status `axiomatized` + badge `axiom` correctly reflect axiom usage. Tier C (axiomatized core theorem) classification appropriate.

## Test plan
- [x] Verified counts via grep against Erdos1124Problem.lean
- [x] Confirmed axiom names match assumptions narrative
- [x] No True stubs / no sorries