### PR TITLE
fix(meta): brouwer-fixed-point-oq-02 register BrouwerFixedPointOQ02Stability orphan

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -9,6 +9,9 @@
     "date": "2009",
     "status": "verified",
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ02.lean",
+    "additionalFiles": [
+      "Proofs/BrouwerFixedPointOQ02Stability.lean"
+    ],
     "tags": [
       "topology",
       "fixed-point-theory",
@@ -224,7 +227,10 @@
     "theoremCount": 13,
     "definitionCount": 5,
     "path": "Proofs/BrouwerFixedPointOQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/BrouwerFixedPointOQ02Stability.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register \`Proofs/BrouwerFixedPointOQ02Stability.lean\` (197 LOC, 0 sorries) as an \`additionalFile\` for the \`brouwer-fixed-point-oq-02\` slug. The file was an unregistered orphan.

## Evidence

**Before** — slug had no \`additionalFiles\` field in either \`meta\` or \`leanFile\`.

**After** — both fields list the stability companion:
\`\`\`json
\"additionalFiles\": [\"Proofs/BrouwerFixedPointOQ02Stability.lean\"]
\`\`\`

**Provenance** — the file's own docstring declares it as \"Brouwer Fixed Point OQ-02: Stability and Averaged Iteration / Fixed Point Stability Under Perturbation and Krasnoselskii-Mann Damping\". It proves four results (0 sorries):
1. Fixed-point stability under δ-perturbation (≤ δ/(1−L))
2. Krasnoselskii-Mann averaged iteration T(x) = (1−t)x + t·f(x) preserves self-mapping and Lipschitz constant (1−t+tL)
3. Geometric decay lemma for monotone sequences
4. Parametric family sensitivity

Both fields updated together per the mirror convention (PRs #21818 / #21816 / #21817 / #21819 / #21829 / #21831 / #21835 / #21836 / #21838 / #21893 / #21894 / #21895).

---
Automated fix by lean-mechanic agent.