### PR TITLE
fix(meta): bounded-prime-gaps register Sieve+TPC orphan companions

### DIFF
--- a/src/data/proofs/bounded-prime-gaps/meta.json
+++ b/src/data/proofs/bounded-prime-gaps/meta.json
@@ -9,6 +9,10 @@
     "date": "2026",
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BoundedPrimeGaps.lean",
+    "additionalFiles": [
+      "Proofs/BoundedPrimeGapsSieve.lean",
+      "Proofs/BoundedPrimeGapsTPC.lean"
+    ],
     "tags": [
       "number-theory",
       "primes",
@@ -317,7 +321,11 @@
     "theoremCount": 128,
     "definitionCount": 17,
     "path": "Proofs/BoundedPrimeGaps.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/BoundedPrimeGapsSieve.lean",
+      "Proofs/BoundedPrimeGapsTPC.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register two orphan companion files for the `bounded-prime-gaps` slug:

- `Proofs/BoundedPrimeGapsSieve.lean` — Maynard-Tao sieve reduction framework + dense cluster analysis (Part I + II of the file docstring); 367 LOC, 0 axioms, 0 sorries.
- `Proofs/BoundedPrimeGapsTPC.lean` — Twin Prime Conjecture index-value bridge (`nthPrime_surjective`, `twin_primes_are_consecutive`, `tpc_iff_twin_prime_pairs`); 281 LOC, 0 axioms, 0 sorries.

Both files extend the primary `Proofs/BoundedPrimeGaps.lean` and were previously unreferenced from any gallery slug — orphans visible only to importers `AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean` and each other.

## Evidence

**Before**:
- `meta.additionalFiles`: absent
- `leanFile.additionalFiles`: absent
- Both `BoundedPrimeGapsSieve.lean` and `BoundedPrimeGapsTPC.lean` are unregistered orphans

**After**: both fields list both files in string form (auditor string-only convention).

## Audit impact

- `axiomCount`: stays at **3** (both companions are 0-axiom).
- `sorries`: stays at **0** (both companions are 0-sorry).
- `status: axiomatized` unchanged.
- `theoremCount` / `definitionCount`: cosmetic drift only per [[project-mechanic-drained-state-2026-06-01]] memory; not updated.

## Why this slug

The slug `bounded-prime-gaps` already covers Polymath 8b (246 bound), Zhang (70M), Maynard-Tao, and twin prime consequences. Both orphans are direct continuations:

- `BoundedPrimeGapsSieve.lean` explicitly references `BoundedPrimeGaps.lean`'s `maynard_tao_sieve` / `maynard_tao_sieve_eh` sieve axioms and derives the 246 and EH-12 bounds from them.
- `BoundedPrimeGapsTPC.lean` explicitly closes a gap that `BoundedPrimeGaps.lean` notes under "What's NOT Proven": the full equivalence between `TwinPrimeConjecture` (index quantification) and twin prime pairs (value quantification).

No sibling slug is a better fit — file names contain no `OQ` markers and don't match any sub-slug (`bounded-prime-gaps-oq-01`, `-oq-03`, `-oq-04` etc. exist but none for Sieve/TPC themes).

## Source

Resolves two of the non-Aristotle companion orphans surfaced in the broader scan ([[project-mechanic-non-aristotle-companion-orphans]] memory).

---
Automated fix by lean-mechanic agent.