### PR TITLE
fix(meta): central-limit-theorem-oq-03 register OQ01 + OQ02 orphan companions

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/meta.json
@@ -48,7 +48,9 @@
     "theoremCount": 8,
     "definitionCount": 5,
     "additionalFiles": [
-      "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean"
+      "Proofs/CentralLimitTheoremOQ03OQ01.lean",
+      "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean",
+      "Proofs/CentralLimitTheoremOQ03OQ02.lean"
     ]
   },
   "sections": [
@@ -175,7 +177,9 @@
     "path": "Proofs/CentralLimitTheoremOQ03.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean"
+      "Proofs/CentralLimitTheoremOQ03OQ01.lean",
+      "Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean",
+      "Proofs/CentralLimitTheoremOQ03OQ02.lean"
     ]
   },
   "references": [


### PR DESCRIPTION
## Summary

Registers two orphan Lean companion files for slug **central-limit-theorem-oq-03**:

- `Proofs/CentralLimitTheoremOQ03OQ01.lean` — slowly-varying / regular-variation algebra; 7 theorems, 2 defs, **0 axioms, 0 sorries**, 94 LOC.
- `Proofs/CentralLimitTheoremOQ03OQ02.lean` — infinitely divisible distributions + Lévy–Khintchine; 13 theorems, 3 defs, **11 axioms, 0 sorries**, 134 LOC.

Both added to `meta.additionalFiles` AND `leanFile.additionalFiles` (mirrored per gallery convention).

Auditor scan v4 confirms both files were unreferenced orphans relative to slug central-limit-theorem-oq-03 (primary `CentralLimitTheoremOQ03.lean` matches the prefix; only `…OQ01Aristotle.lean` was previously registered).

## What changed

`src/data/proofs/central-limit-theorem-oq-03/meta.json`
- `meta.additionalFiles`: 1 → 3 entries (added OQ01, OQ02; kept OQ01Aristotle)
- `leanFile.additionalFiles`: 1 → 3 entries (same)

## What did not change

Meta-only fix. Primary `CentralLimitTheoremOQ03.lean` counts (axiomCount=14, theoremCount=8, definitionCount=5) unchanged — the companion files carry independent counts and are not aggregated into the primary's totals here.

## Test plan

- [x] JSON validates (`python3 -c 'import json; json.load(open(...))'`)
- [x] Files exist on disk
- [x] Re-run orphan scan v4 confirms both files no longer orphaned
- [x] No duplicate PR (`gh pr list --search central-limit-theorem-oq-03` → empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)