### PR TITLE
research(erdos-929): general lower bound S(k) ≥ 3 for k ≥ 2

### DIFF
--- a/proofs/Proofs/Erdos929Problem.lean
+++ b/proofs/Proofs/Erdos929Problem.lean
@@ -252,10 +252,14 @@ theorem trivial_upper (k : ℕ) (_hk : 2 ≤ k) :
     smoothThreshold k ≤ k + 1 := by
   exact Nat.find_le (smoothBlockSet_pos_density k)
 
-/-- **Rosser's sieve.** S(k) > k^{1/2−o(1)}.
-For every ε > 0 and large enough k, S(k) ≥ k^{1/2−ε}. -/
-/-- **Ford–Green–Konyagin–Maynard–Tao (2018).**
-S(k) ≪ k · log log log k / (log log k · log log log log k). -/
+/- **Rosser's sieve.** S(k) > k^{1/2−o(1)}.
+For every ε > 0 and large enough k, S(k) ≥ k^{1/2−ε}.
+(Not formalized — appears as commentary only.)
+
+**Ford–Green–Konyagin–Maynard–Tao (2018).**
+S(k) ≪ k · log log log k / (log log k · log log log log k).
+(Not formalized — appears as commentary only.) -/
+
 /- ## Structural Observations -/
 
 /-- If k₁ ≤ k₂, the small-factor block set for k₂ is contained in that for k₁. -/
@@ -375,3 +379,51 @@ theorem smooth_threshold_2 : smoothThreshold 2 = 3 := by
     calc (smoothBlockSet 2 2).upperDensity
         ≤ ({0} : Set ℕ).upperDensity := upperDensity_mono smoothBlockSet_two_two_sub_zero
       _ ≤ 0 := upperDensity_singleton_zero
+
+/- ## General Lower Bound: S(k) ≥ 3 for k ≥ 2 -/
+
+/-- For k ≥ 2 and x ≤ 1, the block set is empty.
+Proof: smoothBlockSet k x ⊆ smoothBlockSet 2 x = ∅ by antitone in k. -/
+theorem smoothBlockSet_empty_of_ge_two_le_one {k x : ℕ}
+    (hk : 2 ≤ k) (hx : x ≤ 1) : smoothBlockSet k x = ∅ := by
+  rw [Set.eq_empty_iff_forall_notMem]
+  intro n hn
+  have h2 : n ∈ smoothBlockSet 2 x := smoothBlockSet_antitone 2 k x hk hn
+  rw [smoothBlockSet_two_empty_of_le_one hx] at h2
+  exact h2
+
+/-- For k ≥ 2, smoothBlockSet k 2 ⊆ {0}.
+Proof: smoothBlockSet k 2 ⊆ smoothBlockSet 2 2 ⊆ {0} by antitone in k. -/
+theorem smoothBlockSet_two_sub_zero_of_ge_two {k : ℕ} (hk : 2 ≤ k) :
+    smoothBlockSet k 2 ⊆ {0} :=
+  fun _ hn => smoothBlockSet_two_two_sub_zero (smoothBlockSet_antitone 2 k 2 hk hn)
+
+/-- Upper density of the empty set is 0. -/
+theorem upperDensity_empty : (∅ : Set ℕ).upperDensity = 0 := by
+  simp [Set.upperDensity, Filter.limsup_const]
+
+/-- **General lower bound.** S(k) ≥ 3 for k ≥ 2.
+For x ≤ 1, smoothBlockSet k x is empty.
+For x = 2, smoothBlockSet k 2 ⊆ {0} has upper density 0.
+Hence no x ≤ 2 witnesses positive density, so smoothThreshold k ≥ 3.
+
+Together with `trivial_upper`, we have 3 ≤ S(k) ≤ k+1 for k ≥ 2. -/
+theorem smoothThreshold_ge_three (k : ℕ) (hk : 2 ≤ k) :
+    3 ≤ smoothThreshold k := by
+  unfold smoothThreshold
+  rw [Nat.le_find_iff]
+  intro x hx hd
+  interval_cases x
+  · -- x = 0: smoothBlockSet k 0 = ∅
+    rw [smoothBlockSet_empty_of_ge_two_le_one hk (by omega : (0:ℕ) ≤ 1)] at hd
+    rw [upperDensity_empty] at hd
+    exact lt_irrefl 0 hd
+  · -- x = 1: smoothBlockSet k 1 = ∅
+    rw [smoothBlockSet_empty_of_ge_two_le_one hk (le_refl 1)] at hd
+    rw [upperDensity_empty] at hd
+    exact lt_irrefl 0 hd
+  · -- x = 2: smoothBlockSet k 2 ⊆ {0}, density ≤ 0
+    have hle : (smoothBlockSet k 2).upperDensity ≤ 0 :=
+      le_trans (upperDensity_mono (smoothBlockSet_two_sub_zero_of_ge_two hk))
+        upperDensity_singleton_zero
+    linarith

