### PR TITLE
fix(meta): brouwer-fixed-point-oq-02 register OQ03 orphan companion

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-02/meta.json
@@ -11,7 +11,8 @@
     "proofRepoPath": "Proofs/BrouwerFixedPointOQ02.lean",
     "additionalFiles": [
       "Proofs/BrouwerFixedPointOQ02Ext.lean",
-      "Proofs/BrouwerFixedPointOQ02Stability.lean"
+      "Proofs/BrouwerFixedPointOQ02Stability.lean",
+      "Proofs/BrouwerFixedPointOQ02OQ03.lean"
     ],
     "tags": [
       "topology",
@@ -231,7 +232,16 @@
     "sorries": 0,
     "additionalFiles": [
       "Proofs/BrouwerFixedPointOQ02Ext.lean",
-      "Proofs/BrouwerFixedPointOQ02Stability.lean"
+      "Proofs/BrouwerFixedPointOQ02Stability.lean",
+      {
+        "path": "Proofs/BrouwerFixedPointOQ02OQ03.lean",
+        "lineCount": 214,
+        "theorems": 5,
+        "definitions": 3,
+        "axioms": 0,
+        "sorries": 1,
+        "description": "Companion file for the sibling open question OQ-02-OQ-03 (Newton's method quadratic convergence). Establishes the one-step quadratic bound |xₙ₊₁ − x*| ≤ M/(2m) · |xₙ − x*|² for C² functions via Mathlib's Taylor remainder, with the explicit error formula xₙ₊₁ − x* = f''(ξ)/(2f'(xₙ)) · (x* − xₙ)². One remaining sorry in newton_convergence_rate (iterated 2^n-rate induction step). Namespace NewtonMethod."
+      }
     ]
   },
   "sorries": 0


### PR DESCRIPTION
## Fix

Register orphaned Lean file `Proofs/BrouwerFixedPointOQ02OQ03.lean` (Newton's method quadratic convergence) in the gallery metadata for `brouwer-fixed-point-oq-02`.

## Evidence

**Before**: `src/data/proofs/brouwer-fixed-point-oq-02/meta.json` listed only `BrouwerFixedPointOQ02Ext.lean` and `BrouwerFixedPointOQ02Stability.lean` in `meta.additionalFiles` and `leanFile.additionalFiles`. `proofs/Proofs/BrouwerFixedPointOQ02OQ03.lean` (214 lines, 5 theorems, 3 definitions, 0 axioms, 1 sorry) sat unreferenced.

**After**: Both arrays now include `Proofs/BrouwerFixedPointOQ02OQ03.lean`. `leanFile.additionalFiles` carries a rich object with the file's metadata; `meta.additionalFiles` carries the string (auditor-compatible per the `additionalFiles format convention`).

## What is the OQ03 companion

The OQ03 companion formalizes Newton's method quadratic convergence — the analytic counterpart to the parent's computational fixed-point complexity story (open question oq-02-oq-03):

- **One-step quadratic bound** (`newton_step_quadratic_bound`, `newton_step_C2_bound`): If f is C² near a simple root x* with |f''| ≤ M and |f'| ≥ m, then |xₙ₊₁ − x*| ≤ M/(2m) · |xₙ − x*|². Fully proved using Mathlib's Taylor remainder.
- **Explicit error formula** (`newton_error_formula`): xₙ₊₁ − x* = f''(ξ)/(2f'(xₙ)) · (x* − xₙ)². Fully proved.
- **Iterated convergence rate** (`newton_convergence_rate`): one remaining sorry on the 2ⁿ-rate induction step (the deep iteration analysis tracking how the constant C evolves with xₙ).

Namespace: `NewtonMethod`. Parent slug: `brouwer-fixed-point-oq-02` (verified, 0 sorries).

---
Automated fix by lean-mechanic agent.