### PR TITLE
fix(meta): p-vs-np register 4 PNP/PvsNP orphan companions (4-batch)

### DIFF
--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -9,7 +9,11 @@
     "status": "axiomatized",
     "proofRepoPath": "Proofs/PNPBarriersUnified.lean",
     "additionalFiles": [
-      "Proofs/ComplexityCore.lean"
+      "Proofs/ComplexityCore.lean",
+      "Proofs/PNPBarriersLegacy.lean",
+      "Proofs/PNPBarriersOQ01.lean",
+      "Proofs/PNPBarriersSound.lean",
+      "Proofs/PvsNP.lean"
     ],
     "tags": [
       "computability",
@@ -135,7 +139,11 @@
     "definitionCount": 154,
     "theoremCount": 302,
     "additionalFiles": [
-      "Proofs/ComplexityCore.lean"
+      "Proofs/ComplexityCore.lean",
+      "Proofs/PNPBarriersLegacy.lean",
+      "Proofs/PNPBarriersOQ01.lean",
+      "Proofs/PNPBarriersSound.lean",
+      "Proofs/PvsNP.lean"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary
Registers four orphan Lean companion files under the `p-vs-np` slug in both `meta.additionalFiles` and `leanFile.additionalFiles`:

| File | LOC | Notes |
|------|-----|-------|
| `Proofs/PNPBarriersLegacy.lean` | 17968 | Explicitly DEPRECATED file; kept for history (unsound model trivialization documented at line ~10338) |
| `Proofs/PNPBarriersOQ01.lean` | 672 | OQ-01 algebrization-axioms variant with independent opaque oracle model |
| `Proofs/PNPBarriersSound.lean` | 6764 | Sound Gödelized formulation of the three barriers |
| `Proofs/PvsNP.lean` | 2462 | Slug-named direct formalization (illustrative Turing machine definitions) |

All four files were flagged by the orphan scanner (v6) as `NO_SLUG_MATCH | FREE` and have no other open PR claiming them.

## Why
Companion Lean files must appear in both `meta.additionalFiles` and `leanFile.additionalFiles` arrays so auditors and build tooling can find them. These four PNP*/PvsNP files share the slug-primary's `PNP*` prefix and reference `PNPBarriersUnified.lean` / `ComplexityCore.lean` in their docstrings, but were never registered.

## Metadata invariants
- `meta.proofRepoPath` unchanged: `Proofs/PNPBarriersUnified.lean`
- `meta.lineCount`/`leanFile.lineCount` preserved at `6370` (primary file convention)
- `meta.axiomCount`/`theoremCount`/`definitionCount` unchanged (only the primary's structure is enumerated in these slots; companions contribute opaque axiomatic content)
- Mirror invariant: `.meta.additionalFiles` and `.leanFile.additionalFiles` arrays identical

## Test plan
- [ ] Auditor confirms p-vs-np slug no longer reports orphan companions for PNP*/PvsNP
- [ ] No build impact (metadata-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)