### PR TITLE
research(minkowski-theorem-oq-04): S30 ACT PR-B — `blichfeldt_general_lattice` (basis-parametric covering form, Docker 3075 jobs clean)

### DIFF
--- a/proofs/Proofs/MinkowskiTheoremOQ04.lean
+++ b/proofs/Proofs/MinkowskiTheoremOQ04.lean
@@ -438,6 +438,144 @@ theorem blichfeldt_general {n : ℕ} [NeZero n]
     _ = (k : ENNReal) * 1 := by rw [stdLattice_covolume]
     _ = (k : ENNReal) := mul_one _
 
+/-- **Blichfeldt's General Theorem for an arbitrary full-rank `ℤ`-lattice**.
+
+For any basis `b : Module.Basis (Fin n) ℝ (Fin n → ℝ)` and any
+measurable set `s ⊆ ℝⁿ` with
+`volume s > k · volume(ZSpan.fundamentalDomain b)`,
+there exist `k + 1` distinct points in `s` whose pairwise differences
+lie in the `ℤ`-submodule `Submodule.span ℤ (Set.range b)`.
+
+Specialises to `blichfeldt_general` at `b := stdBasis n` (covolume 1).
+
+S23 PR-B (researcher-1, 2026-06-02). Mechanical substitution of
+`stdLattice n → Submodule.span ℤ (Set.range b)`, `stdFundDomain n →
+ZSpan.fundamentalDomain b`, and `volume_eq_setLIntegral_indicator_tsum
+→ volume_eq_setLIntegral_indicator_tsum_lattice b` per S23 §4. The
+volume identity `volume F = 1` (the only `stdLattice`-specific step)
+is abstracted by quoting `volume (ZSpan.fundamentalDomain b)` directly
+in the hypothesis. -/
+theorem blichfeldt_general_lattice {n : ℕ} [NeZero n]
+    (b : Module.Basis (Fin n) ℝ (Fin n → ℝ))
+    (k : ℕ) (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s)
+    (h_vol : (k : ENNReal) * volume (ZSpan.fundamentalDomain b) < volume s) :
+    ∃ pts : Fin (k+1) → Fin n → ℝ,
+      Function.Injective pts ∧ (∀ i, pts i ∈ s) ∧
+      ∀ i j, pts i - pts j ∈
+        (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ)) := by
+  haveI : Countable (Submodule.span ℤ (Set.range b)).toAddSubgroup := by
+    change Countable (Submodule.span ℤ (Set.range b))
+    infer_instance
+  -- Container reformulation: factor out the lattice translation z.
+  suffices h : ∃ z : Fin n → ℝ,
+      ∃ vs : Fin (k+1) → (Submodule.span ℤ (Set.range b)).toAddSubgroup,
+        Function.Injective vs ∧ ∀ i, z + (vs i : Fin n → ℝ) ∈ s by
+    obtain ⟨z, vs, hvs_inj, hvs_in⟩ := h
+    refine ⟨fun i => z + (vs i : Fin n → ℝ), ?_, hvs_in, ?_⟩
+    · intro i j hij
+      have h_coe : (vs i : Fin n → ℝ) = (vs j : Fin n → ℝ) := add_left_cancel hij
+      exact hvs_inj (Subtype.ext h_coe)
+    · intro i j
+      show (z + (vs i : Fin n → ℝ)) - (z + (vs j : Fin n → ℝ))
+        ∈ (Submodule.span ℤ (Set.range b) : Set (Fin n → ℝ))
+      have h_sub : (z + (vs i : Fin n → ℝ)) - (z + (vs j : Fin n → ℝ))
+                = (vs i : Fin n → ℝ) - (vs j : Fin n → ℝ) := by ring
+      rw [h_sub, ← AddSubgroupClass.coe_sub]
+      exact (vs i - vs j).2
+  -- Contrapose to a volume bound.
+  by_contra h_neg
+  push_neg at h_neg
+  -- h_neg : ∀ z, ∀ vs, Injective vs → ∃ i, z + (vs i : ℝⁿ) ∉ s
+  apply absurd h_vol (not_lt.mpr ?_)
+  -- Move A: ∫⁻ z in F, c z ∂volume = volume s
+  rw [← volume_eq_setLIntegral_indicator_tsum_lattice b h_meas]
+  -- Move B: pointwise c z ≤ (k : ℝ≥0∞)
+  have h_pointwise : ∀ z : Fin n → ℝ,
+      (∑' v : (Submodule.span ℤ (Set.range b)).toAddSubgroup,
+          s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z))
+        ≤ (k : ENNReal) := by
+    intro z
+    set T : Set (Submodule.span ℤ (Set.range b)).toAddSubgroup :=
+      {v | (v : Fin n → ℝ) + z ∈ s} with hT_def
+    -- Bridge: tsum-of-indicators on L = T.encard.
+    have h_summand_eq : ∀ v : (Submodule.span ℤ (Set.range b)).toAddSubgroup,
+        s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)
+          = T.indicator (fun _ => (1 : ENNReal)) v := by
+      intro v
+      by_cases hv : (v : Fin n → ℝ) + z ∈ s
+      · simp [Set.indicator, hv, hT_def, Set.mem_setOf_eq]
+      · simp [Set.indicator, hv, hT_def, Set.mem_setOf_eq]
+    have h_bridge :
+        ∑' v : (Submodule.span ℤ (Set.range b)).toAddSubgroup,
+            s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)
+          = (T.encard : ENNReal) := by
+      rw [tsum_congr h_summand_eq, ← tsum_subtype, ENNReal.tsum_set_one]
+    rw [h_bridge]
+    -- Bound encard ≤ k via contrapositive of h_neg.
+    by_contra h_too_many
+    push_neg at h_too_many
+    -- h_too_many : (k : ℝ≥0∞) < (T.encard : ℝ≥0∞)
+    have h_le_encard : ((k + 1 : ℕ) : ℕ∞) ≤ T.encard := by
+      have h_lt_enat : (k : ℕ∞) < T.encard := by
+        have h_cast : ((k : ℕ∞) : ENNReal) < ((T.encard : ENNReal)) := by
+          exact_mod_cast h_too_many
+        exact_mod_cast h_cast
+      have h_succ : (k : ℕ∞) + 1 ≤ T.encard :=
+        (ENat.add_one_le_iff (ENat.coe_ne_top k)).mpr h_lt_enat
+      exact_mod_cast h_succ
+    obtain ⟨T₀, hT₀_sub, hT₀_card⟩ :=
+      Set.exists_subset_encard_eq h_le_encard
+    have hT₀_finite : T₀.Finite := by
+      rw [← Set.encard_lt_top_iff, hT₀_card]
+      exact ENat.coe_lt_top _
+    set F₀ : Finset _ := hT₀_finite.toFinset with hF₀_def
+    have hF₀_card : F₀.card = k + 1 := by
+      have h_eq : T₀.encard = (F₀.card : ℕ∞) := by
+        show T₀.encard = (hT₀_finite.toFinset.card : ℕ∞)
+        exact hT₀_finite.encard_eq_coe_toFinset_card
+      rw [hT₀_card] at h_eq
+      exact_mod_cast h_eq.symm
+    obtain ⟨vs, hvs_inj, hvs_range⟩ :
+        ∃ vs : Fin (k+1) → (Submodule.span ℤ (Set.range b)).toAddSubgroup,
+          Function.Injective vs ∧ Set.range vs = ↑F₀ := by
+      have h_card :
+          Fintype.card (↑F₀ : Set ↥(Submodule.span ℤ (Set.range b)).toAddSubgroup)
+            = k + 1 := by
+        rw [← Set.toFinset_card]
+        simp [hF₀_card]
+      let e : (↑F₀ : Set ↥(Submodule.span ℤ (Set.range b)).toAddSubgroup) ≃ Fin (k+1) :=
+        Fintype.equivFinOfCardEq h_card
+      refine ⟨fun i => (e.symm i).1, ?_, ?_⟩
+      · intro i j hij; exact e.symm.injective (Subtype.ext hij)
+      · ext x
+        simp only [Set.mem_range, Finset.mem_coe]
+        constructor
+        · rintro ⟨i, rfl⟩; exact (e.symm i).2
+        · intro hx; exact ⟨e ⟨x, hx⟩, by simp⟩
+    -- Each vs i ∈ T (via T₀ ⊆ T), i.e., (vs i : ℝⁿ) + z ∈ s.
+    have h_all_in : ∀ i, z + (vs i : Fin n → ℝ) ∈ s := by
+      intro i
+      have h_in_F₀ : vs i ∈ F₀ := by
+        have : vs i ∈ Set.range vs := ⟨i, rfl⟩
+        rwa [hvs_range, Finset.mem_coe] at this
+      have h_in_T₀ : vs i ∈ T₀ := by
+        rw [hF₀_def, Set.Finite.mem_toFinset] at h_in_F₀
+        exact h_in_F₀
+      have h_in_T : vs i ∈ T := hT₀_sub h_in_T₀
+      have h_swap : (vs i : Fin n → ℝ) + z = z + (vs i : Fin n → ℝ) := by ring
+      rwa [Set.mem_setOf_eq, h_swap] at h_in_T
+    obtain ⟨i, h_not_in⟩ := h_neg z vs hvs_inj
+    exact h_not_in (h_all_in i)
+  -- Move C: integrate the pointwise bound.
+  calc ∫⁻ z in ZSpan.fundamentalDomain b,
+          (∑' v : (Submodule.span ℤ (Set.range b)).toAddSubgroup,
+              s.indicator (fun _ => (1 : ENNReal)) ((v : Fin n → ℝ) + z)) ∂volume
+      ≤ ∫⁻ _ in ZSpan.fundamentalDomain b, (k : ENNReal) ∂volume := by
+        apply MeasureTheory.setLIntegral_mono_ae measurable_const.aemeasurable
+        exact MeasureTheory.ae_of_all _ (fun z _ => h_pointwise z)
+    _ = (k : ENNReal) * volume (ZSpan.fundamentalDomain b) := by
+        rw [MeasureTheory.setLIntegral_const]
+
 /-- The k=1 case follows from the general theorem. -/
 theorem blichfeldt_basic_from_general {n : ℕ} [NeZero n]
     (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s)
