### PR TITLE
fix(meta): amgm-inequality-oq-04 register AmgmInequalityOQ04OQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -25,6 +25,9 @@
     "lineCount": 306,
     "theoremCount": 22,
     "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/AmgmInequalityOQ04OQ01.lean"
+    ],
     "assumptions": "0 axioms in this parent file (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the child file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). The Gauss AGM-elliptic-integral identity remains axiomatized in the child slug oq-04-oq-01 as agm_ellipticK_connection (200+ page classical proof, requires Landen/theta-function theory not in Mathlib).",
     "mathlib_version": "4.26.0"
   },
@@ -160,7 +163,18 @@
     "theoremCount": 22,
     "definitionCount": 5,
     "path": "Proofs/AmgmInequalityOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/AmgmInequalityOQ04OQ01.lean",
+        "lineCount": 187,
+        "theorems": 10,
+        "definitions": 2,
+        "axioms": 1,
+        "sorries": 0,
+        "description": "OQ-04-OQ-01: Rigorous K(k) elliptic integral definition via Mathlib intervalIntegral. Defines ellipticK as ∫₀^{π/2} dθ/√(1-k²sin²θ), proves ellipticK_zero (K(0)=π/2), positivity for |k|<1, and axiomatizes the deep Gauss AGM-K identity M(a,b)=aπ/(2K(k')) (1 axiom: agm_ellipticK_connection)"
+      }
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

`amgm-inequality-oq-04` was missing `Proofs/AmgmInequalityOQ04OQ01.lean` from its `additionalFiles` registration. The file is a companion that rigorously defines K(k) (the complete elliptic integral of the first kind) via Mathlib `intervalIntegral`, superseding the placeholder `ellipticK` axiom deleted from the parent file in the S2 Lever A refactor (2026-05-16). It appeared nowhere in any `meta.json` `additionalFiles` list — making it an orphan.

The companion is already referenced in prose throughout this `meta.json`:

- `meta.assumptions` — "now superseded by rigorous definitions in the child file AmgmInequalityOQ04OQ01.lean"
- `conclusion.summary` — "the elliptic-integral connection (ellipticK definition + Gauss identity) lives in the child slug oq-04-oq-01 (AmgmInequalityOQ04OQ01.lean)"
- `conclusion.openQuestions[0]` — "Define K(k) = ∫₀^{π/2} dθ/√(1-k²sin²θ) in Lean using Mathlib's intervalIntegral"

## Evidence

**Before**:
```json
"meta.additionalFiles":    None
"leanFile.additionalFiles":None
```

**After**:
```json
"meta.additionalFiles":    ["Proofs/AmgmInequalityOQ04OQ01.lean"]
"leanFile.additionalFiles":[{ "path": "Proofs/AmgmInequalityOQ04OQ01.lean", lineCount: 187, theorems: 10, definitions: 2, axioms: 1, sorries: 0, description: "OQ-04-OQ-01: Rigorous K(k) elliptic integral definition via Mathlib intervalIntegral. ..." }]
```

Verification:
- `AmgmInequalityOQ04OQ01.lean:2`: `import Proofs.AmgmInequalityOQ04`
- `proofs/Proofs/AmgmInequalityOQ04OQ01.lean` exists (187 lines, 10 theorems, 2 defs, 1 axiom, 0 sorries — stripped)
- Not referenced via `leanFile.path` or `additionalFiles` from any meta.json before this fix

Registered in both `meta.additionalFiles` (string) and `leanFile.additionalFiles` (rich object) per the canonical mirror convention.

---
Automated fix by lean-mechanic agent.