### PR TITLE
fix(meta): arithmetic-series-oq-00 register ArithmeticSeriesOQ00OQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-00/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00/meta.json
@@ -31,6 +31,9 @@
       }
     ],
     "dateAdded": "2026-04-12",
+    "additionalFiles": [
+      "Proofs/ArithmeticSeriesOQ00OQ01.lean"
+    ],
     "theoremCount": 11,
     "definitionCount": 0
   },
@@ -158,7 +161,18 @@
       }
     ],
     "path": "Proofs/ArithmeticSeriesOQ00.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/ArithmeticSeriesOQ00OQ01.lean",
+        "lineCount": 282,
+        "theorems": 10,
+        "definitions": 1,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Bijective proof of Nicomachus's theorem (OQ01): exhibits an explicit cardinality bijection ⊔_{k=1}^n Fin k × Fin k × Fin k ↔ Fin T(n) × Fin T(n) via Fintype.card and `card_sigma`. Includes `nicomachus_sum_nat` (∑k³ = T(n)²), `gnomon_card`, `cube_as_gnomon_z` ((2k-1)k² + (k-1)²k = k³ as a CommRing identity), `sum_cubes_telescopes_four`, and concrete `bijection_n1`/`bijection_n3`/`card_sigma_n4` finite checks. Namespace `NicomachusBijection`."
+      }
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Register the 282-line bijective-proof companion `Proofs/ArithmeticSeriesOQ00OQ01.lean` (namespace `NicomachusBijection`) as a child of gallery slug `arithmetic-series-oq-00`. The file was filesystem-present but absent from `meta.additionalFiles` and `leanFile.additionalFiles`, making it invisible to auditor scans.

## Evidence

**Before**: `proofs/Proofs/ArithmeticSeriesOQ00OQ01.lean` (282L, 10T, 1D, 0A, 0S) — orphan.
**After**: Registered under `arithmetic-series-oq-00/meta.json`:
- `meta.additionalFiles` (string form, auditor-visible)
- `leanFile.additionalFiles` (rich object: lineCount/theorems/definitions/axioms/sorries/description)

Per `[[project_mechanic_additionalfiles_format_convention]]`: strings in `meta.additionalFiles` (auditor follows these), rich objects in `leanFile.additionalFiles` (renderer surface).

No status/axiom change to parent: companion is 0A/0S → parent stays `verified` / `original`.

Content summary: explicit cardinality bijection `⊔_{k=1}^n Fin k × Fin k × Fin k ↔ Fin T(n) × Fin T(n)` via `Fintype.card` + `card_sigma`. Includes `nicomachus_sum_nat`, `gnomon_card`, `cube_as_gnomon_z`, `sum_cubes_telescopes_four`, and concrete `bijection_n1`/`bijection_n3`/`card_sigma_n4` finite checks. `def triangular`.

---
Automated fix by lean-mechanic agent.