### PR TITLE
research(gauss-wilson-non-cyclic-oq-03): S5b.1+.2 ACT — small power-of-2 unit counts (k=1,2)

### DIFF
--- a/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
+++ b/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean
@@ -332,4 +332,65 @@ theorem card_filter_sq_eq_one_units_zmod_prime_pow_odd
   -- 2 ∣ p^(k-1) * (p-1) because p odd ⇒ 2 ∣ (p - 1).
   exact dvd_mul_of_dvd_right (hp.even_sub_one hp_odd).two_dvd _
 
+-- ============================================================================
+-- Section 8: Power-of-2 small prime-power cases (S5b.1, S5b.2)
+-- ============================================================================
+
+/-! ### S5b — small power-of-2 unit counts
+
+Companion to S5: handles the even prime `p = 2` case at small exponents
+`k ∈ {1, 2}`. The structural `k ≥ 3` case (`(ZMod 2^k)ˣ ≅ ℤ/2 × ℤ/2^(k-2)`,
+count = 4) is deferred to S5b.3.
+
+The mathematical content (verified numerically in `knowledge.md` and proved
+here for `k ≤ 2`):
+
+```
+  k = 1 : (ZMod 2)ˣ trivial               → count = 1
+  k = 2 : (ZMod 4)ˣ cyclic order 2        → count = 2
+  k ≥ 3 : (ZMod 2^k)ˣ ≅ ℤ/2 × ℤ/2^(k-2)   → count = 4   [S5b.3]
+```
+
+Both proofs here are `decide`-based: the unit groups have decidable
+equality and computable Fintype instances (via `ZMod.card_units_eq_totient`
+and `Nat.totient_prime_pow`), so the filter cardinality reduces to a
+concrete natural-number equality at elaboration time.
+
+These per-prime-power facts, together with S5
+(`card_filter_sq_eq_one_units_zmod_prime_pow_odd`), are the base-case
+inputs that the eventual CRT multiplicativity step (S6) consumes when
+assembling the closed-form `numSqrtsOne(n) = 2^(ω_odd(n) + ε₂(n))`
+formula. -/
+
+/-- **S5b.1 — `(ZMod 2)ˣ` has exactly one square root of `1`.**
+
+The unit group `(ZMod 2)ˣ` is trivial: only the residue `1` is coprime
+to `2`, so `|(ZMod 2)ˣ| = φ(2) = 1`. The unique element is the identity,
+which satisfies `1^2 = 1`. Count = `1`.
+
+This is the `ε₂(n) = 0` half of the two-adic correction: when `2 ∥ n`
+(i.e. `v₂(n) = 1`), the power-of-2 factor contributes no extra square
+roots beyond the trivial one. -/
+theorem card_filter_sq_eq_one_units_zmod_two :
+    (Finset.univ.filter (fun u : (ZMod 2)ˣ => u ^ 2 = 1)).card = 1 := by
+  decide
+
+/-- **S5b.2 — `(ZMod 4)ˣ` has exactly two square roots of `1`.**
+
+The unit group `(ZMod 4)ˣ = {1, 3}` is cyclic of order 2 (cardinality
+`φ(4) = 2`). Both elements satisfy `u^2 = 1`: `1^2 = 1` directly, and
+`3^2 = 9 ≡ 1 (mod 4)`. Count = `2`.
+
+This is the `ε₂(n) = 1` case of the two-adic correction: when `4 ∥ n`
+(i.e. `v₂(n) = 2`), the power-of-2 factor contributes a single extra
+square root (`-1 ≡ 3 (mod 4)`), doubling the count.
+
+Alternative proof (not used here, for reference): `(ZMod 4)ˣ` is cyclic
+of even order, so the S4 generic `card_filter_sq_eq_one_cyclic_even`
+applies directly. The `decide` route is shorter (no `IsCyclic` instance
+plumbing) and equally robust at this small size. -/
+theorem card_filter_sq_eq_one_units_zmod_four :
+    (Finset.univ.filter (fun u : (ZMod 4)ˣ => u ^ 2 = 1)).card = 2 := by
+  decide
+
 end GaussWilsonNonCyclicOQ03

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/sessions/2026-06-04-s5b-1-2-act-small-2pow-cases.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/sessions/2026-06-04-s5b-1-2-act-small-2pow-cases.md
@@ -1,0 +1,145 @@
+# S5b.1 + S5b.2 ACT — small power-of-2 unit-side counts (k = 1, k = 2)
+
+**Slug**: `gauss-wilson-non-cyclic-oq-03`
+**Iteration**: S5b.1 + S5b.2 (ACT, batched)
+**Date**: 2026-06-04
+**Researcher**: researcher-1
+**Phase**: ACT
+**Build**: pending (PR CI; researcher worktree `.lake` symlink loop
+prevents local docker verification)
+**Mathlib pin**: `inputRev v4.26.0`, lake-manifest rev
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+
+## 1. Summary
+
+Implements the batched proposal from S5b PREP `#18648` (researcher-8,
+2026-05-13, doc-only) for the two small even-prime-power cases.
+
+Two new theorems added in a new Section 8 of
+`proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`:
+
+| Theorem | Statement | Proof |
+| ------- | --------- | ----- |
+| `card_filter_sq_eq_one_units_zmod_two` | `#{u : (ZMod 2)ˣ | u² = 1} = 1` | `decide` |
+| `card_filter_sq_eq_one_units_zmod_four` | `#{u : (ZMod 4)ˣ | u² = 1} = 2` | `decide` |
+
+Both proofs are pure `decide`: the unit groups have decidable equality
+and computable Fintype instances, so the filter cardinality reduces to
+a concrete numeric equality at elaboration time.
+
+**File delta**: 335 → 396 lines (+61). +2 theorems, +1 section header
+docstring (~30 lines of explanation including the count table from
+the S5b PREP and the mathematical rationale linking these to the
+two-adic correction `ε₂(n) ∈ {0, 1}`).
+
+**Sorry / axiom delta**: 0 / 0 (the main theorem
+`card_sqrts_one_eq_numSqrtsOne` sorry is unchanged; this iteration
+adds two fully-closed lemmas).
+
+## 2. Why this batching
+
+The S5b PREP §3.1 and §3.2 explicitly recommended batching S5b.1 and
+S5b.2 into a single Lean PR (~25 LOC of Lean code, ~70 LOC total
+including docstrings). This iteration follows that recommendation:
+
+> S5b PREP §8 Recommendation 2: "S5b.1 ACT next session: trivial,
+> can be batched with S5b.2 into a single Lean PR (~25 LOC total)."
+
+The PREP also verified at the pinned Mathlib commit
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` that the necessary decls
+exist (`isCyclic_units_two`, `isCyclic_units_four`,
+`ZMod.card_units_eq_totient`), though for the `decide`-only route
+adopted here, none of these decls are invoked by name — the proof is
+fully automatic at elaboration time.
+
+## 3. Choice of proof tactic — `decide` vs the S4 generic route
+
+The PREP §3.2 sketched two alternative proofs for S5b.2 (`k = 2`):
+
+* **A — S4 generic + IsCyclic**: instantiate the merged
+  `card_filter_sq_eq_one_cyclic_even` at `(ZMod 4)ˣ`, providing the
+  `IsCyclic (ZMod 4)ˣ` instance and the `2 ∣ Fintype.card (ZMod 4)ˣ`
+  hypothesis. Estimated ~15-20 LOC.
+* **B — pure `decide`**: rely on the computable Fintype instance.
+  Estimated ≤ 5 LOC.
+
+This ACT picks **B** for both `k = 1` and `k = 2`:
+
+* For `k = 1`, the S4 generic theorem **does not apply** (the group
+  has order 1, so `2 ∤ |G|`); a different argument would be needed.
+  `decide` handles this trivially.
+* For `k = 2`, `decide` is strictly simpler than the IsCyclic plumbing
+  and equally robust at this small size.
+
+The docstring on `card_filter_sq_eq_one_units_zmod_four` documents the
+S4 generic alternative for reference, since it remains the canonical
+mathematical justification (cyclic of even order → exactly 2 square
+roots of 1).
+
+## 4. Build verification status
+
+**Local docker build**: NOT performed.
+
+The researcher worktree `.lake` symlink is a self-loop — the same trap
+documented in many prior sessions on this slug. Local
+`./proofs/scripts/docker-build.sh Proofs.GaussWilsonNonCyclicOQ03`
+cannot run from the worktree without manual setup that risks
+clobbering the cache volume.
+
+**PR CI**: will run on the merge commit. The two `decide` proofs are
+the only Lean changes; everything else is documentation (Section 8
+header docstring + the two theorem docstrings).
+
+**Risk assessment**: low.
+
+* `decide` on `(Finset.univ.filter (predicate)).card = constant` is a
+  standard Lean idiom for finite types. The parent file
+  `GaussWilsonNonCyclic.lean` uses the same pattern (lines 94-109)
+  for natural-number computations.
+* The Fintype instances for `(ZMod 2)ˣ` and `(ZMod 4)ˣ` are
+  Mathlib-canonical (via `Units.instFintype` + `ZMod.instFintype`).
+* The DecidableEq instance for ZMod n is canonical for `n ≥ 1`.
+
+If `decide` unexpectedly times out at elaboration time, the immediate
+fallback is `native_decide` (faster via compiled bytecode); if even
+that fails, the S4 generic route remains available.
+
+## 5. Race-safety
+
+`gh pr list --search "gauss-wilson-non-cyclic-oq-03 in:title" --state open`
+returns: (none — confirmed at iteration start).
+
+No other open PRs on this slug; conflict-free.
+
+The five sibling PREPs (`#18356`, `#18423`, `#18465`, `#18510`,
+`#18597`, `#18648`) have all merged. This ACT is the **first Lean
+change** on this slug since S5 ACT `#18233` (2026-05-12).
+
+## 6. Estimated next-step LOC ledger (post-merge)
+
+After S5b.1 + S5b.2 land:
+
+| Sub-iter | Status | New theorems | Lean LOC delta |
+| -------- | ------ | ------------ | -------------- |
+| S5b.1    | **MERGED THIS PR** | +1 | +1 LOC of proof + ~25 LOC docstring |
+| S5b.2    | **MERGED THIS PR** | +1 | +1 LOC of proof + ~30 LOC docstring |
+| S5b.3    | next ACT (S5b PREP §3.3) | +1 + auxiliaries | ~60-90 LOC |
+| S6       | after S5b.3 (S6 PREP) | CRT multiplicativity | ~80 LOC |
+| S7       | after S6 (S7 PREP) | induction assembly | ~40 LOC |
+
+**This PR alone closes 2 of 3 per-prime-power inputs** that S6 needs.
+
+## 7. Honesty (§10 of researcher role)
+
+* **No `lake build` performed**: the worktree `.lake` symlink loop
+  precludes local docker build in this iteration. PR CI will verify.
+* **Mathlib decl validity**: the PREP `#18648` audited each decl at
+  the pinned commit, but this ACT does not invoke any of them by name
+  — the `decide` route bypasses them. The risk surface is the
+  computable Fintype + DecidableEq infrastructure for ZMod units,
+  which is Mathlib-canonical and used throughout the repo.
+* **No new mathematical content** beyond what the S5b PREP and S5b
+  OBSERVE already laid out. This iteration is implementation work.
+* **Section 8 header docstring** is the only original prose; it
+  reproduces the count table and links it to the eventual `ε₂(n)`
+  correction (already documented in `knowledge.md`).

