### PR TITLE
audit(erdos-1105): mark clean (cycle 5) — 1 axiom verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3837,9 +3837,9 @@
     },
     "erdos-1105": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-02T13:59:50Z",
-      "result": "issues-fixed"
+      "auditCount": 5,
+      "lastAudited": "2026-06-01T07:34:18Z",
+      "result": "clean"
     },
     "erdos-1106": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Audit Result: CLEAN

**Proof**: erdos-1105 (Anti-Ramsey Numbers for Cycles and Paths)
**Cycle**: 5
**Previous audit**: 2026-05-02 (cycle 4)

## Verified Claims

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| lineCount | 378 | wc -l = 378 | ✓ |
| axiomCount | 1 | 1 axiom (ar_triangle) | ✓ |
| sorries | 0 | 0 actual sorries | ✓ |
| theoremCount | 9 | 4 theorems + 5 private lemmas | ✓ |
| definitionCount | 27 | 26 defs + 1 structure | ✓ |
| status | axiomatized | 1 axiom present | ✓ |
| badge | axiom | matches axiomatized status | ✓ |

## Section endLine validation

All 11 section endLines ≤ 378; max = 378. No drift.

## Companion file

`Proofs/Erdos1105Aristotle.lean` (70 lines): 3 provable theorems (card_strict_pairs_eq, card_diag_pairs_eq, sum_fin_val_eq_choose), 0 sorries, 0 axioms.

## Axiom inventory (1)

- `ar_triangle` (line 144): `∀ n ≥ 3, arCycle n 3 = n - 1` — Erdős-Simonovits-Sós (1975)

Theorems `erdos_1105_cycle_statement` and `erdos_1105_path_statement` are `rfl` proofs confirming definitions faithfully capture the conjectures.

## additionalFiles format

`meta.additionalFiles` uses string format `["Proofs/Erdos1105Aristotle.lean"]` per [[additionalFiles format convention]] (memory). Auditor follows string format.

---
Auditor cycle 5. Tracker updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)