### PR TITLE
audit(erdos-77): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9503,8 +9503,8 @@
     },
     "erdos-77": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-02T22:35:00Z",
+      "auditCount": 5,
+      "lastAudited": "2026-06-04T21:38:04Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- 5th audit of erdos-77 (Ramsey Number Growth Rate, open problem)
- All gallery integrity checks pass — no claim/source mismatches
- Tracker auditCount: 4 → 5, lastAudited bumped to 2026-06-04

## Audit Findings
- **Axioms**: 5 declared (RamseyNumber, erdos_upper_bound, liminf_lower_bound, limsup_upper_bound, gnnw_2024_limsup) — matches meta.axiomCount: 5
- **Theorems**: 4 (erdos_upper_bound', erdos_bounds, current_best_bounds, erdos_conjecture_consistent) — matches meta.theoremCount: 4
- **Definitions**: 3 (ramseyGrowthRate, LimitExists, ErdosConjecture) — matches meta.definitionCount: 3
- **Sorries**: 0 — matches meta.sorries: 0
- **True stubs**: 0
- **Line count**: 244 — matches meta.lineCount: 244
- **Status/badge**: axiomatized/axiom — consistent (axioms present, no overclaim)

No issues to file.

## Test plan
- [x] grep counts validated against meta.json
- [x] tracker JSON valid (auto-bumped via claim-target.sh complete)