### PR TITLE
Enrich algebraic-numbers-countable-oq-04 (Baker's theorem): mainTheorems line fields + Part VI annotation

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-04/annotations.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-04/annotations.json
@@ -194,5 +194,34 @@
       "Polynomial.natDegree",
       "minpoly"
     ]
+  },
+  {
+    "id": "ann-baker-quantitative-derived",
+    "proofId": "algebraic-numbers-countable-oq-04",
+    "range": {
+      "startLine": 641,
+      "endLine": 754
+    },
+    "type": "insight",
+    "title": "Part VI: Baker's Quantitative Theorem as a Derived Consequence (Axiom Count Drops 4 → 3)",
+    "content": "**Part VI is the load-bearing deaxiomatization step of the file**: `baker_quantitative` is *not* a separate axiom — it is *proved* as a theorem from `baker_homogeneous` and `baker_wustholz_bound`. This drops the total axiom count from 4 to 3 (`baker_homogeneous`, `baker_inhomogeneous`, `baker_wustholz_bound`), exactly matching the `axiomCount: 3` declared in meta.json.\n\n**Eight-step proof structure** (lines 680–752):\n1. **Λ ≠ 0**: `baker_homogeneous` applied to integer coefficients (which are algebraic via `isAlgebraic_int`) gives $\\sum_i b_i \\log \\alpha_i \\neq 0$.\n2. **Degree witness** $d := (\\sum_i \\deg(\\text{minpoly}\\,\\alpha_i)) + 1 > 0$ — uniformly bounds individual minimal-polynomial degrees via `Finset.single_le_sum`.\n3. **Height witnesses** $A_i := \\alpha_i + 1 > 1 > 0$ with $\\log|\\alpha_i| \\leq \\log A_i$ via `Real.log_le_log`.\n4. **Baker–Wüstholz constant** $C_0 := 18 \\cdot (n+1)! \\cdot n^{n+1} \\cdot (32d)^{n+2} \\cdot \\log(2nd) > 0$.\n5. **Final constant** $C := C_0 \\cdot \\prod_i \\log A_i > 0$ via `Finset.prod_pos` (each $\\log A_i > 0$ since $A_i > 1$).\n6. **Cast** $|b_i| \\leq B$ from $\\mathbb{Z}$ to $\\mathbb{R}$ via `exact_mod_cast`.\n7. **Apply Baker–Wüstholz** to obtain $\\log|\\Lambda| > -C_0 \\cdot (\\prod_i \\log A_i) \\cdot \\log B$, rewritten as $-C \\cdot \\log B$ via `ring`.\n8. **Convert log to rpow** via `Real.log_rpow` and strict monotonicity `Real.log_lt_log_iff`, yielding $B^{-C} < |\\Lambda|$.\n\nThe theorem returns an *existence* statement: $\\exists C > 0$ depending only on the $\\alpha_i$ (not on $B$), uniformly bounding the linear form below by $B^{-C}$ for all integer-coefficient combinations of bounded height. This is the explicit *effective* form needed for Diophantine applications (Thue, Mordell, S-unit equations).",
+    "mathContext": "**The reduction's logical structure**: the qualitative axiom (`baker_homogeneous`, lines 310–328) and the quantitative axiom (`baker_wustholz_bound`, lines 596–616) together imply the quantitative theorem `baker_quantitative` — so listing `baker_quantitative` as a separate axiom would be *redundant*. This is the file's main *philosophical* contribution: separating the irreducible axiomatic core (qualitative non-vanishing + quantitative lower bound) from the derivable corollaries. **Why the qualitative axiom is needed for the quantitative statement**: `baker_wustholz_bound` provides the lower bound $\\log|\\Lambda| > -C_0 \\cdot (\\prod \\log A_i) \\cdot \\log B$ assuming $\\Lambda \\neq 0$; without `baker_homogeneous` we cannot conclude $\\Lambda \\neq 0$ from the linear-independence and non-triviality hypotheses, and the bound becomes vacuous (since $|\\Lambda| = 0$ would force $\\log|\\Lambda| = -\\infty$). The two axioms are *complementary*: qualitative non-vanishing + quantitative non-degeneracy = effective Diophantine bound. **The rpow conversion** in step 8 is non-trivial: `Real.log_rpow hBpos (-C)` requires $B > 0$, and `Real.log_lt_log_iff` requires both arguments positive, so the proof carries positivity hypotheses for $B$, $B^{-C}$, and $|\\Lambda|$ throughout. The final inequality $B^{-C} < |\\Lambda|$ is in $\\mathbb{R}$ (not $\\mathbb{Q}$), reflecting that the effective constant $C$ is generally irrational.",
+    "significance": "key",
+    "relatedConcepts": [
+      "axiom-count reduction by derivation",
+      "qualitative ⊕ quantitative axiomatic decomposition",
+      "isAlgebraic_int (ℤ ↪ algebraic reals)",
+      "Real.log_rpow / Real.log_lt_log_iff conversion",
+      "Finset.single_le_sum (uniform-bound from sum-bound)",
+      "Finset.prod_pos (positivity of finite product)",
+      "effective Diophantine bounds (Thue, Mordell, S-unit)"
+    ],
+    "prerequisites": [
+      "baker_homogeneous (qualitative non-vanishing axiom)",
+      "baker_wustholz_bound (Baker-Wüstholz quantitative axiom)",
+      "isAlgebraic_int : ∀ n : ℤ, IsAlgebraic ℚ (n : ℝ)",
+      "Real.log_rpow, Real.log_lt_log_iff",
+      "Finset.single_le_sum, Finset.prod_pos"
+    ]
   }
 ]

