### PR TITLE
fix(meta): schroeder-bernstein register SchroederBernsteinOQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/schroeder-bernstein/meta.json
+++ b/src/data/proofs/schroeder-bernstein/meta.json
@@ -53,7 +53,10 @@
     "assumptions": "0 axioms, 0 sorries. Core Schröder-Bernstein theorem (Function.Embedding.schroeder_bernstein, antisymm) from Mathlib; original work is corollaries and pedagogical infrastructure.",
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/SchroederBernsteinOQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Schroeder-Bernstein theorem has a rich and tangled history, with at least four independent discoveries spanning two decades of foundational set theory.\n\n**Georg Cantor (1887)** stated the result without proof in a letter to Dedekind, recognizing its importance for his theory of transfinite cardinals. He relied on the well-ordering principle but sought a proof independent of this assumption.\n\n**Richard Dedekind (1887)** provided the first correct proof, using his chain theory (*Kettentheorie*): given injections $f: A \\to B$ and $g: B \\to A$, consider the chain $C = \\bigcup_{n=0}^{\\infty} (g \\circ f)^n(A \\setminus g(B))$. Then $h(a) = f(a)$ if $a \\in C$, $h(a) = g^{-1}(a)$ otherwise. Dedekind communicated this to Cantor but never published it; it was found in his *Nachlass* and published posthumously.\n\n**Ernst Schroder (1896)** published a proof that contained a gap identified by Alwin Korselt in 1902. Schroder's name persists in the theorem's attribution despite the flawed proof.\n\n**Felix Bernstein (1898)**, then a 19-year-old student of Cantor at Halle, presented a correct proof using the orbit decomposition that has become the standard textbook approach. His proof was published in Borel's *Lecons sur la theorie des fonctions* (1898).\n\nThe theorem holds in ZF (without choice), unlike many other results in cardinal arithmetic. The name varies by tradition: Cantor-Bernstein (Germany), Schroder-Bernstein (English-speaking countries), or Cantor-Bernstein-Schroder.",
@@ -244,7 +247,18 @@
     "theoremCount": 5,
     "definitionCount": 3,
     "path": "Proofs/SchroederBernstein.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      {
+        "path": "Proofs/SchroederBernsteinOQ01.lean",
+        "description": "Categorical SBP (OQ-01): defines HasSBP — the property that mutual monomorphisms in a category imply isomorphism. Proves Type (via mono_iff_injective + Function.Embedding.antisymm), Discrete, IsDiscrete, IsGroupoid all have HasSBP, while TopCat does not (counterexample via continuous bijections that are not homeomorphisms). Includes a fullFaithful-forget transfer result. 0 own axioms, 0 sorries.",
+        "lineCount": 353,
+        "axiomCount": 0,
+        "sorries": 0,
+        "theoremCount": 6,
+        "definitionCount": 1
+      }
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Register `SchroederBernsteinOQ01.lean` (categorical-SBP companion) in `src/data/proofs/schroeder-bernstein/meta.json` so it is no longer orphaned in `proofs/Proofs/`.

## Evidence

**Before**: `SchroederBernsteinOQ01.lean` exists in `proofs/Proofs/` but is not referenced from any `meta.json` — flagged by orphan scan.

**After**: Listed in
- `meta.additionalFiles` (string form, auditor-visible)
- `leanFile.additionalFiles` (rich form with line/declaration counts)

**Companion file profile** (verified at HEAD):
- Path: `Proofs/SchroederBernsteinOQ01.lean`
- 353 lines
- Theorems: 6 (`hasSBP_Type`, `hasSBP_Discrete`, `not_hasSBP_TopCat`, `hasSBP_of_isDiscrete`, `hasSBP_of_isGroupoid`, `hasSBP_of_fullFaithful_forget`)
- Definitions: 1 (`HasSBP`)
- Axioms: 0
- Sorries: 0
- Topic: categorical Schroeder-Bernstein property (OQ-01). Defines `HasSBP C` as "mutual monos imply iso" and proves it for `Type u`, `Discrete α`, any `IsDiscrete` category, any `IsGroupoid` category, plus the TopCat counterexample and a fullFaithful-forget transfer result.

No Lean source changes; metadata-only.

---
Automated fix by lean-mechanic agent.