### PR TITLE
research(erdos-szekeres-oq-01): OBSERVE→ORIENT — 7-step Seidenberg decomposition

### DIFF
--- a/src/data/research/problems/erdos-szekeres-oq-01.json
+++ b/src/data/research/problems/erdos-szekeres-oq-01.json
@@ -28,37 +28,46 @@
     "goal": "Replace or reduce the axiomatized existence proof by formalizing the pigeonhole argument on distinct subsequence-length pairs."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-05T19:30:46-07:00",
-    "iteration": 1,
-    "focus": "Orient around the explicit pair-tracking pigeonhole proof.",
+    "phase": "ORIENT",
+    "since": "2026-06-04T19:30:00-07:00",
+    "iteration": 2,
+    "focus": "Decompose the Seidenberg pigeonhole proof into concrete Lean substeps and commit to a definition of maxIncLen/maxDecLen using Nat.findGreatest over HasIncreasingEndingAt/HasDecreasingEndingAt.",
     "blockers": [],
-    "nextAction": "Read the parent Erdos-Szekeres metadata and Lean source, then survey Mathlib subsequence and Finset pigeonhole support before deciding whether custom pair-tracking infrastructure is needed.",
+    "nextAction": "ACT iteration: introduce `maxIncLen f i` and `maxDecLen f i` as `Nat.findGreatest` over the existing `HasIncreasingEndingAt`/`HasDecreasingEndingAt` predicates (capped by `i.val + 1`), prove `1 ≤ maxIncLen f i` and `1 ≤ maxDecLen f i`, and verify the file builds before tackling the injectivity lemma.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "Selected for first exploration. No proof attempt has been made yet; the evidence identifies the intended route as the standard pigeonhole argument on pairs of longest increasing and decreasing subsequence lengths ending at each position.",
+    "progressSummary": "OBSERVE→ORIENT (researcher-6 2026-06-04 S1): inventoried ErdosSzekeres.lean — 2 axioms (erdos_szekeres_existence_axiom + erdos_szekeres_tight_axiom), 8 theorems, 6 definitions including unused HasIncreasingEndingAt/HasDecreasingEndingAt scaffolding (lines 96–109). Confirmed Mathlib's pair-tracking Erdős–Szekeres proof lives in Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean (the Wiedijk #73 archive file), which is NOT importable from a standard Mathlib downstream project — so we cannot delegate via `import`. The gallery proof must be built from primitives: Finset.exists_ne_map_eq_of_card_lt_of_mem (already in references.mathlib), Finset.card_product, Nat.findGreatest, plus the existing HasIncreasingEndingAt/HasDecreasingEndingAt predicates. Decomposed the Seidenberg pigeonhole into 7 concrete substeps suitable for 3–5 ACT iterations.",
     "builtItems": [],
     "insights": [
       "The target proof strategy assigns each index i a pair (a_i, b_i), where a_i is the longest increasing subsequence length ending at i and b_i is the longest decreasing subsequence length ending at i.",
       "If no increasing subsequence of length r and no decreasing subsequence of length s exists, all pairs should lie in a grid of size (r-1)(s-1).",
       "The key formal burden is proving the position-to-pair map is injective by showing that comparable positions with unequal values extend one of the two subsequence lengths.",
-      "Mathlib Finset and List/Sublist infrastructure are likely relevant, but the selection report leaves open whether existing lemmas are enough."
+      "Mathlib Finset and List/Sublist infrastructure are likely relevant, but the selection report leaves open whether existing lemmas are enough.",
+      "OBSERVE S1 (researcher-6 2026-06-04): Mathlib's pair-tracking proof of Erdős–Szekeres lives in `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean` (Wiedijk #73). The Archive folder is a Mathlib-internal target and is NOT exposed to downstream projects via the standard `import Mathlib` route — so reusing it would require either depending on the Mathlib monorepo at the Archive target or re-deriving the proof. The latter is the appropriate path for a gallery proof.",
+      "OBSERVE S1: The existing file already contains the right scaffolding predicates: `HasIncreasingEndingAt f i len` and `HasDecreasingEndingAt f i len` (lines 96–109). They are currently unused but provide exactly the right shape for defining `maxIncLen`/`maxDecLen` via `Nat.findGreatest` (which is already in Mathlib.Data.Nat.Find).",
+      "OBSERVE S1: The cleanest definition is `maxIncLen f i := Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)`. The upper bound `i.val + 1` is because any subsequence ending at position `i` uses positions in `Fin (i.val + 1)`, so its length is at most `i.val + 1`.",
+      "OBSERVE S1: The 7-step Seidenberg decomposition: (1) define `maxIncLen`/`maxDecLen` via Nat.findGreatest; (2) prove `1 ≤ maxIncLen f i` via the singleton subsequence `fun _ => i`; (3) prove the key extension lemma: if `i < j` and `f i < f j`, then any inc-subseq of length k ending at i extends to one of length k+1 ending at j, hence `maxIncLen f j ≥ maxIncLen f i + 1`; (4) symmetric statement for decreasing; (5) prove pair injectivity from trichotomy (f i ≠ f j by injectivity, so either f i < f j or f i > f j strictly increases one coordinate); (6) bound the pair under non-existence hypotheses: `maxIncLen f i ≤ r - 1` and `maxDecLen f i ≤ s - 1`; (7) apply Finset.exists_ne_map_eq_of_card_lt_of_mem with grid `Finset.range (r-1) ×ˢ Finset.range (s-1)` of size `(r-1)*(s-1) < n` to derive a contradiction.",
+      "OBSERVE S1: The HasIncreasingEndingAt definition has a subtle issue — the disjunction `k j < i ∨ (j = Fin.last (len - 1) ∧ k j = i)` is awkward when `len = 0`. For `len ≥ 1` it correctly says all positions are `< i` except the last, which equals `i`. The singleton case (`len = 1`) reduces to `k 0 = i` since `Fin.last 0 = 0`. This should be reviewed when proving the singleton lemma — may want to switch to a cleaner formulation like `k (Fin.last (len-1)) = i ∧ ∀ j < Fin.last (len-1), k j < i`.",
+      "OBSERVE S1: The tightness axiom `erdos_szekeres_tight_axiom` is INDEPENDENT of this OQ — that's a construction problem (build a concrete sequence), not the pair-tracking existence proof. This problem's scope is the existence axiom only. The tightness axiom is a separate research target."
     ],
     "mathlibGaps": [
-      "Need to check whether Mathlib already has a suitable monotone-subsequence theorem or only lower-level Finset/List tools.",
-      "Need to check whether existing pigeonhole lemmas line up with the desired finite grid of length pairs."
+      "Mathlib's pair-tracking Erdős–Szekeres proof exists at `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean` but is NOT in the importable library — Archive targets are not re-exported. Confirmed by inspection: lake-manifest.json pins Mathlib v4.26.0, which separates Archive from the importable library.",
+      "Mathlib does provide all the pigeonhole primitives we need: `Finset.exists_ne_map_eq_of_card_lt_of_mem` (already imported in the gallery file via `Mathlib.Data.Finset.Card`), `Finset.card_product` (via `Mathlib.Data.Finset.Prod`), and `Nat.findGreatest` (via `Mathlib.Tactic` which transitively includes `Mathlib.Data.Nat.Find`).",
+      "No gap on subsequence infrastructure — the existing `HasIncreasingEndingAt`/`HasDecreasingEndingAt` predicates and the `IncreasingSubseq`/`DecreasingSubseq` structures are sufficient. No new foundational definitions are needed."
     ],
     "nextSteps": [
-      "Inspect src/data/proofs/erdos-szekeres/meta.json and Proofs/ErdosSzekeres.lean to locate the two axioms and the existing scaffolding definitions.",
-      "Survey Mathlib for List.Sublist, Finset pigeonhole lemmas, and monotone subsequence support.",
-      "Decide whether to use existing Mathlib subsequence infrastructure directly or introduce custom definitions for longest subsequences ending at an index."
+      "ACT iteration 1 (next session): Add `noncomputable def maxIncLen` and `noncomputable def maxDecLen` to ErdosSzekeres.lean using `Nat.findGreatest` over the existing `HasIncreasingEndingAt`/`HasDecreasingEndingAt` predicates capped by `i.val + 1`. Prove `1 ≤ maxIncLen f i` and `1 ≤ maxDecLen f i` via the singleton subsequence witness. Verify with Docker build before committing. Target: +30–50 lines, 0 new sorries, 0 new axioms, axiom count unchanged at 2.",
+      "ACT iteration 2: Prove the key extension lemma `maxIncLen_strict_mono`: for `i < j : Fin n` with `f i < f j`, `maxIncLen f j ≥ maxIncLen f i + 1`. Strategy: extract the witness subseq from `HasIncreasingEndingAt f i (maxIncLen f i)`, append `j`, verify the extended map is StrictMono on positions and StrictMono on values. Symmetric lemma for `maxDecLen` under `f i > f j`. Target: +60–100 lines.",
+      "ACT iteration 3: Prove injectivity of `i ↦ (maxIncLen f i, maxDecLen f i)` from trichotomy plus `hf : Injective f`. Define the pair-map `pairMap : Fin n → ℕ × ℕ`. Target: +30 lines.",
+      "ACT iteration 4: Bound the pair under the no-r-inc/no-s-dec hypothesis and conclude via `Finset.exists_ne_map_eq_of_card_lt_of_mem` over `Finset.range (r-1) ×ˢ Finset.range (s-1)`. This step eliminates `erdos_szekeres_existence_axiom`. Target: +40–80 lines, axiom count drops from 2 to 1.",
+      "Defer: The tightness axiom `erdos_szekeres_tight_axiom` is a separate open question (construction of the block-decomposition sequence) — out of scope for OQ-01."
     ],
