### PR TITLE
fix(meta): chinese-remainder-constructive-oq-04-oq-03 register ChineseRemainderConstructiveOQ04OQ03 orphan

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
@@ -8,6 +8,9 @@
     "date": "1952",
     "status": "verified",
     "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeList.lean",
+    "additionalFiles": [
+      "Proofs/ChineseRemainderConstructiveOQ04OQ03.lean"
+    ],
     "tags": [
       "number-theory",
       "modular-arithmetic",
@@ -150,7 +153,10 @@
     "theoremCount": 10,
     "definitionCount": 5,
     "path": "Proofs/ChineseRemainderNonCoprimeList.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/ChineseRemainderConstructiveOQ04OQ03.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/ChineseRemainderConstructiveOQ04OQ03.lean` as `additionalFile` of the `chinese-remainder-constructive-oq-04-oq-03` slug in both `meta.additionalFiles` and `leanFile.additionalFiles`.

## Evidence

**Before**:
- `meta.additionalFiles`: `null`
- `leanFile.additionalFiles`: absent
- File `Proofs/ChineseRemainderConstructiveOQ04OQ03.lean` is an unregistered orphan (only importer is the `AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` hub)

**After**: both fields list `["Proofs/ChineseRemainderConstructiveOQ04OQ03.lean"]`.

## Why this slug

The orphan file's docstring opens with:

> Chinese Remainder Theorem — Weakening Coprimality (OQ-04-OQ-03)
>
> This file references the complete proofs in `ChineseRemainderNonCoprimeList.lean`

The slug `chinese-remainder-constructive-oq-04-oq-03` has `proofRepoPath: Proofs/ChineseRemainderNonCoprimeList.lean` (the underlying machinery file). The orphan is the OQ-04-OQ-03 gloss/statement layer that the docstring puts on top of that machinery — natural additionalFile of the same slug. (The filename suggests `chinese-remainder-constructive-oq-04-oq-03`, which matches the actual slug — clean name-correspondence case.)

## Stats

99 LOC, 0 sorries, 0 axioms — no audit count change.
- Slug status before: `verified`, sorries 0, axiomCount 0
- After registration: still `verified`, sorries 0, axiomCount 0 (auditor will see same totals)

## Source

Resolves one of the deferred name-mismatch orphan candidates from the broader non-Aristotle orphan scan ([[project-mechanic-non-aristotle-companion-orphans]] memory).

---
Automated fix by lean-mechanic agent.