### PR TITLE
fix(meta): batch register 8 misc orphan companions (erdos/sqrt2-minpoly/sylow/wolstenholme/...)

### DIFF
--- a/src/data/proofs/erdos-117-oq-01/meta.json
+++ b/src/data/proofs/erdos-117-oq-01/meta.json
@@ -29,7 +29,8 @@
     "theoremCount": 8,
     "definitionCount": 9,
     "additionalFiles": [
-      "Proofs/Erdos117OQ01Aristotle.lean"
+      "Proofs/Erdos117OQ01Aristotle.lean",
+      "Proofs/Erdos117OQ01OQ01.lean"
     ]
   },
   "overview": {
@@ -146,7 +147,8 @@
     "path": "Proofs/Erdos117OQ01.lean",
     "sorries": 1,
     "additionalFiles": [
-      "Proofs/Erdos117OQ01Aristotle.lean"
+      "Proofs/Erdos117OQ01Aristotle.lean",
+      "Proofs/Erdos117OQ01OQ01.lean"
     ]
   },
   "sorries": 1

--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -151,7 +151,10 @@
         "namespace": "Erdos152APN"
       }
     ],
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos152ProblemAPN.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-321/meta.json
+++ b/src/data/proofs/erdos-321/meta.json
@@ -227,7 +227,10 @@
       }
     ],
     "path": "Proofs/Erdos321Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Erdos321ProblemR1.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-659-oq-01/meta.json
+++ b/src/data/proofs/erdos-659-oq-01/meta.json
@@ -116,7 +116,10 @@
     "axiomCount": 3,
     "sorries": 0,
     "definitionCount": 5,
-    "theoremCount": 3
+    "theoremCount": 3,
+    "additionalFiles": [
+      "Proofs/Erdos659OQ01OQ02.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/sqrt2-minpoly/meta.json
+++ b/src/data/proofs/sqrt2-minpoly/meta.json
@@ -201,7 +201,10 @@
     "mainTheorem": "minpoly_sqrt_two",
     "namespace": "Sqrt2Minpoly",
     "definitionCount": 0,
-    "theoremCount": 9
+    "theoremCount": 9,
+    "additionalFiles": [
+      "Proofs/Sqrt2MinpolyOQ03.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/sum-of-divisors/meta.json
+++ b/src/data/proofs/sum-of-divisors/meta.json
@@ -68,7 +68,10 @@
     "sorries": 0,
     "theoremCount": 81,
     "definitionCount": 5,
-    "path": "Proofs/SumOfDivisors.lean"
+    "path": "Proofs/SumOfDivisors.lean",
+    "additionalFiles": [
+      "Proofs/SumOfDivisorsOQ02.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/sylow-theorems/meta.json
+++ b/src/data/proofs/sylow-theorems/meta.json
@@ -318,6 +318,9 @@
     "theoremCount": 10,
     "definitionCount": 1,
     "sorries": 0,
-    "path": "Proofs/SylowTheorem.lean"
+    "path": "Proofs/SylowTheorem.lean",
+    "additionalFiles": [
+      "Proofs/SylowTheoremOQ03.lean"
+    ]
   }
 }

--- a/src/data/proofs/wolstenholme-theorem/meta.json
+++ b/src/data/proofs/wolstenholme-theorem/meta.json
@@ -9,7 +9,8 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/WolstenholmeTheorem.lean",
     "additionalFiles": [
-      "Proofs/WolstenholmeTheoremOQ02.lean"
+      "Proofs/WolstenholmeTheoremOQ02.lean",
+      "Proofs/WolstenholmeTheoremOQ02OQ02.lean"
     ],
     "tags": [
       "number-theory",
@@ -165,7 +166,8 @@
     "path": "Proofs/WolstenholmeTheorem.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/WolstenholmeTheoremOQ02.lean"
+      "Proofs/WolstenholmeTheoremOQ02.lean",
+      "Proofs/WolstenholmeTheoremOQ02OQ02.lean"
     ]
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

Eight slug-matched orphan companion files across unrelated entries. Bulk-register them via `leanFile.additionalFiles` (and append to `meta.additionalFiles` where present):

| Slug | New companion |
|------|---------------|
| `erdos-117-oq-01`      | `Proofs/Erdos117OQ01OQ01.lean` (appended to existing Aristotle entry) |
| `erdos-152`            | `Proofs/Erdos152ProblemAPN.lean` |
| `erdos-321`            | `Proofs/Erdos321ProblemR1.lean` |
| `erdos-659-oq-01`      | `Proofs/Erdos659OQ01OQ02.lean` |
| `sqrt2-minpoly`        | `Proofs/Sqrt2MinpolyOQ03.lean` |
| `sum-of-divisors`      | `Proofs/SumOfDivisorsOQ02.lean` |
| `sylow-theorems`       | `Proofs/SylowTheoremOQ03.lean` |
| `wolstenholme-theorem` | `Proofs/WolstenholmeTheoremOQ02OQ02.lean` (appended to existing OQ02 entry) |

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on all 8 patched `meta.json`s
- [x] All 8 companion files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)