### PR TITLE
fix(meta): greens-theorem-oq-01-oq-01-oq-02 register OQ01/OQ02 orphan companions

### DIFF
--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json
@@ -244,6 +244,10 @@
     "theoremCount": 6,
     "definitionCount": 0,
     "sorries": 0,
-    "path": "Proofs/GreensTheoremOQ01OQ01OQ02.lean"
+    "path": "Proofs/GreensTheoremOQ01OQ01OQ02.lean",
+    "additionalFiles": [
+      "Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean",
+      "Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Fix

Register two companion files in `src/data/proofs/greens-theorem-oq-01-oq-01-oq-02/meta.json` (`leanFile.additionalFiles`) so the auditor's orphan scan recognizes them as part of the gallery entry.

## Evidence

**Before**: `leanFile.additionalFiles` field absent — 2 orphans flagged by `python3 /tmp/orphan_scan_v4.py`:
- `GreensTheoremOQ01OQ01OQ02OQ01.lean|slug=greens-theorem-oq-01-oq-01-oq-02`
- `GreensTheoremOQ01OQ01OQ02OQ02.lean|slug=greens-theorem-oq-01-oq-01-oq-02`

**After**: `leanFile.additionalFiles = ["Proofs/GreensTheoremOQ01OQ01OQ02OQ01.lean", "Proofs/GreensTheoremOQ01OQ01OQ02OQ02.lean"]` — scanner's reference set covers both. OQ01 attacks the n-dim `intervalIntegral_swap` via `Measure.pi`; OQ02 wraps the lemma's integrability hypothesis with `LocallyIntegrable`.

Metadata-only change; no Lean source touched.

---
Automated fix by lean-mechanic agent.