### PR TITLE
fix(meta): minpoly-charpoly register OQ01/OQ02 orphan companions

### DIFF
--- a/src/data/proofs/minpoly-charpoly/meta.json
+++ b/src/data/proofs/minpoly-charpoly/meta.json
@@ -113,7 +113,11 @@
     "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/MinpolyCharpoly.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/MinpolyCharpolyOQ01.lean",
+      "Proofs/MinpolyCharpolyOQ02.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Two orphan companion files for `minpoly-charpoly` (parent `Proofs/MinpolyCharpoly.lean`) are unregistered. Add to `leanFile.additionalFiles`:

- `Proofs/MinpolyCharpolyOQ01.lean` — Imports `Proofs.MinpolyCharpoly` plus Jordan-Chevalley/triangularizable infrastructure (OQ-01 research).
- `Proofs/MinpolyCharpolyOQ02.lean` — Imports semisimple/eigenspace machinery for the OQ-02 extension.

No sister sub-slugs `minpoly-charpoly-oq-01` or `minpoly-charpoly-oq-02` exist, so they belong under the parent slug. Meta-only fix.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] Both files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)