### PR TITLE
fix(meta): erdos-183 status axiomatized→verified + badge axiom→original

### DIFF
--- a/src/data/proofs/erdos-183/meta.json
+++ b/src/data/proofs/erdos-183/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/183",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos183Problem.lean",
     "tags": [
       "erdos",
@@ -15,7 +15,7 @@
       "combinatorics",
       "extremal-combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "original",
     "sorries": 0,
     "erdosNumber": 183,
     "erdosUrl": "https://erdosproblems.com/183",


### PR DESCRIPTION
## Summary

Resolves gallery `meta.json` drift re-flagged by researcher in PR #22123.

`proofs/Proofs/Erdos183Problem.lean` has been at the stable 0-axiom end state since PR #16378 (merged 2026-05-06) eliminated the `R3k_exponential_lower` axiom via the doubling construction. Gallery meta still claimed `axiomatized` / `axiom` for ~27 days.

## Verification

| Check | Result |
|---|---|
| `grep -c "^axiom "` | 0 |
| `grep -c "sorry"` | 0 |
| `grep -E "structure \|class "` | (no matches) |
| LOC / theorems / definitions | 770 / 13 / 15 (matches `leanFile` counts) |
| `ErdosProblem183` declaration | `def : Prop` (open question, not asserted as theorem) |
| Proved main bound theorem | `erdos_183_main` (only states `R3k k ≥ 3` + factorial upper) |

Per [CLAUDE.md axiom-integrity policy](../blob/main/CLAUDE.md#axiom-integrity-policy) ("0 axiom declarations AND 0 structure-encoded assumptions = verified"), this file qualifies for `status: "verified"` + `badge: "original"`. The open conjecture remains stated as a `Prop` rather than closed by an axiom — the formalization is honest about what is and isn't proved.

## What changed

`src/data/proofs/erdos-183/meta.json`:
- `meta.status`: `"axiomatized"` → `"verified"`
- `meta.badge`: `"axiom"` → `"original"`

Other fields already correct (`axiomCount: 0`, `sorries: 0`, `lineCount: 770`).

## Test plan

- [x] JSON parses (`python3 -c "import json; json.load(open(...))"`)
- [x] `grep` confirms 0 axioms / 0 sorries / no assumption-carrying structures
- [x] Diff exactly 2 lines (no collateral edits)
- [x] No Lean edits / no Docker iterations needed (meta-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)