### PR TITLE
fix(meta): register 55 Stubs/Erdos*.lean orphan companions (27 slugs)

### DIFF
--- a/src/data/proofs/erdos-1018/meta.json
+++ b/src/data/proofs/erdos-1018/meta.json
@@ -32,7 +32,9 @@
     "theoremCount": 4,
     "definitionCount": 15,
     "additionalFiles": [
-      "Proofs/Erdos1018Aristotle.lean"
+      "Proofs/Erdos1018Aristotle.lean",
+      "Proofs/Stubs/Erdos1018Aristotle.lean",
+      "Proofs/Stubs/Erdos1018Problem.lean"
     ]
   },
   "overview": {
@@ -245,7 +247,9 @@
     "path": "Proofs/Erdos1018Problem.lean",
     "sorries": 7,
     "additionalFiles": [
-      "Proofs/Erdos1018Aristotle.lean"
+      "Proofs/Erdos1018Aristotle.lean",
+      "Proofs/Stubs/Erdos1018Aristotle.lean",
+      "Proofs/Stubs/Erdos1018Problem.lean"
     ]
   },
   "sorries": 7

--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -63,7 +63,9 @@
     "definitionCount": 17,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
-      "Proofs/Erdos1039ProblemAristotle.lean"
+      "Proofs/Erdos1039ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos1039Aristotle.lean",
+      "Proofs/Stubs/Erdos1039Problem.lean"
     ]
   },
   "overview": {
@@ -250,7 +252,9 @@
     "sorries": 3,
     "additionalFiles": [
       "Proofs/Erdos1039Aristotle.lean",
-      "Proofs/Erdos1039ProblemAristotle.lean"
+      "Proofs/Erdos1039ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos1039Aristotle.lean",
+      "Proofs/Stubs/Erdos1039Problem.lean"
     ]
   },
   "sorries": 3

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -69,7 +69,9 @@
     "theoremCount": 12,
     "definitionCount": 6,
     "additionalFiles": [
-      "Proofs/Erdos107Aristotle.lean"
+      "Proofs/Erdos107Aristotle.lean",
+      "Proofs/Stubs/Erdos107Aristotle.lean",
+      "Proofs/Stubs/Erdos107Problem.lean"
     ]
   },
   "overview": {
@@ -219,7 +221,9 @@
     "definitionCount": 6,
     "theoremCount": 12,
     "additionalFiles": [
-      "Proofs/Erdos107Aristotle.lean"
+      "Proofs/Erdos107Aristotle.lean",
+      "Proofs/Stubs/Erdos107Aristotle.lean",
+      "Proofs/Stubs/Erdos107Problem.lean"
     ]
   }
 }

