### PR TITLE
fix(meta): ballot-problem-oq-02 axiomCount 2→3 (chain axioms)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-02/meta.json
@@ -41,7 +41,7 @@
       "Main continuous ballot theorem combining all components (0 sorries)"
     ],
     "dateAdded": "2026-02-24",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "Brownian motion and stochastic processes",
       "Reflection principle for random walks",
@@ -50,7 +50,7 @@
       "Lévy's arcsine law and occupation times"
     ],
     "lineCount": 339,
-    "assumptions": "2 axioms: (1) firstPassageTime_eq_maxEvent — {τ_a ≤ T} = maxEvent (requires path continuity + csInf theory), (2) reflection_principle — P(max W ≥ a) = 2·P(W_T ≥ a) (requires strong Markov property). Arcsine law is discussed but not formally axiomatized.",
+    "assumptions": "3 axioms across the chain: (1) firstPassageTime_eq_maxEvent — {τ_a ≤ T} = maxEvent (requires path continuity + csInf theory), (2) reflection_principle — P(max W ≥ a) = 2·P(W_T ≥ a) (requires strong Markov property), (3) donsker_fclt in BallotProblemOQ02OQ05.lean — functional CLT for iid mean-zero unit-variance increments (Wiedijk #45, beyond Mathlib v4.26.0). Arcsine law is discussed but not formally axiomatized.",
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 4,


### PR DESCRIPTION
## Summary

Chain-axiom undercount fix for `ballot-problem-oq-02`.

- **Before**: slug-level `axiomCount: 2` (only counted `BallotProblemOQ02.lean`)
- **After**: `axiomCount: 3` (main 2 + additionalFile `BallotProblemOQ02OQ05.lean` 1)

The OQ05 additional file declares a distinct `donsker_fclt` axiom (functional CLT, Wiedijk #45) and the path-scoped block at line 285 already reports `axioms: 1` — the slug-level total was simply behind.

## Evidence

```
$ grep -n "^axiom " proofs/Proofs/BallotProblemOQ02.lean proofs/Proofs/BallotProblemOQ02OQ05.lean
proofs/Proofs/BallotProblemOQ02.lean:167:axiom firstPassageTime_eq_maxEvent ...
proofs/Proofs/BallotProblemOQ02.lean:184:axiom reflection_principle ...
proofs/Proofs/BallotProblemOQ02OQ05.lean:120:axiom donsker_fclt ...
```

All three are distinct (no name overlap).

## Changes

- `axiomCount`: `2` → `3` (outer/slug-level only)
- `assumptions`: appended donsker_fclt entry
- Per-file path-scoped counts (line 274, 285) left intact

## Test plan

- [x] JSON validates
- [x] Diff scoped to one file, +2/-2 lines
- [ ] Gallery `pnpm build` (skipped — disk AMBER 2.5Gi free; meta-only edit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)