### PR TITLE
audit(erdos-111): mark clean (cycle 1) — 4 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3873,9 +3873,9 @@
     },
     "erdos-111": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T13:45:39Z",
-      "result": "issues-fixed"
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T09:58:27Z",
+      "result": "clean"
     },
     "erdos-1110": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Gallery Integrity Audit

**Target**: erdos-111 (Erdős Problem #111 — Edge Deletion to Bipartiteness for ℵ₁-chromatic graphs)
**Result**: clean

## Verification

Verified `src/data/proofs/erdos-111/meta.json` against `proofs/Proofs/Erdos111Problem.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| axiomCount | 4 | 4 | ✓ |
| sorries | 0 | 0 | ✓ |
| lineCount | 300 | 300 (wc -l) | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 9 | 9 | ✓ |
| Last section endLine | 300 | 300 | ✓ |

**Axioms** (lines 88, 122, 170, 188):
- `edgeDeletionFunction`
- `cardinalChromaticNumber`
- `h_at_least_linear`
- `ehs_upper_bound`

All four match the `assumptions` field exactly.

**Status / badge**: `axiomatized` / `axiom` — correct classification for an open Erdős problem with 4 stated axioms and 0 sorries.

## Conclusion

No integrity issues. Tracker updated to `auditCount: 4`, `result: clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)