--- a/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-03/state.md
@@ -1,10 +1,60 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S5)
-**Iteration**: 6
+**Since**: 2026-06-04 (S5b.1+.2)
+**Iteration**: 7
 
 ## Current Focus
+
+S5b.1+.2 (researcher-1, 2026-06-04): ACT — closed the **two small
+power-of-2 unit-side counts** (`k = 1` and `k = 2`), implementing the
+batched proposal from the S5b PREP `#18648` (researcher-8, 2026-05-13).
+Two new theorems in a new Section 8:
+
+* `card_filter_sq_eq_one_units_zmod_two`: `(ZMod 2)ˣ` has exactly **1**
+  square root of `1` (the trivial group's identity).
+* `card_filter_sq_eq_one_units_zmod_four`: `(ZMod 4)ˣ = {1, 3}` has
+  exactly **2** square roots of `1` (cyclic of order 2; both elements
+  square to `1`).
+
+Both proofs are pure `decide`: the unit groups have decidable equality
+and computable Fintype instances, so the filter cardinality reduces to a
+concrete numeric equality at elaboration time. Per the S5b PREP API
+audit, no Mathlib bridges (`ZMod.card_units_eq_totient`,
+`Nat.totient_prime_pow`, `IsCyclic` instances) are needed at these
+small sizes — the `decide` route is shorter and equally robust.
+
+Together with S5 (`card_filter_sq_eq_one_units_zmod_prime_pow_odd`,
+odd-prime power), this closes **two of three** per-prime-power inputs
+that S6 (CRT multiplicativity) will need. The remaining input is **S5b.3**
+(`k ≥ 3`, count = `4`), which requires the `orderOf_five` toolchain
+documented in the S5b PREP §3.3.
+
+File: `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` 335 → 396 lines
+(+61 lines, +2 theorems, +1 new Section 8 with section header docstring).
+Build: pending (PR CI; researcher worktree's `.lake` symlink loop
+prevents local docker verification — same trap as prior sessions).
+0 axioms, 1 sorry (unchanged, main theorem target).
+
+## Next Action
+
+* **S5b.3 ACT**: the substantive even-prime work — `(ZMod 2^k)ˣ` count
+  for `k ≥ 3` via the `orderOf_five` cardinality squeeze (~60-90 LOC).
+  Complete design in S5b PREP `#18648` §3.3; the proof adapts
+  `Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean:135-148`'s
+  established `orderOf_five` idiom. No new Mathlib gaps.
+
+* **S6 ACT (CRT multiplicativity)**: after S5b.3 lands, combine S5 +
+  S5b.1 + S5b.2 + S5b.3 into a multiplicative formula over
+  `n.primeFactors`. Design in S6 PREP `#18423`.
+
+* **S7 ACT (induction assembly)**: closes the main theorem
+  `card_sqrts_one_eq_numSqrtsOne` via induction on
+  `n.primeFactors.card`. Design in S7 PREP `#18465`.
+
+## Prior Sessions
+
+### S5 (researcher-3, 2026-05-12, merged via #18233)
 
 S5 (researcher-3, 2026-05-12): ACT — closed the **odd-prime-power
 unit-side count** by instantiating the S4 generic theorem
@@ -33,17 +83,6 @@ File: `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean` 296 → 336 lines
 (+40 lines, +1 new theorem in a new Section 7, +1 docstring header).
 Build verified via Docker; 0 axioms, 1 sorry (unchanged — the main
 `card_sqrts_one_eq_numSqrtsOne` theorem target).
-
-## Next Action
-
-* **S5b / S6 next**: even-prime case (k = 1, 2, ≥ 3 give `2`, `2`, `4`
-  respectively) — needs case analysis on `v₂(n)`, possibly via
-  `ZMod.unitsCyclicMulOf_units_pow_two` or direct enumeration.
-* **S6 (CRT multiplicativity)**: pulled back to a Finset.prod over
-  `n.primeFactors`, applying `ZMod.chineseRemainder` and
-  `Finset.prod_filter`.
-* **S7 (main theorem)**: induction on `n.primeFactors.card`,
-  base case `n = p^k` from S5/S5b, inductive step from S6.
 
 ## Prior Sessions
 

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -21,14 +21,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T13:00:00.000Z",
-    "iteration": 6,
-    "focus": "S5-prep (researcher-6, 2026-05-12): ACT — added Section 7 parity lemma two_dvd_card_units_zmod_odd_prime_pow: for any odd prime p and k ≥ 1, |(ZMod p^k)ˣ| = φ(p^k) = p^{k-1}(p-1) is even. Proof: ZMod.card_units_eq_totient + Nat.totient_prime_pow, then dvd_mul_of_dvd_right reduces to 2 ∣ p-1, which is immediate from Odd p via destructure + omega. This is the parity hypothesis required by S4 card_filter_sq_eq_one_cyclic_even when specialising to (ZMod p^k)ˣ. Three docstring references to the non-existent name ZMod.isCyclic_units_of_prime_pow were corrected to point at Mathlib’s real classification ZMod.isCyclic_units_iff. File: 296 → 341 lines (+45), +1 theorem, 0 axioms, 1 sorry unchanged.",
+    "since": "2026-06-04T22:50:00.000Z",
+    "iteration": 7,
+    "focus": "S5b.1+.2 (researcher-1, 2026-06-04): ACT — closed the two small power-of-2 unit-side counts (k=1 and k=2), implementing the batched proposal from the S5b PREP #18648 (researcher-8, 2026-05-13). Two new theorems in a new Section 8: card_filter_sq_eq_one_units_zmod_two (count = 1; trivial group) and card_filter_sq_eq_one_units_zmod_four (count = 2; cyclic order 2). Both proofs are pure `decide` — the unit groups have decidable equality and computable Fintype instances, so the filter cardinality reduces to a concrete numeric equality at elaboration time. Together with S5 (odd-prime power), this closes two of three per-prime-power inputs that S6 (CRT multiplicativity) will need. The remaining input is S5b.3 (k≥3, count=4) via the `orderOf_five` toolchain (design in S5b PREP §3.3). File: 335 → 396 lines (+61), +2 theorems, 0 axioms, 1 sorry unchanged.",
     "blockers": [],
-    "nextAction": "S5: package the cyclic instance via (ZMod.isCyclic_units_iff).mpr on the odd-prime-power disjunct, then combine with two_dvd_card_units_zmod_odd_prime_pow (S5-prep, this iteration) + card_filter_sq_eq_one_cyclic_even (S4) to obtain card_units_sq_eq_one_zmod_odd_prime_pow. Compose with S3 ring↔unit bridge for the full ring-level count. Target ~30 lines on top of S5-prep. Then S6 CRT multiplicativity; S7 induction assembly.",
+    "nextAction": "S5b.3 ACT: substantive even-prime work — (ZMod 2^k)ˣ count for k ≥ 3 via the `orderOf_five` cardinality squeeze (~60-90 LOC). Complete design in S5b PREP #18648 §3.3; the proof adapts `Mathlib/NumberTheory/ArithmeticFunction/Carmichael.lean:135-148`'s established `orderOf_five` idiom. Then S6 ACT (CRT multiplicativity) combines S5 + S5b.1 + S5b.2 + S5b.3 into a multiplicative formula over n.primeFactors (design in S6 PREP #18423). Then S7 ACT (induction assembly) closes the main theorem `card_sqrts_one_eq_numSqrtsOne` (design in S7 PREP #18465).",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 5,
+      "total": 6,
+      "currentApproach": 6,
       "approachesTried": 1
     }
   },
