### PR TITLE
audit(dirichlets-theorem-oq-02): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2477,9 +2477,9 @@
       "result": "clean"
     },
     "dirichlets-theorem-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-02T22:14:43Z",
+      "lastAudited": "2026-06-04T20:05:55Z",
       "result": "clean"
     },
     "dirichlets-theorem-oq-02-oq-01": {


### PR DESCRIPTION
Gallery integrity audit — meta.json matches Lean source. See commit message for details.