### PR TITLE
research(brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02): S18 ACT-B — G12 sphere-nonzero substantive (build verified, 3312 jobs)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -323,6 +323,7 @@ import Proofs.BrouwerFixedPointOQ01
 import Proofs.BrouwerFixedPointOQ01OQ02
 import Proofs.BrouwerFixedPointOQ01OQ02G10
 import Proofs.BrouwerFixedPointOQ01OQ02G11
+import Proofs.BrouwerFixedPointOQ01OQ02G12
 import Proofs.BrouwerFixedPointOQ01OQ02G6
 import Proofs.BrouwerFixedPointOQ01OQ02G7
 import Proofs.BrouwerFixedPointOQ01OQ02G8

--- a/proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean
@@ -1,0 +1,126 @@
+/-
+  Brouwer Fixed Point OQ-01-OQ-02-OQ-03-OQ-02: S18 ACT-B (G12)
+
+  Companion file installing the **G12 sphere-nonzero substantive bridge
+  for retractions at `n ≥ 2`** — the final categorical wire-up identified
+  by S15 PREP §5 as the payload of the main-file integration.
+
+  Purpose: produce the existence statement currently encoded by the mock
+  axiom `H_n_minus_1_sphere_nonzero` (main:261), specialized to `n ≥ 2`,
+  via a substantive derivation chaining G10 + G8 + G11 + the main file's
+  `H_n_minus_1_sphere_nonzero_substantive`. The conclusion is reached by
+  `exfalso` after deriving the substantive contradiction
+  `IsZero (H_{n-1}(𝕊^{n-1}))` ⨯ `¬ IsZero (H_{n-1}(𝕊^{n-1}))`.
+
+  Single declaration in namespace `BrouwerOQ01OQ02`:
+
+  * `H_n_minus_1_sphere_nonzero_for_retraction` — `n ≥ 2` substantive form
+    of the existence statement. Same signature as the mock axiom modulo
+    the `n ≥ 2` hypothesis (axiom uses `n ≥ 1`). Proof: `exfalso` + the
+    homological chain.
+
+  Companion-file (not inline) per the G6/G7/G8/G10/G11 precedent:
+  build-risk isolation + review parallelism. Main-file integration
+  (replacing the mock axiom with this theorem + an `n = 1` branch) is
+  deferred to S19 ACT-C.
+
+  ## Derivation chain (S15 PREP §5)
+
+  1. `r : Retraction n` carries the geometric retraction `B^n → S^{n-1}`.
+  2. **G10** `Retraction.toTopCatHom` packages `r` as a TopCat morphism
+     `ρ : 𝔻 n ⟶ ∂𝔻 n`.
+  3. **G10** `Retraction.section_identity` provides the section equation
+     `diskBoundaryInclusion n ≫ ρ = 𝟙 (∂𝔻 n)` in TopCat.
+  4. **G8** `map_section_of_section` transports the section through the
+     singular-homology functor `F := H_{n-1}(·; ℤ)`:
+     `F.map (incl) ≫ F.map ρ = 𝟙 (F.obj ∂𝔻 n)`.
+  5. **G11** `H_n_minus_1_disk_zero_substantive` provides
+     `IsZero (F.obj 𝔻 n)` (the ULift-lifted form of the ball-zero
+     substantive theorem).
+  6. **G8** `isZero_of_section_into_isZero` combines (4) + (5) to derive
+     `IsZero (F.obj ∂𝔻 n)`.
+  7. The main file's `H_n_minus_1_sphere_nonzero_substantive` asserts
+     `¬ IsZero (F.obj ∂𝔻 n)`, contradicting (6).
+  8. From `False`, `False.elim` produces any `ψ : Unit →+ ℤ` to discharge
+     the existential conclusion.
+
+  Net axiom delta: 0. Net theorem delta: +1.
+
+  ## What this does NOT replace
+
+  This file does NOT remove the main file's `axiom H_n_minus_1_sphere_nonzero`
+  (line 261). That replacement is the S19 ACT-C step: a single edit to the
+  main file changing `axiom` → `theorem` with a body that wraps this G12
+  result for `n ≥ 2` and ships a thin local lemma `Retraction_one_uninhabited`
+  (IVT-based, knowledge.md §G5) for `n = 1`. The split into G12 (this PR) +
+  S19 ACT-C (the main-file edit) isolates the substantive derivation from
+  the main-file rebuild risk.
+
+  ## Bearer audit (Mathlib v4.26.0 / SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+
+  All bearers are reused from the existing chain — no new Mathlib imports
+  beyond what G10/G11 already pull in:
+
+  - `Brouwer FixedPointOQ01OQ02.map_section_of_section` (G8, file:92)
+  - `BrouwerFixedPointOQ01OQ02.isZero_of_section_into_isZero` (G8, file:115)
+  - `BrouwerOQ01OQ02.Retraction.toTopCatHom` (G10, file:50)
+  - `BrouwerOQ01OQ02.Retraction.section_identity` (G10, file:73)
+  - `BrouwerOQ01OQ02.H_n_minus_1_disk_zero_substantive` (G11, file:67)
+  - `BrouwerOQ01OQ02.H_n_minus_1_sphere_nonzero_substantive` (main, file:375)
+-/
+
+import Proofs.BrouwerFixedPointOQ01OQ02
+import Proofs.BrouwerFixedPointOQ01OQ02G8
+import Proofs.BrouwerFixedPointOQ01OQ02G10
+import Proofs.BrouwerFixedPointOQ01OQ02G11
+
+open CategoryTheory TopCat
+
+namespace BrouwerOQ01OQ02
+
+/-- **G12 sphere-nonzero substantive for retractions (`n ≥ 2`)**:
+    the existence statement currently encoded by the mock axiom
+    `H_n_minus_1_sphere_nonzero` (main:261), proved substantively for
+    `n ≥ 2` via the G6/G7/G8/G10/G11 chain.
+
+    Signature matches the mock axiom modulo `n ≥ 2` (mock uses `n ≥ 1`,
+    leaving `n = 1` to a future `Retraction_one_uninhabited` lemma per
+    S15 PREP §5 / knowledge.md §G5).
+
+    The conclusion is reached by `exfalso`: the homological chain derives
+    `IsZero (H_{n-1}(𝕊^{n-1}))` (from G11 + G8 + G10), which contradicts
+    `H_n_minus_1_sphere_nonzero_substantive`. From `False`, any
+    `ψ : Unit →+ ℤ` discharges the existential. -/
+theorem H_n_minus_1_sphere_nonzero_for_retraction
+    (n : ℕ) (hn : 2 ≤ n) (r : Retraction n) (φ : ℤ →+ Unit) :
+    ∃ ψ : Unit →+ ℤ, ψ.comp φ = AddMonoidHom.id ℤ := by
+  exfalso
+  -- The singular-homology functor at degree `n - 1`, coefficients `ℤ`.
+  set F :=
+    ((AlgebraicTopology.singularHomologyFunctor AddCommGrpCat.{0}
+        (n - 1)).obj (AddCommGrpCat.of ℤ)) with hF
+  -- (G10) Section equation in TopCat.
+  have hsect :
+      TopCat.diskBoundaryInclusion.{0} n ≫ r.toTopCatHom
+        = 𝟙 (TopCat.diskBoundary.{0} n) :=
+    r.section_identity
+  -- (G8) Transport the section through F.
+  have hFsect :
+      F.map (TopCat.diskBoundaryInclusion.{0} n) ≫ F.map r.toTopCatHom
+        = 𝟙 (F.obj (TopCat.diskBoundary.{0} n)) :=
+    BrouwerFixedPointOQ01OQ02.map_section_of_section
+      F (TopCat.diskBoundaryInclusion.{0} n) r.toTopCatHom hsect
+  -- (G11) The disk has zero `H_{n-1}`.
+  have hdiskZ : Limits.IsZero (F.obj (TopCat.disk.{0} n)) :=
+    H_n_minus_1_disk_zero_substantive n hn
+  -- (G8) The retract of a zero object is zero.
+  have hSphereZ : Limits.IsZero (F.obj (TopCat.diskBoundary.{0} n)) :=
+    BrouwerFixedPointOQ01OQ02.isZero_of_section_into_isZero
+      hdiskZ
+      (F.map (TopCat.diskBoundaryInclusion.{0} n))
+      (F.map r.toTopCatHom)
+      hFsect
+  -- Contradict the substantive sphere-nonzero theorem.
+  exact H_n_minus_1_sphere_nonzero_substantive n hn hSphereZ
+
+end BrouwerOQ01OQ02

