### PR TITLE
fix(meta): erdos-611 axiomCount 5→10 (Stubs/Erdos611Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-611/meta.json
+++ b/src/data/proofs/erdos-611/meta.json
@@ -52,9 +52,9 @@
       "Statement of Bollobás-Erdős threshold n + 3 - 2√n",
       "Lower bound k_c(n) ≥ n^{c'/log log n}"
     ],
-    "axiomCount": 5,
+    "axiomCount": 10,
     "lineCount": 245,
-    "assumptions": "5 axiom(s) and 13 sorries. See the Lean source for details.",
+    "assumptions": "10 axiom(s) and 13 sorries. See the Lean source for details.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 14,


### PR DESCRIPTION
## Summary

- Chain-aggregate `axiomCount` corrected 5 → 10 for erdos-611.
- `Proofs/Stubs/Erdos611Problem.lean` is a byte-identical duplicate of `Proofs/Erdos611Problem.lean` and is declared in `additionalFiles`; it contributes 5 additional `axiom` declarations to the chain.
- `assumptions` string updated to reflect "10 axiom(s) and 13 sorries".
- Nested `leanFile.axiomCount=5` left unchanged (describes only the main file).

Same chain-axiom undercount pattern as #22072, #22073, #22074, #22076.

## Test plan
- [x] `grep -c "^axiom "` confirms 5 axioms in main + 5 in `Stubs/Erdos611Problem.lean` (other chain files = 0).
- [x] `diff` shows main and Stubs files are byte-identical.
- [x] No Lean changes; meta.json only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)