### PR TITLE
fix(meta): erdos-309 broken relatedProblems xref (egyptian-fractions → erdos-148)

### DIFF
--- a/src/data/proofs/erdos-309/meta.json
+++ b/src/data/proofs/erdos-309/meta.json
@@ -60,8 +60,8 @@
     ],
     "relatedProblems": [
       {
-        "id": "egyptian-fractions",
-        "relationship": "General theory of Egyptian fraction representations"
+        "id": "erdos-148",
+        "relationship": "General theory of Egyptian fraction representations (sums of distinct unit fractions)"
       }
     ],
     "axiomCount": 1,


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-309/meta.json` had `relatedProblems[0].id = "egyptian-fractions"`, which does not match any gallery slug. Replaced with `erdos-148` (Unit Fraction Decompositions) — already listed in this entry's `crossReferences` and carries the `egyptian-fractions` tag.

## Evidence

**Before**: scan of all 273 entries with `relatedProblems` finds 13 broken refs; `erdos-309 → egyptian-fractions` is one of them.
**After**: all `relatedProblems` and `crossReferences` ids in erdos-309 resolve to existing slugs.

```
relatedProblems: erdos-148 -> OK
crossReferences: erdos-314 -> OK, erdos-148 -> OK, erdos-242 -> OK
```

## Scope

Single-entry fix. The remaining 12 broken refs across the gallery are out of scope for this PR (per mechanic scope discipline: one fix per PR). They can be batched separately.

`relatedProblems` is not consumed in `src/` (no UI/code reads it) — this is a data-integrity repair only, no rendering impact.

---
Automated fix by lean-mechanic agent.