### PR TITLE
fix(meta): register 25 Stubs/Erdos*Aristotle.lean orphan companions (25 slugs)

### DIFF
--- a/src/data/proofs/erdos-104/meta.json
+++ b/src/data/proofs/erdos-104/meta.json
@@ -27,7 +27,10 @@
     "assumptions": "0 axioms, 0 sorries. All geometric lemmas fully proved: two_points_no_circle (triangle inequality), two_points_one_circle (parallelogram law uniqueness), strong_implies_weak, quadratic_at_most_two_roots. The main conjecture O(n^{3/2}) remains open. Open conjecture; supporting lemmas fully verified.",
     "mathlib_version": "4.26.0",
     "theoremCount": 4,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos104Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem was posed by Erdős in 1975 as part of his extensive program on combinatorial and discrete geometry, and carries a $100 prize. It sits in the family of unit distance and incidence problems that have driven much of modern computational geometry. The fundamental observation is that any two points at distance at most 2 determine at most 2 unit circles through both (the centers lie on the perpendicular bisector), giving a trivial O(n²) upper bound on the number of unit circles with 3+ points from an n-point set. Harborth and Mengersen (1986) refined this to n(n-1)/3 using the fact that each 3-rich circle contributes at least 3 pairs. Elekes (1984) proved the matching lower bound Ω(n^{3/2}) by constructing point sets on a grid-like structure that create many triple incidences with unit circles. This established the conjectured growth rate as Θ(n^{3/2}), but proving the O(n^{3/2}) upper bound has remained stubbornly open. The problem is closely related to the Szemerédi-Trotter incidence theorem (1983), which bounds point-line incidences as O(n^{2/3}m^{2/3} + n + m). Analogous bounds hold for algebraic curves (Pach-Sharir), but naively applying them to unit circles only recovers the O(n²) trivial bound. The difficulty is that unit circles form a special 2-parameter family (parameterized by center position), and exploiting this algebraic structure has resisted all known techniques including polynomial partitioning (Guth-Katz 2015).",
@@ -150,7 +153,10 @@
     "theoremCount": 4,
     "definitionCount": 13,
     "path": "Proofs/Erdos104Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos104Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-1095/meta.json
+++ b/src/data/proofs/erdos-1095/meta.json
@@ -27,7 +27,10 @@
     "lineCount": 180,
     "mathlib_version": "4.26.0",
     "theoremCount": 6,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos1095Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Erdős-Selfridge function was introduced by Ecklund, Erdős, and Selfridge in their 1974 paper 'A new function associated with the prime factors of C(n,k)' in Mathematics of Computation. They proved the first bounds: k^{1+c} < g(k) ≤ exp((1+o(1))k). Konyagin (1999) dramatically improved the lower bound to exp(c·(log k)²) using Rankin's method and smooth number estimates from Canfield–Erdős–Pomerance (1983). Erdős, Lacampagne, and Selfridge (1993) conjectured that any 'right-thinking person' would believe g(k) ≥ exp(c·k/log k), but this remains unproven. The problem connects to Kummer's theorem (1852) on the p-adic valuation of binomial coefficients, the distribution of smooth numbers (Dickman ρ-function), and the Prime Number Theorem via Chebyshev's ψ-function. Sorenson, Sorenson, and Webster (2020) computed g(k) for k ≤ 200, revealing the wildly irregular behavior predicted by the ratio conjectures. The sequence is OEIS A003458.",
@@ -192,7 +195,10 @@
     "theoremCount": 6,
     "definitionCount": 6,
     "path": "Proofs/Erdos1095Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos1095Aristotle.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-1100/meta.json
+++ b/src/data/proofs/erdos-1100/meta.json
@@ -28,7 +28,8 @@
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Erdos1100ProblemAristotle.lean",
-      "Proofs/Erdos1100OQ01Aristotle.lean"
+      "Proofs/Erdos1100OQ01Aristotle.lean",
+      "Proofs/Stubs/Erdos1100Aristotle.lean"
     ]
   },
   "overview": {
@@ -285,7 +286,8 @@
     "sorries": 0,
     "additionalFiles": [
       "Proofs/Erdos1100ProblemAristotle.lean",
-      "Proofs/Erdos1100OQ01Aristotle.lean"
+      "Proofs/Erdos1100OQ01Aristotle.lean",
+      "Proofs/Stubs/Erdos1100Aristotle.lean"
     ]
   },
   "sorries": 0

--- a/src/data/proofs/erdos-135/meta.json
+++ b/src/data/proofs/erdos-135/meta.json
@@ -26,7 +26,10 @@
     "assumptions": "5 axioms: erdos_135_false (the five-distance conjecture is false, Tao 2024), tao_counterexample (Tao's explicit randomized parabola counterexample), guth_katz_lower_bound (any n points determine ≥ cn/√(log n) distinct distances, Guth-Katz 2015), parallelogram_few_distances (parallelograms determine ≤ 3 distances), tao_avoids_parallelograms (five-distance sets contain no parallelogram). 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos135Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős and Gyárfás conjectured that local constraints on 4-point configurations would force global distance diversity: if any 4 points determine at least 5 of the 6 possible distinct distances, the total number of distances should be quadratic. This $250-prize problem remained open for decades until Terence Tao disproved it in September 2024 (arXiv:2409.01343). Tao's counterexample, using randomized algebraic curves over finite fields, was part of his broader exploration of erdosproblems.com, partly as a test case for AI-assisted mathematics. The result shows that local constraints on small point subsets cannot guarantee global distance diversity.",
@@ -115,7 +118,10 @@
     "theoremCount": 3,
     "definitionCount": 8,
     "path": "Proofs/Erdos135Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos135Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-138/meta.json
