### PR TITLE
fix(meta): circumference-via-differentiation-oq-03 sync leanFile counts (152->194, 5->6)

### DIFF
--- a/src/data/proofs/circumference-via-differentiation-oq-03/meta.json
+++ b/src/data/proofs/circumference-via-differentiation-oq-03/meta.json
@@ -154,8 +154,8 @@
   "leanFile": {
     "path": "Proofs/CircumferenceViaDifferentiationOQ03.lean",
     "filename": "CircumferenceViaDifferentiationOQ03.lean",
-    "lineCount": 152,
-    "theoremCount": 5,
+    "lineCount": 194,
+    "theoremCount": 6,
     "axiomCount": 0,
     "definitionCount": 0,
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync stale `leanFile` counts for `circumference-via-differentiation-oq-03`:

- `leanFile.lineCount`: 152 -> 194
- `leanFile.theoremCount`: 5 -> 6

The sibling `meta.lineCount` (194) and `meta.theoremCount` (6) were already current. Only the `leanFile` block had drifted, leaving `wc -l` and the declared count disagreeing by 42 lines / 1 theorem.

## Evidence

```
$ wc -l proofs/Proofs/CircumferenceViaDifferentiationOQ03.lean
     194 proofs/Proofs/CircumferenceViaDifferentiationOQ03.lean

$ grep -cE '^(theorem|lemma) ' proofs/Proofs/CircumferenceViaDifferentiationOQ03.lean
6
```

`meta.{lineCount,theoremCount}` and the prose description ("5 theorems, 0 sorries, 0 axioms") are intentionally left untouched — meta values already match `wc -l` and the public-theorem count; the description text bump is out of scope for a leanFile-sync repair.

No sorry / axiom / definition counts changed.

---
Automated fix by lean-mechanic agent.