### PR TITLE
fix(meta): ballot-problem-oq-01-oq-02 register OQ02 LGV orphan + 2 axiom undercount

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-02",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/BallotProblemOQ01OQ02.lean",
     "tags": [
       "combinatorics",
@@ -16,14 +16,17 @@
       "projection-principle",
       "counting"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 0,
-    "assumptions": "None. All axioms eliminated: fiber_card_uniform proved via fiberSwap bijection, uniformOn_fiber_transfer proved via cross-multiplication bijection showing |(MCS ∩ MSP)| · |CS| = |(CS ∩ SP)| · |MCS|.",
+    "axiomCount": 2,
+    "assumptions": "0 axioms in the parent file BallotProblemOQ01OQ02.lean (all axioms eliminated: fiber_card_uniform proved via fiberSwap bijection, uniformOn_fiber_transfer proved via cross-multiplication bijection showing |(MCS ∩ MSP)| · |CS| = |(CS ∩ SP)| · |MCS|). 2 axioms in the registered companion BallotProblemOQ01OQ02OQ02.lean (LGV path-ordering extension): three_candidate_ordering_formula and three_ordering_product_conjecture, both stating the 3-candidate ordering probability as the product of pairwise ballot ratios via the Lindström-Gessel-Viennot lemma (non-intersecting lattice path theory not in Mathlib). Chain axiom total: 2.",
     "lineCount": 1047,
     "theoremCount": 40,
     "definitionCount": 19,
+    "additionalFiles": [
+      "Proofs/BallotProblemOQ01OQ02OQ02.lean"
+    ],
     "originalContributions": [
       "projectToSign: projection from multi-candidate sequences to ±1 sequences",
       "prefixSumPreservation: prefix sums are preserved under projection (leadsAllCombined ↔ positive prefix sums)",
@@ -80,7 +83,18 @@
     "theoremCount": 40,
     "definitionCount": 19,
     "path": "Proofs/BallotProblemOQ01OQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BallotProblemOQ01OQ02OQ02.lean",
+        "lineCount": 260,
+        "theorems": 15,
+        "definitions": 2,
+        "axioms": 2,
+        "sorries": 0,
+        "description": "LGV Determinant for Path Orderings (sub-OQ-02 of OQ-01-OQ-02, namespace inferred from imports of Archive.Wiedijk100Theorems.BallotProblem). Defines ballotRatio a b := (a-b)/(a+b) (the classical 2-candidate ballot ratio) and ballotMatrix2 a b (the 2×2 LGV matrix). Proves antisymmetry, positivity, upper bound, monotonicity (ballotRatio_antisymm, ballotRatio_pos, ballotRatio_le_one, ballotRatio_mono); concrete numerical verifications (example_3_1, example_4_2, example_5_1, example_4_2_1, example_5_3_1, example_6_4_2); the 2-candidate reduction orderingProbability_two (from Mathlib's Ballot.ballot_problem); 2×2 determinant identities (det_ballotMatrix2, ballotMatrix2_entry_01); and the 3-candidate ordering verifications ordering_4_2_1, ordering_5_3_1. Axiomatized (LGV non-intersecting lattice path theory not in Mathlib): three_candidate_ordering_formula (3-candidate ordering probability = product of pairwise ballot ratios) and three_ordering_product_conjecture (product factorization in (a-b)(b-c)(a-c) / (a+b)(b+c)(a+c) form)."
+      }
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register the 260-line LGV-path-ordering companion `Proofs/BallotProblemOQ01OQ02OQ02.lean` as a child of gallery slug `ballot-problem-oq-01-oq-02`, and roll up its 2 LGV axioms into the parent's axiom accounting per CLAUDE.md axiom integrity policy.

## Evidence

**Before**
- Orphan: filesystem-present but absent from `meta.additionalFiles` and `leanFile.additionalFiles`.
- `axiomCount: 0`, `status: verified`, `badge: mathlib` — undercounted the **2 `axiom` declarations** in the companion file (`three_candidate_ordering_formula` at L196 and `three_ordering_product_conjecture` at L204).
- `assumptions: "None. All axioms eliminated…"` — false once the companion is registered.

**After**
- `meta.additionalFiles` (string form, auditor-visible) + rich-object `leanFile.additionalFiles` registration (260 lines, 15 theorems, 2 defs, 2 axioms, 0 sorries).
- `axiomCount: 0 → 2`, `status: verified → axiomatized`, `badge: mathlib → axiom`.
- `assumptions:` rewritten to split parent (0 axioms, Mathlib-only) from companion (2 LGV axioms requiring non-intersecting lattice path theory not in Mathlib).

Per `[[project_mechanic_additionalfiles_format_convention]]`: strings in `meta.additionalFiles` (auditor follows these), rich objects in `leanFile.additionalFiles` (renderer surface).

Per CLAUDE.md Axiom Integrity Policy: companion axioms count toward the chain total, and `status` flips to `axiomatized` once stated assumptions exist anywhere in the registered chain.

Companion content: `ballotRatio = (a-b)/(a+b)` (classical 2-candidate ratio), the 2×2 `ballotMatrix2`, antisymmetry/positivity/monotonicity lemmas, six concrete numerical verifications ((3,1), (4,2), (5,1), (4,2,1), (5,3,1), (6,4,2)), the `orderingProbability_two` reduction to Mathlib's `Ballot.ballot_problem`, `det_ballotMatrix2`, and the two LGV axioms underwriting the 3-candidate product factorization `(a-b)(b-c)(a-c) / (a+b)(b+c)(a+c)`.

---
Automated fix by lean-mechanic agent.