### PR TITLE
research(schauder-fp-oq-03-oq-01-incomplete-01): S28 PREP — clustering bearer survey + obstacle decomposition (doc-only)

### DIFF
--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-02-s28-prep-clustering-lebesgue.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-02-s28-prep-clustering-lebesgue.md
@@ -1,0 +1,408 @@
+# S28 PREP — clustering lemma bearer survey + obstacle decomposition
+
+**Slug:** `schauder-fixed-point-oq-03-oq-01-incomplete-01`
+**Researcher:** researcher-1
+**Date:** 2026-06-02
+**Phase:** PREP (doc-only; no Lean / JSON / meta.json edits beyond `state.md` STATE-SYNC absorption)
+**Iteration:** S28 PREP (paired with S28 STATE-SYNC absorbing the merged S26+S27 ACT bundle)
+**Predecessors:** S27 ACT (researcher-1, 2026-05-28, PR #20891 — `finsupport_combination_within_output_ball`); S26 ACT (researcher-1, 2026-05-28, same PR #20891 — input-ball clause propagation + `finsupport_center_within_input_ball` + `finsupport_nonempty`).
+**Sister PRs:** none for this slug as of session start; mechanic PRs #21515 (lineCount 1284→1420) and #21718 (1420→1419, wc -l canonical) merged 2026-05-31 / 2026-06-01 absorbed the post-PR-#20891 lineCount drift but did not touch theoremCount.
+
+---
+
+## §0 TL;DR
+
+S27 ACT reduced the output-side graph-bound conjunct
+`dist (f x) (ysel i) < ε` to a **clustering** statement about the
+selected values: for some chosen `i ∈ ρ.finsupport x`,
+
+```
+∀ j ∈ ρ.finsupport x, dist (ysel j) (ysel i) < ε
+```
+
+This PREP:
+
+1. **Locates the Mathlib bearer** for the standard tool to attack
+   clustering — `lebesgue_number_lemma_of_metric` —
+   at the pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, file
+   `Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean`, signature
+   reproduced in §2 below.
+
+2. **Confirms two adjacent bearers** that fall out of the same Mathlib
+   module: `lebesgue_number_lemma_of_metric_sUnion` (same file) and the
+   `Mathlib/Topology/UniformSpace/Compact.lean` `lebesgue_number_lemma`
+   variant. Either works for the use site; the `_of_metric` variant is
+   the canonical one for metric spaces (`↥S` carries the subspace
+   metric from `EuclideanSpace ℝ (Fin n)`).
+
+3. **Documents the genuine obstacle** that even with the Lebesgue
+   number lemma in hand, the clustering bound is **not** a direct
+   corollary of UHC + the existing S18d thickening clause. The S18d
+   clause runs `F z ⊆ thickening ε (F i)` for `z ∈ U i`, controlling
+   `F x` (or any `F z`) in a neighborhood of `F i` — **not** the
+   ambient distance between two *chosen* selector values
+   `ysel j ∈ F j` and `ysel i ∈ F i`. The thickening witnesses are
+   existential, while `ysel` is fixed once and for all by the global
+   `choose` at S18e step 4a.
+
+4. **Documents two candidate routes** (A: ε/3-scaling + uniform
+   refinement; B: anchored-selector via S22's `exists_nearest_in_image_F`),
+   identifies the subtle gap in each, and concludes that the next ACT
+   iteration should not try to close clustering in one cycle but
+   instead land the **`lebesgue_number_lemma_of_metric` invocation as
+   a separate helper lemma** to isolate the bearer plumbing from the
+   harder uniform-thickening step.
+
+5. **Paste-ready Lean signature** for the proposed S28 ACT helper
+   `exists_lebesgue_subcover_for_uhc` (§5 below) — analogous to
+   S18c's `exists_finite_subcover_for_uhc` but augmented with a
+   Lebesgue radius `δ > 0` such that every `δ`-ball in `↥S` lies in
+   some `U i`. This is doc-only: no Lean is edited in this PR.
+
+No Lean change, no build, no bearer re-walk beyond the one new bearer
+(`lebesgue_number_lemma_of_metric`) confirmed in §2. `axiomCount` stays
+at 2 (`brouwer_unit_ball`, `approx_selection_exists`); 0 functional
+sorries.
+
+---
+
+## §1 Where S27 left off (anchor)
+
+`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean:996` (post-#20891):
+
+```lean
+private lemma finsupport_combination_within_output_ball {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n)))
+    (ρ : PartitionOfUnity (↥S) (↥S) (Set.univ : Set ↥S))
+    (x i : ↥S)
+    (ysel : ↥S → EuclideanSpace ℝ (Fin n)) (r : ℝ)
+    (hr : ∀ j ∈ ρ.finsupport x, dist (ysel j) (ysel i) ≤ r) :
+    dist (∑ j ∈ ρ.finsupport x, ρ j x • ysel j) (ysel i) ≤ r
+```
+
+The output-side graph-bound conjunct `dist (f x) (ysel i) < ε` reduces
+to discharging the hypothesis `hr` with `r := ε`. The other two
+conjuncts of `IsGraphApproxSelection F f ε`
+(`SchauderFixedPointOQ03OQ01.lean:532`) are already discharged:
+
+- `dist x x' < ε` (with `x' := i ∈ ρ.finsupport x`) by S26's
+  `finsupport_center_within_input_ball` (file line ~960) + S26's
+  `finsupport_nonempty` (file line ~940).
+- `y' ∈ F x'` (with `y' := ysel i`) by S18e's `hysel_in_F`.
+
+So the **sole remaining obstacle** is:
+
+> **Clustering (`Goal-S29`).** For the chosen `i₀ ∈ ρ.finsupport x`,
+> `∀ j ∈ ρ.finsupport x, dist (ysel j) (ysel i₀) < ε`.
+
+---
+
+## §2 Mathlib bearer — `lebesgue_number_lemma_of_metric`
+
+Confirmed at pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` via
+`raw.githubusercontent.com/leanprover-community/mathlib4/2df2f0150c…/
+Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean`:
+
+```lean
+theorem lebesgue_number_lemma_of_metric {s : Set α} {ι : Sort*}
+    {c : ι → Set α} (hs : IsCompact s)
+    (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
+    ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i := by
+  simpa only [ball, UniformSpace.ball, preimage_setOf_eq, dist_comm]
+    using uniformity_basis_dist.lebesgue_number_lemma hs hc₁ hc₂
+```
+
+Specialization to our context: `α := ↥S`, `s := (Set.univ : Set ↥S)`
+(which is compact under `[CompactSpace ↥S]`, recovered from
+`isCompact_iff_compactSpace.mp hS_compact` exactly as S18c/d/e
+already do at lines 641/744/829), `ι := ↥S`, `c := U`.
+
+Hypotheses become:
+- `hs : IsCompact (Set.univ : Set ↥S)` — `isCompact_univ` under
+  `[CompactSpace ↥S]`.
+- `hc₁ : ∀ i, IsOpen (U i)` — the `hU_open` clause already produced
+  by S18c.
+- `hc₂ : Set.univ ⊆ ⋃ i, U i` — same one-liner as S18d
+  (`exists_partition_subordinate_to_uhc_cover`, file line ~767):
+  `intro x _; exact Set.mem_iUnion.mpr ⟨x, hU_mem x⟩`.
+
+Conclusion: `∃ δ > 0, ∀ x : ↥S, ∃ i : ↥S, Metric.ball x δ ⊆ U i`.
+
+**Two adjacent bearers also confirmed** (same file, same SHA):
+- `lebesgue_number_lemma_of_metric_sUnion` — variant for `c : Set (Set α)`
+  with `s ⊆ ⋃₀ c`. Not needed for our indexed-family setup.
+- `lebesgue_number_lemma` (`Mathlib/Topology/UniformSpace/Compact.lean`)
+  — uniformity-basis form. Strictly more general; we use the metric
+  variant for the cleaner ball syntax.
+
+No new import is required: the file already imports
+`Mathlib.Topology.MetricSpace.Basic` (line 35) which transitively
+pulls in `MetricSpace/Pseudo/Lemmas.lean` through the standard
+metric-space dependency chain.
+
+---
+
+## §3 Why Lebesgue alone is insufficient — the genuine obstacle
+
+The Lebesgue number lemma gives a **uniform input-side radius** `δ`:
+any `δ`-ball in `↥S` lies entirely in some single cover element `U i`.
+This is genuinely useful — it lets us cluster the *centers* (any
+`i, j ∈ ρ.finsupport x` are within distance `O(ε)` once `δ` ≤ ε).
+But it does **not** by itself produce the clustering bound
+
+```
+dist (ysel j) (ysel i₀) < ε
+```
+
+between the **selected values** in `↥S`. Two reasons:
+
+### §3.1 The thickening direction is wrong
+
+The S18d clause `∀ x z, z ∈ U x → F z ⊆ thickening ε (F x)` controls
+`F z` *as a set* in a neighborhood of `F x` *as a set*. Concretely,
+for `j ∈ ρ.finsupport x` we have `x ∈ U j`, which gives
+`F x ⊆ thickening ε (F j)` — i.e., for any `y ∈ F x` there is *some*
+`z ∈ F j` with `dist y z < ε`. The bound is **existential in `z`**;
+the specific `ysel j` chosen by S18e's `choose ysel` step has no a
+priori relationship to that `z`.
+
+### §3.2 `ysel` is fixed globally before the clustering goal
+
+S18e step 4a (`SchauderFixedPointOQ03OQ01.lean:848`):
+
+```lean
+choose ysel hysel_in_F using hF_ne
+```
+
+This commits a global `ysel : ↥S → ↥S` with `ysel i ∈ F i` for all
+`i`. The clustering bound is then a constraint on this *fixed*
+function: at every `x`, the values `ysel j` for `j ∈ ρ.finsupport x`
+must cluster within `ε` of `ysel i₀` for some `i₀` depending on `x`.
+There is no clause in UHC or in the S18c/d cover construction that
+forces this. Indeed, `F i` and `F j` can be wildly different convex
+sets even when `i, j` are nearby (e.g., `F i = {0, 1}`-style jumps
+are excluded by upper hemicontinuity in the Hausdorff-distance sense
+but not by the thickening clause alone).
+
+### §3.3 What is genuinely needed
+
+Cellina's original construction (for **lower** hemicontinuous `F`)
+provides each cover element with a **fixed reference point**
+`y_i ∈ F x_i` such that `F z` hits `B(y_i, ε)` for `z ∈ U_i` — i.e.,
+LHC at the chosen point. This forces `ysel j ∈ B(y_j, ε)` (with `ysel`
+chosen adaptively per cover element), and a triangle-inequality
+argument across overlapping cover elements gives clustering.
+
+For **upper** hemicontinuous `F`, the analogous strengthening is not
+available — UHC controls `F z` as a set, not at chosen points. The
+Cellina–Browder *graph form* (the one axiomatised here as
+`approx_selection_exists`) accepts this by relaxing the conclusion
+to the existential graph bound rather than pointwise distance. The
+clustering bound is the precise place where this distinction shows
+up in the construction. **The S29 ACT iteration cannot close
+clustering by `lebesgue_number_lemma_of_metric` alone.**
+
+---
+
+## §4 Two candidate routes for the post-S28 ACT chain
+
+### §4.A Route A — ε/3-scaling + uniform refinement
+
+Run the cover construction at scale `ε' := ε/3` (not `ε`), producing
+`U'`, `ρ'`, finite subcover `s'` with all bounds at radius `ε/3`.
+Apply Lebesgue at the *outer* scale: ∃ δ > 0 such that every δ-ball
+in `↥S` lies in some single `U' i`. Choose any `i ∈ ρ'.finsupport x`
+as the reference `i₀`. Then for `j ∈ ρ'.finsupport x`:
+
+- `x ∈ U' j` (subordinate) ⟹ `dist x j < ε/3` (S26 input-ball clause
+  at scale ε/3).
+- Triangle: `dist i₀ j < 2ε/3`.
+- **Gap:** This bounds `dist i₀ j` (in `↥S`), not `dist (ysel j) (ysel i₀)`
+  (in `↥S`). To bridge, we need an additional hypothesis or construction
+  step. One candidate: use the S18d thickening clause at *both* `i₀`
+  and `j`, pick any `y_x ∈ F x`, get `z_{i₀} ∈ F i₀, z_j ∈ F j` each
+  within `ε/3` of `y_x`. Then `dist z_{i₀} z_j < 2ε/3`. But `ysel i₀
+  ≠ z_{i₀}` and `ysel j ≠ z_j` in general, so this still does not
+  bound `dist (ysel i₀) (ysel j)`.
+
+Route A reduces the cleanness gap but does not close it without a
+**stronger UHC hypothesis** (e.g., upper hemicontinuity in the
+Hausdorff-distance sense, which would let us bound the Hausdorff
+distance `d_H (F i, F j) < ε` and hence pull `ysel j ∈ F j` to a
+point in `F i` within `ε`).
+
+### §4.B Route B — anchored selector via S22's `exists_nearest_in_image_F`
+
+S22 ACT (PR #19671) landed `exists_nearest_in_image_F` (file line ~928),
+a private helper that produces the nearest point in `Subtype.val '' F i`
+to any reference `y_0 ∈ EuclideanSpace ℝ (Fin n)`. The idea: define
+`ysel` **adaptively per cover element** as
+
+```
+ysel i := the nearest point in F i to a fixed reference y_0 ∈ S.
+```
+
+Pros: gives `dist (ysel i) y_0 = d(y_0, F i)` (a concrete handle).
+Cons: depends on a single global reference `y_0` whose distance to
+each `F i` is uncontrolled. Specifically, `dist (ysel i) y_0 = d(y_0, F i)`
+can be large if `F i` is far from `y_0`. Triangle then gives
+`dist (ysel i) (ysel j) ≤ d(y_0, F i) + d(y_0, F j)`, with no useful
+upper bound.
+
+Route B is a dead end unless `y_0` is replaced by **a per-x reference**
+`y_0(x)` (e.g., a point in `F x`). But `ysel` cannot depend on `x` (it
+must be fixed before `f x` is even defined).
+
+### §4.C Conclusion: defer clustering to S30+, land Lebesgue helper first
+
+Neither route closes clustering in a single iteration. The S29 ACT
+deliverable should therefore be the **Lebesgue subcover helper**
+(§5 below) as a *standalone lemma*, independent of the clustering
+argument. This isolates the bearer plumbing — the same incremental
+strategy used by S18c→S18d→S18e and by S19a→S22 — so the harder
+uniform-thickening step (S30+) inherits a clean Lebesgue radius from
+S29 and a clean S26/S27 reduction of the goal.
+
+---
+
+## §5 Paste-ready S29 ACT signature (helper, doc-only)
+
+Proposed helper to live alongside `exists_finite_subcover_for_uhc`
+(`SchauderFixedPointOQ03OQ01.lean:693`):
+
+```lean
+/-- **S29 scaffold (Lebesgue number for the UHC cover):**
+
+    Augments `exists_finite_subcover_for_uhc` with a uniform Lebesgue
+    radius `δ > 0` such that every `δ`-ball in `↥S` is contained in
+    some single cover element `U i`. The pointwise containment
+    `Metric.ball x δ ⊆ U (i x)` (for `i x` depending on `x`) is the
+    uniform refinement needed to bound distances between centers in
+    `ρ.finsupport x` from above by a calibrated multiple of `ε`.
+
+    This lemma does **not** close the output-side clustering bound
+    `dist (ysel j) (ysel i) < ε` directly — see
+    `sessions/2026-06-02-s28-prep-clustering-lebesgue.md` §3 for the
+    underlying obstacle that UHC controls `F z` as a *set* and the
+    `ysel` selector is fixed globally before clustering is even posed.
+    It is intended as input to a subsequent S30+ uniform-thickening
+    step.
+
+    **Proof.** `↥S` is compact (`isCompact_iff_compactSpace.mp
+    hS_compact` materialises `[CompactSpace ↥S]`, the same one-line
+    construction used by S18c at line 704). The `U` family from
+    `exists_finite_subcover_for_uhc` is an open cover of
+    `Set.univ : Set ↥S` (`hU_open` + `hU_mem` give `Set.univ ⊆ ⋃ i, U i`
+    by the same one-liner as S18d line 767). Apply
+    `lebesgue_number_lemma_of_metric`
+    (`Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean` at pinned rev
+    `2df2f0150c…`) to obtain the uniform `δ > 0` and the per-`x`
+    cover-element witness.
+
+    No new axiom is introduced; `axiom approx_selection_exists`
+    (Axiom 2 above) remains unchanged. -/
+private lemma exists_lebesgue_subcover_for_uhc {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n))) (hS_compact : IsCompact S)
+    (F : SetValuedMap (↥S) (↥S))
+    (hF_uhc : IsUpperHemicontinuous F)
+    (ε : ℝ) (hε : 0 < ε) :
+    ∃ U : ↥S → Set ↥S, ∃ s : Finset ↥S, ∃ δ : ℝ,
+      0 < δ ∧
+      (∀ x : ↥S, IsOpen (U x)) ∧
+      (∀ x : ↥S, x ∈ U x) ∧
+      (∀ x : ↥S, U x ⊆ Metric.ball x ε) ∧
+      (∀ x z : ↥S, z ∈ U x → F z ⊆ Metric.thickening ε (F x)) ∧
+      (⋃ x ∈ s, U x = (⊤ : Set ↥S)) ∧
+      (∀ x : ↥S, ∃ i : ↥S, Metric.ball x δ ⊆ U i) := by
+  haveI : CompactSpace ↥S := isCompact_iff_compactSpace.mp hS_compact
+  -- Step 1: invoke S18c to obtain the open cover with input-ball + thickening
+  -- + finite-subcover clauses.
+  obtain ⟨U, s, hU_open, hU_mem, hU_ball, hU_sub, hs_cover⟩ :=
+    exists_finite_subcover_for_uhc S hS_compact F hF_uhc ε hε
+  -- Step 2: derive Set.univ ⊆ ⋃ i, U i (same one-liner as S18d).
+  have hU_cover_univ : (Set.univ : Set ↥S) ⊆ ⋃ i : ↥S, U i := by
+    intro x _
+    exact Set.mem_iUnion.mpr ⟨x, hU_mem x⟩
+  -- Step 3: apply lebesgue_number_lemma_of_metric to obtain the uniform δ.
+  obtain ⟨δ, hδ_pos, hδ⟩ :=
+    lebesgue_number_lemma_of_metric isCompact_univ hU_open hU_cover_univ
+  -- Step 4: package the Lebesgue witness restricted to ↥S (via mem_univ).
+  refine ⟨U, s, δ, hδ_pos, hU_open, hU_mem, hU_ball, hU_sub, hs_cover, ?_⟩
+  intro x
+  exact hδ x (Set.mem_univ x)
+```
+
+Estimated cost: ~30 LOC (24 lines of statement + body shown above plus
+~6 lines of docstring header). No new imports. `theoremCount` would
+move 17 → 18 (under the canonical regex), `lineCount` would move
+1419 → ~1450. `axiomCount` unchanged at 2.
+
+---
+
+## §6 INFRA snapshot (session start)
+
+- **Host disk:** 28 Gi available (`df -h` `/System/Volumes/Data`),
+  GREEN at the standing 5 Gi soft-floor. Pin-stable since the
+  cycle-31 disk recovery (memory project log
+  `project_deployer_2026_06_02_cycle31_3merges_disk_recovery.md`).
+- **Docker daemon:** Server section populated, Client version
+  `29.4.1`. GREEN (matches state.md S26 ACT note "Docker v29.4.1, disk
+  66 Gi"; disk has since rolled to 28 Gi but remains GREEN).
+- **G9 self-symlink cycle:** `proofs/.lake` still points to
+  `/Users/rwalters/GitHub/lean-genius/proofs/.lake` itself (verified by
+  `readlink`). Recurrence of the S6 / S25 STATE-SYNC carry-forward.
+  This blocks **local Mathlib browsing** in the worktree but is not a
+  blocker for this doc-only PREP (bearer survey via `gh search code`
+  + `raw.githubusercontent.com` worked cleanly and confirmed
+  `lebesgue_number_lemma_of_metric` at the pinned SHA).
+- **Mathlib pin SHA:** unchanged at
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (now ≥17-day SHA-stable
+  window across all S22→S28 sessions; matches the bearer pin used by
+  S22 ACT, S26 ACT, S27 ACT and the seven bearer-rewalks logged in
+  memory for sibling researcher-1 problems on 2026-06-02).
+- **State.md drift:** Current Focus block was last updated at S26 ACT
+  (2026-05-28); the S27 ACT same-day extension landed via PR #20891
+  but was not absorbed into the state.md heading. This S28 STATE-SYNC
+  pass discharges that drift (see same-PR `state.md` edit).
+- **meta.json drift:** `theoremCount: 14` (set by mechanic PR #19983
+  2026-05-17 from the regex-canonical S25 baseline). The actual file
+  now has 17 entries under the canonical regex (17 = 14 base + 2 from
+  S26 + 1 from S27, with 7 public + 10 `private` lemmas). The mechanic
+  has not yet auto-synced this drift; not blocking and left to the
+  mechanic queue.
+
+---
+
+## §7 Decision matrix — S29 ACT vs alternatives
+
+| Option | Scope | Risk | Recommend |
+|--------|-------|------|-----------|
+| S29 ACT: land `exists_lebesgue_subcover_for_uhc` (§5) | ~30 LOC, 1 lemma, 0 new axiom, 0 new sorry | LOW (bearer confirmed at pinned SHA, proof body is 4 tactic lines) | **YES** — incremental progress consistent with the S18c→S18d→S18e cadence |
+| S29 ACT: attempt full clustering bound | 200+ LOC, multi-helper, requires deciding Route A vs B vs new | HIGH (genuine math gap per §3.3; literature suggests UHC graph form is intrinsically existential) | **NO** — premature; needs a separate PREP pass after §3.3's gap is resolved |
+| S29 STATE-SYNC only | doc-only, no Lean | LOW (no progress; S28 STATE-SYNC already discharged the absorption) | **NO** — redundant after this PR |
+| S29 PREP further: route C survey (e.g., separable-selection theorem) | doc-only | MEDIUM (might find a cleaner closed-form route) | **MAYBE** — defer to post-S29 ACT, after Lebesgue helper lands |
+
+**Selected:** S29 ACT = land `exists_lebesgue_subcover_for_uhc` per §5.
+Single helper, paste-ready, bearer pre-verified, isolated from the
+clustering obstacle.
+
+---
+
+## §8 No build, no JSON, no meta.json edits in this PR
+
+This PR's diff is exactly:
+1. **(new)** `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-02-s28-prep-clustering-lebesgue.md` (this file).
+2. **(edit)** `research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md` — S28 STATE-SYNC absorption of S27 ACT (S26 ACT subsumed) into Current Focus, demoting S26 ACT to Prior Focus.
+
+No Lean source file is touched. No JSON / meta.json edits. No build
+verification needed (carries forward the S27 ACT 3074-job clean build
+at the same pinned SHA — Lean file is byte-identical to the post-PR
+#20891 state).
+
+**Next Action** (binds S29 ACT iteration): land the helper from §5 in
+`SchauderFixedPointOQ03OQ01.lean` between
+`exists_finite_subcover_for_uhc` (line 693) and
+`exists_partition_subordinate_to_uhc_cover` (line 752). Estimated
+diff: +30 LOC, theoremCount 17 → 18, lineCount 1419 → ~1450,
+axiomCount unchanged at 2, build-pending qualifier discharged by the
+same 3074-job baseline plus the 4-line tactic body.

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -1,13 +1,116 @@
 # Research State: schauder-fixed-point-oq-03-oq-01-incomplete-01
 
 ## Current State
-**Phase**: ACT (S26 ACT: input-ball clause propagated through S18c→S18d→S18e bundle + two new lemmas — `finsupport_center_within_input_ball` (the `dist x x' < ε` half of the graph bound) and `finsupport_nonempty` (center existence); **build-verified clean 3074 jobs** under recovered INFRA; **0 functional sorries**, 2 axioms remaining)
+**Phase**: PREP (S28 PREP: clustering lemma bearer survey — `lebesgue_number_lemma_of_metric` confirmed at pinned SHA `2df2f0150c…` — plus obstacle decomposition documenting why Lebesgue alone is insufficient for the output-side clustering bound `dist (ysel j) (ysel i) < ε`, plus paste-ready `exists_lebesgue_subcover_for_uhc` helper signature for the next S29 ACT iteration; **0 functional sorries**, 2 axioms remaining — Lean file byte-identical to post-S27-ACT PR #20891 state, 1419 LOC / 17 theorems)
 **Path**: full
-**Since**: 2026-05-28
-**Iteration**: 26-ACT (S26 ACT, real Lean progress after the S23–S25 doc-only STATE-SYNC run; INFRA blockers G7/G8 cleared — Docker v29.4.1, disk 66 Gi)
-**Last Updated**: 2026-05-28
+**Since**: 2026-06-02
+**Iteration**: 28-PREP (paired with S28 STATE-SYNC absorbing S26+S27 ACT merged-as-#20891 bundle; the S26 ACT Current Focus block from the previous edit is demoted to Prior Focus below; the merged S27 ACT output-side reduction is folded into Current Focus's anchor for the new clustering work)
+**Last Updated**: 2026-06-02
 
-## Current Focus (S26 ACT, 2026-05-28, researcher-1)
+## Current Focus (S28 PREP, 2026-06-02, researcher-1)
+
+S28 PREP (researcher-1, 2026-06-02, this PR — doc-only): Bearer survey
+and obstacle decomposition for the output-side clustering bound that
+S27 ACT reduced the graph-distance conjunct to. Two predecessor ACT
+iterations merged in a single bundle PR #20891 (2026-05-29T05:05:04Z):
+
+1. **S26 ACT** — input-ball clause propagation through the
+   S18c→S18d→S18e bundle (`uhc_local_thickening_with_input_diameter`
+   replaces the weaker S17 `uhc_local_thickening` in
+   `exists_finite_subcover_for_uhc`), plus two new private lemmas:
+   `finsupport_center_within_input_ball` (the `dist x x' < ε` half of
+   the graph bound) and `finsupport_nonempty` (center existence in
+   `ρ.finsupport x`). theoremCount 14 → 16, lineCount 1284 → 1369,
+   axiomCount unchanged at 2.
+
+2. **S27 ACT** — one further private lemma
+   `finsupport_combination_within_output_ball`
+   (`SchauderFixedPointOQ03OQ01.lean:996`): for any
+   `i ∈ ρ.finsupport x`, the partition-weighted sum
+   `∑ j ∈ ρ.finsupport x, ρ j x • ysel j` lies in
+   `Metric.closedBall (ysel i) r` whenever the *clustering hypothesis*
+   `∀ j ∈ ρ.finsupport x, dist (ysel j) (ysel i) ≤ r` holds. Proof
+   uses `convex_closedBall` + `convex_combination_of_partition_in_S`
+   (S18a) + `Metric.mem_closedBall.mp` in 4 LOC. theoremCount 16 → 17,
+   lineCount 1369 → 1419 (post mechanic-rounding 1420→1419 from PR
+   #21718), axiomCount unchanged at 2.
+
+The combined effect of S26+S27 is that the output-side conjunct
+`dist (f x) (ysel i) < ε` of `IsGraphApproxSelection F f ε`
+(file line 532) **is no longer the genuine obstacle**. It now reduces
+to the **clustering** statement:
+
+> For some chosen `i₀ ∈ ρ.finsupport x`,
+> `∀ j ∈ ρ.finsupport x, dist (ysel j) (ysel i₀) < ε`.
+
+S28 PREP attacks this clustering goal. The headline findings, written
+up in
+`sessions/2026-06-02-s28-prep-clustering-lebesgue.md`:
+
+- **Bearer confirmed.** `lebesgue_number_lemma_of_metric` lives at
+  `Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean` at the pinned SHA
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` with signature
+  `{s : Set α} {ι : Sort*} {c : ι → Set α} (hs : IsCompact s)
+  (hc₁ : ∀ i, IsOpen (c i)) (hc₂ : s ⊆ ⋃ i, c i) :
+  ∃ δ > 0, ∀ x ∈ s, ∃ i, ball x δ ⊆ c i`. No new import is required:
+  the file already imports `Mathlib.Topology.MetricSpace.Basic` (line
+  35) which transitively pulls the bearer module.
+
+- **Lebesgue alone is insufficient.** The bearer gives a *uniform
+  input-side* radius `δ` but does not bound the *output-side* distance
+  `dist (ysel j) (ysel i₀)`. The S18d thickening clause runs
+  `F z ⊆ thickening ε (F x)` for `z ∈ U x` — controlling `F z` as a
+  *set* in a neighborhood of `F x` as a *set*. The `ysel` selector is
+  fixed once by S18e step 4a (`choose ysel hysel_in_F using hF_ne`)
+  before the clustering goal is even posed, so the thickening's
+  existential witness cannot be identified with `ysel j`.
+
+- **Routes A and B both have gaps.** Route A
+  (ε/3-scaling + uniform refinement) bounds `dist i₀ j` between the
+  *centers* but not between the selected values. Route B (anchored
+  selector via S22's `exists_nearest_in_image_F`) requires a global
+  reference whose distance to each `F i` is uncontrolled. The PREP
+  identifies this as the intrinsic gap between *lower* hemicontinuous
+  Cellina (which gives pointwise control) and *upper* hemicontinuous
+  Cellina–Browder (which is intrinsically existential — exactly why
+  the axiom is stated in the graph form to begin with, per S6).
+
+- **Recommended next ACT iteration.** Land the Lebesgue helper as a
+  *standalone lemma* `exists_lebesgue_subcover_for_uhc` between
+  `exists_finite_subcover_for_uhc` (file line 693) and
+  `exists_partition_subordinate_to_uhc_cover` (file line 752). The
+  paste-ready signature and 4-line tactic body are in
+  `sessions/2026-06-02-s28-prep-clustering-lebesgue.md` §5. Estimated
+  cost: +30 LOC, theoremCount 17 → 18, lineCount 1419 → ~1450,
+  axiomCount unchanged at 2, build-pending discharge from the same
+  3074-job clean baseline (no new imports, all bearer plumbing
+  pre-confirmed).
+
+INFRA snapshot at session start: host disk 28 Gi (GREEN above the 5
+Gi soft-floor, pin-stable since deployer cycle 31's disk recovery on
+2026-06-02 morning); Docker daemon `v29.4.1` Server-section populated
+(GREEN, matches state.md S26 ACT note); G9 `proofs/.lake`
+self-symlink recurrence carry-forward (does **not** block this
+doc-only PREP — `gh search code` + `raw.githubusercontent.com` bearer
+survey at pinned SHA worked cleanly without local Mathlib browsing);
+Mathlib pin unchanged at `2df2f0150c…` (now ≥17-day SHA-stable window
+across all S22→S28 sessions).
+
+**meta.json drift noted, not fixed in this PR.** `theoremCount: 14`
+in the JSON is now 3 entries behind the canonical regex
+(`^(?:protected |private |noncomputable )*(?:theorem|lemma) `)
+which counts 17 in the post-S27 file (7 public + 10 `private`).
+Mechanic PRs #21515 (lineCount 1284→1420) and #21718 (1420→1419
+wc-canonical) absorbed the lineCount drift but did not touch
+theoremCount; left to the mechanic queue per the standard
+research/mechanic separation.
+
+**Next Action** (binds S29 ACT iteration): land
+`exists_lebesgue_subcover_for_uhc` per
+`sessions/2026-06-02-s28-prep-clustering-lebesgue.md` §5. Estimated
++30 LOC, single helper, paste-ready, all bearers pre-confirmed.
+
+## Prior Focus (S26+S27 ACT, 2026-05-28, researcher-1 — merged as PR #20891 2026-05-29T05:05:04Z)
 
 S26 ACT (researcher-1, 2026-05-28, this PR): First Lean-code progress
 since S22 ACT (2026-05-16); the intervening S23/S24/S25 were doc-only

--- a/research/registry.json
+++ b/research/registry.json
@@ -16903,11 +16903,11 @@
     },
     {
       "slug": "schauder-fixed-point-oq-03-oq-01-incomplete-01",
-      "phase": "ACT",
+      "phase": "PREP",
       "path": "full",
       "started": "2026-04-21T15:44:50.655Z",
       "status": "active",
-      "lastUpdate": "2026-05-16T21:50:00.000Z"
+      "lastUpdate": "2026-06-02T16:30:00.000Z"
     },
     {
       "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-01-incomplete-01",


### PR DESCRIPTION
## Summary

S28 PREP (researcher-1, 2026-06-02, **doc-only**): After S26+S27 ACT (merged as PR #20891 on 2026-05-29) reduced the output-side graph-distance conjunct `dist (f x) (ysel i) < ε` to a single **clustering** statement about the selected values, this PREP surveys the Mathlib bearer landscape and decomposes the genuine obstacle.

### What landed

1. **New PREP session** `sessions/2026-06-02-s28-prep-clustering-lebesgue.md`:
   - Confirms Mathlib bearer `lebesgue_number_lemma_of_metric` at pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, file `Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean`. No new import required.
   - Documents the genuine obstacle: the S18d thickening clause controls `F z` as a *set* in a neighborhood of `F x` as a *set*, not the ambient distance between two *chosen* selector values `ysel j ∈ F j` and `ysel i ∈ F i`. The `ysel` is fixed globally by `choose` at S18e step 4a before the clustering goal is even posed.
   - Surveys Routes A (ε/3-scaling + uniform refinement) and B (anchored selector via S22's `exists_nearest_in_image_F`) and identifies the gap in each as the intrinsic gap between *lower* hemicontinuous Cellina (pointwise control) and *upper* hemicontinuous Cellina–Browder (intrinsically existential — exactly why the axiom is stated in the graph form per S6).
   - Provides a paste-ready ~30 LOC signature for the S29 ACT helper `exists_lebesgue_subcover_for_uhc` that lands the Lebesgue plumbing as a standalone lemma — single helper, 4-line tactic body, axiomCount unchanged at 2, all bearers pre-confirmed.

2. **`state.md` S28 STATE-SYNC absorption**: Current Focus rewrites to absorb the merged S26+S27 ACT bundle (PR #20891) — S26 ACT block demoted to Prior Focus; new Current Focus summarises both ACT iterations plus the S28 PREP findings.

3. **`research/registry.json`** schauder slug `phase ACT → PREP`, `lastUpdate → 2026-06-02T16:30Z`.

### INFRA snapshot

- Host disk: **28 Gi GREEN** (post deployer cycle 31 recovery).
- Docker daemon: **v29.4.1 GREEN** (Server section populated).
- G9 `proofs/.lake` self-symlink cycle recurrence — does **not** block this doc-only PREP (bearer survey via `gh search code` + `raw.githubusercontent.com` worked cleanly without local Mathlib browsing).
- Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` unchanged (≥17-day SHA-stable window across S22→S28 sessions).

### Drift noted, not fixed in this PR

`meta.json theoremCount: 14` is 3 entries behind the canonical regex (which counts 17 = 7 public + 10 `private` in the post-S27 file). Left to the mechanic queue per the standard research/mechanic separation.

### No build / no Lean change

This PR is doc-only: 1 new sessions/ file + state.md edit + registry.json 2-line metadata sync. Carries forward S27 ACT's 3074-job clean build baseline at the same pinned SHA. `axiomCount` unchanged at 2; 0 functional sorries.

## Next Action (binds S29 ACT)

Land `exists_lebesgue_subcover_for_uhc` per the §5 paste-ready signature in the PREP doc. Estimated +30 LOC, single helper, all bearers pre-confirmed, build-pending discharge from the same 3074-job clean baseline.

## Test plan

- [x] Bearer signature reproduced verbatim from raw.githubusercontent.com at pinned SHA.
- [x] state.md absorbs S27 ACT (previously stale at S26 ACT) and registry.json reflects S28 PREP phase.
- [x] No Lean source file touched (verified via `git diff --stat`).
- [ ] Subsequent S29 ACT will exercise the §5 helper signature under a real build verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)