+++ b/src/data/proofs/erdos-138/meta.json
@@ -59,7 +59,10 @@
     "assumptions": "8 axiom(s) and 1 sorry(s). Axioms: W_is_nonempty (van der Waerden's theorem — pinned-Mathlib v4.26.0 lacks Combinatorics.exists_mono_homothetic_copy, so this is a foundational assumption); berlekamp_lower_bound, gowers_upper_bound, kozik_shabanov_lower_bound (literature bounds); W_three=9, W_four=35, W_five=178, W_six=1132 (exact small values from exhaustive search / SAT). The lone sorry is the main_conjecture_implies_exponential filter-limit implication. The bound W(k+1) − W(k) ≥ k underlying the difference-variant result is proven from W_is_nonempty without further assumptions, via the AlphaProof Nexus coloring-extension argument.",
     "mathlib_version": "4.26.0",
     "theoremCount": 21,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos138Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Van der Waerden proved his theorem in 1927, answering a conjecture of Baudet. The original proof gave Ackermann-type bounds on W(k). Berlekamp (1968) gave the first strong lower bounds using finite field constructions: coloring integers by discrete logarithm mod p avoids long APs. Shelah (1988) obtained the first primitive recursive upper bound, and Gowers (2001) dramatically improved it to tower-of-height-5 using his uniformity norms, winning a Fields Medal partly for this work. Kozik and Shabanov (2016) established the current best general lower bound W(k) ≫ 2^k via the Lovász Local Lemma. Erdős posed this problem in 1980 with a $500 prize, asking whether W(k) grows faster than any exponential — the vast gap between known bounds remains one of the central open problems in Ramsey theory. On 2026-05-21, DeepMind's AlphaProof Nexus system announced (arXiv:2605.22763v1) a Lean proof for the **difference variant**, W(k+1) − W(k) → ∞: a short coloring-extension argument shows W(k+1) − W(k) ≥ k unconditionally, given van der Waerden's theorem. The proof file in this entry ports that AlphaProof Nexus output to our Mathlib-only setup; the main k-th root conjecture remains OPEN.",
@@ -157,7 +160,10 @@
     "theoremCount": 21,
     "definitionCount": 13,
     "path": "Proofs/Erdos138Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos138Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-165/meta.json
+++ b/src/data/proofs/erdos-165/meta.json
@@ -56,7 +56,10 @@
     "assumptions": "10 axioms: ramseyNumber, ramseyNumber_symm, ramseyNumber_recurrence, R3_small_values, aks_upper_bound, shearer_upper_bound, kim_lower_bound, bk_pgm_bound, cjms_bound, hhkp_bound. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 3,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos165Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**The R(3,k) Ramsey Number Problem**\n\nThis is one of the most actively studied problems in Ramsey theory. R(3,k) is the minimum N such that any graph on N vertices contains either a triangle (K₃) or an independent set of size k.\n\n**Timeline:**\n- **1980**: Ajtai-Komlós-Szemerédi prove R(3,k) = O(k²/log k)\n- **1983**: Shearer improves to R(3,k) ≤ (1+o(1))k²/log k (tight upper bound)\n- **1995**: Kim proves R(3,k) = Ω(k²/log k) using the triangle-free process\n- **2020-2021**: Bohman-Keevash and Pontiveros-Griffiths-Morris: c ≥ 1/4\n- **2025**: Campos-Jenssen-Michelen-Sahasrabudhe: c ≥ 1/3\n- **2025**: Hefty-Horn-King-Pfender: c ≥ 1/2 (current best)\n\nThe $250 prize was claimed when Kim established the order of magnitude.",
@@ -164,7 +167,10 @@
     "theoremCount": 2,
     "definitionCount": 3,
     "path": "Proofs/Erdos165Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos165Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-211/meta.json
+++ b/src/data/proofs/erdos-211/meta.json
@@ -52,7 +52,10 @@
     "lineCount": 246,
     "assumptions": "10 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "theoremCount": 1,
-    "definitionCount": 9
+    "definitionCount": 9,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos211Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #211: Lines Formed by Points in the Plane**\n\nThis problem sits at the heart of combinatorial incidence geometry, asking how bounded collinearity forces many determined lines.\n\n**Origins and Context:**\nThe study of incidences between points and lines has roots in classical geometry (Sylvester 1893, Gallai 1944), but the quantitative theory began with Erdős in the 1960s-70s. Problem #211 was posed by Erdős as part of his systematic investigation of extremal problems in discrete geometry, with a $100 prize attached.\n\n**The Two Independent Solutions (1983):**\n- **József Beck** proved the result in 'On the lattice property of the plane and some problems of Dirac, Motzkin, and Erdős in combinatorial geometry' (Combinatorica, 1983). His approach introduced the now-famous *Beck dichotomy*: either many points are collinear, or many lines are formed. The proof uses double counting and the Cauchy-Schwarz inequality.\n- **Endre Szemerédi and William T. Trotter** independently proved the result in 'Extremal problems in discrete geometry' (Combinatorica, 1983). Their approach established the Szemerédi-Trotter incidence theorem $I(P,L) = O(m^{2/3}n^{2/3} + m + n)$, from which the Erdős bound follows as a corollary. The original proof used a cell decomposition; László Székely gave a simpler proof via the crossing number inequality in 1997.\n\n**The Optimal Constant:**\nErdős further speculated that the bound could be sharpened to $\\geq (1+o(1))kn/6$ lines, with the constant $1/6$ being best possible. This constant arises from Steiner-type configurations where every line contains exactly 3 points, yielding $\\binom{n}{2}/3 \\approx n^2/6$ lines. Burr, Grünbaum, and Sloane constructed explicit extremal configurations.\n\n**Legacy:**\nThe Szemerédi-Trotter theorem became one of the most widely-used tools in combinatorial geometry, with applications to sum-product estimates (Elekes 1997), distinct distances (Guth-Katz 2015), and additive combinatorics. The crossing number technique has been called the most useful application of graph theory to geometry.",
@@ -147,7 +150,10 @@
     "theoremCount": 1,
     "definitionCount": 9,
     "path": "Proofs/Erdos211Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos211Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-27/meta.json
