### PR TITLE
fix(meta): abel-ruffini-galois-extensions-oq-05-oq-01 theoremCount 8->7, definitionCount 0->1

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -26,8 +26,8 @@
     "axiomCount": 1,
     "assumptions": "galois_compositum_product: For two Galois extensions K₁/ℚ and K₂/ℚ with coprime Galois group orders (supported on disjoint primes), their compositum has Galois group K₁ × K₂. Provable from conductor/discriminant theory of cyclotomic fields (~500 Lean lines); identifies the exact Mathlib gap for the abelian case of Shafarevich.",
     "lineCount": 201,
-    "theoremCount": 8,
-    "definitionCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
     "originalContributions": [
       "coprime_product_cyclic_realizable: ℤ/mℤ × ℤ/nℤ is realizable when gcd(m,n)=1 — CRT reduces to the cyclic case (new result)",
       "zmod_coprime_crt: explicit CRT isomorphism ZMod m × ZMod n ≃+ ZMod (m*n) as the key algebraic tool",
@@ -440,8 +440,8 @@
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean",
     "axiomCount": 1,
     "lineCount": 201,
-    "theoremCount": 8,
-    "definitionCount": 0,
+    "theoremCount": 7,
+    "definitionCount": 1,
     "sorries": 0
   },
   "mainTheorems": [


### PR DESCRIPTION
## Fix

`src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json` reported `theoremCount: 8` and `definitionCount: 0` in both `.meta` and `.leanFile`, but the canonical enrichment script (`scripts/research/enrich-research.ts:156, 162`) counts top-level declarations matching `^(theorem|lemma) ` and `^(def|noncomputable def|opaque def) `.

Updated to match the script-canonical counts.

## Evidence

`proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean` declarations (verified by `grep -nE "^(theorem|lemma|axiom|def|noncomputable def) "`):

**7 public theorems:**
- `cyclic_realizable` (line 65)
- `coprime_product_cyclic_realizable` (line 91)
- `z2z3_realizable` (line 101)
- `z5z7_realizable` (line 108)
- `s3_realizable_via_cubic` (line 165)
- `s3_is_solvable` (line 173)
- `shafarevich_cyclic_case_proved` (line 195)

**1 def:** `noncomputable def zmod_coprime_crt` (line 85)

**1 axiom:** `galois_compositum_product` (line 141) -- matches existing meta

No `private` declarations.

**Before**: `theoremCount: 8`, `definitionCount: 0`
**After**: `theoremCount: 7`, `definitionCount: 1`

All other meta counts already match reality:
- `axiomCount: 1` (matches `^axiom ` count)
- `sorries: 0` (no `\bsorry\b` matches)
- `lineCount: 201` (matches `wc -l`)

Same pattern as #22139 (erdos-1096), #22133 (ballot-problem-oq-03-oq-02), and #22126 (binomial-clt).

---
Automated fix by lean-mechanic agent.