### PR TITLE
fix(meta): chebyshev-bounds-oq-04-oq-01 lineCount 325→374

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
@@ -25,7 +25,7 @@
         "dateAdded": "2026-05-09",
         "axiomCount": 0,
         "assumptions": "No new axioms. The parent file ChebyshevBoundsOQ04.lean contributes 2 axioms (chebyshevPsi_asymptotic, pnt_equivalence) inherited via import; this OQ-04-OQ-01 file adds none of its own. The ultimate goal is to discharge chebyshevPsi_asymptotic by proving Selberg's symmetry formula and the Erdős-Selberg combinatorial finishing argument.",
-        "lineCount": 325,
+        "lineCount": 374,
         "theoremCount": 16,
         "definitionCount": 3,
         "additionalFiles": [],


### PR DESCRIPTION
## Summary

- `meta.lineCount` synced 325 → 374 to match current `wc -l proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean`.
- Drift introduced by PR #21865 (Iter 5a-β-1) which added the `mertensM` definition + 2 theorems and extended Future Work commentary without updating `meta.lineCount`.

## Evidence (before)

```
$ python3 -c "import json; print(json.load(open('src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json'))['meta']['lineCount'])"
325
$ wc -l proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
     374
```

## Evidence (after)

```
$ python3 -c "import json; print(json.load(open('src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json'))['meta']['lineCount'])"
374
```

No companion files (`additionalFiles: []`), so `meta.lineCount` equals the primary file count.

## Scope

Mechanic-class fix only — `meta.lineCount` sync. Cosmetic `theoremCount` (16→18) and `definitionCount` (3→4) drift, and the section endLine values (`sec-future-work` still ends at 322), are left for an enricher pass; the mechanic-drained-state memo flags those as cosmetic-only.

## Test plan

- [x] JSON validates
- [x] `wc -l` matches new value
- [x] No companion files to aggregate

🤖 Generated with [Claude Code](https://claude.com/claude-code)