### PR TITLE
fix(meta): ballot-problem-oq-01-oq-01-oq-02 register OQ01 orphan companion

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json
@@ -21,6 +21,9 @@
     "lineCount": 211,
     "theoremCount": 9,
     "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean"
+    ],
     "dateAdded": "2026-05-04",
     "assumptions": "None. All 9 theorems are fully proved (0 axioms, 0 sorries).",
     "mathlibDependencies": [
@@ -134,7 +137,18 @@
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/BallotProblemOQ01OQ01OQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean",
+        "lineCount": 626,
+        "theorems": 12,
+        "definitions": 0,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "m-jump downward IVT (OQ01 child research direction, namespace BallotMJumpCycleLemma): m-jump step bounds (m_jump_step_bound, m_jump_step_bound_upward), downward/upward IVT with conclusion window [v - m + 1, v] (m_jump_downward_ivt, m_jump_upward_ivt), unit recovery at m=1 (m_jump_downward_ivt_unit_recovery, m_jump_upward_ivt_unit_recovery), and step-alphabet cardinality lemmas for {-m, ..., -1, +1} and Option C two-sided variants (step_in_one_neg_m_count, step_in_one_pos_mixed_neg_card_eq/_bound, step_le_one_card_eq, step_in_one_pos_pm_card_eq/_bound). Generalizes the parent's unit-decrement IVT to arbitrary m ≥ 1."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the 626-line m-jump-IVT companion `Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` (namespace `BallotMJumpCycleLemma`) as a child of gallery slug `ballot-problem-oq-01-oq-01-oq-02`. The file was filesystem-present but absent from `meta.additionalFiles` and `leanFile.additionalFiles`, making it invisible to auditor scans.

## Evidence

**Before**: `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` (626L, 12T, 0D, 0A, 0S) — orphan.
**After**: Registered under `ballot-problem-oq-01-oq-01-oq-02/meta.json`:
- `meta.additionalFiles` (string form, auditor-visible)
- `leanFile.additionalFiles` (rich object: lineCount/theorems/definitions/axioms/sorries/description)

Per `[[project_mechanic_additionalfiles_format_convention]]`: strings in `meta.additionalFiles` (auditor follows these), rich objects in `leanFile.additionalFiles` (renderer surface).

No status/axiom change to parent: companion is 0A/0S → parent stays `verified` / `original`.

Content summary: m-jump downward/upward IVT (conclusion window `[v - m + 1, v]` for arbitrary m ≥ 1), unit-recovery lemmas at m=1, step bounds, and step-alphabet cardinality lemmas for `{-m, ..., -1, +1}` and Option C two-sided variants. Generalizes the parent's unit-decrement IVT.

---
Automated fix by lean-mechanic agent.