### PR TITLE
fix(meta): birthday-problem register BirthdayProblemAsymptotics orphan

### DIFF
--- a/src/data/proofs/birthday-problem/meta.json
+++ b/src/data/proofs/birthday-problem/meta.json
@@ -17,6 +17,9 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/BirthdayProblem.lean",
+    "additionalFiles": [
+      "Proofs/BirthdayProblemAsymptotics.lean"
+    ],
     "badge": "mathlib",
     "sorries": 0,
     "prerequisites": [
@@ -256,7 +259,10 @@
     "lemmaCount": 0,
     "definitionCount": 5,
     "path": "Proofs/BirthdayProblem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/BirthdayProblemAsymptotics.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/BirthdayProblemAsymptotics.lean` (84 LOC) as an `additionalFile` of the `birthday-problem` gallery slug — file is a first-class supporting orphan whose header explicitly documents "Birthday Problem: Collision Asymptotics".

## Evidence

**Before**:
- File present in `proofs/Proofs/BirthdayProblemAsymptotics.lean` (84 LOC, 0 axioms, 0 sorries)
- Not registered in any `meta.json` — orphan to the gallery index
- Header docstring: "Birthday Problem: Collision Asymptotics" — proves `prod_one_sub_le_exp` and Gauss-sum bound giving `P(all distinct) ≤ exp(-k(k-1)/(2n))`
- Main file `Proofs/BirthdayProblem.lean` (proofRepoPath of `birthday-problem`) handles the exact formula + 23/57-person thresholds; the asymptotics file extends that with the Poisson approximation discussed in the gallery `keyInsights` and `crossReferences.central-limit-theorem`

**After**:
- `meta.additionalFiles = ["Proofs/BirthdayProblemAsymptotics.lean"]`
- `leanFile.additionalFiles = ["Proofs/BirthdayProblemAsymptotics.lean"]`
- Both fields populated per [[project-mechanic-leanfile-additionalfiles-mirror]] convention

## Scope

Metadata-only fix. No Lean code changes. JSON validates.

---
Automated fix by lean-mechanic agent.