### PR TITLE
Enrich abel-ruffini: bridge structural threshold to Bhargava quantitative threshold

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -458,14 +458,16 @@
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
     "content": "Part VI explains the sharp transition at degree 5 by comparing the derived series of $S_4$ and $S_5$.\n\nFor $S_4$: the derived series terminates because $A_4$ contains the Klein four-group $V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\}$ as a normal subgroup. The full chain is $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright \\langle(12)(34)\\rangle \\triangleright \\{e\\}$, with all quotients abelian. Each abelian quotient in the composition series corresponds to a radical extraction step in Cardano/Ferrari's formulas: $S_4/A_4 \\cong \\mathbb{Z}/2$ gives the discriminant square root, $A_4/V_4 \\cong \\mathbb{Z}/3$ gives the cube root in Cardano's resolvent, and so on.\n\nFor $S_5$: the derived series stalls at $A_5$ because $A_5$ is simple and non-abelian. $[S_5, S_5] = A_5$ and $[A_5, A_5] = A_5$ (since $A_5$ is perfect), so $D^k(S_5) = A_5$ for all $k \\geq 1$. No abelian quotient can be extracted, so no radical step can proceed.\n\n**Geometric picture.** This algebraic threshold has a Platonic-solid interpretation: $S_4$ is the rotation group of the cube (acting on its four space diagonals), $A_4$ is the rotation group of the regular tetrahedron inscribed in the cube, and $V_4$ comprises the three 180° rotations about the cube's face-axes — geometrically *visible* normal subgroups whose abelian quotients underwrite Ferrari's formula. The icosahedron's rotation group $I \\cong A_5$ admits no analogous inscribed sub-symmetry: simplicity of $A_5$ means no rotation orbit short of the full group is closed under conjugation. The cube/icosahedron dichotomy is thus the geometric face of the radical-solvability threshold.\n\nThe Lean formalization now captures this transition completely: `inferInstance` succeeds for $S_0, S_1$ (Part IV), `Equiv.Perm.not_solvable` blocks $S_n$ for $n \\geq 5$ (Part III), and the companion entry `abel-ruffini-oq-04-oq-02` provides the three intermediate instances — $S_2$ via commutativity (`isSolvable_of_comm`), $S_3$ via the short exact sequence $1 \\to A_3 \\to S_3 \\to \\mathbb{Z}^\\times \\to 1$ using `solvable_of_ker_le_range`, and $S_4$ via the Klein four-group chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$. Together these results establish the full biconditional: $S_n$ is solvable if and only if $n \\leq 4$.",
