### PR TITLE
fix(meta): inverse-galois register InverseGaloisOQ06OQ01.lean orphan companion

### DIFF
--- a/src/data/proofs/inverse-galois/meta.json
+++ b/src/data/proofs/inverse-galois/meta.json
@@ -23,7 +23,8 @@
       "Proofs/InverseGaloisD4.lean",
       "Proofs/InverseGaloisF20.lean",
       "Proofs/AbelRuffiniGaloisExtensions.lean",
-      "Proofs/AbelRuffini.lean"
+      "Proofs/AbelRuffini.lean",
+      "Proofs/InverseGaloisOQ06OQ01.lean"
     ],
     "badge": "axiom",
     "sorries": 0,
@@ -360,7 +361,8 @@
       "Proofs/InverseGaloisD4.lean",
       "Proofs/InverseGaloisF20.lean",
       "Proofs/AbelRuffiniGaloisExtensions.lean",
-      "Proofs/AbelRuffini.lean"
+      "Proofs/AbelRuffini.lean",
+      "Proofs/InverseGaloisOQ06OQ01.lean"
     ]
   }
 }


### PR DESCRIPTION
## Summary

`Proofs/InverseGaloisOQ06OQ01.lean` is unregistered. Add to both `meta.additionalFiles` and `leanFile.additionalFiles` for the parent `inverse-galois` slug (the canonical [strings-only] auditor convention).

- Slug-matched to `inverse-galois` via primary file `Proofs/InverseGalois.lean` (longest-prefix match: `InverseGaloisOQ06OQ01` ⊃ `InverseGalois`).
- Content: research toward eliminating the `three_dvd_gal_card` axiom in `InverseGaloisA5.lean` via Dedekind's theorem mod 7 (OQ-06 → OQ-01 progression).
- Imports `Proofs.InverseGaloisA5`; sibling to the four A5 companions registered separately under `inverse-galois-oq-06` (#21968).

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] File exists at `proofs/Proofs/InverseGaloisOQ06OQ01.lean`
- [x] Both `meta.additionalFiles` and `leanFile.additionalFiles` updated (mirrored)
- [ ] Auditor cycle removes this from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)