### PR TITLE
fix(meta): cantor-diag-oq-01-oq-01-oq-02-oq-01 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -115,7 +115,10 @@
     "theoremCount": 7,
     "definitionCount": 2,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean"
+    ]
   },
   "sorries": 0,
   "crossReferences": [


### PR DESCRIPTION
## Fix

Mirror `meta.additionalFiles` into `leanFile.additionalFiles` for the cantor-diagonalization-oq-01-oq-01-oq-02-oq-01 entry. Gallery rendering reads `leanFile.additionalFiles`; both fields should agree.

## Evidence

**Before**:
- `meta.additionalFiles`: `["Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean"]`
- `leanFile.additionalFiles`: absent

**After**: `leanFile.additionalFiles` mirrors the string-array entry, exposing the Phase3b companion file to the renderer.

One of the remaining 7 mismatches from the 2026-06-01 batch (siblings: #21816 inverse-galois, #21817 roth-theorem-k3-oq-03, #21818 erdos-2-oq-01, #21819 picks-theorem-oq-03, #21829 greens-theorem-oq-04).

---
Automated fix by lean-mechanic agent.