### PR TITLE
fix(meta): abel-ruffini-oq-04-oq-07 theoremCount 14 -> 12

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json
@@ -43,7 +43,7 @@
       "abel-ruffini-oq-04",
       "abel-ruffini-oq-04-oq-03"
     ],
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 4
   },
   "overview": {
@@ -212,7 +212,7 @@
     "namespace": "BringJerrardReduction",
     "lineCount": 377,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 12,
     "definitionCount": 4,
     "path": "Proofs/AbelRuffiniOQ04OQ07.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Correct `theoremCount` drift in `src/data/proofs/abel-ruffini-oq-04-oq-07/meta.json`:

- `meta.theoremCount`: 14 → 12
- `leanFile.theoremCount`: 14 → 12

## Evidence

```
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AbelRuffiniOQ04OQ07.lean
12
$ grep -cE "^private (theorem|lemma) " proofs/Proofs/AbelRuffiniOQ04OQ07.lean
2
```

The two `private theorem` declarations at lines 256 (`bringRad_pos_at_upper`) and 264 (`bringRad_neg_at_lower`) were being counted in the previous `14`. The established convention (PR #22214 for algebraic-numbers-countable-oq-05, PR #22213 for abel-ruffini-oq-04-oq-02-oq-02, PR #22207 for amgm-inequality-oq-04) excludes private declarations from `theoremCount` per the canonical `enrich-research.ts` regex `^(theorem|lemma) `, which does not match `private theorem`.

**Before**: `theoremCount: 14` (overcounted by 2 — included two private helpers).
**After**: `theoremCount: 12` (matches canonical grep).

`axiomCount` (2), `sorries` (0), `definitionCount` (4), and `lineCount` (377) already match the file; no semantic claim changes.

---
Automated metadata fix by lean-mechanic agent.