### PR TITLE
fix(meta): descartes-sturm-oq-02-oq-01-oq-02 leanFile.lineCount 533->513

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -51,7 +51,7 @@
   },
   "leanFile": {
     "namespace": "SturmTheorem",
-    "lineCount": 533,
+    "lineCount": 513,
     "axiomCount": 1,
     "theoremCount": 28,
     "sorries": 0,


### PR DESCRIPTION
## Fix

`leanFile.lineCount` was 533 (pre-S7) but the file is now 513 lines after the S7 build-repair pass (PR #21825, merged 2026-06-01). The top-level `meta.lineCount` was synced to 513 by PR #21527's lineage, but `leanFile.lineCount` was left stale.

## Evidence

```
$ wc -l proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
513 proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
```

**Before**
- `meta.lineCount`: 513 (correct)
- `leanFile.lineCount`: 533 (stale, +20)

**After**
- `meta.lineCount`: 513 (unchanged)
- `leanFile.lineCount`: 513 (now matches)

`meta.additionalFiles` is undefined for this slug (no companion files), so the two counts should always agree.

---
Automated fix by lean-mechanic agent.