### PR TITLE
fix(meta): register 27 orphan companion files across 25 slugs

### DIFF
--- a/src/data/proofs/brouwer-fixed-point/meta.json
+++ b/src/data/proofs/brouwer-fixed-point/meta.json
@@ -314,6 +314,14 @@
     "sorries": 0,
     "path": "Proofs/BrouwerFixedPoint.lean",
     "definitionCount": 7,
-    "theoremCount": 5
-  }
+    "theoremCount": 5,
+    "additionalFiles": [
+      "Proofs/BrouwerFixedPointOQ01OQ02G8.lean",
+      "Proofs/BrouwerFixedPointOQ01OQ02G10.lean"
+    ]
+  },
+  "additionalFiles": [
+    "Proofs/BrouwerFixedPointOQ01OQ02G8.lean",
+    "Proofs/BrouwerFixedPointOQ01OQ02G10.lean"
+  ]
 }

--- a/src/data/proofs/cayley-hamilton-minpoly/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly/meta.json
@@ -227,7 +227,10 @@
     "theoremCount": 30,
     "definitionCount": 0,
     "path": "Proofs/CayleyHamiltonOQ01.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean"
+    ]
   },
   "crossReferences": [
     {
@@ -289,5 +292,8 @@
       "leanType": "aeval A p = 0 -> Monic p -> minpoly.natDegree <= p.natDegree"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean"
+  ]
 }

--- a/src/data/proofs/cramers-rule/meta.json
+++ b/src/data/proofs/cramers-rule/meta.json
@@ -213,7 +213,10 @@
     "theoremCount": 9,
     "definitionCount": 0,
     "path": "Proofs/CramersRule.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CramersRuleOQ03OQ03.lean"
+    ]
   },
   "references": [
     {
@@ -253,5 +256,8 @@
       "leanType": "det A != 0 -> A.mulVec x = b -> x i = det (A.updateColumn i b) / det A"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/CramersRuleOQ03OQ03.lean"
+  ]
 }

--- a/src/data/proofs/dirichlets-theorem/meta.json
+++ b/src/data/proofs/dirichlets-theorem/meta.json
@@ -208,7 +208,10 @@
     "theoremCount": 10,
     "definitionCount": 7,
     "path": "Proofs/DirichletsTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/DirichletsTheoremOQ03Incomplete01.lean"
+    ]
   },
   "references": [
     {
@@ -255,5 +258,8 @@
       "leanType": "Nat.Coprime a d -> Set.Infinite {p | Nat.Prime p and p % d = a % d}"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/DirichletsTheoremOQ03Incomplete01.lean"
+  ]
 }

--- a/src/data/proofs/elementary-quadratic-reciprocity/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity/meta.json
@@ -175,7 +175,10 @@
     "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/ElementaryQuadraticReciprocity.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean"
+    ]
   },
   "crossReferences": [
     {
@@ -248,5 +251,8 @@
       "leanType": "odd_prime p -> odd_prime q -> p != q -> legendreSym p q * legendreSym q p = (-1)^((p-1)/2 * (q-1)/2)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean"
+  ]
 }

--- a/src/data/proofs/euler-totient/meta.json
+++ b/src/data/proofs/euler-totient/meta.json
@@ -203,7 +203,10 @@
     "theoremCount": 5,
     "definitionCount": 0,
     "path": "Proofs/EulerTotient.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/EulerTotientOQ04OQ01.lean"
+    ]
   },
   "references": [
     {
@@ -248,5 +251,8 @@
       "leanType": "Nat.Coprime a n -> a ^ Nat.totient n % n = 1"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/EulerTotientOQ04OQ01.lean"
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem-defs/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs/meta.json
@@ -201,7 +201,10 @@
     "theoremCount": 38,
     "definitionCount": 36,
     "path": "Proofs/FeuerbachsTheoremDefs.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremDefsOQ03.lean"
+    ]
   },
   "references": [
     {
@@ -228,5 +231,8 @@
       "leanType": "ninePointCircle : Triangle -> Circle"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/FeuerbachsTheoremDefsOQ03.lean"
+  ]
 }

