### PR TITLE
research(roth-theorem-k3-oq-02-incomplete-01): S3 ACT YZ + XZ edge-uniqueness helpers (SzemerediCounting v4.26.0 blocker documented)

### DIFF
--- a/proofs/Proofs/RothTriangleRemoval.lean
+++ b/proofs/Proofs/RothTriangleRemoval.lean
@@ -248,6 +248,75 @@ theorem xy_edge_unique_triangle {N : ℕ} [NeZero N]
     linear_combination this
   linear_combination hz₁ - hz₂
 
+/-- When A is AP-free, each YZ-edge determines a unique triangle.
+
+    Edge (1,y)-(2,z) has b = z-y. AP-freeness forces a = b in any triangle
+    on this edge, so x = y - a = y - (z-y) = 2y - z is uniquely determined. -/
+theorem yz_edge_unique_triangle {N : ℕ} [NeZero N]
+    (A : Finset (ZMod N)) (hAP : APFree A) (y z : ZMod N)
+    (hyz : (ruzsaSzemerediGraph A).Adj (yVert y) (zVert z))
+    (x₁ x₂ : ZMod N)
+    (h₁ : (ruzsaSzemerediGraph A).Adj (xVert x₁) (yVert y) ∧
+           (ruzsaSzemerediGraph A).Adj (xVert x₁) (zVert z))
+    (h₂ : (ruzsaSzemerediGraph A).Adj (xVert x₂) (yVert y) ∧
+           (ruzsaSzemerediGraph A).Adj (xVert x₂) (zVert z)) :
+    x₁ = x₂ := by
+  obtain ⟨t₁, ht₁a, ht₁b⟩ := triangle_yields_ap_triple A x₁ y z h₁.1 hyz h₁.2
+  obtain ⟨t₂, ht₂a, ht₂b⟩ := triangle_yields_ap_triple A x₂ y z h₂.1 hyz h₂.2
+  have ⟨hab₁, _⟩ := ap_free_forces_equal A hAP t₁
+  have ⟨hab₂, _⟩ := ap_free_forces_equal A hAP t₂
+  -- y - x_i = a_i = b_i = z - y, so x_i = 2y - z (no Odd N needed)
+  have hx₁ : x₁ = 2 * y - z := by
+    have : y - x₁ = z - y := by rw [← ht₁a, ← ht₁b]; exact hab₁
+    linear_combination -this
+  have hx₂ : x₂ = 2 * y - z := by
+    have : y - x₂ = z - y := by rw [← ht₂a, ← ht₂b]; exact hab₂
+    linear_combination -this
+  linear_combination hx₁ - hx₂
+
+/-- When A is AP-free and N is odd, each XZ-edge determines a unique triangle.
+
+    Edge (0,x)-(2,z) has some witness c ∈ A with z - x = 2c. AP-freeness
+    forces a = b = c in any triangle on this edge, so y - x = (z-x)/2 = c,
+    i.e. y = x + c is uniquely determined (since 2 is invertible in ZMod N
+    when N is odd). -/
+theorem xz_edge_unique_triangle {N : ℕ} [NeZero N]
+    (A : Finset (ZMod N)) (hAP : APFree A) (hOdd : Odd N) (x z : ZMod N)
+    (hxz : (ruzsaSzemerediGraph A).Adj (xVert x) (zVert z))
+    (y₁ y₂ : ZMod N)
+    (h₁ : (ruzsaSzemerediGraph A).Adj (xVert x) (yVert y₁) ∧
+           (ruzsaSzemerediGraph A).Adj (yVert y₁) (zVert z))
+    (h₂ : (ruzsaSzemerediGraph A).Adj (xVert x) (yVert y₂) ∧
+           (ruzsaSzemerediGraph A).Adj (yVert y₂) (zVert z)) :
+    y₁ = y₂ := by
+  obtain ⟨t₁, ht₁a, ht₁b⟩ := triangle_yields_ap_triple A x y₁ z h₁.1 h₁.2 hxz
+  obtain ⟨t₂, ht₂a, ht₂b⟩ := triangle_yields_ap_triple A x y₂ z h₂.1 h₂.2 hxz
+  have ⟨hab₁, _⟩ := ap_free_forces_equal A hAP t₁
+  have ⟨hab₂, _⟩ := ap_free_forces_equal A hAP t₂
+  -- y_i - x = a_i = b_i = z - y_i, so 2 y_i = x + z
+  have hy₁ : 2 * y₁ = x + z := by
+    have : y₁ - x = z - y₁ := by rw [← ht₁a, ← ht₁b]; exact hab₁
+    linear_combination this
+  have hy₂ : 2 * y₂ = x + z := by
+    have : y₂ - x = z - y₂ := by rw [← ht₂a, ← ht₂b]; exact hab₂
+    linear_combination this
+  -- 2 * (y₁ - y₂) = 0; use Odd N to cancel
+  have h_diff : (2 : ZMod N) * y₁ = (2 : ZMod N) * y₂ := by
+    linear_combination hy₁ - hy₂
+  -- N = 1 case is trivial (ZMod 1 is subsingleton); N ≥ 2 case uses IsUnit 2
+  by_cases hN1 : N = 1
+  · subst hN1; exact Subsingleton.elim y₁ y₂
+  · have hN2 : 2 ≤ N := by
+      have : N ≠ 0 := NeZero.ne N
+      omega
+    haveI : Fact (1 < N) := ⟨hN2⟩
+    have h2unit : IsUnit ((2 : ℕ) : ZMod N) :=
+      (ZMod.isUnit_iff_coprime 2 N).mpr (Odd.coprime_two_left hOdd)
+    have h2cast : ((2 : ℕ) : ZMod N) = (2 : ZMod N) := by norm_cast
+    rw [h2cast] at h2unit
+    have h2ne : (2 : ZMod N) ≠ 0 := h2unit.ne_zero
+    exact mul_left_cancel₀ h2ne h_diff
+
 /-- When A is AP-free, for each a ∈ A and x ∈ Z/NZ, the triple
     (0,x), (1,x+a), (2,x+2a) forms a triangle in the RS graph. -/
 theorem ap_free_triangle_exists {N : ℕ} [NeZero N]

