### PR TITLE
research(angle-trisection-cos-pi-n): expand consistency checks to n=4,6,8,10,12 + fix stale docs

### DIFF
--- a/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean
@@ -15,14 +15,18 @@
   conjugation in CyclotomicField(2n,ℚ), which is Galois since conjSubgroup is normal
   in the abelian Galois group (ℤ/2nℤ)×).
 
-  **Main results:**
-  1. `cos_pi_minpoly_natDegree`: natDegree(minpoly ℚ (cos(π/n))) = φ(2n)/2 — PROVED
-  2. `cos_pi_extension_degree`: ∃ K ⊆ ℝ with cos(π/n) ∈ K, [K:ℚ] = φ(2n)/2 — PROVED
-  3. `cos_pi_gal_card`: |Gal(minpoly ℚ (cos(π/n)))| = φ(2n)/2 — proved modulo
-     normality of ℚ(cos(π/n))/ℚ (documented sorry)
+  **Main results (all PROVED, 0 sorries):**
+  1. `cos_pi_minpoly_natDegree`: natDegree(minpoly ℚ (cos(π/n))) = φ(2n)/2
+  2. `cos_pi_extension_degree`: ∃ K ⊆ ℝ with cos(π/n) ∈ K, [K:ℚ] = φ(2n)/2
+  3. `cos_pi_splitting_finrank`: finrank ℚ (SplittingField p) = φ(2n)/2
+     (closes the normality of ℚ(cos(π/n))/ℚ inline via autEquivPow + abelian Gal)
+  4. `cos_pi_gal_card` and `gal_order_eq_totient_div2_general`:
+     |Gal(minpoly ℚ (cos(π/n)))| = φ(2n)/2
 
-  **Gallery consistency checks** (n=5,7,9 verified against φ(2n)/2 formula):
-    n=5: φ(10)/2 = 2  ✓   n=7: φ(14)/2 = 3  ✓   n=9: φ(18)/2 = 3  ✓
+  **Gallery consistency checks** (φ(2n)/2 formula at n = 4,5,6,7,8,9,10,12):
+    n=4:  φ(8)/2  = 2  ✓   n=5:  φ(10)/2 = 2  ✓   n=6:  φ(12)/2 = 2  ✓
+    n=7:  φ(14)/2 = 3  ✓   n=8:  φ(16)/2 = 4  ✓   n=9:  φ(18)/2 = 3  ✓
+    n=10: φ(20)/2 = 4  ✓   n=12: φ(24)/2 = 4  ✓
 -/
 
 import Mathlib
@@ -279,16 +283,36 @@ theorem gal_order_eq_totient_div2_general (n : ℕ) (hn : 3 ≤ n) :
 -- § 6. Gallery Consistency Checks
 -- ============================================================================
 
--- Verify φ(2n)/2 matches the known cases (n=5,7,9)
+-- Verify φ(2n)/2 matches known values across constructible and
+-- non-constructible cases.
 
+theorem totient_formula_n4 : Nat.totient (2 * 4) / 2 = 2 := by decide
 theorem totient_formula_n5 : Nat.totient (2 * 5) / 2 = 2 := by decide
+theorem totient_formula_n6 : Nat.totient (2 * 6) / 2 = 2 := by decide
 theorem totient_formula_n7 : Nat.totient (2 * 7) / 2 = 3 := by decide
+theorem totient_formula_n8 : Nat.totient (2 * 8) / 2 = 4 := by decide
 theorem totient_formula_n9 : Nat.totient (2 * 9) / 2 = 3 := by decide
