### PR TITLE
erdos-101-oq-01 S14: unify maxFourPointLines surrogate ↔ maxCountAtSize sup

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -396,6 +396,57 @@ theorem maxCountAtSize_lt_of_forall {n : ℕ} {X : ℝ} (hX : 0 < X)
     rw [← hQeq]
     exact h Q hQcard hQ5
 
+/-! ### S14 ACT: surrogate ↔ true-sup unification
+
+The S12 surrogate `maxFourPointLines n := n*(n-1)/12` and the S13 true sup
+`maxCountAtSize n := sSup {fourPointLineCount Q | …}` are related by an
+elementary pointwise inequality: `maxCountAtSize n ≤ maxFourPointLines n`.
+This is `improved_upper_bound` lifted uniformly over all candidates.
+
+The surrogate is `Θ(n²)` (its rate is `1/12` away from `(n : ℝ)^2`); the
+genuine sup is the precise extremal quantity OQ-01 asks about. Bridging
+them lets `maxCountAtSize` inherit the surrogate's `O(n²)` certificate
+without duplicating the cast bookkeeping.
+-/
+
+/-- The genuine size-indexed supremum `maxCountAtSize` is bounded above by
+the elementary surrogate `maxFourPointLines = n*(n-1)/12`. Uniform lift of
+`improved_upper_bound`: every candidate `Q` of size `n` is bounded by the
+same surrogate value, hence so is their supremum (the empty case is
+covered by `sSup ∅ = 0`). -/
+theorem maxCountAtSize_le_maxFourPointLines (n : ℕ) :
+    maxCountAtSize n ≤ maxFourPointLines n := by
+  unfold maxCountAtSize maxFourPointLines
+  rcases Set.eq_empty_or_nonempty {k : ℕ | ∃ Q : PlanarPointSet,
+      Q.points.card = n ∧ NoFiveCollinear Q ∧ fourPointLineCount Q = k}
+      with he | hne
+  · rw [he]
+    have hz : sSup (∅ : Set ℕ) = 0 := csSup_empty
+    rw [hz]
+    exact Nat.zero_le _
+  · refine csSup_le hne ?_
+    rintro k ⟨Q, hQcard, hQ5, rfl⟩
+    rw [← hQcard]
+    exact improved_upper_bound Q hQ5
+
+/-- The genuine supremum `maxCountAtSize` inherits the `O(n²)` certificate
+from the surrogate `maxFourPointLines` via
+`maxCountAtSize_le_maxFourPointLines` and
+`maxFourPointLines_isBigO_n_squared`. -/
+theorem maxCountAtSize_isBigO_n_squared :
+    Asymptotics.IsBigO Filter.atTop
+      (fun n : ℕ => (maxCountAtSize n : ℝ))
+      (fun n : ℕ => (n : ℝ)^2) := by
+  have h_le :
+      Asymptotics.IsBigO Filter.atTop
+        (fun n : ℕ => (maxCountAtSize n : ℝ))
+        (fun n : ℕ => (maxFourPointLines n : ℝ)) := by
+    apply Asymptotics.IsBigO.of_norm_le
+    intro n
+    rw [Real.norm_of_nonneg (by positivity)]
+    exact_mod_cast maxCountAtSize_le_maxFourPointLines n
+  exact h_le.trans maxFourPointLines_isBigO_n_squared
+
 /-- **OQ-01 primary form ↔ rate form.** The ε-N statement
 `erdos_101_oq_01_conjecture` is equivalent to the existence of an
 `o(n²)` witness rate bounding every no-five-collinear count

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,11 +1,60 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-24 (S12 ACT lands IsBigO/IsLittleO bridge)
-**Iteration**: 12
-**Last Updated**: 2026-05-24 (researcher-1, S12 ACT)
+**Since**: 2026-06-03 (S14 ACT unifies surrogate ↔ true-sup)
+**Iteration**: 14
+**Last Updated**: 2026-06-03 (researcher-1, S14 ACT)
 
 ## Current Focus
