### PR TITLE
fix(meta): factor-remainder-theorem register FactorRemainderTheoremOQ02.lean orphan

### DIFF
--- a/src/data/proofs/factor-remainder-theorem/meta.json
+++ b/src/data/proofs/factor-remainder-theorem/meta.json
@@ -48,7 +48,10 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/FactorRemainderTheoremOQ02.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The connection between polynomial roots and factors has ancient origins. Chinese mathematicians of the Song dynasty (960–1279), notably Qin Jiushao in his *Shùshū Jiǔzhāng* (1247), used a method equivalent to Horner's scheme to evaluate polynomials — effectively computing remainders upon division by linear factors, though without the modern algebraic framework.\n\nIn Europe, the explicit relationship between roots and divisibility emerged with the development of symbolic algebra. François Viète's *In Artem Analyticem Isagoge* (1591) established that knowing a root allows factoring out a linear term, though his notation was still verbal. René Descartes' *La Géométrie* (1637), published as an appendix to his *Discours de la méthode*, gave the first clear statement of what we now call the Factor Theorem: if $a$ is a root of $p(x)$, then $(x - a)$ divides $p(x)$. Descartes used this to argue that a degree-$n$ polynomial has at most $n$ roots.\n\nThe Remainder Theorem in its modern form was articulated by Étienne Bézout in his *Théorie générale des équations algébriques* (1779), as part of his systematic treatment of polynomial division and resultants. Bézout's theorem on the number of intersections of algebraic curves also relies on this polynomial division framework.\n\nThe Factor Theorem gained renewed importance with the development of Galois theory in the 19th century: the factorization of a polynomial's splitting field into a tower of extensions — each obtained by adjoining a root and factoring out the corresponding linear term — is the fundamental mechanism underlying the connection between polynomial solvability and group theory. Today the Factor and Remainder Theorems are entry points to the Euclidean algorithm for polynomial GCD, Hensel's lemma in $p$-adic analysis, and the Chinese Remainder Theorem for polynomial rings.\n\nThis formalization is #89 on Freek Wiedijk's list of 100 theorems formalized in proof assistants.",
@@ -151,7 +154,18 @@
     "theoremCount": 14,
     "definitionCount": 0,
     "path": "Proofs/FactorRemainderTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/FactorRemainderTheoremOQ02.lean",
+        "lineCount": 102,
+        "theorems": 6,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-02 extension: Rational Root Theorem for ℤ[X]/ℚ. Proves numerator divides constant term, denominator divides leading coefficient, Integral Root Theorem for monic polynomials, and connection to the Factor Theorem via factor_of_rational_root. Built on Mathlib's num_dvd_of_is_root / den_dvd_of_is_root (Mathlib.RingTheory.Polynomial.RationalRoot)."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register orphan companion file `Proofs/FactorRemainderTheoremOQ02.lean` (Rational Root Theorem extension) in `factor-remainder-theorem` meta.

## Evidence

**Before**: File existed in `proofs/Proofs/FactorRemainderTheoremOQ02.lean` (102 lines, 6 theorems, 0 axioms, 0 sorries) but was unreferenced in any `meta.json`. The auditor's reachability scan flagged it as an orphan.

**After**: Registered in two places per canonical mirror convention:
- `meta.additionalFiles[0] = "Proofs/FactorRemainderTheoremOQ02.lean"` (string form)
- `leanFile.additionalFiles[0]` (rich object with `lineCount: 102`, `theorems: 6`, `axioms: 0`, `sorries: 0`, and a description)

## Content

The OQ-02 file proves:
- Rational Root Theorem (numerator divides constant; denominator divides leading coefficient)
- Integral Root Theorem (monic case ⇒ all rational roots are integers)
- `factor_of_rational_root`: bridges back to the Factor Theorem
- `no_rational_root_of_no_integer_root`: contrapositive utility

All from Mathlib's `num_dvd_of_is_root` / `den_dvd_of_is_root` in `Mathlib.RingTheory.Polynomial.RationalRoot`.

---
Automated fix by lean-mechanic agent.