### PR TITLE
fix(meta): zsqrtd-neg-two-oq-03 drop broken sibling xrefs

### DIFF
--- a/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
@@ -68,14 +68,6 @@
       {
         "id": "zsqrtd-neg-two",
         "relationship": "Extends: this is the n = 3 analog of the parent's n = 2 representation theorem"
-      },
-      {
-        "id": "zsqrtd-neg-two-oq-01",
-        "relationship": "Sibling: the same Eisenstein construction is one route to the bidirectional characterization the parent's OQ-01 asks for"
-      },
-      {
-        "id": "zsqrtd-neg-two-oq-02",
-        "relationship": "Sibling: the n = 3 case of the bidirectionality sub-question"
       }
     ]
   },


### PR DESCRIPTION
## Fix

`src/data/proofs/zsqrtd-neg-two-oq-03/meta.json` referenced two non-existent gallery slugs in `meta.relatedProblems`:
- `zsqrtd-neg-two-oq-01`
- `zsqrtd-neg-two-oq-02`

Neither has ever existed as a gallery entry — they're aspirational references to as-yet-unfiled sub-questions of the parent `zsqrtd-neg-two`. The parent's `overview.openQuestions` lists three OQs (unified iff statement, Legendre three-square, n ∈ {3,7,11}) but none have been promoted to standalone `oq-01`/`oq-02` slugs.

Dropped the broken entries. The valid `zsqrtd-neg-two` parent xref (relationship: *"Extends: this is the n = 3 analog of the parent's n = 2 representation theorem"*) remains and fully captures the gallery relationship.

## Evidence

**Before** — three entries, two broken:
```json
"relatedProblems": [
  { "id": "zsqrtd-neg-two", "relationship": "Extends: ..." },
  { "id": "zsqrtd-neg-two-oq-01", "relationship": "Sibling: ..." },
  { "id": "zsqrtd-neg-two-oq-02", "relationship": "Sibling: ..." }
]
```
`ls src/data/proofs/ | grep zsqrtd-neg-two-oq-0` → only `zsqrtd-neg-two-oq-03`.

**After** — one valid parent xref retained.

Combined with PR #21889, gallery broken-xref count drops **3 → 0**.

---
Automated fix by lean-mechanic agent.