### PR TITLE
research(erdos-1118-oq-02): de-genericize section-66 + correct "3 axioms" comment

### DIFF
--- a/proofs/Proofs/Erdos1118OQ02.lean
+++ b/proofs/Proofs/Erdos1118OQ02.lean
@@ -96,8 +96,9 @@ theorem growth_increases_with_dim :
   - Hartogs extension phenomena
   - Growth measured by pluricomplex Green function
 
-  3 axioms (Camera-Gol'dberg, higher-dim differences, PSH).
-  0 sorries. 4 theorems.
+  3 documented theoretical principles (Camera-Gol'dberg, higher-dim
+  differences, PSH) — these are docstring exposition, not `axiom`
+  declarations. 0 axioms. 0 sorries. 3 theorems, 1 definition.
 -/
 
 end Erdos1118OQ02

--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -62,10 +62,10 @@
     },
     {
       "id": "section-66",
-      "title": "Part II: The 1D vs nD Comparison (continued)",
+      "title": "Part II (cont.): Plurisubharmonicity and Dimensional Anchors",
       "startLine": 66,
       "endLine": 86,
-      "summary": "Continuation: remaining proofs and definitions in this section."
+      "summary": "Two docstring blocks — plurisubharmonicity of log|f| (the SCV analogue of subharmonicity, equivalent to ∂∂̄ log|f| ≥ 0 in the sense of currents) and real-dimension scaling (E(c) ⊂ ℂⁿ ≅ ℝ^(2n) lives in a space of growing dimension as n increases) — anchor two trivial theorems: superlevel_dimension (2n = 2n by rfl) and growth_increases_with_dim (n₁ < n₂ → 2n₁ < 2n₂ by omega). The latter encodes the heuristic that the Camera-Gol'dberg growth threshold tightens with dimension — for f ~ exp(r^α), finiteness of |E(c)|_(2n) requires α > 2n/(2n-1), a condition approaching 1 as n → ∞."
     },
     {
       "id": "summary",


### PR DESCRIPTION
## Summary

Two small docs corrections to the SCV superlevel-set OQ entry (Erdős 1118, OQ-02):

- **meta.json `section-66`** had a generic auto-title `"Part II: The 1D vs nD Comparison (continued)"` with placeholder summary `"Continuation: remaining proofs and definitions in this section."` Replaced with a descriptive title `"Part II (cont.): Plurisubharmonicity and Dimensional Anchors"` and a full summary covering the two docstring blocks in that range (plurisubharmonicity of $\log|f|$ as $\partial\bar\partial \log|f| \geq 0$ in the sense of currents; real-dimension scaling $\mathbb{C}^n \cong \mathbb{R}^{2n}$) and the two anchor theorems (`superlevel_dimension` by `rfl`, `growth_increases_with_dim` by `omega`), including the heuristic $\alpha > 2n/(2n-1)$ for finiteness of $|E(c)|_{2n}$ when $f \sim \exp(r^\alpha)$.

- **Lean file's final summary comment** said `"3 axioms (Camera-Gol'dberg, higher-dim differences, PSH). 0 sorries. 4 theorems."` This was misleading on two counts:
  - the three docstring blocks are documentation, not `axiom` declarations (the file has 0 axioms);
  - the file has 3 theorems + 1 definition, not 4 theorems.
  
  Updated to `"3 documented theoretical principles (Camera-Gol'dberg, higher-dim differences, PSH) — these are docstring exposition, not `axiom` declarations. 0 axioms. 0 sorries. 3 theorems, 1 definition."`

The `meta.json` `assumptions` field already documents this correctly:
> "0 axioms. 0 sorries. All theorems fully proved. The three docstring blocks (Camera-Gol'dberg criterion, SCV differences, plurisubharmonicity) are documentation, not axiom declarations."

Per the [Axiom Integrity Policy](https://github.com/rjwalters/lean-genius/blob/main/CLAUDE.md) (CLAUDE.md), `status: "verified"` requires 0 axioms, 0 sorries, 0 structure-encoded assumptions — confirmed for this file. The in-file comment now matches that status.

## Scope

- Comment-only change to the Lean file (inside a `/- ... -/` block); cannot affect compilation.
- Metadata-only change to `meta.json` (one section's `title` and `summary` strings); JSON validated with `JSON.parse`.

## Test plan

- [x] `node -e "JSON.parse(...)"` confirms meta.json still parses
- [x] Lean diff is entirely inside the trailing `/- ... -/` comment block — no code touched
- [x] Counts match meta.json (`axiomCount: 0`, `theoremCount: 3`, `definitionCount: 1`)
- [ ] Gallery renders with the new section title

🤖 Generated with [Claude Code](https://claude.com/claude-code)