### PR TITLE
Fix: erdos-1133 build at Mathlib v4.26.0 (#21803)

### DIFF
--- a/proofs/Proofs/Erdos1133Problem.lean
+++ b/proofs/Proofs/Erdos1133Problem.lean
@@ -32,10 +32,12 @@ Mathematica (Cluj) (1967), 65-73.
 Tags: analysis, polynomials, interpolation, approximation-theory
 -/
 
+import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.Algebra.Polynomial.Eval.Defs
+import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Polynomial.Basic
-import Mathlib.Data.Polynomial.Eval
 import Mathlib.Data.Finset.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Analysis.Normed.Field.Basic
 
@@ -58,7 +60,7 @@ def polyEval (P : Polynomial ℝ) (x : ℝ) : ℝ := P.eval x
 max_{x ∈ [-1,1]} |P(x)|
 -/
 noncomputable def maxNormOnInterval (P : Polynomial ℝ) : ℝ :=
-  sSup { |P.eval x| | x : ℝ, -1 ≤ x ∧ x ≤ 1 }
+  sSup ((fun x : ℝ => |P.eval x|) '' Set.Icc (-1 : ℝ) 1)
 
 /--
 **Sample Points:**
@@ -118,15 +120,14 @@ def ErdosConjecture1133 : Prop :=
 ## Part IV: Related Result (Known by Erdős)
 -/
 
-/--
+/-
 **Erdős's Related Result:**
 For any C > 0, there exists ε > 0 such that for large n and m = ⌊(1+ε)n⌋:
 For any x₁,...,xₘ ∈ [-1,1], there EXISTS a polynomial P of degree n with
 |P(xᵢ)| ≤ 1 for all i, yet max_{[-1,1]} |P| > C.
 
 This is weaker: it asks for existence of P, not choice of yᵢ values.
--/
-/-
+
 ## Part V: Connection to Lagrange Interpolation
 -/
 
@@ -139,12 +140,11 @@ axiom lagrange_interpolation (n : ℕ) (x y : Fin n → ℝ)
     (hdistinct : Function.Injective x) :
     ∃! P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i
 
-/--
+/-
 **Divergence of Lagrange Interpolation:**
 There exist continuous functions for which Lagrange interpolation
 on uniformly spaced nodes diverges.
--/
-/-
+
 ## Part VI: The Chebyshev Connection
 -/
 
@@ -152,14 +152,13 @@ on uniformly spaced nodes diverges.
 **Chebyshev Nodes:**
 Points xₖ = cos(π(2k+1)/(2n)) minimize Lagrange interpolation error.
 -/
-def chebyshevNodes (n : ℕ) (k : Fin n) : ℝ :=
+noncomputable def chebyshevNodes (n : ℕ) (k : Fin n) : ℝ :=
   Real.cos (Real.pi * (2 * k + 1) / (2 * n))
 
-/--
+/-
 **Optimal Node Distribution:**
 Chebyshev nodes give the best possible bound for polynomial interpolation.
--/
-/-
+
 ## Part VII: Summary
 -/
 
@@ -173,8 +172,8 @@ theorem exact_interpolation_case :
     ∀ x : Fin n → ℝ, Function.Injective x →
     ∀ y : Fin n → ℝ,
     ∃ P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i := by
-  intro n hn x hx y
-  exact Classical.choose_spec (ExistsUnique.exists (lagrange_interpolation n x y hx))
+  intro n _hn x hx y
+  exact (lagrange_interpolation n x y hx).exists
 
 /--
 **Erdős Problem #1133: Summary**

--- a/src/data/proofs/erdos-1133/meta.json
+++ b/src/data/proofs/erdos-1133/meta.json
@@ -28,12 +28,17 @@
       {
         "theorem": "Polynomial",
         "description": "Polynomial definitions and evaluation",
-        "module": "Mathlib.Data.Polynomial.Basic"
+        "module": "Mathlib.Algebra.Polynomial.Basic"
       },
       {
         "theorem": "Polynomial.eval",
         "description": "Polynomial evaluation at a point",
-        "module": "Mathlib.Data.Polynomial.Eval"
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      },
+      {
+        "theorem": "Polynomial.natDegree",
+        "description": "Natural-number degree of a polynomial",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
       },
       {
         "theorem": "Real.cos",
@@ -89,7 +94,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 195,
+    "lineCount": 194,
     "assumptions": "1 axiom: lagrange_interpolation (existence and uniqueness of degree-<n polynomial through n distinct points). All other results proved as theorems (0 sorries).",
     "theoremCount": 2,
     "definitionCount": 8
@@ -267,10 +272,12 @@
   },
   "leanFile": {
     "imports": [
+      "Mathlib.Algebra.Polynomial.Basic",
+      "Mathlib.Algebra.Polynomial.Eval.Defs",
+      "Mathlib.Algebra.Polynomial.Degree.Definitions",
       "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Polynomial.Basic",
-      "Mathlib.Data.Polynomial.Eval",
       "Mathlib.Data.Finset.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
       "Mathlib.Topology.MetricSpace.Basic",
       "Mathlib.Analysis.Normed.Field.Basic"
     ],
@@ -278,7 +285,7 @@
       "Polynomial"
     ],
     "namespace": "Erdos1133",
-    "lineCount": 195,
+    "lineCount": 194,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Repairs `Erdos1133Problem.lean` so the kernel actually verifies the `axiomatized` status. Without this the file failed to compile and `exact_interpolation_case` / `erdos_1133_summary` were never kernel-checked, overstating gallery integrity.

## Evidence

**Before**: `./proofs/scripts/docker-build.sh Proofs.Erdos1133Problem` failed with:
- `Mathlib.Data.Polynomial.Basic` / `Mathlib.Data.Polynomial.Eval` — paths removed in v4.26.0
- Floating `/-- ... -/` docstrings between block comments (parser: `unexpected token '/--'; expected 'lemma'`)
- Set-builder pipe-clash in `maxNormOnInterval`: `sSup { |P.eval x| | x : ℝ, ... }`
- `chebyshevNodes` uses `Real.pi` but not marked `noncomputable`
- `Classical.choose_spec (ExistsUnique.exists ...)` had wrong type at `exact_interpolation_case`

**After**: `Built Proofs.Erdos1133Problem (10s)` — 1855 jobs successful at Mathlib v4.26.0.

### Lean changes
- Imports: replace `Mathlib.Data.Polynomial.{Basic,Eval}` with `Mathlib.Algebra.Polynomial.{Basic,Eval.Defs,Degree.Definitions}`; add `Trigonometric.Basic` for `Real.cos` / `Real.pi`.
- `maxNormOnInterval`: rewrite as `sSup ((fun x : ℝ => |P.eval x|) '' Set.Icc (-1 : ℝ) 1)`.
- Two floating docstrings (Erdős's Related Result, Divergence of Lagrange Interpolation) → block comments.
- `chebyshevNodes` → `noncomputable def`.
- `exact_interpolation_case` body uses `(lagrange_interpolation n x y hx).exists` directly.

### Meta changes
- `mathlibDependencies` and `leanFile.imports` synced to the new module paths.
- `meta.lineCount` and `leanFile.lineCount`: 195 → 194 (wc -l canonical after edits).

Closes #21803

---
Automated fix by lean-mechanic agent.