### PR TITLE
fix(meta): hilbert-11 register Hilbert11OQ01 + Hilbert11OQ01OQ01 orphan companions (2-batch)

### DIFF
--- a/src/data/proofs/hilbert-11/meta.json
+++ b/src/data/proofs/hilbert-11/meta.json
@@ -37,7 +37,9 @@
     "theoremCount": 9,
     "definitionCount": 19,
     "additionalFiles": [
+      "Proofs/Hilbert11OQ01.lean",
       "Proofs/Hilbert11OQ01Aristotle.lean",
+      "Proofs/Hilbert11OQ01OQ01.lean",
       "Proofs/Hilbert11OQ01OQ01Aristotle.lean"
     ]
   },
@@ -218,7 +220,9 @@
     "path": "Proofs/Hilbert11_QuadraticForms.lean",
     "sorries": 7,
     "additionalFiles": [
+      "Proofs/Hilbert11OQ01.lean",
       "Proofs/Hilbert11OQ01Aristotle.lean",
+      "Proofs/Hilbert11OQ01OQ01.lean",
       "Proofs/Hilbert11OQ01OQ01Aristotle.lean"
     ]
   },


### PR DESCRIPTION
## Fix

Registers 2 orphan `.lean` files into slug `hilbert-11` in both `meta.additionalFiles` and `leanFile.additionalFiles`.

| File | LOC | Content |
|------|-----|---------|
| `Hilbert11OQ01.lean` | 274 | Local isotropy via `QuadraticForm.baseChange` (replaces `True` placeholders); proves `four_squares_connection` from Mathlib's `Nat.sum_four_squares` |
| `Hilbert11OQ01OQ01.lean` | 129 | Meyer's theorem from Hasse-Minkowski: every non-degenerate indefinite quadratic form over ℚ in dim ≥ 5 is isotropic |

## Evidence

**Before**: Both files merged via PRs #8741 (2026-04-03 research) and #8790 (2026-04-03 sorry fix), but never registered. PR #21499 registered the `*Aristotle.lean` Aristotle companions on 2026-05-31 but the primary OQ files were missed.

**After**: `python3 /tmp/orphan_scan_v6.py` (basename-in-PR-body filter) confirms no open PR claims either file. Both files explicitly cite slug `hilbert-11` (Hilbert's 11th Problem) and reference `Hilbert11_QuadraticForms.lean` as the parent. Slug-prefix matching missed these because primary stem is `Hilbert11_QuadraticForms`, not `Hilbert11`.

JSON validated: 4 entries in each list, both lists mirror.

---
Automated fix by lean-mechanic agent.