### PR TITLE
fix(meta): erdos-360 axiomCount 4→8 (chain duplicate axioms)

### DIFF
--- a/src/data/proofs/erdos-360/meta.json
+++ b/src/data/proofs/erdos-360/meta.json
@@ -57,9 +57,9 @@
       "Small cases f(2), f(3), f(4)",
       "erdos_360_solved theorem: main result"
     ],
-    "axiomCount": 4,
+    "axiomCount": 8,
     "lineCount": 170,
-    "assumptions": "4 axiom(s) and 2 sorry(s). See the Lean source for details.",
+    "assumptions": "8 axiom(s) and 2 sorry(s). See the Lean source for details.",
     "theoremCount": 4,
     "definitionCount": 4,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Chain-aggregate axiom undercount: `Stubs/Erdos360Problem.lean` is byte-identical to `Proofs/Erdos360Problem.lean` (md5 `fac09fa07c2af6a29d9d826fc15b6cd9`) and contributes the same 4 axioms via `additionalFiles` traversal — `alon_erdos_1996`, `vu_2007`, `conlon_fox_pham_2021`, `primorial_totient_ratio`.

The audit script flagged: `axiom undercount: claims 4, actual declarations 8`.

## Changes

- `src/data/proofs/erdos-360/meta.json` — `axiomCount` 4 → 8; `assumptions` string 4 → 8.
- `leanFile.axiomCount` stays at 4 (per script comment: main file only; `meta.axiomCount` is the chain).
- No Lean code changes.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues | grep erdos-360` returns nothing (issue cleared).
- [x] Stats: "With issues" decreased 18 → 17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)