### PR TITLE
fix(meta): area-of-circle-oq-05 register AreaOfCircleOQ05OQ04.lean orphan companion

### DIFF
--- a/src/data/proofs/area-of-circle-oq-05/meta.json
+++ b/src/data/proofs/area-of-circle-oq-05/meta.json
@@ -29,7 +29,10 @@
       }
     ],
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/AreaOfCircleOQ05OQ04.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Gaussian integral $\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$ has a remarkable history spanning three centuries. Abraham de Moivre (1733) first implicitly encountered it while deriving normal approximations to binomial coefficients. Euler (1729) computed related integrals involving $e^{-x^2}$ in the context of the gamma function. Laplace (1774) gave the celebrated polar-coordinate proof — arguably the most elegant computation in all of analysis — which shows that π appears because squaring the integral reveals a hidden circle. Gauss studied the integral extensively in his work on the error function (1809) while developing least-squares estimation; he connected it to the normal distribution for measurement errors. By the late 19th century, the integral had found its way into statistical mechanics (Maxwell–Boltzmann distribution), and in the 20th century into quantum field theory (Gaussian path integrals). The result is entry #49 on Mizar's list of 100 theorems important to formalize, and appears implicitly in Mathlib's probability theory infrastructure.",
@@ -152,7 +155,18 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 4
+    "theoremCount": 4,
+    "additionalFiles": [
+      {
+        "path": "Proofs/AreaOfCircleOQ05OQ04.lean",
+        "lineCount": 854,
+        "theorems": 25,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-05-OQ-04: Complex Gaussian integral results on ℂ and ℂⁿ. Proves ∫_ℂ exp(-π‖z‖²)=1, parametric scalings ∫_ℂ exp(-b‖z‖²)=π/b, multidimensional ∫_{ℂⁿ} exp(-b∑‖zᵢ‖²)=(π/b)ⁿ, shifted/translation-invariant variants, normalised probability densities, and Fourier-eigenvalue identities for the complex Gaussian. 25 theorems, sorry-free, axiom-free; derived from Mathlib's real Gaussian infrastructure via the canonical ℂ ≃ ℝ² identification."
+      }
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register `proofs/Proofs/AreaOfCircleOQ05OQ04.lean` (854 lines, 25 theorems, 0 sorries, 0 axioms — complex-Gaussian-integral results on ℂ and ℂⁿ) as a companion file of the parent gallery slug `area-of-circle-oq-05`. No `area-of-circle-oq-05-oq-04` slug exists.

## Evidence

**Before**: `AreaOfCircleOQ05OQ04.lean` is imported by `proofs/Proofs.lean` and tracked by `src/data/research/problems/area-of-circle-oq-05-oq-04.json`, but no `src/data/proofs/*/meta.json` referenced it (orphan companion).

**After**: `area-of-circle-oq-05/meta.json` lists it in both `meta.additionalFiles` (string form, auditor-followed) and `leanFile.additionalFiles` (rich object with lineCount/theorems/axioms/sorries/description), matching the convention used by sibling `AmgmInequalityOQ04OQ01` (PR #21920) and the godel-second-incompleteness-oq02 / picks-theorem-oq-03 / etc. orphans drained in earlier cycles.

---
Automated fix by lean-mechanic agent.