### PR TITLE
Enrich cantor-diagonalization ann-main-theorem: expand thin RC/PR on central theorem

### DIFF
--- a/src/data/proofs/cantor-diagonalization/annotations.json
+++ b/src/data/proofs/cantor-diagonalization/annotations.json
@@ -56,7 +56,7 @@
       "startLine": 55,
       "endLine": 62
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Diagonal Differs at Each Position",
     "content": "The key lemma: our constructed diagonal sequence differs from $f(n)$ specifically at position $n$.\n\nSince `diagonal f n = !(f n n)`, we have `diagonal f n != f n n` by the fact that `!b != b` for any boolean.\n\nThis one-line observation is the heart of the proof.",
     "mathContext": "The Lean proof: `unfold diagonal` replaces `diagonal f n` with `!(f n n)`, then `cases f n n <;> simp` performs case analysis on both `Bool.true` and `Bool.false`. In each case `simp` discharges the goal: `!true ≠ true` becomes `false ≠ true` (true by `Bool.false_ne_true`), and `!false ≠ false` becomes `true ≠ false` (true by `Bool.true_ne_false`). The `<;>` combinator applies `simp` to both cases simultaneously. This lemma encapsulates the one-line core of Cantor's argument: $\\lnot b \\neq b$ for any $b \\in \\{0, 1\\}$, which holds because boolean negation is a fixed-point-free involution.",
@@ -89,14 +89,36 @@
     "prerequisites": [
       "diagonal definition",
       "diagonal_differs lemma",
-      "congrFun (function congruence)"
+      "congrFun (function congruence)",
+      "Function-type equality and pointwise equality (`funext` ⇔ `∀ n, f n = g n`)",
+      "Bool.not / negation of boolean values and `Bool.not_ne_self` / `Bool.not_eq_self`",
+      "Proof by contradiction (`intro h; exact contra ...`)",
+      "Existential elimination + introduction in Lean (`∃ s, ...` proved by `use witness; ...`)",
+      "Negation of surjectivity: 'no $f$ is surjective' = 'for every $f$, there is a point not in its image'",
+      "Self-application / diagonal evaluation $f \\mapsto f(n)(n)$ as a fundamental operation (the `Δ` map)",
+      "Familiarity with `BinarySeq := ℕ → Bool` and the function-space perspective on power sets",
+      "The reading: '$f n \\neq s$' = 'sequences $f n$ and $s$ are not pointwise equal' — and the contrapositive used in the proof"
     ],
     "relatedConcepts": [
       "surjectivity",
       "uncountability",
       "congrFun tactic",
       "constructive proof",
-      "existential witness"
+      "existential witness",
+      "Cantor's 1891 paper 'Über eine elementare Frage der Mannigfaltigkeitslehre' (the diagonal method's debut)",
+      "Cantor's 1874 paper 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (the original cardinality argument using nested intervals)",
+      "Russell's paradox (1901): same fixed-point-avoidance pattern, applied to set membership $x \\notin x$ — derived from Cantor's argument",
+      "Tarski's undefinability of truth (1933): no formula $T(x)$ in arithmetic captures 'x is true', proved by diagonalization on Gödel-numbered formulas",
+      "Gödel's first incompleteness theorem (1931): self-referential sentence $G$ asserting 'G is unprovable', constructed via diagonal lemma",
+      "Turing's halting problem (1936): no decidable predicate $H(p, x)$ captures 'p halts on x', proved by diagonalization on machine indices",
+      "Lawvere's fixed-point theorem (1969): categorical generalization — if $\\Delta: A \\to A \\times A$ has no weak fixed point, then $A^A$ has no surjection from $A$",
+      "Cantor's theorem: $|X| < |\\mathcal{P}(X)|$ for any set $X$ (the diagonal argument with characteristic functions)",
+      "Power set as $2^X$ via characteristic functions: $\\mathcal{P}(X) \\cong (X \\to \\{0, 1\\}) = 2^X$",
+      "$|\\mathbb{N}| = \\aleph_0 < 2^{\\aleph_0} = \\mathfrak{c}$ (continuum hypothesis context)",
+      "halting-problem (gallery entry: same fixed-point structure on machine indices)",
+      "godel-incompleteness (gallery entry: same fixed-point structure on formulas)",
+      "cantor-diagonalization-oq-* (cousin gallery entries extending the argument)",
+      "cantors-theorem (gallery entry: |X| < |𝒫(X)| via diagonal on characteristic functions)"
     ]
   },
   {
@@ -106,7 +128,7 @@
       "startLine": 66,
       "endLine": 86
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Constructing the Witness",
     "content": "We exhibit the diagonal sequence as our witness. The `use` tactic provides this existential witness.\n\nNow we must prove this sequence differs from every $f(n)$.",
     "mathContext": "The `use diagonal f` tactic in Lean 4 discharges the `∃ s : BinarySeq, ...` goal by substituting `s := diagonal f`, leaving the goal `∀ n : ℕ, f n ≠ diagonal f`. This is a *constructive* witness — the diagonal sequence is given explicitly as `fun n => !(f n n)`. Classical logic would allow a non-constructive existence proof (by excluded middle, assuming no such sequence and deriving a contradiction), but this proof constructs the witness directly. The `use` tactic corresponds to the existential introduction rule: from `P(t)`, conclude `∃ x, P(x)`.",
@@ -130,7 +152,7 @@
       "startLine": 88,
       "endLine": 98
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Deriving the Contradiction",
     "content": "Suppose for contradiction that $f(n) = \\text{diagonal}(f)$ for some $n$.\n\nThen at position $n$: $f(n)(n) = \\text{diagonal}(f)(n)$.\n\nBut $\\text{diagonal}(f)(n) = \\neg f(n)(n)$ by definition.\n\nSo $f(n)(n) = \\neg f(n)(n)$, which is impossible for any boolean.\n\nContradiction! Therefore $f(n) \\neq \\text{diagonal}(f)$ for all $n$.",
     "mathContext": "In `no_surjection_nat_to_binary`: `intro ⟨f, hf⟩` destructs the assumed surjection; `obtain ⟨s, hs⟩ := cantor_diagonalization f` gives the diagonal sequence not in range; `obtain ⟨n, hn⟩ := hf s` uses surjectivity to find $n$ with $f(n) = s$; `exact hs n hn` applies `hs : ∀ n, f n ≠ s` to `hn : f n = s`, deriving `False` from `f n ≠ s` and `f n = s`. The key tactic pattern is `exact hs n hn`: `hs n : f n ≠ s` is a function `f n = s → False`, and `hn : f n = s` is the input. The `exact` tactic applies the former to the latter. This is a 4-line proof that neatly separates concerns: Cantor proves non-surjectivity for any enumeration; this theorem packages it as '¬∃ surjection'.",
@@ -179,7 +201,7 @@
       "startLine": 102,
       "endLine": 107
     },
