### PR TITLE
fix(erdos-1133): repair build at Mathlib v4.26.0

### DIFF
--- a/proofs/Proofs/Erdos1133Problem.lean
+++ b/proofs/Proofs/Erdos1133Problem.lean
@@ -32,10 +32,12 @@ Mathematica (Cluj) (1967), 65-73.
 Tags: analysis, polynomials, interpolation, approximation-theory
 -/
 
+import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.Algebra.Polynomial.Eval.Defs
+import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Polynomial.Basic
-import Mathlib.Data.Polynomial.Eval
 import Mathlib.Data.Finset.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Analysis.Normed.Field.Basic
 
@@ -58,7 +60,7 @@ def polyEval (P : Polynomial ℝ) (x : ℝ) : ℝ := P.eval x
 max_{x ∈ [-1,1]} |P(x)|
 -/
 noncomputable def maxNormOnInterval (P : Polynomial ℝ) : ℝ :=
-  sSup { |P.eval x| | x : ℝ, -1 ≤ x ∧ x ≤ 1 }
+  sSup {y : ℝ | ∃ x : ℝ, -1 ≤ x ∧ x ≤ 1 ∧ y = |P.eval x|}
 
 /--
 **Sample Points:**
@@ -118,7 +120,7 @@ def ErdosConjecture1133 : Prop :=
 ## Part IV: Related Result (Known by Erdős)
 -/
 
-/--
+/-
 **Erdős's Related Result:**
 For any C > 0, there exists ε > 0 such that for large n and m = ⌊(1+ε)n⌋:
 For any x₁,...,xₘ ∈ [-1,1], there EXISTS a polynomial P of degree n with
@@ -126,6 +128,7 @@ For any x₁,...,xₘ ∈ [-1,1], there EXISTS a polynomial P of degree n with
 
 This is weaker: it asks for existence of P, not choice of yᵢ values.
 -/
+
 /-
 ## Part V: Connection to Lagrange Interpolation
 -/
@@ -139,11 +142,12 @@ axiom lagrange_interpolation (n : ℕ) (x y : Fin n → ℝ)
     (hdistinct : Function.Injective x) :
     ∃! P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i
 
-/--
+/-
 **Divergence of Lagrange Interpolation:**
 There exist continuous functions for which Lagrange interpolation
 on uniformly spaced nodes diverges.
 -/
+
 /-
 ## Part VI: The Chebyshev Connection
 -/
@@ -152,13 +156,14 @@ on uniformly spaced nodes diverges.
 **Chebyshev Nodes:**
 Points xₖ = cos(π(2k+1)/(2n)) minimize Lagrange interpolation error.
 -/
-def chebyshevNodes (n : ℕ) (k : Fin n) : ℝ :=
+noncomputable def chebyshevNodes (n : ℕ) (k : Fin n) : ℝ :=
   Real.cos (Real.pi * (2 * k + 1) / (2 * n))
 
-/--
+/-
 **Optimal Node Distribution:**
 Chebyshev nodes give the best possible bound for polynomial interpolation.
 -/
+
 /-
 ## Part VII: Summary
 -/
@@ -174,7 +179,7 @@ theorem exact_interpolation_case :
     ∀ y : Fin n → ℝ,
     ∃ P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i := by
   intro n hn x hx y
-  exact Classical.choose_spec (ExistsUnique.exists (lagrange_interpolation n x y hx))
+  exact ⟨_, Classical.choose_spec (ExistsUnique.exists (lagrange_interpolation n x y hx))⟩
 
 /--
 **Erdős Problem #1133: Summary**