+++ b/src/data/proofs/erdos-27/meta.json
@@ -71,7 +71,10 @@
     ],
     "assumptions": "4 axioms for deep mathematical results: (1) erdos_27_ffkpy — FFKPY 2007 main disproof (JAMS Theorem 1.1); (2) growing_C_achieves — FFKPY 2007 positive direction (Theorem 1.2); (3) averaging_bound_exists — probabilistic averaging argument; (4) bbmst_2024 — Bloom-Briggs-Maynard-Smith-Tao 2024 minimum modulus bound. All are published theorems.",
     "theoremCount": 11,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos27Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #27: Almost Covering Systems**\n\nThis $\\$100$ Erdős prize problem sits at the heart of the theory of covering systems — one of Erdős's most sustained research interests.\n\n**Background: Covering Systems**\nA covering system is a finite collection of congruence classes $a_i \\pmod{n_i}$ with distinct moduli $n_1 < \\ldots < n_k$ such that every integer belongs to at least one class. Erdős initiated the systematic study of these objects in 1950 and posed dozens of problems about them over the next five decades.\n\n**The Almost-Covering Question:**\nErdős asked a natural relaxation: instead of covering *every* integer, what if we only need to cover all but a small fraction? An $\\varepsilon$-almost covering leaves at most density $\\varepsilon$ of integers uncovered. The specific question was whether a fixed constant $C > 1$ suffices to achieve $\\varepsilon$-almost covering with all moduli in the bounded range $[N, CN]$, for *all* $\\varepsilon > 0$ and $N \\geq 1$.\n\n**The FFKPY Disproof:**\nFilaseta, Ford, Konyagin, Pomerance, and Yu resolved this negatively. Their key insight: for moduli in $[N, CN]$ with fixed $C$, the total 'coverage capacity' is $\\sum_{n=N}^{CN} 1/n \\approx \\ln C$, which is bounded. Using a critical exponent $\\alpha(N) = \\frac{\\log\\log\\log N}{4\\log\\log N}$, they showed that for $C \\leq N^{\\alpha(N)}$ (which includes all constants), the uncovered density is bounded below by approximately $1/(2C)$. No fixed $C$ can make this arbitrarily small.\n\n**What Does Work:**\nIf $C$ is allowed to grow with $N$ (e.g., $C(N) = N^{1/\\log\\log N}$), then $\\varepsilon$-almost coverings exist for any fixed $\\varepsilon$. The boundary between success and failure lies at the growth rate of the critical exponent.\n\n**Connection to Perfect Coverings:**\nThe related question for perfect coverings (covering *every* integer) was resolved by Hough (2015): covering systems cannot have all moduli exceeding some absolute bound. Bloom, Briggs, Maynard, Smith, and Tao (2024) improved the bound to $616{,}000$.",
@@ -198,7 +201,10 @@
     "theoremCount": 11,
     "definitionCount": 18,
     "path": "Proofs/Erdos27Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos27Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-357/meta.json
+++ b/src/data/proofs/erdos-357/meta.json
@@ -58,7 +58,10 @@
     "assumptions": "3 axioms: weisenberg_lower_bound (f(n) ≥ (2+o(1))√n via B₂ sequences), hegyvari_bounds ((1/3+o(1))n ≤ g(n) ≤ (2/3+o(1))n, Hegyvári 1986), infinite_set_lower_density_zero (proved: any infinite A with distinct consecutive sums has lower density 0). 0 sorries.",
     "lineCount": 137,
     "theoremCount": 0,
-    "definitionCount": 8
+    "definitionCount": 8,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos357Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #357 was posed in Erdős's 1977 paper 'Problems and results on combinatorial number theory III.' Given a strictly increasing sequence $1 \\leq a_1 < a_2 < \\cdots < a_k \\leq n$, consider all 'consecutive sums' $\\sum_{i=u}^{v} a_i$ for $1 \\leq u \\leq v \\leq k$. There are $k(k+1)/2$ such sums. The function $f(n)$ measures the maximum $k$ for which all these sums can be distinct.\n\nWeisenberg connected this to **Sidon sets** (B₂ sequences), introduced by Simon Sidon in the 1930s and studied by Erdős and Turán (1941). Any B₂ set — where all pairwise sums $a_i + a_j$ (with $i \\ne j$) are distinct — automatically has distinct consecutive sums, because consecutive sums are differences of partial sums and hence determined by pairs. Since the largest B₂ set in $[1,n]$ has size $(1+o(1))\\sqrt{n}$ (Erdős–Turán 1941), this gives $f(n) \\geq (2+o(1))\\sqrt{n}$.\n\nHegyvári (1986) studied the **non-monotone variant** $g(n)$ in 'On consecutive sums in sequences' (Acta Math. Hungar. 48, 193–200), proving $(1/3+o(1))n \\leq g(n) \\leq (2/3+o(1))n$. The dramatic contrast — $g(n) = \\Theta(n)$ vs. conjectured $f(n) = o(n)$ — shows that strict monotonicity is the fundamental constraint.",
@@ -205,7 +208,10 @@
     "theoremCount": 0,
     "definitionCount": 8,
     "path": "Proofs/Erdos357Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos357Aristotle.lean"
