### PR TITLE
fix(meta): yang-mills register YangMills/Core.lean orphan (stacked on #22007)

### DIFF
--- a/src/data/proofs/yang-mills/meta.json
+++ b/src/data/proofs/yang-mills/meta.json
@@ -64,6 +64,7 @@
     "theoremCount": 0,
     "definitionCount": 0,
     "additionalFiles": [
+      "Proofs/YangMills/Core.lean",
       "Proofs/YangMills/Classical.lean",
       "Proofs/YangMills/Quantum.lean",
       "Proofs/OSBridge.lean"
@@ -216,6 +217,7 @@
     "path": "Proofs/YangMillsMassGap.lean",
     "sorries": 0,
     "additionalFiles": [
+      "Proofs/YangMills/Core.lean",
       "Proofs/YangMills/Classical.lean",
       "Proofs/YangMills/Quantum.lean",
       "Proofs/OSBridge.lean"


### PR DESCRIPTION
## Summary

**Stacks on PR #22007** (yang-mills 3-batch + nth-root + sperner-mathlib4).
Registers the **single remaining unregistered** `YangMills/*.lean` file:

- `Proofs/YangMills/Core.lean` — 118 L, 7 T, 6 D, 0 A, 0 S.

After #22007 + this PR merge, all four files in
`proofs/Proofs/YangMills/` (Core, Classical, Quantum, Exploration)
will be registered. `Exploration.lean` is already the `proofRepoPath`
for the sibling slugs `yang-mills-2d`, `yang-mills-lattice`,
`yang-mills-transfer-matrix`.

## Why Core was missed by mechanic-3's PR #22007

The scan-v10 substring-claim heuristic looked for the basename
`Core.lean` across all open PR bodies. PR #21994 (p-vs-np 4-batch)
mentions `ComplexityCore.lean` — the suffix `Core.lean` matched and
caused v10 to **false-positive** YangMills/Core.lean as already
claimed.

The per-PR-diff cross-check (grep the orphan's full path against
`gh pr diff` of every open mechanic PR) catches this — see the
attached commit message for the chain-of-evidence one-liner.

## Why this slug (not yang-mills-2d/lattice/transfer-matrix)

Per the import chain rooted at the slug's primary (`YangMillsMassGap.lean`):

- `YangMillsMassGap → Quantum → Classical → Core`
- `YangMillsMassGap → Classical → Core`

`Exploration.lean` (used by the three sibling slugs) consumes
`Classical` and `Quantum`. Per gallery convention each companion is
owned by one slug; Core belongs with the chain root.

## Format

Both registries get the same string entry, matching #22007's choice:

- `meta.additionalFiles`: prepend `"Proofs/YangMills/Core.lean"`.
- `leanFile.additionalFiles`: prepend `"Proofs/YangMills/Core.lean"`.

Net diff (against #22007's tree): **2 insertions / 0 deletions** in one
meta.json. No content edits, no theorem/axiom-count alterations.

## Stacking note

`--base` is `fix/mechanic-N55-no-slug-match-10batch` (PR #22007).
When #22007 merges, GitHub auto-retargets this PR to `main` and the
diff stays minimal.

## Test plan
- [x] `python3 -m json.tool` validates the edited `meta.json`
- [x] Local re-scan confirms `Core.lean` flips unregistered → registered
- [x] Diff against `origin/fix/mechanic-N55-no-slug-match-10batch` shows
      only the two `Core.lean` line insertions
- [x] No conflict with PR #22007

🤖 Automated fix by lean-mechanic agent (mechanic-1, cycle N+55).