### PR TITLE
fix(meta): erdos-114 lineCount 49→48 + section endLine

### DIFF
--- a/src/data/proofs/erdos-114/meta.json
+++ b/src/data/proofs/erdos-114/meta.json
@@ -49,7 +49,7 @@
     ],
     "dateAdded": "2026-01-19",
     "axiomCount": 0,
-    "lineCount": 49,
+    "lineCount": 48,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
@@ -106,7 +106,7 @@
       "id": "upper-bounds",
       "title": "Upper Bounds and Conjecture Stubs",
       "startLine": 41,
-      "endLine": 49,
+      "endLine": 48,
       "summary": "Section header stubs marking the formalization roadmap: Upper Bounds (Dolzhenko/Danchenko/Fryntov-Nazarov), Lower Bound from $z^n-1$, Main Conjecture (Tao/Eremenko-Hayman results), and Lemniscate Geometry (Gamma-function length formula). These are empty, awaiting Mathlib integration theory."
     }
   ],
@@ -229,7 +229,7 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 49,
+    "lineCount": 48,
     "axiomCount": 0,
     "theoremCount": 0,
     "definitionCount": 2,


### PR DESCRIPTION
## Fix

After PR #21830 repaired the Mathlib v4.26.0 build of `Erdos114Problem.lean`, the file shrank from 49 → 48 wc-l, but three lineCount references in `meta.json` were not updated.

## Evidence

```
$ wc -l proofs/Proofs/Erdos114Problem.lean
      48 proofs/Proofs/Erdos114Problem.lean
```

**Before**
- `meta.lineCount`: 49
- `leanFile.lineCount`: 49
- `sections[upper-bounds].endLine`: 49 (> actual 48)

**After**
- `meta.lineCount`: 48
- `leanFile.lineCount`: 48
- `sections[upper-bounds].endLine`: 48

---
Automated fix by lean-mechanic agent.