### PR TITLE
Enrich szemeredi-theorem-oq-01: tactic walkthrough + import-level depth

### DIFF
--- a/src/data/proofs/szemeredi-theorem-oq-01/annotations.json
+++ b/src/data/proofs/szemeredi-theorem-oq-01/annotations.json
@@ -77,11 +77,38 @@
     ]
   },
   {
+    "id": "ann-imports",
+    "proofId": "szemeredi-theorem-oq-01",
+    "range": {
+      "startLine": 43,
+      "endLine": 50
+    },
+    "type": "structure",
+    "title": "Imports, Namespace, and `open Real`",
+    "content": "**Imports.**\n\n- `Mathlib.Combinatorics.Additive.Corner.Roth` — provides `rothNumberNat : ℕ → ℕ`, the Mathlib invariant against which the Kelley–Meka bound is stated. Choosing this exact name (rather than redefining a parallel `r_3` in this file) makes the axiom directly composable with the rest of Mathlib's additive-combinatorics chain — any downstream theorem already using `rothNumberNat` can consume `kelley_meka_bound` without translation.\n\n- `Mathlib.Analysis.SpecialFunctions.Log.Basic` — provides `Real.log : ℝ → ℝ`, the natural logarithm. Note that `Real.log` is defined for all reals (with `Real.log x = 0` for `x ≤ 0`); this is why the axiom's threshold `N₀` exists, to skirt the regime where `log N` is non-positive.\n\n- `Mathlib.Analysis.SpecialFunctions.Pow.Real` — provides `Real.rpow : ℝ → ℝ → ℝ` (notated `^` with a real exponent), giving the `(log N) ^ ((1 : ℝ) / 12)` expression its meaning. The `(1 : ℝ) / 12` type ascription is required because `1 / 12 = 0` in `ℕ` and `ℤ`; without it Lean would silently truncate the exponent to `0` and the bound would degenerate to `r_3(N) ≤ N · exp(-c)`, a trivially false statement.\n\n- `Mathlib.Tactic` — bulk import of Mathlib's tactic library, providing `obtain`, `refine`, `exact_mod_cast`, and the `simp`/`linarith`/`positivity` family used inline in the corollary.\n\n**Namespace `SzemerediTheoremOQ01`** — encloses the axiom and corollary so that their names do not collide with future variants (`SzemerediTheoremOQ02.kelley_meka_bound`, e.g., for a different exponent). Anchoring the namespace to the slug `szemeredi-theorem-oq-01` keeps gallery and Lean naming in sync.\n\n**`open Real`** — brings `exp`, `log`, and `rpow` into local scope. Without it, the axiom and corollary would need to write `Real.exp (-(c * Real.log N ^ ...))`; with it, the expressions read as in mathematical notation. The `open` is local to the namespace section and does not affect downstream files.",
+    "mathContext": "**Naming discipline.** Stating $r_3(N)$ as `rothNumberNat` (rather than introducing a parallel definition) is a deliberate gallery convention: any future formalization of Kelley–Meka can replace the `axiom` by a `theorem` with the *exact same signature*, so downstream consumers (proofs of corollaries, surveys, exponent-improvement entries) need no rewrites.\n\n**Type-ascription trap on `1/12`.** A common Lean mistake is to write `Real.log N ^ (1/12)` without the `(1 : ℝ)` ascription. Because `^` for an `ℕ`-exponent is `Monoid.npow`, and `1/12 = 0` in `ℕ`, Lean would silently use the zero-power and the bound would read $r_3(N) \\leq N \\cdot e^{-c}$ — a false statement absorbed by Lean's elaboration. The explicit `((1 : ℝ) / 12)` forces `Real.rpow`, which is what we want.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "Mathlib naming conventions for additive combinatorics",
+      "Real.rpow vs Monoid.npow distinction",
+      "namespace-per-entry gallery convention",
+      "open Real notation idiom",
+      "rothNumberNat (Mathlib)",
+      "type-ascription discipline for rpow exponents"
+    ],
+    "prerequisites": [
+      "Lean 4 module system and namespace resolution",
+      "Mathlib.Analysis.SpecialFunctions.Pow.Real (Real.rpow)",
+      "Mathlib's Real.log convention for non-positive inputs",
+      "distinction between Monoid.npow and Real.rpow"
+    ]
+  },
+  {
     "id": "ann-density-corollary",
     "proofId": "szemeredi-theorem-oq-01",
     "range": {
       "startLine": 68,
-      "endLine": 83
+      "endLine": 77
     },
     "type": "concept",
     "title": "rothNumberNat_density_le_kelley_meka: Non-Axiomatic Density Form",
@@ -99,6 +126,36 @@
       "kelley_meka_bound axiom",
       "div_le_iff₀ for positive denominators",
       "max-threshold idiom (`max N₀ 1` to fuse boundary and asymptotic conditions)"
+    ]
+  },
+  {
+    "id": "ann-proof-tactics",
+    "proofId": "szemeredi-theorem-oq-01",
+    "range": {
+      "startLine": 78,
+      "endLine": 86
+    },
+    "type": "proof-step",
+    "title": "Tactic-by-Tactic Walkthrough of the Density Corollary",
+    "content": "The 9-line proof body is denser than it looks; each tactic does one bookkeeping job.\n\n**Line 78** — `obtain ⟨c, hc, N₀, hbound⟩ := kelley_meka_bound`. Anonymous-constructor destructuring on the existential `∃ c, 0 < c ∧ ∃ N₀, ∀ N ≥ N₀, ...`. Extracts four things: the constant `c : ℝ`, the positivity proof `hc : 0 < c`, the threshold `N₀ : ℕ`, and the witnessing function `hbound : ∀ N, N₀ ≤ N → r_3(N) ≤ N · exp(...)`. Note: Lean's `obtain` is smart enough to pierce the nested `∧` and `∃` without requiring `⟨c, ⟨hc, N₀, hbound⟩⟩` parentheses.\n\n**Line 79** — `refine ⟨c, hc, max N₀ 1, ?_⟩`. Provides three of the four pieces for the corollary's existential: same `c`, same `hc`, threshold `max N₀ 1`. The `?_` defers the universal statement to a sub-goal that the rest of the proof discharges. Choosing `max N₀ 1` (rather than just `N₀`) is the key threshold-engineering step: it ensures `1 ≤ N` so `(N : ℝ) > 0`, which is required for `div_le_iff₀`.\n\n**Line 80** — `intro N hN`. Standard universal-introduction. After this, the goal is `r_3(N)/N ≤ exp(-c (log N)^(1/12))` and the context has `hN : max N₀ 1 ≤ N`.\n\n**Line 81** — `have hN₀ : N₀ ≤ N := (le_max_left N₀ 1).trans hN`. Decomposes `max N₀ 1 ≤ N` into `N₀ ≤ N`. The pattern `(le_max_left ...).trans hN` is the canonical way to recover one side of a `max` after a `max ≤` hypothesis.\n\n**Line 82** — `have hN1 : 1 ≤ N := (le_max_right N₀ 1).trans hN`. Symmetric: recovers `1 ≤ N` from the other side of the `max`. This is what makes `max N₀ 1` work as a fused threshold.\n\n**Line 83** — `have hN_pos : (0 : ℝ) < N := by exact_mod_cast Nat.lt_of_succ_le hN1`. Promotes `1 ≤ N` (in `ℕ`) to `0 < N` (in `ℝ`). `Nat.lt_of_succ_le` converts `1 ≤ N` to `0 < N` in `ℕ`; `exact_mod_cast` then handles the `ℕ → ℝ` coercion. This positivity is what `div_le_iff₀` requires.\n\n**Line 84** — `have hb := hbound N hN₀`. Applies the axiom's witnessing function with our `N` and the recovered `hN₀`, yielding `r_3(N) ≤ N · exp(-c (log N)^(1/12))`. This is the axiom's content specialized to the current `N`.\n\n**Line 85** — `rw [div_le_iff₀ hN_pos, mul_comm]`. Two rewrites in one tactic. First, `div_le_iff₀ hN_pos : a/b ≤ c ↔ a ≤ c * b` rewrites the goal from `r_3(N)/N ≤ exp(...)` to `r_3(N) ≤ exp(...) * N`. Second, `mul_comm` swaps the right-hand side to `N · exp(...)`, matching the axiom's exact form. The order matters: `div_le_iff₀` first, then `mul_comm` once the division is gone.\n\n**Line 86** — `exact hb`. The goal `r_3(N) ≤ N · exp(...)` is now syntactically identical to `hb`. The proof closes.\n\n**Why this matters as enrichment**: the 9-line proof showcases three reusable patterns — anonymous-constructor destructuring for nested ∃/∧, the `max N₀ 1` fused threshold for combining boundary and asymptotic conditions, and the `div_le_iff₀ ; mul_comm` rewrite chain for moving from `r_3(N)/N ≤ ...` to `r_3(N) ≤ ... · N`. Any future quantitative-density entry (e.g., for higher k or improved exponents) can copy this skeleton directly.",
+    "mathContext": "**Tactical complexity vs mathematical content**: this proof is purely bookkeeping. The mathematical content (the bound itself) is entirely in the axiom; the corollary is just a division by $N$. The 9 tactics are all of the type \"unpack the existential / set up positivity / rewrite the division.\" This separation is intentional — once `kelley_meka_bound` is replaced by an unconditional theorem, the corollary's proof body needs zero changes.\n\n**Why the `max N₀ 1` fused threshold is sharp**. The axiom's $N_0$ is unspecified; the corollary needs $N \\geq 1$ for the division by $N$ to be well-defined and for `div_le_iff₀` to apply. Rather than asserting both `N ≥ N₀` and `N ≥ 1` separately, the proof fuses them into a single `max N₀ 1 ≤ N` hypothesis. This is a small but recurring idiom in quantitative-bound proofs: when a theorem needs multiple lower bounds on the input, fuse them with `max` rather than carrying multiple hypotheses.\n\n**Casting layer**: `exact_mod_cast Nat.lt_of_succ_le hN1` is the standard Lean 4 idiom for `1 ≤ N` (in `ℕ`) ⟹ `(0 : ℝ) < N`. The chain `Nat.lt_of_succ_le : 0 + 1 ≤ N → 0 < N` is in `ℕ`; `exact_mod_cast` performs the `Nat.cast`. Writing this in one line beats unfolding it as `have : (0 : ℕ) < N := Nat.lt_of_succ_le hN1; exact_mod_cast this`.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "anonymous-constructor destructuring on nested ∃/∧",
+      "div_le_iff₀ rewrite pattern",
+      "exact_mod_cast for ℕ → ℝ positivity",
+      "fused max-threshold idiom",
+      "le_max_left / le_max_right transitivity chain",
+      "Nat.lt_of_succ_le",
+      "refine with `?_` placeholder",
+      "two-step rw chain (div_le_iff₀; mul_comm)"
+    ],
+    "prerequisites": [
+      "Lean 4 tactic syntax (obtain, refine, intro, have, rw, exact)",
+      "Mathlib.Algebra.Order.Field.Basic (div_le_iff₀)",
+      "Mathlib.Order.Lattice (le_max_left, le_max_right)",
+      "Nat.lt_of_succ_le and the ℕ ↪ ℝ cast",
+      "anonymous-constructor pattern for ∃/∧ destructuring"
     ]
   }
 ]

