### PR TITLE
fix(meta): register 3 NO_SLUG_MATCH companions across 2 slugs (3-batch)

### DIFF
--- a/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
+++ b/src/data/proofs/chinese-remainder-constructive-oq-04-oq-03/meta.json
@@ -9,7 +9,8 @@
     "status": "verified",
     "proofRepoPath": "Proofs/ChineseRemainderNonCoprimeList.lean",
     "additionalFiles": [
-      "Proofs/ChineseRemainderConstructiveOQ04OQ03.lean"
+      "Proofs/ChineseRemainderConstructiveOQ04OQ03.lean",
+      "Proofs/ChineseRemainderExplicitOQ04OQ03OQ01.lean"
     ],
     "tags": [
       "number-theory",
@@ -155,7 +156,8 @@
     "path": "Proofs/ChineseRemainderNonCoprimeList.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/ChineseRemainderConstructiveOQ04OQ03.lean"
+      "Proofs/ChineseRemainderConstructiveOQ04OQ03.lean",
+      "Proofs/ChineseRemainderExplicitOQ04OQ03OQ01.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/halting-problem/meta.json
+++ b/src/data/proofs/halting-problem/meta.json
@@ -32,6 +32,10 @@
     "axiomCount": 0,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "proofRepoPath": "Proofs/HaltingProblem.lean",
+    "additionalFiles": [
+      "Proofs/RelativizedHalting.lean",
+      "Proofs/RelativizedHaltingBridge.lean"
+    ],
     "mathlib_version": "4.26.0",
     "lineCount": 172,
     "theoremCount": 5,
@@ -239,7 +243,11 @@
     "opens": [],
     "path": "Proofs/HaltingProblem.lean",
     "sorries": 0,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/RelativizedHalting.lean",
+      "Proofs/RelativizedHaltingBridge.lean"
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Summary
Registers three previously unhomed Lean orphan files into two gallery slugs:

- **chinese-remainder-constructive-oq-04-oq-03**: `ChineseRemainderExplicitOQ04OQ03OQ01.lean`
  - File header: `Source: chinese-remainder-constructive-oq-04-oq-03-oq-01`
  - Sub-companion (OQ-04→OQ-03→OQ-01 sub-problem of the parent slug)

- **halting-problem**: `RelativizedHalting.lean` + `RelativizedHaltingBridge.lean`
  - Both file headers tie to `halting-problem-OQ-03` (sub-goal OQ-03a / S4 ACT-C)
  - No `halting-problem-oq-03` standalone slug exists; parent slug is the canonical home

## Why
v6 NO_SLUG_MATCH scan surfaced 21 FREE orphans whose basenames don't match any meta `proofRepoPath` primary. This batch drains 3 by inferring the home slug from each file's docstring header.

Both `meta.additionalFiles` (auditor-tracked, strings) and `leanFile.additionalFiles` (rich data) updated per existing convention.

## Test plan
- [x] JSON parses cleanly (`python3 -c "import json; json.load(...)"` both files)
- [x] `meta.additionalFiles` are string arrays (auditor convention)
- [x] `leanFile.additionalFiles` mirrors meta (per convention)
- [x] Diff small (+13/-3, metadata-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)