--- a/research/problems/roth-theorem-k3-oq-02-incomplete-01/sessions/2026-06-01-s3-act-yz-xz-helpers-szc-blocker.md
+++ b/research/problems/roth-theorem-k3-oq-02-incomplete-01/sessions/2026-06-01-s3-act-yz-xz-helpers-szc-blocker.md
@@ -1,0 +1,116 @@
+# Session 2026-06-01 (S3 ACT) — YZ + XZ edge-uniqueness helpers (SzemerediCounting build-verification blocker)
+
+**Date**: 2026-06-01
+**Researcher**: researcher-1
+**Phase**: ACT (S3 ACT; consumes the paste-ready code from S3 PREP `sessions/2026-05-31-s3-prep-yz-xz-helpers-paste-ready.md`)
+**Type**: Code paste in `proofs/Proofs/RothTriangleRemoval.lean` (+69 LOC, 2 theorems). Docker verification deferred — see §Verification status.
+**Lake-pinned Mathlib SHA**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (unchanged from S3 PREP).
+
+## What this session did
+
+Applied the S3 PREP paste-ready code verbatim into `proofs/Proofs/RothTriangleRemoval.lean` between line 249 (end of `xy_edge_unique_triangle`) and line 251 (start of `ap_free_triangle_exists`'s docstring). Adds two new theorems:
+
+1. **`yz_edge_unique_triangle`** (~22 LOC, no `Odd N` requirement). Parallel to `xy_edge_unique_triangle` with swapped subscripts; one sign flip in `linear_combination -this`.
+2. **`xz_edge_unique_triangle`** (~37 LOC, requires `hOdd : Odd N`). Uses `Odd.coprime_two_left` + `ZMod.isUnit_iff_coprime` + `mul_left_cancel₀` for cancellation in the N ≥ 2 branch; `Subsingleton.elim` handles the N = 1 edge case.
+
+File now: 534 LOC (was 465), 0 axioms, 2 sorries (unchanged — sorries at lines 292 and 309 remain; these are the S4 / S5 ACT targets).
+
+## Verification status — IMPORTANT
+
+**Docker build of `Proofs.RothTriangleRemoval` is BLOCKED by a pre-existing v4.26.0 regression in `Proofs.SzemerediCounting`** (the import dependency).
+
+### Baseline (before this session's paste)
+
+Running `./proofs/scripts/docker-build.sh Proofs.RothTriangleRemoval` against the unmodified file (commit `d735868cfd1`) produces three deterministic heartbeat timeouts inside `triangle_removal_quantitative` (`SzemerediCounting:594`):
+
+```
+error: Proofs/SzemerediCounting.lean:665:5: (deterministic) timeout at «tactic execution» [200000 heartbeats]
+error: Proofs/SzemerediCounting.lean:882:43: (deterministic) timeout at `whnf` [200000 heartbeats]
+error: Proofs/SzemerediCounting.lean:1031:6: (deterministic) timeout at «tactic execution» [200000 heartbeats]
+```
+
+### After bumping `maxHeartbeats` (experimental, reverted)
+
+Adding `set_option maxHeartbeats 1600000 in` before `triangle_removal_quantitative` makes the three heartbeat timeouts pass but exposes **more pre-existing v4.26.0 API-drift errors**:
+
+```
+error: Proofs/SzemerediCounting.lean:444:42: failed to prove positivity/nonnegativity/nonzeroness
+error: Proofs/SzemerediCounting.lean:576:8: Tactic `rewrite` failed: Did not find an occurrence of the pattern
+error: Proofs/SzemerediCounting.lean:640:16: Unknown identifier `pow_lt_pow_left`
+error: Proofs/SzemerediCounting.lean:642:37: No goals to be solved
+error: Proofs/SzemerediCounting.lean:645:10: Unknown identifier `pow_le_pow_left`
+error: Proofs/SzemerediCounting.lean:727:19: linarith failed to find a contradiction
+error: Proofs/SzemerediCounting.lean:730:34: Tactic `rewrite` failed: motive is not type correct
+... + nlinarith failure in counting-lemma chain
+```
+
+These are the same pattern that PRs #21803, #21813, #21825, #21830 fixed in other files: `pow_lt_pow_left` / `pow_le_pow_left` renamed to `pow_lt_pow_left₀` / `pow_le_pow_left₀` (and arity changes), plus `linarith`/`rewrite` motive issues.
+
+**Decision**: revert the `maxHeartbeats` bump and **defer SzemerediCounting v4.26.0 repair to a separate PR**. Adding the repair to this PR would be unbounded scope creep (~6–8 distinct fixes across multiple lemmas) and obscures the S3 ACT signal.
+
+### Why the YZ/XZ helpers are reliable despite no Docker verification
+
+The two new theorems use only:
+
+| Bearer | Source | Verification |
+|---|---|---|
+| `triangle_yields_ap_triple` | `RothTriangleRemoval.lean:143` (already proved, 0 sorry) | Used by existing `xy_edge_unique_triangle` |
+| `ap_free_forces_equal` | `RothTriangleRemoval.lean:196` (already proved, 0 sorry) | Used by existing `xy_edge_unique_triangle` |
+| `linear_combination`, `ring` | Mathlib (stable since v4.0) | Used throughout the file |
+| `Odd.coprime_two_left` | Mathlib `Data/Nat/Prime/Basic.lean:149` | Re-verified at pin SHA in S3 PREP §Bearer 2 |
+| `ZMod.isUnit_iff_coprime` | Mathlib `Data/ZMod/Basic.lean:810` | Re-verified at pin SHA in S3 PREP §Bearer 1 |
+| `mul_left_cancel₀` | Mathlib `Algebra/GroupWithZero/Basic.lean` | Stable since v4.0 |
+| `IsUnit.ne_zero` | Mathlib (requires `Nontrivial`) | Guarded by `Fact (1 < N)` instance via `haveI` |
+| `Subsingleton.elim` | Mathlib (always available) | Used only in N = 1 branch |
+
+None of these touch the broken `SzemerediCounting` machinery (which is about Szemerédi regularity / triangle counting, not about ZMod arithmetic or graph-theoretic triangle identification).
+
+The YZ helper is a direct subscript-swap of the existing XY helper, which the file presumably built before the v4.26.0 regression in SzemerediCounting hit. The XZ helper has more novel content (the by_cases on N = 1 and the IsUnit chain), but all the bearers are individually verified at the pinned SHA by direct source inspection.
+
+## Files modified
+
+- `proofs/Proofs/RothTriangleRemoval.lean`: +69 LOC (2 new theorems between line 249 and former line 251)
+
+## Sorries / axioms delta
+
+- Sorries: 2 → 2 (no change — S4 / S5 targets unchanged)
+- Axioms: 0 → 0
+- Structure-encoded assumptions: 0 → 0
+- meta.json `status`: `formalized` → `formalized` (no change)
+
+## Honest framing
+
+- **This is a stepping-stone ACT**, not a sorry-closing ACT. The S3 helpers don't directly discharge either sorry; they are preconditions for the S4 / S5 ACTs that close `rs_tc_ap_free_le` (line 292) and `rs_removal_lb` (line 309) respectively.
+- **No Docker verification this session**. Transitive build blocked by upstream SzemerediCounting v4.26.0 regression (pre-existing, not caused by this paste). The helpers themselves are derived directly from the S3 PREP paste-ready code, which traced bearers at the pinned SHA.
+- **No new mathematics**. The proof shape was implicit in the existing XY template (line 228); this session just makes the YZ and XZ analogues explicit and discovers the Odd-N dependency for XZ.
+- **Hypothesis discovery (already flagged in S3 PREP)**: `xz_edge_unique_triangle` requires `hOdd : Odd N` because cancellation by 2 in `ZMod N` needs 2 to be a unit. The parent sorries already carry `Odd N` (currently as `_hOdd`), so propagating the hypothesis to the helper call sites in S4 / S5 will be a no-op rename.
+
+## What to do next
+
+### S4 ACT (recommended next session — depends on SzemerediCounting repair OR ships under explicit "v4.26.0 SzemerediCounting blocker" qualifier)
+
+Discharge sorry #1 (`rs_tc_ap_free_le`, line 292): build the embedding `T ↪ Fin 6 × A × ZMod N` via `Finset.card_le_of_injective` + `Finset.card_product`. Uses `triangle_yields_ap_triple` + `ap_free_forces_equal` to extract the canonical `(a, x)` parametrization; `Fin 6` indexes the ordering permutation of the 3 vertices. Estimated ~60 LOC.
+
+### S5 ACT (subsequent session — depends on S4)
+
+Discharge sorry #2 (`rs_removal_lb`, line 309): use Classical choice on the 6-way disjunction from `ap_free_min_removal` to define a function `A × ZMod N → R` landing in the edge-removal set. Injectivity uses both YZ and XZ edge-uniqueness helpers from this S3 ACT. Estimated ~70 LOC.
+
+### Sibling work needed
+
+A separate **`fix: repair Proofs.SzemerediCounting build at Mathlib v4.26.0`** PR should address:
+- `pow_lt_pow_left` → `pow_lt_pow_left₀` (line 640)
+- `pow_le_pow_left` → `pow_le_pow_left₀` (line 645)
+- `linarith` failure at line 727
+- `rewrite` motive issue at line 730
+- nlinarith failure in counting-lemma chain (post-bump)
+- Heartbeat budget in `triangle_removal_quantitative` (line 594, ~1.6M needed if the underlying nlinarith etc. issues are resolved)
+
+This sibling repair unblocks Docker verification of all files transitively importing `SzemerediCounting` (currently: only `RothTriangleRemoval.lean`).
+
+## Cross-references
+
+- S1 (2026-04-03): problem.md authored.
+- S2 (2026-05-30, researcher-1): full attack plan for both sorries via canonical (a, x) parametrization. `sessions/2026-05-30-s2-observe-sorry-attack-plan.md`.
+- S3 PREP (2026-05-31, researcher-1): paste-ready code + bearer audit + `Odd N` discovery. `sessions/2026-05-31-s3-prep-yz-xz-helpers-paste-ready.md`.
+- S3 ACT (2026-06-01, researcher-1, THIS SESSION): paste applied; Docker verification deferred due to upstream SzemerediCounting regression.
+- S4 / S5 (subsequent iters): discharge sorries #1 and #2 using the helpers shipped here.

--- a/research/problems/roth-theorem-k3-oq-02-incomplete-01/state.md
+++ b/research/problems/roth-theorem-k3-oq-02-incomplete-01/state.md
@@ -1,13 +1,28 @@
 # Research State: roth-theorem-k3-oq-02-incomplete-01
 
 ## Current State
-**Phase**: PREP → done (S3 PREP shipped; S3 ACT next)
+**Phase**: ACT → done (S3 ACT shipped; S4 ACT next, blocked on SzemerediCounting v4.26.0 repair)
 **Path**: full
 **Since**: 2026-04-03T02:25:34-07:00
-**Iteration**: 3-PREP (S3, researcher-1, 2026-05-31, doc-only)
-**Last Updated**: 2026-05-31
+**Iteration**: 4-ACT (S3, researcher-1, 2026-06-01, paste applied)
+**Last Updated**: 2026-06-01
 
-## Current Focus (S3 PREP, researcher-1, 2026-05-31)
+## Current Focus (S3 ACT, researcher-1, 2026-06-01)
+
+S3 ACT iteration: paste-ready code from S3 PREP applied verbatim into `proofs/Proofs/RothTriangleRemoval.lean` between line 249 and former line 251. Two new theorems:
+
+- `yz_edge_unique_triangle` (~22 LOC) — no `Odd N` requirement; direct subscript-swap of XY template
+- `xz_edge_unique_triangle` (~37 LOC) — requires `Odd N`; uses `Subsingleton.elim` (N=1) + `Fact (1<N)` instance + `ZMod.isUnit_iff_coprime` + `Odd.coprime_two_left` + `mul_left_cancel₀` (N≥2)
+
+File now 534 LOC (was 465), 0 axioms, 2 sorries unchanged. Sorries at lines 292 and 309 still pending (S4 / S5 targets).
+
+**Docker verification deferred** — pre-existing v4.26.0 regression in `Proofs.SzemerediCounting` (transitive dep) blocks transitive build. Three heartbeat timeouts (lines 665/882/1031) mask deeper `pow_lt_pow_left`/`pow_le_pow_left` rename + `linarith`/`rewrite`/`nlinarith` failures (lines 640/645/727/730/+). Not caused by this S3 ACT paste; needs sibling repair PR before S4/S5 ACTs can Docker-verify.
+
+The full ACT memo is captured in:
+
+- `sessions/2026-06-01-s3-act-yz-xz-helpers-szc-blocker.md` (this session)
+
+## Prior focus snapshot (S3 PREP, 2026-05-31, researcher-1 — preserved for history)
 
 S3 PREP iteration: paste-ready Lean code for `yz_edge_unique_triangle` (~22 LOC, no `Odd N`) and `xz_edge_unique_triangle` (~37 LOC, requires `Odd N` — newly discovered hypothesis dependency not flagged by S2). Two Mathlib bearers re-verified at lake-pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:
 
@@ -102,10 +117,12 @@ All stable since Mathlib v4.0. Pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67
 
 ## Attempt Counts
 
-- Total attempts: 3 (S1 = problem.md only 2026-04-03; S2 = OBSERVE attack
-  plan 2026-05-30; S3 = PREP paste-ready helpers + Odd N bearer audit
-  2026-05-31, this session)
-- Current approach attempts: 2 (S2 doc-only OBSERVE → S3 doc-only PREP)
+- Total attempts: 4 (S1 = problem.md only 2026-04-03; S2 = OBSERVE attack
+  plan 2026-05-30; S3 PREP = paste-ready helpers + Odd N bearer audit
+  2026-05-31; S3 ACT = paste applied + SzemerediCounting v4.26.0 blocker
+  documented 2026-06-01, this session)
+- Current approach attempts: 3 (S2 doc-only OBSERVE → S3 doc-only PREP →
+  S3 code-paste ACT)
 - Approaches tried: 1 (canonical-(a,x) parametrization, viable)
 
 ## Blockers
@@ -117,24 +134,40 @@ to be added in S3, but copy-paste from the existing XY case is expected.
 
 ## Next Action
 
-S3 ACT (next iter, ANY researcher): apply the paste-ready code from
-`sessions/2026-05-31-s3-prep-yz-xz-helpers-paste-ready.md` to
-`proofs/Proofs/RothTriangleRemoval.lean` immediately after `xy_edge_unique_triangle`
-(line 249). Expected diff: +60 LOC (revised upward from S2's ~50 estimate due
-to the Odd N branching in `xz_edge_unique_triangle`), 2 new theorems, 0 axioms,
-0 sorries.
+**S4 ACT (next iter, ANY researcher)**: discharge sorry #1
+(`rs_tc_ap_free_le`, currently at line 292 of the updated file) via the
+Fin 6 × A × ZMod N embedding — uses `triangle_yields_ap_triple` +
+`ap_free_forces_equal` to extract the canonical `(a, x)` parametrization;
+`Fin 6` indexes the 3! orderings of an unordered triangle's vertices.
+Estimated ~60 LOC.
 
-Build verification: ship under "build pending — G9 lake self-loop" qualifier
-per `[[project_lake_self_loop_main_repo]]` memory. Cache-replay forecast:
-~5-10s compile of `Proofs.RothTriangleRemoval` post-paste (cache hit on all
-`import Mathlib.*` modules at lake-pin `2df2f0150c…`).
+**Sibling repair PR REQUIRED before Docker verification of S4/S5 ACTs**:
+fix Proofs.SzemerediCounting at Mathlib v4.26.0. Specific failures
+(verified 2026-06-01 by running docker-build.sh against the unmodified
+file at HEAD `d735868cfd1`, then with a `maxHeartbeats` bump on
+`triangle_removal_quantitative` line 594):
 
-Likely v4.26.0-syntax-drift candidates at ACT time (per S3 PREP §"Risk"):
-1. `Fact (1 < N)` instance trigger for `Nontrivial (ZMod N)` may need manual
-   `haveI : Nontrivial (ZMod N) := ⟨0, 1, by decide⟩` fallback.
-2. `Odd.coprime_two_left` namespace may be `_root_.Odd.coprime_two_left` or
-   `Nat.Odd.coprime_two_left` — current pin shows `_root_.Odd.coprime_two_left`.
-3. `linear_combination` sign drift between v4.25 → v4.26 (parenthesization).
+1. Heartbeat timeouts at lines 665 (tactic execution), 882 (`nlinarith`
+   via `whnf`), 1031 (tactic execution) — all under default 200000
+   budget; ~1.6M needed once the underlying tactic logic is fixed.
+2. `pow_lt_pow_left` (line 640) renamed to `pow_lt_pow_left₀` in v4.26.0.
+3. `pow_le_pow_left` (line 645) renamed to `pow_le_pow_left₀` in v4.26.0.
+4. `linarith` failure at line 727.
+5. `rewrite` motive issue at line 730.
+6. `nlinarith` failure in counting-lemma chain (post-bump, exact line
+   inside `triangle_removal_quantitative` proof body).
+7. Positivity failure at line 444.
+8. `rewrite` pattern failure at line 576.
+
+This sibling-repair pattern matches existing v4.26.0 fix PRs
+#21803, #21813, #21825, #21830. After repair, Docker verification of
+both this S3 ACT and the planned S4/S5 ACTs becomes possible.
+
+Pre-existing build state (before S3 ACT): `Proofs.RothTriangleRemoval`
+transitive build was already broken at v4.26.0 due to the SzemerediCounting
+issues above. The 2026-05-30/05-31 "build-clean otherwise" comment in
+prior state.md and knowledge.md was true for the file in isolation but
+not for the import dependency chain at v4.26.0.
 
 ## References
 

--- a/src/data/research/problems/roth-theorem-k3-oq-02-incomplete-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-02-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "roth-theorem-k3-oq-02-incomplete-01",
   "title": "Roth's Theorem via Triangle Removal Lemma",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -30,43 +30,46 @@
     "goal": "Fill the remaining triangle-count and removal-lower-bound helper lemmas so the triangle-removal proof of Roth's theorem no longer depends on sorries."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-03T02:25:34-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 4,
+    "focus": "S3 ACT shipped — YZ + XZ edge-uniqueness helpers pasted from S3 PREP; +69 LOC, file 465→534 LOC, 0/2 axioms/sorries unchanged. Docker verification deferred due to pre-existing SzemerediCounting v4.26.0 regression (heartbeat timeouts + pow_lt_pow_left rename + nlinarith failures). Helpers depend only on already-proven in-file lemmas (triangle_yields_ap_triple, ap_free_forces_equal) + Mathlib bearers re-verified at pin SHA in S3 PREP.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "S4 ACT: discharge sorry #1 (rs_tc_ap_free_le, line 292) via Fin 6 × A × ZMod N embedding. Blocked on Docker verification by SzemerediCounting v4.26.0 regression — recommend SzemerediCounting v4.26.0 repair PR first.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 4,
+      "currentApproach": 3,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Local evidence identifies this as an incomplete research task attached to roth-theorem-k3-oq-02. The parent metadata reports 2 sorries and 0 axioms; the source confirms the sorries are in private helpers rs_tc_ap_free_le and rs_removal_lb. The main theorem roth_via_triangle_removal is present but should not be treated as fully complete independently of those helpers.",
+    "progressSummary": "PROGRESS: S3 ACT shipped (2026-06-01, researcher-1) — yz_edge_unique_triangle + xz_edge_unique_triangle helpers added between line 249 and former line 251 of RothTriangleRemoval.lean. +69 LOC, file 465→534. xz helper requires Odd N (discovered in S3 PREP); parent sorries already carry hOdd so propagation is no-op. SzemerediCounting v4.26.0 regression blocks Docker verification but does NOT touch any bearer used by the new helpers — all four bearers (triangle_yields_ap_triple, ap_free_forces_equal, Odd.coprime_two_left, ZMod.isUnit_iff_coprime) re-verified at pin SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67.",
     "builtItems": [
       "RSVertex N as Fin 3 x ZMod N",
       "ruzsaSzemerediGraph with XY, YZ, and XZ adjacency relations determined by A",
       "APTriple and both directions of the triangle-to-3AP correspondence",
       "AP-free edge-disjointness ingredients, including xy_edge_unique_triangle and ap_free_triangle_exists",
       "ap_free_min_removal hitting statement for explicit AP-free triangles",
-      "roth_via_triangle_removal theorem depending on the two sorry'd private helpers"
+      "roth_via_triangle_removal theorem depending on the two sorry'd private helpers",
+      "yz_edge_unique_triangle in proofs/Proofs/RothTriangleRemoval.lean:251 (S3 ACT, no Odd N)",
+      "xz_edge_unique_triangle in proofs/Proofs/RothTriangleRemoval.lean:278 (S3 ACT, requires Odd N)"
     ],
     "insights": [
       "The Ruzsa-Szemeredi construction encodes generalized 3-AP triples a + b = 2c as triangles in a tripartite graph.",
       "When A is AP-free, every AP triple is forced to be trivial, giving edge-disjoint explicit triangles of the form (x, x + a, x + 2a).",
       "The target contradiction compares the removal lower bound |A| * N with the triangle removal lemma upper bound for a sparse-triangle graph.",
-      "The local problem statement mentions delta' = delta / 18, while the Lean theorem chooses eps_q with 9 * eps_q < delta."
+      "The local problem statement mentions delta' = delta / 18, while the Lean theorem chooses eps_q with 9 * eps_q < delta.",
+      "SzemerediCounting v4.26.0 regression discovered 2026-06-01: heartbeat timeouts at lines 665/882/1031 mask deeper pow_lt_pow_left / pow_le_pow_left rename + linarith/rewrite failures at lines 640/645/727/730 (bump maxHeartbeats to surface them). Pre-existing — not caused by S3 ACT paste. Separate v4.26.0 repair PR needed before S4/S5 ACTs can Docker-verify.",
+      "xz_edge_unique_triangle Odd N hypothesis discovery (already in S3 PREP) confirmed at ACT time — the proof uses Subsingleton.elim for N=1 and the Fact (1<N)-triggered Nontrivial (ZMod N) instance for N≥2 to enable IsUnit.ne_zero + mul_left_cancel₀."
     ],
     "mathlibGaps": [
       "A formal counting argument for ordered triangle triples in the RS graph under AP-freeness.",
       "A finite injection or disjointness argument turning one required removed edge per explicit triangle into |A| * N <= |R|."
     ],
     "nextSteps": [
-      "Inspect the exact shapes of triangleCount and removeEdges from the imported counting development.",
-      "Prove rs_tc_ap_free_le by reducing all triangles to explicit AP-free triangles and accounting for ordered permutations.",
-      "Prove rs_removal_lb by assigning each pair (a, x) to a removed edge from its explicit triangle and proving enough injectivity using edge uniqueness.",
-      "Re-run the Lean proof after each helper is replaced."
+      "Sibling PR: repair Proofs.SzemerediCounting at Mathlib v4.26.0 — pow_lt_pow_left/pow_le_pow_left renames (lines 640/645), linarith failure (line 727), rewrite motive issue (line 730), nlinarith chain post-bump, and maxHeartbeats budget on triangle_removal_quantitative.",
+      "S4 ACT: discharge sorry #1 (rs_tc_ap_free_le, line 292 in updated file) via Fin 6 x A x ZMod N embedding. Uses the S3 helpers shipped this session.",
+      "S5 ACT: discharge sorry #2 (rs_removal_lb, updated line ~378) via Classical choice + injection from canonical (a,x) parametrization. Uses the S3 helpers shipped this session."
     ],
     "markdown": "# Knowledge Base: roth-theorem-k3-oq-02-incomplete-01\n\n## Problem Understanding\n\nThis research problem is a scaffolded follow-up to the gallery proof `roth-theorem-k3-oq-02`, Roth's theorem via the Ruzsa-Szemeredi triangle removal construction. The local problem statement asks for the triangle-removal reduction, with a quantitative choice described as `delta' = delta / 18`.\n\n## Current Evidence\n\nThe parent metadata reports `0 axioms` and `2 sorries`. The Lean source confirms both sorries are private helper lemmas in `proofs/Proofs/RothTriangleRemoval.lean`: `rs_tc_ap_free_le`, the AP-free ordered triangle-count upper bound, and `rs_removal_lb`, the finite edge-removal lower bound. The theorem `roth_via_triangle_removal` is present but calls those helpers, so the proof status remains conservative.\n\n## Built Structure\n\nThe source defines the RS graph on `Fin 3 x ZMod N`, proves the triangle/AP correspondence, proves that AP-freeness forces AP triples to be trivial, and provides the explicit AP-free triangle construction. The remaining work is concentrated in the two quantitative/private helper lemmas needed for the final contradiction.\n\n## Dead Ends\n\nNo research attempts have been recorded yet; state.md preserves zero attempts.\n"
   },


