### PR TITLE
Enrich abel-ruffini-oq-04-oq-02-oq-02: fix mainTheorems line numbers + TAB-escape corruption

### DIFF
--- a/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
+++ b/src/data/proofs/abel-ruffini-oq-04-oq-02-oq-02/meta.json
@@ -220,37 +220,43 @@
         "name": "alternating_solvable_iff",
         "type": "core",
         "description": "The full bidirectional classification: $A_n$ is solvable if and only if $n \\leq 4$. Forward direction by contradiction via `an_not_solvable_of_ge_five`; backward direction by `interval_cases n` enumerating $n = 0, 1, 2, 3, 4$.",
-        "leanType": "(n : ℕ) → IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4"
+        "leanType": "(n : ℕ) → IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4",
+        "line": 123
       },
       {
         "name": "an_not_solvable_of_ge_five",
         "type": "key",
         "description": "$A_n$ is not solvable for $n \\geq 5$. Proof: assume $A_n$ solvable; the sign exact sequence $1 \\to A_n \\to S_n \\to \\{\\pm 1\\} \\to 1$ gives $S_n$ solvable, contradicting Mathlib's `Equiv.Perm.not_solvable`.",
-        "leanType": "{n : ℕ} → 5 ≤ n → ¬IsSolvable (alternatingGroup (Fin n))"
+        "leanType": "{n : ℕ} → 5 ≤ n → ¬IsSolvable (alternatingGroup (Fin n))",
+        "line": 106
       },
       {
         "name": "a4_solvable",
         "type": "key",
         "description": "$A_4$ is solvable. The largest solvable alternating group; its solvability rests on the Klein four-group $V_4 \\trianglelefteq A_4$ with composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4$ having abelian factors $(\\mathbb{Z}/2\\mathbb{Z})^2$ and $\\mathbb{Z}/3\\mathbb{Z}$.",
-        "leanType": "IsSolvable (alternatingGroup (Fin 4))"
+        "leanType": "IsSolvable (alternatingGroup (Fin 4))",
+        "line": 75
       },
       {
         "name": "a3_solvable",
         "type": "supporting",
         "description": "$A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ is solvable (abelian). Proved via `isSolvable_of_comm` plus `decide` on the commutativity check.",
-        "leanType": "IsSolvable (alternatingGroup (Fin 3))"
+        "leanType": "IsSolvable (alternatingGroup (Fin 3))",
+        "line": 69
       },
       {
         "name": "sharp_threshold",
         "type": "key",
         "description": "Witnesses the sharp dichotomy: $A_4$ is solvable AND $A_5$ is not. A single quotable conjunction making the transition at $n = 5$ a one-line corollary.",
-        "leanType": "IsSolvable (alternatingGroup (Fin 4)) ∧ ¬IsSolvable (alternatingGroup (Fin 5))"
+        "leanType": "IsSolvable (alternatingGroup (Fin 4)) ∧ ¬IsSolvable (alternatingGroup (Fin 5))",
+        "line": 163
       },
       {
         "name": "a5_not_solvable",
         "type": "specialization",
         "description": "$A_5$ is not solvable. Direct application of `an_not_solvable_of_ge_five` with $n = 5$. Illustrates the smallest non-solvable alternating group.",
-        "leanType": "¬IsSolvable (alternatingGroup (Fin 5))"
+        "leanType": "¬IsSolvable (alternatingGroup (Fin 5))",
+        "line": 145
       }
     ],
     "path": "Proofs/AbelRuffiniOQ04OQ02OQ02.lean",
@@ -447,37 +453,43 @@
       "name": "alternating_solvable_iff",
       "type": "core",
       "description": "The full bidirectional classification: $A_n$ is solvable if and only if $n \\leq 4$. Forward direction by contradiction via `an_not_solvable_of_ge_five`; backward direction by `interval_cases n` enumerating $n = 0, 1, 2, 3, 4$.",
