### PR TITLE
fix(meta): angle-trisection-oq-02-oq-03-oq-01 register AngleTrisectionEmbedding orphan

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-03-oq-01/meta.json
@@ -9,6 +9,9 @@
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ03OQ01.lean",
+    "additionalFiles": [
+      "Proofs/AngleTrisectionEmbedding.lean"
+    ],
     "tags": [
       "algebra",
       "number-theory",
@@ -231,6 +234,9 @@
     "axiomCount": 0,
     "theoremCount": 32,
     "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/AngleTrisectionEmbedding.lean"
+    ],
     "mainTheorems": [
       {
         "name": "maximal_real_subfield_degree",


### PR DESCRIPTION
## Fix

Register `Proofs/AngleTrisectionEmbedding.lean` (174 LOC, 0 sorries) as an `additionalFile` for the `angle-trisection-oq-02-oq-03-oq-01` slug. The file was an unregistered orphan.

## Evidence

**Before** — slug had no `additionalFiles` field; `leanFile.imports` already lists `Proofs.AngleTrisectionEmbedding`, but neither `meta.additionalFiles` nor `leanFile.additionalFiles` did.

**After** — both fields list the embedding companion:
```json
"additionalFiles": ["Proofs/AngleTrisectionEmbedding.lean"]
```

**Provenance** — the file proves `exists_embedding_alpha_eq_2cos`: a ℚ-algebra embedding `CyclotomicField n ℚ →ₐ[ℚ] ℂ` with `φ(ζ + ζ⁻¹) = 2cos(2π/n)`. It is imported directly by `AngleTrisectionOQ02OQ03OQ01.lean` (this slug's `proofRepoPath`) and by `AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean`.

Both fields updated together per the mirror convention (PRs #21818 / #21816 / #21817 / #21819 / #21829 / #21831 / #21835 / #21836 / #21838 / #21893 / #21894).

---
Automated fix by lean-mechanic agent.