+
+S14 ACT (researcher-1, 2026-06-03): **surrogate ↔ true-sup unification**.
+Adds the pointwise bridge `maxCountAtSize_le_maxFourPointLines : maxCountAtSize n ≤ maxFourPointLines n`
+and propagates the `O(n²)` certificate from the S12 surrogate to the S13
+genuine sup via `maxCountAtSize_isBigO_n_squared`. Closes the explicit
+S13 nextStep: "consider relating `maxCountAtSize ≤ maxFourPointLines`".
+
+**Two artifacts added** in `Erdos101OQ01.lean`:
+
+1. `theorem maxCountAtSize_le_maxFourPointLines (n : ℕ) :
+   maxCountAtSize n ≤ maxFourPointLines n` — uniform lift of
+   `improved_upper_bound` via `csSup_le` (nonempty branch) +
+   `csSup_empty` (empty branch). Empty case: `sSup ∅ = 0 ≤
+   maxFourPointLines n` by `Nat.zero_le`.
+2. `theorem maxCountAtSize_isBigO_n_squared :
+   Asymptotics.IsBigO Filter.atTop ↑maxCountAtSize (·^2)` — inherits
+   via `Asymptotics.IsBigO.of_norm_le` + `.trans` from
+   `maxFourPointLines_isBigO_n_squared`. The intermediate
+   `O(maxFourPointLines)` step uses `Real.norm_of_nonneg (by positivity)`
+   on the LHS (single-norm shape per S12 Bug-I).
+
+**Counters**:
+- Sorries 2 → 2 (unchanged; the two OPEN sorries `erdos_101_oq_01`
+  and `solymosi_stojakovic_lower_bound` are untouched)
+- Axioms 0 → 0
+- Theorems 17 → 19 (+2: bridge + IsBigO inheritance) — S12 state.md
+  undercounted at "13 → 15" because S13's 4 additions were not propagated
+- Defs 6 → 6 (no new defs)
+- LOC 711 → 762 (+51)
+
+**Build status**: NOT verified locally. Docker host has a containerd
+metadata I/O error
+(`/var/lib/desktop-containerd/.../meta.db: input/output error`)
+preventing image build; worktree's `.lake` self-symlink prevents direct
+`lake build`. Defer to mechanic / CI per S12 precedent (S12 was shipped
+unverified, mechanic-fixed in S13 GREEN).
+
+## Previous Focus (S13)
+
+S13 (researcher-1, 2026-05-29): BUILD-FIX + conjecture↔rate_form
+equivalence; Docker-VERIFIED GREEN. Cleared the dormant build-blocker
+from S12 (`mod_cast` beta-redex in `rate_form_iff_isLittleO`). Added the
+genuine size-indexed sup `maxCountAtSize` and the
+`conjecture ↔ rate_form` equivalence, allowing
+`erdos_101_oq_01_isLittleO` to be **derived** from `erdos_101_oq_01`
+(sorries 3 → 2). S13's explicit next-step "consider relating
+`maxCountAtSize ≤ maxFourPointLines`" is what S14 discharges.
+
+## Previous Focus (S12)
 
 S12 ACT (researcher-1, 2026-05-24): IsBigO/IsLittleO bridge to Mathlib
 idiom **landed** per S10 PREP §5.1–§5.3 recipe with all five S9 + S10

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -24,12 +24,12 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 711,
-    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificate, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
+    "lineCount": 762,
+    "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S14 (2026-06-03) unifies the S12 surrogate `maxFourPointLines` with the S13 genuine sup `maxCountAtSize` via the pointwise bridge `maxCountAtSize_le_maxFourPointLines` (uniform lift of `improved_upper_bound`) and propagates the `O(n²)` certificate to the sup via `maxCountAtSize_isBigO_n_squared`. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificates for surrogate + true sup, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
+    "theoremCount": 19,
     "definitionCount": 6,
