### PR TITLE
audit(erdos-1123): mark clean (cycle 4) — 2 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3991,13 +3991,13 @@
       "notes": "Issue #14781 — phantom axioms (erdos_1122, omega_*) in narrative; meta.axiomCount=3 is correct"
     },
     "erdos-1123": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "proofStrategy claims 'axiomatizes the Just-Krawczyk conditional isomorphism and ZFC independence' — neither is axiomatized (only docstring placeholders)",
         "section line drift: just-krawczyk (80-97 vs actual 80-88), ideal-properties (98-110 vs actual 89-94); Part V Summary missing from sections array"
       ],
-      "lastAudited": "2026-05-02T13:17:48Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-06-01T06:05:03Z",
+      "result": "clean",
       "notes": "Issue #14783 — proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
     },
     "erdos-1124": {


### PR DESCRIPTION
## Summary

Cycle 4 re-audit of **erdos-1123** (Boolean Algebras Modulo Density Zero Sets). All meta.json claims verified against `proofs/Proofs/Erdos1123Problem.lean`.

## Integrity Checks

| Field | Claimed | Actual | OK |
|-------|---------|--------|----|
| lineCount | 110 | 110 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 1 | 1 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | n/a | 0 | ✓ |
| status | axiomatized | 2 axioms exist | ✓ |
| badge | axiom | (consistent) | ✓ |

Axioms in `assumptions` field match Lean source:
1. `density_zero_implies_log_density_zero`
2. `log_density_ideal_strictly_larger`

## Narrative Integrity

- Set-theoretic dependence (Just-Krawczyk under CH) clearly stated.
- Just-Krawczyk Theorem and ZFC independence appear only as docstrings, not Lean declarations — correctly disclosed in section descriptions.
- `proofStrategy` honestly distinguishes axiomatized vs documentation-only content.
- `erdos_1123_summary` proven by `exact ⟨_, _⟩` of the two axioms — honest packaging, no overclaim.

## Test plan

- [x] Counts verified via grep against Lean source
- [x] Section endLines within file bounds
- [x] No phantom axioms
- [x] Set-theoretic dependence properly contextualized

🤖 Generated with [Claude Code](https://claude.com/claude-code)