### PR DESCRIPTION
## Summary

S3 ACT for `roth-theorem-k3-oq-02-incomplete-01`. Applies the S3 PREP paste-ready code into `proofs/Proofs/RothTriangleRemoval.lean`, adding two new theorems that close the YZ / XZ edge-uniqueness gap identified by S2 OBSERVE:

- **`yz_edge_unique_triangle`** (~22 LOC) — direct subscript-swap of the existing `xy_edge_unique_triangle` template with one sign flip. No `Odd N` requirement.
- **`xz_edge_unique_triangle`** (~37 LOC) — requires `hOdd : Odd N`. Handles `N = 1` via `Subsingleton.elim` and `N ≥ 2` via `Fact (1 < N)` instance + `ZMod.isUnit_iff_coprime` + `Odd.coprime_two_left` + `mul_left_cancel₀`.

File now 534 LOC (was 465). Sorries unchanged at 2 (lines 292 and 309 → lines 361 and 378 after the paste); axioms unchanged at 0. The two sorries are the S4 / S5 ACT targets (`rs_tc_ap_free_le` and `rs_removal_lb`) for which the helpers shipped here are preconditions.

## Verification status — Docker deferred

**Pre-existing v4.26.0 regression in `Proofs.SzemerediCounting`** (the import dependency, NOT touched by this PR) blocks transitive Docker verification. Reproduced against HEAD `d735868cfd1` with **no S3 ACT changes applied**:

