### PR TITLE
fix(meta): erdos-627 axiomCount 8→16 (Stubs/Erdos627Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-627/meta.json
+++ b/src/data/proofs/erdos-627/meta.json
@@ -63,9 +63,9 @@
       "Mycielski and Kneser graph constructions with chromatic properties",
       "Strong Perfect Graph Theorem statement (Chudnovsky et al. 2006)"
     ],
-    "axiomCount": 8,
+    "axiomCount": 16,
     "lineCount": 236,
-    "assumptions": "8 axiom(s) and 18 sorries.",
+    "assumptions": "16 axioms total (chain count) and 18 sorries. Main file Proofs/Erdos627Problem.lean (8): tutte_zykov_construction, erdos_lower_bound, erdos_asymptotic, limit_if_exists_bounded, strong_perfect_graph_theorem, ramsey_upper_bound, mycielski_properties, lovasz_kneser. Stubs/Erdos627Problem.lean (8, byte-identical duplicate of main file): same 8 axioms redeclared.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
     "definitionCount": 10


### PR DESCRIPTION
## Summary

Gallery integrity audit: `erdos-627` reports `axiomCount: 8` but the
chain (main + `additionalFiles`) actually contains **16 axioms**.

| File | Axioms |
|------|--------|
| `Proofs/Erdos627Problem.lean` (main) | 8 — `tutte_zykov_construction`, `erdos_lower_bound`, `erdos_asymptotic`, `limit_if_exists_bounded`, `strong_perfect_graph_theorem`, `ramsey_upper_bound`, `mycielski_properties`, `lovasz_kneser` |
| `Proofs/Stubs/Erdos627Problem.lean` | 8 — byte-identical duplicate (md5 `72c900db…`) |
| **Total** | **16** |

## Fix

- `axiomCount`: 8 → 16
- `assumptions`: enumerated per-file axioms

Status remains `axiomatized`.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer flags `erdos-627`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`3fabeb2ac8d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)