### PR TITLE
audit(schauder-fixed-point-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -12912,9 +12912,9 @@
       "result": "clean"
     },
     "schauder-fixed-point-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-05-02T21:07:08Z",
+      "lastAudited": "2026-06-04T01:16:29Z",
       "result": "clean"
     },
     "schauder-fixed-point-oq-03": {


### PR DESCRIPTION
## Summary

7th audit of `schauder-fixed-point-oq-01` (Schauder Projection Lemma) — **clean**, no issues found.

## Integrity Checks

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 (no `axiom`, no assumption-carrying structures) | ✅ |
| True stubs | — | 0 | ✅ |
| theoremCount | 17 | 17 | ✅ |
| definitionCount | 3 | 3 | ✅ |
| lineCount | 315 | 315 | ✅ |
| structureCount | 0 | 0 | ✅ |

## Status / Badge Justification

`status: "verified"` / `badge: "original"` are appropriate. The main theorem `schauder_projection_lemma` is genuinely proved from first principles using a bump function partition-of-unity construction built within the file (`bumpFn`, `bumpSum`, `schauderProj`, plus continuity / convex-hull-membership / ε-approximation lemmas). The Mathlib dependencies listed in meta.json (`IsCompact.elim_finite_subcover_image`, `convexHull`, `Set.Finite.isCompact_convexHull`) are infrastructure used in standard ways, not deep theorems doing the core work — so this is not a "0 sorries with hidden imports" failure mode.

The two convex-hull corollaries (`isCompact_convexHull_range`, `isClosed_convexHull_range`) in PART 7 are thin Mathlib wrappers, but `originalContributions` correctly lists this as "Convex hull compactness for finite ranges" — a specialization claim, not a from-scratch proof claim.

## Test plan

- [x] `grep "sorry"` returns only comment references (line 34, 299, 303), no proof-body sorries
- [x] `grep "^axiom "` returns 0
- [x] No `:= trivial` / `: True :=` / `: True` patterns
- [x] Counts (theorem/def/line) match meta.json exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)