### PR TITLE
fix(meta): erdos-107 axiomCount 6→12 (Stubs/Erdos107Problem.lean chain)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3522,9 +3522,9 @@
       "result": "clean"
     },
     "erdos-107": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-05T06:04:15Z",
+      "lastAudited": "2026-06-02T13:52:40Z",
       "result": "issues-fixed"
     },
     "erdos-1070": {

--- a/src/data/proofs/erdos-107/meta.json
+++ b/src/data/proofs/erdos-107/meta.json
@@ -62,9 +62,9 @@
       "HappyEndingConjecture as Prop (correctly open)"
     ],
     "dateAdded": "2026-01-19",
-    "axiomCount": 6,
+    "axiomCount": 12,
     "lineCount": 255,
-    "assumptions": "6 axioms (deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds). All theorems proved (0 sorries). f_finite proved from ersz_lower_bound by contradiction.",
+    "assumptions": "12 axiom declarations (6 in Erdos107Problem.lean + 6 duplicates in Stubs/Erdos107Problem.lean): deep combinatorial bounds: f(4)=5, f(5)=9, Erdos-Szekeres bounds, Suk/HMPT bounds. All theorems proved (0 sorries). f_finite proved from ersz_lower_bound by contradiction.",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary

- erdos-107 lists `Proofs/Stubs/Erdos107Problem.lean` in `additionalFiles`, but that file declares the same 6 axioms as `Erdos107Problem.lean` (`f_four_eq`, `f_five_eq`, `ersz_lower_bound`, `ersz_upper_bound`, `suk_bound`, `hmpt_bound`).
- `axiomCount` should reflect all axiom declarations across audited files (6 + 6 = 12), not just the main file.
- Updates `assumptions` to record the chain decomposition.

## Evidence

```bash
$ grep -c "^axiom " proofs/Proofs/Erdos107Problem.lean proofs/Proofs/Stubs/Erdos107Problem.lean
proofs/Proofs/Erdos107Problem.lean:6
proofs/Proofs/Stubs/Erdos107Problem.lean:6
```

Both files declare an identical axiom set (verified by name comparison).

## Test plan

- [x] `axiomCount` updated 6 → 12
- [x] `assumptions` field notes chain decomposition
- [x] audit-tracker updated via `claim-target.sh complete erdos-107 issues-fixed`

---
Discovered during gallery integrity audit (auditor agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)