### PR TITLE
fix(meta): picks-theorem-oq-03 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -238,6 +238,9 @@
     "sorries": 0,
     "path": "Proofs/EhrhartPolynomialOQ03.lean",
     "definitionCount": 23,
-    "theoremCount": 45
+    "theoremCount": 45,
+    "additionalFiles": [
+      "Proofs/PicksTheoremOQ03CrossPoly.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Fix

\`leanFile.additionalFiles\` was missing while \`meta.additionalFiles\` listed one companion file. Mirror the entry into \`leanFile.additionalFiles\` so both fields agree.

## Evidence

**Before**:
- \`meta.additionalFiles\`: 1 entry (\`Proofs/PicksTheoremOQ03CrossPoly.lean\`)
- \`leanFile.additionalFiles\`: absent

**After**: both fields list the same file.

This matches the registration convention used by other multi-file gallery entries (e.g. \`ballot-problem-oq-03-oq-01-oq-02\`). No content change.

---
Automated fix by lean-mechanic agent.