### PR TITLE
research(minpoly-charpoly-oq-02): add missing gallery entry (meta.json + 7 annotations)

### DIFF
--- a/src/data/proofs/minpoly-charpoly-oq-02/annotations.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/annotations.json
@@ -1,0 +1,149 @@
+[
+  {
+    "id": "ann-mcpoq02-imports",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 1, "endLine": 10 },
+    "type": "context",
+    "title": "Import Stack: Charpoly + Semisimple + Eigenspace + Parent",
+    "content": "Ten imports stage the three Mathlib layers used by the OQ-02 discharge plan:\n\n* **Minpoly / charpoly layer** (L1-2): `Matrix.Charpoly.Basic` for charpoly and `Matrix.Charpoly.Minpoly` for `Matrix.minpoly_toLin'` — the Bridge D used to transport squarefree across the matrix↔endo correspondence.\n* **Diagonal-matrix predicate** (L3): `LinearAlgebra.Matrix.IsDiag` — the codomain of the similarity-transform existential in `Matrix.IsDiagonalizable`. Note: the S7 ACT v4.26.0 import regression fix added this import after the silently-removed `Mathlib.Algebra.Polynomial.Squarefree` (file renamed in v4.26.0).\n* **Semisimplicity** (L4): `LinearAlgebra.Semisimple` — provides `Module.End.IsSemisimple`, the engine of the entire iff. Includes both directions of Bridge C: `Module.End.IsSemisimple.minpoly_squarefree` and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero`.\n* **Eigenspace layer** (L5-6): `Eigenspace.Semisimple` for `IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace` (the second link in Bridge B forward's 3-lemma chain); `Eigenspace.Triangularizable` for `Module.End.iSup_maxGenEigenspace_eq_top` (the third link, the endpoint).\n* **Finite-dim transport** (L7-8): `FreeModule.Finite.Matrix` for the `Matrix.toLin'` algebra hookups; `FieldTheory.IsAlgClosed.Basic` for the headline's `[IsAlgClosed K]` hypothesis.\n* **Tactic + Parent** (L9-10): `Mathlib.Tactic` for `simpa`/`refine`/calc; `Proofs.MinpolyCharpoly` for the parent's 17 minpoly | charpoly theorems.",
+    "mathContext": "Two endomorphism-level bridges (B forward and C) are built directly on top of `Module.End.IsSemisimple` and its companion eigenspace lemmas. The matrix-level discharge uses `Matrix.toLin'` + `Matrix.minpoly_toLin'` for transport.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Module.End.IsSemisimple",
+      "Matrix.minpoly_toLin'",
+      "Matrix.IsDiag",
+      "iSup_maxGenEigenspace_eq_top"
+    ],
+    "prerequisites": [
+      "Lean 4 import syntax",
+      "Mathlib namespace layout (v4.26.0)"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-resolution",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 28, "endLine": 56 },
+    "type": "concept",
+    "title": "S1 OBSERVE Resolution — Three Ingredients, No Mathlib Gap",
+    "content": "The S1 OBSERVE docstring resolves OQ-02 affirmatively by identifying three Mathlib-level ingredients that compose into the matrix-level iff:\n\n1. **Module.End.IsSemisimple ↔ Squarefree (minpoly K f)** — already in Mathlib at v4.26.0 (`Module.End.isSemisimple_iff_squarefree_minpoly` ships in `Mathlib.LinearAlgebra.Semisimple`, with both directions named). Bridge C ships this in-tree as a packaged iff (lines 162-167).\n\n2. **IsSemisimple + minpoly splits → diagonalizable**: over alg-closed `K` the splits hypothesis is automatic; semisimplicity then implies the eigenspaces span the whole space (Bridge B forward, lines 146-155). Composed with the converse direction (Bridge B reverse, deferred to S8 ACT) this gives the operator-theoretic characterisation.\n\n3. **Matrix ↔ endomorphism transport**: `Matrix.toLin' M` carries the minpoly across (`Matrix.minpoly_toLin'`, Bridge D) and lets us read the matrix-level diagonalizability statement back from the endomorphism-level iff.\n\nNo Mathlib gap is required. The remaining work for OQ-02 is purely *integrative* — assemble the three pieces into the headline matrix-level statement. The four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) decompose this integration into ~450 LOC across four iterations.",
+    "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ diagonalizable $\\Leftrightarrow$ $\\mathrm{toLin}'(M)$ semisimple + minpoly splits $\\Leftrightarrow$ minpoly $\\mathrm{toLin}'(M)$ squarefree + splits $\\Leftrightarrow$ minpoly $M$ squarefree + splits. Over $K$ alg-closed: the splits clause is automatic. Over $K$ char-0: every polynomial is separable, so squarefree is the strongest squarefree-style condition.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Module.End.IsSemisimple",
+      "Squarefree polynomial",
+      "Matrix.minpoly_toLin'",
+      "Bridge composition",
+      "Sub-OQ decomposition"
+    ],
+    "prerequisites": [
+      "Semisimplicity of endomorphisms",
+      "Cayley-Hamilton",
+      "Matrix.toLin' algebra equivalence"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-isdiagonalizable",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 100, "endLine": 108 },
+    "type": "definition",
+    "title": "Matrix.IsDiagonalizable — the Matrix-Level Predicate",
+    "content": "`Matrix.IsDiagonalizable M` is defined as `∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the existential over similarity transforms `P` whose conjugate of `M` is a diagonal matrix.\n\nDesign choices:\n\n* **Existential over `P` rather than fixed `P`**: the definition is intrinsic to the similarity class. Two diagonalizable matrices may use very different `P`s, and the predicate abstracts that out.\n* **`IsUnit P` rather than `P.Invertible` or `Nonsing`**: `IsUnit` is the Mathlib idiom for invertibility in a monoid; `Matrix.IsUnit_iff_isUnit_det` connects it to the determinant for downstream calculations.\n* **`IsDiag` rather than `Matrix.diagonal d` for some explicit `d`**: `IsDiag` is the predicate ('every off-diagonal entry is zero'), which is what callers actually need. The explicit eigenvalue-multiplicity diagonal is reconstructable from `IsDiag` + `Matrix.diag` extraction.\n* **`_root_.Matrix.IsDiagonalizable`**: the `_root_` prefix exposes the predicate at the top-level `Matrix` namespace, matching `Matrix.IsDiag` / `Matrix.IsUnit_iff_isUnit_det` etc.\n\nThis predicate corresponds at the endomorphism level to `Module.End.IsSemisimple ∧ Polynomial.Splits (algebraMap K K) (minpoly K f)` — the alg-closed condition makes the splits clause vacuous, so under `[IsAlgClosed K]` the predicate is equivalent to `IsSemisimple (toLin' M)`.",
+    "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ is diagonalizable $\\Leftrightarrow$ $\\exists P \\in \\mathrm{GL}_n(K),\\ P^{-1} M P \\in \\mathrm{Diag}_n(K)$, where $\\mathrm{Diag}_n(K) = \\{ D : \\forall i \\neq j,\\ D_{ij} = 0 \\}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matrix.IsDiag",
+      "IsUnit",
+      "Similarity",
+      "Module.End.IsSemisimple"
+    ],
+    "prerequisites": [
+      "Matrix multiplication",
+      "Group of units in a matrix ring",
+      "Existential quantifiers in Lean 4"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-headline",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 110, "endLine": 122 },
+    "type": "insight",
+    "title": "diagonalizable_iff_squarefree_minpoly — The S1 Headline (Sorry-Guarded)",
+    "content": "The S1 statement is the textbook gold form: over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. A single `sorry` at line 122 carries the proof — the four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) and the ~59 LOC ACT synthesis are designed to discharge it.\n\n**Why these specific hypotheses?**\n\n* **`[IsAlgClosed K]`**: makes `Polynomial.Splits (algebraMap K K) (minpoly K M)` automatic, so the textbook 'minpoly squarefree *and splits*' condition collapses to just 'minpoly squarefree'.\n* **`[CharZero K]`**: every polynomial is separable in char 0, so 'squarefree' and 'product of distinct irreducible factors' coincide. This is the cleanest target for the OQ-02-OQ-04 sub-OQ.\n\nThe minimum hypotheses are weaker — 'perfect field + minpoly splits in K' suffices — but the alg-closed-char-0 case is what most callers (linear-algebra texts, computer algebra systems, downstream applications) expect. The general-field form is the target of **OQ-02-OQ-03** and could be added as `diagonalizable_iff_squarefree_minpoly_general` once that sub-OQ ships.\n\n**Discharge plan (~59 LOC, picker-estimated by S7c PREP §5.1)**:\n\n| Bridge | Direction | Source | LOC |\n|---|---|---|---:|\n| A fwd | M.IsDiagonalizable → eigenbasis | S2 PREP-3 §2 | ~12 |\n| A rev | eigenbasis → M.IsDiagonalizable | S2 PREP-3 §3.2 | ~8 |\n| B fwd | IsSemisimple → ⨆ eigenspace = ⊤ | **In-tree** (this file, lines 146-155) | 0 |\n| B rev | ⨆ eigenspace = ⊤ → IsSemisimple | S5b PREP §5 + S7c §3.3 Option A | ~33 |\n| C | IsSemisimple ↔ Squarefree minpoly | **In-tree** (this file, lines 162-167) | 0 |\n| D | minpoly K (toLin' M) = minpoly K M | `Matrix.minpoly_toLin'` (Mathlib, @[simp]) | 1 |\n| Compose | iff headline | 4 bridges + finiteness | ~5 |",
+    "mathContext": "For $K$ algebraically closed of characteristic 0 and $M \\in \\mathrm{Mat}_n(K)$: $M$ is diagonalizable $\\Leftrightarrow$ $\\mathrm{minpoly}_K(M) \\in K[X]$ is squarefree.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Polynomial.Squarefree",
+      "minpoly",
+      "Diagonalizability",
+      "Algebraically closed field",
+      "Characteristic zero"
+    ],
+    "prerequisites": [
+      "Minimum polynomial of a matrix",
+      "Squarefree polynomials",
+      "Splitting field"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-sanity",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 124, "endLine": 134 },
+    "type": "theorem",
+    "title": "Sanity Helpers — of_isDiag and zero (Unconditional)",
+    "content": "Two unconditional sanity lemmas give the file a non-trivial public surface even before the headline discharge:\n\n* **`Matrix.IsDiagonalizable.of_isDiag`** (lines 126-129): any diagonal matrix is diagonalizable, witnessed by `P = 1`. Proof: `refine ⟨1, isUnit_one, ?_⟩; simpa using hM`. The `simpa` simp-set rewrites `1⁻¹ * M * 1 = M`, reducing the goal to `IsDiag M` which is the hypothesis. Note: the S7 ACT v4.26.0 patch dropped `Matrix.inv_one` from this `simpa` lemma list (now subsumed by the default simp set) and added the `Matrix.IsDiag` namespace qualification (M → Matrix.IsDiag M, since just `IsDiag` is ambiguous at v4.26.0).\n\n* **`Matrix.IsDiagonalizable.zero`** (lines 132-134): the zero matrix is diagonalizable. Proof: `Matrix.IsDiagonalizable.of_isDiag Matrix.isDiag_zero`. A one-liner combining the previous sanity helper with `Matrix.isDiag_zero` (the zero matrix is diagonal).\n\nThese helpers are not the discharge target — they exist so the file passes 'has-non-trivial-public-content' checks (e.g. for the gallery card thumbnail) and as worked examples of the `Matrix.IsDiagonalizable` predicate API.",
+    "mathContext": "(a) Any $M \\in \\mathrm{Diag}_n(K)$ is diagonalizable (take $P = I$). (b) $0 \\in \\mathrm{Mat}_n(K)$ is diagonalizable.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Matrix.isDiag_zero",
+      "isUnit_one",
+      "simpa tactic"
+    ],
+    "prerequisites": [
+      "Identity matrix",
+      "Matrix.IsDiag predicate"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-bridge-b-fwd",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 140, "endLine": 155 },
+    "type": "theorem",
+    "title": "Bridge B Forward — Phantom-Corrected 3-Lemma Chain",
+    "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`: over a finite-dimensional alg-closed-K space, if `f` is semisimple then its eigenspaces span the whole space (⨆ μ : K, f.eigenspace μ = ⊤).\n\n**Why a 3-lemma chain?** The natural-looking direct form `Module.End.IsSemisimple.iSup_eigenspace_eq_top` *does not exist in Mathlib*. S3 PREP #18481 originally claimed it as a single lemma — caught as phantom by the S4 PREP #18626 audit. The corrected route composes three steps:\n\n1. **`hss.isFinitelySemisimple`**: upgrade semisimplicity to its finitely-semisimple companion (uses `[FiniteDimensional K V]`).\n2. **`hfin.maxGenEigenspace_eq_eigenspace μ`**: under finite semisimplicity, the maximal generalized eigenspace equals the eigenspace at each `μ`. (Reverse direction taken via `.symm`.)\n3. **`Module.End.iSup_maxGenEigenspace_eq_top f`**: over alg-closed-K in finite dim, the sum of maximal generalized eigenspaces is the whole space.\n\nComposition: `iSup μ, eigenspace μ = iSup μ, maxGenEigenspace μ = ⊤`, fused by `iSup_congr`.\n\nThis is the **Bridge B forward** of the four-bridge synthesis. Combined with the (still-pending) Bridge B reverse (S5b PREP §5 + S7c §3.3 Option A) it gives the eigenspace-decomposition ↔ semisimple iff, which together with Bridge C (squarefree ↔ semisimple) and Bridges A/D (matrix↔endo) discharges the headline.",
+    "mathContext": "For $V$ finite-dim over $K$ algebraically closed and $f : V \\to V$ a $K$-linear semisimple endomorphism: $\\bigsqcup_{\\mu \\in K} \\ker(f - \\mu \\cdot \\mathrm{id}) = V$. Equivalently: $V$ admits an eigenbasis for $f$.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Module.End.IsSemisimple",
+      "Module.End.IsFinitelySemisimple",
+      "maxGenEigenspace",
+      "iSup_congr",
+      "Phantom lemma corrections"
+    ],
+    "prerequisites": [
+      "Generalized eigenspace",
+      "iSup (supremum in a complete lattice)",
+      "Algebraically closed field"
+    ]
+  },
+  {
+    "id": "ann-mcpoq02-bridge-c",
+    "proofId": "minpoly-charpoly-oq-02",
+    "range": { "startLine": 157, "endLine": 167 },
+    "type": "theorem",
+    "title": "Bridge C — IsSemisimple ↔ Squarefree minpoly",
+    "content": "**S7 ACT contribution (#19095, merged 2026-05-15)**. `Module.End.isSemisimple_iff_squarefree_minpoly`: over a finite-dimensional `K`-space, an endomorphism `f` is semisimple iff its minimal polynomial is squarefree.\n\n* **Forward**: `Module.End.IsSemisimple.minpoly_squarefree` (Mathlib, in `LinearAlgebra.Semisimple`). Directly gives `f.IsSemisimple → Squarefree (minpoly K f)`.\n* **Reverse**: `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` (Mathlib) applied to `minpoly.aeval K f`. The lemma's general form takes any polynomial `p` that's squarefree and annihilates `f` and concludes `f.IsSemisimple`; specialising `p := minpoly K f` (with `minpoly.aeval` witnessing `p.aeval f = 0`) gives the reverse direction.\n\nThis Bridge C is the **endomorphism-level iff** — the heart of OQ-02. Transporting it to the matrix level via Bridge D (`Matrix.minpoly_toLin'`) yields `IsSemisimple (toLin' M) ↔ Squarefree (minpoly K M)`, and combining with Bridges A/B yields the headline.\n\n**Note**: this iff is field-independent and characteristic-independent — `[CharZero K]` is *not* required for the iff itself. The CharZero hypothesis on the headline enters only to simplify the OQ-02-OQ-04 sub-OQ (where 'squarefree' coincides with 'separable + product of distinct linear factors over `K`').",
+    "mathContext": "For $V$ finite-dim over a field $K$ and $f \\in \\mathrm{End}_K(V)$: $f$ is semisimple $\\Leftrightarrow$ $\\mathrm{minpoly}_K(f) \\in K[X]$ is squarefree.",
+    "significance": "core",
+    "relatedConcepts": [
+      "Module.End.IsSemisimple.minpoly_squarefree",
+      "Module.End.isSemisimple_of_squarefree_aeval_eq_zero",
+      "minpoly.aeval",
+      "Polynomial.Squarefree"
+    ],
+    "prerequisites": [
+      "Minimum polynomial of an endomorphism",
+      "Squarefree polynomial predicate",
+      "Annihilating polynomial"
+    ]
+  }
+]

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -1,0 +1,320 @@
+{
+  "id": "minpoly-charpoly-oq-02",
+  "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial (S7 ACT Scaffold)",
+  "slug": "minpoly-charpoly-oq-02",
+  "description": "S1 OBSERVE → S7 ACT scaffold resolving the parent's second open question: 'Can the diagonalizability characterisation M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F) be formalized in Lean 4?' Affirmative: defines Matrix.IsDiagonalizable, states the headline iff theorem guarded by a single sorry, and ships two pre-verified endomorphism-level bridges (Bridge B forward: IsSemisimple → ⨆ eigenspace = ⊤; Bridge C: IsSemisimple ↔ Squarefree minpoly) that the eventual ACT picker will compose with matrix↔endo transport bridges to discharge the sorry.",
+  "meta": {
+    "author": "Lean Genius Research",
+    "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Semisimple.html",
+    "date": "2026",
+    "status": "formalized",
+    "proofRepoPath": "Proofs/MinpolyCharpolyOQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "diagonalizable",
+      "minimal-polynomial",
+      "characteristic-polynomial",
+      "semisimple",
+      "eigenspace",
+      "research"
+    ],
+    "badge": "research",
+    "sorries": 1,
+    "axiomCount": 0,
+    "lineCount": 169,
+    "assumptions": "0 axioms; 1 sorry guarding the proof of `diagonalizable_iff_squarefree_minpoly`. The statement itself is unconditional (hypotheses [IsAlgClosed K] [CharZero K] are explicit, not assumed-as-axiom). The two pre-shipped endomorphism-level bridges (Module.End.iSup_eigenspace_eq_top_of_isSemisimple and Module.End.isSemisimple_iff_squarefree_minpoly) are fully proved with no sorry. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 (estimated ~450 lines total) are the planned discharge route, with the picker-estimated final synthesis at ~59 LOC (~12 + 8 + 33 + 1 + 5 for Bridges A fwd + A rev + B rev + D + compose). Pinned at Mathlib v4.26.0; 18 bearer lemmas verified at SHA 2df2f015… by S7c PREP #19257.",
+    "mathlib_version": "4.26.0",
+    "dateAdded": "2026-06-04",
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "originalContributions": [
+      "Matrix.IsDiagonalizable predicate: ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P) — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits for the associated endomorphism",
+      "Module.End.iSup_eigenspace_eq_top_of_isSemisimple: the corrected 3-lemma chain (IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⊤) for alg-closed finite-dimensional spaces (Bridge B forward, shipped S7 ACT #19095 after S4 PREP #18626 caught the phantom direct-form name)",
+      "Module.End.isSemisimple_iff_squarefree_minpoly: the endomorphism-level iff (Bridge C), constructed by composing Module.End.IsSemisimple.minpoly_squarefree (forward) with Module.End.isSemisimple_of_squarefree_aeval_eq_zero applied to minpoly.aeval (reverse)",
+      "Four-sub-OQ decomposition (OQ-02-OQ-01..OQ-02-OQ-04): bridge Module.End.IsSemisimple ↔ Squarefree to matrices (~100 LOC); diagonalizable predicate + alg-closed form (~150 LOC); general-field form with explicit Splits hypothesis (~120 LOC); char-0 specialisation: minpoly automatically separable (~80 LOC); total roadmap ~450 LOC (smaller than OQ-01 / OQ-03 because Module.End.IsSemisimple absorbs most of the work)",
+      "Sanity helpers: Matrix.IsDiagonalizable.of_isDiag (any diagonal matrix is diagonalizable via P=1) and Matrix.IsDiagonalizable.zero (the zero matrix is diagonalizable, via of_isDiag and isDiag_zero) — exposing a non-trivial public surface even before the headline discharge"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Module.End.IsSemisimple",
+        "description": "Predicate: an endomorphism f is semisimple if every f-invariant submodule has an f-invariant complement",
+        "module": "Mathlib.LinearAlgebra.Semisimple"
+      },
+      {
+        "theorem": "Module.End.IsSemisimple.minpoly_squarefree",
+        "description": "Bridge C forward: semisimplicity implies the minimal polynomial is squarefree",
+        "module": "Mathlib.LinearAlgebra.Semisimple"
+      },
+      {
+        "theorem": "Module.End.isSemisimple_of_squarefree_aeval_eq_zero",
+        "description": "Bridge C reverse: if a squarefree polynomial annihilates an endomorphism, the endomorphism is semisimple. Applied to minpoly.aeval to recover the iff",
+        "module": "Mathlib.LinearAlgebra.Semisimple"
+      },
+      {
+        "theorem": "Module.End.IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace",
+        "description": "Over a finite-dimensional space, the maximal generalized eigenspace coincides with the eigenspace — required because the direct ⨆ eigenspace = ⊤ lemma was phantom (caught by S4 PREP #18626)",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Semisimple"
+      },
+      {
+        "theorem": "Module.End.iSup_maxGenEigenspace_eq_top",
+        "description": "Over an alg-closed field in finite dimensions, the sum of maximal generalized eigenspaces is the whole space. The endpoint of the Bridge B forward 3-lemma chain",
+        "module": "Mathlib.LinearAlgebra.Eigenspace.Triangularizable"
+      },
+      {
+        "theorem": "Matrix.minpoly_toLin'",
+        "description": "Bridge D: the minimal polynomial of a matrix equals the minimal polynomial of its toLin' endomorphism. Transports the squarefree property across the matrix↔endo correspondence",
+        "module": "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly"
+      },
+      {
+        "theorem": "Matrix.IsDiag",
+        "description": "Predicate that a matrix is diagonal (off-diagonal entries are zero). The codomain of the similarity-transform existential in Matrix.IsDiagonalizable",
+        "module": "Mathlib.LinearAlgebra.Matrix.IsDiag"
+      },
+      {
+        "theorem": "Polynomial.Squarefree",
+        "description": "A polynomial p is squarefree if any q² ∣ p forces q to be a unit. Equivalent (over a field) to no repeated irreducible factors",
+        "module": "Mathlib.Algebra.Polynomial.Squarefree (renamed in v4.26.0)"
+      }
+    ],
+    "prerequisites": [
+      "MinpolyCharpoly: parent file with 17 theorems on minpoly | charpoly",
+      "Module.End.IsSemisimple (Mathlib v4.26.0)",
+      "Eigenspace / generalized eigenspace theory (Mathlib.LinearAlgebra.Eigenspace.*)",
+      "Polynomial.Squarefree predicate",
+      "Matrix ↔ endomorphism transport via Matrix.toLin'"
+    ]
+  },
+  "overview": {
+    "historicalContext": "The characterisation of diagonalizable matrices via their minimal polynomial is a textbook result (Hoffman-Kunze §6.4, Hungerford §VII.4, Lang §XIV.3): a matrix M over a field F is diagonalizable iff minpoly(M) splits in F and has only simple roots — equivalently, iff minpoly(M) is squarefree and splits. Over algebraically closed fields the 'splits' condition is automatic, so the statement reduces to 'diagonalizable iff minpoly squarefree'. The result generalises the analogous statement for unitary / normal operators on Hilbert spaces and is the operator-theoretic precursor to the spectral theorem. In modern presentations the result is typically derived from the structural fact that semisimple endomorphisms (those whose every invariant subspace has an invariant complement) coincide with those whose minimal polynomial is squarefree (Bourbaki, Algèbre, ch. VIII).",
+    "problemStatement": "**Open Question (minpoly-charpoly-oq-02)**: Can the diagonalizability characterisation `M ∈ Matₙ(F) diagonalizable ⇔ minpoly M ∈ F[X] is squarefree (and splits in F)` be formalized in Lean 4 using the parent's minpoly | charpoly infrastructure? — `conclusion.openQuestions[1]` of the parent gallery entry `minpoly-charpoly`. Sibling open questions: OQ-01 (Jordan normal form) and OQ-03 (rational canonical form).",
+    "text": "**Resolution (S1 OBSERVE): YES.** Mathlib's `Module.End.IsSemisimple` API provides the endomorphism-level squarefree↔semisimple equivalence directly. Combined with the eigenspace-decomposition theorem over alg-closed fields and the matrix↔endo transport (Matrix.minpoly_toLin'), the matrix-level iff requires only integrative work — no Mathlib gap. The S7 ACT iteration shipped two of the four required bridges (B forward and C); the remaining ~59 LOC synthesis is the discharge target for a future S8 ACT.",
+    "proofStrategy": "**S1 → S7 ACT scaffold**: define `Matrix.IsDiagonalizable`, state the headline iff with explicit hypotheses [IsAlgClosed K] [CharZero K], and ship two pre-verified bridges (B forward via the 3-lemma chain, C iff via mp-mpr composition). Sanity lemmas `of_isDiag` and `zero` give a non-trivial public surface.\n\n**S8+ ACT (planned, ~59 LOC)**: discharge the headline sorry via four bridges:\n\n1. **Bridge A** (matrix ↔ endomorphism eigenbasis transport, ~20 LOC): identify M.IsDiagonalizable with toLin' M having an eigenbasis.\n2. **Bridge B reverse** (⨆ eigenspace = ⊤ → IsSemisimple, ~33 LOC): explicit construction using S5b PREP §5 body and S7c PREP §3.3 Option A (`let q := (S \\ {μ}).prod fun ν ↦ X - C ν`).\n3. **Bridge D** (Matrix.minpoly_toLin', 1 LOC): transport squarefree across matrix↔endo.\n4. **Compose** (~5 LOC): assemble the four-way iff using bridges A both directions, B forward (in-tree), B reverse, C (in-tree), D.\n\n**Future sub-OQs** (~450 LOC roadmap):\n- OQ-02-OQ-01 (~100 LOC): bridge Module.End.IsSemisimple ↔ Squarefree to matrices uniformly.\n- OQ-02-OQ-02 (~150 LOC): diagonalizable predicate variants + alg-closed unconditional form.\n- OQ-02-OQ-03 (~120 LOC): general-field form with explicit Polynomial.Splits hypothesis.\n- OQ-02-OQ-04 (~80 LOC): char-0 specialisation: minpoly is automatically separable, so the squarefree side simplifies.",
+    "keyInsights": [
+      "**No Mathlib gap**: Mathlib's `Module.End.IsSemisimple` API (in `Mathlib.LinearAlgebra.Semisimple`) already provides the squarefree↔semisimple iff at the endomorphism level. The remaining work is integrative — matrix↔endomorphism transport plus the eigenspace-decomposition step.",
+      "**Bridge B forward is a 3-lemma chain, not a single lemma**: the natural-looking direct form `Module.End.IsSemisimple.iSup_eigenspace_eq_top` does not exist in Mathlib (phantom caught by S4 PREP #18626). The correct path is `IsSemisimple.isFinitelySemisimple → IsFinitelySemisimple.maxGenEigenspace_eq_eigenspace μ → iSup_maxGenEigenspace_eq_top`, composed via `iSup_congr`. This is now shipped in-tree as `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`.",
+      "**Char-0 simplifies the squarefree condition**: over a characteristic-0 field, every polynomial is separable, so 'squarefree' (the statement-level condition) coincides with 'product of distinct linear factors' over the algebraic closure. The OQ-02-OQ-04 sub-OQ exploits this to reduce the char-0 form to the explicit eigenvalue-multiplicity statement.",
+      "**Why the alg-closed hypothesis matters at the matrix level but not the endomorphism level**: the endomorphism iff `IsSemisimple ↔ Squarefree minpoly` holds over any field. To upgrade 'semisimple' to 'diagonalizable' at the matrix level requires that the minimal polynomial actually splits — automatic over alg-closed fields, but otherwise an explicit `Polynomial.Splits (algebraMap K K) (minpoly K M)` hypothesis is needed. This split is the substance of OQ-02-OQ-03.",
+      "**Sub-OQ decomposition is asymmetric**: OQ-02's ~450 LOC roadmap is smaller than OQ-01 (JNF, generalized eigenspaces) and OQ-03 (RCF, ~900 LOC via PID structure theorem) precisely because the squarefree-minpoly route avoids the full invariant-factor decomposition. The price is that OQ-02 only handles the *diagonalizable* case — non-diagonalizable matrices still need JNF (OQ-01) or RCF (OQ-03).",
+      "**Headline statement vs gold form**: the S1 statement uses `[IsAlgClosed K] [CharZero K]` (the textbook gold form). The minimum hypotheses are weaker — `perfect field + minpoly splits in K` suffices — but the alg-closed-char-0 case is what most callers expect. The general-field form is the target of OQ-02-OQ-03 and could be added as `diagonalizable_iff_squarefree_minpoly_general` once OQ-02-OQ-03 ships."
+    ],
+    "prerequisites": [
+      "Linear algebra: matrices, similarity transforms, minpoly, charpoly",
+      "Module-endomorphism semisimplicity (Module.End.IsSemisimple)",
+      "Eigenspace and generalized eigenspace theory",
+      "Polynomial squarefree-ness; separable polynomials in char 0",
+      "Lean 4 typeclass system (IsAlgClosed, CharZero, Field)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports",
+      "title": "§0: Imports — Eigenspace and Semisimple Infrastructure",
+      "startLine": 1,
+      "endLine": 10,
+      "summary": "Ten imports covering minpoly / charpoly (parent MinpolyCharpoly + Mathlib's Matrix.Charpoly.Basic/Minpoly), the diagonal-matrix predicate (Matrix.IsDiag), semisimplicity and eigenspace theory (LinearAlgebra.Semisimple + Eigenspace.Semisimple + Eigenspace.Triangularizable), finitely-generated-module utilities (FreeModule.Finite.Matrix), and algebraically closed fields (FieldTheory.IsAlgClosed.Basic). The S7 ACT v4.26.0 import regression fix replaced the removed Mathlib.Algebra.Polynomial.Squarefree with the eigenspace+IsDiag imports — silently masked by 7 doc-only PREPs before being caught.",
+      "mathContext": "Toolkit: Module.End.IsSemisimple, Matrix.IsDiag, eigenspace/maxGenEigenspace, Matrix.minpoly_toLin'. Imports `Proofs.MinpolyCharpoly` for the 17-theorem parent layer."
+    },
+    {
+      "id": "intro-docstring",
+      "title": "§1: Open Question, Resolution, and Sub-OQ Decomposition",
+      "startLine": 11,
+      "endLine": 92,
+      "summary": "Top-level docstring stating OQ-02 (formalize diagonalizable ⇔ squarefree minpoly), the affirmative S1 OBSERVE resolution (no Mathlib gap — Module.End.IsSemisimple API absorbs most of the work), and a four-sub-OQ decomposition (OQ-02-OQ-01 bridge to matrices ~100 LOC; OQ-02-OQ-02 diagonalizable predicate + alg-closed form ~150 LOC; OQ-02-OQ-03 general-field form with Splits hypothesis ~120 LOC; OQ-02-OQ-04 char-0 specialisation ~80 LOC). Total roadmap ≈ 450 LOC — smaller than OQ-01 / OQ-03 because Module.End.IsSemisimple does the heavy lifting.",
+      "mathContext": "OQ-02: 'M diagonalizable ⇔ minpoly M squarefree (and splits)'. Resolution: YES via three pieces — (1) Module.End.IsSemisimple ↔ Squarefree minpoly (Mathlib in-tree), (2) IsSemisimple + splits → eigenspace decomposition = ⊤, (3) Matrix.toLin' + Matrix.minpoly_toLin' for matrix↔endo transport."
+    },
+    {
+      "id": "matrix-isdiagonalizable",
+      "title": "§2: Matrix.IsDiagonalizable — Predicate Definition",
+      "startLine": 100,
+      "endLine": 108,
+      "summary": "Defines `Matrix.IsDiagonalizable M : Prop := ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P)` — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits. Sealed at S1; no structural changes since (S7 ACT only fixed the `IsDiag` namespace qualification). The existential over similarity transforms `P` reads the iff back from endomorphism language into matrix language.",
+      "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ is diagonalizable $\\Leftrightarrow$ $\\exists P \\in \\mathrm{GL}_n(K),\\ P^{-1} M P$ is diagonal."
+    },
+    {
+      "id": "main-theorem",
+      "title": "§3: diagonalizable_iff_squarefree_minpoly — Headline Sorry",
+      "startLine": 110,
+      "endLine": 122,
+      "summary": "**The S1 headline theorem (statement only, single sorry at line 122).** Over `[IsAlgClosed K] [CharZero K]`, a matrix M is diagonalizable iff its minimal polynomial is squarefree. The four sub-OQs (OQ-02-OQ-01..OQ-02-OQ-04) are designed to discharge the sorry. The docstring notes the hypothesis can be weakened to 'perfect field + minpoly splits', but alg-closed-char-0 is the textbook gold form expected by most callers.",
+      "mathContext": "$M \\in \\mathrm{Mat}_n(K)$ over $K$ algebraically closed of char 0: $M$ is diagonalizable $\\Leftrightarrow$ $\\mathrm{minpoly}_K(M) \\in K[X]$ is squarefree."
+    },
+    {
+      "id": "sanity-lemmas",
+      "title": "§4: Sanity Lemmas — of_isDiag and zero",
+      "startLine": 124,
+      "endLine": 134,
+      "summary": "Two unconditional sanity helpers: `Matrix.IsDiagonalizable.of_isDiag` (any diagonal matrix is diagonalizable, witnessed by P = 1 and `simpa`) and `Matrix.IsDiagonalizable.zero` (the zero matrix is diagonalizable, derived from of_isDiag and `Matrix.isDiag_zero`). These give the file a non-trivial public surface before the headline discharge.",
+      "mathContext": "If $\\mathrm{IsDiag}(M)$ then $M$ is diagonalizable (take $P = I$). In particular $0 \\in \\mathrm{Mat}_n(K)$ is diagonalizable."
+    },
+    {
+      "id": "bridge-b-forward",
+      "title": "§5: Bridge B Forward — IsSemisimple → ⨆ eigenspace = ⊤",
+      "startLine": 136,
+      "endLine": 155,
+      "summary": "**S7 ACT contribution (#19095, merged 2026-05-15).** `Module.End.iSup_eigenspace_eq_top_of_isSemisimple`: over an alg-closed field in finite dimensions, semisimplicity implies the eigenspaces span the whole space. Proved by a 3-lemma chain via `iSup_congr`: IsSemisimple → IsFinitelySemisimple → maxGenEigenspace μ = eigenspace μ → ⨆ eigenspace = ⨆ maxGenEigenspace = ⊤. The direct-form lemma `Module.End.IsSemisimple.iSup_eigenspace_eq_top` does not exist (phantom caught by S4 PREP #18626) — this composite is the corrected path.",
+      "mathContext": "For $V$ finite-dim over alg-closed $K$ and $f \\in \\mathrm{End}_K(V)$: if $f$ is semisimple then $\\bigsqcup_{\\mu \\in K} \\ker(f - \\mu) = V$. Chain: $f.\\mathrm{IsSemisimple} \\to f.\\mathrm{IsFinitelySemisimple} \\to (\\forall \\mu,\\ \\mathrm{eigenspace}\\ \\mu = \\mathrm{maxGenEigenspace}\\ \\mu) \\to \\bigsqcup \\mathrm{maxGenEigenspace} = \\top$."
+    },
+    {
+      "id": "bridge-c-iff",
+      "title": "§6: Bridge C — IsSemisimple ↔ Squarefree minpoly",
+      "startLine": 157,
+      "endLine": 167,
+      "summary": "**S7 ACT contribution (#19095, merged 2026-05-15).** `Module.End.isSemisimple_iff_squarefree_minpoly`: over a finite-dimensional space, an endomorphism is semisimple iff its minimal polynomial is squarefree. Forward direction: `Module.End.IsSemisimple.minpoly_squarefree` (Mathlib). Reverse direction: `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applied to `minpoly.aeval` (so that the squarefree polynomial annihilating f is precisely the minpoly). This is the endomorphism-level iff that the matrix-level discharge will transport via Bridge D (Matrix.minpoly_toLin').",
+      "mathContext": "For $V$ finite-dim over field $K$ and $f \\in \\mathrm{End}_K(V)$: $f$ is semisimple $\\Leftrightarrow \\mathrm{minpoly}_K(f) \\in K[X]$ is squarefree."
+    }
+  ],
+  "conclusion": {
+    "summary": "S1 OBSERVE → S7 ACT scaffold for the diagonalizable-iff-squarefree-minpoly characterisation. Defines `Matrix.IsDiagonalizable`, states the headline iff (sorry-guarded over [IsAlgClosed K] [CharZero K]), and ships two pre-verified endomorphism-level bridges (B forward and C iff) plus two unconditional sanity helpers. The remaining ~59 LOC discharge is decomposed into four sub-OQs (~450 LOC roadmap), with all 18 required bearer lemmas pin-verified at Mathlib v4.26.0 SHA 2df2f015… by S7c PREP #19257.",
+    "implications": "Discharging OQ-02 completes the matrix-level diagonalisability characterisation in Lean 4, sibling to OQ-01 (JNF) and OQ-03 (RCF). Together with the parent's 17 minpoly | charpoly theorems, this gives a complete formal toolkit for matrix similarity questions over algebraically closed fields. Practical applications include automated detection of diagonalizability in symbolic computation, formalised spectral analysis, and the operator-theoretic precursor to the spectral theorem on inner-product spaces.",
+    "openQuestions": [
+      "**OQ-02-OQ-01** (~100 LOC): Bridge `Module.End.IsSemisimple ↔ Squarefree (minpoly K f)` from endomorphism to matrix level, transporting via `Matrix.toLin'` and `Matrix.minpoly_toLin'`.",
+      "**OQ-02-OQ-02** (~150 LOC): Discharge the headline `diagonalizable_iff_squarefree_minpoly` over `[IsAlgClosed K]` (without CharZero), assembling Bridges A both directions + B both directions + C + D.",
+      "**OQ-02-OQ-03** (~120 LOC): Generalize to arbitrary fields with explicit `Polynomial.Splits (algebraMap K K) (minpoly K M)` hypothesis — the textbook 'splits + squarefree' form.",
+      "**OQ-02-OQ-04** (~80 LOC): In char-0 specialise: minpoly is automatically separable, so squarefree ⇔ has distinct irreducible factors. Yields a streamlined statement for the most common practical case.",
+      "**Bridge B reverse**: ship as a standalone in-tree lemma (the S5b PREP §5 + S7c §3.3 Option A body), so future picks of OQ-02-OQ-02 can skip the ~33 LOC paste."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Basic",
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.LinearAlgebra.Matrix.IsDiag",
+      "Mathlib.LinearAlgebra.Semisimple",
+      "Mathlib.LinearAlgebra.Eigenspace.Semisimple",
+      "Mathlib.LinearAlgebra.Eigenspace.Triangularizable",
+      "Mathlib.LinearAlgebra.FreeModule.Finite.Matrix",
+      "Mathlib.FieldTheory.IsAlgClosed.Basic",
+      "Mathlib.Tactic",
+      "Proofs.MinpolyCharpoly"
+    ],
+    "opens": [
+      "Matrix",
+      "Polynomial"
+    ],
+    "namespace": "Proofs.MinpolyCharpolyOQ02",
+    "lineCount": 169,
+    "axiomCount": 0,
+    "theoremCount": 5,
+    "definitionCount": 1,
+    "path": "Proofs/MinpolyCharpolyOQ02.lean",
+    "sorries": 1
+  },
+  "crossReferences": [
+    {
+      "targetId": "minpoly-charpoly",
+      "relationship": "parent",
+      "description": "Parent entry establishing the minpoly | charpoly relationship via 17 theorems. This OQ-02 entry resolves the second of three open questions enumerated at the end of the parent's `conclusion.openQuestions`."
+    },
+    {
+      "targetId": "minpoly-charpoly-oq-03",
+      "relationship": "sibling",
+      "description": "Sibling sub-OQ: rational canonical form via invariant-factor chains. OQ-03 (~900 LOC roadmap) is the field-independent canonical form covering both diagonalizable and non-diagonalizable matrices; OQ-02 (~450 LOC roadmap) is the smaller specialisation handling only the diagonalizable case but with a cleaner squarefree-minpoly criterion."
+    },
+    {
+      "targetId": "cayley-hamilton",
+      "relationship": "depends-on",
+      "description": "Cayley-Hamilton (charpoly(M)(M) = 0) ensures minpoly(M) divides charpoly(M) and is therefore non-trivial — a precondition for the squarefree characterisation to make sense (the zero polynomial is not squarefree)."
+    },
+    {
+      "targetId": "cayley-hamilton-cyclic-vector-all-fields",
+      "relationship": "related",
+      "description": "Cyclic-vector theory: when M has a cyclic vector, minpoly(M) = charpoly(M) and the matrix is non-derogatory. Such matrices are diagonalizable iff their charpoly is squarefree — a special case of OQ-02 where the squarefree condition transports through the equality."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "diagonalizable_iff_squarefree_minpoly",
+      "type": "core",
+      "statement": "∀ {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n] [IsAlgClosed K] [CharZero K] (M : Matrix n n K), M.IsDiagonalizable ↔ Squarefree (minpoly K M)",
+      "description": "Headline theorem (S1 statement, sorry-guarded at line 122). Over an algebraically closed field of characteristic zero, a matrix is diagonalizable iff its minimal polynomial is squarefree. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 are designed to discharge the sorry via composition of Bridges A (matrix↔endo), B (semisimple↔eigenspace-decomp), C (semisimple↔squarefree, in-tree), and D (matrix↔endo minpoly transport).",
+      "significance": "The textbook operator-theoretic characterisation of diagonalisability via minpoly"
+    },
+    {
+      "name": "Module.End.iSup_eigenspace_eq_top_of_isSemisimple",
+      "type": "supporting",
+      "statement": "∀ {K : Type*} [Field K] [IsAlgClosed K] {V : Type*} [AddCommGroup V] [Module K V] [FiniteDimensional K V] {f : Module.End K V}, f.IsSemisimple → ⨆ μ : K, f.eigenspace μ = ⊤",
+      "description": "**Bridge B forward** (S7 ACT contribution). Over an alg-closed field in finite dimensions, semisimplicity implies the eigenspaces span the whole space. Constructed as a 3-lemma chain because the direct form is phantom in Mathlib (caught by S4 PREP #18626).",
+      "significance": "The Bridge B forward used to convert semisimplicity into the eigenspace-decomposition that yields a diagonal similarity transform"
+    },
+    {
+      "name": "Module.End.isSemisimple_iff_squarefree_minpoly",
+      "type": "supporting",
+      "statement": "∀ {K : Type*} [Field K] {V : Type*} [AddCommGroup V] [Module K V] [FiniteDimensional K V] {f : Module.End K V}, f.IsSemisimple ↔ Squarefree (minpoly K f)",
+      "description": "**Bridge C iff** (S7 ACT contribution). Over a finite-dimensional space, an endomorphism is semisimple iff its minimal polynomial is squarefree. Forward via Mathlib's `Module.End.IsSemisimple.minpoly_squarefree`; reverse via `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` applied to `minpoly.aeval`.",
+      "significance": "The endomorphism-level iff transported via Bridge D into the matrix-level headline"
+    },
+    {
+      "name": "Matrix.IsDiagonalizable.of_isDiag",
+      "type": "supporting",
+      "statement": "∀ {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n] {M : Matrix n n K}, Matrix.IsDiag M → M.IsDiagonalizable",
+      "description": "Sanity helper (unconditional, proven). Any diagonal matrix is diagonalizable — take P = 1.",
+      "significance": "Non-trivial public surface before the headline discharge"
+    },
+    {
+      "name": "Matrix.IsDiagonalizable.zero",
+      "type": "supporting",
+      "statement": "∀ {K : Type*} [Field K] {n : Type*} [Fintype n] [DecidableEq n], (0 : Matrix n n K).IsDiagonalizable",
+      "description": "Sanity helper (unconditional, proven). The zero matrix is diagonalizable, derived from `of_isDiag` and `Matrix.isDiag_zero`.",
+      "significance": "Concrete instance of the diagonalizable predicate"
+    }
+  ],
+  "sorries": 1,
+  "references": [
+    {
+      "authors": [
+        "Hoffman, Kenneth",
+        "Kunze, Ray"
+      ],
+      "year": 1971,
+      "title": "Linear Algebra",
+      "venue": "Prentice-Hall, 2nd edition, §6.4 (Diagonalization)",
+      "note": "Classical textbook treatment of the diagonalizable-iff-minpoly-squarefree-and-splits characterisation."
+    },
+    {
+      "authors": [
+        "Hungerford, Thomas W."
+      ],
+      "year": 1974,
+      "title": "Algebra",
+      "venue": "Graduate Texts in Mathematics 73, Springer-Verlag, §VII.4",
+      "note": "Graduate-level treatment of the spectral / canonical-form theory containing the diagonalizability characterisation as a corollary."
+    },
+    {
+      "authors": [
+        "Lang, Serge"
+      ],
+      "year": 2002,
+      "title": "Algebra",
+      "venue": "Graduate Texts in Mathematics 211, Springer-Verlag, §XIV.3",
+      "note": "Reference for the structural form: semisimple endomorphisms over a field with squarefree minimal polynomial coincide with those admitting an eigenspace decomposition."
+    },
+    {
+      "authors": [
+        "Bourbaki, Nicolas"
+      ],
+      "year": 2012,
+      "title": "Algèbre, Chapitre 8: Modules et anneaux semi-simples",
+      "venue": "Springer-Verlag, 2nd edition",
+      "note": "Original reference for the semisimple / squarefree-minpoly structural correspondence at the level of modules and rings."
+    },
+    {
+      "authors": [
+        "The mathlib Community"
+      ],
+      "year": 2024,
+      "title": "Mathlib4: Module.End.IsSemisimple",
+      "venue": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/LinearAlgebra/Semisimple.html",
+      "note": "Source of `Module.End.IsSemisimple.minpoly_squarefree` and `Module.End.isSemisimple_of_squarefree_aeval_eq_zero` — the two Mathlib lemmas composed into Bridge C iff."
+    },
+    {
+      "authors": [
+        "Wikipedia"
+      ],
+      "year": 2025,
+      "title": "Diagonalizable matrix",
+      "venue": "https://en.wikipedia.org/wiki/Diagonalizable_matrix",
+      "note": "General-audience overview of the diagonalizability characterisation via minimal polynomial."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

The Lean file `proofs/Proofs/MinpolyCharpolyOQ02.lean` (169 LOC, 1 sorry, 0 axioms) has been in-tree since S1 OBSERVE PR #18276 (2026-05-12) and got its last code update in S7 ACT PR #19095 (2026-05-15) — but **has no gallery entry** at `src/data/proofs/minpoly-charpoly-oq-02/`, leaving the work invisible on the website. Sibling OQ-03 has had a gallery entry since 2026-05-12; this PR closes the gap for OQ-02.

- New `src/data/proofs/minpoly-charpoly-oq-02/meta.json` (~17 KB): full gallery metadata matching the `minpoly-charpoly-oq-03` schema — description, status, `originalContributions` (5 items), `mathlibDependencies` (8 items), historical context (Hoffman-Kunze, Hungerford, Lang, Bourbaki), `keyInsights` (6), 7 sections matching the file structure, 5 `mainTheorems`, 4 `crossReferences` (parent, sibling, dependencies), 6 references.
- New `src/data/proofs/minpoly-charpoly-oq-02/annotations.json` (~13 KB, 7 annotations): imports, S1 resolution, `Matrix.IsDiagonalizable` def, headline sorry + discharge ledger, sanity helpers, Bridge B forward (phantom-corrected 3-lemma chain), Bridge C iff.

## Scope

- **0 Lean file changes** — purely a gallery-side documentation contribution.
- **0 sorries / 0 axioms** delta to the proof itself.
- Two new files only (no edits to existing files).
- `meta.json` and `annotations.json` validated via `node -e \"JSON.parse(...)\"`.
- Schema follows the existing `minpoly-charpoly-oq-03` entry pattern exactly.

## Why this is research-shaped, not just decorative

This OQ has an unusually rich PREP history — 7 doc-only PREPs (S2..S7c) spanning 2026-05-12 to 2026-05-15 produced an 18-bearer Mathlib v4.26.0 pin-verification ledger at SHA `2df2f015…` and caught **3 phantom-bearer claims + 1 latent `ring`-bridge bug**:

1. PHANTOM `Module.End.IsSemisimple.iSup_eigenspace_eq_top` (S3 PREP #18481) — corrected to the 3-lemma chain by S4 PREP #18626 and shipped in-tree as `Module.End.iSup_eigenspace_eq_top_of_isSemisimple` by S7 ACT #19095.
2. PHANTOM `Polynomial.squarefree_prod_X_sub_C` (S5 PREP #18680) — corrected by S5b PREP #18715.
3. INFORMAL `f.eigenvalues.toFinset` (S5 PREP #18680) — corrected to `f.finite_hasEigenvalue.toFinset` by S5b PREP #18715.
4. LATENT `Finset.erase` vs `S \\ {μ}` `ring`-bridge bug — caught by S7c PREP #19257 §3.3 (Option A: `let q := (S \\ {μ}).prod fun ν ↦ X - C ν`).

Documenting the resulting scaffold in the gallery surfaces this work — the phantom-corrected 3-lemma chain, the sub-OQ decomposition, the ~59-LOC discharge ledger — to a wider audience than the `research/problems/minpoly-charpoly-oq-02/` notes reach. It also makes the OQ-02 entry navigable from the parent's `openQuestions[1]` cross-reference (currently a dead anchor since the gallery dir didn't exist).

## Test plan

- [x] `node -e \"JSON.parse(...)\"` confirms both files parse
- [x] `meta.json` counts (`axiomCount: 0`, `sorries: 1`, `theoremCount: 5`, `definitionCount: 1`, `lineCount: 169`) match the actual Lean file
- [x] Section ranges (1-10, 11-92, 100-108, 110-122, 124-134, 136-155, 157-167) match the file structure verified by `grep -n '^theorem\\|^lemma\\|^def' MinpolyCharpolyOQ02.lean`
- [x] All `mathlibDependencies.theorem` names and `mainTheorems.statement` signatures correspond to declarations actually present in the Lean file or in Mathlib v4.26.0 at the pinned SHA
- [ ] Gallery renders with the new entry visible under the `minpoly-charpoly` parent's children

🤖 Generated with [Claude Code](https://claude.com/claude-code)