### PR TITLE
Research: zsqrtd-neg-two-oq-03 — S15 ACT Step 2 discharge legendreSym_neg_three_eq_one_iff (Docker-verified 3058 jobs, 0 sorries/axioms)

### DIFF
--- a/proofs/Proofs/ZsqrtdNegTwoOQ03.lean
+++ b/proofs/Proofs/ZsqrtdNegTwoOQ03.lean
@@ -76,6 +76,19 @@ quadratic reciprocity) yields a non-trivial factorisation
 This file has 0 axioms, 0 sorries.
 -/
 
+/-- Closed `decide` helper hoisted outside `namespace Proofs`: `(2 : ZMod 3) ≠ 0`.
+    Used inside `legendreSym_three_eq_one_iff_p_mod_three_eq_one`; the in-namespace
+    `by decide` failed with a "free variables" error due to the surrounding
+    universe-polymorphic context. -/
+private lemma two_ne_zero_zmod_three : (2 : ZMod 3) ≠ 0 := by decide
+
+/-- Closed `decide` helper hoisted outside `namespace Proofs`: `2` is not a square
+    in `ZMod 3`. Used inside `legendreSym_three_eq_one_iff_p_mod_three_eq_one`. -/
+private lemma not_isSquare_two_zmod_three : ¬ IsSquare (2 : ZMod 3) := by
+  rintro ⟨r, hr⟩
+  have : ∀ x : ZMod 3, x * x ≠ 2 := by decide
+  exact this r hr.symm
+
 namespace Proofs
 
 /-- The Eisenstein integers `ℤ[ω]`, where `ω = exp(2πi/3)` is a
@@ -461,5 +474,86 @@ needed at this step. -/
 lemma legendreSym_neg_three (p : ℕ) [Fact p.Prime] :
     legendreSym p (-3) = legendreSym p (-1) * legendreSym p 3 := by
   rw [show ((-3 : ℤ) = (-1) * 3) by norm_num, legendreSym.mul]
