### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02-oq-02 register OQ06 orphan companion

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -65,6 +65,9 @@
     "mathlib_version": "4.26.0",
     "theoremCount": 14,
     "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean"
+    ],
     "relatedProblems": [
       {
         "id": "abel-ruffini",
@@ -251,7 +254,18 @@
       }
     ],
     "path": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean",
+        "lineCount": 244,
+        "theorems": 11,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 1,
+        "description": "OQ-04-OQ-02-OQ-02-OQ-06: Derived series length gap — A₄ has derived length exactly 2 (a4_derived1_ne_bot + a4_derived2_eq_bot) while A₅ is perfect and never reaches ⊥ (a5_perfect + a5_derived_never_bot). Quantifies the phase transition at n = 5 of the parent's solvability classification. Namespace AbelRuffiniOQ04OQ02OQ02OQ06; imports parent Proofs.AbelRuffiniOQ04OQ02OQ02. 1 remaining sorry in a4_derived2_eq_bot (commutator A4 is abelian)."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Registers `Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean` as a companion of `abel-ruffini-oq-04-oq-02-oq-02`. The file was orphaned (not referenced by any `meta.json`) despite being a proper child file importing `Proofs.AbelRuffiniOQ04OQ02OQ02`.

## Evidence

**Before**: `proofs/Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean` (244 lines, 11 theorems) existed on disk but no `meta.json` `additionalFiles` entry referenced it. The auditor flags such orphans.

**After**: Both `meta.additionalFiles` (string form, for auditor enumeration) and `leanFile.additionalFiles` (rich object, for gallery rendering) register the file under the parent slug. Stats: 244 lines, 11 theorems, 0 definitions, 0 axioms, 1 sorry (`a4_derived2_eq_bot`).

The file proves the **derived series length gap** between $A_4$ (length exactly 2: `a4_derived1_ne_bot` + `a4_derived2_eq_bot`) and $A_5$ (perfect: `a5_perfect`, `a5_derived_never_bot`). This quantifies the phase transition at $n = 5$ of the parent's `alternating_solvable_iff` classification.

---
Automated fix by lean-mechanic agent.