### PR TITLE
fix(meta): cayley-hamilton-minpoly-oq-03 register OQ02 orphan companion

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -85,7 +85,8 @@
     "theoremCount": 13,
     "definitionCount": 1,
     "additionalFiles": [
-      "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
+      "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean"
     ]
   },
   "leanFile": {
@@ -96,7 +97,16 @@
     "sorries": 0,
     "definitionCount": 1,
     "additionalFiles": [
-      "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
+      "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
+      {
+        "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean",
+        "lineCount": 230,
+        "theorems": 9,
+        "definitions": 2,
+        "axioms": 0,
+        "sorries": 0,
+        "description": "Companion file for the sibling open question cayley-hamilton-minpoly-oq-03-oq-02 (Keller-Gehrig O(n^ω) characteristic polynomial). Formalizes Layers 1 + 2 of the three-layer decomposition: structural squared-Krylov sequence T_k := M^(2^k) via repeated squaring with bridge T_k = M^(2^k); correctness bridge M^j = ∏_{i ∈ bitIndices j} T_i via Mathlib's Nat.twoPowSum_bitIndices; vector-level corollaries (squareKrylovProd_mulVec, krylov_in_squareKrylov_range). Layer 3 (complexity) out of scope — Mathlib has no complexity monad and no fast matmul. Namespace MinpolyComplexity.SubcubicKrylov."
+      }
     ]
   },
   "sections": [


### PR DESCRIPTION
## Fix

Register orphaned Lean file `Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` in the gallery metadata for `cayley-hamilton-minpoly-oq-03`.

## Evidence

**Before**: `src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json` listed only `Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean` in `meta.additionalFiles` and `leanFile.additionalFiles`. `proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` (230 lines, 9 theorems, 2 definitions, 0 axioms, 0 sorries) sat unreferenced.

**After**: Both arrays now include `Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean`. `leanFile.additionalFiles` carries a rich object with the file's metadata; `meta.additionalFiles` carries the string (auditor-compatible per the `additionalFiles format convention`).

## What is the OQ02 companion

The OQ02 companion formalizes Layers 1+2 of the three-layer Keller-Gehrig decomposition for `cayley-hamilton-minpoly-oq-03-oq-02` (the subcubic O(n^ω) characteristic polynomial open question):

- **Layer 1 (structural)** — squared-Krylov sequence T_k := M^(2^k) via repeated squaring, with bridge T_k = M^(2^k).
- **Layer 2 (correctness)** — every matrix power M^j is a product of squared-Krylov matrices indexed by the set bits of j (via Mathlib's `Nat.twoPowSum_bitIndices`). Plus vector-level corollaries.

Layer 3 (complexity) is out of scope — Mathlib has no complexity monad and no fast matmul, so any quantitative statement is axiomatic.

Namespace: `MinpolyComplexity.SubcubicKrylov`.

---
Automated fix by lean-mechanic agent.