### PR TITLE
fix(meta): algebraic-numbers-countable-oq-05 theoremCount 13 -> 12

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-05/meta.json
@@ -21,7 +21,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 296,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "definitionCount": 2,
     "dateAdded": "2026-04-26",
     "assumptions": "",
@@ -105,7 +105,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization completes Cantor's original 1874 proof that the algebraic reals are countable, using the height function H(p) = deg(p) + ∑|aᵢ| to stratify algebraic reals into finite (not just countable) strata. All 13 theorems are proved with 0 sorries and 0 axioms, making this a fully verified formalization. The key innovation over the main gallery proof (`AlgebraicNumbersCountable.lean`) is the HEIGHT STRATIFICATION producing finite strata, which is more constructive and historically accurate.",
+    "summary": "This formalization completes Cantor's original 1874 proof that the algebraic reals are countable, using the height function H(p) = deg(p) + ∑|aᵢ| to stratify algebraic reals into finite (not just countable) strata. All 12 theorems are proved with 0 sorries and 0 axioms, making this a fully verified formalization. The key innovation over the main gallery proof (`AlgebraicNumbersCountable.lean`) is the HEIGHT STRATIFICATION producing finite strata, which is more constructive and historically accurate.",
     "implications": "The height function proof has two advantages over degree stratification: (1) it gives finite strata (stronger than countable), and (2) it is constructive — for each h, the finitely many height-h algebraic reals can in principle be enumerated. This connects to computational algebra: height bounds appear in algorithms for root isolation, algebraic number arithmetic, and determining algebraic independence.\n\nThe finiteness of height strata has applications beyond algebraic numbers: any mathematical object that can be 'measured' by a height function with finite level sets can be enumerated. This principle appears in Diophantine geometry (Weil heights for rational points on varieties), algebraic combinatorics (graded algebras), and coding theory.",
     "openQuestions": [
       "Can we make the height enumeration explicit? That is, can we produce a computable bijection $\\mathbb{N} \\leftrightarrow$ algebraic reals using the height function? The construction: at height $h$ there are finitely many polynomials $p \\in \\mathbb{Z}[X]$ with $\\deg(p) + \\sum|a_i| = h$, each with at most $\\deg(p) \\leq h - 1$ real roots; ordering by height and within each height by lexicographic-coefficient-and-root-position gives a computable enumeration. Companion entry `algebraic-numbers-countable-oq-02-oq-04` formalizes the general computable-real countability that this would specialize.",
@@ -171,7 +171,7 @@
   "leanFile": {
     "path": "Proofs/AlgebraicNumbersCountableOQ05.lean",
     "lineCount": 296,
-    "theoremCount": 13,
+    "theoremCount": 12,
     "axiomCount": 0,
     "definitionCount": 2,
     "sorries": 0


### PR DESCRIPTION
## Fix

Correct `theoremCount` drift in `src/data/proofs/algebraic-numbers-countable-oq-05/meta.json`:

- `meta.theoremCount`: 13 → 12
- `leanFile.theoremCount`: 13 → 12
- `conclusion.summary`: "All 13 theorems" → "All 12 theorems"

## Evidence

```
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AlgebraicNumbersCountableOQ05.lean
12
$ grep -cE "^private " proofs/Proofs/AlgebraicNumbersCountableOQ05.lean
1
```

The single `private lemma poly_eq_fin_sum` at line 115 was being counted in the previous `13`. The established convention (PR #22207 for amgm-inequality-oq-04, PR #22213 for abel-ruffini-oq-04-oq-02-oq-02) excludes private declarations from `theoremCount`. The 12 entries already enumerated in `meta.originalContributions` exactly match the 12 public theorems/lemmas in the file.

**Before**: `theoremCount: 13` (overcounted by 1 — included the private helper)
**After**: `theoremCount: 12` (matches canonical grep)

`axiomCount` (0), `sorries` (0), `definitionCount` (2), and `lineCount` (296) already match the file; no semantic claim changes.

---
Automated metadata fix by lean-mechanic agent.