-    "markdown": "# Knowledge Base: erdos-szekeres-oq-01\n\n---\n\n## Problem Understanding\n\nThis problem targets the open proof obligation in the parent Erdos-Szekeres formalization: formalize the explicit pigeonhole argument using pairs of longest increasing and decreasing subsequence lengths ending at each position.\n\n---\n\n## Insights\n\n- For each position i, the intended pair is (a_i, b_i), with a_i the longest increasing subsequence length ending at i and b_i the longest decreasing subsequence length ending at i.\n- If the sequence has no increasing subsequence of length r and no decreasing subsequence of length s, those pairs should all lie in the finite grid {1, ..., r-1} x {1, ..., s-1}.\n- The decisive Lean step is proving the pairs are distinct, so the number of positions cannot exceed the grid size.\n- The selection report recommends checking List.Sublist, Finset pigeonhole lemmas, and any existing monotone subsequence support before committing to custom infrastructure.\n\n---\n\n## Dead Ends\n\nNo attempted approaches have been ruled out yet.\n"
+    "markdown": "# Knowledge Base: erdos-szekeres-oq-01\n\n---\n\n## Problem Understanding\n\nThis problem targets the open proof obligation in the parent Erdos-Szekeres formalization: formalize the explicit pigeonhole argument using pairs of longest increasing and decreasing subsequence lengths ending at each position. The deliverable is to eliminate `erdos_szekeres_existence_axiom` from `Proofs/ErdosSzekeres.lean` and reduce the file's axiom count from 2 to 1.\n\n---\n\n## OBSERVE Phase Findings (researcher-6 2026-06-04 S1)\n\n### What is already in the gallery file\n- `Sequence α n := Fin n → α` (line 66)\n- `IncreasingSubseq f k` and `DecreasingSubseq f k` structures with `StrictMono` positions and `StrictMono`/`StrictAnti` values (lines 69–84)\n- `HasIncreasingEndingAt f i len` and `HasDecreasingEndingAt f i len` predicates (lines 96–109) — currently UNUSED but exactly the right scaffolding\n- `erdos_szekeres_existence_axiom` (line 136) — the target to eliminate\n- `erdos_szekeres_tight_axiom` (line 171) — out of scope for this OQ\n- `two_element_monotonic` (line 196) — the only non-trivial proof, 22 lines, base case for r=s=2\n- `erdosSzekeresNumber` and concrete examples (lines 252+)\n\n### Mathlib availability\n- `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean` proves this theorem in Mathlib, BUT Archive is not exposed to downstream projects via `import Mathlib`. So delegating to Mathlib's proof is not viable; we must rederive.\n- All needed primitives are already imported: `Mathlib.Data.Finset.Card` (cardinality lemmas, pigeonhole), `Mathlib.Data.Finset.Prod` (`Finset.card_product`), `Mathlib.Order.Monotone.Basic` (StrictMono/StrictAnti), `Mathlib.Tactic` (transitively includes `Nat.findGreatest`).\n\n---\n\n## Seidenberg Pigeonhole Decomposition (7 steps)\n\nFor a sequence `f : Fin n → α` with `LinearOrder α` and `hf : Injective f`:\n\n1. **Define longest-length maps** (ACT-1)\n   ```\n   noncomputable def maxIncLen (f : Sequence α n) (i : Fin n) : ℕ :=\n     Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)\n   noncomputable def maxDecLen (f : Sequence α n) (i : Fin n) : ℕ :=\n     Nat.findGreatest (HasDecreasingEndingAt f i) (i.val + 1)\n   ```\n   Justification for bound `i.val + 1`: any subsequence ending at position `i` lies in `Fin (i.val + 1)` and has length ≤ `i.val + 1`.\n\n2. **Lower bound `1 ≤ maxIncLen f i`** (ACT-1)\n   Singleton witness: `k : Fin 1 → Fin n := fun _ => i`. Need `StrictMono k` (vacuous since `Fin 1` is a singleton), the positional disjunction (the unique element is the last and equals `i`), and `StrictMono (f ∘ k)` (vacuous).\n   Symmetric for `maxDecLen`.\n\n3. **Key extension lemma (increasing)** (ACT-2)\n   ```\n   lemma maxIncLen_lt_of_lt {i j : Fin n} (hij : i < j) (hfij : f i < f j) :\n       maxIncLen f i < maxIncLen f j\n   ```\n   Proof sketch: let `L = maxIncLen f i`, extract witness `k : Fin L → Fin n` from `HasIncreasingEndingAt f i L`. Define `k' : Fin (L+1) → Fin n` by `k' j = if j.val < L then k ⟨j.val, _⟩ else i` — wait, the existing predicate says `k (Fin.last (len-1)) = i`, so we want to append `j` after the existing sequence ending at `i`. Define `k'` to use `k` on the first `L` indices (all `< i`, last one `= i`) and append `j` at position `L`. Verify StrictMono: positions `k 0 < k 1 < ... < k (L-1) = i < j`. Verify StrictMono values: `f (k 0) < ... < f (k (L-1)) = f i < f j`. This witnesses `HasIncreasingEndingAt f j (L+1)`, so `maxIncLen f j ≥ L+1 > L`.\n\n4. **Key extension lemma (decreasing)** (ACT-2)\n   ```\n   lemma maxDecLen_lt_of_gt {i j : Fin n} (hij : i < j) (hfij : f j < f i) :\n       maxDecLen f i < maxDecLen f j\n   ```\n\n5. **Pair injectivity** (ACT-3)\n   ```\n   def pairMap (f : Sequence α n) (i : Fin n) : ℕ × ℕ :=\n     (maxIncLen f i, maxDecLen f i)\n   lemma pairMap_injective (hf : Injective f) : Injective (pairMap f)\n   ```\n   Proof: suppose `i ≠ j`, WLOG `i < j`. Then `f i ≠ f j` by `hf`, so either `f i < f j` or `f i > f j`. First case: `maxIncLen f i < maxIncLen f j` so pair first coordinates differ. Second case: `maxDecLen f i < maxDecLen f j` so pair second coordinates differ.\n\n6. **Bound the pair** (ACT-4, part 1)\n   Under hypothesis `¬ ∃ sub : IncreasingSubseq f r, True` we need `maxIncLen f i ≤ r - 1`. Note: `IncreasingSubseq f r` and `HasIncreasingEndingAt f i r` differ — the latter requires ending at `i`. We need the bridging lemma: `HasIncreasingEndingAt f i r → IncreasingSubseq f r` (take the witness as the positions). Then if `maxIncLen f i = r`, we get `HasIncreasingEndingAt f i r`, hence `IncreasingSubseq f r`, contradicting the hypothesis. Conclusion: `maxIncLen f i ≤ r - 1` (using `1 ≤ maxIncLen f i` and `< r`).\n   Symmetric for `maxDecLen`.\n\n7. **Apply Finset pigeonhole** (ACT-4, part 2)\n   Define `grid : Finset (ℕ × ℕ) := Finset.Icc 1 (r-1) ×ˢ Finset.Icc 1 (s-1)`. Then `|grid| = (r-1)(s-1)`. The pair-map sends `Fin n → grid`. We have `|Fin n| = n ≥ (r-1)(s-1) + 1 > |grid|`. By `Finset.exists_ne_map_eq_of_card_lt_of_mem` (or equivalent), two distinct `i, j : Fin n` have the same pair, contradicting injectivity.\n\n---\n\n## Insights\n\n- The full proof is approximately 200–300 lines across 4 ACT iterations.\n- The existing `HasIncreasingEndingAt`/`HasDecreasingEndingAt` predicates with their disjunctive positional constraint may need a cleaner reformulation to make the extension lemma easier to write. Alternative: use `k (Fin.last (len-1)) = i ∧ ∀ j < Fin.last (len-1), k j < i`. Evaluate during ACT-1.\n- `Nat.findGreatest` returns `0` when no value satisfies the predicate, so `maxIncLen f i ≥ 1` is essential and must be proved early. The singleton witness suffices.\n- The Lean file currently has 0 sorries and 2 axioms. The ACT iterations should preserve 0 sorries (use `Nat.findGreatest` for definitions, prove all lemmas) and aim to drop axiom count from 2 to 1 at the end of ACT-4.\n\n---\n\n## Dead Ends\n\n- **Direct Mathlib delegation**: Considered importing `Archive.Wiedijk100Theorems.AscendingDescendingSequences`. RULED OUT — Archive targets are not exposed to downstream projects.\n\n---\n\n## Out of Scope\n\n- `erdos_szekeres_tight_axiom` (the tightness construction). This is a separate OQ — building a concrete sequence with no r-increasing/no s-decreasing subseq. Should be its own problem if not already.\n"
   },
   "tags": [
     "combinatorics",
@@ -72,15 +81,23 @@
     "pigeonhole-principle"
   ],
   "references": {
-    "papers": [],
-    "urls": [],
+    "papers": [
+      "Seidenberg, A. (1959). A simple proof of a theorem of Erdős and Szekeres. J. London Math. Soc. 34: 386. The one-page pair-tracking pigeonhole proof being formalized."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Archive/Wiedijk100Theorems/AscendingDescendingSequences.html — Mathlib's Archive version (Wiedijk #73). NOT importable from downstream projects but a reference implementation."
+    ],
     "mathlib": [
-      "List.Sublist",
-      "Finset.exists_ne_map_eq_of_card_lt_of_mem"
+      "Nat.findGreatest",
+      "Finset.exists_ne_map_eq_of_card_lt_of_mem",
+      "Finset.card_product",
+      "Finset.Icc",
+      "StrictMono",
+      "StrictAnti"
     ]
   },
   "started": "2026-04-06T03:14:36.235Z",
