### PR TITLE
audit(twin-primes-special-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13753,8 +13753,8 @@
       ]
     },
     "twin-primes-special-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-02T21:39:04Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-04T18:55:54Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- Re-audit of `twin-primes-special-oq-01` against `proofs/Proofs/TwinPrimesSpecialOQ01.lean`
- All meta.json claims verified: 25 theorems, 0 sorries, 1 inherited axiom (`twin_prime_conjecture` from parent `TwinPrimes.lean:163`), lineCount 150
- Status `axiomatized` / badge `axiom` correctly reflects use of inherited TPC axiom
- No issues found — tracker `auditCount` bumped 1 → 2

## Test plan
- [x] Inspected Lean source vs meta.json
- [x] Verified theorem count (`grep -cE "^theorem "` = 25)
- [x] Verified no local `axiom` or `sorry` declarations
- [x] Confirmed parent file declares `twin_prime_conjecture` axiom