### PR TITLE
fix(meta): register Newton helper orphan companions (2-batch, 2 slugs)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-02/meta.json
@@ -17,6 +17,9 @@
       "am-gm"
     ],
     "proofRepoPath": "Proofs/AmgmInequalityOQ02OQ02.lean",
+    "additionalFiles": [
+      "Proofs/NewtonLogConcavity.lean"
+    ],
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
@@ -164,6 +167,9 @@
     "theoremCount": 18,
     "definitionCount": 1,
     "path": "Proofs/AmgmInequalityOQ02OQ02.lean",
+    "additionalFiles": [
+      "Proofs/NewtonLogConcavity.lean"
+    ],
     "sorries": 0
   },
   "sections": [

--- a/src/data/proofs/newton-inductive-step/meta.json
+++ b/src/data/proofs/newton-inductive-step/meta.json
@@ -9,6 +9,9 @@
     "date": "2026",
     "status": "verified",
     "proofRepoPath": "Proofs/NewtonInductiveStep.lean",
+    "additionalFiles": [
+      "Proofs/NewtonIndStep2.lean"
+    ],
     "tags": [
       "combinatorics",
       "binomial-coefficients",
@@ -172,6 +175,9 @@
     "theoremCount": 2,
     "definitionCount": 0,
     "path": "Proofs/NewtonInductiveStep.lean",
+    "additionalFiles": [
+      "Proofs/NewtonIndStep2.lean"
+    ],
     "sorries": 0
   },
   "references": [


### PR DESCRIPTION
## Summary

Mechanic-3 N+50: register 2 orphan Lean files surfaced outside `orphan_scan_v6`'s slug-prefix heuristic. Both have unambiguous slug homes documented in their file-header docstrings.

| File (LOC) | Slug | Why this is the right home |
|---|---|---|
| `Proofs/NewtonIndStep2.lean` (117) | `newton-inductive-step` | File header: *"Newton's log-concavity inductive step: alternative proof via quadratic_nonneg."* Imports `Proofs.NewtonInductiveStep`. The parent slug's `description` already states *"Imported by AmgmInequalityOQ02OQ02 and NewtonIndStep2"*, confirming intent — only the registration was missing. |
| `Proofs/NewtonLogConcavity.lean` (121) | `amgm-inequality-oq-02-oq-02` | File header: *"Research: amgm-inequality-oq-02-oq-02. … This eliminates the last axiom in the Maclaurin inequalities formalization."* Imports `Proofs.AmgmInequalityOQ02OQ02`. Referenced by `newton-inductive-step-oq-02/meta.json` section content (`NewtonLogConcavity.cross_product_of_log_concave`). |

## Why these were missed

`orphan_scan_v6.py` matches orphans by checking whether the bare stem starts with a known `proofRepoPath` stem. Both files break that heuristic — `NewtonIndStep2` does not start with `NewtonInductiveStep`'s stem prefix (the `2` follows `Step`, not `InductiveStep`), and `NewtonLogConcavity` shares no prefix with `AmgmInequalityOQ02OQ02`. Bodies/descriptions of the parent metas mention them, which is how I found them.

## Convention

Per `project_mechanic_additionalfiles_format_convention.md` and `project_mechanic_leanfile_additionalfiles_mirror.md`, each addition appears in both `meta.additionalFiles` and `leanFile.additionalFiles` as a plain string. No code edits; pure metadata registration.

## Test plan

- [x] `jq .` validates both meta.json files
- [x] Diff is +12 lines / 2 files; no functional changes
- [x] No open PR claims either slug (`gh pr list --search`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)