### PR TITLE
research(amgm-inequality-oq-04-oq-03): S3 ACT — Wallis half-period closed form

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -53,6 +53,7 @@ import Proofs.AmgmInequalityOQ04
 import Proofs.AmgmInequalityOQ04OQ01
 import Proofs.AmgmInequalityOQ04OQ02
 import Proofs.AmgmInequalityOQ04OQ03
+import Proofs.AmgmInequalityOQ04OQ03Wallis
 import Proofs.AmgmInequalityOQ04OQ05
 import Proofs.AmgmInequalityPowerMeanLimits
 import Proofs.AngleTrisection

--- a/proofs/Proofs/AmgmInequalityOQ04OQ03Wallis.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03Wallis.lean
@@ -1,0 +1,100 @@
+import Mathlib
+
+/-
+# Wallis Half-Period Integral for Even Powers
+
+Companion to `AmgmInequalityOQ04OQ03.lean`.
+
+Discharges one of the four remaining "legs" of the axiomatized identity
+  `ellipticK_eq_hyp2F1 : K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`
+in the companion file.
+
+The Wallis half-period integral closed form:
+  `∫₀^{π/2} sin^{2n}θ dθ = (π/2) · centralBinom n / 4^n`
+is the closed-form needed for the term-by-term integration argument that
+proves the hypergeometric series representation of K(k). Mathlib has the
+full-period analogue `Real.integral_sin_pow_even` over `[0, π]`, and the
+Wallis product file builds on it, but the half-period closed form needed by
+the elliptic integral substitution is not packaged directly.
+
+## Proof Outline
+
+Use the Mathlib reduction formula `intervalIntegral.integral_sin_pow`:
+  `∫_a^b sin x ^ (n+2)
+    = (sin a ^ (n+1) · cos a − sin b ^ (n+1) · cos b)/(n+2)
+      + ((n+1)/(n+2)) · ∫_a^b sin x ^ n`.
+
+Specialized to `[0, π/2]`: `sin 0 = 0` and `cos(π/2) = 0`, so both boundary
+terms vanish, leaving the clean recurrence
+  `W(n+2) = ((n+1)/(n+2)) · W(n)`
+where `W(n) := ∫₀^{π/2} sin^n θ dθ`. Induction on `n` then yields the
+closed form for even powers, threaded through the central-binomial
+recurrence `Nat.succ_mul_centralBinom_succ`:
+  `(n+1) · centralBinom (n+1) = 2 · (2n+1) · centralBinom n`.
+
+## Status
+- [x] `wallisHalf_zero` : W(0) = π/2
+- [x] `wallisHalf_recurrence` : W(n+2) = ((n+1)/(n+2)) · W(n)
+- [x] `wallisHalf_even` : W(2n) = (π/2) · centralBinom n / 4^n  (main)
+
+Axioms: 0
+Sorries: 0
+-/
+
+namespace AmgmInequalityOQ04OQ03Wallis
+
+open Real intervalIntegral MeasureTheory
+
+/-- The Wallis half-period integral: `W(n) = ∫₀^{π/2} sin^n θ dθ`. -/
+noncomputable def wallisHalf (n : ℕ) : ℝ :=
+  ∫ θ in (0 : ℝ)..π / 2, Real.sin θ ^ n
+
+/-- Base case: `W(0) = π/2`. -/
+theorem wallisHalf_zero : wallisHalf 0 = π / 2 := by
+  unfold wallisHalf
+  simp
+
+/-- Reduction formula on `[0, π/2]`: both boundary terms in
+    `integral_sin_pow` vanish (`sin 0 = 0`, `cos(π/2) = 0`), giving the
+    clean half-period recurrence
+      `W(n+2) = ((n+1)/(n+2)) · W(n)`. -/
+theorem wallisHalf_recurrence (n : ℕ) :
+    wallisHalf (n + 2) = ((n + 1 : ℝ) / (n + 2)) * wallisHalf n := by
+  unfold wallisHalf
+  rw [integral_sin_pow]
+  have h0 : (0 : ℝ) ^ (n + 1) = 0 := by rw [pow_succ, mul_zero]
+  rw [Real.sin_zero, Real.cos_pi_div_two, h0]
+  ring
+
+/-- **Closed form for even powers** (the Wallis integral):
+    `W(2n) = (π/2) · centralBinom n / 4^n`.
+
+    This is the closed form needed for the term-by-term integration step of
+    the hypergeometric series representation of the complete elliptic
+    integral `K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`. -/
+theorem wallisHalf_even (n : ℕ) :
+    wallisHalf (2 * n) = (π / 2) * ((Nat.centralBinom n : ℝ) / (4 : ℝ) ^ n) := by
+  induction n with
+  | zero =>
+      simp [wallisHalf_zero]
+  | succ k ih =>
+      have hrec : wallisHalf (2 * (k + 1))
+          = ((2 * (k : ℝ) + 1) / (2 * k + 2)) * wallisHalf (2 * k) := by
+        have hidx : 2 * (k + 1) = (2 * k) + 2 := by ring
+        rw [hidx, wallisHalf_recurrence]
+        push_cast
+        ring
+      have hcb : ((k : ℝ) + 1) * (Nat.centralBinom (k + 1) : ℝ)
+          = 2 * (2 * k + 1) * (Nat.centralBinom k : ℝ) := by
+        exact_mod_cast Nat.succ_mul_centralBinom_succ k
+      have hk1 : ((k : ℝ) + 1) ≠ 0 := by positivity
+      have h4k : ((4 : ℝ) ^ k) ≠ 0 := by positivity
+      have hc1 : (Nat.centralBinom (k + 1) : ℝ)
+          = 2 * (2 * k + 1) * (Nat.centralBinom k : ℝ) / ((k : ℝ) + 1) := by
+        rw [eq_div_iff hk1]
+        linear_combination hcb
+      rw [hrec, ih, hc1, pow_succ]
+      field_simp
+      ring
+
+end AmgmInequalityOQ04OQ03Wallis

