### PR TITLE
fix(meta): brouwer-fixed-point-oq-04 axiomCount 2→4 (chain axioms)

### DIFF
--- a/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04/meta.json
@@ -52,9 +52,9 @@
       }
     ],
     "historicalContext": "Shizuo Kakutani (1941) proved this generalization of Brouwer's theorem. John Nash (1950) used it to prove the existence of Nash equilibria, earning the Nobel Prize in Economics (1994). The theorem is essential in mathematical economics (Arrow-Debreu general equilibrium) and optimal control (Filippov's lemma).",
-    "axiomCount": 2,
+    "axiomCount": 4,
     "lineCount": 505,
-    "assumptions": "2 axioms: kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ) and brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). 0 sorries.",
+    "assumptions": "4 axioms across the chain. Main file Proofs/BrouwerFixedPointOQ04.lean (2): kakutani_fixed_point_axiom (Kakutani fixed-point theorem for compact convex sets in ℝⁿ), brouwer_pi_compact_convex (Brouwer FPT for products of compact convex sets — requires Schoenflies-type theorem not yet in Mathlib). Companion Proofs/BrouwerFixedPointOQ04OQ01.lean (2): bestResponse_uhc (upper hemicontinuity of the best-response correspondence for finite games), kakutani_product_simplex (Kakutani FPT applied to the product simplex of mixed strategies). 0 sorries.",
     "theoremCount": 22,
     "definitionCount": 14,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Gallery integrity audit: `brouwer-fixed-point-oq-04` reports
`axiomCount: 2` but the chain (main + `additionalFiles`) actually
contains **4 axioms**.

| File | Axioms |
|------|--------|
| `Proofs/BrouwerFixedPointOQ04.lean` (main) | 2 — `kakutani_fixed_point_axiom`, `brouwer_pi_compact_convex` |
| `Proofs/BrouwerFixedPointOQ04OQ01.lean` | 2 — `bestResponse_uhc`, `kakutani_product_simplex` |
| **Total** | **4** |

## Fix

- `axiomCount`: `2` → `4`
- `assumptions`: expanded to enumerate all four axioms with source files.

Status remains `axiomatized` (Mathlib lacks Schoenflies-type theorem
and Berge UHC theory).

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer
      flags `brouwer-fixed-point-oq-04`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`fd413760cf7`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)