### PR TITLE
fix(meta): mvt-oq-02-oq-04-oq-01 axiomCount 0→1 + axiomatized status

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius researchers (refutation by Runge counterexample, formalized 2026)",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/MeanValueTheoremOQ02OQ04OQ01.lean",
     "tags": [
       "calculus",
@@ -20,11 +20,11 @@
       "analysis",
       "research"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 758,
-    "assumptions": "0 new axioms in this file. The parent file's axiom analytic_taylor_remainder_uniform_bound is shown mathematically false (Runge counterexample, fully formalized in section 2). The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S7, zero sorries remain. The finite-radius form cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R)) was discharged in S7 via Mathlibs Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le. The boundary form cauchy_diag_norm_bound (with norm of w over R) is PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven.",
+    "assumptions": "1 axiom (inherited from additionalFiles only; main file declares 0 new axioms): taylor_lagrange_remainder in the grandparent file MeanValueTheoremOQ02.lean (qualitative pointwise Lagrange remainder, used to ground the Taylor-polynomial framework reused via MeanValueTheoremOQ02.taylorPolynomial / taylorPolynomial_zero). The parent file's axiom analytic_taylor_remainder_uniform_bound was retracted (S2 retraction; MeanValueTheoremOQ02OQ04.lean now declares 0 axioms) — its mathematical falsity is established by the Runge counterexample fully formalized in section 2. The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S7, zero sorries remain. The finite-radius form cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R)) was discharged in S7 via Mathlibs Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le. The boundary form cauchy_diag_norm_bound (with norm of w over R) is PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven.",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [


### PR DESCRIPTION
## Fix

Auditor flagged `mean-value-theorem-oq-02-oq-04-oq-01` for **axiom undercount: claims 0, actual declarations 1** while `status: "verified"`.

Inherited axiom `taylor_lagrange_remainder` in grandparent file `Proofs/MeanValueTheoremOQ02.lean` (listed in `meta.additionalFiles`) is auditor-followed but unaccounted for.

## Evidence

**Before**: `status: "verified"`, `badge: "mathlib"`, `axiomCount: 0`, assumptions claimed "0 new axioms in this file" (ignoring inherited).

**After**: `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 1`, assumptions rewritten to declare the inherited grandparent axiom.

Auditor `find-targets.ts --issues --json` now returns `[]` (was the one flagged entry).

## Precedent

Sibling slug `mean-value-theorem-oq-02-oq-04` already counts this same inherited axiom (`axiomCount: 1`, `status: "axiomatized"`, `badge: "axiom"`) per its `assumptions` field: *"1 axiom (inherited from additionalFiles only…): taylor_lagrange_remainder…"*. This PR aligns the child slug with the parent's convention.

## Policy

Per `CLAUDE.md` axiom integrity: `axiomCount` must reflect ALL assumptions including those inherited via `additionalFiles`. Status `"verified"` requires 0 axioms; the inherited grandparent axiom forces `"axiomatized"`.

## Note on adjacent PR

PR #21887 (OPEN) marks this slug *"clean — 0 axioms, 0 sorries verified"*, which contradicts the auditor's actual output. That audit PR is stale; once this fix merges, the audit tracker can be re-run and #21887 either updated or closed.

---
Automated fix by lean-mechanic agent.