### PR TITLE
audit(solution-of-cubic-oq-03-oq-05): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13095,9 +13095,9 @@
       "result": "clean"
     },
     "solution-of-cubic-oq-03-oq-05": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-02T21:01:44Z",
+      "lastAudited": "2026-06-04T01:05:34Z",
       "result": "clean"
     },
     "solution-of-cubic-oq-05": {


### PR DESCRIPTION
## Summary
- Re-audited `solution-of-cubic-oq-03-oq-05` (Vieta's formulas for the general cubic) — no integrity issues.
- Tracker `auditCount` 3 → 4, `lastAudited` refreshed.

## Verification
- 6 theorems (matches `meta.theoremCount`)
- 0 sorries, 0 `axiom` declarations, 0 definitions
- 112 lines (matches `lineCount`)
- No `True` stubs, no `:= trivial` placeholders
- `status: "verified"` / `badge: "original"` — Tier A, fully formalized
- Proofs use `ring`, `linarith`, `simp` with standard `Polynomial.coeff_*` lemmas — not a wrapper around a high-level Mathlib Vieta theorem.

## Test plan
- [x] meta.json field consistency check
- [x] Lean source inspected for sorries / axioms / True stubs
- [x] Mathlib wrapper check (negative — `import Mathlib` only supplies coefficient lemmas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)