### PR TITLE
fix(meta): infinitude-primes-4k3 register OQ01/Klein2/Tower orphan companions

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3/meta.json
@@ -64,7 +64,12 @@
     "theoremCount": 8,
     "definitionCount": 0,
     "path": "Proofs/InfinitudePrimes4k3.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/InfinitudePrimes4k3OQ01.lean",
+      "Proofs/InfinitudePrimes4k3OQ01Klein2.lean",
+      "Proofs/InfinitudePrimes4k3OQ01Tower.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Register three companion files in `src/data/proofs/infinitude-primes-4k3/meta.json` (`leanFile.additionalFiles`) so the auditor's orphan scan recognizes them as part of the gallery entry.

## Evidence

**Before**: `leanFile.additionalFiles` field absent — 3 orphans flagged by `python3 /tmp/orphan_scan_v4.py`:
- `InfinitudePrimes4k3OQ01.lean|slug=infinitude-primes-4k3`
- `InfinitudePrimes4k3OQ01Klein2.lean|slug=infinitude-primes-4k3`
- `InfinitudePrimes4k3OQ01Tower.lean|slug=infinitude-primes-4k3`

**After**: `leanFile.additionalFiles` lists all three. Per file headers:
- OQ01 — S2 ACT(a) bridge between elementary `% 4 = 3` form and Mathlib ZMod `(3 : ZMod 4)` form (imports `DirichletsTheorem`).
- OQ01Klein2 — S3 ACT parametric Klein-2 moduli q ∈ {3, 4, 6}; regression-resilient (no `DirichletsTheorem` dependency).
- OQ01Tower — S6 PREP Path C factorial-tower explicit bound; regression-resilient.

Metadata-only change; no Lean source touched.

---
Automated fix by lean-mechanic agent.