### PR TITLE
Fix: cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01 prose vs verified status (#22319)

### DIFF
--- a/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01/meta.json
@@ -2,7 +2,7 @@
   "id": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
   "title": "Lp Riesz Representation for Sigma-Finite Measures",
   "slug": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01",
-  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes in principle — the key Lp approximation ingredient (spanning-set truncation) is partially formalized, with the full generalization reduced to three HARD (not OPEN) sorries.",
+  "description": "Can the Riesz representation theorem for Lp duality be generalized from finite to purely sigma-finite measures? Answer: yes — the three previously HARD (not OPEN) sorries (Lp truncation convergence, localization construction, and density extension) are now completed via delegation to the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean` (namespace `RieszSigmaFiniteComplete`).",
   "meta": {
     "status": "verified",
     "proofRepoPath": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",
@@ -25,15 +25,15 @@
   },
   "overview": {
     "problemStatement": "Can Mathlib's sigma-finite infrastructure (`spanningSets`, `SigmaFinite`) be composed with the finite-measure Riesz representation proof to eliminate the `IsFiniteMeasure` hypothesis?",
-    "text": "The parent file (CauchySchwarzIntegralOQ01OQ01OQ02OQ01) proves the Riesz representation theorem for $L^p$ duality under $[\\mathrm{IsFiniteMeasure}\\, \\mu]$. This file explores the generalization to purely sigma-finite measures, identifying the key new analytic ingredient: for $f \\in L^p(\\mu)$ with $\\mu$ sigma-finite, the spanning-set truncations $f \\cdot \\mathbf{1}_{S_n}$ converge to $f$ in $L^p$ norm. Two foundational results are proved; the full theorem is reduced to three HARD (non-OPEN) sorries.",
+    "text": "The parent file (CauchySchwarzIntegralOQ01OQ01OQ02OQ01) proves the Riesz representation theorem for $L^p$ duality under $[\\mathrm{IsFiniteMeasure}\\, \\mu]$. This file generalizes to purely sigma-finite measures, identifying the key new analytic ingredient: for $f \\in L^p(\\mu)$ with $\\mu$ sigma-finite, the spanning-set truncations $f \\cdot \\mathbf{1}_{S_n}$ converge to $f$ in $L^p$ norm. Two foundational pointwise lemmas are proved in this wrapper; the three main theorems (`lp_truncation_tendsto_zero`, `localization_existence`, `riesz_lp_surjective_sigma_finite`) are stated here with identical signatures and proved via direct delegation to `RieszSigmaFiniteComplete.*` in the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`, yielding a complete sigma-finite Riesz representation with 0 sorries and 0 axioms.",
     "historicalContext": "The $L^p$ Riesz representation theorem — identifying $(L^p(\\mu))^*$ with $L^q(\\mu)$ for $1/p + 1/q = 1$ — is one of the central results of functional analysis. The $p = 2$ case (Hilbert space duality) goes back to Riesz (1907) and Fréchet (1907). The general $1 < p < \\infty$ case for finite measures was established in the 1920s–30s (Banach 1932). The sigma-finite extension required the development of abstract measure theory in the 1940s–50s, particularly Halmos's 1950 *Measure Theory* and the Radon-Nikodym approach via the Lebesgue decomposition.\n\nThe classical proof strategy (Folland, Real Analysis 2nd ed., Theorem 6.15; Rudin, Real and Complex Analysis 3rd ed., Theorem 6.16) localizes via a sigma-finite exhaustion: restrict to the spanning sets $S_n$, apply the finite-measure result on each to get $g_n \\in L^q(\\mu|_{S_n})$, prove consistency of the $g_n$ via $L^q$ uniqueness, and glue via MCT. The key analytic subtlety — that $L^p$ truncations $f \\cdot \\mathbf{1}_{S_n}$ converge in $L^p$ norm — is the sigma-finite analogue of measure continuity and uses Vitali's convergence theorem.\n\nIn Lean's Mathlib, the finite-measure case was formalized in the parent gallery entry. The present file identifies the three specific Lean infrastructure gaps that remain for the sigma-finite case and establishes two foundational pointwise convergence results (proved without sorry). The HARD sorries are blocked by Lp restriction map infrastructure and Vitali's API verbosity, estimated at ~280 total lines — all known classical mathematics.",
-    "proofStrategy": "**Step A — Localization** (HARD sorry, ~150 lines): Fix the sigma-finite exhaustion $S_0 \\subseteq S_1 \\subseteq \\cdots$ with $\\mu(S_n) < \\infty$ and $\\bigcup_n S_n = \\alpha$. For each $n$, the restriction $\\mu|_{S_n}$ is finite; apply the parent's 7-step Radon-Nikodym proof to get $g_n \\in L^q(\\mu|_{S_n})$ with $\\varphi(f \\cdot \\mathbf{1}_{S_n}) = \\int f g_n \\,d(\\mu|_{S_n})$. Consistency $g_{n+1}|_{S_n} = g_n$ a.e. follows from $L^q$ uniqueness. Set $g = \\lim_n g_n \\cdot \\mathbf{1}_{S_n \\setminus S_{n-1}}$; then $g \\in L^q(\\mu)$ by MCT and $\\|g\\|_q \\leq \\|\\varphi\\|$. **Step B — Lp approximation** (HARD sorry, ~80 lines): For $f \\in L^p(\\mu)$, let $\\Delta_n = f - f \\cdot \\mathbf{1}_{S_n}$. Apply Vitali's theorem (`tendsto_Lp_of_tendsto_ae`): (i) a.e. convergence $\\Delta_n \\to 0$ from `pointwise_mul_indicator_tendsto`; (ii) UnifIntegrable from $|\\Delta_n| \\leq 2|f|$ via `unifIntegrable_of`; (iii) UnifTight from `unifTight_const` on dominator $2|f| \\in L^p$. Gives $\\|\\Delta_n\\|_p \\to 0$. **Step C — Density extension** (HARD sorry, ~50 lines): The functional $\\psi = \\varphi - (f \\mapsto \\int fg \\,d\\mu)$ vanishes on $\\{\\mathbf{1}_E : \\mu(E) < \\infty\\}$ (by Step A). Since this set spans a dense subspace of $L^p(\\mu)$ for sigma-finite $\\mu$ (via `Lp.induction`), continuity gives $\\psi \\equiv 0$, completing the proof.",
+    "proofStrategy": "**Step A — Localization** (~150 lines, proved in companion `RieszSigmaFiniteComplete.localization_existence`): Fix the sigma-finite exhaustion $S_0 \\subseteq S_1 \\subseteq \\cdots$ with $\\mu(S_n) < \\infty$ and $\\bigcup_n S_n = \\alpha$. For each $n$, the restriction $\\mu|_{S_n}$ is finite; apply the parent's 7-step Radon-Nikodym proof to get $g_n \\in L^q(\\mu|_{S_n})$ with $\\varphi(f \\cdot \\mathbf{1}_{S_n}) = \\int f g_n \\,d(\\mu|_{S_n})$. Consistency $g_{n+1}|_{S_n} = g_n$ a.e. follows from $L^q$ uniqueness. Set $g = \\lim_n g_n \\cdot \\mathbf{1}_{S_n \\setminus S_{n-1}}$; then $g \\in L^q(\\mu)$ by MCT and $\\|g\\|_q \\leq \\|\\varphi\\|$. **Step B — Lp approximation** (~80 lines, proved in companion `RieszSigmaFiniteComplete.lp_truncation_tendsto_zero`): For $f \\in L^p(\\mu)$, let $\\Delta_n = f - f \\cdot \\mathbf{1}_{S_n}$. Apply Vitali's theorem (`tendsto_Lp_of_tendsto_ae`): (i) a.e. convergence $\\Delta_n \\to 0$ from `pointwise_mul_indicator_tendsto`; (ii) UnifIntegrable from $|\\Delta_n| \\leq 2|f|$ via `unifIntegrable_of`; (iii) UnifTight from `unifTight_const` on dominator $2|f| \\in L^p$. Gives $\\|\\Delta_n\\|_p \\to 0$. **Step C — Density extension** (~50 lines, proved in companion as part of `RieszSigmaFiniteComplete.riesz_lp_surjective_sigma_finite`): The functional $\\psi = \\varphi - (f \\mapsto \\int fg \\,d\\mu)$ vanishes on $\\{\\mathbf{1}_E : \\mu(E) < \\infty\\}$ (by Step A). Since this set spans a dense subspace of $L^p(\\mu)$ for sigma-finite $\\mu$ (via `Lp.induction`), continuity gives $\\psi \\equiv 0$, completing the proof.",
     "keyInsights": [
       "The spanning-set exhaustion (`spanningSets_eventually_mem`) gives pointwise convergence of truncations; this is proved without sorry — it is the set-theoretic input to all three steps.",
       "UnifTight for the truncation sequence follows from `unifTight_const` applied to the dominator $2|f| \\in L^p$, combined with `eLpNorm_mono`. Crucially, `unifTight_const` does NOT require `IsFiniteMeasure` — this is precisely the point where the generalization from finite to sigma-finite measures becomes possible.",
       "Vitali's convergence theorem (`tendsto_Lp_of_tendsto_ae`) is the correct Mathlib API for Step B — there is no `tendsto_Lp_of_dominated_convergence` in Mathlib. Vitali's theorem requires UnifIntegrable AND UnifTight (not just a dominator), but is available for sigma-finite measures.",
       "The density extension step (Step C) is a direct port of the parent proof: `Lp.induction` does not use `IsFiniteMeasure` — it only requires `SigmaFinite`. This makes Step C the cheapest of the three sorries (~50 lines) and confirms that sigma-finiteness is the right generality for the full theorem.",
-      "The Lp restriction map infrastructure (`Lp(μ) → Lp(μ.restrict S)` isometric embedding and its adjoint) is the main Lean gap for Step A (~150 lines). This gap is not a mathematics problem but a Mathlib API coverage problem — the restriction map exists conceptually but is not yet in Mathlib as an isometric linear map.",
+      "The Lp restriction map infrastructure (`Lp(μ) → Lp(μ.restrict S)` isometric embedding and its adjoint) is the main analytic ingredient for Step A (~150 lines) and is constructed in the companion file. This was a Mathlib API coverage gap rather than a mathematics problem — extracting the restriction map into a standalone Mathlib PR would generalize the technique to other localization arguments.",
       "The sorry classification ('HARD not OPEN') is a mathematical contribution in its own right: it distinguishes between missing Lean infrastructure (a bounded, finite coding task) and genuinely unsolved mathematics. This taxonomy is essential for the gallery's curation of 'what's left to formalize' vs 'what's known to be unsolved'.",
       "The `noncomputable` annotation is required because `Lp` spaces use `Classical.choice` in their construction — the Lp equivalence classes are defined via propositional choice. This is a recurring pattern in Mathlib's measure theory and is purely a definitional necessity, not a constructive weakness.",
       "**Radon-Nikodym as the mathematical engine**: The Lp Riesz representation theorem is essentially a corollary of the Radon-Nikodym theorem. Every continuous linear functional φ on Lp(μ) defines a signed measure ν via ν(E) = φ(1_E), absolutely continuous with respect to μ for E with μ(E) < ∞. Radon-Nikodym yields a density g = dν/dμ, which is then identified as the representing function in Lq via the Hölder bound ||φ|| ≤ ||g||_q. The sigma-finite extension in this file is precisely the step where the Radon-Nikodym argument must be glued over the exhaustion {Sₙ}.",
@@ -59,32 +59,32 @@
     },
     {
       "id": "lp-truncation",
-      "title": "Step B: Lp Truncation Convergence (HARD sorry)",
+      "title": "Step B: Lp Truncation Convergence",
       "startLine": 87,
       "endLine": 130,
-      "summary": "HARD sorry: f·1_{Sₙ} → f in Lp norm. Proof via tendsto_Lp_of_tendsto_ae (Vitali) with UnifIntegrable/UnifTight from domination by 2|f| ∈ Lp.",
+      "summary": "Proved via delegation to `RieszSigmaFiniteComplete.lp_truncation_tendsto_zero` in the companion file: f·1_{Sₙ} → f in Lp norm. Strategy: tendsto_Lp_of_tendsto_ae (Vitali) with UnifIntegrable/UnifTight from domination by 2|f| ∈ Lp.",
       "mathContext": "$\\|f - f \\cdot \\mathbf{1}_{S_n}\\|_p \\to 0$. Strategy: Vitali's theorem with $|\\Delta_n| \\leq 2|f|$ giving UnifIntegrable (cutoff) + UnifTight (unifTight_const). No IsFiniteMeasure needed."
     },
     {
       "id": "localization",
-      "title": "Step A: Localization Construction (HARD sorry)",
+      "title": "Step A: Localization Construction",
       "startLine": 132,
       "endLine": 165,
-      "summary": "HARD sorry (~150 lines): constructs g ∈ Lq(μ) from localizations to μ.restrict Sₙ using the parent's finite-measure proof. Blocked by Lp restriction map infrastructure.",
+      "summary": "Proved via delegation to `RieszSigmaFiniteComplete.localization_existence` in the companion file: constructs g ∈ Lq(μ) from localizations to μ.restrict Sₙ using the parent's finite-measure proof together with the Lp restriction map infrastructure built in the companion.",
       "mathContext": "Constructs $g \\in L^q(\\mu)$ with $\\phi(\\mathbf{1}_E) = \\int_E g \\,d\\mu$ for $\\mu(E) < \\infty$. Uses parent's proof on $\\mu|_{S_n}$ + consistency ($L^q$ uniqueness) + MCT gluing. Gap: Lp restriction isometry in Mathlib."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem: Sigma-Finite Riesz Representation (HARD sorry)",
+      "title": "Main Theorem: Sigma-Finite Riesz Representation",
       "startLine": 167,
       "endLine": 208,
-      "summary": "HARD sorry (~50 lines): assembles localization + density extension to prove riesz_lp_surjective_sigma_finite. Density extension ports the parent's integral_representation.",
+      "summary": "Proved via delegation to `RieszSigmaFiniteComplete.riesz_lp_surjective_sigma_finite` in the companion file: assembles localization + density extension into the main sigma-finite Riesz representation. The density extension is the port of the parent's integral_representation; the companion supplies the full proof.",
       "mathContext": "$(L^p(\\mu))^* \\cong L^q(\\mu)$ for sigma-finite $\\mu$, $1 < p < \\infty$, $1/p + 1/q = 1$. Proof: indicator agreement (Step A) + Lp.induction over simple functions (Step C). Removes IsFiniteMeasure from parent result."
     }
   ],
   "conclusion": {
-    "summary": "Two foundational lemmas are proved (spanning-set pointwise convergence). The full sigma-finite Riesz representation is reduced to three HARD sorries totaling ~280 lines — all known classical mathematics, none involving unsolved problems.",
-    "implications": "Once the three sorries are filled, this completes the Riesz representation theorem for all sigma-finite measures in Lean 4, matching the classical scope of Folland Theorem 6.15 / Rudin Theorem 6.16. The two proved lemmas (`mem_spanningSets_eventually`, `pointwise_mul_indicator_tendsto`) are reusable infrastructure for other sigma-finite results in the gallery. The sorry taxonomy (HARD vs OPEN) is itself a contribution: it maps the gap between the current Mathlib infrastructure and the full classical theorem.",
+    "summary": "Two foundational lemmas are proved directly in the wrapper (spanning-set pointwise convergence). The three main theorems (Lp truncation convergence, localization construction, full sigma-finite Riesz representation) — previously HARD sorries — are now established by direct delegation to `RieszSigmaFiniteComplete.*` in the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`, yielding a complete proof with 0 sorries and 0 axioms.",
+    "implications": "This file, together with its companion `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`, completes the Riesz representation theorem for all sigma-finite measures in Lean 4, matching the classical scope of Folland Theorem 6.15 / Rudin Theorem 6.16. The two proved-in-wrapper lemmas (`mem_spanningSets_eventually`, `pointwise_mul_indicator_tendsto`) are reusable infrastructure for other sigma-finite results in the gallery. The wrapper/companion split keeps the user-facing signatures compact while isolating the heavier analytic machinery (Vitali, Lp restriction maps, density extension) in the companion.",
     "openQuestions": [
       "Does the proof extend to complex-valued Lp spaces? The Riesz representation for $(L^p(\\mu, \\mathbb{C}))^*$ is analogous but requires complex conjugation in the inner product, adding one extra step to the density extension.",
       "Can the localization argument be abstracted into a general 'finite-to-sigma-finite lifting' tactic for Lp results? The pattern (restrict → apply → glue via MCT) appears in Tonelli's theorem, the sigma-finite Fubini–Tonelli, and dominated convergence for sigma-finite measures.",
@@ -98,6 +98,11 @@
       "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01",
       "relationship": "extends",
       "description": "The parent file which proves the finite-measure Riesz representation; this file generalizes to sigma-finite measures"
+    },
+    {
+      "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01-oq-01-incomplete-01",
+      "relationship": "depends-on",
+      "description": "Companion file in namespace `RieszSigmaFiniteComplete` that contains the full analytic proofs of the three main theorems (lp_truncation_tendsto_zero, localization_existence, riesz_lp_surjective_sigma_finite). This wrapper file delegates each main theorem directly to the corresponding `RieszSigmaFiniteComplete.*` proof."
     },
     {
       "targetId": "cauchy-schwarz-integral-oq-01-oq-01-oq-02",
@@ -146,18 +151,18 @@
       },
       {
         "name": "lp_truncation_tendsto_zero",
-        "type": "sorry",
-        "description": "HARD: f·1_{Sₙ} → f in Lp norm via Vitali's convergence theorem"
+        "type": "proved",
+        "description": "f·1_{Sₙ} → f in Lp norm via Vitali's convergence theorem (proved via delegation to RieszSigmaFiniteComplete.lp_truncation_tendsto_zero in the companion file)"
       },
       {
         "name": "localization_existence",
-        "type": "sorry",
-        "description": "HARD: constructs representing function g ∈ Lq via localization to spanning sets"
+        "type": "proved",
+        "description": "Constructs representing function g ∈ Lq via localization to spanning sets (proved via delegation to RieszSigmaFiniteComplete.localization_existence in the companion file)"
       },
       {
         "name": "riesz_lp_surjective_sigma_finite",
-        "type": "sorry",
-        "description": "HARD: main sigma-finite Riesz representation — assembles localization + density extension"
+        "type": "proved",
+        "description": "Main sigma-finite Riesz representation — assembles localization + density extension (proved via delegation to RieszSigmaFiniteComplete.riesz_lp_surjective_sigma_finite in the companion file)"
       }
     ],
     "path": "Proofs/CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean",


### PR DESCRIPTION
## Fix

Update narrative fields in `meta.json` to reflect that the three previously HARD sorries (`lp_truncation_tendsto_zero`, `localization_existence`, `riesz_lp_surjective_sigma_finite`) have been eliminated via direct delegation to `RieszSigmaFiniteComplete.*` in the companion file `CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01Incomplete01.lean`.

## Evidence

**Before**: meta.json prose claimed "full theorem reduced to three HARD sorries" and listed the three main theorems with `type: "sorry"`, contradicting the top-level fields (`status: verified`, `sorries: 0`, `axiomCount: 0`).

**After**: Narrative fields (`description`, `overview.text`, `proofStrategy`, sections[2..4], `conclusion.summary`, `implications`, `keyInsights[4]`) and `leanFile.mainTheorems[2..4].type` now describe the wrapper as delegating to the companion, matching the Lean source. Added `depends-on` crossReference to the companion entry.

**Verification**: \`grep -c "^\\s*sorry\\b\\|:= sorry\\|:= by sorry"\` returns 0 for both \`CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean\` and \`Incomplete01.lean\`; \`grep -c "^axiom "\` returns 0 for both. The three main theorems in the wrapper have bodies of the form \`RieszSigmaFiniteComplete.<same-name> ...\`.

Closes #22319

---
Automated fix by lean-mechanic agent.