--- a/src/data/proofs/erdos-179/meta.json
+++ b/src/data/proofs/erdos-179/meta.json
@@ -29,7 +29,9 @@
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos179ProblemAristotle.lean",
-      "Proofs/Erdos179Aristotle.lean"
+      "Proofs/Erdos179Aristotle.lean",
+      "Proofs/Stubs/Erdos179Aristotle.lean",
+      "Proofs/Stubs/Erdos179Problem.lean"
     ]
   },
   "overview": {
@@ -168,7 +170,9 @@
     "sorries": 8,
     "additionalFiles": [
       "Proofs/Erdos179ProblemAristotle.lean",
-      "Proofs/Erdos179Aristotle.lean"
+      "Proofs/Erdos179Aristotle.lean",
+      "Proofs/Stubs/Erdos179Aristotle.lean",
+      "Proofs/Stubs/Erdos179Problem.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-263/meta.json
+++ b/src/data/proofs/erdos-263/meta.json
@@ -28,7 +28,9 @@
     "theoremCount": 31,
     "definitionCount": 19,
     "additionalFiles": [
-      "Proofs/Erdos263Aristotle.lean"
+      "Proofs/Erdos263Aristotle.lean",
+      "Proofs/Stubs/Erdos263Aristotle.lean",
+      "Proofs/Stubs/Erdos263Problem.lean"
     ]
   },
   "overview": {
@@ -171,7 +173,9 @@
     "path": "Proofs/Erdos263Problem.lean",
     "sorries": 4,
     "additionalFiles": [
-      "Proofs/Erdos263Aristotle.lean"
+      "Proofs/Erdos263Aristotle.lean",
+      "Proofs/Stubs/Erdos263Aristotle.lean",
+      "Proofs/Stubs/Erdos263Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -63,7 +63,9 @@
     "theoremCount": 4,
     "definitionCount": 4,
     "additionalFiles": [
-      "Proofs/Erdos360Aristotle.lean"
+      "Proofs/Erdos360Aristotle.lean",
+      "Proofs/Stubs/Erdos360Aristotle.lean",
+      "Proofs/Stubs/Erdos360Problem.lean"
     ]
   },
   "overview": {
@@ -180,7 +182,9 @@
     "path": "Proofs/Erdos360Problem.lean",
     "sorries": 2,
     "additionalFiles": [
-      "Proofs/Erdos360Aristotle.lean"
+      "Proofs/Erdos360Aristotle.lean",
+      "Proofs/Stubs/Erdos360Aristotle.lean",
+      "Proofs/Stubs/Erdos360Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-415/meta.json
+++ b/src/data/proofs/erdos-415/meta.json
@@ -78,7 +78,9 @@
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/Erdos415ProblemAristotle.lean",
-      "Proofs/Erdos415Aristotle.lean"
+      "Proofs/Erdos415Aristotle.lean",
+      "Proofs/Stubs/Erdos415Aristotle.lean",
+      "Proofs/Stubs/Erdos415Problem.lean"
     ]
   },
   "overview": {
@@ -236,7 +238,9 @@
     "sorries": 14,
     "additionalFiles": [
       "Proofs/Erdos415ProblemAristotle.lean",
-      "Proofs/Erdos415Aristotle.lean"
+      "Proofs/Erdos415Aristotle.lean",
+      "Proofs/Stubs/Erdos415Aristotle.lean",
+      "Proofs/Stubs/Erdos415Problem.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -113,7 +113,9 @@
     "theoremCount": 16,
     "definitionCount": 6,
     "additionalFiles": [
-      "Proofs/Erdos456Aristotle.lean"
+      "Proofs/Erdos456Aristotle.lean",
+      "Proofs/Stubs/Erdos456Aristotle.lean",
+      "Proofs/Stubs/Erdos456Problem.lean"
     ]
   },
   "overview": {
@@ -210,7 +212,9 @@
     "path": "Proofs/Erdos456Problem.lean",
     "sorries": 0,
     "additionalFiles": [
-      "Proofs/Erdos456Aristotle.lean"
+      "Proofs/Erdos456Aristotle.lean",
+      "Proofs/Stubs/Erdos456Aristotle.lean",
+      "Proofs/Stubs/Erdos456Problem.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-545/meta.json
+++ b/src/data/proofs/erdos-545/meta.json
@@ -26,7 +26,9 @@
     "theoremCount": 9,
     "definitionCount": 11,
     "additionalFiles": [
-      "Proofs/Erdos545Aristotle.lean"
+      "Proofs/Erdos545Aristotle.lean",
+      "Proofs/Stubs/Erdos545Aristotle.lean",
+      "Proofs/Stubs/Erdos545Problem.lean"
     ]
   },
   "overview": {
@@ -150,7 +152,9 @@
     "path": "Proofs/Erdos545Problem.lean",
     "sorries": 12,
     "additionalFiles": [
-      "Proofs/Erdos545Aristotle.lean"
+      "Proofs/Erdos545Aristotle.lean",
+      "Proofs/Stubs/Erdos545Aristotle.lean",
+      "Proofs/Stubs/Erdos545Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-548/meta.json
+++ b/src/data/proofs/erdos-548/meta.json
@@ -29,7 +29,9 @@
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos548Aristotle.lean",
-      "Proofs/Erdos548ProblemAristotle.lean"
+      "Proofs/Erdos548ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos548Aristotle.lean",
+      "Proofs/Stubs/Erdos548Problem.lean"
     ]
   },
   "overview": {
@@ -165,7 +167,9 @@
     "sorries": 6,
     "additionalFiles": [
       "Proofs/Erdos548Aristotle.lean",
-      "Proofs/Erdos548ProblemAristotle.lean"
+      "Proofs/Erdos548ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos548Aristotle.lean",
+      "Proofs/Stubs/Erdos548Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-552/meta.json
+++ b/src/data/proofs/erdos-552/meta.json
@@ -28,7 +28,9 @@
     "theoremCount": 11,
     "definitionCount": 16,
     "additionalFiles": [
-      "Proofs/Erdos552Aristotle.lean"
+      "Proofs/Erdos552Aristotle.lean",
+      "Proofs/Stubs/Erdos552Aristotle.lean",
+      "Proofs/Stubs/Erdos552Problem.lean"
     ]
   },
   "overview": {
@@ -164,7 +166,9 @@
     "path": "Proofs/Erdos552Problem.lean",
     "sorries": 12,
     "additionalFiles": [
-      "Proofs/Erdos552Aristotle.lean"
+      "Proofs/Erdos552Aristotle.lean",
+      "Proofs/Stubs/Erdos552Aristotle.lean",
+      "Proofs/Stubs/Erdos552Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-553/meta.json
+++ b/src/data/proofs/erdos-553/meta.json
@@ -53,7 +53,9 @@
     "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos553Aristotle.lean",
-      "Proofs/Erdos553ProblemAristotle.lean"
+      "Proofs/Erdos553ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos553Aristotle.lean",
+      "Proofs/Stubs/Erdos553Problem.lean"
     ]
   },
   "overview": {
@@ -168,7 +170,9 @@
     "sorries": 15,
     "additionalFiles": [
       "Proofs/Erdos553Aristotle.lean",
-      "Proofs/Erdos553ProblemAristotle.lean"
+      "Proofs/Erdos553ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos553Aristotle.lean",
+      "Proofs/Stubs/Erdos553Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-559/meta.json
+++ b/src/data/proofs/erdos-559/meta.json
@@ -27,7 +27,9 @@
     "theoremCount": 9,
     "definitionCount": 11,
     "additionalFiles": [
-      "Proofs/Erdos559Aristotle.lean"
+      "Proofs/Erdos559Aristotle.lean",
+      "Proofs/Stubs/Erdos559Aristotle.lean",
+      "Proofs/Stubs/Erdos559Problem.lean"
     ]
   },
   "overview": {
@@ -138,7 +140,9 @@
     "path": "Proofs/Erdos559Problem.lean",
     "sorries": 10,
     "additionalFiles": [
-      "Proofs/Erdos559Aristotle.lean"
+      "Proofs/Erdos559Aristotle.lean",
+      "Proofs/Stubs/Erdos559Aristotle.lean",
+      "Proofs/Stubs/Erdos559Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-589/meta.json
+++ b/src/data/proofs/erdos-589/meta.json
@@ -30,7 +30,8 @@
     "theoremCount": 7,
     "definitionCount": 10,
     "additionalFiles": [
-      "Proofs/Erdos589Aristotle.lean"
+      "Proofs/Erdos589Aristotle.lean",
+      "Proofs/Stubs/Erdos589Aristotle.lean"
     ]
   },
   "overview": {
@@ -163,7 +164,8 @@
     "path": "Proofs/Erdos589Problem.lean",
     "sorries": 2,
     "additionalFiles": [
-      "Proofs/Erdos589Aristotle.lean"
+      "Proofs/Erdos589Aristotle.lean",
+      "Proofs/Stubs/Erdos589Aristotle.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -94,7 +94,9 @@
     "definitionCount": 16,
     "additionalFiles": [
       "Proofs/Erdos610Aristotle.lean",
-      "Proofs/Erdos610ProblemAristotle.lean"
+      "Proofs/Erdos610ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos610Aristotle.lean",
+      "Proofs/Stubs/Erdos610Problem.lean"
     ]
   },
   "overview": {
@@ -217,7 +219,9 @@
     "sorries": 17,
     "additionalFiles": [
       "Proofs/Erdos610Aristotle.lean",
-      "Proofs/Erdos610ProblemAristotle.lean"
+      "Proofs/Erdos610ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos610Aristotle.lean",
+      "Proofs/Stubs/Erdos610Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -60,7 +60,9 @@
     "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos611Aristotle.lean",
-      "Proofs/Erdos611ProblemAristotle.lean"
+      "Proofs/Erdos611ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos611Aristotle.lean",
+      "Proofs/Stubs/Erdos611Problem.lean"
     ]
   },
   "overview": {
@@ -191,7 +193,9 @@
     "sorries": 13,
     "additionalFiles": [
       "Proofs/Erdos611Aristotle.lean",
-      "Proofs/Erdos611ProblemAristotle.lean"
+      "Proofs/Erdos611ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos611Aristotle.lean",
+      "Proofs/Stubs/Erdos611Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-613/meta.json
+++ b/src/data/proofs/erdos-613/meta.json
@@ -63,7 +63,9 @@
     "definitionCount": 14,
     "additionalFiles": [
       "Proofs/Erdos613Aristotle.lean",
-      "Proofs/Erdos613ProblemAristotle.lean"
+      "Proofs/Erdos613ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos613Aristotle.lean",
+      "Proofs/Stubs/Erdos613Problem.lean"
     ]
   },
   "overview": {
@@ -203,7 +205,9 @@
     "sorries": 12,
     "additionalFiles": [
       "Proofs/Erdos613Aristotle.lean",
-      "Proofs/Erdos613ProblemAristotle.lean"
+      "Proofs/Erdos613ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos613Aristotle.lean",
+      "Proofs/Stubs/Erdos613Problem.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -12,7 +12,9 @@
     "additionalFiles": [
       "Proofs/Erdos626Aristotle.lean",
       "Proofs/Erdos626ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos626Aristotle.lean",
+      "Proofs/Stubs/Erdos626Problem.lean"
     ],
     "tags": [
       "erdos",
@@ -225,7 +227,9 @@
     "additionalFiles": [
       "Proofs/Erdos626Aristotle.lean",
       "Proofs/Erdos626ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos626Aristotle.lean",
+      "Proofs/Stubs/Erdos626Problem.lean"
     ]
   },
   "sorries": 15

--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -12,7 +12,9 @@
     "additionalFiles": [
       "Proofs/Erdos627ProblemAristotle.lean",
       "Proofs/Erdos627Aristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos627Aristotle.lean",
+      "Proofs/Stubs/Erdos627Problem.lean"
     ],
     "tags": [
       "erdos",
@@ -205,7 +207,9 @@
     "additionalFiles": [
       "Proofs/Erdos627ProblemAristotle.lean",
       "Proofs/Erdos627Aristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos627Aristotle.lean",
+      "Proofs/Stubs/Erdos627Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-628/meta.json
+++ b/src/data/proofs/erdos-628/meta.json
@@ -12,7 +12,9 @@
     "additionalFiles": [
       "Proofs/Erdos628Aristotle.lean",
       "Proofs/Erdos628ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos628Aristotle.lean",
+      "Proofs/Stubs/Erdos628Problem.lean"
     ],
     "tags": [
       "erdos",
@@ -228,7 +230,9 @@
     "additionalFiles": [
       "Proofs/Erdos628Aristotle.lean",
       "Proofs/Erdos628ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos628Aristotle.lean",
+      "Proofs/Stubs/Erdos628Problem.lean"
     ]
   },
   "sorries": 12

--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -12,7 +12,9 @@
     "additionalFiles": [
       "Proofs/Erdos630Aristotle.lean",
       "Proofs/Erdos630ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos630Aristotle.lean",
+      "Proofs/Stubs/Erdos630Problem.lean"
     ],
     "tags": [
       "erdos",
@@ -220,7 +222,9 @@
     "additionalFiles": [
       "Proofs/Erdos630Aristotle.lean",
       "Proofs/Erdos630ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos630Aristotle.lean",
+      "Proofs/Stubs/Erdos630Problem.lean"
     ]
   },
   "sorries": 15

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -12,7 +12,9 @@
     "additionalFiles": [
       "Proofs/Erdos631Aristotle.lean",
       "Proofs/Erdos631ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos631Aristotle.lean",
+      "Proofs/Stubs/Erdos631Problem.lean"
     ],
     "tags": [
       "erdos",
@@ -219,7 +221,9 @@
     "additionalFiles": [
       "Proofs/Erdos631Aristotle.lean",
       "Proofs/Erdos631ProblemAristotle.lean",
-      "Proofs/GraphCore.lean"
+      "Proofs/GraphCore.lean",
+      "Proofs/Stubs/Erdos631Aristotle.lean",
+      "Proofs/Stubs/Erdos631Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-715/meta.json
+++ b/src/data/proofs/erdos-715/meta.json
@@ -88,7 +88,10 @@
     "definitionCount": 11,
     "additionalFiles": [
       "Proofs/Erdos715Aristotle.lean",
-      "Proofs/Erdos715ProblemAristotle.lean"
+      "Proofs/Erdos715ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos715Aristotle.lean",
+      "Proofs/Stubs/Erdos715Problem.lean",
+      "Proofs/Stubs/Erdos715ProblemAristotle.lean"
     ]
   },
   "overview": {
@@ -198,7 +201,10 @@
     "sorries": 15,
     "additionalFiles": [
       "Proofs/Erdos715Aristotle.lean",
-      "Proofs/Erdos715ProblemAristotle.lean"
+      "Proofs/Erdos715ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos715Aristotle.lean",
+      "Proofs/Stubs/Erdos715Problem.lean",
+      "Proofs/Stubs/Erdos715ProblemAristotle.lean"
     ]
   },
   "references": [

--- a/src/data/proofs/erdos-795/meta.json
+++ b/src/data/proofs/erdos-795/meta.json
@@ -29,7 +29,9 @@
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Erdos795Aristotle.lean",
-      "Proofs/Erdos795ProblemAristotle.lean"
+      "Proofs/Erdos795ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos795Aristotle.lean",
+      "Proofs/Stubs/Erdos795Problem.lean"
     ]
   },
   "overview": {
@@ -181,7 +183,9 @@
     "sorries": 14,
     "additionalFiles": [
       "Proofs/Erdos795Aristotle.lean",
-      "Proofs/Erdos795ProblemAristotle.lean"
+      "Proofs/Erdos795ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos795Aristotle.lean",
+      "Proofs/Stubs/Erdos795Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -66,7 +66,9 @@
     "theoremCount": 5,
     "definitionCount": 12,
     "additionalFiles": [
-      "Proofs/Erdos820Aristotle.lean"
+      "Proofs/Erdos820Aristotle.lean",
+      "Proofs/Stubs/Erdos820Aristotle.lean",
+      "Proofs/Stubs/Erdos820Problem.lean"
     ]
   },
   "overview": {
@@ -211,7 +213,9 @@
     "path": "Proofs/Erdos820Problem.lean",
     "sorries": 6,
     "additionalFiles": [
-      "Proofs/Erdos820Aristotle.lean"
+      "Proofs/Erdos820Aristotle.lean",
+      "Proofs/Stubs/Erdos820Aristotle.lean",
+      "Proofs/Stubs/Erdos820Problem.lean"
     ]
   },
   "crossReferences": [

--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -54,7 +54,9 @@
     "theoremCount": 2,
     "definitionCount": 17,
     "additionalFiles": [
-      "Proofs/Erdos898Aristotle.lean"
+      "Proofs/Erdos898Aristotle.lean",
+      "Proofs/Stubs/Erdos898Aristotle.lean",
+      "Proofs/Stubs/Erdos898Problem.lean"
     ]
   },
   "overview": {
@@ -197,7 +199,9 @@
     "path": "Proofs/Erdos898Problem.lean",
     "sorries": 8,
     "additionalFiles": [
-      "Proofs/Erdos898Aristotle.lean"
+      "Proofs/Erdos898Aristotle.lean",
+      "Proofs/Stubs/Erdos898Aristotle.lean",
+      "Proofs/Stubs/Erdos898Problem.lean"
     ]
   },
   "sorries": 8

--- a/src/data/proofs/erdos-901/meta.json
+++ b/src/data/proofs/erdos-901/meta.json
@@ -24,7 +24,10 @@
     "theoremCount": 19,
     "additionalFiles": [
       "Proofs/Erdos901Aristotle.lean",
-      "Proofs/Erdos901ProblemAristotle.lean"
+      "Proofs/Erdos901ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos901Aristotle.lean",
+      "Proofs/Stubs/Erdos901Problem.lean",
+      "Proofs/Stubs/Erdos901ProblemAristotle.lean"
     ]
   },
   "meta": {
@@ -92,7 +95,10 @@
     "definitionCount": 10,
     "additionalFiles": [
       "Proofs/Erdos901Aristotle.lean",
-      "Proofs/Erdos901ProblemAristotle.lean"
+      "Proofs/Erdos901ProblemAristotle.lean",
+      "Proofs/Stubs/Erdos901Aristotle.lean",
+      "Proofs/Stubs/Erdos901Problem.lean",
+      "Proofs/Stubs/Erdos901ProblemAristotle.lean"
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

N+69 mechanic-1 cycle. Resolves 55 of the 79 `Stubs/Erdos*.lean` orphan files
surfaced by `orphan_scan_v12.py` (diff-based PR-claim cross-check) at HEAD
`f486a19e2e0`.

Each of the 27 erdős-numbered slugs already references its top-level
`Proofs/Erdos<N>{Problem,Aristotle}.lean` via `proofRepoPath` /
`additionalFiles`. This PR adds the parallel `Proofs/Stubs/Erdos<N>{Aristotle,Problem,ProblemAristotle}.lean`
entries to both `meta.additionalFiles` and `leanFile.additionalFiles`.

## Slug → file mapping

| Slug | Files added |
|------|-------------|
| erdos-1018, 1039, 107, 179, 263, 360, 415, 456, 545, 548, 552, 553, 559, 610, 611, 613, 626, 627, 628, 630, 631, 795, 820, 898 | Aristotle.lean + Problem.lean |
| erdos-715 | Aristotle.lean + Problem.lean + ProblemAristotle.lean |
| erdos-901 | Aristotle.lean + Problem.lean + ProblemAristotle.lean |
| erdos-589 | Aristotle.lean only |

Totals: 27 slugs / 55 files / 0 axioms / 0 sorries (meta-only).

## Why these aren't overlapping with PR #22019

PR #22019 registered 25 *different* slugs (erdos-104, 1095, 1100, 135, …, 97).
Scan v12's diff-based PR-claim detection filters those out, and the slug list
above is the disjoint remainder.

The remaining 24 `Stubs/Erdos*Problem.lean` orphans belong to PR #22019's
slugs (where I registered only the `Aristotle.lean` companion last cycle).
Those should be addressed in a follow-up after #22019 merges.

## Test plan

- [x] `python3 register_n69.py` reports 55 files / 27 slugs updated
- [x] Each of the 55 `Proofs/Stubs/Erdos<N>*.lean` files verified to exist on disk
- [x] `git diff --stat` shows only `additionalFiles` additions (164 ins / 54 del are matched-brace insertions)
- [x] Verified non-overlap with the 25 erdős slugs claimed by open PR #22019
- [x] Verified non-overlap with PRs #21974 (Erdos*ProblemProvable) and #21995 (5 Erdos*Problem)
- [ ] CI must pass (auditor / structure-checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)