@@ -39,7 +39,8 @@
       "research/problems/gauss-wilson-non-cyclic-oq-03/state.md (new): phase NEW → OBSERVE; concrete S2 skeleton for proofs/Proofs/GaussWilsonNonCyclicOQ03.lean with 1 sorry placeholder.",
       "research/problems/gauss-wilson-non-cyclic-oq-03/knowledge.md (new, ~200 lines): numerical table N=1..120 verifying the formula at 18 values, closed-formula derivation, parent-file API summary, Mathlib status with module names, three equivalent counts (ring / units / characters), S2 skeleton.",
       "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean (new, ~120 lines): epsTwo, omegaOdd, numSqrtsOne defs; numSqrtsOne_pos proved; 13 decide examples spanning powers of 2, odd-only, and mixed cases; card_sqrts_one_eq_numSqrtsOne main theorem statement with sorry.",
-      "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean S4 generic endpoint: card_filter_sq_eq_one_cyclic_even (Section 6). For any [Group][DecidableEq][Fintype][IsCyclic] G with 2 ∣ Fintype.card G, #{u : G | u^2 = 1} = 2. Proof: rw card_filter_sq_eq_one_decomp; rw card_orderOf_eq_totient at d=1 and d=2; decide. 257 → 296 lines."
+      "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean S4 generic endpoint: card_filter_sq_eq_one_cyclic_even (Section 6). For any [Group][DecidableEq][Fintype][IsCyclic] G with 2 ∣ Fintype.card G, #{u : G | u^2 = 1} = 2. Proof: rw card_filter_sq_eq_one_decomp; rw card_orderOf_eq_totient at d=1 and d=2; decide. 257 → 296 lines.",
+      "proofs/Proofs/GaussWilsonNonCyclicOQ03.lean S5b.1+.2 endpoint (researcher-1, 2026-06-04): Section 8 — card_filter_sq_eq_one_units_zmod_two (count = 1; trivial group (ZMod 2)ˣ) and card_filter_sq_eq_one_units_zmod_four (count = 2; cyclic order 2 (ZMod 4)ˣ). Both via pure `decide`. Implements the batched proposal from S5b PREP #18648 (researcher-8, 2026-05-13). File: 335 → 396 lines, +2 theorems, 0 axioms, 1 sorry unchanged."
     ],
     "insights": [
       "Closed formula: # = 2^(ω_odd(n) + ε₂(n)) where ω_odd(n) is the number of distinct odd prime factors of n and ε₂(n) is 0 if v₂(n) ≤ 1, 1 if v₂(n) = 2, 2 if v₂(n) ≥ 3.",
@@ -95,7 +96,7 @@
     ]
   },
   "started": "2026-05-12T04:44:06.000Z",
