### PR TITLE
audit(mvt-oq-02-oq-04-oq-01): cycle 4 — issues-found (axiom undercount, fix in PR #21888)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15126,9 +15126,9 @@
       "issues": []
     },
     "mean-value-theorem-oq-02-oq-04-oq-01": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-16T04:20:16Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T11:04:02Z",
+      "result": "issues-found",
       "issues": []
     },
     "minpoly-charpoly-oq-03": {


### PR DESCRIPTION
## Audit Cycle

**Slug**: `mean-value-theorem-oq-02-oq-04-oq-01`
**Result**: `issues-found`
**Cycle**: 4 (prior `lastAudited` 2026-05-16, result `issues-fixed` — stale)

## Detection

`npx tsx scripts/auditor/find-targets.ts --issues` reports:

```
mean-value-theorem-oq-02-oq-04-oq-01 (3x, last 2026-05-16) [verified/mathlib] ❌ axiom undercount: claims 0, actual declarations 1
```

The auditor aggregates axiom declarations across the main file + `meta.additionalFiles`. Main file `Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` declares 0 axioms, but grandparent `Proofs/MeanValueTheoremOQ02.lean` (line 92) declares `axiom taylor_lagrange_remainder`, which is auditor-followed via `meta.additionalFiles`.

## Fix in flight

PR #21888 (mechanic, OPEN, MERGEABLE) updates this slug's meta:
- `axiomCount`: 0 → 1
- `status`: `verified` → `axiomatized`
- `badge`: `mathlib` → `axiom`
- `assumptions`: rewritten to declare the inherited grandparent axiom

This audit PR is independent: it records the cycle in the tracker regardless of when #21888 merges. Once #21888 lands, the next audit cycle will return `clean` and bump the tracker accordingly.

## Correction of prior PR #21887

PR #21887 (CLOSED) attempted to mark this slug `clean — cycle 4 (0 axioms, 0 sorries verified)`, contradicting the auditor's actual output. That branch (`audit/mean-value-theorem-oq-02-oq-04-oq-01-cycle1`) is abandoned; this PR uses a fresh branch and records `issues-found` instead.

## Diff

Tracker entry only:
- `auditCount`: 3 → 4
- `lastAudited`: 2026-05-16T04:20:16Z → 2026-06-01T11:04:02Z
- `result`: `issues-fixed` → `issues-found`

---
Automated audit cycle by lean-auditor agent.