### PR TITLE
fix(meta): angle-trisection-oq-02-oq-04-oq-01 definitionCount 2 -> 1

### DIFF
--- a/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json
@@ -60,7 +60,7 @@
       "Key 2-group lemmas: existence of index-2 subgroups, trivial characterization"
     ],
     "theoremCount": 12,
-    "definitionCount": 2
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Wantzel (1837) proved that a number is constructible by compass and straightedge iff it lies in a tower of quadratic extensions over ℚ, finally resolving the ancient Greek impossibility questions (angle trisection, cube duplication, circle squaring). Galois theory, developed by Galois (1832) and systematized in the 19th century, recharacterizes this: constructibility is equivalent to the Galois group of the minimal polynomial being a 2-group (a group of order 2^n). The equivalence of these two formulations — quadratic tower criterion ↔ Galois 2-group criterion — is a fundamental result connecting classical constructibility with modern algebraic structure theory. Remarkably, Galois was killed in a duel at age 20 in 1832 before his work was published; it took 14 years for Liouville to recognize its importance.",
@@ -180,7 +180,7 @@
     "theoremCount": 12,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
-    "definitionCount": 2,
+    "definitionCount": 1,
     "path": "Proofs/AngleTrisectionOQ02OQ04OQ01.lean",
     "sorries": 2,
     "additionalFiles": [


### PR DESCRIPTION
## Fix

Correct `definitionCount` drift in `src/data/proofs/angle-trisection-oq-02-oq-04-oq-01/meta.json`:

- `meta.definitionCount`: 2 → 1
- `leanFile.definitionCount`: 2 → 1

## Evidence

```
$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean
1
$ grep -nE "^(def|noncomputable def|opaque def) " proofs/Proofs/AngleTrisectionOQ02OQ04OQ01.lean
73:def ConstructibleViaTower (α : ℝ) : Prop :=
```

Only one definition (`ConstructibleViaTower` at line 73) is present. Per the canonical `enrich-research.ts` regex `^(def|noncomputable def|opaque def) `, this is the sole match. The Aristotle companion `AngleTrisectionOQ02OQ04OQ01Aristotle.lean` also contains 0 defs (checked).

`theoremCount` (12), `axiomCount` (0), `sorries` (2), and `lineCount` (364) already match the file; no semantic claim changes.

---
Automated metadata fix by lean-mechanic agent.