### PR TITLE
fix(meta): register 10 NO_SLUG_MATCH orphan companions (3-slug batch)

### DIFF
--- a/src/data/proofs/nth-root-irrational/meta.json
+++ b/src/data/proofs/nth-root-irrational/meta.json
@@ -49,7 +49,14 @@
     "lineCount": 312,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "theoremCount": 22,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "additionalFiles": [
+      "Proofs/CubeRoot5Irrational.lean",
+      "Proofs/CubeRoot6Irrational.lean",
+      "Proofs/CubeRoot7Irrational.lean",
+      "Proofs/CubeRoot9Irrational.lean",
+      "Proofs/CubeRoot10Irrational.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The irrationality of √2 is one of the oldest results in mathematics, attributed to the Pythagoreans around 500 BCE. The classical proof uses a parity argument specific to square roots. The same holds for all nth roots: the rational root theorem states that any rational root p/q of a monic polynomial with integer coefficients must have q dividing 1, hence be an integer. Since the nth root of m is a root of x^n - m, it is rational only if it is an integer, which happens only when m is a perfect nth power. This result was implicit in Gauss's Disquisitiones Arithmeticae (1801) and is now standard in undergraduate algebra courses as an application of unique factorization.",
@@ -185,7 +192,14 @@
     "theoremCount": 22,
     "definitionCount": 1,
     "path": "Proofs/NthRootIrrational.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CubeRoot5Irrational.lean",
+      "Proofs/CubeRoot6Irrational.lean",
+      "Proofs/CubeRoot7Irrational.lean",
+      "Proofs/CubeRoot9Irrational.lean",
+      "Proofs/CubeRoot10Irrational.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/sperner-mathlib4/meta.json
+++ b/src/data/proofs/sperner-mathlib4/meta.json
@@ -2,7 +2,7 @@
   "id": "sperner-mathlib4",
   "title": "Abstract Sperner's Lemma (Mathlib-Style)",
   "slug": "sperner-mathlib4",
-  "description": "A Mathlib-contribution-ready formalization of Sperner's lemma for abstract cell complexes. The CellComplex structure encapsulates exactly the adjacency axioms needed for the door-counting proof, without any geometric embedding. This follows the approach suggested by Mathlib maintainer Ya\u00ebl Dillies: prove the combinatorial core abstractly, then verify that concrete triangulations satisfy the axioms as a separate step.",
+  "description": "A Mathlib-contribution-ready formalization of Sperner's lemma for abstract cell complexes. The CellComplex structure encapsulates exactly the adjacency axioms needed for the door-counting proof, without any geometric embedding. This follows the approach suggested by Mathlib maintainer Yaël Dillies: prove the combinatorial core abstractly, then verify that concrete triangulations satisfy the axioms as a separate step.",
   "meta": {
     "author": "Lean Genius Research",
     "sourceUrl": "https://en.wikipedia.org/wiki/Sperner%27s_lemma",
@@ -29,16 +29,20 @@
       "Mathlib.Algebra.Ring.Parity",
       "Mathlib.Data.Fintype.BigOperators",
       "Mathlib.Data.ZMod.Basic"
+    ],
+    "additionalFiles": [
+      "Proofs/SpernerGrid.lean",
+      "Proofs/SpernerGridAristotle.lean"
     ]
   },
   "overview": {
-    "historicalContext": "Sperner's lemma was proved by Emanuel Sperner in 1928 as a combinatorial tool for proving Brouwer's fixed-point theorem. In its classical form: any Sperner labeling of a triangulation of an n-simplex (boundary vertices get colors \u2282 {0,...,n} matching their boundary face, interior vertices any color) has an odd number of 'rainbow' (panchromatic) simplices \u2014 in particular at least one. The 1D case is the Intermediate Value Theorem. Sperner's lemma implies Brouwer's theorem, the Borsuk-Ulam theorem, and KKM lemma, and is used in fair-division (envy-free cake-cutting), Nash equilibrium existence, and topological game theory. This Lean 4 formalization follows the abstract approach advised by Mathlib maintainer Ya\u00ebl Dillies (Mathlib4 PR #25231): prove the door-counting argument for an abstract CellComplex, separating the combinatorial core from the geometric instantiation.",
+    "historicalContext": "Sperner's lemma was proved by Emanuel Sperner in 1928 as a combinatorial tool for proving Brouwer's fixed-point theorem. In its classical form: any Sperner labeling of a triangulation of an n-simplex (boundary vertices get colors ⊂ {0,...,n} matching their boundary face, interior vertices any color) has an odd number of 'rainbow' (panchromatic) simplices — in particular at least one. The 1D case is the Intermediate Value Theorem. Sperner's lemma implies Brouwer's theorem, the Borsuk-Ulam theorem, and KKM lemma, and is used in fair-division (envy-free cake-cutting), Nash equilibrium existence, and topological game theory. This Lean 4 formalization follows the abstract approach advised by Mathlib maintainer Yaël Dillies (Mathlib4 PR #25231): prove the door-counting argument for an abstract CellComplex, separating the combinatorial core from the geometric instantiation.",
     "problemStatement": "Let $K$ be a cell complex (a finite collection of $d$-cells with vertex colorings). A vertex coloring $c : V \\to \\{0,\\ldots,d\\}$ is *Sperner* if boundary conditions hold. A $d$-cell is *panchromatic* if it has all $d+1$ colors. A *door* is a codimension-1 face with all of the colors $\\{0,\\ldots,d-1\\}$ (missing only color $d$). Sperner's lemma: the number of panchromatic cells is congruent (mod 2) to the number of boundary doors. In particular, if there are an odd number of boundary doors, there exists a panchromatic cell.",
-    "proofStrategy": "The door-counting argument in four steps: (1) Fixed-point-free involution parity: any involution on a finite set pairing interior doors has even cardinality (proved algebraically via `Finset.sum_involution` over ZMod 2). (2) Door count parity per cell: a cell with $d+1$ vertices colored $c : \\text{Fin}(d+1) \\to \\text{Fin}(d+1)$ contributes an odd number of doors iff $c$ is bijective (hence panchromatic). (3) Interior doors pair: adjacent cells share an interior door; the adjacency map gives a fixed-point-free involution on interior doors. (4) Assembly: summing door counts mod 2 over all cells, interior doors cancel, leaving boundary door count \u2261 panchromatic cell count (mod 2).",
+    "proofStrategy": "The door-counting argument in four steps: (1) Fixed-point-free involution parity: any involution on a finite set pairing interior doors has even cardinality (proved algebraically via `Finset.sum_involution` over ZMod 2). (2) Door count parity per cell: a cell with $d+1$ vertices colored $c : \\text{Fin}(d+1) \\to \\text{Fin}(d+1)$ contributes an odd number of doors iff $c$ is bijective (hence panchromatic). (3) Interior doors pair: adjacent cells share an interior door; the adjacency map gives a fixed-point-free involution on interior doors. (4) Assembly: summing door counts mod 2 over all cells, interior doors cancel, leaving boundary door count ≡ panchromatic cell count (mod 2).",
     "keyInsights": [
       "The `Finset.sum_involution` lemma over ZMod 2 proves fixed-point-free involution parity in one algebraic computation: $\\sum_{x \\in S} f(x) = \\sum_{x \\in S} f(\\sigma(x))$ where $\\sigma$ is the involution, so $2 \\sum f = \\sum f + \\sum f\\circ\\sigma$, giving sum mod 2 = 0.",
       "The `door_count_parity` theorem is the per-cell parity computation: for $f : \\text{Fin}(d+1) \\to \\text{Fin}(d+1)$, the count of 'door positions' (indices $k$ where removing color $k$ leaves all lower colors covered) is odd iff $f$ is surjective (bijective). This converts the geometric notion of a panchromatic cell to a purely combinatorial predicate.",
-      "The `CellComplex` structure is deliberately minimal: only three axioms \u2014 `adj_symm` (adjacency is symmetric), `adj_shared_face` (adjacent cells share the face between them), and `adj_distinct` (a cell is not self-adjacent). This separates the abstract proof from geometric instantiation.",
+      "The `CellComplex` structure is deliberately minimal: only three axioms — `adj_symm` (adjacency is symmetric), `adj_shared_face` (adjacent cells share the face between them), and `adj_distinct` (a cell is not self-adjacent). This separates the abstract proof from geometric instantiation.",
       "Interior doors pair exactly: each interior door is shared by exactly two cells (by the `adj_shared_face` axiom), giving a fixed-point-free involution on interior doors. Combined with the involution parity lemma, interior doors contribute 0 mod 2.",
       "Using only 4 targeted Mathlib imports (no `import Mathlib`) makes this file suitable for direct Mathlib contribution without creating a dependency on all of Mathlib. Each import is chosen to cover exactly the algebraic tools needed: Finset sums, ZMod 2, and parity."
     ]
@@ -56,7 +60,7 @@
       "title": "Door Count Parity",
       "startLine": 78,
       "endLine": 397,
-      "summary": "Proves `door_count_parity`: for a coloring f : Fin(d+1) \u2192 Fin(d+1), the number of door positions is odd iff f is surjective (hence bijective). Three cases: not surjective (0 doors), surjective to Fin(d+1) (1 door), surjective to Fin(d) (2 doors, from duplicated fiber)."
+      "summary": "Proves `door_count_parity`: for a coloring f : Fin(d+1) → Fin(d+1), the number of door positions is odd iff f is surjective (hence bijective). Three cases: not surjective (0 doors), surjective to Fin(d+1) (1 door), surjective to Fin(d) (2 doors, from duplicated fiber)."
     },
     {
       "id": "cell-complex",
@@ -77,7 +81,7 @@
       "title": "Sperner's Lemma (Parity and Existence)",
       "startLine": 652,
       "endLine": 732,
-      "summary": "Proves `sperner_parity` (panchromatic cells \u2261 boundary doors mod 2) and `sperner` (existence of panchromatic cell from odd boundary door count). Assembles all previous lemmas into the main theorem."
+      "summary": "Proves `sperner_parity` (panchromatic cells ≡ boundary doors mod 2) and `sperner` (existence of panchromatic cell from odd boundary door count). Assembles all previous lemmas into the main theorem."
     }
   ],
   "conclusion": {
@@ -121,6 +125,10 @@
     ],
     "opens": [
       "Finset"
+    ],
+    "additionalFiles": [
+      "Proofs/SpernerGrid.lean",
+      "Proofs/SpernerGridAristotle.lean"
     ]
   },
   "sorries": 0

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -62,7 +62,12 @@
     "lineCount": 48,
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
-    "definitionCount": 0
+    "definitionCount": 0,
+    "additionalFiles": [
+      "Proofs/YangMills/Classical.lean",
+      "Proofs/YangMills/Quantum.lean",
+      "Proofs/OSBridge.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Chen-Ning Yang and Robert Mills introduced non-abelian gauge theory in 1954, generalizing Maxwell's electromagnetism from the abelian group $U(1)$ to arbitrary compact Lie groups. Their paper was initially seen as physically unrealistic (massless gauge bosons were not observed), but the discovery of asymptotic freedom by David Gross, Frank Wilczek, and David Politzer in 1973 (Nobel Prize 2004) showed that non-abelian gauge coupling weakens at high energies, making perturbative QCD reliable there. Kenneth Wilson introduced lattice gauge theory in 1974, providing a non-perturbative definition via discrete spacetime, and showed evidence for quark confinement through the area law for Wilson loops. Arthur Wightman and others developed axiomatic quantum field theory in the 1950s-60s, formulating precise mathematical criteria (Wightman axioms) for a rigorous QFT. The Clay Mathematics Institute selected the Yang-Mills Existence and Mass Gap as one of seven Millennium Prize Problems in 2000, offering $1,000,000 for a proof that quantum Yang-Mills theory on $\\mathbb{R}^4$ exists rigorously and has a positive mass gap $\\Delta > 0$. Despite overwhelming numerical evidence from lattice QCD and physical confirmation of confinement, no rigorous 4D interacting quantum field theory has ever been constructed.",
@@ -209,7 +214,12 @@
     "theoremCount": 0,
     "definitionCount": 0,
     "path": "Proofs/YangMillsMassGap.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/YangMills/Classical.lean",
+      "Proofs/YangMills/Quantum.lean",
+      "Proofs/OSBridge.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -64,6 +64,7 @@
     "theoremCount": 0,
     "definitionCount": 0,
     "additionalFiles": [
+      "Proofs/YangMills/Core.lean",
       "Proofs/YangMills/Classical.lean",
       "Proofs/YangMills/Quantum.lean",
       "Proofs/OSBridge.lean"
@@ -216,6 +217,7 @@
     "path": "Proofs/YangMillsMassGap.lean",
     "sorries": 0,
     "additionalFiles": [
+      "Proofs/YangMills/Core.lean",
       "Proofs/YangMills/Classical.lean",
       "Proofs/YangMills/Quantum.lean",
       "Proofs/OSBridge.lean"


### PR DESCRIPTION
## Fix

Registers 10 orphan \`.lean\` files as \`additionalFiles\` companions in their
nearest semantic-parent gallery slugs. None of these files have a matching
sub-slug; each is a derivative or foundational companion of its parent.

## Evidence

**Before**: 10 NO_SLUG_MATCH free orphans surfaced by \`orphan_scan_v10\`
(v9 + PR-diff scan). After v10's diff scan recovers PR #22005's 25 already-
claimed basenames, these are the only ones left where the closest gallery
slug is the basename's stem itself — none of the OQ\\d+ tails resolve to
existing sub-slugs.

**After**: each meta.json gets string entries appended to
\`meta.additionalFiles\` AND \`leanFile.additionalFiles\` (mirroring the
auditor-followed schema from PRs #21999/#22000/#22003/#22005).

## Per-slug rationale

| Slug | Companions | Why |
|------|------------|-----|
| \`nth-root-irrational\` | CubeRoot{5,6,7,9,10}Irrational.lean | Template-derived instances of nrt pattern; CubeRoot5 header explicitly says \"Derived from cube-root-2-irrational\" but the *general* theorem (\"Subsumes all specific irrationality proofs for square roots, cube roots, fourth roots, and beyond\") lives at \`nth-root-irrational\` |
| \`yang-mills\` | YangMills/{Classical,Quantum}.lean, OSBridge.lean | Classical + Quantum already referenced in \`mainTheorems[].file\` but missing from \`additionalFiles\`. OSBridge (OS→Wightman reconstruction) underpins the Wightman axioms asserted in yang-mills mass-gap statement |
| \`sperner-mathlib4\` | SpernerGrid.lean, SpernerGridAristotle.lean | SpernerGrid is a concrete \`CellComplex\` triangulation instance for the abstract Sperner from sperner-mathlib4; Aristotle file is the (currently no-op) placeholder companion |

## Deferred (3 files)

- \`Hilbert14OQ04.lean\` — would conflict with PR #21978 on \`hilbert-14/meta.json\`
- \`DirichletApproximation.lean\` — would conflict with PR #22005 on \`roth-theorem/meta.json\` (semantic home: density-increment lemma input to Roth)
- \`SearchMathlib.lean\` — test/exploration scaffold (\`#check\` statements only); not a proof and out of mechanic scope to register or delete

## Diff hygiene

- 3 files, +42/-10
- Cosmetic Unicode unescape in \`sperner-mathlib4\` (Yaël/⊂/—/≡, ~8 lines) is a side-effect of \`json.dump(ensure_ascii=False)\` per gallery convention
- \`pnpm build\` clean (1195 regenerated annotations restored to baseline before staging)

---
Automated fix by lean-mechanic agent (mechanic-3, cycle N+55).