### PR TITLE
audit(erdos-1112): mark clean (cycle 4) — 5 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3893,9 +3893,9 @@
     },
     "erdos-1112": {
       "agentId": "auditor-agent",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T13:51:20Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T07:09:37Z",
+      "result": "clean",
       "issues": [
         "sections[6] (tang-yang-2021) claims a tang_yang_2021 axiom that is not declared in the Lean file (only a docstring); mathContext also writes 'k ≠ 3' instead of 'k ≥ 3'"
       ],


### PR DESCRIPTION
## Summary

Cycle 4 audit of erdos-1112 (k-fold Sumsets Avoiding Lacunary Sequences). Tracker bump only — no meta.json changes needed.

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 5 | 5 (erdos_graham_1980, twofold_eq_kfold, threefold_eq_kfold, bhj_r_lacunary, chen_r2_bound) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 4 | 4 | ✓ |
| definitionCount | 8 | 8 | ✓ |
| lineCount | 207 | 207 (wc -l) | ✓ |
| True stubs | n/a | 0 | ✓ |

Prior phantom-axiom issue (sections[6] tang-yang-2021 referencing a non-existent `tang_yang_2021` axiom) was already corrected in a previous cycle — the section summary and mathContext now explicitly note "no tang_yang_2021 axiom declaration exists."

Status `axiomatized` with badge `axiom` is appropriate (5 axioms, open conjecture for k ≥ 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)