### PR TITLE
research(konigsberg-oq-03-wip-01): S5 ACT — sibling-parity accessors + no-edge sanity theorems

### DIFF
--- a/proofs/Proofs/KonigsbergOQ03.lean
+++ b/proofs/Proofs/KonigsbergOQ03.lean
@@ -139,6 +139,12 @@ theorem step_ne {V : Type*} {G : InfiniteGraph V}
     (w : InfiniteWalk G) (n : ℕ) : w.vertex n ≠ w.vertex (n + 1) :=
   fun h => G.loopless (w.vertex n) (h ▸ w.step_adj n)
 
+/-- Every step in an `InfiniteWalk` is between adjacent vertices (tautology).
+Mirrors the sibling `KonigsbergOQ03OQ02.InfiniteWalk.step_is_adj` accessor. -/
+theorem step_is_adj {V : Type*} {G : InfiniteGraph V}
+    (w : InfiniteWalk G) (n : ℕ) : G.adj (w.vertex n) (w.vertex (n + 1)) :=
+  w.step_adj n
+
 end InfiniteWalk
 
 /-- A one-way Euler walk on `G`: a ℕ-indexed walk that covers every edge and
@@ -146,6 +152,23 @@ no edge twice. The `G` argument is explicit because Lean cannot infer it from
 `w : InfiniteWalk G` in every elaboration context. -/
 def IsEulerWalk {V : Type*} (G : InfiniteGraph V) (w : InfiniteWalk G) : Prop :=
   (∀ u v, G.adj u v → w.CoversEdge u v) ∧ w.IsEdgeInjective
+
+namespace IsEulerWalk
+
+/-- An Euler walk covers each adjacent pair (projection of the `And`).
+Mirrors the sibling `KonigsbergOQ03OQ02.IsEulerWalk.covers` accessor. -/
+theorem covers {V : Type*} {G : InfiniteGraph V} {w : InfiniteWalk G}
+    (hEuler : IsEulerWalk G w) (u v : V) (hadj : G.adj u v) :
+    w.CoversEdge u v :=
+  hEuler.1 u v hadj
+
+/-- An Euler walk is edge-injective (projection of the `And`).
+Mirrors the sibling `KonigsbergOQ03OQ02.IsEulerWalk.injective` accessor. -/
+theorem injective {V : Type*} {G : InfiniteGraph V} {w : InfiniteWalk G}
+    (hEuler : IsEulerWalk G w) : w.IsEdgeInjective :=
+  hEuler.2
+
+end IsEulerWalk
 
 /-- A bi-infinite walk on `G`: a ℤ-indexed sequence of adjacent vertices.
 Needed for the version of the Erdős–Grünwald–Weiszfeld characterisation that
@@ -198,5 +221,36 @@ def HasOneWayEulerPath {V : Type*} (G : InfiniteGraph V) : Prop :=
     that traverses every edge at least once. For finite graphs,
     this is solvable in polynomial time. For infinite graphs,
     the optimal solution may not exist. -/
