### PR TITLE
fix(meta): birthday-problem-oq-01 register BirthdayProblemOQ01OQ02.lean orphan companion

### DIFF
--- a/src/data/proofs/birthday-problem-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01/meta.json
@@ -34,7 +34,10 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/BirthdayProblemOQ01OQ02.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The birthday problem was first analyzed by von Mises in the 1930s and popularized by the observation that in a group of 23 people, the probability of at least one shared birthday exceeds 50%. The expected-value formulation studied here — how many shared pairs do we *expect* — provides a different and often more useful quantity for applications like hash collision analysis and cryptography. By linearity of expectation, E[shared pairs] = C(n,2)/d, a formula whose simplicity belies the probabilistic subtlety: the pair indicators are highly correlated (three people can form three overlapping pairs), yet linearity bypasses all correlation arguments. The threshold n=28 for E[X]>1 with d=365 is 22% larger than the classic n=23 threshold, reflecting that the expected value exceeds 1 before the probability of any collision exceeds e^{-1} ≈ 37% (Poisson approximation). In cryptography, the birthday bound says that collisions in a hash function with 2^k outputs become likely after about 2^{k/2} evaluations — this file's formulation captures that 'likely' quantitatively via the expected count.",
@@ -115,7 +118,18 @@
     "theoremCount": 53,
     "definitionCount": 8,
     "path": "Proofs/BirthdayProblemOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BirthdayProblemOQ01OQ02.lean",
+        "lineCount": 235,
+        "theorems": 4,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-01-OQ-02: Helper lemma `one_sub_prod_le_sum` — real-valued union bound for products, 1 - ∏(1-f i) ≤ ∑ f i for f i ∈ [0,1]. S2 ACT layer of the OQ01-OQ02 coupling roadmap. Proves probCollision_le_choose_two_div (Markov upper bound), probCollision_ge_paley_zygmund (Paley-Zygmund lower bound), and probAllDistinct_eq_descFactorial_div (exact product formula). S3 (separate PR) chains these with gauss_sum_div (OQ02) and two_mul_choose_two (OQ01) to derive the full coupling."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/BirthdayProblemOQ01OQ02.lean` (235 lines, 4 thm, 0 def, 0 axiom, 0 sorries) as an additional file under the parent `birthday-problem-oq-01` gallery slug. The companion existed in `proofs/Proofs/` but was not referenced from `src/data/proofs/birthday-problem-oq-01/meta.json`.

## Evidence

**Before**:
- `meta.additionalFiles` absent
- `leanFile.additionalFiles` absent
- `BirthdayProblemOQ01OQ02.lean` flagged as orphan (not referenced in any `meta.json` on `origin/main` post `f486a19e2e0`)

**After**:
- `meta.additionalFiles: ["Proofs/BirthdayProblemOQ01OQ02.lean"]` (string form, auditor-readable)
- `leanFile.additionalFiles: [{ path, lineCount: 235, theorems: 4, definitions: 0, axioms: 0, sorries: 0, description }]` (rich UI form)

The OQ-02 sub-slug `birthday-problem-oq-01-oq-02` does NOT exist as a separate gallery entry, so the companion correctly belongs with the parent.

Companion content (S2 ACT layer): helper lemma `one_sub_prod_le_sum` (real-valued union bound for products) plus three coupling theorems — `probCollision_le_choose_two_div` (Markov upper bound), `probCollision_ge_paley_zygmund` (Paley–Zygmund lower bound), and `probAllDistinct_eq_descFactorial_div` (exact product formula). S3 (separate PR) will chain these with `gauss_sum_div` (OQ02) and `two_mul_choose_two` (OQ01) to derive the full first-moment coupling.

---
Automated fix by lean-mechanic agent.