### PR TITLE
Add Aristotle companion for erdos-931 (consecutive-product factor lemmas)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2146,6 +2146,7 @@ import Proofs.Erdos928Problem
 import Proofs.Erdos929Problem
 import Proofs.Erdos92Problem
 import Proofs.Erdos930Problem
+import Proofs.Erdos931Aristotle
 import Proofs.Erdos931Problem
 import Proofs.Erdos932Problem
 import Proofs.Erdos933Aristotle

--- a/proofs/Proofs/Erdos931Aristotle.lean
+++ b/proofs/Proofs/Erdos931Aristotle.lean
@@ -1,0 +1,76 @@
+/-
+  Aristotle targets for Erdős Problem #931
+  Routine supporting lemmas for automated proof search.
+  See Erdos931Problem.lean for the main formalization.
+
+  Criteria for inclusion:
+  - NOT the main open conjecture (ErdosProblem931, StrongerConjecture)
+  - NOT the smooth-number-theory reductions (stronger_implies_main,
+    exists_prime_between_blocks_hard) — these depend on Mathlib infra
+    that does not yet exist (Stoermer's theorem, smooth-number bounds)
+  - Routine supporting facts about consecutiveProduct and
+    consecutivePrimeFactors that are derivable from existing
+    Mathlib lemmas
+  - No definition sorries
+  - No axioms
+-/
+import Proofs.Erdos931Problem
+import Mathlib
+
+namespace Erdos931Aristotle
+
+open Erdos931 Nat Finset
+
+/-- Recurrence: extending the block by one factor multiplies the product
+    by the new endpoint `n + k + 1`. Follows from `Finset.prod_Icc_succ_top`. -/
+theorem consecutiveProduct_succ (n k : ℕ) :
+    consecutiveProduct n (k + 1) = consecutiveProduct n k * (n + (k + 1)) := by
+  sorry
+
+/-- The product over a shorter block divides the product over a longer block.
+    Direct corollary of `consecutiveProduct_succ` by induction on `k₂ - k₁`. -/
+theorem consecutiveProduct_dvd_of_le (n k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
+    consecutiveProduct n k₁ ∣ consecutiveProduct n k₂ := by
+  sorry
+
+/-- Prime factors are monotone in `k`: extending the block only adds
+    prime factors. Follows from `consecutiveProduct_dvd_of_le` and
+    `Nat.primeFactors_mono` (the divisibility version). -/
+theorem consecutivePrimeFactors_mono_k (n k₁ k₂ : ℕ) (h : k₁ ≤ k₂) :
+    consecutivePrimeFactors n k₁ ⊆ consecutivePrimeFactors n k₂ := by
+  sorry
+
+/-- For `k ≥ 3`, the prime `3` is always a factor: at least one of
+    `n+1, n+2, n+3` is divisible by `3`. Specializes
+    `Erdos931.prime_le_k_mem_factors` to `p = 3`. -/
+theorem three_mem_factors (n k : ℕ) (hk : 3 ≤ k) :
+    3 ∈ consecutivePrimeFactors n k :=
+  prime_le_k_mem_factors n k 3 (by decide) hk
+
+/-- For `k ≥ 5`, the prime `5` is always a factor. -/
+theorem five_mem_factors (n k : ℕ) (hk : 5 ≤ k) :
+    5 ∈ consecutivePrimeFactors n k :=
+  prime_le_k_mem_factors n k 5 (by decide) hk
+
+/-- Every prime factor of the consecutive product is at most `n + k`,
+    since each prime divides some factor `n + i` with `1 ≤ i ≤ k`,
+    and divisibility implies the prime is no larger than the dividend. -/
+theorem consecutivePrimeFactors_le (n k p : ℕ)
+    (hp : p ∈ consecutivePrimeFactors n k) : p ≤ n + k := by
+  sorry
+
+/-- If two blocks share the same prime factors, then any prime dividing
+    one of the second-block factors divides one of the first-block factors.
+    Direct restatement of `SamePrimeFactors` in dvd form. -/
+theorem samePrimeFactors_transfer
+    {n₁ k₁ n₂ k₂ : ℕ} (h : SamePrimeFactors n₁ k₁ n₂ k₂)
+    {p : ℕ} (hp : p.Prime) (hdvd : p ∣ consecutiveProduct n₂ k₂) :
+    p ∣ consecutiveProduct n₁ k₁ := by
+  sorry
+
+/-- The empty block (k = 0) has no prime factors. -/
+theorem consecutivePrimeFactors_zero (n : ℕ) :
+    consecutivePrimeFactors n 0 = ∅ := by
+  sorry
+
+end Erdos931Aristotle


### PR DESCRIPTION
## Fix

Creates `Proofs.Erdos931Aristotle` exposing routine supporting lemmas about `consecutiveProduct` and `consecutivePrimeFactors` for automated proof search. Targets cover monotonicity, recurrence, and divisibility transfer — none of which are the deep open conjectures.

## Evidence

**Before**: `Erdos931Problem.lean` has 4 actual code sorries (12 by raw grep — most in comments; real sorries at lines 217, 319 plus 2 more in other parts of the file). Two are the deep reductions blocked by smooth-number theory (`stronger_implies_main`, `exists_prime_between_blocks_hard`). The parent file has already converted its former `axiom` declarations into `theorem … := by sorry` form. No Aristotle companion file existed for any `Erdos931*` proof in the gallery.

**After**: `Erdos931Aristotle.lean` exposes 6 sorry-bodied routine lemmas Aristotle can attempt, plus 2 directly proved corollaries of the existing `prime_le_k_mem_factors` API:

Sorry targets:
- `consecutiveProduct_succ` — `consecutiveProduct n (k+1) = consecutiveProduct n k * (n + k + 1)`
- `consecutiveProduct_dvd_of_le` — block-length divisibility
- `consecutivePrimeFactors_mono_k` — prime-factor monotonicity in `k`
- `consecutivePrimeFactors_le` — every prime factor `≤ n + k`
- `samePrimeFactors_transfer` — divisibility-transfer form of `SamePrimeFactors`
- `consecutivePrimeFactors_zero` — empty block has no prime factors

Proved corollaries:
- `three_mem_factors` — for `k ≥ 3`, `3 ∈ consecutivePrimeFactors n k`
- `five_mem_factors` — for `k ≥ 5`, `5 ∈ consecutivePrimeFactors n k`

Pre-submission checklist (companion files):
- [x] No `def ... := sorry` (no definitions in this file)
- [x] No `axiom` declarations
- [x] No `theorem ... : True` placeholders
- [x] No `/-!` docstring sections (uses `/-` only)
- [x] No open conjectures (excludes the parent file's hard sorries)

Build verification skipped (mechanic protocol forbids direct `lake build`; Docker wrapper has 32GB / 60min defaults). Aristotle will validate target tractability when picking these up.

---
Automated companion creation by lean-mechanic agent.