--- a/src/data/proofs/szemeredi-theorem-oq-01/meta.json
+++ b/src/data/proofs/szemeredi-theorem-oq-01/meta.json
@@ -105,7 +105,9 @@
       "The non-axiomatic density corollary `rothNumberNat_density_le_kelley_meka` certifies that the axiom is non-vacuous in the asymptotic direction: it directly produces the form `r_3(N)/N ≤ exp(-c (log N)^{1/12})` that is most often cited in surveys.",
       "The exponent 1/12 in Kelley–Meka is not the best possible; subsequent work has improved it (e.g., Bloom–Sisask follow-ups). This entry intentionally fixes 1/12 to match the original paper, leaving exponent-improvement as a separate follow-up question.",
       "The gap between Kelley–Meka (exp(-c (log N)^{1/12})) and Behrend (exp(-c sqrt(log N))) leaves an open exponent question: what is the right exponent θ such that r_3(N) = N · exp(-(log N)^θ + o(1))? Kelley–Meka give θ ≥ 1/12 (i.e., the upper bound holds with exponent ≥ 1/12), Behrend gives θ ≤ 1/2. Closing this gap is a central open problem; even Behrend's exponent 1/2 is conjectured to be sharp for the lower bound side, so the question reduces to whether the upper bound can be pushed to exponent 1/2.",
