### PR TITLE
fix(meta): basel-problem-oq-01-oq-01-oq-02 register OQ02 orphan companion

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -10,7 +10,8 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/BaselProblemOQ01OQ01OQ02.lean",
     "additionalFiles": [
-      "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+      "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean"
     ],
     "tags": [
       "number-theory",
@@ -193,7 +194,8 @@
     "sorries": 0,
     "notes": "11 pre-existing build errors fixed (Mathlib API changes: sum_le_sum_of_subset removed, Finset.lcm normalization, dcstring parser incompatibilities). Parts XVII-XVIII added: telescoping upper bound for ζ(3) tail + L₂ > 0 via native_decide.",
     "additionalFiles": [
-      "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+      "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean",
+      "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

Register \`BaselProblemOQ01OQ01OQ02OQ02.lean\` (972 lines — Apéry denominator-control cubed-LCM lemma) in both \`meta.additionalFiles\` and \`leanFile.additionalFiles\` for slug \`basel-problem-oq-01-oq-01-oq-02\`.

The companion provides the cubed-divisibility lemma \`pow_dvd_lcmRange_pow\` used to attack the \`denominator_control\` axiom in the primary file \`Proofs/BaselProblemOQ01OQ01OQ02.lean\`.

## Diff

\`\`\`diff
   "additionalFiles": [
-    "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean"
+    "Proofs/BaselProblemOQ01OQ01OQ02Aristotle.lean",
+    "Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean"
   ],
\`\`\`

(Applied in both \`meta.additionalFiles\` and \`leanFile.additionalFiles\` to satisfy the mirror convention.)

## Test plan

- [x] meta.json parses as valid JSON
- [x] Diff limited to additionalFiles arrays (4 insertions / 2 deletions)
- [x] No other open PR claims this slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)