@@ -976,6 +1114,7 @@ end BlichfeldtTheorem
 
 #check BlichfeldtTheorem.blichfeldt_basic
 #check BlichfeldtTheorem.blichfeldt_general
+#check BlichfeldtTheorem.blichfeldt_general_lattice
 #check BlichfeldtTheorem.blichfeldt_three_points
 #check BlichfeldtTheorem.blichfeldt_four_points
 #check BlichfeldtTheorem.blichfeldt_general_pairwise

--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -1,11 +1,68 @@
 # Research State: minkowski-theorem-oq-04
 
 ## Current State
-**Phase**: ACT (S24 PR-A landed Docker-clean; PR-B / PR-C still Docker-blocked — B1 hung 19.9h, Path C window EXPIRED 7.9h ago; B2 disk RED 3.4 Gi)
+**Phase**: ACT (S30 PR-B landed Docker-clean; PR-C is the only remaining S24 ACT — bearers and helpers all in scope; infra GREEN since 2026-06-02)
 **Path**: full
-**Since**: 2026-05-17T01:55:00Z (S29 STATE-SYNC — post-S28-PREP catchup, doc-only)
-**Last Updated**: 2026-05-17 (S29 STATE-SYNC — 4 drift items: focus stale "this PR" loci, B1 age, NEW B2 disk RED, leanFiles[2] post-S27 numerics)
-**Iteration**: 29 (S29 STATE-SYNC — doc-only JSON+state catchup; researcher-4)
+**Since**: 2026-06-02T00:25:00Z (S30 ACT PR-B — `blichfeldt_general_lattice` shipped; Docker 3075 jobs clean)
+**Last Updated**: 2026-06-02 (S30 ACT PR-B — Lean +139 LOC, 1126 lines, 17 theorems, build-verified; B1/B2 CLEARED)
+**Iteration**: 30 (S30 ACT PR-B — researcher-1)
+
+## S30 — S30 ACT PR-B 2026-06-02 (researcher-1)
+
+**Focus**: ship S24 PR-B per S23 spec §2.1 / §4 — `blichfeldt_general_lattice` (lattice-side k+1
+covering-count averaging). Builds on S27 PR-A `volume_eq_setLIntegral_indicator_tsum_lattice`.
+T+16d since S29 STATE-SYNC. Pre-flight at S30: B1 (Docker hung 19.9h at S29) CLEARED — `timeout 10 docker info` returns full Server: section (Containers: 0, Images: 3); B2 (disk RED 3.4 Gi at S29) CLEARED — `df -h /System/Volumes/Data` reports 55 Gi avail / 94% used. Both gates of S29 nextAction §(c) GREEN, unblocking option (c) "paste S23 spec §2.1 and ship".
+
+### Deliverables (S30 PR-B)
+
+| Field | Value |
+| --- | --- |
+| New theorem | `BlichfeldtTheorem.blichfeldt_general_lattice` (basis-parametric, k+1 covering form) |
+| Insertion site | `proofs/Proofs/MinkowskiTheoremOQ04.lean:441` (immediately after `blichfeldt_general` at :324; before `blichfeldt_basic_from_general` at :442 in pre-edit numbering) |
+| Body size | ~110 LOC body + ~17 LOC docstring (+1 `#check` line in Export section); total +139 LOC |
+| Proof strategy | Mechanical bearer-substitution per S23 §4: `stdLattice n → Submodule.span ℤ (Set.range b)`, `stdFundDomain n → ZSpan.fundamentalDomain b`, `volume_eq_setLIntegral_indicator_tsum → volume_eq_setLIntegral_indicator_tsum_lattice b` (the S27 PR-A helper). The covolume-= 1 step (`stdLattice_covolume`) is the only `stdLattice`-specific step; abstracted by quoting `volume (ZSpan.fundamentalDomain b)` directly in the hypothesis (per S23 §5 normalisation). Otherwise structurally identical to `blichfeldt_general`. |
+| Docker build | **3075 jobs / first-try clean** at Lean 4.26.0 + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` |
+| Source file growth | 987 → **1126** lines (+139) |
+| Theorem count | 16 → **17** |
+| Axioms | **0** textually / **0** structure-encoded (unchanged) |
+| Sorries | **0** (unchanged) |
+| New `#check` entries | 1 (`BlichfeldtTheorem.blichfeldt_general_lattice` at Export check :1117) |
+
+### Bearer drift recheck at this commit (B1-B4 from S25 manifest, lake-SHA `2df2f0150c`)
+
+| # | Symbol | Bearer file | S25 line | S30 status |
+|---|---|---|---|---|
+| B1 | `ZSpan.isAddFundamentalDomain'` | `Mathlib/Algebra/Module/ZLattice/Basic.lean` | 359 | ✅ used via `volume_eq_setLIntegral_indicator_tsum_lattice` (S27); no direct call in PR-B |
+| B2 | `ZSpan.volume_fundamentalDomain` | `Mathlib/Algebra/Module/ZLattice/Basic.lean` | 386 | ✅ not needed in PR-B (covolume term left abstract per S23 §5) |
+| B3 | `exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure` | `Mathlib/MeasureTheory/Group/GeometryOfNumbers.lean` | 65 | ✅ deferred to PR-C |
+| B4 | `Module.finrank_fin_fun` | `Mathlib/LinearAlgebra/FreeModule/Finite/Matrix.lean` | 328 | ✅ deferred to PR-C |
+
+### S24 sequencing — post-PR-B state
+
+| PR | Theorem | Status | Insertion site |
+|---|---|---|---|
+| **PR-A** | `volume_eq_setLIntegral_indicator_tsum_lattice` | ✅ **shipped (S27)** | `MinkowskiTheoremOQ04.lean:264` |
+| **PR-B** | `blichfeldt_general_lattice` (~110 LOC body + docstring) | ✅ **shipped (S30, this iteration)** | `MinkowskiTheoremOQ04.lean:441` (post-edit) |
+| PR-C | `minkowski_general_k_lattice` (~50 LOC) | ⏳ unblocked (PR-B shipped + Docker GREEN) | after `minkowski_general_k` at :719 |
+
+### Pre-flight
+
+- `gh pr list -R rjwalters/lean-genius --search "minkowski-theorem-oq-04 in:title" --state open` → 0 results. No concurrent researcher PR; #17599 (Iter 21 DIRTY 8-day-stale) merged or closed between S29 and S30 (T+16d).
+- `timeout 10 docker info 2>&1 | grep -A 5 "^Server:"` → Containers: 0 + Images: 3 visible (B1 CLEARED).
+- `df -h /System/Volumes/Data | tail -1` → 55 Gi avail / 94% used (B2 CLEARED, well above 5 Gi soft-floor).
+- Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` unchanged from S25/S26/S27/S28/S29 — bearer manifest carries forward (no full re-spot-check; only the helper `volume_eq_setLIntegral_indicator_tsum_lattice` is directly invoked).
+- Concurrent researcher slugs (`elementary-quadratic-reciprocity-oq-01-oq-02` S8 STATE-SYNC PR #22012 just shipped by this same researcher-1 session at T-20min) — no cross-slug conflict.
+
+### Honest calibration
+
+Adds +139 Lean LOC (1 new theorem `blichfeldt_general_lattice` + 1 `#check`), closes 0 sorries (already 0), retires 0 axioms (already 0). Build-verified 3075 jobs clean on first try via Docker. Mechanic territory deferred per S27 precedent: `meta.json.lineCount: 987 → 1126`, `meta.json.theoremCount: 16 → 17`, `mainTheorems[]` append for `blichfeldt_general_lattice` (rich object with significance/mathContext). Sibling-slug `leanFiles[0/1]` drift NOT touched.
+
+### Next picker (S31)
+
+- Verify Docker still GREEN: `timeout 10 docker info 2>&1 | grep -E "^Server:" -A 5`.
+- Verify host disk ≥ 5 Gi: `df -h /System/Volumes/Data | tail -1`.
+- IF BOTH GREEN: paste S23 spec §2.2 and ship `minkowski_general_k_lattice` via `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04`. Estimated ~50 LOC body, parameter-lifted from `minkowski_general_k` at :719, calling PR-B's `blichfeldt_general_lattice` after the half-scaling step. Bearers B3 + B4 enter scope here.
+- IF EITHER RED: ship a doc-only S31 STATE-SYNC absorbing any new mechanic / sibling drift.
 
 ## S29 — S29 STATE-SYNC 2026-05-17 (researcher-4)
 

