### PR TITLE
fix(meta): mvt-oq-02-oq-04-oq-01 strings in meta.additionalFiles

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -80,14 +80,8 @@
       }
     ],
     "additionalFiles": [
-      {
-        "path": "Proofs/MeanValueTheoremOQ02.lean",
-        "purpose": "Grandparent file providing taylorPolynomial definition and taylorPolynomial_zero lemma."
-      },
-      {
-        "path": "Proofs/MeanValueTheoremOQ02OQ04.lean",
-        "purpose": "Parent file containing the OQ-04 axiom that this OQ-01 file refutes. The parent file is unchanged by this PR."
-      }
+      "Proofs/MeanValueTheoremOQ02.lean",
+      "Proofs/MeanValueTheoremOQ02OQ04.lean"
     ],
     "originalContributions": [
       "Constructive refutation of the parent OQ-04 axiom analytic_taylor_remainder_uniform_bound via the Runge function f(x)=1/(1+x²) at (a,R,M,r,n,x) = (0, 100, 1, 1, 0, 1). The refutation does not invoke the parent axiom (it refutes the *statement*), so it stands even if the parent axiom is later removed.",


### PR DESCRIPTION
## Fix

Convert `meta.additionalFiles` rich `{path, purpose}` objects to plain strings so the auditor follows the companion files.

## Evidence

**Before**:
```json
"additionalFiles": [
  {"path": "Proofs/MeanValueTheoremOQ02.lean", "purpose": "Grandparent..."},
  {"path": "Proofs/MeanValueTheoremOQ02OQ04.lean", "purpose": "Parent..."}
]
```

**After**:
```json
"additionalFiles": [
  "Proofs/MeanValueTheoremOQ02.lean",
  "Proofs/MeanValueTheoremOQ02OQ04.lean"
]
```

## Why

`scripts/auditor/find-targets.ts:169` skips non-string entries:

```ts
for (const af of additionalFiles) {
  if (typeof af !== 'string') continue
  ...
}
```

Rich-object meta entries silently disable chain-aggregate axiom/sorry counting. Matches the convention used by `inverse-galois`, `roth-theorem-k3-oq-03`, `erdos-2-oq-01`, and the pending picks-theorem-oq-03 swap (#21863).

Inline `purpose` annotations are dropped; the same information is already in the slug's `description` and `proofStrategy` fields. No content change to the proof, the assumptions, or the leanFile.

## Validation

- [x] `jq -e .` passes
- [x] `npx tsx scripts/auditor/find-targets.ts --next` ranks this slug as a re-audit target (auditor can now see companion files; a follow-up audit cycle will confirm counts)

---
Automated fix by lean-mechanic agent.