+    ]
   },
   "mainTheorems": [
     {

--- a/src/data/proofs/erdos-392/meta.json
+++ b/src/data/proofs/erdos-392/meta.json
@@ -63,7 +63,10 @@
     "lineCount": 192,
     "assumptions": "12 axiom(s) and 0 sorries. See the Lean source for details.",
     "theoremCount": 1,
-    "definitionCount": 1
+    "definitionCount": 1,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos392Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős Problem #392 asks about the most efficient way to express n! as a product of bounded factors. Given the constraint that each factor aᵢ ≤ n², what is the minimum number of factors needed?\n\nThe answer involves a beautiful interplay between Stirling's approximation and factor pairing. Stirling tells us log(n!) ≈ n log n, so if each factor is at most n², contributing at most 2 log n to the logarithm, we need roughly (n log n)/(2 log n) = n/2 factors.\n\nCambie observed that the problem with bound n² can be reduced to the variant with bound n via factor pairing. If a₁...aₜ = n! with each aᵢ ≤ n, define a'ᵢ = a₂ᵢ₋₁ · a₂ᵢ. Then each a'ᵢ ≤ n² and we have roughly t/2 factors. The variant with bound n is solved by a greedy algorithm: use n as often as possible, then n-1, and so on.",
@@ -175,7 +178,10 @@
     "theoremCount": 1,
     "definitionCount": 1,
     "path": "Proofs/Erdos392Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos392Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-43/meta.json
+++ b/src/data/proofs/erdos-43/meta.json
@@ -73,7 +73,10 @@
     "lineCount": 312,
     "assumptions": "3 axioms (maxSidonSize, sidon_size_asymptotic, barreto_counterexample). 0 sorries — all theorems proved.",
     "theoremCount": 6,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos43Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #43** ($100 bounty)\n\nThis is one of Erdős's celebrated prize problems in additive combinatorics, concerning the structure of **Sidon sets** (also called $B_2$ sets) under a disjoint difference constraint.\n\n**Historical Development:**\n- **Erdős & Turán (1941):** Proved $f(N) \\le \\sqrt{N} + O(N^{1/4})$ and constructed Sidon sets achieving $f(N) \\ge \\sqrt{N} - O(N^{1/4})$ using Singer difference sets from finite projective planes. This established $f(N) \\sim \\sqrt{N}$.\n- **Chowla (1944):** Simplified the Singer construction, showing explicit Sidon sets of size $\\sim \\sqrt{p}$ for primes $p$.\n- **Erdős (1950s-1970s):** Posed Problem #43 asking whether two Sidon sets with disjoint nonzero differences are \"complementary\" — their combined pair count cannot exceed what a single optimal Sidon set achieves, up to $O(1)$.\n- **Tao:** Proved partial results for the equal-size case: if $|A| = |B| = m$, then $m \\le (1/\\sqrt{2} + o(1))\\sqrt{N}$.\n- **Barreto:** Showed the equal-size variant with a multiplicative savings factor $(1-c)$ is false for infinitely many $N$.\n\n**Mathematical Context:**\nThe problem sits at the intersection of additive combinatorics and extremal set theory. Sidon sets are fundamental objects: a set $A \\subseteq \\{1,\\ldots,N\\}$ is Sidon if all pairwise sums $a + b$ ($a \\le b$) are distinct, equivalently if all nonzero differences are distinct. The maximum size $f(N) \\sim \\sqrt{N}$ arises because a Sidon set of size $m$ produces $\\binom{m}{2}$ distinct sums in $\\{2,\\ldots,2N\\}$, giving $\\binom{m}{2} \\lesssim N$. Problem #43 asks whether this constraint is tight even when the difference space is partitioned between two sets.",
@@ -288,7 +291,10 @@
     "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos43Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos43Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-546/meta.json
+++ b/src/data/proofs/erdos-546/meta.json
@@ -25,7 +25,10 @@
     "assumptions": "10 axiom(s) and 0 sorry(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos546Aristotle.lean"
+    ]
   },
   "sections": [
     {
@@ -155,7 +158,10 @@
     "theoremCount": 2,
     "definitionCount": 11,
     "path": "Proofs/Erdos546Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos546Aristotle.lean"
+    ]
   },
   "references": [
     "Erdős (1984): Original problem on Ramsey numbers and edge count",

--- a/src/data/proofs/erdos-606/meta.json
+++ b/src/data/proofs/erdos-606/meta.json
@@ -25,7 +25,10 @@
     "assumptions": "12 axioms: numDistinctLines, numDistinctLines_collinear, numDistinctLines_general_position, numDistinctLines_min_noncollinear, sylvester_gallai, not_achievable_max_minus_1, not_achievable_max_minus_3, achievable_max_minus_2, erdos_density_result, beck_theorem, szemeredi_trotter_bound, erdos_salamon_characterization. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 10
+    "definitionCount": 10,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos606Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**The Distinct Lines Problem**\n\nThis classic problem in discrete geometry asks: given $n$ points in the plane, how many distinct lines can they determine? The answer ranges from 1 (all collinear) to $\\binom{n}{2}$ (general position).\n\n**Key Historical Results**:\n- **Sylvester (1893)**: Posed the question of whether $n$ non-collinear points always determine an ordinary line (one with exactly 2 points). This went unresolved for 50 years.\n- **Gallai (1944)**: Proved Sylvester's conjecture using an elegant extremal argument. The result is now called the Sylvester-Gallai theorem.\n- **Motzkin (1951)**: Gave a shorter proof and established that non-collinear points determine at least $n$ distinct lines.\n- **Beck (1983)**: Proved the fundamental dichotomy — either many points are collinear, or the number of lines is $\\Omega(n^2)$.\n- **Szemerédi-Trotter (1983)**: Established the tight incidence bound $O((nm)^{2/3} + n + m)$, a cornerstone of combinatorial geometry.\n- **Erdős (1985)**: Posed the complete characterization problem as Problem #606.\n- **Erdős-Salamon (1988)**: Solved it for large $n$ — all values from $n$ to $\\binom{n}{2}$ are achievable except exactly two: $\\binom{n}{2}-1$ and $\\binom{n}{2}-3$.\n\n**Why These Exceptions?**\n- $\\binom{n}{2}-1$: Three collinear points reduce the line count by $\\binom{3}{2}-1 = 2$, not 1. More generally, $k$ collinear points reduce by $\\binom{k}{2}-1 \\ge 2$. No combination of collinearities can yield a reduction of exactly 1.\n- $\\binom{n}{2}-3$: The possible reductions from collinearities are sums of numbers $\\ge 2$, so the achievable reductions are $\\{0, 2, 4, 5, 6, \\ldots\\}$. Since 3 is not in this set, $\\binom{n}{2}-3$ is excluded.\n\n**Related Theorems**: Beck's theorem, the Szemerédi-Trotter incidence bound, the orchard problem, and the Dirac-Motzkin conjecture (proved by Green-Tao, 2013) are all closely connected.",
@@ -162,7 +165,10 @@
     "theoremCount": 2,
     "definitionCount": 10,
     "path": "Proofs/Erdos606Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos606Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-607/meta.json
+++ b/src/data/proofs/erdos-607/meta.json
@@ -70,7 +70,10 @@
     "assumptions": "10 axioms: incidenceSignature, incidence_at_least_two, incidence_at_most_n, incidence_pair_constraint, F, F_two, F_three, szemeredi_trotter_incidence, sz_trotter_upper_bound, f_lower_bound. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos607Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "The Szemerédi-Trotter theorem (1983) is one of the most influential results in combinatorial geometry. Endre Szemerédi and William T. Trotter proved that the number of incidences between $n$ points and $m$ lines in $\\mathbb{R}^2$ is at most $O((nm)^{2/3} + n + m)$, resolving a conjecture of Erdős. This bound is tight, achieved by grid configurations.\n\nProblem #607 applies the Szemerédi-Trotter machinery to a counting problem: given $n$ points $P \\subset \\mathbb{R}^2$, the 'incidence signature' $A = \\{|\\ell \\cap P| : \\ell \\text{ determined by } P\\}$ records how many points lie on each line. Let $F(n)$ count the number of distinct achievable signatures. Erdős asked whether $F(n) \\leq \\exp(O(\\sqrt{n}))$ and noted this would be optimal. Szemerédi and Trotter confirmed the upper bound using their incidence theorem.\n\nThe $\\sqrt{n}$ growth connects to the Hardy-Ramanujan partition asymptotic $p(n) \\sim \\frac{1}{4n\\sqrt{3}} \\exp(\\pi\\sqrt{2n/3})$: signatures correspond to constrained integer partitions of $\\binom{n}{2}$ into parts $\\binom{k_i}{2}$, and the partition count grows as $\\exp(\\Theta(\\sqrt{n}))$. This problem carried a \\$250 prize.",
@@ -194,7 +197,10 @@
     "theoremCount": 2,
     "definitionCount": 6,
     "path": "Proofs/Erdos607Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos607Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-609/meta.json
+++ b/src/data/proofs/erdos-609/meta.json
@@ -52,7 +52,10 @@
     "assumptions": "11 axioms: HasMonoOddCycle, K_2n_avoids_odd_cycles, K_2n_plus_1_forces_odd_cycle, f, f_forces, f_minimal, short_cycles_avoidable, day_johnson_lower_bound, f_tends_to_infinity, girao_hunter_upper_bound, janzer_yip_upper_bound. 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 3,
-    "definitionCount": 5
+    "definitionCount": 5,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos609Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős and Graham's work on Ramsey theory for cycles in edge-colored complete graphs. The key observation is a sharp dichotomy: $K_{2^n}$ can be $n$-colored with no monochromatic odd cycles at all (via a recursive doubling construction where each color class is bipartite), but $K_{2^n+1}$ forces at least one monochromatic odd cycle. The question is: how short must that forced cycle be?\n\nThe doubling construction, implicit in Ramsey-theoretic work since the 1970s, produces $n$ bipartite graphs whose edge-union covers $K_{2^n}$. Adding one more vertex to get $K_{2^n+1}$ breaks this: $n$ bipartite graphs cannot partition the edges of $K_{2^n+1}$, since each bipartite graph on $2^n + 1$ vertices has at most $\\lfloor(2^n+1)^2/4\\rfloor$ edges, and $n$ of these cannot reach $\\binom{2^n+1}{2}$.\n\nFan Chung (1997) asked whether $f(n) \\to \\infty$, i.e., whether longer and longer cycles become avoidable as $n$ grows. Day and Johnson (2017) answered YES, proving the lower bound $f(n) \\geq 2^{c\\sqrt{\\log n}}$ for some constant $c > 0$. This super-polynomial but sub-exponential growth shows the avoidance phenomenon is non-trivial.\n\nOn the upper side, Girão and Hunter (2024) proved $f(n) \\leq C \\cdot 2^n / n^{1-o(1)}$, and Janzer and Yip (2025) dramatically improved this to $f(n) \\leq C \\cdot n^{3/2} \\cdot 2^{n/2}$ — an exponential improvement replacing $2^n$ with $2^{n/2}$. The exponential gap between $2^{c\\sqrt{\\log n}}$ and $n^{3/2} \\cdot 2^{n/2}$ remains one of the most intriguing open problems in graph Ramsey theory.",
@@ -183,7 +186,10 @@
     "theoremCount": 3,
     "definitionCount": 5,
     "path": "Proofs/Erdos609Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos609Aristotle.lean"
+    ]
   },
   "sorries": 0
 }

