### PR TITLE
Fix: Add Aristotle companion for erdos-545 (Ramsey/maximally-complete)

### DIFF
--- a/proofs/Proofs/Erdos545ProblemAristotle.lean
+++ b/proofs/Proofs/Erdos545ProblemAristotle.lean
@@ -1,0 +1,278 @@
+/-
+  Aristotle targets for Erdos545Problem
+  Routine supporting lemmas for automated proof search.
+  See Erdos545Problem.lean for the main formalization.
+
+  These lemmas provide building blocks for the Ramsey number formalization
+  of the Erdős-Graham "maximally complete graph" conjecture:
+  - Triangular-number arithmetic: m = C(n,2) + t with 0 <= t < n
+  - Classical Ramsey number bounds (TRIVIAL small cases, HARD asymptotic bounds)
+  - Monochromatic clique elementary closure properties
+  - Edge-coloring structural lemmas
+-/
+import Mathlib.Combinatorics.SimpleGraph.Basic
+import Mathlib.Combinatorics.SimpleGraph.Clique
+import Mathlib.Data.Finset.Basic
+import Mathlib.Data.Nat.Choose.Basic
+import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Pow.Real
+import Mathlib.Tactic
+
+namespace Erdos545.Aristotle
+
+open SimpleGraph Finset
+
+/-
+  ## Section 1: Triangular Numbers and Edge Decomposition
+
+  Any natural m can be written as C(n,2) + t with 0 <= t < n.
+  We expose the basic arithmetic identities Aristotle can verify.
+-/
+
+/-- The triangular number n choose 2 = n*(n-1)/2. -/
+def tri (n : ℕ) : ℕ := n * (n - 1) / 2
+
+-- Small triangular values (TRIVIAL targets)
+theorem tri_zero : tri 0 = 0 := by unfold tri; norm_num
+theorem tri_one : tri 1 = 0 := by unfold tri; norm_num
+theorem tri_two : tri 2 = 1 := by unfold tri; norm_num
+theorem tri_three : tri 3 = 3 := by unfold tri; norm_num
+theorem tri_four : tri 4 = 6 := by unfold tri; norm_num
+theorem tri_five : tri 5 = 10 := by unfold tri; norm_num
+theorem tri_six : tri 6 = 15 := by unfold tri; norm_num
+theorem tri_seven : tri 7 = 21 := by unfold tri; norm_num
+theorem tri_eight : tri 8 = 28 := by unfold tri; norm_num
+
+-- tri matches Nat.choose n 2 (HARD, standard Mathlib equivalence)
+theorem tri_eq_choose_two (n : ℕ) : tri n = Nat.choose n 2 := by sorry
+
+-- tri is monotone in n (HARD, basic arithmetic)
+theorem tri_mono {n m : ℕ} (h : n ≤ m) : tri n ≤ tri m := by sorry
+
+-- tri is strictly monotone for n >= 1
+theorem tri_strict_mono {n m : ℕ} (hn : n ≥ 1) (h : n < m) : tri n < tri m := by sorry
+
+-- Decomposition existence: any m has a representation m = tri n + t with t < n
+theorem decompose_exists (m : ℕ) (hm : m ≥ 1) :
+    ∃ n t : ℕ, n ≥ 1 ∧ t < n ∧ m = tri n + t := by sorry
+
+-- Decomposition uniqueness
+theorem decompose_unique (m n₁ t₁ n₂ t₂ : ℕ)
+    (h1 : t₁ < n₁) (h2 : t₂ < n₂)
+    (heq1 : m = tri n₁ + t₁) (heq2 : m = tri n₂ + t₂) :
+    n₁ = n₂ ∧ t₁ = t₂ := by sorry
+
+/-
+  ## Section 2: Maximally Complete Edge Count
+
+  The "maximally complete" graph H on (n+1) vertices has C(n,2)+t edges,
+  where K_n contributes C(n,2) and the extra vertex contributes t.
+-/
+
+/-- Edge count of the maximally complete graph H with decomposition m = tri n + t. -/
+def maxCompleteEdges (n t : ℕ) : ℕ := tri n + t
+
+-- The maximally complete graph realizes exactly m edges (TRIVIAL)
+theorem maxCompleteEdges_eq (n t : ℕ) :
+    maxCompleteEdges n t = tri n + t := rfl
+
+-- Monotonicity in t (TRIVIAL)
+theorem maxCompleteEdges_mono_t (n t₁ t₂ : ℕ) (h : t₁ ≤ t₂) :
+    maxCompleteEdges n t₁ ≤ maxCompleteEdges n t₂ := by sorry
+
+-- Monotonicity in n
+theorem maxCompleteEdges_mono_n (n₁ n₂ t : ℕ) (h : n₁ ≤ n₂) :
+    maxCompleteEdges n₁ t ≤ maxCompleteEdges n₂ t := by sorry
+
+-- When t = 0, H is just K_n (HARD)
+theorem maxCompleteEdges_t_zero (n : ℕ) :
+    maxCompleteEdges n 0 = tri n := by sorry
+
+-- When t = n-1, H has one fewer edge than K_{n+1}
+theorem maxCompleteEdges_t_max (n : ℕ) (hn : n ≥ 1) :
+    maxCompleteEdges n (n - 1) = tri (n + 1) - 1 := by sorry
+
+/-
+  ## Section 3: Classical Ramsey Numbers
+
+  Diagonal Ramsey numbers R(k,k) and their small values.
+  We define R(k) := R(k,k) as the minimum n such that any 2-coloring
+  of K_n contains a monochromatic K_k.
+
+  We expose only the algebraic targets (bounds and small values) that
+  Aristotle can verify without graph theory machinery.
+-/
+
+/-- The (conjectured/known) value of the diagonal Ramsey number for small k. -/
+def smallRamsey : ℕ → ℕ
+  | 0 => 0
+  | 1 => 1
+  | 2 => 2
+  | 3 => 6
+  | 4 => 18
+  | _ => 0  -- unknown for k >= 5
+
+-- Specific values (TRIVIAL)
+theorem smallRamsey_zero : smallRamsey 0 = 0 := rfl
+theorem smallRamsey_one : smallRamsey 1 = 1 := rfl
+theorem smallRamsey_two : smallRamsey 2 = 2 := rfl
+theorem smallRamsey_three : smallRamsey 3 = 6 := rfl
+theorem smallRamsey_four : smallRamsey 4 = 18 := rfl
+
+-- Monotonicity for small Ramsey values where defined
+theorem smallRamsey_one_le_two : smallRamsey 1 ≤ smallRamsey 2 := by decide
+theorem smallRamsey_two_le_three : smallRamsey 2 ≤ smallRamsey 3 := by decide
+theorem smallRamsey_three_le_four : smallRamsey 3 ≤ smallRamsey 4 := by decide
+
+/-
+  ## Section 4: Upper Bound R(k) <= 4^k (Erdős-Szekeres, HARD)
+
+  Classical pigeonhole-based upper bound. The arithmetic form is
+  routine but the combinatorial content is HARD.
+-/
+
+-- Upper bound matches 4^k for small k where defined (TRIVIAL checks)
+theorem upper_bound_one : smallRamsey 1 ≤ 4 ^ 1 := by decide
+theorem upper_bound_two : smallRamsey 2 ≤ 4 ^ 2 := by decide
+theorem upper_bound_three : smallRamsey 3 ≤ 4 ^ 3 := by decide
+theorem upper_bound_four : smallRamsey 4 ≤ 4 ^ 4 := by decide
+
+-- 4^k is strictly increasing (HARD: standard Mathlib)
+theorem four_pow_strict_mono {a b : ℕ} (h : a < b) : 4 ^ a < 4 ^ b := by sorry
+
+-- 4^k grows faster than 2^k (HARD: standard Mathlib)
+theorem four_pow_ge_two_pow (k : ℕ) : 2 ^ k ≤ 4 ^ k := by sorry
+
+/-
+  ## Section 5: Lower Bound R(k) >= 2^(k/2) (Erdős 1947, HARD)
+
+  The probabilistic-method bound. Routine algebraic targets.
+-/
+
+-- 2^(k/2) is a real-valued lower bound; for small k the integer version checks (HARD)
+theorem lower_bound_two : (smallRamsey 2 : ℝ) ≥ 2 ^ ((2 : ℝ) / 2) := by sorry
+
+theorem lower_bound_three : (smallRamsey 3 : ℝ) ≥ 2 ^ ((3 : ℝ) / 2) := by sorry
+
+theorem lower_bound_four : (smallRamsey 4 : ℝ) ≥ 2 ^ ((4 : ℝ) / 2) := by sorry
+
+-- For k = 1, the bound says R(1) >= sqrt(2) which 1 does NOT satisfy.
+-- The lower bound only applies for k >= 2; we provide the k=2 base case.
+theorem lower_bound_holds_at_two : (smallRamsey 2 : ℝ) ≥ 2 ^ ((2 : ℝ) / 2) := by sorry
+
+/-
+  ## Section 6: Monochromatic Clique Closure Properties
+
+  We use a simplified self-contained model of edge 2-colorings on Fin n.
+  These are TRIVIAL/HARD set-theoretic closure facts.
+-/
+
+/-- An edge 2-coloring on n vertices (no symmetry/irreflexivity enforced here;
+    captured separately in IsValidColoring). -/
+def Coloring (n : ℕ) := Fin n → Fin n → Bool
+
+/-- A set S forms a monochromatic clique of color b in coloring c. -/
+def MonoClique {n : ℕ} (c : Coloring n) (S : Finset (Fin n)) (b : Bool) : Prop :=
+  ∀ i ∈ S, ∀ j ∈ S, i ≠ j → c i j = b
+
+-- The empty set is trivially monochromatic in any color (TRIVIAL)
+theorem MonoClique_empty {n : ℕ} (c : Coloring n) (b : Bool) :
+    MonoClique c (∅ : Finset (Fin n)) b := by sorry
+
+-- Any singleton is trivially monochromatic in any color (TRIVIAL)
+theorem MonoClique_singleton {n : ℕ} (c : Coloring n) (b : Bool) (v : Fin n) :
+    MonoClique c ({v} : Finset (Fin n)) b := by sorry
+
+-- A subset of a monochromatic clique is also monochromatic (HARD: routine but useful)
+theorem MonoClique_subset {n : ℕ} (c : Coloring n) (S T : Finset (Fin n))
+    (b : Bool) (h : S ⊆ T) (hT : MonoClique c T b) :
+    MonoClique c S b := by sorry
+
+-- Insertion preserves monochromaticity when the new vertex sees the right color
+theorem MonoClique_insert {n : ℕ} (c : Coloring n) (S : Finset (Fin n))
+    (b : Bool) (v : Fin n) (hS : MonoClique c S b)
+    (hv : ∀ j ∈ S, v ≠ j → c v j = b ∧ c j v = b) :
+    MonoClique c (insert v S) b := by sorry
+
+/-
+  ## Section 7: Edge Counts in Finite Simple Graphs
+
+  Routine cardinality and monotonicity lemmas relating SimpleGraph.edgeFinset
+  to graph operations.
+-/
+
+/-- Edge count of a finite simple graph. -/
+noncomputable def edgeCard {V : Type*} [Fintype V] [DecidableEq V]
+    (G : SimpleGraph V) [DecidableRel G.Adj] : ℕ :=
+  G.edgeFinset.card
+
+-- Empty graph has zero edges (TRIVIAL)
+theorem edgeCard_empty {V : Type*} [Fintype V] [DecidableEq V] :
+    edgeCard (⊥ : SimpleGraph V) = 0 := by sorry
+
+-- Complete graph K_n has tri(n) = C(n,2) edges (HARD, standard Mathlib)
+theorem edgeCard_complete {n : ℕ} :
+    edgeCard (⊤ : SimpleGraph (Fin n)) = tri n := by sorry
+
+-- Subgraph relation respects edge count (HARD)
+theorem edgeCard_mono {V : Type*} [Fintype V] [DecidableEq V]
+    (G H : SimpleGraph V) [DecidableRel G.Adj] [DecidableRel H.Adj]
+    (h : G ≤ H) : edgeCard G ≤ edgeCard H := by sorry
+
+/-
+  ## Section 8: No-Isolated-Vertices Predicate
+
+  Elementary closure facts about "every vertex has at least one neighbor".
+-/
+
+/-- A graph has no isolated vertices if every vertex has at least one neighbor. -/
+def NoIso {V : Type*} (G : SimpleGraph V) : Prop :=
+  ∀ v : V, ∃ w : V, G.Adj v w
+
+-- Complete graph K_n for n >= 2 has no isolated vertices (HARD)
+theorem NoIso_complete (n : ℕ) (hn : n ≥ 2) :
+    NoIso (⊤ : SimpleGraph (Fin n)) := by sorry
+
+-- Empty graph on >= 1 vertex has isolated vertices (HARD, contrapositive structure)
+theorem not_NoIso_bot {V : Type*} [Inhabited V] :
+    ¬ NoIso (⊥ : SimpleGraph V) := by sorry
+
+-- Superset of a graph with no isolated vertices also has no isolated vertices
+theorem NoIso_mono {V : Type*} (G H : SimpleGraph V) (hGH : G ≤ H) (hG : NoIso G) :
+    NoIso H := by sorry
+
+/-
+  ## Section 9: Known Small Counterexamples (m in {2,3,4,5,7,8,9})
+
+  The Erdős-Graham conjecture is known to fail for these specific small
+  edge counts. We expose the index set as a Finset and verify membership.
+-/
+
+/-- The set of edge counts where the conjecture is known to fail. -/
+def SmallCounterIndices : Finset ℕ := {2, 3, 4, 5, 7, 8, 9}
+
+-- Membership checks (TRIVIAL)
+theorem mem_smallCounter_two : 2 ∈ SmallCounterIndices := by decide
+theorem mem_smallCounter_three : 3 ∈ SmallCounterIndices := by decide
+theorem mem_smallCounter_four : 4 ∈ SmallCounterIndices := by decide
+theorem mem_smallCounter_five : 5 ∈ SmallCounterIndices := by decide
+theorem mem_smallCounter_seven : 7 ∈ SmallCounterIndices := by decide
+theorem mem_smallCounter_eight : 8 ∈ SmallCounterIndices := by decide
+theorem mem_smallCounter_nine : 9 ∈ SmallCounterIndices := by decide
+
+-- Non-membership: m = 1, 6, 10, ... are NOT in the counterexample set (TRIVIAL)
+theorem not_mem_smallCounter_one : 1 ∉ SmallCounterIndices := by decide
+theorem not_mem_smallCounter_six : 6 ∉ SmallCounterIndices := by decide
+theorem not_mem_smallCounter_ten : 10 ∉ SmallCounterIndices := by decide
+
+-- Cardinality of the counterexample set
+theorem smallCounter_card : SmallCounterIndices.card = 7 := by decide
+
+-- The maximum counterexample index is 9
+theorem smallCounter_max : ∀ m ∈ SmallCounterIndices, m ≤ 9 := by decide
+
+-- For m >= 10, the conjecture is not known to fail; this is the asymptotic regime
+theorem smallCounter_threshold (m : ℕ) (hm : m ≥ 10) :
+    m ∉ SmallCounterIndices := by sorry
+
+end Erdos545.Aristotle


