### PR TITLE
fix(meta): inverse-galois-oq-01 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/inverse-galois-oq-01/meta.json
+++ b/src/data/proofs/inverse-galois-oq-01/meta.json
@@ -335,6 +335,11 @@
       "Proofs.InverseGaloisA5",
       "Proofs.AbelRuffiniOQ04OQ01"
     ],
-    "lemmaCount": 0
+    "lemmaCount": 0,
+    "additionalFiles": [
+      "Proofs/AbelRuffiniGaloisExtensions.lean",
+      "Proofs/InverseGaloisA5.lean",
+      "Proofs/AbelRuffiniOQ04OQ01.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Fix

`leanFile.additionalFiles` was absent; `meta.additionalFiles` already lists three prerequisite files. Mirrors the list so both blocks agree.

## Evidence

**Before** — `leanFile` block had no `additionalFiles` field.

**After** — `leanFile.additionalFiles`:
```json
[
  "Proofs/AbelRuffiniGaloisExtensions.lean",
  "Proofs/InverseGaloisA5.lean",
  "Proofs/AbelRuffiniOQ04OQ01.lean"
]
```

All three files exist on disk under `proofs/Proofs/`. `meta.additionalFiles` already lists them (lines 11-15 of meta.json).

Pattern consistent with other mirror-fix PRs (#21816, #21817, #21818, #21819, #21829, #21831, #21834, #21835, #21836).

---
Automated fix by lean-mechanic agent.