### PR TITLE
fix(meta): friendship-theorem axiomCount 0→1 + verified→axiomatized (chain axioms)

### DIFF
--- a/src/data/proofs/friendship-theorem/meta.json
+++ b/src/data/proofs/friendship-theorem/meta.json
@@ -7,7 +7,7 @@
     "author": "Erdős, Rényi, and Sós (formalized in Lean 4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Friendship_theorem",
     "date": "1966",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "graph-theory",
       "combinatorics",
@@ -16,7 +16,7 @@
       "wiedijk-100"
     ],
     "proofRepoPath": "Proofs/FriendshipTheorem.lean",
-    "badge": "mathlib",
+    "badge": "axiom",
     "sorries": 0,
     "mathlibDependencies": [
       {
@@ -43,8 +43,8 @@
     ],
     "dateAdded": "2025-12-27",
     "wiedijkNumber": 83,
-    "axiomCount": 0,
-    "assumptions": "Fully verified: 0 axioms, 0 sorries. FriendshipTheorem.lean imports FriendshipTheoremOQ01.lean which provides both key results: (1) regularity of friendship graphs without universal vertex (via A³ commutativity + complement-connectivity), and (2) k-regular friendship implies k=2 (via characteristic polynomial analysis). Both former axioms eliminated.",
+    "axiomCount": 1,
+    "assumptions": "1 axiom in the FriendshipTheoremOQ02.lean chain companion (a directed-graph extension to the classical undirected theorem): `directed_friendship_mod4` (in a directed friendship tournament, the vertex count satisfies n ≡ 3 (mod 4) — the Longyear–Parsons regularity + tournament out-degree counting argument is out of scope and axiomatized). The main FriendshipTheorem.lean (Wiedijk #83) is itself axiom-free and sorry-free: it imports FriendshipTheoremOQ01.lean which provides both key results — (1) regularity of friendship graphs without universal vertex (via A³ commutativity + complement-connectivity), and (2) k-regular friendship implies k=2 (via characteristic polynomial analysis). No sorries anywhere in the chain.",
     "lineCount": 373,
     "mathlib_version": "4.26.0",
     "theoremCount": 10,


### PR DESCRIPTION
## Summary

- Bumps `axiomCount` 0→1 to reflect the 1 axiom in the `additionalFiles` chain companion `FriendshipTheoremOQ02.lean` (`directed_friendship_mod4`)
- Flips `status: verified` → `axiomatized` and `badge: mathlib` → `axiom` per CLAUDE.md axiom integrity policy
- Rewrites the `assumptions` field to disclose the OQ-02 directed-tournament Longyear–Parsons axiom while clarifying that the main Wiedijk #83 result remains axiom-free

## Chain Inventory

| File | axioms | sorries | Role |
|------|--------|---------|------|
| `FriendshipTheorem.lean` (main) | 0 | 0 | Wiedijk #83 — undirected statement |
| `FriendshipTheoremOQ01.lean` (imported) | 0 | 0 | Spectral infrastructure (A³ commutativity, char-poly) |
| `FriendshipTheoremOQ02.lean` (additionalFiles) | **1** | 0 | Directed-tournament extension (OQ-02) |
| **Total** | **1** | **0** | |

The lone axiom is `directed_friendship_mod4 (D : Digraph V) (hT : IsTournament D) (hF : IsDirectedFriendshipGraph D) : Fintype.card V % 4 = 3` — the Longyear–Parsons regularity + tournament out-degree counting argument is out of scope for the current formalization.

## Why axiomatized, not verified

Per CLAUDE.md:
> `verified`: 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions
> `axiomatized`: Has `axiom` declarations OR structure-encoded assumptions

The chain has 1 `axiom` declaration, so the slug must report `axiomatized`. Same pattern shipped in #22063 (amgm), #22064 (erdos-179), #22065 (LLN), #22066 (lagrange-four-squares), and #22068 (inclusion-exclusion).

## Test plan
- [ ] `pnpm build` succeeds (no schema regressions)
- [ ] Audit queue no longer flags `friendship-theorem` axiom undercount

🤖 Generated with [Claude Code](https://claude.com/claude-code)