### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04: ann-jordan-holder surfaces gallery prime-factorization dictionary

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/annotations.json
@@ -296,19 +296,24 @@
     },
     "type": "insight",
     "title": "Jordan-Hölder Theorem: One-Line Delegation",
-    "content": "With the JordanHolderLattice instance in place, the Jordan-Hölder theorem for groups reduces to a single call to `CompositionSeries.jordan_holder` from Mathlib. This demonstrates the power of the typeclass abstraction: once the three axioms are verified for `Subgroup G`, the full Jordan-Hölder machinery — which works for any `JordanHolderLattice` — applies automatically. `jordan_holder_subgroups` takes two composition series with matching head and last subgroups, and concludes they are `CompositionSeries.Equivalent` (same length, same composition factors up to permutation and isomorphism). The `jordan_holder_finite_groups` variant adds `[Finite G]` for the common case, but the underlying proof is identical — the finiteness only ensures composition series exist in the first place.",
-    "mathContext": "The Jordan-Hölder theorem for groups: if $G$ has composition series $1 = H_0 \\trianglelefteq \\cdots \\trianglelefteq H_n = G$ and $1 = K_0 \\trianglelefteq \\cdots \\trianglelefteq K_m = G$, then $n = m$ and there exists a permutation $\\sigma$ of $\\{0,\\ldots,n-1\\}$ such that $H_{i+1}/H_i \\simeq_* K_{\\sigma(i)+1}/K_{\\sigma(i)}$ for all $i$. This is the group-theoretic analogue of the uniqueness of prime factorization in $\\mathbb{Z}$: every group has a 'prime factorization' into simple groups, and that factorization is essentially unique. For $S_5$ specifically, this uniqueness ensures the composition series $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ is the only one — making the non-abelian simple factor $A_5$ unavoidable, which is the engine of the Abel-Ruffini insolubility result.",
+    "content": "With the JordanHolderLattice instance in place, the Jordan-Hölder theorem for groups reduces to a single call to `CompositionSeries.jordan_holder` from Mathlib. This demonstrates the power of the typeclass abstraction: once the three axioms are verified for `Subgroup G`, the full Jordan-Hölder machinery — which works for any `JordanHolderLattice` — applies automatically. `jordan_holder_subgroups` takes two composition series with matching head and last subgroups, and concludes they are `CompositionSeries.Equivalent` (same length, same composition factors up to permutation and isomorphism). The `jordan_holder_finite_groups` variant adds `[Finite G]` for the common case, but the underlying proof is identical — the finiteness only ensures composition series exist in the first place.\n\n**Gallery counterparts of the prime-factorization analogue.** The keyInsight #9 dictionary that this annotation invokes — Jordan-Hölder as the group-theoretic analogue of unique prime factorization in $\\mathbb{Z}$ — has a concrete formalized counterpart in the gallery: `fundamental-arithmetic` (the fundamental theorem of arithmetic, Wiedijk #67) gives the integer-side uniqueness theorem, while this entry gives the group-side uniqueness. Reading the two together makes the analogy precise: primes ↔ finite simple groups (the *indecomposable building blocks*), multiplication ↔ group extension (the *combination operation*), prime factorization ↔ composition series (the *canonical decomposition*), unique up to permutation ↔ unique up to permutation and isomorphism. The asymmetry highlighted in keyInsight #9 — that integer multiplication is commutative but group extension is not, so 'same composition factors' does not imply 'isomorphic groups' (e.g., $\\mathbb{Z}/6\\mathbb{Z}$ vs $S_3$) — is the structural reason the open extension problem in openQuestion #8 has no integer analogue.\n\n**Cross-reference to the Abel-Ruffini chain.** The S₅-application paragraph (composition series $\\{e\\} \\triangleleft A_5 \\triangleleft S_5$ is the only one) is the structural punchline pulled into the gallery's `abel-ruffini` (`not_solvable_by_rad_of_not_solvable_gal`) and parent `abel-ruffini-galois-extensions` (`symmetric_solvable_iff`): without Jordan-Hölder's uniqueness clause proved here, one could in principle hope for an alternative decomposition of $S_5$ avoiding the non-abelian simple factor $A_5$; Jordan-Hölder forecloses that hope at the structural level. The keyInsight #11 dictionary (Galois correspondence: composition series ↔ radical towers) makes this precise: each cyclic-prime composition factor corresponds to a radical-extraction step, while the $A_5$ factor corresponds to a step that *cannot* be a radical extension — and Jordan-Hölder makes the obstruction unavoidable across all presentations.",
     "significance": "key",
     "relatedConcepts": [
       "CompositionSeries",
       "CompositionSeries.jordan_holder",
       "composition factors",
-      "Schreier refinement theorem"
+      "Schreier refinement theorem",
+      "fundamental-arithmetic (Wiedijk #67 — integer-side analogue of Jordan-Hölder uniqueness)",
+      "abel-ruffini (uses A₅ as the unavoidable composition factor blocking radical solvability)",
+      "abel-ruffini-galois-extensions (parent — S_n solvable ↔ n ≤ 4, threshold absolute by Jordan-Hölder)",
+      "prime ↔ finite simple group dictionary",
+      "extension problem (the gap Jordan-Hölder leaves open)"
     ],
     "prerequisites": [
       "composition series",
       "normal series",
-      "Jordan-Hölder theorem statement"
+      "Jordan-Hölder theorem statement",
+      "fundamental theorem of arithmetic (analogous integer-side uniqueness)"
     ]
   },
   {


### PR DESCRIPTION
## Summary

2nd-pass enrichment to `src/data/proofs/abel-ruffini-galois-extensions-oq-04/` (Jordan-Hölder uniqueness via JordanHolderLattice, quality 100, 1 prior pass).

**Gap**: The `ann-jordan-holder` annotation invokes keyInsight #9's prime-factorization analogue and the S₅ application (composition series unique) but does not cross-reference the gallery's two formalized counterparts that the analogy lives between:
- **`fundamental-arithmetic`** (Wiedijk #67) — the integer-side uniqueness theorem
- **`abel-ruffini` / `abel-ruffini-galois-extensions`** — where the A₅ unavoidability becomes the radical-solvability obstruction

**Edit**:

1. Add a "Gallery counterparts of the prime-factorization analogue" paragraph making the dictionary precise: primes ↔ finite simple groups, multiplication ↔ group extension, unique prime factorization (`fundamental-arithmetic`) ↔ unique composition series (this entry). Note the asymmetry — group extension is non-commutative so 'same factors' ≠ 'isomorphic group' ($\mathbb{Z}/6$ vs $S_3$).
2. Add a "Cross-reference to the Abel-Ruffini chain" paragraph anchoring the S₅ application to `abel-ruffini`'s `not_solvable_by_rad_of_not_solvable_gal` and `abel-ruffini-galois-extensions`'s `symmetric_solvable_iff` — Jordan-Hölder uniqueness is precisely what makes the obstruction unavoidable across all presentations of $S_5$, not an artifact of one particular composition-series choice.
3. Add cross-references to `relatedConcepts` and `prerequisites`.

This makes the annotation's role explicit: it isn't just an abstract delegation to Mathlib's `CompositionSeries.jordan_holder` — it is the structural lemma that converts the parent file's *one-shot* $S_n$-solvability classification into an *absolute* uniqueness statement underpinning the entire Abel-Ruffini program.

## Test plan

- [x] JSON validates
- [x] No other files in the entry directory modified
- [ ] CI: build + typecheck + frontend bundle pass on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)