--- a/src/data/proofs/feuerbachs-theorem/meta.json
+++ b/src/data/proofs/feuerbachs-theorem/meta.json
@@ -125,7 +125,10 @@
     "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/FeuerbachsTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FeuerbachsTheoremOQ01OQ03.lean"
+    ]
   },
   "references": [
     {
@@ -183,5 +186,8 @@
       "leanType": "Triangle ABC -> tangent (ninePointCircle ABC) (incircle ABC)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/FeuerbachsTheoremOQ01OQ03.lean"
+  ]
 }

--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -202,7 +202,10 @@
     "theoremCount": 10,
     "definitionCount": 6,
     "path": "Proofs/FriendshipTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FriendshipTheoremOQ02.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -212,5 +215,8 @@
       "leanType": "(forall u v, u != v -> exists! w, adj u w and adj v w) -> exists v, forall u, u != v -> adj u v"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/FriendshipTheoremOQ02.lean"
+  ]
 }

--- a/src/data/proofs/fundamental-theorem-algebra/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra/meta.json
@@ -308,7 +308,10 @@
       }
     ],
     "path": "Proofs/FundamentalTheoremAlgebra.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FundamentalTheoremAlgebraOQ02.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -330,5 +333,8 @@
       "leanType": "{p : ℂ[X]} → p ≠ 0 → Multiset.card p.roots = p.natDegree"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/FundamentalTheoremAlgebraOQ02.lean"
+  ]
 }

--- a/src/data/proofs/fundamental-theorem-calculus/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus/meta.json
@@ -258,7 +258,10 @@
     "theoremCount": 7,
     "definitionCount": 2,
     "path": "Proofs/FundamentalTheoremCalculus.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/FundamentalTheoremCalculusOQ04.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -274,5 +277,8 @@
       "leanType": "a <= b -> ContinuousOn F (Icc a b) -> (forall x in Ioo a b, HasDerivAt F (f x) x) -> integral x in a..b, f x = F b - F a"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/FundamentalTheoremCalculusOQ04.lean"
+  ]
 }

--- a/src/data/proofs/knights-tour-oblique/meta.json
+++ b/src/data/proofs/knights-tour-oblique/meta.json
@@ -157,7 +157,10 @@
     "opens": [],
     "path": "Proofs/KnightsTourOblique.lean",
     "sorries": 0,
-    "definitionCount": 42
+    "definitionCount": 42,
+    "additionalFiles": [
+      "Proofs/KnightsTourObliqueOQ02.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -167,5 +170,8 @@
       "leanType": "board_size >= threshold -> exists tour, is_hamiltonian_path tour"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/KnightsTourObliqueOQ02.lean"
+  ]
 }

--- a/src/data/proofs/law-of-cosines/meta.json
+++ b/src/data/proofs/law-of-cosines/meta.json
@@ -189,7 +189,10 @@
     "theoremCount": 14,
     "definitionCount": 3,
     "path": "Proofs/LawOfCosines.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LawOfCosinesOQ04OQ02OQ01.lean"
+    ]
   },
   "references": [
     {
@@ -208,5 +211,8 @@
       "leanType": "c^2 = a^2 + b^2 - 2*a*b*Real.cos C"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/LawOfCosinesOQ04OQ02OQ01.lean"
+  ]
 }

--- a/src/data/proofs/laws-of-large-numbers/meta.json
+++ b/src/data/proofs/laws-of-large-numbers/meta.json
@@ -266,7 +266,10 @@
     "theoremCount": 11,
     "definitionCount": 3,
     "path": "Proofs/LawsOfLargeNumbers.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/LawsOfLargeNumbersOQ02.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -282,5 +285,8 @@
       "leanType": "[IID X] -> E[X] = mu -> ae (fun omega => Tendsto (fun n => sum X_i(omega) / n) atTop (nhds mu))"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/LawsOfLargeNumbersOQ02.lean"
+  ]
 }

--- a/src/data/proofs/mathematical-induction/meta.json
+++ b/src/data/proofs/mathematical-induction/meta.json
@@ -155,7 +155,10 @@
     "theoremCount": 11,
     "definitionCount": 0,
     "path": "Proofs/MathematicalInduction.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/MathematicalInductionOQ03.lean"
