### PR TITLE
fix(meta): amgm-inequality-oq-03-oq-02-oq-01-oq-01 register AmgmInequalityOQ03OQ02OQ01 orphan

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-03-oq-02-oq-01-oq-01/meta.json
@@ -8,6 +8,9 @@
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean",
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    ],
     "tags": [
       "real-analysis",
       "power-mean",
@@ -119,7 +122,10 @@
     "path": "Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean",
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 5
+    "theoremCount": 5,
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ03OQ02OQ01.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register \`Proofs/AmgmInequalityOQ03OQ02OQ01.lean\` as an \`additionalFile\` of slug \`amgm-inequality-oq-03-oq-02-oq-01-oq-01\` in both \`meta.additionalFiles\` and \`leanFile.additionalFiles\`.

## Evidence

The orphan was a deferred name-mismatch candidate: its filename matches sibling slug \`amgm-inequality-oq-03-oq-02-oq-01\`, but that slug's canonical \`proofRepoPath\` is \`Proofs/PowerMeanCrossZeroOQ.lean\` (a cleaner parallel rewrite via direct AM-GM, 225 LOC). The orphan represents the earlier formalization (186 LOC, 12 theorems, 1 def) which is still imported and extended by slug \`amgm-inequality-oq-03-oq-02-oq-01-oq-01\`:

- \`Proofs/AmgmInequalityOQ03OQ02OQ01OQ01.lean\` (the slug's \`proofRepoPath\`):
  - line 40: \`import Proofs.AmgmInequalityOQ03OQ02OQ01\`
  - line 37 (docstring): \`"Parent: AmgmInequalityOQ03OQ02OQ01.lean (crossing-zero case + power_mean_monotone_all)"\`
- The OQ01OQ01 file uses \`power_mean_monotone_mixed\` from the orphan to build the unified extended power mean theorem

**Before**: \`AmgmInequalityOQ03OQ02OQ01.lean\` was an orphan despite being directly imported by a slug's \`proofRepoPath\`.
**After**: registered as additionalFile of the importing slug.

Resolves one of the four deferred name-mismatch orphan candidates from prior mechanic scans.

---
Automated fix by lean-mechanic agent.