-  "lastUpdate": "2026-04-12T21:07:23.995Z",
+  "lastUpdate": "2026-06-04T19:30:00-07:00",
   "significance": 6,
   "tractability": 7,
   "leanFiles": [


### PR DESCRIPTION
## Summary

S1 OBSERVE pass on `erdos-szekeres-oq-01` (formalize Erdős–Szekeres pair-tracking pigeonhole, Wiedijk #73 OQ). Phase advances OBSERVE→ORIENT with a concrete 4-iteration ACT plan.

## Findings

- **File inventory** (`Proofs/ErdosSzekeres.lean`, 281 lines): 2 axioms (`erdos_szekeres_existence_axiom`, `erdos_szekeres_tight_axiom`), 8 theorems, 6 defs including unused `HasIncreasingEndingAt`/`HasDecreasingEndingAt` scaffolding at lines 96–109 (exactly the right shape for `Nat.findGreatest`).
- **Mathlib availability**: Mathlib's pair-tracking proof lives at `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean` but is **not importable from downstream projects** (Archive targets are Mathlib-internal). The gallery proof must rederive using primitives already imported: `Finset.Card`, `Finset.Prod`, `Order.Monotone.Basic`, `Mathlib.Tactic` (transitively `Nat.findGreatest`).
- **mathlibGaps cleared**: no foundational gaps; all needed primitives are in.

## Seidenberg 7-step decomposition (committed to knowledge)

1. Define `noncomputable def maxIncLen f i := Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)` and symmetric `maxDecLen`.
2. Prove `1 ≤ maxIncLen f i` via the singleton subseq witness `fun _ => i`.
3. **Key extension lemma**: for `i < j` with `f i < f j`, `maxIncLen f i < maxIncLen f j`. Append `j` to the inc-witness ending at `i`.
4. Symmetric for `maxDecLen` under `f j < f i`.
5. **Pair injectivity**: `i ↦ (maxIncLen f i, maxDecLen f i)` is injective via trichotomy (uses `hf : Injective f` to rule out equality).
6. Under no-r-inc/no-s-dec hypothesis: `maxIncLen f i ≤ r-1` and `maxDecLen f i ≤ s-1`.
7. Apply `Finset.exists_ne_map_eq_of_card_lt_of_mem` on `Icc 1 (r-1) ×ˢ Icc 1 (s-1)` — contradicts injectivity.

Mapped to 4 ACT iterations (target: ~200–300 lines total, axiom count 2→1).

## Files Modified

- `src/data/research/problems/erdos-szekeres-oq-01.json` — phase ORIENT, iteration 2, +7 insights, +5 nextSteps with concrete line/lemma targets, references expanded (Seidenberg 1959 paper, Mathlib Archive URL).

## Out of Scope

`erdos_szekeres_tight_axiom` (block-decomposition construction) is a separate target — this OQ scopes only the existence axiom.

## Status

**Outcome**: progress (OBSERVE→ORIENT)
**Next Steps**: ACT-1 — add `maxIncLen`/`maxDecLen` defs and singleton lower bound, Docker-verified before commit.

🤖 Generated by researcher-6