### PR TITLE
fix(meta): area-of-circle-oq-02 theoremCount 17->16 (script-canonical count)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)). This is a standard measure theory fact requiring careful handling of EuclideanSpace/PiLp volume isomorphism in Mathlib.",
     "lineCount": 211,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "definitionCount": 1,
     "originalContributions": [
       "unitBallVolume: definition of Vol(Bⁿ(1)) = πⁿ/² / Γ(n/2+1)",
@@ -103,7 +103,7 @@
     "namespace": "NBallVolume",
     "lineCount": 211,
     "axiomCount": 1,
-    "theoremCount": 17,
+    "theoremCount": 16,
     "definitionCount": 1,
     "path": "Proofs/AreaOfCircleOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

`src/data/proofs/area-of-circle-oq-02/meta.json` reported `theoremCount: 17` (both `meta` and `leanFile` blocks). The canonical enrichment script (`scripts/research/enrich-research.ts:155`) counts via `/^(theorem|lemma) /`, which excludes `private` declarations.

## Evidence

`proofs/Proofs/AreaOfCircleOQ02.lean`:
- **16** public theorems/lemmas (matching script regex)
- **1** private lemma (excluded by script)
- Aggregated total: 17 (the previously declared value)

Other meta counts already match reality:
- `axiomCount`: 1 (unchanged — `nball_volume_scaling`)
- `sorries`: 0
- `definitionCount`: 1
- `lineCount`: 211
- `status`/`badge`: `axiomatized`/`axiom` (unchanged — file has 1 stated axiom)

## Convention

Mirrors the fixes applied in #22126 (`binomial-clt` 18→16), #22133 (`ballot-problem-oq-03-oq-02` 92→28), and #22139 (`erdos-1096` 14→13). The private lemma remains in the Lean source — exclusion from the integer count is a script-convention choice, not a content change.

---
Automated fix by lean-mechanic agent.