### PR TITLE
fix(meta): register 3 NO_SLUG_MATCH orphan companions (3-batch, 3 slugs)

### DIFF
--- a/src/data/proofs/erdos-szekeres/meta.json
+++ b/src/data/proofs/erdos-szekeres/meta.json
@@ -46,7 +46,10 @@
     "lineCount": 280,
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/RamseyHypergraph.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Paul Erdős and George Szekeres proved this theorem in 1935 in their paper \"A combinatorial problem in geometry.\" It was one of Erdős's first major results, published when he was just 22 years old. The theorem arose from the Happy Ending Problem about convex polygons and has since become a cornerstone of combinatorics and Ramsey theory. The elegant pigeonhole proof gives an exact tight bound. Dilworth's theorem (1950) generalized it: in any finite partially ordered set, the minimum number of chains covering it equals the maximum antichain size; the Erdős-Szekeres theorem is the linear order special case. The result is also a foundational instance of the general Ramsey principle that any large enough structure must contain order.",
@@ -222,7 +225,10 @@
     "theoremCount": 8,
     "definitionCount": 6,
     "path": "Proofs/ErdosSzekeres.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/RamseyHypergraph.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/legendre-partial/meta.json
+++ b/src/data/proofs/legendre-partial/meta.json
@@ -35,7 +35,10 @@
     "assumptions": "1 axiom(s) encoding mathematical hypotheses. See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 21,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/LegendreGapEquivalence.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Adrien-Marie Legendre stated this conjecture in his *Essai sur la Théorie des Nombres* (1798), the same work that introduced the prime counting function approximation $\\pi(x) \\approx x/(\\ln x - 1.08366)$. The conjecture asks whether every interval $(n^2, (n+1)^2)$ contains at least one prime — a natural question about the regularity of prime distribution near perfect squares.\n\nThe conjecture sits in a hierarchy of progressively stronger statements about prime gaps. Bertrand's postulate — a prime exists in $(n, 2n)$ — was conjectured by Bertrand (1845) and proved by Chebyshev (1852), with an elegant proof later given by Erdős (1932) at age 19. Legendre's conjecture is strictly stronger: the interval $(n^2, (n+1)^2)$ has length $2n$, much shorter than $(n, 2n)$'s length $n$ when measured relative to the numbers involved. Oppermann's conjecture (1882) is stronger still: it asserts primes in both $(n^2, n^2 + n)$ and $(n^2 + n, (n+1)^2)$, splitting Legendre's interval in half.\n\nThe best unconditional progress toward Legendre is due to Baker, Harman, and Pintz (2001), who proved there is always a prime in $(x, x + x^{0.525})$ for sufficiently large $x$. For $x = n^2$, this gives a prime in $(n^2, n^2 + n^{1.05})$, which is contained in $(n^2, (n+1)^2)$ for large $n$ — so the BHP result actually implies Legendre's conjecture asymptotically. Earlier milestones include Ingham (1937) who proved a prime in $(x, x + x^{5/8})$, and Huxley (1972) who improved this to $x^{7/12}$.\n\nUnder the Riemann Hypothesis, much stronger results hold: von Koch (1901) showed that the prime gap near $x$ is $O(\\sqrt{x} \\log x)$, which for $x = n^2$ gives gaps of $O(n \\log n)$ — far smaller than the Legendre interval's length $2n$. So the Riemann Hypothesis implies Legendre's conjecture.\n\nComputationally, Legendre's conjecture has been verified for $n$ up to at least $10^{18}$. The conjecture is closely related to Andrica's conjecture (1985): $\\sqrt{p_{n+1}} - \\sqrt{p_n} < 1$, which is equivalent to asserting that consecutive primes never straddle a perfect square — precisely Legendre's claim.",
@@ -128,7 +131,10 @@
     "theoremCount": 21,
     "definitionCount": 3,
     "path": "Proofs/LegendrePartial.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LegendreGapEquivalence.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/unit-distance-independence/meta.json
+++ b/src/data/proofs/unit-distance-independence/meta.json
@@ -25,6 +25,7 @@
     "theoremCount": 65,
     "definitionCount": 12,
     "additionalFiles": [
+      "Proofs/UnitDistanceHN7.lean",
       "Proofs/UnitDistanceHN7Aristotle.lean"
     ],
     "originalContributions": [
@@ -79,6 +80,7 @@
     "path": "Proofs/UnitDistanceIndependence.lean",
     "sorries": 0,
     "additionalFiles": [
+      "Proofs/UnitDistanceHN7.lean",
       "Proofs/UnitDistanceHN7Aristotle.lean"
     ]
   },


### PR DESCRIPTION
## Summary

Register 3 orphan Lean files whose basenames don't match any gallery slug prefix
(NO_SLUG_MATCH FREE branch of `orphan_scan_v6`), but whose **file-header content**
unambiguously identifies the natural parent slug.

| Orphan file | Parent slug | Signal |
|---|---|---|
| `Proofs/UnitDistanceHN7.lean` | `unit-distance-independence` | Aristotle companion `UnitDistanceHN7Aristotle.lean` already registered; only the 287-LOC main HN7 implementation was missing |
| `Proofs/LegendreGapEquivalence.lean` | `legendre-partial` | Header: "Legendre's Conjecture: Equivalent Gap and Distance Forms" — same topic as parent's `LegendrePartial.lean` |
| `Proofs/RamseyHypergraph.lean` | `erdos-szekeres` | Header self-identifies as "Ramsey Numbers for k-Uniform Hypergraphs (OQ-03 of erdos-szekeres)"; no separate `erdos-szekeres-oq-03` slug exists |

Each addition mirrors into both `.meta.additionalFiles` and
`.leanFile.additionalFiles` per Mechanic convention.

Pure metadata change — no Lean source modifications.

## Test plan

- [x] `python3 /tmp/orphan_scan_v6.py` produced the 3 candidates as `NO_SLUG_MATCH|FREE`
- [x] Each file inspected; header content matches the parent slug's mathematical topic
- [x] No competing open PRs touch any of the 3 target meta.json files (rechecked just before commit)
- [x] All 3 meta.json files parse as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)