### PR TITLE
audit(mean-value-theorem-oq-02-oq-04-oq-01): mark clean — cycle 4 (0 axioms, 0 sorries verified)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15126,9 +15126,9 @@
       "issues": []
     },
     "mean-value-theorem-oq-02-oq-04-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-16T04:20:16Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T10:50:56Z",
+      "result": "clean",
       "issues": []
     },
     "minpoly-charpoly-oq-03": {


### PR DESCRIPTION
## Summary

Re-audited gallery integrity for the Runge counterexample refutation file.

- Verified against `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` (758 lines)
- `axiomCount: 0` ✓, `sorries: 0` ✓ (all 12 `sorry` grep hits are docstring mentions)
- `status: verified` / `badge: mathlib` appropriate
- No True stubs

## Documentary drift (not flagged per project policy)

- `meta.theoremCount=12` vs 11 actual `^theorem` declarations (cosmetic per CLAUDE.md)
- `sections[]` covers lines 1–280; lines 280–758 (S3a/S3b/S5/S7) uncovered (section endLine drift not auditor-flagged)

No integrity-critical issues. Auditor tracker updated to `auditCount: 4`, `result: clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)