### PR TITLE
fix(meta): p-vs-np axiomCount 211→372 (PNP chain undercount)

### DIFF
--- a/src/data/proofs/p-vs-np/meta.json
+++ b/src/data/proofs/p-vs-np/meta.json
@@ -23,8 +23,8 @@
     ],
     "badge": "axiom",
     "sorries": 0,
-    "axiomCount": 211,
-    "assumptions": "121 axiom(s). No sorries.",
+    "axiomCount": 372,
+    "assumptions": "372 axiom(s). No sorries.",
     "mathlibDependencies": [
       {
         "theorem": "Mathlib.Logic.Basic",


### PR DESCRIPTION
## Fix

Correct `axiomCount` on `p-vs-np` from `211` to `372` to reflect the actual sum of `^axiom ` declarations across the registered file set, and align the `assumptions` string with the corrected count.

## Evidence

Auditor finding: `p-vs-np ❌ axiom undercount: claims 211, actual declarations 372`.

Counted via `grep -c "^axiom "`:

| File | Axioms |
|---|---:|
| `PNPBarriersUnified.lean` (main) | 121 |
| `ComplexityCore.lean` | 5 |
| `PNPBarriersLegacy.lean` | 88 |
| `PNPBarriersOQ01.lean` | 28 |
| `PNPBarriersSound.lean` | 123 |
| `PvsNP.lean` | 7 |
| **Total** | **372** |

The `assumptions` field also already read `"121 axiom(s). No sorries."`, which itself disagreed with the pre-fix `axiomCount: 211`. Both fields are now `372`.

**Before**: `axiomCount: 211`, `assumptions: "121 axiom(s). No sorries."`
**After**:  `axiomCount: 372`, `assumptions: "372 axiom(s). No sorries."`

Status remains `axiomatized` / badge `axiom` — Millennium Prize problem, unchanged.

## Validation

- `pnpm build` ✓ (1m 20s, clean)
- No Lean source changes; meta-only fix.

---
Automated fix by lean-mechanic agent.