### PR TITLE
fix(meta): erdos-1018-oq-04-incomplete-01 narrative drift

### DIFF
--- a/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
+++ b/proofs/Proofs/Erdos1018OQ04Incomplete01.lean
@@ -716,22 +716,23 @@ theorem r2_implies_main_r2 :
 
     2. `turanNumber` (parent sorry) → still sorry (deep, requires Turán theory)
 
-    3. K₃ planar (parent axiom) → K3_planar (theorem with remaining sorry in geom part)
-       Now has explicit coordinates, sorry only on the geometric non-crossing verification.
+    3. K₃ planar (parent axiom) → K3_planar (theorem, fully proved) ✓
+       Explicit coordinates (0,0),(1,0),(0,1) with linear-functional projections on
+       convex hulls discharging the non-crossing condition.
 
-    4. K₄ planar (parent axiom) → K4_planar (theorem with remaining sorry)
-       Now has explicit coordinates, sorry only on geometric verification.
+    4. K₄ planar (parent axiom) → K4_planar (theorem, fully proved) ✓
+       Explicit coordinates (0,0),(3,0),(1,2),(2,2) with linear-functional projections
+       on convex hulls discharging the non-crossing condition.
 
     5. `r2_implies_main_r2` → proved (2026-05-02) ✓
        isEmbeddableConc and isEmbeddable have identical bodies so are definitionally equal.
        criticalDim 2 = 2 * (2-1) = 2, and hasSmallNonEmbeddable/isNonEmbeddable unfold cleanly.
 
     **Remaining work**:
-    - Fill in the geometric verification sorries for K₃ and K₄ (require convex hull intersection theory)
-    - Euler's formula bound for planar_graphs_edge_bound
+    - Euler's formula bound for planar_graphs_edge_bound (|E| ≤ 3|V| - 6, not yet in Mathlib)
 
     **Axiom count**: 1 (Kostochka-Pyber r=2 case, proven but deep)
