### PR TITLE
fix(meta): lagrange-four-squares-waring-g2 register OQ01 4-batch orphan companions

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -117,7 +117,13 @@
     "theoremCount": 69,
     "definitionCount": 8,
     "path": "Proofs/LagrangeFourSquaresWaringG2.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LagrangeFourSquaresWaringG2OQ01.lean",
+      "Proofs/LagrangeFourSquaresWaringG2OQ01Counting.lean",
+      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG4.lean",
+      "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG5.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Four OQ-01 orphan companion files for `lagrange-four-squares-waring-g2` are unregistered. Add to `leanFile.additionalFiles`:

- `Proofs/LagrangeFourSquaresWaringG2OQ01.lean` — Waring's problem for $k \geq 3$, S2 ACT entrypoint.
- `Proofs/LagrangeFourSquaresWaringG2OQ01Counting.lean` — $g(3) \geq 9$ via counting+omega template (S2b ACT).
- `Proofs/LagrangeFourSquaresWaringG2OQ01CountingG4.lean` — $g(4) \geq 19$ lower bound (S3 ACT).
- `Proofs/LagrangeFourSquaresWaringG2OQ01CountingG5.lean` — $g(5) \geq 37$ lower bound (S5 ACT).

All four are sibling research files for the OQ-01 sub-problem. No `lagrange-four-squares-waring-g2-oq-01` sister slug exists, so they belong under the parent slug.

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] All four companion files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)