-    "substantiveTheoremCount": 11
+    "substantiveTheoremCount": 17
   },
   "sections": [
     {
@@ -129,9 +129,9 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 711,
+    "lineCount": 762,
     "axiomCount": 0,
-    "theoremCount": 13,
+    "theoremCount": 19,
     "definitionCount": 6,
     "path": "Proofs/Erdos101OQ01.lean",
     "sorries": 2


### PR DESCRIPTION
## Summary

S14 ACT for [erdos-101-oq-01](research/problems/erdos-101-oq-01/) (Erdős Problem #101's OQ-01: is the four-point line count $o(n^2)$? $100 prize, OPEN). Closes S13's explicit next-step.

**Two artifacts added** in `proofs/Proofs/Erdos101OQ01.lean` (between `maxCountAtSize_lt_of_forall` L382 and `erdos_101_oq_01_conjecture_iff_rate_form` L450):

1. `theorem maxCountAtSize_le_maxFourPointLines (n : ℕ) : maxCountAtSize n ≤ maxFourPointLines n` — uniform lift of `improved_upper_bound` via `csSup_le` (nonempty branch) + `csSup_empty` (empty branch). Empty case: `sSup ∅ = 0 ≤ maxFourPointLines n` by `Nat.zero_le`.

2. `theorem maxCountAtSize_isBigO_n_squared : IsBigO atTop ↑maxCountAtSize (·^2)` — propagates the `O(n²)` certificate from S12's surrogate to S13's genuine sup via `Asymptotics.IsBigO.of_norm_le` + `.trans`. The intermediate `O(maxFourPointLines)` step uses `Real.norm_of_nonneg (by positivity)` on the LHS (single-norm shape per S12 Bug-I).

## Counters

- Sorries 2 → 2 (unchanged; the two OPEN sorries `erdos_101_oq_01` and `solymosi_stojakovic_lower_bound` are untouched)
- Axioms 0 → 0
- Theorems 17 → 19 (+2)
- Defs 6 → 6
- LOC 711 → 762 (+51)

## Build status — NOT verified locally

- Docker daemon on the build host has a containerd metadata I/O error (`/var/lib/desktop-containerd/.../meta.db: input/output error`) preventing image build.
- Worktree's `proofs/.lake` is a self-symlink — direct `lake build` from worktree won't work either.
- Defer verification to mechanic / CI per the documented S12 → S13 precedent: S12 was shipped unverified, S13 verified GREEN after fixing a mod_cast beta-redex.
- The patch uses idioms already exercised in the file: `csSup_empty` handling is verbatim from `maxCountAtSize_lt_of_forall` (L382); `IsBigO.of_norm_le` single-norm shape is the S12 Bug-I idiom.

## Test plan

- [ ] Mechanic / CI: \`./proofs/scripts/docker-build.sh Proofs.Erdos101OQ01\` (target ≤ 2 iterations per S10 §8 gate 7)
- [ ] If iter-1 fails, likely targets per S10 §11 fallbacks:
  - \`csSup_le\` signature drift: fall back to manual \`Nat.sSup_le\` or \`iSup_le\` indexed by Set membership.
  - \`Asymptotics.IsBigO.trans\` signature drift: fall back to inlined \`IsBigO.of_norm_le\` with the full chain.

## Mathematical content

These two artifacts unify two parallel design choices that were previously disconnected:

- The S12 surrogate \`maxFourPointLines n = n*(n-1)/12\` is \`Θ(n²)\` (rate \`1/12\`, not \`o(n²)\`); it was introduced as the cheapest aggregator that makes \`IsBigO\` typeclass resolution go through (the slug's \`PlanarPointSet\` lacks a \`Preorder\` instance, so the bridge has to route through \`ℕ → ℝ\`).
- The S13 genuine sup \`maxCountAtSize n = sSup {fourPointLineCount Q | |Q| = n ∧ NoFiveCollinear Q}\` is the precise extremal quantity OQ-01 asks about.

Without this bridge, the surrogate's \`IsBigO\` certificate was orphaned — useful only for the \`erdos_101_oq_01_isLittleO_form\` existential's witness selection. S14 lets both forms coexist with a clean hierarchy: \`maxCountAtSize ≤ maxFourPointLines = Θ(n²)\`, so \`maxCountAtSize = O(n²)\` unconditionally. The open content is precisely whether the same bound holds in \`o(n²)\` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)