### PR TITLE
fix(meta): buffons-needle drop stale additionalFiles reference

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13637,8 +13637,8 @@
     },
     "wolstenholme-theorem": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T10:06:47Z",
       "result": "clean"
     },
     "wolstenholme-theorem-oq-01": {
@@ -13794,9 +13794,9 @@
       "issues": []
     },
     "ehrhart-cube-proven": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-02T08:56:08Z",
-      "result": "issues-fixed",
+      "auditCount": 3,
+      "lastAudited": "2026-06-02T10:13:13Z",
+      "result": "clean",
       "issues": []
     },
     "ehrhart-cube-proven-oq-01": {

--- a/src/data/proofs/buffons-needle/meta.json
+++ b/src/data/proofs/buffons-needle/meta.json
@@ -43,10 +43,7 @@
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 9,
-    "definitionCount": 3,
-    "additionalFiles": [
-      "Proofs/BuffonsNoodle.lean"
-    ]
+    "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Buffon's Needle Problem was posed by Georges-Louis Leclerc, Comte de Buffon in his 1777 *Essai d'arithmétique morale*, making it one of the earliest problems in geometric probability. Buffon was a polymath — naturalist, mathematician, and director of the Jardin du Roi — who used this problem to explore the foundations of probability theory. The elegant answer $P = 2\\ell/(\\pi d)$ stunned contemporaries: how could $\\pi$, a geometric constant, arise from a probability calculation about random needle drops? Pierre-Simon Laplace recognized its deeper significance and connected it to what we now call integral geometry. In 1812, Laplace used the needle experiment to propose one of the first Monte Carlo methods for estimating $\\pi$: drop $n$ needles, count $k$ crossings, then $\\pi \\approx 2\\ell n/(kd)$. The Italian mathematician Mario Lazzarini claimed in 1901 to have estimated $\\pi$ to six decimal places with 3,408 throws — a result widely suspected to be fabricated, as the ratio $355/113$ (an excellent rational approximation to $\\pi$) fits suspiciously well. In the 20th century, Augustin-Louis Cauchy and later Mark Kac generalized Buffon's result to the Cauchy-Crofton formula, which relates the length of any rectifiable curve to its expected number of intersections with random lines, founding the field of integral geometry.",
@@ -225,10 +222,7 @@
     "theoremCount": 9,
     "definitionCount": 3,
     "path": "Proofs/BuffonsNeedle.lean",
-    "sorries": 0,
-    "additionalFiles": [
-      "Proofs/BuffonsNoodle.lean"
-    ]
+    "sorries": 0
   },
   "mainTheorems": [
     {


### PR DESCRIPTION
## Summary
- Audit flagged `buffons-needle` as `axiom undercount: claims 0, actual declarations 2`.
- Root cause: `meta.additionalFiles` and `leanFile.additionalFiles` listed `Proofs/BuffonsNoodle.lean`; the auditor follows that registration and aggregates its 2 axioms (`smoothExpectedCrossings`, `buffon_noodle_smooth_eq`).
- The main `Proofs/BuffonsNeedle.lean` does **not** import or use any symbols from `BuffonsNoodle.lean` (imports only `Mathlib.*`). It is genuinely axiom-free, as the meta description and `assumptions` field claim ("None. Fully verified with 0 axioms and 0 sorries.").
- `BuffonsNoodle.lean` explicitly axiomatizes the needle result ("We axiomatize this result (proved in BuffonsNeedle.lean) and build upon it") to prove the Noodle generalization downstream. Its theorem already has its own gallery entries (`buffons-needle-oq-01`, `-oq-01-oq-01`, `-oq-01-oq-01-oq-01`, `-oq-02`, `-oq-02-oq-02`), so registering its file here double-attributes the axioms.
- Fix: drop the stale `additionalFiles` entries from both blocks.

Same pattern as #22050 (ehrhart-cube-proven), which fixed the analogous false positive introduced by PR #21998's bulk orphan-companion registration.

## Verification
- `BuffonsNeedle.lean`: 0 axioms, 0 sorries, 9 theorems, 3 defs ✓
- `npx tsx scripts/auditor/find-targets.ts --json` → no longer lists `buffons-needle`
- `python3 -c "import json; json.load(...)"` → JSON parses cleanly
- Sibling entries (`buffons-needle-oq-*`) do not register `BuffonsNoodle.lean` — that file is conceptual context, not a structural dependency.

## Test plan
- [x] JSON parses
- [x] `find-targets.ts` no longer flags `buffons-needle`
- [x] Main Lean file confirmed to import only `Mathlib.*` (no `import Proofs.BuffonsNoodle`)
- [x] No symbols from `BuffonsNoodle.lean` referenced in `BuffonsNeedle.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)