--- a/src/data/research/problems/minkowski-theorem-oq-04.json
+++ b/src/data/research/problems/minkowski-theorem-oq-04.json
@@ -17,30 +17,17 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-17T01:55:00Z",
-    "iteration": 29,
-    "focus": "S29 STATE-SYNC (researcher-4, 2026-05-17, doc-only) — post-S28-PREP (PR #19640 merged 2026-05-16T15:20:34Z, ~10.5h before this STATE-SYNC) JSON+state catchup. Four drift items closed: (1) `currentState.focus` had four \"this PR\" loci referring to merged S28 PREP — repointed to \"PR #19640 (S28 PREP)\" + rewrote focus to S29 narrative; (2) `currentState.blockers[0]` (B1) said \"9h since hang ... within < 12h Path C cancellation window; ~3 h remaining within window\" — refreshed to \"19.9h since hang ... Path C window EXPIRED at 2026-05-16T18:01Z (7.9h past)\"; mitigation said \"currently 6.7 Gi avail, above 1 Gi threshold but trending down\" — refreshed to \"3.4 Gi avail (RED, below 5 Gi soft-floor); host-level intervention required since Path C window expired\"; (3) NEW B2 added to `currentState.blockers[]`: host disk RED 3.4 Gi (-3.3 Gi vs S28 PREP 6.7 Gi snapshot ~10.5h ago); (4) `leanFiles[2]` (MinkowskiTheoremOQ04.lean) carried pre-S27 numerics — surgical refresh lineCount 922→987 (+65 from S27 PR-A), theoremCount 15→16 (+1), sorryCount 0→1 (raw `\\bsorry\\b` matches the docstring phrase \"sorry-free\" at line 59; not a proof-level sorry — `meta.json.meta.sorryCount` left at null by mechanic PR #19542 intentionally). Predecessor S28 contributions all retained: re-add of B1 (now refreshed), acknowledgement of mechanic PR #19542's status/badge flip, lastUpdate refresh. STILL PENDING (mechanic territory, unchanged from S28): `mainTheorems[]` entry for `volume_eq_setLIntegral_indicator_tsum_lattice` (S27 PR-A theorem). Anti-scope: no Lean changes (Docker B1 escalated past Path C window, all builds blocked), no `meta.json` edits (mechanic territory), no bearer re-spot-check (Mathlib pin unchanged at `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`; carries forward from S25/S26/S27/S28), no sibling-slug leanFiles[0]/[1] fixes (OQ02 lineCount 285→284 and OQ02OQ01 lineCount 268→267 + theoremCount 7→8 are sibling territory deferred to their respective mechanic batches).",
-    "blockers": [
-      {
-        "id": "B1",
-        "description": "Docker daemon hung — `timeout 10 docker info` returns only `Client:` section; no `Server:` Containers/Runtime/Storage Driver/Server Version lines (canonical hung-daemon signature). Hang start recorded at 2026-05-16T06:01Z (per concurrent slug `bounded-prime-gaps-oq-03-oq-02`); now ~19.9h since hang at S29 STATE-SYNC time (2026-05-17T01:55Z). Blocks all `./proofs/scripts/docker-build.sh` invocations, including the queued S24 ACT PR-B (`blichfeldt_general_lattice`) and PR-C (`minkowski_general_k_lattice`).",
-        "since": "2026-05-16T06:01:00Z",
-        "mitigation": "Wait for host disk recovery (currently 3.4 Gi avail — RED, below 5 Gi soft-floor; -3.3 Gi vs S28 PREP 6.7 Gi snapshot ~10.5h ago); `docker desktop restart` on the host when feasible. Path C cancellation window EXPIRED at 2026-05-16T18:01Z (12 h since hang); now ~7.9h past Path C expiry — host-level intervention required (not auto-recoverable inside the cancellation window). Precedent: PR #18707 → cleared by PR #18980 (schroeder-bernstein-oq-01 S5 ACT). Not researcher-scope."
-      },
-      {
-        "id": "B2",
-        "description": "Host disk RED — `df -h /System/Volumes/Data` reports 3.4 Gi avail / 100% used (below 5 Gi soft-floor; -3.3 Gi vs S28 PREP 6.7 Gi snapshot ~10.5h ago). Cross-validates B1 (Docker daemon hang at 06:01Z correlates with the disk floor crossing). Concurrent slug `ballot-problem-oq-03-oq-01-oq-02` S80 STATE-SYNC (PR #19994 merged 2026-05-17T01:36:05Z) escalated this same disk delta from 4.5→2.9 Gi in its B2 — multi-source corroboration of the host-wide degradation.",
-        "since": "2026-05-17T01:55:00Z",
-        "mitigation": "Daemon-level cleanup of `proofs/.lake/build` (cache pruning), of `.loom/worktrees/*` stale (`git worktree prune`), of Docker volume `lean-mathlib-cache` (last accessed >24h). Not researcher-scope; must be done from host outside any worktree."
-      }
-    ],
-    "nextAction": "S24 ACT PR-B (`blichfeldt_general_lattice`, ~80 LOC) — STILL BLOCKED on B1 (Docker hung 19.9h, Path C window expired 7.9h ago) and B2 (disk RED 3.4 Gi). Paste-ready Lean lives in `s23-lattice-generalization-spec.md §2.1`. Next picker should: (a) verify Docker has recovered: `timeout 10 docker info 2>&1 | grep -E \"^Server:\" -A 5`; (b) verify host disk ≥ 5 Gi: `df -h /System/Volumes/Data | tail -1`; (c) IF BOTH GREEN: paste S23 spec §2.1 and ship under `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04` (Iter 23 BUILD-VERIFY baseline ~12 min cold start); (d) IF EITHER STILL RED: ship another doc-only S30 STATE-SYNC absorbing any new mechanic / sibling drift (focus + leanFiles refresh + INFRA snapshot). Followed by PR-C (`minkowski_general_k_lattice`, ~50 LOC, parameter-lifted from `minkowski_general_k`). Anti-scope retained from S23/S24: no `_symm`, no `_five_points`, no wrapper-square closers. Mechanic-pending (unchanged from S28): `mainTheorems[]` entry for `volume_eq_setLIntegral_indicator_tsum_lattice` (researcher cannot edit `meta.json`). Also still parallel: #17599 (Iter 21 DIRTY 8-day-stale) — next picker should rebase or close.",
+    "since": "2026-06-02T00:25:00Z",
+    "iteration": 30,
+    "focus": "S30 ACT PR-B (researcher-1, 2026-06-02): shipped `blichfeldt_general_lattice` to `MinkowskiTheoremOQ04.lean:441` (post-edit numbering) via mechanical S23 §4 substitution from `blichfeldt_general` — `stdLattice n → Submodule.span ℤ (Set.range b)`, `stdFundDomain n → ZSpan.fundamentalDomain b`, `volume_eq_setLIntegral_indicator_tsum → volume_eq_setLIntegral_indicator_tsum_lattice b` (the S27 PR-A helper). Hypothesis form `(k : ENNReal) * volume (ZSpan.fundamentalDomain b) < volume s` per S23 §5 (covolume term abstract; the `stdLattice_covolume = 1` reduction is the only `stdLattice`-specific step in `blichfeldt_general` and is the substitution target). Docker 3075-job clean on first try (pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, unchanged since S25/S26/S27/S28/S29). Pre-flight INFRA at S30: B1 (Docker hung 19.9h at S29) CLEARED — full Server: section returned; B2 (disk RED 3.4 Gi at S29) CLEARED — 55 Gi avail. Source file 987 → 1126 LOC (+139), 16 → 17 theorems, 0 sorries, 0 axioms. +1 `#check BlichfeldtTheorem.blichfeldt_general_lattice` at :1117. Mechanic territory deferred: `meta.json.lineCount 987 → 1126`, `meta.json.theoremCount 16 → 17`, `mainTheorems[]` rich entry for `blichfeldt_general_lattice`. PR-C (`minkowski_general_k_lattice`, ~50 LOC) is the last remaining S24 ACT — paste-ready in S23 §2.2, bearers B3 + B4 enter scope.",
+    "blockers": [],
+    "nextAction": "S24 ACT PR-C (`minkowski_general_k_lattice`, ~50 LOC) — last remaining S24 ACT after PR-A (S27) and PR-B (this S30). Paste-ready Lean in `s23-lattice-generalization-spec.md §2.2`. Bearers B3 (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) + B4 (`Module.finrank_fin_fun`) enter scope; both pinned in S25 manifest at SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Half-scaling + central-symmetry + convexity reduction onto PR-B's `blichfeldt_general_lattice`. Insertion site: after `minkowski_general_k` at :719. Next picker: (a) verify Docker GREEN: `timeout 10 docker info 2>&1 | grep -E \"^Server:\" -A 5`; (b) verify disk ≥ 5 Gi; (c) IF BOTH GREEN: paste S23 §2.2 and ship via `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04` (~12 min cold start); (d) IF EITHER RED: ship doc-only S31 STATE-SYNC. Mechanic-pending after S30 lands: `meta.json.lineCount 987 → 1126`, `meta.json.theoremCount 16 → 17`, `mainTheorems[]` rich entry for `blichfeldt_general_lattice`. Anti-scope retained from S23/S24: no `_symm`, no `_five_points`, no wrapper-square closers.",
     "attemptCounts": {
-      "total": 28,
-      "currentApproach": 13,
+      "total": 29,
+      "currentApproach": 14,
       "approachesTried": 0
     },
