### PR TITLE
fix(meta): algebraic-numbers-countable-oq-02-oq-02 register OQ01 orphan companion

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-02/meta.json
@@ -71,7 +71,10 @@
     ],
     "assumptions": "0 axioms. Relies only on Mathlib's completeness of ℝ (conditional supremum) and basic real arithmetic.",
     "theoremCount": 20,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "In 1874, Georg Cantor published 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (Journal für die reine und angewandte Mathematik, 77, pp. 258-262), introducing his first proof that the real numbers are uncountable. This predates the more famous diagonal argument (1891) by 17 years.\n\nThe nested interval proof is remarkable for its constructive character: given any proposed enumeration f : ℕ → ℝ, it explicitly constructs an interval-based witness — a real number guaranteed not to appear in the list. Cantor's original paper was primarily about algebraic numbers being countable; the uncountability of ℝ was a corollary demonstrating the existence of transcendental numbers.\n\nThis Lean 4 formalization uses a thirds-based subdivision (rather than the halves that might seem natural), a key technical choice that ensures left endpoints strictly increase at every step. Cantor's original argument had this monotonicity property implicitly; making it explicit and proved is the main contribution of this formalization over a naive bisection approach.",
@@ -224,7 +227,18 @@
     ],
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02.lean",
     "sorries": 0,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "additionalFiles": [
+      {
+        "path": "Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean",
+        "lineCount": 133,
+        "theorems": 3,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-02-OQ-02-OQ-01: Constructive convergence — quantifies the parent's nested-interval construction. Proves width_formula (width f n = (1/3)^n), cauchy_sequence (geometric Cauchy bound on left endpoints), and limit_agrees (the sSup limit equals Filter.lim). Namespace CantorNestedIntervalsConstructive; imports parent Proofs.AlgebraicNumbersCountableOQ02OQ02. 0 sorries."
+      }
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Registers `Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean` as a companion of `algebraic-numbers-countable-oq-02-oq-02`. The file was orphaned (not referenced by any `meta.json`) despite being a proper child importing `Proofs.AlgebraicNumbersCountableOQ02OQ02` under namespace `CantorNestedIntervalsConstructive`.

## Evidence

**Before**: `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ02OQ01.lean` (133 lines, 3 theorems, 0 sorries) existed on disk but no `meta.json` `additionalFiles` entry referenced it.

**After**: Both `meta.additionalFiles` (string form) and `leanFile.additionalFiles` (rich object) register the file. Adds an explicit `(1/3)^n` width formula, a geometric `CauchySeq` bound on the parent's left-endpoint sequence, and a proof that the parent's `sSup` limit agrees with `Filter.lim`.

---
Automated fix by lean-mechanic agent.