### PR TITLE
Enrich abel-ruffini cluster: per-section prerequisites (2 proofs)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -920,6 +920,12 @@
         "short exact sequence",
         "derived series",
         "Galois solvability criterion"
+      ],
+      "prerequisites": [
+        "Lean 4 module/import syntax",
+        "Mathlib group theory namespaces",
+        "Mathlib field theory hierarchy",
+        "basic familiarity with symmetric and alternating groups"
       ]
     },
     {
@@ -937,6 +943,14 @@
         "derived series",
         "alternatingGroup",
         "normal subgroup"
+      ],
+      "prerequisites": [
+        "symmetric group $S_n = \\mathrm{Perm}(\\mathrm{Fin}\\,n)$",
+        "alternating group $A_n$ as kernel of the sign homomorphism",
+        "short exact sequences of groups",
+        "subsingleton/`Unique` typeclass arguments",
+        "Klein four-group $V_4$ as normal subgroup of $A_4$",
+        "`isSolvable_of_comm` and `solvable_of_ker_le_range` (Mathlib)"
       ]
     },
     {
@@ -952,6 +966,13 @@
         "solvability threshold",
         "Cardinal.mk",
         "biconditional"
+      ],
+      "prerequisites": [
+        "biconditional ($\\iff$) proof structure",
+        "derived series of a group",
+        "`Equiv.Perm.not_solvable` for $n \\ge 5$ (Mathlib)",
+        "`omega` tactic for arithmetic on $\\mathbb{N}$",
+        "case split on $n \\le 4$ vs $5 \\le n$"
       ]
     },
     {
@@ -968,6 +989,14 @@
         "IsSolvableByRad",
         "IsGalois.card_aut_eq_finrank",
         "composition factor"
+      ],
+      "prerequisites": [
+        "simple groups and composition series",
+        "`alternatingGroup.isSimpleGroup_five` (Mathlib)",
+        "fundamental theorem of Galois theory",
+        "`IsGalois.card_aut_eq_finrank`",
+        "contrapositive of `solvableByRad.isSolvable'`",
+        "order of $A_5 = 60$"
       ]
     },
     {
@@ -982,6 +1011,12 @@
         "hereditary property",
         "subgroup",
         "typeclass inference"
+      ],
+      "prerequisites": [
+        "subgroup inclusion as a group homomorphism",
+        "`Subgroup.subtype` and `solvable_of_surjective`",
+        "derived subgroup commutes with restriction",
+        "hereditary properties of group classes"
       ]
     },
     {
@@ -997,6 +1032,13 @@
         "proof by contradiction",
         "sign homomorphism",
         "biconditional"
+      ],
+      "prerequisites": [
+        "sign exact sequence $1 \\to A_n \\to S_n \\to \\{\\pm 1\\} \\to 1$",
+        "`solvable_of_ker_le_range` as a closure principle",
+        "proof by contradiction in Lean (`fun h => ...`)",
+        "`symmetric_not_solvable_of_five_le` from Part II",
+        "subgroup solvability (Part VI)"
       ]
     },
     {
@@ -1013,6 +1055,13 @@
         "factorial",
         "index of a subgroup",
         "proof by reflection"
+      ],
+      "prerequisites": [
+        "`Fintype.card` and decidable equality",
+        "factorial recursion $n! = n \\cdot (n-1)!$",
+        "index of a subgroup and Lagrange's theorem",
+        "`Nat.factorial` API in Mathlib",
+        "`native_decide` for elaboration-time computation"
       ]
     },
     {
@@ -1029,6 +1078,13 @@
         "closed class of groups",
         "Galois correspondence",
         "derived series"
+      ],
+      "prerequisites": [
+        "quotient group $G/N$ for normal $N$",
+        "image of derived series under homomorphisms",
+        "`solvable_of_surjective` (Mathlib)",
+        "group isomorphism `MulEquiv`",
+        "closure under subgroup/quotient/isomorphism"
       ]
     },
     {
@@ -1043,6 +1099,12 @@
         "named corollary",
         "A5 obstruction",
         "le_rfl"
+      ],
+      "prerequisites": [
+        "`Subgroup.index` and $[G : H]$ notation",
+        "sign homomorphism as surjection onto $\\{\\pm 1\\}$",
+        "kernel/image decomposition",
+        "`Subgroup.index_eq_two_iff` patterns"
       ]
     },
     {
@@ -1058,6 +1120,12 @@
         "subgroup obstruction",
         "subgroup heredity",
         "non-solvable group"
+      ],
+      "prerequisites": [
+        "general thresholds `symmetric_not_solvable_of_five_le`, `alternating_not_solvable_of_five_le`",
+        "`omega` for numeric bounds $5 \\le n$",
+        "contrapositive of subgroup solvability",
+        "`inferInstance` to invoke typeclass resolution"
       ]
     },
     {
@@ -1074,6 +1142,12 @@
         "Equiv.Perm.mem_alternatingGroup",
         "composition series",
         "abelian factors"
+      ],
+      "prerequisites": [
+        "sign homomorphism $\\mathrm{sgn} : S_n \\to \\{\\pm 1\\}$",
+        "kernel = alternating group identity",
+        "`MonoidHom.ker` and `Subgroup.ext`",
+        "derived series chain $G \\supseteq G' \\supseteq G'' \\supseteq \\dots$"
       ]
     },
     {
@@ -1089,6 +1163,12 @@
         "non-abelian group",
         "solvability vs commutativity",
         "A5 minimal simple group"
+      ],
+      "prerequisites": [
+        "`push_neg` tactic for negating universal quantifiers",
+        "`decide` vs `native_decide` for finite verification",
+        "commutator $[a,b] = aba^{-1}b^{-1}$",
+        "transition from abelian ($n \\le 2$) to non-abelian ($n \\ge 3$) in $S_n$"
       ]
     },
     {
@@ -1105,6 +1185,12 @@
         "GL_4(F_2)",
         "finite simple groups",
         "classification of finite simple groups"
+      ],
+      "prerequisites": [
+        "`native_decide` (kernel-evaluated decidability)",
+        "`Fintype.card (Equiv.Perm (Fin n))` evaluation",
+        "group orders $|S_7|=5040$, $|S_8|=40320$, $|A_7|=2520$, $|A_8|=20160$",
+        "index-2 relation $|A_n| = |S_n|/2$"
       ]
     },
     {
@@ -1121,6 +1207,12 @@
         "index of a subgroup",
         "simp lemma",
         "sign homomorphism"
+      ],
+      "prerequisites": [
+        "`Nat.factorial` definition",
+        "Lagrange's theorem $|G| = |H|\\cdot[G:H]$",
+        "fintype cardinality bridge to `Nat.factorial`",
+        "use as `simp` lemmas in downstream proofs"
       ]
     },
     {
@@ -1136,6 +1228,11 @@
         "Galois solvability criterion",
         "namespace",
         "theorem inventory"
+      ],
+      "prerequisites": [
+        "overview of all 57 theorems and 12 instances",
+        "`#check` for inventory verification",
+        "role of this file as the structural complement to `AbelRuffini.lean`"
       ]
     }
   ],

