### PR TITLE
research(brouwer-fpt-oq02): S16 ACT-A — G10 companion file (Retraction.toTopCatHom + section_identity), Docker-verified

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean
@@ -1,0 +1,83 @@
+/-
+  Brouwer Fixed Point OQ-01-OQ-02-OQ-03-OQ-02: S16 ACT-A
+
+  Companion file installing the **G10 retraction-to-TopCat bridge** —
+  the infrastructure piece identified by S15 PREP (PR #21862) §3 as
+  the first of two gaps blocking the S9 ACT-D-3 EXEC integration.
+
+  Purpose: convert a `Retraction n` (custom structure with continuous
+  map on `EuclideanSpace ℝ (Fin n)`) into a categorical morphism
+  `𝔻 n ⟶ ∂𝔻 n` in `TopCat`, so that G8 (`map_section_of_section`)
+  and G9 (`isZero_of_section_into_isZero`) can fire on the inclusion-
+  retraction pair `(diskBoundaryInclusion n, r.toTopCatHom)`.
+
+  Two declarations are exposed in namespace `BrouwerOQ01OQ02`:
+
+  * `Retraction.toTopCatHom` — the TopCat morphism built from the
+    underlying retraction function, with ULift wrap/unwrap, subtype
+    restriction (via `Continuous.codRestrict`), and continuity
+    transported through the chain
+    `ULift.up ∘ codRestrict r.toFun (UnitSphere n) _ ∘ Subtype.val ∘ ULift.down`.
+
+  * `Retraction.section_identity` — the section identity
+    `diskBoundaryInclusion n ≫ r.toTopCatHom = 𝟙 (∂𝔻 n)`, the
+    categorical witness that `r` retracts the inclusion. Follows
+    directly from `r.fixes_sphere` (the structure field asserting
+    pointwise fixity on the sphere).
+
+  Companion-file (not inline) per §N5 Option A precedent (G6 / G7 / G8):
+  build-risk isolation + review parallelism. Build cost is a subset of
+  the main file's import closure (no `AlgebraicTopology` dependency);
+  expected ~400-500 jobs per S15 PREP §7.
+
+  Net axiom delta: 0. Net theorem delta: +1 (plus 1 definition).
+-/
+
+import Mathlib.Topology.Category.TopCat.Sphere
+import Proofs.BrouwerFixedPointOQ01OQ02
+
+open CategoryTheory TopCat
+
+namespace BrouwerOQ01OQ02
+
+/-- **G10 retraction-to-TopCat bridge**: a `Retraction n` produces a
+    TopCat morphism `𝔻 n ⟶ ∂𝔻 n`. The underlying function unwraps
+    the `ULift (Metric.closedBall …)` carrier of `𝔻 n`, applies the
+    retraction's continuous function, and repacks the result into the
+    `ULift (Metric.sphere …)` carrier of `∂𝔻 n` using
+    `r.maps_to_sphere`. Continuity is built from `r.continuous'`
+    via `Continuous.codRestrict` and the ULift homeomorphism. -/
+noncomputable def Retraction.toTopCatHom {n : ℕ} (r : Retraction n) :
+    TopCat.disk.{0} n ⟶ TopCat.diskBoundary.{0} n :=
+  TopCat.ofHom
+    { toFun := fun x =>
+        ⟨⟨r.toFun x.down.val, by
+          have hp : x.down.val ∈ ClosedBall n := by
+            simp [ClosedBall, x.down.property]
+          simpa [UnitSphere] using r.maps_to_sphere x.down.val hp⟩⟩
+      continuous_toFun := by
+        refine continuous_uliftUp.comp
+          (Continuous.codRestrict ?_ ?_)
+        · exact r.continuous'.comp
+            (continuous_subtype_val.comp continuous_uliftDown)
+        · intro x
+          have hp : x.down.val ∈ ClosedBall n := by
+            simp [ClosedBall, x.down.property]
+          simpa [UnitSphere] using r.maps_to_sphere x.down.val hp }
+
+/-- **G10 section identity**: the inclusion-retraction pair
+    `(diskBoundaryInclusion n, r.toTopCatHom)` satisfies the section
+    equation `i ≫ ρ = 𝟙 (∂𝔻 n)` in `TopCat`. Direct consequence of
+    `r.fixes_sphere`: on the boundary sphere, the retraction is the
+    identity. -/
+theorem Retraction.section_identity {n : ℕ} (r : Retraction n) :
+    TopCat.diskBoundaryInclusion.{0} n ≫ r.toTopCatHom =
+      𝟙 (TopCat.diskBoundary.{0} n) := by
+  ext ⟨⟨p, hp⟩⟩
+  have hsphere : p ∈ UnitSphere n := by
+    simpa [UnitSphere] using hp
+  apply ULift.ext
+  apply Subtype.ext
+  exact r.fixes_sphere p hsphere
+
+end BrouwerOQ01OQ02

--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-01-s16-act-a-g10-companion-file.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-01-s16-act-a-g10-companion-file.md
@@ -1,0 +1,145 @@
+# S16 ACT-A — G10 companion file (`Retraction.toTopCatHom` + `section_identity`)
+
+- **Date**: 2026-06-01
+- **Session**: 17 (S1–S15)
+- **Phase**: ACT-A (first of the two PRs recommended by S15 PREP §8)
+- **Author**: researcher-1
+- **Mathlib pin**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0, unchanged)
+- **Scope**: ships `proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean` (1 def + 1 theorem) and the session memo. Doc-only updates to JSON `currentState.*` + `builtItems`. No edits to main file, no edits to G6/G7/G8, no `axiom` delta, no `sorry`, no `meta.json` (slug has no gallery directory).
+
+## 1. What this PR delivers
+
+The first of the two-PR split recommended by S15 PREP §8: a **new
+companion file** `proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean`
+(78 LOC including docstring) installing two declarations in namespace
+`BrouwerOQ01OQ02`:
+
+* **`Retraction.toTopCatHom`** (definition, noncomputable) — the
+  TopCat morphism `𝔻 n ⟶ ∂𝔻 n` built from the underlying retraction's
+  continuous function. ULift wrap/unwrap, subtype restriction via
+  `Continuous.codRestrict`, continuity transported through the chain
+  `ULift.up ∘ codRestrict r.toFun (UnitSphere n) _ ∘ Subtype.val ∘ ULift.down`.
+
+* **`Retraction.section_identity`** (theorem) — the section equation
+  `diskBoundaryInclusion n ≫ r.toTopCatHom = 𝟙 (∂𝔻 n)` in `TopCat`.
+  Proof: after `ext ⟨⟨p, hp⟩⟩`, apply `ULift.ext` + `Subtype.ext` to
+  reduce to `r.toFun p = p`, which is exactly `r.fixes_sphere p hsphere`.
+
+Closes **Gap-1** of S15 PREP. The pre-staged paste skeleton (§3.1) is
+realized with two adjustments to match Mathlib v4.26.0 names actually
+in the pin:
+
+| PREP §3.1 | Realized | Reason |
+|---|---|---|
+| `continuous_uLift_up` | `continuous_uliftUp` | Camel-case spelling in v4.26.0 |
+| `continuous_uLift_down` | `continuous_uliftDown` | Same |
+| Inner subtype shape `r.maps_to_sphere p this` rewrite via `simpa [UnitSphere]` | Same (works) | Matched |
+
+The `section_identity` proof uses the cleaner `ext + ULift.ext + Subtype.ext` chain rather than the PREP §3.1 `funext + Retraction.toTopCatHom` `simp` chain (the latter left `r.toFun p = p` as an "unused simp argument" rewrite — the `congr` step needed an explicit `ULift.ext` / `Subtype.ext` lift before `r.fixes_sphere` would close).
+
+## 2. Docker build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ01OQ02G10
+...
+✔ [3309/3309] Built Proofs.BrouwerFixedPointOQ01OQ02G10 (64s)
+Build completed successfully (3309 jobs).
+=== Build succeeded ===
+```
+
+**3309 jobs**, ~64s wall on warm cache (post-Mathlib cache hit, 56 Gi
+free at S15 PREP time). This is at the high end of the S15 PREP §7
+estimate (~400–500 jobs for the companion file alone) — the gap is
+because the companion file pulls in
+`Mathlib.Topology.Category.TopCat.Sphere` (which transitively pulls in
+the `module`-system `EpiMono` + `Analysis.InnerProductSpace.PiL2`),
+materially increasing the import closure beyond what S15 PREP
+estimated from G6/G7/G8.
+
+**Build-cost honest update**: the §7 estimate was based on companion-
+file deltas from G6 (~600 jobs) + G7 (~700 jobs) + G8 (~600 jobs).
+Those companions don't import `TopCat.Sphere`. G10 does, which is why
+the job count jumped to 3309 — Sphere's import closure is the bulk.
+
+## 3. Three iterations to reach green
+
+| Attempt | Tactic | Result |
+|---|---|---|
+| 1 | PREP §3.1 verbatim with `continuous_uLift_up` / `continuous_uLift_down` (S15 PREP names) | **Failed at 3309/3309**: errors at `section_identity` `show ULift.up ⟨_, _⟩ = ULift.up ⟨_, _⟩` — `⟨...⟩` notation needs explicit type |
+| 2 | Replaced `show` with `simp [Retraction.toTopCatHom, TopCat.diskBoundaryInclusion, r.fixes_sphere p hsphere]` | **Failed**: `simp` reduced to `{ down := ⟨r.toFun p, _⟩ } = { down := ⟨p, hp⟩ }` but `r.fixes_sphere` was unused (no `r.toFun p` literally on either side after reduction) |
+| 3 | `ext ⟨⟨p, hp⟩⟩` + `apply ULift.ext` + `apply Subtype.ext` + `exact r.fixes_sphere p hsphere` | **Built green** at 3309/3309, 64s warm |
+
+The PREP §3.1 skeleton was right on the spec but the proof closure
+needed Mathlib's `@[ext]` chain `ULift.ext` → `Subtype.ext`, not a
+single `simp` call. Honest tagging: PREP "paste-ready but unverified"
+qualifier was load-bearing — three iterations to close `section_identity`.
+
+## 4. What this unblocks for S16 ACT-B
+
+With G10 on main, the S16 ACT-B (main-file integration) can:
+
+1. Add `import Proofs.BrouwerFixedPointOQ01OQ02G10` to the main file's
+   import list.
+2. Use `r.toTopCatHom` as the `ρ : 𝔻 n ⟶ ∂𝔻 n` argument to G8's
+   `map_section_of_section`.
+3. Use `r.section_identity` as the `h : i ≫ r = 𝟙 X` hypothesis to
+   the same G8 call.
+
+ACT-B still needs to:
+
+* Close **Gap-2** (ULift mismatch between substantive ball/sphere):
+  ship `H_n_minus_1_disk_zero_substantive` per S15 PREP §4.1 (~12 LOC).
+* Decide the **n=1 branch** treatment (thin IVT axiom OR 5-line IVT
+  proof) — see S15 PREP §5 final paragraph.
+* Replace the mock axiom `H_n_minus_1_sphere_nonzero`
+  (main:261) with the substantive theorem chaining G10 + G8 + G9 +
+  `H_n_minus_1_disk_zero_substantive` + `H_n_minus_1_sphere_nonzero_substantive`.
+
+Expected ACT-B build size: ~3300–3400 jobs per S15 PREP §7 (this
+estimate is for the main-file rebuild, not the cumulative closure).
+
+## 5. On-disk reality (this PR, 2026-06-01)
+
+| File | LOC | Theorems | Definitions | Axioms | Sorries |
+|------|-----|----------|-------------|--------|---------|
+| `BrouwerFixedPointOQ01OQ02.lean` | 462 | 14 | … | 4 | 0 |
+| `BrouwerFixedPointOQ01OQ02G6.lean` | 88 | 4 + 1 local | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G7.lean` | 94 | 2 | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G8.lean` | 134 | 2 | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G10.lean` | **78** | **1** | **1** | **0** | **0** |
+| **Total** | **856** | **24** | … | **4** | **0** |
+
+Net delta this PR: +78 LOC, +1 theorem, +1 definition, +0 axioms, +0 sorries.
+
+## 6. Anti-targets (S16 ACT-A)
+
+- No edits to `BrouwerFixedPointOQ01OQ02.lean` (Gap-2 / mock-axiom
+  removal deferred to S16 ACT-B per the recommended split).
+- No edits to G6/G7/G8 (already on main, build verified).
+- No `meta.json` updates (slug has no gallery directory; verified
+  `src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/`
+  does not exist).
+- No upstream Mathlib contribution (B1 / B2 still on the queue).
+
+## 7. Honesty notes
+
+- The S15 PREP §7 build-cost estimate (~400–500 jobs) was **off by
+  ~7×** — actual was 3309. Reason: `Mathlib.Topology.Category.TopCat.Sphere`'s
+  import closure dominates. The PREP estimate looked only at G6/G7/G8
+  deltas, none of which import Sphere. ACT-B's estimate (~3300–3400)
+  remains plausible — it was based on the main-file rebuild, which
+  also imports Sphere.
+- The `section_identity` proof required three iterations to close.
+  Two PREP-implicit assumptions failed: (a) the v4.26.0 ULift
+  continuity lemma names are `continuous_uliftUp` / `continuous_uliftDown`,
+  not `continuous_uLift_{up,down}` as the PREP wrote; (b) closing the
+  ULift+Subtype equality needs explicit `ULift.ext` + `Subtype.ext`
+  calls, not just `simp [Retraction.toTopCatHom, …]`. Both are
+  cosmetic — the underlying spec is right.
+- The PR does not retire any axiom from the main file. The mock
+  axiom `H_n_minus_1_sphere_nonzero` is still live; its retirement
+  is the ACT-B deliverable.
+- Build-cost surprise (3309 vs 400–500 estimate) is recorded honestly
+  here; the future ACT-B planner should expect ~3300–3400 for the
+  full main-file rebuild including G10's import closure, not double-
+  count G10's jobs.

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "PREP (S15 PREP shipped doc-only TopCat-bridge audit; S16 ACT EXEC will execute the G6/G7/G8/G10 + Disk-IsZero integration)",
-    "since": "2026-06-01T07:00:00Z",
-    "iteration": 16,
-    "focus": "S15 PREP (researcher-1, 2026-06-01, doc-only) — TopCat-morphism bridge audit for the S9 ACT-D-3 EXEC integration. Surfaces TWO infrastructure gaps that earlier PREPs (S10, S12) missed and that a literal 'add 3 imports + paste proof' would have hit at Docker time: Gap-1 — Retraction.toTopCatHom (the categorical retraction 𝔻 n ⟶ ∂𝔻 n from a Retraction n structure) is not in Mathlib and needs a new ~45-LOC companion file BrouwerFixedPointOQ01OQ02G10.lean; Gap-2 — H_n_minus_1_ball_zero_substantive returns IsZero on the non-ULift TopCat.of ↥(closedBall …) while H_n_minus_1_sphere_nonzero_substantive returns ¬IsZero on the ULift-wrapped TopCat.diskBoundary n, requiring a ~12-LOC ULift-reconciliation theorem H_n_minus_1_disk_zero_substantive via TopCat.uliftFunctor / TopCat.isoOfHomeo / Homeomorph.ulift.symm. Bearer audit at pinned rev 2df2f0150c… confirms all required Mathlib decls present. Risk inventory: 4 LOW + 3 MEDIUM + 1 OPEN (n=1 branch — Retraction 1 uninhabited but not formally proved). Honest axiom-count expectation revised 4→3 to 4→4 (replace mock composite with thin IVT). S16 ACT recommended split: G10 PR first (~400–500 jobs), then main-file integration (~3300–3400 jobs). No Lean / meta.json / problem.md / state.md / knowledge.md body edits.",
+    "phase": "ACT-A (S16 ACT-A shipped G10 companion file Docker-verified at 3309 jobs; S16 ACT-B will execute Gap-2 + mock-axiom removal in main file)",
+    "since": "2026-06-01T13:00:00Z",
+    "iteration": 17,
+    "focus": "S16 ACT-A (researcher-1, 2026-06-01) — ships proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean (78 LOC, 1 def + 1 theorem in namespace BrouwerOQ01OQ02), closing Gap-1 of S15 PREP. Two declarations: (a) Retraction.toTopCatHom (noncomputable def) — the TopCat morphism 𝔻 n ⟶ ∂𝔻 n built from r.toFun via ULift wrap/unwrap + Subtype.codRestrict + r.maps_to_sphere; continuity via continuous_uliftUp.comp (Continuous.codRestrict ... continuous_uliftDown). (b) Retraction.section_identity (theorem) — diskBoundaryInclusion n ≫ r.toTopCatHom = 𝟙 (∂𝔻 n) closed via ext ⟨⟨p,hp⟩⟩ + ULift.ext + Subtype.ext + r.fixes_sphere. Docker-verified: 3309 jobs / 64s warm cache (S15 PREP §7 estimated ~400–500 — gap because TopCat.Sphere import closure dominates, not the G10 delta itself). Took 3 attempts to close section_identity: (1) PREP §3.1 verbatim → ⟨...⟩ elaboration failure; (2) simp on Retraction.toTopCatHom + diskBoundaryInclusion + r.fixes_sphere → r.fixes_sphere flagged unused (simp couldn't match it); (3) ULift.ext + Subtype.ext chain → green. PREP names continuous_uLift_{up,down} corrected to v4.26.0 spelling continuous_uliftUp / continuous_uliftDown. Net delta: +78 LOC, +1 theorem, +1 definition, +0 axioms, +0 sorries. Main file unchanged. No meta.json edits (slug has no gallery directory).",
     "activeApproach": "S9 ACT-D-3 decomposes into four categorical/algebraic bridges G6 + G7 + G8 + G9 — ALL NOW ON MAIN as of S13 ACT 2026-05-16T14:32:50Z. Status: G6 on main (`BrouwerFixedPointOQ01OQ02G6.lean` 87 LOC / 4 thm + 1 local lemma / 0 ax / 0 sorry, S13 ACT PR #19624 companion-file pivot), G7 on main (`BrouwerFixedPointOQ01OQ02G7.lean`, PR #18951), G8 on main (`BrouwerFixedPointOQ01OQ02G8.lean:96`, PR #19114), G9 on main (`BrouwerFixedPointOQ01OQ02G8.lean:117`, same PR). PR #18011 (original G6 path via main-file expansion) SUPERSEDED by the companion-file pivot. The substantive replacement of mock axiom `H_n_minus_1_sphere_nonzero` chains them as before: (1) `H_n_minus_1_ball_zero_substantive` (main:~310) → IsZero (H_{n-1}(B^n)). (2) G8 applied to TopCat inclusion/retraction → section on H_{n-1}. (3) G9 → IsZero (H_{n-1}(𝕊^{n-1})). (4) Contradicts `H_n_minus_1_sphere_nonzero_substantive` (main:~375). (5) G7 + G6 (now from companion file) extract the `∃ ψ, ψ.comp φ = id` shape consumed by `singular_homology_retraction_split`. S9 ACT-D-3 EXEC integration step (add 3 import lines + main-file delta) is Lean-unblocked but Docker-blocked on B3. Net Lean delta this STATE-SYNC: 0 (doc-only).",
     "blockers": [
       "B1 (Mathlib gap) — prism operator / topological-homotopy → chain-homotopy bridge. Encoded as thin local axiom contractible_singularHomology_zero (S5 ACT-B exec).",
@@ -27,11 +27,11 @@
       "B3 (INFRA) — RESOLVED (S13b 2026-05-30: Docker 29.4.1 up, 56 Gi free at S15 PREP time; Docker-verify capable).",
       "PR #18011 — SUPERSEDED by the S13 ACT G6 companion-file pivot (PR #19624 merged 2026-05-16). Disposition is mechanic/champion scope."
     ],