--- a/research/problems/erdos-929/sessions/2026-06-04-s2-general-lower-bound.md
+++ b/research/problems/erdos-929/sessions/2026-06-04-s2-general-lower-bound.md
@@ -1,0 +1,55 @@
+# Session 2026-06-04 (Session 2) — General lower bound S(k) ≥ 3
+
+**Mode**: ACT (RICH, knowledge score 15, MODERATE+)
+**Outcome**: completed (4 new theorems, +52 LOC, 0 sorries, 0 axioms)
+
+## What I Did
+
+Added a general lower bound complementing the existing trivial upper bound:
+
+- **`smoothBlockSet_empty_of_ge_two_le_one`** — For k ≥ 2 and x ≤ 1, smoothBlockSet k x = ∅
+  (Generalizes private k=2 lemma via `smoothBlockSet_antitone`)
+- **`smoothBlockSet_two_sub_zero_of_ge_two`** — For k ≥ 2, smoothBlockSet k 2 ⊆ {0}
+  (Generalizes private k=2 lemma via `smoothBlockSet_antitone`)
+- **`upperDensity_empty`** — Upper density of ∅ is 0
+- **`smoothThreshold_ge_three`** — For k ≥ 2, smoothThreshold k ≥ 3
+  (Combined with `trivial_upper`, gives 3 ≤ S(k) ≤ k+1 for k ≥ 2)
+
+Also fixed two pre-existing parse errors (orphan docstrings on lines 255-258 — `/-- ... -/`
+without an attached declaration). Converted to plain `/- ... -/` comments. Build was
+silently failing — these errors weren't visible at the surface but caused docker build
+exit code 139 (initially) and exit code 1 after retry surfaced them.
+
+Also fixed a deprecation warning: `Set.eq_empty_iff_forall_not_mem` →
+`Set.eq_empty_iff_forall_notMem`.
+
+## Key Findings
+
+- `Nat.le_find_iff` is the dual of `Nat.find_eq_iff`: `k ≤ Nat.find h ↔ ∀ n < k, ¬ p n`.
+  Used to convert the lower bound goal into case analysis on x ∈ {0, 1, 2}.
+- The `smoothBlockSet_antitone` lemma cleanly lifts k=2 emptiness/subset results to
+  k ≥ 2: smoothBlockSet k x ⊆ smoothBlockSet 2 x for k ≥ 2.
+- `upperDensity_empty` follows immediately from `Filter.limsup_const` once the
+  filter range filter is identified as ∅ (then card = 0, ratio = 0).
+- Build process: Lean 4.26.0 with `Set.eq_empty_iff_forall_not_mem` is deprecated;
+  use `notMem` (camelCase).
+
+## Files Modified
+
+- `proofs/Proofs/Erdos929Problem.lean` (377→429 lines, +4 theorems, fixed 2 parse errors + 1 deprecation)
+- `src/data/proofs/erdos-929/meta.json` (lineCount 377→429, theoremCount 19→23)
+
+## Status
+
+- 0 sorries, 0 axioms (unchanged)
+- 23 theorems (was 19), 7 definitions (unchanged)
+- Known bounds: trivial upper (S(k) ≤ k+1), monotonicity (S monotone), specific
+  S(2)=3, and now **general lower bound S(k) ≥ 3 for k ≥ 2**.
+
+## Next Steps
+
+- The main conjecture S(k) ≥ k^{1−o(1)} remains open and requires sieve-theory
+  infrastructure not yet in Mathlib.
+- A possible incremental next step: prove S(3) = 3 specifically (the AP n ≡ 1 mod 6
+  has 3 ∣ n+1, 2 ∣ n+2 (wait, no — n+1 = 6t+2, 6t+3, 6t+4), all with minFac ≤ 3).
+  Together with `smoothThreshold_ge_three`, that would close out S(3).