--- a/src/data/proofs/erdos-1133/meta.json
+++ b/src/data/proofs/erdos-1133/meta.json
@@ -28,12 +28,17 @@
       {
         "theorem": "Polynomial",
         "description": "Polynomial definitions and evaluation",
-        "module": "Mathlib.Data.Polynomial.Basic"
+        "module": "Mathlib.Algebra.Polynomial.Basic"
       },
       {
         "theorem": "Polynomial.eval",
         "description": "Polynomial evaluation at a point",
-        "module": "Mathlib.Data.Polynomial.Eval"
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      },
+      {
+        "theorem": "Polynomial.natDegree",
+        "description": "Polynomial degree (natural number)",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
       },
       {
         "theorem": "Real.cos",
@@ -89,7 +94,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 195,
+    "lineCount": 200,
     "assumptions": "1 axiom: lagrange_interpolation (existence and uniqueness of degree-<n polynomial through n distinct points). All other results proved as theorems (0 sorries).",
     "theoremCount": 2,
     "definitionCount": 8
@@ -117,50 +122,50 @@
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "Defines polyEval (P.eval x wrapper), maxNormOnInterval (sSup of |P(x)| on [-1,1] — the Chebyshev/L∞ norm), SamplePoints n (functions Fin n → [-1,1] for sample locations), and TargetValues n (functions Fin n → [-1,1] for chosen values). These are the building blocks for the interpolation game.",
-      "startLine": 46,
-      "endLine": 74
+      "startLine": 48,
+      "endLine": 76
     },
     {
       "id": "interpolation",
       "title": "Interpolation Conditions",
       "summary": "Defines ApproximatelyInterpolates: ∃ S ⊆ Fin n with |S| ≥ n - ⌊εn⌋ and P(x_i) = y_i on S — the polynomial matches at least (1-ε)n points exactly. Defines HasBoundedDegree: natDegree P < ⌊(1+ε)n⌋. For ε = 0, these reduce to exact Lagrange interpolation of degree < n through all n points.",
-      "startLine": 75,
-      "endLine": 94
+      "startLine": 77,
+      "endLine": 96
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
       "summary": "ErdosConjecture1133 as a five-quantifier Lean Prop: ∀ C > 0, ∃ ε > 0, ∃ N, ∀ n ≥ N, ∀ x ∈ [-1,1]^n, ∃ y ∈ [-1,1]^n, ∀ P with bounded degree and approximate interpolation: ‖P‖_∞ > C. The adversarial ∃y∀P structure makes this a minimax problem. Status: OPEN since 1967.",
-      "startLine": 95,
-      "endLine": 116
+      "startLine": 97,
+      "endLine": 118
     },
     {
       "id": "related",
       "title": "Related Result (Known by Erdős)",
       "summary": "Documents Erdős's weaker existence theorem in a docstring (Part IV): for any C > 0, ∃ ε > 0 such that for large n and m = ⌊(1+ε)n⌋ sample points, ∃ P of degree ≤ n with |P(x_i)| ≤ 1 for all i yet ‖P‖_∞ > C. The key difference: this quantifies ∃P (finds one bad polynomial) while the conjecture quantifies ∀P (all polynomials matching y are bad). No Lean declaration is made here — background context only.",
-      "startLine": 117,
-      "endLine": 128
+      "startLine": 119,
+      "endLine": 131
     },
     {
       "id": "lagrange",
       "title": "Lagrange Interpolation Theory",
       "summary": "One axiom: lagrange_interpolation (∃! P of degree < n through n distinct points — the classical existence-uniqueness theorem). The divergence of Lagrange interpolation on uniform nodes (Runge's phenomenon) is documented in a surrounding docstring as background only — no `axiom lagrange_divergence` is declared. The Lebesgue constant Λ_n → ∞ for ANY node sequence (Faber 1914).",
-      "startLine": 129,
-      "endLine": 146
+      "startLine": 132,
+      "endLine": 150
     },
     {
       "id": "chebyshev",
       "title": "Chebyshev Connection",
       "summary": "Defines `chebyshevNodes(n, k) = cos(π(2k+1)/(2n))` — the roots of the Chebyshev polynomial T_n. Notes in a docstring that Chebyshev nodes minimize the Lebesgue constant (optimality property), but no `axiom chebyshev_optimal` is declared — only the definition and background context. These nodes don't resolve the conjecture since the adversary chooses arbitrary nodes.",
-      "startLine": 147,
-      "endLine": 161
+      "startLine": 151,
+      "endLine": 166
     },
     {
       "id": "summary",
       "title": "Summary and Main Results",
       "summary": "exact_interpolation_case: for ε = 0, Lagrange gives the unique polynomial through all n points (proved from lagrange_interpolation via Classical.choose_spec). erdos_1133_summary wraps this as the main result. ErdosConjecture1133 remains OPEN — formalized as a Lean Prop but with no proof or disproof.",
-      "startLine": 162,
-      "endLine": 195
+      "startLine": 167,
+      "endLine": 200
     }
   ],
   "crossReferences": [
@@ -267,10 +272,12 @@
   },
   "leanFile": {
     "imports": [
+      "Mathlib.Algebra.Polynomial.Basic",
+      "Mathlib.Algebra.Polynomial.Eval.Defs",
+      "Mathlib.Algebra.Polynomial.Degree.Definitions",
       "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Polynomial.Basic",
-      "Mathlib.Data.Polynomial.Eval",
       "Mathlib.Data.Finset.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
       "Mathlib.Topology.MetricSpace.Basic",
       "Mathlib.Analysis.Normed.Field.Basic"
     ],
@@ -278,7 +285,7 @@
       "Polynomial"
     ],
     "namespace": "Erdos1133",
