### PR TITLE
fix(meta): picks-theorem-oq-03 swap additionalFiles formats

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -64,15 +64,7 @@
     ],
     "dateAdded": "2026-03-06",
     "additionalFiles": [
-      {
-        "path": "Proofs/PicksTheoremOQ03CrossPoly.lean",
-        "lineCount": 695,
-        "theorems": 69,
-        "definitions": 12,
-        "axioms": 0,
-        "sorries": 0,
-        "description": "Cross-polytope (hyperoctahedron) Ehrhart theory: polynomials, reciprocity, h*-vectors, duality"
-      }
+      "Proofs/PicksTheoremOQ03CrossPoly.lean"
     ],
     "axiomCount": 2,
     "lineCount": 710,
@@ -240,7 +232,15 @@
     "definitionCount": 23,
     "theoremCount": 45,
     "additionalFiles": [
-      "Proofs/PicksTheoremOQ03CrossPoly.lean"
+      {
+        "path": "Proofs/PicksTheoremOQ03CrossPoly.lean",
+        "lineCount": 695,
+        "theorems": 69,
+        "definitions": 12,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Cross-polytope (hyperoctahedron) Ehrhart theory: polynomials, reciprocity, h*-vectors, duality"
+      }
     ]
   }
 }


### PR DESCRIPTION
## Fix

Swap formats between `meta.additionalFiles` and `leanFile.additionalFiles` so the auditor traces the companion file.

## Evidence

**Before**:
- `meta.additionalFiles`: rich `{path, lineCount, theorems, ...}` object (auditor-blind)
- `leanFile.additionalFiles`: plain `"Proofs/PicksTheoremOQ03CrossPoly.lean"`

**After**:
- `meta.additionalFiles`: plain `"Proofs/PicksTheoremOQ03CrossPoly.lean"` (auditor traces)
- `leanFile.additionalFiles`: rich object (file stats preserved)

The auditor (`scripts/auditor/find-targets.ts:169`) only follows string entries in `meta.additionalFiles` -- it skips object entries via `if (typeof af !== 'string') continue`. Rich-object meta entries silently disable companion file tracing.

This swap matches the convention used by `lagrange-theorem-oq-01-oq-01-oq-01` and `tractatus-ontology` (strings in meta, rich in leanFile). No assumption-count change: CrossPoly has 0 axioms, 0 sorries.

---
Automated fix by lean-mechanic agent.