--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -330,6 +330,13 @@
         "Polynomial.Gal",
         "Equiv.Perm.not_solvable",
         "alternatingGroup.isSimpleGroup_five"
+      ],
+      "prerequisites": [
+        "Mathlib namespace conventions",
+        "Lean 4 `import` syntax",
+        "`IsSolvableByRad` and `IsSolvable` predicates",
+        "basic Galois theory and polynomial Galois groups",
+        "symmetric vs alternating group distinction"
       ]
     },
     {
@@ -346,6 +353,13 @@
         "composition series",
         "solvable group",
         "minimal polynomial"
+      ],
+      "prerequisites": [
+        "radical extensions and tower of fields",
+        "`Polynomial.Gal` (Galois group of a polynomial)",
+        "`solvableByRad.isSolvable'` from Mathlib",
+        "derived series and solvable groups",
+        "irreducible polynomials and their splitting fields"
       ]
     },
     {
@@ -354,7 +368,20 @@
       "startLine": 69,
       "endLine": 75,
       "summary": "Part III docstring + the general theorem: for $n \\geq 5$, the permutation group `Equiv.Perm (Fin n)` is *not* solvable. Proof is a two-line bridge that lifts the natural-number bound $5 \\leq n$ into Mathlib's expected `5 \\leq \\#\\alpha` over `Cardinal`, then delegates to `Equiv.Perm.not_solvable`. This is the group-theoretic *non*-solvability ingredient of Abel-Ruffini — the obstruction side of the contrapositive synthesized in Part V (`not_solvable_by_rad_of_not_solvable_gal`).",
-      "mathContext": "Statement: $\\forall n,\\ 5 \\leq n \\Rightarrow \\neg\\,\\mathrm{IsSolvable}\\,(\\mathrm{Equiv.Perm}\\,(\\mathrm{Fin}\\,n))$. Mathematically, the derived series is $D^0(S_n) = S_n$, $D^1(S_n) = [S_n, S_n] = A_n$, and $D^k(S_n) = A_n$ for every $k \\geq 1$ (because $A_n$ is *perfect* for $n \\geq 5$: $[A_n, A_n] = A_n$). The series never reaches $\\{e\\}$, so $S_n$ is not solvable. The contrast at $n = 4$ — $D^4(S_4) = \\{e\\}$ via the abelian Klein four-group $V_4$ — is the sharp algebraic discontinuity exploited downstream."
+      "mathContext": "Statement: $\\forall n,\\ 5 \\leq n \\Rightarrow \\neg\\,\\mathrm{IsSolvable}\\,(\\mathrm{Equiv.Perm}\\,(\\mathrm{Fin}\\,n))$. Mathematically, the derived series is $D^0(S_n) = S_n$, $D^1(S_n) = [S_n, S_n] = A_n$, and $D^k(S_n) = A_n$ for every $k \\geq 1$ (because $A_n$ is *perfect* for $n \\geq 5$: $[A_n, A_n] = A_n$). The series never reaches $\\{e\\}$, so $S_n$ is not solvable. The contrast at $n = 4$ — $D^4(S_4) = \\{e\\}$ via the abelian Klein four-group $V_4$ — is the sharp algebraic discontinuity exploited downstream.",
+      "prerequisites": [
+        "`Equiv.Perm.not_solvable` (Mathlib)",
+        "natural number to `Cardinal` coercion",
+        "derived series chain $S_n \\supset A_n \\supset A_n$",
+        "$A_n$ simple for $n \\ge 5$ implies $S_n$ non-solvable"
+      ],
+      "relatedConcepts": [
+        "Equiv.Perm.not_solvable",
+        "derived series of $S_n$",
+        "simple group $A_n$ for $n \\ge 5$",
+        "cardinal coercion $\\mathbb{N} \\hookrightarrow \\mathrm{Cardinal}$",
+        "IsSolvable predicate"
+      ]
     },
     {
       "id": "cardinal-bridge",
@@ -362,7 +389,20 @@
       "startLine": 77,
       "endLine": 84,
       "summary": "The two-line tactic block embedded inside `symmetric_group_not_solvable` that performs the type-theoretic bridge from $\\mathbb{N}$ (where the user-facing hypothesis `5 ≤ n` lives) to `Cardinal` (where Mathlib's `Equiv.Perm.not_solvable` consumes `5 ≤ #α`). The bridge is: `simp only [Cardinal.mk_fintype, Fintype.card_fin]` rewrites the goal `5 ≤ #(Fin n)` to `5 ≤ n` via the canonical equalities $\\#\\,\\mathrm{Fin}\\,n = n$ and $\\#\\,\\alpha = |\\alpha|$ for finite types, after which `exact_mod_cast hn` discharges the remaining $\\mathbb{N}$-to-`Cardinal` numeric coercion using the supplied hypothesis `hn : 5 ≤ n`.",
-      "mathContext": "Type-theoretic bridge: $5 \\leq n \\in \\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $(\\uparrow 5 \\leq \\uparrow n) \\in \\mathrm{Cardinal}$ $\\xleftarrow{\\text{simp}}$ $5 \\leq \\#\\,\\mathrm{Fin}\\,n$. The canonical identifications $\\#\\,\\mathrm{Fin}\\,n = n$ (`Cardinal.mk_fin`) and `Fintype.card_fin` collapse the chain. Cast lemmas like `exact_mod_cast` are the Mathlib idiom for moving across the natural inclusion $\\mathbb{N} \\hookrightarrow \\mathrm{Cardinal}$."
+      "mathContext": "Type-theoretic bridge: $5 \\leq n \\in \\mathbb{N}$ $\\xrightarrow{\\text{cast}}$ $(\\uparrow 5 \\leq \\uparrow n) \\in \\mathrm{Cardinal}$ $\\xleftarrow{\\text{simp}}$ $5 \\leq \\#\\,\\mathrm{Fin}\\,n$. The canonical identifications $\\#\\,\\mathrm{Fin}\\,n = n$ (`Cardinal.mk_fin`) and `Fintype.card_fin` collapse the chain. Cast lemmas like `exact_mod_cast` are the Mathlib idiom for moving across the natural inclusion $\\mathbb{N} \\hookrightarrow \\mathrm{Cardinal}$.",
+      "prerequisites": [
+        "Lean 4 universe of `Cardinal`s",
+        "`Cardinal.mk` (a.k.a. `#α`) on finite types",
+        "natural-number cast `Nat.cast_le`",
+        "`simp` for finite cardinal arithmetic"
+      ],
+      "relatedConcepts": [
+        "Cardinal universe",
+        "`Cardinal.mk` (a.k.a. `#α`)",
+        "natural number cast `Nat.cast_le`",
+        "type-theoretic universe polymorphism",
+        "`simp` normalization"
+      ]
     },
     {
       "id": "s5-s6-not-solvable",
@@ -370,7 +410,20 @@
       "startLine": 86,
       "endLine": 93,
       "summary": "Two one-line corollaries specializing the general `symmetric_group_not_solvable` to the named cases $n = 5$ and $n = 6$. For $n = 5$, the bound $5 \\leq 5$ is `le_rfl`; for $n = 6$, the bound $5 \\leq 6$ is discharged by `omega`. These named theorems exist *only* for pedagogical accessibility — downstream consumers can write `s5_not_solvable` rather than threading the general form with an explicit numerical argument — and they document the two cases ($n = 5$, the boundary; $n = 6$, the first interior non-solvable case) that anchor the rest of the file's argument.",
-      "mathContext": "$S_5 = \\mathrm{Equiv.Perm}(\\mathrm{Fin}\\,5)$, $|S_5| = 120 = 5!$. $S_6 = \\mathrm{Equiv.Perm}(\\mathrm{Fin}\\,6)$, $|S_6| = 720 = 6!$. Derived series of either: $S_n \\triangleright A_n \\triangleright A_n \\triangleright \\cdots$ (stalled at $A_n$ for $n \\geq 5$ because $[A_n, A_n] = A_n$, i.e., $A_n$ is perfect). The composition series of $S_n$ for $n \\geq 5$ has length 2 with simple quotients $\\mathbb{Z}/2$ (the sign) and $A_n$ — the *non-abelian* quotient is exactly what blocks solvability."
+      "mathContext": "$S_5 = \\mathrm{Equiv.Perm}(\\mathrm{Fin}\\,5)$, $|S_5| = 120 = 5!$. $S_6 = \\mathrm{Equiv.Perm}(\\mathrm{Fin}\\,6)$, $|S_6| = 720 = 6!$. Derived series of either: $S_n \\triangleright A_n \\triangleright A_n \\triangleright \\cdots$ (stalled at $A_n$ for $n \\geq 5$ because $[A_n, A_n] = A_n$, i.e., $A_n$ is perfect). The composition series of $S_n$ for $n \\geq 5$ has length 2 with simple quotients $\\mathbb{Z}/2$ (the sign) and $A_n$ — the *non-abelian* quotient is exactly what blocks solvability.",
+      "prerequisites": [
+        "`le_rfl` for $5 \\le 5$",
+        "`Nat.le.step` / `decide` for $5 \\le 6$",
+        "`symmetric_group_not_solvable` as the generic threshold",
+        "specialization vs the general theorem"
+      ],
+      "relatedConcepts": [
+        "$|S_5| = 120$ and $|S_6| = 720$",
+        "derived series of $S_n$",
+        "`le_rfl` and `decide` for arithmetic bounds",
+        "specialization corollary pattern",
+        "Galois groups of irreducible quintics"
+      ]
     },
     {
       "id": "a5-is-simple",
@@ -378,7 +431,20 @@
       "startLine": 94,
       "endLine": 98,
       "summary": "One-line declaration `a5_is_simple : IsSimpleGroup (alternatingGroup (Fin 5)) := inferInstance` exposing Mathlib's `alternatingGroup.isSimpleGroup_five` instance under a memorable name. The simplicity of $A_5$ — the smallest non-abelian simple group, order 60 — is the *structural reason* $S_5$ (and hence every $S_n$ for $n \\geq 5$) fails to be solvable: a simple non-abelian group is *perfect* ($[G, G] = G$), so the derived series stalls. The Mathlib proof of `alternatingGroup.isSimpleGroup_five` is itself nontrivial (it uses Sylow theory: $n_2 = 5,\\ n_3 = 10,\\ n_5 = 6$ all exceed 1, hence no Sylow subgroup is normal); see cross-references `sylow-theorem-oq-04`, `sylow-theorems-oq-04`, and `sylow-theorem-oq-02` for explicit machine-verified Sylow-counting proofs of the same statement.",
-      "mathContext": "$A_5 = \\ker(\\mathrm{sign} : S_5 \\to \\{\\pm 1\\}) = \\{\\sigma \\in S_5 : \\mathrm{sign}(\\sigma) = +1\\}$, $|A_5| = 60 = 5!/2$. In $A_5$ the 5-cycles split into two conjugacy classes of size 12 each (a subtlety distinguishing $A_5$-conjugacy from $S_5$-conjugacy); the full $A_5$-conjugacy partition is $\\{1, 12, 12, 15, 20\\}$, summing to 60. The class-equation $|G| = \\sum |\\mathrm{cl}(g_i)|$ with no proper sub-sum starting with 1 dividing 60 (other than $\\{1\\}$ and $\\{60\\}$) is the explicit class-arithmetic obstruction to normality used in the Sylow-cross-referenced proofs."
+      "mathContext": "$A_5 = \\ker(\\mathrm{sign} : S_5 \\to \\{\\pm 1\\}) = \\{\\sigma \\in S_5 : \\mathrm{sign}(\\sigma) = +1\\}$, $|A_5| = 60 = 5!/2$. In $A_5$ the 5-cycles split into two conjugacy classes of size 12 each (a subtlety distinguishing $A_5$-conjugacy from $S_5$-conjugacy); the full $A_5$-conjugacy partition is $\\{1, 12, 12, 15, 20\\}$, summing to 60. The class-equation $|G| = \\sum |\\mathrm{cl}(g_i)|$ with no proper sub-sum starting with 1 dividing 60 (other than $\\{1\\}$ and $\\{60\\}$) is the explicit class-arithmetic obstruction to normality used in the Sylow-cross-referenced proofs.",
+      "prerequisites": [
+        "`alternatingGroup.isSimpleGroup_five` (Mathlib)",
+        "`inferInstance` for typeclass resolution",
+        "order of $A_5 = 60$ and conjugacy class structure",
+        "simplicity ⟹ non-solvability for non-abelian groups"
+      ],
+      "relatedConcepts": [
+        "alternatingGroup.isSimpleGroup_five",
+        "IsSimpleGroup predicate",
+        "5-cycle conjugacy classes in $A_5$",
+        "minimal non-abelian simple group",
+        "icosahedral symmetry (geometric $A_5$)"
+      ]
     },
     {
       "id": "small-solvable",
@@ -394,6 +460,12 @@
         "Ferrari formula",
         "abelian group",
         "typeclass inference"
+      ],
+      "prerequisites": [
+        "subsingleton groups and `Unique` typeclass",
+        "derived length 0 ⟺ trivial group",
+        "quadratic/cubic/quartic formula sharp boundary $n \\le 4$",
+        "`inferInstance` for $S_0$, $S_1$ via Mathlib `Equiv.permUnique`"
       ]
     },
     {
@@ -402,7 +474,20 @@
       "startLine": 120,
       "endLine": 129,
       "summary": "Docstring framing the logical synthesis that closes the impossibility argument: Parts II and III prepared the two independent ingredients — the Galois bridge (`galois_bridge`: solvable by radicals $\\Rightarrow$ solvable Galois group) and the group-theoretic obstruction (`symmetric_group_not_solvable`: $S_n$ not solvable for $n \\geq 5$). Part V composes them. The synthesis is the *contrapositive* form: assume the Galois group is *not* solvable; if a root were solvable by radicals, the bridge would give a solvable Galois group — contradiction. The docstring also signposts the difference between the *universal* contrapositive proved here and the *concrete* instances (specific quintics with $\\mathrm{Gal} \\cong S_5$) that the gallery's witnesses (`abel-ruffini-oq-04-oq-01`, `inverse-galois-a5`, `inverse-galois-oq-06`) supply.",
-      "mathContext": "Logical layout: $P \\Rightarrow Q$ (Part II's `galois_bridge`), $\\neg Q$ (Part III's `symmetric_group_not_solvable` applied to a polynomial whose Galois group is $S_5$), $\\therefore \\neg P$ (Part V's `not_solvable_by_rad_of_not_solvable_gal`). Here $P = \\mathrm{IsSolvableByRad}\\,F\\,\\alpha$ and $Q = \\mathrm{IsSolvable}\\,q.\\mathrm{Gal}$. The synthesis is a textbook modus tollens: the universal-quantifier form $\\forall q,\\ \\neg\\,\\mathrm{IsSolvable}\\,q.\\mathrm{Gal} \\Rightarrow \\neg\\,\\mathrm{IsSolvableByRad}\\,F\\,(\\text{root}\\,q)$ ranges over all irreducible $q$ and all base fields $F$ simultaneously — *that* universality is the structural content."
+      "mathContext": "Logical layout: $P \\Rightarrow Q$ (Part II's `galois_bridge`), $\\neg Q$ (Part III's `symmetric_group_not_solvable` applied to a polynomial whose Galois group is $S_5$), $\\therefore \\neg P$ (Part V's `not_solvable_by_rad_of_not_solvable_gal`). Here $P = \\mathrm{IsSolvableByRad}\\,F\\,\\alpha$ and $Q = \\mathrm{IsSolvable}\\,q.\\mathrm{Gal}$. The synthesis is a textbook modus tollens: the universal-quantifier form $\\forall q,\\ \\neg\\,\\mathrm{IsSolvable}\\,q.\\mathrm{Gal} \\Rightarrow \\neg\\,\\mathrm{IsSolvableByRad}\\,F\\,(\\text{root}\\,q)$ ranges over all irreducible $q$ and all base fields $F$ simultaneously — *that* universality is the structural content.",
+      "prerequisites": [
+        "modus tollens: $P \\Rightarrow Q$ and $\\neg Q$ yield $\\neg P$",
+        "role of the Galois bridge as the structural pivot",
+        "composition: bridge (Part II) + obstruction (Part III)",
+        "distinction between an *existential* and a *contrapositive* form"
+      ],
+      "relatedConcepts": [
+        "modus tollens (contrapositive)",
+        "galois_bridge (Part II)",
+        "symmetric_group_not_solvable (Part III)",
+        "logical synthesis P ⟹ Q, ¬Q ⟹ ¬P",
+        "existential closure of the impossibility"
+      ]
     },
     {
       "id": "exists-quintic-placeholder",
@@ -410,7 +495,20 @@
       "startLine": 131,
       "endLine": 135,
       "summary": "A four-line corollary stating $\\exists\\,q \\in \\mathbb{Q}[X],\\ q.\\mathrm{natDegree} = 5$, witnessed trivially by $X^5$ via `Polynomial.natDegree_pow` and `Polynomial.natDegree_X`. **Mathematically trivial and not used in the main proof.** Peer review (`review.json` finding 4) explicitly flags this: the *substantive* statement the file would need is $\\exists\\,q \\in \\mathbb{Q}[X],\\ \\mathrm{Irreducible}\\,q \\land q.\\mathrm{natDegree} = 5 \\land \\neg\\,\\mathrm{IsSolvable}\\,q.\\mathrm{Gal}$ — i.e., a *non-solvable-Galois* quintic, not merely a degree-5 polynomial. The placeholder marks a *deliberate pedagogical seam* between the universal contrapositive (this file) and the concrete witnesses (`abel-ruffini-oq-04-oq-01` proves $\\mathrm{Gal}(x^5 - 4x + 2) \\cong S_5$ via Eisenstein at $p = 2$ with 0 sorries / 0 axioms; `inverse-galois-a5` and `inverse-galois-oq-06` realize $A_5$).",
-      "mathContext": "Witness: $p = X^5 \\in \\mathbb{Q}[X]$, $\\mathrm{natDegree}(X^n) = n$ by `natDegree_pow` + `natDegree_X` + `mul_one`. What the proof *should* deliver but does not: $\\exists\\,q,\\ \\mathrm{Irreducible}\\,q \\land q.\\mathrm{natDegree} = 5 \\land \\mathrm{Gal}(q) \\cong S_5$. The gallery now contains three machine-verified instances of this sharper statement, so the placeholder is no longer a *gap* — it is a deliberate teaching seam recording 'this is the universal theorem; for the concrete witness, follow the cross-reference'."
+      "mathContext": "Witness: $p = X^5 \\in \\mathbb{Q}[X]$, $\\mathrm{natDegree}(X^n) = n$ by `natDegree_pow` + `natDegree_X` + `mul_one`. What the proof *should* deliver but does not: $\\exists\\,q,\\ \\mathrm{Irreducible}\\,q \\land q.\\mathrm{natDegree} = 5 \\land \\mathrm{Gal}(q) \\cong S_5$. The gallery now contains three machine-verified instances of this sharper statement, so the placeholder is no longer a *gap* — it is a deliberate teaching seam recording 'this is the universal theorem; for the concrete witness, follow the cross-reference'.",
+      "prerequisites": [
+        "`Polynomial.natDegree_pow`, `natDegree_X`",
+        "distinguishing degree-5 existence from `Gal ≅ S₅` existence",
+        "`Irreducible` predicate on `Polynomial ℚ`",
+        "see cross-reference `abel-ruffini-oq-04-oq-01` for the concrete $x^5 - 4x + 2$ witness"
+      ],
+      "relatedConcepts": [
+        "Polynomial.natDegree",
+        "Irreducible polynomial predicate",
+        "concrete quintic $x^5 - 4x + 2$ (cross-ref oq-04-oq-01)",
+        "trivial existence vs substantive existence",
+        "placeholder/scaffold theorem pattern"
+      ]
     },
     {
       "id": "main-contrapositive",
@@ -418,7 +516,20 @@
       "startLine": 137,
       "endLine": 149,
       "summary": "**The load-bearing theorem of the file.** Statement: for irreducible $q \\in F[X]$ with root $\\alpha$, if $\\mathrm{Gal}(q)$ is *not* solvable, then $\\alpha$ is *not* solvable by radicals. The two-line proof is `intro hrad; exact hns (galois_bridge α q hq hroot hrad)` — assume radical solvability, apply the bridge to deduce solvable Galois group, contradict the hypothesis. The economy is the point: once Part II established the bridge at the right level of generality, this is a one-line corollary. The classical 19th-century framing 'the equation $x^5 - x - 1 = 0$ cannot be solved by radicals' is the *application* of this universal contrapositive to a specific witness; the *theorem* is the universal implication ranging over every irreducible $q$ and every base field $F$. Modus ponens against any concrete $q$ with $\\mathrm{Gal}(q) \\in \\{S_5, A_5\\}$ — e.g. `abel-ruffini-oq-04-oq-01`'s $x^5 - 4x + 2$ — recovers the classical statement.",
-      "mathContext": "$\\neg\\,\\mathrm{IsSolvable}\\,(q.\\mathrm{Gal}) \\Rightarrow \\neg\\,\\mathrm{IsSolvableByRad}\\,F\\,\\alpha$, given `Irreducible q` and `aeval α q = 0`. Proof (contrapositive of `galois_bridge`): assume `hrad : IsSolvableByRad F α`; then `galois_bridge α q hq hroot hrad : IsSolvable q.Gal` contradicts `hns : ¬ IsSolvable q.Gal`. The field-theoretic content (radical tower $F = K_0 \\subset \\cdots \\subset K_m \\ni \\alpha$ $\\Rightarrow$ each $K_{i+1}/K_i$ cyclic after adjoining roots of unity $\\Rightarrow$ Galois group solvable) lives entirely inside `solvableByRad.isSolvable'`, which the bridge invokes — the 2-line proof here is the *closing link*, not the whole argument."
+      "mathContext": "$\\neg\\,\\mathrm{IsSolvable}\\,(q.\\mathrm{Gal}) \\Rightarrow \\neg\\,\\mathrm{IsSolvableByRad}\\,F\\,\\alpha$, given `Irreducible q` and `aeval α q = 0`. Proof (contrapositive of `galois_bridge`): assume `hrad : IsSolvableByRad F α`; then `galois_bridge α q hq hroot hrad : IsSolvable q.Gal` contradicts `hns : ¬ IsSolvable q.Gal`. The field-theoretic content (radical tower $F = K_0 \\subset \\cdots \\subset K_m \\ni \\alpha$ $\\Rightarrow$ each $K_{i+1}/K_i$ cyclic after adjoining roots of unity $\\Rightarrow$ Galois group solvable) lives entirely inside `solvableByRad.isSolvable'`, which the bridge invokes — the 2-line proof here is the *closing link*, not the whole argument.",
+      "prerequisites": [
+        "contrapositive proof structure (`intro hrad; exact hns (...)`)",
+        "`galois_bridge` from Part II",
+        "irreducible polynomial as minimal polynomial of its root",
+        "use of `Polynomial.aeval` to express \"$\\alpha$ is a root\""
+      ],
+      "relatedConcepts": [
+        "galois_bridge (Part II)",
+        "contrapositive proof technique",
+        "IsSolvableByRad predicate",
+        "Polynomial.aeval (root evaluation)",
+        "irreducibility hypothesis"
+      ]
     },
     {
       "id": "threshold",
@@ -434,6 +545,12 @@
         "composition series",
         "simple group",
         "solvability threshold"
+      ],
+      "prerequisites": [
+        "Klein four-group $V_4 \\trianglelefteq A_4$",
+        "derived length of $S_4 = 3$ vs $S_5 = \\infty$",
+        "composition series and the Jordan-Hölder theorem",
+        "order-60 minimal non-abelian simple group $A_5$"
       ]
     },
     {
@@ -450,6 +567,12 @@
         "Lindemann-Weierstrass theorem",
         "expressibility hierarchy",
         "fundamental theorem of algebra"
+      ],
+      "prerequisites": [
+        "Lagrange (1770) resolvent and pre-history",
+        "Ruffini (1799), Abel (1824), Galois (1832) chronology",
+        "birth of abstract group theory from solvability questions",
+        "Lindemann-Weierstrass and the expressibility hierarchy"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

Two-proof enrichment pass adding structured per-section guidance to the abel-ruffini cluster.

### Commit 1 — `abel-ruffini-galois-extensions` (+97 lines)
Adds `prerequisites` (3-6 items) to all 15 sections — `solvable_of_ker_le_range` and the sign exact sequence in Parts I-II, `Equiv.Perm.not_solvable` and the sharp threshold in Part II, `alternatingGroup.isSimpleGroup_five` and `IsGalois.card_aut_eq_finrank` in Part III/IV, `native_decide` and the four explicit orders 5040/40320/2520/20160 in Part XIV, etc. Brings sections into parity with the per-annotation prerequisites already in annotations.json.

### Commit 2 — `abel-ruffini` (+131/-8 lines)
- Adds `prerequisites` (4-5 items) to all 12 sections.
- Adds `relatedConcepts` (5 items) to the 7 sections that previously had `[]`: `symmetric-group-not-solvable`, `cardinal-bridge`, `s5-s6-not-solvable`, `a5-is-simple`, `part-v-synthesis`, `exists-quintic-placeholder`, `main-contrapositive`.

## Why

Across both proofs, sections previously exposed no `prerequisites` field even though their annotations already carried one. This gives the proof page a per-section "what you need to know" entry point, matching how Mathlib APIs (`solvableByRad.isSolvable'`, `Equiv.Perm.not_solvable`, `alternatingGroup.isSimpleGroup_five`) and Lean tactics (`omega`, `native_decide`, `push_neg`, `decide`) are introduced in the proof.

## Changes

- `src/data/proofs/abel-ruffini-galois-extensions/meta.json`: +97 (15 sections × prerequisites)
- `src/data/proofs/abel-ruffini/meta.json`: +131/-8 (12 sections × prerequisites + 7 × relatedConcepts)

No existing summary/mathContext content modified or removed.

## Test plan
- [x] `pnpm build` passes for both proofs (JSON schema valid, listings rebuild clean)
- [x] All sections in both files now have `prerequisites`
- [x] LaTeX in prerequisites uses `$...$` inline math
- [x] No changes outside the two target proof directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)