### PR TITLE
fix(meta): angle-trisection-oq-04-oq-03 theoremCount 55 -> 54

### DIFF
--- a/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-04-oq-03/meta.json
@@ -22,8 +22,8 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 328,
-    "theoremCount": 55,
-    "assumptions": "None. All 55 theorems proved. Pierpont prime verification via native_decide.",
+    "theoremCount": 54,
+    "assumptions": "None. All 54 theorems proved. Pierpont prime verification via native_decide.",
     "mathlibDependencies": [
       {
         "theorem": "Nat.Prime",
@@ -90,7 +90,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The number-theoretic component of the Pierpont prime criterion is fully formalized: 55 theorems, 0 sorries, 0 axioms. 12 Pierpont primes and 4 non-examples verified, plus 3-smooth totient verification for 7 specific polygons. The geometric connection (n-gon is neusis-constructible iff φ(n) is 3-smooth) requires Galois theory and is stated but not proved in Lean.",
+    "summary": "The number-theoretic component of the Pierpont prime criterion is fully formalized: 54 theorems, 0 sorries, 0 axioms. 12 Pierpont primes and 4 non-examples verified, plus 3-smooth totient verification for 7 specific polygons. The geometric connection (n-gon is neusis-constructible iff φ(n) is 3-smooth) requires Galois theory and is stated but not proved in Lean.",
     "implications": "Pierpont primes are the neusis analog of Fermat primes. This formalization demonstrates that extending compass-and-straightedge constructibility to neusis is captured by a simple number-theoretic condition on the prime factorization.",
     "openQuestions": [
       "Are there infinitely many Pierpont primes? (Open — similar to Fermat primes problem)",
@@ -109,7 +109,7 @@
     "namespace": "AngleTrisectionOQ04OQ03",
     "lineCount": 328,
     "axiomCount": 0,
-    "theoremCount": 55,
+    "theoremCount": 54,
     "definitionCount": 2,
     "path": "Proofs/AngleTrisectionOQ04OQ03.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Correct `theoremCount` drift in `src/data/proofs/angle-trisection-oq-04-oq-03/meta.json`:

- `meta.theoremCount`: 55 → 54
- `leanFile.theoremCount`: 55 → 54
- `meta.assumptions`: "All 55 theorems proved" → "All 54 theorems proved"
- `conclusion.summary`: "55 theorems" → "54 theorems"

## Evidence

```
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AngleTrisectionOQ04OQ03.lean
54
$ grep -cE "^private (theorem|lemma) " proofs/Proofs/AngleTrisectionOQ04OQ03.lean
1
```

The single `private theorem prime_factor_not_two_three_of_smooth` at line 99 was being counted in the previous 55. Per the canonical `enrich-research.ts` regex `^(theorem|lemma) `, private declarations are excluded (matching PR #22216 / #22214 / #22207 convention).

`axiomCount` (0), `sorries` (0), `definitionCount` (2), and `lineCount` (328) already match the file; no semantic claim changes.

---
Automated metadata fix by lean-mechanic agent.