### PR TITLE
fix(meta): arithmetic-series-...-OQ03 register OQ02 orphan companion

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -62,6 +62,9 @@
     "prerequisites": [
       "Gaussian binomial coefficients (Proofs/CombinationsFormulaOQ03.lean)",
       "Multiset Vandermonde identity (Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02.lean)"
+    ],
+    "additionalFiles": [
+      "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean"
     ]
   },
   "overview": {
@@ -171,7 +174,10 @@
     "lineCount": 228,
     "theoremCount": 12,
     "definitionCount": 1,
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` (S2-S4 ACT companion for the (q,t)-multichoose sub-OQ) in the parent `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03` meta.json. It was an orphan — present in `proofs/Proofs/` but not referenced from any meta.

## Evidence

**Before**: `meta.additionalFiles` and `leanFile.additionalFiles` both absent; orphan scan v4 flagged the file as unclaimed (`slug=arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03 | primary=ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03`).

**After**: Both `meta.additionalFiles` and `leanFile.additionalFiles` list `Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean`.

Companion stats: 347 lines, 13 theorems + 2 defs + 1 private lemma, 0 sorries, 0 `axiom` declarations.

---
Automated fix by lean-mechanic agent.