### PR TITLE
research(sperner-mathlib-oq-01): S3 ACT — door_count_parity_hyper strict case closed (Docker-verified)

### DIFF
--- a/proofs/Proofs/SpernerMathlibHyper.lean
+++ b/proofs/Proofs/SpernerMathlibHyper.lean
@@ -132,8 +132,61 @@ theorem door_count_parity_hyper
     (Finset.univ.filter (fun k : ι_one =>
       ∀ p : P, p ≠ top → ∃ i : ι_one, i ≠ k ∧ f i = p)).card % 2
     = if Function.Surjective f then 1 else 0 := by
-  -- Strategic sorry — see S2c PREP for the cardinality-dichotomy recipe.
-  sorry
+  classical
+  by_cases hcard : Fintype.card ι_one < Fintype.card P
+  · -- Strict case (S3 ACT): pigeonhole rules out doors and rules out
+    -- surjectivity, so both sides are 0.
+    have hnotsurj : ¬ Function.Surjective f := fun hsurj =>
+      absurd (Fintype.card_le_of_surjective f hsurj) (not_le.mpr hcard)
+    have hP_pos : 0 < Fintype.card P := Fintype.card_pos_iff.mpr ⟨top⟩
+    have hempty : (Finset.univ.filter (fun k : ι_one =>
+        ∀ p : P, p ≠ top → ∃ i : ι_one, i ≠ k ∧ f i = p)) = ∅ := by
+      rw [Finset.eq_empty_iff_forall_notMem]
+      intro k hk
+      rw [Finset.mem_filter] at hk
+      obtain ⟨_, hdoor⟩ := hk
+      -- The "door" hypothesis says every non-`top` palette element appears in
+      -- the image of `Finset.univ.erase k` under `f`. Chain through
+      -- `card_le_card` + `card_image_le` to deduce card P ≤ card ι_one,
+      -- contradicting the strict-case hypothesis.
+      have hsub : (Finset.univ.erase top : Finset P)
+          ⊆ ((Finset.univ.erase k : Finset ι_one).image f) := by
+        intro p hp
+        rw [Finset.mem_erase] at hp
+        obtain ⟨hp_ne, _⟩ := hp
+        obtain ⟨i, hi_ne, hi_eq⟩ := hdoor p hp_ne
+        exact Finset.mem_image.mpr
+          ⟨i, Finset.mem_erase.mpr ⟨hi_ne, Finset.mem_univ i⟩, hi_eq⟩
+      have hcardP : (Finset.univ.erase top : Finset P).card =
+          Fintype.card P - 1 := by
+        rw [Finset.card_erase_of_mem (Finset.mem_univ top), Finset.card_univ]
+      have hcardι : (Finset.univ.erase k : Finset ι_one).card =
+          Fintype.card ι_one - 1 := by
+        rw [Finset.card_erase_of_mem (Finset.mem_univ k), Finset.card_univ]
+      have h1 : (Finset.univ.erase top : Finset P).card ≤
+          ((Finset.univ.erase k : Finset ι_one).image f).card :=
+        Finset.card_le_card hsub
+      have h2 : ((Finset.univ.erase k : Finset ι_one).image f).card ≤
+          (Finset.univ.erase k : Finset ι_one).card := Finset.card_image_le
+      have h12 : Fintype.card P - 1 ≤ Fintype.card ι_one - 1 := by
+        rw [← hcardP, ← hcardι]; exact le_trans h1 h2
+      -- `k : ι_one` exhibits inhabitation; combined with `hP_pos`, this lets
+      -- us cancel both `- 1`s.
+      have hι_pos : 0 < Fintype.card ι_one := Fintype.card_pos_iff.mpr ⟨k⟩
+      have hP_le : Fintype.card P ≤ Fintype.card ι_one := by
+        calc Fintype.card P
+            = Fintype.card P - 1 + 1 := (Nat.sub_add_cancel hP_pos).symm
+          _ ≤ Fintype.card ι_one - 1 + 1 := Nat.add_le_add_right h12 1
+          _ = Fintype.card ι_one := Nat.sub_add_cancel hι_pos
+      exact absurd hP_le (not_le.mpr hcard)
+    rw [hempty]
+    simp [hnotsurj]
+  · -- Equality case (deferred to S4): `card ι_one = card P` via
+    -- `le_antisymm hι_size (not_lt.mp hcard)`; transport `f` to the parent's
+    -- `Fin (d+1)` shape via `Fintype.equivOfCardEq` + a `top`-permutation
+    -- normalisation, then invoke `SpernerMathlib.door_count_parity`. See
+    -- S2c PREP cardinality dichotomy and S2d PREP bearer chains.
+    sorry
 
 end PerCellParity
 

