### PR TITLE
fix(meta): abel-ruffini-galois-extensions register OQ06 orphan companion

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -8,6 +8,9 @@
     "date": "2026-02-15",
     "status": "verified",
     "proofRepoPath": "Proofs/AbelRuffiniGaloisExtensions.lean",
+    "additionalFiles": [
+      "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"
+    ],
     "tags": [
       "group-theory",
       "galois-theory",
@@ -162,6 +165,17 @@
     "definitionCount": 1,
     "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean",
+        "lineCount": 530,
+        "theorems": 16,
+        "definitions": 5,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-06 (S2): Primitive solvable permutation groups of prime degree p — Galois (1832) classification. Constructs the concrete affine group AGL(1, p) = ℤ/pℤ ⋊ (ℤ/pℤ)ˣ on (ZMod p) × (ZMod p)ˣ with the semidirect-product law `(a, u) * (b, v) = (a + u·b, u·v)`, supplies the manual `Group (AGL1Z p)` instance (associativity, identity, inverses), and proves the order calculation `Nat.card (AGL1Z p) = p · (p - 1)` via a bijection with the cartesian product (using `ZMod.card` and `ZMod.card_units_eq_totient` + `Nat.totient_prime`). Deferred to S3+: `IsSolvable (AGL1Z p)`, the natural permutation action `AGL1Z p →* Equiv.Perm (ZMod p)` and its primitivity, and the Galois direction embedding every primitive solvable subgroup of S_p into AGL(1, p)."
+      }
+    ],
     "mainTheorems": [
       {
         "name": "symmetric_solvable_iff",


### PR DESCRIPTION
## Fix

Register `Proofs/AbelRuffiniGaloisExtensionsOQ06.lean` (530 lines, 16 thm, 5 def, 0 axiom, 0 sorry) as an additional file under the parent `abel-ruffini-galois-extensions` gallery slug. The companion existed in `proofs/Proofs/` but was not referenced from `src/data/proofs/abel-ruffini-galois-extensions/meta.json`.

## Evidence

**Before**:
- `meta.additionalFiles` absent
- `leanFile.additionalFiles` absent
- `AbelRuffiniGaloisExtensionsOQ06.lean` flagged as orphan (not referenced in any meta.json on `origin/main` `f486a19e2e0`)

**After**:
- `meta.additionalFiles: ["Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"]` (string form, auditor-readable)
- `leanFile.additionalFiles: [{ path, lineCount: 530, theorems: 16, definitions: 5, axioms: 0, sorries: 0, description }]` (rich UI form)

The OQ-06 sub-slug `abel-ruffini-galois-extensions-oq-06` does NOT exist as a separate gallery entry, while OQ-04, OQ-05, OQ-05-OQ-01, and OQ-07 each have their own slugs — so the companion correctly belongs with the parent.

The companion (S2 in its internal cycle) builds the forward-direction infrastructure for Galois's 1832 classification of primitive solvable permutation groups of prime degree p: defines `AGL1Z p` as a structure on `(ZMod p) × (ZMod p)ˣ` with the semidirect-product law `(a, u) * (b, v) = (a + u·b, u·v)`, supplies the manual `Group (AGL1Z p)` instance, and proves the order calculation `Nat.card (AGL1Z p) = p · (p - 1)` via `ZMod.card` + `ZMod.card_units_eq_totient` + `Nat.totient_prime`.

---
Automated fix by lean-mechanic agent.