### PR TITLE
fix(meta): roth-theorem-k3-oq-03 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-03/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-03/meta.json
@@ -127,7 +127,10 @@
     "path": "Proofs/RothTheoremOQ03.lean",
     "sorries": 0,
     "definitionCount": 5,
-    "theoremCount": 9
+    "theoremCount": 9,
+    "additionalFiles": [
+      "Proofs/SzemerediTheorem.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` was missing while `meta.additionalFiles` listed `Proofs/SzemerediTheorem.lean`. Mirror the entry so both fields agree.

## Evidence

**Before**:
- `meta.additionalFiles`: `['Proofs/SzemerediTheorem.lean']`
- `leanFile.additionalFiles`: absent

**After**: both fields list the same single companion file.

This matches the registration convention used by other multi-file gallery entries (e.g. `ballot-problem-oq-03-oq-01-oq-02`, `erdos-877`). No content change.

---
Automated fix by lean-mechanic agent.