```
error: Proofs/SzemerediCounting.lean:665:5: (deterministic) timeout at «tactic execution» [200000 heartbeats]
error: Proofs/SzemerediCounting.lean:882:43: (deterministic) timeout at `whnf` [200000 heartbeats]
error: Proofs/SzemerediCounting.lean:1031:6: (deterministic) timeout at «tactic execution» [200000 heartbeats]
```

Bumping `maxHeartbeats` to 1.6M on `triangle_removal_quantitative` (line 594) makes the heartbeat timeouts pass but exposes **more pre-existing v4.26.0 API drift**:

- `pow_lt_pow_left` (line 640) — renamed to `pow_lt_pow_left₀` in v4.26.0
- `pow_le_pow_left` (line 645) — renamed to `pow_le_pow_left₀` in v4.26.0
- `linarith` failure (line 727)
- `rewrite` motive issue (line 730)
- positivity (line 444)
- `rewrite` pattern (line 576)
- `nlinarith` chain failure (post-bump, inside the counting-lemma chain)

This is the same v4.26.0 API-drift pattern fixed by repair PRs #21803, #21813, #21825, #21830 in other files. A separate **`fix: repair Proofs.SzemerediCounting at Mathlib v4.26.0`** PR is needed before this S3 ACT and the planned S4 / S5 ACTs can be Docker-verified. The maxHeartbeats bump applied during diagnosis was reverted from this PR to keep its scope tight.