-    "type": "concept",
+    "type": "technique",
     "title": "Proof of Uncountability",
     "content": "Assume for contradiction that some surjective $f$ exists.\n\nBy Cantor's theorem, there exists $s$ with $f(n) \\neq s$ for all $n$.\n\nBut surjectivity says every $s$ equals some $f(n)$.\n\nThese contradict: $s = f(n)$ but also $f(n) \\neq s$.",
     "mathContext": "`reals_uncountable` is a one-line alias: `no_surjection_nat_to_binary`. Its docstring explains the informal bridge: binary sequences $(b_n) \\in \\{0,1\\}^{\\mathbb{N}}$ map to reals via $\\sum b_n/2^{n+1} \\in [0,1]$, and $|[0,1]| = |\\mathbb{R}|$. But the Lean type is `¬∃ f : ℕ → BinarySeq, Function.Surjective f` — not a statement about $\\mathbb{R}$. The peer review (ai-3) flagged this equivocation; as a resolution, the theorem's name signals the *informal* interpretation while the type gives the *formal* content. This honest naming pattern is common in proof galleries: the formal statement is technically narrower than its name suggests.",

--- a/src/data/proofs/cantor-diagonalization/annotations.source.json
+++ b/src/data/proofs/cantor-diagonalization/annotations.source.json
@@ -95,12 +95,34 @@
       "uncountability",
       "congrFun tactic",
       "constructive proof",
