### PR TITLE
fix(meta): erdos-630 axiomCount 11→22 (Stubs/Erdos630Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -57,9 +57,9 @@
       "Connection to Combinatorial Nullstellensatz",
       "Graph polynomial formulation"
     ],
-    "axiomCount": 11,
+    "axiomCount": 22,
     "lineCount": 246,
-    "assumptions": "11 axiom(s) and 15 sorries(s).",
+    "assumptions": "22 axiom(s) and 15 sorries(s).",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 8
@@ -214,7 +214,7 @@
     ],
     "namespace": "Erdos630",
     "lineCount": 246,
-    "axiomCount": 11,
+    "axiomCount": 22,
     "theoremCount": 11,
     "definitionCount": 8,
     "path": "Proofs/Erdos630Problem.lean",


### PR DESCRIPTION
## Fix

Bump erdos-630 `axiomCount` from 11 → 22 to reflect the byte-identical `Stubs/Erdos630Problem.lean` duplicate (md5 `2b7c50d672`).

## Evidence

**Before**: `meta.json` claimed 11 axioms (main file only).
**After**: `meta.json` claims 22 axioms (main + Stubs duplicate).

Counted by `grep -c '^axiom ' proofs/Proofs/Erdos630Problem.lean proofs/Proofs/Stubs/Erdos630Problem.lean` → 11 + 11 = 22.

`npx tsx scripts/auditor/find-targets.ts --issues` confirms erdos-630 no longer flags after this change.

## Pattern

Same chain-axiom undercount pattern as recently merged:
- #22087 ballot-problem-oq-02
- #22084 erdos-360
- #22089 erdos-1018
- #22100 erdos-1039 (in flight)
- #22102 erdos-627 (in flight)

---
Automated fix by lean-mechanic agent.