### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-02-oq-02 theoremCount 14 -> 12

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -63,7 +63,7 @@
     "lineCount": 167,
     "assumptions": "0 axioms, 0 sorries. Small cases via inferInstance and isSolvable_of_comm. Large cases via exact sequence: if A_n solvable then S_n solvable, but Mathlib's Equiv.Perm.not_solvable gives contradiction.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 0,
     "additionalFiles": [
       "Proofs/AbelRuffiniOQ04OQ02OQ02OQ06.lean"
@@ -213,7 +213,7 @@
     "namespace": "AbelRuffiniOQ04OQ02OQ02",
     "lineCount": 167,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Fix

Correct `theoremCount` drift in `src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json`:

- `meta.theoremCount`: 14 → 12
- `leanFile.theoremCount`: 14 → 12

## Evidence

```
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean
12
$ wc -l proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean
167
$ grep -cE "^axiom " proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean
0
```

The two extra hits in the broader `^(private |protected )?(theorem|lemma) ` grep are the file's two `private theorem` declarations (`sn_solvable_of_an_solvable`, `sn_not_solvable`). The established convention (PR #22207 for amgm-inequality-oq-04) excludes private declarations from `theoremCount`.

**Before**: `theoremCount: 14` (overcounted by 2)
**After**: `theoremCount: 12` (matches canonical grep)

`axiomCount`, `sorries`, `lineCount`, `definitionCount` already matched the file; no semantic claim changes. `conclusion.summary` does not reference a theorem count, so narrative is unaffected.

---
Automated metadata fix by lean-mechanic agent.