--- a/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
@@ -28,14 +28,39 @@ hypergeometric representation of the complete elliptic integral of the first kin
 - The k = 0 case is provable WITHOUT the deep identity: K(0) = π/2 (`ellipticK_zero`) and
   ₂F₁(…;0) = 1 (`hyp2F1_zero`), so both sides equal π/2
   (`ellipticK_hyp2F1_consistent_zero`). This anchors the axiom's correctness at k = 0.
+- **Wallis half-period structural fact (S3)**: Mathlib's `integral_sin_pow_even`
+  and `Real.Wallis.W` cover [0, π], not [0, π/2]. The half-period closed form
+  is NOT packaged directly. Fix: apply the reduction `integral_sin_pow` (a, b
+  parameterised) at a=0, b=π/2 — both boundary terms `sin a^(n+1)·cos a` and
+  `sin b^(n+1)·cos b` vanish (`sin 0 = 0`, `cos(π/2) = 0`), yielding the
+  clean recurrence W(n+2) = ((n+1)/(n+2)) · W(n).
+- **Central binomial recurrence threading**: closed form
+  W(2n) = (π/2)·centralBinom n / 4^n proved by induction using
+  `Nat.succ_mul_centralBinom_succ`:
+  `(n+1) · centralBinom (n+1) = 2 · (2n+1) · centralBinom n`. After casting to
+  ℝ and substituting centralBinom(k+1) = 2(2k+1)·centralBinom(k) / (k+1),
+  `field_simp; ring` closes the algebraic step cleanly.
 
-## Built (this session, Proofs/AmgmInequalityOQ04OQ03.lean — builds clean, 0 sorries, 1 axiom)
+## Built (across sessions, Proofs/AmgmInequalityOQ04OQ03*.lean — builds clean, 0 sorries)
 
+In `Proofs/AmgmInequalityOQ04OQ03.lean` (S1, merged):
 - `hypCoeff`, `hyp2F1` definitions (central-binomial series).
 - `hypCoeff_zero` (=1), `hypCoeff_one` (=1/4), `hypCoeff_nonneg`, `hypCoeff_pos`.
 - `hyp2F1_zero` : ₂F₁(…;0) = 1 (via `tsum_eq_single`).
 - `ellipticK_hyp2F1_consistent_zero` : K(0) = (π/2)·₂F₁(…;0), independent of the axiom.
 - `ellipticK_eq_hyp2F1` (axiom) : K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) for |k|<1.
