### PR TITLE
audit(erdos-1127): mark clean (cycle 4) — 5 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4033,12 +4033,12 @@
       "result": "clean"
     },
     "erdos-1127": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "#14765: phantom 'Statement of Erdős-Hajnal necessity result' contribution + false 'former axioms now proved as theorems or definitions' claim (none of the named identifiers exist) + section line drift starting at davies-theorem (Parts VIII/IX missing entirely)"
       ],
-      "lastAudited": "2026-05-02T12:11:47Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-01T06:45:05Z",
+      "result": "clean"
     },
     "erdos-1128": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

Audit of `erdos-1127` (Decomposing ℝⁿ into Sets with Distinct Distances) — result: **clean**.

All meta.json claims match the Lean source `proofs/Proofs/Erdos1127Problem.lean`:

| Field | meta.json | Verified |
|---|---|---|
| `axiomCount` | 5 | ✓ erdos_kakutani_equivalence, ch_implies_1d_image_distinct, ch_implies_1d_union_cover, davies_theorem, kunen_theorem |
| `theoremCount` | 3 | ✓ ch_implies_1d, erdos_1127, erdos_1127_summary |
| `definitionCount` | 9 | ✓ 1 abbrev + 8 def/noncomputable def |
| `sorries` | 0 | ✓ |
| `lineCount` | 279 | ✓ `wc -l` |
| `status` | `axiomatized` | ✓ matches Tier C (axiomatized core results) |
| `badge` | `axiom` | ✓ |

The `assumptions` field accurately enumerates all 5 axiom declarations. `originalContributions` are honestly framed as formalization of definitions and axiomatization of the Erdős-Kakutani/Davies/Kunen theorems (no overclaiming of independent proof).

## Test plan

- [x] Verified axiom/theorem/def counts via grep
- [x] Verified sorry count = 0
- [x] Verified line count matches
- [x] Confirmed badge/status alignment with Tier C scaffold

🤖 Generated with [Claude Code](https://claude.com/claude-code)