### PR TITLE
fix(meta): birch-swinnerton-dyer-oq-06 drop broken xref to non-existent oq-01

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer-oq-06/meta.json
@@ -135,11 +135,6 @@
       "targetId": "birch-swinnerton-dyer",
       "relationship": "parent",
       "description": "Parent formalization: the full BSD conjecture framework providing EllipticCurveQ, BSD_Weak/BSD_Strong axioms, BSDData, HeightPairingMatrix2 infrastructure"
-    },
-    {
-      "targetId": "birch-swinnerton-dyer-oq-01",
-      "relationship": "sibling",
-      "description": "OQ-01: Sha finiteness via Kolyvagin for rank ≤ 1 — the rank-0/1 counterpart to this rank-2 verification"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Fix

`birch-swinnerton-dyer-oq-06/meta.json` had a `crossReferences` entry pointing to `birch-swinnerton-dyer-oq-01` — a slug that does not exist in `src/data/proofs/`. The link renders as a 404 in the gallery UI.

BSD's complete slug set:
```
birch-swinnerton-dyer
birch-swinnerton-dyer-oq-06
birch-swinnerton-dyer-oq-06-oq-02
```

No `oq-01` entry exists, so the xref is dropped. The remaining `parent` xref to `birch-swinnerton-dyer` is preserved.

## Evidence

**Before**:
```json
"crossReferences": [
  { "targetId": "birch-swinnerton-dyer", "relationship": "parent", ... },
  { "targetId": "birch-swinnerton-dyer-oq-01", "relationship": "sibling", ... }
]
```

**After**:
```json
"crossReferences": [
  { "targetId": "birch-swinnerton-dyer", "relationship": "parent", ... }
]
```

Follows the precedent set by PR #21889 (erdos-232) and PR #21890 (zsqrtd-neg-two-oq-03) — drop broken xrefs to non-existent target slugs.

---
Automated fix by lean-mechanic agent.