--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-04-s18-act-b-g12-sphere-nonzero-substantive.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-04-s18-act-b-g12-sphere-nonzero-substantive.md
@@ -1,0 +1,170 @@
+# S18 ACT-B — G12 companion file (`H_n_minus_1_sphere_nonzero_for_retraction`)
+
+- **Date**: 2026-06-04
+- **Session**: 19 (S1–S17 + S13b BUILD-VERIFY-AND-FIX)
+- **Phase**: ACT-B (delivers the categorical wire-up identified by S15
+  PREP §5 as the payload of the main-file integration; main-file edit
+  still deferred to S19 ACT-C)
+- **Author**: researcher-7
+- **Mathlib pin**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0, unchanged)
+- **Scope**: ships `proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean`
+  (single-theorem companion file, ~120 LOC including docstring) plus
+  the `proofs/Proofs.lean` rollup catch-up (G12). No edits to main
+  file, no edits to G6/G7/G8/G10/G11, no `axiom` delta, no `sorry`,
+  no `meta.json` (slug has no gallery directory).
+
+## 1. What this PR delivers
+
+The S15 PREP §5 paste-ready integration body shipped as a fresh
+companion file rather than as an in-line edit to the main file. Single
+theorem in namespace `BrouwerOQ01OQ02`:
+
+* **`H_n_minus_1_sphere_nonzero_for_retraction`** — for `n ≥ 2`, any
+  `Retraction n`, and any `φ : ℤ →+ Unit`, there exists `ψ : Unit →+ ℤ`
+  with `ψ.comp φ = AddMonoidHom.id ℤ`. Signature matches the mock
+  axiom `H_n_minus_1_sphere_nonzero` (main:261) modulo the strengthened
+  `n ≥ 2` hypothesis (mock uses `n ≥ 1`, with the `n = 1` case left to
+  the future `Retraction_one_uninhabited` lemma per S15 PREP §5 /
+  knowledge.md §G5).
+
+The proof reaches the conclusion by `exfalso` after deriving the
+substantive contradiction `IsZero (H_{n-1}(𝕊^{n-1}))` ⨯
+`¬ IsZero (H_{n-1}(𝕊^{n-1}))` via the chain:
+
+1. (G10) `Retraction.section_identity` gives
+   `diskBoundaryInclusion n ≫ r.toTopCatHom = 𝟙 (∂𝔻 n)` in TopCat.
+2. (G8) `map_section_of_section` transports the section through
+   `F := (singularHomologyFunctor AddCommGrpCat.{0} (n-1)).obj (AddCommGrpCat.of ℤ)`.
+3. (G11) `H_n_minus_1_disk_zero_substantive` gives `IsZero (F.obj 𝔻 n)`.
+4. (G8) `isZero_of_section_into_isZero` combines (2) + (3) to derive
+   `IsZero (F.obj ∂𝔻 n)`.
+5. The main file's `H_n_minus_1_sphere_nonzero_substantive` (main:375)
+   contradicts (4).
+
+This closes the **categorical wire-up step** of the S9 ACT-D-3 EXEC
+plan that S15 PREP §5 first sketched and S16/S17 ACT-A/ACT-B-PRE
+pre-staged via G10/G11.
+
+## 2. Docker build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ01OQ02G12
+...
+✔ [3312/3312] Built Proofs.BrouwerFixedPointOQ01OQ02G12 (14s)
+Build completed successfully (3312 jobs).
+=== Build succeeded ===
+```
+
+**3312 jobs**, ~14s wall for the G12 step itself (cold-cache total
+wall ~3.5 min including Mathlib cache download via `lake exe cache get`).
+Matches the G11 import-closure cost (3309 jobs) within ±3 jobs: G12 adds
+no new Mathlib imports beyond G10/G11; the only extra inputs are in-repo
+G8 declarations (`map_section_of_section`, `isZero_of_section_into_isZero`).
+
+The build was preceded by a single false-start: the first attempt
+attempted to build a host-mounted file `/workspace/proofs/Proofs/…G12.lean`
+that did not exist inside the worktree (the file had been written to the
+main-repo path by mistake). After moving to the worktree path and
+re-running, the build succeeded on the first attempt.
+
+## 3. What this does NOT do
+
+This file does NOT remove the main file's `axiom H_n_minus_1_sphere_nonzero`
+(line 261). That removal is the **S19 ACT-C** step: a single edit to
+the main file changing `axiom` → `theorem` with a body that wraps the
+G12 result for `n ≥ 2` and ships a thin local lemma
+`Retraction_one_uninhabited` (IVT-based, knowledge.md §G5) for `n = 1`.
+
+The split into G12 (this PR) + S19 ACT-C (the main-file edit) isolates
+the substantive derivation from the main-file rebuild risk — the same
+companion-file pattern that S13/S16/S17 used for G6/G10/G11.
+
+## 4. Bearer audit (Mathlib v4.26.0 / SHA `2df2f0150c…`)
+
+No new Mathlib bearers beyond what G10/G11 already pull in. The G12
+proof body cites only in-repo bearers:
+
+| Bearer | Source | Line | Used for |
+|---|---|---|---|
+| `BrouwerFixedPointOQ01OQ02.map_section_of_section` | `…G8.lean` | 92 | Functoriality of F on the section |
+| `BrouwerFixedPointOQ01OQ02.isZero_of_section_into_isZero` | `…G8.lean` | 115 | Retract of zero is zero |
+| `BrouwerOQ01OQ02.Retraction.toTopCatHom` | `…G10.lean` | 50 | TopCat morphism `𝔻 n ⟶ ∂𝔻 n` |
+| `BrouwerOQ01OQ02.Retraction.section_identity` | `…G10.lean` | 73 | `i ≫ ρ = 𝟙` in TopCat |
+| `BrouwerOQ01OQ02.H_n_minus_1_disk_zero_substantive` | `…G11.lean` | 67 | `IsZero (F.obj 𝔻 n)` |
+| `BrouwerOQ01OQ02.H_n_minus_1_sphere_nonzero_substantive` | `…OQ02.lean` | 375 | `¬ IsZero (F.obj ∂𝔻 n)` |
+
+All bearers are in-repo and on `origin/main`. No Mathlib API drift
+re-check needed beyond what S17 ACT-B-PRE already discharged for G11.
+
+## 5. Universe handling
+
+The G12 body is universe-monomorphic at `.{0}`, matching the G10/G11
+precedent. The main file's `H_n_minus_1_sphere_nonzero_substantive`
+uses the bare form `TopCat.diskBoundary n` without explicit `.{0}`;
+universe inference from the functor application disambiguates to
+`.{0}`, so the contradiction step `H_n_minus_1_sphere_nonzero_substantive
+n hn hSphereZ` unifies the universes via Lean's elaboration.
+
+## 6. On-disk reality (this PR, 2026-06-04)
+
+| File | LOC | Theorems | Definitions | Axioms | Sorries |
+|------|-----|----------|-------------|--------|---------|
+| `BrouwerFixedPointOQ01OQ02.lean` | 462 | 14 | … | 4 | 0 |
+| `BrouwerFixedPointOQ01OQ02G6.lean` | 88 | 4 + 1 local | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G7.lean` | 94 | 2 | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G8.lean` | 134 | 2 | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G10.lean` | 78 | 1 | 1 | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G11.lean` | 73 | 1 | … | 0 | 0 |
+| `BrouwerFixedPointOQ01OQ02G12.lean` | **126** | **1** | … | **0** | **0** |
+| **Total** | **1055** | **26** | **1** | **4** | **0** |
+
+Net delta this PR: +126 LOC, +1 theorem, +0 definitions, +0 axioms,
++0 sorries (plus +1 line in `Proofs.lean`).
+
+## 7. What this unblocks for S19 ACT-C (main-file integration)
+
+With G12 on main, the S19 ACT-C main-file edit reduces to:
+
+1. Add 1 import: `import Proofs.BrouwerFixedPointOQ01OQ02G12`.
+2. Change line 261 `axiom H_n_minus_1_sphere_nonzero …` to
+   `theorem H_n_minus_1_sphere_nonzero (n : ℕ) (hn : n ≥ 1) (r : Retraction n)
+       (φ : ℤ →+ Unit) : ∃ ψ : Unit →+ ℤ, ψ.comp φ = AddMonoidHom.id ℤ := by …`.
+3. Body: `by_cases hn2 : 2 ≤ n` →
+   - `case pos`: `exact H_n_minus_1_sphere_nonzero_for_retraction n hn2 r φ`.
+   - `case neg`: handle `n = 1` via `Retraction_one_uninhabited` (IVT,
+     knowledge.md §G5) — either a thin local axiom (net axiom 4 → 4)
+     or a ~5-line IVT proof (net axiom 4 → 3).
+
+Expected S19 build size: ~3300–3400 jobs (main-file rebuild + G12
+import closure).
+
+## 8. Anti-targets (S18 ACT-B)
+
+- No edits to `BrouwerFixedPointOQ01OQ02.lean` (mock-axiom removal
+  deferred to S19 ACT-C).
+- No edits to G6/G7/G8/G10/G11 (already on main, build verified).
+- No `meta.json` updates (slug has no gallery directory; verified
+  `src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/`
+  does not exist).
+- No `Retraction_one_uninhabited` introduction (deferred to S19 ACT-C
+  so the n=1 design decision is made in the same PR that retires the
+  mock axiom).
+- No upstream Mathlib contribution (B1 / B2 still on the queue).
+
+## 9. Honesty notes
+
+- The mock axiom `H_n_minus_1_sphere_nonzero` (main:261) is still live
+  after this PR. Net axiom delta: 0. The retirement is the S19 ACT-C
+  deliverable; G12 only validates that the substantive derivation
+  type-checks and builds clean before the main-file edit lands.
+- The `n = 1` branch is still open in the same sense as it was at S17.
+  G12 cleanly handles `n ≥ 2`; `n = 1` requires either an IVT proof of
+  `Retraction 1` uninhabited (5 lines, dischargeable) or a thin local
+  axiom (net 4 → 4 in axiom count).
+- This PR follows the G6/G10/G11 companion-file precedent rather than
+  doing the main-file edit in one shot. Reasons: (a) build-risk
+  isolation — G12 builds in ~3300 jobs but if it fails, the main file
+  is untouched; (b) review parallelism — G12 can be reviewed and
+  merged independently of the S19 axiom-replacement PR; (c) the n=1
+  design decision (axiom-vs-proof) is genuinely open and benefits from
+  its own PR rather than being bundled into the integration.

--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md
@@ -1,12 +1,29 @@
 # Current State
 
-**Phase**: ACT (G6/G7/G8/G9 all on main; G6 via S13 companion-file pivot; S9 ACT-D-3 EXEC integration step is the next blocker; Docker daemon hung — B3 INFRA RED)
-**Since**: 2026-05-16T15:05:00Z (Session 14, researcher-11, S14 STATE-SYNC — research-JSON catchup post-S12 PREP + S13 ACT)
-**Iteration**: 14
+**Phase**: ACT-B (G6/G7/G8/G10/G11/G12 all on main; main-file axiom retirement deferred to S19 ACT-C)
+**Since**: 2026-06-04T18:05:00Z (Session 19, researcher-7, S18 ACT-B — G12 sphere-nonzero substantive companion)
+**Iteration**: 19
 
 ## Current Focus
 
-S14 STATE-SYNC (this session, researcher-11, 2026-05-16, doc-only) —
+S18 ACT-B (this session, researcher-7, 2026-06-04) — ships
+`proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean` (~120 LOC, single
+theorem `H_n_minus_1_sphere_nonzero_for_retraction`, 0 axioms, 0
+sorries). G12 packages the S15 PREP §5 paste-ready integration body
+for `n ≥ 2` as a standalone companion file rather than as an in-line
+edit to the main file. The conclusion (`∃ ψ, ψ.comp φ = id`) is
+reached by `exfalso` after the homological chain G10 + G8 + G11 +
+`H_n_minus_1_sphere_nonzero_substantive` derives the substantive
+contradiction `IsZero (F.obj ∂𝔻 n)` ⨯ `¬ IsZero (F.obj ∂𝔻 n)`.
+
+The mock axiom `H_n_minus_1_sphere_nonzero` (main:261) is still live
+after this PR — retirement deferred to S19 ACT-C (a one-import edit
+to the main file changing `axiom` → `theorem` and dispatching `n ≥ 2`
+to G12 and `n = 1` to a new `Retraction_one_uninhabited` lemma).
+
+## Historical Focus (S14)
+
+S14 STATE-SYNC (researcher-11, 2026-05-16, doc-only) —
 research-JSON `currentState.*` + `knowledge.builtItems` + top-level
 `lastUpdate` catchup absorbing S12 PREP (PR #19474, doc-only G6
 companion-file pivot pre-staging, merged 2026-05-16T08:54:15Z) +
@@ -93,10 +110,13 @@ alone (single bridge, distinct import set — pure algebra over
 
 | Bridge | On main? | Where |
 |--------|----------|-------|
-| **G6** (`id ℤ` cannot factor through subsingleton) | **Yes (this PR; build pending)** | `…G6.lean:80` as `no_split_through_subsingleton` |
+| **G6** (`id ℤ` cannot factor through subsingleton) | **Yes** | `…G6.lean:80` as `no_split_through_subsingleton` |
 | **G7** (`¬ IsZero (X : AddCommGrpCat) → ∃ x ≠ 0`) | **Yes** | `…G7.lean` (PR #18951) |
 | **G8** (`F.map i ≫ F.map r = 𝟙`) | **Yes** | `…G8.lean:96` (PR #19114, merged 2026-05-15T22:58Z) |
 | **G9** (retract of zero is zero) | **Yes** | `…G8.lean:117` (same PR) |
+| **G10** (`Retraction → TopCat morphism`) | **Yes** | `…G10.lean:50/73` (S16 ACT-A) |
+| **G11** (disk-zero substantive, ULift form) | **Yes** | `…G11.lean:67` (S17 ACT-B-PRE) |
+| **G12** (sphere-nonzero substantive for retractions, `n ≥ 2`) | **Yes (this PR)** | `…G12.lean` as `H_n_minus_1_sphere_nonzero_for_retraction` |
 
 ## Active Approach (unchanged)
 
@@ -168,6 +188,31 @@ the S12 PREP §4 pin exactly.
   knowledge.md §R writeup.
 
 ## Next Action
+
+**S19 ACT-C (main-file axiom retirement)** — replace the mock axiom
+`H_n_minus_1_sphere_nonzero` (main:261) with a `theorem` that wraps
+G12's `H_n_minus_1_sphere_nonzero_for_retraction` for `n ≥ 2` and
+dispatches `n = 1` via a new `Retraction_one_uninhabited` lemma
+(intermediate value theorem, knowledge.md §G5). One-import edit
+(`import Proofs.BrouwerFixedPointOQ01OQ02G12`), `by_cases hn2 : 2 ≤ n`
+body. Expected build size ~3300–3400 jobs (main-file rebuild).
+
+Decision point for S19: ship `Retraction_one_uninhabited` as a thin
+local axiom (net axiom 4 → 4, axiom-count parity with the mock) or
+as a ~5-line IVT proof (net axiom 4 → 3, axiom-count improvement).
+Recommend the proof — IVT is in Mathlib (`intermediate_value`) and
+the n=1 case reduces to: `r : [-1,1] → {-1,1}` continuous, with
+`r(±1) = ±1`, contradicting IVT at 0. See knowledge.md §G5 for the
+sketch.
+
+**S20 ACT-D (post-S19) housekeeping**: after S19 ACT-C lands, the
+mock axiom is gone and only the two B1/B2 thin surrogate axioms
+remain (`contractible_singularHomology_zero`, `sphere_singularHomology_nonzero`).
+Either or both can be discharged by upstream Mathlib contributions
+per knowledge.md Section H (B1 prism operator) or §L3 / B2-CW (B2
+sphere homology).
+
+### Historical Next Action (S13b, retired by S13b PR)
 
 **S13b BUILD-VERIFY (Docker-restored)** — discharge gate 6b. Run
 `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ01OQ02G6`


### PR DESCRIPTION
## Summary

- Ships `proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean` (126 LOC, 1 theorem, 0 axioms, 0 sorries) — packages the S15 PREP §5 paste-ready integration body for `n ≥ 2` as a standalone companion file.
- Theorem `H_n_minus_1_sphere_nonzero_for_retraction` matches the mock axiom `H_n_minus_1_sphere_nonzero` (main:261) signature modulo `n ≥ 2` (mock uses `n ≥ 1`). Proof: `exfalso` after the homological chain G10 + G8 + G11 + `H_n_minus_1_sphere_nonzero_substantive` derives the substantive contradiction `IsZero (F.obj ∂𝔻 n)` ⨯ `¬ IsZero (F.obj ∂𝔻 n)`.
- Build verified at **3312 jobs** (14s for the G12 step, ~3.5 min cold-cache total). Matches G11 import-closure cost (3309 jobs) within ±3.
- Main file untouched. Mock axiom retirement deferred to **S19 ACT-C** (one-import edit dispatching `n ≥ 2` to G12 + `n = 1` to a new `Retraction_one_uninhabited` lemma).

## Derivation chain (S15 PREP §5)

1. (G10) `Retraction.section_identity`: `diskBoundaryInclusion n ≫ r.toTopCatHom = 𝟙 (∂𝔻 n)` in TopCat.
2. (G8) `map_section_of_section`: transport the section through `F := (singularHomologyFunctor AddCommGrpCat.{0} (n-1)).obj (AddCommGrpCat.of ℤ)`.
3. (G11) `H_n_minus_1_disk_zero_substantive`: `IsZero (F.obj 𝔻 n)`.
4. (G8) `isZero_of_section_into_isZero`: combine (2) + (3) → `IsZero (F.obj ∂𝔻 n)`.
5. (main:375) `H_n_minus_1_sphere_nonzero_substantive`: `¬ IsZero (F.obj ∂𝔻 n)` — contradicts (4).

## Test plan

- [x] G12 builds clean: `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ01OQ02G12` → `Built Proofs.BrouwerFixedPointOQ01OQ02G12 (14s)`, 3312 jobs total.
- [x] No new axioms (file-level `grep -c "^axiom " G12.lean` = 0; structure-encoded assumptions = 0).
- [x] No `sorry` (file-level `grep -c "sorry" G12.lean` = 0).
- [x] Universe-monomorphic at `.{0}` matching G10/G11 precedent.
- [x] `proofs/Proofs.lean` rollup updated.
- [x] State.md + session memo updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)