### PR TITLE
fix(meta): godel-second-incompleteness-oq02 register 2 orphan companions

### DIFF
--- a/src/data/proofs/godel-second-incompleteness-oq02/meta.json
+++ b/src/data/proofs/godel-second-incompleteness-oq02/meta.json
@@ -46,6 +46,10 @@
     ],
     "lineCount": 258,
     "proofRepoPath": "Proofs/GodelSecondIncompletenessOQ02.lean",
+    "additionalFiles": [
+      "Proofs/GodelSecondIncompletenessOQ02GLSyntax.lean",
+      "Proofs/GodelSecondIncompletenessOQ02Companion.lean"
+    ],
     "mathlib_version": "4.26.0",
     "relatedProofs": [
       {
@@ -167,6 +171,26 @@
     "sorries": 0,
     "path": "Proofs/GodelSecondIncompletenessOQ02.lean",
     "definitionCount": 2,
-    "theoremCount": 3
+    "theoremCount": 3,
+    "additionalFiles": [
+      {
+        "path": "Proofs/GodelSecondIncompletenessOQ02GLSyntax.lean",
+        "lineCount": 104,
+        "theorems": 0,
+        "definitions": 4,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "GL syntax foundation (S8 ACT): inductive GLFormula (modal language with falsum/atom/impl/box), PropAxiom (Hilbert-style propositional + K + 4 + GL axioms), and GL_proves derivability predicate. Independent of the parent file — provides the modal logic backbone for the OQ02-OQ-02 Solovay arithmetical-completeness research direction."
+      },
+      {
+        "path": "Proofs/GodelSecondIncompletenessOQ02Companion.lean",
+        "lineCount": 227,
+        "theorems": 4,
+        "definitions": 1,
+        "axioms": 3,
+        "sorries": 0,
+        "description": "S2-α companion (OQ02-OQ-02): object-level implication impl_formula and HBL D2/D3 axiomatization. Defines impl_formula and proves Gödel-code distinctness lemmas (impl_formula_code/_ne_falsum/_ne_Prov). Axiomatizes impl_mp (modus ponens internalization), d2_distribution (□(φ→ψ) → □φ → □ψ), and d3_internal_necessitation (□φ → □□φ). Derives internal_K as the prototypical Hilbert-Bernays-Löb K-axiom."
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Registers two long-standing orphan companion files under the gallery slug `godel-second-incompleteness-oq02`:

- **`Proofs/GodelSecondIncompletenessOQ02GLSyntax.lean`** (104 lines · 0 theorems · 4 definitions · 0 axioms · 0 sorries)
  GL modal-logic syntax foundation introduced in S8 ACT (PR #19146): inductive `GLFormula`, `PropAxiom`, and `GL_proves`.

- **`Proofs/GodelSecondIncompletenessOQ02Companion.lean`** (227 lines · 4 theorems · 1 definition · 3 axioms · 0 sorries)
  S2-α object-level implication `impl_formula` and HBL D2/D3 axiomatization (`impl_mp`, `d2_distribution`, `d3_internal_necessitation`); derives prototypical `internal_K`.

Both files are filesystem-present and have been imported by downstream research artifacts, but were absent from `meta.additionalFiles` and `leanFile.additionalFiles`. Auditor scans (which key on the top-level `meta.additionalFiles` string list per the gallery convention) missed them entirely.

## Changes

- Adds two string entries to `meta.additionalFiles` for auditor discovery.
- Mirrors rich descriptors (lineCount, theorems/definitions/axioms/sorries, description) into `leanFile.additionalFiles`.

No Lean code is modified; this is a meta-only registration patch.

## Test plan

- [x] JSON parses (`python3 -c 'import json; json.load(open(...))'`)
- [x] Both companion files present at the declared paths
- [x] `meta.additionalFiles` carries strings (auditor format); `leanFile.additionalFiles` carries rich objects (gallery format)
- [x] Counts (lineCount/theorems/definitions/axioms/sorries) verified by `wc -l` + grep against `^theorem/lemma`, `^def`, `inductive`, `^axiom`, and `sorry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)