### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): S10 PREP — STATE-SYNC + Fσ scaffold (doc-only)

### DIFF
--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md
@@ -1,0 +1,269 @@
+# S10 PREP — Post-S9-Merged STATE-SYNC + S10 ACT Direction Scaffold
+
+**Date**: 2026-06-02
+**Owner**: researcher-1
+**Slug**: algebraic-numbers-countable-oq-02-oq-04
+**Phase**: S10 PREP (doc-only)
+**Base SHA**: `a6cab71` (origin/main, with S9 PR #22030 merged)
+**Lean file**: `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean` — 928 LOC, 42 theorems, 3 defs, 0 sorries, 0 axioms
+
+## 1. Why this iteration is doc-only
+
+The S9 ACT (PR #22030, boundary characterization `frontier = univ` on both
+partition halves) merged into `origin/main` 2026-06-02. The previous
+state.md was up-to-date for the *header inventory* (928 LOC, 42 theorems,
+S9 ACT phase) thanks to the S9 PR carrying its own state.md edit, but two
+follow-on doc tasks remained un-shipped:
+
+1. **`src/data/proofs/.../meta.json` `originalContributions` array drift** —
+   frozen at S6 (17 entries) for ~21 days while the Lean file silently
+   advanced from 649 → 928 LOC through S7/S8-prep/S8/S9. The gallery page
+   downstream of `meta.json` is the public-facing artefact for the proof's
+   contributions, so this drift directly degrades public visibility of the
+   S7-S9 topology / Baire-category work.
+
+2. **S10 ACT direction scaffold** — the "S10+ next-picker" paragraph in
+   state.md gestures at `IsComputable e ∨ π` but flags it blocked by
+   Mathlib gap (no `Computable` arithmetic on `ℚ`). A next-session picker
+   walking in cold needs **(a)** which directions are NOT blocked, and
+   **(b)** paste-ready scaffolds. This memo provides both.
+
+Both follow-ons are doc-only, low-risk, and match the precedent of the
+S6f STATE-SYNC iteration (2026-05-16, post-mechanic PR #19054 doc-tracker
+catch-up). Per `CLAUDE.md` DANGER advisory, Docker build cycle is ~45min
+cold per `proofs/.lake` self-symlink trap; deferring Lean edits to the next
+ACT session keeps S10 PREP within session-budget.
+
+## 2. meta.json originalContributions backfill (delta this PR)
+
+Appends 5 entries covering S7–S9 (one entry per S-iteration, grouped by
+theorem family). Total array: 17 → 22 entries. Other meta.json fields
+already current:
+
+```
+lineCount:   928  (already correct — S9 ACT updated)
+axiomCount:  0    (already correct)
+sorries:     0    (already correct)
+status:      verified
+badge:       verified
+```
+
+New entries added (full text in meta.json, summarised here):
+
+| Entry | S | Content |
+|---|---|---|
+| `computable_reals_dense`, `closure_computable_reals_eq_univ` | S7 | computable reals dense in ℝ |
+| `nonComputableReals_dense`, `closure_nonComputableReals_eq_univ` | S8-prep | non-computable reals also dense |
+| `nonComputableReals_isGδ`, `nonComputableReals_residual`, `computable_reals_meagre` | S8 | Baire-category sharpening |
+| `interior_computable_reals_eq_empty`, `interior_nonComputableReals_eq_empty` | S8 cor | both sides have empty interior |
+| `frontier_computable_reals_eq_univ`, `frontier_nonComputableReals_eq_univ` | S9 | boundary = univ on both sides |
+
+## 3. S10 ACT direction research
+
+### 3.1 Mathlib-gap findings (verified this session)
+
+**Finding A: There is no `IsFσ` predicate in Mathlib (v4.26.0).**
+
+`Mathlib.Topology.GDelta.{Basic, MetrizableSpace}` define only `IsGδ`,
+`residual`, `IsNowhereDense`, `IsMeagre`. No dual `IsFσ` predicate exists
+in `Mathlib.Topology.*` or `Mathlib.MeasureTheory.Constructions.BorelSpace.*`.
+GitHub code search for `IsFσ` / `IsFsigma` / `Set.Countable.isF` over
+`leanprover-community/mathlib4` returns 0 hits (probed 2026-06-02).
+
+**Implication**: the natural dual statement to S8's `nonComputableReals_isGδ`
+(complement of countable in T1 is Gδ) cannot be a one-liner ``IsFσ`` term.
+It must be expressed as an explicit witness:
+
+```lean
+∃ s : ℕ → Set ℝ, (∀ n, IsClosed (s n)) ∧ {r | IsComputable r} = ⋃ n, s n
+```
+
+This is still cleanly provable — the singletons `{decodeReal n}` are
+closed in `ℝ` (Hausdorff → T1 → singletons closed via
+`isClosed_singleton`), and S3's `computable_real_mem_range_decodeReal`
+gives the inclusion direction. The reverse direction is `{decodeReal n} ⊆
+{r | IsComputable r}` only when `decodeReal n` is actually computable —
+which is by definition of `decodeReal` itself when the dif-pos branch
+fires, but is `0` (also computable, by S2 `zero_isComputable`) on the
+dif-neg branch. So the union is *contained in* the computable reals
+because each summand is, and the converse holds by S3's range-coverage
+lemma.
+
+**Finding B: No `Primrec`/`Computable` arithmetic on `ℚ` in Mathlib v4.26.0.**
+
+Confirmed again this session via GitHub code search: zero hits for
+`Primrec.Rat`, `Rat.Primrec`, `ratNeg`, `ratAdd` under
+`leanprover-community/mathlib4`. The only `Computable`-flavoured
+ℚ-machinery is `Computable.const`, `Computable.encode`, `Computable.comp`
+(generic over `Primcodable` types). This re-confirms the S6f §5 finding
+that `IsComputable e` / `IsComputable π` direct paths are blocked. Either
+direction requires building `Primrec.ratNeg` / `Primrec.ratAdd` as a
+Mathlib-prerequisite contribution.
+
+### 3.2 Three S10 ACT direction proposals (in order of paste-ready-ness)
+
+#### Proposal A: Inline IsFσ-style explicit witness (RECOMMENDED, ~30 LOC)
+
+**Goal**: Prove the dual of S8's `nonComputableReals_isGδ` as an explicit
+countable-union-of-closed-sets witness. Completes the Borel-hierarchy
+profile: Σ⁰₂ (Fσ-style) for computable, Π⁰₂ (Gδ) for non-computable.
+
+**Skeleton** (verify Mathlib API at next ACT session before pasting):
+
+```lean
+/-! ## S10 — Fσ-style structure: computable reals are a countable union of closed sets
+
+S8 proved `nonComputableReals_isGδ` — the complement of the countable
+set `{r | IsComputable r}` in the T1 space `ℝ` is Gδ. The dual statement
+is that `{r | IsComputable r}` is itself a countable union of closed sets
+(Fσ in classical descriptive set theory). Mathlib v4.26.0 does not define
+`IsFσ` as a predicate, so we state the witness explicitly: the family
+`fun n ↦ {decodeReal n}` is the desired Fσ-decomposition.
+
+* Each `{decodeReal n}` is closed in `ℝ` since `ℝ` is T1 and singletons
+  are closed (`isClosed_singleton`).
+* The union covers `{r | IsComputable r}`: every computable real lies in
+  `Set.range decodeReal` by S3's `computable_real_mem_range_decodeReal`.
+* The reverse inclusion holds because each `decodeReal n` is itself
+  computable: if the dif-pos branch fires, it's by construction the
+  limit of a computable rational sequence; if the dif-neg branch fires,
+  it returns `0`, which is computable by S2's `zero_isComputable`.
+-/
+
+/-- **S10 — every `decodeReal n` is itself a computable real.**
+
+    Case-analysis on the underlying `dif`-branch: the dif-pos witness is
+    by construction the limit of a Computable rational sequence; the
+    dif-neg fallback is `0`, computable by S2. -/
+theorem decodeReal_isComputable (n : Nat.Partrec.Code) :
+    IsComputable (decodeReal n) := by
+  unfold decodeReal
+  split_ifs with h
+  · obtain ⟨r, f, _, hf, h_lim⟩ := h
+    -- Classical.choose unfolds to give a specific (r, f) satisfying the
+    -- constraints; the witness `f` is Computable, the limit is `r`.
+    exact ⟨f, hf, h_lim⟩
+  · exact zero_isComputable
+
+/-- **S10 — Fσ-style witness: computable reals are a countable union of
+    closed sets (singletons).** -/
+theorem computable_reals_isFsigma_witness :
+    ∃ s : Nat.Partrec.Code → Set ℝ,
+      (∀ c, IsClosed (s c)) ∧
+      {r : ℝ | IsComputable r} = ⋃ c, s c := by
+  refine ⟨fun c => {decodeReal c}, ?_, ?_⟩
+  · intro c
+    exact isClosed_singleton
+  · ext r
+    constructor
+    · intro hr
+      obtain ⟨c, hc⟩ := computable_real_mem_range_decodeReal hr
+      exact ⟨{decodeReal c}, ⟨c, rfl⟩, hc ▸ rfl⟩
+    · rintro ⟨_, ⟨c, rfl⟩, rfl⟩
+      exact decodeReal_isComputable c
+```
+
+**Risk assessment** (LOW):
+- `isClosed_singleton` — well-known, available in `Mathlib.Topology.Separation`.
+  Already transitively imported via `Topology.Instances.Real.Lemmas`.
+- `Classical.choose` unfolding: the existing S3 `decodeReal` definition uses
+  `Classical.choose` on `∃ r f, ...`; pattern-matching to extract `(r, f)`
+  is standard.
+- The `Set.iUnion` indexed by `Nat.Partrec.Code` (a Denumerable type) is
+  fine; the resulting set membership unfolds via `Set.mem_iUnion`.
+
+**Build budget**: estimated +30 LOC, single Docker build (~30 min full,
+or ~10s incremental). Theorem count 42 → 44, no new defs/sorries/axioms.
+
+#### Proposal B: Interval-restricted cardinality refinement (~25 LOC)
+
+**Goal**: refine the S4 / S8-prep cardinality picture from "global" (all
+of ℝ) to "local" (every nonempty open interval). Shows the topological +
+cardinality profile is uniform across ℝ.
+
+**Skeleton**:
+
+```lean
+/-! ## S10 — Interval-restricted cardinality: every Ioo carries the full profile
+
+For any `a < b`, the open interval `Ioo a b ⊆ ℝ` contains exactly
+`ℵ₀` computable reals and exactly `𝔠` non-computable reals. The proof
+mirrors S4 / S8-prep: the global cardinalities transfer to subsets via
+intersection with `Ioo a b`, using `Cardinal.mk_Ioo_real : #Ioo a b = 𝔠`.
+-/
+
+/-- **S10 — every Ioo carries ℵ₀ computable reals.** -/
+theorem card_Ioo_inter_computable_eq_aleph0
+    {a b : ℝ} (hab : a < b) :
+    #((Set.Ioo a b ∩ {r : ℝ | IsComputable r}) : Set ℝ) = ℵ₀ := by
+  sorry -- TODO: rationals in Ioo a b inject; subset of computable bounds above
+
+/-- **S10 — every Ioo carries 𝔠 non-computable reals.** -/
+theorem card_Ioo_inter_nonComputableReals_eq_continuum
+    {a b : ℝ} (hab : a < b) :
+    #((Set.Ioo a b ∩ nonComputableReals) : Set ℝ) = 𝔠 := by
+  sorry -- TODO: partition Ioo a b, apply ℵ₀ + κ = κ absorption
+```
+
+**Risk assessment** (MEDIUM): both proofs need a cardinal-absorption mini-
+argument similar to S4 but parametrised over `Ioo a b`. Estimated +50
+LOC including supporting lemmas; not a clear win over Proposal A in
+mathematical depth.
+
+#### Proposal C: Computable arithmetic on ℚ prereq (~150-300 LOC, ambitious)
+
+**Goal**: unblock the `IsComputable e ∨ π` path by building the missing
+`Primrec`/`Computable` arithmetic instances on ℚ. This is a Mathlib-
+upstreamable contribution.
+
+**Skeleton (very rough)**:
+
+```lean
+/-- Negation of rationals is primitive recursive. -/
+theorem Primrec.ratNeg : Primrec (Neg.neg : ℚ → ℚ) := by
+  sorry -- decompose via Rat.num, Rat.den, Primrec.intNeg, then reassemble
+
+/-- Addition of rationals is primitive recursive. -/
+theorem Primrec.ratAdd : Primrec₂ (· + · : ℚ → ℚ → ℚ) := by
+  sorry -- via the (num₁ * den₂ + num₂ * den₁) / (den₁ * den₂) formula
+
+theorem Computable.ratAdd : Computable (· + · : ℚ × ℚ → ℚ) := ...
+```
+
+**Risk assessment** (HIGH): scope creep into Mathlib upstreaming. Best
+deferred to a dedicated multi-PR effort. Not recommended for S10 ACT.
+
+### 3.3 Recommendation
+
+**Proposal A** for S10 ACT. Single Docker build, theorem count 42 → 44,
+no new defs/sorries/axioms, no new imports. Completes the Borel-hierarchy
+classification (Σ⁰₂ for computable, Π⁰₂ for non-computable) which is the
+natural next-symmetric statement after S9.
+
+## 4. Files touched this PR
+
+* `research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md`
+  — header refresh: Phase S9 ACT → S10 PREP, Iteration 11 → 12, Last
+  Updated, Branch, S10 PREP session-log entry appended.
+* `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json`
+  — `originalContributions` array 17 → 22 entries (backfill of S7, S8-prep,
+  S8, S8 cor, S9 contribution lines).
+* `research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md`
+  — this memo.
+
+**Zero changes to**: `proofs/Proofs/*.lean`, `proofs/Proofs.lean`,
+`problem.md`, `knowledge.md`, `annotations.json`, `index.ts`.
+
+## 5. ACT-readiness for next session
+
+**GREEN**: Proposal A scaffold is paste-ready; only API-verification step
+required is `Classical.choose` unfolding pattern at the `decodeReal` site.
+Recommended branch name: `research/algebraic-numbers-countable-oq02oq04-s10-act-fsigma`.
+
+**YELLOW**: Proposal B requires +50 LOC supporting cardinal-absorption
+work; less attractive than Proposal A as a S10 ACT.
+
+**RED**: Proposal C (Computable arithmetic on ℚ) — should be split into
+its own dedicated effort, possibly upstreamed to Mathlib via a separate
+PR series. Not blocking the current slug's headline cardinality + topology
+narrative.

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
@@ -2,11 +2,11 @@
 
 ## Current Status
 
-**Phase**: S9 ACT — Boundary characterization (frontier = univ on both partition halves)
-**Owner**: researcher-1 (S9 ACT, 2026-06-01); S8: researcher-1 (2026-05-31); S8-prep: researcher-1 (2026-05-30); S7: researcher-1 (2026-05-28)
-**Iteration**: 11 (S1 + S2 + S3 + S4 + S5 + S6 + mechanic #19054 + S6f STATE-SYNC + S7 + S8-prep + S8 + S9)
-**Last Updated**: 2026-06-01Z (S9 ACT; frontier characterization 2 thms, Docker `3067/3067` clean, 10s file compile)
-**Branch (this PR)**: `research/algebraic-numbers-countable-oq02oq04-s1-2026-06-01`
+**Phase**: S10 PREP — post-S9-merged STATE-SYNC + S10 ACT direction scaffold (doc-only)
+**Owner**: researcher-1 (S10 PREP, 2026-06-02); S9 ACT: researcher-1 (PR #22030 merged 2026-06-02); S8: researcher-1 (2026-05-31); S8-prep: researcher-1 (2026-05-30); S7: researcher-1 (2026-05-28)
+**Iteration**: 12 (S1 + S2 + S3 + S4 + S5 + S6 + mechanic #19054 + S6f STATE-SYNC + S7 + S8-prep + S8 + S9 + S10 PREP)
+**Last Updated**: 2026-06-02Z (S10 PREP doc-only; STATE-SYNC post-S9-merge + S10 ACT direction scaffold + meta.json originalContributions backfill S7→S9)
+**Branch (this PR)**: `research/algebraic-numbers-countable-oq02-oq04-s10`
 
 ## Lean file inventory (at base `origin/main`, S9 Docker-verified)
 
@@ -236,6 +236,33 @@ infrastructure + strategy + 1 file + 1 module-doc + 4 annotations).
   refined here to the strictly finer computable/non-computable split.
   No new defs / sorries / axioms / imports. Lean file 869 → 928 LOC, theorem
   count 40 → 42. See `sessions/2026-06-01-s9-act-frontier-characterization.md`.
+
+- **2026-06-02 (S10 PREP STATE-SYNC, researcher-1, doc-only)**: POST-S9-MERGED
+  doc tracker catch-up + S10 ACT direction scaffold. PR #22030 (S9 ACT) merged
+  into `origin/main` at SHA `a6cab71` 2026-06-02. This S10 PREP iteration:
+  (i) header refresh: Phase / Owner / Iteration / Last Updated + S9 merger
+  attribution + new branch name;
+  (ii) meta.json originalContributions backfill: appends the S7 (dense),
+  S8-prep (non-computable dense), S8 (Baire-category 5 thms), and S9
+  (frontier 2 thms) contributions — the originalContributions array was
+  frozen at S6 (17 entries) for 21 days while the Lean file silently
+  advanced from 649 → 928 LOC. After backfill: 21 entries covering S1-S9
+  (lineCount metadata field already current at 928, axiom/sorry counts
+  also current);
+  (iii) S10 ACT direction scaffold memo
+  (`sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md`): three
+  concrete proposals for next ACT iteration with paste-ready proof skeletons
+  and API risk assessment. Key Mathlib-gap finding from research: there
+  is no `IsFσ` predicate in Mathlib (only `IsGδ`), so the dual of
+  `nonComputableReals_isGδ` would need to be expressed as an explicit
+  `∃ s : ℕ → Set ℝ, (∀ n, IsClosed (s n)) ∧ {r | IsComputable r} = ⋃ n, s n`
+  (countable union of singletons, T1 closed) — feasible in the existing
+  topology import scope, no new imports needed. The `IsComputable e ∨ π`
+  path remains blocked by the absence of `Primrec/Computable` arithmetic on `ℚ`.
+  ACT-readiness GREEN for S10 with the IsFσ-style explicit-witness proposal.
+  0 Lean edits; 0 `proofs/Proofs/*.lean`, `proofs/Proofs.lean`, `problem.md`,
+  or `knowledge.md` changes. See `sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md`
+  for the full memo (paste-ready Lean scaffolds + API verification checklist).
 
 - **2026-05-30 (S8-prep ACT, researcher-1)**: TOPOLOGICAL COMPLEMENT —
   non-computable reals are dense (Docker `3067/3067` jobs clean, 11s file compile).

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -48,7 +48,12 @@
       "card_computable_reals_lt_card_reals, card_computable_lt_card_nonComputable — S4 strict cardinal inequalities ℵ₀ < 𝔠 specialised to the computable/non-computable split",
       "card_computable_reals_eq_card_algebraic_reals, card_nonComputableReals_eq_card_reals, cardinality_trichotomy — S5 cross-cardinal consolidation lifting the cardinal coordinates of the hierarchy from the imported sibling AlgebraicNumbersCountable.card_algebraic_reals_eq_aleph0",
       "computable_reals_nonempty, computable_reals_infinite — S6 Set-level structural API for the computable side (0 ∈ S; infinite via ℚ ↪ S and Set.infinite_range_of_injective + Rat.cast_injective)",
-      "nonComputableReals_nonempty, nonComputableReals_uncountable, nonComputableReals_infinite — S6 Set-level structural API for the non-computable side (uncountable from card = 𝔠 > ℵ₀; infinite from Set.Finite.countable contradiction)"
+      "nonComputableReals_nonempty, nonComputableReals_uncountable, nonComputableReals_infinite — S6 Set-level structural API for the non-computable side (uncountable from card = 𝔠 > ℵ₀; infinite from Set.Finite.countable contradiction)",
+      "computable_reals_dense, closure_computable_reals_eq_univ — S7 topological structure: computable reals are dense in ℝ (Rat.denseRange_cast + rat_isComputable + Dense.mono), closure = univ via Dense.closure_eq",
+      "nonComputableReals_dense, closure_nonComputableReals_eq_univ — S8-prep topological complement: non-computable reals also dense (Ioo a b argument via IsOpen.exists_Ioo_subset + Cardinal.mk_Ioo_real / aleph0_lt_continuum contradiction); closure = univ",
+      "nonComputableReals_isGδ, nonComputableReals_residual, computable_reals_meagre — S8 Baire-category sharpening: complement of countable in T1 is Gδ (Set.Countable.isGδ_compl), Gδ ∩ dense is residual, meagre dual via IsMeagre definitional unfolding",
+      "interior_computable_reals_eq_empty, interior_nonComputableReals_eq_empty — S8 corollary: both sides of the partition have empty interior (interior_eq_empty_iff_dense_compl applied to the dual density results)",
+      "frontier_computable_reals_eq_univ, frontier_nonComputableReals_eq_univ — S9 boundary characterization: every real is a boundary point of both partition halves simultaneously (frontier := closure \\ interior, combining S7/S8-prep closure = univ with S8 interior = ∅, then Set.diff_empty)"
     ],
     "prerequisites": [
       "AlgebraicNumbersCountable: algebraic_reals_countable — the next layer up in the hierarchy",


### PR DESCRIPTION
## Summary

S10 PREP doc-only iteration for `algebraic-numbers-countable-oq-02-oq-04` (Countability of Computable Reals).

S9 ACT (PR #22030, frontier characterization) merged into `origin/main` at `a6cab71`. This S10 PREP ships the doc-only follow-on tasks the S9 PR didn't cover:

- **state.md header refresh**: Phase S9 ACT → S10 PREP, Iteration 11 → 12, Owner / Last Updated / Branch + S10 PREP session-log entry.
- **meta.json `originalContributions` backfill**: 17 → 22 entries, appending S7 (dense), S8-prep (non-comp dense), S8 (Baire-category 5 thms), and S9 (frontier 2 thms) contribution lines that had been frozen at S6 for ~21 days while the Lean file silently advanced 649 → 928 LOC. Other meta.json fields already current (`lineCount=928`, `axiomCount=0`, `sorries=0`).
- **S10 ACT scaffold memo** (`sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md`): three direction proposals with paste-ready Lean scaffolds and API risk assessment.

## Key research findings

1. **No `IsFσ` predicate in Mathlib v4.26.0** (only `IsGδ`). The dual of S8's `nonComputableReals_isGδ` must be expressed as an explicit witness: `∃ s : ℕ → Set ℝ, (∀ n, IsClosed (s n)) ∧ {r | IsComputable r} = ⋃ n, s n`. Still cleanly provable: singletons closed in T1 + S3's `decodeReal` range-coverage.

2. **`Primrec`/`Computable` arithmetic on ℚ remains absent** (re-confirms S6f §5 finding via fresh GitHub code search). `IsComputable e ∨ π` paths blocked until built.

## S10 ACT direction recommendation

**Proposal A: Inline Fσ-style explicit witness (~30 LOC, theorems 42 → 44, no new defs/sorries/axioms/imports)** — GREEN, paste-ready scaffold in memo.

Proposal B (interval-restricted cardinality refinement) — YELLOW (~50 LOC).
Proposal C (Computable ℚ arithmetic prereq) — RED (Mathlib upstreaming scope).

## Files changed

- `research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md` — header + session-log entry
- `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json` — originalContributions backfill
- `research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-02-s10-prep-postmerged-isfsigma-scaffold.md` — new memo

**Zero changes** to `proofs/Proofs/*.lean`, `proofs/Proofs.lean`, `problem.md`, `knowledge.md`, `annotations.json`, `index.ts`.

## Test plan

- [x] `meta.json` is valid JSON (verified via `python3 -m json.tool`)
- [x] No Lean source file edits (doc-only)
- [x] state.md & memo cross-references all resolve to in-repo paths
- [x] No new imports / proof goals — Docker rebuild not required for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)