### PR TITLE
Research: ballot-problem-oq-02-oq-05 — S9 ACT R4-sub hτ discharged (Docker-verified, 7744 jobs OK, 4→3 sorries)

### DIFF
--- a/proofs/Proofs/BallotProblemOQ02OQ05.lean
+++ b/proofs/Proofs/BallotProblemOQ02OQ05.lean
@@ -189,6 +189,21 @@ lemma reflectAt_eq_below_firstHit
   unfold reflectAt
   exact if_neg (Nat.not_le_of_lt hi)
 
+/-- **R4-sub helper (S9 ACT).** Partial sums up to a position not exceeding
+    the first hit time are unchanged by reflection. The sum's `i.val < k.val`
+    guard restricts each summand index `i` to satisfy `i.val < k.val ≤ τ.val`,
+    so `reflectAt_eq_below_firstHit` collapses every summand pointwise. -/
+lemma partialSumBool_congr_below
+    {ω : Fin n → Bool} {a : ℤ} {k : Fin (n+1)}
+    (hk : k.val ≤ (firstHitFin ω a).val) :
+    partialSumBool (reflectAt ω a) k = partialSumBool ω k := by
+  unfold partialSumBool
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  by_cases hi : i.val < k.val
+  · rw [if_pos hi, if_pos hi,
+        reflectAt_eq_below_firstHit (Nat.lt_of_lt_of_le hi hk)]
+  · rw [if_neg hi, if_neg hi]
+
 /-- **R4** Reflection is involutive **on the non-empty-hit-set branch**.
     `reflectAt (reflectAt ω a) a = ω` whenever `(hitSet ω a).Nonempty`.
 
@@ -207,13 +222,40 @@ lemma reflectAt_involutive {ω : Fin n → Bool} {a : ℤ}
     (h : (hitSet ω a).Nonempty) :
     reflectAt (reflectAt ω a) a = ω := by
   -- Step 1: firstHitFin is preserved under reflection (uses h).
-  -- Discharge sketch (S7 PREP §3, 6 bullets):
-  --   τ := (hitSet ω a).min' h ∈ hitSet (reflectAt ω a) a via
-  --   `reflectAt_eq_below_firstHit` + `Finset.sum_congr`;
-  --   antisymmetry on `Fin (n+1)` via `min'_le` (both directions).
-  -- Left as a named sub-sorry for S9; ~15 LOC inline discharge planned.
+  -- Discharged inline (S9 ACT): the partial-sum equality below τ
+  -- (`partialSumBool_congr_below`) shows τ ∈ hitSet (reflectAt ω a) a and
+  -- that the reflected path has no earlier hit; min'-antisymmetry closes.
   have hτ : firstHitFin (reflectAt ω a) a = firstHitFin ω a := by