--- a/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-04/meta.json
@@ -197,43 +197,50 @@
       "name": "two_pow_ne_three_pow",
       "type": "supporting",
       "description": "Elementary prime-factorization lemma: $2^p \\neq 3^q$ for any positive naturals $p, q$. Proved from `Nat.Prime.dvd_of_dvd_pow`: if $2^p = 3^q$ then $2 \\mid 2^p = 3^q$, so $2 \\mid 3$ by primality, contradiction. This is the entire elementary prerequisite for the irrationality of $\\log_2 3$.",
-      "leanType": "∀ (p q : ℕ), 0 < p → 0 < q → (2 : ℕ)^p ≠ 3^q"
+      "leanType": "∀ (p q : ℕ), 0 < p → 0 < q → (2 : ℕ)^p ≠ 3^q",
+      "line": 154
     },
     {
       "name": "log2_3_irrational",
       "type": "core",
       "description": "Irrationality of $\\log_2 3 = \\log 3 / \\log 2$, proved elementarily *without* transcendence theory. Strategy: if $\\log_2 3 = m/n$ in lowest terms then $3^n = 2^m$, contradicting `two_pow_ne_three_pow`. Shows that a classical transcendence fact has an elementary kernel — Baker's theorem upgrades irrationality to transcendence.",
-      "leanType": "Irrational (Real.log 3 / Real.log 2)"
+      "leanType": "Irrational (Real.log 3 / Real.log 2)",
+      "line": 192
     },
     {
       "name": "log2_log3_rat_indep",
       "type": "core",
       "description": "$\\mathbb{Q}$-linear independence of $\\{\\log 2, \\log 3\\}$ as a Mathlib `LinearIndependent` statement on the indexed family `![Real.log 2, Real.log 3]`. Directly derived from `log2_3_irrational`: any nontrivial rational dependence $c_0 \\log 2 + c_1 \\log 3 = 0$ would give $\\log_2 3 \\in \\mathbb{Q}$, contradicting irrationality. The hypothesis of Baker's homogeneous form for the $n = 2$ case.",
-      "leanType": "LinearIndependent ℚ (![Real.log 2, Real.log 3])"
+      "leanType": "LinearIndependent ℚ (![Real.log 2, Real.log 3])",
+      "line": 246
     },
     {
       "name": "log2_3_transcendental",
       "type": "core",
       "description": "Transcendence of $\\log_2 3 = \\log 3 / \\log 2$ over $\\mathbb{Z}$ (hence over $\\mathbb{Q}$), derived from `baker_homogeneous`. If $\\beta := \\log_2 3$ were algebraic, the linear form $\\beta \\log 2 - \\log 3 = 0$ would have all-algebraic coefficients $(\\beta, -1)$ with $\\mathbb{Q}$-independent logs $(\\log 2, \\log 3)$, contradicting Baker. A flagship application of Baker beyond the classical Gelfond-Schneider $n = 2$ case.",
-      "leanType": "Transcendental ℤ (Real.log 3 / Real.log 2)"
+      "leanType": "Transcendental ℤ (Real.log 3 / Real.log 2)",
+      "line": 421
     },
     {
       "name": "log2_log3_alg_indep",
       "type": "core",
       "description": "$\\overline{\\mathbb{Q}}$-linear independence of $\\{\\log 2, \\log 3\\}$: for any algebraic $\\beta_1, \\beta_2$ not both zero, $\\beta_1 \\log 2 + \\beta_2 \\log 3 \\neq 0$. Direct $n = 2$ application of `baker_homogeneous` to the family $\\alpha = (2, 3)$ with `log2_log3_rat_indep` providing the $\\mathbb{Q}$-independence hypothesis. The 'lift from $\\mathbb{Q}$-independence to $\\overline{\\mathbb{Q}}$-independence' that defines Baker's theorem.",
-      "leanType": "∀ (β₁ β₂ : ℝ), IsAlgebraic ℚ β₁ → IsAlgebraic ℚ β₂ → (β₁ ≠ 0 ∨ β₂ ≠ 0) → β₁ * Real.log 2 + β₂ * Real.log 3 ≠ 0"
+      "leanType": "∀ (β₁ β₂ : ℝ), IsAlgebraic ℚ β₁ → IsAlgebraic ℚ β₂ → (β₁ ≠ 0 ∨ β₂ ≠ 0) → β₁ * Real.log 2 + β₂ * Real.log 3 ≠ 0",
+      "line": 468
     },
     {
       "name": "baker_n1_log_independence",
       "type": "supporting",
       "description": "The $n = 1$ case of Baker's theorem in clean form: if $\\alpha > 0$ is algebraic with $\\alpha \\neq 1$ and $\\beta \\neq 0$ is algebraic, then $\\beta \\log \\alpha \\neq 0$. Proved from `baker_homogeneous` applied to a singleton family. Connects Baker to Hermite-Lindemann ($n = 1$ case for the exponential): together they say that the multiplicative span of $\\log \\alpha$ over $\\overline{\\mathbb{Q}}$ is all of $\\mathbb{R}$ for non-trivial algebraic $\\alpha$.",
-      "leanType": "∀ (α : ℝ), 0 < α → IsAlgebraic ℚ α → α ≠ 1 → ∀ (β : ℝ), IsAlgebraic ℚ β → β ≠ 0 → β * Real.log α ≠ 0"
+      "leanType": "∀ (α : ℝ), 0 < α → IsAlgebraic ℚ α → α ≠ 1 → ∀ (β : ℝ), IsAlgebraic ℚ β → β ≠ 0 → β * Real.log α ≠ 0",
+      "line": 513
     },
     {
       "name": "baker_quantitative",
       "type": "core",
       "description": "**The PART VI deaxiomatization.** Effective lower bound $|\\Lambda| > B^{-C}$ for the linear form $\\Lambda = \\sum_i b_i \\log \\alpha_i$ with integer $b_i$ bounded by $B$, derived (not axiomatized) from the combination of `baker_homogeneous` (gives $\\Lambda \\neq 0$ via algebraicity of integer coefficients) and `baker_wustholz_bound` (gives the explicit $\\log$ lower bound). This is the load-bearing reduction from 4 axioms to 3: previously `baker_quantitative` was its own axiom; the bridge `baker_homogeneous` + `baker_wustholz_bound` $\\Rightarrow$ `baker_quantitative` is now a proper theorem.",
-      "leanType": "∀ (n : ℕ), 0 < n → ∀ (α : Fin n → ℝ), (∀ i, 0 < α i) → (∀ i, IsAlgebraic ℚ (α i)) → ∀ (b : Fin n → ℤ), (∃ i, b i ≠ 0) → LinearIndependent ℚ (fun i => Real.log (α i)) → ∃ C : ℝ, 0 < C ∧ ∀ B : ℕ, 1 < B → (∀ i, |b i| ≤ B) → B^(-C) < |∑ i, (b i : ℝ) * Real.log (α i)|"
+      "leanType": "∀ (n : ℕ), 0 < n → ∀ (α : Fin n → ℝ), (∀ i, 0 < α i) → (∀ i, IsAlgebraic ℚ (α i)) → ∀ (b : Fin n → ℤ), (∃ i, b i ≠ 0) → LinearIndependent ℚ (fun i => Real.log (α i)) → ∃ C : ℝ, 0 < C ∧ ∀ B : ℕ, 1 < B → (∀ i, |b i| ≤ B) → B^(-C) < |∑ i, (b i : ℝ) * Real.log (α i)|",
+      "line": 669
     }
   ],
   "references": [


### PR DESCRIPTION
Enrichment pass for algebraic-numbers-countable-oq-04 (Baker's Theorem entry).

## meta.json mainTheorems
- Add line field to all 7 entries (lines 154, 192, 246, 421, 468, 513, 669) pinning each theorem to its source location — matches the line-cross-reference convention in sibling entries.

## annotations.json
- Add ann-baker-quantitative-derived covering Part VI (lines 641–754), which was previously uncovered. Part VI is the load-bearing axiom-count reduction (4 → 3) where baker_quantitative is *derived* from baker_homogeneous + baker_wustholz_bound rather than axiomatized. The annotation walks through the 8-step proof structure and explains the qualitative ⊕ quantitative axiomatic decomposition.

All line numbers verified by grep against proofs/Proofs/AlgebraicNumbersCountableOQ04.lean. pnpm build exits 0.