### PR TITLE
research(triangular-reciprocals-oq-02): S2→S8 COMPLETE — main HasSum proved, 0 sorries / 0 axioms

### DIFF
--- a/proofs/Proofs/TriangularReciprocalsOQ02.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02.lean
@@ -20,7 +20,7 @@
     4. summable_one_div_n_mul_n_add_k:   1/(n(n+k)) ≤ 1/n^2  ⇒  Summable
     Main: combine 2 + 3 + 4 to pass partial sums to HasSum.
 
-  Status: S4 SCAFFOLD — all proofs are `sorry`. ACT phases S5+ will close them.
+  Status: S7/S8 COMPLETE — all lemmas closed; main `HasSum` proved.
 
   Sibling reuse:
     `Proofs/TriangularReciprocalGeneralized.lean` (slug `triangular-reciprocals-oq-03`,
@@ -62,7 +62,74 @@ theorem partial_fraction {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
 theorem partial_sum_closed_form (N k : ℕ) (hk : 0 < k) :
     ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
       (1 / (k : ℝ)) * ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))) := by
-  sorry
+  have hk_ne_nat : k ≠ 0 := Nat.pos_iff_ne_zero.mp hk
+  -- (harmonic m : ℝ) viewed as a sum in ℝ.
+  have harm_R : ∀ m : ℕ,
+      (harmonic m : ℝ) = ∑ i ∈ Finset.Icc 1 m, (1 : ℝ) / (i : ℝ) := by
+    intro m
+    have h := harmonic_eq_sum_Icc (n := m)
+    have hR : ((harmonic m : ℚ) : ℝ) = (((∑ i ∈ Finset.Icc 1 m, (↑i)⁻¹ : ℚ) : ℝ)) := by
+      exact_mod_cast congrArg (Rat.cast : ℚ → ℝ) h
+    rw [hR]
+    push_cast
+    apply Finset.sum_congr rfl
+    intro i _
+    rw [one_div]
+  -- Telescoped diff identity.
+  have h_diff_NK_k : (harmonic (N + k) : ℝ) - (harmonic k : ℝ) =
+      ∑ i ∈ Finset.Icc (k + 1) (N + k), (1 : ℝ) / (i : ℝ) := by
+    rw [harm_R (N + k), harm_R k]
+    rw [show (Finset.Icc 1 (N + k)) = Finset.Ico 1 (N + k + 1) from
+          (Nat.Ico_succ_right (a := 1) (b := N + k)).symm,
+        show (Finset.Icc 1 k) = Finset.Ico 1 (k + 1) from
+          (Nat.Ico_succ_right (a := 1) (b := k)).symm,
+        show Finset.Icc (k + 1) (N + k) = Finset.Ico (k + 1) (N + k + 1) from
+          (Nat.Ico_succ_right (a := k + 1) (b := N + k)).symm]
+    have h_cons :
+        (∑ i ∈ Finset.Ico 1 (k + 1), (1 : ℝ) / (i : ℝ)) +
+          (∑ i ∈ Finset.Ico (k + 1) (N + k + 1), (1 : ℝ) / (i : ℝ)) =
+            ∑ i ∈ Finset.Ico 1 (N + k + 1), (1 : ℝ) / (i : ℝ) :=
+      Finset.sum_Ico_consecutive _ (by omega) (by omega)
+    linarith [h_cons]
+  -- Apply partial_fraction termwise.
+  have h_partial :
+      ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
+        (1 / (k : ℝ)) * ∑ n ∈ Finset.Icc 1 N,
+          ((1 : ℝ) / (n : ℝ) - (1 : ℝ) / ((n : ℝ) + ↑k)) := by
+    rw [Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro n hn
+    rw [Finset.mem_Icc] at hn
+    have hn_ne : n ≠ 0 := Nat.pos_iff_ne_zero.mp hn.1
+    exact partial_fraction hn_ne hk_ne_nat
+  rw [h_partial, Finset.sum_sub_distrib]
+  -- Identify the first sum as harmonic N.
+  have h_sum1 :
+      ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / (n : ℝ) = (harmonic N : ℝ) :=
+    (harm_R N).symm
+  -- Reindex the second sum.
+  have h_sum2 :
+      ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) + ↑k) =
+        ∑ m ∈ Finset.Icc (k + 1) (N + k), (1 : ℝ) / (m : ℝ) := by
+    rw [show (Finset.Icc 1 N) = Finset.Ico 1 (N + 1) from
+          (Nat.Ico_succ_right (a := 1) (b := N)).symm,
+        show Finset.Icc (k + 1) (N + k) = Finset.Ico (k + 1) (N + k + 1) from
+          (Nat.Ico_succ_right (a := k + 1) (b := N + k)).symm]
+    -- Rewrite summand so the shift is on a ℕ cast.
+    have summand_eq : ∀ n ∈ Finset.Ico 1 (N + 1),
+        (1 : ℝ) / ((n : ℝ) + ↑k) = (1 : ℝ) / ((↑(n + k) : ℝ)) := by
+      intro n _; push_cast; ring
+    rw [Finset.sum_congr rfl summand_eq]
+    -- Apply sum_Ico_add' (additive version of prod_Ico_add').
+    have key := Finset.sum_Ico_add'
+      (fun i : ℕ => (1 : ℝ) / (i : ℝ)) 1 (N + 1) (c := k)
+    -- key : ∑ x ∈ Ico 1 (N+1), 1 / ((x+k : ℕ) : ℝ)
+    --        = ∑ x ∈ Ico (1+k) (N+1+k), 1 / ((x : ℕ) : ℝ)
+    rw [show (k + 1) = (1 + k) from by ring,
+        show (N + k + 1) = (N + 1 + k) from by ring]
+    exact key
+  rw [h_sum1, h_sum2, ← h_diff_NK_k]
+  ring
 
 -- ═══════════════════════════════════════════════════
 -- Lemma 3: Harmonic Tail Difference Tends to Zero
@@ -157,7 +224,58 @@ theorem summable_one_div_n_mul_n_add_k (k : ℕ) :
 theorem generalized_triangular_reciprocals (k : ℕ) (hk : 0 < k) :
     HasSum (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k)))
       ((harmonic k : ℝ) / (k : ℝ)) := by
-  sorry
+  -- The summand is nonneg, so HasSum ↔ Tendsto of partial sums.
+  have h_nonneg : ∀ n : ℕ,
+      0 ≤ (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k)) := by
+    intro n
+    have h1 : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_pos n
+    have h2 : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    positivity
+  rw [hasSum_iff_tendsto_nat_of_nonneg h_nonneg]
+  -- Identify the partial sum over `range N` with the Icc-form `∑ n ∈ Icc 1 N, 1/(n(n+k))`.
+  have h_range_to_Icc : ∀ N : ℕ,
+      ∑ i ∈ Finset.range N,
+          (1 : ℝ) / (((i + 1 : ℕ) : ℝ) * (((i + 1 : ℕ) : ℝ) + ↑k)) =
+        ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) := by
+    intro N
+    rw [show (Finset.Icc 1 N) = Finset.Ico 1 (N + 1) from
+          (Nat.Ico_succ_right (a := 1) (b := N)).symm,
+        ← Nat.Ico_zero_eq_range]
+    have key := Finset.sum_Ico_add'
+      (fun m : ℕ => (1 : ℝ) / ((m : ℝ) * ((m : ℝ) + ↑k))) 0 N (c := 1)
+    -- key : ∑ x ∈ Ico 0 N, (fun m => 1/(m*(m+k))) (x + 1)
+    --       = ∑ x ∈ Ico (0+1) (N+1), 1/(x*(x+k))
+    simp only [zero_add] at key
+    -- `rw [← key]` closes the goal: after the index shift, summands β-reduce to match.
+    rw [← key]
+  -- Apply Lemma 2 pointwise.
+  have h_closed_form : ∀ N : ℕ,
+      ∑ i ∈ Finset.range N,
+          (1 : ℝ) / (((i + 1 : ℕ) : ℝ) * (((i + 1 : ℕ) : ℝ) + ↑k)) =
+        (1 / (k : ℝ)) *
+          ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))) := by
+    intro N
+    rw [h_range_to_Icc N, partial_sum_closed_form N k hk]
+  rw [show (fun N : ℕ => ∑ i ∈ Finset.range N, (1 : ℝ) /
+              (((i + 1 : ℕ) : ℝ) * (((i + 1 : ℕ) : ℝ) + ↑k))) =
+          fun N : ℕ => (1 / (k : ℝ)) *
+            ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))) from
+        funext h_closed_form]
+  -- (1/k) * (H_k - (H_{N+k} - H_N)) → (1/k) * (H_k - 0) = H_k/k.
+  have h_tail : Tendsto (fun N : ℕ => (harmonic (N + k) : ℝ) - (harmonic N : ℝ))
+      atTop (𝓝 (0 : ℝ)) := tail_to_zero k
+  have h_paren : Tendsto (fun N : ℕ =>
+      (harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)))
+      atTop (𝓝 ((harmonic k : ℝ) - 0)) :=
+    tendsto_const_nhds.sub h_tail
+  have h_mul : Tendsto (fun N : ℕ => (1 / (k : ℝ)) *
+      ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))))
+      atTop (𝓝 ((1 / (k : ℝ)) * ((harmonic k : ℝ) - 0))) :=
+    h_paren.const_mul (1 / (k : ℝ))
+  have h_simp : (1 / (k : ℝ)) * ((harmonic k : ℝ) - 0) =
+      (harmonic k : ℝ) / (k : ℝ) := by ring
+  rw [← h_simp]
+  exact h_mul
 
 /-- tsum version of the main result. -/
 theorem generalized_triangular_reciprocals_tsum (k : ℕ) (hk : 0 < k) :

--- a/proofs/Proofs/TriangularReciprocalsOQ02.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02.lean
@@ -42,7 +42,11 @@ open Finset BigOperators Filter Topology Real
 theorem partial_fraction {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
     (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
       (1 / ↑k) * (1 / (n : ℝ) - 1 / ((n : ℝ) + ↑k)) := by
-  sorry
+  have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn
+  have hk' : (↑k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hk
+  have hnk : (n : ℝ) + ↑k ≠ 0 := by positivity
+  field_simp
+  ring
 
 -- ═══════════════════════════════════════════════════
 -- Lemma 2: Closed Form for the Partial Sum
@@ -84,7 +88,26 @@ theorem tail_to_zero (k : ℕ) :
     compare with `Real.summable_one_div_nat_pow` at p = 2. -/
 theorem summable_one_div_n_mul_n_add_k (k : ℕ) :
     Summable (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k))) := by
-  sorry
+  -- Dominate by the p-series ∑ 1/(n+1)^2, summable via `summable_one_div_nat_pow` at p=2.
+  have h_p : Summable (fun n : ℕ => (1 : ℝ) / ((n : ℝ)) ^ 2) :=
+    summable_one_div_nat_pow.mpr one_lt_two
+  have h_shift : Summable (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ)) ^ 2) := by
+    have := (summable_nat_add_iff (f := fun n : ℕ => (1 : ℝ) / ((n : ℝ)) ^ 2) 1).mpr h_p
+    simpa using this
+  refine Summable.of_nonneg_of_le ?_ ?_ h_shift
+  · intro n
+    have h1 : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_pos n
+    have h2 : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    positivity
+  · intro n
+    have h1 : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_pos n
+    have h2 : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    have hprod : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + (k : ℝ)) := by positivity
+    have hsq : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) ^ 2 := by positivity
+    rw [div_le_div_iff₀ hprod hsq]
+    have : ((n + 1 : ℕ) : ℝ) ^ 2 = ((n + 1 : ℕ) : ℝ) * ((n + 1 : ℕ) : ℝ) := by ring
+    rw [this]
+    nlinarith [Nat.cast_nonneg (α := ℝ) k]
 
 -- ═══════════════════════════════════════════════════
 -- Main Theorem
@@ -115,14 +138,30 @@ theorem generalized_triangular_reciprocals_tsum (k : ℕ) (hk : 0 < k) :
 
 /-- k = 1: H_1 / 1 = 1, recovering the classical Leibniz identity. -/
 theorem special_case_k1 : ((harmonic 1 : ℝ) / (1 : ℝ)) = 1 := by
-  sorry
+  have h : harmonic 1 = 1 := by
+    rw [show (1 : ℕ) = 0 + 1 from rfl, harmonic_succ, harmonic_zero]
+    norm_num
+  rw [h]; norm_num
 
 /-- k = 2: H_2 / 2 = 3/4. -/
 theorem special_case_k2 : ((harmonic 2 : ℝ) / (2 : ℝ)) = 3 / 4 := by
-  sorry
+  have h : harmonic 2 = 3 / 2 := by
+    rw [show (2 : ℕ) = 1 + 1 from rfl, harmonic_succ,
+        show (1 : ℕ) = 0 + 1 from rfl, harmonic_succ, harmonic_zero]
+    norm_num
+  rw [h]
+  push_cast
+  norm_num
 
 /-- k = 3: H_3 / 3 = 11/18. -/
 theorem special_case_k3 : ((harmonic 3 : ℝ) / (3 : ℝ)) = 11 / 18 := by
-  sorry
+  have h : harmonic 3 = 11 / 6 := by
+    rw [show (3 : ℕ) = 2 + 1 from rfl, harmonic_succ,
+        show (2 : ℕ) = 1 + 1 from rfl, harmonic_succ,
+        show (1 : ℕ) = 0 + 1 from rfl, harmonic_succ, harmonic_zero]
+    norm_num
+  rw [h]
+  push_cast
+  norm_num
 
 end TriangularReciprocalsHarmonic

--- a/proofs/Proofs/TriangularReciprocalsOQ02.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02.lean
@@ -70,13 +70,46 @@ theorem partial_sum_closed_form (N k : ℕ) (hk : 0 < k) :
 
 /-- For fixed k, the harmonic difference H_{N+k} - H_N tends to 0 as N → ∞.
 
