### PR TITLE
fix(meta): lagrange-four-squares axiomCount 5→7 (chain axioms)

### DIFF
--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -33,8 +33,8 @@
       "two_squares_multiplicative: Brahmagupta-Fibonacci identity for 2-square sums"
     ],
     "dateAdded": "2025-12-26",
-    "axiomCount": 5,
-    "assumptions": "5 axiom declarations: legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound). fermat_two_squares has been formally proved. jacobi_four_squares, hurwitz_quaternions_euclidean, and hurwitz_representation_count True stubs removed — Jacobi's r₄(n) formula and Hurwitz quaternion results are not formalized.",
+    "axiomCount": 7,
+    "assumptions": "7 axioms across the chain (main 5 + FourSquareRepresentations.lean 2): main file declares legendre_three_squares (3-square obstruction criterion), hilbert_waring (g(k) exists for all k), wieferich_nine_cubes (g(3)=9), waring_general_formula (g(k) general formula), vinogradov_waring_bound (G(k) upper bound); FourSquareRepresentations.lean declares jacobi_four_square (r₄(n) = 8·σ*(n)) and r₄_zero (r₄ 0 = 1). fermat_two_squares has been formally proved. hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed — Hurwitz quaternion results are not formalized.",
     "lineCount": 392,
     "prerequisites": [
       "Quaternion algebra and norm multiplicativity",


### PR DESCRIPTION
## Summary

Chain-aggregate underclaim. `lagrange-four-squares/meta.json` declared `axiomCount: 5` reflecting only the main file's declarations. The registered `additionalFiles` chain adds 2 more axioms.

## Evidence

```
$ grep -c "^axiom " proofs/Proofs/LagrangeFourSquares.lean proofs/Proofs/FourSquareRepresentations.lean
proofs/Proofs/LagrangeFourSquares.lean:5
proofs/Proofs/FourSquareRepresentations.lean:2
```

Main file (5): `legendre_three_squares`, `hilbert_waring`, `wieferich_nine_cubes`, `waring_general_formula`, `vinogradov_waring_bound`
FourSquareRepresentations (2): `jacobi_four_square`, `r₄_zero`

Chain total = 5 + 2 = **7**.

## Fix

- `axiomCount`: 5 → 7
- `assumptions`: rewritten to enumerate the chain split (main 5 + companion 2)
- Per-file `axiomCount: 5` at line 183 left unchanged (it documents the main file only)

Per CLAUDE.md axiom integrity policy, `axiomCount` must reflect ALL assumptions across the registered chain.

## Test plan

- [x] `grep -c "^axiom "` against main + additionalFiles confirms 5 + 2 = 7
- [x] Status stays `axiomatized` / badge `axiom` (already correct)
- [x] audit-tracker.json bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)