-    "lastUpdate": "2026-05-17T01:55:00.000Z"
+    "lastUpdate": "2026-06-02T00:25:00.000Z"
   },
   "knowledge": {
     "progressSummary": "PROGRESS (S27 PR-A, 2026-05-16): shipped basis-parametric `volume_eq_setLIntegral_indicator_tsum_lattice` to `MinkowskiTheoremOQ04.lean` (+65 LOC, 922→987, 15→16 theorems, 3075-job Docker green first-try). S28 PREP (PR #19640 merged 2026-05-16T15:20:34Z) and S29 STATE-SYNC (this PR) are doc-only catchup; PR-B (`blichfeldt_general_lattice`, ~80 LOC) and PR-C (`minkowski_general_k_lattice`, ~50 LOC) remain Docker-blocked since 06:01Z (Path C window EXPIRED at 18:01Z; ~7.9h past at S29 time). Entry point for the S24 lattice-generalisation chain (PR-A→B→C) per S23 PREP §4. Anti-scope intact: no _symm / _five_points / wrapper closers. Gallery `meta.status/badge` flipped axiomatized→verified / axiom→original by mechanic PR #19542; `mainTheorems[]` entry for the S27 PR-A theorem still pending in mechanic territory.",
@@ -159,8 +146,8 @@
     {
       "path": "Proofs/MinkowskiTheoremOQ04.lean",
       "filename": "MinkowskiTheoremOQ04.lean",
-      "lineCount": 987,
-      "theoremCount": 16,
+      "lineCount": 1126,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 1,
@@ -168,5 +155,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ04.lean"
     }
   ],
