### PR TITLE
fix(meta): amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03 theoremCount 3 -> 2

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json
@@ -28,7 +28,7 @@
     "sorries": 0,
     "axiomCount": 0,
     "lineCount": 186,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 1,
     "assumptions": "No sorries, no axiom declarations. All results proved from Mathlib foundations via induction. Imports AmgmInequalityOQ02 for the elemSymm definition and elemSymm_succ (variable-adding recurrence).",
     "mathlib_version": "4.26.0"
@@ -205,7 +205,7 @@
   "leanFile": {
     "path": "Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean",
     "lineCount": 186,
-    "theoremCount": 3,
+    "theoremCount": 2,
     "definitionCount": 1,
     "axiomCount": 0,
     "sorries": 0


### PR DESCRIPTION
## Fix

Correct `theoremCount` drift in `src/data/proofs/amgm-inequality-oq-02-oq-01-oq-02-oq-01-oq-03/meta.json`.

- `meta.theoremCount`: 3 -> 2
- `leanFile.theoremCount`: 3 -> 2

## Evidence

```
$ grep -cE "^(theorem|lemma) " proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean
2
$ grep -cE "^private " proofs/Proofs/AmgmInequalityOQ02OQ01OQ02OQ01OQ03.lean
1
```

Public declarations: `powerSum_succ` (line 40), `newton_girard` (line 90).
Private (excluded): `cancel_sum` (line 53).

Convention precedent: #22214, #22213, #22207.

axiomCount (0), sorries (0), definitionCount (1), lineCount (186) all already match.

---
Automated fix by lean-mechanic agent.
