### PR TITLE
fix(meta): erdos-820 axiomCount 3→6 (Stubs/Erdos820Problem.lean chain)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9847,9 +9847,9 @@
     },
     "erdos-820": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:53:24Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T11:28:22Z",
+      "result": "issues-fixed"
     },
     "erdos-821": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -10396,8 +10396,8 @@
     },
     "erdos-898": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T00:16:40Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T11:26:17Z",
       "result": "clean"
     },
     "erdos-899": {

--- a/src/data/proofs/erdos-820/meta.json
+++ b/src/data/proofs/erdos-820/meta.json
@@ -60,9 +60,9 @@
       "oeisA263647: set of n with gcd(2^n-1, 3^n-1)=1",
       "Connection to Problem #770 (h(n) function)"
     ],
-    "axiomCount": 3,
+    "axiomCount": 6,
     "lineCount": 284,
-    "assumptions": "3 axiom(s) and 6 sorries. See the Lean source for details.",
+    "assumptions": "6 axioms across the chain (main 3 + Stubs/Erdos820Problem.lean 3 byte-identical duplicate): main file declares erdos_1974_lower_bound (Erdős's 1974 weaker bound on H(n)), van_doorn_lower_bound (van Doorn's improved infinitely-often lower bound), and erdos_820_open (formal marker that the three main conjectures remain open). Proofs/Stubs/Erdos820Problem.lean is byte-identical to the main file (md5 match) and is exposed for Aristotle proof search; per the raw-count heuristic (no name-deduplication, consistent with #22064 erdos-179, #22072 erdos-898), it contributes the same 3 axiom declarations to the chain tally. 6 sorries remain in the main file; see the Lean source for details.",
     "theoremCount": 5,
     "definitionCount": 12,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

- `axiomCount` 3→6 to reflect the chain-aggregate of `axiom` declarations across the registered chain. `Proofs/Stubs/Erdos820Problem.lean` is byte-identical to `Proofs/Erdos820Problem.lean` (md5 match) and is exposed for Aristotle proof search; per the auditor's raw-count heuristic (no name-deduplication, consistent with #22064 erdos-179, #22072 erdos-898), it contributes the same 3 axiom declarations to the chain tally.
- `assumptions` text expanded to enumerate the 3/0/0/3 split and name the individual main-file axioms (`erdos_1974_lower_bound`, `van_doorn_lower_bound`, `erdos_820_open`).

## Chain breakdown

| File | Axioms |
|------|-------:|
| `Erdos820Problem.lean` | 3 |
| `Erdos820Aristotle.lean` | 0 |
| `Stubs/Erdos820Aristotle.lean` | 0 |
| `Stubs/Erdos820Problem.lean` | 3 (byte-identical duplicate of main) |
| **Total** | **6** |

Per CLAUDE.md axiom integrity policy, `axiomCount` must include every declaration in the chain.

## Verification

- Raw chain counts confirmed via `grep -c "^axiom "` per file (3/0/0/3).
- `md5sum` confirms `Stubs/Erdos820Problem.lean` is byte-identical to main (991ce282750ef3f6d262bb1293bb7f4c).
- `npx tsx scripts/auditor/find-targets.ts --issues` no longer flags erdos-820 after the edit.
- JSON parses cleanly.

## Test plan

- [x] JSON parses cleanly
- [x] find-targets no longer flags erdos-820
- [ ] Site build picks up new axiomCount / assumptions text

🤖 Generated with [Claude Code](https://claude.com/claude-code)