### PR TITLE
chore(tracker): mark szemeredi-theorem-oq-01 clean (first audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15262,6 +15262,12 @@
       "lastAudited": "2026-05-31T11:03:38Z",
       "result": "clean",
       "issues": []
+    },
+    "szemeredi-theorem-oq-01": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-03T20:32:10Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

First audit of `szemeredi-theorem-oq-01` (Kelley–Meka 2023 quantitative bound for 3-AP-free sets) — result: **clean**.

## Verification

- **1 axiom** (`kelley_meka_bound`) ✓ matches `axiomCount: 1`
- **1 theorem** (`rothNumberNat_density_le_kelley_meka`) ✓ matches `theoremCount: 1`
- **0 sorries** ✓
- **0 definitions** ✓
- `status: "axiomatized"` + `badge: "axiom"` consistent for an axiomatized open conjecture
- No `True` stubs, no Mathlib wrappers
- Density corollary closes via `div_le_iff₀ hN_pos` + `mul_comm` against the axiom
- `assumptions` field accurately describes the Bohr-set / sifted-Fourier / U^3 infrastructure missing from Mathlib 4.26

## Test plan

- [x] Sorry count: `grep "sorry" proofs/Proofs/SzemerediTheoremOQ01.lean` → 0
- [x] Axiom count: 1 `axiom` declaration, no structure-encoded assumptions
- [x] Theorem proof terminates without `sorry`
- [x] meta.json status/badge match the axiomatized state