### PR TITLE
fix(erdos-1133): repair Mathlib v4.26.0 build

### DIFF
--- a/proofs/Proofs/Erdos1133Problem.lean
+++ b/proofs/Proofs/Erdos1133Problem.lean
@@ -32,10 +32,12 @@ Mathematica (Cluj) (1967), 65-73.
 Tags: analysis, polynomials, interpolation, approximation-theory
 -/
 
+import Mathlib.Algebra.Polynomial.Basic
+import Mathlib.Algebra.Polynomial.Eval.Defs
+import Mathlib.Algebra.Polynomial.Degree.Definitions
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Polynomial.Basic
-import Mathlib.Data.Polynomial.Eval
 import Mathlib.Data.Finset.Basic
+import Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic
 import Mathlib.Topology.MetricSpace.Basic
 import Mathlib.Analysis.Normed.Field.Basic
 
@@ -58,7 +60,7 @@ def polyEval (P : Polynomial ℝ) (x : ℝ) : ℝ := P.eval x
 max_{x ∈ [-1,1]} |P(x)|
 -/
 noncomputable def maxNormOnInterval (P : Polynomial ℝ) : ℝ :=
-  sSup { |P.eval x| | x : ℝ, -1 ≤ x ∧ x ≤ 1 }
+  sSup {y : ℝ | ∃ x : ℝ, -1 ≤ x ∧ x ≤ 1 ∧ y = |P.eval x|}
 
 /--
 **Sample Points:**
@@ -118,15 +120,14 @@ def ErdosConjecture1133 : Prop :=
 ## Part IV: Related Result (Known by Erdős)
 -/
 
-/--
+/-
 **Erdős's Related Result:**
 For any C > 0, there exists ε > 0 such that for large n and m = ⌊(1+ε)n⌋:
 For any x₁,...,xₘ ∈ [-1,1], there EXISTS a polynomial P of degree n with
 |P(xᵢ)| ≤ 1 for all i, yet max_{[-1,1]} |P| > C.
 
 This is weaker: it asks for existence of P, not choice of yᵢ values.
--/
-/-
+
 ## Part V: Connection to Lagrange Interpolation
 -/
 
@@ -139,12 +140,11 @@ axiom lagrange_interpolation (n : ℕ) (x y : Fin n → ℝ)
     (hdistinct : Function.Injective x) :
     ∃! P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i
 
-/--
+/-
 **Divergence of Lagrange Interpolation:**
 There exist continuous functions for which Lagrange interpolation
 on uniformly spaced nodes diverges.
--/
-/-
+
 ## Part VI: The Chebyshev Connection
 -/
 
@@ -152,14 +152,13 @@ on uniformly spaced nodes diverges.
 **Chebyshev Nodes:**
 Points xₖ = cos(π(2k+1)/(2n)) minimize Lagrange interpolation error.
 -/
-def chebyshevNodes (n : ℕ) (k : Fin n) : ℝ :=
+noncomputable def chebyshevNodes (n : ℕ) (k : Fin n) : ℝ :=
   Real.cos (Real.pi * (2 * k + 1) / (2 * n))
 
-/--
+/-
 **Optimal Node Distribution:**
 Chebyshev nodes give the best possible bound for polynomial interpolation.
--/
-/-
+
 ## Part VII: Summary
 -/
 
@@ -173,8 +172,8 @@ theorem exact_interpolation_case :
     ∀ x : Fin n → ℝ, Function.Injective x →
     ∀ y : Fin n → ℝ,
     ∃ P : Polynomial ℝ, P.natDegree < n ∧ ∀ i, P.eval (x i) = y i := by
-  intro n hn x hx y
-  exact Classical.choose_spec (ExistsUnique.exists (lagrange_interpolation n x y hx))
+  intro n _ x hx y
+  exact (lagrange_interpolation n x y hx).exists
 
 /--
 **Erdős Problem #1133: Summary**

