### PR TITLE
Fix erdos-125 sorry count: 12 -> 17 (Aristotle companion)

### DIFF
--- a/src/data/proofs/erdos-125/meta.json
+++ b/src/data/proofs/erdos-125/meta.json
@@ -21,13 +21,13 @@
       "alphaproof-nexus"
     ],
     "badge": "wip",
-    "sorries": 12,
+    "sorries": 17,
     "erdosNumber": 125,
     "erdosUrl": "https://erdosproblems.com/125",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
     "lineCount": 92,
-    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 12 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
+    "assumptions": "Original Erdos125Problem.lean (92 lines): 0 axioms, 0 sorries, 7 definitions, 0 theorems — states the open question without proving it. Companion Erdos125PositiveLowerDensity.lean (277 lines): integrates the structural skeleton of DeepMind AlphaProof Nexus's 2026-05-21 proof (arXiv:2605.22763v1) that the positive_lower_density variant of Erdős #125 is FALSE — i.e., lower density of A+B equals 0. The companion file declares 20 lemmas/theorems mirroring the AlphaProof Nexus source (`APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean`) with 12 sorry placeholders pending a faithful tactic-by-tactic port from FormalConjectures.Util.ProblemImports to pure Mathlib v4.26.0. The Aristotle companion Erdos125PositiveLowerDensityAristotle.lean (114 lines) exposes 5 additional routine digit-combinatorics targets (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`) as `sorry` for automated proof search. Chain-aggregate sorry count: 12 + 5 = 17. The mathematical result is established in the AlphaProof Nexus repository; this gallery entry awaits full mechanization here.",
     "mathlib_version": "4.26.0",
     "theoremCount": 0,
     "definitionCount": 7
@@ -203,5 +203,5 @@
       "note": "Source of the ported Lean proof: APNOutputs/ErdosProblems/erdos_125.variants.positive_lower_density.lean (370 lines)."
     }
   ],
-  "sorries": 12
+  "sorries": 17
 }


### PR DESCRIPTION
## Summary

Updates `src/data/proofs/erdos-125/meta.json` to reflect the actual chain-aggregate sorry count of 17 (was claiming 12).

## Evidence

| File | Sorries |
|------|---------|
| `Proofs/Erdos125Problem.lean` (main) | 0 |
| `Proofs/Erdos125PositiveLowerDensity.lean` | 12 |
| `Proofs/Erdos125PositiveLowerDensityAristotle.lean` | 5 |
| **Chain total** | **17** |

The 5 new sorries come from the Aristotle companion's routine digit-combinatorics targets (`A_max_k`, `B_max_m`, `A_B_gap`, `A_decomp`, `B_decomp`), added to `additionalFiles` but never reflected in `meta.sorries`.

## Changes

- `meta.sorries`: 12 → 17 (top-level and nested)
- `assumptions` field: documents the Aristotle companion and the 12 + 5 = 17 chain-aggregate breakdown

After this PR, `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 targets.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 targets

---
Discovered during gallery integrity audit (loom:auditor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)