### PR TITLE
audit(cayley-hamilton-cyclic-vector-all-fields): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1729,9 +1729,9 @@
       "result": "clean"
     },
     "cayley-hamilton-cyclic-vector-all-fields": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-02T21:15:43Z",
+      "lastAudited": "2026-06-04T16:03:37Z",
       "result": "clean"
     },
     "cayley-hamilton-cyclic-vector-all-fields-oq-01": {


### PR DESCRIPTION
## Summary

Audit of `cayley-hamilton-cyclic-vector-all-fields` — **clean**.

Verified against `proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean`:

- `sorries: 0` ✓ (no actual `sorry` in code; docstring refs to outdated 1-sorry state)
- `axiomCount: 0` ✓ (no `^axiom ` declarations; WIP04 dep also has 0 axioms/sorries)
- `theoremCount: 8` ✓ (3 public + 5 private)
- `definitionCount: 2` ✓ (2 `abbrev`)
- `lineCount: 268` ✓
- `status: "verified"` + `badge: "mathlib"` ✓ (Tier B — uses Mathlib UFD via `UniqueFactorizationMonoid.exists_prime_factors`)
- No True stubs
- Additional files exist (`CayleyHamiltonCyclicVectorAllFieldsAristotle.lean`, `CayleyHamiltonCyclicVectorCommRingOQ01.lean`)

## Test plan

- [x] `audit-tracker.json` bumped: auditCount 2 → 3, lastAudited 2026-06-04, result `clean`