### PR TITLE
fix(meta): register 3 NO_SLUG_MATCH orphan companions v2 (3-batch, 3 slugs)

### DIFF
--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -43,7 +43,10 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/BuffonsNoodle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Buffon's Needle Problem was posed by Georges-Louis Leclerc, Comte de Buffon in his 1777 *Essai d'arithmétique morale*, making it one of the earliest problems in geometric probability. Buffon was a polymath — naturalist, mathematician, and director of the Jardin du Roi — who used this problem to explore the foundations of probability theory. The elegant answer $P = 2\\ell/(\\pi d)$ stunned contemporaries: how could $\\pi$, a geometric constant, arise from a probability calculation about random needle drops? Pierre-Simon Laplace recognized its deeper significance and connected it to what we now call integral geometry. In 1812, Laplace used the needle experiment to propose one of the first Monte Carlo methods for estimating $\\pi$: drop $n$ needles, count $k$ crossings, then $\\pi \\approx 2\\ell n/(kd)$. The Italian mathematician Mario Lazzarini claimed in 1901 to have estimated $\\pi$ to six decimal places with 3,408 throws — a result widely suspected to be fabricated, as the ratio $355/113$ (an excellent rational approximation to $\\pi$) fits suspiciously well. In the 20th century, Augustin-Louis Cauchy and later Mark Kac generalized Buffon's result to the Cauchy-Crofton formula, which relates the length of any rectifiable curve to its expected number of intersections with random lines, founding the field of integral geometry.",
@@ -222,7 +225,10 @@
     "theoremCount": 9,
     "definitionCount": 3,
     "path": "Proofs/BuffonsNeedle.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/BuffonsNoodle.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/ehrhart-cube-proven/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven/meta.json
@@ -48,7 +48,10 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 1
+    "definitionCount": 1,
+    "additionalFiles": [
+      "Proofs/EhrhartPolynomials.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Eugène Ehrhart (1912–2000) was a French mathematician who, while teaching at a lycée, spent the 1950s and 1960s studying lattice points in dilated polytopes. His key discovery — published in the 1962 paper *Sur les polyèdres rationnels homothétiques à n dimensions* — was that for any convex lattice polytope $P$, the function $n \\mapsto |nP \\cap \\mathbb{Z}^d|$ is a polynomial in $n$ of degree $\\dim P$, now called the **Ehrhart polynomial** $L(P, n)$.\n\nThe story of the unit cube is elementary: $n \\cdot [0,1]^d = [0,n]^d$ contains exactly $\\{0, 1, \\ldots, n\\}^d$ integer points, giving $(n+1)^d$. This is the simplest instance of Ehrhart's theorem — a polynomial of degree $d$ with leading coefficient $\\text{vol}([0,1]^d) = 1$ (the normalized volume), constant term 1, and all coefficients given by the binomial formula $\\binom{d}{k}$. The formula $(n+1)^d = \\sum_{k=0}^d \\binom{d}{k} n^k$ is just the binomial theorem.\n\nThe deeper structural results for the cube follow equally directly. The **interior lattice point polynomial** $L^*([0,1]^d, n) = (n-1)^d$ is the Ehrhart polynomial evaluated at $-n$ with a sign: $(-1)^d(1-n)^d = (n-1)^d$, confirming **Ehrhart-Macdonald reciprocity** (1971), which Ian Macdonald proved for all lattice polytopes. **Pick's theorem** (1899), Georg Pick's classical formula Area $= I + B/2 - 1$ for lattice polygons, appears as a specialization to $d=2$: the Ehrhart polynomial $(n+1)^2 = n^2 + 2n + 1$ encodes area (leading coefficient $n^2$), boundary (linear term $2n$, contributing $B/2 = 2n/2 = n$ boundary points per unit dilation), and Euler characteristic (constant 1).\n\nEhrhart's work was initially largely ignored — he was not in an academic research position and published primarily in the *Comptes Rendus*. Recognition came slowly: Richard Stanley's 1980 connection of Ehrhart theory to commutative algebra (via the Hilbert series of the associated graded ring), and Barvinok's 1994 polynomial-time algorithm for counting lattice points in polytopes of fixed dimension, transformed Ehrhart theory into a central tool in combinatorics, optimization, and algebraic geometry. Today it underpins integer programming via the theory of Ehrhart $h^*$-polynomials and applications to scheduling, network flows, and the geometry of numbers.",
@@ -144,7 +147,10 @@
     "theoremCount": 26,
     "definitionCount": 1,
     "path": "Proofs/EhrhartCubeProven.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/EhrhartPolynomials.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-1/meta.json
+++ b/src/data/proofs/erdos-1/meta.json
@@ -57,7 +57,8 @@
     "theoremCount": 3,
     "definitionCount": 2,
     "additionalFiles": [
-      "Proofs/Erdos1OQ03Aristotle.lean"
+      "Proofs/Erdos1OQ03Aristotle.lean",
+      "Proofs/Erdos1Wip01.lean"
     ]
   },
   "overview": {
@@ -232,7 +233,8 @@
     "path": "Proofs/Erdos1Problem.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos1OQ03Aristotle.lean"
+      "Proofs/Erdos1OQ03Aristotle.lean",
+      "Proofs/Erdos1Wip01.lean"
     ]
   },
   "sorries": 0


### PR DESCRIPTION
## Summary
Three Lean files in `proofs/Proofs/` were not registered in any meta.json's `additionalFiles` array but unambiguously extend existing gallery slugs (each already referenced by name in sibling OQ-slug descriptions or `mathlibDependencies`):

- **erdos-1**: `Proofs/Erdos1Wip01.lean` — powers-of-2 DSS construction. Referenced from `erdos-1-oq-03` `mathlibDependencies` as `Erdos1Wip01.dss_existence` closing the `minDSSBound` sorry.
- **buffons-needle**: `Proofs/BuffonsNoodle.lean` — smooth axiomatization. Referenced from `buffons-needle-oq-01/-01-01/-01-01-01/-02/-02-02` descriptions as the precursor whose axioms were eliminated downstream.
- **ehrhart-cube-proven**: `Proofs/EhrhartPolynomials.lean` — general Ehrhart axiomatization. Referenced from `ehrhart-cube-proven-oq-01` `mathlibDependencies` as the polytope-existence axiom.

Each file added to both `meta.additionalFiles` and `leanFile.additionalFiles` (string form per gallery convention; auditor follows strings only).

## Test plan
- [x] Diff inspected — 3 meta.json files; +20/-6 lines
- [x] No Lean source changes (doc-only metadata)
- [x] String form used in both arrays (auditor convention)
- [x] Each orphan file's content confirmed thematically matches the assigned slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)