### PR TITLE
fix(meta): cevas-theorem-oq-04 register CevasTheoremOQ04OQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/cevas-theorem-oq-04/meta.json
+++ b/src/data/proofs/cevas-theorem-oq-04/meta.json
@@ -58,6 +58,9 @@
     ],
     "assumptions": "Fully verified. 0 axioms, 0 sorries.",
     "mathlib_version": "4.26.0",
+    "additionalFiles": [
+      "Proofs/CevasTheoremOQ04OQ01.lean"
+    ],
     "theoremCount": 22,
     "definitionCount": 4
   },
@@ -153,7 +156,18 @@
     "theoremCount": 22,
     "definitionCount": 4,
     "path": "Proofs/CevasTheoremOQ04.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/CevasTheoremOQ04OQ01.lean",
+        "lineCount": 215,
+        "theorems": 11,
+        "definitions": 4,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "N-dimensional mass-point Ceva scaffold (OQ01 child research direction, namespace NDimMassPoint): lifts the parent's triangle MassPoint structure to a Fin (n+1)-indexed family. Defines MassPoint (structure), MassPoint.total, MassPoint.ratio (= 1 - mass i / total), and uniform (centroid example). Headline identity sum_ratio_eq: ∑ ratio i = n. Auxiliary lemmas: total_pos, total_ne_zero, sum_erase_eq_total_sub, ratio_eq_one_sub, ratio_lt_one, ratio_pos, sum_mass_div_total, uniform_total, uniform_ratio."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the 215-line N-dimensional mass-point Ceva scaffold `Proofs/CevasTheoremOQ04OQ01.lean` (namespace `NDimMassPoint`) as a child of gallery slug `cevas-theorem-oq-04`. The file was filesystem-present but absent from `meta.additionalFiles` and `leanFile.additionalFiles`, making it invisible to auditor scans.

## Evidence

**Before**: `proofs/Proofs/CevasTheoremOQ04OQ01.lean` (215L, 11T, 4D, 0A, 0S) — orphan.
**After**: Registered under `cevas-theorem-oq-04/meta.json`:
- `meta.additionalFiles` (string form, auditor-visible)
- `leanFile.additionalFiles` (rich object: lineCount/theorems/definitions/axioms/sorries/description)

Per `[[project_mechanic_additionalfiles_format_convention]]`: strings in `meta.additionalFiles` (auditor follows these), rich objects in `leanFile.additionalFiles` (renderer surface).

No status/axiom change to parent: companion is 0A/0S → parent stays `verified` / `mathlib`.

Content summary: lifts the parent's triangle `MassPoint` structure to a `Fin (n+1)`-indexed family. Defines `MassPoint` structure, `MassPoint.total`, `MassPoint.ratio = 1 - mass i / total`, `uniform` (centroid example). Headline identity `sum_ratio_eq: ∑ ratio i = n`. Auxiliary lemmas: `total_pos`, `ratio_eq_one_sub`, `ratio_lt_one`, `ratio_pos`, `sum_mass_div_total`, `uniform_total`, `uniform_ratio`.

---
Automated fix by lean-mechanic agent.