### PR TITLE
chore(tracker): mark taylor-sincos-convergence-oq-03 clean (re-audit #5)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13442,9 +13442,9 @@
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-02T15:50:25Z",
+      "lastAudited": "2026-06-03T21:41:20Z",
       "result": "clean"
     },
     "taylor-sincos-convergence-oq-04": {


### PR DESCRIPTION
## Summary
Gallery integrity re-audit (#5) of `taylor-sincos-convergence-oq-03` — clean.

## Verification
- `sorries`: 3 (matches meta.json) — `alternating_tail_bound`, `sin_alternating_remainder`, `cos_alternating_remainder`
- `axiomCount`: 0 (no `axiom` declarations, no structure-encoded assumptions)
- No True stubs
- `lineCount` 224, `theoremCount` 12, `definitionCount` 2 — all match
- `status`: `formalized`, `badge`: `wip` — appropriate given remaining sorries
- `originalContributions` accurately describe what is proved: pair_nonneg, alternating_partial_sum_even_bounds, sinTermAbs_antitone, sinTermAbs_tendsto, alternating_tighter_than_lagrange_sin all fully proved

Not a Mathlib wrapper: the abstract alternating partial-sum bound is proved fully here; sorries are for connecting `Real.sin`/`Real.cos` to their Taylor series expansions.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` confirms audit tracker is the only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)