-    Quantitative bound: 0 ≤ H_{N+k} - H_N ≤ k/(N+1), so the squeeze theorem applies.
-    The numeric content is purely the k consecutive terms 1/(N+1), …, 1/(N+k), each
-    of which is ≤ 1/(N+1). -/
+    Proof by induction on k:
+      * k = 0: the difference is identically 0.
+      * k → k+1: H_{N+(k+1)} - H_N = (H_{N+k} - H_N) + 1/(N+k+1). The first summand
+        tends to 0 by the IH; the second is a constant-shift of 1/(N+1), hence → 0
+        via `tendsto_one_div_add_atTop_nhds_zero_nat`. -/
 theorem tail_to_zero (k : ℕ) :
     Tendsto (fun N : ℕ => (harmonic (N + k) : ℝ) - (harmonic N : ℝ))
       atTop (𝓝 0) := by
-  sorry
+  induction k with
+  | zero =>
+    have hfun : (fun N : ℕ => (harmonic (N + 0) : ℝ) - (harmonic N : ℝ)) =
+        fun _ : ℕ => (0 : ℝ) := by
+      funext N; simp
+    rw [hfun]
+    exact tendsto_const_nhds
+  | succ k ih =>
+    -- Reciprocal-of-shift limit: 1/(N + (k+1)) → 0.
+    have h_base : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 (0 : ℝ)) :=
+      tendsto_one_div_add_atTop_nhds_zero_nat
+    have h_shift : Tendsto (fun N : ℕ => N + k) atTop atTop :=
+      tendsto_add_atTop_nat k
+    have h_term : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + (k : ℝ) + 1))
+        atTop (𝓝 (0 : ℝ)) := by
+      refine (h_base.comp h_shift).congr ?_
+      intro N
+      simp only [Function.comp_apply]
+      push_cast
+      ring
+    -- Rewrite the target into the form (H_{N+k} - H_N) + 1/(N+k+1), then sum two zero limits.
+    have hgoal :
+        (fun N : ℕ => (harmonic (N + (k + 1)) : ℝ) - (harmonic N : ℝ)) =
+          fun N : ℕ => ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)) +
+            (1 : ℝ) / ((N : ℝ) + (k : ℝ) + 1) := by
+      funext N
+      have h1 : N + (k + 1) = (N + k) + 1 := rfl
+      rw [h1, harmonic_succ]
+      push_cast
+      ring
+    rw [hgoal]
+    simpa using ih.add h_term
 
 -- ═══════════════════════════════════════════════════
 -- Lemma 4: Summability via p-Series Comparison

--- a/proofs/Proofs/TriangularReciprocalsOQ02.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02.lean
@@ -1,0 +1,128 @@
+/-
+  Generalized Triangular Reciprocals via Harmonic Numbers
+
+  Result: For every integer k ≥ 1,
+    ∑_{n=1}^∞ 1/(n(n+k)) = H_k / k
+
+  where H_k = harmonic k = ∑_{i=1}^k 1/i is the k-th harmonic number (Mathlib's
+  `harmonic : ℕ → ℚ`, cast to ℝ at the statement boundary).
+
+  Special cases:
+    k=1: H_1/1 = 1            (matches the classical Leibniz sum 1/(n(n+1)))
+    k=2: H_2/2 = (1 + 1/2)/2 = 3/4
+    k=3: H_3/3 = (1 + 1/2 + 1/3)/3 = 11/18
+
+  Proof outline (S3 lock):
+    1. partial_fraction:        1/(n(n+k)) = (1/k)(1/n - 1/(n+k))     [lifted from sibling]
+    2. partial_sum_closed_form: ∑_{n=1}^N 1/(n(n+k)) = (1/k)(H_k - (H_{N+k} - H_N))
+       (reindex the second telescoped term by m = n+k via Finset.sum_Ico_add')
+    3. tail_to_zero:            H_{N+k} - H_N → 0 as N → ∞  (since ≤ k/(N+1))
+    4. summable_one_div_n_mul_n_add_k:   1/(n(n+k)) ≤ 1/n^2  ⇒  Summable
+    Main: combine 2 + 3 + 4 to pass partial sums to HasSum.
+
+  Status: S4 SCAFFOLD — all proofs are `sorry`. ACT phases S5+ will close them.
+
+  Sibling reuse:
+    `Proofs/TriangularReciprocalGeneralized.lean` (slug `triangular-reciprocals-oq-03`,
+    the *alternating* generalization) provides the `partial_fraction` lemma verbatim.
+-/
+import Mathlib
+
+namespace TriangularReciprocalsHarmonic
+
+open Finset BigOperators Filter Topology Real
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 1: Partial Fraction Decomposition
+-- ═══════════════════════════════════════════════════
+
+/-- Partial fraction decomposition: 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)) for k ≠ 0, n ≠ 0.
+
+    Transferred verbatim from `Proofs/TriangularReciprocalGeneralized.lean:133`. -/
+theorem partial_fraction {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
+    (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
+      (1 / ↑k) * (1 / (n : ℝ) - 1 / ((n : ℝ) + ↑k)) := by
+  sorry
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 2: Closed Form for the Partial Sum
+-- ═══════════════════════════════════════════════════
+
+/-- Closed form for the partial sum:
+
+    ∑_{n=1}^{N} 1/(n(n+k)) = (1/k)(H_k - (H_{N+k} - H_N))
+
+    Proof strategy: apply `partial_fraction` to each term, split the sum, reindex the
+    second piece by `m = n + k` via `Finset.sum_Ico_add'` (the same lemma used by
+    `harmonic_eq_sum_Icc`), and read off the harmonic differences. -/
+theorem partial_sum_closed_form (N k : ℕ) (hk : 0 < k) :
+    ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
+      (1 / (k : ℝ)) * ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))) := by
+  sorry
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 3: Harmonic Tail Difference Tends to Zero
+-- ═══════════════════════════════════════════════════
+
+/-- For fixed k, the harmonic difference H_{N+k} - H_N tends to 0 as N → ∞.
+
+    Quantitative bound: 0 ≤ H_{N+k} - H_N ≤ k/(N+1), so the squeeze theorem applies.
+    The numeric content is purely the k consecutive terms 1/(N+1), …, 1/(N+k), each
+    of which is ≤ 1/(N+1). -/
+theorem tail_to_zero (k : ℕ) :
+    Tendsto (fun N : ℕ => (harmonic (N + k) : ℝ) - (harmonic N : ℝ))
+      atTop (𝓝 0) := by
+  sorry
+
+-- ═══════════════════════════════════════════════════
+-- Lemma 4: Summability via p-Series Comparison
+-- ═══════════════════════════════════════════════════
+
+/-- The series ∑_{n=1}^∞ 1/(n(n+k)) is summable.
+
+    Proof: term-wise bound 1/(n(n+k)) ≤ 1/n² (since n + k ≥ n ≥ 1 for n ≥ 1), then
+    compare with `Real.summable_one_div_nat_pow` at p = 2. -/
+theorem summable_one_div_n_mul_n_add_k (k : ℕ) :
+    Summable (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k))) := by
+  sorry
+
+-- ═══════════════════════════════════════════════════
+-- Main Theorem
+-- ═══════════════════════════════════════════════════
+
+/-- **Generalized Triangular Reciprocals via Harmonic Numbers.**
+
+    For every integer k ≥ 1,
+      ∑_{n=1}^∞ 1/(n(n+k)) = H_k / k.
+
+    The indexing here is shifted to `n : ℕ` ranging over ℕ, with the running index
+    being `n + 1` (avoiding the n = 0 division). This matches the convention used by
+    `hasSum_nat_add_iff 1` in the sibling proof. -/
+theorem generalized_triangular_reciprocals (k : ℕ) (hk : 0 < k) :
+    HasSum (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k)))
+      ((harmonic k : ℝ) / (k : ℝ)) := by
+  sorry
+
+/-- tsum version of the main result. -/
+theorem generalized_triangular_reciprocals_tsum (k : ℕ) (hk : 0 < k) :
+    ∑' n : ℕ, (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k)) =
+      (harmonic k : ℝ) / (k : ℝ) :=
+  (generalized_triangular_reciprocals k hk).tsum_eq
+
+-- ═══════════════════════════════════════════════════
+-- Verification of Special Cases (k = 1, 2, 3)
+-- ═══════════════════════════════════════════════════
+
+/-- k = 1: H_1 / 1 = 1, recovering the classical Leibniz identity. -/
+theorem special_case_k1 : ((harmonic 1 : ℝ) / (1 : ℝ)) = 1 := by
+  sorry
+
+/-- k = 2: H_2 / 2 = 3/4. -/
+theorem special_case_k2 : ((harmonic 2 : ℝ) / (2 : ℝ)) = 3 / 4 := by
+  sorry
+
+/-- k = 3: H_3 / 3 = 11/18. -/
+theorem special_case_k3 : ((harmonic 3 : ℝ) / (3 : ℝ)) = 11 / 18 := by
+  sorry
+
+end TriangularReciprocalsHarmonic

--- a/proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean
@@ -23,7 +23,11 @@ open Finset BigOperators Filter Topology Real
 theorem partial_fraction_aristotle {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
     (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
       (1 / ↑k) * (1 / (n : ℝ) - 1 / ((n : ℝ) + ↑k)) := by
-  sorry
+  have hn' : (n : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hn
+  have hk' : (↑k : ℝ) ≠ 0 := Nat.cast_ne_zero.mpr hk
+  have hnk : (n : ℝ) + ↑k ≠ 0 := by positivity
+  field_simp
+  ring
 
 /-- Lemma 3 (companion form): the harmonic tail difference tends to 0.
 
@@ -40,6 +44,24 @@ theorem tail_to_zero_aristotle (k : ℕ) :
     `Real.summable_one_div_nat_pow` at p = 2. -/
 theorem summable_one_div_n_mul_n_add_k_aristotle (k : ℕ) :
     Summable (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k))) := by
-  sorry
+  have h_p : Summable (fun n : ℕ => (1 : ℝ) / ((n : ℝ)) ^ 2) :=
+    summable_one_div_nat_pow.mpr one_lt_two
+  have h_shift : Summable (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ)) ^ 2) := by
+    have := (summable_nat_add_iff (f := fun n : ℕ => (1 : ℝ) / ((n : ℝ)) ^ 2) 1).mpr h_p
+    simpa using this
+  refine Summable.of_nonneg_of_le ?_ ?_ h_shift
+  · intro n
+    have h1 : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_pos n
+    have h2 : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    positivity
+  · intro n
+    have h1 : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) := by exact_mod_cast Nat.succ_pos n
+    have h2 : (0 : ℝ) ≤ (k : ℝ) := Nat.cast_nonneg k
+    have hprod : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + (k : ℝ)) := by positivity
+    have hsq : (0 : ℝ) < ((n + 1 : ℕ) : ℝ) ^ 2 := by positivity
+    rw [div_le_div_iff₀ hprod hsq]
+    have : ((n + 1 : ℕ) : ℝ) ^ 2 = ((n + 1 : ℕ) : ℝ) * ((n + 1 : ℕ) : ℝ) := by ring
+    rw [this]
+    nlinarith [Nat.cast_nonneg (α := ℝ) k]
 
 end TriangularReciprocalsHarmonic.Aristotle

--- a/proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean
@@ -1,0 +1,45 @@
+/-
+  Aristotle companion for `TriangularReciprocalsOQ02.lean`.
+
+  Exposes only the *transferable / mechanizable* supporting lemmas (1, 3, 4) as
+  theorem sorries, in shapes Aristotle is likely to close. Lemma 2
+  (`partial_sum_closed_form`) carries the substantive reindexing argument and is
+  kept inside the main file per gallery convention.
+
+  See `research/SORRY-CLASSIFICATION.md` for the companion-file template and rules
+  (definitions complete, no axioms, no `True` placeholders, etc.).
+-/
+import Mathlib
+
+namespace TriangularReciprocalsHarmonic.Aristotle
+
+open Finset BigOperators Filter Topology Real
+
+/-- Lemma 1 (companion form): partial fraction decomposition.
+
+    1/(n(n+k)) = (1/k)(1/n - 1/(n+k))  for k ≠ 0, n ≠ 0.
+
+    Direct from `field_simp; ring` after the `Nat.cast_ne_zero` hypotheses. -/
+theorem partial_fraction_aristotle {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
+    (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) =
+      (1 / ↑k) * (1 / (n : ℝ) - 1 / ((n : ℝ) + ↑k)) := by
+  sorry
+
+/-- Lemma 3 (companion form): the harmonic tail difference tends to 0.
+
+    For fixed k, H_{N+k} - H_N → 0 as N → ∞. Aristotle target: combine the
+    quantitative bound H_{N+k} - H_N ≤ k/(N+1) with `tendsto_const_div_atTop_nhds_zero_nat`. -/
+theorem tail_to_zero_aristotle (k : ℕ) :
+    Tendsto (fun N : ℕ => (harmonic (N + k) : ℝ) - (harmonic N : ℝ))
+      atTop (𝓝 0) := by
+  sorry
+
+/-- Lemma 4 (companion form): the series ∑ 1/((n+1)((n+1)+k)) is summable.
+
+    Aristotle target: p-series comparison with 1/(n+1)^2 via
+    `Real.summable_one_div_nat_pow` at p = 2. -/
+theorem summable_one_div_n_mul_n_add_k_aristotle (k : ℕ) :
+    Summable (fun n : ℕ => (1 : ℝ) / (((n + 1 : ℕ) : ℝ) * (((n + 1 : ℕ) : ℝ) + ↑k))) := by
+  sorry
+
+end TriangularReciprocalsHarmonic.Aristotle

--- a/proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean
@@ -31,12 +31,42 @@ theorem partial_fraction_aristotle {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
 
 /-- Lemma 3 (companion form): the harmonic tail difference tends to 0.
 
-    For fixed k, H_{N+k} - H_N → 0 as N → ∞. Aristotle target: combine the
-    quantitative bound H_{N+k} - H_N ≤ k/(N+1) with `tendsto_const_div_atTop_nhds_zero_nat`. -/
+    For fixed k, H_{N+k} - H_N → 0 as N → ∞. Proof by induction on k, using
+    `tendsto_one_div_add_atTop_nhds_zero_nat` for the per-term limit
+    1/(N+k+1) → 0 in the successor step. -/
 theorem tail_to_zero_aristotle (k : ℕ) :
     Tendsto (fun N : ℕ => (harmonic (N + k) : ℝ) - (harmonic N : ℝ))
       atTop (𝓝 0) := by
-  sorry
+  induction k with
+  | zero =>
+    have hfun : (fun N : ℕ => (harmonic (N + 0) : ℝ) - (harmonic N : ℝ)) =
+        fun _ : ℕ => (0 : ℝ) := by
+      funext N; simp
+    rw [hfun]
+    exact tendsto_const_nhds
+  | succ k ih =>
+    have h_base : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + 1)) atTop (𝓝 (0 : ℝ)) :=
+      tendsto_one_div_add_atTop_nhds_zero_nat
+    have h_shift : Tendsto (fun N : ℕ => N + k) atTop atTop :=
+      tendsto_add_atTop_nat k
+    have h_term : Tendsto (fun N : ℕ => (1 : ℝ) / ((N : ℝ) + (k : ℝ) + 1))
+        atTop (𝓝 (0 : ℝ)) := by
+      refine (h_base.comp h_shift).congr ?_
+      intro N
+      simp only [Function.comp_apply]
+      push_cast
+      ring
+    have hgoal :
+        (fun N : ℕ => (harmonic (N + (k + 1)) : ℝ) - (harmonic N : ℝ)) =
+          fun N : ℕ => ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)) +
+            (1 : ℝ) / ((N : ℝ) + (k : ℝ) + 1) := by
+      funext N
+      have h1 : N + (k + 1) = (N + k) + 1 := rfl
+      rw [h1, harmonic_succ]
+      push_cast
+      ring
+    rw [hgoal]
+    simpa using ih.add h_term
 
 /-- Lemma 4 (companion form): the series ∑ 1/((n+1)((n+1)+k)) is summable.
 

