### PR TITLE
fix(meta): cube-root-3-irrational register OQ04/OQ04Helpers orphan companions

### DIFF
--- a/src/data/proofs/cube-root-3-irrational/meta.json
+++ b/src/data/proofs/cube-root-3-irrational/meta.json
@@ -143,7 +143,11 @@
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 1,
-    "theoremCount": 5
+    "theoremCount": 5,
+    "additionalFiles": [
+      "Proofs/CubeRoot3IrrationalOQ04.lean",
+      "Proofs/CubeRoot3IrrationalOQ04Helpers.lean"
+    ]
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Two orphan companion files for `cube-root-3-irrational` are not registered in `meta.json`, so the auditor's orphan scan flags them. Add them to `leanFile.additionalFiles`:

- `Proofs/CubeRoot3IrrationalOQ04.lean` — Continued-fraction partial quotients $a_0$–$a_6$ of $\sqrt[3]{3}$ (S2–S8, multi-researcher progression). 64 KB.
- `Proofs/CubeRoot3IrrationalOQ04Helpers.lean` — Cubing-bound biconditional helpers (`lt_cbrt3_iff_cube_lt`, `cbrt3_lt_iff_three_lt_cube`) condensing the `by_contra + cube + nlinarith` template (S5-prep). 21 KB.

Both files exist on `main` and are research files for the OQ04 conjecture (CF expansion of $\sqrt[3]{3}$, OEIS A002945). No sister slug `cube-root-3-irrational-oq-04` exists, so they belong under the parent slug.

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] Both files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)