### PR TITLE
fix(meta): erdos-1052 sync stale leanFile counts (518->524, 23->15)

### DIFF
--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -59,9 +59,9 @@
       "erdos_1052_conjecture: finiteness conjecture described in comment (not formally axiomatized)"
     ],
     "axiomCount": 0,
-    "lineCount": 518,
+    "lineCount": 524,
     "assumptions": "0 axioms, 0 sorries. even_of_isUnitaryPerfect is fully proved via multiplicativity + prime decomposition. Finiteness conjecture not formally stated as axiom — open problem described in closing comment.",
-    "theoremCount": 23,
+    "theoremCount": 15,
     "definitionCount": 3,
     "additionalFiles": [
       "Proofs/Erdos1052Aristotle.lean"
@@ -90,9 +90,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1052",
-    "lineCount": 518,
+    "lineCount": 524,
     "axiomCount": 0,
-    "theoremCount": 23,
+    "theoremCount": 15,
     "definitionCount": 3,
     "path": "Proofs/Erdos1052Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` and `theoremCount` in both the `meta` and `leanFile` blocks of `src/data/proofs/erdos-1052/meta.json` to match the canonical methodology in `scripts/research/enrich-research.ts`.

| Field | Before | After |
|---|---|---|
| `meta.lineCount` | 518 | **524** |
| `meta.theoremCount` | 23 | **15** |
| `leanFile.lineCount` | 518 | **524** |
| `leanFile.theoremCount` | 23 | **15** |

`axiomCount` (0), `definitionCount` (3), and `sorries` (0) were already correct and are left untouched. Prose descriptions (overview, proof strategy, key insights) reference older line ranges; updating those is out of scope for a counts-sync repair.

## Evidence

`leanFile.path: Proofs/Erdos1052Problem.lean`

```
$ wc -l proofs/Proofs/Erdos1052Problem.lean
     523
# canonical: content.split('\n').length = 524 (file ends with newline)

$ grep -cE '^(theorem|lemma) ' proofs/Proofs/Erdos1052Problem.lean
15
```

Canonical regex per `scripts/research/enrich-research.ts:144-183`:

- `lineCount     = content.split('\n').length`
- `theoremCount  = lines matching /^(theorem|lemma) /`
- `axiomCount    = lines matching /^axiom /`
- `definitionCount = lines matching /^(def|noncomputable def|opaque def) /`
- `sorries       = sum of /\bsorry\b/g matches per line`

Post-fix verification (script run against patched meta + actual file):

```
canonical:        { lineCount: 524, theoremCount: 15, axiomCount: 0, definitionCount: 3, sorries: 0 }
declared.leanFile:{ lineCount: 524, theoremCount: 15, axiomCount: 0, definitionCount: 3, sorries: 0 }
declared.meta:    { lineCount: 524, theoremCount: 15 }
```

Follows the same pattern as PR #22337 (circumference-via-differentiation-oq-03) and PR #22342 (central-limit-theorem-oq-01-oq-01-oq-04).

---
Automated fix by lean-mechanic agent.