--- a/research/problems/triangular-reciprocals-oq-02/knowledge.md
+++ b/research/problems/triangular-reciprocals-oq-02/knowledge.md
@@ -87,13 +87,109 @@ the partial-fraction main result instead, once the latter is proved.
 
 ---
 
+## Decisions Locked in S3 (researcher-1, 2026-06-01)
+
+### File and namespace
+- **File**: `proofs/Proofs/TriangularReciprocalsOQ02.lean`.
+- **Namespace**: `TriangularReciprocalsHarmonic`.
+- **Companion**: `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` exposing
+  Lemmas 1, 3, 4 (Lemma 2 stays in the main file because its proof is the substantive
+  index manipulation, which Aristotle will not crack).
+
+### Hypothesis convention
+- `(k : ℕ) (hk : 0 < k)` — matches sibling
+  `TriangularReciprocalGeneralized.lean` (`generalized_alternating_sum k hk`).
+
+### Index convention
+- Prove Lemma 2 over `Finset.Icc 1 N` (matches `harmonic_eq_sum_Icc`).
+- Convert to `Finset.range` at the `HasSum` boundary using `hasSum_nat_add_iff 1` to
+  drop the $n=0$ term — exactly the trick used at
+  `TriangularReciprocalGeneralized.lean:124`.
+
+### Casting recipe (ℚ → ℝ)
+At each statement using `harmonic`, cast at the **statement** level: write
+`(harmonic k : ℝ)`. Inside proofs, unfold via
+```
+simp only [harmonic_eq_sum_Icc, Rat.cast_sum, Rat.cast_inv, Rat.cast_natCast]
+```
+This is the canonical recipe at `NumberTheory/Harmonic/Bounds.lean:24` and `:31`.
+
+### Lean Signatures (for S4 scaffold)
+
+```lean
+import Mathlib
+
+namespace TriangularReciprocalsHarmonic
+
+open Finset BigOperators Filter Topology Real
+
+/-- Partial fraction decomposition. -/
+theorem partial_fraction {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
+    (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + k)) =
+      (1 / k) * (1 / (n : ℝ) - 1 / ((n : ℝ) + k)) := by sorry
+
+/-- Closed form for the N-th partial sum. -/
+theorem partial_sum_closed_form (k N : ℕ) (hk : 0 < k) :
+    ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + k)) =
+      (1 / (k : ℝ)) *
+        ((harmonic k : ℝ) - ((harmonic (N + k) : ℝ) - (harmonic N : ℝ))) := by sorry
+
+/-- The shifted-harmonic tail $H_{N+k} - H_N$ tends to 0. -/
+theorem tail_to_zero (k : ℕ) :
+    Filter.Tendsto (fun N : ℕ => ((harmonic (N + k) : ℝ) - (harmonic N : ℝ)))
+      Filter.atTop (𝓝 0) := by sorry
+
+/-- Summability of $1/(n(n+k))$ by comparison with $1/n^2$. -/
+theorem summable_one_div_n_mul_n_add_k (k : ℕ) :
+    Summable (fun n : ℕ => if n = 0 then (0 : ℝ)
+      else 1 / ((n : ℝ) * ((n : ℝ) + k))) := by sorry
+
+/-- **Main theorem**: $\sum_{n=1}^\infty 1/(n(n+k)) = H_k/k$. -/
+theorem triangular_reciprocals_harmonic (k : ℕ) (hk : 0 < k) :
+    HasSum (fun n : ℕ => if n = 0 then (0 : ℝ)
+      else 1 / ((n : ℝ) * ((n : ℝ) + k)))
+      ((harmonic k : ℝ) / (k : ℝ)) := by sorry
+
+end TriangularReciprocalsHarmonic
+```
+
+### Reindex sketch for Lemma 2 (the substantive lemma)
+
+Working over ℝ, let $S_N(k) = \sum_{n \in \text{Icc } 1 N} \tfrac{1}{n(n+k)}$. Then:
+1. Apply `partial_fraction` pointwise inside the sum, factor out $1/k$:
+   $S_N(k) = (1/k) \cdot \bigl(\sum_{n \in \text{Icc } 1 N} 1/n -
+                                \sum_{n \in \text{Icc } 1 N} 1/(n+k)\bigr)$.
+2. First sum is $(H_N : \mathbb{R})$ by `harmonic_eq_sum_Icc` after the cast recipe.
+3. Second sum: reindex $m = n+k$. As $n$ ranges over $\text{Icc } 1 N$, $m$ ranges over
+   $\text{Icc } (k+1) (N+k)$. Tactically:
+   ```
+   rw [show Finset.Icc 1 N = Finset.Ico 1 (N+1) from Nat.Icc_succ_right_eq_Ico_succ ▸ rfl,
+       Finset.sum_Ico_add' (fun (m : ℕ) ↦ (m : ℝ)⁻¹) 1 (N+1) (c := k)]
+   -- now sum is over Ico (k+1) (N+k+1) of m⁻¹, i.e. Icc (k+1) (N+k) of m⁻¹.
+   ```
+4. Split $\text{Icc } (k+1) (N+k) = \text{Icc } 1 (N+k) \setminus \text{Icc } 1 k$ via
+   `Finset.sum_Icc_consecutive` or `Finset.sum_Ioc_consecutive`. Result:
+   $\sum_{\text{Icc } (k+1)(N+k)} 1/m = H_{N+k} - H_k$.
+5. Combine: $S_N(k) = (1/k) \cdot (H_N - (H_{N+k} - H_k)) = (1/k) \cdot (H_k - (H_{N+k} - H_N))$.
+
+The trickiest step is (3)/(4); both are mechanizable with `omega` for index bounds and
+`Finset.sum_Ico_consecutive`. If `sum_Ico_add'` requires `range`-style indexing, fall
+back to converting Icc ↔ Ico via `Finset.Icc_eq_Ico_add_one` (or whatever the v4.26.0
+name is).
+
+### Risk register for S4
+
+- (low) Mathlib lemma name churn for the Icc ↔ Ico conversion. Mitigation: probe with
+  `#check` in scaffold or `exact?` if a name fails.
+- (low) `Finset.sum_Ico_add'` signature has subtle argument order; copy the call site
+  from `harmonic_eq_sum_Icc` source verbatim.
+- (medium) The ℝ-cast over harmonic differences may need `push_cast` rather than the
+  explicit `Rat.cast_*` chain; both work but the explicit chain is more diagnostic.
+
 ## Open Questions for Next Iteration
 
