### PR TITLE
Enrich abel-ruffini-galois-extensions: correct declaration counts

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-galois-extensions",
   "title": "Abel-Ruffini Galois Theory Extensions",
   "slug": "abel-ruffini-galois-extensions",
-  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |S₈|=40320, |A₇|=2520, |A₈|=20160 via `native_decide`. 59 theorems, 1 definition, 0 axioms.",
+  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |S₈|=40320, |A₇|=2520, |A₈|=20160 via `native_decide`. 57 theorems, 12 typeclass instances, 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -21,8 +21,9 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
     "lineCount": 534,
-    "theoremCount": 59,
-    "definitionCount": 1,
+    "theoremCount": 57,
+    "definitionCount": 0,
+    "instanceCount": 12,
     "mathlibDependencies": [
       {
         "theorem": "Equiv.Perm.not_solvable",
@@ -158,8 +159,9 @@
     "namespace": "AbelRuffiniGaloisExtensions",
     "lineCount": 534,
     "axiomCount": 0,
-    "theoremCount": 59,
-    "definitionCount": 1,
+    "theoremCount": 57,
+    "definitionCount": 0,
+    "instanceCount": 12,
     "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "sorries": 0,
     "mainTheorems": [


### PR DESCRIPTION
## Summary

Accuracy pass on `src/data/proofs/abel-ruffini-galois-extensions/meta.json`. The declaration counts had drifted from the actual Lean source.

| Field | Before | After | Source of truth |
|-------|--------|-------|-----------------|
| `theoremCount` | 59 | 57 | `grep -c '^theorem ' proofs/Proofs/AbelRuffiniGaloisExtensions.lean` = 57 |
| `definitionCount` | 1 | 0 | `grep -c '^def ' …` = 0 |
| `instanceCount` | — | 12 | 11 named `instance` + 1 anonymous |
| description string | "59 theorems, 1 definition, 0 axioms" | "57 theorems, 12 typeclass instances, 0 axioms, 0 sorries" | matches actual file |

Counting convention follows the sibling entry `src/data/proofs/abel-ruffini/meta.json`, where `theoremCount` counts the `theorem` keyword only and excludes `instance` declarations.

`axiomCount: 0`, `sorries: 0`, and `lineCount: 534` were already correct and verified against the source.

## Test plan
- [x] `python3 -c "import json; json.load(open('.../meta.json'))"` — JSON parses
- [x] `grep -cE "^theorem " …` — 57
- [x] `grep -cE "^def " …` — 0
- [x] `grep -cE "^instance" …` — 11 (plus 1 anonymous `instance : IsSolvable ℤˣ`)
- [x] `pnpm build` ran enrichment script successfully (final `tsc` failed unrelatedly due to missing `node_modules` in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)