### PR TITLE
fix(meta): erdos-631 axiomCount 16→32 (Stubs/Erdos631Problem.lean chain)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8515,9 +8515,9 @@
     },
     "erdos-631": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:35Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T11:32:32Z",
+      "result": "issues-fixed"
     },
     "erdos-632": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-631/meta.json
+++ b/src/data/proofs/erdos-631/meta.json
@@ -73,9 +73,9 @@
       "alon_tarsi_theorem, outerplanar_3_choosable, planar_girth_5_choosable: restricted bounds",
       "erdos_631_status: complete resolution ⟨Thomassen, Voigt⟩ (proved from axioms)"
     ],
-    "axiomCount": 16,
+    "axiomCount": 32,
     "lineCount": 269,
-    "assumptions": "16 axioms: euler_formula, planar_edge_bound, four_color_theorem, five_color_theorem, thomassen_five_list_theorem, thomassen_proof_technique, and 10 more. 10 sorries.",
+    "assumptions": "32 axioms: 16 in main file (euler_formula, planar_edge_bound, four_color_theorem, five_color_theorem, thomassen_five_list_theorem, thomassen_proof_technique, and 10 more) + 16 byte-identical duplicates in Proofs/Stubs/Erdos631Problem.lean. 10 sorries.",
     "mathlib_version": "4.26.0",
     "theoremCount": 7,
     "definitionCount": 7


### PR DESCRIPTION
## Summary

`Proofs/Stubs/Erdos631Problem.lean` is a byte-identical duplicate of `Proofs/Erdos631Problem.lean` (same 269 lines, same 16 `axiom` declarations). Both files are registered in `additionalFiles`, so per the axiom-integrity policy the chain-aggregate `axiomCount` is **32**, not 16.

## Evidence

```
$ wc -l proofs/Proofs/Erdos631Problem.lean proofs/Proofs/Stubs/Erdos631Problem.lean
     269 proofs/Proofs/Erdos631Problem.lean
     269 proofs/Proofs/Stubs/Erdos631Problem.lean

$ diff proofs/Proofs/Erdos631Problem.lean proofs/Proofs/Stubs/Erdos631Problem.lean
(no output — byte-identical)

$ grep -c "^axiom " proofs/Proofs/Erdos631Problem.lean   # 16
$ grep -c "^axiom " proofs/Proofs/Stubs/Erdos631Problem.lean  # 16
```

## Changes

- `axiomCount`: 16 → 32
- `assumptions`: refreshed to credit the duplicate `Stubs/Erdos631Problem.lean`

No Lean source code modified — meta-only fix. Status remains `axiomatized` / badge `axiom` (correct).

## Test plan

- [x] Diff is meta-only
- [x] axiomCount equals chain-aggregate `grep -c "^axiom "` across `proofRepoPath` + `additionalFiles`
- [x] Status and badge unchanged (`axiomatized` / `axiom`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)