-1. Exact form for the main theorem signature — `HasSum` vs `tsum =` vs both?
-   (Mathlib idiom: prove `HasSum` first, derive `tsum` via `HasSum.tsum_eq`.)
-2. Should the result be stated for `k : ℕ, hk : 0 < k` or `k : ℕ+`?
-   (Lean idiom and sibling files prefer `k : ℕ, hk : k ≠ 0` or `hk : 0 < k` —
-   `triangular-reciprocals-oq-03` uses `hk : 0 < k`.)
-3. Index convention for the sum — `Finset.range` (0-indexed, shift) vs `Finset.Icc 1 N`
-   (1-indexed, natural)?
-   (Mathlib's `harmonic` is `range`-defined but `harmonic_eq_sum_Icc` gives both views.)
+1. Should `summable_one_div_n_mul_n_add_k` be stated as plain `Summable` (no $n=0$ guard)
+   or with the `if n = 0` indicator (matching `HasSum` style in the sibling)?
+   — Decision deferred to S4: write both and keep whichever simplifies the main theorem.
+2. Does Aristotle close `partial_fraction` automatically given the `field_simp; ring`
+   recipe is so short? — Test in S4: include in Aristotle companion.

--- a/research/problems/triangular-reciprocals-oq-02/knowledge.md
+++ b/research/problems/triangular-reciprocals-oq-02/knowledge.md
@@ -1,21 +1,99 @@
 # Knowledge Base: triangular-reciprocals-oq-02
 
-Insights accumulated during research on this problem.
+Insights accumulated during research on $\sum_{n=1}^\infty \frac{1}{n(n+k)} = \frac{H_k}{k}$.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The identity is the natural $k$-shift generalization of the Wiedijk-100 Leibniz sum
+$\sum 1/(n(n+1)) = 1$. The closed form is rational (a finite harmonic sum divided by $k$),
+which makes the result mechanizable without leaving ℚ until the final ℝ-cast for `tsum`.
+
+The same identity has an analytic reading via the digamma function:
+$\psi(x+1) = -\gamma + \sum_{n=1}^\infty \frac{x}{n(n+x)}$. Specializing $x=k$ gives
+$\psi(k+1) + \gamma = \sum_{n=1}^\infty \frac{k}{n(n+k)} = k \cdot \frac{H_k}{k} = H_k$,
+which matches Mathlib's $\Gamma'(n+1) = n!(-\gamma + H_n)$ (`deriv_Gamma_nat`,
+`NumberTheory/Harmonic/GammaDeriv.lean`, David Loeffler 2024).
 
 ---
 
-## Insights
+## Insights (S2, 2026-06-01)
 
-[Insights from research attempts will be accumulated here]
+### Mathlib API map
+
+- `harmonic : ℕ → ℚ := fun n => ∑ i ∈ Finset.range n, (↑(i+1))⁻¹` — `NumberTheory.Harmonic.Defs`.
+  - `harmonic_zero : harmonic 0 = 0`.
+  - `harmonic_succ n : harmonic (n+1) = harmonic n + (↑(n+1))⁻¹`.
+  - `harmonic_eq_sum_Icc : harmonic n = ∑ i ∈ Finset.Icc 1 n, (↑i)⁻¹`.
+- `Real.deriv_Gamma_nat n : deriv Real.Gamma (n+1) = n! * (-γ + harmonic n)` — gives the
+  digamma corollary once the main identity is in place.
+- `Mathlib.Topology.Algebra.InfiniteSum.Basic` — `tsum`, `HasSum`, `Summable`.
+- `Mathlib.Analysis.PSeries.summable_one_div_nat_pow` — p-series for the dominating
+  comparison $1/(n(n+k)) \le 1/n^2$.
+
+### Sibling proof reuse
+
+`Proofs/TriangularReciprocalGeneralized.lean` (gallery slug `triangular-reciprocals-oq-03`,
+*alternating* generalization) has a `partial_fraction` lemma at line 133:
+
+```
+theorem partial_fraction {n k : ℕ} (hn : n ≠ 0) (hk : k ≠ 0) :
+  (1 : ℝ)/((n : ℝ) * ((n : ℝ) + k)) = (1/k) * ((1/n) - (1/((n : ℝ)+k)))
+```
+
+This is **identical** to the partial fraction we need (the alternating sign appears at the
+sum level, not the lemma). We can lift this verbatim or restate.
+
+### Telescoping closed form (sketch)
+
+Reindex: $\sum_{n=1}^{N} \tfrac{1}{n} - \tfrac{1}{n+k} =
+\sum_{n=1}^{N} \tfrac{1}{n} - \sum_{m=k+1}^{N+k} \tfrac{1}{m}
+= H_N - (H_{N+k} - H_k) = H_k - (H_{N+k} - H_N)$.
+
+So $\sum_{n=1}^{N} \tfrac{1}{n(n+k)} = \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$.
+
+### Tail bound
+
+For $k \ge 1$: $0 \le H_{N+k} - H_N = \sum_{j=N+1}^{N+k} \tfrac{1}{j} \le \tfrac{k}{N+1}$.
+Hence $H_{N+k} - H_N \to 0$ as $N \to \infty$. Taking the limit in the partial sum gives
+$\sum_{n=1}^\infty \tfrac{1}{n(n+k)} = H_k/k$.
+
+### Summability
+
+$\tfrac{1}{n(n+k)} \le \tfrac{1}{n^2}$ for $n \ge 1$, $k \ge 0$ (since $n+k \ge n$). The
+RHS is summable by the p-series with $p=2 > 1$, so the original series converges absolutely
+by direct comparison. This justifies passing from `HasSum` of partial sums to `tsum =`.
+
+### ℚ ↔ ℝ casting
+
+Because Mathlib's `harmonic` is ℚ-valued, the `tsum` in ℝ requires casting at the
+boundary. Standard `push_cast` / `Rat.cast_sum`+`Rat.cast_inv`+`Rat.cast_natCast` chain
+(as used in `NumberTheory.Harmonic.Bounds` lines 24, 31). This is a one-liner per
+harmonic reference, not a structural obstacle.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+### Pure digamma route
+
+Trying to prove the identity by first proving the digamma series expansion
+$\psi(x+1) = -\gamma + \sum \tfrac{x}{n(n+x)}$ requires significant analytic machinery
+(uniform convergence of the series, comparison with $\Gamma'$). Mathlib has the integer-
+case derivative `deriv_Gamma_nat` but not the series identity. Pursuing this would
+require a long detour into special functions. **Parked**: derive as a corollary of
+the partial-fraction main result instead, once the latter is proved.
+
+---
+
+## Open Questions for Next Iteration
+
+1. Exact form for the main theorem signature — `HasSum` vs `tsum =` vs both?
+   (Mathlib idiom: prove `HasSum` first, derive `tsum` via `HasSum.tsum_eq`.)
+2. Should the result be stated for `k : ℕ, hk : 0 < k` or `k : ℕ+`?
+   (Lean idiom and sibling files prefer `k : ℕ, hk : k ≠ 0` or `hk : 0 < k` —
+   `triangular-reciprocals-oq-03` uses `hk : 0 < k`.)
+3. Index convention for the sum — `Finset.range` (0-indexed, shift) vs `Finset.Icc 1 N`
+   (1-indexed, natural)?
+   (Mathlib's `harmonic` is `range`-defined but `harmonic_eq_sum_Icc` gives both views.)

--- a/research/problems/triangular-reciprocals-oq-02/problem.md
+++ b/research/problems/triangular-reciprocals-oq-02/problem.md
@@ -1,107 +1,189 @@
-# Problem: [Problem Title]
+# Problem: Generalized Triangular Reciprocals via Digamma — ∑1/(n(n+k)) = H_k/k
 
 **Slug**: triangular-reciprocals-oq-02
 **Created**: 2026-04-05T19:30:46-07:00
-**Status**: Active
-**Source**: user-request <!-- gallery-gap | proof-suggestion | user-request | external -->
+**Status**: Active (OBSERVE → ORIENT, S2)
+**Source**: proof-suggestion
 
 ## Problem Statement
 
 ### Formal Statement
 
+For every integer $k \ge 1$,
+
 $$
-\text{[LaTeX formulation of the theorem/conjecture]}
+\sum_{n=1}^{\infty} \frac{1}{n(n+k)} \;=\; \frac{H_k}{k},
+$$
+
+where $H_k = \sum_{i=1}^{k} \frac{1}{i}$ is the $k$-th harmonic number.
+
+Equivalently, via the digamma function $\psi$ and Euler–Mascheroni constant $\gamma$:
+
+$$
+\sum_{n=1}^{\infty} \frac{1}{n(n+k)} \;=\; \frac{\psi(k+1) + \gamma}{k}.
 $$
 
 ### Plain Language
 
-[Explain what we're trying to prove in accessible terms]
+For each fixed offset $k$, the infinite sum of $\tfrac{1}{n(n+k)}$ over $n \ge 1$ has a closed
+form: a finite rational, namely the $k$-th partial harmonic sum divided by $k$. The result
+generalizes the classical Leibniz identity $\sum 1/(n(n+1)) = 1$ (which is the $k=1$ case,
+since $H_1 = 1$) to arbitrary shifts.
 
 ### Why This Matters
 
-[Significance of the problem - mathematical importance, applications, connections]
+- It is the natural one-parameter generalization of the Wiedijk-100 result
+  `triangular-reciprocals` (the $k=1$ scaled version, sum $=2$).
+- Provides the connection between partial-fraction telescoping and the harmonic numbers,
+  exposing the digamma function as the analytic interpolation of $H_k$.
+- The same finite-difference identity $H_{N+k} - H_N \to 0$ underlies many series
+  evaluations in number theory and combinatorial analysis.
 
 ## Known Results
 
-### What's Already Proven
+### What's Already Proven (in this gallery)
 
-- [Related theorem 1] — [citation/location]
-- [Related theorem 2] — [citation/location]
+- `triangular-reciprocals` — $\sum_{n=1}^\infty 2/(n(n+1)) = 2$ (Wiedijk 42, fully verified).
+- `triangular-reciprocals-oq-03` — alternating analogue (verified;
+  `Proofs/TriangularReciprocalGeneralized.lean` despite the filename treats the
+  *alternating* generalization, with `partial_fraction`, `generalized_alternating_sum`,
+  `generalized_alternating_tsum`).
+- `triangular-reciprocals-oq-01` — figurate-number reciprocal sums (in-progress sibling,
+  `Proofs/TriangularReciprocalsFigurate.lean`).
+- `harmonic-divergence` / `oq-01/oq-02/oq-04` — establish $H_n$ unbounded; not directly used
+  here but supply the harmonic-sum infrastructure.
 
-### What's Still Open
+### What Mathlib Provides
 
-- [Open question 1]
-- [Open question 2]
+- `Mathlib.NumberTheory.Harmonic.Defs.harmonic : ℕ → ℚ`
+  `harmonic n = ∑ i ∈ Finset.range n, (↑(i+1))⁻¹` with `harmonic_succ`, `harmonic_eq_sum_Icc`.
+- `Mathlib.NumberTheory.Harmonic.Bounds` — log bounds on $H_n$.
+- `Mathlib.NumberTheory.Harmonic.GammaDeriv.deriv_Gamma_nat`:
+  `deriv Real.Gamma (n+1) = n! * (-γ + harmonic n)` (David Loeffler, 2024).
+  This gives `Real.Gamma.logDeriv (n+1) = -γ + harmonic n`, i.e. the digamma identity
+  $\psi(n+1) = -\gamma + H_n$ in Mathlib form.
+- `Mathlib.Analysis.SpecialFunctions.Gamma.Beta` — $\Gamma$ beta integral, useful if pivoting
+  to integral representation.
+- `Mathlib.Topology.Algebra.InfiniteSum.Basic.tsum`,
+  `Mathlib.Analysis.PSeries.Real.summable_nat_rpow_inv` — convergence machinery already used
+  by the base proof.
+
+### What's Still Open in This Gallery
+
+- A direct Lean proof of $\sum 1/(n(n+k)) = H_k/k$ for general $k$.
+- The digamma reformulation $(\psi(k+1) + \gamma)/k$ as a corollary.
 
 ### Our Goal
 
-[Specific scope of what we're attempting — which piece of the puzzle]
+Produce a Lean 4 file (provisional name `Proofs/TriangularReciprocalsHarmonic.lean` or
+`TriangularReciprocalsOQ02.lean`) that:
+
+1. Establishes the partial-fraction identity
+   $\tfrac{1}{n(n+k)} = \tfrac{1}{k}\bigl(\tfrac{1}{n} - \tfrac{1}{n+k}\bigr)$ for
+   $n, k \ge 1$.
+2. Computes the partial sum $S_N(k) = \sum_{n=1}^{N} 1/(n(n+k))$ in closed form as
+   $\tfrac{1}{k}(H_{N+k} - H_N - (-H_k))$, i.e.
+   $S_N(k) = \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$.
+3. Shows $H_{N+k} - H_N \to 0$ as $N \to \infty$.
+4. Concludes $\sum_{n=1}^\infty 1/(n(n+k)) = H_k/k$ and packages summability + value.
+5. Optionally derives the digamma reformulation via `Real.deriv_Gamma_nat`.
 
 ## Related Gallery Proofs
 
 | Proof | Relevance | Techniques |
 |-------|-----------|------------|
-| [proof-slug-1] | [why related] | [techniques used] |
-| [proof-slug-2] | [why related] | [techniques used] |
+| `triangular-reciprocals` | $k=1$ scaled (sum $=2$) base case | partial fractions, telescoping, p-series comparison |
+| `triangular-reciprocals-oq-03` | alternating analogue | `shifted_alternating_hasSum`, `partial_fraction` |
+| `triangular-reciprocals-oq-01` | figurate reciprocal sums | sibling, in-progress |
+| `harmonic-divergence` family | $H_n$ properties | log bounds, divergence |
 
 ## Initial Thoughts
 
 ### Potential Approaches
 
-1. **Approach A**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+1. **Direct partial fractions + harmonic telescoping (recommended).**
+   - Why it might work: the alternating sibling already has a `partial_fraction` lemma
+     for $\tfrac{1}{n(n+k)}$; only the non-alternating telescoping and the tail
+     estimate $H_{N+k} - H_N \to 0$ are needed. Both are routine.
+   - Risk: managing the index shift between `Finset.range` and `Finset.Icc` sums and the
+     ℚ↔ℝ cast (Mathlib's `harmonic` lives in ℚ; the `tsum` will need ℝ).
 
-2. **Approach B**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+2. **Digamma route.**
+   - Why it might work: $\sum 1/(n(n+k))$ is exactly $\psi(k+1) + \gamma$ over $k$ by a
+     standard series for $\psi$.
+   - Risk: Mathlib does not expose a `digamma` definition or a series formula. The Gamma
+     derivative at integers is available (`deriv_Gamma_nat`), but the series identity
+     $\psi(x+1) = -\gamma + \sum_{n=1}^\infty \tfrac{x}{n(n+x)}$ is not in Mathlib at this
+     version. Heavy lift.
+
+3. **Reduce to oq-03 (alternating) + auxiliary.**
+   - Combine alternating and non-alternating sums to isolate either; algebraically clean
+     but no obvious lift over the direct route.
 
 ### Key Difficulties
 
-- [Difficulty 1]
-- [Difficulty 2]
+- ℚ/ℝ casting: `Mathlib.NumberTheory.Harmonic.harmonic` is rational; the `tsum` is real.
+  Need `(harmonic n : ℝ) = ∑ i ∈ Finset.Icc 1 n, (↑i : ℝ)⁻¹` (likely a one-line `push_cast`).
+- Index shift: partial sum runs $n \in [1, N]$ but telescoping gives sums over
+  $[N+1, N+k]$; getting that into the right `Finset` form needs care.
+- Tail decay: $0 \le H_{N+k} - H_N \le k/(N+1)$ — elementary, but needs the right Mathlib
+  lemma name (likely a one-line `sum_le_card_nsmul`).
 
 ### What Would a Proof Need?
 
-- Key lemma 1: ...
-- Key lemma 2: ...
-- Technical requirements: ...
+- **Lemma 1 (partial fraction)**: for $n,k \ge 1$,
+  `(1 : ℝ)/(n*(n+k)) = (1/k) * (1/n - 1/(n+k))`. Field arithmetic.
+- **Lemma 2 (partial sum closed form)**:
+  `∑ n ∈ Finset.Icc 1 N, 1/(n*(n+k)) = (1/k) * ((harmonic k : ℝ) - ((harmonic (N+k) : ℝ) - (harmonic N : ℝ)))`.
+  Reindex + cancel.
+- **Lemma 3 (tail decay)**: `(harmonic (N+k) - harmonic N : ℝ) → 0` as $N \to \infty$
+  (for fixed $k$). Bound by `k * (1/(N+1))`.
+- **Lemma 4 (summability)**: comparison with $\sum 1/n^2$ via $1/(n(n+k)) \le 1/n^2$.
+- **Main theorem**: `HasSum (fun n => 1/((n+1:ℝ)*((n+1)+k))) ((harmonic k : ℝ)/k)`.
 
 ## Tractability Assessment
 
-**Difficulty**: Low | Medium | High | Moonshot
+**Difficulty**: Medium
 
 **Justification**:
-- [Reason for assessment]
-- [Similar problems that have been solved]
-- [Techniques available in Mathlib]
+- The base case ($k=1$) is solved in this gallery with the same technique.
+- The alternating sibling oq-03 has the same partial-fraction lemma already (different sign).
+- All Mathlib pieces exist; no missing infrastructure.
 
 **Estimated Effort**:
-- Exploration: [hours/days]
-- If tractable: [days/weeks]
-- If hard: [unknown]
+- ORIENT (literature + sketch confirmation): 1–2 iterations.
+- DECIDE (approach lock + file scaffold): 1 iteration.
+- ACT (proof execution): 3–5 iterations, primarily Lemma 2 (reindex) and Lemma 3 (tail decay).
+- Build/verify under Docker: 1 iteration.
 
 ## References
 
-### Papers
-- [Author, Title, Year] — [brief note]
+### Papers / Sources
+- Gradshteyn & Ryzhik §0.234.2 — $\sum_{n=1}^\infty \frac{1}{n(n+k)} = \frac{H_k}{k}$.
+- Abramowitz & Stegun §6.3.5 — digamma series $\psi(x+1) = -\gamma + \sum_{n=1}^\infty \frac{x}{n(n+x)}$.
+- David Loeffler, *Derivative of Gamma at positive integers*, Mathlib `NumberTheory.Harmonic.GammaDeriv` (2024).
 
-### Online Resources
-- [URL] — [description]
-
-### Mathlib
-- [Relevant Mathlib module] — [what it provides]
+### Mathlib Modules
+- `Mathlib.NumberTheory.Harmonic.Defs` — `harmonic`, `harmonic_succ`, `harmonic_eq_sum_Icc`.
+- `Mathlib.NumberTheory.Harmonic.Bounds` — log bounds on $H_n$ (not needed but adjacent).
+- `Mathlib.NumberTheory.Harmonic.GammaDeriv` — `Real.deriv_Gamma_nat`.
+- `Mathlib.Topology.Algebra.InfiniteSum.Basic` — `tsum`, `HasSum`.
+- `Mathlib.Analysis.PSeries` — `summable_one_div_nat_pow`.
 
 ## Metadata
 
 ```yaml
 tags:
-  - number-theory  # or: algebra, analysis, topology, combinatorics, etc.
-  - prime-gaps
-  - sieve-methods
+  - analysis
+  - series
+  - special-functions
+  - harmonic-numbers
+  - telescoping
 related_proofs:
-  - infinitude-of-primes
-  - sieve-of-eratosthenes
+  - triangular-reciprocals
+  - triangular-reciprocals-oq-01
+  - triangular-reciprocals-oq-03
+  - harmonic-divergence
 difficulty: medium
 source: proof-suggestion
 created: 2026-04-05T19:30:46-07:00

--- a/research/problems/triangular-reciprocals-oq-02/state.md
+++ b/research/problems/triangular-reciprocals-oq-02/state.md
@@ -1,61 +1,87 @@
 # Research State: triangular-reciprocals-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: DECIDE
 **Path**: full
-**Since**: 2026-06-01 (S2 — researcher-1 OBSERVE→ORIENT pass)
-**Iteration**: 2
-**Prior**: OBSERVE iter 1 (2026-04-05, template only — no actual observation recorded)
+**Since**: 2026-06-01 (S3 — researcher-1 ORIENT→DECIDE pass)
+**Iteration**: 3
+**Prior**: S2 OBSERVE→ORIENT (2026-06-01, researcher-1 — problem.md + Mathlib scout)
 
 ## Current Focus
-Approach lock-in. With problem.md now filled and the Mathlib API mapped, the next
-iteration should DECIDE between the direct partial-fraction route and the digamma
-route, and scaffold the Lean file accordingly.
+S3 locks in Approach 1 (direct partial fractions + harmonic telescoping), commits to
+the file name `Proofs/TriangularReciprocalsOQ02.lean`, and records the concrete Lean
+signatures + reindex strategy. The next pass (S4, ACT) will scaffold the file with
+the four lemmas and main theorem as `by sorry`.
 
 ## Active Approach
-**Approach 1 — Direct partial fractions + harmonic telescoping (provisional).**
-- Lemma 1: $\tfrac{1}{n(n+k)} = \tfrac{1}{k}(\tfrac{1}{n} - \tfrac{1}{n+k})$ for $n, k \ge 1$.
-- Lemma 2: $\sum_{n=1}^{N} \tfrac{1}{n(n+k)} = \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$
-  via reindexing.
-- Lemma 3: $H_{N+k} - H_N \to 0$ as $N \to \infty$, bounded by $k/(N+1)$.
-- Lemma 4: summability via comparison with $\sum 1/n^2$.
-- Main: `HasSum (fun n => 1/((n+1)*((n+1)+k))) (H_k/k)`.
+**Approach 1 — Direct partial fractions + harmonic telescoping (LOCKED).**
+- Lemma 1 (`partial_fraction`): $\tfrac{1}{n(n+k)} = \tfrac{1}{k}(\tfrac{1}{n} - \tfrac{1}{n+k})$
+  for $n, k \ge 1$. **Transfer verbatim** from `TriangularReciprocalGeneralized.lean:133`
+  (`field_simp; ring` after `Nat.cast_ne_zero` hypotheses).
+- Lemma 2 (`partial_sum_closed_form`): $\sum_{n=1}^{N} \tfrac{1}{n(n+k)} =
+  \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$.
+  Strategy: split via Lemma 1 → two sums; reindex the second by $m = n+k$ using
+  `Finset.sum_Ico_add'` (the same lemma `harmonic_eq_sum_Icc` uses).
+- Lemma 3 (`tail_to_zero`): $|H_{N+k} - H_N| \le k/(N+1)$; take limit to get $\to 0$.
+- Lemma 4 (`summable_one_div_n_mul_n_add_k`): $0 \le 1/(n(n+k)) \le 1/n^2$ for $n \ge 1$,
+  comparison with `Real.summable_one_div_nat_pow.mpr (by norm_num : (1:ℝ) < 2)`.
+- Main: `HasSum (fun n : ℕ => 1/((n+1:ℝ)*((n+1)+k))) ((harmonic k : ℝ)/k)`.
 
-Approach 2 (digamma) is parked: Mathlib has $\Gamma'$ at integers but not the digamma
-series expansion, so it would require us to prove the series identity from scratch.
+Approach 2 (digamma) remains parked. May surface as a one-line corollary using
+`Real.deriv_Gamma_nat` after the main result is in place, but is not part of S4.
 
 ## Attempt Count
-- Total attempts: 0 (S2 is the first substantive research pass; iter 1 was template only)
-- Current approach attempts: 0 (not yet executed)
+- Total attempts: 0 (S3 is still planning; no Lean code yet)
+- Current approach attempts: 0
 - Approaches tried: 0
+- Approaches considered & parked: 1 (digamma series)
 
 ## Blockers
 None.
 
 ## Next Action
 
-DECIDE phase (S3):
-1. Confirm Approach 1 by sketching Lemma 2 reindex in detail (ℕ-shift between
-   `Finset.range`, `Finset.Icc`, and the partial-fraction telescoping).
-2. Verify the ℝ-cast of `harmonic k` (Mathlib defines `harmonic : ℕ → ℚ`).
-3. Pick a file name. Candidates:
-   - `Proofs/TriangularReciprocalsOQ02.lean` (Aristotle-friendly, matches slug).
-   - `Proofs/TriangularReciprocalsHarmonic.lean` (semantically descriptive).
-   Recommendation: `TriangularReciprocalsOQ02.lean` to match the gallery slug pattern
-   used by `HarmonicDivergenceOQ01.lean`, `HarmonicDivergenceOQ02.lean`, etc.
-4. Then ACT (S4): scaffold the file with the four lemmas + main theorem, leaving each
-   `by sorry` for incremental closure.
+ACT phase (S4) — scaffold the Lean file:
 
-## Key Observations from S2 (researcher-1, 2026-06-01)
+1. Create `proofs/Proofs/TriangularReciprocalsOQ02.lean` with namespace
+   `TriangularReciprocalsHarmonic` (or `TriangularReciprocals.Harmonic`), `import Mathlib`,
+   and the four lemmas + main theorem as `by sorry`. Keep all numeric statements ℝ-valued
+   except harmonic numbers (cast at use sites via the `Rat.cast_sum + cast_inv + cast_natCast`
+   chain documented in `NumberTheory/Harmonic/Bounds.lean:24`).
+2. Add `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` companion exposing only
+   Lemmas 1, 3, 4 as theorem sorries (Lemma 2 carries the substantive index work, gallery
+   convention is to keep it in the main file; Aristotle may close Lemmas 1/3/4 trivially).
+3. Do NOT create the gallery dir yet — wait until the main theorem closes (S5+) so we
+   don't ship a broken gallery entry.
+4. Docker-build the scaffold so we know baseline imports compile, then push.
 
-- `Proofs/TriangularReciprocalGeneralized.lean` (202 lines) handles the **alternating**
-  generalization (slug `triangular-reciprocals-oq-03`), not this one. Its
-  `partial_fraction` lemma is for $\tfrac{1}{n(n+k)} = \tfrac{1}{k}(\tfrac{1}{n} -
-  \tfrac{1}{n+k})$ — directly transferable.
-- `Mathlib.NumberTheory.Harmonic.Defs` puts `harmonic` in ℚ, so the final ℝ-valued
-  `tsum` requires a `push_cast` step on every harmonic reference.
-- `Mathlib.NumberTheory.Harmonic.GammaDeriv.deriv_Gamma_nat` gives the digamma identity
-  $\Gamma'(n+1) = n!(-\gamma + H_n)$, which yields the optional corollary
-  $\sum 1/(n(n+k)) = (\psi(k+1) + \gamma)/k$ once the main identity is proved.
-- No gallery dir `src/data/proofs/triangular-reciprocals-oq-02/` exists yet — will need
-  to be created when the Lean file lands.
+S5 will be the first ACT closure pass on Lemmas 1, 4 (easy) and then 3 (tail bound).
+S6+ will tackle Lemma 2 (the reindex) and the main theorem.
+
+## Key Decisions from S3 (researcher-1, 2026-06-01)
+
+- **File name**: `Proofs/TriangularReciprocalsOQ02.lean` (slug-matching, Aristotle-friendly).
+  Rejected `TriangularReciprocalsHarmonic.lean` — slug match wins for gallery discovery.
+- **Namespace**: `TriangularReciprocalsHarmonic` (descriptive; avoids collision with the
+  alternating sibling's `AlternatingTriangularReciprocals.Generalized`).
+- **Hypothesis convention**: `(k : ℕ) (hk : 0 < k)` — matches sibling
+  `TriangularReciprocalGeneralized.lean` (`generalized_alternating_sum k hk`).
+- **Index convention**: prove Lemma 2 with `Finset.Icc 1 N` (matches `harmonic_eq_sum_Icc`),
+  then convert to `Finset.range` at the `HasSum` boundary using `hasSum_nat_add_iff 1` to
+  drop the $n=0$ term (same trick used at `TriangularReciprocalGeneralized.lean:124`).
+- **Casting site**: cast `harmonic` to ℝ at the statement level
+  (`(harmonic k : ℝ)`), not inside the proof. The Bounds.lean recipe
+  `simp only [harmonic_eq_sum_Icc, Rat.cast_sum, Rat.cast_inv, Rat.cast_natCast]`
+  unfolds the rational into the real Icc-sum cleanly.
+
+## Key Mathlib Anchors (S3-verified, Mathlib v4.26.0)
+
+| Symbol | Source | Use |
+|--------|--------|-----|
+| `harmonic : ℕ → ℚ` | `NumberTheory/Harmonic/Defs.lean:21` | Definition |
+| `harmonic_eq_sum_Icc` | `Defs.lean:37` | Switch to 1-indexed Icc view |
+| `Finset.sum_Ico_add'` | `Algebra/BigOperators/Intervals.lean` | Reindex shift $n \mapsto n+k$ |
+| `Rat.cast_sum`, `cast_inv`, `cast_natCast` | `Bounds.lean:24,31` | ℚ→ℝ unfold |
+| `Real.summable_one_div_nat_pow` | `Analysis/PSeries` | $p=2$ comparison |
+| `hasSum_nat_add_iff` | `Topology/Algebra/InfiniteSum/NatInt` | Drop $n=0$ term |
+| `Real.deriv_Gamma_nat` | `NumberTheory/Harmonic/GammaDeriv.lean` | Optional digamma corollary |

--- a/research/problems/triangular-reciprocals-oq-02/state.md
+++ b/research/problems/triangular-reciprocals-oq-02/state.md
@@ -1,29 +1,38 @@
 # Research State: triangular-reciprocals-oq-02
 
 ## Current State
-**Phase**: ACT (S6 tail-limit close shipped — companion fully closed)
+**Phase**: COMPLETE (S7+S8 — main `HasSum` proved; both files sorry-free)
 **Path**: full
-**Since**: 2026-06-01 (S6 — researcher-1 ACT close tail_to_zero + Aristotle mirror)
-**Iteration**: 6
-**Prior**: S5 ACT mechanical-close (2026-06-01, researcher-1 — 5/8 + 2/3 sorries)
+**Since**: 2026-06-01 (S7/S8 — researcher-1 ACT close Lemma 2 + main theorem)
+**Iteration**: 7 (S7) + 8 (S8) — bundled in one session
+**Prior**: S6 ACT close tail_to_zero (2026-06-01, researcher-1 — main + Aristotle)
+         S5 ACT mechanical-close (2026-06-01, researcher-1 — 5/8 + 2/3 sorries)
          S4 ACT SCAFFOLD (2026-06-01, researcher-1 — both files build clean with sorries)
          S3 ORIENT→DECIDE (2026-06-01, researcher-1 — approach lock + signatures)
          S2 OBSERVE→ORIENT (2026-06-01, researcher-1 — problem.md + Mathlib scout)
 
 ## Current Focus
-S6 closed `tail_to_zero` (Lemma 3) and its Aristotle mirror via induction on `k`
-plus `tendsto_one_div_add_atTop_nhds_zero_nat ∘ tendsto_add_atTop_nat k`. The
-Aristotle companion is now sorry-free; the main file is down to two sorries
-(Lemma 2 reindex + main `HasSum` assembly).
+S7 closed `partial_sum_closed_form` (Lemma 2) by applying `partial_fraction`
+term-wise, splitting via `Finset.sum_sub_distrib`, and reindexing the
+`∑ 1/(n+k)` piece via `Finset.sum_Ico_add'` (c := k). The harmonic differences
+are identified through `harmonic_eq_sum_Icc` + `Finset.sum_Ico_consecutive`.
 
-| # | Lemma | File / line | Status (S6) |
+S8 closed `generalized_triangular_reciprocals` (the main `HasSum`) via
+`hasSum_iff_tendsto_nat_of_nonneg`, identifying the `range N` partial sum with
+the `Icc 1 N` form (again `Finset.sum_Ico_add'`), then applying Lemma 2's
+closed form and Lemma 3's tail limit through
+`(tendsto_const_nhds.sub tail).const_mul (1/k)`.
+
+Result: **main file is 0 sorries / 0 axioms; companion is 0 sorries / 0 axioms.**
+
+| # | Lemma | File / line | Status (S8) |
 |---|-------|-------------|-------------|
 | 1 | `partial_fraction`                      | main:~42  | **closed (S5)** — `field_simp; ring` lifted verbatim from `TriangularReciprocalGeneralized.lean:133` |
-| 2 | `partial_sum_closed_form`               | main:~62  | sorry (S7+) — reindex via `Finset.sum_Ico_add'` |
+| 2 | `partial_sum_closed_form`               | main:~62  | **closed (S7)** — `partial_fraction` termwise + `Finset.sum_sub_distrib` + `Finset.sum_Ico_add'` reindex + `Finset.sum_Ico_consecutive` decomp |
 | 3 | `tail_to_zero`                          | main:~78  | **closed (S6)** — induction on k; succ step uses `tendsto_one_div_add_atTop_nhds_zero_nat.comp (tendsto_add_atTop_nat k)` and `harmonic_succ` |
 | 4 | `summable_one_div_n_mul_n_add_k`        | main:~117 | **closed (S5)** — `Summable.of_nonneg_of_le` against `1/(n+1)^2`, p-series at p=2 + `summable_nat_add_iff 1` shift |
-|   | `generalized_triangular_reciprocals`    | main:~153 | sorry (S7) — combine 2+3+4 to lift partial sums to `HasSum` |
-|   | `special_case_k1` / `_k2` / `_k3`       | main:~169+| **closed (S5)** — unfold `harmonic_succ` then `push_cast; norm_num` |
+|   | `generalized_triangular_reciprocals`    | main:~225 | **closed (S8)** — `hasSum_iff_tendsto_nat_of_nonneg` + `range→Icc` reindex + Lemma 2 + Lemma 3 + `const_mul` |
+|   | `special_case_k1` / `_k2` / `_k3`       | main:~250+| **closed (S5)** — unfold `harmonic_succ` then `push_cast; norm_num` |
 
 Aristotle companion (`TriangularReciprocalsOQ02Aristotle.lean`) — **fully sorry-free**:
 - `partial_fraction_aristotle`              — **closed (S5)**
@@ -59,43 +68,30 @@ Approach 2 (digamma) remains parked. May surface as a one-line corollary using
 `Real.deriv_Gamma_nat` after the main result is in place.
 
 ## Attempt Count
-- Total attempts: 2 (S5 mechanical pass; S6 tail-limit close — both succeeded on Docker)
-- Current approach attempts: 2
+- Total attempts: 4 (S5 mechanical; S6 tail-limit; S7 Lemma 2; S8 main `HasSum`)
+- Current approach attempts: 4
 - Approaches tried: 1
 - Approaches considered & parked: 1 (digamma series)
 
 ## Blockers
-None. The remaining two sorries (Lemma 2 reindex, main `HasSum`) are mathematical,
-not API-blocked.
+None — problem fully closed.
 
 ## Next Action
 
-**S7** — close `partial_sum_closed_form` (Lemma 2).
+**Problem complete.** Update gallery meta.json to reflect 0 sorries + verified
+status (was previously RECOVERING / surveyed). Consider Mathlib upstream
+contribution after the deprecation warnings for `Nat.Ico_succ_right` are
+addressed (replacement `Finset.Ico_succ_right_eq_Icc` not yet available in
+v4.26.0; will land in a future Mathlib bump).
 
-Strategy: apply `partial_fraction` term-wise to split `∑ n ∈ Icc 1 N, 1/(n(n+k))`
-into `(1/k) * (∑ 1/n − ∑ 1/(n+k))`. The first sum is `harmonic N` via
-`harmonic_eq_sum_Icc`. For the second, reindex via `Finset.sum_Ico_add'`
-(treating `Icc 1 N = Ico 1 (N+1)`): substitution `m = n + k` gives
-`∑ m ∈ Icc (1+k) (N+k), 1/m = harmonic (N+k) − harmonic k`
-(via `Finset.sum_Ico_consecutive` splitting `Icc 1 (N+k)` at `k`). Combine to
-`(1/k) * (H_k - (H_{N+k} - H_N))`.
+## S4–S8 Build Artifacts (researcher-1, 2026-06-01)
 
-**S8** — close the main `generalized_triangular_reciprocals` (`HasSum`).
-
-Strategy: use `HasSum.tendsto_sum_nat`-style conversion. Show
-`Tendsto (partial sum over Icc 1 N) atTop (𝓝 (H_k / k))` via Lemma 2 + Lemma 3,
-then convert to `HasSum (fun n : ℕ => 1/((n+1)((n+1)+k))) (H_k/k)` via
-`hasSum_iff_tendsto_nat_of_summable_norm` or the
-`(hasSum_nat_add_iff 1)` trick used at `TriangularReciprocalGeneralized.lean:124`.
-The summability witness is `summable_one_div_n_mul_n_add_k` (Lemma 4).
-
-## S4–S6 Build Artifacts (researcher-1, 2026-06-01)
-
-- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 197 lines, 8 sorries (S4) → 3 (S5) → 2 (S6).
-- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 78 lines, 3 sorries (S4) → 1 (S5) → 0 (S6).
+- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 287 lines, 8 sorries (S4) → 3 (S5) → 2 (S6) → 1 (S7) → 0 (S8).
+- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 97 lines, 3 sorries (S4) → 1 (S5) → 0 (S6).
 - Docker build (Mathlib v4.26.0, 7743/7743 jobs):
   * Main file S6: ✓ (only Lemma 2 + main HasSum sorries remain)
   * Companion S6: ✓ (sorry-free)
+  * Main file S8: ✓ (sorry-free, 0 axioms; deprecation warnings only — see Mathlib API notes)
 
 ## Key Decisions from S3 (researcher-1, 2026-06-01)
 

--- a/research/problems/triangular-reciprocals-oq-02/state.md
+++ b/research/problems/triangular-reciprocals-oq-02/state.md
@@ -1,38 +1,45 @@
 # Research State: triangular-reciprocals-oq-02
 
 ## Current State
-**Phase**: ACT (S5 mechanical-closure pass shipped)
+**Phase**: ACT (S6 tail-limit close shipped — companion fully closed)
 **Path**: full
-**Since**: 2026-06-01 (S5 — researcher-1 ACT close-mechanical-sorries)
-**Iteration**: 5
-**Prior**: S4 ACT SCAFFOLD (2026-06-01, researcher-1 — both files build clean with sorries)
+**Since**: 2026-06-01 (S6 — researcher-1 ACT close tail_to_zero + Aristotle mirror)
+**Iteration**: 6
+**Prior**: S5 ACT mechanical-close (2026-06-01, researcher-1 — 5/8 + 2/3 sorries)
+         S4 ACT SCAFFOLD (2026-06-01, researcher-1 — both files build clean with sorries)
          S3 ORIENT→DECIDE (2026-06-01, researcher-1 — approach lock + signatures)
          S2 OBSERVE→ORIENT (2026-06-01, researcher-1 — problem.md + Mathlib scout)
 
 ## Current Focus
-S5 closed 5 of 8 sorries in `TriangularReciprocalsOQ02.lean` and 2 of 3 in the
-Aristotle companion. Both files Docker-build clean on Mathlib v4.26.0 with the
-remaining sorries explicitly localised to the substantive math (Lemma 2 reindex,
-Lemma 3 tail bound, main `HasSum` assembly).
+S6 closed `tail_to_zero` (Lemma 3) and its Aristotle mirror via induction on `k`
+plus `tendsto_one_div_add_atTop_nhds_zero_nat ∘ tendsto_add_atTop_nat k`. The
+Aristotle companion is now sorry-free; the main file is down to two sorries
+(Lemma 2 reindex + main `HasSum` assembly).
 
-| # | Lemma | File / line | Status (S5) |
+| # | Lemma | File / line | Status (S6) |
 |---|-------|-------------|-------------|
-| 1 | `partial_fraction`                      | main:~42  | **closed** — `field_simp; ring` lifted verbatim from `TriangularReciprocalGeneralized.lean:133` |
+| 1 | `partial_fraction`                      | main:~42  | **closed (S5)** — `field_simp; ring` lifted verbatim from `TriangularReciprocalGeneralized.lean:133` |
 | 2 | `partial_sum_closed_form`               | main:~62  | sorry (S7+) — reindex via `Finset.sum_Ico_add'` |
-| 3 | `tail_to_zero`                          | main:~76  | sorry (S6)  — bound `H_{N+k} − H_N ≤ k/(N+1)` |
-| 4 | `summable_one_div_n_mul_n_add_k`        | main:~88  | **closed** — `Summable.of_nonneg_of_le` against `1/(n+1)^2`, p-series at p=2 + `summable_nat_add_iff 1` shift |
-|   | `generalized_triangular_reciprocals`    | main:~124 | sorry (S7) — combine 2+3+4 to lift partial sums to `HasSum` |
-|   | `special_case_k1` / `_k2` / `_k3`       | main:~140+| **closed** — unfold `harmonic_succ` then `push_cast; norm_num` |
+| 3 | `tail_to_zero`                          | main:~78  | **closed (S6)** — induction on k; succ step uses `tendsto_one_div_add_atTop_nhds_zero_nat.comp (tendsto_add_atTop_nat k)` and `harmonic_succ` |
+| 4 | `summable_one_div_n_mul_n_add_k`        | main:~117 | **closed (S5)** — `Summable.of_nonneg_of_le` against `1/(n+1)^2`, p-series at p=2 + `summable_nat_add_iff 1` shift |
+|   | `generalized_triangular_reciprocals`    | main:~153 | sorry (S7) — combine 2+3+4 to lift partial sums to `HasSum` |
+|   | `special_case_k1` / `_k2` / `_k3`       | main:~169+| **closed (S5)** — unfold `harmonic_succ` then `push_cast; norm_num` |
 
-Aristotle companion (`TriangularReciprocalsOQ02Aristotle.lean`):
-- `partial_fraction_aristotle`              — **closed** (S5)
-- `tail_to_zero_aristotle`                  — sorry (S6)
-- `summable_one_div_n_mul_n_add_k_aristotle` — **closed** (S5)
+Aristotle companion (`TriangularReciprocalsOQ02Aristotle.lean`) — **fully sorry-free**:
+- `partial_fraction_aristotle`              — **closed (S5)**
+- `tail_to_zero_aristotle`                  — **closed (S6)** (mirror of main S6 proof)
+- `summable_one_div_n_mul_n_add_k_aristotle` — **closed (S5)**
 
-## Mathlib v4.26.0 API notes (S5 session)
+## Mathlib v4.26.0 API notes (S5–S6 sessions)
 
 - `div_le_div_iff` → `div_le_div_iff₀` (rename in v4.26).
 - `Nat.cast_nonneg` named arg is `α`, not `R` (regression of an older R-convention).
+- S6 gotcha: `.comp` dot notation on `tendsto_one_div_add_atTop_nhds_zero_nat`
+  triggered `ContinuousSMul ℚ≥0 ?m` typeclass instability. Workaround: bind the
+  RHS to a typed `have h_base : Tendsto _ atTop (𝓝 (0 : ℝ))` first, then
+  `h_base.comp h_shift`.
+- S6 gotcha: `Tendsto.add` of two `(𝓝 0)` limits produces `(𝓝 (0 + 0))`, not
+  `(𝓝 0)` — close with `simpa using ih.add h_term` (or `(by simp : (0+0:ℝ)=0) ▸`).
 
 ## Active Approach
 **Approach 1 — Direct partial fractions + harmonic telescoping (LOCKED at S3).**
@@ -52,32 +59,43 @@ Approach 2 (digamma) remains parked. May surface as a one-line corollary using
 `Real.deriv_Gamma_nat` after the main result is in place.
 
 ## Attempt Count
-- Total attempts: 1 (S5 close-mechanical-sorries pass — succeeded on Docker)
-- Current approach attempts: 1
+- Total attempts: 2 (S5 mechanical pass; S6 tail-limit close — both succeeded on Docker)
+- Current approach attempts: 2
 - Approaches tried: 1
 - Approaches considered & parked: 1 (digamma series)
 
 ## Blockers
-None. The remaining three sorries (Lemma 2, Lemma 3, main `HasSum`) are mathematical,
+None. The remaining two sorries (Lemma 2 reindex, main `HasSum`) are mathematical,
 not API-blocked.
 
 ## Next Action
 
-**S6** — close `tail_to_zero` (Lemma 3) and its Aristotle mirror.
+**S7** — close `partial_sum_closed_form` (Lemma 2).
 
-Strategy: write `harmonic (N+k) - harmonic N` as `∑ i ∈ Finset.Icc (N+1) (N+k), (1:ℝ)/i`
-via `harmonic_eq_sum_Icc` and `Finset.sum_Icc_consecutive` (or `Finset.sum_Ioc_consecutive`).
-Bound each term by `1/(N+1)`. Squeeze using `tendsto_const_div_atTop_nhds_zero_nat`
-applied to the constant bound `k/(N+1)`.
+Strategy: apply `partial_fraction` term-wise to split `∑ n ∈ Icc 1 N, 1/(n(n+k))`
+into `(1/k) * (∑ 1/n − ∑ 1/(n+k))`. The first sum is `harmonic N` via
+`harmonic_eq_sum_Icc`. For the second, reindex via `Finset.sum_Ico_add'`
+(treating `Icc 1 N = Ico 1 (N+1)`): substitution `m = n + k` gives
+`∑ m ∈ Icc (1+k) (N+k), 1/m = harmonic (N+k) − harmonic k`
+(via `Finset.sum_Ico_consecutive` splitting `Icc 1 (N+k)` at `k`). Combine to
+`(1/k) * (H_k - (H_{N+k} - H_N))`.
 
-**S7+** — close `partial_sum_closed_form` (Lemma 2). The reindex via `Finset.sum_Ico_add'`
-is the substantive step. Then assemble the main `HasSum` from 2+3+4.
+**S8** — close the main `generalized_triangular_reciprocals` (`HasSum`).
 
-## S4 Scaffold Artifacts (researcher-1, 2026-06-01)
+Strategy: use `HasSum.tendsto_sum_nat`-style conversion. Show
+`Tendsto (partial sum over Icc 1 N) atTop (𝓝 (H_k / k))` via Lemma 2 + Lemma 3,
+then convert to `HasSum (fun n : ℕ => 1/((n+1)((n+1)+k))) (H_k/k)` via
+`hasSum_iff_tendsto_nat_of_summable_norm` or the
+`(hasSum_nat_add_iff 1)` trick used at `TriangularReciprocalGeneralized.lean:124`.
+The summability witness is `summable_one_div_n_mul_n_add_k` (Lemma 4).
 
-- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 125 lines, 8 sorries (S4 → 3 sorries S5).
-- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 45 lines, 3 sorries (S4 → 1 sorry S5).
-- Docker build: both files compile clean (Mathlib v4.26.0, 7743/7743 jobs).
+## S4–S6 Build Artifacts (researcher-1, 2026-06-01)
+
+- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 197 lines, 8 sorries (S4) → 3 (S5) → 2 (S6).
+- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 78 lines, 3 sorries (S4) → 1 (S5) → 0 (S6).
+- Docker build (Mathlib v4.26.0, 7743/7743 jobs):
+  * Main file S6: ✓ (only Lemma 2 + main HasSum sorries remain)
+  * Companion S6: ✓ (sorry-free)
 
 ## Key Decisions from S3 (researcher-1, 2026-06-01)
 

--- a/research/problems/triangular-reciprocals-oq-02/state.md
+++ b/research/problems/triangular-reciprocals-oq-02/state.md
@@ -1,95 +1,87 @@
 # Research State: triangular-reciprocals-oq-02
 
 ## Current State
-**Phase**: ACT (scaffold landed; closures pending)
+**Phase**: ACT (S5 mechanical-closure pass shipped)
 **Path**: full
-**Since**: 2026-06-01 (S4 — researcher-1 ACT SCAFFOLD)
-**Iteration**: 4
-**Prior**: S3 ORIENT→DECIDE (2026-06-01, researcher-1 — approach lock + signatures)
+**Since**: 2026-06-01 (S5 — researcher-1 ACT close-mechanical-sorries)
+**Iteration**: 5
+**Prior**: S4 ACT SCAFFOLD (2026-06-01, researcher-1 — both files build clean with sorries)
+         S3 ORIENT→DECIDE (2026-06-01, researcher-1 — approach lock + signatures)
          S2 OBSERVE→ORIENT (2026-06-01, researcher-1 — problem.md + Mathlib scout)
 
 ## Current Focus
-S4 scaffolds the Lean files with all proofs as `sorry`. Both files Docker-build
-clean on Mathlib v4.26.0:
+S5 closed 5 of 8 sorries in `TriangularReciprocalsOQ02.lean` and 2 of 3 in the
+Aristotle companion. Both files Docker-build clean on Mathlib v4.26.0 with the
+remaining sorries explicitly localised to the substantive math (Lemma 2 reindex,
+Lemma 3 tail bound, main `HasSum` assembly).
 
-- `proofs/Proofs/TriangularReciprocalsOQ02.lean` (8 sorries: 4 lemmas, main HasSum
-  + tsum corollary, 3 special-case sanity checks for k=1,2,3).
-- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` (3 sorries: companion
-  forms of Lemmas 1, 3, 4 exposed to Aristotle).
+| # | Lemma | File / line | Status (S5) |
+|---|-------|-------------|-------------|
+| 1 | `partial_fraction`                      | main:~42  | **closed** — `field_simp; ring` lifted verbatim from `TriangularReciprocalGeneralized.lean:133` |
+| 2 | `partial_sum_closed_form`               | main:~62  | sorry (S7+) — reindex via `Finset.sum_Ico_add'` |
+| 3 | `tail_to_zero`                          | main:~76  | sorry (S6)  — bound `H_{N+k} − H_N ≤ k/(N+1)` |
+| 4 | `summable_one_div_n_mul_n_add_k`        | main:~88  | **closed** — `Summable.of_nonneg_of_le` against `1/(n+1)^2`, p-series at p=2 + `summable_nat_add_iff 1` shift |
+|   | `generalized_triangular_reciprocals`    | main:~124 | sorry (S7) — combine 2+3+4 to lift partial sums to `HasSum` |
+|   | `special_case_k1` / `_k2` / `_k3`       | main:~140+| **closed** — unfold `harmonic_succ` then `push_cast; norm_num` |
 
-Lemma 2 (`partial_sum_closed_form`) is intentionally NOT exposed to the companion —
-the reindex argument is the substantive content of this proof and is kept in the
-main file per gallery convention.
+Aristotle companion (`TriangularReciprocalsOQ02Aristotle.lean`):
+- `partial_fraction_aristotle`              — **closed** (S5)
+- `tail_to_zero_aristotle`                  — sorry (S6)
+- `summable_one_div_n_mul_n_add_k_aristotle` — **closed** (S5)
 
-The next pass (S5, ACT) will close Lemmas 1 + 4 (mechanical) plus the three
-special-case sanity checks; S6 attacks Lemma 3 (tail bound); S7+ attacks Lemma 2
-(the reindex) and the main theorem closure.
+## Mathlib v4.26.0 API notes (S5 session)
+
+- `div_le_div_iff` → `div_le_div_iff₀` (rename in v4.26).
+- `Nat.cast_nonneg` named arg is `α`, not `R` (regression of an older R-convention).
 
 ## Active Approach
-**Approach 1 — Direct partial fractions + harmonic telescoping (LOCKED).**
+**Approach 1 — Direct partial fractions + harmonic telescoping (LOCKED at S3).**
 - Lemma 1 (`partial_fraction`): $\tfrac{1}{n(n+k)} = \tfrac{1}{k}(\tfrac{1}{n} - \tfrac{1}{n+k})$
-  for $n, k \ge 1$. **Transfer verbatim** from `TriangularReciprocalGeneralized.lean:133`
-  (`field_simp; ring` after `Nat.cast_ne_zero` hypotheses).
+  for $n, k \ge 1$. **Closed S5** via verbatim lift from `TriangularReciprocalGeneralized.lean:133`.
 - Lemma 2 (`partial_sum_closed_form`): $\sum_{n=1}^{N} \tfrac{1}{n(n+k)} =
-  \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$.
-  Strategy: split via Lemma 1 → two sums; reindex the second by $m = n+k$ using
-  `Finset.sum_Ico_add'` (the same lemma `harmonic_eq_sum_Icc` uses).
-- Lemma 3 (`tail_to_zero`): $|H_{N+k} - H_N| \le k/(N+1)$; take limit to get $\to 0$.
-- Lemma 4 (`summable_one_div_n_mul_n_add_k`): $0 \le 1/(n(n+k)) \le 1/n^2$ for $n \ge 1$,
-  comparison with `Real.summable_one_div_nat_pow.mpr (by norm_num : (1:ℝ) < 2)`.
+  \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$. Strategy: split via Lemma 1 → two sums;
+  reindex the second by $m = n+k$ using `Finset.sum_Ico_add'` (the same lemma `harmonic_eq_sum_Icc` uses).
+- Lemma 3 (`tail_to_zero`): $0 \le H_{N+k} - H_N \le k/(N+1)$; take limit to get $\to 0$.
+- Lemma 4 (`summable_one_div_n_mul_n_add_k`): **Closed S5**. We dominate
+  $1/((n+1)((n+1)+k)) \le 1/(n+1)^2$ since $(n+1)+k \ge (n+1)$, then use
+  `summable_one_div_nat_pow.mpr one_lt_two` shifted by `(summable_nat_add_iff 1).mpr` and
+  squeeze via `Summable.of_nonneg_of_le`.
 - Main: `HasSum (fun n : ℕ => 1/((n+1:ℝ)*((n+1)+k))) ((harmonic k : ℝ)/k)`.
 
 Approach 2 (digamma) remains parked. May surface as a one-line corollary using
 `Real.deriv_Gamma_nat` after the main result is in place.
 
 ## Attempt Count
-- Total attempts: 0 (S4 ships scaffolds only; no proof bodies yet)
-- Current approach attempts: 0 (closures begin in S5)
-- Approaches tried: 0
+- Total attempts: 1 (S5 close-mechanical-sorries pass — succeeded on Docker)
+- Current approach attempts: 1
+- Approaches tried: 1
 - Approaches considered & parked: 1 (digamma series)
 
 ## Blockers
-None.
+None. The remaining three sorries (Lemma 2, Lemma 3, main `HasSum`) are mathematical,
+not API-blocked.
 
 ## Next Action
 
-ACT phase (S5) — close the easy lemmas:
+**S6** — close `tail_to_zero` (Lemma 3) and its Aristotle mirror.
 
-1. **Lemma 1 (`partial_fraction`)**: lift from `TriangularReciprocalGeneralized.lean:133`
-   (`field_simp; ring` after `Nat.cast_ne_zero` derived hypotheses). Mirror to the
-   Aristotle companion.
-2. **Lemma 4 (`summable_one_div_n_mul_n_add_k`)**: `Summable.of_nonneg_of_le` (or
-   `Summable.comparison`) against `Real.summable_one_div_nat_pow` at p=2. Bound
-   `1/((n+1)((n+1)+k)) ≤ 1/((n+1)^2)` since `(n+1)+k ≥ (n+1)`. Mirror to companion.
-3. **Special cases k=1,2,3**: `simp only [harmonic_succ, harmonic_zero]; norm_num`
-   should close all three in one tactic each (rational arithmetic).
-4. Docker-build, commit, push, refresh PR description.
+Strategy: write `harmonic (N+k) - harmonic N` as `∑ i ∈ Finset.Icc (N+1) (N+k), (1:ℝ)/i`
+via `harmonic_eq_sum_Icc` and `Finset.sum_Icc_consecutive` (or `Finset.sum_Ioc_consecutive`).
+Bound each term by `1/(N+1)`. Squeeze using `tendsto_const_div_atTop_nhds_zero_nat`
+applied to the constant bound `k/(N+1)`.
 
-S6 attacks Lemma 3 (the tail bound `H_{N+k} - H_N ≤ k/(N+1)` + squeeze to 0).
-S7+ attacks Lemma 2 (the reindex via `Finset.sum_Ico_add'`).
-S8+ assembles the main theorem from Lemmas 2 + 3 + 4 + partial_sum_closed_form.
+**S7+** — close `partial_sum_closed_form` (Lemma 2). The reindex via `Finset.sum_Ico_add'`
+is the substantive step. Then assemble the main `HasSum` from 2+3+4.
 
 ## S4 Scaffold Artifacts (researcher-1, 2026-06-01)
 
-- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 125 lines, 8 sorries:
-  - `partial_fraction` (line 42)
-  - `partial_sum_closed_form` (line 58)
-  - `tail_to_zero` (line 72)
-  - `summable_one_div_n_mul_n_add_k` (line 85)
-  - `generalized_triangular_reciprocals` (line 101, main HasSum)
-  - `generalized_triangular_reciprocals_tsum` (line 117, tsum corollary — closed via
-    `.tsum_eq` once main lands, but currently uses the main as a sorry)
-  - `special_case_k1` / `_k2` / `_k3` (lines 121, 125, 129)
-- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 45 lines, 3 sorries:
-  - `partial_fraction_aristotle` (line 23)
-  - `tail_to_zero_aristotle` (line 32)
-  - `summable_one_div_n_mul_n_add_k_aristotle` (line 41)
+- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 125 lines, 8 sorries (S4 → 3 sorries S5).
+- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 45 lines, 3 sorries (S4 → 1 sorry S5).
 - Docker build: both files compile clean (Mathlib v4.26.0, 7743/7743 jobs).
 
 ## Key Decisions from S3 (researcher-1, 2026-06-01)
 
 - **File name**: `Proofs/TriangularReciprocalsOQ02.lean` (slug-matching, Aristotle-friendly).
-  Rejected `TriangularReciprocalsHarmonic.lean` — slug match wins for gallery discovery.
 - **Namespace**: `TriangularReciprocalsHarmonic` (descriptive; avoids collision with the
   alternating sibling's `AlternatingTriangularReciprocals.Generalized`).
 - **Hypothesis convention**: `(k : ℕ) (hk : 0 < k)` — matches sibling
@@ -98,9 +90,7 @@ S8+ assembles the main theorem from Lemmas 2 + 3 + 4 + partial_sum_closed_form.
   then convert to `Finset.range` at the `HasSum` boundary using `hasSum_nat_add_iff 1` to
   drop the $n=0$ term (same trick used at `TriangularReciprocalGeneralized.lean:124`).
 - **Casting site**: cast `harmonic` to ℝ at the statement level
-  (`(harmonic k : ℝ)`), not inside the proof. The Bounds.lean recipe
-  `simp only [harmonic_eq_sum_Icc, Rat.cast_sum, Rat.cast_inv, Rat.cast_natCast]`
-  unfolds the rational into the real Icc-sum cleanly.
+  (`(harmonic k : ℝ)`), not inside the proof.
 
 ## Key Mathlib Anchors (S3-verified, Mathlib v4.26.0)
 
@@ -110,6 +100,9 @@ S8+ assembles the main theorem from Lemmas 2 + 3 + 4 + partial_sum_closed_form.
 | `harmonic_eq_sum_Icc` | `Defs.lean:37` | Switch to 1-indexed Icc view |
 | `Finset.sum_Ico_add'` | `Algebra/BigOperators/Intervals.lean` | Reindex shift $n \mapsto n+k$ |
 | `Rat.cast_sum`, `cast_inv`, `cast_natCast` | `Bounds.lean:24,31` | ℚ→ℝ unfold |
-| `Real.summable_one_div_nat_pow` | `Analysis/PSeries` | $p=2$ comparison |
-| `hasSum_nat_add_iff` | `Topology/Algebra/InfiniteSum/NatInt` | Drop $n=0$ term |
+| `summable_one_div_nat_pow` | `Analysis/PSeries` | $p=2$ comparison (S5 used) |
+| `summable_nat_add_iff` | `Topology/Algebra/InfiniteSum/NatInt` | Drop $n=0$ term (S5 used to shift index by 1) |
+| `Summable.of_nonneg_of_le` | `Topology/Instances/ENNReal` | Comparison test (S5 used) |
+| `div_le_div_iff₀` | `Algebra/Order/GroupWithZero/Unbundled/Basic.lean:1364` | Cross-multiply for div bounds (was `div_le_div_iff` in v4.10) |
+| `hasSum_nat_add_iff` | `Topology/Algebra/InfiniteSum/NatInt` | Drop $n=0$ term in main proof |
 | `Real.deriv_Gamma_nat` | `NumberTheory/Harmonic/GammaDeriv.lean` | Optional digamma corollary |

--- a/research/problems/triangular-reciprocals-oq-02/state.md
+++ b/research/problems/triangular-reciprocals-oq-02/state.md
@@ -1,25 +1,61 @@
 # Research State: triangular-reciprocals-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-04-05T19:30:46-07:00
-**Iteration**: 1
+**Since**: 2026-06-01 (S2 — researcher-1 OBSERVE→ORIENT pass)
+**Iteration**: 2
+**Prior**: OBSERVE iter 1 (2026-04-05, template only — no actual observation recorded)
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Approach lock-in. With problem.md now filled and the Mathlib API mapped, the next
+iteration should DECIDE between the direct partial-fraction route and the digamma
+route, and scaffold the Lean file accordingly.
 
 ## Active Approach
-None yet.
+**Approach 1 — Direct partial fractions + harmonic telescoping (provisional).**
+- Lemma 1: $\tfrac{1}{n(n+k)} = \tfrac{1}{k}(\tfrac{1}{n} - \tfrac{1}{n+k})$ for $n, k \ge 1$.
+- Lemma 2: $\sum_{n=1}^{N} \tfrac{1}{n(n+k)} = \tfrac{1}{k}\bigl(H_k - (H_{N+k} - H_N)\bigr)$
+  via reindexing.
+- Lemma 3: $H_{N+k} - H_N \to 0$ as $N \to \infty$, bounded by $k/(N+1)$.
+- Lemma 4: summability via comparison with $\sum 1/n^2$.
+- Main: `HasSum (fun n => 1/((n+1)*((n+1)+k))) (H_k/k)`.
+
+Approach 2 (digamma) is parked: Mathlib has $\Gamma'$ at integers but not the digamma
+series expansion, so it would require us to prove the series identity from scratch.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
+- Total attempts: 0 (S2 is the first substantive research pass; iter 1 was template only)
+- Current approach attempts: 0 (not yet executed)
 - Approaches tried: 0
 
 ## Blockers
 None.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+
+DECIDE phase (S3):
+1. Confirm Approach 1 by sketching Lemma 2 reindex in detail (ℕ-shift between
+   `Finset.range`, `Finset.Icc`, and the partial-fraction telescoping).
+2. Verify the ℝ-cast of `harmonic k` (Mathlib defines `harmonic : ℕ → ℚ`).
+3. Pick a file name. Candidates:
+   - `Proofs/TriangularReciprocalsOQ02.lean` (Aristotle-friendly, matches slug).
+   - `Proofs/TriangularReciprocalsHarmonic.lean` (semantically descriptive).
+   Recommendation: `TriangularReciprocalsOQ02.lean` to match the gallery slug pattern
+   used by `HarmonicDivergenceOQ01.lean`, `HarmonicDivergenceOQ02.lean`, etc.
+4. Then ACT (S4): scaffold the file with the four lemmas + main theorem, leaving each
+   `by sorry` for incremental closure.
+
+## Key Observations from S2 (researcher-1, 2026-06-01)
+
+- `Proofs/TriangularReciprocalGeneralized.lean` (202 lines) handles the **alternating**
+  generalization (slug `triangular-reciprocals-oq-03`), not this one. Its
+  `partial_fraction` lemma is for $\tfrac{1}{n(n+k)} = \tfrac{1}{k}(\tfrac{1}{n} -
+  \tfrac{1}{n+k})$ — directly transferable.
+- `Mathlib.NumberTheory.Harmonic.Defs` puts `harmonic` in ℚ, so the final ℝ-valued
+  `tsum` requires a `push_cast` step on every harmonic reference.
+- `Mathlib.NumberTheory.Harmonic.GammaDeriv.deriv_Gamma_nat` gives the digamma identity
+  $\Gamma'(n+1) = n!(-\gamma + H_n)$, which yields the optional corollary
+  $\sum 1/(n(n+k)) = (\psi(k+1) + \gamma)/k$ once the main identity is proved.
+- No gallery dir `src/data/proofs/triangular-reciprocals-oq-02/` exists yet — will need
+  to be created when the Lean file lands.

--- a/research/problems/triangular-reciprocals-oq-02/state.md
+++ b/research/problems/triangular-reciprocals-oq-02/state.md
@@ -1,17 +1,29 @@
 # Research State: triangular-reciprocals-oq-02
 
 ## Current State
-**Phase**: DECIDE
+**Phase**: ACT (scaffold landed; closures pending)
 **Path**: full
-**Since**: 2026-06-01 (S3 — researcher-1 ORIENT→DECIDE pass)
-**Iteration**: 3
-**Prior**: S2 OBSERVE→ORIENT (2026-06-01, researcher-1 — problem.md + Mathlib scout)
+**Since**: 2026-06-01 (S4 — researcher-1 ACT SCAFFOLD)
+**Iteration**: 4
+**Prior**: S3 ORIENT→DECIDE (2026-06-01, researcher-1 — approach lock + signatures)
+         S2 OBSERVE→ORIENT (2026-06-01, researcher-1 — problem.md + Mathlib scout)
 
 ## Current Focus
-S3 locks in Approach 1 (direct partial fractions + harmonic telescoping), commits to
-the file name `Proofs/TriangularReciprocalsOQ02.lean`, and records the concrete Lean
-signatures + reindex strategy. The next pass (S4, ACT) will scaffold the file with
-the four lemmas and main theorem as `by sorry`.
+S4 scaffolds the Lean files with all proofs as `sorry`. Both files Docker-build
+clean on Mathlib v4.26.0:
+
+- `proofs/Proofs/TriangularReciprocalsOQ02.lean` (8 sorries: 4 lemmas, main HasSum
+  + tsum corollary, 3 special-case sanity checks for k=1,2,3).
+- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` (3 sorries: companion
+  forms of Lemmas 1, 3, 4 exposed to Aristotle).
+
+Lemma 2 (`partial_sum_closed_form`) is intentionally NOT exposed to the companion —
+the reindex argument is the substantive content of this proof and is kept in the
+main file per gallery convention.
+
+The next pass (S5, ACT) will close Lemmas 1 + 4 (mechanical) plus the three
+special-case sanity checks; S6 attacks Lemma 3 (tail bound); S7+ attacks Lemma 2
+(the reindex) and the main theorem closure.
 
 ## Active Approach
 **Approach 1 — Direct partial fractions + harmonic telescoping (LOCKED).**
@@ -28,11 +40,11 @@ the four lemmas and main theorem as `by sorry`.
 - Main: `HasSum (fun n : ℕ => 1/((n+1:ℝ)*((n+1)+k))) ((harmonic k : ℝ)/k)`.
 
 Approach 2 (digamma) remains parked. May surface as a one-line corollary using
-`Real.deriv_Gamma_nat` after the main result is in place, but is not part of S4.
+`Real.deriv_Gamma_nat` after the main result is in place.
 
 ## Attempt Count
-- Total attempts: 0 (S3 is still planning; no Lean code yet)
-- Current approach attempts: 0
+- Total attempts: 0 (S4 ships scaffolds only; no proof bodies yet)
+- Current approach attempts: 0 (closures begin in S5)
 - Approaches tried: 0
 - Approaches considered & parked: 1 (digamma series)
 
@@ -41,22 +53,38 @@ None.
 
 ## Next Action
 
-ACT phase (S4) — scaffold the Lean file:
+ACT phase (S5) — close the easy lemmas:
 
-1. Create `proofs/Proofs/TriangularReciprocalsOQ02.lean` with namespace
-   `TriangularReciprocalsHarmonic` (or `TriangularReciprocals.Harmonic`), `import Mathlib`,
-   and the four lemmas + main theorem as `by sorry`. Keep all numeric statements ℝ-valued
-   except harmonic numbers (cast at use sites via the `Rat.cast_sum + cast_inv + cast_natCast`
-   chain documented in `NumberTheory/Harmonic/Bounds.lean:24`).
-2. Add `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` companion exposing only
-   Lemmas 1, 3, 4 as theorem sorries (Lemma 2 carries the substantive index work, gallery
-   convention is to keep it in the main file; Aristotle may close Lemmas 1/3/4 trivially).
-3. Do NOT create the gallery dir yet — wait until the main theorem closes (S5+) so we
-   don't ship a broken gallery entry.
-4. Docker-build the scaffold so we know baseline imports compile, then push.
+1. **Lemma 1 (`partial_fraction`)**: lift from `TriangularReciprocalGeneralized.lean:133`
+   (`field_simp; ring` after `Nat.cast_ne_zero` derived hypotheses). Mirror to the
+   Aristotle companion.
+2. **Lemma 4 (`summable_one_div_n_mul_n_add_k`)**: `Summable.of_nonneg_of_le` (or
+   `Summable.comparison`) against `Real.summable_one_div_nat_pow` at p=2. Bound
+   `1/((n+1)((n+1)+k)) ≤ 1/((n+1)^2)` since `(n+1)+k ≥ (n+1)`. Mirror to companion.
+3. **Special cases k=1,2,3**: `simp only [harmonic_succ, harmonic_zero]; norm_num`
+   should close all three in one tactic each (rational arithmetic).
+4. Docker-build, commit, push, refresh PR description.
 
-S5 will be the first ACT closure pass on Lemmas 1, 4 (easy) and then 3 (tail bound).
-S6+ will tackle Lemma 2 (the reindex) and the main theorem.
+S6 attacks Lemma 3 (the tail bound `H_{N+k} - H_N ≤ k/(N+1)` + squeeze to 0).
+S7+ attacks Lemma 2 (the reindex via `Finset.sum_Ico_add'`).
+S8+ assembles the main theorem from Lemmas 2 + 3 + 4 + partial_sum_closed_form.
+
+## S4 Scaffold Artifacts (researcher-1, 2026-06-01)
+
+- `proofs/Proofs/TriangularReciprocalsOQ02.lean` — 125 lines, 8 sorries:
+  - `partial_fraction` (line 42)
+  - `partial_sum_closed_form` (line 58)
+  - `tail_to_zero` (line 72)
+  - `summable_one_div_n_mul_n_add_k` (line 85)
+  - `generalized_triangular_reciprocals` (line 101, main HasSum)
+  - `generalized_triangular_reciprocals_tsum` (line 117, tsum corollary — closed via
+    `.tsum_eq` once main lands, but currently uses the main as a sorry)
+  - `special_case_k1` / `_k2` / `_k3` (lines 121, 125, 129)
+- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` — 45 lines, 3 sorries:
+  - `partial_fraction_aristotle` (line 23)
+  - `tail_to_zero_aristotle` (line 32)
+  - `summable_one_div_n_mul_n_add_k_aristotle` (line 41)
+- Docker build: both files compile clean (Mathlib v4.26.0, 7743/7743 jobs).
 
 ## Key Decisions from S3 (researcher-1, 2026-06-01)
 


### PR DESCRIPTION
## Problem

Generalized Triangular Reciprocals via Harmonic Numbers — prove

$$\sum_{n=1}^{\infty} \frac{1}{n(n+k)} = \frac{H_k}{k}$$

for every integer $k \ge 1$, where $H_k$ is the $k$-th harmonic number.

## What this PR ships (S2 → S6)

- **S2 OBSERVE→ORIENT** (`f87d8500a91`) — problem statement, plain-language summary,
  related results in the gallery, Mathlib scout (`harmonic`, `harmonic_eq_sum_Icc`,
  `summable_one_div_nat_pow`, etc.).
- **S3 ORIENT→DECIDE** (`bc2be9c51b0`) — locks Approach 1 (direct partial fractions
  + harmonic telescoping); records the four Lean signatures and the reindex strategy.
- **S4 ACT SCAFFOLD** (`cb187e618e2`) — adds the two Lean files with all proofs as
  `sorry`. Both files Docker-build clean on Mathlib v4.26.0.
- **S5 ACT close-mechanical-sorries** (`00e1a409a4a`) — closes 5/8 sorries in the
  main file and 2/3 in the Aristotle companion.
- **S6 ACT close tail_to_zero** (`2f614909363`) — closes Lemma 3 (`tail_to_zero`)
  and its Aristotle mirror by induction on `k`. Aristotle companion is now
  **sorry-free**. Main file is down to 2 sorries (Lemma 2 + main `HasSum`).

## Files

- `proofs/Proofs/TriangularReciprocalsOQ02.lean` (8 → 3 → **2 sorries**):
  - ✅ `partial_fraction` — lifted from sibling (`field_simp; ring`)
  - ⌛ `partial_sum_closed_form` — S7, reindex via `Finset.sum_Ico_add'`
  - ✅ `tail_to_zero` (S6) — induction on k; succ step uses
        `tendsto_one_div_add_atTop_nhds_zero_nat.comp (tendsto_add_atTop_nat k)`
        and `harmonic_succ`
  - ✅ `summable_one_div_n_mul_n_add_k` — `Summable.of_nonneg_of_le` against `1/(n+1)^2`
  - ⌛ `generalized_triangular_reciprocals` (main `HasSum`) — S8, assemble from 2+3+4
  - ✅ `generalized_triangular_reciprocals_tsum` — derived via `.tsum_eq`
  - ✅ `special_case_k1` / `_k2` / `_k3` — `harmonic_succ` unfold + `norm_num`
- `proofs/Proofs/TriangularReciprocalsOQ02Aristotle.lean` (3 → 1 → **0 sorries**):
  - ✅ `partial_fraction_aristotle`
  - ✅ `tail_to_zero_aristotle` (S6 mirror)
  - ✅ `summable_one_div_n_mul_n_add_k_aristotle`
- `research/problems/triangular-reciprocals-oq-02/` — `problem.md`, `knowledge.md`,
  `state.md` (S6 iteration 6), `selection-report.md`, `literature/`.

## Mathlib v4.26.0 API notes from S5–S6

- `div_le_div_iff` → `div_le_div_iff₀` (zero-class refactor;
  `GroupWithZero/Unbundled/Basic.lean:1364`).
- `Nat.cast_nonneg` named arg is `α`, not `R`.
- S6 gotcha: `.comp` dot notation on `tendsto_one_div_add_atTop_nhds_zero_nat`
  triggers `ContinuousSMul ℚ≥0 ?m` typeclass instability — workaround: bind to a
  typed `have h_base : Tendsto _ atTop (𝓝 (0 : ℝ))` first, then `h_base.comp h_shift`.
- S6 gotcha: `Tendsto.add` of two `(𝓝 0)` limits produces `(𝓝 (0 + 0))`, not
  `(𝓝 0)` — close with `simpa using ih.add h_term`.

## Next steps

- **S7**: close `partial_sum_closed_form` (Lemma 2) — the substantive reindex via
  `Finset.sum_Ico_add'`. Strategy in `state.md`.
- **S8**: assemble the main `generalized_triangular_reciprocals` from Lemmas 2 + 3 + 4.

The gallery directory (`src/data/proofs/triangular-reciprocals-oq-02/`) will only be
created once the main theorem closes, so we don't ship a broken entry.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.TriangularReciprocalsOQ02` — succeeds
      (2 sorry warnings as expected).
- [x] `./proofs/scripts/docker-build.sh Proofs.TriangularReciprocalsOQ02Aristotle` —
      succeeds with no warnings (sorry-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)