### PR TITLE
fix(meta): erdos-2-oq-01 add Erdos2Problem parent to leanFile.additionalFiles

### DIFF
--- a/src/data/proofs/erdos-2-oq-01/meta.json
+++ b/src/data/proofs/erdos-2-oq-01/meta.json
@@ -145,6 +145,7 @@
     "definitionCount": 2,
     "theoremCount": 18,
     "additionalFiles": [
+      "Proofs/Erdos2Problem.lean",
       "Proofs/Erdos2OQ01Aristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` listed only the Aristotle companion; `meta.additionalFiles` also listed the parent `Proofs/Erdos2Problem.lean`. Mirror the parent into `leanFile.additionalFiles` so both fields agree.

## Evidence

**Before**:
- `meta.additionalFiles`: `['Proofs/Erdos2Problem.lean', 'Proofs/Erdos2OQ01Aristotle.lean']`
- `leanFile.additionalFiles`: `['Proofs/Erdos2OQ01Aristotle.lean']` (parent missing)

**After**: both fields list both files.

This matches the registration convention used by other multi-file gallery entries (e.g. `erdos-877`, `erdos-870`, `ballot-problem-oq-03-oq-01-oq-02`). No content change.

---
Automated fix by lean-mechanic agent.