### PR TITLE
fix(meta): central-limit-theorem-oq-03 axiomCount 14→25 (chain companion axioms)

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-03/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-03/meta.json
@@ -41,9 +41,9 @@
       "Gaussian stability under normalized convolution powers"
     ],
     "historicalContext": "The algebraic structure of probability distributions under convolution has been studied since Lévy (1925). Cramér's theorem (1936) revealed that the Gaussian is 'indecomposable' in this structure, and the CLT can be interpreted as a convergence statement in the convolution monoid.",
-    "axiomCount": 14,
+    "axiomCount": 25,
     "lineCount": 241,
-    "assumptions": "14 axioms: convolution, convolution_assoc, convolution_dirac_left, and 11 more. See Lean source for complete statements.",
+    "assumptions": "25 axiom declarations across the chain: 14 in main file CentralLimitTheoremOQ03.lean (convolution, convolution_assoc, convolution_dirac_left, convolution_dirac_right, convolution_comm, charFun, charFun_convolution, charFun_dirac_zero, mean, variance, standardGaussian, gaussian_variance, normalizedConvPow, clt_convergence) and 11 in companion CentralLimitTheoremOQ03OQ02.lean (convolution, convolution_assoc, convolution_comm, convolution_dirac_right, charFun, charFun_convolution, charFun_dirac_zero, standardGaussian, standardGaussian_infDivisible, levyKhintchineExponent, levy_khintchine). Eight names are duplicated across main and OQ02 — they are independent declarations per module. Companions OQ01 and OQ01Aristotle declare no axioms (OQ01 carries 2 sorries; OQ01Aristotle carries 4 sorries — Aristotle scaffolding). See Lean sources for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 5,


### PR DESCRIPTION
## Summary

- Updates `meta.axiomCount` 14 → 25 for `central-limit-theorem-oq-03` to chain-aggregate axiom declarations across registered companion files.
- Expands `meta.assumptions` with the full per-file breakdown and flags the 8 duplicated axiom names (main ∩ OQ02) as independent declarations per module.

## Why

PR #21960 registered the OQ01 + OQ02 companions but explicitly left the primary's `axiomCount` unchanged ("the companion files carry independent counts and are not aggregated into the primary's totals here"). Recent auditor precedent supersedes this convention:

- #22053 (hilbert-11) chain-aggregated axiomCount 3 → 5 (main 3 + OQ01 1 + OQ01OQ01 1)
- #22054 (cauchy-schwarz-integral-oq-01-oq-02) chain-aggregated 2 → 3 (main 2 + HadamardThreeLines 1)

## Per-file axiom counts (verified with `grep -c '^axiom ' …`)

| File | Axioms | Sorries |
|---|---|---|
| `Proofs/CentralLimitTheoremOQ03.lean` (main) | 14 | 0 |
| `Proofs/CentralLimitTheoremOQ03OQ01.lean` | 0 | 2 |
| `Proofs/CentralLimitTheoremOQ03OQ01Aristotle.lean` | 0 | 4 |
| `Proofs/CentralLimitTheoremOQ03OQ02.lean` | 11 | 0 |
| **Chain total** | **25** | **6** |

`leanFile.axiomCount` (primary-file scope) intentionally stays at 14 — same convention as #22053 and #22054.

## Test plan

- [x] JSON validates (`python3 -c "import json; json.load(open(...))"`)
- [x] axiomCount matches `grep -c '^axiom '` aggregate
- [x] No duplicate PRs (`gh pr list --search central-limit-theorem-oq-03` → empty)
- [x] `leanFile.axiomCount` (primary scope) unchanged at 14

🤖 Generated with [Claude Code](https://claude.com/claude-code)