### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-04: add missing instanceCount

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-04/meta.json
@@ -24,6 +24,7 @@
     "lineCount": 234,
     "theoremCount": 3,
     "definitionCount": 2,
+    "instanceCount": 1,
     "mathlibDependencies": [
       {
         "theorem": "JordanHolderLattice",
@@ -156,6 +157,7 @@
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 2,
+    "instanceCount": 1,
     "path": "Proofs/AbelRuffiniGaloisExtensionsOQ04.lean",
     "sorries": 0,
     "imports": [


### PR DESCRIPTION
## Summary

The `JordanHolderLattice (Subgroup G)` instance at line 72 of `Proofs/AbelRuffiniGaloisExtensionsOQ04.lean` was not reflected in the declaration counts. The `instanceCount` field was missing entirely from both the `meta` and `leanFile` blocks of `meta.json`. Added `instanceCount: 1` in both places.

**Verified against the Lean source**:

```
$ grep -cE '^(noncomputable )?instance' Proofs/AbelRuffiniGaloisExtensionsOQ04.lean
1     # noncomputable instance instJordanHolderLatticeSubgroup (line 72)
```

This is consistent with the file's stated purpose ("Instantiates Mathlib's `JordanHolderLattice` typeclass for `Subgroup G`"), which the description already advertises but the structured count field omitted.

## Test plan

- [x] JSON validates (`python3 -m json.tool meta.json`)
- [x] `pnpm build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)