### PR TITLE
fix(meta): picks-theorem-oq-03 register PicksTheoremOQ03.lean orphan companion

### DIFF
--- a/src/data/proofs/picks-theorem-oq-03/meta.json
+++ b/src/data/proofs/picks-theorem-oq-03/meta.json
@@ -64,11 +64,12 @@
     ],
     "dateAdded": "2026-03-06",
     "additionalFiles": [
-      "Proofs/PicksTheoremOQ03CrossPoly.lean"
+      "Proofs/PicksTheoremOQ03CrossPoly.lean",
+      "Proofs/PicksTheoremOQ03.lean"
     ],
-    "axiomCount": 2,
+    "axiomCount": 3,
     "lineCount": 710,
-    "assumptions": "2 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change).",
+    "assumptions": "3 axioms: ehrhart_is_polynomial (Ehrhart counting function is polynomial), ehrhart_macdonald_reciprocity (interior count via sign-change), and ehrhart_fn (Ehrhart counting function as a typed primitive, declared in PicksTheoremOQ03.lean for the d=2 Pick's-theorem specialization).",
     "mathlib_version": "4.26.0",
     "theoremCount": 45,
     "definitionCount": 23
@@ -240,6 +241,15 @@
         "axioms": 0,
         "sorries": 0,
         "description": "Cross-polytope (hyperoctahedron) Ehrhart theory: polynomials, reciprocity, h*-vectors, duality"
+      },
+      {
+        "path": "Proofs/PicksTheoremOQ03.lean",
+        "lineCount": 437,
+        "theorems": 19,
+        "definitions": 6,
+        "axioms": 1,
+        "sorries": 0,
+        "description": "d=2 Pick's-theorem specialization of Ehrhart theory: ehrhart_fn primitive, polygon_2d / unit-simplex / unit-cube / reeve-tetrahedra concrete instances, and reciprocity-recovers-Picks check"
       }
     ]
   }


### PR DESCRIPTION
## Fix

Register the 437-line `Proofs/PicksTheoremOQ03.lean` orphan companion in both `meta.additionalFiles` (string — auditor-visible) and `leanFile.additionalFiles` (rich object — renderer). Sync `axiomCount` 2 → 3 to reflect the now-visible `ehrhart_fn` axiom.

## Evidence

**Before**:
- `proofs/Proofs/PicksTheoremOQ03.lean` (437 lines, namespace `PicksTheoremOQ03`, 1 axiom `ehrhart_fn`, 19 theorems, 6 defs, 0 sorries) was an orphan — not listed in any `meta.json`.
- `picks-theorem-oq-03` slug only registered the main file `EhrhartPolynomialOQ03.lean` (`leanFile.path`) and `PicksTheoremOQ03CrossPoly.lean` (companion).
- `meta.axiomCount: 2`; `assumptions` mentioned only `ehrhart_is_polynomial` + `ehrhart_macdonald_reciprocity`.

**After**:
- Both `meta.additionalFiles` and `leanFile.additionalFiles` now include `Proofs/PicksTheoremOQ03.lean` (string form in meta per the swap convention adopted in #21863; rich object form in leanFile mirroring the existing CrossPoly entry).
- `meta.axiomCount` bumped to 3 and `assumptions` text now lists all three axioms (`ehrhart_is_polynomial`, `ehrhart_macdonald_reciprocity`, `ehrhart_fn`).
- Legacy parallel field `meta.axioms: 3` (top of meta block) was already correct — this PR brings the canonical `axiomCount` into alignment.

Slug status (`axiomatized`, badge `axiom`) unchanged — the file was already axiomatized, this just exposes one more axiom that was already mathematically in the slug's inventory.

---
Automated fix by lean-mechanic agent.