-    **Sorry count**: 3 (geometric verifications + Euler's formula; down from 4 after r2_implies_main_r2)
+    **Sorry count**: 1 (Euler's formula bound in planar_graphs_edge_bound)
 -/
 
 end Erdos1018OQ04Completion

--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -41,7 +41,7 @@
       "K₃ and K₄ are just barely planar by Euler's formula: K₄ satisfies |E| = 3|V| - 6 = 6 with equality, while K₅ has 10 edges vs the planar bound of 3·5 - 6 = 9. This is why K₅ is the smallest non-planar graph.",
       "The density argument is purely asymptotic: n^(1+ε) = n · n^ε eventually exceeds 3n because n^ε → ∞. This uses Mathlib's `Real.tendsto_rpow_atTop`, illustrating how real analysis infrastructure in Mathlib supports combinatorial arguments.",
       "There is a proof-of-concept gap: even after defining `isEmbeddableConc` concretely, connecting it to the parent's `isEmbeddable` sorry requires a definitional equivalence that cannot be proved — highlighting how sorry definitions propagate upward to block all downstream reasoning.",
-      "The geometric verification sorries (convex hull non-crossing for specific coordinates) expose a genuine Mathlib gap: while Mathlib has convex hull theory, the infrastructure for computing explicit convex hull intersections for finite point sets in ℝ² is not yet fully developed."
+      "The K₃ and K₄ non-crossing conditions are discharged via linear-functional projections on convex hulls: a separating linear functional on ℝ² is shown to be constant on `convexHull` (using `convexHull_min` against affine half-spaces), reducing edge-disjointness to a finite arithmetic check on the projected vertex coordinates."
     ],
     "prerequisites": [
       "Convex hulls in ℝ^d",
@@ -71,7 +71,7 @@
       "title": "K₃ and K₄ Planarity",
       "startLine": 80,
       "endLine": 130,
-      "summary": "Provides explicit coordinate embeddings for K₃ (0,0),(1,0),(0,1) and K₄ (0,0),(3,0),(1,2),(2,2). Injectivity is proved; the non-crossing condition has a sorry (requires convex hull intersection theory).",
+      "summary": "Provides explicit coordinate embeddings for K₃ (0,0),(1,0),(0,1) and K₄ (0,0),(3,0),(1,2),(2,2). Both injectivity and the non-crossing condition are fully proved using linear-functional projections on convex hulls.",
       "mathContext": "K₃ at {(0,0),(1,0),(0,1)}: non-degenerate triangle. K₄ at {(0,0),(3,0),(1,2),(2,2)}: valid planar quadrilateral configuration."
     },
     {
@@ -92,8 +92,8 @@
     }
   ],
   "conclusion": {
-    "summary": "This completion pass replaces the vacuous sorry-based `isEmbeddable` with a concrete definition via vertex maps and convex hull separation. K₃ and K₄ planarity are established with explicit coordinates, reducing them from axioms to theorems (pending geometric verification sorries). The density argument shows n^(1+ε) edges eventually exceed the planar bound 3n, and the Kostochka-Pyber r=2 result is axiomatized as a bridge to the main conjecture.",
-    "implications": "With `isEmbeddableConc` in place, the van Kampen-Flores axioms in the parent formalization now make genuine mathematical claims. The 3 remaining sorries are more tractable than the original `isEmbeddable` sorry: 2 are geometric edge-crossing verifications for the K₃ and K₄ explicit embeddings (potentially provable with Mathlib's convex set library), and 1 is the planar edge bound |E| ≤ 3|V| - 6 (Euler's formula for planar graphs, not yet in Mathlib). This pattern — resolving a central conceptual sorry to expose finer technical sorries — represents steady progress in formalization. If the convex hull intersection sorries are filled, the file would establish K₃ and K₄ planarity as proper theorems in Lean 4, which are not yet in Mathlib.",
+    "summary": "This completion pass replaces the vacuous sorry-based `isEmbeddable` with a concrete definition via vertex maps and convex hull separation. K₃ and K₄ planarity are established with explicit coordinates, reducing them from axioms to theorems. The density argument shows n^(1+ε) edges eventually exceed the planar bound 3n, and the Kostochka-Pyber r=2 result is axiomatized as a bridge to the main conjecture.",
+    "implications": "With `isEmbeddableConc` in place, the van Kampen-Flores axioms in the parent formalization now make genuine mathematical claims. The 1 remaining sorry is more tractable than the original `isEmbeddable` sorry: the planar edge bound |E| ≤ 3|V| - 6 (Euler's formula for planar graphs, not yet in Mathlib). This pattern — resolving a central conceptual sorry to expose finer technical sorries — represents steady progress in formalization. K₃ and K₄ planarity are established as proper theorems in Lean 4 via explicit coordinates and linear-functional convex hull arguments.",
     "openQuestions": [
       "Can Mathlib's `Convex.Hull` and `Set.inter` machinery prove that two non-parallel line segments in ℝ² in general position share at most one point (needed for K₃ and K₄ planarity)?",
       "Can `turanNumber` be defined using Mathlib's extremal graph theory (which is under active development)?",


### PR DESCRIPTION
## Fix

Sync `meta.json` narrative fields and Lean trailing docstring with the actual proof state for `erdos-1018-oq-04-incomplete-01`. The structured counts (sorries: 1, axiomCount: 1, etc.) were already correct, but the narrative fields still referenced K₃/K₄ "geometric verification sorries" that have since been resolved.

## Evidence

**Before**:
- `keyInsights` last bullet asserted "geometric verification sorries (convex hull non-crossing for specific coordinates) expose a genuine Mathlib gap."
- `sections[k3-k4-planar].summary`: "the non-crossing condition has a sorry (requires convex hull intersection theory)."
- `conclusion.summary`: "(pending geometric verification sorries)."
- `conclusion.implications`: "The 3 remaining sorries are more tractable… 2 are geometric edge-crossing verifications for the K₃ and K₄ explicit embeddings."
- Lean trailing docstring (lines 712–723): items 3 and 4 (K3_planar, K4_planar) labelled as having "remaining sorry in geom part"; sorry count listed as 3.

**After**:
- `keyInsights` last bullet now describes the linear-functional projections on `convexHull` (via `convexHull_min`) actually used.
- `sections[k3-k4-planar].summary` marks both injectivity and the non-crossing condition as fully proved.
- `conclusion.summary` drops the stale parenthetical.
- `conclusion.implications` corrected to "1 remaining sorry" (Euler's formula bound only).
- Lean trailing docstring updated to mark K3_planar and K4_planar as fully proved; sorry count corrected to 1.

**Verification**:
- Only one actual proof-obligation `sorry` remains in the file (line 652, `planar_graphs_edge_bound`); other `sorry` occurrences are inside comments and docstrings describing the historical sorry trail.
- Both `theorem K3_planar` (line 126) and `theorem K4_planar` (line 239) contain zero `sorry` calls in their proof bodies.
- `meta.json` is still valid JSON.

Closes #22373

---
Automated fix by lean-mechanic agent.