### PR TITLE
fix(meta): erdos-630 axiomCount 11→22 (Stubs/Erdos630Problem.lean chain)

### DIFF
--- a/src/data/proofs/erdos-630/meta.json
+++ b/src/data/proofs/erdos-630/meta.json
@@ -57,9 +57,9 @@
       "Connection to Combinatorial Nullstellensatz",
       "Graph polynomial formulation"
     ],
-    "axiomCount": 11,
+    "axiomCount": 22,
     "lineCount": 246,
-    "assumptions": "11 axiom(s) and 15 sorries(s).",
+    "assumptions": "22 axioms total (chain count) and 15 sorries. Main file Proofs/Erdos630Problem.lean (11): complete_bipartite_list_chromatic, euler_formula, four_color_theorem, thomassen_five_list, alon_tarsi_theorem, combinatorial_nullstellensatz, alon_tarsi_coefficient, k24_list_chromatic, complete_bipartite_lower_bound, list_coloring_conjecture_open, outerplanar_3_choosable. Stubs/Erdos630Problem.lean (11, byte-identical duplicate of main file): same 11 axioms redeclared.",
     "mathlib_version": "4.26.0",
     "theoremCount": 11,
     "definitionCount": 8


### PR DESCRIPTION
## Summary

Gallery integrity audit: `erdos-630` reports `axiomCount: 11` but the
chain (main + `additionalFiles`) actually contains **22 axioms**.

| File | Axioms |
|------|--------|
| `Proofs/Erdos630Problem.lean` (main) | 11 — `complete_bipartite_list_chromatic`, `euler_formula`, `four_color_theorem`, `thomassen_five_list`, `alon_tarsi_theorem`, `combinatorial_nullstellensatz`, `alon_tarsi_coefficient`, `k24_list_chromatic`, `complete_bipartite_lower_bound`, `list_coloring_conjecture_open`, `outerplanar_3_choosable` |
| `Proofs/Stubs/Erdos630Problem.lean` | 11 — byte-identical duplicate (md5 `2b7c50d6…`) |
| **Total** | **22** |

## Fix

- `axiomCount`: 11 → 22
- `assumptions`: enumerated per-file axioms

Status remains `axiomatized`.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` no longer flags `erdos-630`.
- [x] No Lean source touched.
- [x] Branched off latest `main` (`3fabeb2ac8d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)