### PR TITLE
fix(meta): borsuk-ulam axiomCount 1→3 (BorsukUlamOQ01.lean chain)

### DIFF
--- a/src/data/proofs/borsuk-ulam/meta.json
+++ b/src/data/proofs/borsuk-ulam/meta.json
@@ -41,7 +41,7 @@
     ],
     "dateAdded": "2025-12-22",
     "lineCount": 267,
-    "axiomCount": 1,
+    "axiomCount": 3,
     "additionalFiles": [
       "Proofs/BorsukUlamOQ01.lean"
     ],
@@ -53,7 +53,9 @@
       "Basic topology: compactness and connectedness"
     ],
     "assumptions": [
-      "no_continuous_odd_nonzero_on_sphere: For n ≥ 1, there is no continuous odd function h: ℝ^(n+1) → ℝ^n that is nonzero on the n-sphere. This requires covering space theory and fundamental groups beyond Mathlib's current algebraic topology coverage."
+      "no_continuous_odd_nonzero_on_sphere (BorsukUlam.lean): For n ≥ 1, there is no continuous odd function h: ℝ^(n+1) → ℝ^n that is nonzero on the n-sphere. This requires covering space theory and fundamental groups beyond Mathlib's current algebraic topology coverage.",
+      "borsuk_ulam_exact (BorsukUlamOQ01.lean): The original existence statement of an antipodal point f(x) = f(-x) for any continuous f: Sⁿ → ℝⁿ — axiomatized to bridge to OQ01 sharpness questions.",
+      "tuckers_lemma (BorsukUlamOQ01.lean): Tucker's combinatorial lemma on antipodally-labelled triangulations, used in OQ01 to study sharpness of antipodal collapse maps."
     ],
     "relatedProblems": [
       {


### PR DESCRIPTION
## Summary

Gallery integrity audit: `borsuk-ulam` reports `axiomCount: 1` but the
chain (main + `additionalFiles`) actually contains **3 axioms**.

| File | Axioms |
|------|--------|
| `Proofs/BorsukUlam.lean` (main) | 1 — `no_continuous_odd_nonzero_on_sphere` |
| `Proofs/BorsukUlamOQ01.lean` | 2 — `borsuk_ulam_exact`, `tuckers_lemma` |
| **Total** | **3** |

## Fix

- `axiomCount`: `1` → `3`
- `assumptions`: each entry tagged with its source file; added entries
  for `borsuk_ulam_exact` and `tuckers_lemma`.

Status remains `axiomatized`.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer
      flags `borsuk-ulam`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`fd413760cf7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)