### PR TITLE
fix(meta): lhopital register LHopitalOQ03.lean orphan companion

### DIFF
--- a/src/data/proofs/lhopital/meta.json
+++ b/src/data/proofs/lhopital/meta.json
@@ -56,7 +56,10 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/LHopitalOQ03.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Johann Bernoulli discovered this rule around 1694 as part of his work on infinitesimal calculus, and communicated it privately to Guillaume de l'Hôpital, a French marquis and amateur mathematician. L'Hôpital paid Bernoulli an annual retainer of 300 livres for exclusive rights to Bernoulli's results, and published the rule in his 1696 textbook *Analyse des Infiniment Petits pour l'Intelligence des Lignes Courbes* — the first calculus textbook ever printed. After l'Hôpital's death in 1704, Bernoulli publicly claimed credit, sparking one of mathematics' most famous priority disputes. The rule became central to 18th-century analysis: Euler extended it systematically in his *Introductio in analysin infinitorum* (1748), and Cauchy later placed it on rigorous foundations using his generalized Mean Value Theorem. Today the result is a standard tool in real analysis and appears as entry #64 on Wiedijk's list of 100 greatest theorems. Mathlib formalizes several variants covering right limits, left limits, and limits at infinity.",
@@ -190,7 +193,18 @@
     "theoremCount": 4,
     "definitionCount": 0,
     "path": "Proofs/LHopital.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/LHopitalOQ03.lean",
+        "description": "Multivariate generalization (OQ-03): L'Hôpital's rule extends to higher dimensions only via restriction to smooth curves. Curvilinear L'Hôpital reduces to the univariate case for f∘γ and g∘γ; the naive multivariate extension fails because the limit of f(x)/g(x) depends on the path of approach. 0 own axioms, 0 sorries.",
+        "lineCount": 138,
+        "axiomCount": 0,
+        "sorries": 0,
+        "theoremCount": 4,
+        "definitionCount": 0
+      }
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Fix

Register `LHopitalOQ03.lean` (multivariate generalization companion) in `src/data/proofs/lhopital/meta.json` so it is no longer orphaned in `proofs/Proofs/`.

## Evidence

**Before**: `LHopitalOQ03.lean` exists in `proofs/Proofs/` but is not referenced from any `meta.json` — flagged by orphan scan.

**After**: Listed in
- `meta.additionalFiles` (string form, auditor-visible)
- `leanFile.additionalFiles` (rich form with line/declaration counts)

**Companion file profile** (verified at HEAD):
- Path: `Proofs/LHopitalOQ03.lean`
- 138 lines
- Theorems: 4 (curvilinear L'Hôpital, path-dependent ratio, two-slope counterexample, chain-rule form)
- Definitions: 0
- Axioms: 0
- Sorries: 0
- Topic: multivariate generalization (OQ-03) — the naive multivariate extension fails because the limit of f(x)/g(x) depends on the path of approach; the rule survives only via restriction to smooth curves.

No Lean source changes; metadata-only.

---
Automated fix by lean-mechanic agent.