+theorem totient_formula_n10 : Nat.totient (2 * 10) / 2 = 4 := by decide
+theorem totient_formula_n12 : Nat.totient (2 * 12) / 2 = 4 := by decide
+
+/-- natDegree(minpoly ℚ (cos(π/4))) = 2. cos(π/4) = √2/2 lies in a degree-2
+    extension (constructible). -/
+theorem cos_pi4_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 4))).natDegree = 2 := by
+  have h := cos_pi_minpoly_natDegree 4 (by norm_num)
+  simp only [Nat.cast_ofNat, show Nat.totient (2 * 4) / 2 = 2 from by decide] at h
+  exact h
 
 /-- natDegree(minpoly ℚ (cos(π/5))) = 2, consistent with |Gal| = 2 for n=5. -/
 theorem cos_pi5_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 5))).natDegree = 2 := by
   have h := cos_pi_minpoly_natDegree 5 (by norm_num)
   simp only [Nat.cast_ofNat, show Nat.totient (2 * 5) / 2 = 2 from by decide] at h
+  exact h
+
+/-- natDegree(minpoly ℚ (cos(π/6))) = 2. cos(π/6) = √3/2 lies in a degree-2
+    extension (constructible). -/
+theorem cos_pi6_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 6))).natDegree = 2 := by
+  have h := cos_pi_minpoly_natDegree 6 (by norm_num)
+  simp only [Nat.cast_ofNat, show Nat.totient (2 * 6) / 2 = 2 from by decide] at h
   exact h
 
 /-- natDegree(minpoly ℚ (cos(π/7))) = 3, consistent with |Gal| = 3 for n=7. -/
@@ -297,10 +321,31 @@ theorem cos_pi7_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 7))).natDegre
   simp only [Nat.cast_ofNat, show Nat.totient (2 * 7) / 2 = 3 from by decide] at h
   exact h
 
+/-- natDegree(minpoly ℚ (cos(π/8))) = 4. cos(π/8) = √(2+√2)/2 lies in a
+    degree-4 extension (constructible, regular 16-gon). -/
+theorem cos_pi8_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 8))).natDegree = 4 := by
+  have h := cos_pi_minpoly_natDegree 8 (by norm_num)
+  simp only [Nat.cast_ofNat, show Nat.totient (2 * 8) / 2 = 4 from by decide] at h
+  exact h
+
 /-- natDegree(minpoly ℚ (cos(π/9))) = 3, consistent with |Gal| = 3 for n=9. -/
 theorem cos_pi9_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 9))).natDegree = 3 := by
   have h := cos_pi_minpoly_natDegree 9 (by norm_num)
   simp only [Nat.cast_ofNat, show Nat.totient (2 * 9) / 2 = 3 from by decide] at h
+  exact h
+
+/-- natDegree(minpoly ℚ (cos(π/10))) = 4. Connects to cos(π/5) via
+    cos(π/10) = √((1+cos(π/5))/2); regular 20-gon is constructible. -/
+theorem cos_pi10_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 10))).natDegree = 4 := by
+  have h := cos_pi_minpoly_natDegree 10 (by norm_num)
+  simp only [Nat.cast_ofNat, show Nat.totient (2 * 10) / 2 = 4 from by decide] at h
+  exact h
+
+/-- natDegree(minpoly ℚ (cos(π/12))) = 4. cos(π/12) = (√6+√2)/4 lies in a
+    degree-4 extension (constructible). -/
+theorem cos_pi12_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 12))).natDegree = 4 := by
+  have h := cos_pi_minpoly_natDegree 12 (by norm_num)
+  simp only [Nat.cast_ofNat, show Nat.totient (2 * 12) / 2 = 4 from by decide] at h
   exact h
 
 -- ============================================================================
@@ -326,7 +371,9 @@ theorem cos_pi9_minpoly_degree : (minpoly ℚ (Real.cos (Real.pi / 9))).natDegre
    Reduces to: finrank ℚ (SplittingField p) = φ(2n)/2.
    This follows from: ℚ(cos(π/n)) = maxRealSubfield(2n) is Galois over ℚ
    (conjSubgroup abelian → normal), hence minpoly splits over it, hence
