### PR TITLE
fix(meta): cevas-theorem-oq-02 register CevasTheoremSinRatio.lean orphan

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-02/meta.json
@@ -9,6 +9,9 @@
     "date": "1678",
     "status": "verified",
     "proofRepoPath": "Proofs/CevasTheoremOQ02.lean",
+    "additionalFiles": [
+      "Proofs/CevasTheoremSinRatio.lean"
+    ],
     "tags": [
       "geometry",
       "non-euclidean",
@@ -158,7 +161,10 @@
     "theoremCount": 22,
     "definitionCount": 11,
     "path": "Proofs/CevasTheoremOQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CevasTheoremSinRatio.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Registers orphaned companion file `Proofs/CevasTheoremSinRatio.lean` (145 LOC, 0 axioms, 0 sorries) to slug `cevas-theorem-oq-02` by adding it to both `meta.additionalFiles` and `leanFile.additionalFiles`.

## Evidence

**Before**: File present at `proofs/Proofs/CevasTheoremSinRatio.lean` was not listed in any `meta.json`'s `additionalFiles` — orphan to the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` arrays in `src/data/proofs/cevas-theorem-oq-02/meta.json` now include the file.

**Parentage confirmation**:
- Docstring header (line 9): *"Spherical Ceva: The Sin-Ratio Formula for Unit Vectors"*
- Self-declared role (lines 22–29): *"This bridges the algebraic spherical Ceva (CevasTheoremOQ02.lean) with a vector-geometric proof"* — supplies `sin(arcDist B D) / sin(arcDist D C) = β/α` in any real inner product space (no Riemannian manifolds), which is the algebraic ingredient the OQ-02 spherical Ceva proof relies on.
- Namespace `CevasTheoremSinRatio` — no conflict with parent's anonymous top-level namespace.

**Audit metrics unchanged**: companion is 0 axioms, 0 sorries — slug's `status: verified`, `axiomCount: 0`, `sorries: 0` remain accurate.

---
Automated fix by lean-mechanic agent.