### PR TITLE
fix(meta): amgm-inequality axiomCount 0→5 + verified→axiomatized (chain axioms)

### DIFF
--- a/src/data/proofs/amgm-inequality/meta.json
+++ b/src/data/proofs/amgm-inequality/meta.json
@@ -7,7 +7,7 @@
     "author": "Euclid / Cauchy (formalized via Mathlib)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Analysis/MeanInequalities.html",
     "date": "~300 BCE / 1821",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/AMGMInequality.lean",
     "additionalFiles": [
       "Proofs/AMGMInequalityAristotle.lean",
@@ -20,7 +20,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -72,8 +72,8 @@
     ],
     "dateAdded": "2025-12-26",
     "wiedijkNumber": 38,
-    "axiomCount": 0,
-    "assumptions": "None. Fully verified with 0 axioms, 0 sorries, and 0 structure-encoded assumptions. The elementary two-variable proof (`am_gm_two`) and equality characterization (`am_gm_two_eq_iff`) are original constructions using `sq_nonneg`, `Real.sq_sqrt`, and `linarith`. The general weighted form (`am_gm_weighted`) and three-variable case (`am_gm_three`) are pedagogical wrappers around Mathlib's `Real.geom_mean_le_arith_mean_weighted` and `Real.geom_mean_le_arith_mean3_weighted` respectively. Wiedijk 100 theorem #38.",
+    "axiomCount": 5,
+    "assumptions": "5 axiom(s), all in the AMGMOperatorMeans.lean chain companion (operator/Loewner-order AM-GM, a separate matrix-AM-GM formalization): matGeomMean, matGeomMean_self (matrix geometric mean), operator_am_gm (the operator AM-GM inequality, Ando 1979 / Kubo-Ando 1980), matHarmonicMean, harmonic_le_geometric. The main scalar AMGMInequality.lean (Wiedijk #38) is itself axiom-free: the elementary two-variable proof (`am_gm_two`) and equality characterization (`am_gm_two_eq_iff`) are original constructions using `sq_nonneg`, `Real.sq_sqrt`, and `linarith`; the general weighted form (`am_gm_weighted`) and three-variable case (`am_gm_three`) are pedagogical wrappers around Mathlib's `Real.geom_mean_le_arith_mean_weighted` and `Real.geom_mean_le_arith_mean3_weighted`. No sorries.",
     "lineCount": 225,
     "mathlib_version": "4.26.0",
     "relatedProblems": [


### PR DESCRIPTION
## Summary

- `axiomCount` 0→5 to include the 5 axioms in registered chain companion `Proofs/AMGMOperatorMeans.lean` (matGeomMean, matGeomMean_self, operator_am_gm, matHarmonicMean, harmonic_le_geometric).
- `status` verified→axiomatized and `badge` mathlib→axiom (chain is no longer axiom-free).
- `assumptions` text rewritten to enumerate the 5 chain axioms and clarify that the scalar AMGMInequality.lean is itself axiom-free.

## Why update axiomCount instead of dropping the additionalFiles entry?

`Proofs/AMGMOperatorMeans.lean` has no separate gallery slug, so removing it from `additionalFiles` (cf. #22062 buffons-needle / #22050 ehrhart-cube-proven) would create an unregistered orphan companion that the orphan registrar would likely re-add on a future cycle.

Per CLAUDE.md axiom integrity policy, the chain-aggregate `axiomCount` must reflect ALL assumptions including additionalFiles, and `status: "verified"` is only permitted with 0 chain axioms.

## Verification

- main `AMGMInequality.lean`: 0 axioms, 0 sorries (`leanFile.axiomCount` stays 0).
- `AMGMInequalityAristotle.lean`: 0 axioms.
- `AMGMOperatorMeans.lean`: 5 axioms (confirmed by `grep -c '^axiom '`).
- Chain total: 5 — matches new `meta.axiomCount`.
- `npx tsx scripts/auditor/find-targets.ts --next` no longer surfaces amgm-inequality (next target erdos-179).
- JSON parses cleanly via `python3 -m json.tool`.

## Test plan

- [x] JSON parses cleanly
- [x] find-targets no longer flags amgm-inequality
- [ ] Site build picks up new status/badge correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)