### PR TITLE
audit(descartes-rule-of-signs-oq-02-oq-01-oq-02): tracker bump — clean (3rd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2449,9 +2449,9 @@
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-02-oq-01-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-02T23:46:42Z",
+      "lastAudited": "2026-06-05T02:30:52Z",
       "result": "clean"
     },
     "descartes-rule-of-signs-oq-03": {


### PR DESCRIPTION
## Summary

Re-audit of Sturm's Theorem (Exact Root Count via Sign-Change Sequences) — 3rd audit, no integrity issues.

## Verification

All meta.json claims match `proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean`:

| Field | Claimed | Actual |
|-------|---------|--------|
| sorries | 0 | 0 ✓ |
| axiomCount | 1 | 1 (`sturm_exact_count_axiom` @ L332) ✓ |
| lineCount | 513 | 513 ✓ |
| definitionCount | 6 | 6 ✓ |
| status | axiomatized | matches presence of axiom ✓ |
| badge | axiom | correct for axiomatized ✓ |

- No `True` stubs detected
- No undisclosed Mathlib wrapper — badge `axiom` is correct (not `mathlib`)
- `assumptions` field accurately describes the additive-form axiom and what it bundles
- Title clearly identifies Sturm's classical theorem; description correctly attributes to Sturm (1829)
- Tier C (axiomatized) classification — appropriate for a single-axiom formalization

## Change

Tracker bump only: \`auditCount\` 1 → 2, \`lastAudited\` updated to 2026-06-05.

## Test plan
- [ ] CI passes (no runtime changes; data-only update)

🤖 Generated by the Lean Auditor