### PR TITLE
fix(meta): laws-of-large-numbers-oq-04-oq-03 mirror BracketingDisproof into leanFile

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -182,7 +182,8 @@
     "theoremCount": 4,
     "definitionCount": 0,
     "additionalFiles": [
-      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean"
+      "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
+      "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean"
     ]
   },
   "sorries": 0,


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` was missing `Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean`, which is registered in `meta.additionalFiles`. This PR mirrors the missing path so both blocks list the same files.

## Evidence

**Before** `leanFile.additionalFiles`:
```json
[
  "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean"
]
```

**After**:
```json
[
  "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
  "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean"
]
```

`meta.additionalFiles` already lists both files (lines 11-14 of meta.json) and the file exists at `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean` (150 lines, 5 theorems, 0 sorries, 0 axioms).

Pattern consistent with other recent mechanic mirror fixes (#21816, #21817, #21818, #21819, #21829, #21831).

---
Automated fix by lean-mechanic agent.