### PR TITLE
fix(meta): geometric-series-oq-01 register GeometricSeriesOQ01Neumann.lean orphan

### DIFF
--- a/src/data/proofs/geometric-series-oq-01/meta.json
+++ b/src/data/proofs/geometric-series-oq-01/meta.json
@@ -9,6 +9,9 @@
     "date": "1703",
     "status": "verified",
     "proofRepoPath": "Proofs/GeometricSeriesOQ01.lean",
+    "additionalFiles": [
+      "Proofs/GeometricSeriesOQ01Neumann.lean"
+    ],
     "tags": [
       "analysis",
       "series",
@@ -223,6 +226,9 @@
     "theoremCount": 13,
     "definitionCount": 1,
     "sorries": 0,
-    "path": "Proofs/GeometricSeriesOQ01.lean"
+    "path": "Proofs/GeometricSeriesOQ01.lean",
+    "additionalFiles": [
+      "Proofs/GeometricSeriesOQ01Neumann.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Registers an orphan companion `.lean` file in `src/data/proofs/geometric-series-oq-01/meta.json` so it surfaces in the gallery and is auditor-visible.

- `Proofs/GeometricSeriesOQ01Neumann.lean` (91 LOC; 7 theorems, 1 noncomputable definition, 0 axioms, 0 sorries) — proves the Neumann series theorem for bounded operators on a Banach space (operator-valued generalization of the scalar geometric series): if `‖T‖ < 1` then `(1 - T)` is a unit with inverse `∑ Tⁿ`, plus operator-norm bound and partial-sum convergence.

The file was originally merged via PR #7928 ("Research: geometric-series-oq-01 — Neumann series for bounded operators (0 sorry)") but never registered.

## Approach

- Adds string entries to **both** `meta.additionalFiles` (auditor-visible) and `leanFile.additionalFiles` per [[project-mechanic-leanfile-additionalfiles-mirror]].
- Both string-form (matches the slug's existing schema — no rich-object precedent here).
- Companion lives in `namespace NeumannSeries`, independent of parent's `GeometricSeriesOQ01` namespace and imports; no conflict.

## Test plan

- [x] `python3 -m json.tool src/data/proofs/geometric-series-oq-01/meta.json` — valid JSON.
- [x] Counts verified by `grep ^theorem | ^def | sorry | ^axiom` against the Lean file.
- [x] Pre-push race-check: no open PR or branch on origin matching the slug+Neumann.
- [ ] Deployer / auditor cycle picks up the new file on next run.

Parent-file `axiomCount` (0), `sorries` (0), and main counts unchanged — this is metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)