### PR TITLE
fix(meta): brouwer-fixed-point-oq-04 register BrouwerFixedPointOQ04OQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -56,7 +56,10 @@
     "lineCount": 505,
     "assumptions": "2 axioms: kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ) and brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). 0 sorries.",
     "theoremCount": 22,
-    "definitionCount": 14
+    "definitionCount": 14,
+    "additionalFiles": [
+      "Proofs/BrouwerFixedPointOQ04OQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Shizuo Kakutani proved his fixed point theorem in 1941, motivated by von Neumann's 1937 minimax theorem and its use of Brouwer's theorem for existence proofs in economics. Kakutani's insight was that many economic and game-theoretic models naturally involve set-valued maps (e.g., a consumer's demand given prices is a set of optimal bundles, not a single point), and that Brouwer's theorem could be extended to handle these. John Nash's 1950 proof of equilibrium existence in non-cooperative games — for which he received the 1994 Nobel Prize in Economics — relies essentially on Kakutani's theorem applied to the best-response correspondence. The Arrow-Debreu proof of general competitive equilibrium (1954), which earned Arrow the 1972 Nobel Prize, also depends on it. The theorem has since become indispensable in mathematical economics, optimal control theory (Filippov's lemma for differential inclusions, 1962), and nonlinear analysis. The infinite-dimensional generalization by Glicksberg (1952) and Fan (1952) extends it to locally convex spaces, enabling applications to infinite-horizon economic models.",
@@ -211,7 +214,18 @@
     "theoremCount": 22,
     "definitionCount": 14,
     "path": "Proofs/BrouwerFixedPointOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BrouwerFixedPointOQ04OQ01.lean",
+        "lineCount": 296,
+        "theorems": 8,
+        "definitions": 6,
+        "axioms": 2,
+        "sorries": 0,
+        "description": "OQ-04-OQ-01: Nash Equilibrium Existence via Kakutani. Formalizes finite N-player normal-form games, expected utility, best-response correspondences with nonemptiness/convexity/closedness, and proves Nash's theorem from kakutani_product_simplex (Kakutani FPT applied to the joint best-response). Also defines the Prisoner's Dilemma and matching-pennies as concrete examples. Companion to BrouwerFixedPointOQ04.lean."
+      }
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register the orphaned `Proofs/BrouwerFixedPointOQ04OQ01.lean` (Nash equilibrium via Kakutani) companion file in `src/data/proofs/brouwer-fixed-point-oq-04/meta.json`.

## Evidence

**Before**: `BrouwerFixedPointOQ04OQ01.lean` (296 lines, 8 theorems, 6 defs, 2 axioms, 0 sorries) lived in `proofs/Proofs/` but was absent from every `meta.json`. Auditor scan at HEAD `f486a19e2e0` flagged it as one of 259 orphans / 126 viable slug-matched.

**After**:
- `meta.additionalFiles`: `["Proofs/BrouwerFixedPointOQ04OQ01.lean"]` (string form — auditor follows strings)
- `leanFile.additionalFiles`: rich object with `lineCount`, `theorems`, `definitions`, `axioms`, `sorries`, and a description naming the Nash existence content, kakutani_product_simplex, prisoner's-dilemma example, matching-pennies

## Verification

```bash
python3 -c "import json; json.load(open('src/data/proofs/brouwer-fixed-point-oq-04/meta.json'))"
# JSON OK
```

Companion is not an Aristotle target (contains the main Nash existence theorem); registered as a standard companion only.

---
Automated fix by lean-mechanic agent.