### PR TITLE
research(cauchy-schwarz-weighted-power-mean): mark completed — proof on main since PR #19454

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03",
   "title": "The weighted power mean $M_p^w(a,b) = (w_1 a^p + w_2 b^p)^{1/p}$ for weights ...",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "completed",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-04T11:17:07.542Z",
+    "phase": "completed",
+    "since": "2026-06-04T18:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proof completed and merged in PR #19454. Gallery entry verified (badge: original, 0 sorries, 0 axioms).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — problem solved. Possible follow-ups: general M_r^w ≤ M_s^w monotonicity, n-variable generalization.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
Sync the research problem JSON for cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03 with reality.

## What was already done (on main)

proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ01OQ02OQ03.lean — 210 LOC, 0 sorries, 0 axioms, badge original, status verified in the gallery. Proves WHM ≤ WGM ≤ WAM ≤ WQM for a, b > 0 and weights w1 + w2 = 1 with w1, w2 > 0. Three-step chain (WGM ≤ WAM via Real.geom_mean_le_arith_mean2_weighted; WAM ≤ WQM via Jensen identity + ring; WHM ≤ WGM via reciprocal + inv_le_comm₀). Equal-weights specialization recovers HM ≤ GM ≤ AM ≤ QM. Shipped in PR #19454.

## Change

Data-only edit to src/data/research/problems/cauchy-schwarz-integral-oq-01-oq-01-oq-01-oq-02-oq-03.json:

- phase: NEW → completed
- status: active → completed
- currentState.phase: NEW → completed
- currentState.since: 2026-05-04T11:17 → 2026-06-04T18:00
- currentState.focus and currentState.nextAction updated

The pool's candidate-pool.json (gitignored) was also marked completed via claim-problem.sh update.

## Test plan

- [x] jq . parses the updated JSON
- [x] Diff is data-only (no Lean changes), no build/verification required
- [x] Gallery entry on main already says status: verified, badge: original

🤖 Generated with [Claude Code](https://claude.com/claude-code)