-   SplittingField ≅ ℚ(cos(π/n)). One sorry remains on the normality step.
+   SplittingField ≅ ℚ(cos(π/n)). FULLY PROVED — see `cos_pi_splitting_finrank`
+   for the explicit two-sided finrank pinch via IsSplittingField.lift (upper)
+   and exists_root_of_splits + IntermediateField.adjoin.finrank (lower).
 
 ## Techniques Used
 - **IsCyclotomicExtension**: via AngleTrisectionOQ02OQ03OQ01's `alphaCos`, `maxRealSubfield`

--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/state.md
@@ -1,16 +1,21 @@
 # Current State
 
 **Phase**: COMPLETED
-**Since**: 2026-05-29T19:14:09.071Z
-**Iteration**: 1
+**Since**: 2026-06-04T00:00:00.000Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+The original open question (Can `gal_order_eq_totient_div2_general` be proved
+using `IsCyclotomicExtension`?) was already answered YES in the existing file
+`AngleTrisectionCos20GalOQ01OQ02OQ02.lean` (0 sorries, 0 axioms, verified).
+Iteration 2 extended the gallery consistency checks from 3 cases to 8 cases
+and corrected stale documentation that mentioned a "remaining sorry" no
+longer present in the file.
 
 ## Active Approach
 
-None yet.
+None — completed.
 
 ## Blockers
 
@@ -18,10 +23,16 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+Open questions documented in meta.json conclusion:
+1. Cleaner proof of `cos_pi_gal_card` that avoids the splitting-field detour.
+2. Generalisation to `sin(π/n)` (non-uniform behaviour) or `cos(kπ/n)` for
+   general k.
+
+These are flagged as future research targets but the original problem is
+resolved.
 
 ## Attempt Counts
 
-- Total attempts: 0
+- Total attempts: 2
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (cosine identity + cyclotomic field reduction — succeeded)

--- a/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02/knowledge.md
+++ b/research/problems/angle-trisection-cos-20-gal-oq-01-oq-02/knowledge.md
@@ -44,3 +44,52 @@ g = (a∘ℓ_inv)·(b∘ℓ_inv) over the field.
 - Follow-up questions:
   1. Can `gal_order_eq_totient_div2_general` be proved for all n using IsCyclotomicExtension?
   2. Can the n=4 and n=6 cases (cos(π/4), cos(π/6)) be added using this proof structure?