+    ]
   },
   "references": [
     {
@@ -243,5 +246,8 @@
       "leanType": "P 0 -> (forall n, P n -> P (n+1)) -> forall n, P n"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/MathematicalInductionOQ03.lean"
+  ]
 }

--- a/src/data/proofs/minkowski-theorem/meta.json
+++ b/src/data/proofs/minkowski-theorem/meta.json
@@ -296,7 +296,10 @@
       }
     ],
     "path": "Proofs/MinkowskiFundamentalTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/MinkowskiTheoremOQ02OQ03.lean"
+    ]
   },
   "references": [
     {
@@ -363,5 +366,8 @@
       "leanType": "forall (p : Nat), Nat.Prime p -> p % 4 = 1 -> exists a b : Nat, a^2 + b^2 = p"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/MinkowskiTheoremOQ02OQ03.lean"
+  ]
 }

--- a/src/data/proofs/motivic-flag-maps/meta.json
+++ b/src/data/proofs/motivic-flag-maps/meta.json
@@ -188,7 +188,8 @@
     "path": "Proofs/MotivicFlagMaps.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/MotivicFlagMapsProvable.lean"
+      "Proofs/MotivicFlagMapsProvable.lean",
+      "Proofs/MotivicFlagMapsOQ03.lean"
     ]
   },
   "crossReferences": [
@@ -225,5 +226,8 @@
       "leanType": "FlagVariety G B -> MotivicMap -> K_theory_class"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/MotivicFlagMapsOQ03.lean"
+  ]
 }

--- a/src/data/proofs/prime-number-theorem/meta.json
+++ b/src/data/proofs/prime-number-theorem/meta.json
@@ -360,7 +360,10 @@
       }
     ],
     "path": "Proofs/PrimeNumberTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/PrimeNumberTheoremOQ01OQ01.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -382,5 +385,8 @@
       "leanType": "RiemannHypothesis -> |primePi x - logIntegral x| = O(sqrt(x) * ln(x))"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/PrimeNumberTheoremOQ01OQ01.lean"
+  ]
 }

--- a/src/data/proofs/prob-method-alteration/meta.json
+++ b/src/data/proofs/prob-method-alteration/meta.json
@@ -176,7 +176,10 @@
     "theoremCount": 2,
     "definitionCount": 0,
     "path": "Proofs/ProbMethodAlteration.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/ProbMethodAlterationOQ02.lean"
+    ]
   },
   "references": [
     {
@@ -223,5 +226,8 @@
       "leanType": "random_object X -> E[violations] < k -> exists x, violations x = 0"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/ProbMethodAlterationOQ02.lean"
+  ]
 }

--- a/src/data/proofs/pythagorean-theorem/meta.json
+++ b/src/data/proofs/pythagorean-theorem/meta.json
@@ -305,7 +305,10 @@
       }
     ],
     "path": "Proofs/PythagoreanTheorem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/PythagoreanTheoremOQ05.lean"
+    ]
   },
   "mainTheorems": [
     {
@@ -327,5 +330,8 @@
       "leanType": "{s : Finset i} -> {v : i -> Vec2} -> pairwise_perp -> norm(sum v)^2 = sum(norm(v i)^2)"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/PythagoreanTheoremOQ05.lean"
+  ]
 }

--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -79,7 +79,10 @@
     "definitionCount": 6,
     "path": "Proofs/RothTheorem.lean",
     "sorries": 0,
-    "additionalFiles": ["Proofs/RothTheoremAristotle.lean"]
+    "additionalFiles": [
+      "Proofs/RothTheoremAristotle.lean",
+      "Proofs/RothTheoremOQ02.lean"
+    ]
   },
   "sections": [
     {
@@ -140,5 +143,8 @@
       "Prove Szemerédi's theorem (k=4 case) using the regularity lemma approach"
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/RothTheoremOQ02.lean"
+  ]
 }

