### PR TITLE
fix(meta): tractatus-ontology register TractatusOntologySpectrum.lean orphan

### DIFF
--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -16,7 +16,8 @@
     "additionalFiles": [
       "Proofs/TractatusQuantifiers.lean",
       "Proofs/TractatusOntologyHorn.lean",
-      "Proofs/TractatusOntologyEquiv.lean"
+      "Proofs/TractatusOntologyEquiv.lean",
+      "Proofs/TractatusOntologySpectrum.lean"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -302,6 +303,15 @@
         "axioms": 0,
         "sorries": 0,
         "description": "T1b tier (tractatus-ontology-oq-06): EquivModel constructor for biconditional-constrained worlds, structural iso witnessing T1b ⊆ T1a-symmetric (cs ++ cs.map Prod.swap), refinement into T1a sharing the constraint list, and biconditional-tier independence-failure theorem."
+      },
+      {
+        "path": "Proofs/TractatusOntologySpectrum.lean",
+        "lineCount": 307,
+        "theorems": 19,
+        "definitions": 4,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "World-model refinement preorder (S2-α, OQ-06): Refines relation, refl/trans/freeModel-is-maximum, evaluation/tautology/contradiction pullback along refinements."
       }
     ]
   },


### PR DESCRIPTION
## Fix

Registers orphaned companion file `Proofs/TractatusOntologySpectrum.lean` (307 LOC, 0 axioms, 0 sorries, 19 theorems, 4 definitions) to slug `tractatus-ontology` by adding it to both `meta.additionalFiles` (string form) and `leanFile.additionalFiles` (rich-object form, matching the existing TractatusQuantifiers.lean schema convention).

## Evidence

**Before**: File present at `proofs/Proofs/TractatusOntologySpectrum.lean` was not listed in any `meta.json`'s `additionalFiles` — orphan to the gallery.

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` arrays in `src/data/proofs/tractatus-ontology/meta.json` now include the file (alphabetically before `TractatusQuantifiers.lean`).

**Parentage confirmation**:
- `import Proofs.TractatusOntology` (line 1) — true companion, not a sibling proof.
- Same namespace `Tractatus` as parent — extends parent's API.
- Docstring header (line 4): *"Tractatus World-Model Spectrum (S2-α)"*
- Self-declared role (lines 6-7): *"Companion to TractatusOntology.lean addressing the open question tractatus-ontology-oq-06"* — installs the refinement preorder on `WorldModel S`, proves `freeModel S` is its maximum, and provides evaluation / tautology / contradiction pullback along refinements.

**Audit metrics unchanged**: companion is 0 axioms, 0 sorries — slug's `status: axiomatized`, `axiomCount: 1`, `sorries: 0` remain accurate.

---
Automated fix by lean-mechanic agent.