### PR TITLE
fix(meta): register cayley-hamilton orphan companions (2-batch)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -52,7 +52,8 @@
         "dateAdded": "2026-04-26",
         "definitionCount": 2,
         "additionalFiles": [
-          "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+          "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+          "Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean"
         ]
     },
     "overview": {
@@ -133,7 +134,8 @@
         "path": "Proofs/CayleyHamiltonCyclicVectorAllFields.lean",
         "sorries": 0,
         "additionalFiles": [
-            "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean"
+            "Proofs/CayleyHamiltonCyclicVectorAllFieldsAristotle.lean",
+            "Proofs/CayleyHamiltonCyclicVectorCommRingOQ01.lean"
         ]
     },
     "crossReferences": [

--- a/src/data/proofs/cayley-hamilton-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01/meta.json
@@ -67,7 +67,10 @@
     "theoremCount": 30,
     "definitionCount": 0,
     "path": "Proofs/CayleyHamiltonOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonOQ01OQ01.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Fix

Registers 2 orphan companion `.lean` files into their parent slugs:

| File | Slug | Pattern |
|------|------|---------|
| `CayleyHamiltonCyclicVectorCommRingOQ01.lean` (96L) | `cayley-hamilton-cyclic-vector-all-fields` | Both lists (canonical mirror, meta.additionalFiles exists) |
| `CayleyHamiltonOQ01OQ01.lean` (145L) | `cayley-hamilton-oq-01` | Only `leanFile.additionalFiles` (no `meta.additionalFiles` on slug) |

## Evidence

**Before**: `python3 /tmp/orphan_scan_v4.py` flagged both with no claiming open PR (and cross-checked against open-PR `files` so the false-positive bug from prior cycles doesn't apply).

**After**: both files now appear in `additionalFiles` and will be auditor-tracked.

### File 1 — CayleyHamiltonCyclicVectorCommRingOQ01.lean
> Backward direction of the Cayley-Hamilton cyclic-vector ↔ nonderogatory biconditional, extended from `[Field K]` to `[CommRing R] [Nontrivial R]`.

Introduces sibling namespace `GeneralCyclicVectorRing` over a nontrivial commutative ring. Forward direction fails over `ZMod 4` (counterexample in slug's knowledge.md).

### File 2 — CayleyHamiltonOQ01OQ01.lean
> Open question from `cayley-hamilton-oq-01`.

Proves K[X]-annihilator of K^n via `Module.AEval' M.mulVecLin`:
1. `kn_module_annihilator_eq_minpoly`: K[X]-annihilator of K^n = `Ideal.span {minpoly K M}`
2. `minpoly_mem_vecAnnIdeal`, `minpoly_ideal_le_vecAnnIdeal`
3. `cyclic_vecAnnIdeal_eq_minpoly`: cyclic case via polynomial division

Closes 2 orphans of the auditor's companion-orphan pool.

---
Automated fix by lean-mechanic agent.