-      "leanType": "(n : ℕ) → IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4"
+      "leanType": "(n : ℕ) → IsSolvable (alternatingGroup (Fin n)) ↔ n ≤ 4",
+      "line": 123
     },
     {
       "name": "an_not_solvable_of_ge_five",
       "type": "key",
-      "description": "$A_n$ is not solvable for $n \\geq 5$. Proof: assume $A_n$ solvable; the sign exact sequence $1 \to A_n \to S_n \to \\{\\pm 1\\} \to 1$ gives $S_n$ solvable, contradicting Mathlib’s `Equiv.Perm.not_solvable`.",
-      "leanType": "{n : ℕ} → 5 ≤ n → ¬IsSolvable (alternatingGroup (Fin n))"
+      "description": "$A_n$ is not solvable for $n \\geq 5$. Proof: assume $A_n$ solvable; the sign exact sequence $1 \\to A_n \\to S_n \\to \\{\\pm 1\\} \\to 1$ gives $S_n$ solvable, contradicting Mathlib's `Equiv.Perm.not_solvable`.",
+      "leanType": "{n : ℕ} → 5 ≤ n → ¬IsSolvable (alternatingGroup (Fin n))",
+      "line": 106
     },
     {
       "name": "a4_solvable",
       "type": "key",
-      "description": "$A_4$ is solvable. The largest solvable alternating group; its solvability rests on the Klein four-group $V_4 \trianglelefteq A_4$ with composition series $\\{e\\} \trianglelefteq V_4 \trianglelefteq A_4$ having abelian factors $(\\mathbb{Z}/2\\mathbb{Z})^2$ and $\\mathbb{Z}/3\\mathbb{Z}$.",
-      "leanType": "IsSolvable (alternatingGroup (Fin 4))"
+      "description": "$A_4$ is solvable. The largest solvable alternating group; its solvability rests on the Klein four-group $V_4 \\trianglelefteq A_4$ with composition series $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4$ having abelian factors $(\\mathbb{Z}/2\\mathbb{Z})^2$ and $\\mathbb{Z}/3\\mathbb{Z}$.",
+      "leanType": "IsSolvable (alternatingGroup (Fin 4))",
+      "line": 75
     },
     {
       "name": "a3_solvable",
       "type": "supporting",
       "description": "$A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$ is solvable (abelian). Proved via `isSolvable_of_comm` plus `decide` on the commutativity check.",
-      "leanType": "IsSolvable (alternatingGroup (Fin 3))"
+      "leanType": "IsSolvable (alternatingGroup (Fin 3))",
+      "line": 69
     },
     {
       "name": "sharp_threshold",
       "type": "key",
       "description": "Witnesses the sharp dichotomy: $A_4$ is solvable AND $A_5$ is not. A single quotable conjunction making the transition at $n = 5$ a one-line corollary.",
-      "leanType": "IsSolvable (alternatingGroup (Fin 4)) ∧ ¬IsSolvable (alternatingGroup (Fin 5))"
+      "leanType": "IsSolvable (alternatingGroup (Fin 4)) ∧ ¬IsSolvable (alternatingGroup (Fin 5))",
+      "line": 163
     },
     {
       "name": "a5_not_solvable",
       "type": "specialization",
       "description": "$A_5$ is not solvable. Direct application of `an_not_solvable_of_ge_five` with $n = 5$. Illustrates the smallest non-solvable alternating group.",
-      "leanType": "¬IsSolvable (alternatingGroup (Fin 5))"
+      "leanType": "¬IsSolvable (alternatingGroup (Fin 5))",
+      "line": 145
     }
   ]
 }


### PR DESCRIPTION
## Summary

First enrichment pass on `abel-ruffini-oq-04-oq-02-oq-02` (passes=0, quality=100). Two real integrity bugs found and fixed in `meta.json`.

### Bug 1: Missing `line` field on all 12 mainTheorems entries

Both `meta.leanFile.mainTheorems` (6 entries) and the duplicate top-level `meta.mainTheorems` (6 entries) were missing `line` numbers. The gallery UI uses these to deep-link from the theorem list to the Lean source. Added verified line numbers:

| name | line |
|---|---|
| `a3_solvable` | 69 |
| `a4_solvable` | 75 |
| `an_not_solvable_of_ge_five` | 106 |
| `alternating_solvable_iff` | 123 |
| `a5_not_solvable` | 145 |
| `sharp_threshold` | 163 |

Each verified against `proofs/Proofs/AbelRuffiniOQ04OQ02OQ02.lean` (current HEAD).

### Bug 2: TAB-character corruption in two top-level descriptions

In the top-level `mainTheorems` array (not `meta.leanFile.mainTheorems`, which is fine), two LaTeX-bearing descriptions used `\to` and `\trianglelefteq`. JSON parses `\t` as a TAB-character escape, so the stored strings actually contained:

- `an_not_solvable_of_ge_five.description`: `"1 [TAB]o A_n [TAB]o S_n [TAB]o ..."` (should be `\to`, the arrow)
- `a4_solvable.description`: `"V_4 [TAB]rianglelefteq A_4"` (should be `\trianglelefteq`, the normal-subgroup symbol)

Fixed by double-escaping (`\\to`, `\\trianglelefteq`) so the LaTeX source is preserved literally and renders correctly. Also normalized one curly apostrophe (`'`) to a straight one for consistency with the rest of the file.

## Audit findings (pre-existing; verified clean)

- 12 theorems / 0 def / 0 axiom / 0 sorry in Lean — matches `meta.meta.{theoremCount, definitionCount, axiomCount, sorries}`
- `meta.meta.lineCount = 167` matches Lean file
- All 14 `crossReferences.targetId`s resolve to existing `src/data/proofs/<id>/` directories
- All 7 annotations have `mathContext`, `significance`, `relatedConcepts`, and `prerequisites` populated
- Sections cover lines 1–167 (full file)
- No remaining TAB-char corruption anywhere in `meta.json` or `annotations.json`
- `status: verified` + `badge: mathlib` + `axiomCount: 0` consistent (no structure-encoded assumptions)

## Test plan

- [x] `meta.json` JSON validates
- [x] All 12 `mainTheorems[*].line` values verified to point at lines containing the named theorem in the current Lean source
- [x] TAB-char scan over `meta.json` and `annotations.json` returns clean