### PR TITLE
fix(meta): erdos-626 axiomCount 7→14 (Stubs/Erdos626Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-626/meta.json
+++ b/src/data/proofs/erdos-626/meta.json
@@ -58,8 +58,8 @@
       "Connection to Erdős's 1959 probabilistic method result",
       "Limit existence question formalization"
     ],
-    "axiomCount": 7,
-    "assumptions": "7 axiom declarations: g_well_defined (g_k(n) well-defined for k >= 4), erdos_high_girth_high_chromatic (high-chi high-girth graphs exist), erdos_upper_bound (g_k(n) <= (2/log(k-2))*log n + 1), kostochka_lower_bound (g_k(n) >= (1/(4 log k))*log n), limit_question_open (limit existence is open), h_bounds (dual problem polynomial bounds), erdos_1959_probabilistic_method (Erdos 1959 probabilistic existence)",
+    "axiomCount": 14,
+    "assumptions": "14 axiom declarations total (chain count). Main file Proofs/Erdos626Problem.lean (7): g_well_defined (g_k(n) well-defined for k >= 4), erdos_high_girth_high_chromatic (high-chi high-girth graphs exist), erdos_upper_bound (g_k(n) <= (2/log(k-2))*log n + 1), kostochka_lower_bound (g_k(n) >= (1/(4 log k))*log n), limit_question_open (limit existence is open), h_bounds (dual problem polynomial bounds), erdos_1959_probabilistic_method (Erdos 1959 probabilistic existence). Stubs/Erdos626Problem.lean (7, byte-identical duplicate of main file): same 7 axioms redeclared.",
     "lineCount": 244,
     "theoremCount": 13,
     "definitionCount": 9


### PR DESCRIPTION
## Summary

Gallery integrity audit: `erdos-626` reports `axiomCount: 7` but the
chain (main + `additionalFiles`) actually contains **14 axioms**.

| File | Axioms |
|------|--------|
| `Proofs/Erdos626Problem.lean` (main) | 7 — `g_well_defined`, `erdos_high_girth_high_chromatic`, `erdos_upper_bound`, `kostochka_lower_bound`, `limit_question_open`, `h_bounds`, `erdos_1959_probabilistic_method` |
| `Proofs/Stubs/Erdos626Problem.lean` | 7 — byte-identical duplicate (md5 `09b70d36…`) |
| **Total** | **14** |

## Fix

- `axiomCount`: 7 → 14
- `assumptions`: enumerated per-file axioms

Status remains `axiomatized`.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer flags `erdos-626`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`3fabeb2ac8d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)