### PR TITLE
fix(meta): erdos-898 axiomCount 11→22 (Stubs/Erdos898Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-898/meta.json
+++ b/src/data/proofs/erdos-898/meta.json
@@ -47,9 +47,9 @@
       "Formalized generalizations to tetrahedra and regular n-gons",
       "Axiomatized Viviani's theorem and Weitzenbock inequality as related results"
     ],
-    "axiomCount": 11,
+    "axiomCount": 22,
     "lineCount": 251,
-    "assumptions": "11 axiom(s) and 8 sorries(s). See the Lean source for details.",
+    "assumptions": "22 axiom(s) chain-aggregate across the registered chain (`Proofs/Erdos898Problem.lean` main + `Proofs/Stubs/Erdos898Problem.lean` is a byte-identical duplicate exposed for Aristotle proof search; raw axiom-declaration count without name-deduplication per the auditor's heuristic). Main file contributes 11 axioms: erdos_mordell_inequality (the main inequality PA + PB + PC ≥ 2(PX + PY + PZ)), equilateral_centers_coincide, erdos_mordell_equality, weighted_erdos_mordell, mordell_proof, barrow_proof, kazarinoff_proof, bankoff_proof (four independent classical proofs), erdos_mordell_polygon (n-gon generalization), viviani_theorem, weitzenbock_inequality. The `Proofs/Erdos898Aristotle.lean` and `Proofs/Stubs/Erdos898Aristotle.lean` companion files contribute 0 axioms (only routine distance-fact sorries for proof search). Plus 8 sorries in the main file (definition sorries for perpendicularFoot, isInteriorPoint, etc.).",
     "mathlib_version": "4.26.0",
     "theoremCount": 2,
     "definitionCount": 17,


### PR DESCRIPTION
## Summary

- `axiomCount` 11→22 to reflect the chain-aggregate of `axiom` declarations across the registered chain. `Proofs/Stubs/Erdos898Problem.lean` is byte-identical to `Proofs/Erdos898Problem.lean` (md5 match) and is exposed for Aristotle proof search; per the auditor's raw-count heuristic (no name-deduplication, consistent with #22064 erdos-179), it contributes 11 additional axiom declarations to the chain tally.
- `assumptions` text expanded to enumerate the 11/0/0/11 split and name the individual main-file axioms (erdos_mordell_inequality, the four classical proofs, polygon generalization, viviani, weitzenbock).

## Chain breakdown

| File | Axioms |
|------|-------:|
| `Erdos898Problem.lean` | 11 |
| `Erdos898Aristotle.lean` | 0 |
| `Stubs/Erdos898Aristotle.lean` | 0 |
| `Stubs/Erdos898Problem.lean` | 11 (byte-identical duplicate of main) |
| **Total** | **22** |

Per CLAUDE.md axiom integrity policy, `axiomCount` must include every declaration in the chain.

## Verification

- Raw chain counts confirmed via `grep -c \"^axiom \"` per file (11/0/0/11).
- `md5sum` confirms `Stubs/Erdos898Problem.lean` is byte-identical to main.
- `npx tsx scripts/auditor/find-targets.ts --slug erdos-898` no longer flags the slug after the edit.
- JSON parses cleanly.

## Test plan

- [x] JSON parses cleanly
- [x] find-targets no longer flags erdos-898
- [ ] Site build picks up new axiomCount / assumptions text

🤖 Generated with [Claude Code](https://claude.com/claude-code)