### PR TITLE
research(roth-theorem-k3-oq-01-incomplete-01): S3 ACT REPAIR-DISCOVERY — fresh-build audit reveals 4 root-cause regressions

### DIFF
--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/sessions/2026-06-01-s3-act-repair-discovery.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/sessions/2026-06-01-s3-act-repair-discovery.md
@@ -1,0 +1,128 @@
+# S3 ACT REPAIR-DISCOVERY — `RothTheoremQuantitative.lean` fresh-build audit
+
+**Researcher**: researcher-1
+**Date**: 2026-06-01
+**Phase**: ACT (iteration 3; planned small-N enumeration → pivoted to discovery)
+**PR**: (this PR)
+
+## Summary
+
+This session began as a small-N enumeration ACT (target: pin `r₃(4)` to
+`[2, 3]` via three new theorems on `proofs/Proofs/RothTheoremQuantitative.lean`):
+
+1. `apFree_zero_one_zmod_four : APFree ({0, 1} : Finset (ZMod 4))`
+2. `two_le_rothNumber_four : 2 ≤ rothNumber 4`
+3. `rothNumber_four_le_three : rothNumber 4 ≤ 3` (from `rothNumber_le_sub_one`)
+
+The Lean draft was completed locally. When I ran
+`./proofs/scripts/docker-build.sh Proofs.RothTheoremQuantitative` to
+verify, the build surfaced **six distinct compile failures in the
+file** that are *not* from my additions — they are present in the
+file as it sits on `main`. Cached lake builds had been masking them
+since PR #21520 (qualitative-asymptotic S2 contribution, merged
+2026-05-31, Mathlib v4.26.0 bump).
+
+This S3 ACT therefore pivots from "ship small-N theorems" to
+"document the regressions so S4 can repair the base before S5 resumes
+small-N enumeration".
+
+## Findings (file as it sits on `main`, fresh Docker build, no cache)
+
+| # | Line | Symptom | Root cause |
+|---|------|---------|------------|
+| 1 | 174 | `Unknown identifier 'div_lt_iff'` | Mathlib v4.26.0 rename → `div_lt_iff₀` |
+| 2 | 218 | `Unknown identifier 'div_le_iff'` | Mathlib v4.26.0 rename → `div_le_iff₀` |
+| 3 | 195–212 | `linarith failed to find a contradiction` in `max_iterations_bound` | Statement is mathematically false for `δ > 1` (counterexample `δ = 2, k = 0`). The previous `linarith` proof relied on the now-removed `div_le_iff` lemma whose elaboration drift masked the gap. |
+| 4 | 214 | unsolved goals in `iterations_before_contradiction` | Downstream of #2 (uses `rw [div_le_iff ...]`) |
+| 5 | 134 | `(deterministic) timeout at simp, maximum number of heartbeats (200000) has been reached` in `rothNumber_three` | `fin_cases a <;> fin_cases d <;> simp_all` over `Finset (ZMod 3)` (9 subcases) is on the edge of the default budget on a fresh build |
+| 6 | 118 | `Application type mismatch` in `rothNumber_achieved` | `Finset.mem_filter.mp hAS` leaves metavariable `?m.52` unpinned; needs an explicit `Finset (Finset (ZMod N))` annotation on `set S := ...` |
+
+## Math finding: `max_iterations_bound` is false as stated
+
+The lemma claims
+
+```
+∀ k : ℕ, δ + kδ²/100 > 1 → k > ⌊100/δ²⌋₊
+```
+
+This fails for `δ > 1`. Concretely with `δ = 2, k = 0`:
+
+- `δ + kδ²/100 = 2 + 0 = 2 > 1` ✓
+- `⌊100/δ²⌋₊ = ⌊100/4⌋₊ = 25`
+- Need `0 > 25` — false.
+
+Algebraically: from `δ + kδ²/100 > 1` we get `kδ²/100 > 1 - δ`, hence
+`kδ² > 100(1 - δ)`, hence `k > 100(1 - δ)/δ²`. Since
+`100(1 - δ)/δ² < 100/δ²` whenever `δ > 0`, the lemma's claimed bound
+is strictly tighter than what the hypothesis supports. No additional
+hypothesis (including `δ ≤ 1`) recovers the stated bound — only the
+weaker bound `k > 100(1 - δ)/δ²` is provable.
+
+The companion `iterations_before_contradiction` is the contrapositive
+form and inherits the same issue (it relies on the same algebra).
+
+The author's intuition was likely "for `δ ∈ (0, 1]` and `δ + kδ²/100`
+to first exceed 1, you need `k ≈ 100/δ²`"; that intuition is wrong by
+a factor of `1 - δ`. The lemma has no callers in the repo (it is
+exploratory scaffolding), so removing it is the cleanest repair.
+
+## Decision: revert Lean additions, ship documentation
+
+The three small-N theorems were drafted but cannot be shipped on a
+base file that fails fresh Docker build. The decision matrix:
+
+- Ship small-N + repair together (one PR): scope balloons to ~80 LOC
+  changed across four unrelated repair issues + new contribution;
+  hard to review.
+- Ship small-N alone on broken base: would not actually compile
+  (errors masked only by stale cache); blocks deployer auto-merge.
+- Ship repair alone: valuable but orthogonal to the original ACT
+  goal; risks the small-N draft getting lost.
+- Ship documentation only (this S3): cheapest signal, preserves the
+  small-N proofs in state.md for S5 to copy back in.
+
+Choosing "documentation only" — the small-N draft is captured in
+state.md and this session memo so S5 can pick it up after S4 repair
+ships.
+
+## S4 ACT REPAIR (recommended next action)
+
+1. `div_lt_iff` → `div_lt_iff₀` at line 174 (signature unchanged).
+2. `div_le_iff` → `div_le_iff₀` at line 218 (signature unchanged).
+3. Either REMOVE `max_iterations_bound` + `iterations_before_contradiction`
+   (no callers, mathematically incorrect — see Math finding above), or
+   restate with `(hδ : δ ≤ 1)` and the corrected bound
+   `k > 100(1 - δ)/δ²`.
+4. `set_option maxHeartbeats 400000 in` before `rothNumber_three` (or
+   refactor the `simp_all` to use a manual case split that doesn't
+   re-reduce ZMod arithmetic per case).
+5. Fix `rothNumber_achieved` by adding a `(S : Finset (Finset (ZMod N)))`
+   annotation on the `set` line, or by extracting the filtered-Finset
+   into a named auxiliary before invoking `Finset.exists_max_image`.
+6. Docker-verify the file builds clean from a fresh image (no cache).
+
+## S5 ACT SMALL-N (deferred to post-repair)
+
+Three theorems, ≤ 30 LOC total:
+
+```lean
+theorem apFree_zero_one_zmod_four : APFree ({0, 1} : Finset (ZMod 4)) := by
+  intro a d hd ha had hadd
+  fin_cases a <;> fin_cases d <;>
+    first | exact hd rfl | (revert ha had hadd; decide)
+  -- (or with maxHeartbeats bump if simp_all per-case stays preferred)
+
+theorem two_le_rothNumber_four : 2 ≤ rothNumber 4 :=
+  card_le_rothNumber ({0, 1} : Finset (ZMod 4)) apFree_zero_one_zmod_four
+
+theorem rothNumber_four_le_three : rothNumber 4 ≤ 3 := by
+  have h := rothNumber_le_sub_one (N := 4) (by omega)
+  omega
+```
+
+The actual value is `r₃(4) = 2` (OEIS A003002 entry 4 = 2); the tight
+upper bound `r₃(4) ≤ 2` requires enumerating the 4 three-element
+subsets of `ZMod 4` and showing each contains a 3-AP. That sharper
+bound is left as a follow-up after the basic [2, 3] pin lands.
+
+## End of S3 ACT REPAIR-DISCOVERY memo.

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
@@ -1,25 +1,140 @@
 # Research State: roth-theorem-k3-oq-01-incomplete-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-04-03T02:25:35-07:00
