### PR TITLE
research(euler-totient-oq-04-oq-01): S3 ACT — discharge both Möbius sorries

### DIFF
--- a/proofs/Proofs/EulerTotientOQ04OQ01.lean
+++ b/proofs/Proofs/EulerTotientOQ04OQ01.lean
@@ -25,14 +25,17 @@ and the alternating binomial-sum identity (`Mathlib.Data.Nat.Choose.Sum.sum_powe
 This is the squarefree analogue of the parent file's GCD-class partition.
 
 ## Status
-**S2 SCAFFOLD** — main statement proved modulo three strategic sorries:
-- `moebius_prod_squarefree`: μ of a product of distinct primes is `(-1)^k`
-- `prod_primeFactors_bij_squarefree`: bijection prod-on-powerset is squarefree
-- `sum_normalizedFactors_eq_sum_primeFactors`: bridge from Mathlib's
-  `normalizedFactors`-formulation back to `primeFactors`
+**Verified** — main theorem `sum_moebius_eq_indicator` fully proved.
+Zero `sorry`s, zero `axiom`s.
 
-The intended S3 ACT discharges all three via `cardFactors_apply_prime`
-+ `prod_primeFactors_of_squarefree` + `factors_eq` (Nat-specific).
+Key building blocks:
+- `moebius_prod_squarefree`: μ of a product of distinct primes is `(-1)^k`
+  (uses `isMultiplicative_moebius.map_prod_of_prime`).
+- `normalizedFactors_toFinset_eq`: Nat-side bridge from
+  `(normalizedFactors n).toFinset` to `n.primeFactors`.
+- `sum_filter_squarefree_moebius_eq_powerset`: combines the Mathlib
+  bijection `Nat.sum_divisors_filter_squarefree` with
+  `moebius_prod_squarefree` on each `S ⊆ primeFactors n`.
 
 ## Mathlib Dependencies
 - `Mathlib.NumberTheory.ArithmeticFunction.Moebius` — `μ`, `moebius_eq_zero_of_not_squarefree`
@@ -69,13 +72,13 @@ theorem sum_moebius_divisors_eq_filter_squarefree (n : ℕ) :
 
 /-- For a finite set `s` of distinct primes, `μ (∏ s) = (-1)^|s|`.
 
-Strategic sorry (S3 ACT): combine `prod_primeFactors_of_squarefree`-style
-argument that `s.prod id` is squarefree (since elements are distinct
-primes), then `moebius_apply_of_squarefree` + `cardFactors` of a
-squarefree product equals `s.card`. -/
+Uses multiplicativity of `μ` on the product of pairwise-coprime primes
+(`isMultiplicative_moebius.map_prod_of_prime`), then `μ p = -1` on each
+prime, then `Finset.prod_eq_pow_card`. -/
 theorem moebius_prod_squarefree (s : Finset ℕ) (hs : ∀ p ∈ s, p.Prime) :
     μ (∏ p ∈ s, p) = (-1 : ℤ) ^ s.card := by
-  sorry
+  rw [isMultiplicative_moebius.map_prod_of_prime s hs]
+  exact Finset.prod_eq_pow_card (fun p hp => moebius_apply_prime (hs p hp))
 
 /- ## Part III: bridge from Mathlib's normalizedFactors form to primeFactors -/
 
@@ -101,9 +104,12 @@ theorem sum_filter_squarefree_moebius_eq_powerset (n : ℕ) (hn : n ≠ 0) :
   -- Rewrite the powerset index via `normalizedFactors_toFinset_eq`
   rw [normalizedFactors_toFinset_eq n hn]
   -- For each S ⊆ primeFactors n, μ(S.val.prod) = (-1)^|S|.
-  -- This needs that elements of S are primes (from S ⊆ primeFactors n)
-  -- combined with `moebius_prod_squarefree`. Strategic sorry; see S3 plan.
-  sorry
+  refine Finset.sum_congr rfl fun S hS => ?_
+  rw [Finset.mem_powerset] at hS
+  -- Rewrite `S.val.prod` to `∏ p ∈ S, p` via `Finset.prod_val`
+  rw [Finset.prod_val]
+  -- Each element of `S ⊆ n.primeFactors` is prime, so apply `moebius_prod_squarefree`.
+  exact moebius_prod_squarefree S (fun p hp => Nat.prime_of_mem_primeFactors (hS hp))
 
 /- ## Part V: main result -/
 

--- a/research/problems/euler-totient-oq-04-oq-01/sessions/2026-06-04-s04-act-mobius-discharge.md
+++ b/research/problems/euler-totient-oq-04-oq-01/sessions/2026-06-04-s04-act-mobius-discharge.md
@@ -1,0 +1,90 @@
+## Session 2026-06-04 (Session 4) — S3 ACT: discharge both strategic sorries
+
+**Mode**: FRESH (claimed problem from available pool)
+**Outcome**: completed
+**Agent**: researcher-4
+
+### What I Did
+
+Discharged both strategic sorries left by S2 SCAFFOLD (2026-05-14), producing
+a fully verified Möbius indicator identity (`Σ_{d|n} μ(d) = [n=1]`) with
+0 sorries and 0 axioms.
+
+1. `moebius_prod_squarefree (s : Finset ℕ) (hs : ∀ p ∈ s, p.Prime) :
+       μ (∏ p ∈ s, p) = (-1 : ℤ) ^ s.card`
+
+   Discharged in 2 lines via the multiplicativity route, **not** the
+   squarefreeness route anticipated in the S2 plan:
+
+   ```lean
+   rw [isMultiplicative_moebius.map_prod_of_prime s hs]
+   exact Finset.prod_eq_pow_card (fun p hp => moebius_apply_prime (hs p hp))
+   ```
+
+   `isMultiplicative_moebius.map_prod_of_prime` (Mathlib's
+   `NumberTheory.ArithmeticFunction.Defs`) directly turns
+   `μ (∏ p ∈ s, p)` into `∏ p ∈ s, μ p` when the elements of `s` are
+   primes (uses `coprime_primes` under the hood for pairwise coprimality).
+   Then `moebius_apply_prime` gives `μ p = -1` for each prime, and
+   `Finset.prod_eq_pow_card` collapses the constant product to `(-1)^s.card`.
+
+   This bypasses entirely the `Squarefree.prod` + `cardFactors_mul` +
+   `moebius_apply_of_squarefree` chain envisioned in S2/S3 plan.
+
+2. `sum_filter_squarefree_moebius_eq_powerset (n : ℕ) (hn : n ≠ 0) :
+       (∑ d ∈ n.divisors with Squarefree d, μ d : ℤ)
+         = ∑ S ∈ n.primeFactors.powerset, (-1 : ℤ) ^ S.card`
+
+   Discharged in 6 lines following S2 plan exactly, with one extra step
+   needed: `Finset.prod_val` to bridge `S.val.prod` (multiset product
+   from `Nat.sum_divisors_filter_squarefree`) to `∏ p ∈ S, p` (Finset
+   product expected by `moebius_prod_squarefree`).
+
+   ```lean
+   rw [Nat.sum_divisors_filter_squarefree hn, normalizedFactors_toFinset_eq n hn]
+   refine Finset.sum_congr rfl fun S hS => ?_
+   rw [Finset.mem_powerset] at hS
+   rw [Finset.prod_val]
+   exact moebius_prod_squarefree S (fun p hp => Nat.prime_of_mem_primeFactors (hS hp))
+   ```
+
+3. Updated file header docstring: `S2 SCAFFOLD` → `Verified` with
+   updated bullet list of key building blocks.
+
+### Key Findings
+
+- **`isMultiplicative_moebius.map_prod_of_prime` is the right tool** for
+  `μ (∏ s)` when `s` is a Finset of distinct primes. The squarefree
+  route (compute `cardFactors` of the product) is unnecessarily indirect.
+  This shortcut may apply to other multiplicative arithmetic functions:
+  whenever the target is `f (∏ p ∈ s, p)` for `f` multiplicative and
+  `s` distinct primes, prefer the multiplicativity route.
+
+- **`Finset.prod_val` is the missing bridge** between Mathlib's
+  `Nat.sum_divisors_filter_squarefree` (which yields `f i.val.prod` in
+  the powerset index) and the Finset-product form expected by
+  multiplicativity lemmas. Without it, you can't directly apply
+  `moebius_prod_squarefree` to the per-S goal.
+
+- **Total discharge size (8 lines) << anticipated (S2 plan estimated
+  30-50 lines)**. The Mathlib v4.26.0 API for multiplicative arithmetic
+  functions is much more direct than the squarefree-cardFactors chain
+  the S2 OBSERVE phase identified.
+
+### Files Modified
+
+- `proofs/Proofs/EulerTotientOQ04OQ01.lean`: 158 → 164 LOC; 2 sorries → 0;
+  0 axioms unchanged.
+- `research/problems/euler-totient-oq-04-oq-01/state.md`: phase
+  SCAFFOLD → COMPLETED, iter 3 → 4.
+
+### Next Steps
+
+- (follow-up, lower priority): create
+  `src/data/proofs/euler-totient-oq-04-oq-01/` gallery entry with
+  `status: verified` and `badge: original`. Parent file
+  `EulerTotientOQ04.lean` already lists this in `additionalFiles`,
+  so the basic linkage is there.
+- (technique propagation): consider documenting
+  `isMultiplicative_moebius.map_prod_of_prime` as the canonical
+  approach for `μ ∘ prod-of-distinct-primes` in the technique index.

--- a/research/problems/euler-totient-oq-04-oq-01/state.md
+++ b/research/problems/euler-totient-oq-04-oq-01/state.md
@@ -1,27 +1,33 @@
 # Research State: euler-totient-oq-04-oq-01
 
 ## Current State
-**Phase**: SCAFFOLD
+**Phase**: COMPLETED
 **Path**: full
-**Since**: 2026-05-14T19:30:00Z
-**Iteration**: 2
+**Since**: 2026-06-04T19:00:00Z
+**Iteration**: 3
 
 ## Current Focus
-S2 SCAFFOLD landed (PR pending): `proofs/Proofs/EulerTotientOQ04OQ01.lean`
-states the main identity `Σ_{d|n} μ(d) = [n = 1]` and proves it modulo
-two strategic sorries:
+S3 ACT (2026-06-04, researcher-4): both strategic sorries discharged,
+file builds clean with 0 sorries / 0 axioms (Docker 1118 jobs, freshly
+built — not replayed).
 
-| Sorry | Location | Discharge plan (S3 ACT) |
+| Sorry (S2) | Location | S3 discharge |
 |---|---|---|
-| `moebius_prod_squarefree` | line 76 | `Squarefree.prod` of distinct primes + `moebius_apply_of_squarefree` + `cardFactors_prod_of_squarefree` |
-| `sum_filter_squarefree_moebius_eq_powerset` | line 96 | unfold Mathlib's `sum_divisors_filter_squarefree`, then `Finset.sum_congr` with `moebius_prod_squarefree` on each `S.val.prod` |
+| `moebius_prod_squarefree` | line 76 | `isMultiplicative_moebius.map_prod_of_prime` + `Finset.prod_eq_pow_card` over `moebius_apply_prime` (2 lines of proof) |
+| `sum_filter_squarefree_moebius_eq_powerset` | line 96 | `Nat.sum_divisors_filter_squarefree` → `normalizedFactors_toFinset_eq` → `Finset.sum_congr` → `Finset.prod_val` → `moebius_prod_squarefree` (6 lines of proof) |
+
+Both discharges came in much shorter than the S2 plan estimate
+(2+6 lines vs ~30-50 anticipated): the multiplicativity route via
+`isMultiplicative_moebius.map_prod_of_prime` (Mathlib gives this directly
+for pairwise-coprime distinct primes) bypassed the `Squarefree.prod` +
+`cardFactors_prod_of_squarefree` chain entirely.
 
 Main theorem `sum_moebius_eq_indicator` and the squarefree-vs-not split
 (`sum_moebius_divisors_eq_filter_squarefree`) are FULLY proved (no sorry).
 The Nat-side bridge `normalizedFactors_toFinset_eq` is fully proved (closes
 via `simp [Nat.factors_eq, Nat.mem_primeFactors, hn]`).
 
-Build verified: 1118 jobs, 2 strategic sorries (warnings only).
+Build verified: 1118 jobs, 0 sorries, 0 axioms (S3 ACT, freshly built).
 
 ## Active Approach
 **Squarefree-divisor / powerset bijection** (S1 OBSERVE recommendation S2-B):
@@ -38,41 +44,27 @@ This is genuinely orthogonal to Mathlib's `moebius_mul_coe_zeta` proof
 (via `recOnPosPrimePosCoprime` multiplicative induction).
 
 ## Attempt Count
-- Total attempts: 3 (Docker iters)
-- Current approach attempts: 3
+- Total attempts: 4 (Docker iters)
+- Current approach attempts: 4
 - Approaches tried: 1 (squarefree-divisor / powerset)
 
 ### Docker build log
 - Iter 1: `EulerTotientOQ04OQ01.lean` file not in worktree (Write-tool path bug); copied + rebuilt
 - Iter 2: `Nat.eq_one_or_self_lt_of_prime_factorization` unknown + `rw [hpf]` motive failure on `if`-Decidable + simp closes goal extra `sorry` "no goals to be solved" + `id` ambiguous (`_root_.id` vs `ArithmeticFunction.id` after `open ArithmeticFunction`)
-- Iter 3: ✅ **CLEAN** — 1118 jobs, 2 strategic sorries, no errors
+- Iter 3: ✅ S2 SCAFFOLD CLEAN — 1118 jobs, 2 strategic sorries, no errors
+- Iter 4 (2026-06-04, researcher-4): ✅ **S3 ACT CLEAN** — 1118 jobs, 0 sorries, 0 axioms; first-pass clean build of both discharges
 
 ## Blockers
-None. Strategic sorries are deliberate S2 SCAFFOLD scope.
+None. File is verified.
 
 ## Next Action
-**S3 ACT** discharges both strategic sorries:
+**Gallery integration (follow-up)**: add `src/data/proofs/euler-totient-oq-04-oq-01/`
+directory (meta.json, annotations.json, index.ts) with `status: verified`
+and `badge: original`. This is the squarefree analogue of the parent
+file's GCD-class partition. Lower priority than the parent's gallery
+entry which already references this file via `additionalFiles`.
 
-1. `moebius_prod_squarefree (s : Finset ℕ) (hs : ∀ p ∈ s, p.Prime) :
-       μ (∏ p ∈ s, p) = (-1 : ℤ) ^ s.card`
-   - Show `∏ p ∈ s, p` is squarefree (using `Squarefree.prod` + `hs`).
-   - Apply `moebius_apply_of_squarefree`.
-   - Compute `cardFactors (∏ p ∈ s, p) = s.card` (sum of `cardFactors_apply_prime`
-     over distinct primes; uses `Nat.cardFactors_mul` + `Coprime` between distinct primes).
-
-2. `sum_filter_squarefree_moebius_eq_powerset (n : ℕ) (hn : n ≠ 0) :
-       ∑ d ∈ n.divisors with Squarefree d, μ d
-         = ∑ S ∈ n.primeFactors.powerset, (-1 : ℤ) ^ S.card`
-   - Rewrite via `Nat.sum_divisors_filter_squarefree hn`.
-   - Rewrite powerset index via `normalizedFactors_toFinset_eq` (already proved).
-   - For each `S ∈ powerset`, `S.val.prod = ∏ p ∈ S, p` and apply
-     `moebius_prod_squarefree`.
-
-S3 target: discharge both, plus add gallery `src/data/proofs/euler-totient-oq-04-oq-01/`
-directory (meta.json, annotations.json, index.ts) with explicit
-"original" vs "axiomatized" status decision based on remaining sorries.
-
-Expected LOC after S3 ACT: 100-150 (currently ~145 with 2 sorries).
+LOC: 165 (was ~145 with 2 sorries; +20 LOC for the discharges + updated header docstring).
 
 ## Cross-references
 - Parent file: `proofs/Proofs/EulerTotientOQ04.lean` (231 LOC, 0 sorries,


### PR DESCRIPTION
## Summary
- Discharges both strategic sorries left by S2 SCAFFOLD in `proofs/Proofs/EulerTotientOQ04OQ01.lean`
- Result: `Σ_{d|n} μ(d) = [n=1]` fully verified — **0 sorries, 0 axioms**, Docker 1118 jobs clean (freshly built, not replayed)
- Original constructive proof via squarefree-divisor / powerset bijection, orthogonal to Mathlib's `moebius_mul_coe_zeta` (multiplicative-induction)

## Proofs

**`moebius_prod_squarefree`** (2 lines): μ of a product of distinct primes is `(-1)^k`.
```lean
rw [isMultiplicative_moebius.map_prod_of_prime s hs]
exact Finset.prod_eq_pow_card (fun p hp => moebius_apply_prime (hs p hp))
```
Uses multiplicativity of μ on pairwise-coprime distinct primes — bypasses the `Squarefree.prod` + `cardFactors_mul` chain anticipated in the S2 plan.

**`sum_filter_squarefree_moebius_eq_powerset`** (6 lines):
```lean
rw [Nat.sum_divisors_filter_squarefree hn, normalizedFactors_toFinset_eq n hn]
refine Finset.sum_congr rfl fun S hS => ?_
rw [Finset.mem_powerset] at hS
rw [Finset.prod_val]
exact moebius_prod_squarefree S (fun p hp => Nat.prime_of_mem_primeFactors (hS hp))
```
The `Finset.prod_val` step bridges the multiset product from `sum_divisors_filter_squarefree` to the Finset product expected by `moebius_prod_squarefree`.

## Test plan
- [x] Docker build clean: `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ04OQ01` — 1118 jobs, freshly built
- [x] 0 sorries in file
- [x] 0 axioms in file
- [x] Main theorem `sum_moebius_eq_indicator` and 3 concrete validation examples (n=1, n=5, n=6) all close

🤖 Generated with [Claude Code](https://claude.com/claude-code)