### PR TITLE
fix(meta): register 5 NO_SLUG_MATCH orphan companions (5-batch, 5 slugs)

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -10,7 +10,8 @@
     "status": "verified",
     "proofRepoPath": "Proofs/AMGMInequality.lean",
     "additionalFiles": [
-      "Proofs/AMGMInequalityAristotle.lean"
+      "Proofs/AMGMInequalityAristotle.lean",
+      "Proofs/AMGMOperatorMeans.lean"
     ],
     "tags": [
       "analysis",
@@ -314,7 +315,8 @@
     "path": "Proofs/AMGMInequality.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/AMGMInequalityAristotle.lean"
+      "Proofs/AMGMInequalityAristotle.lean",
+      "Proofs/AMGMOperatorMeans.lean"
     ]
   },
   "mainTheorems": [

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -43,10 +43,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 3,
-    "additionalFiles": [
-      "Proofs/BuffonsNoodle.lean"
-    ]
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Buffon's Needle Problem was posed by Georges-Louis Leclerc, Comte de Buffon in his 1777 *Essai d'arithmétique morale*, making it one of the earliest problems in geometric probability. Buffon was a polymath — naturalist, mathematician, and director of the Jardin du Roi — who used this problem to explore the foundations of probability theory. The elegant answer $P = 2\\ell/(\\pi d)$ stunned contemporaries: how could $\\pi$, a geometric constant, arise from a probability calculation about random needle drops? Pierre-Simon Laplace recognized its deeper significance and connected it to what we now call integral geometry. In 1812, Laplace used the needle experiment to propose one of the first Monte Carlo methods for estimating $\\pi$: drop $n$ needles, count $k$ crossings, then $\\pi \\approx 2\\ell n/(kd)$. The Italian mathematician Mario Lazzarini claimed in 1901 to have estimated $\\pi$ to six decimal places with 3,408 throws — a result widely suspected to be fabricated, as the ratio $355/113$ (an excellent rational approximation to $\\pi$) fits suspiciously well. In the 20th century, Augustin-Louis Cauchy and later Mark Kac generalized Buffon's result to the Cauchy-Crofton formula, which relates the length of any rectifiable curve to its expected number of intersections with random lines, founding the field of integral geometry.",
@@ -225,10 +222,7 @@
     "theoremCount": 9,
     "definitionCount": 3,
     "path": "Proofs/BuffonsNeedle.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/BuffonsNoodle.lean"
-    ]
+    "sorries": 0
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -43,7 +43,10 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/BuffonsNoodle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Buffon's Needle Problem was posed by Georges-Louis Leclerc, Comte de Buffon in his 1777 *Essai d'arithmétique morale*, making it one of the earliest problems in geometric probability. Buffon was a polymath — naturalist, mathematician, and director of the Jardin du Roi — who used this problem to explore the foundations of probability theory. The elegant answer $P = 2\\ell/(\\pi d)$ stunned contemporaries: how could $\\pi$, a geometric constant, arise from a probability calculation about random needle drops? Pierre-Simon Laplace recognized its deeper significance and connected it to what we now call integral geometry. In 1812, Laplace used the needle experiment to propose one of the first Monte Carlo methods for estimating $\\pi$: drop $n$ needles, count $k$ crossings, then $\\pi \\approx 2\\ell n/(kd)$. The Italian mathematician Mario Lazzarini claimed in 1901 to have estimated $\\pi$ to six decimal places with 3,408 throws — a result widely suspected to be fabricated, as the ratio $355/113$ (an excellent rational approximation to $\\pi$) fits suspiciously well. In the 20th century, Augustin-Louis Cauchy and later Mark Kac generalized Buffon's result to the Cauchy-Crofton formula, which relates the length of any rectifiable curve to its expected number of intersections with random lines, founding the field of integral geometry.",
@@ -222,7 +225,10 @@
     "theoremCount": 9,
     "definitionCount": 3,
     "path": "Proofs/BuffonsNeedle.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/BuffonsNoodle.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-02/meta.json