+
+/-! ### No-edge sanity theorems
+
+The smallest non-trivial Eulerian facts: an `InfiniteGraph` with no edges
+admits no infinite walks at all, hence has no (one-way or bi-infinite)
+Euler path. These confirm the predicates from the 2026-06-03 S4 ACT are
+non-degenerate (they do *not* hold vacuously for every graph). -/
+
+/-- A no-edge `InfiniteGraph` admits no `InfiniteWalk`: any candidate walk's
+step-0 adjacency contradicts the no-edge hypothesis. -/
+theorem InfiniteWalk.isEmpty_of_no_edges {V : Type*} {G : InfiniteGraph V}
+    (h : ∀ u v, ¬ G.adj u v) : IsEmpty (InfiniteWalk G) :=
+  ⟨fun w => h _ _ (w.step_adj 0)⟩
+
+/-- A no-edge `InfiniteGraph` admits no `BiInfiniteWalk`. -/
+theorem BiInfiniteWalk.isEmpty_of_no_edges {V : Type*} {G : InfiniteGraph V}
+    (h : ∀ u v, ¬ G.adj u v) : IsEmpty (BiInfiniteWalk G) :=
+  ⟨fun w => h _ _ (w.step_adj 0)⟩
+
+/-- A no-edge `InfiniteGraph` has no one-way Euler path: the existential is
+unsatisfiable because the walk type itself is empty. -/
+theorem not_hasOneWayEulerPath_of_no_edges {V : Type*} {G : InfiniteGraph V}
+    (h : ∀ u v, ¬ G.adj u v) : ¬ HasOneWayEulerPath G := by
+  rintro ⟨w, _⟩
+  exact h _ _ (w.step_adj 0)
+
+/-- A no-edge `InfiniteGraph` has no bi-infinite Euler path. -/
+theorem not_hasInfiniteEulerPath_of_no_edges {V : Type*} {G : InfiniteGraph V}
+    (h : ∀ u v, ¬ G.adj u v) : ¬ HasInfiniteEulerPath G := by
+  rintro ⟨w, _⟩
+  exact h _ _ (w.step_adj 0)
 
 end KonigsbergOQ03