--- a/research/problems/erdos-929/state.md
+++ b/research/problems/erdos-929/state.md
@@ -1,27 +1,36 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T11:43:50.649Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-06-04T00:00:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Structural threshold infrastructure for S(k). With the new
+`smoothThreshold_ge_three`, we have 3 ≤ S(k) ≤ k+1 for k ≥ 2 in addition to
+monotonicity. The conjecture S(k) ≥ k^{1−o(1)} remains a Prop definition;
+formalizing genuine sieve bounds requires Mathlib analytic number theory
+infrastructure not yet present.
 
 ## Active Approach
 
-None yet.
+Lift k=2 emptiness/subset arguments to general k ≥ 2 via the
+`smoothBlockSet_antitone` lemma. This gives concrete strict lower bounds at
+the bottom of the threshold without requiring sieve theory.
 
 ## Blockers
 
-None.
+Mathlib lacks the sieve-theory and prime-gap infrastructure to formalize
+Rosser's k^{1/2−o(1)} lower bound or the FGKMT upper bound.
 
 ## Next Action
 
-Begin problem exploration.
+Optional: prove S(3) = 3 specifically by combining `smoothThreshold_ge_three`
+with a positive-density witness at x = 3 (e.g., the AP n ≡ 1 mod 6 makes
+n+1, n+2, n+3 cover residues 2, 3, 4 mod 6, all with minFac ≤ 3).
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Current approach attempts: 1
+- Approaches tried: 1 (general antitone lift)

--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -21,10 +21,10 @@
     "erdosUrl": "https://erdosproblems.com/929",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 377,
