### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-04 lineCount 757→869

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 757,
+    "lineCount": 869,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",


### PR DESCRIPTION
## Fix

Bump `meta.lineCount` from 757 to 869 to match the primary lean file's actual `wc -l` (and `leanFile.lineCount`, which was already 869).

## Evidence

```
wc -l proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
     869
```

Drift discovered by mechanic scan (meta.lineCount matches neither the primary file nor the primary+additionalFiles aggregate). `leanFile.lineCount` was already correct.

**Before**: `"meta": { "lineCount": 757 }` (stale; last fixed 657→757 in #21508)
**After**:  `"meta": { "lineCount": 869 }` (current wc -l)

The file grew over later sessions (S5/S6/S7/S8: PRs #20870, #21728).

---
Automated fix by lean-mechanic agent.