+
+---
+
+## Session 2026-06-04 (Session 2, by researcher-1) — CONSISTENCY EXPANSION
+
+**Mode**: ENRICHMENT (downstream of OQ02OQ02 child file)
+**Outcome**: Extended consistency check coverage; corrected stale documentation
+
+### What I Did
+- Verified parent open question OQ-01-OQ-02 (Can the formula be proved for all n
+  via IsCyclotomicExtension?) was ALREADY ANSWERED YES in child file
+  `AngleTrisectionCos20GalOQ01OQ02OQ02.lean` (verified, 0 sorries, 0 axioms)
+- Extended `§6 Gallery Consistency Checks` from 3 cases (n=5,7,9) to 8 cases
+  (n=4,5,6,7,8,9,10,12), giving systematic coverage across both constructible
+  and non-constructible regimes:
+  - Constructible (deg power of 2): n=4(d=2), n=5(d=2), n=6(d=2), n=8(d=4),
+    n=10(d=4), n=12(d=4)
+  - Non-constructible (deg=3): n=7, n=9 (these witness Wantzel's obstruction)
+- Updated stale header docstring and §7 summary text that incorrectly claimed
+  "one documented sorry" remained on the Galois order step — the actual file
+  has 0 sorries; this was leftover documentation from before the
+  `cos_pi_splitting_finrank` proof was completed inline.
+- Updated meta.json: lineCount 338→385, theoremCount 12→22, §6 section
+  description, §5 line range to reflect new layout.
+
+### Key Findings (Session 2)
+- The general formula natDegree(minpoly ℚ (cos(π/n))) = φ(2n)/2 specialises
+  uniformly via `simp only [Nat.cast_ofNat, show Nat.totient (2*k)/2 = v from
+  by decide]` — same 3-line proof pattern for each n.
+- The boundary between constructible and non-constructible cos(π/n) is exactly
+  the boundary between φ(2n)/2 being a power of 2 versus not (Wantzel's
+  constructibility criterion applied to the maximal real subfield).
+- Verified totient values used: φ(8)=4, φ(10)=4, φ(12)=4, φ(14)=6, φ(16)=8,
+  φ(18)=6, φ(20)=8, φ(24)=8.
+
+### Files Modified (Session 2)
+- `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean`: +5 totient
+  identities, +5 cos_pi*_minpoly_degree consistency theorems; corrected
+  header + §7 summary to remove stale "remaining sorry" claim.
+- `src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json`:
+  lineCount, theoremCount, §6 section description updated.
+
+### Open Questions Still Live
+1. (Original OQ from meta.json) Cleaner proof of `cos_pi_gal_card` working
+   directly with the maximal real subfield, avoiding the splitting-field
+   detour.
+2. (Original OQ from meta.json) Galois group / minpoly degree formula for
+   `sin(π/n)` (non-uniform: sin(π/6) ∈ ℚ but sin(π/5) has degree 4) or for
+   `cos(kπ/n)` with general k.

--- a/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
+++ b/src/data/proofs/angle-trisection-cos-20-gal-oq-01-oq-02-oq-02/meta.json
@@ -22,12 +22,12 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 338,
+    "lineCount": 385,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "historicalContext": "The formula |Gal(minpoly(cos(π/n))/ℚ)| = φ(2n)/2 connects classical angle trisection impossibility to cyclotomic field theory. Individual cases n=5 (|Gal|=2), n=7 (|Gal|=3), n=9 (|Gal|=3) were proved in earlier gallery entries. This file provides the general proof using IsCyclotomicExtension, answering the open question from AngleTrisectionCos20GalOQ01OQ02.",
     "proofStrategy": "The key observation is cos(π/n) = cos(2π/(2n)). This reduces the problem to the cos(2π/m) family handled by AngleTrisectionOQ02OQ03OQ01 (which formalizes the (m)-th cyclotomic field machinery). Applying that infrastructure with m = 2n gives: natDegree(minpoly(cos(π/n))) = φ(2n)/2. The full Galois order = degree requires additionally showing the splitting field has degree φ(2n)/2, which follows from normality of ℚ(cos(π/n))/ℚ (conjSubgroup is normal in the abelian Galois group).",
-    "theoremCount": 12,
+    "theoremCount": 22,
     "definitionCount": 0
   },
   "overview": {
@@ -55,9 +55,9 @@
       "Proofs.AngleTrisectionCos20GalOQ01OQ02"
     ],
     "namespace": "AngleTrisectionCos20GalOQ01OQ02OQ02",
-    "lineCount": 338,
+    "lineCount": 385,
     "axiomCount": 0,
-    "theoremCount": 12,
+    "theoremCount": 22,
     "definitionCount": 0,
     "path": "Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean",
     "sorries": 0
