### PR TITLE
fix(meta): amgm-inequality-oq-04 register AmgmInequalityOQ04OQ03.lean orphan companion

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -26,7 +26,8 @@
     "theoremCount": 22,
     "definitionCount": 5,
     "additionalFiles": [
-      "Proofs/AmgmInequalityOQ04OQ01.lean"
+      "Proofs/AmgmInequalityOQ04OQ01.lean",
+      "Proofs/AmgmInequalityOQ04OQ03.lean"
     ],
     "assumptions": "0 axioms in this parent file (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the child file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). The Gauss AGM-elliptic-integral identity remains axiomatized in the child slug oq-04-oq-01 as agm_ellipticK_connection (200+ page classical proof, requires Landen/theta-function theory not in Mathlib).",
     "mathlib_version": "4.26.0"
@@ -173,6 +174,15 @@
         "axioms": 1,
         "sorries": 0,
         "description": "OQ-04-OQ-01: Rigorous K(k) elliptic integral definition via Mathlib intervalIntegral. Defines ellipticK as ∫₀^{π/2} dθ/√(1-k²sin²θ), proves ellipticK_zero (K(0)=π/2), positivity for |k|<1, and axiomatizes the deep Gauss AGM-K identity M(a,b)=aπ/(2K(k')) (1 axiom: agm_ellipticK_connection)"
+      },
+      {
+        "path": "Proofs/AmgmInequalityOQ04OQ03.lean",
+        "lineCount": 158,
+        "theorems": 7,
+        "definitions": 2,
+        "axioms": 1,
+        "sorries": 0,
+        "description": "OQ-04-OQ-03: Hypergeometric series representation of K. Defines hypCoeff n = ((2n choose n)/4ⁿ)² and hyp2F1 x = ∑ hypCoeff n · xⁿ realizing ₂F₁(1/2,1/2;1;x). Proves c₀=1, c₁=1/4, cₙ>0, ₂F₁(…;0)=1, and the k=0 consistency theorem K(0)=(π/2)·₂F₁(…;0) independently of the deep identity. Axiomatizes the series identity ellipticK_eq_hyp2F1: K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) for |k|<1 (1 axiom — full proof needs binomial series + Wallis integrals + term-by-term integration, parallel to companion OQ04OQ01)"
       }
     ]
   },


### PR DESCRIPTION
## Fix

`amgm-inequality-oq-04` was missing `Proofs/AmgmInequalityOQ04OQ03.lean` from its `additionalFiles` registration. The file is a sibling companion to `AmgmInequalityOQ04OQ01.lean` (registered in #21920) and develops the hypergeometric series representation of K(k) as the second route toward Gauss's AGM theorem.

Docstring evidence (line 8): `Open Question (OQ-04-OQ-03 from AmgmInequality)`. The file imports `Proofs.AmgmInequalityOQ04` (parent file) and `Proofs.AmgmInequalityOQ04OQ01` (sibling), reusing `ellipticK` and `ellipticK_zero` from the latter for its k=0 consistency theorem.

## Evidence

**Before**:
```json
"meta.additionalFiles":    ["Proofs/AmgmInequalityOQ04OQ01.lean"]
"leanFile.additionalFiles":[{ ... OQ01 only ... }]
```

**After**:
```json
"meta.additionalFiles":    ["Proofs/AmgmInequalityOQ04OQ01.lean", "Proofs/AmgmInequalityOQ04OQ03.lean"]
"leanFile.additionalFiles":[{ ... OQ01 ... }, { "path": "Proofs/AmgmInequalityOQ04OQ03.lean", lineCount: 158, theorems: 7, definitions: 2, axioms: 1, sorries: 0, description: "OQ-04-OQ-03: Hypergeometric series representation of K. ..." }]
```

Verification:
- `AmgmInequalityOQ04OQ03.lean:2-3`: `import Proofs.AmgmInequalityOQ04` + `import Proofs.AmgmInequalityOQ04OQ01`
- `proofs/Proofs/AmgmInequalityOQ04OQ03.lean` exists (158 lines, 2 defs, 7 theorems, 1 axiom `ellipticK_eq_hyp2F1`, 0 sorries)
- Not referenced via `proofRepoPath` or `additionalFiles` from any meta.json before this fix
- Sibling slug `amgm-inequality-oq-04-oq-03` does not exist (parent slug owns it)

Registered in both `meta.additionalFiles` (string) and `leanFile.additionalFiles` (rich object) per the canonical mirror convention.

---
Automated fix by lean-mechanic agent.