### PR TITLE
fix(meta): wolstenholme-theorem axiomCount 2→3 (chain companion axiom)

### DIFF
--- a/src/data/proofs/wolstenholme-theorem/meta.json
+++ b/src/data/proofs/wolstenholme-theorem/meta.json
@@ -35,8 +35,8 @@
       "Wolstenholme prime definition and examples"
     ],
     "dateAdded": "2025-12-31",
-    "axiomCount": 2,
-    "assumptions": "2 axiom(s). No sorries.",
+    "axiomCount": 3,
+    "assumptions": "3 axiom(s): wolstenholme_theorem, harmonic_divisibility (WolstenholmeTheorem.lean); wolstenholme_prime_mod4_question (WolstenholmeTheoremOQ02OQ02.lean). No sorries.",
     "lineCount": 220,
     "prerequisites": [
       "Binomial coefficients and central binomial coefficients",


### PR DESCRIPTION
## Summary
- Aggregates main file (2) + WolstenholmeTheoremOQ02OQ02.lean (1) per chain-aggregate axiom-symmetric counting (PR #18120).
- Auditor flagged 2-vs-3 undercount via `find-targets.ts --issues`.

## Evidence

**meta.json claims**: `axiomCount: 2`

**Lean chain actually declares 3 axioms:**
```
proofs/Proofs/WolstenholmeTheorem.lean:132:axiom wolstenholme_theorem
proofs/Proofs/WolstenholmeTheorem.lean:196:axiom harmonic_divisibility
proofs/Proofs/WolstenholmeTheoremOQ02OQ02.lean:312:axiom wolstenholme_prime_mod4_question
```
(WolstenholmeTheoremOQ02.lean has 0 axioms; all three files have 0 sorries; no structure-encoded assumptions.)

## Test plan
- [ ] CI passes
- [ ] `find-targets.ts --issues` no longer reports wolstenholme-theorem

🤖 Generated with [Claude Code](https://claude.com/claude-code)