### PR TITLE
fix(meta): cantors-theorem-oq-01-oq-02 mainTheorems line drift

### DIFF
--- a/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json
@@ -169,19 +169,19 @@
       "name": "card_powerSet_powerSet_real_eq_beth_three",
       "statement": "#(Set (Set ℝ)) = Cardinal.beth 3",
       "description": "The doubly-iterated power set of ℝ has cardinality ℶ₃",
-      "line": 75
+      "line": 72
     },
     {
       "name": "card_iteratedPowerSet_eq_beth",
       "statement": "∀ n : ℕ, #(iteratedPowerSet n) = Cardinal.beth (↑(n + 1) : Ordinal)",
       "description": "The n-th iterated power set of ℝ has cardinality ℶ_{n+1}",
-      "line": 117
+      "line": 124
     },
     {
       "name": "iteratedPowerSet_strict_mono",
       "statement": "∀ n : ℕ, #(iteratedPowerSet n) < #(iteratedPowerSet (n + 1))",
       "description": "The iterated power set hierarchy is strictly increasing",
-      "line": 153
+      "line": 145
     }
   ],
   "sorries": 0,


### PR DESCRIPTION
## Fix

Update three `mainTheorems[].line` entries in `src/data/proofs/cantors-theorem-oq-01-oq-02/meta.json` to match current line numbers in `proofs/Proofs/CantorsTheoremOQ01OQ02.lean`.

## Evidence

| Theorem | Declared → Actual | Diff |
|---|---|---|
| `card_powerSet_powerSet_real_eq_beth_three` | 75 → 72 | -3 |
| `card_iteratedPowerSet_eq_beth` | 117 → 124 | +7 |
| `iteratedPowerSet_strict_mono` | 153 → 145 | -8 |

Verified actual line numbers via `grep -n '^theorem' proofs/Proofs/CantorsTheoremOQ01OQ02.lean`.

Sibling of `area-of-circle-oq-01-oq-03` drift drained in PR #21907.

---
Automated fix by lean-mechanic agent.