### PR TITLE
fix(meta): inverse-galois mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -354,6 +354,13 @@
       "Mathlib.NumberTheory.LSeries.PrimesInAP",
       "Proofs.NthRootIrrationalOQ01"
     ],
-    "lemmaCount": 1
+    "lemmaCount": 1,
+    "additionalFiles": [
+      "Proofs/InverseGaloisA5.lean",
+      "Proofs/InverseGaloisD4.lean",
+      "Proofs/InverseGaloisF20.lean",
+      "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "Proofs/AbelRuffini.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` was missing while `meta.additionalFiles` listed 5 companion files. Mirror the 5 entries into `leanFile.additionalFiles` so both fields agree.

## Evidence

**Before**:
- `meta.additionalFiles`: 5 entries (InverseGaloisA5/D4/F20, AbelRuffiniGaloisExtensions, AbelRuffini)
- `leanFile.additionalFiles`: absent

**After**: both fields list the same 5 files.

This matches the registration convention used by other multi-file gallery entries (e.g. `ballot-problem-oq-03-oq-01-oq-02`). No content change.

---
Automated fix by lean-mechanic agent.