### PR TITLE
Enrich abel-ruffini-galois-extensions: correct instance/definition counts

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-galois-extensions",
   "title": "Abel-Ruffini Galois Theory Extensions",
   "slug": "abel-ruffini-galois-extensions",
-  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |S₈|=40320, |A₇|=2520, |A₈|=20160 via `native_decide`. 57 theorems, 12 typeclass instances, 0 axioms, 0 sorries.",
+  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |S₈|=40320, |A₇|=2520, |A₈|=20160 via `native_decide`. 57 theorems, 15 typeclass instances (11 public + 4 private), 1 private definition (`klein_four`), 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -25,8 +25,8 @@
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
     "lineCount": 534,
     "theoremCount": 57,
-    "definitionCount": 0,
-    "instanceCount": 12,
+    "definitionCount": 1,
+    "instanceCount": 15,
     "mathlibDependencies": [
       {
         "theorem": "Equiv.Perm.not_solvable",
@@ -177,8 +177,8 @@
     "lineCount": 534,
     "axiomCount": 0,
     "theoremCount": 57,
-    "definitionCount": 0,
-    "instanceCount": 12,
+    "definitionCount": 1,
+    "instanceCount": 15,
     "path": "Proofs/AbelRuffiniGaloisExtensions.lean",
     "sorries": 0,
     "additionalFiles": [


### PR DESCRIPTION
## Summary

Corrects two declaration-count inaccuracies in `meta.json` for `abel-ruffini-galois-extensions`. The previous count fix (#22040) missed three anonymous `private instance` declarations inside the `klein_four` block and the single `private def klein_four`.

**Verified against the Lean source** (`Proofs/AbelRuffiniGaloisExtensions.lean`):

```
$ grep -cE '^(private )?instance' Proofs/AbelRuffiniGaloisExtensions.lean
15      # 11 public + 4 private (3 anonymous + 1 named: klein_four_normal)

$ grep -cE '^(private )?def ' Proofs/AbelRuffiniGaloisExtensions.lean
1       # private def klein_four (line 107)
```

## Changes

- `meta.instanceCount`: 12 → 15
- `meta.definitionCount`: 0 → 1
- `leanFile.instanceCount`: 12 → 15
- `leanFile.definitionCount`: 0 → 1
- `description` updated to reflect actual counts with public/private split

## Test plan

- [x] JSON validates (`python3 -m json.tool meta.json`)
- [x] `pnpm build` completes successfully
- [x] Counts verified against `grep` on the Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)