### PR TITLE
fix(meta): area-of-circle-oq-01-oq-03-oq-02 theoremCount 17->15, definitionCount 5->4

### DIFF
--- a/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 6,
     "axiomCount": 2,
-    "theoremCount": 17,
+    "theoremCount": 15,
     "lineCount": 565,
     "defCount": 4,
     "assumptions": "2 axioms: (1) wirtinger_ac — Wirtinger inequality for Lipschitz/AC 2π-periodic functions with zero mean: ∫f² ≤ ∫(f')²; (2) exists_lip_nice_reparam — arc-length reparametrization for Lipschitz curves with positive speed a.e., giving constant-speed and zero-mean reparametrization. 6 technical sorries remain: lip_x/lip_y (MVT bound for periodic C¹ → Lipschitz), hdx_int/hdy_int (derivative-squared integrability from LipschitzWith), harea_zero (area=0 from circumference=0), hf_int (integrability of xy'−yx' for Lipschitz curves).",
@@ -54,7 +54,7 @@
       }
     ],
     "dateAdded": "2026-05-03",
-    "definitionCount": 5
+    "definitionCount": 4
   },
   "overview": {
     "historicalContext": "Hurwitz (1901) proved the isoperimetric inequality for smooth curves using Fourier series. The Wirtinger inequality is the key analytical ingredient: for a zero-mean 2π-periodic smooth function f, ∫₀²π f² ≤ ∫₀²π (f')². The natural regularity level for the isoperimetric inequality is Lipschitz (or even rectifiable) curves, since these include all piecewise-smooth curves (polygons, convex bodies). For Lipschitz curves, Rademacher's theorem guarantees differentiability a.e., so the arc-length and Green's theorem formulas remain valid as Lebesgue integrals. The Wirtinger inequality extends to W^{1,2}(S¹) and hence to all Lipschitz functions. Maz'ya (1985) and Federer (1969) contain the foundational measure-theoretic machinery for this generalization.",
@@ -153,9 +153,9 @@
     "namespace": "LipschitzIsoperimetric",
     "lineCount": 565,
     "axiomCount": 2,
-    "theoremCount": 17,
+    "theoremCount": 15,
     "lemmaCount": 1,
-    "definitionCount": 5,
+    "definitionCount": 4,
     "substantiveTheoremCount": 5,
     "sorries": 6,
     "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean"


### PR DESCRIPTION
## Fix

Sync `src/data/proofs/area-of-circle-oq-01-oq-03-oq-02/meta.json` to the canonical-script counts in `scripts/research/enrich-research.ts:155-170` (regexes `/^(theorem|lemma) /` and `/^(def|noncomputable def|opaque def) /`).

## Evidence

`proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean`:
- **15** total theorems/lemmas matching `^(theorem|lemma) ` (14 `theorem` + 1 `lemma`).
- 2 declarations excluded by the line-start regex: `@[simp] theorem toLipschitz_circumference` (line 103) and `@[simp] theorem toLipschitz_area` (line 107) — the `@[simp]` attribute prefix shifts the keyword off column 0.
- **4** definitions matching `^(def|noncomputable def|opaque def) ` (lines 76, 81, 92, 128). The previously counted fifth is the `structure LipschitzClosedCurve` on line 65, which the canonical def regex does not match.

Both the `meta` block and the `leanFile` block reported `theoremCount: 17` and `definitionCount: 5`; both are updated to `15` and `4`.

## Fields left untouched

- `axiomCount: 2` (wirtinger_ac, exists_lip_nice_reparam) — already correct.
- `sorries: 6` — real tactic-sorries (lines 99, 100, 296, 300, 340, 386). Per the #22189 convention, the script's `\bsorry\b` word-boundary count is **not** used here because it picks up two `sorry` mentions inside `/-` comment blocks at lines 547 and 551, which are documentation, not unproven obligations. The narrative `assumptions` field correctly states '6 technical sorries remain'.
- `lineCount: 565` — already correct.
- `defCount: 4` (already correct in the `meta` block; `definitionCount: 5` was the drifted sibling).
- `lemmaCount: 1` and `substantiveTheoremCount: 5` — not in the canonical script's output, so untouched.

## Convention

Mirrors the script-canonical-count fixes in #22315 (`area-of-circle-oq-02` 17->16, same `@[simp]` issue), #22227, and #22139. No content change in the Lean source.

---
Automated fix by lean-mechanic agent.