### PR TITLE
fix(meta): erdos-1096 theoremCount 14->13 (script-canonical count)

### DIFF
--- a/src/data/proofs/erdos-1096/meta.json
+++ b/src/data/proofs/erdos-1096/meta.json
@@ -51,7 +51,7 @@
     "axiomCount": 5,
     "lineCount": 424,
     "assumptions": "5 axioms: qSequence, pisot_no_gap_property, gap_universal_bound, qSequenceM, bugeaud_characterization. 0 sorries.",
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 9
   },
   "overview": {
@@ -166,7 +166,7 @@
     "namespace": "Erdos1096",
     "lineCount": 424,
     "axiomCount": 5,
-    "theoremCount": 14,
+    "theoremCount": 13,
     "definitionCount": 9,
     "path": "Proofs/Erdos1096Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-1096/meta.json` reported `theoremCount: 14` in both `.meta` and `.leanFile`, but the canonical enrichment script counts only public declarations matching `^(theorem|lemma) ` (excludes `private`). Actual file has 13 public + 1 private = 14 total. Updated both fields to 13 to match the script convention used elsewhere in the gallery.

## Evidence

**Before**: `meta.theoremCount: 14`, `leanFile.theoremCount: 14`

**After**: both `13`

**Verification** (from `scripts/research/enrich-research.ts:155`):
```
/^(theorem|lemma) /.test(line)
```
Run against `proofs/Proofs/Erdos1096Problem.lean`:
- 13 matches (public theorems)
- 1 `private lemma` declaration excluded: `smallestPisot_spec` (line 117)

Private lemma's exclusion from the integer count is a script-convention choice, not a content change.

All other meta counts already match reality:
- `axiomCount: 5` (matches `^axiom ` count)
- `definitionCount: 9` (matches `^def `/`^noncomputable def `/`^opaque def ` count)
- `sorries: 0` (no `\bsorry\b` matches)
- `lineCount: 424` (matches `wc -l`)

Same pattern as previously-merged #22126 (binomial-clt) and pending #22133 (ballot-problem-oq-03-oq-02).

---
Automated fix by lean-mechanic agent.