### PR TITLE
fix(meta): amgm-inequality-oq-04 axiom undercount (0 → 1, verified → axiomatized)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Arithmetic%E2%80%93geometric_mean",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AmgmInequalityOQ04.lean",
     "tags": [
       "analysis",
@@ -19,16 +19,16 @@
       "arithmetic-geometric-mean",
       "research"
     ],
-    "badge": "verified",
+    "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 0,
+    "axiomCount": 1,
     "lineCount": 306,
     "theoremCount": 22,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/AmgmInequalityOQ04OQ01.lean"
     ],
-    "assumptions": "0 axioms in this parent file (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the child file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). The Gauss AGM-elliptic-integral identity remains axiomatized in the child slug oq-04-oq-01 as agm_ellipticK_connection (200+ page classical proof, requires Landen/theta-function theory not in Mathlib).",
+    "assumptions": "0 axioms in the parent file AmgmInequalityOQ04.lean (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the companion file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). 1 axiom in the registered companion AmgmInequalityOQ04OQ01.lean: agm_ellipticK_connection — Gauss's AGM-elliptic-integral identity M(a,b) = aπ/(2K(k')), a 200+ page classical proof requiring Landen/theta-function theory not in Mathlib. Chain axiom total: 1.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Fix

After PR #21920 registered `AmgmInequalityOQ04OQ01.lean` (1 axiom: `agm_ellipticK_connection`) in `additionalFiles`, the parent slug's chain holds 1 axiom but `meta.axiomCount` remained 0. The auditor flagged this as `axiom undercount: claims 0, actual declarations 1`.

Aligns the slug with the gallery's chain-aggregation convention. 8 sibling slugs already follow this pattern (parent file 0 axioms + companion N axioms → `axiomCount=N`, `status=axiomatized`, `badge=axiom`):

- cantor-diagonalization-oq-01-oq-01-oq-02-oq-01 (4)
- erdos-2-oq-01 (3)
- erdos-25 (3)
- greens-theorem-oq-04 (2)
- inverse-galois-oq-01 (1)
- laws-of-large-numbers-oq-04 (1)
- laws-of-large-numbers-oq-04-oq-03 (1)
- mean-value-theorem-oq-02-oq-04 / -oq-04-oq-01 (1 each)

## Evidence

**Before**:
```
status: verified | badge: verified | axiomCount: 0
chain: AmgmInequalityOQ04.lean (0 axioms) + AmgmInequalityOQ04OQ01.lean (1 axiom)
auditor: axiom undercount: claims 0, actual declarations 1
```

**After**:
```
status: axiomatized | badge: axiom | axiomCount: 1
auditor: clean (Top 0 audit targets)
```

The `assumptions` narrative is also updated to attribute the 1 axiom to `agm_ellipticK_connection` in the companion file rather than to a non-existent "child slug `oq-04-oq-01`" (no such slug exists in the gallery).

Verification:
- `npx tsx scripts/auditor/find-targets.ts --issues` → `Top 0 audit targets (of 0 total)`
- `grep -c "^axiom " proofs/Proofs/AmgmInequalityOQ04.lean` → 0
- `grep -c "^axiom " proofs/Proofs/AmgmInequalityOQ04OQ01.lean` → 1

---
Automated fix by lean-mechanic agent.