### PR TITLE
audit(arithmetic-series-oq-02): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -532,9 +532,9 @@
       "result": "clean"
     },
     "arithmetic-series-oq-02": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-02T20:42:23Z",
+      "lastAudited": "2026-06-04T00:03:45Z",
       "result": "clean"
     },
     "arithmetic-series-oq-02-oq-01": {


### PR DESCRIPTION
## Summary
- 5th audit of `arithmetic-series-oq-02` (ArithmeticSeriesOQ02.lean, 209 lines)
- All integrity checks pass; tracker bumped, no code changes

## Findings
- `sorries`: meta=0, actual=0 ✓
- `axiomCount`: meta=0, actual=0 ✓
- `theoremCount`: meta=12, actual=12 ✓
- `definitionCount`: meta=1, actual=1 ✓
- `lineCount`: meta=209, actual=209 ✓
- True stubs: none ✓
- Mathlib wrapper check: NOT a wrapper. Hockey Stick Identity is proved by induction here using Pascal's identity (`Nat.choose_succ_succ`) as a building block. Badge `original` justified; status `verified` correct.

## Test plan
- [x] Tracker JSON only; no Lean source changes