--- a/research/problems/konigsberg-oq-03-wip-01/sessions/2026-06-04-s5-act-accessors-and-no-edge-sanity.md
+++ b/research/problems/konigsberg-oq-03-wip-01/sessions/2026-06-04-s5-act-accessors-and-no-edge-sanity.md
@@ -1,0 +1,222 @@
+# S5 ACT — Sibling-style accessor theorems + no-edge sanity theorems
+
+**Researcher**: researcher-1
+**Date**: 2026-06-04
+**Phase**: ACT (iteration 5, S4 ACT's "trivial closure lemma" S5 candidate executed)
+**PR**: (this PR)
+
+## Summary
+
+Added **7 small theorems** to `proofs/Proofs/KonigsbergOQ03.lean` in two
+groups:
+
+1. **Three sibling-parity accessors** (`InfiniteWalk.step_is_adj`,
+   `IsEulerWalk.covers`, `IsEulerWalk.injective`) — mirrors the
+   `KonigsbergOQ03OQ02.lean` API so callers can use either file
+   interchangeably for the one-way infinite case. Pure projections.
+
+2. **Four no-edge sanity theorems** — for an `InfiniteGraph` with no
+   adjacencies (`∀ u v, ¬ G.adj u v`):
+   * `InfiniteWalk.isEmpty_of_no_edges` — `IsEmpty (InfiniteWalk G)`.
+   * `BiInfiniteWalk.isEmpty_of_no_edges` — `IsEmpty (BiInfiniteWalk G)`.
+   * `not_hasOneWayEulerPath_of_no_edges` — `¬ HasOneWayEulerPath G`.
+   * `not_hasInfiniteEulerPath_of_no_edges` — `¬ HasInfiniteEulerPath G`.
+
+Each no-edge theorem is a 2-line `rintro ⟨w, _⟩; exact h _ _ (w.step_adj 0)`
+that uses the `step_adj` field of the walk structure to derive a
+contradiction with the no-edge hypothesis.
+
+## Net file deltas
+
+| Metric | Before (S4 ACT, `origin/main`) | After (this S5 ACT) | Δ |
+|--------|--------------------------------|---------------------|---|
+| LOC | 202 | 256 | +54 |
+| theorems | 2 | 9 | +7 |
+| defs+structures | 14 | 14 | 0 |
+| `:= True` placeholders | 0 | 0 | 0 |
+| sorries | 0 | 0 | 0 |
+| axioms | 0 | 0 | 0 |
+
+## Why this is the right S5 work
+
+The S4 ACT memo's S5 candidate menu listed five options:
+
+1. **(trivial closure lemma)** — smallest non-trivial Eulerian fact.
+2. **(EGW statement)** — state the theorem as `theorem ... := by sorry`.
+3. **(sibling DRY refactor — cross-slug)** — separate claim.
+4. **(EGW proof — multi-week)** — too large for one session.
+5. **(skip)** — move on.
+
+This PR executes option **(1)** with a small addition: the "trivial
+closure lemma" is the **no-edge sanity theorems**, which confirm the
+S4-discharged predicates `HasOneWayEulerPath` / `HasInfiniteEulerPath`
+are non-degenerate — they do not hold for every graph.
+
+I deliberately did **not** go with option (1)'s original suggestion of
+*"constant `InfiniteWalk` as a (vacuous) `IsEulerWalk`"* because:
+
+* `InfiniteGraph.loopless` forbids `G.adj v v`, so the constant walk
+  `v, v, v, …` violates `step_adj : ∀ n, G.adj (vertex n) (vertex (n+1))`.
+* No constant `InfiniteWalk` exists for any graph at all; the suggested
+  lemma was simply wrong.
+
+The no-edge variant is the correct dual: it shows that when there are
+no edges, *no* `InfiniteWalk` can exist (the type is `IsEmpty`), so the
+Eulerian existentials are `False`. This is the smallest concrete claim
+that exercises both the walk types and the Eulerian existentials.
+
+The sibling-parity accessors `step_is_adj` / `covers` / `injective` are
+pure projections that mirror the sibling file's `Part 4: Basic
+Properties` section. They are useful because callers writing
+`hEuler.covers u v hadj` reads more naturally than `hEuler.1 u v hadj`,
+and matches the API style already established in the gallery.
+
+I considered option (2) (EGW statement as `sorry`-target) but deferred
+it because:
+
+* Stating EGW correctly requires a `Connected` predicate on
+  `InfiniteGraph`, which we don't have yet — committing to a definition
+  is itself a non-trivial design choice (path-connectivity? Closure
+  under finite walks?).
+* The non-locally-finite regime needs a finite-edge-cut even-cardinality
+  condition that requires further infrastructure.
+* Premature `sorry`-targets can lock in a bad statement shape.
+
+A dedicated S6 (or later) session can take that on once a `Connected`
+def is committed.
+
+## Implementation walkthrough
+
+### Group 1: Sibling-parity accessors
+
+#### `InfiniteWalk.step_is_adj`
+
+Pure restatement of `step_adj` field of the structure, scoped under
+`namespace InfiniteWalk`:
+
+```lean
+theorem step_is_adj {V : Type*} {G : InfiniteGraph V}
+    (w : InfiniteWalk G) (n : ℕ) : G.adj (w.vertex n) (w.vertex (n + 1)) :=
+  w.step_adj n
+```
+
+Mirrors `KonigsbergOQ03OQ02.InfiniteWalk.step_is_adj` exactly.
+
+#### `IsEulerWalk.covers` and `IsEulerWalk.injective`
+
+These required wrapping the two `theorem`s in a new `namespace IsEulerWalk`
+block (the parent file did not previously have one). The accessors are
+projections of the `And` in `IsEulerWalk`:
+
+```lean
+namespace IsEulerWalk
+
+theorem covers {V : Type*} {G : InfiniteGraph V} {w : InfiniteWalk G}
+    (hEuler : IsEulerWalk G w) (u v : V) (hadj : G.adj u v) :
+    w.CoversEdge u v :=
+  hEuler.1 u v hadj
+
+theorem injective {V : Type*} {G : InfiniteGraph V} {w : InfiniteWalk G}
+    (hEuler : IsEulerWalk G w) : w.IsEdgeInjective :=
+  hEuler.2
+
+end IsEulerWalk
+```
+
+Mirrors the sibling file's lines 134–142 exactly.
+
+### Group 2: No-edge sanity theorems
+
+```lean
+theorem InfiniteWalk.isEmpty_of_no_edges {V : Type*} {G : InfiniteGraph V}
+    (h : ∀ u v, ¬ G.adj u v) : IsEmpty (InfiniteWalk G) :=
+  ⟨fun w => h _ _ (w.step_adj 0)⟩
+```
+
+The constructor of `IsEmpty α` takes `α → False`. Given a candidate walk
+`w`, its `step_adj 0` field is a proof of `G.adj (w.vertex 0) (w.vertex 1)`,
+which directly contradicts `h _ _`. Same shape for `BiInfiniteWalk`.
+
+For the non-existence corollaries:
+
+```lean
+theorem not_hasOneWayEulerPath_of_no_edges {V : Type*} {G : InfiniteGraph V}
+    (h : ∀ u v, ¬ G.adj u v) : ¬ HasOneWayEulerPath G := by
+  rintro ⟨w, _⟩
+  exact h _ _ (w.step_adj 0)
+```
+
+The `rintro` destructures `HasOneWayEulerPath G = ∃ w : InfiniteWalk G,
+IsEulerWalk G w` into `w` (discarding the `IsEulerWalk` proof since the
+contradiction comes from the walk type itself). Same shape for
+`HasInfiniteEulerPath` (with `BiInfiniteWalk`).
+
+We could have proved these as `IsEmpty.elim` applications of the first
+two theorems, but the direct `step_adj 0` proof is 1 line and avoids
+introducing an `IsEmpty.false` unfolding.
+
+## Build status — NOT verified locally
+
+Docker daemon on this host is still broken as of 2026-06-04 (same
+containerd content-store I/O issue noted in the S4 session memo —
+`docker ps` returns "Cannot connect to the Docker daemon"). Build
+verification deferred to CI / next-auditor pass. Confidence in the code
+grounded in:
+
+* **Pattern equivalence**: `step_is_adj`, `covers`, `injective` are
+  line-for-line ports of sibling-file theorems that build cleanly under
+  the same `Mathlib v4.26.0` pin.
+* **Trivial term proofs**: `step_is_adj` is `w.step_adj n` (structure
+  projection); `covers` is `hEuler.1 u v hadj` (And-left + apply);
+  `injective` is `hEuler.2` (And-right). No tactic state to go wrong.
+* **No-edge proofs**: use only `rintro`, `exact`, and field projections
+  — all built-in. The `IsEmpty` constructor takes `α → False` directly;
+  the `step_adj 0` field is a proof of `G.adj (w.vertex 0) (w.vertex 1)`
+  whose application against the no-edge hypothesis is type-checked
+  syntactically.
+* **No new imports**: file already has `import Mathlib`; all new
+  symbols (`IsEmpty`, `rintro`, structure field projection) are
+  Mathlib-resident.
+
+## Meta sync
+
+`src/data/proofs/konigsberg-oq-03/meta.json`:
+
+* `lineCount` 202 → 256.
+* `theoremCount` 2 → 9 (both at top-level `leanFile` block and the
+  nested `meta` block).
+
+Other meta fields unchanged. `assumptions` text still accurate (the no-edge
+theorems are about *what is not Eulerian*, not new placeholders).
+`originalContributions` left as is — these are small accessor/sanity
+theorems, not new mathematical content worth listing.
+
+## Iteration outcome
+
+Slug remains `placeholder-free` with **9 theorems** about the infinite-walk
+infrastructure (up from 2). Two distinct API styles now coexist:
+the sibling `KonigsbergOQ03OQ02` and this parent file both expose
+`step_is_adj` / `covers` / `injective` on their respective `InfiniteWalk`
+/ `IsEulerWalk` types.
+
+The no-edge sanity theorems are the smallest **non-trivial** Eulerian facts
+about `InfiniteGraph` — they're not vacuous because they apply to a
+non-trivial subclass of graphs (the empty ones), and they confirm the
+S4-discharged predicates have non-trivial content.
+
+## Next Action (S6 candidate menu)
+
+* **(EGW statement)** — state EGW as a `theorem ... := by sorry` once a
+  `Connected` predicate is committed for `InfiniteGraph`. ~5 LOC + def.
+* **(one-edge graph Euler walk)** — for an `InfiniteGraph` with exactly
+  one edge `{u, v}`, prove `¬ HasInfiniteEulerPath G` (a single edge
+  cannot support a non-repeating bi-infinite walk). Smaller than EGW,
+  exercises the `IsEdgeInjective` condition. ~20 LOC.
+* **(sibling DRY refactor — cross-slug)** — collapses ~100 LOC across
+  the parent and `KonigsbergOQ03OQ02` slug. Pure refactor.
+* **(EGW proof — multi-week)** — locally-finite case using
+  `SimpleGraph.Walk.IsEulerian` + König's lemma machinery.
+
+Recommended for S6: **(EGW statement) + (one-edge graph)** in one
+session — both small, both concrete, both immediately useful as
+Aristotle targets / sanity checks.

--- a/research/problems/konigsberg-oq-03-wip-01/state.md
+++ b/research/problems/konigsberg-oq-03-wip-01/state.md
@@ -2,10 +2,63 @@
 
 ## Current State
 
-**Phase**: ACT (S4, this PR — remaining True placeholders discharged via InfiniteWalk + BiInfiniteWalk infrastructure)
+**Phase**: ACT (S5, this PR — sibling-parity accessors + no-edge sanity theorems)
 **Path**: full
-**Since**: 2026-06-03 (S4 ACT, researcher-1)
-**Iteration**: 4
+**Since**: 2026-06-04 (S5 ACT, researcher-1)
+**Iteration**: 5
+
+## S5 ACT Summary (2026-06-04, researcher-1)
+
+**Mode**: ACT (theorems only; build NOT verified — Docker daemon still broken on this host, same containerd issue as S4).
+
+Added **7 small theorems** in two groups:
+
+1. **Three sibling-parity accessors** (`InfiniteWalk.step_is_adj`,
+   `IsEulerWalk.covers`, `IsEulerWalk.injective`) ported line-for-line
+   from `KonigsbergOQ03OQ02.lean`. Brings the parent's `InfiniteWalk` /
+   `IsEulerWalk` API into parity with the sibling.
+
+2. **Four no-edge sanity theorems** — for an `InfiniteGraph` with no
+   adjacencies: walk types are `IsEmpty`, and the
+   `HasOneWayEulerPath` / `HasInfiniteEulerPath` predicates evaluate
+   to `False`. These confirm the S4-discharged predicates are
+   non-degenerate.
+
+### Net file deltas
+
+| Metric | Before (S4 ACT, `origin/main`) | After (this S5 ACT) | Δ |
+|--------|--------------------------------|---------------------|---|
+| LOC | 202 | 256 | +54 |
+| theorems | 2 | 9 | +7 |
+| defs+structures | 14 | 14 | 0 |
+| `:= True` placeholders | 0 | 0 | 0 |
+| sorries | 0 | 0 | 0 |
+| axioms | 0 | 0 | 0 |
+
+The S4 ACT's recommended S5 candidate "trivial closure lemma" originally
+suggested a constant `InfiniteWalk` on a no-edge graph as a vacuous
+`IsEulerWalk`. That proposal is mathematically wrong:
+`InfiniteGraph.loopless` forbids `G.adj v v`, so no constant walk
+satisfies `step_adj`. This S5 ACT delivers the *correct* dual: when
+there are no edges, no walk exists at all. The resulting
+`isEmpty_of_no_edges` theorems are 1-line term proofs grounded in the
+`step_adj` field of the walk structures.
+
+### Build status — NOT verified locally
+
+Same Docker breakage as the S4 ACT memo. Confidence grounded in:
+
+* **Pattern equivalence**: the three accessors are line-for-line ports
+  of sibling theorems that already build under `Mathlib v4.26.0`.
+* **Trivial term proofs**: every theorem reduces to a single field
+  projection (`w.step_adj 0`, `hEuler.1`, `hEuler.2`) or
+  `rintro ⟨w, _⟩; exact h _ _ (w.step_adj 0)`.
+* **No new imports**: `IsEmpty`, `rintro` are all `import Mathlib`-resident.
+
+See `sessions/2026-06-04-s5-act-accessors-and-no-edge-sanity.md` for the
+full implementation walkthrough and the S6 candidate menu.
+
+## Prior State (S4 ACT, 2026-06-03)
 
 ## S4 ACT Summary (2026-06-03, researcher-1)
 
@@ -175,17 +228,19 @@ This replaces one of the three `True` placeholders with a real definition.
 
 ## Active Approach
 
-All three Eulerian predicates are now bound to genuine content; the
-slug is **placeholder-free**. Next layer of work is theorems
-*about* these predicates (currently 0 theorems specifically about
-`IsEulerWalk` / `IsBiInfiniteEulerWalk` beyond the trivial
-`InfiniteWalk.step_ne`). See `## Next Action` for S5 candidate menu.
+All three Eulerian predicates remain bound to genuine content; the
+slug is **placeholder-free with 9 theorems** (up from 2 at S4). API
+parity with sibling `KonigsbergOQ03OQ02` is now in place
+(`step_is_adj` / `covers` / `injective` accessors), and the
+predicates are confirmed non-degenerate via the no-edge sanity
+theorems. See `## Next Action` for S6 candidate menu (EGW statement,
+one-edge graph, sibling DRY refactor).
 
 ## Attempt Count
 
-- Total attempts: 3 (S2 SURVEY + S3 ACT r=2 case + this S4 ACT infinite/bi-infinite predicates)
-- Current approach attempts: 2 (S3 candidate A: r=2 case; S4: option-3 parent-companion port)
-- Approaches tried: 2
+- Total attempts: 4 (S2 SURVEY + S3 ACT r=2 case + S4 ACT infinite/bi-infinite predicates + this S5 ACT accessors+no-edge sanity)
+- Current approach attempts: 1 (S5: trivial closure lemma via no-edge non-existence + sibling-parity accessors)
+- Approaches tried: 3
 
 ## Blockers
 
@@ -205,15 +260,15 @@ blockers concern the *theorem-statement and proof* stage:
 
 ## Next Action
 
-**S5 candidate menu**:
+**S6 candidate menu**:
 
-* **(trivial closure lemma)** Prove the smallest non-trivial Eulerian
-  fact — e.g. "a no-edge `InfiniteGraph` admits the constant `InfiniteWalk`
-  as a (vacuous) `IsEulerWalk`". ~10 LOC. Confirms the new definitions
-  are non-degenerate.
 * **(EGW statement)** State the Erdős–Grünwald–Weiszfeld characterisation
-  as `theorem ... := by sorry` so Aristotle has a target. Decompose
-  into locally-finite (easy) and non-locally-finite (hard) cases.
+  as `theorem ... := by sorry` once a `Connected` predicate is committed
+  for `InfiniteGraph`. ~5 LOC + supporting def. Useful Aristotle target.
+* **(one-edge graph Euler walk)** For an `InfiniteGraph` with exactly
+  one edge `{u, v}`, prove `¬ HasInfiniteEulerPath G` (a single edge
+  cannot support a non-repeating bi-infinite walk). Smaller than EGW,
+  exercises the `IsEdgeInjective` condition. ~20 LOC.
 * **(sibling DRY refactor — cross-slug)** Claim
   `konigsberg-oq-03-oq-02`, refactor the sibling to import this parent
   and drop its locally-redeclared `InfiniteGraph` / `InfiniteWalk` /
@@ -223,12 +278,12 @@ blockers concern the *theorem-statement and proof* stage:
   using `SimpleGraph.Walk.IsEulerian` extension lemmas + König's
   lemma. Requires assembling graph-theoretic compactness machinery
   not yet aggregated in Mathlib for this purpose.
-* **(skip)** Park this slug as `placeholder-free / theorem-light` and
+* **(skip)** Park this slug as theorem-rich-but-EGW-deferred and
   return to other slugs.
 
-Recommended for S5: (trivial closure lemma) + (EGW statement) in one
-session — both small, both concrete, both immediately useful to
-Aristotle. Sibling DRY refactor can be a separate claim.
+Recommended for S6: (EGW statement) + (one-edge graph) in one
+session — both small, both concrete. Sibling DRY refactor remains a
+separate claim.
 
 ## Iteration history
 
@@ -237,4 +292,5 @@ Aristotle. Sibling DRY refactor can be a separate claim.
 | S1 | 2026-04-04 | (init) | OBSERVE | Initial slug creation; problem.md + state.md scaffolds; no knowledge.md / no Lean edits |
 | S2 | 2026-05-30 | researcher-1 | SURVEY | Honest gap assessment: 3 `True` placeholders are the real gaps; r=2 case (~30 LOC) is the cleanest forward step (PR #21222, doc-only) |
 | S3 | 2026-06-01 | researcher-1 | ACT | r=2 Euler-tour case implemented per S2 SURVEY candidate A: `toSimpleGraph` map + meaningful `HasEulerTour` def via `SimpleGraph.Walk.IsEulerian` + sanity lemma. 74 → 114 LOC (+40), 0 → 1 theorem, 7 → 8 defs, `True` placeholders 3 → 2. Docker build verified clean (PR a8a1307aecf / #21877) |
-| S4 | 2026-06-03 | researcher-1 | ACT | Discharged remaining 2 `True` placeholders by porting sibling `KonigsbergOQ03OQ02.lean`'s `InfiniteWalk` / `BiInfiniteWalk` / `IsEulerWalk` / `IsBiInfiniteEulerWalk` infrastructure adapted to parent's own `InfiniteGraph`. 114 → 202 LOC (+88), 1 → 2 theorems, 8 → 14 defs, `True` placeholders 2 → 0. Build NOT verified (Docker daemon broken on host). (this PR) |
+| S4 | 2026-06-03 | researcher-1 | ACT | Discharged remaining 2 `True` placeholders by porting sibling `KonigsbergOQ03OQ02.lean`'s `InfiniteWalk` / `BiInfiniteWalk` / `IsEulerWalk` / `IsBiInfiniteEulerWalk` infrastructure adapted to parent's own `InfiniteGraph`. 114 → 202 LOC (+88), 1 → 2 theorems, 8 → 14 defs, `True` placeholders 2 → 0. Build NOT verified (Docker daemon broken on host). (PR #22179) |
+| S5 | 2026-06-04 | researcher-1 | ACT | Sibling-parity accessors (`step_is_adj` / `covers` / `injective`) + four no-edge sanity theorems (walk types `IsEmpty` and Eulerian predicates `False` for no-edge graphs). 202 → 256 LOC (+54), 2 → 9 theorems. S4 ACT's S5 "trivial closure lemma" suggestion corrected (constant walk doesn't satisfy `step_adj`; no-edge non-existence is the correct dual). Build NOT verified (Docker daemon still broken). (this PR) |

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -23,7 +23,7 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 256,
     "assumptions": "0 axioms, 0 sorries, **0 `:= True` placeholders**. The 2026-06-03 S4 ACT discharged the remaining 2 placeholders (`HasInfiniteEulerPath`, `HasOneWayEulerPath`) by porting the `InfiniteWalk` / `BiInfiniteWalk` / `IsEulerWalk` / `IsBiInfiniteEulerWalk` infrastructure from sibling `Proofs/KonigsbergOQ03OQ02.lean` (adapted to use this file's own `InfiniteGraph`). All three Eulerian predicates (`HasEulerTour` from 2026-06-01 S3 ACT for the r=2 hypergraph case, `HasInfiniteEulerPath` for the bi-infinite case, `HasOneWayEulerPath` for the one-way infinite case) are now bound to genuine mathematical content. The file remains badge=`wip` because, while the predicates are now honestly defined, no nontrivial theorems characterising when they hold (e.g. Erdős–Grünwald–Weiszfeld) have been proved yet. Structure fields (uniform, symm, loopless, step_adj) are definitional, not assumptions. Build NOT independently verified after the S4 ACT (Docker daemon broken on the contributor's host) — confidence grounded in line-for-line pattern equivalence with the verified sibling file.",
     "sourceUrl": "https://en.wikipedia.org/wiki/Eulerian_path#In_directed_graphs",
     "mathlibDependencies": [
@@ -67,7 +67,7 @@
       "HasInfiniteEulerPath (S4 ACT, 2026-06-03): bi-infinite Euler path bound to ∃ w : BiInfiniteWalk G, IsBiInfiniteEulerWalk G w — replaces the prior := True placeholder",
       "HasOneWayEulerPath (S4 ACT, 2026-06-03): one-way infinite Euler path bound to ∃ w : InfiniteWalk G, IsEulerWalk G w — replaces the prior := True placeholder"
     ],
-    "theoremCount": 2,
+    "theoremCount": 9,
     "definitionCount": 14
   },
   "overview": {
@@ -266,11 +266,11 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 202,
+    "lineCount": 256,
     "path": "Proofs/KonigsbergOQ03.lean",
     "sorries": 0,
     "definitionCount": 14,
-    "theoremCount": 2
+    "theoremCount": 9
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

- Add 3 sibling-parity accessor theorems (`InfiniteWalk.step_is_adj`, `IsEulerWalk.covers`, `IsEulerWalk.injective`) bringing the parent `KonigsbergOQ03.lean` API into parity with sibling `KonigsbergOQ03OQ02.lean`.
- Add 4 no-edge sanity theorems confirming the S4-discharged Eulerian predicates are non-degenerate: walk types are `IsEmpty` and `HasOneWayEulerPath` / `HasInfiniteEulerPath` evaluate to `False` for graphs with no adjacencies.
- Sync meta: `lineCount` 202 → 256, `theoremCount` 2 → 9.

## Why this is the right S5 work

The S4 ACT memo's S5 candidate menu listed five options. This PR executes option **(1) trivial closure lemma** with a small correction: the original suggestion ("constant `InfiniteWalk` as vacuous `IsEulerWalk`") is mathematically wrong because `InfiniteGraph.loopless` forbids `G.adj v v` — no constant walk satisfies `step_adj`. The no-edge dual captures the intended sanity check correctly.

The sibling-parity accessors are pure projections that mirror `KonigsbergOQ03OQ02`'s `Part 4: Basic Properties` section — `hEuler.covers u v hadj` reads more naturally than `hEuler.1 u v hadj`.

## Net file deltas (vs `origin/main`)

| Metric | Before (S4 ACT) | After (this S5 ACT) | Δ |
|--------|-----------------|---------------------|---|
| LOC | 202 | 256 | +54 |
| theorems | 2 | 9 | +7 |
| defs+structures | 14 | 14 | 0 |
| `:= True` placeholders | 0 | 0 | 0 |
| sorries / axioms | 0 / 0 | 0 / 0 | 0 / 0 |

## Build status — NOT verified locally

Docker daemon on this host is still broken (same containerd content-store issue as S4 — `docker ps` returns "Cannot connect to the Docker daemon"). Build verification deferred to CI. Confidence grounded in:

- **Pattern equivalence**: 3 accessors are line-for-line ports of sibling theorems that build cleanly under `Mathlib v4.26.0`.
- **Trivial term proofs**: every theorem reduces to a single field projection (`w.step_adj 0`, `hEuler.1`, `hEuler.2`) or `rintro ⟨w, _⟩; exact h _ _ (w.step_adj 0)`.
- **No new imports**: `IsEmpty`, `rintro` are all already `import Mathlib`-resident.

## Test plan

- [ ] CI builds `Proofs.KonigsbergOQ03` (Lake / Docker)
- [ ] Verify gallery renders konigsberg-oq-03 with updated `lineCount` / `theoremCount`
- [ ] (Optional) Aristotle batch tests the new no-edge sanity theorems' definitional unfolding

## Files

- `proofs/Proofs/KonigsbergOQ03.lean` — +54 LOC (7 new theorems, sibling pattern)
- `src/data/proofs/konigsberg-oq-03/meta.json` — lineCount + theoremCount sync
- `research/problems/konigsberg-oq-03-wip-01/state.md` — S5 ACT summary + S6 candidate menu
- `research/problems/konigsberg-oq-03-wip-01/sessions/2026-06-04-s5-act-accessors-and-no-edge-sanity.md` — full walkthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)