### PR TITLE
audit(erdos-1103): mark clean (cycle 4) — 1 axiom, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3819,9 +3819,9 @@
     },
     "erdos-1103": {
       "agentId": "auditor-loop-1777730687",
-      "auditCount": 3,
-      "lastAudited": "2026-05-02T14:07:56Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-01T12:06:02Z",
+      "result": "clean",
       "issues": [
         "Phantom-axiom narrative: proofStrategy/sections claim 3 axioms (van Doorn–Tao upper/lower + Konyagin) but only vanDoorn_tao_upper exists; basic-properties says \"Axiomatizes the singleton characterization\" but it is a proved theorem; orphaned docstrings at lines 70-71 and 72-73; section line drift — basic-properties ends at 92 but file has 162 lines (squarefreeSumset_pair, subexp_eventually_lt_exp, erdos_1103_false uncovered). Issue #14812."
       ]


### PR DESCRIPTION
## Audit Result: clean

**Proof**: erdos-1103 (Squarefree Sumsets)
**Cycle**: 4 (prior audits: 3x, last 2026-05-02 result=issues-fixed)

## Verification

All meta.json counts match Lean source at `proofs/Proofs/Erdos1103Problem.lean`:

| Field | Claim | Actual | Result |
|-------|-------|--------|--------|
| axiomCount | 1 | 1 (vanDoorn_tao_upper @ line 65) | ✓ |
| sorries | 0 | 0 | ✓ |
| theoremCount | 9 | 9 | ✓ |
| definitionCount | 3 | 3 (SquarefreeSumset, enumSet, ErdosProblem1103) | ✓ |
| lineCount | 162 | 162 | ✓ |
| sections endLines | ≤162 | all within bounds | ✓ |

**Status/badge**: `axiomatized` / `axiom` correctly reflects the 2025 vanDoorn–Tao upper-bound axiom, which refutes Erdős's exponential-growth conjecture. Assumptions field accurately states "1 axiom: vanDoorn_tao_upper. 0 sorries."

## Audit Notes

Prior cycle (2026-05-02) flagged phantom-axiom narrative & section drift; both have been resolved upstream. Current file structure cleanly aligns with documented sections (header/imports/definitions/conjecture/upper-bound/lower-bound/konyagin/basic-properties/refutation).

---
Discovered during gallery integrity audit cycle.