-      "Once Bohr sets and sifted Fourier are formalized (per the prerequisites laid out in this entry), the Kelley–Meka axiom can be discharged *without* changing this file's downstream API: every consumer continues to import `kelley_meka_bound` and the density corollary `rothNumberNat_density_le_kelley_meka` as before. This is the gallery's `axiomatized → verified` upgrade pathway in action: an axiom whose statement is calibrated to Mathlib's existing combinator (`rothNumberNat`) can later be replaced by a `theorem` with no consumer-side breakage. Compare with the `abel-ruffini` chain, where the upgrade analogue replaced axioms about `Gal(x^5 − 4x + 2)` with a full bijectivity proof — same pattern, different domain."
+      "Once Bohr sets and sifted Fourier are formalized (per the prerequisites laid out in this entry), the Kelley–Meka axiom can be discharged *without* changing this file's downstream API: every consumer continues to import `kelley_meka_bound` and the density corollary `rothNumberNat_density_le_kelley_meka` as before. This is the gallery's `axiomatized → verified` upgrade pathway in action: an axiom whose statement is calibrated to Mathlib's existing combinator (`rothNumberNat`) can later be replaced by a `theorem` with no consumer-side breakage. Compare with the `abel-ruffini` chain, where the upgrade analogue replaced axioms about `Gal(x^5 − 4x + 2)` with a full bijectivity proof — same pattern, different domain.",
+      "The proof of the density corollary is a 9-line bookkeeping exercise that does not depend on the Kelley–Meka exponent. Replace `1/12` by any future improved exponent `θ ∈ (0, 1/2]` in the axiom and the entire corollary still type-checks unchanged. This decoupling means an exponent-improvement entry (e.g., a Heath-Brown-reduction follow-up pushing 1/12 → 1/9) can swap the axiom in-place without touching the corollary — a concrete instance of the `axiomatized → verified → improved` ratchet.",
+      "The type ascription `((1 : ℝ) / 12)` on the exponent is load-bearing. Without it, Lean would elaborate `1 / 12` in `ℕ` (where it equals `0`), silently degrading `(Real.log N) ^ (1/12)` to `(Real.log N) ^ 0 = 1` and reducing the bound to `r_3(N) ≤ N · exp(-c)` — false. This is the canonical `Real.rpow` vs `Monoid.npow` trap that any future quantitative-density formalization must avoid; recording the exact ascription pattern here documents the workaround for the next agent."
     ],
     "prerequisites": [
       "Roth's theorem in its qualitative form (covered by `szemeredi-theorem`)",
@@ -116,28 +118,44 @@
   },
   "sections": [
     {
-      "id": "preamble",
-      "title": "Module Header and Imports",
+      "id": "preamble-docstring",
+      "title": "Module Docstring",
       "startLine": 1,
+      "endLine": 41,
+      "summary": "Module-level docstring stating the Kelley–Meka bound, the reason for axiomatizing, the rate gap against Mathlib's tower-type `cornersTheoremBound`, and the sibling slug for Approach B. Records the FOCS 2023 / Annals 2024 citation.",
+      "mathContext": "Frames the bound r_3(N) ≤ N · exp(-c (log N)^{1/12}) and contrasts it with Mathlib's existing chain (which gives only iterated-log class density via inversion of tower-type SzemerediRegularity.bound)."
+    },
+    {
+      "id": "imports-namespace",
+      "title": "Imports, Namespace, and `open Real`",
+      "startLine": 43,
       "endLine": 50,
-      "summary": "Module docstring stating the Kelley–Meka bound, the reason for axiomatizing, the rate gap against Mathlib's tower-type `cornersTheoremBound`, and the sibling slug for Approach B. Imports `Corner.Roth` (for `rothNumberNat`), `Log.Basic`, `Pow.Real`, and `Tactic`.",
-      "mathContext": "Statement: ∃ c > 0, ∃ N₀, ∀ N ≥ N₀, rothNumberNat N ≤ N · exp(-c (log N)^{1/12}). The exponent 1/12 follows the Kelley–Meka 2023 paper."
+      "summary": "Imports `Corner.Roth` (for `rothNumberNat`), `Log.Basic`, `Pow.Real`, and `Tactic`. Opens namespace `SzemerediTheoremOQ01` and `Real`. The `Pow.Real` import provides `Real.rpow`, used for the fractional exponent `(log N) ^ (1/12)`.",
+      "mathContext": "The `Real.rpow` import is load-bearing: the type ascription `((1 : ℝ) / 12)` in the axiom forces `Real.rpow` instead of `Monoid.npow`, avoiding the silent `1/12 = 0 in ℕ` trap."
     },
     {
       "id": "kelley-meka-axiom",
       "title": "Kelley–Meka Axiom",
-      "startLine": 55,
-      "endLine": 66,
-      "summary": "Axiomatizes the Kelley–Meka bound `kelley_meka_bound`: there exists an absolute constant c > 0 and N₀ such that for all N ≥ N₀, `(rothNumberNat N : ℝ) ≤ N · Real.exp (-(c * (Real.log N) ^ (1/12)))`.",
-      "mathContext": "∃ c > 0, ∃ N₀, ∀ N ≥ N₀, r_3(N) ≤ N · exp(-c (log N)^{1/12}). Stated against Mathlib's `rothNumberNat` exactly."
+      "startLine": 52,
+      "endLine": 65,
+      "summary": "Axiomatizes the Kelley–Meka bound `kelley_meka_bound`: there exists an absolute constant c > 0 and N₀ such that for all N ≥ N₀, `(rothNumberNat N : ℝ) ≤ N · Real.exp (-(c * (Real.log N) ^ (1/12)))`. The doc comment notes the exponent 1/12 follows the 2023 paper; subsequent improvements are out of scope here.",
+      "mathContext": "∃ c > 0, ∃ N₀, ∀ N ≥ N₀, r_3(N) ≤ N · exp(-c (log N)^{1/12}). Stated against Mathlib's `rothNumberNat` exactly. The `((1 : ℝ) / 12)` ascription forces `Real.rpow` rather than `Monoid.npow`."
     },
     {
-      "id": "density-corollary",
-      "title": "Density Corollary",
-      "startLine": 68,
-      "endLine": 83,
-      "summary": "**Proved.** `rothNumberNat_density_le_kelley_meka`: under the axiom, `r_3(N) / N ≤ exp(-c (log N)^{1/12})` for `N ≥ max N₀ 1`. Proof: extract `c, N₀` from `kelley_meka_bound`, take the threshold `max N₀ 1`, divide by `N` using `div_le_iff₀` and `mul_comm`.",
-      "mathContext": "From `r_3(N) ≤ N · exp(-c (log N)^{1/12})` and `N ≥ 1`, dividing both sides by `N` gives `r_3(N)/N ≤ exp(-c (log N)^{1/12})`. The `max N₀ 1` threshold ensures `N > 0` for the division."
+      "id": "density-corollary-statement",
+      "title": "Density Corollary Statement and Doc",
+      "startLine": 67,
+      "endLine": 77,
+      "summary": "Doc comment and statement of `rothNumberNat_density_le_kelley_meka`: under the axiom, `r_3(N) / N ≤ exp(-c (log N)^{1/12})` for `N ≥ max N₀ 1`. The doc comment explains why this is the surveyor-cited form and why the right-hand side beats every `(log N)^{-k}`.",
+      "mathContext": "Statement form `∃ c > 0, ∃ N₀, ∀ N ≥ N₀, r_3(N)/N ≤ exp(-c (log N)^{1/12})`. The shift from `r_3(N) ≤ N · exp(...)` to `r_3(N)/N ≤ exp(...)` requires `N > 0` for the division to be well-defined."
+    },
+    {
+      "id": "density-corollary-proof",
+      "title": "Density Corollary Proof Tactics",
+      "startLine": 78,
+      "endLine": 86,
+      "summary": "9-line tactic proof. Extracts `c, N₀, hbound` from the axiom, takes the fused threshold `max N₀ 1`, decomposes `max N₀ 1 ≤ N` into `N₀ ≤ N` (for the axiom) and `1 ≤ N` (for positivity), casts `1 ≤ N` to `(0 : ℝ) < N`, applies the axiom's witnessing function, and closes via the rewrite chain `div_le_iff₀ hN_pos; mul_comm`. Purely bookkeeping — no new mathematics.",
+      "mathContext": "Tactical complexity: the proof is 9 lines but uses three reusable patterns. (1) anonymous-constructor destructuring on the nested ∃ ∧ ∃ ∀; (2) `max N₀ 1` as a fused threshold satisfying both the axiom's lower bound and the positivity required by `div_le_iff₀`; (3) `div_le_iff₀ ; mul_comm` rewrite chain to align with the axiom's right-hand side."
     }
   ],
   "crossReferences": [
@@ -169,7 +187,9 @@
       "Can the Kelley–Meka exponent `1/12` be improved? Subsequent work has nudged it; a follow-up gallery entry could record the current best.",
       "Closing the Kelley–Meka / Behrend gap (1/12 vs 1/2 in the (log N)^α exponent) is open. What is the true exponent?",
       "Can Bohr sets, sifted Fourier analysis on Z/NZ, and the U^3 inverse theorem be formalized in Mathlib, allowing this axiom to be discharged?",
-      "Approach B (Salem–Spencer quantitative `O(N / log log N)`) is recommended as the sibling slug `szemeredi-theorem-oq-01-incomplete-01`. When will the upstream infrastructure for that bound be available?"
+      "Approach B (Salem–Spencer quantitative `O(N / log log N)`) is recommended as the sibling slug `szemeredi-theorem-oq-01-incomplete-01`. When will the upstream infrastructure for that bound be available?",
+      "Does the Kelley–Meka argument extend to the `k = 4` (4-AP-free) case? The pre-Kelley–Meka best for `k = 4` is a tower-type bound from Gowers' hypergraph regularity; whether a sifted-Fourier-style argument can break the tower barrier for `k ≥ 4` is open. A positive answer would yield a sibling gallery entry for higher k.",
+      "Is there a constructive (algorithmic) version of the Kelley–Meka bound? Behrend's lower bound construction is explicit; whether one can produce a randomized or derandomized polynomial-time algorithm that *finds* a 3-AP-free set witnessing the matching upper bound is a separate open question of interest to TCS."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Enrichment Pass: szemeredi-theorem-oq-01 (Kelley–Meka 2023 Bound)

Quality 83 → enriched. Pass 0 → 1.

### Additions

**Annotations (3 → 5):**
- `ann-imports` (lines 43-50): walks through each import (`Corner.Roth`, `Log.Basic`, `Pow.Real`, `Tactic`), the `open Real` idiom, and the **load-bearing `((1 : ℝ) / 12)` ascription** that prevents Lean from silently using `Monoid.npow` with a `1/12 = 0` exponent.
- `ann-proof-tactics` (lines 78-86): tactic-by-tactic walkthrough of the 9-line density-corollary proof, surfacing three reusable patterns — anonymous-constructor destructuring on nested `∃/∧`, the `max N₀ 1` fused-threshold idiom, and the `div_le_iff₀; mul_comm` rewrite chain.

**Sections (3 → 5):**
- Split `preamble` (was lines 1-50) into `preamble-docstring` (1-41) and `imports-namespace` (43-50).
- Split `density-corollary` (was 68-83) into `density-corollary-statement` (67-77) and `density-corollary-proof` (78-86) for finer coverage.
- Adjusted axiom range from 55-66 to 52-65 to match the Lean source exactly.

**keyInsights (8 → 10):**
- Decoupling of the corollary's proof from the axiom's exponent — any future exponent improvement reuses the corollary unchanged.
- The `Real.rpow` vs `Monoid.npow` type-ascription trap, documented as a workaround for the next agent.

**openQuestions (4 → 6):**
- Does the Kelley–Meka argument extend to `k = 4` (4-AP-free)?
- Is there a constructive (polynomial-time algorithmic) version of the Kelley–Meka bound?

### Mathematical accuracy notes
- Historical timeline (Roth 1953, Heath-Brown 1987, Bourgain 1999/2008, Schoen 2017, Bloom-Sisask 2020, Kelley-Meka 2023, Behrend 1946 lower bound) left untouched.
- Axiom integrity: `axiomCount: 1` confirmed against the single `axiom kelley_meka_bound` declaration; no structure-encoded hypotheses.

### Verification
- JSON validates.
- Enrichment script processed: `Enriched szemeredi-theorem-oq-01: 2 lean files, 3 related proofs`.
- `pnpm build` blocked at `tsc` due to a pre-existing native-dependency build failure on `better-sqlite3` in this worktree's `pnpm install`; unrelated to JSON content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)