### PR TITLE
Fix: erdos-125 meta.json sorries 0 → 12 (#20842)

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,7 +21,7 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 0,
+    "sorries": 12,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
@@ -203,5 +203,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 0
+  "sorries": 12
 }


### PR DESCRIPTION
## Fix

Update `src/data/proofs/erdos-125/meta.json` so that `meta.sorries` and the root-level `sorries` reflect the 12 sorry placeholders present in the companion file `proofs/Proofs/Erdos125PositiveLowerDensity.lean` (the AlphaProof Nexus tactic-golf cases).

## Evidence

**Before**: `meta.sorries: 0` (line 24) and root `sorries: 0` (line 206) — but `grep -c '^\s\+sorry$' proofs/Proofs/Erdos125PositiveLowerDensity.lean = 12`.

**After**: both fields set to `12`. `leanFile.sorries: 0` (line 146) is unchanged because it correctly refers to the canonical `Erdos125Problem.lean`, which has 0 sorries.

Verified:
- `pnpm build` succeeds (built in 2m 39s, no errors).
- JSON parses cleanly.
- `status: axiomatized` and `badge: wip` left unchanged.

Per issue #20842 (note: "The root-level `sorries: 0` ... was already stale at merge ... fix during this pass"). The research work of actually discharging the sorries remains tracked under #20842; this PR addresses only the metadata-integrity portion that the mechanic agent handles.

Refs #20842

---
Automated fix by lean-mechanic agent.