### PR TITLE
fix(meta): erdos-613 axiomCount 4→8 (Stubs/Erdos613Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-613/meta.json
+++ b/src/data/proofs/erdos-613/meta.json
@@ -56,8 +56,8 @@
         "relationship": "Size Ramsey numbers generalize classical Ramsey numbers by minimizing edge count rather than vertex count. The formalization explicitly connects via `size_ramsey_generalizes`."
       }
     ],
-    "axiomCount": 4,
-    "assumptions": "4 axiom declarations: pikhurko_lower_bound (size Ramsey lower bound), pikhurko_upper_bound (size Ramsey upper bound), tao_counterexample_n5 (Lean-verified n=5 counterexample), faudree_partial (holds when |V|=2n+1)",
+    "axiomCount": 8,
+    "assumptions": "8 axiom declarations total (chain count). Main file Proofs/Erdos613Problem.lean (4): pikhurko_lower_bound (size Ramsey lower bound), pikhurko_upper_bound (size Ramsey upper bound), tao_counterexample_n5 (Lean-verified n=5 counterexample), faudree_partial (holds when |V|=2n+1). Stubs/Erdos613Problem.lean (4, same axiom names redeclared): pikhurko_lower_bound, pikhurko_upper_bound, tao_counterexample_n5, faudree_partial.",
     "lineCount": 260,
     "theoremCount": 11,
     "definitionCount": 14,


### PR DESCRIPTION
## Summary

Gallery integrity audit: `erdos-613` reports `axiomCount: 4` but the
chain (main + `additionalFiles`) actually contains **8 axioms**.

| File | Axioms |
|------|--------|
| `Proofs/Erdos613Problem.lean` (main) | 4 — `pikhurko_lower_bound`, `pikhurko_upper_bound`, `tao_counterexample_n5`, `faudree_partial` |
| `Proofs/Stubs/Erdos613Problem.lean` | 4 — same names redeclared |
| **Total** | **8** |

## Fix

- `axiomCount`: 4 → 8
- `assumptions`: expanded to enumerate per-file axioms

Status remains `axiomatized` (open problem).

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer flags `erdos-613`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`3fabeb2ac8d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)