-    "lineCount": 195,
+    "lineCount": 200,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Repairs build failure in `Proofs/Erdos1133Problem.lean` so `status: \"axiomatized\"` is honest (kernel actually verifies the file).

## Evidence

**Before**: Docker build failed with five distinct errors at Mathlib v4.26.0:
1. Imports `Mathlib.Data.Polynomial.Basic` / `.Eval` no longer exist (moved to `Mathlib.Algebra.Polynomial.*`).
2. `Real.cos` and `Polynomial.natDegree` used but not imported.
3. Three orphaned `/--` docstrings (Parts IV/V/VI) with no following declaration — `unexpected token '/--'; expected 'lemma'`.
4. `chebyshevNodes` not marked `noncomputable` despite depending on `Real.pi` and `Real.cos`.
5. `maxNormOnInterval` set-builder used invalid `{ |P.eval x| | x : ℝ, p ∧ q }` syntax.
6. `exact_interpolation_case` proof type-mismatched: `Classical.choose_spec` returns a conjunction, but goal is `∃ P, ...`.

**After**: `./proofs/scripts/docker-build.sh Proofs.Erdos1133Problem` succeeds at Mathlib v4.26.0.

## Changes

- **Imports**: switch to `Mathlib.Algebra.Polynomial.*`, add `Degree.Definitions` (for `natDegree`) and `Analysis.SpecialFunctions.Trigonometric.Basic` (for `Real.cos`).
- **Orphan docstrings**: convert Part IV (`Erdős's Related Result`), Part V (`Divergence of Lagrange Interpolation`), and Part VI (`Optimal Node Distribution`) from `/--` to `/-` since they document context, not declarations.
- **noncomputable**: add to `chebyshevNodes`.
- **maxNormOnInterval**: rewrite as `{y : ℝ | ∃ x : ℝ, -1 ≤ x ∧ x ≤ 1 ∧ y = |P.eval x|}`.
- **exact_interpolation_case**: wrap `Classical.choose_spec ...` in `⟨_, ...⟩` to package as existential.
- **meta.json**: update `mathlibDependencies` modules + `leanFile.imports` to match, bump `lineCount` 195→200, shift `sections[].startLine/endLine` for the small layout drift.

Status remains `axiomatized` — the file now genuinely compiles with one declared axiom (`lagrange_interpolation`), matching the meta.

Closes #21803

---
Automated fix by lean-mechanic agent.