## Why the YZ/XZ helpers are reliable despite no Docker verification

| Bearer | Source | Verification |
|---|---|---|
| `triangle_yields_ap_triple` | `RothTriangleRemoval.lean:143` (already proved, 0 sorry) | Used by existing `xy_edge_unique_triangle` |
| `ap_free_forces_equal` | `RothTriangleRemoval.lean:196` (already proved, 0 sorry) | Used by existing `xy_edge_unique_triangle` |
| `linear_combination`, `ring` | Mathlib (stable since v4.0) | Used throughout the file |
| `Odd.coprime_two_left` | `Mathlib/Data/Nat/Prime/Basic.lean:149` | Re-verified at pin SHA in S3 PREP |
| `ZMod.isUnit_iff_coprime` | `Mathlib/Data/ZMod/Basic.lean:810` | Re-verified at pin SHA in S3 PREP |
| `mul_left_cancel₀` | `Mathlib/Algebra/GroupWithZero/Basic.lean` | Stable since v4.0 |
| `IsUnit.ne_zero` | Mathlib (requires `Nontrivial`) | Guarded by `Fact (1 < N)` instance via `haveI` |
| `Subsingleton.elim` | Mathlib (always available) | Used only in `N = 1` branch |

None of these touch the broken SzemerediCounting machinery (which is about Szemerédi regularity / triangle counting, not about ZMod arithmetic or in-graph triangle identification).

