### PR TITLE
fix(meta): inclusion-exclusion axiomCount 0→2 + verified→axiomatized (chain axioms)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -99,8 +99,8 @@
     "amgm-inequality": {
       "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-02T10:34:06Z",
-      "result": "issues-found"
+      "lastAudited": "2026-06-02T10:49:16Z",
+      "result": "clean"
     },
     "amgm-inequality-oq-02": {
       "auditCount": 5,
@@ -5015,8 +5015,8 @@
     "erdos-179": {
       "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-06-02T10:34:31Z",
-      "result": "issues-found"
+      "lastAudited": "2026-06-02T10:49:17Z",
+      "result": "clean"
     },
     "erdos-18": {
       "agentId": "auditor-cycle-20-batch",
@@ -11885,9 +11885,9 @@
     },
     "inclusion-exclusion": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T23:01:59Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T10:51:36Z",
+      "result": "issues-fixed"
     },
     "inclusion-exclusion-oq-01": {
       "auditCount": 3,
@@ -12092,9 +12092,9 @@
     },
     "lagrange-four-squares": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:18Z",
-      "result": "issues-fixed",
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T10:49:17Z",
+      "result": "clean",
       "issues": [
         "hurwitz_quaternions_euclidean and hurwitz_representation_count True stubs removed; lineCount 410→392, theoremCount 17→15"
       ]
@@ -12188,8 +12188,8 @@
     },
     "laws-of-large-numbers": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T22:58:02Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T10:49:17Z",
       "result": "clean"
     },
     "laws-of-large-numbers-oq-01": {

--- a/src/data/proofs/inclusion-exclusion/meta.json
+++ b/src/data/proofs/inclusion-exclusion/meta.json
@@ -7,7 +7,7 @@
     "author": "Abraham de Moivre (1718), formalized via Mathlib",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/Data/Finset/Card.html",
     "date": "1718",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/InclusionExclusion.lean",
     "tags": [
       "combinatorics",
@@ -16,7 +16,7 @@
       "wiedijk-100",
       "classic"
     ],
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -45,9 +45,9 @@
       "Finset.card_union_add_card_inter identity"
     ],
     "wiedijkNumber": 96,
-    "axiomCount": 0,
+    "axiomCount": 2,
     "lineCount": 218,
-    "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
+    "assumptions": "2 axiom(s), both in the MobiusInversionIE.lean chain companion (a Möbius-inversion extension that lifts inclusion-exclusion to the divisor lattice): derangement_formula (the inclusion-exclusion derangement count D(n) = Σ (-1)^k C(n,k) (n-k)!, axiomatized because the underlying permutation infrastructure is out of scope) and totient_mobius_inversion (φ(n) = Σ_{d|n} μ(d)·(n/d), Möbius inversion on the divisor lattice). The main InclusionExclusion.lean (Wiedijk #96) is itself axiom-free: the two-set, three-set, disjoint, Bonferroni, and symmetric-difference theorems are derived from Mathlib's `Finset.card_union_add_card_inter` and `Finset.card_union_of_disjoint` via `omega` and distributivity. No sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
     "definitionCount": 0,


### PR DESCRIPTION
## Summary

Auditor flagged `inclusion-exclusion` for axiom undercount. The main file
`InclusionExclusion.lean` is axiom-free, but the registered chain companion
`MobiusInversionIE.lean` (in `meta.additionalFiles`) contains 2 `axiom`
declarations:

- `derangement_formula` — D(n) = Σ (-1)^k C(n,k) (n-k)!; permutation
  infrastructure left out of scope (line 307)
- `totient_mobius_inversion` — φ(n) = Σ_{d|n} μ(d)·(n/d); Möbius
  inversion on the divisor lattice (line 315)

## Changes

| Field | Before | After |
|---|---|---|
| `axiomCount` | 0 | 2 |
| `status` | verified | axiomatized |
| `badge` | mathlib | axiom |
| `assumptions` | "None. Fully verified…" | enumerates the 2 axioms; clarifies main file is axiom-free |

## Why not drop `additionalFiles`?

`MobiusInversionIE.lean` has no separate gallery slug; dropping the entry
would create an unregistered-orphan companion that the orphan registrar
would re-add (cf. buffons-needle #22062 / ehrhart-cube-proven #22050 where
the dropped files were already-registered duplicates).

## Pattern

Follows the same chain-aggregate axiom-count fix as #22063 (amgm-inequality
0→5), #22064 (erdos-179 6→14), #22065 (laws-of-large-numbers 1→3), and
#22066 (lagrange-four-squares 5→7).

## Test plan

- [x] `jq .` parses meta.json cleanly
- [x] `grep -nE "^axiom " proofs/Proofs/InclusionExclusion.lean proofs/Proofs/MobiusInversionIE.lean` → 2 axioms (matches new axiomCount)
- [x] `npx tsx scripts/auditor/find-targets.ts --next` no longer surfaces inclusion-exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)