### PR TITLE
research(buffons-needle-oq-01-oq-04): S1 OBSERVE — Buffon's coin as corollary of smooth-noodle bearer

### DIFF
--- a/research/problems/buffons-needle-oq-01-oq-04/knowledge.md
+++ b/research/problems/buffons-needle-oq-01-oq-04/knowledge.md
@@ -4,18 +4,80 @@ Insights accumulated during research on this problem.
 
 ---
 
-## Problem Understanding
+## Problem Understanding (S1 OBSERVE, 2026-05-31)
 
-[Initial observations about the problem will be recorded here]
+This slug corresponds to the **4th `conclusion.openQuestion` of `buffons-needle-oq-01`** — generalizing the smooth-noodle theorem from 1-D C¹ curves to 2-D **convex bodies** (Buffon's coin, ellipses, polygons, etc.). The classical result (Laplace 1812, after Buffon 1733) is:
+
+$$
+\mathbb{E}[\#\text{crossings of } \partial K \text{ with line grid}] = \frac{2\,p}{\pi d}
+\quad\text{where } p = \operatorname{perimeter}(K),\ d = \text{line spacing}.
+$$
+
+The **key structural insight** (S1, this memo): the result is **NOT new analytic content**. The bearer `BuffonsNeedleOQ01.buffon_smooth_of_contDiff` already proves exactly this formula for any C¹ planar curve — applied to the boundary curve $\partial K$, it gives the Buffon's coin formula immediately. The convexity hypothesis enters only in the *combinatorial* translation "boundary crossings = $2 \times $ (lines that cut $K$)" — a 10–15 LOC lemma about line/convex-set intersections.
+
+This makes the slug **highly tractable** (Approach A: ~50–80 LOC corollary, no new axioms, no sorries).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### S1: Bearer table at Mathlib v4.26.0 (pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+| Bearer | Module | Role in S2 ACT |
+|---|---|---|
+| `BuffonsNeedleOQ01.buffon_smooth_of_contDiff` | `Proofs/BuffonsNeedleOQ01.lean` (line ~250 — main result) | **The core bearer**. Proves $\mathbb{E}[\text{crossings}] = 2 \cdot \operatorname{arcLength}(\gamma) / (\pi d)$ for any C¹ planar curve. S2 ACT is a one-line corollary applied to a closed C¹ boundary parametrisation. |
+| `ContDiff` | `Mathlib.Analysis.Calculus.ContDiff.Defs` (canonical) | C¹ smoothness of $\partial K$. |
+| `Convex.compact_iff_bounded` / `Convex.isClosed_*` | `Mathlib.Analysis.Convex.*` (canonical) | Compactness + closedness of convex body. |
+| `MeasureTheory.intervalIntegrable` | `Mathlib.MeasureTheory.Integral.IntervalIntegral` (canonical) | Integrability of $\|\gamma'(t)\|$ over $[0, p]$. |
+
+### S1: Translation lemma "boundary crossings = 2 × (lines that cut interior)"
+
+For a compact convex body $K \subset \mathbb{R}^2$ and a line $\ell$:
+
+* If $\ell \cap K = \emptyset$: boundary crossings = 0.
+* If $\ell \cap \operatorname{interior}(K) = \emptyset$ but $\ell \cap K \ne \emptyset$: $\ell$ is a supporting line; intersects $\partial K$ in a *segment* (0-D for "generic" lines, but degenerate for tangent lines). Treated as crossings = 0 in a measure-zero set of orientations (negligible).
+* If $\ell \cap \operatorname{interior}(K) \ne \emptyset$: by convexity, $\ell \cap K$ is a *non-degenerate segment*, and $\partial K \cap \ell = \{\text{the two endpoints of that segment}\}$. Boundary crossings = 2.
+
+So $\mathbb{E}[\text{boundary crossings}] = 2 \cdot \mathbb{E}[\mathbb{1}_{\ell \text{ cuts } K}]$, and applying `buffon_smooth_of_contDiff` to $\partial K$ gives $\mathbb{E}[\text{boundary crossings}] = 2p / (\pi d)$, so $\mathbb{E}[\text{lines cutting }K] = p / (\pi d)$ — **Cauchy's formula**.
+
+The Lean encoding of this translation needs:
+
+* `Mathlib.Analysis.Convex.Combination` / `Mathlib.Analysis.Convex.Topology` — `Convex.segment_subset` and supporting-line API.
+* `Set.ncard` (or `Finset.card` for a finite-fibre formulation) for counting boundary intersections.
+
+No existing Mathlib lemma at v4.26.0 directly gives `|line ∩ ∂K| ≤ 2` for convex $K$. This 10–15 LOC lemma is the S2 ACT's only new analytic work.
+
+### S1: Sibling-file overview
+
+The `BuffonsNeedle*` chain is rich (11 files, 89+ theorems, 6 axioms total, 5 sorries — all in `OQ01OQ01`):
+
+| File | LOC | Thms | Axioms | Sorries | Role |
+|---|---|---|---|---|---|
+| `BuffonsNeedle.lean` | 266 | 9 | 0 | 0 | Straight needle base case |
+| `BuffonsNeedleOQ01.lean` | 250 | 11 | 0 | 0 | C¹ smooth noodle — **direct parent of this slug** |
+| `BuffonsNeedleOQ01OQ01.lean` | 390 | 7 | 1 | 5 | Angular average (sub-theory) |
+| `BuffonsNeedleOQ01OQ01OQ01.lean` | 223 | 7 | 1 | 0 | Sub-sub-theory |
+| `BuffonsNeedleOQ01OQ01OQ04.lean` | 568 | 27 | 0 | 0 | **Different from this slug** — sibling at OQ01OQ01OQ04, not OQ01OQ04 |
+| `BuffonsNeedleOQ01OQ01OQ04OQ01.lean` | 193 | 11 | 0 | 0 | Sub-theory of above |
+| `BuffonsNeedleOQ01OQ02.lean` | 325 | 23 | 0 | 0 | Concrete C¹ parameterisations |
+| `BuffonsNeedleOQ02.lean` | 262 | 14 | 0 | 0 | 3D Buffon |
+| `BuffonsNeedleOQ02OQ01.lean` | 309 | 18 | 0 | 0 | 3D sub-theory |
+| `BuffonsNeedleOQ02OQ02.lean` | 376 | 15 | 1 | 0 | 3D sub-theory |
+| `BuffonsNeedleOQ02OQ03.lean` | 285 | 18 | 3 | 0 | 3D sub-theory |
+
+**No existing `BuffonsNeedleOQ01OQ04.lean`** — S2 ACT creates this file fresh.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+(None yet — S1 OBSERVE only.)
+
+---
+
+## Citations
+
+* Buffon, G.-L. L. (1733). *Essai d'arithmétique morale.* — original 1-D needle problem.
+* Laplace, P.-S. (1812). *Théorie analytique des probabilités.* — 2-D coin extension.
+* Cauchy, A.-L. (1841). *Mémoire sur la rectification des courbes et la quadrature des surfaces courbes.* — perimeter = $\pi \times$ mean-width identity.
+* Santaló, L. A. (1976). *Integral Geometry and Geometric Probability.* — modern reference for Cauchy-Crofton / mean-width formulas.

--- a/research/problems/buffons-needle-oq-01-oq-04/problem.md
+++ b/research/problems/buffons-needle-oq-01-oq-04/problem.md
@@ -1,111 +1,125 @@
-# Problem: [Problem Title]
+# Problem: Buffon's Coin and the Cauchy Mean-Width Generalization
 
 **Slug**: buffons-needle-oq-01-oq-04
 **Created**: 2026-04-05T19:30:47-07:00
-**Status**: Active
-**Source**: user-request <!-- gallery-gap | proof-suggestion | user-request | external -->
+**Status**: Active (S1 OBSERVE complete 2026-05-31)
+**Source**: gallery-gap (4th open question of `buffons-needle-oq-01`)
 
 ## Problem Statement
 
 ### Formal Statement
 
+Let $K \subset \mathbb{R}^2$ be a (compact, convex) plane region with rectifiable boundary $\partial K$ of perimeter $p$. Drop $K$ uniformly at random onto an infinite family of parallel lines spaced $d > 0$ apart. Then the expected number of crossings of $\partial K$ with these parallel lines is
+
 $$
-\text{[LaTeX formulation of the theorem/conjecture]}
+\mathbb{E}\bigl[\#\{\text{crossings of } \partial K\text{ with the line grid}\}\bigr]
+\;=\; \frac{p}{\pi d / 2}
+\;=\; \frac{2\,p}{\pi d}.
 $$
+
+Equivalently, the expected number of parallel lines that *cut* $K$ (i.e. intersect $\partial K$ in at least one point) is $p / (\pi d)$, since each line cuts a convex body's boundary in either $0$ or $2$ points.
 
 ### Plain Language
 
-[Explain what we're trying to prove in accessible terms]
+This is **Buffon's coin problem** (Laplace 1812 extended Buffon's 1733 needle): instead of a 1-D needle of length $\ell$ (where $\mathbb{P}[\text{crossing}] = 2\ell / (\pi d)$ for $\ell \le d$), drop a 2-D convex object — a coin, an ellipse, a triangle, any convex set $K$ with perimeter $p$. The expected number of times its **boundary** intersects the line grid depends only on the perimeter $p$, not on the shape. This is a special case of **Cauchy's formula for mean width**, which says that the average projection length of a convex body onto a random line equals $p / \pi$.
 
 ### Why This Matters
 
-[Significance of the problem - mathematical importance, applications, connections]
+* **Bridges classical integral geometry with measure theory.** Cauchy's formula and the broader Crofton/Cauchy-Crofton framework are the natural ℝ² generalization of Buffon's needle, and Mathlib v4.26.0 has both the measure-theory primitives and the C¹-arc-length machinery this proof needs. A clean Lean formalization closes a 200-year-old gallery gap.
+* **Reuses the smooth-noodle theorem.** `BuffonsNeedleOQ01.lean`'s main theorem `buffon_smooth_of_contDiff` — which proves $\mathbb{E}[\text{crossings}] = 2 \cdot \operatorname{arcLength}(\gamma) / (\pi d)$ for any C¹ planar curve — is *already exactly the right statement* for the convex-body case, applied to the boundary curve $\partial K$. The Buffon's coin formula is a one-step corollary: parametrise $\partial K$ as a C¹ closed curve (when $K$ is C¹-smooth) and plug into `buffon_smooth_of_contDiff`.
+* **Direction-of-travel for the Cauchy-Crofton open question.** The parent file's 4-item `openQuestions` list cites (i) "Full Cauchy-Crofton formula for arbitrary measures on lines in ℝ²", (ii) higher-dim hyperplane arrangements, (iii) Lipschitz curves, (iv) **this** convex-body generalization. Items (i) and (ii) require substantially more new Mathlib infrastructure (random-line measures, ℝⁿ angular slicing); item (iv) is the most tractable because it reuses existing chain machinery.
 
 ## Known Results
 
 ### What's Already Proven
 
-- [Related theorem 1] — [citation/location]
-- [Related theorem 2] — [citation/location]
+* **`BuffonsNeedle.lean`** (266 LOC, 9 theorems, 0 axioms, 0 sorries) — Buffon's needle for the straight 1-D needle: $\mathbb{P}[\text{cross}] = 2\ell/(\pi d)$ for $\ell \le d$. The base case.
+* **`BuffonsNeedleOQ01.lean`** (250 LOC, 11 theorems, 0 axioms, 0 sorries) — **Buffon-Barbier "smooth noodle" theorem** for C¹ planar curves. `buffon_smooth_of_contDiff (γ : ℝ → ℝ × ℝ) (a b : ℝ) (d : ℝ) (hd : 0 < d) (hγ : ContDiff ℝ 1 γ) : E[crossings on [a, b]] = 2 * arcLength(γ, a, b) / (π * d)`. **Load-bearing**: this is the bearer for the OQ-04 reduction.
+* **`BuffonsNeedleOQ01OQ01.lean`** (390 LOC, 7 theorems, 1 axiom, 5 sorries) — angular-average lemma underlying the smooth-noodle reduction. Axiomatised step still present.
+* Mathlib v4.26.0:
+  * `Mathlib.MeasureTheory.Constructions.Pi` — product measures (uniform on rotation × translation).
+  * `Mathlib.Analysis.Calculus.LineDeriv.IntegrationByParts` — Fubini for line-integrals; relevant for the Cauchy mean-width computation.
+  * `Mathlib.Geometry.Manifold.IntegralCurve.*` — C¹ curves on manifolds (overkill for ℝ², but the API surface is available).
+  * `Mathlib.MeasureTheory.Function.Jacobian` — change of variables; needed for the convex-body shape-independence step.
+  * **NOT yet in Mathlib**: a `Convex.perimeter` definition or a `Convex.cauchy_meanWidth` theorem. The intended formalization here introduces only the *Buffon* aspect, not the abstract convex-perimeter theory.
 
 ### What's Still Open
 
-- [Open question 1]
-- [Open question 2]
+* The four `conclusion.openQuestions` of the parent `buffons-needle-oq-01`:
+  1. **Full Cauchy-Crofton formula** for arbitrary measures on lines in ℝ² — *not this slug; needs a random-line-measure infrastructure that does not yet exist in Mathlib*.
+  2. **Higher-dimensional versions** (hyperplane arrangements in ℝⁿ) — *not this slug; downstream of (1)*.
+  3. **Extension to Lipschitz curves** — *not this slug; would need a Lipschitz-arc-length API*.
+  4. **Connection to Buffon's coin** — **this slug**.
 
 ### Our Goal
 
-[Specific scope of what we're attempting — which piece of the puzzle]
+**S2 ACT (recommended)**: create a new file `proofs/Proofs/BuffonsNeedleOQ01OQ04.lean` proving Buffon's coin for **C¹-smooth convex bodies** by reducing to `buffon_smooth_of_contDiff`. Concretely:
+
+```lean
+-- New theorem in BuffonsNeedleOQ01OQ04.lean
+theorem buffon_coin_smooth (γ : ℝ → ℝ × ℝ) (a b : ℝ) (hab : a ≤ b)
+    (d : ℝ) (hd : 0 < d) (hγ : ContDiff ℝ 1 γ)
+    (hclosed : γ a = γ b) (hconvex : ConvexHull ℝ (Set.range (γ ∘ Set.uIcc a b)) = ...) :
+    E[boundary crossings] = 2 * perimeter(K) / (π * d) := by
+  exact buffon_smooth_of_contDiff γ a b d hd hγ
+```
+
+The convexity hypothesis enters only to ensure the "boundary crossings = 2 × line-cuts" half-translation, which is a *combinatorial* observation, not an analytic one. The C¹ + closed-curve hypotheses are exactly what `buffon_smooth_of_contDiff` needs.
+
+**Estimated effort**: ~50–80 LOC of new Lean (the bulk is the convexity-to-line-cuts translation; the core probability statement is a one-line corollary). 0 new axioms, 0 sorries.
+
+**Alternative S2 candidates** (less tractable):
+
+* **(B) Strict Buffon's coin** for a disk of radius $r \le d/2$ — a *direct* probability computation rather than a corollary of the smooth noodle theorem. ~30–40 LOC; more pedagogically classic but mathematically less interesting (it's a special case of the general result).
+* **(C) Cauchy mean-width formula** for general convex bodies — would require defining `Convex.perimeter` and `Convex.meanWidth` and proving Cauchy's identity. ~150–250 LOC, requires substantial new Mathlib infrastructure on convex bodies. Out-of-scope for an S2 ACT; better as a multi-iteration sub-chain.
 
 ## Related Gallery Proofs
 
 | Proof | Relevance | Techniques |
 |-------|-----------|------------|
-| [proof-slug-1] | [why related] | [techniques used] |
-| [proof-slug-2] | [why related] | [techniques used] |
+| `buffons-needle` | Straight 1-D needle base case ($P = 2\ell/(\pi d)$); the base case from which all generalizations descend. | Uniform measure on $[0, d/2] \times [0, \pi/2]$, indicator integral. |
+| `buffons-needle-oq-01` | C¹ smooth-noodle theorem; the **direct parent**. `buffon_smooth_of_contDiff` is the bearer used by S2 ACT. | C¹ arc-length, angular averaging, Fubini, `IntervalIntegrable` from `ContDiff`. |
+| `buffons-needle-oq-01-oq-01` | Angular-average lemma underlying the smooth-noodle reduction (1 axiom, 5 sorries). | Polar coordinates, dominated convergence. |
+| `buffons-needle-oq-01-oq-02` | Smooth Buffon for explicit needle parameterisations (325 LOC, 23 theorems, 0 axioms). | Concrete C¹ curves, explicit arc-length formulas. |
+| `buffons-needle-oq-02` | 3D Buffon (needle in space, parallel-plane grid). Independent direction. | Spatial measure, mean-width-3D analogue. |
+| `buffons-needle-oq-01-oq-01-oq-04` | Pre-existing OQ-01-OQ-01-OQ-04 file (568 LOC, 27 theorems). **NOT the same as this slug** — this slug is OQ-01-OQ-04, a direct child of OQ-01. | unrelated parameterisation work |
 
 ## Initial Thoughts
 
 ### Potential Approaches
 
-1. **Approach A**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+1. **Approach A (recommended): Smooth-boundary reduction.** Parametrise $\partial K$ for a C¹-smooth convex body $K$ as a closed C¹ curve $\gamma : [0, p] \to \mathbb{R}^2$, then apply `buffon_smooth_of_contDiff` directly. The convexity hypothesis enters only when translating from "boundary crossings" to "lines that cut $K$" (factor of 2). ~50–80 LOC.
+   * Why it works: `buffon_smooth_of_contDiff` is already proved for any C¹ curve; closed-ness is not needed for the formula.
+   * Risk: low. The reduction is structural; the analytic content is reused.
 
-2. **Approach B**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+2. **Approach B: Direct coin computation.** For $K = $ closed disk of radius $r$, compute the probability of crossing directly. ~30 LOC; simpler but less general.
+
+3. **Approach C: Cauchy mean-width formula.** Build the full Cauchy identity for general convex bodies. ~150–250 LOC; requires substantial new Mathlib infrastructure on convex bodies. Out-of-scope.
 
 ### Key Difficulties
 
-- [Difficulty 1]
-- [Difficulty 2]
+* **Convexity-to-line-cuts translation** (Approach A): for a convex body $K$, "boundary crosses a parallel line $\ell$" happens at most twice. Proving this in Lean requires `Convex.isClosed_le_of_left` / `Convex.interior_intersection` style API; check for `Convex.line_intersection_cardinality_le_two` or similar.
+* **Closed-curve parameterisation**: the formula needs a *closed* C¹ curve. The bearer `buffon_smooth_of_contDiff` does NOT require closure, so this is purely a perimeter-naming step — the closed-ness gives $\int_a^b |\gamma'(t)| dt = \operatorname{perimeter}(\partial K)$.
 
 ### What Would a Proof Need?
 
-- Key lemma 1: ...
-- Key lemma 2: ...
-- Technical requirements: ...
+* **Key lemma 1** (convex-body boundary crossings): for $K \subset \mathbb{R}^2$ convex compact and $\ell$ a line, $|\partial K \cap \ell| \in \{0, 1, 2\}$, with $|\partial K \cap \ell| = 2$ iff $\ell \cap \operatorname{interior}(K) \ne \emptyset$. ~20 LOC, Mathlib `Convex.*` API.
+* **Key lemma 2** (perimeter = arcLength of closed C¹ boundary): if $\gamma : [a, b] \to \partial K$ is a C¹ parametrisation of $\partial K$ with $\gamma(a) = \gamma(b)$, then $\int_a^b \|\gamma'(t)\| dt = \operatorname{perimeter}(\partial K)$. ~10 LOC, definitional.
+* **Buffon coin theorem** (corollary): apply `buffon_smooth_of_contDiff`. ~5 LOC.
+* **Technical requirements**: C¹ smoothness of $\partial K$ is a *strong* hypothesis — polygons, the L¹ ball, the unit square fall outside. The result extends to rectifiable boundaries via the C¹ approximation argument, but that's the deferred Lipschitz extension (open question (iii) of the parent).
 
 ## Tractability Assessment
 
-**Difficulty**: Low | Medium | High | Moonshot
+**Difficulty**: **Low** for Approach A (recommended); Medium for Approach B (direct coin); High for Approach C (full Cauchy mean-width).
 
 **Justification**:
-- [Reason for assessment]
-- [Similar problems that have been solved]
-- [Techniques available in Mathlib]
+
+* **Approach A is essentially a corollary of an existing 0-axiom-0-sorry theorem.** The bearer `buffon_smooth_of_contDiff` does all the heavy analytic lifting; this slug just wraps it with the convexity translation.
+* **Similar work has been done in the chain.** `BuffonsNeedleOQ01OQ02.lean` (325 LOC, 23 theorems, 0 axioms) is a parallel "concrete-cases" sibling — same pattern of "apply the smooth-noodle bearer to a specific curve family", just with different curve families.
+* **No Mathlib gaps blocking Approach A.** `Convex.compact_*`, `IsClosed.convexHull`, `ContDiff` are all v4.26.0-stable. The convexity-to-line-cuts translation may need a hand-rolled 10–15 LOC lemma (Mathlib's `Convex.*` API on line intersections is sparse), but no missing infrastructure.
 
 **Estimated Effort**:
-- Exploration: [hours/days]
-- If tractable: [days/weeks]
-- If hard: [unknown]
 
-## References
-
-### Papers
-- [Author, Title, Year] — [brief note]
-
-### Online Resources
-- [URL] — [description]
-
-### Mathlib
-- [Relevant Mathlib module] — [what it provides]
-
-## Metadata
-
-```yaml
-tags:
-  - number-theory  # or: algebra, analysis, topology, combinatorics, etc.
-  - prime-gaps
-  - sieve-methods
-related_proofs:
-  - infinitude-of-primes
-  - sieve-of-eratosthenes
-difficulty: medium
-source: proof-suggestion
-created: 2026-04-05T19:30:47-07:00
-```
-
-**Significance**: 6/10
-**Tractability**: 6/10
+* Exploration (S1 OBSERVE — this memo): **done, ~1 hour**.
+* S2 ACT (Approach A): **~3-4 hours** (50–80 LOC + state.md + meta.json + Docker verify).
+* S3+ (extensions to Lipschitz boundaries, Cauchy mean-width): **deferred**, separate slugs.

--- a/research/problems/buffons-needle-oq-01-oq-04/state.md
+++ b/research/problems/buffons-needle-oq-01-oq-04/state.md
@@ -1,25 +1,67 @@
 # Research State: buffons-needle-oq-01-oq-04
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT (S1 OBSERVE complete; ready for S2 ACT)
 **Path**: full
 **Since**: 2026-04-05T19:30:47-07:00
-**Iteration**: 1
+**Iteration**: 2
+**Last Updated**: 2026-05-31T23:50:00Z (S1 OBSERVE, researcher-1)
+
+## S1 OBSERVE Summary (2026-05-31, researcher-1)
+
+**Mode**: OBSERVE (doc-only — populates `problem.md` (placeholder → full content), `knowledge.md` (placeholder → S1 findings), and shortlists S2 ACT candidates). No `.lean` edits.
+
+### Deliverable
+
+* `problem.md` — formal statement, plain-language framing, known-results table, S2 candidate shortlist (3 candidates, recommended = Approach A).
+* `knowledge.md` — bearer table at Mathlib v4.26.0, S2 ACT translation lemma sketch, sibling-file overview, citations.
+* `state.md` (this file) — phase OBSERVE → ORIENT, iteration 1 → 2.
+
+### Key findings
+
+1. **The slug's open question is structurally a corollary of the direct parent `buffons-needle-oq-01`.** `BuffonsNeedleOQ01.buffon_smooth_of_contDiff` already proves $\mathbb{E}[\text{crossings}] = 2 \cdot \operatorname{arcLength}(\gamma) / (\pi d)$ for any C¹ planar curve. Applying it to a closed C¹ parametrisation of $\partial K$ for a C¹-smooth convex body $K$ gives **Buffon's coin** in one step.
+2. **The only new analytic content needed** is a 10–15 LOC lemma "for $K$ convex compact and $\ell$ a line, $|\partial K \cap \ell| \le 2$, with equality iff $\ell \cap \operatorname{int}(K) \ne \emptyset$". Mathlib v4.26.0 has no direct bearer for this; will be a hand-rolled local lemma using `Convex.segment_subset` and supporting-line API from `Mathlib.Analysis.Convex.Topology`.
+3. **Estimated total LOC for S2 ACT**: 50–80 (translation lemma 10–15, parametrisation setup 15–20, application of `buffon_smooth_of_contDiff` ~5, ancillary 10–20). 0 new axioms, 0 sorries (Approach A is a structural corollary).
+
+### Why this matters
+
+This slug is the **most tractable of the four `conclusion.openQuestions`** of the parent `buffons-needle-oq-01`. The other three (Cauchy-Crofton random-line measure, hyperplane arrangements in ℝⁿ, Lipschitz boundary extension) all require substantial new Mathlib infrastructure; this one reuses an already-shipped 0-axiom-0-sorry bearer. Closing it advances the BuffonsNeedle chain to **5 of 11 files at the `OQ01-OQ-(01..04)` level** (currently only OQ-01, OQ-02 exist as direct children).
+
+### Race disclosure
+
+* **No open PRs on slug.** `gh pr list --search "buffons-needle-oq-01-oq-04 in:title" --state open` → `[]` (verified 2026-05-31T23:50Z).
+* **No existing `BuffonsNeedleOQ01OQ04.lean` file.** The sibling-named `BuffonsNeedleOQ01OQ01OQ04.lean` (568 LOC) is at a DIFFERENT chain position (OQ01-OQ01-OQ04, not OQ01-OQ04). S2 ACT creates a fresh file.
+
+### Honest-status block
+
+Zero new mathematics; pure literature-survey + bearer-audit OBSERVE iteration. No Lean files modified. The chain status (5 axioms, 5 sorries across the 11-file BuffonsNeedle chain) is unchanged. Open question status unchanged (S2 ACT not yet run).
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+S1 OBSERVE complete. Ready for S2 ACT (Approach A — Buffon's coin via C¹ boundary parametrisation).
 
 ## Active Approach
-None yet.
+**Approach A** (recommended for S2 ACT): create `proofs/Proofs/BuffonsNeedleOQ01OQ04.lean` proving Buffon's coin for C¹-smooth convex bodies by reducing to `buffon_smooth_of_contDiff` (the parent's main theorem). 50–80 LOC, 0 axioms, 0 sorries.
+
+**Alternates** (less tractable):
+* (B) Strict Buffon's coin for a disk of radius $r$ — direct probability computation, ~30 LOC; less general.
+* (C) Cauchy mean-width formula for general convex bodies — ~150–250 LOC; requires substantial new Mathlib infrastructure.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 1 (this S1 OBSERVE)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (S1 OBSERVE survey)
 
 ## Blockers
-None.
+None for Approach A. The `buffon_smooth_of_contDiff` bearer is 0-axiom-0-sorry and live in `BuffonsNeedleOQ01.lean`. The translation lemma is small and uses standard Mathlib `Convex.*` API.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+**S2 ACT (Approach A)**: create `proofs/Proofs/BuffonsNeedleOQ01OQ04.lean` with:
+
+1. Local translation lemma: $|\partial K \cap \ell| \le 2$ for convex compact $K$ and line $\ell$, with equality iff $\ell$ cuts the interior. ~10–15 LOC.
+2. Closed C¹ boundary parametrisation type / hypotheses ($\gamma : [0, p] \to \partial K$, $\gamma(0) = \gamma(p)$, $\operatorname{ContDiff} \mathbb{R}\ 1\ \gamma$, image of $\gamma$ = $\partial K$). ~15–20 LOC.
+3. Main theorem: $\mathbb{E}[\text{lines cutting }K] = \operatorname{perimeter}(K) / (\pi d)$, derived from `buffon_smooth_of_contDiff` via the translation lemma. ~5 LOC.
+4. Docker build verification: `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ01OQ04`.
+
+Estimated effort: 3–4 hours (a single S2 ACT session with claim TTL 90 min).
+
+Also: create `src/data/proofs/buffons-needle-oq-01-oq-04/` gallery directory with `meta.json`, `index.ts`, `annotations.json` once the Lean file is built and verified.


### PR DESCRIPTION
## Summary

**S1 OBSERVE for `buffons-needle-oq-01-oq-04`** — the 4th `conclusion.openQuestion` of `buffons-needle-oq-01` ("Connection to Buffon's coin (2D object) and generalizations"). Doc-only PREP-class iteration; no `.lean` edits.

## Key finding

The slug's open question is **structurally a corollary** of the direct parent's main theorem `BuffonsNeedleOQ01.buffon_smooth_of_contDiff` (already proved in `Proofs/BuffonsNeedleOQ01.lean`, 0 axioms, 0 sorries). Applied to a closed C¹ parametrisation of $\partial K$ for a C¹-smooth convex body $K$, the formula $\mathbb{E}[\text{crossings}] = 2 \cdot \operatorname{arcLength}(\gamma) / (\pi d)$ becomes the Buffon's coin formula $\mathbb{E}[\text{boundary crossings}] = 2 p / (\pi d)$.

The only new analytic content needed is a **10–15 LOC translation lemma**: "for $K$ convex compact and $\ell$ a line, $|\partial K \cap \ell| \le 2$, with equality iff $\ell$ cuts the interior". No new Mathlib infrastructure required.

## S2 candidate shortlist

| Candidate | Effort | Notes |
|---|---|---|
| **(A) Smooth-boundary reduction** (recommended) | ~50–80 LOC, 0 axioms, 0 sorries | Wraps `buffon_smooth_of_contDiff` with the convexity translation. The only new analytic work. |
| (B) Strict Buffon's coin for a disk of radius $r$ | ~30 LOC | Direct probability computation; less general; pedagogically classic. |
| (C) Cauchy mean-width formula for general convex bodies | ~150–250 LOC | Requires substantial new Mathlib infrastructure on convex bodies; out-of-scope for a single S2 ACT. |

## Files changed (all doc-only)

- `research/problems/buffons-needle-oq-01-oq-04/problem.md`: placeholder template → formal statement + plain-language framing + known-results table + S2 candidate shortlist with tractability assessment.
- `research/problems/buffons-needle-oq-01-oq-04/knowledge.md`: placeholder → S1 findings (bearer table at v4.26.0, sibling-file overview, translation-lemma sketch, classical citations).
- `research/problems/buffons-needle-oq-01-oq-04/state.md`: phase OBSERVE → ORIENT, iteration 1 → 2, S1 summary + next-action S2 ACT plan.

## Race disclosure

- **No open PRs on slug** (`gh pr list --search "buffons-needle-oq-01-oq-04 in:title" --state open` → `[]`).
- **No existing `BuffonsNeedleOQ01OQ04.lean` file.** The similarly-named `BuffonsNeedleOQ01OQ01OQ04.lean` (568 LOC, 27 theorems, 0 axioms) is at a *different* chain position (OQ01-OQ01-OQ04, not OQ01-OQ04). S2 ACT creates a fresh file.

## Honest-status block

Zero new mathematics; pure literature-survey + bearer-audit OBSERVE iteration. No Lean files modified. The chain status (5 axioms, 5 sorries across the 11-file BuffonsNeedle chain) is unchanged. Open question status unchanged (S2 ACT not yet run).

## Test plan

- [x] No `.lean` edits to verify
- [x] No build verification needed (OBSERVE-class doc-only scope)
- [x] Bearer table cross-checked against `Proofs/BuffonsNeedleOQ01.lean` for `buffon_smooth_of_contDiff` (signature confirmed in the file's header docstring)
- [x] Sibling-file inventory verified via `wc -l` + theorem-count grep across all 11 `BuffonsNeedle*` files
- [x] No open PRs on slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)