-    "assumptions": "0 axioms, 0 sorries. Known bounds (rosser_lower from Rosser sieve, fgkmt_upper from Ford-Green-Konyagin-Maynard-Tao 2018) appear as docstring comments only — no axiom declarations. smooth_threshold_2 and smoothBlockSet_pos_density fully proved.",
+    "lineCount": 429,
+    "assumptions": "0 axioms, 0 sorries. Known bounds (Rosser sieve, Ford-Green-Konyagin-Maynard-Tao 2018) appear as commentary only — no axiom declarations. Proved: smoothBlockSet_pos_density, smooth_threshold_2, smoothThreshold_mono, smoothThreshold_ge_three (general lower bound S(k) ≥ 3 for k ≥ 2).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 19,
+    "theoremCount": 23,
     "definitionCount": 7
   },
   "overview": {

--- a/src/data/research/problems/erdos-929.json
+++ b/src/data/research/problems/erdos-929.json
@@ -31,26 +31,29 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-18T00:00:00Z",
-    "iteration": 2,
-    "focus": "The Lean source has 0 axioms and 0 sorries; the main lower-bound conjecture is a proposition definition/commentary boundary, while S(k) <= k+1 and S(2)=3 are proved.",
+    "since": "2026-06-04T00:00:00Z",
+    "iteration": 3,
+    "focus": "The Lean source has 0 axioms and 0 sorries; concrete sandwich 3 <= S(k) <= k+1 for k >= 2 is now formalized via smoothThreshold_ge_three. The deeper conjecture S(k) >= k^{1-o(1)} remains a Prop definition.",
     "blockers": [],
-    "nextAction": "Formalize a genuine sieve lower bound only if the required analytic number theory infrastructure becomes available.",
+    "nextAction": "Optional: prove S(3) = 3 by combining smoothThreshold_ge_three with a positive-density witness at x = 3 (AP n ≡ 1 mod 6).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "CURRENT: 19 theorem/lemma declarations, 7 definitions, 0 axioms, 0 sorries. The formalization uses `HasSmallFactor` (some prime factor <= x), proves positive-density factorial/AP witnesses, S(k) <= k+1, monotonicity, and S(2)=3; Rosser and FGKMT bounds remain comments only.",
+    "progressSummary": "CURRENT: 23 theorem/lemma declarations, 7 definitions, 0 axioms, 0 sorries. The formalization uses `HasSmallFactor` (some prime factor <= x), proves positive-density factorial/AP witnesses, S(k) <= k+1, monotonicity, S(2)=3, and the general lower bound S(k) >= 3 for k >= 2; Rosser and FGKMT bounds remain comments only.",
     "builtItems": [
       "`HasSmallFactor`, `SmoothBlock`, and `smoothBlockSet`",
       "`Set.upperDensity`, `densityRatio`, and monotonicity lemmas",
       "`smoothThreshold` and `trivial_upper`",
       "`smoothBlockSet_pos_density` via factorial/AP starts",
       "`smoothThreshold_mono`",
-      "`smooth_threshold_2`"
+      "`smooth_threshold_2`",
+      "`smoothBlockSet_empty_of_ge_two_le_one` and `smoothBlockSet_two_sub_zero_of_ge_two` (antitone-lifted from k=2)",
+      "`upperDensity_empty`",
+      "`smoothThreshold_ge_three` — general lower bound S(k) >= 3 for k >= 2"
     ],
     "insights": [
       "The original x-smooth reading is wrong for this Lean file; the predicate is existence of a prime factor <= x.",


### PR DESCRIPTION
## Summary

Adds a general lower bound complementing the existing trivial upper bound, yielding the concrete sandwich

$$3 \leq S(k) \leq k+1 \quad \text{for } k \geq 2$$

via four new theorems in `Erdos929Problem.lean`:

- **`smoothBlockSet_empty_of_ge_two_le_one`** — For $k \geq 2$ and $x \leq 1$, $\text{smoothBlockSet}\,k\,x = \emptyset$ (lifts the private $k=2$ lemma via `smoothBlockSet_antitone`)
- **`smoothBlockSet_two_sub_zero_of_ge_two`** — For $k \geq 2$, $\text{smoothBlockSet}\,k\,2 \subseteq \{0\}$ (same lift)
- **`upperDensity_empty`** — upper density of $\emptyset$ is $0$
- **`smoothThreshold_ge_three`** — $S(k) \geq 3$ for $k \geq 2$ (proved via `Nat.le_find_iff` and case analysis on $x \in \{0,1,2\}$)

## Bug fixes (pre-existing)

- Two orphan docstrings (`/-- ... -/` without an attached declaration) on the Rosser/FGKMT commentary lines, which were generating Lean parse errors. Converted to plain `/- ... -/` comments.
- Deprecation: `Set.eq_empty_iff_forall_not_mem` → `Set.eq_empty_iff_forall_notMem`.

## State

- 0 sorries, 0 axioms (unchanged)
- 23 theorems (was 19), 7 definitions (unchanged)
- 429 lines (was 377)

## Verification

- Docker build clean: `./proofs/scripts/docker-build.sh Proofs.Erdos929Problem` → 3060/3060 jobs, Lean 4.26.0

## Test plan

- [x] Builds cleanly via the docker wrapper
- [x] No new sorries, no new axioms
- [x] meta.json updated (lineCount 377→429, theoremCount 19→23)
- [x] Session log written

🤖 Generated with [Claude Code](https://claude.com/claude-code)