### PR TITLE
Enrich szemeredi-theorem-oq-01: PFR co-temporality, Sanders lineage, drift fixes

### DIFF
--- a/src/data/proofs/szemeredi-theorem-oq-01/annotations.json
+++ b/src/data/proofs/szemeredi-theorem-oq-01/annotations.json
@@ -41,8 +41,8 @@
     "id": "ann-axiom",
     "proofId": "szemeredi-theorem-oq-01",
     "range": {
-      "startLine": 55,
-      "endLine": 66
+      "startLine": 52,
+      "endLine": 65
     },
     "type": "concept",
     "title": "kelley_meka_bound: Axiomatized Quantitative Density Bound",
@@ -52,14 +52,18 @@
     "relatedConcepts": [
       "Bloom–Sisask 2020 (pre-Kelley–Meka best bound)",
       "Bohr sets",
+      "Gowers–Green–Manners–Tao 2023 (PFR / Marton conjecture)",
       "Heath-Brown reduction",
+      "Polynomial Freiman–Ruzsa conjecture (2023 co-temporal result)",
       "Real.exp",
       "Real.log",
       "Real.rpow",
       "Real.rpow convention for fractional powers",
+      "Sanders 2011 (Bohr-set framework ancestor)",
       "U^3 inverse theorem",
       "axiom integrity policy",
       "density-increment argument",
+      "entropy / spectral structure-vs-randomness framework",
       "exponent-tracking in increment loops",
       "quasi-polynomial vs poly-logarithmic vs polynomial density savings",
       "rothNumberNat",
@@ -80,8 +84,8 @@
     "id": "ann-density-corollary",
     "proofId": "szemeredi-theorem-oq-01",
     "range": {
-      "startLine": 68,
-      "endLine": 83
+      "startLine": 67,
+      "endLine": 86
     },
     "type": "concept",
     "title": "rothNumberNat_density_le_kelley_meka: Non-Axiomatic Density Form",

--- a/src/data/proofs/szemeredi-theorem-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-theorem-oq-01/meta.json
@@ -48,7 +48,7 @@
       "Documentation of the rate gap between Mathlib's tower-type `cornersTheoremBound` (which gives an iterated-log class density rate) and the quasi-polynomial Kelley–Meka rate.",
       "Pointer to the recommended sibling slug `szemeredi-theorem-oq-01-incomplete-01` for the Salem–Spencer-quantitative Approach B, BLOCKED on the same Bohr-set / sifted-Fourier / U^3 upstream infrastructure."
     ],
-    "lineCount": 84,
+    "lineCount": 88,
     "assumptions": "1 axiom (`kelley_meka_bound`) encoding the Kelley–Meka 2023 quantitative density bound. Discharging it would require formalizing Bohr sets, sifted Fourier analysis on Z/NZ, and the U^3 inverse-theorem control used in the original proof — none of which is in Mathlib 4.26.",
     "mathlib_version": "4.26.0",
     "theoremCount": 1,
