### PR TITLE
fix(meta): roth-theorem axiomCount 0→2 + status verified→axiomatized

### DIFF
--- a/src/data/proofs/roth-theorem/meta.json
+++ b/src/data/proofs/roth-theorem/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research Agent (formalized in Lean 4 with Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Roth%27s_theorem_on_arithmetic_progressions",
     "date": "Classical result (Roth 1953); Fourier-analytic approach formalized 2026",
-    "status": "verified",
+    "status": "axiomatized",
     "tags": [
       "combinatorics",
       "additive-combinatorics",
@@ -20,8 +20,8 @@
     "proofRepoPath": "Proofs/RothTheorem.lean",
     "badge": "mathlib",
     "sorries": 0,
-    "axiomCount": 0,
-    "assumptions": "None. All 42 theorems verified with 0 sorries and 0 axioms. The main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat` (itself verified via the corners theorem chain: Regularity → Triangle Removal → Corners → Roth). The Fourier-analytic infrastructure (Parts I–V, including `fourier_large_coefficient`) is independently verified.",
+    "axiomCount": 2,
+    "assumptions": "Main file Proofs/RothTheorem.lean: 0 axioms, 0 sorries. All 42 theorems verified; the main theorem `roth_density_bound` invokes Mathlib's `roth_3ap_theorem_nat` (itself verified via the corners theorem chain: Regularity → Triangle Removal → Corners → Roth), and the Fourier-analytic infrastructure (Parts I–V, including `fourier_large_coefficient`) is independently verified. Chain total: 2 axioms from the OQ-02 companion Proofs/RothTheoremOQ02.lean — `rothNumberNat_bloom_sisask` (Bloom–Sisask 2020 logarithmic-barrier bound, arXiv:2007.03528) and `rothNumberNat_kelley_meka` (Kelley–Meka 2023 polynomial bound). The companion axiomatizes state-of-the-art quantitative refinements that require Bohr-set / density-increment infrastructure not yet in Mathlib v4.26.0; the qualitative Roth result itself remains fully verified.",
     "originalContributions": [
       "APFree definition and basic properties (apFree_empty, apFree_singleton, apFree_subset) on ZMod N",
       "tripleCount: exact count of 3-APs; apFree_iff_tripleCount_zero equivalence",


### PR DESCRIPTION
## Summary

Gallery integrity audit (HIGH-risk): `roth-theorem` is currently
labelled `status: verified` with `axiomCount: 0`, but the chain
(main + `additionalFiles`) declares **2 axioms** via the OQ-02
companion file.

| File | Axioms | Sorries |
|------|--------|---------|
| `Proofs/RothTheorem.lean` (main) | 0 | 0 |
| `Proofs/RothTheoremAristotle.lean` | 0 | 0 |
| `Proofs/RothTheoremOQ02.lean` | **2** | 0 |
| **Total** | **2** | **0** |

The two axioms in OQ-02:

- `rothNumberNat_bloom_sisask` — Bloom–Sisask 2020 logarithmic-barrier
  bound (arXiv:2007.03528).
- `rothNumberNat_kelley_meka` — Kelley–Meka 2023 polynomial bound.

Both axiomatize state-of-the-art **quantitative refinements** that
require infrastructure (Bohr sets, density increment, refined Fourier
analysis) not yet in Mathlib v4.26.0. The **qualitative Roth result
itself** — the only claim made by the main file — is fully verified
via `roth_3ap_theorem_nat`.

## Fix

- `axiomCount`: `0` → `2`
- `status`: `verified` → `axiomatized` (required by Axiom Integrity
  Policy: `verified` ⇒ 0 chain axioms)
- `badge`: kept as `mathlib` — accurately describes the main proof
  strategy (the OQ-02 axioms are scope-separated future-work landmarks)
- `assumptions`: rewritten to (a) state the main file remains 0/0/0,
  (b) enumerate the 2 OQ-02 axioms with citations, (c) clarify that
  the qualitative theorem is verified.

## Why not just delete OQ-02 from additionalFiles?

That would orphan the companion file (triggers a different audit error
class: `NO_SLUG_MATCH orphan companion`). Keeping it registered and
downgrading status is the more honest reflection of what the gallery
artifact actually contains.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer
      flags `roth-theorem`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`6096a469374`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)