## Files modified

- `proofs/Proofs/RothTriangleRemoval.lean` — +69 LOC (2 new theorems between line 249 and former line 251)
- `research/problems/roth-theorem-k3-oq-02-incomplete-01/state.md` — phase ACT, iteration 4, S4 next action + SzemerediCounting blocker
- `research/problems/roth-theorem-k3-oq-02-incomplete-01/sessions/2026-06-01-s3-act-yz-xz-helpers-szc-blocker.md` — new ACT memo
- `src/data/research/problems/roth-theorem-k3-oq-02-incomplete-01.json` — phase ACT, iter 4, built items + insights

## Status

**Outcome**: progress (stepping-stone ACT — helpers shipped; sorries unchanged; Docker verification deferred)

**Next Steps**:
1. Sibling repair PR for `Proofs.SzemerediCounting` v4.26.0 API drift (see error list above)
2. S4 ACT: discharge sorry #1 (`rs_tc_ap_free_le`) via Fin 6 × A × ZMod N embedding (~60 LOC)
3. S5 ACT: discharge sorry #2 (`rs_removal_lb`) via canonical-triangle → R injection using these S3 helpers (~70 LOC)

## Honest framing

- This is a **stepping-stone ACT**, not a sorry-closing ACT. Helpers don't directly close either sorry; they are preconditions for S4 / S5.
- **No Docker verification** this session — transitive build blocked by upstream SzemerediCounting v4.26.0 regression (pre-existing, not caused by this paste).
- **No new mathematics**. The proof shape was already implicit in the XY template; this PR just makes the YZ / XZ analogues explicit and discovers the `Odd N` dependency for XZ.

🤖 Generated by researcher-1