### PR TITLE
fix(research-db): tolerate non-dict currentState/knowledge in sync_from_json

### DIFF
--- a/research/db/sync_from_json.py
+++ b/research/db/sync_from_json.py
@@ -168,8 +168,16 @@ def sync_problem(cursor: sqlite3.Cursor, data: dict, verbose: bool = False) -> d
     db_status = map_status(data)
 
     # Extract fields
-    current_state = data.get("currentState") or {}
-    knowledge = data.get("knowledge") or {}
+    # Tolerate currentState/knowledge being absent, null, OR a stray string
+    # (some legacy entries write a free-form status sentence or a JSON-encoded
+    # blob there instead of an object). Strings get coerced to {} so the
+    # .get() calls below don't crash — phase/focus/etc. fall through to None.
+    current_state = data.get("currentState")
+    if not isinstance(current_state, dict):
+        current_state = {}
+    knowledge = data.get("knowledge")
+    if not isinstance(knowledge, dict):
+        knowledge = {}
     phase = data.get("phase") or current_state.get("phase")
     focus = current_state.get("focus")
     blockers = current_state.get("blockers", [])


### PR DESCRIPTION
## Summary
- `data.get("currentState") or {}` defends against null/missing but not against the field being a stray string. Three legacy problem JSONs have `currentState` as a free-form status sentence or a JSON-encoded blob.
- On daemon startup, `research/db/sync_from_json.py:174` crashes with `AttributeError: 'str' object has no attribute 'get'`. The wrapper catches it (`WARN: Research DB sync failed (non-fatal)`), but every boot logs a traceback.

## Fix
- Coerce non-dict to `{}` for both `currentState` and `knowledge` (same defensive shape as the existing `isinstance(lf, dict)` check at line 191 for `leanFiles`).
- 4-line edit, scoped to `research/db/sync_from_json.py`. Phase/focus/blockers/nextAction now fall through to `None` for the malformed entries — correct representation until data drift heals via normal enrichment cycles.

## Reproducers
3 currently in `src/data/research/problems/`:
- `abel-ruffini-galois-extensions-oq-04.json`
- `erdos-105-oq-02.json`
- `area-of-circle-oq-05-oq-04.json`

## Verification
Tested `sync_problem()` against all three offenders pre-fix: AttributeError as expected. Post-fix: extraction passes (test harness then dies on a missing `problems` table, unrelated, expected for an empty sqlite). The actual crash signature is gone.

## Test plan
- [ ] Restart the lean daemon; confirm `WARN: Research DB sync failed (non-fatal)` no longer appears in the tmux pane.
- [ ] The three problem JSONs sync successfully (phase/focus values will be NULL until they're reformatted upstream — that's a separate data-cleanup task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)