### PR TITLE
fix(meta): ballot-problem-oq-03 mainTheorems line drift

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -324,7 +324,7 @@
     "mainTheorems": [
       {
         "name": "lgv_lemma_2x2",
-        "line": 2834,
+        "line": 2878,
         "statement": "The 2x2 LGV Lemma: niPairCount equals lgvDet under proper source/target ordering (a1 <= a2, b1 <= b2)",
         "description": "Core result. The count of non-intersecting lattice path pairs equals the 2x2 determinant of binomial path counts. Proved via complement counting and the Lindstrom involution bijection."
       },
@@ -342,7 +342,7 @@
       },
       {
         "name": "lindstrom_involution",
-        "line": 2803,
+        "line": 2847,
         "statement": "Dual injections between intersecting identity pairs and crossing pairs yield equal cardinalities",
         "description": "The Lindstrom sign-reversing involution: swapping suffixes at the canonical shared point bijects intersecting identity pairs with all crossing pairs."
       },
@@ -378,7 +378,7 @@
       },
       {
         "name": "lgvDet_nonneg",
-        "line": 2872,
+        "line": 2916,
         "statement": "0 <= lgvDet(m, a1, b1, a2, b2) under proper ordering",
         "description": "Non-negativity of the LGV determinant follows from the LGV lemma since it counts non-intersecting path pairs."
       }


### PR DESCRIPTION
## Fix

3 `mainTheorems[].line` entries in `ballot-problem-oq-03/meta.json` pointed at stale positions in `Proofs/BallotProblemOQ03.lean`. All drifted by exactly +44 (lines added in the file's terminal region without a metadata refresh).

| Theorem               | Stale | Actual |
|-----------------------|------:|-------:|
| `lgv_lemma_2x2`       | 2834  | 2878   |
| `lindstrom_involution`| 2803  | 2847   |
| `lgvDet_nonneg`       | 2872  | 2916   |

The other 7 entries (`crossing_lemma`, `path_count_eq_choose`, `ballot_formula`, `catalan_formula`, `catalan_eq_ballot`, `vandermonde`, `choose_symm_via_paths`) are correctly placed.

## Evidence

```
$ grep -n "^theorem \(lgv_lemma_2x2\|lindstrom_involution\|lgvDet_nonneg\) " \
    proofs/Proofs/BallotProblemOQ03.lean
2847:theorem lindstrom_involution (m n₁ n₂ n₁' n₂' a₁ a₂ : ℕ)
2878:theorem lgv_lemma_2x2 (m a₁ b₁ a₂ b₂ : ℕ)
2916:theorem lgvDet_nonneg (m a₁ b₁ a₂ b₂ : ℕ)
```

Metadata-only — primary file unchanged.

---
Automated fix by lean-mechanic agent.