### PR TITLE
fix(meta): central-limit-theorem-oq-01-oq-01 axiomCount 3→6 (chain companion axioms)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1908,10 +1908,10 @@
       "result": "clean"
     },
     "central-limit-theorem-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T18:33:05Z",
-      "result": "clean"
+      "lastAudited": "2026-06-02T09:56:07Z",
+      "result": "issues-fixed"
     },
     "central-limit-theorem-oq-01-oq-02": {
       "auditCount": 4,
@@ -11701,8 +11701,8 @@
     },
     "hilbert-11": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T11:59:18Z",
+      "auditCount": 5,
+      "lastAudited": "2026-06-02T09:54:00Z",
       "result": "clean"
     },
     "hilbert-13": {

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01/meta.json
@@ -51,9 +51,9 @@
       "Stable self-similarity identity via complex exponential arithmetic",
       "Slowly varying function examples: shifted logarithms with power closure"
     ],
-    "axiomCount": 3,
+    "axiomCount": 6,
     "lineCount": 1130,
-    "assumptions": "3 axiom(s): gnedenko_kolmogorov_forward, gnedenko_kolmogorov_gaussian, gnedenko_kolmogorov_converse. See Lean source for complete statements.",
+    "assumptions": "6 axiom(s): gnedenko_kolmogorov_forward, gnedenko_kolmogorov_gaussian, gnedenko_kolmogorov_converse (CentralLimitTheoremOQ01OQ01.lean); gnedenko_kolmogorov_symmetric, gaussian_unique_finite_variance, classical_clt_as_domain (GnedenkoKolmogorov.lean). See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
     "theoremCount": 55,
     "definitionCount": 8,


### PR DESCRIPTION
## Summary
- Audit flagged axiom undercount: meta claims 3, chain aggregate is 6.
- Chain: `CentralLimitTheoremOQ01OQ01.lean` (3) + `GnedenkoKolmogorov.lean` (3, via `additionalFiles`).
- Updated `meta.axiomCount` 3→6 and expanded `assumptions` string to enumerate all six axioms.
- Leaves the per-file `leanFile.axiomCount` at 3 (main-file-only convention).

## Axioms aggregated
**CentralLimitTheoremOQ01OQ01.lean** (3): `gnedenko_kolmogorov_forward`, `gnedenko_kolmogorov_gaussian`, `gnedenko_kolmogorov_converse`

**GnedenkoKolmogorov.lean** (3): `gnedenko_kolmogorov_symmetric`, `gaussian_unique_finite_variance`, `classical_clt_as_domain`

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --limit 10` no longer flags this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)