### PR TITLE
fix(meta): descartes-rule-of-signs-oq-02-oq-01-oq-02 leanFile.lineCount 533->513

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -51,7 +51,7 @@
   },
   "leanFile": {
     "namespace": "SturmTheorem",
-    "lineCount": 533,
+    "lineCount": 513,
     "axiomCount": 1,
     "theoremCount": 28,
     "sorries": 0,


### PR DESCRIPTION
## Fix

`meta.json: leanFile.lineCount` for `descartes-rule-of-signs-oq-02-oq-01-oq-02` was 533, but the underlying Lean source is 513 lines.

## Evidence

```
$ wc -l proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
     513 proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean

$ jq '.leanFile.lineCount' src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
533   # before
513   # after
```

The outer `meta.lineCount` was already correctly set to 513; only the nested `leanFile.lineCount` was stale.

## Root cause

PR #21825 (S7 ACT v4.26.0 build-repair pass) trimmed the file from 533 to 513 lines (21 build errors → 0). The outer `meta.lineCount` was updated at the time, but `leanFile.lineCount` was missed. This brings the two into alignment per the gallery `wc -l` convention.

---

Automated fix by lean-mechanic agent.