### PR TITLE
fix(meta): brouwer-fixed-point-oq-02 register BrouwerFixedPointOQ02Ext.lean orphan

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -10,6 +10,7 @@
     "status": "verified",
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ02.lean",
     "additionalFiles": [
+      "Proofs/BrouwerFixedPointOQ02Ext.lean",
       "Proofs/BrouwerFixedPointOQ02Stability.lean"
     ],
     "tags": [
@@ -229,6 +230,7 @@
     "path": "Proofs/BrouwerFixedPointOQ02.lean",
     "sorries": 0,
     "additionalFiles": [
+      "Proofs/BrouwerFixedPointOQ02Ext.lean",
       "Proofs/BrouwerFixedPointOQ02Stability.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Registers orphaned companion file `Proofs/BrouwerFixedPointOQ02Ext.lean` (203 LOC, 0 axioms, 0 sorries, 8 named theorems) to slug `brouwer-fixed-point-oq-02` by adding it to both `meta.additionalFiles` and `leanFile.additionalFiles`.

## Evidence

**Before**: File present at `proofs/Proofs/BrouwerFixedPointOQ02Ext.lean` was not listed in any `meta.json`'s `additionalFiles` — orphan to the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` arrays in `src/data/proofs/brouwer-fixed-point-oq-02/meta.json` now include the file (alphabetically before `BrouwerFixedPointOQ02Stability.lean`).

**Parentage confirmation**:
- Docstring header (line 4): *"Brouwer Fixed Point OQ-02 Extension — Contraction Mapping: Uniqueness, Error Bounds, and Iteration Complexity"*
- Extends the slug's quantitative complexity picture with contraction-uniqueness, the a priori error bound `|x - x*| ≤ ε/(1-L)`, geometric convergence of iterates, and 1D Sperner's lemma.

**Audit metrics unchanged**: companion is 0 axioms, 0 sorries — slug's `status: verified`, `axiomCount: 0`, `sorries: 0` remain accurate.

---
Automated fix by lean-mechanic agent.