--- a/research/problems/sperner-mathlib-oq-01/sessions/2026-06-01-s3-act-door-count-parity-strict-case.md
+++ b/research/problems/sperner-mathlib-oq-01/sessions/2026-06-01-s3-act-door-count-parity-strict-case.md
@@ -1,0 +1,205 @@
+# S3 ACT — `door_count_parity_hyper` strict case closed
+
+**Date**: 2026-06-01
+**Researcher**: researcher-1
+**Phase**: ACT (S3 first sub-step of three remaining sorries)
+**Predecessor**: S2 ACT (#21489, merged 2026-05-31) — shipped
+`SpernerMathlibHyper.lean` 289 LOC / 3 strategic sorries / 0 axioms.
+
+## 0. TL;DR
+
+Closed the strict case `Fintype.card ι_one < Fintype.card P` of
+`door_count_parity_hyper` via a pigeonhole on
+`Finset.univ.erase top ⊆ (Finset.univ.erase k).image f`. ~38 LOC of
+solid Lean replaces the upper half of one of the three strategic
+sorries. The file grows 289 → 342 LOC. Sorry count unchanged at 3,
+but the `door_count_parity_hyper` sorry is now scoped to the equality
+case `Fintype.card ι_one = Fintype.card P` only.
+
+Both the pre-S3 file (S2 ACT) and the post-S3 file Docker-build clean
+(7744 jobs each). The G9 lake self-loop qualifier flagged in S2 ACT
+§8 was OBSOLETE — `./proofs/scripts/docker-build.sh
+Proofs.SpernerMathlibHyper` works fine. Per `feedback_g9_qualifier_masks_real_bugs`
+this is the expected behaviour.
+
+## 1. The strict-case proof
+
+`door_count_parity_hyper` claims, for `f : ι_one → P`, `top : P`, and
+`hι_size : Fintype.card ι_one ≤ Fintype.card P`:
+
+```
+(Finset.univ.filter (fun k : ι_one =>
+  ∀ p : P, p ≠ top → ∃ i : ι_one, i ≠ k ∧ f i = p)).card % 2
+= if Function.Surjective f then 1 else 0
+```
+
+`by_cases hcard : Fintype.card ι_one < Fintype.card P` splits into the
+two architectural branches identified by S2c PREP cardinality
+dichotomy.
+
+### Strict branch (`hcard` true): both sides reduce to 0
+
+**RHS = 0** is immediate: `Function.Surjective f` contradicts
+`Fintype.card_le_of_surjective f hsurj : Fintype.card P ≤ Fintype.card
+ι_one` against the strict `hcard`.
+
+**LHS = 0** requires showing the filter is empty:
+
+For any candidate door `k`, unfolding the predicate gives
+`hdoor : ∀ p ≠ top, ∃ i ≠ k, f i = p`. Read as a Finset statement, this
+exhibits the inclusion
+
+```
+Finset.univ.erase top ⊆ (Finset.univ.erase k).image f
+```
+
+via `Finset.mem_image.mpr ⟨i, Finset.mem_erase.mpr ⟨hi_ne, _⟩, hi_eq⟩`.
+Chaining `Finset.card_le_card` and `Finset.card_image_le`:
+
+```
+card (Finset.univ.erase top : Finset P)
+  ≤ card ((Finset.univ.erase k).image f)
+  ≤ card (Finset.univ.erase k : Finset ι_one)
+```
+
+With `Finset.card_erase_of_mem (Finset.mem_univ _)` reducing both
+endpoints to `Fintype.card _ - 1`, we obtain:
+
+```
+Fintype.card P - 1 ≤ Fintype.card ι_one - 1
+```
+
+Adding 1 to both sides cancels the truncated `-1` (using
+`Fintype.card_pos_iff.mpr ⟨top⟩` and `Fintype.card_pos_iff.mpr ⟨k⟩`
+to exhibit positivity), yielding `Fintype.card P ≤ Fintype.card ι_one`,
+contradicting `hcard : Fintype.card ι_one < Fintype.card P`.
+
+### Equality branch (`hcard` false): still sorry
+
+`push_neg at hcard` (implicit in `by_cases`) gives `Fintype.card P ≤
+Fintype.card ι_one`; combined with `hι_size` this yields
+`Fintype.card ι_one = Fintype.card P`. From here, `Fintype.equivOfCardEq`
+furnishes an equivalence `ι_one ≃ P` along which the door predicate
+transports to the parent's `Fin (d+1) → Fin (d+1)` shape modulo a
+top-permutation. ~25 LOC of bearer chains remain (S4).
+
+## 2. Pitfalls encountered
+
+### `omega` is opaque-blind to image-card chains
+
+Initial attempt used `omega` after `rw [hcardP] at h1; rw [hcardι] at h2`,
+producing two hypotheses connected via the opaque expression
+`((Finset.univ.erase k).image f).card`. `omega` failed with the
+suggestive counterexample `a ≥ 0, a ≤ 0, a ≤ 0` where
+`a := ↑(Fintype.card P - 1)` — it could see each side independently
+but not chain them through the opaque card. Fix: explicit
+`le_trans h1 h2 : Fintype.card P - 1 ≤ Fintype.card ι_one - 1` before
+the arithmetic step.
+
+### `omega` cannot cancel truncated `-1` without positivity in context
+
+Even with the chained `h12`, `omega` could not directly resolve the
+ℕ-truncated `- 1` because the variables it sees may underflow. The
+fix is an explicit `calc` chain:
+
+```
+Fintype.card P
+    = Fintype.card P - 1 + 1            := (Nat.sub_add_cancel hP_pos).symm
+  _ ≤ Fintype.card ι_one - 1 + 1        := Nat.add_le_add_right h12 1
+  _ = Fintype.card ι_one                := Nat.sub_add_cancel hι_pos
+```
+
+with `hP_pos := Fintype.card_pos_iff.mpr ⟨top⟩` and
+`hι_pos := Fintype.card_pos_iff.mpr ⟨k⟩`. The `k` for `hι_pos` is in
+scope from the `intro k hk` in `Finset.eq_empty_iff_forall_notMem`.
+
+### Mathlib has forward-progressed past v4.26.0 SHA `2df2f01`
+
+`Finset.eq_empty_iff_forall_not_mem` now emits a deprecation warning
+recommending `Finset.eq_empty_iff_forall_notMem`. The build mathlib
+SHA `160af9e8e7d4ae448f3c92edcc5b6a8522453f11` (from
+`proofs/lake-manifest.json`) is newer than the side-cache at
+`~/Projects/lean-genius-proofs/.lake/packages/mathlib/` (SHA `2df2f01`).
+Using the new name avoids the deprecation warning. NOT a forward-
+looking deprecation in this build (cf. `feedback_nat_ico_succ_right_deprecation_forward_looking_v4260`
+which is a separate case where the new name doesn't exist yet).
+
+## 3. What changed
+
+- `proofs/Proofs/SpernerMathlibHyper.lean`: 289 → 342 LOC.
+  - `door_count_parity_hyper`: strict case proven (~38 LOC); equality
+    case remains as sorry inside `by_cases`.
+  - No other declaration changed.
+- `src/data/research/problems/sperner-mathlib-oq-01.json`:
+  iteration 11 → 12; phase remains ACT; focus and nextAction
+  refreshed; built-items entry updated.
+- This session note.
+
+## 4. Sorry status
+
+| # | Declaration | Status pre-S3 | Status post-S3 |
+|---|---|---|---|
+| 1 | `door_count_parity_hyper` | sorry (both cases) | sorry (equality case only) |
+| 2 | `even_card_interior_doors_hyper` | sorry | sorry (unchanged) |
+| 3 | `sperner_parity_hyper` | sorry | sorry (unchanged) |
+
+Total sorry count: 3 → 3 (one is now smaller).
+
+## 5. Build verification
+
+```bash
+./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper
+# ✔ [7744/7744] Built Proofs.SpernerMathlibHyper (10s)
+# Build completed successfully (7744 jobs).
+```
+
+Remaining non-blocking warnings (carried over from S2 ACT, not
+introduced by S3):
+
+1. Three `declaration uses 'sorry'` warnings (lines 129, 251, 287 — one
+   per declaration with sorry).
+2. Two `automatically included section variable(s) unused` lint
+   warnings (lines 204, 220 — `adjHyper_some_of_ne_none` and
+   `isDoorHyper_of_shared_face` carry irrelevant decidability
+   instances). Fixing would require `omit [...] in` syntax which is
+   not present in Mathlib v4.26.0 (`grep -rn "^\s*omit \[" mathlib`
+   returns no matches in the side-cache).
+
+## 6. Honesty disclosure
+
+- The strict-case proof is a complete, audited Lean closure (no
+  cheats; `Docker.sh` build returns exit 0 with no errors). I did NOT
+  attempt the equality-case closure in this session — it requires
+  Equiv-transport via `Fintype.equivOfCardEq` and a top-permutation
+  alignment to the parent's `Fin d`-shaped door predicate, which is
+  ~25 LOC of bearer chain work better-suited to a dedicated session.
+- The total sorry count is unchanged (3 → 3). The S3 deliverable is
+  measured by the LOC of solid proof shipped (~38 LOC) and the
+  reduction of one sorry's logical scope, not by the sorry count.
+- Docker build was verified at the working-branch commit (not yet
+  pushed at session-note write time).
+
+## 7. Race awareness
+
+At push time (2026-06-01), there are no open PRs containing
+"sperner-mathlib-oq-01" in title (verified via
+`gh pr list --search "sperner-mathlib-oq-01 in:title"`). The
+unrelated PR #21978 is the mechanic mega-batch, not a sperner-mathlib
+slug. Worktree branch `research/sperner-mathlib-oq-01-s3-2026-06-01`
+forks from `origin/main @ f486a19e2e0`.
+
+## 8. Files touched
+
+- **MODIFIED**: `proofs/Proofs/SpernerMathlibHyper.lean` (+55 / −2)
+- **MODIFIED**: `src/data/research/problems/sperner-mathlib-oq-01.json`
+- **NEW**: this session note
+- **MODIFIED**: `research/problems/sperner-mathlib-oq-01/state.md`
+  (phase header + S3 row)
+
+Untouched: `proofs/Proofs/SpernerMathlib.lean` (parent, 897 LOC,
+verified — left intact per S2 PREP §6 anti-target).
+
+---
+
+**End of S3 ACT session note — strict case closed, ~38 LOC solid Lean,
+Docker-verified 7744 jobs.**

--- a/research/problems/sperner-mathlib-oq-01/state.md
+++ b/research/problems/sperner-mathlib-oq-01/state.md
@@ -1,9 +1,14 @@
 # Current State
 
-**Phase**: PREP (saturated) — S2 ACT next
+**Phase**: ACT (S3 — `door_count_parity_hyper` strict case closed; equality case + 2 other sorries remaining)
 **Since**: 2026-05-12T20:45:00Z (S1 OBSERVE)
-**Iteration**: 10
-**Last update**: 2026-05-14 (researcher-12) — STATE-SYNC top-level `phase` fix: gallery JSON `phase` was stuck at `OBSERVE` while `currentState.phase = PREP` and state.md header above said `PREP (saturated)` since 2026-05-13 researcher-1 STATE-SYNC. Two-line surgical fix per `feedback_researcher_state_sync_misses_top_level_phase.md`.
+**Iteration**: 12
+**Last update**: 2026-06-01 (researcher-1) — **S3 ACT**: strict case `|ι_one| < |P|` of `door_count_parity_hyper` closed via pigeonhole (`Finset.univ.erase top ⊆ (Finset.univ.erase k).image f` chained through `card_le_card` + `card_image_le`). File 289 → 342 LOC, Docker-verified 7744 jobs. Sorry count unchanged at 3 (the `door_count_parity_hyper` sorry is now scoped to the equality case only). See `sessions/2026-06-01-s3-act-door-count-parity-strict-case.md`. The G9 lake self-loop qualifier from S2 ACT §8 is OBSOLETE — Docker build works clean on both pre-S3 and post-S3 file.
+
+| Session | Date | Mode | PR | Title / focus | LOC |
+|---|---|---|---|---|---|
+| **S2 ACT** | 2026-05-31 | ACT | #21489 | Ship `SpernerMathlibHyper.lean` 289 LOC / 3 sorries / 0 axioms — hypergraph API with `IsDoorHyper`, `IsPanchromaticHyper`, `adjMapHyper`, door-transfer lemmas, structural sorries per S2c/S2d/S2e PREP. | +289 |
+| **S3 ACT** | 2026-06-01 | ACT | (this PR) | Close strict case of `door_count_parity_hyper` (~38 LOC pigeonhole). Equality case remains as the sole sorry inside the by_cases. | +55/-2 |
 
 ## Session Log (STATE-SYNC, 2026-05-13, researcher-1)
 

--- a/src/data/research/problems/sperner-mathlib-oq-01.json
+++ b/src/data/research/problems/sperner-mathlib-oq-01.json
@@ -27,22 +27,22 @@
     "phase": "ACT",
     "since": "2026-05-31T13:10:00Z",
     "iteration": 11,
-    "focus": "S2 ACT shipped (researcher-1, 2026-05-31): proofs/Proofs/SpernerMathlibHyper.lean (289 LOC, 3 strategic sorries) integrating S1b top, S1e hι_size, S2 PREP skeleton, S2c dichotomy, S2d bearer chains, S2e Σ-pair involution. Build pending (G9 lake self-loop). Sorries: (1) door_count_parity_hyper (S2c/S2d recipe), (2) even_card_interior_doors_hyper (S2e involution), (3) sperner_parity_hyper (mechanical chain through 1+2, ~80 LOC bookkeeping). Higher-level exists_panchromatic_hyper proves cleanly via Nat.odd_iff transport.",
+    "focus": "S3 ACT (researcher-1, 2026-06-01): door_count_parity_hyper STRICT CASE closed in proofs/Proofs/SpernerMathlibHyper.lean (342 LOC, 3 sorries, Docker-verified 7744 jobs). The |ι_one| < |P| branch is now fully proven (~38 LOC) via pigeonhole: univ.erase top ⊆ (univ.erase k).image f chained through card_le_card + card_image_le derives card P ≤ card ι_one, contradicting strict <. Both sides of the parity equation reduce to 0 in this branch. Remaining: (1) equality case |ι_one|=|P| of door_count_parity_hyper (Equiv-transport to parent, ~25 LOC); (2) even_card_interior_doors_hyper (S2e involution, ~30 LOC); (3) sperner_parity_hyper (Σ-chain through 1+2, ~80 LOC). Both S2 ACT and S3 ACT Docker-verified — the G9 lake self-loop qualifier is OBSOLETE for this slug.",
     "blockers": [],
-    "nextAction": "S3 — close the three strategic sorries in SpernerMathlibHyper.lean. Order: (a) door_count_parity_hyper via S2c cardinality dichotomy + Equiv-transport to parent door_count_parity (~18-28 LOC); (b) even_card_interior_doors_hyper via Sperner.even_card_fpf_invol on Σ-type (~30 LOC); (c) sperner_parity_hyper via Σ-versions of card_doors_eq_sum and doors_partition (~80 LOC). Then S4 specialization bridge SpernerMathlib.IsDoor ↔ IsDoorHyper at top=Fin.last d.",
+    "nextAction": "S4 — close the equality case |ι_one| = |P| of door_count_parity_hyper via Fintype.equivOfCardEq + top↔Fin.last d permutation transport to parent SpernerMathlib.door_count_parity (~25 LOC); then close even_card_interior_doors_hyper via Sperner.even_card_fpf_invol on Σ-type (~30 LOC); then close sperner_parity_hyper via Σ-versions of card_doors_eq_sum (Fintype.sum_sigma) and doors_partition (~80 LOC). S5 specialization bridge after that.",
     "attemptCounts": {
-      "total": 10,
+      "total": 11,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S2 ACT shipped 2026-05-31 (researcher-1): proofs/Proofs/SpernerMathlibHyper.lean ships the hypergraph API — VertexMap, AdjMap, IsPanchromaticHyper, IsDoorHyper (top : P), adjMapHyper, isDoorHyper_of_shared_face, isDoorHyper_iff_of_adj proven; door_count_parity_hyper / even_card_interior_doors_hyper / sperner_parity_hyper as strategic sorries per S2c/S2d/S2e PREP; exists_panchromatic_hyper proven by Nat.odd_iff chain. 289 LOC, 3 sorries, 0 axioms. Build pending (G9 lake self-loop in worktree). Phase advanced PREP → ACT.",
+    "progressSummary": "S3 ACT shipped 2026-06-01 (researcher-1): door_count_parity_hyper STRICT CASE (|ι_one| < |P|) closed via pigeonhole (~38 LOC). File grows 289 → 342 LOC, sorries unchanged at 3 but one is now smaller (equality case only). Docker-verified clean. Higher-level chain (exists_panchromatic_hyper) still proven via Nat.odd_iff transport. S2 ACT predecessor (2026-05-31): shipped the hypergraph API — VertexMap, AdjMap, IsPanchromaticHyper, IsDoorHyper (top : P), adjMapHyper, isDoorHyper_of_shared_face, isDoorHyper_iff_of_adj proven; door_count_parity_hyper / even_card_interior_doors_hyper / sperner_parity_hyper as strategic sorries per S2c/S2d/S2e PREP.",
     "builtItems": [
       "research/problems/sperner-mathlib-oq-01/problem.md (formal signature targets, three sub-OQs, acceptance criteria)",
       "research/problems/sperner-mathlib-oq-01/knowledge.md (axioms inventory, per-step weakening map, Mathlib alignment, S2 Lean skeleton, non-pure counter-example sketch, risk register)",
       "research/problems/sperner-mathlib-oq-01/state.md (phase OBSERVE, S2 scope lock, race awareness)",
-      "proofs/Proofs/SpernerMathlibHyper.lean (289 LOC, 3 strategic sorries): hypergraph generalisation of Sperner door-counting parity (S2 ACT, 2026-05-31, researcher-1)",
+      "proofs/Proofs/SpernerMathlibHyper.lean (342 LOC, 3 sorries — strict case of door_count_parity_hyper closed): hypergraph generalisation of Sperner door-counting parity (S2 ACT 2026-05-31 + S3 ACT 2026-06-01, researcher-1; Docker-verified at both)",
       "Decidable instances for IsPanchromaticHyper and IsDoorHyper (auto-derived via Fintype.decidableForallFintype + decidableEq chain)",
       "Σ-type adjacency involution adjMapHyper (private) with adjHyper_some_of_ne_none extractor",
       "Door-transfer-through-shared-face proven for the palette-relative form (isDoorHyper_of_shared_face + isDoorHyper_iff_of_adj)"
@@ -58,7 +58,9 @@
       "S2c PREP (#18688) + S2d PREP (#18727): door_count_parity_hyper has a clean two-case architecture under h-iota-size. Case card-equality: Equiv-transport to the pure case via Fintype.card_eq.mp. Case card-strict: per-cell zero-or-even count via at-least-one-missing-color argument. S2d ships paste-ready Mathlib bearer chains for both cases.",
       "S2e PREP (#18788): even_card_interior_doors_hyper uses Sigma-pair involution on the (s, k) Sigma type. New Sigma-bearers cited: Sigma.instFintype, Sigma.instDecidableEq (for the involution well-definedness).",
       "S2 ACT (2026-05-31, researcher-1): the Σ-type involution architecture transfers verbatim from the parent Cell × Fin (d+1) version; the structural lifting cost is concentrated in (a) the cardinality-dichotomy step for door_count_parity_hyper and (b) the Σ-type analogues of card_doors_eq_sum / doors_partition for sperner_parity_hyper. The shared-face door-transfer lemma generalises without any extra hypothesis beyond hadj_vertex.",
-      "Variable section structure: keeping V, Cell, ι, P in separate sections per architectural block (Setup, Definitions, PerCellParity, GlobalParity, MainTheorem) avoids carrying decidability instances across irrelevant theorems. PerCellParity uses a non-dependent ι_one : Type* because the per-cell statement does not need the Cell-indexed family."
+      "Variable section structure: keeping V, Cell, ι, P in separate sections per architectural block (Setup, Definitions, PerCellParity, GlobalParity, MainTheorem) avoids carrying decidability instances across irrelevant theorems. PerCellParity uses a non-dependent ι_one : Type* because the per-cell statement does not need the Cell-indexed family.",
+      "S3 ACT (2026-06-01, researcher-1): strict case |ι_one| < |P| of door_count_parity_hyper is a clean pigeonhole — for each candidate door k, the hypothesis ∀ p ≠ top, ∃ i ≠ k, f i = p exhibits an inclusion `univ.erase top ⊆ (univ.erase k).image f`, which via card_le_card + card_image_le forces card P ≤ card ι_one, contradicting strict<. omega cannot close the ℕ-truncated subtraction directly through opaque image-cards; an explicit `calc` adding 1 to both sides (using Fintype.card_pos_iff to exhibit positivity from `k` and `top`) is required. Closing this branch leaves only the equality case |ι_one|=|P| as the remaining sorry inside door_count_parity_hyper.",
+      "S3 ACT confirms the G9 lake self-loop qualifier (memory feedback_g9_qualifier_masks_real_bugs) is OBSOLETE for this slug: ./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper builds clean (7744 jobs) on both the pre-S3 file and the post-S3 file. Prior 'build pending' from S2 ACT is now verified."
     ],
     "mathlibGaps": [
       "Mathlib.Combinatorics.AbstractSimplicialComplex represents cells as Finset V, not as indexed Fin n → V — incompatible with the door-counting parity.",
@@ -66,12 +68,12 @@
       "No Mathlib API for cell-dependent dependent-index face complexes."
     ],
     "nextSteps": [
-      "S3 (next): close door_count_parity_hyper sorry via S2c PREP cardinality dichotomy — strict case (|ι|<|P|) gives 0=0 by pigeonhole, equality case (|ι|=|P|) reduces to parent SpernerMathlib.door_count_parity via Fintype.equivOfCardEq-transport with top↔Fin.last d swap.",
-      "S3 (next): close even_card_interior_doors_hyper sorry via Sperner.even_card_fpf_invol applied to adjMapHyper — the three side-conditions (involution from hadj_symm, set-stability from isDoorHyper_iff_of_adj, fixed-point-free from hadj_ne) are already wired by the helper lemmas in §4.",
-      "S3 (next): close sperner_parity_hyper sorry via Σ-versions of card_doors_eq_sum (using Fintype.sum_sigma) and doors_partition (mechanical Finset.disjoint_filter argument).",
-      "S4 (after S3): specialization bridge SpernerMathlib.IsDoor ↔ IsDoorHyper (ι := fun _ => Fin (d+1)) (top := Fin.last d) — ~25 LOC per S2 PREP §4 explicit version.",
-      "S5 (deferred): OQ-01-B non-pure complex restriction lemma (cosmetically heavy).",
-      "S6 (deferred): OQ-01-C boundary-axioms minimality formal demonstration."
+      "S4 (next): close the equality case |ι_one| = |P| of door_count_parity_hyper via Fintype.equivOfCardEq + top↔Fin.last d permutation transport to parent SpernerMathlib.door_count_parity. The strict case is already closed (S3 ACT, 2026-06-01).",
+      "S4 (next): close even_card_interior_doors_hyper sorry via Sperner.even_card_fpf_invol applied to adjMapHyper — the three side-conditions (involution from hadj_symm, set-stability from isDoorHyper_iff_of_adj, fixed-point-free from hadj_ne) are already wired by the helper lemmas in §4.",
+      "S4 (next): close sperner_parity_hyper sorry via Σ-versions of card_doors_eq_sum (using Fintype.sum_sigma) and doors_partition (mechanical Finset.disjoint_filter argument).",
+      "S5 (after S4): specialization bridge SpernerMathlib.IsDoor ↔ IsDoorHyper (ι := fun _ => Fin (d+1)) (top := Fin.last d) — ~25 LOC per S2 PREP §4 explicit version.",
+      "S6 (deferred): OQ-01-B non-pure complex restriction lemma (cosmetically heavy).",
+      "S7 (deferred): OQ-01-C boundary-axioms minimality formal demonstration."
     ]
   },
   "tags": [
@@ -121,7 +123,7 @@
     ]
   },
   "started": "2026-05-12T20:45:00Z",
-  "lastUpdate": "2026-05-14T10:55:00.000Z",
+  "lastUpdate": "2026-06-01T20:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": []


### PR DESCRIPTION
## Summary

S3 ACT for `sperner-mathlib-oq-01`. Closes the **strict case**
`Fintype.card ι_one < Fintype.card P` of `door_count_parity_hyper`
in `proofs/Proofs/SpernerMathlibHyper.lean` via a pigeonhole on
`Finset.univ.erase top ⊆ (Finset.univ.erase k).image f`, chained
through `Finset.card_le_card` and `Finset.card_image_le` to derive
`Fintype.card P ≤ Fintype.card ι_one`, contradicting the strict
hypothesis. Both sides of the parity equation reduce to `0` in this
branch.

- **File**: `proofs/Proofs/SpernerMathlibHyper.lean` 289 → 342 LOC
- **Sorries**: 3 → 3 (count unchanged; one sorry is now scoped to the
  equality case `|ι_one| = |P|` only)
- **Solid Lean added**: ~38 LOC for the strict-case proof
- **Docker build**: ✅ clean (7744 jobs)
- **Predecessor**: S2 ACT (PR #21489, merged 2026-05-31)

## What changed
- `proofs/Proofs/SpernerMathlibHyper.lean`: `door_count_parity_hyper`
  now case-splits on `Fintype.card ι_one < Fintype.card P`; strict
  branch is fully proven, equality branch remains as the remaining sorry
  in this declaration.
- `src/data/research/problems/sperner-mathlib-oq-01.json`:
  iteration 11 → 12; focus, nextAction, builtItems, insights, nextSteps,
  lastUpdate refreshed.
- `research/problems/sperner-mathlib-oq-01/state.md`: phase header
  updated; S3 row added to session table.
- New session note: `research/problems/sperner-mathlib-oq-01/sessions/2026-06-01-s3-act-door-count-parity-strict-case.md`.

## Build verification
```
./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper
# ✔ [7744/7744] Built Proofs.SpernerMathlibHyper (10s)
# Build completed successfully (7744 jobs).
```

The G9 lake self-loop qualifier flagged in S2 ACT §8 is **OBSOLETE**
for this slug — Docker build works clean on both pre-S3 and post-S3
files (per `feedback_g9_qualifier_masks_real_bugs`).

## Pitfalls captured (for future sessions)
1. `omega` cannot chain hypotheses through an **opaque** intermediate
   expression like `((Finset.univ.erase k).image f).card`; need an
   explicit `le_trans h1 h2 : ... - 1 ≤ ... - 1` before the arithmetic
   step.
2. `omega` cannot cancel ℕ-truncated `- 1` without positivity in
   context. Explicit `calc` with `Nat.sub_add_cancel` +
   `Fintype.card_pos_iff.mpr ⟨_⟩` is required.
3. `Finset.eq_empty_iff_forall_not_mem` now emits a deprecation
   warning in the build mathlib (SHA `160af9e...`); switched to
   `Finset.eq_empty_iff_forall_notMem`.

## What's next
S4 will close the **equality case** `|ι_one| = |P|` of
`door_count_parity_hyper` via `Fintype.equivOfCardEq` +
top↔`Fin.last d` permutation transport to parent
`SpernerMathlib.door_count_parity` (~25 LOC). The two other sorries
(`even_card_interior_doors_hyper`, `sperner_parity_hyper`) remain on
the S4–S5 schedule per the gallery JSON `nextSteps`.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper` succeeds clean
- [x] No new sorries added; existing 3 declaration-uses-sorry warnings carried over from S2 ACT
- [x] Gallery JSON `lastUpdate` refreshed to 2026-06-01
- [x] Session note + `state.md` ledger updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)