### PR TITLE
research(cube-root-3-irrational-oq-04): S12a Helper-ACT — eleventh CF convergent 13361/9264 < cbrt3 (build verified, 7744 jobs)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean
@@ -469,4 +469,60 @@ theorem seven_one_five_five_over_four_nine_six_one_lt_cbrt3 :
   rw [lt_cbrt3_iff_cube_lt (by norm_num)]
   norm_num
 
+/-! ## S12a prep: new lower bound for `a₁₀ = 2` (the eleventh partial quotient)
+
+The eleventh CF convergent of `∛3` (using `a₁₀ = 2` per OEIS A002945
+prefix `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, …]`, 0-indexed) is
+
+  `p₁₀/q₁₀ = (a₁₀·p₉ + p₈) / (a₁₀·q₉ + q₈)`
+  `       = (2 · 6206 + 949) / (2 · 4303 + 658)`
+  `       = 13361 / 9264`.
+
+This convergent is even-index (10), so it lies on the LOWER side of
+`∛3` (alternating with the upper-side ninth convergent `6206/4303`
+from S10).
+
+Convergent recursion (with `a₁₀ = 2`):
+
+  `q₁₀ = 2 · q₉ + q₈ = 2 · 4303 + 658 = 9264`
+  `p₁₀ = 2 · p₉ + p₈ = 2 · 6206 + 949 = 13361`
+
+After cubing,
+
+  `(13361/9264)³ = 2_385_156_564_881 / 795_052_191_744`
+  `3              = 2_385_156_575_232 / 795_052_191_744`
+
+so `13361³ = 2_385_156_564_881 < 2_385_156_575_232 = 3 · 9264³`
+(strict, diff `10_351`). The new lower cube gap
+`10_351 / 795_052_191_744 ≈ 1.30·10⁻⁸` (relative-to-`3·q³`:
+`≈ 4.34·10⁻⁹`) is roughly an order of magnitude tighter than S11a's
+lower-side gap of `18_168 / 122_097_755_681 ≈ 1.49·10⁻⁷` — consistent
+with `13361/9264` being the true 11th convergent (one rung beyond
+S11a's semi-convergent `7155/4961`, which the S11a comment
+incorrectly framed as the 10th convergent with `a₁₀ = 1`; the actual
+`a₁₀ = 2` per OEIS A002945 entry 11 = 2). The S11a proof
+`(7155/4961 : ℝ) < cbrt3` is numerically true regardless — it lands
+between the 9th and 11th true convergents — and provided a valid
+lower bound for the S11b ACT sandwich proving `cbrt3_a9 = 6`.
+
+(Pre-claim Python sanity check:
+`13361³ = 2_385_156_564_881`, `3 · 9264³ = 2_385_156_575_232`,
+diff `-10_351 < 0` confirming `(13361/9264)³ < 3`, hence
+`13361/9264 < cbrt3` as required for a lower bound. Cross-checked
+against OEIS A002945 via Decimal-arithmetic CF expansion of `∛3` to
+80 digits; first 15 partial quotients
+`[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3]` match independently.)
+
+Two-line proof via the cubing-iff helper. -/
+
+/-- `13361/9264 < ∛3`. Cube target: `(13361/9264)³ =
+2_385_156_564_881 / 795_052_191_744 < 2_385_156_575_232 / 795_052_191_744
+= 3` (strict: `13361³ = 2_385_156_564_881 < 2_385_156_575_232 =
+3 · 9264³`, gap `10_351`). The eleventh convergent of the simple CF
+of `∛3` (using `a₁₀ = 2` per OEIS A002945). -/
+theorem one_three_three_six_one_over_nine_two_six_four_lt_cbrt3 :
+    (13361 / 9264 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+
 end Cbrt3Helpers

--- a/research/problems/cube-root-3-irrational-oq-04/sessions/2026-06-01-s12a-helper-act-eleventh-convergent.md
+++ b/research/problems/cube-root-3-irrational-oq-04/sessions/2026-06-01-s12a-helper-act-eleventh-convergent.md
@@ -1,0 +1,238 @@
+# S12a Helper-ACT — Eleventh CF convergent lower bound `13361/9264 < cbrt3`
+
+**Researcher**: researcher-1
+**Date**: 2026-06-01
+**Phase**: ACT (iteration 13, narrow Helper-ACT)
+**PR**: (this PR)
+
+## Summary
+
+Added one new theorem to `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`:
+
+```lean
+theorem one_three_three_six_one_over_nine_two_six_four_lt_cbrt3 :
+    (13361 / 9264 : ℝ) < cbrt3 := by
+  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
+  norm_num
+```
+
+This is the **true 11th CF convergent** of `∛3` (the simple continued
+fraction `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, …]` = OEIS A002945) using
+the partial quotient `a₁₀ = 2`. It is the lower-side bound that the
+future S12b main theorem will consume to prove `cbrt3_a10 = 2`.
+
+Two-line proof via the established cubing-iff template
+(`lt_cbrt3_iff_cube_lt + norm_num`), exact same pattern as S7/S8/S9/
+S10/S11a helpers.
+
+Helper file: **472 → 528 LOC** (+56 LOC, +1 theorem, +1 prose
+section). 0 sorries, 0 axioms.
+
+## Math-correction precedent #FOUR
+
+The post-S11b `nextAction` sketch in `state.md` and JSON
+`currentState.nextAction` (as of 2026-05-31, written by the S11b
+ACT author = me at that moment) claimed:
+
+> Per OEIS A002945 `[1;2,3,1,4,1,5,1,1,6,1,2,…]`, `a₁₀ = 1` and
+> `a₁₁ = 2`. The 11th convergent using `a₁₁ = 2` is
+> `(2·7155+6206)/(2·4961+4303) = 20516/14225` (upper side).
+
+This is **mathematically incorrect**. The actual OEIS A002945 prefix
+(independently re-verified to 200 digits via Decimal-arithmetic
+Newton-iteration CF expansion of `3^(1/3)` in this S12a session) is:
+
+```
+[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4, ...]
+```
+
+That is, `a₁₀ = 2`, `a₁₁ = 5`, `a₁₂ = 8`. The S11b sketch was off by
+one OEIS position in its `a₁₀` claim (and consequently in its
+`a₁₁ = 2` claim — `a₁₁ = 5` actually).
+
+**Math-correction precedent count for this slug now stands at FOUR**:
+
+1. S7 → S8 sketch
+2. S8 → S9 sketch (PR #19011)
+3. S10 → S11 sketch (PR #19420, three cube-digit errors)
+4. **S11b → S12 sketch (this S12a, OEIS-position-off-by-one in `a₁₀`)**
+
+(Per `feedback_researcher_cf_convergent_recursion_direction_trap`,
+the math-correction frequency in this slug warrants pre-claim Python
+sanity-checks on every cube digit and OEIS lookup. This S12a session
+re-verified the entire OEIS A002945 prefix to position 19 at 200-digit
+Decimal precision — see "Cross-verification" section below.)
+
+## Additional finding: S11a `7155/4961` is a semi-convergent, not a true convergent
+
+The S11a helper's docstring (PR #19456) claims:
+
+> The tenth convergent of the simple CF of `∛3` (using `a₁₀ = 1`
+> per OEIS A002945).
+
+This is also **mathematically incorrect**. With `a₁₀ = 2` (the
+actual OEIS value), the true 11th convergent is
+`p₁₀/q₁₀ = 2·6206 + 949 = 13361, q₁₀ = 2·4303 + 658 = 9264`, i.e.,
+**`13361/9264`** (this S12a's new helper).
+
+The S11a value `7155/4961` is actually a **semi-convergent**:
+
+  `7155/4961 = (1·6206 + 949) / (1·4303 + 658)`
+
+— the best-rational approximation to `∛3` between the 9th true
+convergent (`6206/4303`) and the 11th true convergent (`13361/9264`)
+that you get if you "stop the partial quotient `a₁₀` early at 1
+instead of 2". Such semi-convergents are valid rational
+approximations and the proof `(7155/4961 : ℝ) < cbrt3` is
+**numerically correct** (Decimal computation: gap `−2.4·10⁻⁸`); the
+**S11a proof and the S11b main theorem `cbrt3_a9 = 6` remain
+mathematically correct**. Only the "10th convergent" framing in the
+S11a docstring is off.
+
+(I am NOT correcting the S11a docstring in this PR — that's
+out-of-scope for an S12a Helper-ACT. A future doc-only mechanic or
+auditor pickup can land the 4-character fix `a₁₀ = 1` → `a₁₀ = 2`
+plus a half-sentence acknowledging the semi-convergent nature.)
+
+## Cube arithmetic (verified)
+
+| Quantity | Value |
+|----------|-------|
+| `p₁₀` | `13361` |
+| `q₁₀` | `9264` |
+| `p₁₀³` | `2_385_156_564_881` |
+| `q₁₀³` | `795_052_191_744` |
+| `3 · q₁₀³` | `2_385_156_575_232` |
+| diff `p₁₀³ - 3·q₁₀³` | **`−10_351`** (negative ⇒ `(13361/9264)³ < 3` ⇒ `13361/9264 < ∛3` ✓) |
+| absolute cube gap | `10_351 / 795_052_191_744 ≈ 1.30·10⁻⁸` |
+| relative gap (vs `3 · q³`) | `≈ 4.34·10⁻⁹` |
+
+Compare with prior helpers:
+
+| Helper | Gap (cube-domain) | Convergent type |
+|--------|------------------|-----------------|
+| S7 `437/303` | `≈ −5.0·10⁻⁶` | 7th true convergent (lower) |
+| S8 `cbrt3 < 512/355` | `≈ +2.47·10⁻⁵` | 8th true convergent (upper) |
+| S9 `949/658` | `≈ −2.06·10⁻⁶` | 9th true convergent (lower) |
+| S10 `cbrt3 < 6206/4303` | `≈ +4.79·10⁻⁸` | 10th true convergent (upper) |
+| S11a `7155/4961` | `≈ −1.49·10⁻⁷` | **SEMI-convergent** between 9th and 11th |
+| **S12a (this PR) `13361/9264`** | **`≈ 4.34·10⁻⁹`** | **11th true convergent** (lower) |
+
+The S12a gap is roughly an order of magnitude tighter than S11a's
+gap — the expected behavior when going from a semi-convergent to
+the next true convergent.
+
+## Cross-verification (independent OEIS A002945 re-check)
+
+```python
+# Decimal-precision Newton-iteration CF expansion of ∛3
+from decimal import Decimal, getcontext
+getcontext().prec = 200
+x = Decimal(3) ** (Decimal(1) / Decimal(3))
+# x ≈ 1.44224957030740838232163831078010958839186925349935057754...
+
+def cf(d, n):
+    out = []
+    for _ in range(n):
+        a = int(d); out.append(a)
+        f = d - a
+        if f == 0: break
+        d = 1/f
+    return out
+
+cf(x, 20)
+# [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4]
+```
+
+This matches OEIS A002945 entries 1–20. The cube-direction check
+`13361³ < 3·9264³` is also re-verified in the same script (see "Cube
+arithmetic" table).
+
+## ACT-readiness gate for S12b
+
+| # | Gate | Status | Detail |
+|---|------|--------|--------|
+| 1 | New lower bound `13361/9264 < cbrt3` shipped | ✅ GREEN | This S12a |
+| 2 | Existing upper bound `cbrt3 < 6206/4303` reusable | ✅ GREEN | S10 helper, gap `≈ 2.3·10⁻⁸` (cube-domain `4.79·10⁻⁸`) |
+| 3 | OEIS A002945 cross-verification | ✅ GREEN | 200-digit Decimal CF expansion, positions 0–19 match |
+| 4 | Math-correction precedent flagged | ✅ GREEN | Precedent #FOUR (S11b sketch had `a₁₀ = 1, a₁₁ = 2`; actual `a₁₀ = 2, a₁₁ = 5`) |
+| 5 | Heartbeat budget guess | ✅ GREEN | `set_option maxHeartbeats 3200000 in` (2× S11b's 1.6M) |
+| 6 | Mathlib pin unchanged | ✅ GREEN | `2df2f0150c…` (since S9 build) |
+| 7 | Sibling-slug / parallel ACT race | ✅ GREEN | `gh pr list --search cube-root-3-irrational-oq-04 --state open` = 0 hits at S12a write-time |
+| 8 | Docker daemon responsive | ✅ GREEN | Helper file build verified clean this S12a (see "Build verification") |
+
+## Build verification
+
+```
+./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers
+```
+
+Result: **clean (7744 jobs)**, helper file built in 55s. Pre-existing
+`Mathlib.Data.Real.Irrational` deprecation warning in
+`Proofs/CubeRoot3Irrational.lean:8` unchanged (parent module not
+owned by this slug). 0 new sorries, 0 new axioms.
+
+```
+⚠ [3058/3088] Replayed Proofs.CubeRoot3Irrational
+warning: Proofs/CubeRoot3Irrational.lean:8:7: 'Mathlib.Data.Real.Irrational'
+  has been deprecated: please replace this import by
+  import Mathlib.NumberTheory.Real.Irrational
+✔ [7744/7744] Built Proofs.CubeRoot3IrrationalOQ04Helpers (55s)
+Build completed successfully (7744 jobs).
+=== Build succeeded ===
+```
+
+Build time is consistent with the S11a precedent (52s; 55s here is
++3s for the 56-LOC addition + 1 new theorem).
+
+## Files modified
+
+1. `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean` (472 → 528
+   LOC, +56 LOC; theorem count 15 → 16): added prose section
+   `## S12a prep: new lower bound for a₁₀ = 2 (the eleventh partial
+   quotient)` + the new theorem
+   `one_three_three_six_one_over_nine_two_six_four_lt_cbrt3`.
+2. `src/data/research/problems/cube-root-3-irrational-oq-04.json`:
+   bump `currentState.iteration` 12 → 13, refresh
+   `currentState.focus` / `currentState.nextAction` (records the
+   #FOUR math-correction precedent and supersedes the
+   off-by-one-OEIS-position S11b sketch),
+   update `leanFiles[5]` (Helpers) lineCount 472 → 528 /
+   theoremCount 15 → 16, bump `lastUpdate` /  `knowledge.lastUpdated`
+   / top-level `lastUpdated` to `2026-06-01T00:00:00.000Z`.
+3. `research/problems/cube-root-3-irrational-oq-04/state.md`: bump
+   head Iteration → 13, prepend Current Focus block for S12a, push
+   prior S11b focus to "## Prior Focus (S11b ACT, PR #21654, MERGED
+   2026-06-01T00:32:07Z)", replace Next Action sketch with the
+   corrected S12b sketch (sandwich `13361/9264 < cbrt3 < 6206/4303`,
+   12th-convergent backup `73011/50623`).
+4. NEW `research/problems/cube-root-3-irrational-oq-04/sessions/2026-06-01-s12a-helper-act-eleventh-convergent.md`
+   (this file).
+
+No edits to:
+- `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` (main file, unchanged at 1505 LOC)
+- `proofs/Proofs/CubeRoot3Irrational.lean` (parent, unchanged)
+- `src/data/proofs/cube-root-3-irrational-oq-04/` gallery (no meta changes — slug research JSON is the authoritative tracker for in-progress research)
+- sibling slugs
+- problem.md / knowledge.md (only state.md narrative updated)
+
+## Next ACT picker priority (S12b)
+
+The main S12b theorem `cbrt3_a10 = 2` is now mathematically unblocked.
+The S12b ACT should:
+
+1. **Verify the sandwich tightness**: at depth 10, the existing
+   upper-side `cbrt3 < 6206/4303` (gap `2.3·10⁻⁸`) may or may not
+   be tight enough through the 19-step chain. Strategy: paste the
+   chain and let `linarith` discover whether each step closes.
+2. **If too loose**: add the 12th-convergent upper bound
+   `cbrt3 < 73011/50623` as a Helper-ACT predecessor (using
+   `a₁₁ = 5` per OEIS A002945; pre-claim Python sanity:
+   `73011³ = 389_271_307_557_812_731 > 389_271_307_493_213_241 =
+   3 · 50623³`, diff `+64_599_490`).
+3. **Main theorem**: 19-step chain on a ten-fold-nested fraction,
+   `set_option maxHeartbeats 3200000 in` (2× S11b), ~220 LOC delta.
+4. **Build verify**: `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04`
+   (expected 7745 jobs).
+
+End of S12a Helper-ACT memo.

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,10 +1,52 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-31 (S11b ACT)
-**Iteration**: 12
+**Since**: 2026-06-01 (S12a Helper-ACT)
+**Iteration**: 13
 
 ## Current Focus
+
+S12a Helper-ACT (researcher-1, 2026-06-01, Lean-only narrow-ACT):
+added `Cbrt3Helpers.one_three_three_six_one_over_nine_two_six_four_lt_cbrt3 :
+(13361/9264 : ℝ) < cbrt3` to `CubeRoot3IrrationalOQ04Helpers.lean` via
+the proven two-line cubing-iff template (`lt_cbrt3_iff_cube_lt + norm_num`).
+This is the **true 11th CF convergent** of `∛3` (using `a₁₀ = 2` per
+OEIS A002945 entry 11, independently verified to 200 digits via
+Decimal-arithmetic Newton-iteration CF expansion). Helper file
+472 → 528 LOC (+56 LOC, +1 theorem +1 prose section; theoremCount
+15 → 16). 0 sorries, 0 axioms (slug remains 0/0). Cube-direction
+sanity: `13361³ = 2_385_156_564_881 < 2_385_156_575_232 = 3 · 9264³`
+(diff `−10_351`, relative gap `≈ 4.34·10⁻⁹` — roughly an order of
+magnitude tighter than S11a's `7155/4961` lower-side gap of
+`≈ 4.96·10⁻⁸`, consistent with `13361/9264` being a true convergent
+one rung beyond S11a's semi-convergent).
+
+**Math-correction precedent #FOUR for this slug**: the prior
+post-S11b `nextAction` sketch (JSON `currentState.nextAction` as of
+2026-05-31) claimed OEIS A002945 entries `a₁₀ = 1`, `a₁₁ = 2`. The
+actual prefix is `[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4,
+2, 6, 4, 4, ...]` (200-digit Decimal-precision Newton-iteration CF
+expansion, this S12a session), so `a₁₀ = 2`, `a₁₁ = 5`, `a₁₂ = 8`.
+The S11a helper docstring's claim that `7155/4961` is the "10th
+convergent with `a₁₀ = 1`" is also strictly incorrect: `7155/4961`
+is a **semi-convergent** (best-rational approximation between the
+9th and 11th true CF convergents), not a true CF convergent. **The
+S11a proof and the S11b main theorem remain mathematically correct**
+— `7155/4961 < cbrt3` is true (Decimal computation: gap `−2.4·10⁻⁸`)
+and provided a valid lower bound for the S11b sandwich
+`7155/4961 < cbrt3 < 6206/4303` proving `cbrt3_a9 = 6`. Only the
+"true 10th convergent" framing in the docstring is off.
+
+Docker build of helper file verified clean (build log embedded in
+the S12a session memo at
+`sessions/2026-06-01-s12a-helper-act-eleventh-convergent.md`).
+
+See `sessions/2026-06-01-s12a-helper-act-eleventh-convergent.md`
+for the cube arithmetic, OEIS A002945 cross-verification at 200
+digits, semi-convergent vs true-convergent distinction, and the
+S12b next-action sketch.
+
+## Prior Focus (S11b ACT, PR #21654, MERGED 2026-06-01T00:32:07Z)
 
 S11b ACT (researcher-1, 2026-05-31): shipped the tenth partial
 quotient `cbrt3_a9 = 6` — the largest in the known prefix —
@@ -320,36 +362,41 @@ clone. Strict text-only iterations (this S3) are unaffected.
 
 ## Next Action
 
-**S12 (any researcher)**: Prove the eleventh partial quotient,
-`cbrt3_a10 : ⌊1 / (... - 1)⌋ = (1 : ℤ)`
+**S12b (any researcher)**: Prove the eleventh partial quotient,
+`cbrt3_a10 : ⌊1 / (1 / (... - 1) - 6)⌋ = (2 : ℤ)`
 in `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`. Per OEIS A002945
-`[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 1, 2, …]`, the eleventh partial
-quotient is `a₁₀ = 1`. This requires a new UPPER bound on `cbrt3`
-(alternation: the 11th convergent lies above `cbrt3`).
+`[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, …]` (independently
+verified to 200 digits via Decimal-arithmetic Newton-iteration CF
+expansion in S12a session), `a₁₀ = 2` (**NOT** `a₁₀ = 1` as the
+pre-S12a sketch incorrectly claimed; this is **math-correction
+precedent #FOUR** for this slug — see Current Focus head).
 
-The eleventh CF convergent using `a₁₁ = 2` per OEIS A002945 is:
+This S12a shipped the **true 11th CF convergent lower bound**:
 
-  `q₁₁ = a₁₁ · q₁₀ + q₉ = 2·4961 + 4303 = 14225`
-  `p₁₁ = a₁₁ · p₁₀ + p₉ = 2·7155 + 6206 = 20516`
+```
+Cbrt3Helpers.one_three_three_six_one_over_nine_two_six_four_lt_cbrt3 :
+  (13361/9264 : ℝ) < cbrt3
+```
 
-So `p₁₁/q₁₁ = 20516/14225`. Expected direction: `20516/14225 > cbrt3`
-(odd-index convergent above). Pre-claim Python cube sanity (the S7→S8,
-S8→S9, S10→S11 sketch-correction precedent is mandatory):
+The sandwich pair for S12b is therefore `13361/9264 < cbrt3 < 6206/4303`
+(reusing the S10 upper bound). If the 6206/4303 upper bound proves too
+loose at depth 10 (relative gap `2.3·10⁻⁸` may not contract enough
+through the 19-step chain), the next iteration would add an upper-side
+helper using the **true 12th CF convergent** (with `a₁₁ = 5`):
 
-  `20516³ vs 3·14225³` — verify INDEPENDENTLY before writing the helper.
-  Expected sign: `20516³ > 3·14225³` ⟹ `(20516/14225)³ > 3` ⟹
-  `20516/14225 > cbrt3` (LOWER side of the upper bound).
+  `q₁₁ = a₁₁ · q₁₀ + q₉ = 5 · 9264 + 4303 = 50623`
+  `p₁₁ = a₁₁ · p₁₀ + p₉ = 5 · 13361 + 6206 = 73011`
 
-Candidate helper name:
-`cbrt3_lt_two_oh_five_one_six_over_one_four_two_two_five`.
+So `p₁₁/q₁₁ = 73011/50623 > cbrt3` (relative gap `≈ 1.66·10⁻¹¹` —
+roughly three orders of magnitude tighter). Pre-claim Python cube
+sanity: `73011³ = 389_271_307_557_812_731 > 389_271_307_493_213_241 =
+3 · 50623³` (diff `+64_599_490`).
 
-Algebraic chain: ~19 steps (one rung deeper than S11b's 17 steps).
-Heartbeat budget guess: `set_option maxHeartbeats 3200000 in`
+Algebraic chain for S12b: ~19 steps (one rung deeper than S11b's 17
+steps). Heartbeat budget guess: `set_option maxHeartbeats 3200000 in`
 (2× S11b's 1_600_000; the 2× per-depth scaling has held through
 S7–S11b). Estimated main-file delta: ~220 LOC (consistent with S10
-234-LOC, S11b 216-LOC). Skeleton in
-`sessions/2026-05-31-s11b-act-tenth-partial-quotient.md` §
-"Next ACT picker priority".
+234-LOC, S11b 216-LOC).
 
 ## Prior Next-Action Sketch (S11, now resolved by S11b)
 

--- a/src/data/research/problems/cube-root-3-irrational-oq-04.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-04.json
@@ -21,14 +21,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-31T20:00:00.000Z",
-    "iteration": 12,
-    "focus": "S11b ACT (researcher-1, 2026-05-31): shipped the tenth partial quotient cbrt3_a9 = 6 \u2014 the largest in the OEIS A002945 known prefix \u2014 consuming the S11a + S10 sandwich pair (7155/4961 < cbrt3 < 6206/4303) through a 17-step lt_div_iff\u2080 / div_lt_iff\u2080 / le_div_iff\u2080 chain on a nine-fold-nested fraction followed by floor antisymmetry via Int.le_floor / Int.floor_lt. Main file Proofs/CubeRoot3IrrationalOQ04.lean 1289 \u2192 1505 LOC (+216 LOC, +1 theorem; theoremCount 16 \u2192 17). Heartbeat budget set_option maxHeartbeats 1600000 in (scoped, 2\u00d7 S10s 800_000; the empirical 2\u00d7 per-depth scaling validated through S7\u2013S10 holds at S11b). Docker build verified clean (7745 jobs; main file 218s elaboration on standard image; pre-existing Mathlib.Data.Real.Irrational deprecation warning in Proofs/CubeRoot3Irrational.lean:8 unchanged from S10 build, parent module not owned by this slug). 0 sorries, 0 axioms (slug remains 0/0). The chain cbrt3_a0, \u2026, cbrt3_a9 now covers the full OEIS A002945 prefix that was independently cross-checked to 50 decimal places in S9-prep PR #19011. Algebraic chain bounds: 4303/1903 < 1/(cbrt3-1) < 4961/2194, 497/1903 < x_2 < 573/2194, 2194/573 < 1/x_2 < 1903/497, 475/573 < x_3 < 412/497, 497/412 < 1/x_3 < 573/475, 85/412 < x_4 < 98/475, 475/98 < 1/x_4 < 412/85, 83/98 < x_5 < 72/85, 85/72 < 1/x_5 < 98/83, 13/72 < x_6 < 15/83, 83/15 < 1/x_6 < 72/13, 8/15 < x_7 < 7/13, 13/7 < 1/x_7 < 15/8, 6/7 < x_8 < 7/8, 8/7 < 1/x_8 < 7/6, 1/7 < x_9 < 1/6, 6 < 1/x_9 < 7.",
+    "since": "2026-06-01T00:00:00.000Z",
+    "iteration": 13,
+    "focus": "S12a Helper-ACT (researcher-1, 2026-06-01, Lean-only narrow-ACT): added Cbrt3Helpers.one_three_three_six_one_over_nine_two_six_four_lt_cbrt3 : (13361/9264 : \u211d) < cbrt3 via the two-line cubing-iff template (lt_cbrt3_iff_cube_lt + norm_num) \u2014 the eleventh CF convergent (even-index, lower side of cbrt3) bound that the future S12b main theorem will consume. Helper file 472 \u2192 528 LOC (+56, +1 theorem +1 prose section; theoremCount 15 \u2192 16). Pre-claim Python cube-direction sanity at 200-digit precision: 13361\u00b3 = 2_385_156_564_881 < 2_385_156_575_232 = 3 \u00b7 9264\u00b3 (diff \u221210_351, gap 1.30\u00b710\u207b\u00b9 relative to 3 \u00b7 q\u00b3 \u2248 4.34\u00b710\u207b\u2079) confirmed; recursion check p_10 = 2 \u00b7 6206 + 949 = 13361, q_10 = 2 \u00b7 4303 + 658 = 9264 using a_10 = 2 per OEIS A002945 entry 11. Math-correction precedent #FOUR for this slug: prior nextAction sketch (post-S11b) had a_10 = 1, a_11 = 2 \u2014 incorrect; the actual OEIS A002945 prefix is [1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4, ...] (verified at 200-digit Decimal precision via independent Newton iteration), so a_10 = 2, a_11 = 5, a_12 = 8. The S11a helper docstring's claim that 7155/4961 is the '10th convergent with a_10 = 1' is also strictly incorrect: 7155/4961 is a SEMI-convergent (best-rational approximation between the 9th and 11th true convergents), not a true CF convergent. The S11a proof and the S11b main theorem remain mathematically correct \u2014 7155/4961 < cbrt3 is true and provided a valid lower bound for cbrt3_a9 = 6. Conflict-free narrow Helper-ACT (no main-file or sibling-slug touches); avoiding overlap with potential parallel S12b ACT pickers. Docker build of helper file verified clean (build log to be inserted at PR commit time per the `[G9 qualifier masks real bugs \u2014 ALWAYS Docker-verify]` policy).",
     "blockers": [],
-    "nextAction": "S12 ACT (any researcher): prove the eleventh partial quotient cbrt3_a10 : Int.floor (1/(... - 1)) = (1:Int) in proofs/Proofs/CubeRoot3IrrationalOQ04.lean. Per OEIS A002945 [1;2,3,1,4,1,5,1,1,6,1,2,\u2026], a_10 = 1 and a_11 = 2. New helper needed: an UPPER bound on cbrt3 from the eleventh CF convergent p_11/q_11 = (a_11\u00b7p_10+p_9)/(a_11\u00b7q_10+q_9) = (2\u00b77155+6206)/(2\u00b74961+4303) = 20516/14225. Pre-claim Python cube-direction sanity is MANDATORY per the math-correction precedent at S7\u2192S8, S8\u2192S9, S10\u2192S11 sketches: verify 20516^3 vs 3\u00b714225^3 INDEPENDENTLY. Expected direction (alternation): 20516/14225 > cbrt3 (odd-index convergent above), so 20516^3 > 3\u00b714225^3 is the expected sign. Candidate helper name: cbrt3_lt_two_oh_five_one_six_over_one_four_two_two_five. Algebraic chain: ~19 steps (one rung deeper than S11b's 17-step chain). Heartbeat budget guess: set_option maxHeartbeats 3200000 in (2\u00d7 S11b's 1_600_000; 2\u00d7 per-depth scaling has held through S7\u2013S11b). Estimated main-file delta: ~220 LOC (consistent with S10 234-LOC, S11b 216-LOC trend). Skeleton in sessions/2026-05-31-s11b-act-tenth-partial-quotient.md \u00a7 'Next ACT picker priority'. Build verify: ./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04 (expected 7745 jobs).",
+    "nextAction": "S12b ACT (any researcher): prove the eleventh partial quotient cbrt3_a10 : Int.floor (1/(1/(... - 1) - 6))) = (2:Int) in proofs/Proofs/CubeRoot3IrrationalOQ04.lean. Per OEIS A002945 [1;2,3,1,4,1,5,1,1,6,2,5,8,...] (independently verified to 200 digits via Decimal-arithmetic CF expansion), a_10 = 2 (NOT a_10 = 1 as the pre-S12a sketch incorrectly claimed). The new lower bound 13361/9264 < cbrt3 (S12a, this PR) is the true 11th convergent; combined with S10's upper bound cbrt3 < 6206/4303 (gap 2.3\u00b710\u207b\u2078) it forms the S12b sandwich pair. If the 6206/4303 upper bound proves too loose at depth 10, the next-iteration helper would be the 12th convergent upper bound 73011/50623 (using a_11 = 5: p_11 = 5\u00b713361 + 6206 = 73011, q_11 = 5\u00b79264 + 4303 = 50623; pre-claim Python sanity 73011\u00b3 = 389_271_307_557_812_731 vs 3\u00b750623\u00b3 = 389_271_307_493_213_241, diff +64_599_490 \u00b7 odd-index gap \u22481.66\u00b710\u207b\u00b9\u00b9). Algebraic chain: ~19 steps (one rung deeper than S11b's 17-step chain). Heartbeat budget guess: set_option maxHeartbeats 3200000 in (2\u00d7 S11b's 1_600_000; 2\u00d7 per-depth scaling has held through S7\u2013S11b). Estimated main-file delta: ~220 LOC (consistent with S10 234-LOC, S11b 216-LOC trend). Build verify: ./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04 (expected 7745 jobs).",
     "attemptCounts": {
-      "total": 12,
-      "currentApproach": 12,
+      "total": 13,
+      "currentApproach": 13,
       "approachesTried": 1
     }
   },
@@ -89,7 +89,7 @@
       "S13+ (deferred): convergent lemmas convergent_n cbrt3 = (h_n, k_n) with the recurrence h_n = a_n h_{n-1} + h_{n-2}, k_n = a_n k_{n-1} + k_{n-2}.",
       "S14+ (deferred, structural): Lagrange theorem on this slug as a generic obstacle to all-a\u1d62 formalization. The CF of cbrt3 is non-periodic because cbrt3 is cubic-irrational (degree 3); a Mathlib-side proof of Lagrange (eventually-periodic CF iff quadratic) would let cbrt3-OQ-04 conclude with a formal non-existence statement about closed-form a_i."
     ],
-    "lastUpdated": "2026-05-31T20:00:00.000Z"
+    "lastUpdated": "2026-06-01T00:00:00.000Z"
   },
   "tags": [
     "seeker-selected",
@@ -179,8 +179,8 @@
     {
       "path": "Proofs/CubeRoot3IrrationalOQ04Helpers.lean",
       "filename": "CubeRoot3IrrationalOQ04Helpers.lean",
-      "lineCount": 472,
-      "theoremCount": 15,
+      "lineCount": 528,
+      "theoremCount": 16,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -188,5 +188,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean"
     }
   ],
-  "lastUpdated": "2026-05-16T03:56:40.000Z"
+  "lastUpdated": "2026-06-01T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Session 12a Helper-ACT for `cube-root-3-irrational-oq-04` (researcher-1, 2026-06-01, **Lean-only narrow Helper-ACT**, Docker-verified).

Adds the **true 11th CF convergent lower bound** of `∛3` to `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean`:

```lean
theorem one_three_three_six_one_over_nine_two_six_four_lt_cbrt3 :
    (13361 / 9264 : ℝ) < cbrt3 := by
  rw [lt_cbrt3_iff_cube_lt (by norm_num)]
  norm_num
```

Cube arithmetic: `13361³ = 2_385_156_564_881 < 2_385_156_575_232 = 3 · 9264³` (diff `−10_351`, relative gap `≈ 4.34·10⁻⁹` — an order of magnitude tighter than S11a's `7155/4961` semi-convergent gap).

Convergent recursion check: `p_10 = 2 · 6206 + 949 = 13361`, `q_10 = 2 · 4303 + 658 = 9264`, using `a_10 = 2` per **OEIS A002945 entry 11**.

## Math-correction precedent #FOUR

The post-S11b `nextAction` sketch (state.md + JSON, 2026-05-31) claimed `a_10 = 1`, `a_11 = 2`. The actual OEIS A002945 prefix (verified to 200 digits via Decimal-arithmetic Newton-iteration CF expansion in this S12a) is:

```
[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4, ...]
```

So `a_10 = 2`, `a_11 = 5`, `a_12 = 8`. The S12b ACT plan is now corrected: sandwich pair `13361/9264 < cbrt3 < 6206/4303` (reusing S10 upper bound); 12th-convergent backup `73011/50623` (using `a_11 = 5`) ready if needed.

**Math-correction precedent count for this slug: 4** (S7→S8, S8→S9, S10→S11, **S11b→S12**).

The S11a `7155/4961` is correctly identified in this S12a's memo as a **semi-convergent** (best-rational approximation between the 9th and 11th true convergents), not a true 10th convergent. The S11a proof and the S11b main theorem `cbrt3_a9 = 6` remain **mathematically correct** — only the S11a docstring's "10th convergent" framing is off. Not corrected in this PR (out of scope); flagged for future doc-only mechanic.

## Build verification

```
./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers
✔ [7744/7744] Built Proofs.CubeRoot3IrrationalOQ04Helpers (55s)
Build completed successfully (7744 jobs).
=== Build succeeded ===
```

Only pre-existing parent deprecation warning (`Mathlib.Data.Real.Irrational` import at `Proofs/CubeRoot3Irrational.lean:8`, unchanged from S11b build). 0 new sorries, 0 new axioms (slug remains 0/0).

## Files

| File | Type | Δ |
|------|------|---|
| `proofs/Proofs/CubeRoot3IrrationalOQ04Helpers.lean` | EDIT | +56 LOC, +1 theorem, +1 prose section (472 → 528 LOC) |
| `src/data/research/problems/cube-root-3-irrational-oq-04.json` | EDIT | `currentState.{phase, since, iteration, focus, nextAction}`, `leanFiles[5].{lineCount, theoremCount}`, top-level `lastUpdated`, `knowledge.lastUpdated` |
| `research/problems/cube-root-3-irrational-oq-04/state.md` | EDIT | Iteration 12→13, Current Focus replaced, Next Action superseded with corrected S12b sketch |
| `research/problems/cube-root-3-irrational-oq-04/sessions/2026-06-01-s12a-helper-act-eleventh-convergent.md` | NEW | ~250 LOC session memo |

**0 main-file / 0 parent / 0 gallery / 0 sibling-slug / 0 problem.md / 0 knowledge.md edits.**

## Test plan

- [x] Pre-claim Python cube-direction sanity at 200-digit Decimal precision: `13361³ − 3·9264³ = −10_351 < 0` confirms `13361/9264 < ∛3`
- [x] OEIS A002945 cross-verification: first 20 partial quotients via independent Newton-iteration CF expansion match `[1, 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, 3, 3, 4, 2, 6, 4, 4]`
- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04Helpers` → 7744 jobs clean, helper file 55s
- [x] JSON validates: `python3 -c "import json; json.load(open('src/data/research/problems/cube-root-3-irrational-oq-04.json'))"`
- [ ] Next picker (S12b ACT): paste 19-step chain for `cbrt3_a10 = 2`, `set_option maxHeartbeats 3200000 in`, verify sandwich `13361/9264 < cbrt3 < 6206/4303` is tight enough at depth 10 (add `73011/50623` upper helper if not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)