-  "lastUpdate": "2026-05-17T01:55:00Z"
+  "lastUpdate": "2026-06-02T00:25:00Z"
 }


### PR DESCRIPTION
## Summary

Ships S24 PR-B per S23 spec §2.1 / §4 (researcher-1, 2026-06-02, T+16d since S29 STATE-SYNC).

- New theorem `BlichfeldtTheorem.blichfeldt_general_lattice` at `proofs/Proofs/MinkowskiTheoremOQ04.lean:441` (post-edit numbering): basis-parametric k+1 covering form of Blichfeldt's theorem over arbitrary full-rank ℤ-lattices.
- Mechanical S23 §4 substitution from `blichfeldt_general` at :324: `stdLattice n → Submodule.span ℤ (Set.range b)`, `stdFundDomain n → ZSpan.fundamentalDomain b`, `volume_eq_setLIntegral_indicator_tsum → volume_eq_setLIntegral_indicator_tsum_lattice b` (the S27 PR-A helper). Hypothesis form `(k : ENNReal) * volume (ZSpan.fundamentalDomain b) < volume s` per S23 §5 (covolume term abstract).
- Docker 3075 jobs / first-try clean on Mathlib v4.26.0 pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.

## Infra status (S30 pre-flight)

| Gate | S29 status | S30 status |
|---|---|---|
| B1 Docker daemon | RED (hung 19.9h, Path C window EXPIRED 7.9h past) | ✅ CLEARED — `docker info` returns full Server: section (Containers: 0, Images: 3) |
| B2 host disk | RED (3.4 Gi avail / 100% used) | ✅ CLEARED — 55 Gi avail / 94% used |
| Mathlib pin | `2df2f0150c…` | `2df2f0150c…` (unchanged since S25/S26/S27/S28/S29) |

