### PR TITLE
fix(meta): szemeredi-core register OQ03/OQ04 orphan companions

### DIFF
--- a/src/data/proofs/szemeredi-core/meta.json
+++ b/src/data/proofs/szemeredi-core/meta.json
@@ -172,7 +172,11 @@
     "theoremCount": 3,
     "definitionCount": 4,
     "path": "Proofs/SzemerediCore.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SzemerediCoreOQ03.lean",
+      "Proofs/SzemerediCoreOQ04.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Two orphan companion files for `szemeredi-core` are unregistered. Add to `leanFile.additionalFiles`:

- `Proofs/SzemerediCoreOQ03.lean` — Hypergraph Regularity Lemma foundations (Gowers 2007), OQ-03 research.
- `Proofs/SzemerediCoreOQ04.lean` — Algorithmic Szemerédi (Alon-Duke-Lefmann-Rödl-Yuster 1994), OQ-04 research.

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] Both files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)