### PR TITLE
audit(erdos-1120): issues-fixed (cycle 4) — drop phantom Clunie-Netanyahu axiom claim

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3963,11 +3963,11 @@
       "result": "clean"
     },
     "erdos-1120": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "section line drift across all sections + missing main-open-problem section (filed #14785)"
       ],
-      "lastAudited": "2026-05-02T13:32:17Z",
+      "lastAudited": "2026-06-01T06:06:58Z",
       "result": "issues-fixed"
     },
     "erdos-1121": {

--- a/src/data/proofs/erdos-1120/meta.json
+++ b/src/data/proofs/erdos-1120/meta.json
@@ -39,10 +39,9 @@
       "Defined UnitRootedPoly (monic polynomial with roots in unit disk)",
       "Defined sublevelSet E = {z : |f(z)| ≤ 1}",
       "Defined shortestPathLength and worstCasePathLength",
-      "Stated main conjecture: worstCasePathLength n → ∞",
-      "Stated trivial bound (path length ≥ 1 from f(z) = z^n)",
-      "Axiomatized Clunie-Netanyahu existence result",
-      "Stated connection to Problem #1041"
+      "Axiomatized main conjecture (erdos_1120_conjecture): worstCasePathLength n → ∞",
+      "Axiomatized Erdős growth conjecture (erdos_growth_bound): worstCasePathLength n ≤ C·n",
+      "Documented (docstring only, not axiomatized): trivial lower bound, Clunie-Netanyahu existence theorem, and connection to Problem #1041"
     ],
     "axiomCount": 2,
     "lineCount": 183,


### PR DESCRIPTION
## Summary

Cycle 4 audit of **erdos-1120** (Shortest Path in Polynomial Sublevel Sets) found one phantom-axiom claim in `originalContributions`; fixed inline.

## Integrity Checks

| Field | Claimed | Actual | OK |
|-------|---------|--------|----|
| lineCount | 183 | 183 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 14 | 14 | ✓ |
| definitionCount | 5 | 5 (1 structure + 4 def) | ✓ |
| sorries | 0 | 0 | ✓ |
| status | axiomatized | (2 axioms exist) | ✓ |
| badge | axiom | (consistent) | ✓ |

Actual axioms in `proofs/Proofs/Erdos1120Problem.lean`:
1. `erdos_1120_conjecture` (line 154)
2. `erdos_growth_bound` (line 160)

## Issue Found and Fixed

`originalContributions` previously stated **"Axiomatized Clunie-Netanyahu existence result"** — but Clunie-Netanyahu appears only as a docstring at line 158, NOT as a Lean axiom. The `assumptions` field was already correct (`"2 axioms: erdos_1120_conjecture, erdos_growth_bound"`), so the overstatement was localized to the `originalContributions` narrative.

### Diff

```diff
-      "Stated main conjecture: worstCasePathLength n → ∞",
-      "Stated trivial bound (path length ≥ 1 from f(z) = z^n)",
-      "Axiomatized Clunie-Netanyahu existence result",
-      "Stated connection to Problem #1041"
+      "Axiomatized main conjecture (erdos_1120_conjecture): worstCasePathLength n → ∞",
+      "Axiomatized Erdős growth conjecture (erdos_growth_bound): worstCasePathLength n ≤ C·n",
+      "Documented (docstring only, not axiomatized): trivial lower bound, Clunie-Netanyahu existence theorem, and connection to Problem #1041"
```

Same phantom-axiom pattern previously flagged for erdos-1122 (#14781) and erdos-1123 (#14783).

## Test plan

- [x] Counts re-verified via grep against Lean source
- [x] Axioms enumerated and matched to names in originalContributions
- [x] No genuine axiom omitted from narrative
- [x] Phantom claim removed; Clunie-Netanyahu correctly reclassified as docstring-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)