### PR TITLE
fix(meta): erdos-44 register Erdos44SidonLowerBound.lean orphan companion

### DIFF
--- a/src/data/proofs/erdos-44/meta.json
+++ b/src/data/proofs/erdos-44/meta.json
@@ -57,7 +57,8 @@
     "theoremCount": 8,
     "definitionCount": 0,
     "additionalFiles": [
-      "Proofs/Erdos44Aristotle.lean"
+      "Proofs/Erdos44Aristotle.lean",
+      "Proofs/Erdos44SidonLowerBound.lean"
     ]
   },
   "overview": {
@@ -148,7 +149,8 @@
     "path": "Proofs/Erdos44Problem.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos44Aristotle.lean"
+      "Proofs/Erdos44Aristotle.lean",
+      "Proofs/Erdos44SidonLowerBound.lean"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Fix

`erdos-44` was missing `Proofs/Erdos44SidonLowerBound.lean` from its `additionalFiles` registration. The primary file `Erdos44Problem.lean` imports `Proofs.Erdos44SidonLowerBound` (line 37) but the file appeared nowhere in any `meta.json` `additionalFiles` list, making it an orphan.

## Evidence

**Before**:
```json
"meta.additionalFiles":    ["Proofs/Erdos44Aristotle.lean"]
"leanFile.additionalFiles":["Proofs/Erdos44Aristotle.lean"]
```

**After**:
```json
"meta.additionalFiles":    ["Proofs/Erdos44Aristotle.lean", "Proofs/Erdos44SidonLowerBound.lean"]
"leanFile.additionalFiles":["Proofs/Erdos44Aristotle.lean", "Proofs/Erdos44SidonLowerBound.lean"]
```

Verification:
- `Erdos44Problem.lean:37`: `import Proofs.Erdos44SidonLowerBound`
- `Proofs/Erdos44SidonLowerBound.lean` exists (291 lines)
- The other custom import (`Proofs.Erdos340GreedySidon`) is already the primary of the `erdos-340-greedy-sidon` gallery slug, so no further registrations needed.

Registered in both `meta.additionalFiles` and `leanFile.additionalFiles` per the canonical mirror convention.

---
Automated fix by lean-mechanic agent.