-    "mathContext": "The transition is governed by the structure of $A_n$:\n- $A_3 \\cong \\mathbb{Z}/3$ (cyclic, hence abelian and solvable)\n- $A_4$: has normal subgroup $V_4$ with $A_4/V_4 \\cong \\mathbb{Z}/3$ and $V_4 \\cong (\\mathbb{Z}/2)^2$ (abelian quotients → solvable)\n- $A_5$: simple, $|A_5| = 60$, conjugacy classes of sizes $1, 15, 20, 12, 12$. No proper nontrivial normal subgroup (no sub-sum including 1 divides 60). The jump from $A_4$ (solvable) to $A_5$ (simple) is the structural cause of Abel-Ruffini's impossibility.\n\n$A_5$ is also perfect: $[A_5, A_5] = A_5$ since the only normal subgroups are $\\{e\\}$ and $A_5$ itself, and $[A_5, A_5] \\neq \\{e\\}$ because $A_5$ is non-abelian.",
+    "mathContext": "The transition is governed by the structure of $A_n$:\n- $A_3 \\cong \\mathbb{Z}/3$ (cyclic, hence abelian and solvable)\n- $A_4$: has normal subgroup $V_4$ with $A_4/V_4 \\cong \\mathbb{Z}/3$ and $V_4 \\cong (\\mathbb{Z}/2)^2$ (abelian quotients → solvable)\n- $A_5$: simple, $|A_5| = 60$, conjugacy classes of sizes $1, 15, 20, 12, 12$. No proper nontrivial normal subgroup (no sub-sum including 1 divides 60). The jump from $A_4$ (solvable) to $A_5$ (simple) is the structural cause of Abel-Ruffini's impossibility.\n\n$A_5$ is also perfect: $[A_5, A_5] = A_5$ since the only normal subgroups are $\\{e\\}$ and $A_5$ itself, and $[A_5, A_5] \\neq \\{e\\}$ because $A_5$ is non-abelian.\n\n**Quantitative manifestation of the threshold (the measure-theoretic face).** The structural threshold above is matched by a *measure-theoretic* threshold at the same $n = 5$. For $n \\leq 4$, the entire host group $S_n$ is solvable, so *every* irreducible polynomial $f \\in \\mathbb{Q}[X]$ of degree $n$ has solvable Galois group (since $\\mathrm{Gal}(f)$ embeds as a transitive subgroup of $S_n$ and subgroups of solvable groups are solvable) — the radical-solvable proportion is $1$ at every degree $\\leq 4$. At $n = 5$ this binary inverts: by **van der Waerden (1934)**, the proportion of integer-coefficient quintics with $\\max|c_i| \\leq H$ whose Galois group is *not* $S_5$ is $O(H^{-1/2} \\log H)$, and **Bhargava (2010, *Annals of Math.* 172: 1559–1591)** quantified the analogous discriminant-ordered statement: $N_5(X; S_5) \\sim c_5 X$ dominates, while solvable cases $N_5(X; \\{C_5, D_5, F_{20}\\}) = O(X^{1/2})$ vanish in relative proportion $O(X^{-1/2})$. **Bhargava-Shankar-Tsimerman (2023)** resolved van der Waerden's 1936 conjecture: the unsolvable proportion is exactly $1 - O(H^{-1})$, asymptotically optimal. The threshold at $n = 5$ is therefore both *structural* (derived series stops terminating) and *measure-theoretic* (radical-solvable Galois groups change from totality to thin set). See keyInsight #22 (Hilbert irreducibility / van der Waerden), keyInsight #34 (Bhargava-Shankar-Tsimerman 2023), and openQuestion #13 (Bhargava-Malle quintic field counting) for the full quantitative development, and `inverse-galois-f20` for the explicit solvable degree-5 witness $X^5 - 2$ that lives in the vanishing $O(X^{-1/2})$ proportion.",
     "significance": "key",
     "prerequisites": [
       "derived series",
       "composition series",
       "Klein four-group",
       "simple groups",
-      "conjugacy classes"
+      "conjugacy classes",
+      "transitive subgroups of $S_n$ (Galois group as such)",
+      "asymptotic field counting (van der Waerden 1934; Bhargava 2010)"
     ],
     "relatedConcepts": [
       "perfect group",
@@ -473,7 +475,15 @@
       "abelian quotient",
       "radical extraction",
       "Cardano's formula",
-      "Ferrari's formula"
+      "Ferrari's formula",
+      "van der Waerden 1934 generic-Galois density",
+      "Bhargava 2010 discriminant-ordered counting $N_5(X; G)$",
+      "Bhargava-Shankar-Tsimerman 2023 (van der Waerden's conjecture)",
+      "Hilbert irreducibility theorem",
+      "measure-theoretic vs structural threshold",
+      "inverse-galois-f20 (solvable degree-5 witness)",
+      "keyInsight #22 (Hilbert irreducibility)",
+      "keyInsight #34 (Bhargava-Shankar-Tsimerman)"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -467,7 +467,7 @@
     "type": "insight",
     "title": "Part VI: Why Degree 5 Is the Exact Threshold",
     "content": "Part VI explains the sharp transition at degree 5 by comparing the derived series of $S_4$ and $S_5$.\n\nFor $S_4$: the derived series terminates because $A_4$ contains the Klein four-group $V_4 = \\{e, (12)(34), (13)(24), (14)(23)\\}$ as a normal subgroup. The full chain is $S_4 \\triangleright A_4 \\triangleright V_4 \\triangleright \\langle(12)(34)\\rangle \\triangleright \\{e\\}$, with all quotients abelian. Each abelian quotient in the composition series corresponds to a radical extraction step in Cardano/Ferrari's formulas: $S_4/A_4 \\cong \\mathbb{Z}/2$ gives the discriminant square root, $A_4/V_4 \\cong \\mathbb{Z}/3$ gives the cube root in Cardano's resolvent, and so on.\n\nFor $S_5$: the derived series stalls at $A_5$ because $A_5$ is simple and non-abelian. $[S_5, S_5] = A_5$ and $[A_5, A_5] = A_5$ (since $A_5$ is perfect), so $D^k(S_5) = A_5$ for all $k \\geq 1$. No abelian quotient can be extracted, so no radical step can proceed.\n\n**Geometric picture.** This algebraic threshold has a Platonic-solid interpretation: $S_4$ is the rotation group of the cube (acting on its four space diagonals), $A_4$ is the rotation group of the regular tetrahedron inscribed in the cube, and $V_4$ comprises the three 180° rotations about the cube's face-axes — geometrically *visible* normal subgroups whose abelian quotients underwrite Ferrari's formula. The icosahedron's rotation group $I \\cong A_5$ admits no analogous inscribed sub-symmetry: simplicity of $A_5$ means no rotation orbit short of the full group is closed under conjugation. The cube/icosahedron dichotomy is thus the geometric face of the radical-solvability threshold.\n\nThe Lean formalization now captures this transition completely: `inferInstance` succeeds for $S_0, S_1$ (Part IV), `Equiv.Perm.not_solvable` blocks $S_n$ for $n \\geq 5$ (Part III), and the companion entry `abel-ruffini-oq-04-oq-02` provides the three intermediate instances — $S_2$ via commutativity (`isSolvable_of_comm`), $S_3$ via the short exact sequence $1 \\to A_3 \\to S_3 \\to \\mathbb{Z}^\\times \\to 1$ using `solvable_of_ker_le_range`, and $S_4$ via the Klein four-group chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$. Together these results establish the full biconditional: $S_n$ is solvable if and only if $n \\leq 4$.",
-    "mathContext": "The transition is governed by the structure of $A_n$:\n- $A_3 \\cong \\mathbb{Z}/3$ (cyclic, hence abelian and solvable)\n- $A_4$: has normal subgroup $V_4$ with $A_4/V_4 \\cong \\mathbb{Z}/3$ and $V_4 \\cong (\\mathbb{Z}/2)^2$ (abelian quotients → solvable)\n- $A_5$: simple, $|A_5| = 60$, conjugacy classes of sizes $1, 15, 20, 12, 12$. No proper nontrivial normal subgroup (no sub-sum including 1 divides 60). The jump from $A_4$ (solvable) to $A_5$ (simple) is the structural cause of Abel-Ruffini's impossibility.\n\n$A_5$ is also perfect: $[A_5, A_5] = A_5$ since the only normal subgroups are $\\{e\\}$ and $A_5$ itself, and $[A_5, A_5] \\neq \\{e\\}$ because $A_5$ is non-abelian.",
+    "mathContext": "The transition is governed by the structure of $A_n$:\n- $A_3 \\cong \\mathbb{Z}/3$ (cyclic, hence abelian and solvable)\n- $A_4$: has normal subgroup $V_4$ with $A_4/V_4 \\cong \\mathbb{Z}/3$ and $V_4 \\cong (\\mathbb{Z}/2)^2$ (abelian quotients → solvable)\n- $A_5$: simple, $|A_5| = 60$, conjugacy classes of sizes $1, 15, 20, 12, 12$. No proper nontrivial normal subgroup (no sub-sum including 1 divides 60). The jump from $A_4$ (solvable) to $A_5$ (simple) is the structural cause of Abel-Ruffini's impossibility.\n\n$A_5$ is also perfect: $[A_5, A_5] = A_5$ since the only normal subgroups are $\\{e\\}$ and $A_5$ itself, and $[A_5, A_5] \\neq \\{e\\}$ because $A_5$ is non-abelian.\n\n**Quantitative manifestation of the threshold (the measure-theoretic face).** The structural threshold above is matched by a *measure-theoretic* threshold at the same $n = 5$. For $n \\leq 4$, the entire host group $S_n$ is solvable, so *every* irreducible polynomial $f \\in \\mathbb{Q}[X]$ of degree $n$ has solvable Galois group (since $\\mathrm{Gal}(f)$ embeds as a transitive subgroup of $S_n$ and subgroups of solvable groups are solvable) — the radical-solvable proportion is $1$ at every degree $\\leq 4$. At $n = 5$ this binary inverts: by **van der Waerden (1934)**, the proportion of integer-coefficient quintics with $\\max|c_i| \\leq H$ whose Galois group is *not* $S_5$ is $O(H^{-1/2} \\log H)$, and **Bhargava (2010, *Annals of Math.* 172: 1559–1591)** quantified the analogous discriminant-ordered statement: $N_5(X; S_5) \\sim c_5 X$ dominates, while solvable cases $N_5(X; \\{C_5, D_5, F_{20}\\}) = O(X^{1/2})$ vanish in relative proportion $O(X^{-1/2})$. **Bhargava-Shankar-Tsimerman (2023)** resolved van der Waerden's 1936 conjecture: the unsolvable proportion is exactly $1 - O(H^{-1})$, asymptotically optimal. The threshold at $n = 5$ is therefore both *structural* (derived series stops terminating) and *measure-theoretic* (radical-solvable Galois groups change from totality to thin set). See keyInsight #22 (Hilbert irreducibility / van der Waerden), keyInsight #34 (Bhargava-Shankar-Tsimerman 2023), and openQuestion #13 (Bhargava-Malle quintic field counting) for the full quantitative development, and `inverse-galois-f20` for the explicit solvable degree-5 witness $X^5 - 2$ that lives in the vanishing $O(X^{-1/2})$ proportion.",
     "significance": "key",
     "relatedConcepts": [
       "perfect group",
@@ -475,14 +475,24 @@
       "abelian quotient",
       "radical extraction",
       "Cardano's formula",
-      "Ferrari's formula"
+      "Ferrari's formula",
+      "van der Waerden 1934 generic-Galois density",
+      "Bhargava 2010 discriminant-ordered counting $N_5(X; G)$",
+      "Bhargava-Shankar-Tsimerman 2023 (van der Waerden's conjecture)",
+      "Hilbert irreducibility theorem",
+      "measure-theoretic vs structural threshold",
+      "inverse-galois-f20 (solvable degree-5 witness)",
+      "keyInsight #22 (Hilbert irreducibility)",
+      "keyInsight #34 (Bhargava-Shankar-Tsimerman)"
     ],
     "prerequisites": [
       "derived series",
       "composition series",
       "Klein four-group",
       "simple groups",
-      "conjugacy classes"
+      "conjugacy classes",
+      "transitive subgroups of $S_n$ (Galois group as such)",
+      "asymptotic field counting (van der Waerden 1934; Bhargava 2010)"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Enrichment pass for `abel-ruffini`. Deepens the `ann-part-vi-threshold` annotation's `mathContext` (672 → 2323 chars, ~3.5×) by connecting the *structural* threshold at degree 5 (derived series stops terminating) to the *measure-theoretic* threshold at the same n=5 (radical-solvable Galois groups change from totality to thin set).

The annotation previously covered only the structural side. KeyInsights #22 (Hilbert irreducibility / van der Waerden) and #34 (Bhargava-Shankar-Tsimerman 2023) covered the quantitative side but were not connected to the threshold annotation itself. This commit bridges them in the mathContext where they belong, with references and a concrete pointer to `inverse-galois-f20` as the solvable degree-5 witness $X^5 - 2$ living in the vanishing $O(X^{-1/2})$ proportion.

## Changes

- `annotations.source.json` + regenerated `annotations.json`:
  - `ann-part-vi-threshold.mathContext`: +1650 chars adding the quantitative/measure-theoretic threshold
    - van der Waerden 1934: $O(H^{-1/2} \log H)$ density of non-$S_5$ quintics
    - Bhargava 2010 (Annals 172): $N_5(X; S_5) \sim c_5 X$, solvable cases $O(X^{1/2})$
    - Bhargava-Shankar-Tsimerman 2023: resolution of van der Waerden's 1936 conjecture
  - prerequisites: +2 (transitive subgroups; asymptotic field counting)
  - relatedConcepts: +8 (Bhargava/van der Waerden references, Hilbert irreducibility, measure-theoretic vs structural, etc.)

## Test plan

- [x] \`jq\` validates JSON syntax
- [x] \`pnpm annotations:build\` regenerates \`annotations.json\` cleanly
- [x] \`pnpm build\` succeeds end-to-end (vite build completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)