@@ -66,7 +66,10 @@
     "assumptions": "2 axiom(s): hadamard_three_lines, riesz_thorin. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 28,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/HadamardThreeLines.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Riesz-Thorin Interpolation (1927/1948)**\n\nMarcel Riesz proved the first interpolation theorem for bilinear forms in 1927. Olof Thorin simplified and extended the proof in 1948 using the Hadamard three-lines lemma from complex analysis.\n\nThe theorem states: if a linear operator T is bounded from $L^{p_0}$ to $L^{q_0}$ with norm $M_0$, and from $L^{p_1}$ to $L^{q_1}$ with norm $M_1$, then for any $\\theta \\in [0,1]$, T is bounded from $L^{p_\\theta}$ to $L^{q_\\theta}$ with norm $\\leq M_0^{1-\\theta} \\cdot M_1^\\theta$, where the interpolated exponents satisfy $1/p_\\theta = (1-\\theta)/p_0 + \\theta/p_1$.\n\n**Connection to Hölder**: Hölder's inequality provides the endpoint estimates (the $M_0$ and $M_1$ bounds), while the three-lines lemma provides the interpolation between endpoints.",
@@ -209,7 +212,10 @@
     "theoremCount": 28,
     "definitionCount": 8,
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ02.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/HadamardThreeLines.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
@@ -56,7 +56,10 @@
     "assumptions": "3 axiom(s): gnedenko_kolmogorov_forward, gnedenko_kolmogorov_gaussian, gnedenko_kolmogorov_converse. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 55,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/GnedenkoKolmogorov.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Central Limit Theorem, first rigorously proved by Lyapunov (1901) and Lindeberg (1922), characterizes Gaussian limits for sums of independent random variables with finite variance. The natural question — what happens when variance is infinite? — was resolved by Boris Gnedenko and Andrey Kolmogorov in their 1954 monograph 'Limit Distributions for Sums of Independent Random Variables.' They proved that every possible limit law for normalized sums must be a stable distribution, parameterized by an index $\\alpha \\in (0, 2]$, and that membership in the domain of attraction of $S_\\alpha$ is completely characterized by regularly varying tails. The theory rests on Jovan Karamata's (1930) framework of slowly and regularly varying functions, which provides the precise language for 'power-law tails with logarithmic corrections.' Paul Lévy (1925) had independently discovered stable distributions via characteristic function methods. William Feller's treatment in Volume 2 of his probability textbook (1971) made the theory accessible to a broad audience. The formalization here builds the Karamata framework from scratch in Lean 4 and axiomatizes the deep analytic core (Lévy continuity theorem, Abelian-Tauberian connections) while fully proving the algebraic and structural results.",
@@ -248,7 +251,10 @@
     "theoremCount": 55,
     "definitionCount": 8,
     "path": "Proofs/CentralLimitTheoremOQ01OQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/GnedenkoKolmogorov.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -45,7 +45,10 @@
     ],
     "mathlib_version": "4.26.0",
     "theoremCount": 15,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/FourSquareRepresentations.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Lagrange's four squares theorem was proved by Joseph-Louis Lagrange in 1770, building on earlier work by Euler. The result answered a question that had puzzled mathematicians since antiquity: Diophantus had noted around 250 CE that certain numbers seemed to require many squares.\n\nThe deeper story involves one of mathematics' greatest coincidences: Euler discovered the four-square identity in 1748, showing that the product of two sums-of-four-squares is itself a sum of four squares. Nearly a century later, Hamilton discovered quaternions in 1843. The four-square identity IS quaternion multiplication! The norm of a product equals the product of norms.\n\nThis explains WHY four squares work when three don't: quaternions form a division algebra, but there is no 3-dimensional division algebra (proved by Frobenius in 1877). The algebraic structure that makes four squares work simply doesn't exist for three.\n\nAs one reviewer put it: \"The four squares theorem is astounding, it says something utterly profound about the universe... that's what binds the galaxies together.\"",
