### PR TITLE
fix(meta): erdos-951 sync stale leanFile/meta counts

### DIFF
--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -67,10 +67,10 @@
       "beurlingPi_le_floor_pred: π_a(x) ≤ ⌊x⌋₊ - 1 (sharpened trivial bound — saves one over `beurlingPi_le_floor` by exploiting `aₙ ≥ n + 2`)"
     ],
     "axiomCount": 0,
-    "lineCount": 339,
+    "lineCount": 341,
     "assumptions": "0 axioms. All former axioms eliminated: primeSeq_well_separated proved via FTA (factorization_prod_at), beurlings_conjecture converted to def (Prop, not asserted). File is fully verified. Open conjecture; supporting lemmas fully verified. Trivial upper bound π_a(x) ≤ ⌊x⌋₊ (`beurlingPi_le_floor`) and its sharpening π_a(x) ≤ ⌊x⌋₊ - 1 (`beurlingPi_le_floor_pred`) give weaker forms of the conjecture as verified partial results.",
-    "theoremCount": 15,
-    "definitionCount": 10
+    "theoremCount": 14,
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "**Erdős Problem #951: Beurling Prime Numbers**\n\nThis problem connects Erdős's interest in extremal properties of primes with Beurling's theory of generalized primes, asking whether the ordinary primes are the densest well-separated multiplicative sequence.\n\n**Historical Timeline:**\n- 1937: Arne Beurling introduced generalized primes in his paper 'Analyse de la loi asymptotique de la distribution des nombres premiers généralisés', proving a generalized PNT\n- 1960s: Erdős reported this question was posed during his lecture at Queens College, possibly by S. Shapiro\n- 1977: Diamond proved Beurling's theorem is sharp — the error term $o(\\log x)$ in the generalized PNT cannot be weakened\n- 2000s: Zhang and others developed the modern theory of Beurling generalized integers with applications to number theory\n\n**Beurling's Framework:** A Beurling prime sequence $1 < a_1 < a_2 < \\ldots$ generates 'Beurling integers' via products $\\prod a_i^{k_i}$. The key condition is that distinct products differ by at least 1, mimicking how distinct products of ordinary primes (i.e., distinct positive integers) are at least 1 apart by the Fundamental Theorem of Arithmetic.\n\n**The Deep Question:** Erdős asks whether this well-separation condition alone — without any further structure — forces $\\pi_a(x) \\le \\pi(x)$. This would mean that among all multiplicatively well-separated sequences, the primes pack the most elements below any threshold $x$. This is a remarkable extremality claim about the primes.\n\n**Why It's Hard:** The well-separation condition is global: changing one element of the sequence affects all products, creating complex constraints. There is no known technique to bound $\\pi_a(x)$ from below for arbitrary well-separated sequences.",
@@ -185,10 +185,10 @@
       "Real"
     ],
     "namespace": "Erdos951",
-    "lineCount": 339,
+    "lineCount": 341,
     "axiomCount": 0,
-    "theoremCount": 15,
-    "definitionCount": 10,
+    "theoremCount": 14,
+    "definitionCount": 9,
     "path": "Proofs/Erdos951Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

`src/data/proofs/erdos-951/meta.json` had stale counts (in both the `meta` and `leanFile` blocks) that disagreed with the current `proofs/Proofs/Erdos951Problem.lean`.

## Evidence

Canonical metrics computed using the same rules as `scripts/research/enrich-research.ts:144-183` (`content.split('\n').length`, `^(theorem|lemma) `, `^(def|noncomputable def|opaque def) `, `^axiom `, `\bsorry\b`):

| Field | Before | After | File |
|---|---:|---:|---:|
| lineCount | 339 | 341 | 341 |
| theoremCount | 15 | 14 | 14 |
| definitionCount | 10 | 9 | 9 |
| axiomCount | 0 | 0 | 0 ✓ |
| sorries | 0 | 0 | 0 ✓ |

Both `meta.*` and `leanFile.*` updated in lockstep.

---
Automated fix by lean-mechanic agent.