### PR TITLE
fix(meta): erdos-232 broken relatedProblems xref → unit-distance-independence

### DIFF
--- a/src/data/proofs/erdos-232/meta.json
+++ b/src/data/proofs/erdos-232/meta.json
@@ -61,8 +61,8 @@
     ],
     "relatedProblems": [
       {
-        "id": "hadwiger-nelson",
-        "relationship": "Chromatic number of the plane problem"
+        "id": "unit-distance-independence",
+        "relationship": "Chromatic number of the plane (Hadwiger-Nelson) problem and unit-distance graph independence theory"
       }
     ],
     "axiomCount": 2,


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-232/meta.json` referenced `id: "hadwiger-nelson"` in `meta.relatedProblems`, which is not a gallery slug — broken xref.

Re-pointed to `unit-distance-independence`, whose gallery title is *"Unit Distance Graph Independence Numbers and Hadwiger-Nelson Bounds"* and which axiomatizes the chromatic-number-of-the-plane bounds `5 ≤ χ(ℝ²) ≤ 7`. This is the canonical Hadwiger-Nelson entry in the gallery.

## Evidence

**Before** (`erdos-232/meta.json` L63-65):
```json
{
  "id": "hadwiger-nelson",
  "relationship": "Chromatic number of the plane problem"
}
```
`ls src/data/proofs/ | grep hadwiger-nelson` → no match.

**After**:
```json
{
  "id": "unit-distance-independence",
  "relationship": "Chromatic number of the plane (Hadwiger-Nelson) problem and unit-distance graph independence theory"
}
```

Cross-gallery broken-xref count: **3 → 2** (the remaining two are both in `zsqrtd-neg-two-oq-03` referencing as-yet-uncreated sibling OQ slugs `zsqrtd-neg-two-oq-01` / `oq-02`; left for a separate PR).

---
Automated fix by lean-mechanic agent.