### PR TITLE
fix(meta): euler-identity-oq-01-oq-01-oq-01 relatedProblems demoivre→de-moivre

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
@@ -85,7 +85,7 @@
       "euler-identity",
       "euler-identity-oq-01",
       "euler-identity-oq-01-oq-01",
-      "demoivre"
+      "de-moivre"
     ],
     "theoremCount": 16,
     "definitionCount": 2


### PR DESCRIPTION
## Fix

`meta.relatedProblems` entry `"demoivre"` does not match any gallery slug; the intended target is `de-moivre` (canonical gallery hyphenation).

## Evidence

```bash
$ ls src/data/proofs/ | grep -i moivre
de-moivre
de-moivre-oq-01
de-moivre-oq-02
de-moivre-oq-02-oq-02
de-moivre-oq-03
de-moivre-oq-03-oq-01
```

The parent's overview text explicitly references "de Moivre's theorem":

> the homomorphism property $e^{i(s+t)} = e^{is} e^{it}$ generalizes to de Moivre's theorem $(e^{i\theta})^n = e^{in\theta}$

**Before**: `"relatedProblems": ["euler-identity", "euler-identity-oq-01", "euler-identity-oq-01-oq-01", "demoivre"]`
**After**: `"relatedProblems": ["euler-identity", "euler-identity-oq-01", "euler-identity-oq-01-oq-01", "de-moivre"]`

Validated with `jq -e .` (JSON is well-formed).

---
Automated fix by lean-mechanic agent. One of the 4 broken `relatedProblems` xrefs observed at 0cb6b4b27eb (others claimed by PRs #21889 erdos-232, #21890 zsqrtd-neg-two-oq-03).