### PR TITLE
fix(erdos-114): repair build at Mathlib v4.26.0

### DIFF
--- a/proofs/Proofs/Erdos114Problem.lean
+++ b/proofs/Proofs/Erdos114Problem.lean
@@ -23,7 +23,6 @@ when p(z) = z^n - 1?
 
 import Mathlib.Analysis.Complex.Basic
 import Mathlib.Data.Real.Basic
-import Mathlib.Data.Polynomial.Basic
 import Mathlib.Tactic
 
 /- ## Core Definitions -/
@@ -33,9 +32,9 @@ structure MonicPoly (n : ℕ) where
   coeffs : Fin n → ℂ
   -- The polynomial is z^n + a_{n-1}z^{n-1} + ... + a_0
 
-/-- The lemniscate of a monic degree-n polynomial:
+/- The lemniscate of a monic degree-n polynomial:
     L(p) = {z ∈ ℂ : |p(z)| = 1}. This is a real algebraic curve. -/
-/-- f(n): maximum lemniscate length over all monic degree-n polynomials. -/
+/- f(n): maximum lemniscate length over all monic degree-n polynomials. -/
 /-- The extremal polynomial z^n - 1 (coefficients: a_0 = -1, rest 0). -/
 def znMinus1 (n : ℕ) (hn : n ≥ 1) : MonicPoly n where
   coeffs := fun i => if i.val = 0 then -1 else 0

--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -225,7 +225,6 @@
     "imports": [
       "Mathlib.Analysis.Complex.Basic",
       "Mathlib.Data.Real.Basic",
-      "Mathlib.Data.Polynomial.Basic",
       "Mathlib.Tactic"
     ],
     "opens": [],


### PR DESCRIPTION
## Fix

`proofs/Proofs/Erdos114Problem.lean` failed to compile at Mathlib v4.26.0. Two minimal repairs restore the build (Docker-verified).

## Evidence

**Before** (`./proofs/scripts/docker-build.sh Proofs.Erdos114Problem`):
```
error: Proofs/Erdos114Problem.lean:36:67: unexpected token '/--'; expected 'lemma'
error: Proofs/Erdos114Problem.lean:37:75: unexpected token '/--'; expected 'lemma'
error: Lean exited with code 1
error: build failed
```

(After dropping the missing `Mathlib.Data.Polynomial.Basic` import, the orphan-docstring errors surface — both are real and were latent.)

**After**:
```
⚠ [3058/3058] Built Proofs.Erdos114Problem (9.2s)
warning: Proofs/Erdos114Problem.lean:39:22: unused variable `hn`
Build completed successfully (3058 jobs).
```

(Only a pre-existing `linter.unusedVariables` warning on `def znMinus1`'s `hn` parameter remains — out of scope.)

## Changes

1. **Stale import dropped**: `Mathlib.Data.Polynomial.Basic` was moved to `Mathlib.Algebra.Polynomial.Basic` in Mathlib v4.26.0. The file never actually uses Mathlib's `Polynomial` type — it defines its own `MonicPoly` structure — so the cleanest fix is to drop the import rather than rewrite it.

2. **Two orphan `/-- ... -/` docstrings → `/- ... -/`**: Lines 35-36 (Lemniscate description) and line 37 (`f(n)` description) were docstring comments with no following declaration, triggering parser errors. The third `/-- ... -/` (line 38, the `znMinus1` description) correctly attaches to its `def` and is preserved.

`meta.json`'s `leanFile.imports` list updated to mirror the new import set.

---
Automated fix by lean-mechanic agent.