### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05: add 8 mathlibDependencies

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json
@@ -25,6 +25,48 @@
     "lineCount": 214,
     "theoremCount": 9,
     "definitionCount": 0,
+    "mathlibDependencies": [
+      {
+        "theorem": "IsSolvable",
+        "description": "Typeclass marker for solvable groups, defined via existence of a `CommGroup` quotient witness in the derived series. The companion file's seven corollaries all hinge on `inferInstance` finding a registered `IsSolvable G` instance to feed `shafarevich_inverse_galois` — making `IsSolvable` the *typeclass interface* that converts arbitrary structural solvability proofs (cyclic via `ZMod n` instance, abelian via `CommGroup → IsSolvable` instance, $S_3/S_4$ via parent file's `symmetric_solvable_of_le_four`, subgroups via `subgroup_solvable_of_solvable`, quotients via `quotient_solvable_of_solvable`) into Shafarevich-applicable hypotheses.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "subgroup_solvable_of_solvable",
+        "description": "Subgroups of solvable groups are solvable: $H \\leq G$ with $G$ solvable implies $H$ solvable. Used in `subgroup_of_solvable_realizable` (line 151) to lift Shafarevich's existence statement from a solvable group $G$ to any of its subgroups $H \\leq G$ — providing the inheritance closure of realizability under subgroup formation.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "quotient_solvable_of_solvable",
+        "description": "Quotients of solvable groups are solvable: $G$ solvable and $N \\trianglelefteq G$ normal imply $G/N$ solvable. Used in `quotient_of_solvable_realizable` (line 161) to lift Shafarevich's existence statement across quotient formation — together with subgroup closure, gives the *category-of-solvable-groups closure* under sub/quot operations, mirroring the analogous closure properties on the field side (subfields of Galois extensions, quotients via fixed fields of normal subgroups).",
+        "module": "Mathlib.GroupTheory.Solvable"
+      },
+      {
+        "theorem": "IsGalois",
+        "description": "Typeclass asserting that $L/F$ is a Galois field extension (normal and separable). The Shafarevich axiom existentially quantifies over $L$ with `[IsGalois ℚ L]` as part of the conclusion structure, so every downstream theorem (`cyclic_group_realizable`, `s3_realizable`, etc.) unpacks the existential with `obtain ⟨L, _, _, _, _, hiso⟩` and re-packages it under fresh existential — the `IsGalois ℚ L` typeclass travels along as a structural witness.",
+        "module": "Mathlib.FieldTheory.Galois.Basic"
+      },
+      {
+        "theorem": "AlgEquiv (≃ₐ[F])",
+        "description": "F-algebra equivalences: ring isomorphisms commuting with the $F$-algebra structure. The Galois group $\\mathrm{Gal}(L/\\mathbb{Q})$ is encoded as the automorphism group $L \\simeq_{\\mathbb{Q}\\text{-alg}} L$ (`L ≃ₐ[ℚ] L`), and the `MulEquiv` $G \\simeq^* (L \\simeq_{\\mathbb{Q}\\text{-alg}} L)$ is the formalization of the isomorphism $G \\cong \\mathrm{Gal}(L/\\mathbb{Q})$ underlying the *realizability* statement. Without this Mathlib construction, the Shafarevich conclusion would have no precise meaning.",
+        "module": "Mathlib.Algebra.Algebra.Equiv"
+      },
+      {
+        "theorem": "MulEquiv (≃*)",
+        "description": "Group isomorphisms preserving multiplication. The Shafarevich axiom's payload is `Nonempty (G ≃* (L ≃ₐ[ℚ] L))` — a *nonempty type of isomorphisms* rather than a single chosen isomorphism, matching the mathematical convention that realizability is an existential statement (some extension realizes $G$) rather than a constructive one (an explicit canonical extension realizing $G$, which would require choosing a specific defining polynomial).",
+        "module": "Mathlib.Algebra.Group.Equiv.Basic"
+      },
+      {
+        "theorem": "ZMod n",
+        "description": "Cyclic group of order $n$ (when $n > 0$). Used in `cyclic_group_realizable` (line 97) as the canonical witness for the cyclic-group case: $\\mathbb{Z}/n\\mathbb{Z}$ comes with `CommGroup` (hence `IsSolvable` by Mathlib instance) and `Fintype` instances, so the proof reduces to a single `obtain` from the Shafarevich axiom. This is the *smallest non-trivial case* of Shafarevich's theorem and historically the *first realized* — every cyclic extension of $\\mathbb{Q}$ was constructed (via cyclotomic fields and Kronecker-Weber) decades before Shafarevich's general result.",
+        "module": "Mathlib.Data.ZMod.Basic"
+      },
+      {
+        "theorem": "CommGroup → IsSolvable",
+        "description": "Mathlib instance: every abelian group is solvable (derived series terminates in one step, $G' = [G, G] = \\{e\\}$). Used in `abelian_group_realizable` (line 109) via `haveI : IsSolvable G := inferInstance` — typeclass inference automatically finds this instance once `CommGroup G` is in scope, demonstrating Lean's design of *making instance hierarchies discoverable* without manual citation. The instance is the smallest mathematical fact in Mathlib's solvability infrastructure but underwrites the *infinite parametric family* of all finite abelian Galois groups over $\\mathbb{Q}$.",
+        "module": "Mathlib.GroupTheory.Solvable"
+      }
+    ],
     "originalContributions": [
       "shafarevich_inverse_galois: core axiom — Gal(L/ℚ) ≅ G for every finite solvable G",
       "cyclic_group_realizable: ℤ/nℤ is realizable (abelian → solvable → Shafarevich)",


### PR DESCRIPTION
## Enrichment pass for abel-ruffini-galois-extensions-oq-05

The Shafarevich entry had `mathlibDependencies: 0` despite the Lean file importing 5 Mathlib modules (`Mathlib.FieldTheory.AbelRuffini`, `Mathlib.GroupTheory.Solvable`, `Mathlib.FieldTheory.Galois.Basic`, `Mathlib.NumberTheory.Cyclotomic.Basic`, `Mathlib.FieldTheory.SplittingField.Construction`) and invoking 8+ Mathlib constructs in its 9 theorems. The empty list was particularly misleading because the *structural content* of every corollary is "find the right Mathlib instance, hand it to the Shafarevich axiom" — making Mathlib's solvability/Galois infrastructure the actual workhorse of the file.

### Added entries

| # | theorem | module | role |
|---|---------|--------|------|
| 1 | `IsSolvable` | GroupTheory.Solvable | typeclass interface converting structural solvability proofs into Shafarevich-applicable hypotheses |
| 2 | `subgroup_solvable_of_solvable` | GroupTheory.Solvable | inheritance closure used in `subgroup_of_solvable_realizable` (L151) |
| 3 | `quotient_solvable_of_solvable` | GroupTheory.Solvable | quotient closure used in `quotient_of_solvable_realizable` (L161) |
| 4 | `IsGalois` | FieldTheory.Galois.Basic | structural witness for the conclusion's $L/\mathbb{Q}$ |
| 5 | `AlgEquiv (≃ₐ[F])` | Algebra.Algebra.Equiv | encodes $\mathrm{Gal}(L/\mathbb{Q})$ as `L ≃ₐ[ℚ] L` |
| 6 | `MulEquiv (≃*)` | Algebra.Group.Equiv.Basic | the realizability isomorphism $G \simeq^* \mathrm{Gal}(L/\mathbb{Q})$ |
| 7 | `ZMod n` | Data.ZMod.Basic | cyclic-group witness for `cyclic_group_realizable` |
| 8 | `CommGroup → IsSolvable` | GroupTheory.Solvable | the single Mathlib instance underwriting the infinite family of abelian Galois groups |

Each entry has a substantive 200–500+ char description connecting it to the specific Lean theorems and explaining its mathematical role.

### Historical note in entries

The `ZMod n` entry observes that *the cyclic case of Shafarevich's theorem* (every $\mathbb{Z}/n\mathbb{Z}$ realizable over $\mathbb{Q}$) was already known to Kronecker-Weber decades before Shafarevich's 1954 result — a fact the original entry didn't surface but is directly relevant to readers wanting to understand which corollaries are *strictly* Shafarevich-dependent vs. classical.

### Verification

- `pnpm annotations:build` (with `DISABLE_BUILD_CACHE=1`) succeeded; JSON validated.
- Only `src/data/proofs/abel-ruffini-galois-extensions-oq-05/meta.json` modified.
- Diff: 1 file changed, 42 insertions(+), 0 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)