### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05-oq-01: mainTheorems line fields + Part II annotation

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/annotations.json
@@ -45,6 +45,27 @@
     ]
   },
   {
+    "id": "ann-shafarevich-part2-strategy",
+    "proofId": "abel-ruffini-galois-extensions-oq-05-oq-01",
+    "range": { "startLine": 71, "endLine": 80 },
+    "type": "insight",
+    "title": "Part II: Why Coprime Products Reduce to Cyclic (Strategic Preamble)",
+    "content": "**The Part II docstring (lines 71–80)** frames the central new contribution of the file in one sentence: *when $\\gcd(m, n) = 1$, $\\mathbb{Z}/m \\times \\mathbb{Z}/n$ is itself cyclic (isomorphic to $\\mathbb{Z}/(mn)$ by CRT), so its inverse-Galois realization is **just** `cyclic_realizable (m*n)`*. This collapses what looks like a *new* compositum construction into a *recapitulation* of the cyclic case — no fresh field-theoretic work needed. The preamble identifies the precise hypothesis that triggers the collapse (coprimality) and motivates the two lemmas that follow: `zmod_coprime_crt` (lines 81–88, the algebraic identity) and `coprime_product_cyclic_realizable` (lines 89–112, the one-line application).",
+    "mathContext": "**The reduction in one chain of isomorphisms**: $\\mathbb{Z}/m \\times \\mathbb{Z}/n \\stackrel{\\text{CRT}}{\\cong} \\mathbb{Z}/(mn) \\stackrel{\\text{cyclic_realizable}}{\\cong} \\text{Gal}(K/\\mathbb{Q})$ for some Galois $K/\\mathbb{Q}$. **Why this is the *easy* abelian case**: by the structure theorem for finitely generated abelian groups, every finite abelian $G$ is a product of cyclic groups of prime-power order, $G \\cong \\prod_i \\mathbb{Z}/p_i^{a_i}$. Group factors with *distinct* primes are pairwise coprime, so any number of them assemble — via iterated CRT — into a *single* cyclic group whose realization is one call to `cyclic_realizable`. The *hard* abelian case is the leftover: products like $(\\mathbb{Z}/p)^k$ or $\\mathbb{Z}/p^a \\times \\mathbb{Z}/p^b$ with the same prime $p$ repeated. These are *not* cyclic and CRT does not apply — the genuine compositum theorem (`galois_compositum_product`, Part III) is then required.",
+    "significance": "key",
+    "relatedConcepts": [
+      "structure theorem for finite abelian groups",
+      "prime-power decomposition of cyclic groups",
+      "CRT iterated over coprime moduli",
+      "cyclic vs non-cyclic abelian products"
+    ],
+    "prerequisites": [
+      "cyclic_realizable (Part I)",
+      "Chinese Remainder Theorem for ZMod",
+      "structure theorem for finite abelian groups"
+    ]
+  },
+  {
     "id": "ann-shafarevich-crt-iso",
     "proofId": "abel-ruffini-galois-extensions-oq-05-oq-01",
     "range": { "startLine": 81, "endLine": 88 },

--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -446,24 +446,58 @@
   },
   "mainTheorems": [
     {
-      "name": "coprime_product_cyclic_realizable",
-      "statement": "When gcd(m,n)=1: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = m*n",
-      "significance": "Key new result: coprime abelian product reduced to cyclic via CRT"
+      "name": "cyclic_realizable",
+      "statement": "∀ n > 0: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = n",
+      "significance": "Recap wrapper around InverseGaloisProblem.cyclic_group_realizable (Dirichlet + Galois fixed fields)",
+      "line": 65
     },
     {
       "name": "zmod_coprime_crt",
-      "statement": "ZMod m × ZMod n ≃+ ZMod (m*n) when Coprime m n",
-      "significance": "The algebraic tool making the coprime reduction work"
+      "statement": "Coprime m n → (ZMod (m*n) ≃+ ZMod m × ZMod n)",
+      "significance": "The algebraic tool making the coprime reduction work (extracts the additive iso from ZMod.chineseRemainder)",
+      "line": 85
+    },
+    {
+      "name": "coprime_product_cyclic_realizable",
+      "statement": "When gcd(m,n)=1: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = m*n",
+      "significance": "Key new result: coprime abelian product reduced to cyclic via CRT",
+      "line": 91
+    },
+    {
+      "name": "z2z3_realizable",
+      "statement": "∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = 6",
+      "significance": "Concrete instance: ℤ/2 × ℤ/3 ≅ ℤ/6 realizable (gcd(2,3) = 1)",
+      "line": 101
+    },
+    {
+      "name": "z5z7_realizable",
+      "statement": "∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = 35",
+      "significance": "Concrete instance: ℤ/5 × ℤ/7 ≅ ℤ/35 realizable (gcd(5,7) = 1)",
+      "line": 108
     },
     {
       "name": "galois_compositum_product",
       "statement": "Axiom: Galois extensions with coprime group orders → product Galois group on compositum",
-      "significance": "Single axiom precisely identifying the Mathlib gap for the abelian case"
+      "significance": "Single axiom precisely identifying the Mathlib gap for the abelian case",
+      "line": 141
     },
     {
       "name": "s3_realizable_via_cubic",
       "statement": "∃ K Galois/ℚ, Sym(Fin 3) ≃* Gal(K/ℚ)",
-      "significance": "S₃ realizable by direct cubic construction (non-Shafarevich)"
+      "significance": "S₃ realizable by direct cubic construction (non-Shafarevich)",
+      "line": 165
+    },
+    {
+      "name": "s3_is_solvable",
+      "statement": "IsSolvable (Equiv.Perm (Fin 3))",
+      "significance": "S₃ solvable via derived series S₃ ⊃ A₃ ⊃ {1} (delegates to symmetric_solvable_of_le_four)",
+      "line": 173
+    },
+    {
+      "name": "shafarevich_cyclic_case_proved",
+      "statement": "∀ n > 0: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = n",
+      "significance": "Summary theorem restating the cyclic case as the formal status report's main result",
+      "line": 195
     }
   ],
   "sorries": 0


### PR DESCRIPTION
Enrichment pass for abel-ruffini-galois-extensions-oq-05-oq-01: add line fields to all 9 mainTheorems entries (was 4, missing 5), correct zmod_coprime_crt iso direction to match Lean type, add Part II strategy annotation (lines 71-80). pnpm build OK.