-  "lastUpdate": "2026-06-04T22:32:00.000Z",
+  "lastUpdate": "2026-06-04T22:50:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -113,8 +114,8 @@
     {
       "path": "Proofs/GaussWilsonNonCyclicOQ03.lean",
       "filename": "GaussWilsonNonCyclicOQ03.lean",
-      "lineCount": 335,
-      "theoremCount": 8,
+      "lineCount": 396,
+      "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary

Implements the **batched proposal from S5b PREP #18648** (researcher-8, 2026-05-13) for the two small even-prime-power cases of the gauss-wilson-non-cyclic-oq-03 work.

Two new theorems in a new Section 8 of `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`:

| Theorem | Statement | Proof |
| ------- | --------- | ----- |
| `card_filter_sq_eq_one_units_zmod_two` | `#{u : (ZMod 2)ˣ \| u² = 1} = 1` | `decide` |
| `card_filter_sq_eq_one_units_zmod_four` | `#{u : (ZMod 4)ˣ \| u² = 1} = 2` | `decide` |

Both proofs are pure `decide`: the unit groups have decidable equality and computable `Fintype` instances, so the filter cardinality reduces to a concrete numeric equality at elaboration time.

## Why this batching

S5b PREP `#18648` §8 explicitly recommended: *"S5b.1 ACT next session: trivial, can be batched with S5b.2 into a single Lean PR (~25 LOC total)."* This PR follows that recommendation.

Together with S5 (`card_filter_sq_eq_one_units_zmod_prime_pow_odd`, PR #18233), this closes **two of three** per-prime-power inputs that S6 (CRT multiplicativity) will need. The remaining input is **S5b.3** (`k ≥ 3`, count = 4) via the `orderOf_five` toolchain (design in S5b PREP §3.3).

## File delta

- `proofs/Proofs/GaussWilsonNonCyclicOQ03.lean`: 335 → 396 lines (+61: ~30 LOC section header docstring + 2 theorems with their docstrings).
- 0 axioms, 1 sorry (the main `card_sqrts_one_eq_numSqrtsOne` theorem, unchanged).

## Build status

PR CI will verify. The researcher worktree `.lake` symlink loop prevents local docker build — the standard trap on this slug, documented in prior session files.

**Risk assessment**: low. `decide` on `(Finset.univ.filter (predicate)).card = constant` is a standard Lean idiom for finite types. The parent file uses the same pattern for natural-number computations. If `decide` unexpectedly times out, `native_decide` is the immediate fallback.

## Test plan

- [ ] PR CI Docker build passes
- [ ] No new axioms or sorries
- [ ] Gallery metadata regenerates cleanly (theoremCount 8 → 10, lineCount 335 → 396)

🤖 Generated with [Claude Code](https://claude.com/claude-code)