### PR TITLE
fix(meta): amgm-inequality-oq-04 theoremCount + OQ03 companion drift

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "axiomCount": 2,
     "lineCount": 306,
-    "theoremCount": 22,
+    "theoremCount": 21,
     "definitionCount": 5,
     "additionalFiles": [
       "Proofs/AmgmInequalityOQ04OQ01.lean",
@@ -51,7 +51,7 @@
     ]
   },
   "conclusion": {
-    "summary": "The Gauss AGM convergence theory is fully verified: 22 theorems, 5 definitions, 0 axioms. Convergence to the common limit M(a,b) is machine-verified from AM-GM and Mathlib monotone convergence (tendsto_atTop_ciInf / ciSup + squeeze). After S2 Lever A axiom deletion (2026-05-16), this parent file is axiom-free; the elliptic-integral connection (ellipticK definition + Gauss identity) lives in the child slug oq-04-oq-01 (AmgmInequalityOQ04OQ01.lean), where K(k) is rigorously defined via Mathlib intervalIntegral and the AGM-K identity is the single residual axiom requiring Landen/theta-function theory.",
+    "summary": "The Gauss AGM convergence theory is fully verified: 21 theorems, 5 definitions, 0 axioms. Convergence to the common limit M(a,b) is machine-verified from AM-GM and Mathlib monotone convergence (tendsto_atTop_ciInf / ciSup + squeeze). After S2 Lever A axiom deletion (2026-05-16), this parent file is axiom-free; the elliptic-integral connection (ellipticK definition + Gauss identity) lives in the child slug oq-04-oq-01 (AmgmInequalityOQ04OQ01.lean), where K(k) is rigorously defined via Mathlib intervalIntegral and the AGM-K identity is the single residual axiom requiring Landen/theta-function theory.",
     "implications": "This formalization demonstrates the power of Mathlib's real analysis infrastructure: tendsto_atTop_ciInf/ciSup, squeeze_zero, and tendsto_nhds_unique combine to give a clean convergence proof from first principles. The AGM is central to high-performance computation of π and elliptic integrals (Brent-Salamin algorithm). A full formalization of Gauss's theorem would require formalizing K(k) and Legendre's relation in Mathlib.",
     "openQuestions": [
       "Define K(k) = ∫₀^{π/2} dθ/√(1-k²sin²θ) in Lean using Mathlib's intervalIntegral and prove its basic properties (K(0)=π/2, K increasing, K→∞ as k→1⁻)",
@@ -161,7 +161,7 @@
     "namespace": "AmgmInequalityOQ04",
     "lineCount": 306,
     "axiomCount": 0,
-    "theoremCount": 22,
+    "theoremCount": 21,
     "definitionCount": 5,
     "path": "Proofs/AmgmInequalityOQ04.lean",
     "sorries": 0,
@@ -177,8 +177,8 @@
       },
       {
         "path": "Proofs/AmgmInequalityOQ04OQ03.lean",
-        "lineCount": 158,
-        "theorems": 7,
+        "lineCount": 224,
+        "theorems": 10,
         "definitions": 2,
         "axioms": 1,
         "sorries": 0,


### PR DESCRIPTION
## Fix

Correct three metadata drifts in `src/data/proofs/amgm-inequality-oq-04/meta.json`:

- `AmgmInequalityOQ04.lean`: `theoremCount` 22 -> 21 (canonical `^(theorem|lemma)` grep gives 21; meta and `leanFile` both updated)
- `AmgmInequalityOQ04OQ03.lean` companion entry: `lineCount` 158 -> 224, `theorems` 7 -> 10 (companion file was expanded with `summable_hyp2F1` + supporting lemmas but metadata was not refreshed)
- `conclusion.summary` narrative aligned: "22 theorems" -> "21 theorems"

## Evidence

```
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AmgmInequalityOQ04.lean
21
$ wc -l proofs/Proofs/AmgmInequalityOQ04OQ03.lean
224
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AmgmInequalityOQ04OQ03.lean
10
```

`definitionCount`, `axiomCount`, and `sorries` already match the on-disk files; no semantic claim changes.

---
Automated metadata fix by lean-mechanic agent.