### PR TITLE
fix(meta): erdos-25 register Erdos25LogDensity.lean orphan companion

### DIFF
--- a/src/data/proofs/erdos-25/meta.json
+++ b/src/data/proofs/erdos-25/meta.json
@@ -25,7 +25,10 @@
     "assumptions": "3 axioms inherited from Erdos25LogDensity.lean: naturalDensity_implies_logDensity (natural density implies logarithmic density), exists_logDensity_no_naturalDensity (existence of sets with log density but no natural density), davenport_erdos (Davenport-Erdős theorem on log density). 0 own axioms. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Erdos25LogDensity.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős posed this problem in 1995 (reference [Er95]), asking about a fundamental property of sets defined by congruence exclusions. The question connects to a rich tradition in analytic number theory: the study of how sieve-theoretic constructions interact with different notions of density. Logarithmic density, which weights each integer $m$ by $1/m$, is a weaker notion than natural density—it exists more often. For example, the set of integers whose prime factorization has an odd number of factors (related to the Liouville function) has logarithmic density $1/2$ even though its natural density oscillates. The classical sieve of Eratosthenes produces congruence-sieved sets (with prime moduli and residue 0), and the density of primes can be understood through this lens. Erdős's question generalizes this to arbitrary moduli and residues, asking whether the logarithmic density is always well-defined. The problem is a special case of the broader Problem 486, which asks the same question for more general sieve constructions. The key difficulty is that while finite sieves yield periodic sets (whose density trivially exists), infinite sieves can produce sets with complex, non-periodic structure where the limit defining the density may oscillate.",
@@ -156,7 +159,10 @@
     "theoremCount": 11,
     "definitionCount": 7,
     "path": "Proofs/Erdos25Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos25LogDensity.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

`erdos-25` was missing `Proofs/Erdos25LogDensity.lean` from its `additionalFiles` registration. The primary file `Erdos25Problem.lean:16` imports `Proofs.Erdos25LogDensity`, but the file appeared nowhere in any `meta.json` `additionalFiles` list — making it an orphan.

The companion is already referenced in prose elsewhere in this very `meta.json`:

- `meta.assumptions` attributes 3 axioms to it (`naturalDensity_implies_logDensity`, `exists_logDensity_no_naturalDensity`, `davenport_erdos`)
- `meta.overview.proofStrategy` cites "defined constructively via `Erdos25LogDensity.lean`"
- `sections[*].mathContext` references the companion definition of `HasLogDensity`

## Evidence

**Before**:
```json
"meta.additionalFiles":    None
"leanFile.additionalFiles":None
```

**After**:
```json
"meta.additionalFiles":    ["Proofs/Erdos25LogDensity.lean"]
"leanFile.additionalFiles":["Proofs/Erdos25LogDensity.lean"]
```

Verification:
- `Erdos25Problem.lean:16`: `import Proofs.Erdos25LogDensity`
- `proofs/Proofs/Erdos25LogDensity.lean` exists (736 lines)
- The other primary import is `Mathlib.Tactic` (not custom)

Registered in both `meta.additionalFiles` and `leanFile.additionalFiles` per the canonical mirror convention.

---
Automated fix by lean-mechanic agent.