-    "nextAction": "S16 ACT EXEC integration, in two PRs: (1) ship proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean (~45 LOC, ~400–500 jobs) implementing Retraction.toTopCatHom + Retraction.section_identity per S15 PREP §3.1 paste-ready skeleton; Docker-verify alone. (2) In main file: add 4 imports (G6/G7/G8/G10), add H_n_minus_1_disk_zero_substantive per S15 PREP §4.1 (~12 LOC), replace mock axiom H_n_minus_1_sphere_nonzero (line 261) with the substantive theorem per S15 PREP §5 paste-ready body. Address n=1 branch by adding a thin local axiom Retraction_one_uninhabited (axiom net 4→4) OR a 5-line IVT proof (axiom net 4→3). Docker-verify full main-file build (~3300–3400 jobs). Update meta.json axiom counts.",
+    "nextAction": "S16 ACT-B integration (main file): (1) add 4 imports — Proofs.BrouwerFixedPointOQ01OQ02G6/G7/G8/G10. (2) Spot-check TopCat.isoOfHomeo (or fallback Iso.ofHom over ofHom Homeomorph.toContinuousMap) per S15 PREP §4 risk F3. (3) Add H_n_minus_1_disk_zero_substantive per S15 PREP §4.1 (~12 LOC) using TopCat.uliftFunctor / uliftFunctorObjHomeo (Mathlib v4.26.0 names confirmed at pin 2df2f0150c…). (4) Replace mock axiom H_n_minus_1_sphere_nonzero (main:261) with the substantive theorem chaining BrouwerOQ01OQ02.Retraction.toTopCatHom + Retraction.section_identity (from this PR's G10) + G8.map_section_of_section + G9.isZero_of_section_into_isZero + H_n_minus_1_disk_zero_substantive + H_n_minus_1_sphere_nonzero_substantive per S15 PREP §5 paste-ready body. (5) Resolve n=1 branch: ship thin local axiom Retraction_one_uninhabited (axiom net 4→4 — replace mock composite with thin IVT) OR a 5-line IVT proof (axiom net 4→3). (6) Docker-verify full main-file build (~3300–3400 jobs per S15 PREP §7).",
     "attemptCounts": {
-      "total": 14,
+      "total": 15,
       "currentApproach": 1,
-      "approachesTried": 13
+      "approachesTried": 14
     }
   },
   "knowledge": {
@@ -80,7 +80,17 @@
         "description": "S14 STATE-SYNC (this PR, researcher-11, doc-only): research-JSON `currentState.*` + `knowledge.builtItems` + top-level `lastUpdate` catchup absorbing S12 PREP + S13 ACT. JSON drift items closed (8): iteration 11→13, phase, focus, blockers (+B3 INFRA, blockers[2] PR #18011 re-framed as SUPERSEDED), nextAction, activeApproach, builtItems append, lastUpdate. State.md cosmetic fix on S13 inaccuracy 'this slug has no research-json'.",
         "location": "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/"
       },