@@ -89,11 +89,19 @@
       {
         "id": "erdos-28-additive-bases",
         "relationship": "Erdős additive-bases problem — sits in the same Erdős-density family of additive-combinatorics questions, sharing the structure-vs-randomness theme that powers the Kelley–Meka argument."
+      },
+      {
+        "id": "roth-theorem-k3-oq-03",
+        "relationship": "Gowers-norm density increment for k-APs. The k=3 case (`U^3` inverse theorem) is exactly the structured/random dichotomy that the Kelley–Meka argument exploits; OQ-03 sets up the general-k framework against which this entry's `U^3` axiom slots in."
+      },
+      {
+        "id": "roth-theorem-k3-oq-02",
+        "relationship": "Triangle-removal proof of Roth (Ruzsa–Szemerédi). Methodological contrast: graph regularity (tower-type rate) vs sifted Fourier (quasi-polynomial rate)."
       }
     ]
   },
   "overview": {
-    "historicalContext": "The size r_3(N) of the largest 3-AP-free subset of {1,...,N} has been studied since Roth's 1953 Fourier-analytic proof that r_3(N) = o(N), via a CN/log log N upper bound. The progression of best upper bounds:\n\n- 1953: Roth, r_3(N) ≪ N / log log N (Fourier).\n- 1987: Heath-Brown, r_3(N) ≪ N (log N)^{-c}.\n- 1999: Bourgain, r_3(N) ≪ N (log N)^{-1/2+o(1)}, then 2008 to ≪ N (log log N)^2 / (log N)^{2/3}.\n- 2017: Schoen, r_3(N) ≪ N (log log N)^4 / log N.\n- 2020: Bloom and Sisask, r_3(N) ≪ N (log N)^{-1-c}, the first bound below 1/log N.\n- 2023: Kelley and Meka, r_3(N) ≤ N · exp(-c (log N)^{1/12}), a quasi-polynomial rate, by far the largest jump since Roth.\n\nThe matching lower bound is Behrend (1946): r_3(N) ≥ N · exp(-c sqrt(log N)). Closing the gap between Kelley–Meka and Behrend is one of the central open problems in additive combinatorics.",
+    "historicalContext": "The size r_3(N) of the largest 3-AP-free subset of {1,...,N} has been studied since Roth's 1953 Fourier-analytic proof that r_3(N) = o(N), via a CN/log log N upper bound. The progression of best upper bounds:\n\n- 1953: Roth, r_3(N) ≪ N / log log N (Fourier).\n- 1987: Heath-Brown, r_3(N) ≪ N (log N)^{-c}.\n- 1999: Bourgain, r_3(N) ≪ N (log N)^{-1/2+o(1)}, then 2008 to ≪ N (log log N)^2 / (log N)^{2/3}.\n- 2011: Sanders, r_3(N) ≪ N (log log N)^5 / log N — the first bound matching the `1/log N` barrier (up to a `log log` correction) and the result that crystallised the modern Bohr-set / spectral framework on which Kelley–Meka builds.\n- 2017: Schoen, r_3(N) ≪ N (log log N)^4 / log N.\n- 2020: Bloom and Sisask, r_3(N) ≪ N (log N)^{-1-c}, the first bound strictly below 1/log N.\n- 2023: Kelley and Meka, r_3(N) ≤ N · exp(-c (log N)^{1/12}), a quasi-polynomial rate, by far the largest jump since Roth.\n\nThe matching lower bound is Behrend (1946): r_3(N) ≥ N · exp(-c sqrt(log N)). Closing the gap between Kelley–Meka and Behrend is one of the central open problems in additive combinatorics.\n\n**2023 context.** Kelley–Meka was announced essentially simultaneously with Gowers–Green–Manners–Tao's proof of the Polynomial Freiman–Ruzsa (Marton) conjecture over `F_2^n`. The two results share machinery (entropy / spectral structure-vs-randomness arguments on abelian groups) but are technically independent. Their joint appearance in 2023 marks the most active period in quantitative additive combinatorics since the Heath-Brown / Bourgain era of the late 1980s.",
     "problemStatement": "**Formal statement (axiom)**: There exists an absolute constant c > 0 such that for all sufficiently large N,\n  rothNumberNat N ≤ N · exp(-c · (log N)^{1/12}).\n\nHere `rothNumberNat N` is the Mathlib invariant: the maximum size of a 3-AP-free subset of {0,...,N-1}.",
     "text": "Records the Kelley–Meka (2023) breakthrough density bound for 3-AP-free sets as an axiom in Lean 4 and derives the corresponding density form `r_3(N)/N ≤ exp(-c (log N)^{1/12})` as a non-axiomatic corollary.",
     "proofStrategy": "**Why this is an axiom**: Kelley–Meka's proof proceeds via (i) a structure-vs-randomness dichotomy in Fourier space, (ii) sifted spectral arguments over carefully chosen Bohr sets, and (iii) a U^3-flavored inverse-theorem control to handle the structured case. Bohr sets, sifted Fourier analysis on Z/NZ, and the U^3 inverse theorem are not yet in Mathlib 4.26; a full formalization would require building each of those (an estimated several thousand lines of upstream infrastructure).\n\n**Why Mathlib's existing chain does not suffice**: Mathlib's `roth_3ap_theorem_nat` is driven by `cornersTheoremBound`, whose own docstring states that it depends on `SzemerediRegularity.bound`, a tower-type exponential. Inverting a tower-type bound to extract a density rate yields an iterated-logarithm class rate (`O(N / log* N)`), which is much weaker than Kelley–Meka's quasi-polynomial rate. The Kelley–Meka rate cannot be derived as a corollary of the existing Mathlib chain.\n\n**Non-axiomatic content**: `rothNumberNat_density_le_kelley_meka` shows the axiom implies `r_3(N)/N ≤ exp(-c (log N)^{1/12})` for `N ≥ max N₀ 1`. The proof uses `div_le_iff₀` to rewrite the division, then closes by `mul_comm` against the axiom.",
@@ -105,7 +113,9 @@
       "The non-axiomatic density corollary `rothNumberNat_density_le_kelley_meka` certifies that the axiom is non-vacuous in the asymptotic direction: it directly produces the form `r_3(N)/N ≤ exp(-c (log N)^{1/12})` that is most often cited in surveys.",
       "The exponent 1/12 in Kelley–Meka is not the best possible; subsequent work has improved it (e.g., Bloom–Sisask follow-ups). This entry intentionally fixes 1/12 to match the original paper, leaving exponent-improvement as a separate follow-up question.",
       "The gap between Kelley–Meka (exp(-c (log N)^{1/12})) and Behrend (exp(-c sqrt(log N))) leaves an open exponent question: what is the right exponent θ such that r_3(N) = N · exp(-(log N)^θ + o(1))? Kelley–Meka give θ ≥ 1/12 (i.e., the upper bound holds with exponent ≥ 1/12), Behrend gives θ ≤ 1/2. Closing this gap is a central open problem; even Behrend's exponent 1/2 is conjectured to be sharp for the lower bound side, so the question reduces to whether the upper bound can be pushed to exponent 1/2.",
-      "Once Bohr sets and sifted Fourier are formalized (per the prerequisites laid out in this entry), the Kelley–Meka axiom can be discharged *without* changing this file's downstream API: every consumer continues to import `kelley_meka_bound` and the density corollary `rothNumberNat_density_le_kelley_meka` as before. This is the gallery's `axiomatized → verified` upgrade pathway in action: an axiom whose statement is calibrated to Mathlib's existing combinator (`rothNumberNat`) can later be replaced by a `theorem` with no consumer-side breakage. Compare with the `abel-ruffini` chain, where the upgrade analogue replaced axioms about `Gal(x^5 − 4x + 2)` with a full bijectivity proof — same pattern, different domain."
+      "Once Bohr sets and sifted Fourier are formalized (per the prerequisites laid out in this entry), the Kelley–Meka axiom can be discharged *without* changing this file's downstream API: every consumer continues to import `kelley_meka_bound` and the density corollary `rothNumberNat_density_le_kelley_meka` as before. This is the gallery's `axiomatized → verified` upgrade pathway in action: an axiom whose statement is calibrated to Mathlib's existing combinator (`rothNumberNat`) can later be replaced by a `theorem` with no consumer-side breakage. Compare with the `abel-ruffini` chain, where the upgrade analogue replaced axioms about `Gal(x^5 − 4x + 2)` with a full bijectivity proof — same pattern, different domain.",
+      "Kelley–Meka (2023) and the Gowers–Green–Manners–Tao (2023) proof of the Polynomial Freiman–Ruzsa / Marton conjecture over `F_2^n` were announced essentially simultaneously and share the broader entropy / spectral structure-vs-randomness framework on abelian groups, although they are technically independent. The two results together mark 2023 as the most active year in quantitative additive combinatorics since the late-1980s Heath-Brown / Bourgain era. PFR has since been formalized in Lean 4 (Tao et al., Blueprint project, 2024), so the gallery may eventually carry a PFR entry that exhibits, in parallel with this one, the same `axiomatized → verified` upgrade pattern applied to a different structural lemma.",
+      "Sanders 2011 (`r_3(N) ≪ N (log log N)^5 / log N`) is the direct technical ancestor of Kelley–Meka: it crystallised the modern Bohr-set / spectral framework on `Z/NZ`. Kelley–Meka then replaced Sanders' poly-logarithmic density-increment with a *sifted* Fourier increment that runs the structure-vs-randomness dichotomy through a `U^3` inverse theorem rather than purely through L^2 spectral bounds. Documenting this lineage in the gallery helps future formalizers identify the most economical upstream-Mathlib path: Sanders 2011 is the natural intermediate target before attacking the full Kelley–Meka bound."
     ],
     "prerequisites": [
       "Roth's theorem in its qualitative form (covered by `szemeredi-theorem`)",
@@ -126,17 +136,17 @@
     {
       "id": "kelley-meka-axiom",
       "title": "Kelley–Meka Axiom",
-      "startLine": 55,
-      "endLine": 66,
-      "summary": "Axiomatizes the Kelley–Meka bound `kelley_meka_bound`: there exists an absolute constant c > 0 and N₀ such that for all N ≥ N₀, `(rothNumberNat N : ℝ) ≤ N · Real.exp (-(c * (Real.log N) ^ (1/12)))`.",
+      "startLine": 52,
+      "endLine": 65,
+      "summary": "Axiomatizes the Kelley–Meka bound `kelley_meka_bound`: there exists an absolute constant c > 0 and N₀ such that for all N ≥ N₀, `(rothNumberNat N : ℝ) ≤ N · Real.exp (-(c * (Real.log N) ^ (1/12)))`. Lines 52–61 contain the axiom docstring (statement, calibration to `rothNumberNat`, and the `1/12` exponent caveat); lines 62–65 declare the axiom itself.",
       "mathContext": "∃ c > 0, ∃ N₀, ∀ N ≥ N₀, r_3(N) ≤ N · exp(-c (log N)^{1/12}). Stated against Mathlib's `rothNumberNat` exactly."
     },
     {
       "id": "density-corollary",
       "title": "Density Corollary",
-      "startLine": 68,
-      "endLine": 83,
-      "summary": "**Proved.** `rothNumberNat_density_le_kelley_meka`: under the axiom, `r_3(N) / N ≤ exp(-c (log N)^{1/12})` for `N ≥ max N₀ 1`. Proof: extract `c, N₀` from `kelley_meka_bound`, take the threshold `max N₀ 1`, divide by `N` using `div_le_iff₀` and `mul_comm`.",
+      "startLine": 67,
+      "endLine": 86,
+      "summary": "**Proved.** `rothNumberNat_density_le_kelley_meka`: under the axiom, `r_3(N) / N ≤ exp(-c (log N)^{1/12})` for `N ≥ max N₀ 1`. Proof: extract `c, N₀` from `kelley_meka_bound`, take the threshold `max N₀ 1`, divide by `N` using `div_le_iff₀` and `mul_comm`. The docstring (lines 67–73) records why the right-hand side `1/exp(c (log N)^{1/12})` beats every `1/(log N)^k`, making the rate genuinely quasi-polynomial.",
       "mathContext": "From `r_3(N) ≤ N · exp(-c (log N)^{1/12})` and `N ≥ 1`, dividing both sides by `N` gives `r_3(N)/N ≤ exp(-c (log N)^{1/12})`. The `max N₀ 1` threshold ensures `N > 0` for the division."
     }
   ],
