### PR TITLE
fix(meta): arithmetic-series-oq-00-oq-02-oq-01 theoremCount 8 -> 7

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-00-oq-02-oq-01/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-00-oq-02-oq-01/meta.json
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified.",
     "lineCount": 139,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 1,
     "originalContributions": [
       "nicWeight: definition of the unique rational weight w(k) = k³/(2k-1)",
@@ -211,7 +211,7 @@
     ],
     "axiomCount": 0,
     "lineCount": 139,
-    "theoremCount": 8,
+    "theoremCount": 7,
     "definitionCount": 1,
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Correct `theoremCount` drift in `src/data/proofs/arithmetic-series-oq-00-oq-02-oq-01/meta.json`:

- `meta.theoremCount`: 8 -> 7
- `leanFile.theoremCount`: 8 -> 7

## Evidence

```
$ grep -cE '^(theorem|lemma) ' proofs/Proofs/ArithmeticSeriesOQ00OQ02OQ01.lean
7
$ grep -cE '^private (theorem|lemma) ' proofs/Proofs/ArithmeticSeriesOQ00OQ02OQ01.lean
1
```

The single `private lemma denom_pos` at line 45 was being counted in the previous 8. Per the canonical `enrich-research.ts:156` regex `^(theorem|lemma) `, private declarations are excluded (matching PR #22216 / #22214 / #22218 convention).

`axiomCount` (0), `sorries` (0), `definitionCount` (1), and `lineCount` (139) already match the file; no semantic claim changes.

---
Automated metadata fix by lean-mechanic agent.