### PR TITLE
fix(meta): greens-theorem-oq-04 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -247,7 +247,10 @@
     "theoremCount": 23,
     "definitionCount": 14,
     "path": "Proofs/GreensTheoremOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/GreensTheoremOQ03.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` was absent while `meta.additionalFiles` listed `Proofs/GreensTheoremOQ03.lean` (the parent file providing the inherited axioms). Mirror the entry into `leanFile.additionalFiles` so both fields agree.

## Evidence

**Before**:
- `meta.additionalFiles`: `['Proofs/GreensTheoremOQ03.lean']`
- `leanFile.additionalFiles`: absent

**After**: both fields list `Proofs/GreensTheoremOQ03.lean`.

The companion file provides the two inherited axioms `greens_theorem_typeI` and `disk_area_eq_pi` (per the `assumptions` field, lines 296/280 and 170/179 respectively). Registration matches the convention used by other multi-file gallery entries (e.g. `erdos-2-oq-01`, `inverse-galois`, `picks-theorem-oq-03`). No content change.

---
Automated fix by lean-mechanic agent.