@@ -160,6 +170,16 @@
       "targetId": "szemeredi-counting",
       "relationship": "related",
       "description": "AP-counting infrastructure; Kelley–Meka uses spectral / Fourier methods rather than counting, so this is a complementary technique."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-03",
+      "relationship": "related",
+      "description": "Gowers-norm / U^k density-increment framework for k-APs. The Kelley–Meka argument's `U^3` inverse-theorem control (the missing-from-Mathlib ingredient axiomatized here) is precisely the k=3 case of the Gowers-norm machinery this OQ-03 entry sets up — so a future formalization of Kelley–Meka would discharge this entry's axiom while simultaneously instantiating OQ-03 at k=3."
+    },
+    {
+      "targetId": "roth-theorem-k3-oq-02",
+      "relationship": "related",
+      "description": "Ruzsa–Szemerédi triangle-removal proof of Roth's theorem. Methodological contrast: triangle removal is a graph-theoretic / regularity route (the tower-type chain whose rate Kelley–Meka surpasses), so OQ-02 documents the slower of the two paradigms that Kelley–Meka's Fourier-analytic argument leaves behind."
     }
   ],
   "conclusion": {
@@ -183,7 +203,7 @@
       "Real"
     ],
     "namespace": "SzemerediTheoremOQ01",
