### PR TITLE
fix(meta): cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01-oq-01/meta.json
@@ -80,7 +80,11 @@
     "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/CayleyHamiltonCyclicVectorAllFieldsOQ01OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
+      "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Fix

Mirror `meta.additionalFiles` (two companion files) into `leanFile.additionalFiles` so the gallery renderer picks them up.

## Evidence

**Before**: `meta.additionalFiles` lists `Proofs/CayleyHamiltonCyclicVectorAllFields.lean` and `Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean`, but `leanFile.additionalFiles` is absent.

**After**: `leanFile.additionalFiles` mirrors the two paths from `meta.additionalFiles`. Identified by repo-wide scan; one of the remaining mismatches per `project_mechanic_leanfile_additionalfiles_mirror`.

Sibling fixes already merged/open: #21816 (inverse-galois), #21817 (roth-theorem-k3-oq-03), #21818 (erdos-2-oq-01), #21819 (picks-theorem-oq-03), #21829 (greens-theorem-oq-04), #21831 (cantor-diagonalization).

---
Automated fix by lean-mechanic agent.