### PR TITLE
Enrich abel-ruffini: surface Part VII historical figures in section metadata

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -566,13 +566,29 @@
         "Galois theory",
         "Lindemann-Weierstrass theorem",
         "expressibility hierarchy",
-        "fundamental theorem of algebra"
+        "fundamental theorem of algebra",
+        "Wantzel (1837) compass-and-straightedge impossibilities",
+        "Liouville (1844) transcendental number construction",
+        "Hermite (1873) transcendence of $e$",
+        "Lindemann (1882) transcendence of $\\pi$",
+        "Cantor (1891) diagonal argument and uncountability",
+        "Gödel (1931) incompleteness theorems",
+        "Turing (1936) undecidability of the halting problem",
+        "Cardano (1545) cubic formula",
+        "Ferrari (1545) quartic formula",
+        "Hermite (1858) elliptic-modular quintic solution (bypasses radical barrier)"
       ],
       "prerequisites": [
         "Lagrange (1770) resolvent and pre-history",
         "Ruffini (1799), Abel (1824), Galois (1832) chronology",
         "birth of abstract group theory from solvability questions",
-        "Lindemann-Weierstrass and the expressibility hierarchy"
+        "Lindemann-Weierstrass and the expressibility hierarchy",
+        "Wantzel (1837) as chronologically first descendant of Galois's impossibility paradigm",
+        "Liouville's 1846 posthumous edition of Galois's manuscripts",
+        "the 1832–1846 'Galois underground' (Wantzel's pre-publication access)",
+        "expressibility hierarchy: irrational $\\subset$ radical-inexpressible $\\subset$ algebraic-inexpressible",
+        "existence (FTA) vs symbolic-expressibility (Abel-Ruffini) distinction",
+        "Hermite's 1858 modular-form solution of the quintic (radical barrier vs analytic solvability)"
       ]
     }
   ],


### PR DESCRIPTION
## Summary

The `historical-significance` section summary (Part VII) mentions Wantzel 1837, Liouville 1846, Hermite 1873, Lindemann 1882, Cantor 1891, Gödel 1931, Turing 1936, Cardano/Ferrari 1545, Hermite's 1858 elliptic-modular quintic solution, and the "Galois underground" 1832–1846 — but none were exposed in the section's `relatedConcepts` / `prerequisites` metadata.

Surfacing them improves search and the gallery's related-concept link graph without altering proof content.

- Added 10 relatedConcepts (Wantzel, Liouville, Hermite, Lindemann, Cantor, Gödel, Turing, Cardano, Ferrari, Hermite modular-quintic)
- Added 6 prerequisites (Wantzel as first impossibility descendant; Galois underground chronology; expressibility hierarchy ordering; existence/expressibility distinction; Hermite analytic solvability)

## Test plan

- [x] JSON validates (meta.json)
- [ ] CI build verifies