### PR TITLE
fix(meta): area-of-circle-oq-01-oq-03 mainTheorems line drift

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03/meta.json
@@ -281,37 +281,37 @@
       {
         "name": "isoperimetric_inequality_smooth",
         "statement": "For any SmoothClosedCurve γ, 4π · area(γ) ≤ circumference(γ)²",
-        "line": 1113
+        "line": 1572
       },
       {
         "name": "wirtinger_inequality",
         "statement": "For smooth mean-zero 2π-periodic f: ∫₀²π f² ≤ ∫₀²π (f')²",
-        "line": 643
+        "line": 645
       },
       {
         "name": "equality_implies_circle",
         "statement": "If 4πA = C² then the curve is a circle (C = 2πr, A = πr² for r = C/(2π))",
-        "line": 1253
+        "line": 1713
       },
       {
         "name": "circle_isoperimetric_equality",
         "statement": "For a circle: (2πr)² = 4π · πr²",
-        "line": 102
+        "line": 109
       },
       {
         "name": "ngon_limit_tendsto_circle",
         "statement": "Regular n-gon isoperimetric ratio π/(n·tan(π/n)) → 1 as n → ∞",
-        "line": 219
+        "line": 226
       },
       {
         "name": "parseval_periodic_real",
         "statement": "Parseval's identity: ∫₀²π f² = 2π · Σ ‖ĉₙ‖² for periodic C¹ functions",
-        "line": 350
+        "line": 358
       },
       {
         "name": "fourier_decomposition",
         "statement": "Fourier decomposition with Parseval + derivative identity for periodic C¹ functions",
-        "line": 526
+        "line": 528
       }
     ],
     "path": "Proofs/AreaOfCircleOQ01OQ03.lean",


### PR DESCRIPTION
## Fix

7 `mainTheorems[].line` entries in `area-of-circle-oq-01-oq-03/meta.json` pointed at stale positions in `Proofs/AreaOfCircleOQ01OQ03.lean`.

Re-grep of `^theorem <name>`:

| Theorem | Stale | Actual |
|---|---:|---:|
| `isoperimetric_inequality_smooth` | 1113 | 1572 |
| `wirtinger_inequality`            |  643 |  645 |
| `equality_implies_circle`         | 1253 | 1713 |
| `circle_isoperimetric_equality`   |  102 |  109 |
| `ngon_limit_tendsto_circle`       |  219 |  226 |
| `parseval_periodic_real`          |  350 |  358 |
| `fourier_decomposition`           |  526 |  528 |

## Evidence

```
$ grep -n "^theorem \(isoperimetric_inequality_smooth\|wirtinger_inequality\|equality_implies_circle\|circle_isoperimetric_equality\|ngon_limit_tendsto_circle\|parseval_periodic_real\|fourier_decomposition\) " proofs/Proofs/AreaOfCircleOQ01OQ03.lean
109:theorem circle_isoperimetric_equality (r : ℝ) :
226:theorem ngon_limit_tendsto_circle :
358:theorem parseval_periodic_real (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
528:theorem fourier_decomposition (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
645:theorem wirtinger_inequality (f : ℝ → ℝ) (hf : ContDiff ℝ 1 f)
1572:theorem isoperimetric_inequality_smooth (γ : SmoothClosedCurve)
1713:theorem equality_implies_circle (γ : SmoothClosedCurve)
```

Metadata-only — primary file unchanged.

---
Automated fix by lean-mechanic agent.