--- a/src/data/proofs/erdos-1133/meta.json
+++ b/src/data/proofs/erdos-1133/meta.json
@@ -28,12 +28,17 @@
       {
         "theorem": "Polynomial",
         "description": "Polynomial definitions and evaluation",
-        "module": "Mathlib.Data.Polynomial.Basic"
+        "module": "Mathlib.Algebra.Polynomial.Basic"
       },
       {
         "theorem": "Polynomial.eval",
         "description": "Polynomial evaluation at a point",
-        "module": "Mathlib.Data.Polynomial.Eval"
+        "module": "Mathlib.Algebra.Polynomial.Eval.Defs"
+      },
+      {
+        "theorem": "Polynomial.natDegree",
+        "description": "Natural-number degree of a polynomial",
+        "module": "Mathlib.Algebra.Polynomial.Degree.Definitions"
       },
       {
         "theorem": "Real.cos",
@@ -89,7 +94,7 @@
       }
     ],
     "axiomCount": 1,
-    "lineCount": 195,
+    "lineCount": 194,
     "assumptions": "1 axiom: lagrange_interpolation (existence and uniqueness of degree-<n polynomial through n distinct points). All other results proved as theorems (0 sorries).",
     "theoremCount": 2,
     "definitionCount": 8
@@ -117,50 +122,50 @@
       "id": "definitions",
       "title": "Basic Definitions",
       "summary": "Defines polyEval (P.eval x wrapper), maxNormOnInterval (sSup of |P(x)| on [-1,1] — the Chebyshev/L∞ norm), SamplePoints n (functions Fin n → [-1,1] for sample locations), and TargetValues n (functions Fin n → [-1,1] for chosen values). These are the building blocks for the interpolation game.",
-      "startLine": 46,
-      "endLine": 74
+      "startLine": 48,
+      "endLine": 76
     },
     {
       "id": "interpolation",
       "title": "Interpolation Conditions",
       "summary": "Defines ApproximatelyInterpolates: ∃ S ⊆ Fin n with |S| ≥ n - ⌊εn⌋ and P(x_i) = y_i on S — the polynomial matches at least (1-ε)n points exactly. Defines HasBoundedDegree: natDegree P < ⌊(1+ε)n⌋. For ε = 0, these reduce to exact Lagrange interpolation of degree < n through all n points.",
-      "startLine": 75,
-      "endLine": 94
+      "startLine": 77,
+      "endLine": 95
     },
     {
       "id": "conjecture",
       "title": "The Erdős Conjecture",
       "summary": "ErdosConjecture1133 as a five-quantifier Lean Prop: ∀ C > 0, ∃ ε > 0, ∃ N, ∀ n ≥ N, ∀ x ∈ [-1,1]^n, ∃ y ∈ [-1,1]^n, ∀ P with bounded degree and approximate interpolation: ‖P‖_∞ > C. The adversarial ∃y∀P structure makes this a minimax problem. Status: OPEN since 1967.",
-      "startLine": 95,
-      "endLine": 116
+      "startLine": 96,
+      "endLine": 117
     },
     {
       "id": "related",
       "title": "Related Result (Known by Erdős)",
       "summary": "Documents Erdős's weaker existence theorem in a docstring (Part IV): for any C > 0, ∃ ε > 0 such that for large n and m = ⌊(1+ε)n⌋ sample points, ∃ P of degree ≤ n with |P(x_i)| ≤ 1 for all i yet ‖P‖_∞ > C. The key difference: this quantifies ∃P (finds one bad polynomial) while the conjecture quantifies ∀P (all polynomials matching y are bad). No Lean declaration is made here — background context only.",
-      "startLine": 117,
-      "endLine": 128
+      "startLine": 119,
+      "endLine": 130
     },
     {
       "id": "lagrange",
       "title": "Lagrange Interpolation Theory",
       "summary": "One axiom: lagrange_interpolation (∃! P of degree < n through n distinct points — the classical existence-uniqueness theorem). The divergence of Lagrange interpolation on uniform nodes (Runge's phenomenon) is documented in a surrounding docstring as background only — no `axiom lagrange_divergence` is declared. The Lebesgue constant Λ_n → ∞ for ANY node sequence (Faber 1914).",
-      "startLine": 129,
-      "endLine": 146
+      "startLine": 131,
+      "endLine": 149
     },
     {
       "id": "chebyshev",
       "title": "Chebyshev Connection",
       "summary": "Defines `chebyshevNodes(n, k) = cos(π(2k+1)/(2n))` — the roots of the Chebyshev polynomial T_n. Notes in a docstring that Chebyshev nodes minimize the Lebesgue constant (optimality property), but no `axiom chebyshev_optimal` is declared — only the definition and background context. These nodes don't resolve the conjecture since the adversary chooses arbitrary nodes.",
-      "startLine": 147,
-      "endLine": 161
+      "startLine": 150,
+      "endLine": 163
     },
     {
       "id": "summary",
       "title": "Summary and Main Results",
-      "summary": "exact_interpolation_case: for ε = 0, Lagrange gives the unique polynomial through all n points (proved from lagrange_interpolation via Classical.choose_spec). erdos_1133_summary wraps this as the main result. ErdosConjecture1133 remains OPEN — formalized as a Lean Prop but with no proof or disproof.",
-      "startLine": 162,
-      "endLine": 195
+      "summary": "exact_interpolation_case: for ε = 0, Lagrange gives the unique polynomial through all n points (proved from lagrange_interpolation via ExistsUnique.exists). erdos_1133_summary wraps this as the main result. ErdosConjecture1133 remains OPEN — formalized as a Lean Prop but with no proof or disproof.",
+      "startLine": 164,
+      "endLine": 194
     }
   ],
   "crossReferences": [
@@ -267,10 +272,12 @@
   },
   "leanFile": {
     "imports": [
+      "Mathlib.Algebra.Polynomial.Basic",
+      "Mathlib.Algebra.Polynomial.Eval.Defs",
+      "Mathlib.Algebra.Polynomial.Degree.Definitions",
       "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Polynomial.Basic",
-      "Mathlib.Data.Polynomial.Eval",
       "Mathlib.Data.Finset.Basic",
+      "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic",
       "Mathlib.Topology.MetricSpace.Basic",
       "Mathlib.Analysis.Normed.Field.Basic"
     ],
@@ -278,7 +285,7 @@
       "Polynomial"
     ],
     "namespace": "Erdos1133",
