### PR TITLE
fix(meta): burnside-counting-oq-03 register BurnsideCountingOQ03OQ03.lean orphan companion

### DIFF
--- a/src/data/proofs/burnside-counting-oq-03/meta.json
+++ b/src/data/proofs/burnside-counting-oq-03/meta.json
@@ -29,7 +29,8 @@
     "theoremCount": 18,
     "definitionCount": 1,
     "additionalFiles": [
-      "Proofs/BurnsideCountingOQ03Aristotle.lean"
+      "Proofs/BurnsideCountingOQ03Aristotle.lean",
+      "Proofs/BurnsideCountingOQ03OQ03.lean"
     ],
     "mathlibDependencies": [
       {
@@ -182,7 +183,16 @@
     "definitionCount": 1,
     "theoremCount": 18,
     "additionalFiles": [
-      "Proofs/BurnsideCountingOQ03Aristotle.lean"
+      "Proofs/BurnsideCountingOQ03Aristotle.lean",
+      {
+        "path": "Proofs/BurnsideCountingOQ03OQ03.lean",
+        "lineCount": 152,
+        "theorems": 6,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "OQ-03 (MulAction bridge): connects the cyclic rotation AddAction (ZMod n) on Coloring n k to Mathlib's MulAction framework via the canonical Multiplicative type alias, then derives Burnside's orbit-counting identity for cyclic necklaces. Key bridge: `(Multiplicative.ofAdd r) • c = r +ᵥ c` definitionally. Proves burnside_necklace_count (sum of |fixedBy g| over Multiplicative (ZMod n) = #orbits · n), burnside_necklace_count_zmod (restated over ZMod n with IsFixedByRotation), necklace_count_burnside (necklace count corollary), and orbitRel_iff_coloringEquiv (Mathlib orbit relation coincides with the parent file's ColoringEquiv). Companion to the parent Pólya enumeration file BurnsideCountingOQ03.lean."
+      }
     ]
   },
   "sorries": 0


### PR DESCRIPTION
## Summary

Register `Proofs/BurnsideCountingOQ03OQ03.lean` as an additional file under the parent `burnside-counting-oq-03` gallery slug. The companion existed in `proofs/Proofs/` but was not referenced from `src/data/proofs/burnside-counting-oq-03/meta.json`.

The OQ-03 sub-slug `burnside-counting-oq-03-oq-03` does NOT exist as a separate gallery entry, so the companion correctly belongs under the parent.

## File Metrics

- **Path**: `Proofs/BurnsideCountingOQ03OQ03.lean`
- **lineCount**: 152
- **theorems**: 6
- **definitions**: 0
- **axioms**: 0
- **sorries**: 0

## Companion Content

OQ-03 (MulAction bridge) — connects the cyclic rotation `AddAction (ZMod n)` on `Coloring n k` to Mathlib's `MulAction` framework via the canonical `Multiplicative` type alias, then derives Burnside's orbit-counting identity for cyclic necklaces.

Key bridge: `(Multiplicative.ofAdd r) • c = r +ᵥ c` definitionally.

Proves:
- `burnside_necklace_count` — `Σ |fixedBy g| = #orbits · n` over `Multiplicative (ZMod n)`
- `burnside_necklace_count_zmod` — restated over `ZMod n` with `IsFixedByRotation`
- `necklace_count_burnside` — necklace count corollary
- `orbitRel_iff_coloringEquiv` — Mathlib orbit relation coincides with parent file's `ColoringEquiv`

## Changes

- `meta.additionalFiles`: append `"Proofs/BurnsideCountingOQ03OQ03.lean"` (auditor-readable string form)
- `leanFile.additionalFiles`: append rich-object companion descriptor

## Test Plan

- [x] JSON validates (`jq . src/data/proofs/burnside-counting-oq-03/meta.json`)
- [x] Lean file already exists at `proofs/Proofs/BurnsideCountingOQ03OQ03.lean` (152 lines)
- [x] Parent slug exists at `src/data/proofs/burnside-counting-oq-03/meta.json`
- [x] Sub-slug `burnside-counting-oq-03-oq-03` does NOT exist (no conflict)

Automated fix by lean-mechanic agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)