+
+/-- Helper: `(p/3) = 1 ↔ p ≡ 1 mod 3` for primes `p ≠ 3`.
+
+    Reduces to `IsSquare ((p : ℕ) : ZMod 3)` via `legendreSym.eq_one_iff'`,
+    then case-splits on `p % 3 ∈ {1, 2}` (forced by `p ≠ 3` so `p % 3 ≠ 0`).
+    Branch `p % 3 = 1`: `(1 : ZMod 3)` is a square (`1 = 1 * 1`).
+    Branch `p % 3 = 2`: `(2 : ZMod 3)` is not a square (`decide` on
+    the finite codomain). -/
+private lemma legendreSym_three_eq_one_iff_p_mod_three_eq_one
+    (p : ℕ) [hp_fact : Fact p.Prime] (hp_ne_three : p ≠ 3) :
+    legendreSym 3 p = 1 ↔ p % 3 = 1 := by
+  haveI : Fact (3 : ℕ).Prime := ⟨by decide⟩
+  have hp_prime := hp_fact.out
+  have hp_mod_3 : p % 3 = 1 ∨ p % 3 = 2 := by
+    have h0 : p % 3 ≠ 0 := by
+      intro h
+      have hdvd : 3 ∣ p := Nat.dvd_of_mod_eq_zero h
+      rcases hp_prime.eq_one_or_self_of_dvd 3 hdvd with h1 | h3
+      · exact absurd h1 (by decide)
+      · exact hp_ne_three h3.symm
+    have := Nat.mod_lt p (by norm_num : 0 < 3)
+    omega
+  have hp_cast : (p : ZMod 3) = ((p % 3 : ℕ) : ZMod 3) := (ZMod.natCast_mod p 3).symm
+  rcases hp_mod_3 with hmod | hmod
+  · -- p % 3 = 1: both sides true.
+    have hpZ : (p : ZMod 3) = 1 := by rw [hp_cast, hmod]; rfl
+    have ha0 : (p : ZMod 3) ≠ 0 := by rw [hpZ]; exact one_ne_zero
+    refine ⟨fun _ => hmod, fun _ => ?_⟩
+    rw [legendreSym.eq_one_iff' (3 : ℕ) ha0, hpZ]
+    exact ⟨1, by ring⟩
+  · -- p % 3 = 2: both sides false.
+    have hpZ : (p : ZMod 3) = 2 := by rw [hp_cast, hmod]; rfl
+    have ha0 : (p : ZMod 3) ≠ 0 := by
+      rw [hpZ]; exact two_ne_zero_zmod_three
+    refine ⟨fun hLS => ?_, fun h => ?_⟩
+    · rw [legendreSym.eq_one_iff' (3 : ℕ) ha0, hpZ] at hLS
+      exact (not_isSquare_two_zmod_three hLS).elim
+    · exact absurd (h.symm.trans hmod) (by decide)
+
+/-- Step 2 of the splitting argument: for an odd prime `p ≠ 3`,
+    `(-3/p) = 1 ↔ p ≡ 1 mod 3`. The classical Heegner-number
+    characterization of the primes representable as `x² + 3y²`.
+
+    Proof strategy:
+    1. Decompose via `legendreSym_neg_three`: `(-3/p) = (-1/p) · (3/p)`.
+    2. Compute `(-1/p) = χ₄ p` via `legendreSym.at_neg_one`.
+    3. Case-split on `p % 4 ∈ {1, 3}`:
+       - `p % 4 = 1`: `χ₄ p = 1`; QR_one_mod_four gives `(3/p) = (p/3)`.
+       - `p % 4 = 3`: `χ₄ p = -1`; QR_three_mod_four gives
+         `(3/p) = -(p/3)`. The two `-1`s cancel.
+    4. Both branches reduce to `(p/3) = 1 ↔ p ≡ 1 mod 3`
+       via `legendreSym_three_eq_one_iff_p_mod_three_eq_one`. -/
+lemma legendreSym_neg_three_eq_one_iff
+    (p : ℕ) [hp_fact : Fact p.Prime]
+    (hp_ne_two : p ≠ 2) (hp_ne_three : p ≠ 3) :
+    legendreSym p (-3) = 1 ↔ p % 3 = 1 := by
+  rw [legendreSym_neg_three p, legendreSym.at_neg_one (p := p) hp_ne_two]
+  haveI : Fact (3 : ℕ).Prime := ⟨by decide⟩
+  have hp_prime := hp_fact.out
+  have hp_mod_4 : p % 4 = 1 ∨ p % 4 = 3 := by
+    have hp_odd : p % 2 = 1 := (Nat.Prime.mod_two_eq_one_iff_ne_two hp_prime).mpr hp_ne_two
+    have := Nat.mod_lt p (by norm_num : 0 < 4)
+    omega
+  -- Normalize `(3 : ℤ)` to `((3 : ℕ) : ℤ)` so QR's RHS pattern matches.
+  have h3cast : (3 : ℤ) = ((3 : ℕ) : ℤ) := by norm_cast
+  rcases hp_mod_4 with hp4 | hp4
+  · -- p % 4 = 1: χ₄ p = 1; QR gives (3/p) = (p/3).
+    rw [ZMod.χ₄_nat_one_mod_four hp4, one_mul, h3cast,
+        ← legendreSym.quadratic_reciprocity_one_mod_four hp4
+          (by decide : (3 : ℕ) ≠ 2)]
+    exact legendreSym_three_eq_one_iff_p_mod_three_eq_one p hp_ne_three
+  · -- p % 4 = 3: χ₄ p = -1; QR gives (3/p) = -(p/3).
+    rw [ZMod.χ₄_nat_three_mod_four hp4]
+    have hQR : legendreSym 3 p = -legendreSym p ((3 : ℕ) : ℤ) :=
+      legendreSym.quadratic_reciprocity_three_mod_four hp4
+        (by decide : (3 : ℕ) % 4 = 3)
+    -- From hQR: legendreSym p 3 = -legendreSym 3 p.
+    have hQR' : legendreSym p ((3 : ℕ) : ℤ) = -legendreSym 3 p := by linarith [hQR]
+    rw [h3cast, hQR']
+    rw [show ((-1 : ℤ) * -legendreSym 3 p = legendreSym 3 p) from by ring]
+    exact legendreSym_three_eq_one_iff_p_mod_three_eq_one p hp_ne_three
 
 end Proofs

--- a/research/problems/zsqrtd-neg-two-oq-03/sessions/2026-06-01-s15-act-step2-discharge-legendresym-neg-three-iff.md
+++ b/research/problems/zsqrtd-neg-two-oq-03/sessions/2026-06-01-s15-act-step2-discharge-legendresym-neg-three-iff.md
@@ -1,0 +1,159 @@
+# S15 ACT — discharge legendreSym_neg_three_eq_one_iff (Step 2 of S4)
+
+**Date**: 2026-06-01
+**Researcher**: researcher-1
+**Phase**: ACT
+**Branch**: `research/zsqrtd-neg-two-oq-03-s15-act-step2-2026-06-01`
+**Base commit**: `f486a19e2e0` (HEAD on `main`)
+**Outcome**: lineCount 465 → 559 (+94 LOC); theoremCount 32 → 36 (+4); 0 sorries; 0 axioms; **Docker-verified 3058 jobs OK** (11s incremental)
+
+## 1. Goal
+
+Per S14 PREP (PR #21871) Next Action, discharge Step 2 of the S4
+splitting argument: prove `legendreSym_neg_three_eq_one_iff` — for an
+odd prime `p ≠ 3`, `(-3/p) = 1 ↔ p ≡ 1 mod 3`. This is the classical
+Heegner-number characterization for `n = 3` representability.
+
+## 2. What shipped
+
+Three new lemmas added to `proofs/Proofs/ZsqrtdNegTwoOQ03.lean`:
+
+1. **`two_ne_zero_zmod_three`** (top-level private): `(2 : ZMod 3) ≠ 0`.
+   Hoisted outside `namespace Proofs` because in-namespace `by decide`
+   failed with "Expected type must not contain free variables" due to
+   surrounding context.
+
+2. **`not_isSquare_two_zmod_three`** (top-level private):
+   `¬ IsSquare (2 : ZMod 3)`. Hoisted for the same reason; proof uses
+   `rintro ⟨r, hr⟩` then a `decide` on `∀ x : ZMod 3, x * x ≠ 2`.
+
+3. **`legendreSym_three_eq_one_iff_p_mod_three_eq_one`** (private,
+   inside `namespace Proofs`): the helper bridging `(p/3) = 1 ↔ p ≡ 1 mod 3`
+   for `p ≠ 3`. Uses `legendreSym.eq_one_iff'` + `ZMod.natCast_mod` +
+   case split on `p % 3`. ~28 LOC.
+
+4. **`legendreSym_neg_three_eq_one_iff`** (public, inside
+   `namespace Proofs`): the S4 ACT Step 2 deliverable. ~30 LOC including
+   the `h3cast` coercion shim required to match QR's RHS pattern.
+
+## 3. Proof structure
+
+The main lemma:
+
+```
+legendreSym p (-3) = 1 ↔ p % 3 = 1
+```
+
+splits as:
+
+1. **Decompose via Step 1** (`legendreSym_neg_three` from PR #21226):
+   `(-3/p) = (-1/p) · (3/p)`.
+
+2. **Compute `(-1/p)` via `legendreSym.at_neg_one`**:
+   `(-1/p) = χ₄ p`.
+
+3. **Case-split on `p % 4 ∈ {1, 3}`** (forced by `p ≠ 2`, omega):
+
+   - **`p % 4 = 1`**: `χ₄ p = 1` (via `ZMod.χ₄_nat_one_mod_four`); QR
+     for `p % 4 = 1` gives `(p/3) = (3/p)`. After `one_mul` and the
+     `(3 : ℤ) ↔ ((3 : ℕ) : ℤ)` `h3cast`, rewriting `legendreSym p ↑3`
+     to `legendreSym 3 p` via QR reduces to the helper.
+
+   - **`p % 4 = 3`**: `χ₄ p = -1` (via `ZMod.χ₄_nat_three_mod_four`);
+     QR for `p, q ≡ 3 mod 4` gives `(p/3) = -(3/p)`. After substituting
+     and simplifying `(-1) * -(3/p)` to `(3/p)`, reduces to the helper.
+
+4. **Helper closes both branches**: `(p/3) = 1 ↔ p ≡ 1 mod 3` via
+   `legendreSym.eq_one_iff'` + `IsSquare` characterization on
+   `(p : ZMod 3)`.
+
+## 4. Build iteration log (4 Docker iters)
+
+| Iter | Failure | Root cause | Fix |
+|------|---------|------------|-----|
+| 1 | `Unknown identifier 'χ₄_nat_one_mod_four'` (and `_three_mod_four`) | Lives in `namespace ZMod` not in scope | Namespace-qualify: `ZMod.χ₄_nat_*_mod_four` |
+| 2 | `Expected type must not contain free variables: ∀ (x : ZMod 3), x * x ≠ 2` | In-namespace `decide` cannot evaluate the closed prop because the surrounding context (with `p : ℕ`, `hp_fact`, etc.) is treated as free vars | Hoisted helper above `namespace Proofs` |
+| 3a | `rw failed: Did not find an occurrence of legendreSym p ↑3 in target` | Target has `legendreSym p (3 : ℤ)` via `OfNat`; QR's RHS has `legendreSym p ((3 : ℕ) : ℤ)` via `Nat.cast`. Defeq but not syntactically equal. | Added `h3cast : (3 : ℤ) = ((3 : ℕ) : ℤ)` (proved `by norm_cast`); `rw [h3cast]` before QR |
+| 3b | `Application type mismatch: 3 % 4 = 3 vs p % 4 = 3` | QR_three_mod_four's first hypothesis is for OUR prime `p`, not for the constant `3`. I had the args swapped. | Swapped: `hp4` first, `(by decide : 3 % 4 = 3)` second |
+| 4 | `Type mismatch: False vs p % 3 = 1` | `h_squares r hr.symm : False` doesn't unify with the goal `p % 3 = 1` automatically | Use `(... ).elim` to extract any goal from False |
+| ✓ | — | — | All 3058 jobs succeed in 11s |
+
+## 5. Bearer table (all pin-verified at SHA 2df2f0150c)
+
+| API | File:Line |
+|-----|-----------|
+| `legendreSym.at_neg_one` | `Mathlib/NumberTheory/LegendreSymbol/Basic.lean:272` |
+| `legendreSym.eq_one_iff'` | `Mathlib/NumberTheory/LegendreSymbol/Basic.lean:181` |
+| `ZMod.χ₄_nat_one_mod_four` | `Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean:89` |
+| `ZMod.χ₄_nat_three_mod_four` | `Mathlib/NumberTheory/LegendreSymbol/ZModChar.lean:94` |
+| `legendreSym.quadratic_reciprocity_one_mod_four` | `Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.lean:134` |
+| `legendreSym.quadratic_reciprocity_three_mod_four` | `Mathlib/NumberTheory/LegendreSymbol/QuadraticReciprocity.lean:142` |
+| `ZMod.natCast_mod` | `Mathlib/Data/ZMod/Basic.lean:736` |
+| `Nat.Prime.mod_two_eq_one_iff_ne_two` | core / Mathlib (one_iff variant) |
+
+## 6. Risks fired vs prediction (S14 PREP §5 risk inventory)
+
+| Risk | Predicted | Actual fire | Severity |
+|------|-----------|-------------|----------|
+| R1 PASTE-ONLY (steps a-c) | should fire automatically | ✓ fired, no work | — |
+| R2 LOW (p%4 case-split) | solid bearer | ✓ closed via `omega` | — |
+| R3 MEDIUM (p%3 ≠ 0) | bearer cited | ✓ closed via `Nat.Prime.eq_one_or_self_of_dvd` | — |
+| R4 MEDIUM (sub-lemma `(p/3) = 1 ↔ p % 3 = 1`) | needs ~10 LOC, 2 decide sub-sorries | ✓ closed via `legendreSym.eq_one_iff'` + `IsSquare` characterization | medium |
+| R5 INFRA Docker | run before shipping | ✓ Docker reachable; build clean | — |
+| **R6 NEW** (decide free-var) | not predicted | hoist helpers outside namespace | **post-mortem-add** |
+| **R7 NEW** (ℤ-coercion mismatch on QR's `↑3`) | not predicted | `h3cast` shim | **post-mortem-add** |
+| **R8 NEW** (QR arg order) | not predicted | swap args | **post-mortem-add** |
+
+## 7. File metrics
+
+| Metric | Pre-S15 | Post-S15 | Δ |
+|--------|---------|----------|---|
+| LOC | 465 | 559 | +94 |
+| sorries | 0 | 0 | 0 |
+| axioms | 0 | 0 | 0 |
+| theorems (grep) | ~32 | 36 | +4 |
+
+The +94 LOC overshoots the S14 PREP §5 estimate of ~50 LOC by ~88%
+(main reason: the 3 post-mortem-added risks above each consumed 10-20 LOC).
+
+## 8. Gallery `meta.json` updates
+
+- `meta.lineCount` 465 → 559
+- `meta.theoremCount` 24 → 36 (also closes S14 PREP §7 drift acknowledgement)
+- `leanFile.lineCount` / `leanFile.theoremCount` mirror
+
+## 9. Sibling-coordination
+
+`gh pr list --search "ZsqrtdNegTwoOQ03 is:open"` returns 0 open PRs at
+S15 ACT push time. No race risk.
+
+## 10. S16+ readiness (Step 3 next)
+
+S4 ACT Step 3 (per S14 PREP §6): extract `α : Eisenstein` with
+`norm α = p` from `IsSquare (-3 : ZMod p)`; parity case-split on
+`x_int`. Budget ~30 LOC. Uses `legendreSym.eq_one_iff` (ℤ form) +
+`PrincipalIdealRing.to_uniqueFactorizationMonoid` +
+`UniqueFactorizationMonoid.irreducible_iff_prime`.
+
+After Step 3 lands, S5 ACT (the main theorem
+`sq_add_three_sq_of_prime_one_mod_three`, ~100 LOC) closes the
+gallery entry.
+
+## 11. Decisions log
+
+- **Hoisting `decide` helpers**: 2 helpers (`two_ne_zero_zmod_three`,
+  `not_isSquare_two_zmod_three`) hoisted out of `namespace Proofs`
+  because in-namespace `decide` fails on closed props inside a
+  parameterized context. Cleanest workaround; alternative `decide +revert`
+  was not attempted but would have been equivalent.
+- **`h3cast` shim**: chose explicit `have h3cast : (3 : ℤ) = ((3 : ℕ) : ℤ) := by norm_cast`
+  over `push_cast`/`norm_cast` in the proof body, because the rewrite
+  target is a single subterm in a binder context where the global tactic
+  could over-rewrite.
+- **`.elim` over `exfalso; exact ...`**: chose `(not_isSquare_two_zmod_three hLS).elim`
+  for the contradiction path because it's a single token and Lean's
+  elaborator can produce any goal type from `False`.
+- **Hybrid PREP/ACT execution**: S14 PREP had marked Step 2 as
+  "paste-ready ~50 LOC". The actual discharge took ~94 LOC and 4 Docker
+  iterations due to 3 unanticipated risks (R6-R8). All resolved within
+  the same session — no PREP follow-up needed.

--- a/research/problems/zsqrtd-neg-two-oq-03/state.md
+++ b/research/problems/zsqrtd-neg-two-oq-03/state.md
@@ -1,10 +1,73 @@
 # Current State: zsqrtd-neg-two-oq-03
 
-**Phase**: ACT (S4 ACT Step 1 shipped via PR #21226 — `legendreSym_neg_three` + 2 stranded `@[simp]` projection lemmas `mul_conj_re`/`mul_conj_im`; gallery `lineCount` mirror via PR #21522; **Step 2 ready** — full 4-cell `p mod 12` tableau in S14 PREP §4 with paste-ready ~50-LOC Lean skeleton in §5; Step 3 outline refreshed ~30 LOC in §6; `meta.json` `theoremCount` 24→32 drift acknowledged for mechanic-pickup, §7)
+**Phase**: ACT (S15 ACT Step 2 shipped — `legendreSym_neg_three_eq_one_iff` discharged via S14 PREP §5 paste-ready skeleton; helper `legendreSym_three_eq_one_iff_p_mod_three_eq_one` + 2 hoisted decide-helpers `two_ne_zero_zmod_three`/`not_isSquare_two_zmod_three`; **Docker-verified 3058 jobs OK**; lineCount 465→559, theoremCount 24→36; 0 sorries, 0 axioms; Step 3 next)
 **Path**: full
-**Since**: 2026-06-01T00:00Z (S14 PREP — Step 2 derivation tableau + state-sync post-#21226/#21522; was 2026-05-16T10:00Z post-#19600 merge)
-**Iteration**: 13 (S12 PREP was iter 11 via #19600; S13 S4 ACT incremental was iter 12 via #21226; this S14 PREP is iter 13)
-**Researcher**: researcher-1 (Session 14 PREP, 2026-06-01)
+**Since**: 2026-06-01 (S15 ACT — Step 2 discharge; was S14 PREP 2026-06-01T00:00Z)
+**Iteration**: 14 (S14 PREP was iter 13 doc-only; this S15 ACT is iter 14)
+**Researcher**: researcher-1 (Session 15 ACT, 2026-06-01)
+
+## S15 ACT (researcher-1, 2026-06-01, Docker-verified)
+
+Discharged S4 ACT Step 2 (`legendreSym_neg_three_eq_one_iff`) per the S14
+PREP §5 paste-ready skeleton, plus the supporting helper
+`legendreSym_three_eq_one_iff_p_mod_three_eq_one` and 2 hoisted decide
+helpers needed to dodge "free variable" errors from `decide` inside the
+namespace.
+
+**Patch**:
+
+1. **Helper `legendreSym_three_eq_one_iff_p_mod_three_eq_one`** (~28 LOC):
+   reduces `(p/3) = 1 ↔ p % 3 = 1` for `p ≠ 3`. Uses `legendreSym.eq_one_iff'`
+   + `ZMod.natCast_mod` + case split on `p % 3 ∈ {1, 2}`.
+2. **Helper `legendreSym_neg_three_eq_one_iff`** (~30 LOC, S4 ACT Step 2):
+   uses Step 1 (`legendreSym_neg_three`) + `legendreSym.at_neg_one` + case
+   split on `p % 4 ∈ {1, 3}` with `ZMod.χ₄_nat_*_mod_four` +
+   `legendreSym.quadratic_reciprocity_*_mod_four`. The `(3 : ℤ)` vs
+   `((3 : ℕ) : ℤ)` coercion mismatch from QR's RHS is bridged by an
+   `h3cast` shim.
+3. **Hoisted helpers** (~10 LOC, outside `namespace Proofs`):
+   `two_ne_zero_zmod_three : (2 : ZMod 3) ≠ 0` and
+   `not_isSquare_two_zmod_three : ¬ IsSquare (2 : ZMod 3)`. In-namespace
+   `by decide` was failing with "Expected type must not contain free
+   variables"; hoisting to file-top resolved it.
+
+**Build iteration log** (4 Docker iters):
+
+| Iter | Issue | Fix |
+|------|-------|-----|
+| 1 | `χ₄_*_one_mod_four` unknown identifier | Namespace prefix `ZMod.` |
+| 2 | `decide` failed "free variables" on `∀ x : ZMod 3, x * x ≠ 2` | Hoisted helper outside namespace |
+| 3 | QR arg-order swap + `(3 : ℤ)` vs `((3 : ℕ) : ℤ)` coercion | Swapped + added `h3cast` shim |
+| 4 | Type mismatch False vs `p % 3 = 1` | `.elim` on the contradiction |
+| ✓ | — | All 3058 jobs succeed |
+
+**File metrics**:
+
+| Metric | Pre-S15 | Post-S15 | Δ |
+|--------|---------|----------|---|
+| LOC | 465 | 559 | +94 |
+| sorries | 0 | 0 | 0 |
+| axioms | 0 | 0 | 0 |
+| theorems (grep count) | ~32 (drift, acknowledged S14 PREP §7) | 36 | +4 |
+
+**Build**: **VERIFIED via Docker — 3058 jobs successful, single-file
+target `Proofs.ZsqrtdNegTwoOQ03`, 0 errors, 11s incremental.**
+
+**Bearer 0-drift**: lake-pinned Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+unchanged. All S14 PREP §4 bearers (`legendreSym.at_neg_one`,
+`ZMod.χ₄_nat_*_mod_four`, `legendreSym.quadratic_reciprocity_*_mod_four`,
+`legendreSym.eq_one_iff'`, `ZMod.natCast_mod`) verified at the pinned SHA
+locations.
+
+**Gallery `meta.json` updates**:
+- `meta.lineCount` 465 → 559 (mirrors PR #21522 convention)
+- `meta.theoremCount` 24 → 36 (also closes the S14 PREP §7 drift)
+- `leanFile.lineCount` / `leanFile.theoremCount` mirror
+
+**Sibling-coordination**: no open PRs on this slug at S15 ACT push time.
+
+See `sessions/2026-06-01-s15-act-step2-discharge-legendresym-neg-three-iff.md`
+for the full memo.
 
 ## Current Focus
 

--- a/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
+++ b/src/data/proofs/zsqrtd-neg-two-oq-03/meta.json
@@ -22,8 +22,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 465,
-    "theoremCount": 24,
+    "lineCount": 559,
+    "theoremCount": 36,
     "definitionCount": 3,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries. The S2 + S3 ACT deliverables are present: bare ring, norm, Eisenstein conjugate, division by rounding, and the EuclideanDomain instance. The splitting argument via quadratic reciprocity and the main `p = x² + 3y²` theorem will land in S4-S5 follow-up work.",
     "mathlib_version": "4.26.0",
@@ -72,12 +72,12 @@
     ]
   },
   "leanFile": {
-    "lineCount": 465,
+    "lineCount": 559,
     "path": "Proofs/ZsqrtdNegTwoOQ03.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 3,
-    "theoremCount": 24
+    "theoremCount": 36
   },
   "sorries": 0,
   "sections": [


### PR DESCRIPTION
## Summary

S4 ACT Step 2 for `zsqrtd-neg-two-oq-03`. Discharge
`legendreSym_neg_three_eq_one_iff` per S14 PREP §5 paste-ready skeleton
(PR #21871): for an odd prime `p ≠ 3`, `(-3/p) = 1 ↔ p ≡ 1 mod 3` — the
classical Heegner-number characterization for `n = 3` representability.

- `proofs/Proofs/ZsqrtdNegTwoOQ03.lean`: +94 LOC (465 → 559).
- 0 sorries, 0 axioms (unchanged from main).
- **Docker-verified**: 3058 jobs successful (11s incremental), 0 errors.
- 4 lemmas added (2 hoisted decide helpers + 1 private helper + 1 public
  S4 Step 2 deliverable).

## Proof structure

1. Decompose via Step 1 (`legendreSym_neg_three`): `(-3/p) = (-1/p) · (3/p)`.
2. Compute `(-1/p) = χ₄ p` via `legendreSym.at_neg_one`.
3. Case-split on `p % 4 ∈ {1, 3}`:
   - `p % 4 = 1`: `χ₄ p = 1`; QR gives `(p/3) = (3/p)`.
   - `p % 4 = 3`: `χ₄ p = -1`; QR gives `(p/3) = -(3/p)`. The two `-1`s cancel.
4. Reduce to helper `legendreSym_three_eq_one_iff_p_mod_three_eq_one`
   (`(p/3) = 1 ↔ p ≡ 1 mod 3`), proved via `legendreSym.eq_one_iff'` +
   `IsSquare`-characterization on `ZMod 3`.

## Build iteration log (4 Docker iters)

| Iter | Failure | Fix |
|------|---------|-----|
| 1 | `Unknown identifier χ₄_nat_one_mod_four` | Namespace-qualify: `ZMod.χ₄_nat_*_mod_four` |
| 2 | `decide` failed on closed prop inside namespace | Hoist 2 helpers outside `namespace Proofs` |
| 3 | QR arg-order swap + `(3 : ℤ)` vs `((3 : ℕ) : ℤ)` coercion | Fix arg order + add `h3cast` shim |
| 4 | Type mismatch `False vs p % 3 = 1` | `.elim` on the contradiction |
| ✓ | — | 3058 jobs OK |

## Gallery `meta.json`

- `meta.lineCount` 465 → 559
- `meta.theoremCount` 24 → 36 (closes the S14 PREP §7 acknowledged drift)
- `leanFile.{lineCount,theoremCount}` mirror

## Bearer pins

All bearers pin-verified at Mathlib SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`:
`legendreSym.at_neg_one`, `legendreSym.eq_one_iff'`,
`ZMod.χ₄_nat_one_mod_four`, `ZMod.χ₄_nat_three_mod_four`,
`legendreSym.quadratic_reciprocity_one_mod_four`,
`legendreSym.quadratic_reciprocity_three_mod_four`,
`ZMod.natCast_mod`. No drift.

## Next

S4 ACT Step 3 (~30 LOC, S14 PREP §6): extract `α : Eisenstein` with
`norm α = p` from `IsSquare (-3 : ZMod p)` via parity case-split on
`x_int`. After Step 3 lands, S5 ACT (the main theorem
`sq_add_three_sq_of_prime_one_mod_three`, ~100 LOC) closes the entry.

## Test plan
- [x] Docker build via `./proofs/scripts/docker-build.sh Proofs.ZsqrtdNegTwoOQ03` — exit 0, 3058 jobs.
- [x] 0 sorries, 0 axioms unchanged from main.
- [x] meta.json lineCount/theoremCount aligned with on-disk Lean state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)