### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05-oq-01: per-section relatedConcepts/prerequisites

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -152,7 +152,24 @@
       "startLine": 1,
       "endLine": 45,
       "summary": "Documentation comment posing OQ-05-OQ-01 (Shafarevich in Lean) and laying out the four-cell status table: cyclic (proved), coprime products (proved here), general abelian (1 axiom), full solvable (major missing module).",
-      "mathContext": "Shafarevich (1954) proves every solvable $G$ is realizable as $\\text{Gal}(K/\\mathbb{Q})$. The proof uses embedding problems built on Galois cohomology, Brauer groups, and Tate–Poitou duality."
+      "mathContext": "Shafarevich (1954) proves every solvable $G$ is realizable as $\\text{Gal}(K/\\mathbb{Q})$. The proof uses embedding problems built on Galois cohomology, Brauer groups, and Tate–Poitou duality.",
+      "relatedConcepts": [
+        "Shafarevich's theorem (1954)",
+        "inverse Galois problem (IGP)",
+        "regular inverse Galois problem (RIGP)",
+        "embedding problem",
+        "Brauer group $\\text{Br}(\\mathbb{Q})$",
+        "Galois cohomology $H^2(\\text{Gal}, \\cdot)$",
+        "Tate–Poitou duality",
+        "Mathlib class field theory roadmap"
+      ],
+      "prerequisites": [
+        "finite solvable groups",
+        "Galois extensions of $\\mathbb{Q}$",
+        "number fields",
+        "Mathlib status quo (2026)",
+        "axiom integrity policy"
+      ]
     },
     {
       "id": "part-i-cyclic",
@@ -160,7 +177,25 @@
       "startLine": 51,
       "endLine": 70,
       "summary": "`cyclic_realizable n hn` (line 65) — the *foundational* proved case on which Parts II–III rest. A *thin wrapper* around `InverseGaloisProblem.cyclic_group_realizable` (proved separately with 0 sorries in `InverseGalois.lean`), restated in the `ShafarevichFeasibility` namespace so downstream coprime/disjointness proofs can cite it without crossing namespace boundaries. **Why this case is special**: cyclic groups are the *only* infinite parametric family of solvable groups where Shafarevich's theorem reduces to *classical* algebraic number theory (Kronecker-Weber 1853 + Weber-Dedekind cyclotomic theory), so this case is the *base of induction* in any future complete formalization. **The four-step upstream proof** (visible in the InverseGalois.lean source): (1) **Dirichlet's theorem on primes in arithmetic progressions** (`Nat.forall_exists_prime_gt_and_modEq` in Mathlib) supplies a prime $p \\equiv 1 \\pmod{n}$ — this is the only *deep* analytic ingredient and reduces the existence question to *one* analytic claim; (2) **cyclotomic theory**: the $p$-th cyclotomic field $\\mathbb{Q}(\\zeta_p)$ has $\\mathrm{Gal}(\\mathbb{Q}(\\zeta_p)/\\mathbb{Q}) \\cong (\\mathbb{Z}/p\\mathbb{Z})^\\times \\cong \\mathbb{Z}/(p-1)\\mathbb{Z}$ (Weber); (3) **subgroup selection**: since $n \\mid (p-1)$ by Dirichlet, the cyclic group of order $p-1$ has a *unique* subgroup $H$ of index $n$; (4) **Galois correspondence**: the fixed field $K = \\mathbb{Q}(\\zeta_p)^H$ satisfies $[K:\\mathbb{Q}] = n$ and $\\mathrm{Gal}(K/\\mathbb{Q}) \\cong \\mathrm{Gal}(\\mathbb{Q}(\\zeta_p)/\\mathbb{Q})/H \\cong \\mathbb{Z}/n\\mathbb{Z}$ — formalized via `IsGalois.normalAutEquivQuotient`. **What makes the wrapper necessary in Lean**: the return type packages five existentials ($K$, the `Field` instance, the `Algebra ℚ K` instance, `FiniteDimensional`, `IsGalois`) plus two propositions (`IsCyclic` of $K \\simeq_{\\mathbb{Q}\\text{-alg}} K$ and `Fintype.card = n`); restating the lemma inside this file's namespace lets `coprime_product_cyclic_realizable` (line 91) cite it without `open InverseGaloisProblem` boilerplate in every downstream proof. **Why this is the *only* family closed under reduction**: while every $\\mathbb{Z}/n\\mathbb{Z}$ realization gives infinitely many concrete extensions by varying the Dirichlet prime, *no other solvable family* admits this kind of uniform construction — the next step up (general abelian groups) requires the linear-disjointness machinery of Part III, and the step after that (non-abelian solvable groups like $S_3$) requires Part IV's *ad-hoc explicit polynomial* approach.",
-      "mathContext": "Four-step proof upstream: Dirichlet → cyclotomic field → fixed field → Galois quotient via `IsGalois.normalAutEquivQuotient`. The cyclic case is the *only* uniform construction; abelian ($\\mathbb{Z}/p \\times \\mathbb{Z}/p$ with same $p$) requires linear disjointness; non-abelian solvable (e.g., $S_3$) requires explicit polynomials. Dirichlet's theorem $\\#\\{p \\text{ prime} : p \\equiv a \\pmod{n}, \\gcd(a,n) = 1\\} = \\infty$ is the only analytic input."
+      "mathContext": "Four-step proof upstream: Dirichlet → cyclotomic field → fixed field → Galois quotient via `IsGalois.normalAutEquivQuotient`. The cyclic case is the *only* uniform construction; abelian ($\\mathbb{Z}/p \\times \\mathbb{Z}/p$ with same $p$) requires linear disjointness; non-abelian solvable (e.g., $S_3$) requires explicit polynomials. Dirichlet's theorem $\\#\\{p \\text{ prime} : p \\equiv a \\pmod{n}, \\gcd(a,n) = 1\\} = \\infty$ is the only analytic input.",
+      "relatedConcepts": [
+        "Dirichlet's theorem on primes in arithmetic progressions",
+        "cyclotomic extension $\\mathbb{Q}(\\zeta_p)$",
+        "$(\\mathbb{Z}/p\\mathbb{Z})^\\times \\cong \\mathbb{Z}/(p-1)\\mathbb{Z}$ cyclic",
+        "Galois correspondence",
+        "fixed field $E^H$ of a subgroup",
+        "Kronecker–Weber theorem (1853)",
+        "`Nat.forall_exists_prime_gt_and_modEq` (Mathlib)",
+        "`IsGalois.normalAutEquivQuotient` (Mathlib)",
+        "`InverseGaloisProblem.cyclic_group_realizable`"
+      ],
+      "prerequisites": [
+        "Dirichlet primes in arithmetic progressions",
+        "cyclotomic Galois theory",
+        "Galois correspondence (Mathlib `IntermediateField.fixedField`)",
+        "quotient group structure",
+        "Lean namespace wrapping for cross-file citation"
+      ]
     },
     {
       "id": "part-ii-crt",
@@ -168,7 +203,24 @@
       "startLine": 71,
       "endLine": 112,
       "summary": "Part II proves the *first new content* of this feasibility study: any cyclic-coprime-product abelian group is Shafarevich-realizable. Three theorems:\n\n1. **`zmod_coprime_crt`** (line 71): the standard Chinese Remainder Theorem isomorphism $\\mathbb{Z}/(mn) \\cong \\mathbb{Z}/m \\times \\mathbb{Z}/n$ when $\\gcd(m,n) = 1$, obtained as a direct invocation of Mathlib's `ZMod.prodEquivPi` / `ZMod.chineseRemainder` (which proves the underlying ring isomorphism that restricts to an additive-group isomorphism). The proof is essentially `exact ZMod.chineseRemainder hmn |>.toEquiv.toMulEquiv` modulo unfolding.\n\n2. **`coprime_product_cyclic_realizable`** (line 91): the key reduction — if $\\gcd(m,n) = 1$, then $\\mathbb{Z}/m \\times \\mathbb{Z}/n \\cong \\mathbb{Z}/(mn)$ is *itself cyclic*, so its Shafarevich realizability reduces to applying `cyclic_realizable (m*n)` from Part I. Tactically: rewrite the goal via `zmod_coprime_crt`, then invoke the cyclic case. The pedagogical point — that *coprimality lets CRT collapse the product back into a single cyclic group* — is the essential reason why Part II is *trivial-after-Part-I*, and why the genuinely hard case (Part III) starts with the *non-coprime* product $\\mathbb{Z}/p \\times \\mathbb{Z}/p$ where CRT does not apply.\n\n3. **Concrete instantiations** `z2z3_realizable` ($\\gcd(2,3) = 1$, the group $\\mathbb{Z}/2 \\times \\mathbb{Z}/3 \\cong \\mathbb{Z}/6$ realized as the Galois group of a degree-6 cyclotomic subfield) and `z5z7_realizable` ($\\gcd(5,7) = 1$, $\\mathbb{Z}/5 \\times \\mathbb{Z}/7 \\cong \\mathbb{Z}/35$ realized as a degree-35 subfield of $\\mathbb{Q}(\\zeta_p)$ for some prime $p \\equiv 1 \\pmod{35}$, e.g. $p = 71$). These two named instances exist to make the parametric `coprime_product_cyclic_realizable` directly citable for the smallest interesting cases.\n\n**The Mathlib infrastructure consumed here is shallow**: `ZMod.chineseRemainder` is a 1-page proof in Mathlib's `Data.ZMod.Basic`, in contrast to Part III's missing 500-line conductor-theory module. Part II is therefore the *closing-the-easy-direction* lemma — every reducible-to-cyclic abelian group is realizable, sharply isolating Part III's irreducible cases (rank-2 abelian groups of prime-square type) as the remaining bottleneck.",
-      "mathContext": "**CRT** $\\mathbb{Z}/(mn) \\cong \\mathbb{Z}/m \\times \\mathbb{Z}/n$ when coprime is the algebraic backbone. The 'coprime product is cyclic' observation reduces this case to the existing cyclic realization with a one-line proof."
+      "mathContext": "**CRT** $\\mathbb{Z}/(mn) \\cong \\mathbb{Z}/m \\times \\mathbb{Z}/n$ when coprime is the algebraic backbone. The 'coprime product is cyclic' observation reduces this case to the existing cyclic realization with a one-line proof.",
+      "relatedConcepts": [
+        "Chinese Remainder Theorem (CRT)",
+        "`ZMod.chineseRemainder` (Mathlib)",
+        "$\\mathbb{Z}/(mn)\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ for $\\gcd(m,n) = 1$",
+        "`Nat.Coprime`",
+        "`AddEquiv` vs `RingEquiv`",
+        "cyclic group classification",
+        "named instantiations (`z2z3_realizable`, `z5z7_realizable`)",
+        "compositum strategy gating Part III"
+      ],
+      "prerequisites": [
+        "Chinese Remainder Theorem for integers",
+        "additive group structure of $\\mathbb{Z}/n\\mathbb{Z}$",
+        "Lean `Nat.Coprime` API",
+        "`Nat.mul_pos`",
+        "reduction-to-cyclic principle for abelian groups"
+      ]
     },
     {
       "id": "part-iii-disjointness",
@@ -176,7 +228,26 @@
       "startLine": 114,
       "endLine": 148,
       "summary": "Part III axiomatizes the *single missing Mathlib piece* needed to close the abelian case of Shafarevich's theorem. **The non-coprime obstruction**: for groups like $\\mathbb{Z}/p \\times \\mathbb{Z}/p$ (e.g. $\\mathbb{Z}/2 \\times \\mathbb{Z}/2$, the Klein four-group; $\\mathbb{Z}/3 \\times \\mathbb{Z}/3$), Part II's CRT collapse fails because $\\gcd(p, p) = p \\neq 1$. The product is *not* cyclic — it has rank 2 — so `cyclic_realizable` cannot supply a single cyclotomic-subfield realization.\n\n**The compositum strategy** (the workaround that Shafarevich's full proof uses for abelian groups): take *two* cyclic realizations $K_1/\\mathbb{Q}$ and $K_2/\\mathbb{Q}$ with $\\mathrm{Gal}(K_i/\\mathbb{Q}) \\cong \\mathbb{Z}/p$, chosen with *coprime conductors* (e.g. $K_1 \\subset \\mathbb{Q}(\\zeta_{p_1})$ and $K_2 \\subset \\mathbb{Q}(\\zeta_{p_2})$ with $p_1 \\neq p_2$ both $\\equiv 1 \\pmod{p}$, supplied by Dirichlet's theorem). The compositum $K_1 K_2 / \\mathbb{Q}$ then has Galois group $\\mathrm{Gal}(K_1/\\mathbb{Q}) \\times \\mathrm{Gal}(K_2/\\mathbb{Q}) \\cong \\mathbb{Z}/p \\times \\mathbb{Z}/p$ — *provided* $K_1$ and $K_2$ are **linearly disjoint** over $\\mathbb{Q}$, which the coprime-conductor hypothesis guarantees via the Galois correspondence inside $\\mathbb{Q}(\\zeta_{p_1 p_2})$.\n\n**Why coprime conductors imply linear disjointness**: subfields of $\\mathbb{Q}(\\zeta_{p_1})$ and $\\mathbb{Q}(\\zeta_{p_2})$ intersect only in $\\mathbb{Q}$ because $\\mathbb{Q}(\\zeta_{p_1}) \\cap \\mathbb{Q}(\\zeta_{p_2}) = \\mathbb{Q}$ when $\\gcd(p_1, p_2) = 1$ — a consequence of the *conductor-discriminant formula* (Hilbert), which gives the conductor of $\\mathbb{Q}(\\zeta_n)$ as the integer $n$ itself (or rather its absolute conductor). The intersection then lies in $\\mathbb{Q}(\\zeta_{\\gcd(p_1, p_2)}) = \\mathbb{Q}(\\zeta_1) = \\mathbb{Q}$.\n\n**The axiom `galois_compositum_product`** (line ~150): captures the conditional statement *if $K_1, K_2$ are linearly disjoint Galois extensions of $\\mathbb{Q}$ with cyclic groups $G_1, G_2$ of coprime orders, then their compositum has Galois group $G_1 \\times G_2$*. The axiom is necessary because Mathlib's `Mathlib.NumberTheory.Cyclotomic.Basic` and `Mathlib.FieldTheory.IntermediateField.Adjoin` provide the *linearly disjoint* predicate but lack the *conductor-discriminant formula* and the *compositum Galois group* theorem — together a ~500-line addition to `Mathlib.FieldTheory.Galois.Compositum` and `Mathlib.NumberTheory.Cyclotomic.Disjoint`.\n\n**Bridging axiom or genuine new content?** The axiom is *bridging* in the technical sense of `mathlib-contribution` workflow vocabulary: a Mathlib-blockable assumption that closes the abelian case once Mathlib catches up. It is *not* an open mathematical conjecture — the underlying statement is provable in standard textbooks (Lang, *Algebra*, Ch.VIII §1, or Neukirch, *Algebraic Number Theory*, Ch.IV §1) — so removing it once Mathlib's conductor infrastructure lands is a purely-mechanical formalization task estimated at ~500 LOC. **This is the single remaining 'green-arrow' gap** in the cyclic-to-abelian extension chain of this study; Parts IV–V then pivot to non-abelian cases that need entirely different machinery (Hilbert irreducibility, embedding problems).",
-      "mathContext": "**Linear disjointness**: $K_1 \\otimes K_2 \\cong K_1 K_2$ over $\\mathbb{Q}$. The **discriminant criterion**: coprime discriminants → linearly disjoint. Conductors of cyclotomic subfields are not yet exposed in Mathlib."
+      "mathContext": "**Linear disjointness**: $K_1 \\otimes K_2 \\cong K_1 K_2$ over $\\mathbb{Q}$. The **discriminant criterion**: coprime discriminants → linearly disjoint. Conductors of cyclotomic subfields are not yet exposed in Mathlib.",
+      "relatedConcepts": [
+        "linear disjointness of field extensions",
+        "compositum $K_1 K_2$",
+        "conductor of a number field extension",
+        "cyclotomic conductor of $\\mathbb{Q}(\\zeta_n)$ = $n$",
+        "conductor–discriminant formula (Hilbert)",
+        "discriminant criterion for ramification",
+        "Galois group of a compositum = product (when linearly disjoint)",
+        "`galois_compositum_product` (bridging axiom)",
+        "missing Mathlib modules: `FieldTheory.Galois.Compositum`, `NumberTheory.Cyclotomic.Disjoint` (~500 LOC)"
+      ],
+      "prerequisites": [
+        "compositum of field extensions",
+        "ramification theory and discriminants",
+        "linear disjointness predicate",
+        "Galois group of a compositum",
+        "Mathlib axiom integrity policy (bridging vs open)",
+        "rank-2 abelian groups $(\\mathbb{Z}/p)^2$"
+      ]
     },
     {
       "id": "part-iv-s3",
@@ -184,7 +255,26 @@
       "startLine": 150,
       "endLine": 174,
       "summary": "Part IV pivots from abelian realizability (Parts I-III) to the smallest non-abelian solvable example: the symmetric group $S_3$. Two theorems:\n\n1. **`s3_realizable_via_cubic`** (line ~175): wraps the proved theorem `InverseGaloisProblem.s3_realizable` from `proofs/Proofs/InverseGalois.lean`, exhibiting $S_3 \\cong \\mathrm{Sym}(\\mathrm{Fin}\\,3)$ as the Galois group of $K = \\mathbb{Q}(\\sqrt[3]{2}, \\omega)$ — the splitting field of $X^3 - 2$ over $\\mathbb{Q}$, where $\\omega = e^{2\\pi i/3}$ is a primitive cube root of unity. **Why this polynomial**: $X^3 - 2$ is irreducible over $\\mathbb{Q}$ (Eisenstein at $p=2$), so $[K : \\mathbb{Q}] = 6 = 3! = |S_3|$. The three roots $\\sqrt[3]{2}, \\omega\\sqrt[3]{2}, \\omega^2\\sqrt[3]{2}$ are permuted by the Galois group, which acts faithfully as $S_3$ via the *unique* transitive embedding $\\mathrm{Gal}(K/\\mathbb{Q}) \\hookrightarrow S_3$. The discriminant $\\Delta = -4 \\cdot 0^3 - 27 \\cdot (-2)^2 = -108$ is *not* a rational square (it equals $-2^2 \\cdot 3^3$), confirming $\\mathrm{Gal} \\not\\subseteq A_3$ and hence $\\mathrm{Gal} = S_3$.\n\n2. **`s3_is_solvable`** (line ~190): the derived-series witness $S_3 \\supset A_3 \\cong \\mathbb{Z}/3 \\supset \\{e\\}$ with successive abelian quotients $S_3/A_3 \\cong \\mathbb{Z}/2$ and $A_3/\\{e\\} \\cong \\mathbb{Z}/3$. Tactically: `inferInstance` consumes Mathlib's `IsSolvable (Equiv.Perm (Fin 3))` derived from $S_n$ solvable for $n \\leq 4$ (see parent file's `symmetric_solvable_iff`).\n\n**Why $S_3$ is a *non-Shafarevich* example in this study**: Shafarevich's theorem (the central axiom of this file's parent `oq-05`) gives an *abstract* existence statement — for any finite solvable $G$, *some* Galois extension realizes $G$ over $\\mathbb{Q}$. The `s3_realizable_via_cubic` theorem is *constructive* — it exhibits an *explicit* extension $\\mathbb{Q}(\\sqrt[3]{2}, \\omega)$, bypassing the axiomatic Shafarevich route entirely. **Pedagogical significance**: the explicit/abstract pairing here illustrates that for *small* solvable groups (up to $S_4$), constructive realizations via specific polynomials are *cheaper* than invoking Shafarevich, while the axiom only becomes essential for *generic* solvable groups (like the rank-2 abelian groups of Part III, where no obvious 'canonical' polynomial witness exists). This is the inversion of the typical mathematics-textbook narrative, where Shafarevich's theorem is presented as the *strong* result and explicit constructions as *easy corollaries* — formally, the explicit constructions are *axiom-free* while Shafarevich is *axiomatized*, so the constructive route is the more rigorous one.",
-      "mathContext": "**$S_3$** is the smallest non-abelian solvable group. The realization via $X^3 - 2$ is **ad-hoc**, demonstrating that individual non-abelian solvable groups are achievable without Shafarevich, but a uniform proof needs the embedding-problem machinery."
+      "mathContext": "**$S_3$** is the smallest non-abelian solvable group. The realization via $X^3 - 2$ is **ad-hoc**, demonstrating that individual non-abelian solvable groups are achievable without Shafarevich, but a uniform proof needs the embedding-problem machinery.",
+      "relatedConcepts": [
+        "$S_3 = \\text{Sym}(\\text{Fin}\\,3)$ (smallest non-abelian solvable group)",
+        "splitting field of $X^3 - 2$",
+        "$\\mathbb{Q}(\\sqrt[3]{2}, \\omega)$ with $\\omega = e^{2\\pi i/3}$",
+        "Eisenstein criterion at $p = 2$",
+        "discriminant $\\Delta = -108$ (not a rational square)",
+        "derived series $S_3 \\supset A_3 \\supset \\{e\\}$",
+        "$A_3 \\cong \\mathbb{Z}/3\\mathbb{Z}$",
+        "`AbelRuffiniGaloisExtensions.symmetric_solvable_of_le_four`",
+        "constructive vs axiomatic Galois realization"
+      ],
+      "prerequisites": [
+        "irreducible polynomials over $\\mathbb{Q}$",
+        "primitive root of unity $\\omega = e^{2\\pi i/3}$",
+        "splitting field degree",
+        "transitive subgroup of $S_n$ via root permutation",
+        "solvability via derived series",
+        "`InverseGaloisProblem.s3_realizable`"
+      ]
     },
     {
       "id": "part-v-summary",
@@ -192,7 +282,23 @@
       "startLine": 176,
       "endLine": 200,
       "summary": "shafarevich_cyclic_case_proved restates the cyclic case as a stand-alone summary theorem. Closing comment block restates the 4-cell status table with concrete Lean-line estimates for each gap (50, 500, 5000+).",
-      "mathContext": "The closing summary identifies the two future Mathlib milestones: (a) ~500 lines of conductor theory to close the abelian case, (b) ~5000+ lines of Galois cohomology + Brauer + Tate–Poitou for the full solvable case."
+      "mathContext": "The closing summary identifies the two future Mathlib milestones: (a) ~500 lines of conductor theory to close the abelian case, (b) ~5000+ lines of Galois cohomology + Brauer + Tate–Poitou for the full solvable case.",
+      "relatedConcepts": [
+        "`shafarevich_cyclic_case_proved` summary theorem",
+        "Dirichlet's theorem",
+        "`ZMod.chineseRemainder`",
+        "`galois_compositum_product` axiom",
+        "Galois embedding problem",
+        "Brauer group $\\text{Br}(\\mathbb{Q})$",
+        "Tate–Poitou duality",
+        "Mathlib 2026 roadmap (~500 LOC / ~5000 LOC milestones)"
+      ],
+      "prerequisites": [
+        "Shafarevich theorem (1954)",
+        "Mathlib class field theory roadmap",
+        "solvable group composition series",
+        "LOC estimation discipline for Lean formalization"
+      ]
     },
     {
       "id": "namespace-end",
@@ -200,7 +306,16 @@
       "startLine": 201,
       "endLine": 201,
       "summary": "Closes the ShafarevichFeasibility namespace.",
-      "mathContext": "8 theorems, 1 axiom, 0 sorries, 201 lines — a compact status-report module."
+      "mathContext": "7 theorems, 1 noncomputable definition (`zmod_coprime_crt`), 1 axiom (`galois_compositum_product`), 0 sorries, 201 lines — a compact status-report module.",
+      "relatedConcepts": [
+        "Lean 4 namespace scope",
+        "`ShafarevichFeasibility` namespace boundary",
+        "axiom count discipline (1 bridging axiom for the disjointness gap)"
+      ],
+      "prerequisites": [
+        "Lean 4 `namespace ... end` syntax",
+        "module structure and visibility"
+      ]
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

All 7 sections in `meta.json` for `abel-ruffini-galois-extensions-oq-05-oq-01` had `mathContext` populated but were missing the `relatedConcepts` and `prerequisites` arrays. Added accurate, source-derived terms for each part:

| Section | relatedConcepts | prerequisites |
|---|---|---|
| module-header | 8 (Shafarevich, IGP/RIGP, embedding problem, Brauer, Tate-Poitou) | 5 |
| part-i-cyclic | 9 (Dirichlet, cyclotomic, Kronecker-Weber, fixed field, `IsGalois.normalAutEquivQuotient`) | 5 |
| part-ii-crt | 8 (CRT, `ZMod.chineseRemainder`, named instantiations) | 5 |
| part-iii-disjointness | 9 (linear disjointness, conductor-discriminant, bridging axiom) | 6 |
| part-iv-s3 | 9 (`X^3-2`, omega, Eisenstein, discriminant -108) | 6 |
| part-v-summary | 8 (Mathlib roadmap milestones) | 4 |
| namespace-end | 3 (namespace scope) | 2 |

Also corrected the `namespace-end.mathContext` count: the file has 7 theorems + 1 `noncomputable def` (`zmod_coprime_crt`) + 1 axiom (`galois_compositum_product`), not the previously-stated "8 theorems".

**Verified against the Lean source** (`Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean`):

```
$ grep -cE '^theorem '            # 7
$ grep -cE '^(noncomputable )?def '  # 1
$ grep -cE '^axiom'                # 1
$ grep -c sorry                    # 0
```

## Test plan

- [x] JSON validates (`python3 -m json.tool meta.json`)
- [x] `pnpm build` completes successfully
- [x] All 7 sections now have non-empty `relatedConcepts` and `prerequisites` arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)