### PR TITLE
fix(meta): erdos-610 axiomCount 1→2 (Stubs/Erdos610Problem.lean chain)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -8368,9 +8368,9 @@
     },
     "erdos-610": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:55:36Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-02T11:36:33Z",
+      "result": "issues-fixed"
     },
     "erdos-611": {
       "agentId": "auditor-cycle-20-batch",

--- a/src/data/proofs/erdos-610/meta.json
+++ b/src/data/proofs/erdos-610/meta.json
@@ -87,9 +87,9 @@
         "relationship": "Foundational Ramsey theory (2-complete sets): the Ramsey-theoretic framework underpinning Kim's theorem R(3,k) = Θ(k²/log k)"
       }
     ],
-    "axiomCount": 1,
+    "axiomCount": 2,
     "lineCount": 222,
-    "assumptions": "1 axiom(s) and 17 sorries. See the Lean source for details.",
+    "assumptions": "2 axiom(s) and 17 sorries. See the Lean source for details.",
     "theoremCount": 13,
     "definitionCount": 16,
     "additionalFiles": [


### PR DESCRIPTION
## Summary
- Auditor flagged axiom undercount: meta.json claims 1 but chain audit finds 2 axioms across registered files
- `Stubs/Erdos610Problem.lean` is byte-identical to the main file (`kim_triangle_free_independence`); both files are listed in `additionalFiles`, so the chain audit aggregates them
- Update `axiomCount: 1 → 2` and `assumptions` string to match

## Evidence
```
$ grep -c '^axiom ' proofs/Proofs/Erdos610Problem.lean
1
$ grep -c '^axiom ' proofs/Proofs/Stubs/Erdos610Problem.lean
1
$ diff -q proofs/Proofs/Erdos610Problem.lean proofs/Proofs/Stubs/Erdos610Problem.lean
(byte-identical)
```

Status remains `axiomatized` / badge `axiom` (correct for any axiomCount > 0). The per-file `leanFile.axiomCount=1` is unchanged — it correctly describes the main file in isolation.

## Test plan
- [x] `axiomCount` matches chain-aggregate sum across registered files
- [x] `assumptions` string updated consistently
- [x] No status/badge change required

🤖 Generated with [Claude Code](https://claude.com/claude-code)