### PR TITLE
fix(meta): binary-gcd-oq-03 register BinaryGcdOQ03OQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03/meta.json
@@ -29,7 +29,10 @@
     "lineCount": 488,
     "assumptions": "",
     "theoremCount": 15,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "additionalFiles": [
+      "Proofs/BinaryGcdOQ03OQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Derrick Henry Lehmer proposed his GCD acceleration in 1938, motivated by the observation that the leading digits of two numbers determine the first several quotients in the Euclidean algorithm. Instead of performing expensive full-precision divisions, Lehmer's method extracts the top w bits of a and b, runs the cheap single-precision Euclidean algorithm on these approximations, and records the sequence of quotients as a 2×2 integer cofactor matrix M = [[α,β],[γ,δ]]. One matrix-vector multiply (a',b') = M·(a,b) then performs all those quotient steps at once on the full-precision numbers. Arnold Schönhage (1971) took this further: by recursively applying Lehmer's idea (computing HGCD on the top half of the bits, applying, then recursing), one achieves O(M(n) log n) bit complexity using fast multiplication M(n). The GMP library's mpn_gcd uses this Lehmer-Schönhage hybrid, switching between plain Euclidean (≤64 bits), Lehmer's method (64–few thousand bits), and recursive HGCD (very large inputs). The key mathematical invariant is that unimodular matrices (det = ±1) preserve GCD — a direct consequence of Cramer's rule showing the inverse exists over ℤ.",
@@ -163,7 +166,18 @@
     "theoremCount": 15,
     "definitionCount": 14,
     "path": "Proofs/BinaryGcdOQ03.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BinaryGcdOQ03OQ01.lean",
+        "lineCount": 239,
+        "theorems": 9,
+        "definitions": 2,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-01 (Lehmer step progress + correctness): formalizes the inner Euclidean step (a,b) ↦ (b, a mod b) of Lehmer's 1938 GCD algorithm. Proves lehmerStep_gcd_invariant (gcd-preserving), lehmerGcd_progress (strict a+b decrease when 0 < b ≤ a), and lehmerGcd_correct (lehmerGcd a b = Nat.gcd a b). Companion to the parent Lehmer-Schönhage hybrid algorithm (BinaryGcdOQ03.lean) — supplies the per-step correctness lemmas the parent invariant theory needs."
+      }
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Register `Proofs/BinaryGcdOQ03OQ01.lean` (239 lines, 9 thm, 2 def, 0 axiom, 0 sorries) as an additional file under the parent `binary-gcd-oq-03` gallery slug. The companion existed in `proofs/Proofs/` but was not referenced from `src/data/proofs/binary-gcd-oq-03/meta.json`.

## Evidence

**Before**:
- `meta.additionalFiles` absent
- `leanFile.additionalFiles` absent
- `BinaryGcdOQ03OQ01.lean` flagged as orphan (not referenced in any `meta.json` on `origin/main` post `f486a19e2e0`)

**After**:
- `meta.additionalFiles: ["Proofs/BinaryGcdOQ03OQ01.lean"]` (string form, auditor-readable)
- `leanFile.additionalFiles: [{ path, lineCount: 239, theorems: 9, definitions: 2, axioms: 0, sorries: 0, description }]` (rich UI form)

The OQ-01 sub-slug `binary-gcd-oq-03-oq-01` does NOT exist as a separate gallery entry, so the companion correctly belongs with the parent.

Companion content (Lehmer GCD OQ-01, fully verified): progress + correctness of the inner Euclidean step `(a,b) ↦ (b, a mod b)`. Proves `lehmerStep_gcd_invariant` (GCD-preserving), `lehmerGcd_progress` (strict `a+b` decrease when `0 < b ≤ a`), and `lehmerGcd_correct` (`lehmerGcd a b = Nat.gcd a b`). Supplies the per-step correctness lemmas the parent Lehmer–Schönhage hybrid (BinaryGcdOQ03.lean) needs.

---
Automated fix by lean-mechanic agent.