### PR TITLE
audit(erdos-1102): mark clean (cycle 4) — 1 axiom verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3810,9 +3810,9 @@
     },
     "erdos-1102": {
       "agentId": "auditor-loop-2026-05-02",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T14:05:00Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T09:53:52Z",
+      "result": "clean",
       "issues": [
         "Phantom-axiom narrative: 5 \"Axiom (van Doorn-Tao 2025)\" docstrings but only 1 axiom declared (propertyQ_achievable). Section line ranges drifted (main-axioms 93–130 → actual 93–115; special-sequences 154–154 → actual 140–153). originalContributions/proofStrategy overclaim plural axiomatization. Issue #14809."
       ]


### PR DESCRIPTION
## Summary

- Re-audit of erdos-1102 (van Doorn-Tao 2025 squarefree properties P/Q resolution) at main 8bf8a7b3552
- All meta.json counts match Lean source: 1 axiom, 0 sorries, 2 theorems, 6 defs, 158 lines (wc-l)
- Status `axiomatized`/badge `axiom` correct per Axiom Integrity Policy (assumption-carrying via `propertyQ_achievable`)

## Verification

| Check | meta.json | Lean source | Match |
|---|---|---|---|
| axiomCount | 1 | 1 (`propertyQ_achievable`) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 6 | 6 | ✓ |
| lineCount | 158 | 158 (wc-l) | ✓ |
| True stubs | — | 0 | ✓ |

## Prior cycle notes

Cycle 3 (2026-05-02) flagged phantom-axiom narrative + section drift (#14809). Current meta.json reflects those fixes — `main-axioms` 93–115 and `special-sequences` 140–153, single `propertyQ_achievable` axiom.

## Test plan

- [x] Tracker increment: auditCount 3 → 4, result `clean`
- [x] Counts re-verified against Lean source (Python regex w/ block-comment stripping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)