### PR TITLE
fix(meta): register 2 NO_SLUG_MATCH orphan companions (cube-root + hilbert-15)

### DIFF
--- a/src/data/proofs/cube-root-2-irrational/meta.json
+++ b/src/data/proofs/cube-root-2-irrational/meta.json
@@ -41,6 +41,9 @@
         "id": "abel-ruffini",
         "relationship": "∛2 is a degree-3 algebraic number whose minimal polynomial X³ − 2 is Eisenstein-irreducible. Galois theory of such cubic radicals underlies the Abel–Ruffini impossibility of solving the general quintic by radicals."
       }
+    ],
+    "additionalFiles": [
+      "Proofs/CubeRoot2IrrationalOQ03.lean"
     ]
   },
   "overview": {
@@ -80,7 +83,10 @@
     "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/CubeRoot2Irrational.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/CubeRoot2IrrationalOQ03.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02-oq-03/meta.json
@@ -52,7 +52,10 @@
     ],
     "dateAdded": "2026-05-06",
     "assumptions": "Three axioms: (1) lrCoeffN — general Littlewood-Richardson coefficient for arbitrary n-row partitions (primary missing Mathlib ingredient, ~300 lines); (2) admissible — recursive admissibility predicate for index triples via LR positivity at lower rank (~200 lines); (3) klyachko_theorem — LR positivity iff admissible Horn inequalities hold (requires stable vector bundles and Schubert calculus for G/P, not in Mathlib, ~3000 lines total).",
-    "mathlib_version": "4.26.0"
+    "mathlib_version": "4.26.0",
+    "additionalFiles": [
+      "Proofs/Hilbert15OQ02OQ03OQ01.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The question of which triples (α, β, γ) of eigenvalues can arise from Hermitian matrices A, B, C = A+B is the **Hermitian sum problem**, posed by Weyl in 1912. Weyl proved necessary inequalities λ_k(C) ≤ λ_i(A) + λ_j(B) (now called Weyl inequalities). Horn (1962) conjectured a complete recursive characterization via what are now called *Horn inequalities*. After partial progress by many authors, Klyachko (1998) proved sufficiency using stable vector bundles, and Knutson-Tao (1999) proved the saturation conjecture via their honeycomb model, completing the picture. The key insight: Horn's inequalities for Hermitian eigenvalues are equivalent to Littlewood-Richardson positivity, reducing both problems to a linear program.",
@@ -176,7 +179,10 @@
     "lineCount": 249,
     "theoremCount": 8,
     "definitionCount": 5,
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Hilbert15OQ02OQ03OQ01.lean"
+    ]
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Fix

Registers 2 truly-free orphan `.lean` files surfaced by `orphan_scan_v10`
after the v10 PR-body substring check missed brace-expansion text in two
existing claim PRs (#22007 listed `YangMills/{Classical,Quantum}.lean` and
`CubeRoot{5,6,7,9,10}Irrational.lean`; #21978 mentioned
`Hilbert{14Invariants,15SchubertCalculus}OQ01.lean`).

A per-PR `gh pr view <num> --json files` cross-check confirmed those 9 are
already claimed; only the 2 in this PR remain unhomed.

## Per-file rationale

| File | Parent slug | Why |
|------|-------------|-----|
| `Proofs/CubeRoot2IrrationalOQ03.lean` | `cube-root-2-irrational` | Header docstring: `**Open Question (from cube-root-2-irrational-oq-03)**`. The OQ-03 sub-slug has no gallery entry — its algebraic-degree development (Eisenstein → minpoly → degree-n bounds for non-perfect-power radicands) is a companion to the parent file `CubeRoot2Irrational.lean`. |
| `Proofs/Hilbert15OQ02OQ03OQ01.lean` | `hilbert-15-oq-02-oq-03` | Header docstring: `(hilbert-15-oq-02-oq-03-oq-01)`; OQ-01 sub-slug not in gallery. File imports `Proofs.Hilbert15OQ02OQ03` and provides the S2 scaffold (`SkewSSYTFin`, `lrCoeffN_def`, `Decidable`/`Fintype` instances) that underpins the parent file's `decide`-based `lr_polytime_positivity`. |

## Evidence

```
$ python3 /tmp/orphan_scan_v10.py
REGISTERED basenames: 2750
TOTAL ORPHANS: 250
CLAIMED BY OPEN PR: 145
FREE WITH SLUG MATCH: 0
FREE NO SLUG MATCH: 11
```

After per-PR file cross-check (v10's basename-in-body match was fooled by
shell-style brace expansion), the actual free count is 2.

## Diff hygiene

- 2 files, +15/-3.
- `meta.additionalFiles` AND `leanFile.additionalFiles` both populated
  (auditor schema followed for both keys, per #21999/#22000/#22003/#22005/#22007).
- `ensure_ascii=False` preserved (no Unicode escapes).
- `pnpm build` regenerated 1195+ annotations.json + research/* paths;
  restored to baseline via `git restore` before staging — diff is meta-only.

## Remaining queue

After this PR + cross-check, **0 truly-free orphans** are left at HEAD
`f486a19e2e0`. The 9 cousins (CubeRoot{5,6,7,9,10}Irrational, Hilbert14InvariantsOQ01, Hilbert15SchubertCalculusOQ01, YangMills/{Classical,Quantum}) are all
claimed by open PRs #22007 / #21978.

---
Automated fix by lean-mechanic agent (mechanic-1, cycle N+68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)