### PR TITLE
fix(meta): ehrhart-cube-proven drop stale additionalFiles reference

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13794,9 +13794,9 @@
       "issues": []
     },
     "ehrhart-cube-proven": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:43:36Z",
-      "result": "clean",
+      "auditCount": 2,
+      "lastAudited": "2026-06-02T08:56:08Z",
+      "result": "issues-fixed",
       "issues": []
     },
     "ehrhart-cube-proven-oq-01": {

--- a/src/data/proofs/ehrhart-cube-proven/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven/meta.json
@@ -48,10 +48,7 @@
     ],
     "dateAdded": "2026-05-03",
     "mathlib_version": "4.26.0",
-    "definitionCount": 1,
-    "additionalFiles": [
-      "Proofs/EhrhartPolynomials.lean"
-    ]
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Eugène Ehrhart (1912–2000) was a French mathematician who, while teaching at a lycée, spent the 1950s and 1960s studying lattice points in dilated polytopes. His key discovery — published in the 1962 paper *Sur les polyèdres rationnels homothétiques à n dimensions* — was that for any convex lattice polytope $P$, the function $n \\mapsto |nP \\cap \\mathbb{Z}^d|$ is a polynomial in $n$ of degree $\\dim P$, now called the **Ehrhart polynomial** $L(P, n)$.\n\nThe story of the unit cube is elementary: $n \\cdot [0,1]^d = [0,n]^d$ contains exactly $\\{0, 1, \\ldots, n\\}^d$ integer points, giving $(n+1)^d$. This is the simplest instance of Ehrhart's theorem — a polynomial of degree $d$ with leading coefficient $\\text{vol}([0,1]^d) = 1$ (the normalized volume), constant term 1, and all coefficients given by the binomial formula $\\binom{d}{k}$. The formula $(n+1)^d = \\sum_{k=0}^d \\binom{d}{k} n^k$ is just the binomial theorem.\n\nThe deeper structural results for the cube follow equally directly. The **interior lattice point polynomial** $L^*([0,1]^d, n) = (n-1)^d$ is the Ehrhart polynomial evaluated at $-n$ with a sign: $(-1)^d(1-n)^d = (n-1)^d$, confirming **Ehrhart-Macdonald reciprocity** (1971), which Ian Macdonald proved for all lattice polytopes. **Pick's theorem** (1899), Georg Pick's classical formula Area $= I + B/2 - 1$ for lattice polygons, appears as a specialization to $d=2$: the Ehrhart polynomial $(n+1)^2 = n^2 + 2n + 1$ encodes area (leading coefficient $n^2$), boundary (linear term $2n$, contributing $B/2 = 2n/2 = n$ boundary points per unit dilation), and Euler characteristic (constant 1).\n\nEhrhart's work was initially largely ignored — he was not in an academic research position and published primarily in the *Comptes Rendus*. Recognition came slowly: Richard Stanley's 1980 connection of Ehrhart theory to commutative algebra (via the Hilbert series of the associated graded ring), and Barvinok's 1994 polynomial-time algorithm for counting lattice points in polytopes of fixed dimension, transformed Ehrhart theory into a central tool in combinatorics, optimization, and algebraic geometry. Today it underpins integer programming via the theory of Ehrhart $h^*$-polynomials and applications to scheduling, network flows, and the geometry of numbers.",
@@ -147,10 +144,7 @@
     "theoremCount": 26,
     "definitionCount": 1,
     "path": "Proofs/EhrhartCubeProven.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/EhrhartPolynomials.lean"
-    ]
+    "sorries": 0
   },
   "crossReferences": [
     {


### PR DESCRIPTION
## Summary
- Gallery integrity audit: `ehrhart-cube-proven` flagged as `axiom undercount: claims 0, actual declarations 3`.
- Root cause: `meta.additionalFiles` and `leanFile.additionalFiles` listed `Proofs/EhrhartPolynomials.lean`, which the auditor follows and aggregates axioms from.
- The cube proof's main file (`Proofs/EhrhartCubeProven.lean`) imports only `Mathlib` and uses **no** symbols from `EhrhartPolynomials.lean` (no `LatticePolytope`, `ehrhartCount`, `ehrhart_theorem`, etc.).
- The proof is *intentionally* axiom-free — meta explicitly contrasts it with the axiomatized Ehrhart machinery. The 3 axioms being pulled in (`ehrhart_theorem`, `ehrhart_leading_coeff_volume`, `ehrhart_macdonald_reciprocity`) belong to an unrelated companion entry.
- Fix: remove the stale `additionalFiles` entries from both blocks. Cross-file relationships are already expressed via `crossReferences` (picks-theorem-oq-03, picks-theorem, picks-theorem-oq-03-product).

## Verification
- `npx tsx scripts/auditor/find-targets.ts --json` → `detectedIssues: []`, `actual.axiomCount: 0`.
- `python3 -c "import json; json.load(...)"` → JSON parses cleanly.
- Sibling entry `ehrhart-cube-proven-oq-01` (also `verified/original`, `axiomCount: 0`) uses the same pattern: no `additionalFiles`.

## Test plan
- [x] JSON parses
- [x] `find-targets.ts` no longer flags `ehrhart-cube-proven`
- [x] Main Lean file confirmed to import only `Mathlib` (no `import Proofs.EhrhartPolynomials`)
- [x] No symbols from `EhrhartPolynomials.lean` referenced in `EhrhartCubeProven.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)