-    "lineCount": 84,
+    "lineCount": 88,
     "axiomCount": 1,
     "theoremCount": 1,
     "definitionCount": 0,
@@ -218,6 +238,20 @@
       "year": "1953",
       "venue": "Journal of the London Mathematical Society 28, 104–109",
       "note": "Original quantitative bound `r_3(N) ≪ N / log log N`; the qualitative statement is the k=3 case in `szemeredi-theorem`."
+    },
+    {
+      "authors": "Sanders, Tom",
+      "title": "On Roth's theorem on progressions",
+      "year": "2011",
+      "venue": "Annals of Mathematics 174, 619–636",
+      "note": "First bound matching the `1/log N` barrier up to a `log log` correction: `r_3(N) ≪ N (log log N)^5 / log N`. The Bohr-set / spectral framework introduced and consolidated here is a direct ancestor of the Kelley–Meka argument."
+    },
+    {
+      "authors": "Gowers, W. Timothy; Green, Ben; Manners, Freddie; Tao, Terence",
+      "title": "On a conjecture of Marton",
+      "year": "2023",
+      "venue": "arXiv:2311.05762 (Annals of Mathematics, to appear)",
+      "note": "Resolution of the Polynomial Freiman–Ruzsa (Marton) conjecture over `F_2^n`. Independent of Kelley–Meka but co-temporal and methodologically adjacent (entropy / spectral structure-vs-randomness on abelian groups); together they mark 2023 as a peak year for quantitative additive combinatorics."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Enrichment pass for `szemeredi-theorem-oq-01` (Kelley–Meka quantitative 3-AP bound).

### Drift fixes
- `lineCount` corrected 84 → 88 (both `meta.lineCount` and `leanFile.lineCount`) — actual Lean file is 88 lines.
- Section line ranges resynced to match the Lean file: `kelley-meka-axiom` 52–65 (was 55–66), `density-corollary` 67–86 (was 68–83).
- Annotation line ranges resynced to the same.

### Historical lineage additions
- Added **Sanders 2011** (`r_3(N) ≪ N (log log N)^5 / log N`) to historical context and references — direct technical ancestor of Kelley–Meka and the result that consolidated the Bohr-set / spectral framework.
- Added **Gowers–Green–Manners–Tao 2023** PFR / Marton-conjecture resolution to references and a new "2023 context" paragraph documenting the co-temporal context (independent results sharing the entropy / spectral structure-vs-randomness framework).

### Key insights added
- PFR / Marton co-temporality: 2023 as the most active year in quantitative additive combinatorics since the late-1980s Heath-Brown / Bourgain era; PFR has now been Lean-formalized (Tao et al., Blueprint), making it a natural sibling-pattern entry.
- Sanders 2011 → Kelley–Meka lineage as a concrete formalization roadmap: Sanders' bound is the natural intermediate Mathlib target before attacking the full Kelley–Meka rate.

### Cross-references added
- `roth-theorem-k3-oq-03` (Gowers-norm density increment for k-APs) — the `U^3` case is exactly the inverse-theorem ingredient axiomatized here.
- `roth-theorem-k3-oq-02` (triangle-removal proof of Roth) — methodological contrast (graph regularity tower-type vs sifted Fourier quasi-polynomial).
- Same two added to `relatedProblems`.

### Annotation polish
- Extended `ann-axiom.relatedConcepts` with Sanders 2011, PFR / Marton, GGMT 2023, and "entropy / spectral structure-vs-randomness framework".

## Axiom integrity
No change to `status: "axiomatized"`, `badge: "axiom"`, or `axiomCount: 1`. The Kelley–Meka axiom remains a single structure-free `axiom` declaration; the assumption count is unchanged.

## Test plan
- [x] `pnpm build` succeeds (3m 7s; JSON validation passes for both meta.json and annotations.json).
- [x] Section line ranges cover the actual Lean file 1–86 (preamble 1–50, axiom 52–65, corollary 67–86; lines 51, 66, 87–88 are blank / `end namespace`).
- [x] No changes to the Lean source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)