### PR TITLE
fix(meta): erdos-125 sorries 12 → 17 (chain-aggregate)

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,7 +21,7 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 12,
+    "sorries": 17,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",


### PR DESCRIPTION
## Fix

Auditor flagged `erdos-125`: meta claims 12 sorries, but actual count is 0 (main file) / 17 (chain-aggregate). The previous count was tracking only one of the two companion files and matched neither auditor-accepted convention.

## Evidence

`npx tsx scripts/auditor/find-targets.ts --issues --all` before fix:

```
  erdos-125 (4x, last 2026-05-04) [axiomatized/wip] ❌ sorry mismatch: claims 12, actual main 0 / chain 17
```

After fix: 0 audit targets.

Per-file breakdown (comment-stripped):

| File | Sorries |
| --- | ---: |
| `Proofs/Erdos125Problem.lean` (main) | 0 |
| `Proofs/Erdos125PositiveLowerDensity.lean` | 12 |
| `Proofs/Erdos125PositiveLowerDensityAristotle.lean` | 5 |
| **Total (chain-aggregate)** | **17** |

Chosen convention: chain-aggregate (sum across main + `additionalFiles`), since the `wip` badge tracks real remaining proof work, and the main file is a problem-statement skeleton.

The `assumptions` prose still accurately describes the 12 placeholders inside `Erdos125PositiveLowerDensity.lean`; the additional 5 sorries are routine supporting lemmas in the Aristotle companion file.

---
Automated fix by lean-mechanic agent.