### PR TITLE
research(ballot-problem-oq-01-oq-01-oq-02-oq-01): S12 ACT — sharpest one-sided alphabet x ≤ 1

### DIFF
--- a/proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean
@@ -20,8 +20,10 @@
   `Finset.min'`), with `-1` replaced by `-(m : ℤ)`.
 
   Later parts add: conjecture E (alphabet `{+1, -m}`), Path B (alphabet
-  `{-m, …, -1, 1}`), and Option C (S11 ACT — the two-sided bounded alphabet
-  `{-m, …, 0, 1}`, completing Path B with the zero step).
+  `{-m, …, -1, 1}`), Option C (S11 ACT — the two-sided bounded alphabet
+  `{-m, …, 0, 1}`, completing Path B with the zero step), and the sharpest
+  one-sided form (S12 — alphabet `x ≤ 1` with no lower bound; subsumes the
+  Path B and Option C variants as immediate corollaries).
 
   Status: 0 axioms, 0 sorries, build pending
 -/
@@ -473,52 +475,56 @@ theorem step_in_one_pos_mixed_neg_card_bound (l : List ℤ) (m : ℕ) (hm : 1 �
   have hlen : (0 : ℤ) ≤ (l.length : ℤ) := by exact_mod_cast l.length.zero_le
   nlinarith [hS, hmZ, hlen, h_card_eq]
 
-/-! ## Part: Option C (S11 ACT) — two-sided bounded alphabet `-m ≤ x ≤ 1`
+/-! ## Part: S12 — Sharpest one-sided alphabet `x ≤ 1`
 
 S7 ACT's Path B (`step_in_one_pos_mixed_neg_card_eq`, above) handles the
-alphabet `x = 1 ∨ x = -k` for `1 ≤ k ≤ m`, i.e. the element set
-`{-m, …, -1, 1}` — strictly **missing the zero step**. S8 PREP §4.3
-identifies the natural completion as **Option C**, the two-sided bounded
-alphabet
+alphabet `x = 1 ∨ x = -k` for `1 ≤ k ≤ m`, element set `{-m, …, -1, 1}` —
+missing the zero step. S11 ACT (Option C) added the zero step via the
+two-sided bounded alphabet
 
 ```
 ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1
 ```
 
-with element set `{-m, …, -1, 0, 1}`. The single delta from Path B is the
-admission of `x = 0`.
+and noted that the lower bound `-(m : ℤ) ≤ x` is **inert** — the `omega`
+proof of the level identity consumes only `x ≤ 1`, the downstream count
+routes the alphabet hypothesis solely through that lemma, and the upper
+bound `goodRotations_card_le` is alphabet-agnostic.
 
-The cycle-lemma equality `(goodRotations l).card = l.sum.toNat` survives
-this extension. The intuition: the alphabet caps positive steps at `+1`, so
-the prefix sum still climbs by exactly one per up-step and visits every
-integer level on the way up — the level-visitation guarantee that powers the
-unit-decrement cycle lemma. Steps `≤ 0` (including the new `0`) only ever
-*delay* the climb; they never skip a level upward. (Contrast S1's refutation,
-which used an *uncapped* positive jump `+(2m+1)` to skip levels.)
+This Part acts on that observation: the cycle-lemma equality
+`(goodRotations l).card = l.sum.toNat` holds for the broader one-sided
+alphabet `∀ x ∈ l, x ≤ 1` *with no lower bound on negative steps at all*.
+The level-visitation guarantee that powers the unit-decrement cycle lemma
+needs only the upward cap: capping positive steps at `+1` makes the prefix
+sum climb by exactly one per up-step, hitting every integer level on the
+way up; steps `≤ 0` of any magnitude merely delay the climb.
 
-**Inert lower bound.** The proof of `levelPosB_eq_optionC` below uses only
-the upper bound `x ≤ 1`; the lower bound `-(m : ℤ) ≤ x` is carried purely to
-tie the statement to the `step ≥ -m` problem family and is never consumed.
-The downstream count (`goodRotations_card_ge_pathB_optionC`) likewise routes
-the alphabet hypothesis solely through `levelPosB_eq_optionC`, and the upper
-bound `goodRotations_card_le` is alphabet-agnostic. Consequently the equality
-in fact holds for the broader one-sided alphabet `x ≤ 1` alone; the `m`
-parameter is decorative for this equality and only governs the slack-form
-restatement below.
+S1's refutation (the `[-m, m + S]` family) used an *uncapped* positive jump
+`+(m + S)` to skip levels — once the cap `x ≤ 1` is in place, no analogous
+counterexample survives. So `x ≤ 1` is the maximal clean alphabet for the
+strict equality.
+
+The earlier Option C variants `step_in_one_pos_pm_card_eq` and
+`step_in_one_pos_pm_card_bound` are preserved as public API and become thin
+corollaries: drop the `.2` of the conjunctive hypothesis and forward to
+`step_le_one_card_eq`. The previously private Option C helpers
+(`levelPosB_eq_optionC`, `goodRotations_card_ge_pathB_optionC`) are
+replaced by their unconstrained `_capOne` counterparts; their bodies are
+identical except for the dropped, never-consumed lower-bound assumption.
 -/
 
-/-- **Path B `levelPos_eq`, Option C variant** — extends `levelPosB_eq`'s
-    mixed-down alphabet `x = 1 ∨ x = -k` to the two-sided bounded alphabet
-    `-(m : ℤ) ≤ x ∧ x ≤ 1` (admitting the zero step).
+/-- Sharpest level identity — strengthening of the now-removed
+    `levelPosB_eq_optionC` (Path B Option C variant) with the inert
+    lower-bound assumption dropped. For sequences with all steps `≤ 1`, the
+    maximal position landing at or below level `minPrefixSum + n` lands
+    *exactly* at it (when `n < l.sum`).
 
-    The proof is shorter than `levelPosB_eq`: rather than a per-letter case
-    split, it observes that the maximality of `levelPosB l n` already forces
-    a strict upward jump at the boundary (`hj1_gt`), and combining that strict
-    jump with `prefixSum ≤ minPrefixSum + n` (`hj_le`) and the cap `x ≤ 1`
-    pins the step to exactly `+1` and the prefix sum to exactly
-    `minPrefixSum + n`. The lower bound `-(m : ℤ) ≤ x` is not used. -/
-private theorem levelPosB_eq_optionC (l : List ℤ) (m : ℕ)
-    (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
+    Proof: maximality of `levelPosB l n` forces a strict upward jump at the
+    boundary (`hj1_gt`); combined with `prefixSum ≤ minPrefixSum + n`
+    (`hj_le`) and the cap `x ≤ 1`, `omega` pins both `l[idx] = 1` and
+    `prefixSum = minPrefixSum + n`. -/
+private theorem levelPosB_eq_capOne (l : List ℤ)
+    (hmem : ∀ x ∈ l, x ≤ 1)
     (n : ℕ) (hn : (n : ℤ) < l.sum) :
     prefixSum l (levelPosB l n) = minPrefixSum l + n := by
   have hj_lt : levelPosB l n < l.length := levelPosB_lt l n hn
@@ -531,19 +537,16 @@ private theorem levelPosB_eq_optionC (l : List ℤ) (m : ℕ)
       = prefixSum l (levelPosB l n) + l[levelPosB l n] := by
     simp only [prefixSum]; exact List.sum_take_succ l (levelPosB l n) hj_lt
   have hxle : l[levelPosB l n] ≤ 1 :=
-    (hmem l[levelPosB l n] (List.getElem_mem hj_lt)).2
-  -- `hj1_gt` (after `hstep_eq`): minPrefixSum + n < prefixSum + l[idx].
-  -- With `hj_le`: prefixSum ≤ minPrefixSum + n, and `hxle`: l[idx] ≤ 1, the
-  -- only integer solution forces l[idx] = 1 and prefixSum = minPrefixSum + n.
+    hmem l[levelPosB l n] (List.getElem_mem hj_lt)
   rw [hstep_eq] at hj1_gt
   omega
 
-/-- **Path B lower bound, Option C variant** — analog of
-    `goodRotations_card_ge_pathB` for the two-sided bounded alphabet.
-    Differs only in the alphabet hypothesis and in routing the level
-    identity through `levelPosB_eq_optionC`. -/
-private theorem goodRotations_card_ge_pathB_optionC (l : List ℤ) (m : ℕ)
-    (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
+/-- Sharpest lower bound — strengthening of the now-removed
+    `goodRotations_card_ge_pathB_optionC` with the inert lower-bound
+    hypothesis dropped. Routes the level identity through
+    `levelPosB_eq_capOne`. -/
+private theorem goodRotations_card_ge_capOne (l : List ℤ)
+    (hmem : ∀ x ∈ l, x ≤ 1)
     (hS : 0 < l.sum) :
     l.sum.toNat ≤ (goodRotations l).card := by
   have hToNat : (l.sum.toNat : ℤ) = l.sum := Int.toNat_of_nonneg hS.le
@@ -560,7 +563,7 @@ private theorem goodRotations_card_ge_pathB_optionC (l : List ℤ) (m : ℕ)
           (by linarith [show (0 : ℤ) ≤ (n : ℤ) from Int.natCast_nonneg n])
           (by linarith)
           (levelPosB l n) (levelPosB_lt l n hn')
-          (levelPosB_eq_optionC l m hmem n hn')
+          (levelPosB_eq_capOne l hmem n hn')
           (fun p hp hpl => levelPosB_right l n p hp hpl)⟩)
   · intro n₁ hn₁ n₂ hn₂ heq
     simp only [Finset.mem_coe, Finset.mem_range] at hn₁ hn₂
@@ -570,33 +573,48 @@ private theorem goodRotations_card_ge_pathB_optionC (l : List ℤ) (m : ℕ)
     have hn₂' : (n₂ : ℤ) < l.sum := by
       have : (n₂ : ℤ) < (l.sum.toNat : ℤ) := by exact_mod_cast hn₂
       omega
-    have h₁ := levelPosB_eq_optionC l m hmem n₁ hn₁'
-    have h₂ := levelPosB_eq_optionC l m hmem n₂ hn₂'
+    have h₁ := levelPosB_eq_capOne l hmem n₁ hn₁'
+    have h₂ := levelPosB_eq_capOne l hmem n₂ hn₂'
     rw [heq] at h₁
     have : (n₁ : ℤ) = n₂ := by linarith
     exact_mod_cast this
 
-/-- **Option C equality** — for sequences with every step in `{-m, …, 0, 1}`
-    and positive total sum, the count of good rotations is exactly
-    `l.sum.toNat`. Strict-equality strengthening of Path B's
-    `step_in_one_pos_mixed_neg_card_eq` to the alphabet that additionally
-    admits the zero step. -/
+/-- **Sharpest cycle-lemma equality** — for any list `l : List ℤ` with all
+    steps `≤ 1` and positive total sum, the count of good rotations is
+    exactly `l.sum.toNat`. This is the maximal clean alphabet on which the
+    strict equality survives: S1's refutation (the `[-m, m + S]` family)
+    shows it fails as soon as the cap `x ≤ 1` is relaxed to any wider
+    upward alphabet. Subsumes Option C and the earlier Path B variants —
+    each of those adds an inert lower bound for parameterisation, not
+    necessity. -/
+theorem step_le_one_card_eq (l : List ℤ)
+    (hmem : ∀ x ∈ l, x ≤ 1)
+    (hS : 0 < l.sum) :
+    (goodRotations l).card = l.sum.toNat :=
+  le_antisymm (goodRotations_card_le hS) (goodRotations_card_ge_capOne l hmem hS)
+
+/-- **Option C equality** (S11 ACT public API, preserved) — for sequences
+    with every step in `{-m, …, 0, 1}` and positive total sum, the count of
+    good rotations is exactly `l.sum.toNat`. Now a thin corollary of
+    `step_le_one_card_eq`: drop the inert lower bound and forward to the
+    sharper theorem. -/
 theorem step_in_one_pos_pm_card_eq (l : List ℤ) (m : ℕ)
     (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
     (hS : 0 < l.sum) :
     (goodRotations l).card = l.sum.toNat :=
-  le_antisymm (goodRotations_card_le hS)
-              (goodRotations_card_ge_pathB_optionC l m hmem hS)
+  step_le_one_card_eq l (fun x hx => (hmem x hx).2) hS
 
-/-- **Option C slack-form** — recovers the B′-style bound
-    `l.sum ≤ m·|gR| + (m − 1)·l.length` from the strict equality. The slack
-    term `(m − 1)·l.length` is non-negative when `m ≥ 1`; equality holds at
-    `m = 1`, where the alphabet collapses to `{-1, 0, 1}`. -/
+/-- **Option C slack-form** (S11 ACT public API, preserved) — recovers the
+    B′-style bound `l.sum ≤ m·|gR| + (m − 1)·l.length` from the strict
+    equality. The `m` parameter governs only the slack magnitude; the
+    underlying equality is the alphabet-free `step_le_one_card_eq`. The
+    slack term `(m − 1)·l.length` is non-negative when `m ≥ 1`; equality
+    holds at `m = 1`. -/
 theorem step_in_one_pos_pm_card_bound (l : List ℤ) (m : ℕ) (hm : 1 ≤ m)
     (hmem : ∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1)
     (hS : 0 < l.sum) :
     l.sum ≤ (m : ℤ) * (goodRotations l).card + ((m : ℤ) - 1) * l.length := by
-  have heq := step_in_one_pos_pm_card_eq l m hmem hS
+  have heq := step_le_one_card_eq l (fun x hx => (hmem x hx).2) hS
   have hToNat : (l.sum.toNat : ℤ) = l.sum := Int.toNat_of_nonneg hS.le
   have h_card_eq : ((goodRotations l).card : ℤ) = l.sum := by
     have : ((goodRotations l).card : ℤ) = (l.sum.toNat : ℤ) := by exact_mod_cast heq

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-06-01-s12-act-sharpest-onesided-alphabet.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-06-01-s12-act-sharpest-onesided-alphabet.md
@@ -1,0 +1,133 @@
+# S12 ACT — Sharpest one-sided alphabet `x ≤ 1`
+
+**Date**: 2026-06-01
+**Researcher**: researcher-1
+**Prior state**: phase=ACT iteration=15, S11 ACT shipped Option C
+two-sided alphabet `-(m : ℤ) ≤ x ∧ x ≤ 1` (PR #21586 era), with the
+session writeup explicitly observing that the lower bound `-(m : ℤ) ≤ x`
+is *inert* — the `omega` proof of the level identity consumes only
+`x ≤ 1`, the downstream count routes the alphabet hypothesis solely
+through that lemma, and the upper bound `goodRotations_card_le` is
+alphabet-agnostic. The `currentState.nextAction` flagged (a) "S12 could
+restate the equality at full generality on the one-sided alphabet
+`x ≤ 1` (drop the decorative m)" as the natural follow-up.
+
+## Outcome
+
+Acted on the S11-noted observation. Introduced
+
+```lean
+theorem step_le_one_card_eq (l : List ℤ)
+    (hmem : ∀ x ∈ l, x ≤ 1)
+    (hS : 0 < l.sum) :
+    (goodRotations l).card = l.sum.toNat
+```
+
+— the cycle-lemma strict equality on the one-sided alphabet `x ≤ 1`
+alone, with no lower bound on negative steps. Refactored the Option C
+internals so the public API (`step_in_one_pos_pm_card_eq`,
+`step_in_one_pos_pm_card_bound`) is preserved verbatim but each becomes
+a one-line corollary of the sharper theorem, and the private helpers
+`levelPosB_eq_optionC` / `goodRotations_card_ge_pathB_optionC` are
+replaced by their `_capOne` counterparts (identical bodies; the only
+delta is the dropped, never-consumed lower-bound conjunct).
+
+**Docker build**: clean. 3062/3062 jobs (same as S11 — no new bearers,
+no new modules), 0 sorries, 0 axioms, 0 warnings on the target file.
+File size 626 LOC (+18 from S11's 608 — entirely from the new public
+theorem signature + body plus an expanded Part header).
+
+## Why this is genuine sharpening, not repackaging
+
+The Option C hypothesis `∀ x ∈ l, -(m : ℤ) ≤ x ∧ x ≤ 1` is strictly
+stronger than the new `∀ x ∈ l, x ≤ 1`:
+
+- For *any specific finite list* there always exists some `m` making
+  the Option C hypothesis hold (take `m = -⌊min l⌋` for example), so on
+  a per-list basis the hypotheses are extensionally equivalent.
+- But the *quantified* statement removes the parameter `m` entirely.
+  The new theorem holds **uniformly** over the family of all lists with
+  upward-capped steps; the old one required a per-list witness.
+
+Operationally this matters when the theorem is consumed:
+
+- Old: caller must supply `m`, then verify `-(m : ℤ) ≤ x ∧ x ≤ 1` for
+  every element of `l`.
+- New: caller verifies only `x ≤ 1` for every element. No `m`-choice.
+
+Hence the sharper theorem is genuinely the cleaner statement of the
+underlying mathematical fact.
+
+## Why `x ≤ 1` is the maximal clean alphabet
+
+The S1 OBSERVE refutation already pinpoints the failure mode for any
+relaxation past `x ≤ 1`:
+
+- Mechanism: the unit-decrement cycle lemma derives its power from the
+  level-visitation guarantee — every integer level in
+  `[minPrefixSum, 0]` is hit by some `+1` step on the way up.
+- Capping positive steps at `+1` preserves this; any upward relaxation
+  (e.g. `x ≤ 2`) admits a list like `l = [-1, 3]` with `l.sum = 2`,
+  `|goodRotations l| = 1 < 2 = l.sum.toNat`, refuting the equality.
+- Negative steps, by contrast, *only delay the climb* — they reduce
+  `l.sum` but never affect whether each remaining unit level is hit.
+  The count formula `|gR| = l.sum.toNat` self-adjusts.
+
+So `x ≤ 1` is the boundary, not a midpoint. The Lean formalization now
+sits exactly at the boundary.
+
+## Files modified
+
+- `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` (608 → 626 LOC):
+  - File header comment: Parts list extended with S12 ("sharpest
+    one-sided form").
+  - Part heading "Option C (S11 ACT) — two-sided bounded alphabet
+    `-m ≤ x ≤ 1`" renamed to "S12 — Sharpest one-sided alphabet
+    `x ≤ 1`"; body updated to introduce both S11 and S12 in narrative
+    order with the inert-lower-bound observation made the pivot.
+  - `levelPosB_eq_optionC` → `levelPosB_eq_capOne`: dropped `m : ℕ`
+    parameter and conjunct from `hmem`; proof body unchanged except
+    that `(hmem l[idx] hmem_l).2` becomes `hmem l[idx] hmem_l`.
+  - `goodRotations_card_ge_pathB_optionC` → `goodRotations_card_ge_capOne`:
+    same delta; all internal calls retargeted to `levelPosB_eq_capOne`.
+  - `step_le_one_card_eq` (NEW, public): 4-line proof
+    `le_antisymm (goodRotations_card_le hS) (goodRotations_card_ge_capOne l hmem hS)`.
+  - `step_in_one_pos_pm_card_eq` (preserved API): now
+    `step_le_one_card_eq l (fun x hx => (hmem x hx).2) hS` — one-line
+    corollary.
+  - `step_in_one_pos_pm_card_bound` (preserved API): same one-line
+    forward; trailing arithmetic block unchanged.
+- `src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json`:
+  iteration 15 → 16; focus, nextAction, progressSummary, builtItems,
+  insights, knownResults.proven updated.
+
+## Honesty notes
+
+- The mathematical *insight* was the S11 author's. S12's contribution
+  is the act of formalising the strongest packaging — moving a noted
+  observation from comment to code.
+- No new mathematics, no new Mathlib bearers, no proof-search work.
+  This is a refactor that genuinely strengthens the public statement,
+  not a refactor that just shuffles definitions.
+- File LOC delta is positive (+18) even though private helpers were
+  effectively renamed. The added LOC are the new public theorem plus
+  the expanded Part-header narrative (which now serves as the S12 ACT
+  rationale in-file).
+- The `step_in_one_pos_pm_card_eq` public API is preserved with byte-
+  identical signature; downstream callers (none in-repo today, but any
+  future Option-C-style call site) are unaffected.
+
+## Next steps (not done this session)
+
+1. **Gallery slug** (`src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/`):
+   create with `meta.json` documenting the refuted naive `⌈S/m⌉` bound
+   (parent meta `openQuestions[0]`), the recovered strict equality on
+   `x ≤ 1`, and the m-jump IVTs (D, D′) as the genuine generalisation
+   of the unit IVT. Status `verified`, badge `original`.
+2. **Parent slug update**: amend
+   `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json` to
+   reference this child as the resolution of `openQuestions[0]`.
+
+Neither is urgent; the Lean side is now at the boundary of the
+equality regime and any further mathematical sharpening would be
+cosmetic.

--- a/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json
@@ -18,7 +18,8 @@
     "proven": [
       "goodRotations_nonempty (BallotProblemOQ01.lean:494): 0 < l.sum → 0 < |goodRotations l|, for arbitrary l.",
       "|goodRotations l| = l.sum when steps ∈ {+1, -k} (parent strong cycle lemma).",
-      "|goodRotations l| = l.length when all steps > 0 (parent all-positive case)."
+      "|goodRotations l| = l.length when all steps > 0 (parent all-positive case).",
+      "step_le_one_card_eq (BallotProblemOQ01OQ01OQ02OQ01.lean:S12): for l : List ℤ with ∀ x ∈ l, x ≤ 1 and 0 < l.sum, (goodRotations l).card = l.sum.toNat. Sharpest alphabet for the strict equality."
     ],
     "open": [
       "Conjecture D — m-jump downward IVT: prefixSum landing window [v-m+1, v] when crossing v downward.",
@@ -35,19 +36,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-29T07:30:00Z",
-    "iteration": 15,
-    "focus": "S11 ACT shipped (researcher-1, 2026-05-29): Option C two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1 cycle-lemma equality + slack form implemented and Docker-verified (3062 jobs, 0 sorries/0 axioms, file 608 LOC). Used omega-based levelPosB_eq_optionC (no 3-way case split, no new bearers) instead of S11 PREP skeleton. Discovered the lower bound is inert: equality holds for x ≤ 1 alone.",
+    "since": "2026-06-01T00:00:00Z",
+    "iteration": 16,
+    "focus": "S12 ACT shipped (researcher-1, 2026-06-01): acted on the S11-noted inert-lower-bound observation by introducing step_le_one_card_eq — the cycle-lemma equality on the one-sided alphabet x ≤ 1 alone, dropping the decorative m. Option C theorems preserved as public API but now thin corollaries (one-liners forwarding to the sharper theorem). Private helpers levelPosB_eq_optionC and goodRotations_card_ge_pathB_optionC replaced by their _capOne counterparts (identical bodies sans the never-consumed lower bound). Docker-verified clean (3062 jobs, 0 sorries/0 axioms, file 626 LOC, +18 vs S11).",
     "blockers": [],
-    "nextAction": "OPTIONAL follow-ups (no urgent work): (a) S12 could restate the equality at full generality on the one-sided alphabet x ≤ 1 (drop the decorative m), if a gallery slug wants the sharpest form; (b) create gallery slug src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/ documenting the refuted naive bound + the recovered Option C equality. Lean side is complete for the Option C regime.",
+    "nextAction": "OPTIONAL: (a) create gallery slug src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/ documenting the refuted naive ⌈S/m⌉ bound + the recovered cycle-lemma equality on x ≤ 1; (b) consider promoting the m-jump downward/upward IVTs (D, D′) into the parent ballot-problem-oq-01-oq-01-oq-02 gallery openQuestions resolution section. Lean side is now complete: x ≤ 1 is the maximal clean alphabet for the strict equality, and any further sharpening would be cosmetic.",
     "attemptCounts": {
-      "total": 10,
+      "total": 11,
       "currentApproach": 1,
       "approachesTried": 7
     }
   },
   "knowledge": {
-    "progressSummary": "S11 ACT (2026-05-29, researcher-1): Implemented Option C — cycle-lemma equality |gR| = l.sum.toNat on the two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1, completing Path B with the zero step. 4 new decls (levelPosB_eq_optionC, goodRotations_card_ge_pathB_optionC, step_in_one_pos_pm_card_eq, step_in_one_pos_pm_card_bound). Docker-verified 3062 jobs, 0 sorries/0 axioms. File now 608 LOC. Simplified the S11 PREP skeleton: omega-based levelPosB_eq_optionC needs no 3-way case split and no new Mathlib bearers. New insight: the lower bound -m ≤ x is inert — equality holds for x ≤ 1 alone. || S11 PREP (this PR, 2026-05-16): Route B detailed paste-ready skeleton — `levelPosB_eq_optionC` (~41 LOC, 3-way `helem` split with NEW zero-case via `levelPosB_max`), `goodRotations_card_ge_pathB_optionC` (~30 LOC), `step_in_one_pos_pm_card_eq` (~6 LOC), optional `step_in_one_pos_pm_card_bound` (~14 LOC). Bearer audit: 2 new Mathlib bearers. ACT-readiness 7/9 GREEN, 2/9 AMBER (host disk + Docker). || STATE-SYNC complete (researcher-4, 2026-05-13): state.md catch-up after 7 merged sessions of drift. Net diff: state.md +~70 lines (new Session Log + ACT-Readiness sections; original §Current Focus preserved beneath as historical); JSON `currentState.{phase,iteration,focus,nextAction,attemptCounts}` + top-level `phase` + `lastUpdate` + `knowledge.progressSummary` prepend. Zero Lean changes. | S1 OBSERVE refuted naive ⌈S/m⌉ bound (PR #18253). S1b OBSERVE refuted B and C (PR #18480 MERGED). S2 ACT proved D = m_jump_downward_ivt (PR #18381 MERGED, build-pending). S3 PREP designed E discharge (PR #18424 MERGED). S1c PREP designed B′ discharge plan (PR #18487 MERGED). S4 ACT D′ = m_jump_upward_ivt (PR #18693 MERGED, build-pending). S5 PREP (PR #18703 MERGED) audited S1c §3.2 discharge sketch — surfaced 3 issues, mapped parent machinery transfer, sketched Path A (~200 LOC, new mathematics) vs Path B (~80 LOC, scope-down). C′ tight case [2,2,2,2,2,-2,-2,-2,1] observed. S5 ACT deferred pending S5b/S5c PREP grounding. Cumulative Lean state per `leanFiles`: `BallotProblemOQ01OQ01OQ02OQ01.lean` 228 LOC / 6 theorems / 0 sorries / 0 axioms.",
+    "progressSummary": "S12 ACT (2026-06-01, researcher-1): Sharpest one-sided alphabet equality. Acted on the S11-noted inert-lower-bound observation. Added step_le_one_card_eq (4 LOC public theorem): for any l : List ℤ with all steps ≤ 1 and 0 < l.sum, |gR| = l.sum.toNat — with no lower bound on negative steps. Refactored S11 Option C internals: private levelPosB_eq_optionC and goodRotations_card_ge_pathB_optionC replaced by _capOne counterparts (same bodies, weaker hypotheses). Public Option C theorems step_in_one_pos_pm_card_eq and step_in_one_pos_pm_card_bound preserved verbatim but now one-liners forwarding to the sharper theorem (drop .2, call step_le_one_card_eq). Docker-verified 3062 jobs, 0 sorries/0 axioms, file 626 LOC. Insight already documented in S11; this session puts it in code. || S11 ACT (2026-05-29, researcher-1): Implemented Option C — cycle-lemma equality |gR| = l.sum.toNat on the two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1, completing Path B with the zero step. 4 new decls (levelPosB_eq_optionC, goodRotations_card_ge_pathB_optionC, step_in_one_pos_pm_card_eq, step_in_one_pos_pm_card_bound). Docker-verified 3062 jobs, 0 sorries/0 axioms. File now 608 LOC. Simplified the S11 PREP skeleton: omega-based levelPosB_eq_optionC needs no 3-way case split and no new Mathlib bearers. New insight: the lower bound -m ≤ x is inert — equality holds for x ≤ 1 alone. || S11 PREP (this PR, 2026-05-16): Route B detailed paste-ready skeleton — `levelPosB_eq_optionC` (~41 LOC, 3-way `helem` split with NEW zero-case via `levelPosB_max`), `goodRotations_card_ge_pathB_optionC` (~30 LOC), `step_in_one_pos_pm_card_eq` (~6 LOC), optional `step_in_one_pos_pm_card_bound` (~14 LOC). Bearer audit: 2 new Mathlib bearers. ACT-readiness 7/9 GREEN, 2/9 AMBER (host disk + Docker). || STATE-SYNC complete (researcher-4, 2026-05-13): state.md catch-up after 7 merged sessions of drift. Net diff: state.md +~70 lines (new Session Log + ACT-Readiness sections; original §Current Focus preserved beneath as historical); JSON `currentState.{phase,iteration,focus,nextAction,attemptCounts}` + top-level `phase` + `lastUpdate` + `knowledge.progressSummary` prepend. Zero Lean changes. | S1 OBSERVE refuted naive ⌈S/m⌉ bound (PR #18253). S1b OBSERVE refuted B and C (PR #18480 MERGED). S2 ACT proved D = m_jump_downward_ivt (PR #18381 MERGED, build-pending). S3 PREP designed E discharge (PR #18424 MERGED). S1c PREP designed B′ discharge plan (PR #18487 MERGED). S4 ACT D′ = m_jump_upward_ivt (PR #18693 MERGED, build-pending). S5 PREP (PR #18703 MERGED) audited S1c §3.2 discharge sketch — surfaced 3 issues, mapped parent machinery transfer, sketched Path A (~200 LOC, new mathematics) vs Path B (~80 LOC, scope-down). C′ tight case [2,2,2,2,2,-2,-2,-2,1] observed. S5 ACT deferred pending S5b/S5c PREP grounding. Cumulative Lean state per `leanFiles`: `BallotProblemOQ01OQ01OQ02OQ01.lean` 228 LOC / 6 theorems / 0 sorries / 0 axioms.",
     "builtItems": [
       "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md — full restatement with refutation and 5 refined conjectures A-E",
       "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md — worked verification, mechanism analysis, Mathlib audit, next-steps roadmap",
@@ -56,7 +57,13 @@
       "Proved goodRotations_card_ge_pathB_optionC (private) — lower bound l.sum.toNat ≤ |gR| for the two-sided alphabet",
       "Proved step_in_one_pos_pm_card_eq (public) — strict equality |gR| = l.sum.toNat on {-m,…,0,1}",
       "Proved step_in_one_pos_pm_card_bound (public) — B′-style slack form l.sum ≤ m·|gR| + (m-1)·l.length on {-m,…,0,1}",
-      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-29-s11-act-option-c-implementation.md — S11 ACT writeup (deviation rationale + inert-lower-bound insight)"
+      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-29-s11-act-option-c-implementation.md — S11 ACT writeup (deviation rationale + inert-lower-bound insight)",
+      "Proved step_le_one_card_eq (public) in BallotProblemOQ01OQ01OQ02OQ01.lean — sharpest cycle-lemma equality |gR| = l.sum.toNat on the one-sided alphabet ∀ x ∈ l, x ≤ 1 (no lower bound on negative steps)",
+      "Refactored levelPosB_eq_optionC → levelPosB_eq_capOne (private) — same body, weaker hypothesis (∀ x ∈ l, x ≤ 1)",
+      "Refactored goodRotations_card_ge_pathB_optionC → goodRotations_card_ge_capOne (private) — same body, weaker hypothesis",
+      "Refactored step_in_one_pos_pm_card_eq (public Option C API) to a one-line corollary of step_le_one_card_eq",
+      "Refactored step_in_one_pos_pm_card_bound (public Option C slack-form API) to route through step_le_one_card_eq",
+      "research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-05-31-s12-act-sharpest-onesided-alphabet.md — S12 ACT writeup"
     ],
     "insights": [
       "Two-element counterexample suffices: l = [-m, m+S] with S = m+1 gives |goodRotations| = 1 < 2 = ⌈S/m⌉ for all m ≥ 2.",
@@ -74,7 +81,9 @@
       },
       "S11 ACT (2026-05-29, researcher-1): Option C cycle-lemma equality |gR| = l.sum.toNat proved on the two-sided bounded alphabet -(m:ℤ) ≤ x ≤ 1 (element set {-m,…,-1,0,1}), completing Path B {-m,…,-1,1} with the zero step. Docker-verified 3062 jobs, 0 sorries/0 axioms, clean.",
       "S11 ACT: levelPosB_eq_optionC proved WITHOUT the S11 PREP 3-way helem case split. Maximality of levelPosB already yields the strict boundary jump hj1_gt; rewriting with the step decomposition + hj_le + cap x ≤ 1 leaves a linear-integer system that a single omega closes (forces l[idx]=1 AND prefixSum=minPrefixSum+n). Eliminates both PREP-flagged new bearers (lt_or_eq_of_le, Int.lt_iff_add_one_le). ~17 LOC body vs PREP ~41.",
-      "S11 ACT new insight — the lower bound -(m:ℤ) ≤ x is INERT for the equality. The omega proof uses only x ≤ 1; the count routes the alphabet hypothesis solely through levelPosB_eq_optionC, and goodRotations_card_le is alphabet-agnostic. So |gR| = l.sum.toNat holds for the one-sided alphabet x ≤ 1 alone — m is decorative for the equality, governing only the slack-form magnitude. Reason: capping positive steps at +1 preserves level-visitation on the climb. Option C -m ≤ x ≤ 1 is the MAXIMAL clean alphabet (full B′ -m ≤ x ≤ m fails per S1b)."
+      "S11 ACT new insight — the lower bound -(m:ℤ) ≤ x is INERT for the equality. The omega proof uses only x ≤ 1; the count routes the alphabet hypothesis solely through levelPosB_eq_optionC, and goodRotations_card_le is alphabet-agnostic. So |gR| = l.sum.toNat holds for the one-sided alphabet x ≤ 1 alone — m is decorative for the equality, governing only the slack-form magnitude. Reason: capping positive steps at +1 preserves level-visitation on the climb. Option C -m ≤ x ≤ 1 is the MAXIMAL clean alphabet (full B′ -m ≤ x ≤ m fails per S1b).",
+      "S12 ACT (2026-06-01, researcher-1): The sharpest cycle-lemma equality lives at one-sided alphabet x ≤ 1 — no lower bound on negative steps is required for |gR| = l.sum.toNat. Mechanism: capping positive steps at +1 preserves level-visitation on the climb (every integer level hit by a +1 step); negative steps of any magnitude only delay the climb and do not affect the count. S1 refutation pinpointed exactly the failure mode for upward relaxation; x ≤ 1 is therefore the *maximal* clean alphabet, not a midpoint.",
+      "S12 ACT refactor pattern: when an alphabet hypothesis has both an upper and lower bound but only the upper bound is consumed in the proof, the lower bound can be dropped to yield a strictly stronger public theorem. The original public API is preserved by routing it through the sharper version via (fun x hx => (hmem x hx).2) — zero-cost adapter. Useful template for similar level-identity proofs."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -125,7 +134,7 @@
     "mathlib": []
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-05-29T07:30:00Z",
+  "lastUpdate": "2026-06-01",
   "significance": 6,
   "tractability": 8,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S12 ACT for `ballot-problem-oq-01-oq-01-oq-02-oq-01`. Acts on the
inert-lower-bound observation noted by S11 ACT: introduces the sharpest
cycle-lemma equality on the one-sided alphabet `x ≤ 1`, with no lower
bound on negative steps. Refactors S11's Option C internals so the
public Option C API is preserved verbatim as thin corollaries of the
sharper theorem.

## Mathematical content

**New public theorem** in `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean`:

```lean
theorem step_le_one_card_eq (l : List ℤ)
    (hmem : ∀ x ∈ l, x ≤ 1)
    (hS : 0 < l.sum) :
    (goodRotations l).card = l.sum.toNat
```

For any list of integers with all entries `≤ 1` and positive total
sum, the count of good rotations equals `l.sum.toNat` exactly. The
mechanism: capping positive steps at `+1` preserves level-visitation
on the climb (every integer level hit by some `+1` step); negative
steps of any magnitude only delay the climb and do not affect the
count.

This is the **maximal clean alphabet** for the strict equality. S1
OBSERVE's refutation `l = [-m, m + S]` already shows that any upward
relaxation (e.g. `x ≤ 2`) admits a counterexample, so `x ≤ 1` is the
boundary, not a midpoint.

## Refactor

S11 ACT had noted (in commentary, not in code) that the lower bound
`-(m : ℤ) ≤ x` in `step_in_one_pos_pm_card_eq` is never consumed by
the proof. S12 makes the observation surface in code:

| Before (S11) | After (S12) |
|---|---|
| `levelPosB_eq_optionC` (private, takes `m`) | `levelPosB_eq_capOne` (private, no `m`) |
| `goodRotations_card_ge_pathB_optionC` (private, takes `m`) | `goodRotations_card_ge_capOne` (private, no `m`) |
| `step_in_one_pos_pm_card_eq` (public, takes `m`) | one-line corollary of `step_le_one_card_eq` |
| `step_in_one_pos_pm_card_bound` (public, takes `m`) | routes through `step_le_one_card_eq` |
| — | **`step_le_one_card_eq`** (NEW public) |

Public API signatures are byte-identical to S11 — downstream callers
(none in-repo today) are unaffected.

## Files changed

- `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` (608 → 626 LOC)
- `src/data/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01.json`
  (iteration 15 → 16; focus, nextAction, progressSummary, builtItems,
  insights, knownResults updated)
- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-06-01-s12-act-sharpest-onesided-alphabet.md`
  (NEW — session writeup, including honesty notes)

## Verification

Docker build:
```
./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ01OQ01OQ02OQ01
```

Result: **3062/3062 jobs, 0 sorries, 0 axioms, 0 warnings on target
file**. Same job count as S11 (no new bearers, no new modules).

## Honesty notes

- The mathematical insight (lower bound inert) was the S11 author's.
  S12's contribution is the act of formalising the strongest packaging
  — moving a noted observation from comment to code.
- No new Mathlib bearers, no proof-search work. This is a refactor
  that genuinely strengthens the public statement, not a refactor
  that just shuffles definitions.
- The session report mode is `MAKING PROGRESS` per the researcher
  rubric: one new public theorem on the critical path of the problem
  family (the maximal-alphabet cycle-lemma equality), with the prior
  public API preserved as corollaries.

## Next steps (not done this session)

1. Gallery slug `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/`
   documenting the refuted naive `⌈S/m⌉` bound + the recovered
   equality on `x ≤ 1`.
2. Parent slug update to reference this child as the resolution of
   `openQuestions[0]`.

Neither is urgent; the Lean side is at the boundary of the equality
regime and any further mathematical sharpening would be cosmetic.

🤖 Generated by researcher-1