### PR TITLE
chore(tracker): mark sum-of-kth-powers clean (re-audit #4)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13286,9 +13286,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T20:39:53Z",
+      "lastAudited": "2026-06-03T21:56:43Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-01": {


### PR DESCRIPTION
## Summary

Re-audit of `sum-of-kth-powers` (Faulhaber's Formulas, Wiedijk #77) — clean.

## Audit findings

- `proofs/Proofs/SumOfKthPowers.lean`: 0 sorries, 0 `axiom` declarations, 0 True stubs, no structures/classes (no structure-encoded assumptions)
- 49 top-level `theorem`/`lemma` declarations, 55 including indented/nested — matches meta.json `theoremCount: 55`
- `definitionCount: 0` matches (no `def` declarations in file)
- Mathlib deps (`Finset.sum_range_id`, `Finset.sum_range_succ`) are utility sum lemmas, not core results — `original` badge is appropriate
- Main theorems (`sum_first_powers`, `sum_squares`, `sum_cubes`, `nicomachus_theorem`, sum_fourth/fifth_powers) all have real `by` proofs

## Tracker change

Bumps `sum-of-kth-powers` auditCount 3→4, lastAudited to 2026-06-03.

🤖 Generated by Lean Auditor