@@ -181,7 +184,10 @@
     "theoremCount": 15,
     "definitionCount": 9,
     "path": "Proofs/LagrangeFourSquares.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FourSquareRepresentations.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/prob-method-lovasz-local/meta.json
+++ b/src/data/proofs/prob-method-lovasz-local/meta.json
@@ -54,7 +54,10 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 25,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/MoserTardos.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Lovasz Local Lemma (LLL), proved by Paul Erdos and Laszlo Lovasz in 1975, is widely regarded as the crown jewel of the probabilistic method. It addresses a fundamental limitation of the basic probabilistic method: when bad events are not independent, the naive union bound can be far too pessimistic.\n\nThe LLL shows that if each bad event has small probability and is independent of most other bad events, then with positive probability none of the bad events occur. The precise condition involves a dependency graph: each event must be independent of all events not in its neighborhood, and the probabilities must satisfy a system of inequalities involving the graph structure.\n\nThe symmetric form of the LLL is especially elegant: if each event has probability at most p and depends on at most d other events, and if ep(d+1) <= 1 (where e is Euler's number), then all bad events can be simultaneously avoided. This clean criterion is remarkably powerful.\n\nIn 2010, Moser and Tardos gave a constructive proof of the LLL via a resampling algorithm, resolving a long-standing question about whether the non-constructive existence proof could be made algorithmic. Their proof showed that repeated resampling of violated constraints converges rapidly.",
@@ -209,7 +212,10 @@
     "theoremCount": 25,
     "definitionCount": 3,
     "path": "Proofs/LovaszLocalLemma.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/MoserTardos.lean"
+    ]
   },
   "references": [
     {


### PR DESCRIPTION
## Summary

Register 5 orphan Lean files whose basenames don't match any gallery slug
prefix (`NO_SLUG_MATCH` FREE branch of `orphan_scan_v6`), but whose **file-header
content** unambiguously identifies the natural parent slug.

> **Note on PR #21998 overlap:** Original 6-batch included `BuffonsNoodle.lean → buffons-needle`,
> but mechanic-3 PR #21998 ships the identical diff. Dropped from this PR to avoid race;
> reduces to 5-batch.

| Orphan file | Parent slug | Signal in file header |
|---|---|---|
| `Proofs/GnedenkoKolmogorov.lean` | `central-limit-theorem-oq-01-oq-01` | "Research problem: central-limit-theorem-oq-01-oq-01 / Parent proof: CentralLimitTheoremOQ01.lean" |
| `Proofs/MoserTardos.lean` | `prob-method-lovasz-local` | "OQ-01-A scaffold for `prob-method-lovasz-local-oq-01`" — defers to base slug since `-oq-01` child does not exist |
| `Proofs/HadamardThreeLines.lean` | `cauchy-schwarz-integral-oq-01-oq-02` | "Prior: axiom `riesz_thorin` (in CauchySchwarzIntegralOQ01OQ02.lean) ... Riesz-Thorin derivable from three_lines" |
| `Proofs/AMGMOperatorMeans.lean` | `amgm-inequality` | "Operator AM-GM Inequality: Generalization to Matrix Means" — direct extension of `AMGMInequality.lean` |
| `Proofs/FourSquareRepresentations.lean` | `lagrange-four-squares` | "Distribution of Four-Square Representations" formalizing Jacobi $r_4(n)$ — direct counting refinement of the parent's existence theorem |

Each addition mirrors into both `.meta.additionalFiles` and
`.leanFile.additionalFiles` per Mechanic convention.

Pure metadata change — no Lean source modifications.

## Test plan

- [x] `python3 /tmp/orphan_scan_v6.py` produced all 5 as `NO_SLUG_MATCH|FREE`
- [x] Each file inspected; header content matches the parent slug's mathematical topic
- [x] PR #21998 overlap detected and dropped (BuffonsNoodle → buffons-needle was shared)
- [x] No competing open PRs touch the remaining 5 target meta.json files
- [x] All 5 meta.json files parse as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)