### PR TITLE
fix(meta): amgm-inequality-oq-04 axiomCount 1→2 (OQ03 chain axiom)

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -21,7 +21,7 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 306,
     "theoremCount": 22,
     "definitionCount": 5,
@@ -29,7 +29,7 @@
       "Proofs/AmgmInequalityOQ04OQ01.lean",
       "Proofs/AmgmInequalityOQ04OQ03.lean"
     ],
-    "assumptions": "0 axioms in the parent file AmgmInequalityOQ04.lean (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the companion file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). 1 axiom in the registered companion AmgmInequalityOQ04OQ01.lean: agm_ellipticK_connection — Gauss's AGM-elliptic-integral identity M(a,b) = aπ/(2K(k')), a 200+ page classical proof requiring Landen/theta-function theory not in Mathlib. Chain axiom total: 1.",
+    "assumptions": "0 axioms in the parent file AmgmInequalityOQ04.lean (S2 ACT, 2026-05-16: Lever A deletion of 3 vacuous placeholder axioms ellipticK / ellipticK_zero / agm_ellipticK now superseded by rigorous definitions in the companion file AmgmInequalityOQ04OQ01.lean). The AGM convergence theory is proved entirely from Mathlib (monotone convergence theorem). 1 axiom in the registered companion AmgmInequalityOQ04OQ01.lean: agm_ellipticK_connection — Gauss's AGM-elliptic-integral identity M(a,b) = aπ/(2K(k')), a 200+ page classical proof requiring Landen/theta-function theory not in Mathlib. 1 axiom in the registered companion AmgmInequalityOQ04OQ03.lean: ellipticK_eq_hyp2F1 — the hypergeometric series representation K(k) = (π/2)·₂F₁(1/2,1/2;1;k²) for |k|<1, whose proof requires Wallis integrals + term-by-term integration of the binomial series (sum/integral interchange via dominated convergence); summability is independently established in §6 of the file (S2 ACT, 2026-06-01) and the k=0 instance is independently verified by ellipticK_hyp2F1_consistent_zero. Chain axiom total: 2.",
     "mathlib_version": "4.26.0"
   },
   "overview": {


### PR DESCRIPTION
## Summary

After PR #21929 registered `AmgmInequalityOQ04OQ03.lean` as an `additionalFiles` companion, the slug chain holds **2 axioms** but `meta.axiomCount` remained **1**:

| File | Axiom | Count |
|------|-------|-------|
| `Proofs/AmgmInequalityOQ04.lean` (parent) | — | 0 |
| `Proofs/AmgmInequalityOQ04OQ01.lean` | `agm_ellipticK_connection` (Gauss \`M(a,b) = aπ/(2K(k'))\`) | 1 |
| `Proofs/AmgmInequalityOQ04OQ03.lean` | `ellipticK_eq_hyp2F1` (\`K(k) = (π/2)·₂F₁(1/2,1/2;1;k²)\`) | 1 |
| **Chain total** | | **2** |

This sequels PR #21932 (0→1 fix after OQ01 registration). Per the axiom integrity policy in `CLAUDE.md`, the chain count must reflect all assumptions in the parent + registered companions.

## Changes

- `meta.axiomCount`: 1 → 2
- `meta.assumptions`: appended a complete description of the second axiom and noted (a) S2 ACT summability progress in §6 of `AmgmInequalityOQ04OQ03.lean` and (b) the independently verified k=0 instance (\`ellipticK_hyp2F1_consistent_zero\`). Chain axiom total now correctly stated as 2.

`status: axiomatized` and `badge: axiom` remain unchanged.

Verified with:

\`\`\`bash
grep -cE '^axiom ' proofs/Proofs/AmgmInequalityOQ04.lean       # 0
grep -cE '^axiom ' proofs/Proofs/AmgmInequalityOQ04OQ01.lean   # 1
grep -cE '^axiom ' proofs/Proofs/AmgmInequalityOQ04OQ03.lean   # 1
\`\`\`

Tracker audit PR #21949 (cycle 4 — issues-found, axiom undercount) was filed before OQ03 was registered; this PR closes that gap.

## Test plan

- [x] \`jq empty src/data/proofs/amgm-inequality-oq-04/meta.json\` — JSON valid
- [x] Axiom counts re-verified via grep against parent + 2 registered companions
- [x] Status/badge consistent with axiomCount > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)