### PR TITLE
fix(meta): wolstenholme-theorem register WolstenholmeTheoremOQ02 orphan

### DIFF
--- a/src/data/proofs/wolstenholme-theorem/meta.json
+++ b/src/data/proofs/wolstenholme-theorem/meta.json
@@ -8,6 +8,9 @@
     "date": "1862",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/WolstenholmeTheorem.lean",
+    "additionalFiles": [
+      "Proofs/WolstenholmeTheoremOQ02.lean"
+    ],
     "tags": [
       "number-theory",
       "binomial-coefficients",
@@ -160,7 +163,10 @@
       }
     ],
     "path": "Proofs/WolstenholmeTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/WolstenholmeTheoremOQ02.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/WolstenholmeTheoremOQ02.lean` as an `additionalFile` of the `wolstenholme-theorem` slug in both `meta.additionalFiles` and `leanFile.additionalFiles`.

## Evidence

The filename suggests slug `wolstenholme-theorem-oq-02`, but the file is in fact a supporting companion for the parent `wolstenholme-theorem` slug:

- `Proofs/WolstenholmeTheorem.lean` (the slug's `proofRepoPath`) line 31: `import Proofs.WolstenholmeTheoremOQ02`
- The orphan proves Babbage's lemma — `C(2p-1, p-1) ≡ 1 (mod p²)` for prime `p ≥ 3` — which the main file's docstring explicitly cites as "Proves Babbage's weaker result C(2p-1, p-1) ≡ 1 (mod p²) for p ≥ 3"
- The slug `wolstenholme-theorem-oq-02` has its own canonical `proofRepoPath: Proofs/WolstenholmePrimeMod4.lean` — the orphan does not belong there
- Stats: 144 LOC, 12 theorems, 1 definition, 0 sorries, 0 axioms

**Before**: `WolstenholmeTheoremOQ02.lean` was an orphan — not registered in any gallery entry's `additionalFiles` despite being imported by the canonical Wolstenholme proof file.
**After**: registered in both `meta.additionalFiles` and `leanFile.additionalFiles` of `wolstenholme-theorem`.

Resolves one of the four deferred name-mismatch orphan candidates from prior mechanic scans.

---
Automated fix by lean-mechanic agent.