--- a/src/data/proofs/erdos-612/meta.json
+++ b/src/data/proofs/erdos-612/meta.json
@@ -56,7 +56,8 @@
     "theoremCount": 12,
     "definitionCount": 13,
     "additionalFiles": [
-      "Proofs/Erdos612ProblemAristotle.lean"
+      "Proofs/Erdos612ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos612Aristotle.lean"
     ]
   },
   "overview": {
@@ -186,7 +187,8 @@
     "path": "Proofs/Erdos612Problem.lean",
     "sorries": 16,
     "additionalFiles": [
-      "Proofs/Erdos612ProblemAristotle.lean"
+      "Proofs/Erdos612ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos612Aristotle.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-76/meta.json
+++ b/src/data/proofs/erdos-76/meta.json
@@ -94,7 +94,10 @@
     "lineCount": 246,
     "assumptions": "3 axioms (Gruslys-Letzter theorem, balanced bound tightness, extremal stability) + 1 sorry (packing upper bound). See the Lean source for details.",
     "theoremCount": 4,
-    "definitionCount": 17
+    "definitionCount": 17,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos76Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Ramsey's theorem (1930) guarantees that any 2-coloring of $K_6$ contains a monochromatic triangle, since $R(3,3) = 6$. This qualitative existence result naturally leads to quantitative questions: how many monochromatic triangles must appear, and how many can be packed edge-disjointly?\n\nErdős, Faudree, and Ordman posed Problem #76: in any 2-coloring of $K_n$, what is the minimum number of edge-disjoint monochromatic triangles? They conjectured the answer is $(1 + o(1)) n^2/12$, achieved by the balanced bipartition coloring — partition $[n]$ into two equal halves, color within-half edges blue and between-half edges red. The red graph $K_{n/2, n/2}$ is bipartite (triangle-free), and each blue clique $K_{n/2}$ packs $\\approx (n/2)(n/2-1)/6 \\approx n^2/24$ edge-disjoint triangles via Steiner triple systems (Kirkman 1847). Two halves yield $n^2/12$ total.\n\nThe conjecture was confirmed by Vytautas Gruslys and Shoham Letzter in their 2020 Combinatorica paper. Their proof applies a variant of the Szemerédi regularity lemma (1978) to decompose the 2-colored $K_n$ into structured regular pairs, then uses a greedy-absorption method to build the packing. They also established a stability result: any coloring achieving the bound must be close to the balanced bipartition (up to isomorphism).\n\nThe problem connects Ramsey theory (existence of monochromatic subgraphs), extremal graph theory (extremal constructions and stability), packing theory (edge-disjointness constraints), and design theory (Steiner triple systems for optimal packings).",
@@ -226,7 +229,10 @@
     "theoremCount": 4,
     "definitionCount": 17,
     "path": "Proofs/Erdos76Problem.lean",
-    "sorries": 1
+    "sorries": 1,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos76Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -42,7 +42,10 @@
     "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation` (which had become transitively in scope and blocked iterations since 2026-04-27). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
-    "definitionCount": 7
+    "definitionCount": 7,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos761Aristotle.lean"
+    ]
   },
   "sections": [
     {
@@ -131,7 +134,10 @@
     "theoremCount": 7,
     "definitionCount": 7,
     "path": "Proofs/Erdos761Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos761Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-793/meta.json
+++ b/src/data/proofs/erdos-793/meta.json
@@ -27,7 +27,10 @@
     "assumptions": "5 axiom(s). See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
-    "definitionCount": 13
+    "definitionCount": 13,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos793Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem originates from Erdős's 1938 paper 'On sequences of integers no one of which divides the product of two others', one of his earliest contributions to multiplicative number theory and extremal combinatorics. The concept of primitive sets — where no element divides another — goes back to Besicovitch (1934) and Behrend (1935), who studied their density properties. Erdős strengthened the condition: instead of just pairwise non-divisibility, he required that no element $a$ divides the product $bc$ of any two other distinct elements. In his 1969 paper 'Some applications of graph theory to number theory', Erdős introduced an elegant bipartite graph construction to prove the upper bound, pioneering the use of extremal graph theory in number-theoretic problems. The graph has small integers and large primes as vertices, with edges encoding products in the set; the divisibility condition forces this graph to be $P_3$-free (no path of length 3), hence a forest. This technique — reducing a number theory problem to a forbidden subgraph problem — became a template for many later results in combinatorial number theory, including work by Pomerance and Alon on primitive sets and their generalizations. The exact constant $C$ in the secondary term remains open, connecting to deep questions about the distribution of smooth numbers and the multiplicative structure of integers.",
@@ -136,7 +139,10 @@
     "theoremCount": 1,
     "definitionCount": 13,
     "path": "Proofs/Erdos793Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos793Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-83/meta.json
+++ b/src/data/proofs/erdos-83/meta.json
@@ -75,7 +75,10 @@
     "lineCount": 308,
     "assumptions": "7 axioms: erdos_ko_rado_bound, ekr_achieved, starLikeFamily_achieves, starLikeFamily_valid, ahlswede_khachatrian_theorem, erdos83_from_ak, erdos83_bound_asymptotic. 3 sorry(s).",
     "theoremCount": 5,
-    "definitionCount": 12
+    "definitionCount": 12,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos83Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #83: The Complete Intersection Theorem**\n\nThis problem represents one of the most celebrated successes in extremal set theory, bridging a 36-year gap from conjecture to proof.\n\n**The Erdős-Ko-Rado Foundation (1961):** Erdős, Ko, and Rado proved that for $k$-subsets of $[n]$ with $n \\geq 2k$, the largest *intersecting* family (every pair shares $\\geq 1$ element) has size $\\binom{n-1}{k-1}$. This launched the field of extremal set theory. The 'star' family $\\{A : x \\in A\\}$ achieves this bound.\n\n**The $t$-Intersecting Conjecture:** EKR naturally asked: what about $t$-intersecting families ($|A \\cap B| \\geq t$)? For the specific case of $2n$-subsets of $[4n]$ with $t = 2$, they conjectured the bound $\\frac{1}{2}(\\binom{4n}{2n} - \\binom{2n}{n}^2)$. Erdős attached a **\\$500 prize** — one of his larger prizes, reflecting the difficulty.\n\n**36 Years of Partial Progress:** Wilson (1984) proved the result for $t$ sufficiently large relative to $k$. Frankl (1978) developed the 'shifting' technique, solving many special cases. But the general problem resisted all approaches.\n\n**The Breakthrough (1997):** Ahlswede and Khachatrian proved the **Complete Intersection Theorem**, which determines the maximum $t$-intersecting $k$-uniform family on $[m]$ for *all* valid parameters $(m, k, t)$. Their proof introduced the 'pushing-pulling' technique, a two-directional generalization of Frankl's shifting that preserves the $t$-intersecting property.\n\n**The Key Innovation:** Classical shifting (replacing element $j$ with element $i < j$ if the result stays in the family) preserves $1$-intersecting but can destroy $t$-intersecting for $t \\geq 2$. Ahlswede-Khachatrian's pushing-pulling modifies pairs of elements simultaneously, maintaining the stronger intersection requirement.\n\n**Phase Transitions:** A remarkable feature of the AK theorem is that the extremal family changes structure at critical parameter values. The optimal family $\\mathcal{A}(r)$ consists of all $k$-subsets with $\\geq t+r$ elements from a fixed $(t+2r)$-set, where $r$ depends on $(m, k, t)$. As parameters vary, $r$ jumps — a discrete phase transition.",
@@ -206,7 +209,10 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "path": "Proofs/Erdos83Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos83Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-860/meta.json
+++ b/src/data/proofs/erdos-860/meta.json
@@ -61,7 +61,8 @@
     "theoremCount": 3,
     "definitionCount": 7,
     "additionalFiles": [
-      "Proofs/Erdos860ProblemAristotle.lean"
+      "Proofs/Erdos860ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos860Aristotle.lean"
     ]
   },
   "overview": {
@@ -164,7 +165,8 @@
     "path": "Proofs/Erdos860Problem.lean",
     "sorries": 3,
     "additionalFiles": [
-      "Proofs/Erdos860ProblemAristotle.lean"
+      "Proofs/Erdos860ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos860Aristotle.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-900/meta.json
+++ b/src/data/proofs/erdos-900/meta.json
@@ -54,7 +54,10 @@
     "lineCount": 285,
     "assumptions": "19 axiom(s) and 3 sorries(s). See the Lean source for details.",
     "theoremCount": 2,
-    "definitionCount": 19
+    "definitionCount": 19,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos900Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "**Erdős Problem #900: Longest Path in Sparse Random Graphs**\n\nThe study of random graphs began with the seminal 1960 paper of Paul Erdős and Alfréd Rényi, \"On the evolution of random graphs,\" which introduced the $G(n, m)$ model and discovered the **giant component phase transition** at $m = n/2$ (average degree 1). Below this threshold, $G(n, cn)$ is a forest of small trees; above it, a unique giant component of size $\\Theta(n)$ emerges.\n\nErdős asked (c. 1982, [Er82e]): how long is the longest path in $G(n, cn)$ when $c > 1/2$? The giant component has $\\Theta(n)$ vertices, but having many vertices does not guarantee long paths — the component could be bushy rather than elongated.\n\n**Miklós Ajtai, János Komlós, and Endre Szemerédi** resolved this in 1981 in the first volume of *Combinatorica*. They proved there exists a function $f:(1/2, \\infty) \\to (0,1)$ such that $G(n, cn)$ has whp a path of length $(f(c) + o(1))n$, with $f(c) \\to 0$ as $c \\to 1/2^+$ and $f(c) \\to 1$ as $c \\to \\infty$.\n\nThe proof introduced the **rotation-extension technique** (building on Pósa's 1976 method): start with a DFS path, then repeatedly rotate endpoints and extend until the path covers all reachable vertices. The **expansion property** of random graphs — every small vertex set has many external neighbors — ensures this process terminates with a path of length proportional to the giant component.\n\nThe Hamiltonian path threshold was later determined by Komlós and Szemerédi (1983): $G(n, p)$ has a Hamiltonian path whp when $p = (\\log n + \\log\\log n + \\omega(1))/(2n)$, connecting to the minimum degree condition.\n\nThe AKS theorem exemplifies the **probabilistic method** in combinatorics: random graphs achieve near-optimal path lengths, answering a question about deterministic graph structure through probability.",
@@ -190,7 +193,10 @@
     "theoremCount": 2,
     "definitionCount": 19,
     "path": "Proofs/Erdos900Problem.lean",
-    "sorries": 3
+    "sorries": 3,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos900Aristotle.lean"
+    ]
   },
   "references": [
     {

--- a/src/data/proofs/erdos-94/meta.json
+++ b/src/data/proofs/erdos-94/meta.json
@@ -65,7 +65,10 @@
     "assumptions": "8 axioms: convex_implies_no_collinear (convex position implies no three collinear), sum_multiplicities (Σf(u) = C(n,2) identity), fishburn_theorem (O(n³) bound for convex polygons), lefmann_theile_theorem (O(n³) under no-three-collinear, Lefmann-Theile 1995), regularNGon (regular n-gon construction), regularNGon_card (n-gon has n points), regularNGon_convex (n-gon in convex position), regularNGon_cubic (Θ(n³) lower/upper bound for n-gon). See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
-    "definitionCount": 11
+    "definitionCount": 11,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos94Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős posed this $44 prize problem asking whether $\\sum f(u_i)^2 = O(n^3)$ for $n$ points in convex position, where $f(u)$ counts pairs at distance $u$. The question connects to the broader study of distance distributions in discrete geometry. Fishburn resolved it affirmatively, establishing the cubic upper bound. Lefmann and Theile (1995) strengthened the result by proving the same bound under the weaker assumption that no three points are collinear — a strict generalization since convex position implies no-three-collinear but not conversely. The trivial identity $\\sum f(u) = \\binom{n}{2}$ means the problem asks about the 'concentration' of distances: by Cauchy-Schwarz, $\\sum f(u)^2 \\geq \\binom{n}{2}^2 / |d(P)|$, so the $O(n^3)$ bound constrains how clustered the distance distribution can be. Erdős and Fishburn conjectured that the regular $n$-gon maximizes $\\sum f(u)^2$ among all convex $n$-gons for large $n$, verified computationally for $n \\leq 10$ (OEIS A387858). The formalization includes an Aristotle-proved theorem ($\\sum f(u) = \\binom{n}{2}$) alongside 12 axiomatized results.",
@@ -179,7 +182,10 @@
     "theoremCount": 0,
     "definitionCount": 11,
     "path": "Proofs/Erdos94Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos94Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-952/meta.json
+++ b/src/data/proofs/erdos-952/meta.json
@@ -61,7 +61,10 @@
     "lineCount": 359,
     "assumptions": "2 axioms: (1) gaussian_prime_classification (the full characterization of Gaussian primes via norm type), (2) tsuchimura (computational verification — no walk ≤ √26). All other results proved from these axioms or from Mathlib.",
     "theoremCount": 18,
-    "definitionCount": 18
+    "definitionCount": 18,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos952Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "This problem is notably NOT actually an Erdős problem. According to Erdős himself, the conjecture originated with Theodore Motzkin, Basil Gordon, and others at a 1963 Pasadena number theory meeting. Erdős popularized it by sharing it widely, and the attribution was eventually forgotten.\n\nThe 'Gaussian moat' refers to prime-free regions in ℤ[i]. The question asks whether one can 'walk' from 0 to infinity on Gaussian primes with bounded step size.\n\nKnown results:\n- Jordan and Rabung (1970): No walk with steps ≤ 2\n- Tsuchimura (2005): No walk with steps ≤ √26\n- Gethner et al.: Step size 4 insufficient\n\nTerence Tao has indicated this problem appears quite difficult.",
@@ -162,7 +165,10 @@
     "theoremCount": 18,
     "definitionCount": 18,
     "path": "Proofs/Erdos952Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos952Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {

--- a/src/data/proofs/erdos-97/meta.json
+++ b/src/data/proofs/erdos-97/meta.json
@@ -55,7 +55,10 @@
     "lineCount": 163,
     "assumptions": "4 axioms: danzer_counterexample, fishburn_reeds_example, fishburn_reeds_minimal, no_bound_without_convexity. 0 sorries.",
     "theoremCount": 2,
-    "definitionCount": 6
+    "definitionCount": 6,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos97Aristotle.lean"
+    ]
   },
   "overview": {
     "historicalContext": "Erdős originally conjectured (1946) that every convex polygon has a vertex with no other 3 vertices equidistant from it. Danzer disproved this with a 9-point counterexample where every vertex has exactly 3 vertices equidistant from it.\n\nThe problem was then raised for k = 4: does every convex polygon have a vertex with no other 4 vertices equidistant? This remains open.\n\nFishburn and Reeds (1992) found an even stronger example: a convex 20-gon where every vertex has 3 vertices at UNIT distance (not just equidistant at varying radii). They also proved 20 is minimal for this property.",
@@ -142,7 +145,10 @@
     "theoremCount": 2,
     "definitionCount": 6,
     "path": "Proofs/Erdos97Problem.lean",
-    "sorries": 0
+    "sorries": 0,
+    "additionalFiles": [
+      "Proofs/Stubs/Erdos97Aristotle.lean"
+    ]
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
- Mechanic-1 **N+69** orphan drain. v13 scan classified **25 truly free** `Stubs/Erdos<N>Aristotle.lean` orphans across 25 erdos-N slugs.
- Each is a routine-lemma Aristotle companion whose docstring explicitly targets `Erdős Problem #N`.
- Registered in both `meta.additionalFiles` and `leanFile.additionalFiles` (string form, per auditor convention).

## Slugs (25)
erdos-27 · erdos-43 · erdos-76 · erdos-83 · erdos-94 · erdos-97 · erdos-104 · erdos-135 · erdos-138 · erdos-165 · erdos-211 · erdos-357 · erdos-392 · erdos-546 · erdos-606 · erdos-607 · erdos-609 · erdos-612 · erdos-761 · erdos-793 · erdos-860 · erdos-900 · erdos-952 · erdos-1095 · erdos-1100

## Classification

| Status | Count | Action |
|--------|-------|--------|
| FREE   | 25    | Register here (this PR) |
| REG    | ~17   | Already registered; skipped |
| DUP    | ~16   | Identical-MD5 duplicate at top level; cleanup is hermit territory |

## Notes
- **erdos-612** and **erdos-1100** already register a distinct Aristotle companion (`Erdos612ProblemAristotle.lean` / `Erdos1100ProblemAristotle.lean` + `Erdos1100OQ01Aristotle.lean`). The `Stubs/*` variants are **content-distinct** (MD5-verified) routine-lemma supplements; registering both is valid.
- `Stubs/Erdos<N>Problem.lean` files that are byte-identical duplicates of `Proofs/Erdos<N>Problem.lean` are **not** registered — duplicate content cleanup belongs to hermit/loom, not mechanic.

## Test plan
- [x] All 25 meta.json files parse as valid JSON.
- [x] `additionalFiles` mirrored across `meta` and `leanFile` (auditor convention).
- [x] `ensure_ascii=False` preserved across all edits (no \\uXXXX bloat).
- [ ] Auditor revalidates the 25 slugs and clears orphan flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)