### PR TITLE
fix(meta): erdos-483 axiomCount 5→9 (Proofs/SchursTheorem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-483/meta.json
+++ b/src/data/proofs/erdos-483/meta.json
@@ -52,7 +52,7 @@
       "schurNumber_nondecreasing: proved monotonicity via color embedding",
       "erdos_483_conjecture: formal statement of the open problem"
     ],
-    "axiomCount": 5,
+    "axiomCount": 9,
     "prerequisites": [
       "Schur's theorem (finiteness of Schur numbers)",
       "Ramsey theory fundamentals (colorings, monochromatic solutions)",
@@ -61,7 +61,7 @@
       "Basic additive combinatorics"
     ],
     "lineCount": 343,
-    "assumptions": "5 axioms: schurNumber_4, schurNumber_5, schur_lower_bound, schur_upper_bound, erdos_483_conjecture. Proved: schurNumber_3=14 via native_decide.",
+    "assumptions": "9 axioms across chain: 5 in main (schurNumber_4, schurNumber_5, schur_lower_bound, schur_upper_bound, erdos_483_conjecture) + 4 in Proofs/SchursTheorem.lean (schur_from_ramsey_helper, schur_5, rado_theorem, schur_fermat_application). Proved: schurNumber_3=14 via native_decide.",
     "theoremCount": 19,
     "definitionCount": 3,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

- Chain-aggregate `axiomCount` corrected 5 → 9 for erdos-483.
- `Proofs/SchursTheorem.lean` (declared in `additionalFiles`) adds 4 distinct `axiom` declarations: `schur_from_ramsey_helper`, `schur_5`, `rado_theorem`, `schur_fermat_application`.
- `assumptions` string expanded to enumerate both groups (5 main + 4 companion).
- Nested `leanFile.axiomCount=5` left unchanged (describes only the main file).

Differs from prior chain-axiom fixes (#22072-#22079): the companion is a related-theory file, not a byte-identical Stubs/ duplicate.

## Test plan
- [x] `grep -c "^axiom "` confirms 5 in main + 4 in `SchursTheorem.lean` = 9 total.
- [x] Axiom names are distinct across the two files.
- [x] No Lean changes; meta.json only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)