### PR TITLE
fix(meta): erdos-1039 axiomCount 5→10 (Stubs/Erdos1039Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-1039/meta.json
+++ b/src/data/proofs/erdos-1039/meta.json
@@ -22,9 +22,9 @@
     "erdosUrl": "https://erdosproblems.com/1039",
     "erdosProblemStatus": "open",
     "relatedProblems": [],
-    "axiomCount": 5,
+    "axiomCount": 10,
     "lineCount": 303,
-    "assumptions": "5 axioms: benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected. 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
+    "assumptions": "10 axioms total: 5 distinct (benchmark_upper, pommerenke_lower, klr_lower, klr_area_bound, random_polynomial_expected) declared identically in main file Proofs/Erdos1039Problem.lean and stub file Proofs/Stubs/Erdos1039Problem.lean (byte-identical, md5 bf950441c17b5b0f2ed93175e7181730). 3 sorries remain (area_implies_disc_bound, degree_one_optimal, clustered_implies_large_disc). Fixed sublevelArea type (ENNReal→ℝ via toReal).",
     "mathlib_version": "4.29.0",
     "mathlibDependencies": [
       {


### PR DESCRIPTION
## Fix

Bump `erdos-1039` `axiomCount` from `5` to `10` to reflect the chain of byte-identical axiom declarations in the stub file.

## Evidence

```
$ grep -c "^axiom " proofs/Proofs/Erdos1039Problem.lean
5
$ grep -c "^axiom " proofs/Proofs/Stubs/Erdos1039Problem.lean
5
$ md5 proofs/Proofs/Erdos1039Problem.lean proofs/Proofs/Stubs/Erdos1039Problem.lean
MD5 (proofs/Proofs/Erdos1039Problem.lean)         = bf950441c17b5b0f2ed93175e7181730
MD5 (proofs/Proofs/Stubs/Erdos1039Problem.lean)   = bf950441c17b5b0f2ed93175e7181730
```

The 5 distinct axioms — `benchmark_upper`, `pommerenke_lower`, `klr_lower`, `klr_area_bound`, `random_polynomial_expected` — are declared **identically** in both `Proofs/Erdos1039Problem.lean` (main) and `Proofs/Stubs/Erdos1039Problem.lean` (Aristotle stub chain). Both files are listed under `meta.additionalFiles`, so the chain-aggregate axiom count is **10**.

Per `CLAUDE.md` axiom integrity policy:
> `axiomCount` in meta.json must reflect ALL assumptions: `axiom` declarations + assumption-carrying structure fields … `grep -c "^axiom "` alone is NOT sufficient to count assumptions — always inspect structure fields too.

**Before**: `axiomCount: 5` (undercounted; ignored stub-chain duplicate)
**After**: `axiomCount: 10` (chain-aggregate, with md5 fingerprint logged in `assumptions`)

No status change (`axiomatized` / `axiom` badge already correct).

---
Automated fix by lean-mechanic agent. Same pattern as #22089 (erdos-1018), #22084 (erdos-360), #22087 (ballot-problem-oq-02).