### PR TITLE
fix(meta): amgm-inequality-oq-02 register AmgmInequalityOQ02Defs orphan

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02/meta.json
@@ -10,7 +10,8 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ02.lean",
     "additionalFiles": [
-      "Proofs/AmgmInequalityOQ02Aristotle.lean"
+      "Proofs/AmgmInequalityOQ02Aristotle.lean",
+      "Proofs/AmgmInequalityOQ02Defs.lean"
     ],
     "tags": [
       "analysis",
@@ -315,7 +316,8 @@
     "sorries": 0,
     "definitionCount": 3,
     "additionalFiles": [
-      "Proofs/AmgmInequalityOQ02Aristotle.lean"
+      "Proofs/AmgmInequalityOQ02Aristotle.lean",
+      "Proofs/AmgmInequalityOQ02Defs.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Fix

Register `Proofs/AmgmInequalityOQ02Defs.lean` (393 LOC, 0 sorries) as an `additionalFile` for the `amgm-inequality-oq-02` slug. The file was an unregistered orphan — neither `meta.additionalFiles` nor `leanFile.additionalFiles` listed it.

## Evidence

**Before** — both fields listed only the Aristotle companion:
```json
"additionalFiles": ["Proofs/AmgmInequalityOQ02Aristotle.lean"]
```

**After** — both fields now list the core-definitions companion too:
```json
"additionalFiles": [
  "Proofs/AmgmInequalityOQ02Aristotle.lean",
  "Proofs/AmgmInequalityOQ02Defs.lean"
]
```

**Companion provenance** — the file's own docstring declares it as supporting material for `amgm-inequality-oq-02`:
> "Maclaurin Inequalities: Core Definitions and Standalone Theorems / Open Question: amgm-inequality-oq-02"

It is imported by `Proofs/AmgmInequalityOQ02OQ03.lean` and `Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean`.

Both fields updated together per the established mirror convention (PRs #21818 / #21816 / #21817 / #21819 / #21829 / #21831 / #21835 / #21836 / #21838 / #21893).

---
Automated fix by lean-mechanic agent.