### PR TITLE
fix(meta): ballot-problem-oq-03-oq-02 theoremCount 92->28 (script-canonical count)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -80,7 +80,7 @@
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
     "lineCount": 2528,
-    "theoremCount": 92,
+    "theoremCount": 28,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
       "Binomial coefficients (Mathlib)",
@@ -289,7 +289,7 @@
     "namespace": "LGV",
     "lineCount": 2528,
     "axiomCount": 0,
-    "theoremCount": 92,
+    "theoremCount": 28,
     "definitionCount": 46,
     "path": "Proofs/BallotProblemOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`src/data/proofs/ballot-problem-oq-03-oq-02/meta.json` reported `theoremCount: 92` (both `meta` and `leanFile` blocks), but the canonical enrichment script (`scripts/research/enrich-research.ts:155`) counts via `/^(theorem|lemma) /` which excludes `private` declarations.

## Evidence

`proofs/Proofs/BallotProblemOQ03OQ02.lean`:
- **28** public theorems/lemmas (matching script regex)
- **64** private theorems/lemmas (excluded by script)
- Sample private decls: `northBeforeEast_mono` (line 132), `bool_countP_sum'` (155), `pathMN_countP_true` (185), `crossing_column_exists` (662)

All other meta counts already match reality:
- `axiomCount`: 0
- `sorries`: 0
- `lineCount`: 2528
- `status`/`badge`: `verified`/`mathlib` (unchanged — file has 0 axioms, 0 sorries)

## Convention

Mirrors the fix applied in #22126 (`binomial-clt` 18→16). The private lemmas remain in the Lean source — exclusion from the integer count is a script-convention choice, not a content change.

---
Automated fix by lean-mechanic agent.