### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03 register OQ01 orphan companion

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -25,6 +25,9 @@
     "lineCount": 212,
     "theoremCount": 10,
     "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean"
+    ],
     "originalContributions": [
       "buDim_prime_le_semiprime_left/right: lower bounds from buDim_mono (no new axioms)",
       "buDim_max_le_semiprime: max lower bound proved purely from monotonicity",
@@ -118,7 +121,10 @@
     "sorries": 0,
     "lineCount": 212,
     "theoremCount": 10,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register the 157-line "BU CRT semiprime proved without Smith theory" file `Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean` (namespace `BorsukUlamCRTProved`) as a child of gallery slug `borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03`. The file was filesystem-present but absent from both `meta.additionalFiles` and `leanFile.additionalFiles` (neither field existed for this slug), making it invisible to auditor scans.

Per `[[project_mechanic_additionalfiles_format_convention]]`: introduced both fields as bare-string arrays (auditor follows `meta.additionalFiles` strings; `leanFile.additionalFiles` mirrors for the renderer).

## Evidence

**Before**: `proofs/Proofs/BorsukUlamOQ02OQ01OQ01OQ02OQ03OQ01.lean` (157L, 7T, 0L, 0D, 0 axioms, 0 sorries) — orphan. Sibling `OQ02.lean` is its own gallery entry (slug `...-oq-02`).

**After**: Registered under `borsuk-ulam-oq-02-oq-01-oq-01-oq-02-oq-03/meta.json`:
- `meta.additionalFiles` — new field, bare string
- `leanFile.additionalFiles` — new field, bare string

## Content summary

**Headline result `buDim_crt_semiprime_proved`**: the `buDim_crt_semiprime` axiom from the parent file is in fact a theorem — it follows immediately from the existing `buDim_le_formula` axiom via the prime-factorization computation `Nat.primeFactors (p * q) = {p, q}` (distinct primes). Smith theory for prime-order groups is not needed for the semiprime case.

Downstream theorems:
- `buDim_semiprime_eq_max_proved` — equality via `le_antisymm` (monotonicity lower bound + CRT upper bound)
- `not_exotic_semiprime_proved` — no exotic G-representations for ℤ/pqℤ
- `buDim_six_proved`, `buDim_ten_proved`, `buDim_fifteen_proved` — three concrete cases (n = 6, 10, 15)
- `axiom_reduction_confirmed` — documents the reduction 4 → 3 axioms in the parent (`buDim`, `buDim_mono`, `buDim_le_formula` remain)

No status/axiom change to parent: companion contributes 0 axioms, so parent `axiomCount: 1` stays unchanged. (The reduction it advertises is a meta-mathematical observation, not yet wired through the parent's axiom count.)

---
Automated fix by lean-mechanic agent.