### PR TITLE
fix(meta): gauss-wilson-non-cyclic register OQ01/OQ01A/OQ01B/OQ03 orphan companions

### DIFF
--- a/src/data/proofs/gauss-wilson-non-cyclic/meta.json
+++ b/src/data/proofs/gauss-wilson-non-cyclic/meta.json
@@ -108,7 +108,13 @@
     "lineCount": 323,
     "theoremCount": 21,
     "definitionCount": 1,
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/GaussWilsonNonCyclicOQ01.lean",
+      "Proofs/GaussWilsonNonCyclicOQ01A.lean",
+      "Proofs/GaussWilsonNonCyclicOQ01B.lean",
+      "Proofs/GaussWilsonNonCyclicOQ03.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Fix

Register four companion files in `src/data/proofs/gauss-wilson-non-cyclic/meta.json` (`leanFile.additionalFiles`) so the auditor's orphan scan recognizes them as part of the gallery entry.

## Evidence

**Before**: `leanFile.additionalFiles` field absent — 4 orphans flagged by `python3 /tmp/orphan_scan_v4.py`:
- `GaussWilsonNonCyclicOQ01.lean|slug=gauss-wilson-non-cyclic`
- `GaussWilsonNonCyclicOQ01A.lean|slug=gauss-wilson-non-cyclic`
- `GaussWilsonNonCyclicOQ01B.lean|slug=gauss-wilson-non-cyclic`
- `GaussWilsonNonCyclicOQ03.lean|slug=gauss-wilson-non-cyclic`

**After**: `leanFile.additionalFiles = ["Proofs/GaussWilsonNonCyclicOQ01.lean", ".../OQ01A.lean", ".../OQ01B.lean", ".../OQ03.lean"]` — scanner's reference set covers all four. Each is a Phase-A/B/C decomposition of OQ-01 (`gauss-wilson-non-cyclic-oq-01`) or an OQ-03 exact-count companion.

Files are sorry-free and axiom-free per their headers; this PR is metadata-only and changes no Lean source.

---
Automated fix by lean-mechanic agent.