### PR TITLE
fix(meta): register 2 NO_SLUG_MATCH orphan companions (2-batch, 2 slugs)

### DIFF
--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -63,7 +63,10 @@
     "lineCount": 343,
     "assumptions": "5 axioms: schurNumber_4, schurNumber_5, schur_lower_bound, schur_upper_bound, erdos_483_conjecture. Proved: schurNumber_3=14 via native_decide.",
     "theoremCount": 19,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/SchursTheorem.lean"
+    ]
   },
   "sections": [
     {
@@ -208,7 +211,10 @@
     "theoremCount": 19,
     "definitionCount": 3,
     "path": "Proofs/Erdos483Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/SchursTheorem.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/inclusion-exclusion/meta.json
+++ b/src/data/proofs/inclusion-exclusion/meta.json
@@ -50,7 +50,10 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/MobiusInversionIE.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The inclusion-exclusion principle emerged gradually over two centuries. Abraham de Moivre stated the two-set case in *The Doctrine of Chances* (1718) while computing probabilities of card games. Leonhard Euler used a multi-set version in 1748 to derive his totient formula $\\phi(n) = n \\prod_{p \\mid n}(1 - 1/p)$, counting integers coprime to $n$ by alternately including and excluding multiples of each prime factor.\n\nThe general $n$-set formula was established independently by Daniel Augusto da Silva (1854) and James Joseph Sylvester (1883). Sylvester's formulation appeared in his work on combinatorial chemistry and is sometimes called the 'Sylvester sieve.' The principle is equivalent to Möbius inversion on the Boolean lattice $2^{[n]}$, a connection made explicit by Gian-Carlo Rota in his foundational 1964 paper, which unified inclusion-exclusion, the Euler totient, the chromatic polynomial, and the Möbius function under a single framework.\n\nIn number theory, the Legendre sieve and its refinements (Brun's sieve, the Selberg sieve) are inclusion-exclusion applied to prime counting. In probability, the Bonferroni inequalities $P(A_1 \\cup \\cdots \\cup A_n) \\leq \\sum P(A_i)$ and their refined alternating bounds are truncations of inclusion-exclusion, widely used in statistics and reliability theory.",
@@ -224,7 +227,10 @@
     "theoremCount": 7,
     "definitionCount": 0,
     "path": "Proofs/InclusionExclusion.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/MobiusInversionIE.lean"
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Summary

Register 2 orphan Lean files whose basenames do NOT share a primary-stem
prefix with any gallery slug (NO_SLUG_MATCH branch of `orphan_scan_v6`),
but whose file-header content + import graph unambiguously identify the
natural parent slug.

| Orphan file | Parent slug | Evidence |
|---|---|---|
| `Proofs/SchursTheorem.lean` | `erdos-483` | Imported by `Erdos483Problem.lean` (this slug's primary). Header: "Schur's Theorem (1916), a foundational result in Ramsey theory" — the precise mathematical content used by erdos-483 (defining f(k) Schur numbers). |
| `Proofs/MobiusInversionIE.lean` | `inclusion-exclusion` | Header: "Möbius inversion on the Boolean lattice of finite sets and show that the classical Inclusion-Exclusion Principle is a special case of Möbius inversion on this lattice." Parent's `historicalContext` already states: "equivalent to Möbius inversion on the Boolean lattice […] connection made explicit by Gian-Carlo Rota in his foundational 1964 paper". |

Each addition mirrors into both `.meta.additionalFiles` and
`.leanFile.additionalFiles` per Mechanic convention.

Pure metadata change — no Lean source modifications.

## Test plan

- [x] `python3 /tmp/orphan_scan_v6.py` produced both as `NO_SLUG_MATCH|FREE`
- [x] Each file inspected; header content + import graph match the parent slug's mathematical topic
- [x] No competing open PRs touch the two target meta.json files
- [x] Both meta.json files parse as valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)