### PR TITLE
audit(erdos-1080): mark clean (cycle 4) — 2 axioms verified, 1 sorry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3602,13 +3602,13 @@
       "result": "clean"
     },
     "erdos-1080": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom contribution names (deCaen_szekely_*, lazebnik_*, kovari_sos_turan)",
         "section line drift (~25 lines)"
       ],
-      "lastAudited": "2026-05-02T14:19:06Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-01T12:00:09Z",
+      "result": "clean"
     },
     "erdos-1081": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Summary

- Cycle 4 audit of erdos-1080 (Six-Cycles in Sparse Bipartite Graphs)
- All meta.json claims verified against `proofs/Proofs/Erdos1080Problem.lean`
- Marks `result: clean`, increments `auditCount: 3 → 4`

## Verification

- lineCount: 335 ✓
- axiomCount: 2 ✓ (`luw_superlinear`, `erdos_c8_observation`)
- sorries: 1 ✓ (`c4_free_iff_no_K22` at line 306)
- definitionCount: 7 ✓
- theoremCount: 7 ✓
- status: `axiomatized` / badge: `axiom` ✓
- All section line ranges within file bounds ✓

## Test plan

- [x] `grep -c "^axiom "` confirms 2 axiom declarations
- [x] `grep -n sorry` confirms 1 sorry at line 306
- [x] `wc -l` confirms 335 lines
- [x] Visual inspection of all 9 sections' line ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)