### PR TITLE
fix(meta): borsuk-ulam-oq-02-oq-01-oq-04 register OQ01 orphan companion

### DIFF
--- a/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-02-oq-01-oq-04/meta.json
@@ -41,7 +41,10 @@
     "assumptions": "4 axioms inherited from BorsukUlamOQ02OQ01.lean: buDim (Borsuk-Ulam dimension function), buDim_two (dimension 2 case), buDim_prime (prime dimension case), buDim_mono (monotonicity of buDim). 0 own axioms. 0 sorries.",
     "lineCount": 251,
     "theoremCount": 8,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The **Fadell-Husseini index** (1988) is an ideal-valued cohomological invariant that assigns to each G-space X a homogeneous ideal $\\text{Index}_G(X) \\subseteq H^*(BG; k)$. Unlike numerical indices (which lose information), the ideal-valued index captures the full algebraic structure of the equivariant obstruction.\n\nFor cyclic groups $G = \\mathbb{Z}/p$, the cohomology ring $H^*(B\\mathbb{Z}/p; \\mathbb{F}_p)$ is a polynomial ring, and the FH index is always a principal ideal $(u^m)$. The key computation: for the standard free $\\mathbb{Z}/p$ action on $S^{2n-1}$ (rotation in $\\mathbb{C}^n$), $\\text{Index}_{\\mathbb{Z}/p}(S^{2n-1}) = (u^n)$. This immediately gives the Yang-Borsuk theorem: $\\text{buDim}(p, 2n) = 2n-1$.\n\nFor composite groups $G = \\mathbb{Z}/n$, the FH index provides finer information than simple monotonicity. Restriction maps $\\text{res}_p : H^*(B\\mathbb{Z}/n) \\to H^*(B\\mathbb{Z}/p)$ for each prime $p | n$ give independent constraints on the index ideal.",
@@ -167,7 +170,18 @@
     "path": "Proofs/BorsukUlamOQ02OQ01OQ04.lean",
     "sorries": 0,
     "definitionCount": 7,
-    "theoremCount": 8
+    "theoremCount": 8,
+    "additionalFiles": [
+      {
+        "path": "Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean",
+        "description": "Concrete F_p[u] cohomology ring of BZ/p: realizes the polynomial generator and proves ideal monotonicity + quotient dimension using Mathlib's polynomial infrastructure (AdjoinRoot.powerBasis, Ideal.Quotient.nontrivial_iff). 0 own axioms, 0 sorries.",
+        "lineCount": 235,
+        "axiomCount": 0,
+        "sorries": 0,
+        "theoremCount": 15,
+        "definitionCount": 6
+      }
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register orphaned companion `Proofs/BorsukUlamOQ02OQ01OQ04OQ01.lean` (235 lines, 0 own axioms, 0 sorries, 15 theorems, 6 defs) in both `meta.additionalFiles` and `leanFile.additionalFiles` so the deployer and auditor see it.

## Evidence

**Before**: `BorsukUlamOQ02OQ01OQ04OQ01.lean` unreferenced in any `meta.json` (orphan scan v4).
**After**: registered alongside parent `BorsukUlamOQ02OQ01OQ04.lean`; companion formalizes `H*(BZ/p; F_p) ≅ F_p[u]` using Mathlib's polynomial infrastructure (`AdjoinRoot.powerBasis`, `Ideal.Quotient.nontrivial_iff`).

Slug pool: 91 viable orphans @ HEAD f486a19e2e0 (mechanic-3, 2026-06-01).

---
Automated fix by lean-mechanic agent.