-    "lineCount": 195,
+    "lineCount": 194,
     "axiomCount": 1,
     "theoremCount": 2,
     "definitionCount": 8,


### PR DESCRIPTION
## Fix

Repairs `Proofs.Erdos1133Problem` so it builds at Mathlib v4.26.0 (#21803).

## Evidence

**Before:** Docker build failed with 4 distinct errors (stale `Mathlib.Data.Polynomial.*` paths, missing `natDegree`/`Real.cos` imports, malformed `sSup` set-builder, 3 floating `/--` docstrings causing parse errors, non-`noncomputable` `chebyshevNodes`, type mismatch in `exact_interpolation_case`).

**After:** Docker-verified clean build at v4.26.0:
```
./proofs/scripts/docker-build.sh Proofs.Erdos1133Problem
…
✔ [1855/1855] Built Proofs.Erdos1133Problem (9.0s)
Build completed successfully (1855 jobs).
```

### Changes
1. **Imports** updated to v4.26.0 paths:
   - `Mathlib.Data.Polynomial.Basic` → `Mathlib.Algebra.Polynomial.Basic`
   - `Mathlib.Data.Polynomial.Eval` → `Mathlib.Algebra.Polynomial.Eval.Defs`
   - Add `Mathlib.Algebra.Polynomial.Degree.Definitions` (for `natDegree`)
   - Add `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic` (for `Real.cos`)
2. **`maxNormOnInterval`** — rewrite `{ |P.eval x| | x : ℝ, … }` as proper set-builder `{y : ℝ | ∃ x, … ∧ y = |P.eval x|}`.
3. **Floating docstrings** at three sites (Erdős related result, Lagrange divergence, optimal nodes) converted from `/-- … -/` to `/- … -/` block comments and merged into the adjacent `## Part X` block headers.
4. **`chebyshevNodes`** marked `noncomputable` (depends on `Real.pi`).
5. **`exact_interpolation_case`** — replace `Classical.choose_spec (ExistsUnique.exists …)` (returns the property, not an existential) with `(lagrange_interpolation …).exists`, which directly yields the required `∃ P, …`.
6. **`meta.json`** — bring `mathlibDependencies` + `leanFile.imports` in sync with the new imports, update `lineCount` 195 → 194, shift section line ranges to match the new layout, refresh the summary section's prose reference (`Classical.choose_spec` → `ExistsUnique.exists`). `axiomCount` (1), `theoremCount` (2), `definitionCount` (8), `sorries` (0) unchanged.

Closes #21803

---
Automated fix by lean-mechanic agent.