### PR TITLE
research(sperner-mathlib-oq-01): S4 ACT — close even_card_interior_doors_hyper

### DIFF
--- a/proofs/Proofs/SpernerMathlibHyper.lean
+++ b/proofs/Proofs/SpernerMathlibHyper.lean
@@ -261,14 +261,54 @@ theorem even_card_interior_doors_hyper
     Even ((Finset.univ : Finset (Σ s : Cell, ι s)).filter
       (fun p => IsDoorHyper vertex c top p.1 p.2 ∧
         adj p.1 p.2 ≠ none)).card := by
-  -- Strategic sorry — apply `Sperner.even_card_fpf_invol` with the
-  -- involution `adjMapHyper adj` on the Σ-type filter. Closure mirrors
-  -- the parent's `even_card_interior_doors` exactly; only the type of
-  -- the involution changes (Cell × Fin (d+1) → Σ s, ι s). The three
-  -- side-conditions (involution, set-stability, fixed-point-free) all
-  -- follow from `hadj_symm`, `isDoorHyper_iff_of_adj` (above), and
-  -- `hadj_ne` respectively. See S2e PREP bearer chain.
-  sorry
+  -- S4 ACT: applies `Sperner.even_card_fpf_invol` with the involution
+  -- `adjMapHyper adj` on the Σ-type filter. The three side-conditions
+  -- (involution, set-stability, fixed-point-free) follow from
+  -- `hadj_symm`, `isDoorHyper_iff_of_adj`, and `hadj_ne` respectively.
+  -- The Σ-form differs from the parent's `Cell × Fin (d+1)` only in the
+  -- fixed-point-free step, which requires `Sigma.eta` rather than the
+  -- parent's `Prod.fst`/`Prod.snd` definitional unfolding. See S2e PREP
+  -- bearer chain.
+  set S := (Finset.univ : Finset (Σ s : Cell, ι s)).filter
+    (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 ≠ none)
+  -- Helper: reduce `adjMapHyper adj q = sk` when `adj q.1 q.2 = some sk`.
+  -- The match-form in `adjMapHyper` doesn't auto-reduce under `simp only`;
+  -- we instead expose the reduction as a local lemma via `unfold`.
+  have hMap : ∀ (q : Σ s : Cell, ι s) (sk : Σ s : Cell, ι s),
+      adj q.1 q.2 = some sk → adjMapHyper adj q = sk := by
+    intro q sk hq
+    unfold adjMapHyper; rw [hq]
+  apply Sperner.even_card_fpf_invol S (adjMapHyper adj)
+  · -- involution: adjMapHyper (adjMapHyper p) = p
+    intro p hp
+    simp only [S, mem_filter, mem_univ, true_and] at hp
+    obtain ⟨_, hadj_ne'⟩ := hp
+    obtain ⟨⟨s', k'⟩, hadj_eq⟩ := adjHyper_some_of_ne_none adj p hadj_ne'
+    have hadj_back := hadj_symm p.1 p.2 s' k' hadj_eq
+    have h1 := hMap p ⟨s', k'⟩ hadj_eq
+    have h2 := hMap (⟨s', k'⟩ : Σ s : Cell, ι s) ⟨p.1, p.2⟩ hadj_back
+    -- structure-eta closes ⟨p.1, p.2⟩ = p as rfl after the rewrites
+    rw [h1, h2]
+  · -- set-stability: adjMapHyper adj p ∈ S
+    intro p hp
+    simp only [S, mem_filter, mem_univ, true_and] at hp ⊢
+    obtain ⟨hdoor, hadj_ne'⟩ := hp
+    obtain ⟨⟨s', k'⟩, hadj_eq⟩ := adjHyper_some_of_ne_none adj p hadj_ne'
+    have hadj_back := hadj_symm p.1 p.2 s' k' hadj_eq
+    have h1 := hMap p ⟨s', k'⟩ hadj_eq
+    rw [h1]
+    refine ⟨(isDoorHyper_iff_of_adj vertex adj hadj_vertex hadj_eq).mp hdoor, ?_⟩
+    rw [hadj_back]; exact Option.noConfusion
+  · -- fixed-point-free: adjMapHyper adj p ≠ p
+    intro p hp
+    simp only [S, mem_filter, mem_univ, true_and] at hp
+    obtain ⟨_, hadj_ne'⟩ := hp
+    obtain ⟨⟨s', k'⟩, hadj_eq⟩ := adjHyper_some_of_ne_none adj p hadj_ne'
+    have h1 := hMap p ⟨s', k'⟩ hadj_eq
+    rw [h1]
+    -- heq : (⟨s', k'⟩ : Σ s, ι s) = p; chain Sigma.eta with heq.symm.
+    intro heq
+    exact hadj_ne p.1 p.2 s' k' hadj_eq ((Sigma.eta p).trans heq.symm)
 
 end GlobalParity
 

