### PR TITLE
chore(tracker): mark erdos-115-oq-01 clean (re-audit #4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -4227,12 +4227,12 @@
       "result": "clean"
     },
     "erdos-115-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [
         "phantom theorem citations in meta.json + Lean summary docstring: inverseN_implies_inverseSqrtN, inverseN_implies_inverseLogN, chebyshev_correction_nonneg_eventually do not exist in proofs/Proofs/Erdos115OQ01Problem.lean. Lean docstring also says \"Axioms (8 total)\" while file has 11. Issue #14862."
       ],
-      "lastAudited": "2026-05-02T20:12:14Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-03T20:28:37Z",
+      "result": "clean"
     },
     "erdos-1150": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

Re-audited gallery integrity for `erdos-115-oq-01` ("Rate of o(1) Correction in Lemniscate Derivatives"). All meta.json claims verified against `proofs/Proofs/Erdos115OQ01Problem.lean`.

| Check | Claimed | Actual |
|---|---|---|
| sorries | 0 | 0 |
| axiomCount | 11 | 11 |
| theoremCount | 2 | 2 |
| definitionCount | 6 | 6 |
| lineCount | 178 | 178 |
| True stubs | 0 | 0 |
| Tier | C (axiomatized/axiom) | matches |

Previous audit (#14862) flagged phantom theorem citations and a `(8 total)` axiom count in the Lean docstring; both are confirmed fixed (docstring now says `(11 total)`).

## Test plan

- [x] `grep -c "sorry"` matches `sorries`
- [x] `grep -c "^axiom "` matches `axiomCount`
- [x] No True stubs detected
- [x] Tier C presentation consistent with axiomatized main result

🤖 Generated with [Claude Code](https://claude.com/claude-code)