-      "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-01-s15-prep-topcat-bridge-audit.md — S15 PREP doc-only audit (10 sections: PREP rationale, bearer audit, Gap-1 closure, Gap-2 closure, paste-ready integration body, risk inventory, build cost estimate, S16 execution order, anti-targets, honesty notes)"
+      "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-01-s15-prep-topcat-bridge-audit.md — S15 PREP doc-only audit (10 sections: PREP rationale, bearer audit, Gap-1 closure, Gap-2 closure, paste-ready integration body, risk inventory, build cost estimate, S16 execution order, anti-targets, honesty notes)",
+      {
+        "name": "BrouwerOQ01OQ02.Retraction.toTopCatHom (def) + Retraction.section_identity (theorem) — G10",
+        "description": "G10 retraction-to-TopCat bridge: from a Retraction n structure, build the TopCat morphism ρ : 𝔻 n ⟶ ∂𝔻 n (toTopCatHom, noncomputable def) and prove the section identity diskBoundaryInclusion n ≫ ρ = 𝟙 (∂𝔻 n) (section_identity, theorem). Closes Gap-1 of S15 PREP. Function: ULift wrap/unwrap + Subtype.codRestrict + r.maps_to_sphere for membership + continuous_uliftUp.comp (Continuous.codRestrict _ _ continuous_uliftDown.comp ...) for continuity. Section identity: ext ⟨⟨p,hp⟩⟩ + ULift.ext + Subtype.ext + r.fixes_sphere. Docker-verified at 3309 jobs / 64s warm cache. Net delta: +83 LOC, +1 theorem, +1 definition, +0 axioms, +0 sorries. Companion-file pattern parallels G6/G7/G8 (build-risk isolation + review parallelism).",
+        "location": "proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean:43, 71"
+      },
+      {
+        "name": "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-01-s16-act-a-g10-companion-file.md (session memo, S16 ACT-A)",
+        "description": "S16 ACT-A (this PR, researcher-1, 2026-06-01): G10 companion file. Documents three-iteration close on section_identity, corrections to S15 PREP §3.1 (continuous_uliftUp/Down spelling; ULift.ext + Subtype.ext chain), and the 7× build-cost gap vs PREP §7 estimate (3309 actual vs ~400–500 projected — gap is TopCat.Sphere import closure, not the G10 delta). S16 ACT-B (next) handles Gap-2 + mock-axiom removal in main file.",
+        "location": "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/"
+      }
     ],
     "insights": [
       "B1 (the topological-homotopy → chain-homotopy bridge) factors cleanly into three layers via Mathlib's existing simplicial framework: (i) simplicial-homotopy → chain-homotopy via the alternating-face-map functor, (ii) topological-homotopy → simplicial-homotopy via TopCat.toSSet, (iii) composition gives the singular-chain version. Only layer (i) requires genuinely new Lean code; the other two are routine bridges. (Section H3 of knowledge.md.)",
@@ -181,7 +191,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.561Z",
-  "lastUpdate": "2026-06-01",
+  "lastUpdate": "2026-06-01T13:00:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -250,6 +260,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02G8.lean"
+    },
+    {
+      "path": "Proofs/BrouwerFixedPointOQ01OQ02G10.lean",
+      "filename": "BrouwerFixedPointOQ01OQ02G10.lean",
+      "lineCount": 83,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean"
     },
     {
       "path": "Proofs/BrouwerFixedPointOQ01OQ02OQ03.lean",


### PR DESCRIPTION
## Summary

S16 ACT-A for `brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02`. Ships
`proofs/Proofs/BrouwerFixedPointOQ01OQ02G10.lean` (83 LOC, 1 def + 1
theorem in namespace `BrouwerOQ01OQ02`), closing **Gap-1** of S15 PREP
(PR #21862).

Recommended by S15 PREP §8 as the **first** of the two-PR split (small,
isolated, low-risk companion file; main-file integration follows in ACT-B).

## What lands

* **`Retraction.toTopCatHom`** (noncomputable def) — TopCat morphism
  `𝔻 n ⟶ ∂𝔻 n` from a `Retraction n`. ULift wrap/unwrap, subtype
  restriction via `Continuous.codRestrict`, continuity via
  `continuous_uliftUp.comp (Continuous.codRestrict _ _ …)`.

* **`Retraction.section_identity`** (theorem) — section equation
  `diskBoundaryInclusion n ≫ r.toTopCatHom = 𝟙 (∂𝔻 n)`. Proof:
  `ext ⟨⟨p,hp⟩⟩` + `ULift.ext` + `Subtype.ext` + `r.fixes_sphere p hsphere`.

## Docker verification

```
✔ [3309/3309] Built Proofs.BrouwerFixedPointOQ01OQ02G10 (64s)
Build completed successfully (3309 jobs).
```

3309 jobs / ~64s on warm Mathlib cache.

## Three iterations to close `section_identity`

| Attempt | Tactic | Result |
|---|---|---|
| 1 | PREP §3.1 verbatim with explicit `⟨...⟩` `show` | Failed: untypable in `show` position |
| 2 | `simp [Retraction.toTopCatHom, TopCat.diskBoundaryInclusion, r.fixes_sphere p hsphere]` | Failed: `r.fixes_sphere` flagged unused (simp couldn't match after partial reduction) |
| 3 | `ext ⟨⟨p,hp⟩⟩` + `ULift.ext` + `Subtype.ext` + `r.fixes_sphere` | **Green** at 3309/3309, 64s |

PREP names corrected: `continuous_uLift_{up,down}` → `continuous_uliftUp` / `continuous_uliftDown` (v4.26.0 spelling).

## Build cost vs S15 PREP §7

| Estimate | Actual | Gap |
|---|---|---|
| ~400–500 jobs | 3309 | ~7× |

Cause: `Mathlib.Topology.Category.TopCat.Sphere`'s import closure (PREP
estimate looked only at G6/G7/G8 deltas, none import Sphere). ACT-B
estimate (~3300–3400) remains plausible — based on main-file rebuild
which already imports Sphere.

## On-disk delta

| File | LOC | Theorems | Defs | Axioms | Sorries |
|---|---|---|---|---|---|
| G10 (new) | 83 | 1 | 1 | 0 | 0 |
| Main file (unchanged) | 462 | 14 | … | 4 | 0 |

Net axiom delta: **0** (mock-axiom removal deferred to ACT-B).

## What this unblocks for ACT-B

With G10 on main, ACT-B can:
1. `import Proofs.BrouwerFixedPointOQ01OQ02G10`
2. Use `r.toTopCatHom` as the `ρ : 𝔻 n ⟶ ∂𝔻 n` to G8
3. Use `r.section_identity` as the `i ≫ r = 𝟙 X` hypothesis

ACT-B still owes Gap-2 closure (`H_n_minus_1_disk_zero_substantive`
~12 LOC), the n=1 branch decision (thin IVT axiom vs 5-line proof),
and the mock-axiom substantive replacement at main:261.

## Anti-targets

- No edits to main file
- No edits to G6/G7/G8
- No `meta.json` updates (slug has no gallery directory)

## Honesty notes

- The PREP §7 build-cost estimate was off by ~7× (gap was Sphere's
  import closure, recorded honestly in session memo §7).
- `section_identity` needed three iterations to close; the PREP §3.1
  paste was right on spec but the proof tactic chain needed `ULift.ext`
  + `Subtype.ext`, not `simp` alone.
- This PR does not retire any axiom. Mock-axiom removal is the ACT-B
  deliverable.

## Test plan

- [x] Docker build clean (3309/3309)
- [x] No `sorry` / `admit` / `axiom` introduced in G10
- [x] JSON validates (`jq . | true`)
- [x] No edits to existing Lean files

🤖 Generated by researcher-1