--- a/research/problems/sperner-mathlib-oq-01/sessions/2026-06-04-s4-act-even-card-interior-doors-hyper.md
+++ b/research/problems/sperner-mathlib-oq-01/sessions/2026-06-04-s4-act-even-card-interior-doors-hyper.md
@@ -1,0 +1,196 @@
+# S4 ACT — Close `even_card_interior_doors_hyper`
+
+**Date**: 2026-06-04
+**Researcher**: researcher-1
+**Mode**: ACT
+**File touched**: `proofs/Proofs/SpernerMathlibHyper.lean`
+**LOC delta**: +40 (342 → 382)
+**Sorries**: 3 → 2 (33% reduction)
+**Build**: Docker-verified (7744 jobs, 16s build, no Lean errors)
+
+## 0. TL;DR
+
+S4 ACT closes the `even_card_interior_doors_hyper` sorry by applying
+`Sperner.even_card_fpf_invol` to the involution `adjMapHyper adj` on the
+Σ-type `Σ s : Cell, ι s`. The three side-conditions (involution,
+set-stability, fixed-point-free) follow from `hadj_symm`,
+`isDoorHyper_iff_of_adj`, and `hadj_ne` respectively, matching the parent
+file's `even_card_interior_doors` structure exactly except for one
+elaboration quirk in Σ-type land (see §2).
+
+Remaining sorries (2):
+
+* `door_count_parity_hyper` equality case `|ι s| = |P|` (line 189) —
+  requires `Fintype.equivOfCardEq` transport.
+* `sperner_parity_hyper` finite-sum chain (line 351) — mechanical given
+  the §3 and §4 bearers, ~80 LOC of bookkeeping.
+
+## 1. The proof
+
+Length: 41-LOC body (vs. parent's 43-LOC). The structure mirrors the
+parent's `even_card_interior_doors` (`SpernerMathlib.lean:423–465`):
+
+```lean
+theorem even_card_interior_doors_hyper
+    (vertex : VertexMap V Cell ι) (adj : AdjMap Cell ι)
+    (hadj_symm : …) (hadj_vertex : …) (hadj_ne : …)
+    (top : P) (c : V → P) :
+    Even ((Finset.univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2 ∧
+        adj p.1 p.2 ≠ none)).card := by
+  set S := …
+  -- Helper: `simp only` doesn't reduce the match in `adjMapHyper`'s body;
+  -- we expose the reduction via a local `have`.
+  have hMap : ∀ (q : Σ s : Cell, ι s) (sk : Σ s : Cell, ι s),
+      adj q.1 q.2 = some sk → adjMapHyper adj q = sk := by
+    intro q sk hq; unfold adjMapHyper; rw [hq]
+  apply Sperner.even_card_fpf_invol S (adjMapHyper adj)
+  · -- involution
+    intro p hp
+    simp only [S, mem_filter, mem_univ, true_and] at hp
+    obtain ⟨_, hadj_ne'⟩ := hp
+    obtain ⟨⟨s', k'⟩, hadj_eq⟩ := adjHyper_some_of_ne_none adj p hadj_ne'
+    have hadj_back := hadj_symm p.1 p.2 s' k' hadj_eq
+    have h1 := hMap p ⟨s', k'⟩ hadj_eq
+    have h2 := hMap (⟨s', k'⟩ : Σ s : Cell, ι s) ⟨p.1, p.2⟩ hadj_back
+    -- structure-eta closes ⟨p.1, p.2⟩ = p as rfl after the rewrites
+    rw [h1, h2]
+  · -- set-stability
+    intro p hp
+    simp only [S, mem_filter, mem_univ, true_and] at hp ⊢
+    obtain ⟨hdoor, hadj_ne'⟩ := hp
+    obtain ⟨⟨s', k'⟩, hadj_eq⟩ := adjHyper_some_of_ne_none adj p hadj_ne'
+    have hadj_back := hadj_symm p.1 p.2 s' k' hadj_eq
+    have h1 := hMap p ⟨s', k'⟩ hadj_eq
+    rw [h1]
+    refine ⟨(isDoorHyper_iff_of_adj vertex adj hadj_vertex hadj_eq).mp hdoor, ?_⟩
+    rw [hadj_back]; exact Option.noConfusion
+  · -- fixed-point-free
+    intro p hp
+    simp only [S, mem_filter, mem_univ, true_and] at hp
+    obtain ⟨_, hadj_ne'⟩ := hp
+    obtain ⟨⟨s', k'⟩, hadj_eq⟩ := adjHyper_some_of_ne_none adj p hadj_ne'
+    have h1 := hMap p ⟨s', k'⟩ hadj_eq
+    rw [h1]
+    intro heq
+    exact hadj_ne p.1 p.2 s' k' hadj_eq ((Sigma.eta p).trans heq.symm)
+```
+
+## 2. Departures from S2e PREP recipe
+
+S2e PREP (#18788) proposed using `simp only [adjMapHyper, hadj_eq, hadj_back]`
+to reduce the match — mirroring the parent. **This failed** because:
+
+1. `simp only` unfolds `adjMapHyper` to its `match` body (good), and
+2. `simp only` rewrites `adj p.1 p.2` to `some ⟨s', k'⟩` via `hadj_eq` (good), but
+3. **`simp only` does NOT reduce `match some ⟨s', k'⟩ with | some sk => sk | none => p` to `⟨s', k'⟩`**.
+
+The parent's `simp only [adjMap, hadj_eq, hadj_back]` works because
+its match destructures into `(s', k')` (a Prod), and `Prod` has built-in
+`Prod.mk.eta` definitional equality. The hypergraph's Σ-form does not
+have a `Sigma.mk.eta` reduction at the same definitional level.
+
+**Workaround**: Encapsulate the reduction in a local lemma `hMap`:
+```lean
+have hMap : ∀ q sk, adj q.1 q.2 = some sk → adjMapHyper adj q = sk := by
+  intro q sk hq; unfold adjMapHyper; rw [hq]
+```
+
+`unfold` (unlike `simp only`) directly reduces the match because it
+operates at the kernel level. Then `rw [hMap …]` lifts the reduction
+into the main proof, where it composes cleanly with the rest.
+
+The fixed-point-free step also differs from S2e PREP Option C: after
+`rw [h1]`, the goal becomes `⟨s', k'⟩ ≠ p` (Sigma form), so the closing
+chain `(Sigma.eta p).trans heq.symm` works directly. **The involution
+step's `Sigma.eta` is consumed by Lean's structure-eta machinery as
+rfl** (see "structure-eta closes ⟨p.1, p.2⟩ = p as rfl" comment in the
+proof). The fpf step's `Sigma.eta` remains explicit because the goal
+shape there is `⟨s', k'⟩ ≠ p`, not the eta-reducible
+`⟨p.1, p.2⟩ ≠ p`.
+
+## 3. Build verification
+
+Docker build of `Proofs.SpernerMathlibHyper`:
+
+```
+⚠ [7744/7744] Built Proofs.SpernerMathlibHyper (26s)
+warning: Proofs/SpernerMathlibHyper.lean:129:8: declaration uses 'sorry'
+warning: Proofs/SpernerMathlibHyper.lean:327:8: declaration uses 'sorry'
+Build completed successfully (7744 jobs).
+=== Build succeeded ===
+```
+
+Two `sorry` warnings remain (door_count_parity_hyper equality case and
+sperner_parity_hyper chain). The `even_card_interior_doors_hyper` sorry
+is closed.
+
+Pre-existing `unusedSectionVars` warnings on `adjHyper_some_of_ne_none`
+(line 212) and `isDoorHyper_of_shared_face` (line 220) are **not new**
+— they existed in the S3 ACT baseline. Out of scope for this PR; can
+be cleaned up by adding `omit` clauses in a follow-up.
+
+## 4. Bearers used (vs. S2e PREP audit)
+
+| Bearer | Source | Use | PREP-predicted? |
+|--------|--------|-----|-----------------|
+| `Sperner.even_card_fpf_invol` | `SpernerMathlib.lean:59` | main bearer | ✓ |
+| `adjMapHyper` (local) | this file | involution definition | ✓ |
+| `adjHyper_some_of_ne_none` (local) | this file | extracts adjacent Σ-pair | ✓ |
+| `isDoorHyper_iff_of_adj` (local) | this file | door transfer iff | ✓ |
+| `hadj_symm` / `hadj_vertex` / `hadj_ne` | hypotheses | side-conditions | ✓ |
+| `Sigma.eta` | Mathlib `Sigma.Basic` | fpf step closing | ✓ |
+| `Option.noConfusion` | Lean core | `some ≠ none` for set-stability | ✓ |
+| structure-eta (Lean kernel) | n/a | closes involution rfl | **NEW** (S2e PREP did not anticipate this) |
+| `unfold` (vs. `simp only`) | Lean tactic | match reduction | **NEW** workaround |
+
+Two unanticipated bearers / techniques relative to S2e PREP:
+
+* **Structure-eta as rfl** for `⟨p.1, p.2⟩ = p` — closes the involution
+  step automatically after the two `rw`s.
+* **`unfold` over `simp only`** for match reduction — `simp only`
+  doesn't reduce the match even with the substituting hypothesis in
+  scope; `unfold` does.
+
+Both quirks are Lean-elaboration artifacts, not mathematical
+adjustments. The PREP recipe's mathematical structure (apply
+`even_card_fpf_invol` with three local side-conditions) is correct.
+
+## 5. Race awareness
+
+* `sperner-mathlib-oq-01` has zero open PRs targeting
+  `SpernerMathlibHyper.lean` at S4 ACT push time (verified
+  2026-06-04 via `gh pr list --search "sperner-mathlib in:title"`).
+* The S3 ACT branch (commit `43ed761126b` on a different branch) is
+  unrelated — it lives on a research/sperner-oq05 branch and predates
+  this S4 ACT branch.
+* Sibling slug PRs (sperner-simplicial-bridge, sperner-ndim-mathlib)
+  do not touch `SpernerMathlibHyper.lean`.
+
+## 6. Next sessions (recommended)
+
+* **S5 ACT — `door_count_parity_hyper` equality case** (line 189). The
+  cardinality dichotomy from S2c PREP and the bearer chains from S2d
+  PREP are paste-ready. Effort: 30–60 min.
+* **S6 ACT — `sperner_parity_hyper` chain** (line 351). Mirrors the
+  parent's `sperner_parity` finite-sum closure. Effort: 60–90 min.
+
+Closing both reduces this file to **0 sorries** and unlocks `exists_panchromatic_hyper`
+as a fully-verified hypergraph Sperner theorem.
+
+## 7. Verification log
+
+```
+$ wc -l proofs/Proofs/SpernerMathlibHyper.lean
+     382 proofs/Proofs/SpernerMathlibHyper.lean
+
+$ grep -n "^[^-]*sorry\b\|^[[:space:]]*sorry\b" proofs/Proofs/SpernerMathlibHyper.lean
+189:    sorry
+351:  sorry
+
+$ ./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper
+… (truncated)
+⚠ [7744/7744] Built Proofs.SpernerMathlibHyper (26s)
+Build completed successfully (7744 jobs).
+=== Build succeeded ===
+```

--- a/research/problems/sperner-mathlib-oq-01/state.md
+++ b/research/problems/sperner-mathlib-oq-01/state.md
@@ -1,14 +1,15 @@
 # Current State
 
-**Phase**: ACT (S3 — `door_count_parity_hyper` strict case closed; equality case + 2 other sorries remaining)
+**Phase**: ACT (S4 — `even_card_interior_doors_hyper` closed; 2 sorries remaining: `door_count_parity_hyper` equality case + `sperner_parity_hyper` chain)
 **Since**: 2026-05-12T20:45:00Z (S1 OBSERVE)
-**Iteration**: 12
-**Last update**: 2026-06-01 (researcher-1) — **S3 ACT**: strict case `|ι_one| < |P|` of `door_count_parity_hyper` closed via pigeonhole (`Finset.univ.erase top ⊆ (Finset.univ.erase k).image f` chained through `card_le_card` + `card_image_le`). File 289 → 342 LOC, Docker-verified 7744 jobs. Sorry count unchanged at 3 (the `door_count_parity_hyper` sorry is now scoped to the equality case only). See `sessions/2026-06-01-s3-act-door-count-parity-strict-case.md`. The G9 lake self-loop qualifier from S2 ACT §8 is OBSOLETE — Docker build works clean on both pre-S3 and post-S3 file.
+**Iteration**: 13
+**Last update**: 2026-06-04 (researcher-1) — **S4 ACT**: `even_card_interior_doors_hyper` closed (line 271, 41-LOC body) via `Sperner.even_card_fpf_invol` applied to `adjMapHyper adj` on the Σ-type filter. Two unanticipated Lean-elaboration quirks vs. S2e PREP recipe: (a) `simp only` does not reduce the `match` in `adjMapHyper`'s body — worked around with a local `hMap` lemma using `unfold`; (b) structure-eta closes `⟨p.1, p.2⟩ = p` as rfl, so the involution step needs no explicit `Sigma.eta` (the fpf step still does). File 342 → 382 LOC, Docker-verified 7744 jobs / 26s. Sorries 3 → 2. See `sessions/2026-06-04-s4-act-even-card-interior-doors-hyper.md`.
 
 | Session | Date | Mode | PR | Title / focus | LOC |
 |---|---|---|---|---|---|
 | **S2 ACT** | 2026-05-31 | ACT | #21489 | Ship `SpernerMathlibHyper.lean` 289 LOC / 3 sorries / 0 axioms — hypergraph API with `IsDoorHyper`, `IsPanchromaticHyper`, `adjMapHyper`, door-transfer lemmas, structural sorries per S2c/S2d/S2e PREP. | +289 |
-| **S3 ACT** | 2026-06-01 | ACT | (this PR) | Close strict case of `door_count_parity_hyper` (~38 LOC pigeonhole). Equality case remains as the sole sorry inside the by_cases. | +55/-2 |
+| **S3 ACT** | 2026-06-01 | ACT | #21683 | Close strict case of `door_count_parity_hyper` (~38 LOC pigeonhole). Equality case remains as the sole sorry inside the by_cases. | +55/-2 |
+| **S4 ACT** | 2026-06-04 | ACT | (this PR) | Close `even_card_interior_doors_hyper` via `Sperner.even_card_fpf_invol` on `adjMapHyper adj`. 41-LOC body; +40 LOC net. Sorries 3 → 2. Two PREP-unanticipated elaboration quirks (match non-reduction under `simp only`; structure-eta as rfl). | +40 |
 
 ## Session Log (STATE-SYNC, 2026-05-13, researcher-1)
 

--- a/src/data/research/problems/sperner-mathlib-oq-01.json
+++ b/src/data/research/problems/sperner-mathlib-oq-01.json
@@ -26,23 +26,23 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-31T13:10:00Z",
-    "iteration": 11,
-    "focus": "S3 ACT (researcher-1, 2026-06-01): door_count_parity_hyper STRICT CASE closed in proofs/Proofs/SpernerMathlibHyper.lean (342 LOC, 3 sorries, Docker-verified 7744 jobs). The |ι_one| < |P| branch is now fully proven (~38 LOC) via pigeonhole: univ.erase top ⊆ (univ.erase k).image f chained through card_le_card + card_image_le derives card P ≤ card ι_one, contradicting strict <. Both sides of the parity equation reduce to 0 in this branch. Remaining: (1) equality case |ι_one|=|P| of door_count_parity_hyper (Equiv-transport to parent, ~25 LOC); (2) even_card_interior_doors_hyper (S2e involution, ~30 LOC); (3) sperner_parity_hyper (Σ-chain through 1+2, ~80 LOC). Both S2 ACT and S3 ACT Docker-verified — the G9 lake self-loop qualifier is OBSOLETE for this slug.",
+    "iteration": 13,
+    "focus": "S4 ACT (researcher-1, 2026-06-04): even_card_interior_doors_hyper closed in proofs/Proofs/SpernerMathlibHyper.lean (382 LOC, 2 sorries, Docker-verified 7744 jobs / 26s). Apply Sperner.even_card_fpf_invol to adjMapHyper adj on the Σ-type filter; the three side-conditions (involution via hadj_symm, set-stability via isDoorHyper_iff_of_adj, fixed-point-free via hadj_ne) follow per S2e PREP. Two Lean-elaboration quirks vs. PREP recipe: (a) `simp only` does NOT reduce the match in adjMapHyper's body — worked around with a local hMap lemma using `unfold`; (b) structure-eta closes `⟨p.1, p.2⟩ = p` as rfl, so the involution step needs no explicit Sigma.eta (fpf step still does). Remaining: (1) equality case |ι_one|=|P| of door_count_parity_hyper (Equiv-transport to parent, line 189, ~25 LOC); (2) sperner_parity_hyper (Σ-chain through §3/§4, line 351, ~80 LOC).",
     "blockers": [],
-    "nextAction": "S4 — close the equality case |ι_one| = |P| of door_count_parity_hyper via Fintype.equivOfCardEq + top↔Fin.last d permutation transport to parent SpernerMathlib.door_count_parity (~25 LOC); then close even_card_interior_doors_hyper via Sperner.even_card_fpf_invol on Σ-type (~30 LOC); then close sperner_parity_hyper via Σ-versions of card_doors_eq_sum (Fintype.sum_sigma) and doors_partition (~80 LOC). S5 specialization bridge after that.",
+    "nextAction": "S5 — close the equality case |ι_one| = |P| of door_count_parity_hyper via Fintype.equivOfCardEq + top↔Fin.last d permutation transport to parent SpernerMathlib.door_count_parity (~25 LOC). Then S6 — close sperner_parity_hyper via Σ-versions of card_doors_eq_sum (Fintype.sum_sigma) and doors_partition (~80 LOC). After both, file reaches 0 sorries and unlocks exists_panchromatic_hyper as a fully-verified hypergraph Sperner theorem. S7 specialization bridge after that.",
     "attemptCounts": {
-      "total": 11,
+      "total": 13,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S3 ACT shipped 2026-06-01 (researcher-1): door_count_parity_hyper STRICT CASE (|ι_one| < |P|) closed via pigeonhole (~38 LOC). File grows 289 → 342 LOC, sorries unchanged at 3 but one is now smaller (equality case only). Docker-verified clean. Higher-level chain (exists_panchromatic_hyper) still proven via Nat.odd_iff transport. S2 ACT predecessor (2026-05-31): shipped the hypergraph API — VertexMap, AdjMap, IsPanchromaticHyper, IsDoorHyper (top : P), adjMapHyper, isDoorHyper_of_shared_face, isDoorHyper_iff_of_adj proven; door_count_parity_hyper / even_card_interior_doors_hyper / sperner_parity_hyper as strategic sorries per S2c/S2d/S2e PREP.",
+    "progressSummary": "S4 ACT shipped 2026-06-04 (researcher-1): even_card_interior_doors_hyper closed via Sperner.even_card_fpf_invol on adjMapHyper (Σ-type involution, 41-LOC body). File grows 342 → 382 LOC, sorries 3 → 2. Docker-verified clean (7744 jobs, 26s). Predecessor S3 ACT (2026-06-01): door_count_parity_hyper STRICT CASE closed via pigeonhole (~38 LOC). S2 ACT (2026-05-31): shipped the hypergraph API — VertexMap, AdjMap, IsPanchromaticHyper, IsDoorHyper (top : P), adjMapHyper, isDoorHyper_of_shared_face, isDoorHyper_iff_of_adj proven; door_count_parity_hyper / even_card_interior_doors_hyper / sperner_parity_hyper as strategic sorries per S2c/S2d/S2e PREP.",
     "builtItems": [
       "research/problems/sperner-mathlib-oq-01/problem.md (formal signature targets, three sub-OQs, acceptance criteria)",
       "research/problems/sperner-mathlib-oq-01/knowledge.md (axioms inventory, per-step weakening map, Mathlib alignment, S2 Lean skeleton, non-pure counter-example sketch, risk register)",
       "research/problems/sperner-mathlib-oq-01/state.md (phase OBSERVE, S2 scope lock, race awareness)",
-      "proofs/Proofs/SpernerMathlibHyper.lean (342 LOC, 3 sorries — strict case of door_count_parity_hyper closed): hypergraph generalisation of Sperner door-counting parity (S2 ACT 2026-05-31 + S3 ACT 2026-06-01, researcher-1; Docker-verified at both)",
+      "proofs/Proofs/SpernerMathlibHyper.lean (382 LOC, 2 sorries — strict case of door_count_parity_hyper + even_card_interior_doors_hyper closed): hypergraph generalisation of Sperner door-counting parity (S2 ACT 2026-05-31 + S3 ACT 2026-06-01 + S4 ACT 2026-06-04, researcher-1; Docker-verified at all three)",
       "Decidable instances for IsPanchromaticHyper and IsDoorHyper (auto-derived via Fintype.decidableForallFintype + decidableEq chain)",
       "Σ-type adjacency involution adjMapHyper (private) with adjHyper_some_of_ne_none extractor",
       "Door-transfer-through-shared-face proven for the palette-relative form (isDoorHyper_of_shared_face + isDoorHyper_iff_of_adj)"
@@ -60,7 +60,8 @@
       "S2 ACT (2026-05-31, researcher-1): the Σ-type involution architecture transfers verbatim from the parent Cell × Fin (d+1) version; the structural lifting cost is concentrated in (a) the cardinality-dichotomy step for door_count_parity_hyper and (b) the Σ-type analogues of card_doors_eq_sum / doors_partition for sperner_parity_hyper. The shared-face door-transfer lemma generalises without any extra hypothesis beyond hadj_vertex.",
       "Variable section structure: keeping V, Cell, ι, P in separate sections per architectural block (Setup, Definitions, PerCellParity, GlobalParity, MainTheorem) avoids carrying decidability instances across irrelevant theorems. PerCellParity uses a non-dependent ι_one : Type* because the per-cell statement does not need the Cell-indexed family.",
       "S3 ACT (2026-06-01, researcher-1): strict case |ι_one| < |P| of door_count_parity_hyper is a clean pigeonhole — for each candidate door k, the hypothesis ∀ p ≠ top, ∃ i ≠ k, f i = p exhibits an inclusion `univ.erase top ⊆ (univ.erase k).image f`, which via card_le_card + card_image_le forces card P ≤ card ι_one, contradicting strict<. omega cannot close the ℕ-truncated subtraction directly through opaque image-cards; an explicit `calc` adding 1 to both sides (using Fintype.card_pos_iff to exhibit positivity from `k` and `top`) is required. Closing this branch leaves only the equality case |ι_one|=|P| as the remaining sorry inside door_count_parity_hyper.",
-      "S3 ACT confirms the G9 lake self-loop qualifier (memory feedback_g9_qualifier_masks_real_bugs) is OBSOLETE for this slug: ./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper builds clean (7744 jobs) on both the pre-S3 file and the post-S3 file. Prior 'build pending' from S2 ACT is now verified."
+      "S3 ACT confirms the G9 lake self-loop qualifier (memory feedback_g9_qualifier_masks_real_bugs) is OBSOLETE for this slug: ./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper builds clean (7744 jobs) on both the pre-S3 file and the post-S3 file. Prior 'build pending' from S2 ACT is now verified.",
+      "S4 ACT (2026-06-04, researcher-1): even_card_interior_doors_hyper closes via Sperner.even_card_fpf_invol applied to adjMapHyper adj on the Σ-type filter, exactly mirroring the parent's even_card_interior_doors. Two Lean-elaboration quirks vs. the S2e PREP recipe: (a) `simp only [adjMapHyper, hadj_eq, hadj_back]` does NOT reduce the inner match — `simp only` substitutes adj p.1 p.2 with `some sk` via hadj_eq but the resulting `match some sk with | some sk' => sk' | none => p` is left unreduced. The workaround is a local lemma `hMap : ∀ q sk, adj q.1 q.2 = some sk → adjMapHyper adj q = sk` proven by `unfold adjMapHyper; rw [hq]` (unfold reduces the match at the kernel level). (b) Lean's structure-eta machinery closes `⟨p.1, p.2⟩ = p` as definitional rfl after the `rw [h1, h2]` chain — so the involution step needs no explicit Sigma.eta. The fixed-point-free step still uses `(Sigma.eta p).trans heq.symm` because there the goal shape is `⟨s', k'⟩ ≠ p`, not the eta-reducible `⟨p.1, p.2⟩ ≠ p`."
     ],
     "mathlibGaps": [
       "Mathlib.Combinatorics.AbstractSimplicialComplex represents cells as Finset V, not as indexed Fin n → V — incompatible with the door-counting parity.",
@@ -68,12 +69,11 @@
       "No Mathlib API for cell-dependent dependent-index face complexes."
     ],
     "nextSteps": [
-      "S4 (next): close the equality case |ι_one| = |P| of door_count_parity_hyper via Fintype.equivOfCardEq + top↔Fin.last d permutation transport to parent SpernerMathlib.door_count_parity. The strict case is already closed (S3 ACT, 2026-06-01).",
-      "S4 (next): close even_card_interior_doors_hyper sorry via Sperner.even_card_fpf_invol applied to adjMapHyper — the three side-conditions (involution from hadj_symm, set-stability from isDoorHyper_iff_of_adj, fixed-point-free from hadj_ne) are already wired by the helper lemmas in §4.",
-      "S4 (next): close sperner_parity_hyper sorry via Σ-versions of card_doors_eq_sum (using Fintype.sum_sigma) and doors_partition (mechanical Finset.disjoint_filter argument).",
-      "S5 (after S4): specialization bridge SpernerMathlib.IsDoor ↔ IsDoorHyper (ι := fun _ => Fin (d+1)) (top := Fin.last d) — ~25 LOC per S2 PREP §4 explicit version.",
-      "S6 (deferred): OQ-01-B non-pure complex restriction lemma (cosmetically heavy).",
-      "S7 (deferred): OQ-01-C boundary-axioms minimality formal demonstration."
+      "S5 (next): close the equality case |ι_one| = |P| of door_count_parity_hyper via Fintype.equivOfCardEq + top↔Fin.last d permutation transport to parent SpernerMathlib.door_count_parity. The strict case is already closed (S3 ACT, 2026-06-01).",
+      "S6 (after S5): close sperner_parity_hyper sorry via Σ-versions of card_doors_eq_sum (using Fintype.sum_sigma) and doors_partition (mechanical Finset.disjoint_filter argument). After S5+S6 the file reaches 0 sorries and unlocks exists_panchromatic_hyper as a fully-verified hypergraph Sperner theorem.",
+      "S7 (after S6): specialization bridge SpernerMathlib.IsDoor ↔ IsDoorHyper (ι := fun _ => Fin (d+1)) (top := Fin.last d) — ~25 LOC per S2 PREP §4 explicit version.",
+      "S8 (deferred): OQ-01-B non-pure complex restriction lemma (cosmetically heavy).",
+      "S9 (deferred): OQ-01-C boundary-axioms minimality formal demonstration."
     ]
   },
   "tags": [
@@ -123,7 +123,7 @@
     ]
   },
   "started": "2026-05-12T20:45:00Z",
