### PR TITLE
fix(meta): borsuk-ulam register BorsukUlamOQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -42,6 +42,9 @@
     "dateAdded": "2025-12-22",
     "lineCount": 267,
     "axiomCount": 1,
+    "additionalFiles": [
+      "Proofs/BorsukUlamOQ01.lean"
+    ],
     "prerequisites": [
       "Algebraic topology: fundamental groups and covering spaces",
       "Continuous functions on spheres and antipodal maps",
@@ -276,7 +279,18 @@
     "theoremCount": 9,
     "definitionCount": 6,
     "path": "Proofs/BorsukUlam.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BorsukUlamOQ01.lean",
+        "lineCount": 328,
+        "theorems": 17,
+        "definitions": 10,
+        "axioms": 2,
+        "sorries": 0,
+        "description": "OQ-01: Approximate Borsuk-Ulam and PPAD complexity. Formalizes the approximate antipodal pair problem, Tucker's lemma (axiomatized: tuckers_lemma), the structural reduction from Tucker's lemma to approximate Borsuk-Ulam, and proves exact Borsuk-Ulam (axiomatized: borsuk_ulam_exact) implies the approximate version. Companion to BorsukUlam.lean addressing the computational-complexity open question (Papadimitriou 1994, PPAD-completeness)."
+      }
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Register `BorsukUlamOQ01.lean` (328 lines, 17 thm, 10 def, 2 axiom, 0 sorry) as an additional file under the parent `borsuk-ulam` gallery slug. The companion existed in `proofs/Proofs/` but was not referenced from `src/data/proofs/borsuk-ulam/meta.json`.

## Evidence

**Before**:
- `meta.additionalFiles` absent
- `leanFile.additionalFiles` absent
- `BorsukUlamOQ01.lean` flagged as orphan (not referenced in any meta.json on origin/main `d735868cfd1`)

**After**:
- `meta.additionalFiles: ["Proofs/BorsukUlamOQ01.lean"]` (string form, auditor-readable)
- `leanFile.additionalFiles: [{ path, lineCount: 328, theorems: 17, definitions: 10, axioms: 2, sorries: 0, description }]` (rich UI form)

The OQ-01 sub-slug `borsuk-ulam-oq-01` does NOT exist as a separate gallery entry, so the companion correctly belongs with the parent.

The companion addresses the OQ-01 open question on PPAD computational complexity of approximate Borsuk-Ulam (Papadimitriou 1994). Tucker's lemma and exact Borsuk-Ulam are axiomatized; the reduction from Tucker to approximate Borsuk-Ulam is proved.

---
Automated fix by lean-mechanic agent.