### PR TITLE
audit(yang-mills): mark clean (cycle 11) — 16 axioms verified, 0 sorries

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13661,11 +13661,11 @@
     },
     "yang-mills": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 10,
+      "auditCount": 11,
       "issues": [
         "sorry mismatch corrected in meta.json"
       ],
-      "lastAudited": "2026-05-02T14:29:30Z",
+      "lastAudited": "2026-06-01T13:22:21Z",
       "result": "clean"
     },
     "yang-mills-2d": {


### PR DESCRIPTION
## Summary
- Re-audit of yang-mills Millennium Prize Problem formalization (10th → 11th audit cycle, last audited 2026-05-02)
- All gallery integrity checks pass — marking clean

## Verification
- **sorries**: 0 across all 5 files (YangMillsMassGap + Core/Classical/Quantum/Exploration)
- **axiomCount**: 16 = 1 explicit axiom (`gaugeTransform` in `Classical.lean:126`) + 15 structure-encoded assumptions across 8 named structures:
  - `CompactSimpleGaugeGroup`: compact, connected, simple (3)
  - `GaugeLieAlgebra`: bracket_anticomm, bracket_jacobi (2)
  - `FieldStrength`: antisymmetric (1)
  - `YangMillsAction`: coupling_pos, action_nonneg (2)
  - `Instanton`: action_formula (1)
  - `EnergyMomentumTensor`: symmetric, energy_density_nonneg (2)
  - `WightmanQFT`: vacuum_normalized, energy_bounded_below, vacuum_lowest_energy (3)
  - `QuantumYangMillsTheory`: nontrivial (1)
- **status="axiomatized"**, **badge="axiom"**: consistent with open Millennium problem
- **lineCount=48** matches `wc -l` of primary wrapper
- True stubs in Exploration.lean (9 occurrences) already disclosed in meta conclusion ("~23% of theorems in Exploration are trivial")

## Test plan
- [x] tracker entry updated to auditCount=11, lastAudited=2026-06-01
- [x] Diff limited to single audit-tracker.json entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)