### PR TITLE
fix(meta): tractatus-ontology register TractatusOntologyHorn/Equiv orphans

### DIFF
--- a/src/data/proofs/tractatus-ontology/meta.json
+++ b/src/data/proofs/tractatus-ontology/meta.json
@@ -14,7 +14,9 @@
     ],
     "proofRepoPath": "Proofs/TractatusOntology.lean",
     "additionalFiles": [
-      "Proofs/TractatusQuantifiers.lean"
+      "Proofs/TractatusQuantifiers.lean",
+      "Proofs/TractatusOntologyHorn.lean",
+      "Proofs/TractatusOntologyEquiv.lean"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -282,6 +284,24 @@
         "axioms": 0,
         "sorries": 0,
         "description": "First-order extension: FOProp type with HOAS quantifiers, evaluation, compositionality, duality, and distribution theorems (TLP 5.52, 5.521, 5.526)"
+      },
+      {
+        "path": "Proofs/TractatusOntologyHorn.lean",
+        "lineCount": 130,
+        "theorems": 2,
+        "definitions": 5,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "T1a tier (tractatus-ontology-oq-06): generic HornModel constructor over a list of Horn clauses, single-clause Equiv with ConstrainedWorld, generic Horn-tier independence-failure theorem, and weatherModel as a single-clause HornModel instance."
+      },
+      {
+        "path": "Proofs/TractatusOntologyEquiv.lean",
+        "lineCount": 137,
+        "theorems": 2,
+        "definitions": 4,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "T1b tier (tractatus-ontology-oq-06): EquivModel constructor for biconditional-constrained worlds, structural iso witnessing T1b ⊆ T1a-symmetric (cs ++ cs.map Prod.swap), refinement into T1a sharing the constraint list, and biconditional-tier independence-failure theorem."
       }
     ]
   },


### PR DESCRIPTION
## Summary

Registers two orphan companion `.lean` files in `src/data/proofs/tractatus-ontology/meta.json` so they show up in the gallery and are picked up by integrity audits.

- `Proofs/TractatusOntologyHorn.lean` (130 LOC; 5 defs, 2 theorems, 0 axioms, 0 sorries) — **T1a tier** of `tractatus-ontology-oq-06`: generic `HornModel S cs` constructor over a list of Horn clauses, single-clause `Equiv` with `ConstrainedWorld`, generic Horn-tier independence-failure theorem, `weatherModel` exhibited as a single-clause `HornModel` instance.
- `Proofs/TractatusOntologyEquiv.lean` (137 LOC; 4 defs, 2 theorems, 0 axioms, 0 sorries) — **T1b tier**: `EquivModel S cs` constructor for biconditional-constrained worlds, structural iso witnessing T1b ⊆ T1a-symmetric (`cs ++ cs.map Prod.swap`), refinement into T1a sharing the constraint list, biconditional-tier independence-failure theorem.

Sibling of #21915 (Spectrum); both pulled from the longest-prefix companion-suffix orphan scan documented in the mechanic memory notes.

## Approach

- Mirror entries into both `meta.additionalFiles` (string form — auditor-visible) and `leanFile.additionalFiles` (rich-object schema matching the existing `TractatusQuantifiers` entry).
- Metadata-only — no Lean code changed. Parent-file `axiomCount` (1, the deliberate `silence : True`) and total `sorries` (0) unchanged; companions contribute no new axioms or sorries.
- Both files live in `namespace Tractatus` (same as parent) — no namespace conflicts.

## Test plan

- [x] `python3 -m json.tool src/data/proofs/tractatus-ontology/meta.json` — valid JSON.
- [x] Theorem/def/axiom/sorry counts verified by grep against the actual `.lean` files.
- [x] Pre-push race-check: `gh pr list --search "tractatus-ontology Horn" --state open` empty; no `fix/mechanic-tractatus-ontology-horn*` branch on origin.
- [ ] Deployer / auditor cycle picks up the new files on next run.

Note: PR #21915 (Spectrum) is still open at the time of writing. If it merges first, this PR will need a trivial array-merge rebase to keep the Spectrum entry; if this merges first, #21915 will. No semantic conflict either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)