### PR TITLE
fix(meta): binary-gcd-oq-01 register BinaryGcdOQ01OQ03.lean orphan companion

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -49,7 +49,10 @@
       "Well-founded recursion and termination proofs"
     ],
     "theoremCount": 4,
-    "definitionCount": 2
+    "definitionCount": 2,
+    "additionalFiles": [
+      "Proofs/BinaryGcdOQ01OQ03.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Two Algorithms for the Same Problem**\n\nThe Euclidean algorithm — described in Book VII of Euclid's *Elements* (~300 BCE) — computes gcd(a,b) via repeated division: (a,b) → (b, a mod b). It is one of the oldest known algorithms. Gabriel Lamé's 1844 analysis in *Comptes Rendus* proved that the algorithm takes at most 5d steps where d is the number of decimal digits of the smaller input — one of the first formal complexity analyses in history, predating computer science by a century. Lamé's proof used the key insight that Fibonacci pairs (F_n, F_{n-1}) are the worst case: the quotient is always 1, forcing the maximum number of steps.\n\nBinary GCD (Stein's algorithm) was published by Josef Stein in 1967, though the core idea was known to programmers working on early binary computers. The algorithm replaces expensive division with bit shifts (halving by 2) and subtraction — operations that are far cheaper on binary hardware. On multi-precision integers (as used in cryptography), the savings are dramatic since division is O(n²) in the number of limbs while shifting is O(n).\n\nThe formal comparison formalized here reveals the asymmetry: Binary GCD uses *more* steps but cheaper ones; the total operation count (weighted by hardware cost) often favors Binary GCD for large inputs. This is a recurring theme in algorithm analysis: step count alone doesn't determine practical efficiency.",
@@ -180,7 +183,18 @@
     "theoremCount": 4,
     "definitionCount": 2,
     "path": "Proofs/BinaryGcdOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BinaryGcdOQ01OQ03.lean",
+        "lineCount": 225,
+        "theorems": 5,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-01-OQ-03: Tight Lamé-Fibonacci bound — binaryGcdSteps a b ≤ log₂ a + log₂ b + 2 (factor-of-2 improvement over the parent's 2·(log₂ a + log₂ b) + 2 bound). Proves tightness via binaryGcdSteps (2^n) 1 = n + 1 and a Fibonacci-pair bound binaryGcdSteps_fib_bound. Namespace BinaryGcdOQ01OQ03; imports BinaryGcdOQ01 and GCDAlgorithmOQ01."
+      }
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Registers `Proofs/BinaryGcdOQ01OQ03.lean` as a companion to the `binary-gcd-oq-01` parent.

## Evidence

**Before**: `BinaryGcdOQ01OQ03.lean` (225 LOC) sits orphaned on disk — present in `proofs/Proofs/` but not listed in any `meta.json`'s `additionalFiles`, so auditors and the gallery treat it as untracked.

**After**: Registered in both
- `meta.additionalFiles` (string form, auditor-visible): `"Proofs/BinaryGcdOQ01OQ03.lean"`
- `leanFile.additionalFiles` (rich-object form): line count, theorem/def/axiom/sorry counts, and a description capturing the tight Lamé-Fibonacci bound (`binaryGcdSteps a b ≤ log₂ a + log₂ b + 2` — factor-of-2 improvement over the parent), tightness via `binaryGcdSteps (2^n) 1 = n + 1`, and the Fibonacci-pair bound.

File metrics: 225 LOC, 5 theorems, 0 defs, 0 axioms, 0 sorries. Namespace `BinaryGcdOQ01OQ03`; imports `Proofs.BinaryGcdOQ01` and `Proofs.GCDAlgorithmOQ01`.

---
Automated fix by lean-mechanic agent.