### PR DESCRIPTION
## Fix

Add `Erdos545ProblemAristotle.lean` companion file exposing routine supporting lemmas for automated proof search on Erdős Problem #545 (Ramsey numbers and the "maximally complete graph" conjecture).

## Evidence

**Before**: `Erdos545Problem.lean` has 12 theorem sorries but no Aristotle companion file. Sorry-heavy proofs (>= 5 sorries) without companions are the mechanic's Priority 3 work source.

**After**: 278-line companion at `proofs/Proofs/Erdos545ProblemAristotle.lean` with 26 sorries split TRIVIAL/HARD across nine sections:

1. Triangular numbers / decomposition arithmetic (`tri`, `decompose_exists`, `decompose_unique`)
2. `maximallyCompleteGraph` edge count monotonicity
3. Classical small Ramsey values `R(1..4)`
4. Erdős–Szekeres upper bound `R(k) ≤ 4^k`
5. Erdős (1947) lower bound `R(k) ≥ 2^(k/2)`
6. Monochromatic clique closure (empty / singleton / subset / insert)
7. `edgeCard` and `noIsolatedVertices` helpers
8. `SmallCounterIndices` membership and threshold

Pre-submission checklist passed:
- [x] No definition sorries
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections
- [x] Sub-namespace `Erdos545.Aristotle` (no collision with main file)

Follows the convention of `Erdos551ProblemAristotle.lean` (the sibling companion for the closely related Ramsey-number problem #551).

---
Automated fix by lean-mechanic agent.