### PR TITLE
fix(meta): euler-polyhedral-oq-01 register EulerPolyhedralOQ01OQ04.lean orphan companion

### DIFF
--- a/src/data/proofs/euler-polyhedral-oq-01/meta.json
+++ b/src/data/proofs/euler-polyhedral-oq-01/meta.json
@@ -201,7 +201,10 @@
     "theoremCount": 60,
     "definitionCount": 16,
     "path": "Proofs/EulerPolyhedralOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/EulerPolyhedralOQ01OQ04.lean"
+    ]
   },
   "sections": [
     {


### PR DESCRIPTION
## Summary

One orphan companion file for `euler-polyhedral-oq-01` (parent file `EulerPolyhedralOQ01.lean`, 903L, V−E+F=2 + Six-Color Theorem) is unregistered in any meta.json:

- `Proofs/EulerPolyhedralOQ01OQ04.lean` — **Kuratowski's theorem**: planarity characterization via forbidden minors K₅/K₃,₃, plus Wagner's theorem and edge-bound consequences.

Add to `leanFile.additionalFiles` as a string entry (matches the auditor's string-only convention; mirrors the format used by my prior mega-batch PR #21978).

## Verification

- Slug `euler-polyhedral-oq-01` resolves to parent `Proofs/EulerPolyhedralOQ01.lean` via `meta.proofRepoPath`.
- Orphan companion `Proofs/EulerPolyhedralOQ01OQ04.lean` exists at HEAD `f486a19e2e0` and is **not** referenced by any other meta.json (verified by re-running my orphan-scan v6, which now reads `proofRepoPath` from the `meta.*` block as well as `leanFile.*`).
- No concurrent PR claim: `gh pr list --search "EulerPolyhedralOQ01OQ04"` returns `[]`.
- PR #21978 (mega-batch) touches the sibling slug `euler-polyhedral-formula-oq-01`, **not** `euler-polyhedral-oq-01` — these are distinct gallery entries with different parent Lean files.

## Test plan

- [x] `json.load()` succeeds on patched `meta.json`
- [x] `Proofs/EulerPolyhedralOQ01OQ04.lean` exists at HEAD
- [x] No other meta.json references the file (true orphan)
- [ ] Auditor cycle removes this from orphan list after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)