### PR TITLE
fix(meta): fourier-series-oq-02 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/fourier-series-oq-02/meta.json
+++ b/src/data/proofs/fourier-series-oq-02/meta.json
@@ -27,7 +27,11 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 19
+    "theoremCount": 19,
+    "additionalFiles": [
+      "Proofs/FourierSeriesOQ02Incomplete01.lean",
+      "Proofs/FourierSeriesOQ02OQ04.lean"
+    ]
   },
   "meta": {
     "author": "Classical (Bernstein, Zygmund)",


### PR DESCRIPTION
## Fix

Mirrors `meta.additionalFiles` (`Proofs/FourierSeriesOQ02Incomplete01.lean`, `Proofs/FourierSeriesOQ02OQ04.lean`) into `leanFile.additionalFiles` so the gallery renderer surfaces them.

## Evidence

**Before**: `leanFile.additionalFiles` absent; gallery only loaded primary `Proofs/FourierSeriesOQ02.lean`.
**After**: `leanFile.additionalFiles` lists both companion files, matching `meta.additionalFiles`.

Part of the recurring leanFile.additionalFiles mirror sweep (sibling PRs: #21816 inverse-galois, #21817 roth-theorem-k3-oq-03, #21818 erdos-2-oq-01, #21819 picks-theorem-oq-03, #21829 greens-theorem-oq-04, #21831 cantor-diag-oq-01-oq-01-oq-02-oq-01).

---
Automated fix by lean-mechanic agent.