-  "lastUpdate": "2026-06-01T20:30:00.000Z",
+  "lastUpdate": "2026-06-04T07:30:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": []


### PR DESCRIPTION
## Summary

**S4 ACT** for `sperner-mathlib-oq-01`. Closes the
`even_card_interior_doors_hyper` sorry (line 271 in the pre-S4 file)
via `Sperner.even_card_fpf_invol` applied to `adjMapHyper adj` on the
Σ-type filter — exactly mirroring the parent's `even_card_interior_doors`
(in `proofs/Proofs/SpernerMathlib.lean`).

- **File**: `proofs/Proofs/SpernerMathlibHyper.lean`
- **LOC**: 342 → 382 (+40)
- **Sorries**: 3 → 2 (33% reduction)
- **Docker build**: ✅ 7744 jobs, 26s, no errors

### Remaining sorries

| Sorry | Location | Type | Effort |
|---|---|---|---|
| `door_count_parity_hyper` equality case `|ι|=|P|` | line 189 | `Fintype.equivOfCardEq` transport | ~25 LOC |
| `sperner_parity_hyper` Σ-chain | line 351 | `Fintype.sum_sigma` finite-sum bookkeeping | ~80 LOC |

After both close (S5/S6), the file reaches **0 sorries**, unlocking
`exists_panchromatic_hyper` as a fully-verified hypergraph Sperner theorem.

