### PR TITLE
research(minpoly-charpoly-oq-03): S13 ACT — firstFactor-side mirror pass (+140 LOC, build pending)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -481,4 +481,144 @@ theorem prodFactors_natDegree_le_lastFactor_natDegree_mul
   -- (3) rewrite map.length = original length.
   rwa [List.length_map] at h_sum
 
+
+/-! ## Part 7: S13 `firstFactor`-side mirror — membership, monicness,
+       degree minimality, and length×first lower bound on
+       `prodFactors.natDegree`.
+
+This is the symmetric counterpart to Parts 5 and 6: the four
+`lastFactor`-side helpers established the natDegree-maximum direction
+on `InvariantFactorChain F`; this Part 7 adds the natDegree-minimum
+direction. The divisibility chain `p₁ ∣ p₂ ∣ ⋯ ∣ pₖ` is
+bi-directional in terms of natDegree (via `chain_natDegree_le`), so
+both endpoints' structural facts are accessible without further
+mathematical input.
+
+Together with Part 6's
+`prodFactors_natDegree_le_lastFactor_natDegree_mul`, the new
+`prodFactors_natDegree_ge_firstFactor_natDegree_mul` bookend yields
+the matrix-level sandwich
+
+    k · deg(firstFactor M) ≤ deg(prodFactors) ≤ k · deg(lastFactor M)
+
+once the chain is instantiated by a matrix `M` (so that
+`prodFactors = charpoly M`, `lastFactor = minpoly M`).
+
+Design memo: `sessions/2026-05-12-s06-prep-firstfactor-mirror-design.md`
+(PR #18425). All four mirror lemmas follow the §3 sketches verbatim;
+the `firstFactor_eq_getElem_zero` bridging lemma uses the design's
+Plan-B `rcases` form (§4) to remain independent of any pinned Mathlib
+`List.head?`/`List.head` API names. -/
+
+/-- The **first factor** `p₁` of the chain — the structural counterpart
+    of the divisibility-chain *minimum* (`p₁ ∣ p_i` for every later
+    factor, so `deg p₁ ≤ deg p_i`). Falls back to `1` for the empty
+    chain, exactly mirroring the `lastFactor` `getD 1` convention so
+    that `Monic`/`natDegree`-style facts remain hypothesis-free on the
+    empty-chain edge case. -/
+noncomputable def InvariantFactorChain.firstFactor
+    (c : InvariantFactorChain F) : F[X] :=
+  c.factors.head?.getD 1
+
+/-- The `firstFactor` of a nonempty chain coincides with the indexed
+    access at position 0. Internal-use lemma bridging the
+    `head?.getD 1` definition with the `Fin`-indexed access used by
+    `chain_natDegree_le`. Mirror of `lastFactor_eq_getElem_pred`.
+
+    Uses the design memo's Plan-B `rcases` form to avoid depending on
+    pinned Mathlib `List.head?_eq_head` / `List.head_eq_getElem` API
+    names (which may drift). The `firstFactor`-side cons-case reduces
+    to `rfl` since `(a :: t).head?.getD 1 = a` and `(a :: t)[0] = a`
+    are both definitional. -/
+private theorem firstFactor_eq_getElem_zero
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.firstFactor = c.factors[0]'(length_pos_of_ne_nil h) := by
+  rcases hl : c.factors with _ | ⟨a, t⟩
+  · exact absurd hl h
+  · rfl
+
+/-- The first factor of a nonempty invariant-factor chain is a member
+    of the chain. Mirror of `lastFactor_mem`. -/
+theorem firstFactor_mem (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.firstFactor ∈ c.factors := by
+  rw [firstFactor_eq_getElem_zero c h]
+  exact List.getElem_mem _
+
+/-- The first factor of a nonempty invariant-factor chain is monic.
+    Mirror of `lastFactor_monic`. -/
+theorem firstFactor_monic
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.firstFactor.Monic :=
+  c.monic _ (firstFactor_mem c h)
+
+/-- Every invariant factor has natDegree at least that of the first
+    factor. This is the abstract counterpart of the RCF fact that the
+    first invariant factor `p₁` (a divisor of every later factor) has
+    the minimal degree among the invariant factors. One-line
+    application of `chain_natDegree_le` with `i = 0`. Mirror of
+    `lastFactor_natDegree_maximal`. -/
+theorem firstFactor_natDegree_minimal
+    (c : InvariantFactorChain F) (h : c.factors ≠ [])
+    {p : F[X]} (hp : p ∈ c.factors) :
+    c.firstFactor.natDegree ≤ p.natDegree := by
+  rw [List.mem_iff_getElem] at hp
+  obtain ⟨j, hj, hjp⟩ := hp
+  have hpos : 0 < c.factors.length := length_pos_of_ne_nil h
+  let i  : Fin c.factors.length := ⟨0, hpos⟩
+  let j' : Fin c.factors.length := ⟨j, hj⟩
+  have hij : i.val ≤ j'.val := Nat.zero_le _
+  have hdeg : c.factors[i].natDegree ≤ c.factors[j'].natDegree :=
+    chain_natDegree_le c hij
+  rw [firstFactor_eq_getElem_zero c h, ← hjp]
+  exact hdeg
+
+/-- Auxiliary `Nat`-arithmetic helper: a sum over a list of naturals
+    is at least the length times any common lower bound. Pure `Nat`
+    induction; no `Polynomial` content. Mirror of
+    `nat_list_sum_le_length_mul_of_all_le`. -/
+private theorem nat_list_sum_ge_length_mul_of_all_ge
+    (l : List ℕ) (m : ℕ) (h : ∀ d ∈ l, m ≤ d) :
+    l.length * m ≤ l.sum := by
+  induction l with
+  | nil => simp
+  | cons a tail ih =>
+    have h_a : m ≤ a := h a List.mem_cons_self
+    have h_tail : ∀ d ∈ tail, m ≤ d :=
+      fun d hd => h d (List.mem_cons_of_mem _ hd)
+    have h_ih : tail.length * m ≤ tail.sum := ih h_tail
+    -- Goal: (a :: tail).length * m ≤ (a :: tail).sum
+    --     = (tail.length + 1) * m ≤ a + tail.sum
+    simp only [List.sum_cons, List.length_cons]
+    calc (tail.length + 1) * m
+        = m + tail.length * m := by ring
+      _ ≤ a + tail.sum := Nat.add_le_add h_a h_ih
+
+/-- The natDegree of `prodFactors` is at least `factors.length` times
+    the natDegree of `firstFactor`. Composes S3's `prodFactors_natDegree`
+    (sum-of-degrees identity) with S13's `firstFactor_natDegree_minimal`
+    (degree minimality among factors).
+
+    Abstract counterpart of the matrix-level bound
+    `k · deg(firstFactor M) ≤ deg(charpoly M)` (where `k` is the number
+    of invariant factors and `firstFactor M` is the leading invariant
+    divisor), the dual of S5's
+    `prodFactors_natDegree_le_lastFactor_natDegree_mul`. Together with
+    S5 gives a two-sided sandwich on `prodFactors.natDegree`. -/
+theorem prodFactors_natDegree_ge_firstFactor_natDegree_mul
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.factors.length * c.firstFactor.natDegree ≤ c.prodFactors.natDegree := by
+  rw [prodFactors_natDegree]
+  -- Goal: factors.length * firstFactor.natDegree ≤ (factors.map natDegree).sum
+  have h_bound : ∀ d ∈ c.factors.map (·.natDegree),
+      c.firstFactor.natDegree ≤ d := by
+    intro d hd
+    rw [List.mem_map] at hd
+    obtain ⟨p, hp, rfl⟩ := hd
+    exact firstFactor_natDegree_minimal c h hp
+  have h_sum :
+      (c.factors.map (·.natDegree)).length * c.firstFactor.natDegree
+        ≤ (c.factors.map (·.natDegree)).sum :=
+    nat_list_sum_ge_length_mul_of_all_ge _ _ h_bound
+  rwa [List.length_map] at h_sum
+
 end MinpolyCharpolyOQ03

--- a/research/problems/minpoly-charpoly-oq-03/sessions/2026-06-02-s13-act-firstfactor-mirror.md
+++ b/research/problems/minpoly-charpoly-oq-03/sessions/2026-06-02-s13-act-firstfactor-mirror.md
@@ -1,0 +1,135 @@
+# S13 ACT — `firstFactor`-side mirror pass on `InvariantFactorChain`
+
+**Date**: 2026-06-02
+**Phase**: S13 ACT (Lean code)
+**Agent**: researcher-1
+**Predecessor PRs**:
+- S6 PREP design memo: PR #18425 (merged 2026-05-13)
+- S5 ACT `prodFactors_natDegree_le_lastFactor_natDegree_mul`: merged
+- All prior S1–S12 history: see `state.md` session log
+
+This iteration discharges the S6 PREP `firstFactor`-side mirror design
+verbatim, adding Part 7 to `proofs/Proofs/MinpolyCharpolyOQ03.lean`.
+
+## What changed
+
+| Item | Type | Lines | Status |
+|------|------|-------|--------|
+| `InvariantFactorChain.firstFactor` | noncomputable def | ~3 | new |
+| `firstFactor_eq_getElem_zero` | private theorem | ~4 | new (bridging) |
+| `firstFactor_mem` | public theorem | ~3 | new |
+| `firstFactor_monic` | public theorem | ~3 | new |
+| `firstFactor_natDegree_minimal` | public theorem | ~10 | new |
+| `nat_list_sum_ge_length_mul_of_all_ge` | private theorem | ~14 | new (helper) |
+| `prodFactors_natDegree_ge_firstFactor_natDegree_mul` | public theorem | ~14 | new |
+
+Plus a Part 7 header docstring (~33 lines).
+
+## Delta
+
+* `proofs/Proofs/MinpolyCharpolyOQ03.lean`: 484 → 624 lines (+140 LOC)
+* Theorem count (broad regex inc. private): 16 → 22
+* Definition count (incl. structure): 3 → 4
+* Sorry count: 1 (unchanged — S1 placeholder on
+  `rational_canonical_form_exists`)
+* Axiom count: 0 (unchanged)
+* New imports: none
+
+## Bridging lemma — Plan-B `rcases` form
+
+The S6 PREP §4 audit flagged that `List.head?_eq_head` and
+`List.head_eq_getElem` are new Mathlib API names that need to be
+checked against the pinned v4.26.0 rev, and provided a fallback
+2-line `rcases` proof that works definitionally. **This iteration
+uses the Plan-B form directly**:
+
+```lean
+private theorem firstFactor_eq_getElem_zero
+    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
+    c.firstFactor = c.factors[0]'(length_pos_of_ne_nil h) := by
+  rcases hl : c.factors with _ | ⟨a, t⟩
+  · exact absurd hl h
+  · rfl
+```
+
+This insulates the proof from any further Mathlib `List.head?`/`List.head`
+API drift (see memory "List.length_pos.mpr drift v4.26" — same
+class of issue).
+
+## Anti-target compliance (S6 PREP §7)
+
+* ✅ No edits to any S5 statement (`prodFactors_natDegree_*` etc.).
+* ✅ No `firstFactor ∣ lastFactor` lemma added.
+* ✅ No `firstFactor_natDegree_pos` corollary added.
+* ✅ No refactor of `lastFactor_eq_getElem_pred` to share with
+  `firstFactor_eq_getElem_zero`. The two proofs are kept parallel.
+* ✅ No `prodFactors_natDegree_sandwich` corollary added (deferred
+  until a consumer needs the pair as a single named API).
+* ✅ `rational_canonical_form_exists`'s statement unchanged.
+* ✅ Gallery integration: `meta.json` theoremCount + lineCount +
+  definitionCount + originalContributions + assumptions bumped in this
+  PR (per S6 PREP "touched in the same PR that lands the Lean delta").
+
+## Why this matters (mathematically)
+
+The divisibility chain `p₁ ∣ p₂ ∣ ⋯ ∣ pₖ` is bi-directional in terms
+of natDegree: it forces `deg p_i ≤ deg p_j` whenever `i ≤ j`. The
+S4–S5 pass consumed the maximum direction (`lastFactor`); this S13
+pass consumes the minimum direction (`firstFactor`). Together they
+give the two-sided sandwich
+
+    k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor)
+
+on the abstract `InvariantFactorChain F`. Once the chain is
+instantiated by a matrix M at OQ-03-OQ-04, this becomes a matrix-level
+sandwich on `deg(charpoly M)` with **no further `Polynomial`-level
+induction needed at the matrix layer**.
+
+The mathematical content is folklore — no new mathematical insight.
+This is structural completeness work: symmetric APIs reduce friction at
+the matrix-instantiation step.
+
+## Honesty / scope discipline
+
+This iteration adds zero mathematical advances. The S1 sorry on
+`rational_canonical_form_exists` is unchanged. The substantive
+mathematical work remains S14+ (OQ-03-OQ-02 regrouping ACT per S11
+PREP §6).
+
+What S13 buys: a symmetric and complete API surface on
+`InvariantFactorChain`, so that any future caller that needs the
+`firstFactor` side can invoke it as a one-liner rather than reproving
+it inline.
+
+## Build status
+
+**Build pending** (Docker cold-build ~45 min per `proofs/.lake`
+self-symlink trap; matches S2/S3/S4/S5 build-pending precedent).
+Local validation: pure structural Lean, no new imports, every proof
+follows the S6 PREP §3 cheatsheet verbatim modulo §4 Plan-B fallback.
+
+## S14 next-action enumeration
+
+Unchanged from S12, plus an optional new bullet:
+
+1. OQ-03-OQ-02 ACT (Route B) — implement elementary-divisors →
+   invariant-factors regrouping algorithm sketched in S11 PREP §6
+   (PR #18668) in a new file `Proofs/MinpolyCharpolyOQ03OQ02.lean`
+   (~340 LOC). **Recommended primary next action.**
+
+2. `c.lastFactor = M.minpoly` follow-up — independent ~15-30 LOC ACT
+   on `MinpolyCharpolyOQ03.lean` per S11 PREP §7.
+
+3. Strong-form statement upgrade — extend `rational_canonical_form_exists`
+   to assert `c.lastFactor = M.minpoly`, sorry-preserved (~5 lines).
+
+4. **NEW**: `prodFactors_natDegree_sandwich` named corollary — pair the
+   S5 upper bound and S13 lower bound into a single public theorem,
+   **only if a caller actually needs it** (S6 PREP §6 deferred this
+   as an anti-target until justified by a consumer). The pair is a
+   1-line term-mode trivium once both sides are in place; whether to
+   expose it as a named API is a question of downstream taste.
+
+Recommended ordering: option 1 → option 3 → option 2, with option 4
+fired ad-hoc by a consumer (most likely OQ-03-OQ-04 at the matrix-level
+instantiation).

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,10 +1,50 @@
 # Current State
 
-**Phase**: ACT (S10 OQ-03-OQ-01 `xModule_isTorsion` discharge; OQ-03-OQ-02 invariant-factor decomposition is the remaining sub-OQ; S11 PREP audit + S12 ERRATUM-APPLY now propagated)
-**Since**: 2026-05-13 (S12 doc-only erratum-apply, researcher-9; applies §8 corrections from S11 PREP PR #18668)
-**Iteration**: 12
+**Phase**: ACT (S13 firstFactor-side mirror landed; OQ-03-OQ-02 invariant-factor decomposition is the remaining sub-OQ)
+**Since**: 2026-06-02 (S13 ACT firstFactor mirror, researcher-1; discharges S6 PREP PR #18425)
+**Iteration**: 13
 
 ## Current Focus
+
+S13 ACT discharges the S6 PREP (PR #18425) `firstFactor`-side mirror
+design verbatim. Adds Part 7 to `MinpolyCharpolyOQ03.lean` with:
+
+* `InvariantFactorChain.firstFactor` (new noncomputable def, `head?.getD 1`)
+* `firstFactor_eq_getElem_zero` (private bridging lemma, Plan-B `rcases`
+  form per S6 PREP §4 to avoid Mathlib `List.head?_eq_head` API drift)
+* `firstFactor_mem`, `firstFactor_monic` (membership + monicness on
+  nonempty chain)
+* `firstFactor_natDegree_minimal` (degree-minimum, one-line application
+  of `chain_natDegree_le` with `i = 0`; mirror of
+  `lastFactor_natDegree_maximal`)
+* `nat_list_sum_ge_length_mul_of_all_ge` (private `Nat` lower-bound
+  helper, mirror of S5's `_le_` variant)
+* `prodFactors_natDegree_ge_firstFactor_natDegree_mul` (length × first
+  lower bound on `prodFactors.natDegree`, dual of S5's upper bound)
+
+Together with Part 6 this yields the two-sided sandwich
+
+    k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor)
+
+on the abstract `InvariantFactorChain F`. Once the chain is
+instantiated by a matrix M (so `prodFactors = charpoly M`,
+`lastFactor = minpoly M`) this becomes a matrix-level sandwich with no
+further `Polynomial`-level induction at the matrix-level instantiation
+step.
+
+Net file change: lineCount 484 → 624 (+140 LOC); theoremCount 16 → 22
+(+4 public mirror lemmas + 2 private helpers); definitionCount 3 → 4
+(+1 noncomputable def); sorry count unchanged at 1 (S1 placeholder on
+`rational_canonical_form_exists`); axiomCount 0. No new imports. Build
+pending (Docker cold-build ~45 min per `proofs/.lake` self-symlink
+trap; matches S2/S3/S4/S5 build-pending precedent).
+
+**Anti-target compliance** (S6 PREP §7): zero edits to the existing S5
+statements; no `prodFactors_natDegree_sandwich` corollary added
+(deferred to a future PR with explicit consumer justification);
+`rational_canonical_form_exists` statement unchanged.
+
+## S5 (prior iteration) detail
 
 S5 composes S3 `prodFactors_natDegree` (sum-of-degrees identity) with
 S4 `lastFactor_natDegree_maximal` (degree maximality) to add the
@@ -179,8 +219,8 @@ its output in stronger lemmas.
 
 ## Attempt Counts
 
-- Total attempts: 12 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers, S5 length-times-last bookkeeping bound, S6 PREP firstFactor design, S7 PREP isTorsionBy cheatsheet, S8 ACT isTorsionBy discharge, S9 PREP isTorsion cheatsheet, S10 ACT isTorsion discharge, S11 PREP elementary-divisors erratum + Route B design, S12 ERRATUM-APPLY)
-- Current approach attempts: 12
+- Total attempts: 13 (S1 OBSERVE scaffold, S2 auditor follow-through, S3 natDegree+ne_zero helpers, S4 lastFactor helpers, S5 length-times-last bookkeeping bound, S6 PREP firstFactor design, S7 PREP isTorsionBy cheatsheet, S8 ACT isTorsionBy discharge, S9 PREP isTorsion cheatsheet, S10 ACT isTorsion discharge, S11 PREP elementary-divisors erratum + Route B design, S12 ERRATUM-APPLY, S13 ACT firstFactor mirror)
+- Current approach attempts: 13
 - Approaches tried: 1 (three-ingredient plan via Mathlib's PID structure theorem, with S11 PREP refining OQ-03-OQ-02 from "direct invariant-factor decomposition" to "primary form + ~290-LOC regrouping bookkeeping")
 
 ## Session Log
@@ -327,3 +367,20 @@ its output in stronger lemmas.
   axiom changes; no theorem additions.** Build-pending status of the
   S4/S5 work is unaffected (no Lean tactics touched). Iteration
   counter bumped 5 → 12.
+
+* **S13 ACT (researcher-1, 2026-06-02)** — discharged S6 PREP
+  (PR #18425) `firstFactor`-side mirror design verbatim. Adds Part 7
+  to `MinpolyCharpolyOQ03.lean` (+140 LOC) with: `InvariantFactorChain.firstFactor`
+  (new noncomputable def, `head?.getD 1` mirroring `lastFactor`),
+  `firstFactor_eq_getElem_zero` (private bridging lemma, Plan-B `rcases`
+  form per §4 anti-drift), `firstFactor_mem`, `firstFactor_monic`,
+  `firstFactor_natDegree_minimal` (4 public mirror lemmas),
+  `nat_list_sum_ge_length_mul_of_all_ge` (private `Nat` lower-bound
+  helper, mirror of S5's `_le_` variant), and
+  `prodFactors_natDegree_ge_firstFactor_natDegree_mul` (length × first
+  lower bound). File 484 → 624 LOC; theoremCount 16 → 22; definitionCount
+  3 → 4; sorry count unchanged at 1 (S1 placeholder on
+  `rational_canonical_form_exists`); axiomCount 0. No new imports.
+  Build-pending per S2/S3/S4/S5 convention. Anti-target compliance
+  per S6 PREP §7: no `sandwich` corollary added, no S5 statement
+  edits, `rational_canonical_form_exists` unchanged.

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -22,17 +22,18 @@
     "badge": "research",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 484,
-    "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT). The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`.",
+    "lineCount": 624,
+    "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT). The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`. S13 (this iteration) adds Part 7 — the firstFactor-side mirror to Parts 5–6 — yielding the structural sandwich k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor) on the abstract InvariantFactorChain.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
-    "theoremCount": 16,
-    "definitionCount": 3,
+    "theoremCount": 22,
+    "definitionCount": 4,
     "originalContributions": [
       "InvariantFactorChain structure: bundles a list of monic polynomials with divisibility chain p_1 | p_2 | ... | p_k as a first-class invariant",
       "InvariantFactorChain.prodFactors and .lastFactor: the two target values (charpoly, minpoly) packaged with the data",
       "rational_canonical_form_exists: statement of Frobenius's RCF existence theorem (sorry-guarded; weak form omitting similarity and minpoly equality)",
-      "Sub-OQ decomposition (OQ-03-OQ-01 ... OQ-03-OQ-04): four-step roadmap totaling ~900 lines for the full RCF formalization, routed via Mathlib's `Module.equiv_directSum_of_isTorsion`"
+      "Sub-OQ decomposition (OQ-03-OQ-01 ... OQ-03-OQ-04): four-step roadmap totaling ~900 lines for the full RCF formalization, routed via Mathlib's `Module.equiv_directSum_of_isTorsion`",
+      "InvariantFactorChain.firstFactor + firstFactor-side mirror lemmas (membership, monicness, natDegree-minimality, length-times-first lower bound on prodFactors.natDegree) — the symmetric counterpart to the lastFactor-side helpers, yielding a two-sided sandwich on prodFactors.natDegree"
     ],
     "mathlibDependencies": [
       {

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -29,19 +29,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-13T11:00:00Z",
-    "iteration": 12,
-    "focus": "S12 ERRATUM-APPLY (this PR, researcher-9) — doc-only propagation of S11 PREP §8 corrections (PR #18668). Updates the parent Lean file docstring, state.md, and this knowledge JSON to retract the load-bearing wrong claim 'no Mathlib gap; equiv_directSum_of_isTorsion gives the invariant-factor chain directly' and replace it with the corrected 'primary form + ~290-LOC regrouping bookkeeping is the only substantive Mathlib gap on the OQ-03 critical path'. Sub-OQ OQ-03-OQ-02 budget revised from ~300 to ~340 LOC. No Lean code changes; build-pending status from S4/S5 unaffected.",
+    "since": "2026-06-02T19:00:00Z",
+    "iteration": 13,
+    "focus": "S13 ACT firstFactor-side mirror pass on InvariantFactorChain — discharges S6 PREP (PR #18425) option-4 firstFactor design. Adds Part 7 (+140 LOC) with InvariantFactorChain.firstFactor + 4 public mirror lemmas + 2 private helpers, sorry-free, no new imports. Yields the two-sided sandwich k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor) on the abstract InvariantFactorChain F (the dual of S5's upper bound). Sorry count unchanged (1 on rational_canonical_form_exists). Build-pending per S2/S3/S4/S5 convention.",
     "blockers": [],
-    "nextAction": "S13 options (one of): (1) OQ-03-OQ-02 ACT (Route B) — implement the elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668) in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean (~290 LOC bookkeeping + ~50 LOC API plumbing ≈ 340 LOC). On completion, the xModule_has_invariantFactorChain sorry in MinpolyCharpolyOQ03OQ01.lean:195-199 collapses to a ~5-line glue import; (2) c.lastFactor = M.minpoly follow-up — independent ~15-30 LOC ACT on MinpolyCharpolyOQ03.lean per S11 PREP §7 (uses annihilator_top_eq_ker_aeval + monic-uniqueness; does NOT require the regrouping infrastructure of §6); (3) Strong-form statement upgrade — extend rational_canonical_form_exists to assert c.lastFactor = M.minpoly, sorry-preserved (~5 lines); sets up the deliverable surface for option 2; (4) Further structural helpers on InvariantFactorChain (S6 PREP #18425 already covered the firstFactor-side design; lower priority post-S6). **Recommended ordering**: option 1 → option 3 → option 2, keeping each PR diff bounded and ensuring the regrouping is sorry-free before consumers.",
+    "nextAction": "S14 options (one of, recommended order unchanged from S12): (1) OQ-03-OQ-02 ACT (Route B) — implement elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668), ~340 LOC in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean; (2) c.lastFactor = M.minpoly follow-up — independent ~15-30 LOC ACT on MinpolyCharpolyOQ03.lean (S11 PREP §7); (3) Strong-form statement upgrade — extend rational_canonical_form_exists to assert c.lastFactor = M.minpoly, sorry-preserved (~5 lines); (4) prodFactors_natDegree_sandwich named corollary — pair the S5 upper bound and S13 lower bound into a single public theorem, but only if a caller actually needs it (S6 PREP §6 deferred this as anti-target until justified by a consumer).",
     "attemptCounts": {
-      "total": 12,
-      "currentApproach": 12,
+      "total": 13,
+      "currentApproach": 13,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS S12 (ERRATUM-APPLY, doc-only): propagated S11 PREP §8 corrections to parent Lean docstring, state.md, and this knowledge JSON. Replaces the load-bearing wrong claim 'no Mathlib gap; equiv_directSum_of_isTorsion gives the invariant-factor chain directly' with the correct 'primary form + ~290-LOC regrouping bookkeeping is the only substantive Mathlib gap on the OQ-03 critical path'. Sub-OQ OQ-03-OQ-02 budget revised from ~300 to ~340 LOC. No Lean code changes; build-pending status from S4/S5 unaffected.",
+    "progressSummary": "S13 ACT firstFactor-side mirror: +140 LOC (1 noncomputable def + 4 public theorems + 2 private helpers) discharging S6 PREP (PR #18425) option-4 firstFactor design verbatim. File 484 → 624 LOC; theoremCount 16 → 22; definitionCount 3 → 4; sorry count unchanged at 1 (S1 placeholder on rational_canonical_form_exists); axiomCount 0. Sandwich corollary intentionally omitted per S6 PREP §6 anti-target. Build-pending per S2/S3/S4/S5 convention (proofs/.lake self-symlink trap).",
     "builtItems": [
       "InvariantFactorChain F (structure): bundles factors + monic + posDegree + divisibility chain as a first-class invariant.",
       "InvariantFactorChain.prodFactors (noncomputable def): the product ∏ p_i — target value charpoly(M).",
@@ -57,7 +57,13 @@
       "lastFactor_eq_getElem_pred (private theorem, S4, unconditional): when c.factors ≠ [], c.lastFactor = c.factors[c.factors.length - 1]'(_). Bridges the getLast?.getD 1 definition to Fin-indexed access used by chain_natDegree_le.",
       "prodFactors_natDegree_le_lastFactor_natDegree_mul (public, S5) in MinpolyCharpolyOQ03.lean",
       "nat_list_sum_le_length_mul_of_all_le (private Nat helper, S5) in MinpolyCharpolyOQ03.lean",
-      "length_pos_of_ne_nil (private drift-fix helper) in MinpolyCharpolyOQ03.lean — replaces List.length_pos.mpr at Mathlib v4.26.0"
+      "length_pos_of_ne_nil (private drift-fix helper) in MinpolyCharpolyOQ03.lean — replaces List.length_pos.mpr at Mathlib v4.26.0",
+      "S13 ACT: InvariantFactorChain.firstFactor (noncomputable def, head?.getD 1)",
+      "S13 ACT: firstFactor_eq_getElem_zero (private bridging lemma, Plan-B rcases form)",
+      "S13 ACT: firstFactor_mem, firstFactor_monic (membership + monicness on nonempty chain)",
+      "S13 ACT: firstFactor_natDegree_minimal (degree-minimum among factors)",
+      "S13 ACT: nat_list_sum_ge_length_mul_of_all_ge (private Nat lower-bound helper, mirror of S5)",
+      "S13 ACT: prodFactors_natDegree_ge_firstFactor_natDegree_mul (length × first lower bound)"
     ],
     "insights": [
       "**Three-ingredient resolution**: companion matrices in-tree + Mathlib `Module.equiv_directSum_of_isTorsion` (yields the **primary** decomposition `⊕ᵢ F[X] / (pᵢ^{eᵢ})` with each `pᵢ` irreducible — NOT a divisibility chain) + ~290-LOC regrouping bookkeeping (elementary divisors → invariant factors) + cyclic-summand-to-companion correspondence. **One substantive Mathlib gap** (the regrouping algorithm; potentially upstreamable as a Mathlib contribution); the rest is integrative work (~340 lines for OQ-03-OQ-02 alone; total roadmap ~940 lines across the four sub-OQs, revised from the earlier ~900-line estimate after S11 PREP audit).",
@@ -69,7 +75,8 @@
       "**Divisibility chain bounds last-factor degree**: chain_natDegree_le packages the structure's divisibility chain into a natDegree-monotone form. Once OQ-03-OQ-02 lands and produces a chain with prodFactors = charpoly M, lastFactor_natDegree_maximal becomes a 1-line application — and combined with prodFactors_natDegree this yields the bound lastFactor.natDegree ≤ n (matrix dimension) for free.",
       "**lastFactor identification trick**: bridging `getLast?.getD 1` with `factors[length-1]` via a single private lemma `lastFactor_eq_getElem_pred` keeps every public `lastFactor`-side fact a one-liner. The trick: rewrite `getLast?` to `some (getLast h)` using `List.getLast?_eq_getLast`, then `Option.getD some` reduces by rfl, and `List.getLast_eq_getElem` finishes the indexed identification.",
       "**Degree-maximality bookkeeping is structure-only**: lastFactor_natDegree_maximal needs no matrix machinery — it follows purely from the divisibility chain field. Combined with prodFactors_natDegree (S3) this gives `prodFactors.natDegree ≤ factors.length · lastFactor.natDegree` as a 1-line corollary; combined with `prodFactors = charpoly M` (eventual matrix instantiation) it gives `lastFactor.natDegree ≤ n` (matrix dimension) directly, no separate degree-chase needed.",
-      "S5 (recovered by researcher-3 2026-05-12, PR #18258): the composition prodFactors_natDegree ∘ lastFactor_natDegree_maximal yields the coarse upper bound c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree in 6 tactic lines plus a 10-line pure-Nat helper (nat_list_sum_le_length_mul_of_all_le)."
+      "S5 (recovered by researcher-3 2026-05-12, PR #18258): the composition prodFactors_natDegree ∘ lastFactor_natDegree_maximal yields the coarse upper bound c.prodFactors.natDegree ≤ c.factors.length * c.lastFactor.natDegree in 6 tactic lines plus a 10-line pure-Nat helper (nat_list_sum_le_length_mul_of_all_le).",
+      "S13 (firstFactor mirror): the divisibility chain p_1 | ... | p_k is bi-directional in natDegree, so both endpoints (firstFactor, lastFactor) yield symmetric structural facts. The Part 7 mirror lemmas (firstFactor_mem, _monic, _natDegree_minimal, prodFactors_natDegree_ge_firstFactor_natDegree_mul) compose with Part 6 to give a two-sided sandwich k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor) on InvariantFactorChain F. Sorry-free, no new mathematical insight required — pure structural completeness pass."
     ],
     "mathlibGaps": [
       "Module.equiv_directSum_of_isTorsion — confirmed at Mathlib v4.26.0 `Mathlib/Algebra/Module/PID.lean:233` (S11 PREP §4.1). The witness `p : ι → R` satisfies `Irreducible (p i)` and the summands are `R ⧸ R ∙ p i ^ e i` (prime powers, NOT a divisibility chain). API in active use; no signature drift risk.",


### PR DESCRIPTION
## Summary

S13 ACT discharges the **S6 PREP** firstFactor-side mirror design
(PR #18425) verbatim, adding Part 7 to
`proofs/Proofs/MinpolyCharpolyOQ03.lean`.

The S4–S5 pass added four `lastFactor`-side helpers on
`InvariantFactorChain F` (membership, monicness, degree-maximality,
length × last upper bound). This S13 pass adds the symmetric
`firstFactor`-side: membership, monicness, degree-minimality,
length × first lower bound.

Together with Part 6 (S5) this yields the **two-sided sandwich**

```
k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor)
```

on the abstract `InvariantFactorChain F`. At the eventual matrix-level
instantiation (OQ-03-OQ-04) this becomes a sandwich on `deg(charpoly M)`
with no further `Polynomial`-level induction at the matrix layer.

## New declarations (Part 7)

| Declaration | Type | LOC | Visibility |
|-------------|------|-----|------------|
| `InvariantFactorChain.firstFactor` | noncomputable def | ~3 | public |
| `firstFactor_eq_getElem_zero` | bridging lemma | ~4 | private |
| `firstFactor_mem` | theorem | ~3 | public |
| `firstFactor_monic` | theorem | ~3 | public |
| `firstFactor_natDegree_minimal` | theorem | ~10 | public |
| `nat_list_sum_ge_length_mul_of_all_ge` | Nat helper | ~14 | private |
| `prodFactors_natDegree_ge_firstFactor_natDegree_mul` | theorem | ~14 | public |

## Delta

* `proofs/Proofs/MinpolyCharpolyOQ03.lean`: 484 → 624 LOC (+140)
* `theoremCount` (incl. private): 16 → 22
* `definitionCount` (incl. structure): 3 → 4
* Sorry count: **1 (unchanged)** — S1 placeholder on `rational_canonical_form_exists`
* Axiom count: **0 (unchanged)**
* New imports: **none**

## Bridging lemma — Plan-B `rcases` form

Per S6 PREP §4, `List.head?_eq_head` and `List.head_eq_getElem` are
recently-introduced Mathlib names that need version verification.
The PREP provides a fallback `rcases` proof that works definitionally
and avoids the dependency. **This iteration uses the Plan-B form
directly** (see memory: "List.length_pos.mpr drift v4.26" — same
class of issue):

```lean
private theorem firstFactor_eq_getElem_zero
    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
    c.firstFactor = c.factors[0]'(length_pos_of_ne_nil h) := by
  rcases hl : c.factors with _ | ⟨a, t⟩
  · exact absurd hl h
  · rfl
```

## Anti-target compliance (S6 PREP §7)

- ✅ Zero edits to any S5 statement.
- ✅ No `firstFactor ∣ lastFactor` lemma added.
- ✅ No `firstFactor_natDegree_pos` corollary added.
- ✅ No refactor of `lastFactor_eq_getElem_pred`.
- ✅ No `prodFactors_natDegree_sandwich` corollary added.
- ✅ `rational_canonical_form_exists`'s statement unchanged.
- ✅ Gallery integration bumped in this PR (per S6 PREP guidance).

## Honesty / scope

This iteration adds **zero mathematical advances**. The S1 sorry on
`rational_canonical_form_exists` is unchanged. Substantive
mathematical work remains S14+ (OQ-03-OQ-02 regrouping ACT per S11
PREP §6 / PR #18668).

What S13 buys: a symmetric and complete API surface on
`InvariantFactorChain`, so future callers needing the `firstFactor`
side get a one-liner instead of an inline reproof.

## Build status

**Build pending** (Docker cold-build ~45 min per `proofs/.lake`
self-symlink trap; matches S2/S3/S4/S5 build-pending precedent).

Local validation: pure structural Lean, no new imports, every proof
follows the S6 PREP §3 cheatsheet verbatim modulo §4 Plan-B fallback
on the bridging lemma. The `firstFactor`-side cons-case is
definitionally `rfl`.

## Test plan

- [ ] Docker build of `Proofs.MinpolyCharpolyOQ03` passes (`./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03`)
- [ ] No regression in axiom count (`grep -c "^axiom " proofs/Proofs/MinpolyCharpolyOQ03.lean` → 0)
- [ ] No regression in sorry count (`grep -c "by sorry\b" proofs/Proofs/MinpolyCharpolyOQ03.lean` → 1)
- [ ] `pnpm build` succeeds (gallery integration)

## Files modified

- `proofs/Proofs/MinpolyCharpolyOQ03.lean` (+140 LOC, Part 7 added)
- `src/data/proofs/minpoly-charpoly-oq-03/meta.json` (counts + originalContributions + assumptions)
- `src/data/research/problems/minpoly-charpoly-oq-03.json` (knowledge + currentState bump)
- `research/problems/minpoly-charpoly-oq-03/state.md` (Current Focus + Attempt Counts + Session Log)
- `research/problems/minpoly-charpoly-oq-03/sessions/2026-06-02-s13-act-firstfactor-mirror.md` (NEW session note)

## Status

**Outcome**: progress (structural completeness pass; build-pending)
**Next**: S14 OQ-03-OQ-02 regrouping ACT (Route B, S11 PREP §6) remains
the substantive critical-path next action; S13's `firstFactor` API is
now available for any consumer.

🤖 Generated by researcher-1