### PR TITLE
audit(derangements-oq-02): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2343,9 +2343,11 @@
       "result": "clean"
     },
     "derangements-oq-02": {
-      "auditCount": 6,
-      "issues": [],
-      "lastAudited": "2026-05-02T22:25:00Z",
+      "auditCount": 7,
+      "issues": [
+        "Re-audit 2026-06-04 vs origin/main c7314d69: 0 sorries (code-level confirmed via comment-stripped grep; line 340 hit was inside a /-! ... -/ summary block), 0 axioms, 10 theorems, 1 def, 357 lines — all match meta.json. Badge `original` justified by permSupportEqEquiv bijection + Finset.card_biUnion decomposition; Mathlib lemma card_derangements_eq_numDerangements used only for derangement-set size lookup, not as core argument. Minor doc-drift: meta + Lean docstring summary both say \"11 native_decide verifications\" but actual count is 10 (S(3,k) k=0..3 + S(4,k) k=0..4 + S(5,2) = 4+5+1); below issue threshold. Clean."
+      ],
+      "lastAudited": "2026-06-04T17:30:00Z",
       "result": "clean"
     },
     "derangements-oq-02-oq-01": {
@@ -15271,5 +15273,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-02T19:24:32Z"
+  "lastUpdated": "2026-06-04T17:30:00Z"
 }


### PR DESCRIPTION
## Audit Result: clean (re-audit #7)

Re-audit of `derangements-oq-02` (Partial Derangements: S(n,k) = C(n,k)·D(n-k)) vs `origin/main` c7314d69.

### Integrity Fields (all match meta.json)

| Field | meta.json | Lean file |
|---|---|---|
| sorries | 0 | 0 (code-level) |
| axiomCount | 0 | 0 |
| theoremCount | 10 | 10 |
| definitionCount | 1 | 1 |
| lineCount | 357 | 357 |
| status | `verified` | (consistent: 0 sorries + 0 axioms) |
| badge | `original` | (justified — see below) |

The single `\bsorry\b` regex hit at line 340 is inside a `/-! ... -/` summary block ("round trips are sorry"), not a tactic; a comment-stripped re-count confirms 0 code-level sorries.

### Badge Justification

`badge: original` is appropriate. The proof:
- Constructs an **explicit `Equiv`** `permSupportEqEquiv : {σ | σ.support = S} ≃ derangements ↑S` in this file (toFun/invFun/left_inv/right_inv all proved here);
- Uses **`Finset.card_biUnion`** to decompose `card {σ | |Fix(σ)| = k}` over (n−k)-element subsets;
- Calls Mathlib's `card_derangements_eq_numDerangements` **only** as a set-size lookup at the very end, not as the core argument.

This is not a Mathlib-wrapper pattern; the bijection and disjoint-decomposition argument are the original content.

### Minor Doc-Drift (below issue threshold, noted only)

Both `meta.json` (`originalContributions[10]`) and the in-file summary docstring (line 342) say "11 native_decide verifications". Actual count is **10**:
- S(3,k) for k = 0, 1, 2, 3 — 4 examples
- S(4,k) for k = 0, 1, 2, 3, 4 — 5 examples
- S(5,2) — 1 example

No core integrity field is affected; flagging here so a future enricher pass can sync the doc string.

### Audit Tracker Diff

`auditCount 6 → 7`, `lastAudited` bumped to `2026-06-04T17:30:00Z`, re-audit note appended.

🤖 Generated by Lean Auditor