### PR TITLE
Enrich abel-ruffini ann-small-solvable: expand relatedConcepts and prerequisites

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -346,7 +346,14 @@
     "prerequisites": [
       "IsSolvable typeclass",
       "inferInstance",
-      "Equiv.Perm (Fin n)"
+      "Equiv.Perm (Fin n)",
+      "Solvable groups: derived series and composition series",
+      "Klein four-group $V_4 \\trianglelefteq A_4$ as the normal subgroup that unlocks $A_4$'s solvability",
+      "Short exact sequence $1 \\to A_n \\to S_n \\to \\mathbb{Z}^\\times \\to 1$ (sign-homomorphism kernel-cokernel)",
+      "Mathlib's `solvable_of_ker_le_range` (extension solvability theorem)",
+      "Mathlib's `isSolvable_of_comm` (every commutative group is solvable)",
+      "Galois correspondence: composition series of $\\text{Gal}(L/F)$ ↔ tower of subfields with cyclic Galois groups",
+      "Kummer theory: $\\mathbb{Z}/n$ Galois extension ↔ $n$th-root adjunction (given $\\zeta_n \\in F$)"
     ],
     "relatedConcepts": [
       "Klein four-group",
@@ -356,7 +363,19 @@
       "Cardano's formula",
       "Ferrari's formula",
       "abel-ruffini-oq-04-oq-02",
-      "solvable_of_ker_le_range"
+      "solvable_of_ker_le_range",
+      "isSolvable_of_comm",
+      "solution-of-cubic (positive radical-formula counterpart for $S_3$)",
+      "general-quartic (positive radical-formula counterpart for $S_4$)",
+      "abel-ruffini-galois-extensions (complete $S_n$ solvability classification)",
+      "Brahmagupta's two-root quadratic formula (628 CE)",
+      "Al-Khwarizmi's *al-jabr* (completing-the-square geometric proof, c. 820–825 CE)",
+      "Cardano's *Ars Magna* (1545, cubic formula publication)",
+      "Tartaglia's depressed-cubic algorithm (1535)",
+      "del Ferro's unpublished cubic solution (~1515)",
+      "Ferrari's resolvent cubic reduction for the quartic (1545)",
+      "Composition series with cyclic-of-prime-order quotients (refinement of derived series)",
+      "Radical tower: nested $n$th-root field extensions"
     ]
   },
   {

--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -358,12 +358,31 @@
       "Cardano's formula",
       "Ferrari's formula",
       "abel-ruffini-oq-04-oq-02",
-      "solvable_of_ker_le_range"
+      "solvable_of_ker_le_range",
+      "isSolvable_of_comm",
+      "solution-of-cubic (positive radical-formula counterpart for $S_3$)",
+      "general-quartic (positive radical-formula counterpart for $S_4$)",
+      "abel-ruffini-galois-extensions (complete $S_n$ solvability classification)",
+      "Brahmagupta's two-root quadratic formula (628 CE)",
+      "Al-Khwarizmi's *al-jabr* (completing-the-square geometric proof, c. 820–825 CE)",
+      "Cardano's *Ars Magna* (1545, cubic formula publication)",
+      "Tartaglia's depressed-cubic algorithm (1535)",
+      "del Ferro's unpublished cubic solution (~1515)",
+      "Ferrari's resolvent cubic reduction for the quartic (1545)",
+      "Composition series with cyclic-of-prime-order quotients (refinement of derived series)",
+      "Radical tower: nested $n$th-root field extensions"
     ],
     "prerequisites": [
       "IsSolvable typeclass",
       "inferInstance",
-      "Equiv.Perm (Fin n)"
+      "Equiv.Perm (Fin n)",
+      "Solvable groups: derived series and composition series",
+      "Klein four-group $V_4 \\trianglelefteq A_4$ as the normal subgroup that unlocks $A_4$'s solvability",
+      "Short exact sequence $1 \\to A_n \\to S_n \\to \\mathbb{Z}^\\times \\to 1$ (sign-homomorphism kernel-cokernel)",
+      "Mathlib's `solvable_of_ker_le_range` (extension solvability theorem)",
+      "Mathlib's `isSolvable_of_comm` (every commutative group is solvable)",
+      "Galois correspondence: composition series of $\\text{Gal}(L/F)$ ↔ tower of subfields with cyclic Galois groups",
+      "Kummer theory: $\\mathbb{Z}/n$ Galois extension ↔ $n$th-root adjunction (given $\\zeta_n \\in F$)"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Targeted enrichment of the `ann-small-solvable` annotation in `abel-ruffini` (Solvable Small Symmetric Groups: The Other Side of the Threshold). The annotation discusses $S_0$–$S_4$ solvability, the historical chain of radical formulas (Brahmagupta → Al-Khwarizmi → del Ferro → Tartaglia → Cardano → Ferrari), and the composition-series structure underlying each radical-formula step — but the `relatedConcepts` and `prerequisites` arrays did not previously surface these concepts for discoverability.

## What changed

- **relatedConcepts**: 8 → 20 entries
  - Adds `isSolvable_of_comm`
  - Adds gallery cross-references: `solution-of-cubic`, `general-quartic`, `abel-ruffini-galois-extensions`
  - Surfaces named historical sources discussed in content: Brahmagupta 628 CE, Al-Khwarizmi c. 820–825 CE, del Ferro ~1515, Tartaglia 1535, Cardano 1545, Ferrari 1545
  - Adds: composition series with cyclic-prime-order quotients (refinement of derived series), radical tower as nested $n$th-root field extensions

- **prerequisites**: 3 → 10 entries
  - Adds: solvable groups (derived/composition series), $V_4 \trianglelefteq A_4$ as the normal subgroup unlocking $A_4$'s solvability, $1 \to A_n \to S_n \to \mathbb{Z}^\times \to 1$ short exact sequence, `solvable_of_ker_le_range`, `isSolvable_of_comm`, Galois correspondence (composition series ↔ tower of subfields with cyclic Galois groups), Kummer theory ($\mathbb{Z}/n$ Galois extension ↔ $n$th-root adjunction)

Both `annotations.source.json` (canonical) and `annotations.json` (generated by `pnpm annotations:build`) updated.

## Test plan

- [x] `jq -e . annotations.source.json` validates JSON
- [x] `pnpm annotations:build` regenerates annotations.json successfully
- [x] `tsc -b` succeeds
- [x] `vite build` succeeds (2m 23s)

## Note

An earlier commit in this session (PR #22281, since closed) targeted a different annotation but was inadvertently overwritten by a force-push during branch reset. This PR is the recoverable abel-ruffini work from that session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)