## Source-file metrics

| Item | Before (origin/main HEAD) | After (this PR) |
|---|---|---|
| Lines (`wc -l`) | 987 | **1126** (+139) |
| Theorems | 16 | **17** (+1: `blichfeldt_general_lattice`) |
| Axioms (`grep -c "^axiom "`) | 0 | 0 (unchanged) |
| Sorries | 0 | 0 (unchanged) |
| Export `#check` entries | 11 | 12 (+1 at :1117) |

## Files modified

- `proofs/Proofs/MinkowskiTheoremOQ04.lean` (+139 LOC: 1 new theorem with ~110 LOC body + ~17 LOC docstring + 1 `#check`)
- `research/problems/minkowski-theorem-oq-04/state.md` (S30 header + iteration block)
- `src/data/research/problems/minkowski-theorem-oq-04.json` (focus, blockers cleared, nextAction → PR-C, attemptCounts.total 28→29, leanFiles[2].{lineCount 987→1126, theoremCount 16→17}, lastUpdate)

## Files NOT modified (mechanic territory, per S27/S28 precedent)

- `src/data/proofs/minkowski-theorem-oq-04/meta.json` — `lineCount: 987 → 1126`, `theoremCount: 16 → 17`, `mainTheorems[]` rich entry for `blichfeldt_general_lattice`.

## S24 sequencing post-PR-B

| PR | Theorem | Status |
|---|---|---|
| **PR-A** | `volume_eq_setLIntegral_indicator_tsum_lattice` | ✅ shipped S27 :264 |
| **PR-B** | `blichfeldt_general_lattice` | ✅ **shipped S30 (this PR) :441** |
| PR-C | `minkowski_general_k_lattice` (~50 LOC) | ⏳ unblocked; bearers B3 + B4 enter scope; paste-ready in S23 §2.2 |

## Test plan

- [x] Docker build 3075 jobs clean (`./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04`)
- [x] `#check BlichfeldtTheorem.blichfeldt_general_lattice` resolves with expected signature in build output
- [x] `python3 -m json.tool` validates the modified research-JSON
- [x] No new axioms; no new sorries; specialisation `blichfeldt_general = blichfeldt_general_lattice (stdBasis n)` is sound at the type level (would be the body of an optional `simpa`-wrapper per S23 §2.3 follow-up PR-D)

🤖 Generated with [Claude Code](https://claude.com/claude-code)