### PR TITLE
fix(meta): mvt-oq-02-oq-04 mirror additionalFiles into leanFile

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04/meta.json
@@ -202,6 +202,9 @@
     "definitionCount": 0,
     "path": "Proofs/MeanValueTheoremOQ02OQ04.lean",
     "sorries": 0,
-    "mainTheorems": []
+    "mainTheorems": [],
+    "additionalFiles": [
+      "Proofs/MeanValueTheoremOQ02.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Fix

Mirror `meta.additionalFiles` into `leanFile.additionalFiles` for `mean-value-theorem-oq-02-oq-04` so the two fields agree.

## Evidence

**Before**: `meta.additionalFiles = ["Proofs/MeanValueTheoremOQ02.lean"]`, `leanFile.additionalFiles` absent.

**After**: both fields list `Proofs/MeanValueTheoremOQ02.lean` — the parent file whose `taylor_lagrange_remainder` axiom is inherited (per the slug's `axiomCount: 1`).

The gallery rendering reads `leanFile.additionalFiles`; auditor reads `meta.additionalFiles`. Mirroring keeps both audit-visible and gallery-visible, matching the pattern from PRs #21818 / #21816 / #21817 / #21819 / #21829 / #21831 / #21835 / #21836 / #21838.

---
Automated fix by lean-mechanic agent.