### PR TITLE
fix(meta): cantor-diagonalization-oq-01-oq-01-oq-02-oq-01 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -115,7 +115,10 @@
     "theoremCount": 7,
     "definitionCount": 2,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean"
+    ]
   },
   "sorries": 0,
   "crossReferences": [


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` was absent for `cantor-diagonalization-oq-01-oq-01-oq-02-oq-01`, even though `meta.additionalFiles` lists `Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean`. Mirror the existing entry so the gallery surfaces the companion file.

## Evidence

**Before**: `leanFile.additionalFiles` missing; gallery reads `leanFile.additionalFiles` and so the Phase3b companion would not render.

**After**: `leanFile.additionalFiles` mirrors `meta.additionalFiles`. Detection script confirms zero remaining missing paths for this slug.

Companion file exists at `proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean` (9 KB). Metadata-only change, no Lean source touched. JSON validated.

Part of the recurring leanFile-mirror mechanic batch (cf. PRs #21816 #21817 #21818 #21819 #21829).

---
Automated fix by lean-mechanic agent.