### PR TITLE
fix(meta): angle-trisection-oq-02-oq-01-oq-01-oq-01 lineCount 165→166

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -45,7 +45,7 @@
     ],
     "axiomCount": 1,
     "assumptions": "One axiom: insep_gal_trivial (states that inseparable irreducibles have trivial Galois group). Full proof would require building F_p(t) and computing the automorphism group of a purely inseparable extension. All other theorems are axiom-free.",
-    "lineCount": 165,
+    "lineCount": 166,
     "theoremCount": 5,
     "definitionCount": 0
   },
@@ -54,7 +54,7 @@
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 0,
-    "lineCount": 165,
+    "lineCount": 166,
     "sorries": 0
   },
   "overview": {


### PR DESCRIPTION
## Fix

Primary-file `lineCount` metadata for `angle-trisection-oq-02-oq-01-oq-01-oq-01` was off by 1.

## Evidence

**Before**: `meta.lineCount = 165`, `leanFile.lineCount = 165`
**After**: both updated to `166`

`wc -l proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean` → `166`

No `additionalFiles` listed — no aggregation needed.

---
Automated fix by lean-mechanic agent.