-      "existential witness"
+      "existential witness",
+      "Cantor's 1891 paper 'Über eine elementare Frage der Mannigfaltigkeitslehre' (the diagonal method's debut)",
+      "Cantor's 1874 paper 'Über eine Eigenschaft des Inbegriffes aller reellen algebraischen Zahlen' (the original cardinality argument using nested intervals)",
+      "Russell's paradox (1901): same fixed-point-avoidance pattern, applied to set membership $x \\notin x$ — derived from Cantor's argument",
+      "Tarski's undefinability of truth (1933): no formula $T(x)$ in arithmetic captures 'x is true', proved by diagonalization on Gödel-numbered formulas",
+      "Gödel's first incompleteness theorem (1931): self-referential sentence $G$ asserting 'G is unprovable', constructed via diagonal lemma",
+      "Turing's halting problem (1936): no decidable predicate $H(p, x)$ captures 'p halts on x', proved by diagonalization on machine indices",
+      "Lawvere's fixed-point theorem (1969): categorical generalization — if $\\Delta: A \\to A \\times A$ has no weak fixed point, then $A^A$ has no surjection from $A$",
+      "Cantor's theorem: $|X| < |\\mathcal{P}(X)|$ for any set $X$ (the diagonal argument with characteristic functions)",
+      "Power set as $2^X$ via characteristic functions: $\\mathcal{P}(X) \\cong (X \\to \\{0, 1\\}) = 2^X$",
+      "$|\\mathbb{N}| = \\aleph_0 < 2^{\\aleph_0} = \\mathfrak{c}$ (continuum hypothesis context)",
+      "halting-problem (gallery entry: same fixed-point structure on machine indices)",
+      "godel-incompleteness (gallery entry: same fixed-point structure on formulas)",
+      "cantor-diagonalization-oq-* (cousin gallery entries extending the argument)",
+      "cantors-theorem (gallery entry: |X| < |𝒫(X)| via diagonal on characteristic functions)"
     ],
     "prerequisites": [
       "diagonal definition",
       "diagonal_differs lemma",
-      "congrFun (function congruence)"
+      "congrFun (function congruence)",
+      "Function-type equality and pointwise equality (`funext` ⇔ `∀ n, f n = g n`)",
+      "Bool.not / negation of boolean values and `Bool.not_ne_self` / `Bool.not_eq_self`",
+      "Proof by contradiction (`intro h; exact contra ...`)",
+      "Existential elimination + introduction in Lean (`∃ s, ...` proved by `use witness; ...`)",
+      "Negation of surjectivity: 'no $f$ is surjective' = 'for every $f$, there is a point not in its image'",
+      "Self-application / diagonal evaluation $f \\mapsto f(n)(n)$ as a fundamental operation (the `Δ` map)",
+      "Familiarity with `BinarySeq := ℕ → Bool` and the function-space perspective on power sets",
+      "The reading: '$f n \\neq s$' = 'sequences $f n$ and $s$ are not pointwise equal' — and the contrapositive used in the proof"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Targeted enrichment of `ann-main-theorem` — the central theorem annotation in `cantor-diagonalization`. It stated Cantor's diagonalization theorem itself but had only 5 `relatedConcepts` and 3 `prerequisites`, missing the rich web of diagonal-method descendants the argument seeded (Russell's paradox 1901, Tarski's undefinability of truth 1933, Gödel's incompleteness 1931, Turing's halting problem 1936, Lawvere's categorical fixed-point theorem 1969) and the basic Lean proof prerequisites (`funext`, `Bool.not`, existential/forall manipulation).

## What changed

- **relatedConcepts**: 5 → 19
  - Historical: Cantor's 1891 paper (diagonal method's debut), Cantor's 1874 paper (nested-intervals cardinality)
  - Descendants: Russell's paradox, Tarski's undefinability, Gödel's incompleteness, Turing's halting, Lawvere's fixed-point theorem
  - Foundational: Cantor's theorem $|X| < |\mathcal{P}(X)|$, $\mathcal{P}(X) \cong 2^X$ via characteristic functions, $\aleph_0 < \mathfrak{c}$ (CH context)
  - Gallery cross-refs: `halting-problem`, `godel-incompleteness`, `cantor-diagonalization-oq-*`, `cantors-theorem`

- **prerequisites**: 3 → 11
  - Function-type equality via `funext` / pointwise equality
  - `Bool.not` and `Bool.not_eq_self`
  - Proof-by-contradiction tactic pattern (`intro h; exact contra ...`)
  - Existential intro/elim in Lean (`use witness; ...`)
  - Negation-of-surjectivity reading: "no $f$ is surjective" = "for every $f$, there is a point not in its image"
  - Self-application / diagonal evaluation $\Delta(f)(n) = f(n)(n)$ as a fundamental operation
  - Function-space perspective on power sets: `BinarySeq := ℕ → Bool` as $2^\mathbb{N}$
  - Reading of `f n ≠ s` as pointwise-inequality contrapositive

Both `annotations.source.json` (canonical) and `annotations.json` (regenerated by `pnpm annotations:build`) updated.

## Test plan

- [x] `jq -e . annotations.source.json` validates JSON
- [x] `pnpm annotations:build` succeeds
- [x] `tsc -b` succeeds
- [x] `vite build` succeeds (58.5s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)