### PR TITLE
audit(erdos-1109): mark clean (cycle 4) — 2 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3867,9 +3867,9 @@
     },
     "erdos-1109": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T13:40:18Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T06:40:59Z",
+      "result": "clean"
     },
     "erdos-111": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Summary

Erdős Problem #1109 (Squarefree Sumsets, OPEN problem) — meta.json claims match the Lean source exactly.

| Field | meta.json | Lean file |
|-------|-----------|-----------|
| lineCount | 3713 | 3713 |
| axiomCount | 2 | 2 (`konyagin_lower_2004`, `konyagin_upper_2004`) |
| sorries | 0 | 0 |
| theoremCount | 151 | 151 (including `private theorem`) |
| definitionCount | 8 | 8 |
| True stubs | — | 0 |
| status / badge | `axiomatized` / `axiom` | matches |

Note: a naive `grep -cE "^(theorem\|lemma) "` returns 92 because 59 declarations are prefixed with `private`. The aggregate count of `^(private )?(theorem\|lemma) ` is 151, matching meta.

## Tier Classification

**Tier C** (scaffold / axiomatized) — this is an OPEN problem. Konyagin's 2004 lower and upper bounds are axiomatized. Title and description correctly mark "OPEN" and `originalContributions` transparently lists "konyagin_lower_2004 and konyagin_upper_2004 axioms". No overclaim.

## Test plan

- [x] `wc -l` matches `lineCount`
- [x] `grep -c "^axiom "` matches `axiomCount`
- [x] `grep -cw sorry` = 0
- [x] No `True`-stub theorems
- [x] All 9 section endLines within file bounds (max = 3713 = file length)
- [x] OPEN status correctly reflected in title and description

🤖 Generated with [Claude Code](https://claude.com/claude-code)