-    sorry  -- R4-sub `hτ`: min'-of-hitSet argument; see S7 PREP §3 (6 bullets)
+    have hτ_eq : firstHitFin ω a = (hitSet ω a).min' h := by
+      simp [firstHitFin, dif_pos h]
+    have hτ_mem : firstHitFin ω a ∈ hitSet ω a := by
+      rw [hτ_eq]; exact (hitSet ω a).min'_mem h
+    have hτ_ps : partialSumBool ω (firstHitFin ω a) = a :=
+      (Finset.mem_filter.mp hτ_mem).2
+    have hτ_mem' : firstHitFin ω a ∈ hitSet (reflectAt ω a) a := by
+      refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+      rw [partialSumBool_congr_below (le_refl _)]
+      exact hτ_ps
+    have h' : (hitSet (reflectAt ω a) a).Nonempty := ⟨_, hτ_mem'⟩
+    have hfh' : firstHitFin (reflectAt ω a) a = (hitSet (reflectAt ω a) a).min' h' := by
+      simp [firstHitFin, dif_pos h']
+    apply le_antisymm
+    · rw [hfh']
+      exact Finset.min'_le _ _ hτ_mem'
+    · rw [hfh']
+      refine Finset.le_min' _ _ _ (fun k hk => ?_)
+      by_contra hlt
+      push_neg at hlt
+      have hk_val : k.val < (firstHitFin ω a).val := hlt
+      have hk_ps : partialSumBool (reflectAt ω a) k = a :=
+        (Finset.mem_filter.mp hk).2
+      have hk_ω : partialSumBool ω k = a := by
+        rw [← partialSumBool_congr_below (Nat.le_of_lt hk_val)]
+        exact hk_ps
+      have hk_mem : k ∈ hitSet ω a :=
+        Finset.mem_filter.mpr ⟨Finset.mem_univ _, hk_ω⟩
+      rw [hτ_eq] at hk_val
+      exact absurd ((hitSet ω a).min'_le _ hk_mem) (not_le.mpr hk_val)
   -- Step 2: pointwise `!!b = b` collapse with first-hit alignment.
   --
   -- N.B. we cannot `unfold reflectAt; rw [hτ]` because `unfold` rewrites

--- a/research/problems/ballot-problem-oq-02-oq-05/sessions/2026-06-01-s9-act-htau-discharge-inline.md
+++ b/research/problems/ballot-problem-oq-02-oq-05/sessions/2026-06-01-s9-act-htau-discharge-inline.md
@@ -1,0 +1,239 @@
+# S9 ACT — R4-sub `hτ` discharged inline (Docker-verified)
+
+**Date**: 2026-06-01
+**Researcher**: researcher-1
+**Phase**: ACT
+**Branch**: `research/ballot-problem-oq-02-oq-05-s9-act-2026-06-01`
+**Base commit**: `f486a19e2e0` (HEAD on `main`)
+**Outcome**: 4 sorries → 3 sorries; +42 LOC; **Docker-verified 7744 jobs OK**
+
+## 1. Goal
+
+S8 ACT (2026-05-31) shipped the R4 false-statement fix by adding a
+`(hitSet ω a).Nonempty` hypothesis and replacing the proof body with a
+case-split skeleton, but left the key sub-goal
+
+```
+hτ : firstHitFin (reflectAt ω a) a = firstHitFin ω a
+```
+
+as a named sorry. The S8 Next Action proposed two routes:
+
+- **Route A (PREP)**: stage a `partialSumBool_congr_below` helper lemma
+  + paste-ready `hτ` discharge skeleton.
+- **Route B (ACT)**: discharge `hτ` inline without the helper, ~20 LOC.
+
+S9 ships a hybrid: the helper from Route A **and** the inline `hτ`
+discharge from Route B in a single PR, since the helper is small (~7 LOC
+without docstring) and the inline discharge naturally consumes it twice.
+
+## 2. Patch (verbatim, applied at base `f486a19e2e0`)
+
+### 2.1 New helper `partialSumBool_congr_below`
+
+Inserted between `reflectAt_eq_below_firstHit` (line 185-190) and
+`reflectAt_involutive` (line 206+):
+
+```lean
+/-- **R4-sub helper (S9 ACT).** Partial sums up to a position not exceeding
+    the first hit time are unchanged by reflection. The sum's `i.val < k.val`
+    guard restricts each summand index `i` to satisfy `i.val < k.val ≤ τ.val`,
+    so `reflectAt_eq_below_firstHit` collapses every summand pointwise. -/
+lemma partialSumBool_congr_below
+    {ω : Fin n → Bool} {a : ℤ} {k : Fin (n+1)}
+    (hk : k.val ≤ (firstHitFin ω a).val) :
+    partialSumBool (reflectAt ω a) k = partialSumBool ω k := by
+  unfold partialSumBool
+  refine Finset.sum_congr rfl (fun i _ => ?_)
+  by_cases hi : i.val < k.val
+  · rw [if_pos hi, if_pos hi,
+        reflectAt_eq_below_firstHit (Nat.lt_of_lt_of_le hi hk)]
+  · rw [if_neg hi, if_neg hi]
+```
+
+### 2.2 Inline `hτ` discharge
+
+Replaced the sorry inside `reflectAt_involutive`:
+
+```lean
+  -- Step 1: firstHitFin is preserved under reflection (uses h).
+  -- Discharged inline (S9 ACT): the partial-sum equality below τ
+  -- (`partialSumBool_congr_below`) shows τ ∈ hitSet (reflectAt ω a) a and
+  -- that the reflected path has no earlier hit; min'-antisymmetry closes.
+  have hτ : firstHitFin (reflectAt ω a) a = firstHitFin ω a := by
+    have hτ_eq : firstHitFin ω a = (hitSet ω a).min' h := by
+      simp [firstHitFin, dif_pos h]
+    have hτ_mem : firstHitFin ω a ∈ hitSet ω a := by
+      rw [hτ_eq]; exact (hitSet ω a).min'_mem h
+    have hτ_ps : partialSumBool ω (firstHitFin ω a) = a :=
+      (Finset.mem_filter.mp hτ_mem).2
+    have hτ_mem' : firstHitFin ω a ∈ hitSet (reflectAt ω a) a := by
+      refine Finset.mem_filter.mpr ⟨Finset.mem_univ _, ?_⟩
+      rw [partialSumBool_congr_below (le_refl _)]
+      exact hτ_ps
+    have h' : (hitSet (reflectAt ω a) a).Nonempty := ⟨_, hτ_mem'⟩
+    have hfh' : firstHitFin (reflectAt ω a) a = (hitSet (reflectAt ω a) a).min' h' := by
+      simp [firstHitFin, dif_pos h']
+    apply le_antisymm
+    · rw [hfh']
+      exact Finset.min'_le _ _ hτ_mem'
+    · rw [hfh']
+      refine Finset.le_min' _ _ _ (fun k hk => ?_)
+      by_contra hlt
+      push_neg at hlt
+      have hk_val : k.val < (firstHitFin ω a).val := hlt
+      have hk_ps : partialSumBool (reflectAt ω a) k = a :=
+        (Finset.mem_filter.mp hk).2
+      have hk_ω : partialSumBool ω k = a := by
+        rw [← partialSumBool_congr_below (Nat.le_of_lt hk_val)]
+        exact hk_ps
+      have hk_mem : k ∈ hitSet ω a :=
+        Finset.mem_filter.mpr ⟨Finset.mem_univ _, hk_ω⟩
+      rw [hτ_eq] at hk_val
+      exact absurd ((hitSet ω a).min'_le _ hk_mem) (not_le.mpr hk_val)
+```
+
+## 3. Proof structure (antisymmetry on `Fin (n+1)`)
+
+`Fin (n+1)` has a `LinearOrder` so `le_antisymm` reduces to two `≤` goals.
+Let `τ := firstHitFin ω a = (hitSet ω a).min' h`.
+
+### 3.1 ≤ direction: `firstHitFin (reflectAt ω a) a ≤ τ`
+
+It suffices to show `τ ∈ hitSet (reflectAt ω a) a`, then `Finset.min'_le`
+gives the inequality.
+
+`τ ∈ hitSet (reflectAt ω a) a` ↔ `partialSumBool (reflectAt ω a) τ = a`.
+By the new helper at `k = τ` (hypothesis `τ.val ≤ τ.val`, i.e. `le_refl`):
+`partialSumBool (reflectAt ω a) τ = partialSumBool ω τ`. The right side is
+`a` by `min'_mem` + `mem_filter`.
+
+### 3.2 ≥ direction: `τ ≤ firstHitFin (reflectAt ω a) a`
+
+`Finset.le_min'` reduces to: for any `k ∈ hitSet (reflectAt ω a) a`, show
+`τ ≤ k`.
+
+By contradiction: assume `¬ (τ ≤ k)`, i.e. `k < τ`. Then by the new helper
+at `k` (hypothesis `k.val ≤ τ.val` from `Nat.le_of_lt`):
+`partialSumBool (reflectAt ω a) k = partialSumBool ω k`. Combined with
+`k ∈ hitSet (reflectAt ω a) a`, this gives `partialSumBool ω k = a`, so
+`k ∈ hitSet ω a`. Then `τ = (hitSet ω a).min' h ≤ k` by `Finset.min'_le`,
+contradicting `k < τ`.
+
+## 4. File metrics
+
+| Metric | Pre-S9 | Post-S9 | Δ |
+|--------|--------|---------|---|
+| LOC | 283 | 325 | +42 |
+| Sorries | 4 | 3 | −1 |
+| Axioms | 1 | 1 | 0 |
+| Defs | 6 | 6 | 0 |
+| Lemmas | 4 | 5 | +1 |
+| Theorems | 1 | 1 | 0 |
+| R4 status | TRUE w/ sub-sorry | TRUE, fully discharged | sorry-free |
+
+## 5. Sorry inventory (post-S9)
+
+| Sorry | Decl line | Sorry line | Approach (unchanged from S6/S8) |
+|-------|-----------|------------|----------------------------------|
+| R5 `partialSumBool_reflectAt_endpoint` | 288 | 292 | `Finset.sum_ite` + `min'_mem h` + arithmetic |
+| LOW `reaches_iff_hits_or_above` | 298 | 302 | `Int.le_iff_exists_eq_succ` on ±1 jumps |
+| R6 `discrete_reflection` | 313 | 321 | `Finset.card_nbij'` applied to (ending<a, hits a) ↔ (ending>a), uses R4 + R5 |
+
+## 6. Bearer table (no drift since S8)
+
+All bearers used in the S9 patch were previously pinned at lake-manifest
+SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Mathlib v4.26.0):
+
+| API | File | Line | First pinned |
+|-----|------|------|--------------|
+| `Finset.min'` | `Mathlib/Data/Finset/Max.lean:196` | 196 | S5 PREP |
+| `Finset.min'_mem` | `Mathlib/Data/Finset/Max.lean:207` | 207 | S5 PREP |
+| `Finset.min'_le` | `Mathlib/Data/Finset/Max.lean:210` | 210 | S5 PREP |
+| `Finset.le_min'` | `Mathlib/Data/Finset/Max.lean:213` | 213 | S5 PREP |
+| `Finset.sum_congr` (via `to_additive` of `Finset.prod_congr`) | `Mathlib/Algebra/BigOperators/Group/Finset/Basic.lean:108` | 108 | S5 PREP §4 |
+| `Finset.mem_filter` | `Mathlib/Data/Finset/Filter.lean:127` | 127 | implicit since S2 |
+
+No new pin needed. `Nat.le_of_lt` / `Nat.lt_of_lt_of_le` / `Nat.not_le_of_lt`
+are Lean core.
+
+## 7. Build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ02OQ05
+...
+⚠ [7744/7744] Built Proofs.BallotProblemOQ02OQ05 (11s)
+warning: Proofs/BallotProblemOQ02OQ05.lean:288:6: declaration uses 'sorry'
+warning: Proofs/BallotProblemOQ02OQ05.lean:298:6: declaration uses 'sorry'
+warning: Proofs/BallotProblemOQ02OQ05.lean:313:8: declaration uses 'sorry'
+Build completed successfully (7744 jobs).
+=== Build succeeded ===
+```
+
+Exit code 0. The 3 sorry warnings correspond to the inherited R5, LOW, R6
+sorries (not new). The R4-sub `hτ` warning that was at the previous build
+is gone — `hτ` is now fully discharged.
+
+## 8. Risk inventory
+
+All RED items from S5 PREP §6 either drained or unchanged:
+
+- R1-R4: drained in S6 ACT + S8 ACT.
+- **R4 (MEDIUM)**: drained in S9 ACT (this PR). `reflectAt_involutive` is now
+  fully sorry-free under the `(hitSet ω a).Nonempty` hypothesis.
+- R5/R6 (HIGH): unchanged, queued for S10+.
+- R7 (LOW well-definedness): unchanged.
+- R8 (INFRA): drained 2026-05-31 (Docker daemon GREEN both today and S8).
+
+## 9. S10+ readiness (S9 → S10 handoff)
+
+Three sorries remain; each is independently discharge-able:
+
+- **R5** (~25 LOC): `partialSumBool_reflectAt_endpoint` — sum split at τ
+  via `Finset.sum_ite`, identity on `i < τ` (by Helper-1 inside the sum),
+  sign-flipped on `i ≥ τ`, arithmetize with `min'_mem h`.
+- **LOW** (~8 LOC): `reaches_iff_hits_or_above` — IVT for ℤ-valued ±1 paths:
+  partial sums increase/decrease by exactly 1 each step.
+- **R6** (~20 LOC): `discrete_reflection` — `Finset.card_nbij'` with
+  `i = j = reflectAt _ a`, using R4 (involution) + R5 (endpoint identity).
+
+Plausible Aristotle candidates after S9:
+- **LOW** (jump analysis — borderline; the ±1 IVT is well-scoped).
+- **R5** (sum-splitting + arithmetic — borderline; depends on Aristotle's
+  `Finset.sum_ite` maturity).
+
+S10 can ship any subset of {R5, LOW, R6} since they are not mutually
+blocking (LOW is independent; R5 is needed for R6).
+
+## 10. LOC budget
+
+325 LOC exceeds the 250-LOC informal cap by 75 LOC (30%). Comparable to
+S8's 6% overage; acceptable for the structural-correctness + sorry-count
+gain (4 → 3).
+
+Compression candidates for future S-cycles (after R5/LOW/R6 drained):
+- `reflectAt_involutive` history docstring (~20 LOC, S7 PREP / S8 ACT
+  narrative) can be condensed once the lemma fully discharges.
+- The `dif_pos` / `simp [firstHitFin, ...]` chains around `firstHitFin`
+  could be replaced by a small `firstHitFin_of_nonempty` lemma (~3 LOC
+  saved per call site, ~9 LOC total).
+
+## 11. Sibling-coordination
+
+`grep -rnE 'partialSumBool_congr_below|reflectAt_involutive|discrete_reflection|firstHitFin' proofs/Proofs/`
+returns matches only in this file. `gh pr list --search 'discrete_reflection in:title'`
+returns 0 open PRs. No race risk.
+
+## 12. Decisions log
+
+- **Route choice**: hybrid (helper from Route A + inline discharge from
+  Route B). Rationale: helper is small (~7 LOC body) and reused twice in
+  the discharge, so splitting helper PREP + discharge ACT into two PRs
+  would have spent extra PR overhead for no proof-clarity gain.
+- **`by_contra` for ≥ direction**: chose contradiction over direct proof
+  because the helper applies cleanly under `Nat.le_of_lt` for `k.val < τ.val`,
+  and `min'_le` gives the contradicting inequality immediately.
+- **`simp [firstHitFin, dif_pos h]`**: chosen over `unfold firstHitFin`
+  because `unfold` would also rewrite inner occurrences inside the
+  surrounding `hitSet (reflectAt ω a) a` — same trap S8 hit on `reflectAt`
+  inside `firstHitFin (reflectAt ω a) a`.

--- a/research/problems/ballot-problem-oq-02-oq-05/state.md
+++ b/research/problems/ballot-problem-oq-02-oq-05/state.md
@@ -1,9 +1,84 @@
 # Current State
 
-**Phase**: ACT (S8 — R4 false-statement fix applied: Helper-1 added, R4 signature takes `(h : (hitSet ω a).Nonempty)`, proof skeleton in place with named sub-sorry `hτ`; **build VERIFIED via Docker, 7744 jobs successful, 4 declared sorries**)
-**Since**: 2026-05-31 (S8 ACT, T+1d after S7 PREP)
-**Iteration**: 8 (S1 OBSERVE + S2 ACT + S3 PREP + S4 STATE-SYNC + S5 PREP + S6 ACT + S7 PREP + S8 ACT, this entry)
-**Last Updated**: 2026-05-31T18:30Z
+**Phase**: ACT (S9 — R4-sub `hτ` discharged inline; `partialSumBool_congr_below` helper added; **build VERIFIED via Docker, 7744 jobs successful, 3 declared sorries**)
+**Since**: 2026-06-01 (S9 ACT, T+1d after S8 ACT)
+**Iteration**: 9 (S1 OBSERVE + S2 ACT + S3 PREP + S4 STATE-SYNC + S5 PREP + S6 ACT + S7 PREP + S8 ACT + S9 ACT, this entry)
+**Last Updated**: 2026-06-01
+
+## S9 ACT (researcher-1, 2026-06-01, Docker-verified)
+
+Discharged the R4-sub `hτ` sorry inline (Route B from S8 ACT's Next Action),
+plus added the supporting helper `partialSumBool_congr_below` referenced in
+Route A. Both ship in one PR since the helper is small (~7 LOC) and the
+inline discharge naturally consumes it.
+
+**Patch (42 LOC added, 1 sorry removed)**:
+
+1. **New helper** `partialSumBool_congr_below` (~12 LOC w/ docstring) inserted
+   between `reflectAt_eq_below_firstHit` and `reflectAt_involutive`:
+   for `k.val ≤ (firstHitFin ω a).val`, `partialSumBool (reflectAt ω a) k
+   = partialSumBool ω k`. Proof is `Finset.sum_congr rfl` + per-summand
+   `by_cases hi : i.val < k.val`, then `reflectAt_eq_below_firstHit` on the
+   `if_pos` branch and `rfl` on the `if_neg` branch.
+
+2. **R4-sub `hτ` discharge** (~28 LOC, replacing 1 sorry + ~6 LOC of comments):
+   `firstHitFin (reflectAt ω a) a = firstHitFin ω a` via `le_antisymm`:
+   - **≤ direction**: `firstHitFin ω a ∈ hitSet (reflectAt ω a) a` (using
+     `partialSumBool_congr_below (le_refl _)`), then `Finset.min'_le`.
+   - **≥ direction**: for any `k ∈ hitSet (reflectAt ω a) a`, by contradiction
+     assume `k < firstHitFin ω a`; then `partialSumBool_congr_below
+     (Nat.le_of_lt hk_val)` gives `partialSumBool ω k = a`, so `k ∈ hitSet ω a`,
+     so `firstHitFin ω a ≤ k` by `Finset.min'_le` — contradicting `k <
+     firstHitFin ω a`.
+
+**File metrics**:
+
+| Metric | Pre-S9 | Post-S9 | Δ |
+|--------|--------|---------|---|
+| LOC | 283 | 325 | +42 |
+| Sorries | 4 | 3 | −1 |
+| Axioms | 1 (`donsker_fclt`) | 1 (`donsker_fclt`) | 0 |
+| Defs | 6 | 6 | 0 |
+| Lemmas | 4 (Helper-1 + R4 + R5 + LOW) | 5 (+`partialSumBool_congr_below`) | +1 |
+| R4 status | TRUE with `hτ` sub-sorry | TRUE, fully discharged | **sorry-free** |
+
+**Sorry inventory (post-S9)**:
+
+| Sorry | Discharge approach | Note |
+|-------|-------------------|------|
+| ~~R4-sub `hτ`~~ | — | **DISCHARGED in S9 ACT** |
+| R5 (`partialSumBool_reflectAt_endpoint`) | `Finset.sum_ite` + `min'_mem h` + arithmetic | unchanged from S6 |
+| LOW (`reaches_iff_hits_or_above`) | `Int.le_iff_exists_eq_succ` on ±1 jumps | unchanged from S6 |
+| R6 (`discrete_reflection`) | `Finset.card_nbij'` assembly using R4 + R5 | unchanged from S6 |
+
+**Build status**: **VERIFIED via Docker — 7744 jobs successful, single-file
+target `Proofs.BallotProblemOQ02OQ05`, 3 declared sorries (R5 line 288, LOW
+line 298, R6 line 313), 0 errors**. Bearer pins all unchanged (lake-pinned
+Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`).
+
+**LOC budget**: 325 LOC exceeds the 250-LOC informal cap by 75 LOC (30%).
+Comparable to S8's 6% overage; acceptable for the structural-correctness
++ sorry-count improvement (4 → 3). Compression candidates for future
+S-cycles: the multi-paragraph history docstring on `reflectAt_involutive`
+(~20 LOC) can be condensed once S10+ R5/R6 are also discharged.
+
+**Bearer 0-drift**: lake-pinned Mathlib SHA unchanged since S5 PREP §4. No
+new bearers needed (the discharge uses only previously-pinned APIs:
+`Finset.min'`, `Finset.min'_mem`, `Finset.min'_le`, `Finset.le_min'`,
+`Finset.sum_congr`, `Finset.mem_filter`, all line-verified in
+`~/GitHub/mathlib4` at SHA `2df2f0150c`).
+
+**Sibling-coordination**: no new sibling slug references (`grep -rnE
+'partialSumBool_congr_below|reflectAt_involutive' proofs/Proofs/` returns
+matches only in this file). No race risk.
+
+**Sorry projection** (unchanged from S8): post-S9 = 3 (R5 + LOW + R6).
+Each is independently discharge-able via the discharge sketches in S5 PREP
+§6 / S6 ACT inventory.
+
+See `sessions/2026-06-01-s9-act-htau-discharge-inline.md` for the
+full memo (patch detail, helper proof, two-direction antisymmetry, bearer
+table, sorry projection for S10+).
 
 ## S8 ACT (researcher-1, 2026-05-31, build pending — G9 lake self-loop)
 
@@ -347,24 +422,10 @@ None new. Existing Mathlib gaps tracked in `problem.md` (Mathlib infrastructure 
 
 ## Next Action
 
-**S8 ACT shipped** in this PR (researcher-1, 2026-05-31) — Helper-1 inserted,
-R4 signature changed to take `(h : (hitSet ω a).Nonempty)`, R4 proof body
-replaced with `funext + rw [hτ] + split_ifs + simp [Bool.not_not]`,
-named sub-sorry `hτ : firstHitFin (reflectAt ω a) a = firstHitFin ω a`
-left inline (~15-LOC discharge planned for S9).
-
-**S9 (any researcher)**: two route options:
-
-- **Route A (PREP)**: stage a `partialSumBool_congr_below` helper lemma
-  (~5 LOC, `Finset.sum_congr rfl` on the `i.val < k.val` guard) +
-  paste-ready `hτ` discharge skeleton (~15 LOC, antisymmetry on `Fin (n+1)`
-  via `Finset.min'_le` / `Finset.le_min'`). Same `(build pending — G9)`
-  shipping pattern.
-- **Route B (ACT)**: discharge `hτ` inline without the helper, ~20 LOC.
-  Acceptable but less reusable.
-
-After S9 lands, R4 is fully sorry-free; net file sorry count drops 4 → 3
-(R5, LOW, R6).
+**S9 ACT shipped** in this PR (researcher-1, 2026-06-01, Docker-verified) —
+`partialSumBool_congr_below` helper added; R4-sub `hτ` discharged inline via
+`le_antisymm` on `Fin (n+1)` with `Finset.min'_le` / `Finset.le_min'`.
+R4 is now fully sorry-free; file count drops 4 → 3 (R5, LOW, R6).
 
 **S10+**: discharge the R5 / LOW / R6 chain.
 


### PR DESCRIPTION
## Summary

S9 ACT for `ballot-problem-oq-02-oq-05` (Donsker's FCLT bridge).

Discharge the R4-sub `hτ : firstHitFin (reflectAt ω a) a = firstHitFin ω a`
sorry left by **S8 ACT** (PR #21550). Adds a small helper
`partialSumBool_congr_below` and an inline `le_antisymm` discharge using
`Finset.min'_le` / `Finset.le_min'`.

- `proofs/Proofs/BallotProblemOQ02OQ05.lean`: +42 LOC (283 → 325).
- 4 sorries → 3 sorries. R4 (`reflectAt_involutive`) is now fully
  sorry-free under the `(hitSet ω a).Nonempty` hypothesis added in S8.
- **Docker-verified**: 7744 jobs successful, single-file target
  `Proofs.BallotProblemOQ02OQ05`, 3 declared sorries (R5/LOW/R6).

## Patch detail

- **New helper** `partialSumBool_congr_below` (~12 LOC w/ docstring):
  for `k.val ≤ (firstHitFin ω a).val`,
  `partialSumBool (reflectAt ω a) k = partialSumBool ω k`. Proof is
  `Finset.sum_congr rfl` + per-summand `by_cases` on `i.val < k.val`,
  then `reflectAt_eq_below_firstHit` on the `if_pos` branch.

- **R4-sub `hτ` discharge** (~28 LOC, replacing 1 sorry + 6 LOC of comments):
  - ≤ direction: `firstHitFin ω a ∈ hitSet (reflectAt ω a) a` via the helper
    at `k = firstHitFin ω a` (with `le_refl`), then `Finset.min'_le`.
  - ≥ direction: `by_contra` — assuming `k < firstHitFin ω a` for some
    `k ∈ hitSet (reflectAt ω a) a`, the helper at `k` gives
    `partialSumBool ω k = a`, so `k ∈ hitSet ω a`, so `firstHitFin ω a ≤ k`
    by `Finset.min'_le`, contradicting `k < firstHitFin ω a`.

## Sorry inventory (post-S9)

| Sorry | Line | Approach |
|-------|------|----------|
| R5 `partialSumBool_reflectAt_endpoint` | 288 | `Finset.sum_ite` + `min'_mem` + arithmetic |
| LOW `reaches_iff_hits_or_above` | 298 | `Int.le_iff_exists_eq_succ` on ±1 jumps |
| R6 `discrete_reflection` | 313 | `Finset.card_nbij'` using R4 + R5 |

## Bearer pins

All bearers used were previously pinned at Mathlib SHA
`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0): `Finset.min'`,
`min'_mem`, `min'_le`, `le_min'`, `sum_congr` (via `to_additive` of
`prod_congr`), `mem_filter`. No drift; no new pins.

## Sibling-coordination

`grep` returns matches only in this file; no open PR on
`discrete_reflection`. No race risk.

## Test plan
- [x] Docker build via `./proofs/scripts/docker-build.sh Proofs.BallotProblemOQ02OQ05` — exit 0, 7744/7744 jobs.
- [x] Sorry count verified at 3 (R5/LOW/R6); R4-sub `hτ` gone.
- [x] No new axioms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)