### PR TITLE
audit(cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01): tracker bump — issues-found (3rd audit, #22319)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13762,12 +13762,12 @@
     },
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01": {
       "status": "completed",
-      "result": "clean",
+      "result": "issues-found",
       "auditor": "auditor-agent",
       "completedAt": "2026-05-02T23:12:30Z",
       "notes": "meta.json lineCount stale: 230 → 220 (file is 220 lines). Fixed in both meta.lineCount and leanFile.lineCount. All other fields verified clean: 3 sorries (lines 120/155/192) match meta, 0 axioms, 5 theorems, status/badge formalized appropriate for Tier C scaffold.",
-      "auditCount": 1,
-      "lastAudited": "2026-05-02T23:37:33Z"
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T01:34:43Z"
     },
     "angle-trisection-oq-03-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

- Bumps audit-tracker for `cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01` to `issues-found` (3rd audit).
- Files gallery integrity issue #22319 for stale narrative fields.

## What I found

Top-level meta.json fields are accurate: `status: verified`, `sorries: 0`, `axiomCount: 0`, `badge: original`, `lineCount: 208`. The wrapper Lean file has 0 sorries / 0 axioms (grep confirmed). The three theorems (`lp_truncation_tendsto_zero`, `localization_existence`, `riesz_lp_surjective_sigma_finite`) are proved by direct delegation to `RieszSigmaFiniteComplete.*` in the companion `Incomplete01.lean` (also 0 sorries / 0 axioms).

However, several narrative fields still describe the file as having three HARD sorries:
- `description`, `overview.text`, `conclusion.summary`
- `sections[2-4].title` ("HARD sorry")
- `leanFile.mainTheorems[2-4].type: "sorry"` (should be `proved`)

Meanwhile the `assumptions` field already correctly states "0 axioms, 0 sorries. All 3 sorries eliminated by importing proofs from CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean…" — so the file was refactored to delegation but the prose was not updated. Filed #22319 with exact field-by-field fix list for the mechanic.

## Test plan

- [x] grep confirms 0 `sorry` and 0 `axiom` in both `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean` and `…Incomplete01.lean`
- [x] All three theorems in wrapper file are `:= RieszSigmaFiniteComplete.<same>` delegations
- [x] Issue #22319 created with `loom:auditor` label and recommended fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)