+
+In `Proofs/AmgmInequalityOQ04OQ03.lean` summability section (S2, PR #22021 open mergeable):
+- `centralBinom_le_four_pow` : Nat.centralBinom n ≤ 4^n (upper-bound gap in v4.26.0).
+- `hypCoeff_le_one` : hypCoeff n ≤ 1 (direct corollary).
+- `summable_hyp2F1` : Summable (fun n => hypCoeff n · x^n) for |x| < 1 (comparison
+  with geometric).
+
+In `Proofs/AmgmInequalityOQ04OQ03Wallis.lean` (S3 ACT, this session, additive companion):
+- `wallisHalf n := ∫ θ in 0..π/2, sin θ ^ n` (definition).
+- `wallisHalf_zero` : W(0) = π/2.
+- `wallisHalf_recurrence` : W(n+2) = ((n+1)/(n+2)) · W(n) (half-period reduction).
+- `wallisHalf_even` : W(2n) = (π/2) · centralBinom n / 4^n (main Wallis closed form).
 
 ---
 
@@ -44,5 +69,26 @@ hypergeometric representation of the complete elliptic integral of the first kin
 - No general Gauss hypergeometric ₂F₁ in Mathlib.
 - No off-the-shelf term-by-term integration lemma matching K; the sum/integral interchange
   (dominated convergence, delicate as k → 1) is the genuine obstacle to discharging the axiom.
-- Wallis closed form ∫₀^{π/2} sin^{2n} = (π/2)(2n choose n)/4ⁿ must be assembled from
-  Mathlib's `integral_sin_pow` recurrences (not packaged directly).
+- Mathlib's `integral_sin_pow_even` and `Real.Wallis.W` are over the full period [0, π]; the
+  half-period closed form needed for the elliptic substitution u = k² sin²θ over [0, π/2]
+  must be derived from the reduction formula directly. The S3 companion now ships this leg.
+
+---
+
+## Leg-by-leg axiom discharge plan
+
+To prove `ellipticK_eq_hyp2F1 : K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`:
+
+1. ✅ **Summability** (S2, `summable_hyp2F1` in PR #22021): the series ∑ cₙ x^n
+   converges for |x|<1.
+2. ✅ **Wallis closed form** (S3, `wallisHalf_even`, this session): the half-period
+   integral ∫₀^{π/2} sin^{2n}θ dθ has the explicit central-binomial value.
+3. ⏳ **Binomial series**: (1−u)^(−1/2) = ∑ (centralBinom n / 4ⁿ) uⁿ for |u|<1.
+4. ⏳ **Uniform summability**: on compact k-subsets of (−1, 1), the series
+   ∑ cₙ k^{2n} sin^{2n}θ is dominated and uniformly summable in θ.
+5. ⏳ **Sum/integral interchange**: DCT-style argument combining 3, 4 to compute
+   K(k) term by term, then close using 2 and 1.
+
+The companion files in `Proofs/AmgmInequalityOQ04OQ03*.lean` are built so that legs
+can ship independently without rebasing on each other; the final composition step
+(leg 5) integrates them once leg 3 lands.


### PR DESCRIPTION
## Summary

Strictly-additive Lean ACT shipping the **Wallis half-period leg** of the five-leg discharge plan for the axiomatized identity `ellipticK_eq_hyp2F1 : K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)` in `Proofs/AmgmInequalityOQ04OQ03.lean`.

New companion file `Proofs/AmgmInequalityOQ04OQ03Wallis.lean` (100 LOC, **0 sorries, 0 axioms**) proves the closed form

```
W(2n) := ∫₀^{π/2} sin^{2n}θ dθ = (π/2) · centralBinom n / 4^n
```

via three theorems:

- `wallisHalf_zero` : W(0) = π/2 (base case)
- `wallisHalf_recurrence` : W(n+2) = ((n+1)/(n+2)) · W(n)
  Mathlib's `integral_sin_pow` reduction at a=0, b=π/2: both boundary terms vanish (`sin 0 = 0`, `cos(π/2) = 0`), giving the clean half-period recurrence.
- `wallisHalf_even` : W(2n) = (π/2) · centralBinom n / 4^n
  Induction on n threading `Nat.succ_mul_centralBinom_succ` (`(n+1) · centralBinom (n+1) = 2 · (2n+1) · centralBinom n`).

## Why a separate companion

Mathlib has `integral_sin_pow_even` and `Real.Wallis.W` over [0, π], but the half-period [0, π/2] closed form needed for the elliptic substitution `u = k² sin²θ` is not packaged directly. PR #22021 (S2 ACT, open mergeable) extends `Proofs/AmgmInequalityOQ04OQ03.lean` with the summability leg; this S3 ACT adds the Wallis leg as a **separate companion file** to avoid conflict while #22021 awaits merge.

## Five-leg discharge plan (progress)

1. [x] **Summability** (S2 PR #22021, `summable_hyp2F1`)
2. [x] **Wallis closed form** (S3 this PR, `wallisHalf_even`)
3. [ ] Binomial series for `(1-u)^(-1/2)`
4. [ ] Uniform summability on compact k-subsets of (-1, 1)
5. [ ] DCT-style sum/integral interchange composing 1–4

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ03Wallis` — built 7743/7743 jobs clean
- [x] 0 new sorries, 0 new axioms in `AmgmInequalityOQ04OQ03Wallis.lean`
- [x] No changes to existing files except adding the new import line in auto-generated `proofs/Proofs.lean`
- [ ] Mechanic will register the new orphan companion in `src/data/proofs/amgm-inequality-oq-04/meta.json` `additionalFiles`

🤖 Generated with [Claude Code](https://claude.com/claude-code)