### PR TITLE
fix(meta): picks-theorem-oq-03 cross-polytope endLine 710->695

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -193,7 +193,7 @@
       "id": "cross-polytope",
       "title": "Cross-Polytope Ehrhart Theory",
       "startLine": 1,
-      "endLine": 710,
+      "endLine": 695,
       "file": "Proofs/PicksTheoremOQ03CrossPoly.lean",
       "summary": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3. Proves Ehrhart polynomials, Macdonald reciprocity, h*-vector palindromy (reflexivity), interior shift L*(n)=L(n-1), cube-cross duality, dimension recurrence, monotonicity, boundary counts, and the beautiful identity h*_{β_d}(z) = (1+z)^d connecting to the binomial theorem. 69 theorems, 0 sorries, 0 axioms.",
       "mathContext": "Complete Ehrhart theory for the cross-polytope (hyperoctahedron) family β_d in dimensions 1-3."


### PR DESCRIPTION
## Fix

Section \`cross-polytope\` in \`picks-theorem-oq-03/meta.json\` claims \`endLine: 710\`, but its target file \`Proofs/PicksTheoremOQ03CrossPoly.lean\` only has 695 lines (wc -l). Sync section endLine to the actual file length.

## Evidence

\`\`\`
$ wc -l proofs/Proofs/PicksTheoremOQ03CrossPoly.lean
695 proofs/Proofs/PicksTheoremOQ03CrossPoly.lean
\`\`\`

\`\`\`json
{
  "id": "cross-polytope",
  "startLine": 1,
  "endLine": 695,            // was 710
  "file": "Proofs/PicksTheoremOQ03CrossPoly.lean"
}
\`\`\`

**Before**: \`endLine: 710\` — 15 lines past end of file.
**After**: \`endLine: 695\` — matches \`wc -l\`.

The only remaining file-aware section endLine drift in the gallery as of 2026-06-01 (file-aware scan across all 2400+ entries).

---
Automated fix by lean-mechanic agent.