### PR TITLE
Enrich abel-ruffini-galois-extensions: surface arg-noncommutativity metadata

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -429,14 +429,27 @@
       "fintype enumeration",
       "simple groups",
       "three thresholds: commutativity, solvability, simplicity",
-      "simple non-abelian $\\Rightarrow$ non-solvable"
+      "simple non-abelian $\\Rightarrow$ non-solvable",
+      "derived subgroup identity $[A_4, A_4] = V_4$",
+      "$A_5$ class equation $60 = 1 + 12 + 12 + 15 + 20$",
+      "splitting of 5-cycle conjugacy class in $A_5$ (two classes of 12)",
+      "Coxeter/icosahedral presentation $A_5 = \\langle a, b \\mid a^2 = b^3 = (ab)^5 = e\\rangle$",
+      "von Dyck triangle group $(2, 3, 5)$",
+      "natural embedding $S_3 \\hookrightarrow S_n$ for $n \\geq 3$",
+      "commutator of intersecting 3-cycles lands in Klein four"
     ],
     "prerequisites": [
       "symmetric group",
       "decide tactic",
       "Fintype.decidable_forall_fintype",
       "simple group definition",
-      "Klein four-group $V_4 \\trianglelefteq A_4$"
+      "Klein four-group $V_4 \\trianglelefteq A_4$",
+      "conjugacy classes in $S_n$ via cycle type",
+      "$S_n$-conjugacy may split into two $A_n$-classes when centralizer is odd",
+      "finite presentations of groups (Coxeter / von Dyck)",
+      "Equiv.Perm composition convention $(\\sigma \\cdot \\tau)(x) = \\sigma(\\tau(x))$",
+      "derived series and commutator subgroup",
+      "stabilizer subgroup as embedding of smaller $S_k$"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Surfaces concepts already discussed in the `arg-noncommutativity` annotation body into its `relatedConcepts` and `prerequisites` metadata fields — improving search/cross-reference discoverability without modifying proof content.

The annotation body explicitly references:
- Coxeter / von Dyck presentation $A_5 = \langle a, b \mid a^2 = b^3 = (ab)^5 = e\rangle$
- $A_5$ class equation $60 = 1 + 12 + 12 + 15 + 20$
- 5-cycle conjugacy class splitting into two $A_5$-classes of 12
- Derived-subgroup identity $[A_4, A_4] = V_4$ (from commutator of two intersecting 3-cycles)
- Witness embedding $S_3 \hookrightarrow S_n$ via stabilizer of $\{4, \ldots, n\}$
- Lean `Equiv.Perm` composition convention $(\sigma \cdot \tau)(x) = \sigma(\tau(x))$

These were prose-only; this PR moves them to the structured metadata fields where the gallery's search and related-concept linking can find them.

## Test plan

- [x] JSON validates (both meta.json and annotations.json)
- [x] Enrichment-listings build step succeeds
- [ ] CI pipeline verifies full build