@@ -99,18 +99,18 @@
     {
       "id": "sec-galois-order",
       "title": "§5. Galois Group Order",
-      "startLine": 235,
-      "endLine": 277,
+      "startLine": 238,
+      "endLine": 280,
       "summary": "cos_pi_gal_card: |Gal(minpoly ℚ (cos(π/n)))| = φ(2n)/2. Follows from Polynomial.Gal.card_of_separable (which gives |Gal(p)| = finrank(SplittingField)) and the splitting field degree. The companion gal_order_eq_totient_div2_general is the public-facing restatement.",
       "mathContext": "`Polynomial.Gal.card_of_separable`: for separable $p$, $|\\text{Gal}(p)| = [\\text{SplittingField}(p):\\mathbb{Q}]$. Combined with $\\text{finrank}\\ \\text{SplittingField} = \\varphi(2n)/2$, this gives the Galois group order."
     },
     {
       "id": "sec-consistency",
-      "title": "§6. Consistency Checks for n=5,7,9",
-      "startLine": 279,
-      "endLine": 305,
-      "summary": "Verifies the general formula φ(2n)/2 against the three known special cases: n=5 (φ(10)/2=2), n=7 (φ(14)/2=3), n=9 (φ(18)/2=3). All consistent with previously proved gallery entries.",
-      "mathContext": "Spot checks: $\\varphi(10)/2 = \\varphi(2\\cdot 5)/2 = 4/2 = 2$ ✓; $\\varphi(14)/2 = 6/2 = 3$ ✓; $\\varphi(18)/2 = 6/2 = 3$ ✓. These match the specific entries AngleTrisectionCos20GalOQ01OQ02 (n=5,7) and AngleTrisectionCos20Gal (n=9)."
+      "title": "§6. Consistency Checks at n = 4,5,6,7,8,9,10,12",
+      "startLine": 282,
+      "endLine": 349,
+      "summary": "Verifies the general formula φ(2n)/2 against eight concrete cases covering both constructible angles (n=4,5,6,8,10,12 — minpoly degree a power of 2) and non-constructible angles (n=7,9 — degree 3). For each n we extract both the totient identity and the minimal polynomial degree of cos(π/n) as a direct corollary of cos_pi_minpoly_natDegree.",
+      "mathContext": "Spot checks: $\\varphi(8)/2=2$, $\\varphi(10)/2=2$, $\\varphi(12)/2=2$, $\\varphi(14)/2=3$, $\\varphi(16)/2=4$, $\\varphi(18)/2=3$, $\\varphi(20)/2=4$, $\\varphi(24)/2=4$. The constructible cases (degrees 2 and 4) align with Wantzel's criterion (regular $2n$-gon constructible iff $\\varphi(2n)$ is a power of 2); the n=7,9 cases (degree 3) explicitly witness the angle-trisection obstruction."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

Iteration 2 on `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02`. The original open question (Can `gal_order_eq_totient_div2_general` be proved using `IsCyclotomicExtension`?) was answered YES in iteration 1 (file is verified, 0 sorries). This PR extends the gallery's consistency checks and corrects stale documentation.

### Changes to `proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean`

- **§6 Consistency Checks** expanded from 3 cases (n=5,7,9) to 8 (n=4,5,6,7,8,9,10,12). Each case is a 3-line corollary of `cos_pi_minpoly_natDegree`:
  - **Constructible cases** (degree a power of 2): n=4, 6, 8, 10, 12 — natDegree φ(2n)/2 = 2, 2, 4, 4, 4
  - **Non-constructible cases** (degree 3, witnessing Wantzel): n=7, n=9 — carried over
- **Header docstring + §7 summary**: removed stale claim "one documented sorry remains on the normality step" — the file already has 0 sorries because `cos_pi_splitting_finrank` closes the splitting-field finrank inline via `autEquivPow` + abelian Galois group + `IsSplittingField.lift` + `IntermediateField.adjoin.finrank`.

### Changes to `src/data/proofs/.../meta.json`
- `lineCount` 338 → 385
- `theoremCount` 12 → 22
- §6 section description rewritten; §5 line range updated.

### Mathematical interpretation
The expanded coverage makes the constructible/non-constructible boundary explicit at the file level: cos(π/n) is constructible iff φ(2n) is a power of 2 (Wantzel). The n=7,9 cases (degree 3) sit immediately outside this boundary and explicitly witness the angle-trisection obstruction. Future work tracked in meta.json `openQuestions`: cleaner direct proof avoiding splitting-field detour; sin(π/n) and cos(kπ/n) generalisations.

## Test plan
- [ ] Docker build verifies all 5 new theorems (pattern is mechanical specialisation of the proven general result; no new tactics required)
- [ ] Gallery page renders updated section list and theorem count
- [ ] No regression in dependent files (this file is downstream-only; no other gallery entries import from it yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)