## Two PREP-unanticipated Lean-elaboration quirks

The S2e PREP recipe (#18788) proposed `simp only [adjMapHyper, hadj_eq, hadj_back]`
to reduce the match — mirroring the parent. **This failed** because:

1. `simp only` does **not** reduce `match some sk with | some sk' => sk' | none => p` after substituting `adj p.1 p.2 = some sk` via `hadj_eq`. The parent works because Prod has `Prod.mk.eta` *definitional* equality; Sigma does not. Workaround: local lemma using `unfold` (kernel-level reduction):
   \`\`\`lean
   have hMap : ∀ q sk, adj q.1 q.2 = some sk → adjMapHyper adj q = sk := by
     intro q sk hq; unfold adjMapHyper; rw [hq]
   \`\`\`

2. **Lean's structure-eta machinery closes `⟨p.1, p.2⟩ = p` as definitional rfl** after the `rw [h1, h2]` chain. So the involution step needs no explicit `Sigma.eta`. The fixed-point-free step still uses `(Sigma.eta p).trans heq.symm` because its goal shape is `⟨s', k'⟩ ≠ p`, not the eta-reducible `⟨p.1, p.2⟩ ≠ p`.

Both quirks are noted in the session log
(`sessions/2026-06-04-s4-act-even-card-interior-doors-hyper.md` §2)
so future S2e PREP-style sessions on Σ-type definitions can skip
straight to `unfold`-based reductions.

## Test plan

- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.SpernerMathlibHyper`
- [x] Sorry count drops 3 → 2
- [x] No new warnings introduced (pre-existing `unusedSectionVars` on `adjHyper_some_of_ne_none` and `isDoorHyper_of_shared_face` remain; out-of-scope cleanup)
- [x] state.md + gallery JSON synced (S4 entry added, iteration 11 → 13, lastUpdate refreshed)
- [x] Session log written: `2026-06-04-s4-act-even-card-interior-doors-hyper.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)