### PR TITLE
audit(erdos-1124): mark clean (cycle 5) — 2 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4001,11 +4001,11 @@
       "notes": "Issue #14783 — proofStrategy overstates axiomatization; meta.axiomCount=2 is correct"
     },
     "erdos-1124": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [
         "phantom originalContributions: laczkovich_piece_count, pieces_not_measurable, dubins_hirsch_karush; phantom proofStrategy axiomatize claims; section line drift (laczkovich-theorem, non-measurability, main-result); LaTeX bug in tarski-problem mathContext (issue #14773)"
       ],
-      "lastAudited": "2026-06-01T05:10:00Z",
+      "lastAudited": "2026-06-01T06:50:17Z",
       "result": "clean"
     },
     "erdos-1124-oq-01": {


### PR DESCRIPTION
## Summary

Cycle 5 re-audit of **erdos-1124** (Tarski's Circle-Squaring Problem). All meta.json claims verified against `proofs/Proofs/Erdos1124Problem.lean`.

## Integrity Checks

| Field | Claimed | Actual | OK |
|-------|---------|--------|----|
| lineCount | 190 | 190 | ✓ |
| axiomCount | 2 | 2 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 16 | 16 | ✓ |
| sorries | 0 | 0 | ✓ |
| True stubs | n/a | 0 | ✓ |
| status | axiomatized | 2 axioms exist | ✓ |
| badge | axiom | (consistent) | ✓ |

Axioms in `assumptions` field match Lean source:
1. `laczkovich_theorem` (translation equidecomposability for equal-area disk/square)
2. `translation_implies_isometry`

Theorems verified:
1. `equal_areas` (proved via `field_simp; ring`)
2. `tarski_solved` (derives `TarskiProblem` from the two axioms)
3. `erdos_1124` (packages `tarski_solved` with `laczkovich_theorem`)

## Narrative Integrity

- Tier C correctly reflected: `status=axiomatized`, `badge=axiom`.
- `originalContributions` cleanly lists only what is in source — prior phantom entries (`laczkovich_piece_count`, `pieces_not_measurable`, `dubins_hirsch_karush`) already removed in cycle 4 (PR #21810); no regression.
- `non-measurability` section honestly describes `pieces_not_measurable` and `dubins_hirsch_karush` as source-comment documentation, not Lean declarations.
- `proofStrategy` step 6 notes the piece-count bound is in source comments only.
- `proofStrategy` step 7 notes the non-measurability obstruction is in source comments only.
- Section endLines all within file bounds (≤190).
- LaTeX in `tarski-problem` mathContext (`\sim_E`, `\implies`) renders correctly.

## Test plan

- [x] Counts verified via grep against Lean source
- [x] Section endLines within file bounds
- [x] No phantom axioms or theorems in originalContributions
- [x] Source-comment-only items correctly disclosed

🤖 Generated with [Claude Code](https://claude.com/claude-code)