--- a/src/data/proofs/shapley-folkman/meta.json
+++ b/src/data/proofs/shapley-folkman/meta.json
@@ -225,7 +225,8 @@
     ],
     "namespace": "ShapleyFolkman",
     "additionalFiles": [
-      "Proofs/ShapleyFolkmanAristotle.lean"
+      "Proofs/ShapleyFolkmanAristotle.lean",
+      "Proofs/ShapleyFolkmanOQ01.lean"
     ]
   },
   "mainTheorems": [
@@ -236,5 +237,8 @@
       "leanType": "Decomposition S t x -> d.excessIndices.card <= Module.finrank R E"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/ShapleyFolkmanOQ01.lean"
+  ]
 }

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -103,7 +103,8 @@
     "path": "Proofs/SpernerSimplicialInstance.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/SpernerMathlib4.lean"
+      "Proofs/SpernerMathlib4.lean",
+      "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
     ]
   },
   "sections": [
@@ -160,5 +161,8 @@
       "Connect to David Gale's 1979 Hex theorem: prove that the Hex no-draw property follows from `Triangulation.sperner` applied to the standard 2-d triangulation of the Hex board, and derive 2-d Brouwer as a corollary. Gale's elementary derivation is short and combinatorial — a natural target for a Lean port that exercises the bridge end-to-end."
     ]
   },
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean"
+  ]
 }

--- a/src/data/proofs/spherical-law-of-sines/meta.json
+++ b/src/data/proofs/spherical-law-of-sines/meta.json
@@ -146,6 +146,12 @@
     "theoremCount": 21,
     "definitionCount": 7,
     "sorries": 0,
-    "path": "Proofs/SphericalLawOfSines.lean"
-  }
+    "path": "Proofs/SphericalLawOfSines.lean",
+    "additionalFiles": [
+      "Proofs/SphericalLawOfSinesOQ03.lean"
+    ]
+  },
+  "additionalFiles": [
+    "Proofs/SphericalLawOfSinesOQ03.lean"
+  ]
 }

--- a/src/data/proofs/triangle-inequality/meta.json
+++ b/src/data/proofs/triangle-inequality/meta.json
@@ -203,7 +203,11 @@
     "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/TriangleInequality.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/TriangleInequalityOQ02.lean",
+      "Proofs/TriangleInequalityOQ04OQ01.lean"
+    ]
   },
   "references": [
     {
@@ -250,5 +254,9 @@
       "leanType": "(x y : ℝ) → |x + y| ≤ |x| + |y|"
     }
   ],
-  "sorries": 0
+  "sorries": 0,
+  "additionalFiles": [
+    "Proofs/TriangleInequalityOQ02.lean",
+    "Proofs/TriangleInequalityOQ04OQ01.lean"
+  ]
 }


### PR DESCRIPTION
## Summary
- Mega-batch registration of 27 Lean companion files (basenames OQ.../Incomplete.../G8/G10/Scarf1d) that exist on disk and are imported in `proofs/Proofs.lean` but were absent from `meta.additionalFiles` and `leanFile.additionalFiles` of their parent slugs.
- 25 slugs touched; existing additionalFiles preserved.
- Drained the FREE-WITH-SLUG-MATCH branch of `orphan_scan_v9` at HEAD `f486a19`. PR-diff cross-check confirms none of the 91 open PRs touches these basenames.

## Files registered
brouwer-fixed-point (×2), cayley-hamilton-minpoly, cramers-rule, dirichlets-theorem, elementary-quadratic-reciprocity, euler-totient, feuerbachs-theorem, feuerbachs-theorem-defs, friendship-theorem, fundamental-theorem-algebra, fundamental-theorem-calculus, knights-tour-oblique, law-of-cosines, laws-of-large-numbers, mathematical-induction, minkowski-theorem, motivic-flag-maps, prime-number-theorem, prob-method-alteration, pythagorean-theorem, roth-theorem, shapley-folkman, sperner-simplicial-instance, spherical-law-of-sines, triangle-inequality (×2).

## Test plan
- [x] `python3 /tmp/orphan_scan_v9.py` reports these 27 entries under FREE-WITH-SLUG-MATCH before; reports 0 after.
- [x] `python3 -c "import json; ..."` sanity check confirms every modified meta.json round-trips.
- [x] Diff inspection (`brouwer-fixed-point`, `triangle-inequality`, `roth-theorem`) shows additions stack correctly atop existing entries.
- [ ] Auditor will re-run on next cycle.

🤖 Mechanic batch