### PR TITLE
fix(meta): binomial-clt theoremCount 18→16 (script-canonical count)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -42,7 +42,7 @@
       "binomialCDF_tendsto_one_atTop (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atTop (nhds 1) under 0 ≤ p ≤ 1 — eventually-constant wrapper around `binomialCDF_eq_one` via `Filter.eventually_ge_atTop (n : ℝ)` and `Tendsto.congr'`. Binomial-side companion to the Φ tail-limit lemmas added in parallel S8 PR #17233",
       "binomialCDF_tendsto_zero_atBot (Session 8): Filter.Tendsto (binomialCDF n p) Filter.atBot (nhds 0) — eventually-constant wrapper around `binomialCDF_neg` via `Filter.eventually_lt_atBot (0 : ℝ)`. Left-tail saturation; no constraint on p needed since `binomialCDF_neg` holds for arbitrary p"
     ],
-    "theoremCount": 18,
+    "theoremCount": 16,
     "substantiveTheoremCount": 12,
     "definitionCount": 3
   },
@@ -66,7 +66,7 @@
     "namespace": "BinomialTheoremOQ02OQ01OQ01OQ03",
     "lineCount": 712,
     "axiomCount": 1,
-    "theoremCount": 18,
+    "theoremCount": 16,
     "substantiveTheoremCount": 12,
     "duplicateTheorems": 0,
     "definitionCount": 3,


### PR DESCRIPTION
## Fix

`src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json` reported `theoremCount: 18` in both `.meta` and `.leanFile`, but the canonical enrichment script counts only public declarations matching `^(theorem|lemma) ` (excludes `private`). Actual file has 16 public + 2 private = 18 total. Updated both fields to 16 to match the script convention used elsewhere in the gallery.

## Evidence

**Before**: `meta.theoremCount: 18`, `leanFile.theoremCount: 18`

**After**: both `16`

**Verification** (from `scripts/research/enrich-research.ts:155`):
```
/^(theorem|lemma) /.test(line)
```
Run against `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`:
- 16 matches (public theorems)
- 2 `private lemma` declarations excluded (lines 216, 389)

Private lemmas remain documented in `originalContributions` with `(private)` markers — their exclusion from the integer count is a script-convention choice, not a content change.

All other meta counts already match reality:
- `axiomCount: 1` ✓
- `sorries: 0` ✓
- `definitionCount: 3` ✓
- `lineCount: 712` ✓

## Provenance

Drift re-flagged for 17 days running in successive STATE-SYNC PRs (most recent: #22122). This PR clears the flag.

---
Automated fix by lean-mechanic agent.