### PR TITLE
fix(meta): inverse-galois-oq-06 register A5 Dedekind/Resultant orphan companions

### DIFF
--- a/src/data/proofs/inverse-galois-oq-06/meta.json
+++ b/src/data/proofs/inverse-galois-oq-06/meta.json
@@ -90,7 +90,13 @@
     "theoremCount": 84,
     "definitionCount": 12,
     "path": "Proofs/InverseGaloisA5.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/InverseGaloisA5Dedekind.lean",
+      "Proofs/InverseGaloisA5Resultant.lean",
+      "Proofs/InverseGaloisA5Resultant2.lean",
+      "Proofs/InverseGaloisA5ResultantDet.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Four orphan companion files for `inverse-galois-oq-06` (parent file `InverseGaloisA5.lean`) are unregistered. Add them to `leanFile.additionalFiles`:

- `Proofs/InverseGaloisA5Dedekind.lean` — Dedekind-Frobenius bridge toward eliminating the parent file's last axiom `three_dvd_gal_card`.
- `Proofs/InverseGaloisA5Resultant.lean` — Main resultant computation (Sylvester rows 0-4 + determinant).
- `Proofs/InverseGaloisA5Resultant2.lean` — Helper module: Sylvester rows 5-8 for the resultant.
- `Proofs/InverseGaloisA5ResultantDet.lean` — 9x9 determinant via 7x7 subdeterminants + manual cofactor expansion.

All four imported by or supporting the parent A5 file. Slug-matched via `inverse-galois-oq-06` → `Proofs/InverseGaloisA5.lean` from `proofRepoPath`. Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] All four companion files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)