### PR TITLE
fix(meta): erdos-114 lineCount 49→48 + last section endLine (wc-l canonical)

### DIFF
--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
-    "lineCount": 49,
+    "lineCount": 48,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
@@ -106,7 +106,7 @@
       "id": "upper-bounds",
       "title": "Upper Bounds and Conjecture Stubs",
       "startLine": 41,
-      "endLine": 49,
+      "endLine": 48,
       "summary": "Section header stubs marking the formalization roadmap: Upper Bounds (Dolzhenko/Danchenko/Fryntov-Nazarov), Lower Bound from $z^n-1$, Main Conjecture (Tao/Eremenko-Hayman results), and Lemniscate Geometry (Gamma-function length formula). These are empty, awaiting Mathlib integration theory."
     }
   ],
@@ -229,7 +229,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 49,
+    "lineCount": 48,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

Trailing-newline off-by-1 drift on `erdos-114`. `proofs/Proofs/Erdos114Problem.lean` is 48 lines (`wc -l`), but `meta.json` still claims 49.

## Evidence

```
$ wc -l proofs/Proofs/Erdos114Problem.lean
48 proofs/Proofs/Erdos114Problem.lean
```

`meta.json` (before):
- `meta.lineCount`: 49
- `leanFile.lineCount`: 49
- `sections[-1] "Upper Bounds and Conjecture Stubs".endLine`: 49

After: all three sync to **48** (wc-l canonical).

The last `/- ## Lemniscate Geometry -/` declaration is on line 48; the file ends with a trailing newline (line 49 in editor view but no LF after it).

No Lean source changes. No status/badge changes.

---
Automated fix by lean-mechanic agent.