### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): S10 ACT — Fσ-style witness for the computable reals

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
@@ -925,4 +925,74 @@ theorem frontier_nonComputableReals_eq_univ :
   rw [frontier, closure_nonComputableReals_eq_univ,
       interior_nonComputableReals_eq_empty, Set.diff_empty]
 
+/-! ## S10 — Fσ-style structure: computable reals are a countable union of closed sets
+
+S8 proved `nonComputableReals_isGδ` — the complement of the countable set
+`{r | IsComputable r}` in the T1 space `ℝ` is a Gδ set. The dual classical
+statement is that `{r | IsComputable r}` is itself Fσ: a countable union of
+closed sets. Mathlib v4.26.0 has no `IsFσ` predicate (only `IsGδ`,
+`residual`, `IsNowhereDense`, `IsMeagre` are provided in
+`Mathlib.Topology.GDelta.{Basic, MetrizableSpace}`), so we state the
+witness explicitly via the `Nat.Partrec.Code` codebook of S3.
+
+For each code `c`, the set
+  `s c := {decodeReal c} ∩ {r | IsComputable r}`
+is a subsingleton (it contains at most the point `decodeReal c`), hence
+closed in the T1 space `ℝ` (`Set.Subsingleton.isClosed`). The union covers
+exactly the computable reals:
+
+* Every computable real `r` lies in `Set.range decodeReal` (S3's
+  `computable_real_mem_range_decodeReal`), so the witness code `c` with
+  `decodeReal c = r` gives `r ∈ s c`.
+* Conversely, `r ∈ s c` immediately gives `IsComputable r` from the right
+  factor of the intersection.
+
+This completes the Borel-hierarchy picture: computable reals are Σ⁰₂
+(Fσ-style, S10) and non-computable reals are Π⁰₂ (Gδ, S8) in the classical
+descriptive-set-theoretic hierarchy. The asymmetric proof — `IsGδ`
+predicate for non-computable, explicit-witness for computable — reflects
+the absence of an `IsFσ` predicate in Mathlib v4.26.0 rather than any
+mathematical asymmetry between the two halves.
+
+* `computable_reals_isFsigma_witness` — `∃ s : Nat.Partrec.Code → Set ℝ,
+  (∀ c, IsClosed (s c)) ∧ {r | IsComputable r} = ⋃ c, s c`.
+-/
+
+/-- **S10 — explicit Fσ-style witness for the computable reals.**
+
+    The family `s c := {decodeReal c} ∩ {r | IsComputable r}` is the desired
+    decomposition of `{r | IsComputable r}` into a countable union of closed
+    sets:
+
+    * Each `s c` is contained in the singleton `{decodeReal c}`, hence is a
+      subsingleton; subsingletons are closed in the T1 space `ℝ`
+      (`Set.Subsingleton.isClosed`).
+    * `{r | IsComputable r} = ⋃ c, s c`: forward by S3's
+      `computable_real_mem_range_decodeReal` (every computable real has a
+      decoding code); reverse by the right factor of the intersection in
+      `s c`.
+
+    No Computable-on-`decodeReal c` argument is required — the intersection
+    formulation absorbs the case-analysis into the membership predicate. -/
+theorem computable_reals_isFsigma_witness :
+    ∃ s : Nat.Partrec.Code → Set ℝ,
+      (∀ c, IsClosed (s c)) ∧
+      {r : ℝ | IsComputable r} = ⋃ c, s c := by
+  refine ⟨fun c => ({decodeReal c} : Set ℝ) ∩ {r : ℝ | IsComputable r}, ?_, ?_⟩
+  · intro c
+    apply Set.Subsingleton.isClosed
+    intro x hx y hy
+    have hx1 : x ∈ ({decodeReal c} : Set ℝ) := hx.1
+    have hy1 : y ∈ ({decodeReal c} : Set ℝ) := hy.1
+    rw [Set.mem_singleton_iff] at hx1 hy1
+    exact hx1.trans hy1.symm
+  · ext r
+    refine ⟨fun hr => ?_, fun hr => ?_⟩
+    · obtain ⟨c, hc⟩ := computable_real_mem_range_decodeReal hr
+      refine Set.mem_iUnion.mpr ⟨c, ?_, hr⟩
+      rw [Set.mem_singleton_iff]
+      exact hc.symm
+    · obtain ⟨c, hc⟩ := Set.mem_iUnion.mp hr
+      exact hc.2
+
 end AlgebraicNumbersCountableOQ02OQ04

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-04-s10-act-fsigma-witness.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-04-s10-act-fsigma-witness.md
@@ -1,0 +1,165 @@
+# S10 ACT — Fσ-style witness for the computable reals
+
+**Date**: 2026-06-04
+**Owner**: researcher-1
+**Slug**: algebraic-numbers-countable-oq-02-oq-04
+**Phase**: S10 ACT
+**Base SHA**: `eeca24a5` (origin/main as of 2026-06-04 17:30Z, with S10 PREP
+PR #22049 merged 2026-06-02)
+**Branch**: `research/algebraic-numbers-countable-oq02oq04-s10-act-fsigma`
+**Lean file**: `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean`
+— 998 LOC (was 928), 43 theorems (was 42), 3 defs, 0 sorries, 0 axioms
+
+## 1. What this iteration adds
+
+One new theorem, no new defs / sorries / axioms / imports:
+
+* `computable_reals_isFsigma_witness :
+    ∃ s : Nat.Partrec.Code → Set ℝ,
+      (∀ c, IsClosed (s c)) ∧
+      {r : ℝ | IsComputable r} = ⋃ c, s c`
+
+The explicit witness is the family
+
+```
+s c := {decodeReal c} ∩ {r : ℝ | IsComputable r}
+```
+
+— an intersection of the singleton at the S3 decoder image with the
+predicate itself. Each `s c` is contained in `{decodeReal c}`, hence is a
+subsingleton, hence closed in the T1 space `ℝ` via
+`Set.Subsingleton.isClosed`. The union covers `{r | IsComputable r}` by S3's
+`computable_real_mem_range_decodeReal` (every computable real has a
+decoding code) on the forward direction, and by the right factor of the
+intersection on the reverse direction.
+
+## 2. Why this is the right S10 ACT
+
+The S10 PREP memo (PR #22049, 2026-06-02) surveyed three S10 directions:
+
+* **Proposal A** — inline Fσ-style witness (~30 LOC, RECOMMENDED): completes
+  the Σ⁰₂ side of the Borel-hierarchy classification dual to S8's
+  Π⁰₂ (Gδ) side.
+* **Proposal B** — interval-restricted cardinality refinement (~25 LOC):
+  refines S4 cardinalities to every nonempty `Ioo`. Less mathematically
+  novel than Proposal A.
+* **Proposal C** — `Primrec ℚ` arithmetic (~150–300 LOC): would unblock
+  `IsComputable e` / `π`. Substantial Mathlib-prerequisite contribution;
+  out of scope for a single S10 ACT.
+
+This PR implements Proposal A with one important refinement that the PREP
+memo glossed over: the scaffold's `decodeReal_isComputable` lemma was not
+trivially derivable. Recovering `Computable f` from a witness
+`f : ℕ → ℚ` with `c.eval n = Part.some (Encodable.encode (f n))` requires
+the encode-decode round-trip via `Computable.decode`, which is itself
+~20–30 LOC of careful unfolding and is *not* the headline contribution of
+S10.
+
+The intersection formulation `{decodeReal c} ∩ {r | IsComputable r}`
+side-steps this entirely. Membership in `s c` already carries the
+`IsComputable r` proof in the right factor, so we never need to argue
+whether `decodeReal c` is itself computable. The closure property follows
+from subsingleton-ness (subset of singleton), and the union-covers property
+falls out of S3's existing `computable_real_mem_range_decodeReal` without
+needing a new computability argument.
+
+## 3. Why "Fσ-style witness" rather than `IsFσ`
+
+Mathlib v4.26.0 has no `IsFσ` predicate in
+`Mathlib.Topology.GDelta.{Basic, MetrizableSpace}` — only `IsGδ`,
+`residual`, `IsNowhereDense`, `IsMeagre` are provided. A GitHub code search
+over `leanprover-community/mathlib4` (probed 2026-06-02, re-confirmed
+this session) returns 0 hits for `IsFσ`, `IsFsigma`, `Set.Countable.isF`.
+
+The natural-looking statement `IsFσ {r | IsComputable r}` therefore cannot
+be a one-liner. We state the witness explicitly via the `Nat.Partrec.Code`
+codebook of S3, which has a `Denumerable` instance giving the required
+countable index type.
+
+A future Mathlib PR introducing `IsFσ` (and a `Set.Countable.isFσ`
+companion to the existing `Set.Countable.isGδ_compl`) would shorten this
+theorem to a one-liner. The current explicit-witness formulation is the
+expected workaround.
+
+## 4. Proof sketch
+
+```lean
+theorem computable_reals_isFsigma_witness :
+    ∃ s : Nat.Partrec.Code → Set ℝ,
+      (∀ c, IsClosed (s c)) ∧
+      {r : ℝ | IsComputable r} = ⋃ c, s c := by
+  refine ⟨fun c => ({decodeReal c} : Set ℝ) ∩ {r : ℝ | IsComputable r}, ?_, ?_⟩
+  · intro c
+    apply Set.Subsingleton.isClosed
+    intro x hx y hy
+    have hx1 : x ∈ ({decodeReal c} : Set ℝ) := hx.1
+    have hy1 : y ∈ ({decodeReal c} : Set ℝ) := hy.1
+    rw [Set.mem_singleton_iff] at hx1 hy1
+    exact hx1.trans hy1.symm
+  · ext r
+    refine ⟨fun hr => ?_, fun hr => ?_⟩
+    · obtain ⟨c, hc⟩ := computable_real_mem_range_decodeReal hr
+      refine Set.mem_iUnion.mpr ⟨c, ?_, hr⟩
+      rw [Set.mem_singleton_iff]
+      exact hc.symm
+    · obtain ⟨c, hc⟩ := Set.mem_iUnion.mp hr
+      exact hc.2
+```
+
+Three Mathlib bearers (all verified via mathlib4_docs WebFetch at the
+session start):
+
+| Lemma | Module | Statement |
+|---|---|---|
+| `Set.Subsingleton.isClosed` | `Mathlib.Topology.Separation.*` | `Subsingleton s → IsClosed s` in T1 |
+| `Set.mem_singleton_iff` | `Mathlib.Data.Set.Basic` | `x ∈ ({y} : Set α) ↔ x = y` |
+| `Set.mem_iUnion` | `Mathlib.Data.Set.Lattice` | `x ∈ ⋃ i, s i ↔ ∃ i, x ∈ s i` |
+
+All three are transitively imported via the existing
+`Topology.Instances.Real.Lemmas` + `Mathlib.Tactic` chain. No new
+`import` lines needed.
+
+## 5. Build status
+
+Docker `lake build Proofs.AlgebraicNumbersCountableOQ02OQ04` →
+**✔ 3067/3067 jobs clean** (14s file compile, base SHA `eeca24a5`,
+verified 2026-06-04). The proof type-checks against Mathlib v4.26.0 with
+no new imports or API changes.
+
+## 6. Mathematical takeaway
+
+The descriptive-set-theoretic profile of the computable / non-computable
+partition of `ℝ` is now complete on both sides:
+
+| Side | Cardinality | Topology | Borel class |
+|---|---|---|---|
+| Computable reals | ℵ₀ (S3) | dense + meagre + frontier=univ (S7, S8, S9) | **Σ⁰₂ (S10, this PR)** |
+| Non-computable reals | 𝔠 (S4) | dense + residual + frontier=univ (S8-prep, S8, S9) | Π⁰₂ (Gδ, S8) |
+
+This is the exact descriptive-set-theoretic profile carried by the
+rational / irrational partition of `ℝ`, refined here to the strictly
+finer computable / non-computable split. The asymmetric Lean
+formulation — `IsGδ` predicate on one side, explicit Fσ-witness on the
+other — is a Mathlib-vocabulary artefact (absent `IsFσ`) rather than a
+mathematical asymmetry between the two halves.
+
+## 7. Files touched this PR
+
+* `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean`
+  — +70 LOC: S10 section docstring (~35 LOC) + theorem
+    `computable_reals_isFsigma_witness` (~22 LOC body) +
+    blank-line separation.
+* `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json`
+  — `lineCount` 928→998; `theoremCount` 31→43 (S6 drift catch-up via
+    the S10 increment) and 42→43 in `leanFile`; `originalContributions`
+    array 22→23 entries (appends S10 entry).
+* `research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md`
+  — header refresh: Phase S10 PREP → S10 ACT, Iteration 12 → 13, Last
+    Updated, Branch, inventory snapshot (LOC + thm count), bearer
+    citations updated, S11+ priority paragraph updated, S10 ACT
+    session-log entry appended.
+* `research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-04-s10-act-fsigma-witness.md`
+  — this memo.
+
+**Zero changes to**: `proofs/Proofs.lean`, `problem.md`, `knowledge.md`,
+`annotations.json`, `index.ts`, `src/data/research/problems/*.json`.

--- a/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
+++ b/research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md
@@ -2,25 +2,25 @@
 
 ## Current Status
 
-**Phase**: S10 PREP — post-S9-merged STATE-SYNC + S10 ACT direction scaffold (doc-only)
-**Owner**: researcher-1 (S10 PREP, 2026-06-02); S9 ACT: researcher-1 (PR #22030 merged 2026-06-02); S8: researcher-1 (2026-05-31); S8-prep: researcher-1 (2026-05-30); S7: researcher-1 (2026-05-28)
-**Iteration**: 12 (S1 + S2 + S3 + S4 + S5 + S6 + mechanic #19054 + S6f STATE-SYNC + S7 + S8-prep + S8 + S9 + S10 PREP)
-**Last Updated**: 2026-06-02Z (S10 PREP doc-only; STATE-SYNC post-S9-merge + S10 ACT direction scaffold + meta.json originalContributions backfill S7→S9)
-**Branch (this PR)**: `research/algebraic-numbers-countable-oq02-oq04-s10`
+**Phase**: S10 ACT — Fσ-style witness for the computable reals (Σ⁰₂ Borel-hierarchy classification)
+**Owner**: researcher-1 (S10 ACT, 2026-06-04); S10 PREP: researcher-1 (PR #22049 merged 2026-06-02); S9 ACT: researcher-1 (PR #22030 merged 2026-06-02); S8: researcher-1 (2026-05-31); S8-prep: researcher-1 (2026-05-30); S7: researcher-1 (2026-05-28)
+**Iteration**: 13 (S1 + S2 + S3 + S4 + S5 + S6 + mechanic #19054 + S6f STATE-SYNC + S7 + S8-prep + S8 + S9 + S10 PREP + S10 ACT)
+**Last Updated**: 2026-06-04Z (S10 ACT Lean delta; +1 thm `computable_reals_isFsigma_witness`; 928→998 LOC; 42→43 thms; Docker `3067/3067` jobs clean, 14s file compile)
+**Branch (this PR)**: `research/algebraic-numbers-countable-oq02oq04-s10-act-fsigma`
 
-## Lean file inventory (at base `origin/main`, S9 Docker-verified)
+## Lean file inventory (at base `origin/main`, S10 ACT delta)
 
 ```
 File:        proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
-Lines:       928 (was 869 at S8; +59 in S9 including section docstring)
-Theorems:    42 (S9 adds frontier_computable_reals_eq_univ +
-                  frontier_nonComputableReals_eq_univ)
+Lines:       998 (was 928 at S9; +70 in S10 including section docstring)
+Theorems:    43 (S10 adds computable_reals_isFsigma_witness)
 Definitions: 3 (IsComputable, decodeReal, nonComputableReals)
-Sorries:     0 (S3 discharged the S1 sorry; S4-S9 added no new)
+Sorries:     0 (S3 discharged the S1 sorry; S4-S10 added no new)
 Axioms:      0
-Build:       ✔ VERIFIED S9 (Docker 3067/3067 jobs clean, 10s file compile, 2026-06-01)
-Imports:     no new (frontier / Set.diff_empty already transitively available
-              via the existing Topology.Instances.Real.Lemmas + Mathlib.Tactic chain)
+Build:       ✔ VERIFIED S10 (Docker 3067/3067 jobs clean, 14s file compile, 2026-06-04)
+Imports:     no new (Set.Subsingleton.isClosed / Set.mem_inter_iff /
+              Set.mem_singleton_iff / Set.mem_iUnion already transitively
+              available via Topology.Instances.Real.Lemmas + Mathlib.Tactic)
 ```
 
 4 critical Mathlib bearers used in S8 proof:
@@ -33,21 +33,28 @@ Imports:     no new (frontier / Set.diff_empty already transitively available
 - `frontier` (Topology.Basic) — `frontier s := closure s \ interior s` (definition unfolded)
 - `Set.diff_empty` — `s \ ∅ = s`
 
-**Next-picker priority (S10+)**: With S7 (computable dense), S8-prep (non-computable
-dense), S8 (Baire-category: computable meagre / non-computable Gδ-residual), and
-S9 (frontier = univ on both partition halves) now in place, the topological
-picture is complete on both sides: computable reals show the same topological
-profile as `ℚ` (countable + dense + meagre + frontier-everywhere), and
-non-computable reals are dense + Gδ + residual + frontier-everywhere. The
-remaining headline next step remains shipping `IsComputable e` (or `π`) as the
-explicit computable transcendental witness sharpening `algebraic ⊊ computable`
-beyond pure cardinality + topology. Path A (e via partial sums of `1/n!`) is
-the cleaner-skeleton candidate at v4.26.0; ~80-150 LOC estimate but **blocked
-on Mathlib gap**: there is no `Computable.add` / `Computable.neg` for `ℚ` in
-current Mathlib v4.26.0 (verified by grep: only `Computable.const`,
-`Computable.encode`, `Computable.comp` on `ℚ`; `Primrec ℚ` arithmetic operations
-not yet provided). Building this machinery is itself a sizeable subgoal (S10
-prereq) — see S6f §5 for full priority tree.
+3 critical Mathlib bearers used in S10 ACT proof:
+- `Set.Subsingleton.isClosed` (Topology.Separation) — every subsingleton in a T1 space is closed
+- `Set.mem_singleton_iff` (Data.Set.Basic) — `x ∈ ({y} : Set α) ↔ x = y`
+- `Set.mem_iUnion` (Data.Set.Lattice) — `x ∈ ⋃ i, s i ↔ ∃ i, x ∈ s i`
+
+**Next-picker priority (S11+)**: With S10 ACT shipping the Fσ-style witness,
+the Borel-hierarchy classification is now complete on both partition halves:
+computable reals are Σ⁰₂ (countable union of closed sets, S10) and
+non-computable reals are Π⁰₂ (Gδ, S8). The topological profile is fully
+captured (countable + dense + meagre + frontier-everywhere + Σ⁰₂-explicit on
+the computable side; full-cardinality + dense + Gδ + residual +
+frontier-everywhere on the non-computable side). The remaining headline next
+step remains shipping `IsComputable e` (or `π`) as the explicit computable
+transcendental witness sharpening `algebraic ⊊ computable` beyond pure
+cardinality + topology + Borel-hierarchy. Path A (e via partial sums of
+`1/n!`) is the cleaner-skeleton candidate at v4.26.0; ~80-150 LOC estimate
+but **blocked on Mathlib gap**: there is no `Computable.add` /
+`Computable.neg` for `ℚ` in current Mathlib v4.26.0 (verified by grep: only
+`Computable.const`, `Computable.encode`, `Computable.comp` on `ℚ`;
+`Primrec ℚ` arithmetic operations not yet provided). Building this
+machinery is itself a sizeable subgoal (S11 prereq) — see S6f §5 for full
+priority tree.
 
 ## What's Done
 
@@ -236,6 +243,34 @@ infrastructure + strategy + 1 file + 1 module-doc + 4 annotations).
   refined here to the strictly finer computable/non-computable split.
   No new defs / sorries / axioms / imports. Lean file 869 → 928 LOC, theorem
   count 40 → 42. See `sessions/2026-06-01-s9-act-frontier-characterization.md`.
+
+- **2026-06-04 (S10 ACT, researcher-1)**: Fσ-STYLE WITNESS for the computable
+  reals — completes the Borel-hierarchy classification (Σ⁰₂-explicit on the
+  computable side; Π⁰₂ Gδ already in place on the non-computable side from
+  S8). One new theorem, no new defs/axioms/sorries/imports:
+  - `computable_reals_isFsigma_witness : ∃ s : Nat.Partrec.Code → Set ℝ,
+    (∀ c, IsClosed (s c)) ∧ {r | IsComputable r} = ⋃ c, s c` — explicit
+    witness via the family `s c := {decodeReal c} ∩ {r | IsComputable r}`.
+    Each `s c` is contained in the singleton `{decodeReal c}`, hence is a
+    subsingleton, hence closed in the T1 space `ℝ` via
+    `Set.Subsingleton.isClosed`. The union covers via S3's
+    `computable_real_mem_range_decodeReal` (every computable real has a
+    decoding code).
+  Mathematical content: completes the descriptive-set-theoretic profile
+  begun by S8 (`nonComputableReals_isGδ`). Computable reals are Σ⁰₂
+  (Fσ-style) and non-computable reals are Π⁰₂ (Gδ) in the classical Borel
+  hierarchy. The Mathlib-gap workaround (no `IsFσ` predicate at v4.26.0) is
+  the explicit-witness formulation, which side-steps the otherwise non-
+  trivial computability argument on `decodeReal c` itself: the intersection
+  formulation `{decodeReal c} ∩ {r | IsComputable r}` absorbs the
+  case-analysis into the membership predicate, so we never need to argue
+  whether `decodeReal c` is itself computable. New Mathlib bearers:
+  `Set.Subsingleton.isClosed`, `Set.mem_singleton_iff`, `Set.mem_iUnion`.
+  Lean file 928 → 998 LOC (+70 including section docstring), 42 → 43 thms,
+  0 sorries → 0 sorries, 0 axioms → 0 axioms. Docker `lake build
+  Proofs.AlgebraicNumbersCountableOQ02OQ04` → ✔ 3067/3067 jobs clean
+  (14s file compile, base SHA `eeca24a5`).
+  See `sessions/2026-06-04-s10-act-fsigma-witness.md` for the full memo.
 
 - **2026-06-02 (S10 PREP STATE-SYNC, researcher-1, doc-only)**: POST-S9-MERGED
   doc tracker catch-up + S10 ACT direction scaffold. PR #22030 (S9 ACT) merged

--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 928,
+    "lineCount": 998,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -53,7 +53,8 @@
       "nonComputableReals_dense, closure_nonComputableReals_eq_univ — S8-prep topological complement: non-computable reals also dense (Ioo a b argument via IsOpen.exists_Ioo_subset + Cardinal.mk_Ioo_real / aleph0_lt_continuum contradiction); closure = univ",
       "nonComputableReals_isGδ, nonComputableReals_residual, computable_reals_meagre — S8 Baire-category sharpening: complement of countable in T1 is Gδ (Set.Countable.isGδ_compl), Gδ ∩ dense is residual, meagre dual via IsMeagre definitional unfolding",
       "interior_computable_reals_eq_empty, interior_nonComputableReals_eq_empty — S8 corollary: both sides of the partition have empty interior (interior_eq_empty_iff_dense_compl applied to the dual density results)",
-      "frontier_computable_reals_eq_univ, frontier_nonComputableReals_eq_univ — S9 boundary characterization: every real is a boundary point of both partition halves simultaneously (frontier := closure \\ interior, combining S7/S8-prep closure = univ with S8 interior = ∅, then Set.diff_empty)"
+      "frontier_computable_reals_eq_univ, frontier_nonComputableReals_eq_univ — S9 boundary characterization: every real is a boundary point of both partition halves simultaneously (frontier := closure \\ interior, combining S7/S8-prep closure = univ with S8 interior = ∅, then Set.diff_empty)",
+      "computable_reals_isFsigma_witness — S10 explicit Fσ-style witness: ∃ s : Nat.Partrec.Code → Set ℝ, (∀ c, IsClosed (s c)) ∧ {r | IsComputable r} = ⋃ c, s c, with s c := {decodeReal c} ∩ {r | IsComputable r}. Each s c is a subsingleton (closed in T1 via Set.Subsingleton.isClosed); union covers via S3 computable_real_mem_range_decodeReal. Completes the Σ⁰₂ / Π⁰₂ Borel-hierarchy picture (Fσ-style for computable, Gδ for non-computable from S8)."
     ],
     "prerequisites": [
       "AlgebraicNumbersCountable: algebraic_reals_countable — the next layer up in the hierarchy",
@@ -88,7 +89,7 @@
         "module": "Mathlib.SetTheory.Cardinal.Continuum"
       }
     ],
-    "theoremCount": 31,
+    "theoremCount": 43,
     "definitionCount": 3,
     "relatedProblems": [
       {
@@ -314,9 +315,9 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 928,
+    "lineCount": 998,
     "axiomCount": 0,
-    "theoremCount": 42,
+    "theoremCount": 43,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"


### PR DESCRIPTION
## Summary

- **S10 ACT** for `algebraic-numbers-countable-oq-02-oq-04` — adds the dual of S8's `nonComputableReals_isGδ` as an explicit countable-union-of-closed-sets witness, completing the **Σ⁰₂ / Π⁰₂ Borel-hierarchy classification** of the computable / non-computable partition of ℝ.
- 1 new theorem `computable_reals_isFsigma_witness` (43 total, was 42); 928 → 998 LOC; 0 sorries, 0 axioms, 0 new imports.
- Docker `lake build Proofs.AlgebraicNumbersCountableOQ02OQ04` → **✔ 3067/3067 jobs clean** (14s file compile).

## What this PR adds

```lean
theorem computable_reals_isFsigma_witness :
    ∃ s : Nat.Partrec.Code → Set ℝ,
      (∀ c, IsClosed (s c)) ∧
      {r : ℝ | IsComputable r} = ⋃ c, s c
```

Witness: `s c := {decodeReal c} ∩ {r | IsComputable r}`. Each `s c` is contained in the singleton `{decodeReal c}`, hence is a subsingleton, hence closed in the T1 space ℝ via `Set.Subsingleton.isClosed`. The union covers via S3's `computable_real_mem_range_decodeReal`.

## Why this iteration

The S10 PREP memo (PR #22049, 2026-06-02) recommended a Proposal A Fσ-style witness. This PR implements it with one refinement: the scaffold proposed `s c := {decodeReal c}` directly, which required a separate `decodeReal_isComputable` lemma — a non-trivial encode-decode argument. The intersection formulation absorbs the case-analysis into the membership predicate.

## Why "Fσ-style witness" rather than `IsFσ`

Mathlib v4.26.0 has no `IsFσ` predicate (only `IsGδ`, `residual`, `IsNowhereDense`, `IsMeagre` in `Mathlib.Topology.GDelta.*`). A future Mathlib PR adding `IsFσ` would shorten this theorem to a one-liner.

## Descriptive-set-theoretic profile (after this PR)

| Side | Cardinality | Topology | Borel class |
|---|---|---|---|
| Computable reals | ℵ₀ (S3) | dense + meagre + frontier=univ (S7, S8, S9) | **Σ⁰₂ (S10, this PR)** |
| Non-computable reals | 𝔠 (S4) | dense + residual + frontier=univ (S8-prep, S8, S9) | Π⁰₂ (Gδ, S8) |

## Files touched

- `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean` — +70 LOC (S10 section docstring + theorem body)
- `src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json` — lineCount 928→998, theoremCount sync, +1 originalContributions entry
- `research/problems/algebraic-numbers-countable-oq-02-oq-04/state.md` — header refresh, S10 ACT session log
- `research/problems/algebraic-numbers-countable-oq-02-oq-04/sessions/2026-06-04-s10-act-fsigma-witness.md` — full memo

## Test plan

- [x] Docker build clean: `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ04` → ✔ 3067/3067 jobs clean
- [x] No new sorries (0 → 0)
- [x] No new axioms (0 → 0)
- [x] No new imports
- [x] Tracker docs synced with Lean delta

🤖 Generated with [Claude Code](https://claude.com/claude-code)