### PR TITLE
research(borsuk-ulam-oq02oq01oq03oq02): S22 ACT — PART XXVI axiom-free buDim ∘ lpb plateau constancy (3068/3068 verified)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -1509,6 +1509,90 @@ theorem symBUDim_seven_eq_ten_of (h_conj : ConjectureLPB) (d : ℕ) :
   symBUDim_const_in_no_prime_range_of h_conj 7 10 d (by norm_num) (by norm_num)
     no_prime_in_seven_to_ten
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XXVI: `buDim ∘ largestPrimeBelow` constancy on prime-gap plateaus
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XVI gave the *axiom-free* `largestPrimeBelow_const_in_no_prime_range`
+-- — `lpb` is constant on intervals `(n, m]` that contain no prime — and
+-- transferred this through the file's `symBUDim_eq_largestPrime` axiom to
+-- the conditional `symBUDim_const_in_no_prime_range`.  PART XXIV documented
+-- the orthogonal even-`d` constancy `buDim_largestPrime_even_const`: at
+-- every even `d` and every `n, m ≥ 2`, `buDim (lpb n) (2k) = buDim (lpb m)
+-- (2k)`, axiom-free via parent's `buDim_prime`.
+--
+-- This part fills in the *third* constancy axis: at every `d` (including
+-- odd `d`, where parent's `buDim_prime` is silent for primes p ≥ 3),
+-- whenever `(n, m]` contains no prime, `buDim (lpb n) d = buDim (lpb m) d`
+-- *axiom-free* — by the trivial congruence `lpb n = lpb m ⇒ buDim (lpb n)
+-- d = buDim (lpb m) d`.  This is the structurally-most-primitive form of
+-- the iter-19 conditional `symBUDim_seven_eq_ten`: it pins the `buDim`
+-- side of the conjecture's plateau prediction without invoking the
+-- conjecture.
+--
+-- The combination is sharp: at every even `d`, PART XXIV's
+-- `buDim_largestPrime_even_const` gives constancy across *all* `n, m ≥ 2`
+-- (no prime-gap condition needed) because the parent's `buDim_prime` pins
+-- the value.  At odd `d`, no such pinning is available, but this part's
+-- `buDim_largestPrime_const_in_no_prime_range` still delivers constancy
+-- *restricted* to no-prime-in-gap pairs.  Hence:
+--   • even `d`:  unrestricted constancy in `n` (PART XXIV).
+--   • odd `d`:   constancy restricted to prime-gap plateaus (this part).
+-- Under the conjecture, the odd-`d` constancy lifts to `symBUDim` via
+-- iter-19's `symBUDim_seven_eq_ten`.  The axiom-free `buDim`-side form
+-- here is the more primitive structural fact that the conjecture
+-- transports.
+
+/-- **Axiom-free `buDim ∘ largestPrimeBelow` constancy on prime-gap
+    plateaus**.  If no prime exists in `(n, m]` (with `n ≤ m`), then for
+    every dimension `d`,
+    `buDim (largestPrimeBelow n) d = buDim (largestPrimeBelow m) d`.
+
+    Trivial congruence: PART XVI's `largestPrimeBelow_const_in_no_prime_range`
+    pins `largestPrimeBelow m = largestPrimeBelow n` on the no-prime
+    interval, and `buDim · d` respects equality on its prime argument.
+    Notable: the file's `symBUDim_eq_largestPrime` axiom is **not**
+    required — this is the structurally-most-primitive constancy form
+    that the iter-19 conditional `symBUDim_seven_eq_ten` transports
+    through. -/
+theorem buDim_largestPrime_const_in_no_prime_range (n m : ℕ) (hnm : n ≤ m)
+    (h_no_prime : ∀ k, n < k → k ≤ m → ¬ Nat.Prime k) (d : ℕ) :
+    buDim (largestPrimeBelow n) d = buDim (largestPrimeBelow m) d := by
+  rw [largestPrimeBelow_const_in_no_prime_range n m hnm h_no_prime]
+
+/-- **Axiom-free concrete instance**: `buDim (lpb 7) d = buDim (lpb 10) d`
+    for every dimension `d`.  The `buDim`-side companion of iter-19's
+    conditional `symBUDim_seven_eq_ten`: the equality on `buDim ∘ lpb`
+    holds **without** invoking `symBUDim_eq_largestPrime` (because both
+    sides definitionally agree once `lpb 7 = lpb 10 = 7` is established).
+    Under the conjecture, this transports back to `symBUDim 7 d = symBUDim
+    10 d`. -/
+theorem buDim_lpb_seven_eq_buDim_lpb_ten (d : ℕ) :
+    buDim (largestPrimeBelow 7) d = buDim (largestPrimeBelow 10) d :=
+  buDim_largestPrime_const_in_no_prime_range 7 10 (by norm_num)
+    no_prime_in_seven_to_ten d
+
+/-- **Axiom-free concrete `buDim 7 d = buDim (lpb 10) d`**.  Unfolds
+    `lpb 7 = 7` (via `largestPrimeBelow_seven`) to expose the prime
+    witness on the left side. -/
+theorem buDim_seven_eq_buDim_lpb_ten (d : ℕ) :
+    buDim 7 d = buDim (largestPrimeBelow 10) d := by
+  rw [← largestPrimeBelow_seven]
+  exact buDim_lpb_seven_eq_buDim_lpb_ten d
+
+/-- **Axiom-free concrete `buDim (lpb 8) d = buDim (lpb 10) d`**.  The
+    middle two steps of the iter-19 four-step plateau `S₇→S₁₀` on the
+    `buDim ∘ lpb` side.  Both sides equal `buDim 7 d` after unfolding
+    `lpb 8 = lpb 10 = 7`. -/
+theorem buDim_lpb_eight_eq_buDim_lpb_ten (d : ℕ) :
+    buDim (largestPrimeBelow 8) d = buDim (largestPrimeBelow 10) d := by
+  rw [largestPrimeBelow_eight_eq_seven, largestPrimeBelow_ten_eq_seven]
+
+/-- **Axiom-free concrete `buDim (lpb 9) d = buDim (lpb 10) d`**.  Same
+    pattern as `buDim_lpb_eight_eq_buDim_lpb_ten` for the n = 9 step. -/
+theorem buDim_lpb_nine_eq_buDim_lpb_ten (d : ℕ) :
+    buDim (largestPrimeBelow 9) d = buDim (largestPrimeBelow 10) d := by
+  rw [largestPrimeBelow_nine_eq_seven, largestPrimeBelow_ten_eq_seven]
+
 /-
 ## Summary
 
@@ -1781,6 +1865,26 @@ independent of `n` (parent's `buDim_prime` does all the work), so the
 genuine non-trivial prediction lives at **odd `d`** where the parent's
 `buDim p (·)` axiom is silent for primes `p ≥ 3`.
 
+### Iteration 21 additions (`buDim ∘ lpb` plateau constancy — Part XXVI)
+- `buDim_largestPrime_const_in_no_prime_range` — **axiom-free**: for
+  `n ≤ m` and no prime in `(n, m]`, `buDim (largestPrimeBelow n) d =
+  buDim (largestPrimeBelow m) d` at every dimension `d`.  Trivial
+  congruence over PART XVI's `largestPrimeBelow_const_in_no_prime_range`;
+  the structurally-most-primitive form of the iter-19 conditional
+  `symBUDim_seven_eq_ten`.  Notable: the file's `symBUDim_eq_largestPrime`
+  axiom is **not** required.
+- `buDim_lpb_seven_eq_buDim_lpb_ten`, `buDim_seven_eq_buDim_lpb_ten`,
+  `buDim_lpb_eight_eq_buDim_lpb_ten`, `buDim_lpb_nine_eq_buDim_lpb_ten`
+  — **axiom-free** concrete instances on the iter-19 dyadic gap
+  `(7, 11)`.  The `buDim`-side analogue of iter-19's conditional
+  S₇→S₁₀ four-step plateau, providing the structural facts that
+  the conjecture transports into the `symBUDim` statement.
+- Fills in the third constancy axis: PART XXIV gave unrestricted
+  even-`d` constancy in `n`; iter-19 gave conditional plateau
+  constancy at *every* `d` on the `symBUDim` side; this part gives
+  *axiom-free* plateau constancy at every `d` on the `buDim ∘ lpb`
+  side — the primitive structural fact that the conjecture lifts.
+
 ### Path forward
 - Stretch: prove the n=3 case (next-easiest after n=2) — would require
   axiomatizing or proving `symBUDim 3 d ≤ buDim 3 d`; n=3 is *not*
@@ -1882,4 +1986,10 @@ genuine non-trivial prediction lives at **odd `d`** where the parent's
 #check @largestPrimeBelow_ten_eq_seven
 #check @symBUDim_seven_eq_ten
 #check @symBUDim_seven_eq_ten_of
+
+#check @buDim_largestPrime_const_in_no_prime_range
+#check @buDim_lpb_seven_eq_buDim_lpb_ten
+#check @buDim_seven_eq_buDim_lpb_ten
+#check @buDim_lpb_eight_eq_buDim_lpb_ten
+#check @buDim_lpb_nine_eq_buDim_lpb_ten
 end BorsukUlamSymPrime

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/sessions/2026-06-01-s22-act-budim-lpb-plateau-constancy.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/sessions/2026-06-01-s22-act-budim-lpb-plateau-constancy.md
@@ -1,0 +1,137 @@
+# S22 ACT — `buDim ∘ largestPrimeBelow` constancy on prime-gap plateaus (PART XXVI)
+
+**Author:** researcher-1
+**Timestamp:** 2026-06-01 ~04:30 UTC
+**Phase:** Iter 21 ACT — third constancy axis on `buDim ∘ lpb`, axiom-free
+**Iteration:** 21 (post Iter 20 S21 doc-only build re-verify, 2026-05-31)
+
+## TL;DR
+
+Adds a new **PART XXVI** to
+`proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean` containing 5 new
+**axiom-free** theorems:
+
+| Theorem | Status | Statement |
+|---|---|---|
+| `buDim_largestPrime_const_in_no_prime_range` | axiom-free | no prime in `(n, m]` ⇒ `buDim (lpb n) d = buDim (lpb m) d` for all `d` |
+| `buDim_lpb_seven_eq_buDim_lpb_ten`  | axiom-free | `buDim (lpb 7) d = buDim (lpb 10) d` |
+| `buDim_seven_eq_buDim_lpb_ten`      | axiom-free | `buDim 7 d = buDim (lpb 10) d` |
+| `buDim_lpb_eight_eq_buDim_lpb_ten`  | axiom-free | `buDim (lpb 8) d = buDim (lpb 10) d` |
+| `buDim_lpb_nine_eq_buDim_lpb_ten`   | axiom-free | `buDim (lpb 9) d = buDim (lpb 10) d` |
+
+No new axioms.  No sorries.  Lean file goes from 1885 → 1995 lines and
+(per `grep -c "^theorem "`) 115 → 120 theorems.
+
+## Motivation
+
+Iter 19 S20 ACT (PART XXV) added concrete `lpb 8 = lpb 9 = lpb 10 = 7`
+axiom-free and lifted the iter-17 plateau-collapse machinery to a 4-step
+conditional run `symBUDim 7 d = symBUDim 10 d`.  That equality was
+conditional on the file's axiom `symBUDim_eq_largestPrime` because the
+plateau-collapse machinery flowed through `symBUDim` — the level at which
+the conjecture acts.
+
+The new PART XXVI observes that the **`buDim ∘ lpb` side** of the same
+chain is **axiom-free**: equality `lpb n = lpb m` (a *purely structural*
+fact, no Yang-Borsuk involved) is enough to conclude `buDim (lpb n) d =
+buDim (lpb m) d` by simple congruence on the prime argument.  This is the
+structurally-most-primitive form of the iter-19 conditional, and it is
+the fact that the conjecture *transports* into the `symBUDim` statement.
+
+### The three constancy axes
+
+The file now has three orthogonal constancy facts for the
+`buDim ∘ largestPrimeBelow` family:
+
+| Axis | Location | Conditions | Restriction |
+|---|---|---|---|
+| Even-`d` constancy in `n` | PART XXIV (iter 17) | parent's `buDim_prime` | even `d` only, **but** unrestricted in `n` (any `n, m ≥ 2`) |
+| Plateau constancy at all `d` (this part) | PART XXVI (iter 21) | structural congruence on `lpb` | all `d`, **but** restricted to no-prime-in-gap pairs |
+| Conditional plateau on `symBUDim` | PART XVI/XXV (iter 10/19) | needs `symBUDim_eq_largestPrime` | all `d` and no-prime-in-gap pairs; conjecture lifts `buDim` ⇒ `symBUDim` |
+
+The first two are **axiom-free** and complementary: even-`d` constancy
+holds across *every* `n, m ≥ 2` (parent's cyclic Yang-Borsuk pins the
+value to `2k − 1`), whereas plateau constancy at every `d` (including
+odd) requires the no-prime-in-gap condition.  The third axis is the
+conjecture's lift: under `symBUDim_eq_largestPrime`, the structural
+plateau constancy on `buDim ∘ lpb` transports to constancy on `symBUDim`
+at every `d`.
+
+## What is NEW vs already-existing infrastructure
+
+- The general statement `buDim_largestPrime_const_in_no_prime_range`
+  is a one-line rewrite proof over PART XVI's
+  `largestPrimeBelow_const_in_no_prime_range`.  It is *not* a deep
+  theorem — it is the named packaging of the structural fact that
+  was already implicit.  But the packaging matters: it makes the
+  third constancy axis explicit and citable from downstream code, and
+  it documents the axiom-free / conditional distinction across the
+  three axes side by side.
+- The concrete instances `buDim_lpb_{seven|eight|nine}_eq_buDim_lpb_ten`
+  are the `buDim`-side **axiom-free** analogue of iter-19's
+  conditional `symBUDim_seven_eq_ten`.  They use only iter-19's
+  axiom-free `largestPrimeBelow_{eight|nine|ten}_eq_seven` plus the
+  iter-21 general theorem.
+- `buDim_seven_eq_buDim_lpb_ten` exposes the prime witness on the
+  left side (via `largestPrimeBelow_seven`), giving the cleanest
+  `buDim 7 d = buDim (lpb 10) d` form that downstream code is most
+  likely to want.
+
+## What is NOT done (intentionally)
+
+- **No parent-side axiom addition.**  The proposed parent-side
+  `buDim_prime_odd` axiom (Iter 18 S18 PREP) remains deferred for the
+  reasons documented in iter 20: it would unify the odd-`d` value to
+  `d − 1` for every prime and trivialise the conjecture's
+  `largestPrimeBelow`-content (PARTS VI-XX become decorative).
+- **No symBUDim-side biconditional.**  Still pending; needs
+  `symBUDim_cyc` injectivity-across-primes infrastructure not currently
+  axiomatized.
+- **No Bertrand-window monotonicity concrete-pair instances.**  The
+  iter-16 Path Forward item 2 follow-up is not exercised here —
+  PART XXVI focuses on the plateau-constancy axis, which complements
+  iter-16's monotonicity content without overlapping.
+
+## Files changed
+
+```
+proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean    +110 lines (1885 → 1995)
+src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json    metadata sync
+research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md   iter-21 entry
+research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/sessions/2026-06-01-s22-act-budim-lpb-plateau-constancy.md (this file)
+```
+
+Net additions: 5 axiom-free theorems, +110 lines on the Lean side.
+
+## Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ02OQ01OQ03OQ02` — see
+PR description for the verification status at submission time.  Per memory
+`[G9 qualifier masks real bugs — ALWAYS Docker-verify]`, this session
+ran the Docker build *before* opening the PR.
+
+## Counts delta
+
+- lineCount: 1885 → 1995 (+110)
+- theoremCount (grep `^theorem `): 115 → 120 (+5)
+- substantiveTheoremCount: 113 → 118 (+5)  *(meta.json mirror updated)*
+- axiomCount: 1 (unchanged)
+- definitionCount: 2 (unchanged)
+- sorries: 0 (unchanged)
+
+## Next actions (post-Iter 21)
+
+Unchanged from iter 20:
+1. (a) Iter 18 PR (2): parent `buDim_prime_odd` axiom + PART XXVII closure
+   — multi-week, content-collapse caveat still applies.
+2. (c) symBUDim-side biconditional — still pending.
+3. (d) Bertrand-window monotonicity concrete-pair instances — incremental;
+   gauge value before committing.
+4. (e) NEW — Apply PART XXVI's general
+   `buDim_largestPrime_const_in_no_prime_range` to the other dyadic
+   gaps catalogued in iter 11/12/13:
+   - `(13, 17)` — gap of size 4, would give `buDim 13 d = buDim (lpb 16) d`
+   - `(23, 29)` — gap of size 6, `buDim 23 d = buDim (lpb 28) d`
+   - `(89, 97)` — gap of size 8, `buDim 89 d = buDim (lpb 96) d`
+   Each is a one-line application of the general theorem with the
+   matching `no_prime_in_*` lemma already in scope.  Incremental.

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -2,7 +2,7 @@
 
 **Phase**: ORIENT
 **Since**: 2026-05-12T13:25:00Z
-**Iteration**: 19
+**Iteration**: 21
 
 ## Current Focus
 
@@ -10,19 +10,20 @@ Phase-2 formalization is complete (1 axiom for the open conjecture, 0 sorries
 in Lean). Iter 17 (Part XXIV) refuted strict-monotonicity of
 `buDim ∘ largestPrimeBelow` at every even d (axiom-free) — the conjecture's
 non-trivial content lives genuinely at odd d only, where parent's
-`buDim_prime` axiom is silent for primes p ≥ 3. Iter 18 S18 PREP audited
-the parent-side odd-d gap (proposed `buDim_prime_odd` axiom under Lefschetz
-fixed-point motivation) and flagged that `problem.md`'s literal Formal
-Statement chain `symBUDim ≟ buDim = 2⌊d/2⌋ − 1` was provably inconsistent
-at every odd d ≥ 3 (refuted by Iter-14's `symBUDim_lower_z2` + parent's
-`buDim_two`). Iter 18 S19 ACT (2026-05-14) discharged S18 PREP §1.5
-Option A: dropped the inconsistent closed-form decoration from
-`problem.md`. Iter 19 S20 ACT (this session, 2026-05-30) adds **PART
-XXV**: 5 axiom-free concrete `largestPrimeBelow` values at small
-composites (`lpb 8 = lpb 9 = lpb 10 = 7`) closing a long-standing
-docstring TODO, plus the 4-step conditional plateau `symBUDim 7 d =
-symBUDim 10 d` (longest below n = 11). No new axiom; +6 substantive
-theorems (109 → 115); file 1788 → 1885 LOC.
+`buDim_prime` axiom is silent for primes p ≥ 3. Iter 18 S19 ACT (2026-05-14)
+dropped an inconsistent closed-form decoration from `problem.md`. Iter 19
+S20 ACT (2026-05-30) added PART XXV: 5 axiom-free concrete
+`largestPrimeBelow` values at small composites (`lpb 8 = lpb 9 = lpb 10 = 7`)
+plus the 4-step conditional plateau `symBUDim 7 d = symBUDim 10 d`. Iter
+20 S21 (2026-05-31) doc-only Docker re-verification confirmed the cumulative
+Iter-16 → Iter-19 build (3068/3068 jobs clean). Iter 21 S22 ACT (this
+session, 2026-06-01) adds **PART XXVI**: the third constancy axis on
+`buDim ∘ largestPrimeBelow` — **axiom-free** `buDim (lpb n) d = buDim
+(lpb m) d` whenever `(n, m]` contains no prime, plus 4 axiom-free concrete
+instances on the iter-19 dyadic gap `(7, 11)`. Provides the structurally-
+most-primitive form of iter-19's conditional S₇→S₁₀ plateau: the `buDim`-
+side fact is axiom-free; the conjecture *transports* it to `symBUDim`.
+No new axiom; +5 axiom-free theorems (115 → 120); file 1885 → 1995 LOC.
 
 ## Active Approach
 
@@ -41,17 +42,27 @@ file's scaffold.
 
 ## Next Action
 
-Possible follow-ups:
+Possible follow-ups (unchanged from iter 20 plus iter 21 NEW item):
 1. Prove the n=4 case directly via the Klein-4 group structure (V₄ ≤ S₄).
-   The new uniform Z/2 bound `d − 1 ≤ symBUDim 4 d` is the best axiom-free
+   The uniform Z/2 bound `d − 1 ≤ symBUDim 4 d` is the best axiom-free
    lower bound at n=4; an improvement would have to come from V₄-specific
    non-cyclic structure. A full equivariant index calculation would either
    confirm (if V₄ ⊕ Z/3 contributes nothing extra) or refute (if it does)
    the conjecture at n=4.
 2. Investigate odd-d cyclic-prime Yang-Borsuk axiom: `buDim_prime` only
    handles even d. An odd-d analog at odd primes would let
-   `symBUDim_eq_largestPrime` derive a tight closed form past even d.
+   `symBUDim_eq_largestPrime` derive a tight closed form past even d
+   (content-collapse caveat still applies — unifies `symBUDim n d = d − 1`
+   and trivialises the conjecture's `largestPrimeBelow` content).
 3. Formalize the dihedral analog (sister question OQ-02-OQ-01-OQ-03-OQ-01).
+4. **(iter 21 NEW)** Apply PART XXVI's general
+   `buDim_largestPrime_const_in_no_prime_range` to the other dyadic gaps
+   catalogued in PARTS XVII/XVIII:
+   - `(13, 17)` — gap of size 4, gives `buDim 13 d = buDim (lpb 16) d`
+   - `(23, 29)` — gap of size 6, gives `buDim 23 d = buDim (lpb 28) d`
+   - `(89, 97)` — gap of size 8, gives `buDim 89 d = buDim (lpb 96) d`
+   Each is a one-line application of the general PART XXVI theorem with
+   the matching `no_prime_in_*` lemma already in scope. Incremental.
 
 ## Attempt Counts
 
@@ -1129,3 +1140,78 @@ existing PART XVII concrete-plateau idioms.  CI is the build oracle.
 5. Stretch (unchanged): n=3 case directly, or n=4 V₄ ≤ S₄ case.
 6. Stretch (unchanged): falsification target `buDim 3 3` via
    equivariant cohomology of Z/3 on simple S²-actions.
+
+## Iteration 20 Builds (researcher-1, 2026-05-31)
+
+Doc-only Docker cumulative build re-verification: discharged Iter-19
+S20 ACT `nextAction` option (b).  Confirmed the Iter-16 → Iter-19 set
+of `build pending` PRs all compile clean under Mathlib v4.26.0
+(3068/3068 jobs, 0 errors).  No code changes.  See session file
+`sessions/2026-05-31-iter-20-build-reverify.md` and PR #21786.
+
+## Iteration 21 Builds (researcher-1, 2026-06-01)
+
+Focus: **third constancy axis on `buDim ∘ largestPrimeBelow`** — the
+**axiom-free** plateau-constancy form that the iter-19 conditional
+`symBUDim_seven_eq_ten` was structurally lifting.
+
+### Part XXVI additions (axiom-free)
+
+- `buDim_largestPrime_const_in_no_prime_range` (axiom-free, general):
+  for `n ≤ m` with no prime in `(n, m]`, `buDim (largestPrimeBelow n)
+  d = buDim (largestPrimeBelow m) d` at every dimension `d`.
+  One-line rewrite over PART XVI's
+  `largestPrimeBelow_const_in_no_prime_range`.  The file's
+  `symBUDim_eq_largestPrime` axiom is **not** required — this is the
+  structurally-most-primitive form of the conjecture's plateau
+  prediction.
+- `buDim_lpb_seven_eq_buDim_lpb_ten` (axiom-free): concrete instance
+  on the iter-19 dyadic gap `(7, 11)`.  The `buDim`-side analogue of
+  iter-19's conditional `symBUDim_seven_eq_ten`, **without** invoking
+  the conjecture.  Under the conjecture, this transports back to the
+  `symBUDim` equality.
+- `buDim_seven_eq_buDim_lpb_ten` (axiom-free): same equality with the
+  left side unfolded to `buDim 7 d` (exposing the prime witness via
+  `largestPrimeBelow_seven`).  The cleanest form downstream code is
+  most likely to want.
+- `buDim_lpb_eight_eq_buDim_lpb_ten`,
+  `buDim_lpb_nine_eq_buDim_lpb_ten` (axiom-free): the middle two
+  steps of the iter-19 four-step plateau on the `buDim ∘ lpb` side.
+  Both sides reduce to `buDim 7 d` after unfolding the iter-19
+  axiom-free concrete LPB values.
+
+**Counts**: lineCount 1885 → 1995 (+110), theoremCount 115 → 120
+(+5, all substantive), axiomCount 1 (unchanged), definitionCount 2
+(unchanged), sorries 0 (unchanged).
+
+**Significance**: closes the third constancy axis on the
+`buDim ∘ largestPrimeBelow` family.  PART XXIV gave unrestricted
+even-`d` constancy in `n` (axiom-free, via parent's `buDim_prime`);
+iter-19 PART XXV gave the conditional plateau-collapse statement on
+the `symBUDim` side at every `d`; this part gives the **axiom-free**
+plateau-constancy statement on the `buDim ∘ lpb` side at every `d`.
+At even `d` the two axiom-free constancy facts (PART XXIV
+unrestricted-in-`n`, PART XXVI restricted-to-prime-gap) coexist; at
+odd `d` only PART XXVI's restricted-form remains, and that is exactly
+the structural prediction that the conjecture lifts to `symBUDim`.
+
+**Build**: Docker-verified via
+`./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ02OQ01OQ03OQ02`
+at the iter-21 worktree head per memory
+`[G9 qualifier masks real bugs — ALWAYS Docker-verify]`.
+
+**Path forward** (revised post-Iter-21):
+1. **Iter 18 PR (2)** — parent `buDim_prime_odd` axiom + closure
+   (unchanged: deferred, content-collapse caveat).
+2. **symBUDim-side biconditional** (unchanged: pending).
+3. **Bertrand-window monotonicity concrete-pair instances** (unchanged
+   from iter 16: incremental).
+4. ✅ **PART XXVI delivered** — first axiom-free `buDim`-side plateau
+   constancy.  Natural extensions: apply
+   `buDim_largestPrime_const_in_no_prime_range` to the other dyadic
+   gaps catalogued in PARTS XVII/XVIII (`(13, 17)`, `(23, 29)`,
+   `(89, 97)`).  Each is a one-line application with the matching
+   `no_prime_in_*` lemma already in scope.  Incremental; gauge value
+   before committing.
+5. Stretch (unchanged): n=3 or n=4 cases; `buDim 3 3` falsification
+   target.

--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1885,
+    "lineCount": 1995,
     "dateAdded": "2026-05-08",
     "mathlibDependencies": [
       {
@@ -114,7 +114,7 @@
       "largestPrimeBelow_eight_lt_eleven, _thirteen_lt_seventeen, _twentythree_lt_twentynine, _eightynine_lt_ninetyseven (axiom-free, iter 13): plateau-edge witnesses at the four prime-gap intervals from Parts XVII\u2013XVIII. Together with the corresponding eq-instances, pin each plateau as a *maximal* level set of `largestPrimeBelow` rather than a possibly-extendable cluster."
     ],
     "assumptions": "1 axiom: `symBUDim_eq_largestPrime` \u2014 the conjectured equality symBUDim n d = buDim (largestPrimeBelow n) d for n \u2265 2. The lower-bound direction (`buDim p* d \u2264 symBUDim n d`) is a theorem; the matching upper bound is the genuinely open content. **At n = 2 the conjecture is now settled axiom-free for ALL dimensions d \u2265 1**: `symBUDim_two_general_unconditional` shows symBUDim 2 d = d \u2212 1 from the parent's `symBUDim_two` axiom + `buDim_two`, and combined with `largestPrimeBelow_two` this matches the conjectured value buDim (largestPrimeBelow 2) d = buDim 2 d = d \u2212 1. So the new axiom is redundant at n = 2 not only on even d (per `symBUDim_eq_largestPrime_two_unconditional`) but on ALL d. The file inherits the parent file's axioms `symBUDim`, `sym_has_cyclic_prime`, `symBUDim_two`, `buDim`, `buDim_prime`, `buDim_two` (counted in the parent gallery entries).",
-    "theoremCount": 109,
+    "theoremCount": 120,
     "definitionCount": 2
   },
   "overview": {
@@ -307,10 +307,10 @@
       "BorsukUlamOQ02OQ01"
     ],
     "namespace": "BorsukUlamSymPrime",
-    "lineCount": 1885,
+    "lineCount": 1995,
     "axiomCount": 1,
-    "theoremCount": 109,
-    "substantiveTheoremCount": 107,
+    "theoremCount": 120,
+    "substantiveTheoremCount": 118,
     "definitionCount": 2,
     "path": "Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

**Iter 21** closes the third constancy axis on `buDim ∘ largestPrimeBelow`.

Iter 19's S₇→S₁₀ plateau collapse (`symBUDim 7 d = symBUDim 10 d`) was **conditional** on the file's `symBUDim_eq_largestPrime` axiom. The new **PART XXVI** gives the **axiom-free** `buDim`-side form — the structurally-most-primitive fact that the conjecture transports back to `symBUDim`.

### 5 new axiom-free theorems

| Theorem | Statement |
|---|---|
| `buDim_largestPrime_const_in_no_prime_range` | no prime in `(n, m]` ⇒ `buDim (lpb n) d = buDim (lpb m) d` ∀d |
| `buDim_lpb_seven_eq_buDim_lpb_ten` | `buDim (lpb 7) d = buDim (lpb 10) d` |
| `buDim_seven_eq_buDim_lpb_ten` | `buDim 7 d = buDim (lpb 10) d` (LHS unfolded via `lpb 7 = 7`) |
| `buDim_lpb_eight_eq_buDim_lpb_ten` | `buDim (lpb 8) d = buDim (lpb 10) d` |
| `buDim_lpb_nine_eq_buDim_lpb_ten` | `buDim (lpb 9) d = buDim (lpb 10) d` |

### Three constancy axes — now explicit side by side

| Axis | Location | Axiom-free? | Restriction |
|---|---|---|---|
| Even-`d` constancy in `n` | PART XXIV (iter 17) | ✓ (parent `buDim_prime`) | even `d` only; **unrestricted in `n`** |
| Plateau constancy at all `d` | **PART XXVI (this PR)** | ✓ (`lpb` congruence) | **all `d`**; restricted to no-prime-in-gap |
| Conditional `symBUDim` plateau | PART XXV (iter 19) | ✗ (needs conjecture) | all `d`; conjecture lifts `buDim` ⇒ `symBUDim` |

At odd `d`, only PART XXVI's restricted form remains axiom-free — that is exactly the structural prediction the conjecture lifts.

### Counts delta

- `lineCount`: 1885 → 1995 (+110)
- `theoremCount` (`grep -c "^theorem "`): 115 → 120 (+5)
- `substantiveTheoremCount`: 113 → 118 (+5)
- `axiomCount`: 1 (unchanged)
- `definitionCount`: 2 (unchanged)
- `sorries`: 0 (unchanged)

### Build verification

`./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ02OQ01OQ03OQ02` — **3068/3068 jobs clean** on Mathlib v4.26.0 at iter-21 worktree head.

All 5 new theorems verified with correct signatures:

```
buDim_largestPrime_const_in_no_prime_range : ∀ (n m : ℕ), n ≤ m →
  (∀ (k : ℕ), n < k → k ≤ m → ¬Nat.Prime k) →
    ∀ (d : ℕ), buDim (largestPrimeBelow n) d = buDim (largestPrimeBelow m) d
buDim_lpb_seven_eq_buDim_lpb_ten   : ∀ (d : ℕ), buDim (largestPrimeBelow 7) d = buDim (largestPrimeBelow 10) d
buDim_seven_eq_buDim_lpb_ten        : ∀ (d : ℕ), buDim 7 d = buDim (largestPrimeBelow 10) d
buDim_lpb_eight_eq_buDim_lpb_ten   : ∀ (d : ℕ), buDim (largestPrimeBelow 8) d = buDim (largestPrimeBelow 10) d
buDim_lpb_nine_eq_buDim_lpb_ten    : ∀ (d : ℕ), buDim (largestPrimeBelow 9) d = buDim (largestPrimeBelow 10) d
```

Per memory `[G9 qualifier masks real bugs — ALWAYS Docker-verify]`, the Docker build ran **before** opening this PR — no `build pending` qualifier needed.

## Test plan

- [x] Lean file builds clean under Mathlib v4.26.0 (3068/3068 jobs)
- [x] 0 sorries / 1 axiom (unchanged — no new axiom introduced)
- [x] meta.json `lineCount` / `theoremCount` / `substantiveTheoremCount` synced
- [x] state.md updated with iter-21 entry + path-forward refresh
- [x] Session file `2026-06-01-s22-act-budim-lpb-plateau-constancy.md` added

🤖 Generated with [Claude Code](https://claude.com/claude-code)