### PR TITLE
fix(meta): batch register 37 orphan companions across 36 slugs (mega-batch)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -221,6 +221,9 @@
         "description": "Joint solvability packaging for $n \\leq 4$: simultaneously certifies $\\mathrm{IsSolvable}(S_n)$ AND $\\mathrm{IsSolvable}(A_n)$ as a single anonymous-constructor proof $\\langle \\text{symmetric\\_solvable\\_of\\_le\\_four } hn,\\ \\text{alternating\\_solvable\\_of\\_le\\_four } hn\\rangle$. While `symmetric_solvable_iff` and `alternating_solvable_iff` give the full biconditional classifications, this paired conjunction is the form most directly consumed by downstream proofs that need *both* solvability witnesses to construct composition series with abelian factors (the canonical $\\{e\\} \\trianglelefteq A_n \\trianglelefteq S_n$ tower for $n \\leq 4$, refined by $V_4$ at $n = 4$). Flagged as an original contribution in `meta.originalContributions[3]`: bundles two Mathlib instance inferences into a single ergonomic API surface without requiring re-derivation at the call site.",
         "leanType": "(n : ℕ) (hn : n ≤ 4) : IsSolvable (Equiv.Perm (Fin n)) ∧ IsSolvable (alternatingGroup (Fin n))"
       }
+    ],
+    "additionalFiles": [
+      "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03/meta.json
@@ -169,7 +169,10 @@
   "leanFile": {
     "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean",
     "namespace": "QMultichooseCoefficients",
-    "imports": ["Mathlib", "Proofs.CombinationsFormulaOQ03"],
+    "imports": [
+      "Mathlib",
+      "Proofs.CombinationsFormulaOQ03"
+    ],
     "axiomCount": 0,
     "lineCount": 228,
     "theoremCount": 12,

--- a/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-formula-oq-01/meta.json
@@ -181,7 +181,10 @@
     "theoremCount": 60,
     "definitionCount": 16,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/EulerPolyhedralOQ01OQ04.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/hilbert-14/meta.json
+++ b/src/data/proofs/hilbert-14/meta.json
@@ -141,7 +141,10 @@
     "theoremCount": 4,
     "definitionCount": 2,
     "path": "Proofs/Hilbert14Invariants.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Hilbert14InvariantsOQ01.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -186,7 +186,10 @@
     "theoremCount": 3,
     "definitionCount": 18,
     "path": "Proofs/Hilbert15SchubertCalculus.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Hilbert15SchubertCalculusOQ01.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/infinitude-primes-4k1/meta.json
+++ b/src/data/proofs/infinitude-primes-4k1/meta.json
@@ -65,7 +65,10 @@
     "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/InfinitudePrimes4k1.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/InfinitudePrimes4k1OQ03.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/product-of-segments-of-chords/meta.json
+++ b/src/data/proofs/product-of-segments-of-chords/meta.json
@@ -214,7 +214,10 @@
     "theoremCount": 11,
     "definitionCount": 4,
     "path": "Proofs/ProductOfSegmentsOfChords.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/ProductOfSegmentsOfChordsOQ03.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/sperner-mathlib/meta.json
+++ b/src/data/proofs/sperner-mathlib/meta.json
@@ -108,6 +108,9 @@
     "opens": [
       "Finset"
     ],
-    "namespace": "Sperner"
+    "namespace": "Sperner",
+    "additionalFiles": [
+      "Proofs/SpernerMathlibHyper.lean"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Bulk-register 37 slug-matched orphan companion files across 36 distinct gallery entries to clear the auditor's orphan list. All additions go to `leanFile.additionalFiles` (and are appended to `meta.additionalFiles` where it already exists), following the canonical string-only convention.

### Slugs and companions (one each unless noted)

| Slug | Companion |
|------|-----------|
| `abel-ruffini-galois-extensions` | `AbelRuffiniGaloisExtensionsOQ06.lean` |
| `arithmetic-series-...-oq-03` | `...OQ02.lean` (tail) |
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-04` | `...WIP02.lean` |
| `cramers-rule-oq-03` | `OQ03.lean` sibling |
| `cube-root-2-irrational` | `OQ03.lean` |
| `dirichlets-theorem-oq-03` | `Incomplete01.lean` |
| `elementary-quadratic-reciprocity-oq-03-oq-01-oq-01` | `OQ04.lean` |
| `euler-polyhedral-formula-oq-01` | `OQ04.lean` |
| `euler-totient-oq-04` | `OQ01.lean` |
| `feuerbachs-theorem-defs` | `OQ03.lean` |
| `feuerbachs-theorem-oq-01` | `OQ03.lean` |
| `friendship-theorem` | `OQ02.lean` |
| `fundamental-theorem-algebra` | `OQ02.lean` |
| `fundamental-theorem-calculus` | `OQ04.lean` |
| `hilbert-14` | `InvariantsOQ01.lean` |
| `hilbert-15-oq-02-oq-03` | `OQ01.lean` |
| `hilbert-15` | `SchubertCalculusOQ01.lean` |
| `infinitude-primes-4k1` | `OQ03.lean` |
| `knights-tour-oblique` | `OQ02.lean` |
| `law-of-cosines-oq-04-oq-02` | `OQ01.lean` |
| `laws-of-large-numbers` | `OQ02.lean` |
| `mathematical-induction` | `OQ03.lean` |
| `minkowski-theorem-oq-02` | `OQ03.lean` |
| `motivic-flag-maps` | `OQ03.lean` |
| `partition-theorem` | `OQ04.lean` + `OQ04Aristotle.lean` (pair) |
| `prime-number-theorem-oq-01` | `OQ01.lean` |
| `prob-method-alteration` | `OQ02.lean` |
| `product-of-segments-of-chords` | `OQ03.lean` |
| `pythagorean-theorem` | `OQ05.lean` |
| `roth-theorem` | `OQ02.lean` |
| `shapley-folkman` | `OQ01.lean` |
| `sperner-mathlib` | `Hyper.lean` |
| `sperner-simplicial-instance-oq-05` | `Scarf1d.lean` |
| `spherical-law-of-sines` | `OQ03.lean` |
| `triangle-inequality` | `OQ02.lean` |
| `triangle-inequality-oq-04` | `OQ01.lean` |

Meta-only fix; no Lean source changes.

## Test plan

- [x] `json.load()` succeeds on all 36 patched `meta.json`s
- [x] All 37 companion files exist at `proofs/Proofs/`
- [ ] Auditor cycle removes these from the orphan list

🤖 Generated with [Claude Code](https://claude.com/claude-code)