### PR TITLE
Enrich Newton's Identities (vietas-formulas-oq-02)

### DIFF
--- a/src/data/proofs/vietas-formulas-oq-02/annotations.json
+++ b/src/data/proofs/vietas-formulas-oq-02/annotations.json
@@ -86,6 +86,34 @@
     ]
   },
   {
+    "id": "ann-vieta-newton-bridge",
+    "proofId": "vietas-formulas-oq-02",
+    "range": {
+      "startLine": 173,
+      "endLine": 201
+    },
+    "type": "insight",
+    "title": "The Vieta-Newton Bridge: Power Sums from Coefficients",
+    "content": "Theorem `vieta_newton_bridge` proves $p_2(r_1, r_2, r_3) = e_1(r_1, r_2, r_3)^2 - 2 \\, e_2(r_1, r_2, r_3)$ — a *closed-form* shortcut bypassing the Newton recursion. The mathematical content: for a monic cubic $f(x) = (x - r_1)(x - r_2)(x - r_3) = x^3 - e_1 x^2 + e_2 x - e_3$, *knowing only the coefficients* determines the sum-of-squares $r_1^2 + r_2^2 + r_3^2 = e_1^2 - 2 e_2$, even when the individual roots are inaccessible (irrational, complex, or computationally expensive to extract). This is the *constructive content* of Newton II — the same algebraic identity proved by `newton_identity_2_3`, but here packaged as a single substitution from $(e_1, e_2, e_3)$-space to power-sum space rather than as a recursion. The summary docstring (lines 187–201) frames the bigger picture: Vieta gives coefficients from roots; Newton gives power sums from coefficients; the bridge composes them to give power sums *directly* from coefficients, completing the round-trip $\\text{roots} \\to e_k \\to p_k$ without re-finding roots.\n\n**Why this matters for downstream algorithms**: this single identity is the *base case* of the *Faddeev–LeVerrier algorithm* — a polynomial-time method for computing characteristic-polynomial coefficients from matrix traces. For an $n \\times n$ matrix $A$ with eigenvalues $\\lambda_1, \\ldots, \\lambda_n$, the trace $\\text{tr}(A^k) = \\sum_i \\lambda_i^k = p_k(\\lambda)$, so the algorithm extracts $p_1, \\ldots, p_n$ in $O(n^4)$ time via matrix products, then *inverts* the Newton-Vieta direction (via Waring's formulas, the partner theorem to this bridge) to recover the characteristic-polynomial coefficients $e_k(\\lambda)$. The 3-variable case proved here is *exactly* the algorithm's correctness witness for $3 \\times 3$ matrices: given $\\text{tr}(A) = p_1$, $\\text{tr}(A^2) = p_2$, the bridge yields $e_2 = (p_1^2 - p_2)/2$ — the middle coefficient of $\\chi_A$.\n\n**Why the file proves both `newton_identity_2_3` and `vieta_newton_bridge`**: They are *mathematically equivalent* (both state $p_2 = e_1^2 - 2 e_2$ for 3 variables), but *semantically distinct* in the Lean API: `newton_identity_2_3` is stated in the canonical $p_2 = e_1 \\cdot p_1 - 2 e_2$ form (the Newton recursion shape, useful for general-$k$ induction), while `vieta_newton_bridge` substitutes $p_1 = e_1$ to give the *closed* form $p_2 = e_1^2 - 2 e_2$ (useful as a direct substitution rule in expressions that already eliminate $p_1$ via Newton I). Having both as named theorems lets downstream users pick the version matching their proof context — the Lean-style equivalent of providing both `add_comm` and `add_left_comm` for commutativity in different syntactic positions.",
+    "mathContext": "$p_2(r_1, r_2, r_3) = e_1(r_1, r_2, r_3)^2 - 2 \\, e_2(r_1, r_2, r_3)$, expanding to $r_1^2 + r_2^2 + r_3^2 = (r_1 + r_2 + r_3)^2 - 2(r_1 r_2 + r_1 r_3 + r_2 r_3)$. Equivalently, for the monic cubic $f(x) = x^3 - e_1 x^2 + e_2 x - e_3$ with roots $r_1, r_2, r_3$: $\\sum r_i^2 = e_1^2 - 2 e_2$, derivable from coefficients alone.\n\n**Faddeev–LeVerrier base case** ($n = 3$): given $p_1 = \\text{tr}(A)$, $p_2 = \\text{tr}(A^2)$, $p_3 = \\text{tr}(A^3)$ for a $3 \\times 3$ matrix $A$: $e_1 = p_1$ (Newton I), $e_2 = (p_1^2 - p_2)/2 = (e_1^2 - p_2)/2$ (rearranging this bridge), $e_3 = (p_1^3 - 3 p_1 p_2 + 2 p_3)/6$ (Waring's formula for $e_3$). The characteristic polynomial is then $\\chi_A(\\lambda) = \\lambda^3 - e_1 \\lambda^2 + e_2 \\lambda - e_3$ — recovered without any eigenvalue computation.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Vieta's formulas",
+      "Faddeev–LeVerrier algorithm",
+      "Waring's formulas",
+      "characteristic polynomial",
+      "trace formula",
+      "symmetric function basis change",
+      "closed-form vs recursive identity"
+    ],
+    "prerequisites": [
+      "elementary symmetric polynomial",
+      "power sum",
+      "ring tactic",
+      "Vieta's formulas for monic polynomials"
+    ]
+  },
+  {
     "id": "ann-numerical-examples",
     "proofId": "vietas-formulas-oq-02",
     "range": {

--- a/src/data/proofs/vietas-formulas-oq-02/meta.json
+++ b/src/data/proofs/vietas-formulas-oq-02/meta.json
@@ -31,7 +31,7 @@
     "definitionCount": 10
   },
   "overview": {
-    "historicalContext": "Isaac Newton discovered the identities relating power sums to elementary symmetric polynomials around 1666, though they were first published by Newton in 1707 and independently discovered by Girard (1629). The identities p_k = e_1 p_{k-1} - e_2 p_{k-2} + ... + (-1)^{k-1} k e_k provide the natural multivariate generalization of Vieta's formulas: while Vieta expresses polynomial coefficients as elementary symmetric functions of roots, Newton gives power sums (traces, moments) in terms of the same elementary symmetric functions. The identities are fundamental to the theory of symmetric functions (Macdonald 1995), representation theory (character theory), and random matrix theory.",
+    "historicalContext": "Albert Girard published the identities in *Invention nouvelle en l'algèbre* (1629), pre-dating Newton's independent rediscovery (~1666, in *Arithmetica Universalis* posthumously published 1707) by a generation — the joint attribution as *Newton–Girard formulas* recognizes both contributors. Edward Waring (1762, *Miscellanea Analytica*) gave the first published *inverse* direction, expressing $e_k$ as a polynomial in $p_1, \\ldots, p_k$ (the Waring formulas), and proved every symmetric polynomial is a polynomial in $e_1, \\ldots, e_n$ (the fundamental theorem of symmetric polynomials). The recursive form $p_k = \\sum_{i=1}^{k-1} (-1)^{i-1} e_i p_{k-i} + (-1)^{k-1} k e_k$ becomes the *Newton–Girard recursion*: each line is pure ring arithmetic, but the cumulative system is a triangular invertible map between two generating sets of the symmetric-function ring $\\Lambda = \\mathbb{Z}[e_1, e_2, \\ldots] = \\mathbb{Q}[p_1, p_2, \\ldots]$ (the inversion fails over $\\mathbb{Z}$ — the denominators $k$ in $p_k = \\ldots + (-1)^{k-1} k e_k$ force tensoring with $\\mathbb{Q}$). Macdonald's *Symmetric Functions and Hall Polynomials* (1979, 2nd ed. 1995) is the modern canonical reference, situating Newton's identities as the bridge between the four classical bases of $\\Lambda$ (elementary $e_\\lambda$, complete $h_\\lambda$, power-sum $p_\\lambda$, monomial $m_\\lambda$). The identities are fundamental in: representation theory (character values of $S_n$ via Frobenius's formula are expressed in the $p_\\lambda$ basis), algebraic combinatorics (Schur–Weyl duality, Jack polynomials), random matrix theory (eigenvalue moments of GUE/GOE ensembles via $p_k = \\text{tr}(M^k)$), and computer algebra (the Faddeev–LeVerrier algorithm computes characteristic-polynomial coefficients in $O(n^4)$ via Newton's identities applied to matrix traces — the only direct path from $\\text{tr}(A^k)$ to $\\det(\\lambda I - A)$ without finding eigenvalues).",
     "problemStatement": "Formalize Newton's identities for 2 and 3 variables, connecting power sums to elementary symmetric polynomials, and verify on concrete numerical examples.",
     "proofStrategy": "Define elementary symmetric polynomials e_k and power sums p_k explicitly for 2 and 3 variables. Prove Newton's identities by expanding definitions and using ring arithmetic. Verify on the roots of x^3 - 6x^2 + 11x - 6 = 0 (roots 1, 2, 3) where e_1=6, e_2=11, e_3=6 and p_1=6, p_2=14, p_3=36.",
     "keyInsights": [
@@ -39,7 +39,11 @@
       "Newton's identity III (p_3 = e_1*p_2 - e_2*p_1 + 3*e_3) yields the classical factorization x^3+y^3+z^3 - 3xyz = (x+y+z)(x^2+y^2+z^2-xy-xz-yz).",
       "The corollary that x+y+z=0 implies x^3+y^3+z^3=3xyz connects Newton's identities to number theory (Fermat's Last Theorem for n=3 reduces to this when looking at the ring structure).",
       "All proofs use only `ring` tactic — Newton's identities for fixed n are purely algebraic identities in any commutative ring.",
-      "Newton's identities enable moment reconstruction from coefficients alone: knowing only e₁,e₂,e₃ from a polynomial's factorization, one computes all power sums p₁,p₂,p₃,... without finding roots. This makes elementary symmetric polynomials a computational gateway to spectral invariants — the same structure underlies moment problems in probability and trace formulas in linear algebra."
+      "Newton's identities enable moment reconstruction from coefficients alone: knowing only e₁,e₂,e₃ from a polynomial's factorization, one computes all power sums p₁,p₂,p₃,... without finding roots. This makes elementary symmetric polynomials a computational gateway to spectral invariants — the same structure underlies moment problems in probability and trace formulas in linear algebra.",
+      "**Trace formula bridge to linear algebra**: For an $n \\times n$ matrix $A$ with eigenvalues $\\lambda_1, \\ldots, \\lambda_n$, the power sum $p_k = \\sum_i \\lambda_i^k$ equals $\\text{tr}(A^k)$ (an invariant computable from $A$ without finding eigenvalues), while the elementary symmetric polynomial $e_k$ equals $(-1)^k$ times the coefficient of $\\lambda^{n-k}$ in the characteristic polynomial $\\chi_A(\\lambda) = \\det(\\lambda I - A)$. Newton's identities therefore form the *Faddeev–LeVerrier algorithm*: compute $\\text{tr}(A), \\text{tr}(A^2), \\ldots, \\text{tr}(A^n)$ by $n^2$-cost matrix products, then recover all $n$ coefficients of $\\chi_A$ by triangular solve via $p_k = e_1 p_{k-1} - e_2 p_{k-2} + \\cdots + (-1)^{k-1} k e_k$. This is the only known $O(n^4)$ characteristic-polynomial algorithm that avoids field divisions — critical for matrices over finite fields and rings where division is unavailable.",
+      "**Generating-function identity** (Newton 1666, modern form): the formal-power-series identity $\\sum_{k \\geq 1} p_k \\, t^k / k = -\\log\\bigl(\\sum_{k \\geq 0} (-1)^k e_k \\, t^k\\bigr) = -\\log E(-t)$, where $E(t) = \\prod_i (1 + x_i t) = \\sum_k e_k t^k$ is the elementary symmetric generating function. Differentiating both sides recovers the Newton recursion $p_k = e_1 p_{k-1} - e_2 p_{k-2} + \\cdots + (-1)^{k-1} k e_k$ coefficient-by-coefficient, exposing Newton's identities as the logarithmic derivative of the elementary symmetric generating function. This generating-function form is the entry point to symmetric-function plethysm, Frobenius's character formula, and the bosonic/fermionic Fock space correspondence in mathematical physics.",
+      "**Discriminant via Newton**: The discriminant $\\Delta = \\prod_{i < j} (x_i - x_j)^2$ is a symmetric polynomial, hence expressible in $e_1, \\ldots, e_n$ by the fundamental theorem — but the *direct* expression is unwieldy. Newton's identities provide an indirect route: $\\Delta = \\det(P_{i+j-2})_{1 \\leq i, j \\leq n}$ where $P_k$ are the power sums (the *Vandermonde determinant squared* = power-sum Hankel determinant). For $n = 3$: $\\Delta = \\det\\begin{pmatrix} 3 & p_1 & p_2 \\\\ p_1 & p_2 & p_3 \\\\ p_2 & p_3 & p_4 \\end{pmatrix}$. Combining this with the file's Newton identities gives the cubic discriminant $-4p^3 - 27q^2$ from coefficients alone — the formula gating *cubic Galois group recognition* ($\\mathrm{Gal} = S_3$ iff $\\Delta$ non-square; $\\mathrm{Gal} = A_3$ iff $\\Delta$ is a square, see `solution-of-cubic`).",
+      "**Ring isomorphism $\\Lambda \\cong \\mathbb{Q}[p_1, p_2, \\ldots]$ (only over $\\mathbb{Q}$)**: Newton's identities give the substitution map from the power-sum basis to the elementary-symmetric basis of the ring $\\Lambda$ of symmetric functions in infinitely many variables. The map is *invertible only after tensoring with $\\mathbb{Q}$* — the factor of $k$ in $p_k = \\cdots + (-1)^{k-1} k e_k$ forces denominators when inverting. Concretely: $\\Lambda \\otimes \\mathbb{Q} = \\mathbb{Q}[p_1, p_2, \\ldots]$ (free polynomial ring on the power sums), but $\\Lambda = \\mathbb{Z}[e_1, e_2, \\ldots] \\neq \\mathbb{Z}[p_1, p_2, \\ldots]$ (the latter is not finitely generated over the former without inverting all primes ≤ n). This explains why the formalizations in this file use `CommRing R` (works for any commutative ring) — the Newton identities themselves are integer-coefficient polynomial identities that hold over $\\mathbb{Z}$; only the *inverse* direction (recovering $e_k$ from $p_1, \\ldots, p_k$ via Waring's formulas) requires field-of-fractions structure."
     ]
   },
   "sections": [
@@ -82,21 +86,56 @@
       "endLine": 170,
       "summary": "Verification with roots {1,2,3} and {1,1,1}, showing Newton's identities compute correctly.",
       "mathContext": "For roots 1,2,3: $e_1=6, e_2=11, e_3=6$; $p_1=6, p_2=14, p_3=36$."
+    },
+    {
+      "id": "vieta-newton-bridge",
+      "title": "Part VI: Connection to Vieta's Formulas",
+      "startLine": 173,
+      "endLine": 201,
+      "summary": "Proves the `vieta_newton_bridge` theorem $p_2 = e_1^2 - 2 e_2$ for 3 variables — a closed-form realization of Newton II that bypasses the recursion. Documents how knowing only $e_1, e_2, e_3$ (the Vieta coefficients of a monic cubic) determines all power sums $p_k$ via Newton's identities, without ever computing the roots themselves.",
+      "mathContext": "$p_2(r_1, r_2, r_3) = e_1(r_1, r_2, r_3)^2 - 2 e_2(r_1, r_2, r_3)$. Equivalently: for the monic cubic $(x-r_1)(x-r_2)(x-r_3) = x^3 - e_1 x^2 + e_2 x - e_3$, the sum of squared roots is $r_1^2 + r_2^2 + r_3^2 = e_1^2 - 2 e_2$ — recoverable from coefficients alone."
     }
   ],
   "crossReferences": [
     {
       "targetId": "vietas-formulas",
       "relationship": "extends",
-      "description": "Multivariate generalization of Vieta's formulas via Newton's identities"
+      "description": "Multivariate generalization of Vieta's formulas via Newton's identities. The parent file proves the 2-root case $r + s = b$, $rs = c$ for $x^2 - bx + c$ via `Multiset.esymm`; this file lifts that to power sums for 3 variables via the explicit Newton recursion, then closes the loop with `vieta_newton_bridge` showing $p_2 = e_1^2 - 2 e_2$ is computable from Vieta coefficients alone."
+    },
+    {
+      "targetId": "vietas-formulas-oq-03",
+      "relationship": "sibling",
+      "description": "Sister entry extending Newton's identities to 4 variables and adding the *inversion* direction (Waring's formulas: recover $e_k$ from $p_1, \\ldots, p_k$). Together the three files (`vietas-formulas`, this entry, `vietas-formulas-oq-03`) trace the symmetric-function ring $\\Lambda$ through three of its four classical bases — coefficient/elementary ($e_k$), power-sum ($p_k$), and the Newton/Waring bidirection connecting them."
+    },
+    {
+      "targetId": "solution-of-cubic",
+      "relationship": "related",
+      "description": "The cube-sum factorization $x^3 + y^3 + z^3 - 3xyz = (x+y+z)(x^2+y^2+z^2-xy-xz-yz)$ proved here (`cube_sum_factorization`) is precisely the *Lagrange resolvent* identity underlying Cardano's depressed cubic formula. When $\\omega = e^{2\\pi i/3}$ is a primitive cube root of unity and $L = \\alpha_1 + \\omega\\alpha_2 + \\omega^2\\alpha_3$ is the Lagrange resolvent, $L^3$ and $\\bar L^3$ are symmetric in the three roots and so rational in the coefficients — exactly the structural fact this file's $x^3 + y^3 + z^3$ identity makes explicit at the $\\omega = 1$ specialization."
+    },
+    {
+      "targetId": "general-quartic",
+      "relationship": "related",
+      "description": "Ferrari's quartic formula uses the *resolvent cubic* $R(y) = y^3 - p_2(\\alpha) y^2 + (p_1(\\alpha) p_3(\\alpha) - 4 e_4) y - \\ldots$ in symmetric functions of the quartic's roots; Newton's identities are the engine converting the quartic's coefficients into the resolvent cubic's coefficients without computing roots. The 4-variable extension of Newton III (in `vietas-formulas-oq-03`) is the immediate next step needed for a constructive Ferrari formalization."
+    },
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "related",
+      "description": "The corollary `cube_sum_when_sum_zero` ($x + y + z = 0 \\implies x^3 + y^3 + z^3 = 3xyz$) is the integer identity behind the *Sophie Germain* approach to FLT for $n = 3$: rewriting $a^3 + b^3 = c^3$ as $a^3 + b^3 + (-c)^3 = 0$ forces $a^3 + b^3 + (-c)^3 = 3 a b (-c) = -3abc$, immediately reducing the problem to divisibility conditions on $abc$. The same identity underlies Kummer's ideal-class-group analysis of $\\mathbb{Z}[\\zeta_3]$ in regular-prime cyclotomic FLT."
+    },
+    {
+      "targetId": "newton-inductive-step",
+      "relationship": "complementary",
+      "description": "Different theorem also bearing Newton's name: this entry treats Newton's identities (1666 algebra of symmetric functions); `newton-inductive-step` treats Newton's log-concavity inequality on binomial coefficients (a probability/combinatorics result). The shared attribution to Newton reflects his foundational role in both algebraic and combinatorial generating-function methods — but the two are mathematically independent, and the gallery cross-link disambiguates the namespace collision for searchers."
     }
   ],
   "conclusion": {
     "summary": "A complete formalization of Newton's identities for 2 and 3 variables, with concrete numerical verification. 10 theorems, 10 definitions, 0 axioms, 0 sorries, 204 lines. All proofs by ring arithmetic.",
     "implications": "Newton's identities are the bridge between polynomial coefficients (via Vieta) and power sums (via traces). They are used in: random matrix theory (moments and free cumulants), representation theory (Adams operations on K-theory), and algebraic combinatorics (Schur-Weyl duality).",
     "openQuestions": [
-      "Can the n-variable Newton identity be proved uniformly using Finset sums and MvPolynomial.esymm from Mathlib?",
-      "Can the recurrence p_k = sum_{i=1}^{k} (-1)^{i-1} e_i p_{k-i} be formalized as a single theorem for arbitrary n and k?"
+      "Can the n-variable Newton identity be proved uniformly using Finset sums and MvPolynomial.esymm from Mathlib? The technical bottleneck: Mathlib has `MvPolynomial.esymm` (Mathlib.RingTheory.MvPolynomial.Symmetric) but lacks a uniform `MvPolynomial.psum` and the cross-base identity. A formalization would require ~300 LOC introducing `psum`, proving its symmetry, and establishing the recursion `psum k = ∑ i ∈ range k, (-1)^i * esymm (i+1) * psum (k-i-1) + (-1)^(k-1) * k * esymm k` over a general `Fintype` index type.",
+      "Can the recurrence p_k = sum_{i=1}^{k} (-1)^{i-1} e_i p_{k-i} be formalized as a single theorem for arbitrary n and k?",
+      "**Waring inversion in Lean**: Formalize the inverse direction — express each $e_k$ as a polynomial in $p_1, \\ldots, p_k$ over $\\mathbb{Q}$ (the *Waring formulas*, Waring 1762). Concretely: $e_1 = p_1$, $e_2 = \\tfrac{1}{2}(p_1^2 - p_2)$, $e_3 = \\tfrac{1}{6}(p_1^3 - 3 p_1 p_2 + 2 p_3)$, with the general pattern $e_k = \\tfrac{1}{k!} \\det(M_k)$ where $M_k$ is a triangular matrix with $p_i$ on the subdiagonals. This is the *companion* to the Newton identities, completing the bidirection between the $e$-basis and $p$-basis of the symmetric-function ring. The companion-file `vietas-formulas-oq-03` partially addresses this — extending the Waring formalization to a separate gallery entry would close the loop and provide the gallery's first formalized statement of the $\\Lambda \\otimes \\mathbb{Q} = \\mathbb{Q}[p_1, p_2, \\ldots]$ isomorphism.",
+      "**Faddeev–LeVerrier in Lean**: Implement the Faddeev–LeVerrier algorithm (1840/1955) as a Lean function `charpolyByTrace : Matrix (Fin n) (Fin n) ℚ → Polynomial ℚ` that computes a matrix's characteristic polynomial via $n$ trace computations and Newton's identities, without finding eigenvalues. This would be a purely *computational* application of this file's theorems: the existing `newton_identity_k_3` theorems for $k = 1, 2, 3$ already discharge the $n = 3$ case of the algorithm. A general formalization needs only (i) the $n$-variable Newton recursion (open question #1 above) and (ii) the identity $\\text{tr}(A^k) = \\sum_i \\lambda_i^k$ from `Matrix.trace_pow_eq_sum_eigenvalues`. Mathlib already has `Matrix.charpoly` and `Matrix.trace`, so the formalization would be a $\\sim 200$ LOC bridge connecting symmetric-function machinery to linear-algebra trace machinery — and would give Mathlib its first eigenvalue-free algorithm for $\\det(\\lambda I - A)$."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary

Enrichment pass for `vietas-formulas-oq-02` (Newton's Identities for 2 and 3 variables). This was an early-pass entry (0 prior enrichment passes) with thin historical context (~600 chars), 6 keyInsights, only 1 cross-reference, and an uncovered code range (the Vieta-Newton bridge at lines 173-201).

### Changes

**meta.json**
- `historicalContext`: Expanded to ~1500 chars covering Girard's 1629 priority, Waring's 1762 inverse formulas (fundamental theorem of symmetric polynomials), the Newton-Girard recursion as the bridge between elementary and power-sum bases of Lambda, Macdonald's modern treatment, and the role in representation theory / random matrix theory / Faddeev-LeVerrier
- `keyInsights`: 6 to 10. Added: trace formula bridge to linear algebra, generating-function identity (log-derivative of E(t)), discriminant via Newton (Hankel determinant of power sums), ring isomorphism Lambda tensored with Q = Q[p1, p2, ...] and why the inversion requires Q
- `sections`: 5 to 6. Added "Part VI: Connection to Vieta's Formulas" covering lines 173-201
- `crossReferences`: 1 to 6. Added vietas-formulas-oq-03 (sibling, 4-variable extension), solution-of-cubic (Lagrange resolvent), general-quartic (Ferrari resolvent cubic), fermats-last-theorem (sum-zero corollary as Sophie Germain ingredient), newton-inductive-step (namespace disambiguation)
- `openQuestions`: 2 to 4. Expanded MvPolynomial.esymm question with technical bottleneck; added Waring inversion formalization and Faddeev-LeVerrier algorithm implementation

**annotations.json**
- Added ann-vieta-newton-bridge covering lines 173-201 (the only previously-uncovered code range), with full mathContext/significance/relatedConcepts/prerequisites fields and a deep dive on the algorithm-theoretic content

### Verification

`pnpm build` succeeds. Both JSON files parse cleanly.

Generated with Claude Code