### PR TITLE
Enrich abel-ruffini: sharpen originalContributions precision

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -43,8 +43,8 @@
       }
     ],
     "originalContributions": [
-      "Educational walkthrough of Galois theory connection",
-      "Integration of Mathlib's solvability theory",
+      "Seven-part pedagogical structuring of the Galois-theoretic chain (radicals ⟹ solvable Galois group ⟹ S₅/A₅ obstruction) into a textbook-shaped walkthrough",
+      "Composition of four Mathlib modules (`FieldTheory.AbelRuffini`, `GroupTheory.Solvable`, `GroupTheory.SpecificGroups.Alternating`, `FieldTheory.Galois.Basic`) into a single self-contained 187-line file with zero sorries and zero axioms",
       "General contrapositive form of Abel-Ruffini (non-solvable Galois group implies not solvable by radicals)"
     ],
     "dateAdded": "2025-12-21",


### PR DESCRIPTION
## Summary

Calibration pass on a saturated entry (`abel-ruffini`, passes=7, quality=100, all review action items already resolved). Sharpens `meta.meta.originalContributions[0]` and `[1]` from vague descriptors to precise, factual statements that mirror the precision the peer reviewer praised on `[2]` (see `review.json` action item `ai-3`) and align with the wording already used in `meta.meta.assumptions` ("pedagogical wrappers composing Mathlib lemmas") and `meta.description` ("four Mathlib modules ... zero sorries and zero axioms").

### Before
- `[0]`: "Educational walkthrough of Galois theory connection"
- `[1]`: "Integration of Mathlib's solvability theory"

### After
- `[0]`: "Seven-part pedagogical structuring of the Galois-theoretic chain (radicals ⟹ solvable Galois group ⟹ S₅/A₅ obstruction) into a textbook-shaped walkthrough"
- `[1]`: "Composition of four Mathlib modules (`FieldTheory.AbelRuffini`, `GroupTheory.Solvable`, `GroupTheory.SpecificGroups.Alternating`, `FieldTheory.Galois.Basic`) into a single self-contained 187-line file with zero sorries and zero axioms"

`[2]` is unchanged (already reads "General contrapositive form of Abel-Ruffini …" — the precise wording the reviewer requested in `ai-3`).

## Audit findings (pre-existing; no fixes required)

Verified during this pass; recording so future enrichers can skip a re-audit:

- 9 theorems, 0 def, 0 axiom, 0 sorry in `proofs/Proofs/AbelRuffini.lean` — matches `meta.meta.{theoremCount,definitionCount,axiomCount,sorries}`
- `meta.meta.lineCount = 187` matches Lean file
- All 9 `mainTheorems` line numbers verified against current Lean source
- All 96 `crossReferences.targetId`s resolve to existing `src/data/proofs/<id>/` directories
- All 16 annotations have `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` populated
- Sections cover lines 1–187 (full file)
- All three `review.json` action items targeted at "enricher" are already `status: resolved`
- `status: verified` + `badge: mathlib` + `axiomCount: 0` are consistent (no structure-encoded assumptions in this file)

## Test plan

- [x] `meta.json` JSON validates
- [x] `pnpm build` succeeds (vite build clean in 5m 2s)
- [x] `tsc --noEmit -p tsconfig.json` clean
- [x] Only `src/data/proofs/abel-ruffini/meta.json` staged (other tree changes are pre-build enrichment script artifacts, intentionally not committed)