### PR TITLE
fix(meta): register 9 Erdos*ProblemProvable.lean orphan companions

### DIFF
--- a/src/data/proofs/erdos-1005/meta.json
+++ b/src/data/proofs/erdos-1005/meta.json
@@ -199,7 +199,10 @@
     "theoremCount": 3,
     "definitionCount": 3,
     "path": "Proofs/Erdos1005Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1005ProblemProvable.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-1008/meta.json
+++ b/src/data/proofs/erdos-1008/meta.json
@@ -138,7 +138,10 @@
     "theoremCount": 27,
     "definitionCount": 6,
     "path": "Proofs/Erdos1008Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos1008ProblemProvable.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-184/meta.json
+++ b/src/data/proofs/erdos-184/meta.json
@@ -179,7 +179,10 @@
     "theoremCount": 2,
     "definitionCount": 11,
     "path": "Proofs/Erdos184Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos184ProblemProvable.lean"
+    ]
   },
   "references": [
     "Erdős–Gallai (1966): original conjecture and O(n log n) bound",

--- a/src/data/proofs/erdos-220/meta.json
+++ b/src/data/proofs/erdos-220/meta.json
@@ -64,7 +64,8 @@
     "theoremCount": 3,
     "definitionCount": 14,
     "additionalFiles": [
-      "Proofs/Erdos220Aristotle.lean"
+      "Proofs/Erdos220Aristotle.lean",
+      "Proofs/Erdos220ProblemProvable.lean"
     ]
   },
   "overview": {
@@ -149,7 +150,8 @@
     "path": "Proofs/Erdos220Problem.lean",
     "sorries": 2,
     "additionalFiles": [
-      "Proofs/Erdos220Aristotle.lean"
+      "Proofs/Erdos220Aristotle.lean",
+      "Proofs/Erdos220ProblemProvable.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-501/meta.json
+++ b/src/data/proofs/erdos-501/meta.json
@@ -28,7 +28,8 @@
     "theoremCount": 10,
     "definitionCount": 12,
     "additionalFiles": [
-      "Proofs/Erdos501Aristotle.lean"
+      "Proofs/Erdos501Aristotle.lean",
+      "Proofs/Erdos501ProblemProvable.lean"
     ]
   },
   "overview": {
@@ -146,7 +147,8 @@
     "path": "Proofs/Erdos501Problem.lean",
     "sorries": 3,
     "additionalFiles": [
-      "Proofs/Erdos501Aristotle.lean"
+      "Proofs/Erdos501Aristotle.lean",
+      "Proofs/Erdos501ProblemProvable.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-740/meta.json
+++ b/src/data/proofs/erdos-740/meta.json
@@ -201,7 +201,10 @@
     "theoremCount": 5,
     "definitionCount": 22,
     "path": "Proofs/Erdos740Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Erdos740ProblemProvable.lean"
+    ]
   },
   "sorries": 1
 }

--- a/src/data/proofs/erdos-824/meta.json
+++ b/src/data/proofs/erdos-824/meta.json
@@ -174,7 +174,10 @@
     "theoremCount": 5,
     "definitionCount": 10,
     "path": "Proofs/Erdos824Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos824ProblemProvable.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-873/meta.json
+++ b/src/data/proofs/erdos-873/meta.json
@@ -152,7 +152,10 @@
     "theoremCount": 4,
     "definitionCount": 3,
     "path": "Proofs/Erdos873Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos873ProblemProvable.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-972/meta.json
+++ b/src/data/proofs/erdos-972/meta.json
@@ -153,7 +153,10 @@
     "theoremCount": 7,
     "definitionCount": 6,
     "path": "Proofs/Erdos972Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos972ProblemProvable.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary

Nine `Erdos<N>ProblemProvable.lean` companion files (Aristotle-bound provable-extract subsets of the parent problem files) are unregistered. Add them to the corresponding gallery entries:

| Slug | New companion |
|------|---------------|
| `erdos-1005` | `Proofs/Erdos1005ProblemProvable.lean` |
| `erdos-1008` | `Proofs/Erdos1008ProblemProvable.lean` |
| `erdos-184`  | `Proofs/Erdos184ProblemProvable.lean` |
| `erdos-220`  | `Proofs/Erdos220ProblemProvable.lean` (appended to existing Aristotle entry) |
| `erdos-501`  | `Proofs/Erdos501ProblemProvable.lean` (appended to existing Aristotle entry) |
| `erdos-740`  | `Proofs/Erdos740ProblemProvable.lean` |
| `erdos-824`  | `Proofs/Erdos824ProblemProvable.lean` |
| `erdos-873`  | `Proofs/Erdos873ProblemProvable.lean` |
| `erdos-972`  | `Proofs/Erdos972ProblemProvable.lean` |

For `erdos-220` and `erdos-501`, the new file is appended to both `meta.additionalFiles` and `leanFile.additionalFiles` (the auditor follows `meta.additionalFiles` strings). For the other seven, only `leanFile.additionalFiles` is created (no prior `meta.additionalFiles`).

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on all 9 patched `meta.json`s
- [x] All 9 companion files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)