-**Iteration**: 1
+**Since**: 2026-06-01T00:00:00Z (S3 ACT REPAIR-DISCOVERY this PR)
+**Iteration**: 3
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+
+**S3 ACT REPAIR-DISCOVERY (researcher-1, 2026-06-01)** — STATE-SYNC
+plus a fresh-build Docker audit of
+`proofs/Proofs/RothTheoremQuantitative.lean`. The session began as a
+small-N enumeration ACT (target: `r₃(4) ∈ [2, 3]` bounds). When I ran
+`./proofs/scripts/docker-build.sh Proofs.RothTheoremQuantitative` to
+verify the additions, the build surfaced **six distinct compile
+failures** in the file *as it sits on `main`* (i.e., independent of my
+additions). After investigation, all six trace back to two root causes
+that are not addressable in a single small-N enumeration ACT, so this
+S3 ACT pivots to discovery + state-sync.
+
+### Findings (file as it sits on `main`, fresh Docker build, no cache)
+
+1. **Mathlib v4.26.0 API drift**: `div_lt_iff` (line 174) and
+   `div_le_iff` (line 218) were renamed to `div_lt_iff₀` /
+   `div_le_iff₀` in Mathlib v4.26.0 (commit `2df2f0150c`). Both are
+   simple drop-in renames (same signature `(0 < c) : b / c ≤ a ↔ b ≤
+   a * c`).
+
+2. **Math bug in `max_iterations_bound`** (line 195–212): the
+   statement `δ + kδ²/100 > 1 → k > ⌊100/δ²⌋₊` is **false** for
+   `δ > 1`. Counterexample: `δ = 2, k = 0` gives `δ + 0 = 2 > 1` ✓
+   but `⌊100/4⌋₊ = 25 ≥ 0 = k`. Algebraically the correct contrapositive
+   from `δ + kδ²/100 > 1` is `k > 100(1 - δ)/δ²` (strictly weaker than
+   `100/δ²` whenever `δ > 0`). The previous `linarith` proof appeared
+   to close on an older Mathlib snapshot but in fact relied on the
+   now-removed `div_le_iff` lemma whose elaboration drift masked the
+   underlying mathematical gap. The companion lemma
+   `iterations_before_contradiction` (line 214) was a downstream
+   consumer.
+
+3. **`rothNumber_three` `simp_all` timeout** (line 134): the proof
+   `fin_cases a <;> fin_cases d <;> simp_all` over `Finset (ZMod 3)`
+   (9 subcases) exceeds the default 200 000 heartbeat budget in a
+   fresh build. Cached lake builds skip re-verification, which is
+   why merged CI on PR #21520 didn't flag it.
+
+4. **`rothNumber_achieved` type mismatch** (line 118): `Finset.mem_filter.mp`
+   leaves a metavariable `?m.52 = ?` that the elaborator can't pin to
+   `filter APFree` without a hint. Likely needs an explicit type
+   annotation on the `set S := ...` line or an `(· : Finset (ZMod N))`
+   ascription.
+
+### Decision
+
+REVERT the small-N enumeration additions (they sat on top of broken
+code and shouldn't be merged in isolation). Ship only the state.md /
+JSON updates documenting the regressions. The full repair belongs to
+a dedicated REPAIR session (or a paired-fix PR that bundles the
+small-N enumeration with the four repairs above and a Docker-verified
+fresh build).
+
+### Pre-2026-06-01 STATE-SYNC
+
+The slug's `state.md` had been stuck at "OBSERVE iteration 1" since
+2026-04-03 despite a successful S2 contribution merged on 2026-05-31
+via PR #21520 (`rothNumber_div_tendsto_zero` qualitative asymptotic).
+The JSON's `currentState` had already moved to iteration 2 / ORIENT,
+but state.md was unaware. This S3 ACT also brings state.md into sync
+with the JSON.
+
+## Prior Focus (S2 contribution merged 2026-05-31, PR #21520)
+
+S2 (researcher unknown — pre-S3 STATE-SYNC) shipped the qualitative
+asymptotic `rothNumber_div_tendsto_zero : Tendsto (n ↦ rothNumber n / n)
+atTop (𝓝 0)` to `proofs/Proofs/RothTheoremQuantitative.lean` (lines
+156–207 as of f486a19). Proof reduces to `Szemeredi.Roth.roth_density_bound`
+via the corners-theorem chain. **PR #21520 merged with a green CI
+that relied on Lake's incremental cache; rebuilding the file from a
+clean state on Mathlib v4.26.0 surfaces the four issues above.**
+
+## Prior Focus (S1 OBSERVE, 2026-04-03)
+
+Initial problem understanding from problem.md. The Lean file
+`RothTheoremQuantitative.lean` has 4 landmark sorries remaining
+(Roth 1953, Behrend 1946, Bloom–Sisask 2020, Kelley–Meka 2023),
+each requiring ≥ 1000 LOC of formalization. None tractable in a
+single session. Tractable adjacent contributions identified:
+qualitative asymptotic + small-N exact values.
 
 ## Active Approach
-None yet.
+Small-N enumeration → blocked on pre-existing build regressions.
+S4 should be a REPAIR session (or paired-fix PR) to restore the
+file to a fresh-rebuild-green state before resuming small-N
+enumeration.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3 (S1 OBSERVE, S2 ACT qualitative, S3 ACT REPAIR-DISCOVERY)
+- Current approach attempts: 1
+- Approaches tried: 3 (initial OBSERVE, qualitative ACT, REPAIR-DISCOVERY)
 
 ## Blockers
-None.
+`RothTheoremQuantitative.lean` fails fresh Docker build on Mathlib
+v4.26.0 due to API drift + 1 math bug + 1 `simp_all` heartbeat
+overshoot + 1 type-inference issue (4 root causes, 6 surfaced
+errors). S4 needs to be a dedicated repair session.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+
+**S4 ACT REPAIR (recommended)** — a focused repair PR:
+
+1. Rename `div_lt_iff` → `div_lt_iff₀` at line 174 and
+   `div_le_iff` → `div_le_iff₀` at line 218.
+
+2. Either remove `max_iterations_bound` + `iterations_before_contradiction`
+   as mathematically-incorrect dead code (no callers in the repo),
+   OR restate them with `(hδ : δ ≤ 1)` and the corrected bound
+   `k > 100(1 - δ)/δ²`.
+
+3. Add `set_option maxHeartbeats 400000 in` (or hoist the membership
+   `simp` to a separate helper) for `rothNumber_three` to fit the
+   `fin_cases a <;> fin_cases d <;> simp_all` proof within budget on
+   fresh builds.
+
+4. Fix `rothNumber_achieved`: add a `(S : Finset (Finset (ZMod N)))`
+   annotation on the `set` line, OR refactor to `Finset.exists_max_image`
+   with explicit type arguments, so `Finset.mem_filter.mp hAS` resolves
+   `filter APFree` cleanly.
+
+5. Docker-verify the file builds clean from a fresh image.
+
+Once S4 REPAIR ships, **S5 ACT SMALL-N** can resume the original
+plan: `r₃(4) ∈ [2, 3]` via `apFree_zero_one_zmod_four`,
+`two_le_rothNumber_four`, `rothNumber_four_le_three`. The proofs
+themselves are simple (≤ 30 LOC) and were drafted in this session;
+they just can't ship on a broken base.
+
+The four landmark sorries (`roth_quantitative_upper_bound`,
+`behrend_lower_bound`, `bloom_sisask_bound`, `kelley_meka_upper_bound`)
+remain multi-PR research efforts.

--- a/src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json
@@ -26,16 +26,16 @@
     "goal": "Import from RothTheorem.lean, which uses Mathlib's corners theorem, and complete the 5 remaining sorries."
   },
   "currentState": {
-    "phase": "ORIENT",
-    "since": "2026-04-03T02:25:35-07:00",
-    "iteration": 2,
-    "focus": "Added qualitative asymptotic rothNumber_div_tendsto_zero; documented 4-sorry landmark inventory.",
-    "blockers": [],
-    "nextAction": "Pursue rothNumber → rothNumberNat bridge to transfer Mathlib quantitative results.",
+    "phase": "ACT",
+    "since": "2026-06-01T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "S3 ACT REPAIR-DISCOVERY (researcher-1, 2026-06-01): STATE-SYNC plus a fresh-build Docker audit of proofs/Proofs/RothTheoremQuantitative.lean. Session began as small-N enumeration ACT (target: r₃(4) ∈ [2, 3]). When I Docker-built to verify, the build surfaced SIX distinct compile failures in the file *as it sits on main* — independent of my additions. After investigation, all six trace back to four root causes: (1) Mathlib v4.26.0 API drift: div_lt_iff (line 174) and div_le_iff (line 218) renamed to div_lt_iff₀ / div_le_iff₀ (drop-in rename, same signature); (2) Math bug in max_iterations_bound (line 195): statement δ + kδ²/100 > 1 → k > ⌊100/δ²⌋₊ is FALSE for δ > 1 (counterexample δ=2, k=0: 2 > 1 ✓ but ⌊25⌋ ≥ 0); algebraically the correct bound is k > 100(1-δ)/δ², strictly weaker. linarith proof relied on the now-removed div_le_iff lemma whose elaboration drift masked the math gap; iterations_before_contradiction (line 214) was a downstream consumer; (3) rothNumber_three simp_all timeout: fin_cases × 9 cases × ZMod 3 arithmetic exceeds 200k heartbeat budget on fresh build (cached lake skips re-verification, hence PR #21520 CI didn't flag it); (4) rothNumber_achieved type mismatch (line 118): Finset.mem_filter.mp leaves metavariable ?m.52 unpinned. DECISION: revert small-N additions (can't ship on broken base); document discovery via state.md/JSON. Recommend S4 ACT REPAIR session.",
+    "blockers": ["RothTheoremQuantitative.lean fails fresh Docker build (4 root causes / 6 surfaced errors): div_lt_iff/div_le_iff rename, max_iterations_bound math bug, rothNumber_three simp_all heartbeat overshoot, rothNumber_achieved type-inference issue. All masked by Lake cache."],
+    "nextAction": "S4 ACT REPAIR (recommended): (1) Rename div_lt_iff → div_lt_iff₀ at line 174 and div_le_iff → div_le_iff₀ at line 218 (drop-in, same args, same statement). (2) Remove max_iterations_bound + iterations_before_contradiction as mathematically incorrect dead code (no callers) OR restate with hδ : δ ≤ 1 and corrected bound k > 100(1-δ)/δ². (3) Add `set_option maxHeartbeats 400000 in` for rothNumber_three (or hoist membership simp to a separate helper). (4) Fix rothNumber_achieved: add Finset (Finset (ZMod N)) annotation on the `set S := ...` line, or refactor Finset.exists_max_image with explicit type args so mem_filter.mp hAS resolves filter APFree cleanly. (5) Docker-verify fresh build clean. Once S4 REPAIR ships, S5 ACT SMALL-N can resume the planned r₃(4) ∈ [2, 3] additions (proofs drafted in this session, ≤ 30 LOC: apFree_zero_one_zmod_four, two_le_rothNumber_four, rothNumber_four_le_three). The 4 landmark sorries (Roth 1953, Behrend 1946, Bloom–Sisask 2020, Kelley–Meka 2023) remain multi-PR research efforts.",
     "attemptCounts": {
-      "total": 1,
-      "currentApproach": 0,
-      "approachesTried": 1
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
@@ -62,7 +62,8 @@
       "Once bridge exists, derive Behrend lower bound and Mathlib s qualitative o(N) as immediate corollaries for the gallery rothNumber.",
       "Defer the four landmark sorries until per-bound formalization projects are funded — each is multi-thousand-line work."
     ],
-    "markdown": "# Knowledge Base: roth-theorem-k3-oq-01-incomplete-01\n\n## Problem Understanding\n\nThis task targets the main k=3 formalization of Roth's theorem. The statement in the local notes is: for every density `delta > 0`, sufficiently large cyclic groups have the property that every subset of size at least `delta N` contains a three-term arithmetic progression.\n\n## Known Local Context\n\nThe parent gallery proof `roth-theorem-k3-oq-01` provides the foundation. The notes say the Lean file has 5 remaining sorries and that Mathlib's corners theorem chain, especially `Finset.addCornerFree`, is the key building block.\n\n## Current Focus\n\nThe current phase is OBSERVE. The next local action is to read `problem.md` thoroughly, then move to ORIENT by inspecting literature and the related parent proof.\n"
+    "markdown": "# Knowledge Base: roth-theorem-k3-oq-01-incomplete-01\n\n## Problem Understanding\n\nThis task targets the main k=3 formalization of Roth's theorem. The statement in the local notes is: for every density `delta > 0`, sufficiently large cyclic groups have the property that every subset of size at least `delta N` contains a three-term arithmetic progression.\n\n## Known Local Context\n\nThe parent gallery proof `roth-theorem-k3-oq-01` provides the foundation. The notes say the Lean file has 5 remaining sorries and that Mathlib's corners theorem chain, especially `Finset.addCornerFree`, is the key building block.\n\n## Current Focus\n\nThe current phase is OBSERVE. The next local action is to read `problem.md` thoroughly, then move to ORIENT by inspecting literature and the related parent proof.\n",
+    "lastUpdated": "2026-06-01T00:00:00.000Z"
   },
   "tags": [
     "combinatorics",
@@ -81,5 +82,20 @@
   },
   "started": "2026-04-03T02:25:35-07:00",
   "significance": 8,
-  "tractability": 4
+  "tractability": 4,
+  "leanFiles": [
+    {
+      "path": "Proofs/RothTheoremQuantitative.lean",
+      "filename": "RothTheoremQuantitative.lean",
+      "lineCount": 286,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 4,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RothTheoremQuantitative.lean"
+    }
+  ],
+  "lastUpdate": "2026-06-01T00:00:00.000Z",
+  "lastUpdated": "2026-06-01T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

S3 ACT for `roth-theorem-k3-oq-01-incomplete-01` pivoted from a planned small-N enumeration ACT (target: pin `r₃(4) ∈ [2, 3]`) to a **REPAIR-DISCOVERY** session when a fresh Docker build of `proofs/Proofs/RothTheoremQuantitative.lean` surfaced **six compile failures present in `main`**, all masked by Lake's incremental cache since PR #21520 (Mathlib v4.26.0 bump).

**No code changes to the Lean file in this PR.** Documentation only (state.md + JSON + session memo) so S4 can ship a targeted repair before S5 resumes small-N enumeration.

## Findings (4 root causes / 6 surfaced errors)

| # | Line | Symptom | Root cause |
|---|------|---------|------------|
| 1 | 174 | `Unknown identifier 'div_lt_iff'` | Mathlib v4.26.0 rename → `div_lt_iff₀` |
| 2 | 218 | `Unknown identifier 'div_le_iff'` | Mathlib v4.26.0 rename → `div_le_iff₀` |
| 3 | 195–212 | `linarith failed` in `max_iterations_bound` | **Statement is mathematically false for δ > 1** (counterexample δ=2, k=0: `2 > 1` ✓ but `⌊100/4⌋ ≥ 0`). Algebraically only `k > 100(1-δ)/δ²` is provable. |
| 4 | 214 | unsolved goals in `iterations_before_contradiction` | Downstream consumer of #2 |
| 5 | 134 | `(deterministic) timeout at simp, 200000 heartbeats` in `rothNumber_three` | `fin_cases × 9 subcases × ZMod arithmetic` is on the edge of default budget on a fresh (uncached) build |
| 6 | 118 | `Application type mismatch` in `rothNumber_achieved` | `Finset.mem_filter.mp hAS` leaves metavariable `?m.52` unpinned |

## Recommended next action (S4 ACT REPAIR)

1. `div_lt_iff` → `div_lt_iff₀` at line 174 (drop-in).
2. `div_le_iff` → `div_le_iff₀` at line 218 (drop-in).
3. Either REMOVE `max_iterations_bound` + `iterations_before_contradiction` as mathematically-incorrect dead code (no callers), OR restate with `(hδ : δ ≤ 1)` and the corrected bound `k > 100(1-δ)/δ²`.
4. `set_option maxHeartbeats 400000 in` before `rothNumber_three`.
5. Fix `rothNumber_achieved`: add a `Finset (Finset (ZMod N))` annotation on the `set S := ...` line, or refactor `Finset.exists_max_image` with explicit type args.
6. Docker-verify fresh build clean.

Once S4 REPAIR ships, **S5 ACT SMALL-N** can resume the planned `r₃(4) ∈ [2, 3]` additions (proofs drafted in the session memo, ≤ 30 LOC).

## Also: STATE-SYNC

`state.md` had been stuck at "OBSERVE iteration 1" from 2026-04-03 despite the S2 contribution (`rothNumber_div_tendsto_zero`) shipping on 2026-05-31 via PR #21520. This PR brings `state.md` into sync with the JSON (iteration 3, ACT phase).

## Test plan

- [x] Fresh Docker build of `Proofs.RothTheoremQuantitative` reproduced all 6 errors on a clean checkout of `main`.
- [x] Verified `div_lt_iff₀` / `div_le_iff₀` are the correct v4.26.0 replacements (same signatures) by grepping `~/GitHub/mathlib4` at tag `v4.26.0` (commit `2df2f0150c`).
- [x] Math counterexample for `max_iterations_bound` re-derived from scratch.
- [x] No `.lean` files modified in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)