### PR TITLE
fix(meta): birch-swinnerton-dyer register BirchSwinnertonDyerOQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/birch-swinnerton-dyer/meta.json
+++ b/src/data/proofs/birch-swinnerton-dyer/meta.json
@@ -81,7 +81,8 @@
     "millenniumProblem": "bsd",
     "proofRepoPath": "Proofs/BirchSwinnertonDyer.lean",
     "additionalFiles": [
-      "Proofs/BirchSwinnertonDyerAristotle.lean"
+      "Proofs/BirchSwinnertonDyerAristotle.lean",
+      "Proofs/BirchSwinnertonDyerOQ01.lean"
     ],
     "lineCount": 7435,
     "mathlib_version": "4.26.0",
@@ -728,7 +729,8 @@
     "definitionCount": 261,
     "theoremCount": 254,
     "additionalFiles": [
-      "Proofs/BirchSwinnertonDyerAristotle.lean"
+      "Proofs/BirchSwinnertonDyerAristotle.lean",
+      "Proofs/BirchSwinnertonDyerOQ01.lean"
     ]
   }
 }


### PR DESCRIPTION
## Fix

Register the 297-line Sha-finiteness Kolyvagin rank-1 scaffold `Proofs/BirchSwinnertonDyerOQ01.lean` (namespace `BirchSwinnertonDyer.ShaFiniteness`) as a child of gallery slug `birch-swinnerton-dyer`. The file was filesystem-present but absent from both `meta.additionalFiles` and `leanFile.additionalFiles`, making it invisible to auditor scans.

Per `[[project_mechanic_additionalfiles_format_convention]]`: strings in both `meta.additionalFiles` (auditor-visible) and `leanFile.additionalFiles` (preserving the existing simple-string style used by this slug — the BSD parent already lists `BirchSwinnertonDyerAristotle.lean` as a bare string).

## Evidence

**Before**: `proofs/Proofs/BirchSwinnertonDyerOQ01.lean` (297L, 8T, 0L, 0D, 3S structures, 8 axioms, 0 sorries) — orphan, sibling `BirchSwinnertonDyerAristotle.lean` was the only registered child.

**After**: Registered under `birch-swinnerton-dyer/meta.json`:
- `meta.additionalFiles` — appended as bare string
- `leanFile.additionalFiles` — appended as bare string

## Content summary

OQ-01 derivation: **If ord_{s=1} L(E,s) ≤ 1, then Ш(E/ℚ)[p^∞] is finite for every prime p** — one of the few unconditional results toward BSD, due to Kolyvagin (rank 0, via Euler systems) and Gross-Zagier + Kolyvagin (rank 1).

Structures: `ShaTorsionPrimary` (p-primary Ш group carrier), `HeegnerField` (imaginary quadratic field K with Heegner hypothesis), `HeegnerPoint` (non-torsion CM point y_K).

Axioms (8, all in `BirchSwinnertonDyer.ShaFiniteness` namespace, not inherited by parent):
- `analyticRank_pos_of_L_zero` — L(E,1)=0 → analyticRank ≥ 1
- `heegner_field_exists`, `heegner_point_exists`
- `gross_zagier_height_pos` — non-torsion Heegner point has positive Néron–Tate height
- `kolyvagin_euler_system_rank_zero`, `kolyvagin_euler_system_rank_one`
- `sha_finite_of_selmer_zero`, `sha_finite_of_selmer_rank_one`

Theorems include the two contrapositives `analyticRank_zero_implies_L_nonzero` and `L_zero_of_analyticRank_pos`, plus the headline `sha_finite_rank_one_case`.

No status/axiom change to parent: parent stays `axiomatized` / `axiom`, `axiomCount: 38`.

---
Automated fix by lean-mechanic agent.