### PR TITLE
fix(meta): erdos-456 axiomCount 0→4 (Stubs/Erdos456Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-456/meta.json
+++ b/src/data/proofs/erdos-456/meta.json
@@ -107,9 +107,9 @@
         "relationship": "Primes in arithmetic progressions"
       }
     ],
-    "axiomCount": 0,
+    "axiomCount": 4,
     "lineCount": 271,
-    "assumptions": "0 axioms, 0 sorries. All infrastructure fully verified. The 'axiomatized' status reflects that the three main conjectures (Parts 1-3) are open problems stated as Prop definitions, not theorems. The surrounding infrastructure (definitions, properties, relationships, van Doorn's result) is completely proved.",
+    "assumptions": "Main file Erdos456Problem.lean: 0 axioms, 0 sorries (all infrastructure fully verified, including elimination of the former 12 axioms via Mathlib's PrimesInAP and sInf well-ordering). Chain total: 4 axioms from the legacy Stubs/Erdos456Problem.lean scaffold listed in additionalFiles (dirichlet_primes_mod1, linnik_bound, erdos_strict_inequality, m_over_n_diverges — the original axiomatic problem statement, retained for historical reference). The 'axiomatized' status reflects that the three main conjectures (Parts 1-3) are open problems stated as Prop definitions, not theorems.",
     "theoremCount": 16,
     "definitionCount": 6,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Gallery integrity audit: `erdos-456` (Erdős Problem #456) reports
`axiomCount: 0` but the chain (main + `additionalFiles`) actually
contains **4 axioms**, all in the legacy scaffold
`Proofs/Stubs/Erdos456Problem.lean`:

| File | Axioms |
|------|--------|
| `Proofs/Erdos456Problem.lean` (main) | 0 |
| `Proofs/Erdos456Aristotle.lean` | 0 |
| `Proofs/Stubs/Erdos456Aristotle.lean` | 0 |
| `Proofs/Stubs/Erdos456Problem.lean` | **4** |
| **Total** | **4** |

The four axioms in the stub:

- `dirichlet_primes_mod1` (line 54)
- `linnik_bound` (line 174)
- `erdos_strict_inequality` (line 179)
- `m_over_n_diverges` (line 185)

The main file's narrative correctly reports its own "Axiom reduction
12→0" (eliminated via `PrimesInAP` and `sInf` well-ordering), but
because the legacy problem-statement scaffold is still listed in
`additionalFiles`, its axioms count toward the chain total per the
Axiom Integrity Policy.

## Fix

- `axiomCount`: `0` → `4`
- `assumptions`: expanded to distinguish main-file count from
  scaffold count and list the four axiom names.
- Status remains `axiomatized` (the three Erdős conjectures are open).

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer
      flags `erdos-456`.
- [x] No Lean source touched (meta-only change).
- [x] Branched off latest `main` (`fd413760cf7`), clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)