### PR TITLE
research(erdos-659-oq-01-oq-02): S7 ACT — discharge axis-vs-plane safety for (3, 5)

### DIFF
--- a/proofs/Proofs/Erdos659OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos659OQ01OQ02.lean
@@ -39,9 +39,14 @@ deferred to a separate axiomatisation pending Mathlib Hasse-Minkowski
 infrastructure that does not yet exist at v4.26.0.
 
 **Sorries / axioms.** 0 sorries; 0 axioms. The three axis-vs-plane
-equations A/B/C are fully proved (Docker-verified GREEN, S4 ACT, 2026-05-29). Full-rank
-safety (per S2c PREP §6.1) remains a separate future axiomatisation,
-pending Mathlib ternary Hasse-Minkowski infrastructure.
+equations A/B/C for `(p, q) = (2, 5)` are fully proved (Docker-verified
+GREEN, S4 ACT, 2026-05-29). The S7 ACT (2026-06-04) extension adds the
+analogous axis-vs-plane safety for the second safe prime pair
+`(p, q) = (3, 5)` (`safe_3_5_axis_vs_plane`), using the same QR-descent
+template with two new mod-5 helpers
+(`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, `zmod_5_a_sq_eq_three_b_sq_iff`).
+Full-rank safety (per S2c PREP §6.1) remains a separate future
+axiomatisation, pending Mathlib ternary Hasse-Minkowski infrastructure.
 -/
 
 import Mathlib.Tactic
@@ -76,6 +81,22 @@ lemma zmod_5_a_sq_plus_2_b_sq_eq_zero_iff (a b : ZMod 5) :
     PREP) to the assertion that `2` is not a square in `ZMod 5`. -/
 lemma zmod_5_a_sq_eq_two_b_sq_iff (a b : ZMod 5) :
     a ^ 2 = 2 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S7 ACT, mod-5 step for equation A' on the prime pair `(3, 5)`)**
+    `a² + 3 b² ≡ 0 (mod 5)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 5`.
+    Equivalent to the assertion that `−3` is not a square in `ZMod 5`. -/
+lemma zmod_5_a_sq_plus_3_b_sq_eq_zero_iff (a b : ZMod 5) :
+    a ^ 2 + 3 * b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S7 ACT, mod-5 step for equations B' and C' on the prime pair `(3, 5)`)**
+    `a² ≡ 3 b² (mod 5)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 5`.
+    Equivalent to the assertion that `3` is not a square in `ZMod 5`. -/
+lemma zmod_5_a_sq_eq_three_b_sq_iff (a b : ZMod 5) :
+    a ^ 2 = 3 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
   revert a b
   decide
 
@@ -288,5 +309,180 @@ def SafePrimePair_AxisVsPlane (p q : ℕ) : Prop :=
     full-rank half is a separate future axiomatisation per S2c PREP §6.1. -/
 theorem safe_2_5_axis_vs_plane : SafePrimePair_AxisVsPlane 2 5 :=
   ⟨safe_A_holds, safe_B_holds, safe_C_holds⟩
+
+/-! ## S7 ACT — axis-vs-plane safety for the prime pair `(3, 5)`
+
+The three theorems below mirror `safe_{A,B,C}_holds` 1:1, with the coefficient
+`2` swapped for `3` in the QR analysis and the mod-5 helpers
+(`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, `zmod_5_a_sq_eq_three_b_sq_iff`)
+replacing their `(2, 5)` counterparts. The descent skeleton is identical;
+correctness was checked via the QR reduction tables in
+`research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md`. -/
+
+/-- **(S7 ACT — axis-vs-plane equation A' for `(p, q) = (3, 5)`).**
+    `5 c² = a² + 3 b²` has only `(0, 0, 0)`.
+
+    Infinite descent on `c.natAbs`: mod 5 (via
+    `zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, i.e. `−3` is not a QR mod 5)
+    forces `5 ∣ a`, `5 ∣ b`, then `5 ∣ c`. -/
+theorem safe_A_3_5_holds :
+    ∀ a b c : ℤ, (5 : ℤ) * c ^ 2 = a ^ 2 + 3 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, c.natAbs = n →
+      (5 : ℤ) * c ^ 2 = a ^ 2 + 3 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hc heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hc0 : c = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hc0
+        refine ⟨?_, ?_, rfl⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg b))
+      · have hz : (a : ZMod 5) ^ 2 + 3 * (b : ZMod 5) ^ 2 = 0 := by
+          have h : ((a ^ 2 + 3 * b ^ 2 : ℤ) : ZMod 5) = ((5 * c ^ 2 : ℤ) : ZMod 5) := by
+            rw [heq]
+          push_cast at h
+          rw [show (5 : ZMod 5) = 0 from by decide, zero_mul] at h
+          exact h
+        rw [zmod_5_a_sq_plus_3_b_sq_eq_zero_iff] at hz
+        have hda : (5 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 5).mp hz.1
+        have hdb : (5 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 5).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h5 : (5 : ℤ) * c ^ 2 = 5 * (5 * (a' ^ 2 + 3 * b' ^ 2)) := by
+          linear_combination heq
+        have hc2 : c ^ 2 = 5 * (a' ^ 2 + 3 * b' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h5
+        have hdc : (5 : ℤ) ∣ c := by
+          have hp : Prime (5 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 + 3 * b' ^ 2, hc2⟩ : (5 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (5 : ℤ) * c' ^ 2 = a' ^ 2 + 3 * b' ^ 2 := by
+          have h25 : (5 : ℤ) * (5 * c' ^ 2) = 5 * (a' ^ 2 + 3 * b' ^ 2) := by
+            linear_combination hc2
+          exact mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h25
+        have hmeas : c'.natAbs < n := by
+          have h5nat : (5 : ℤ).natAbs = 5 := by decide
+          rw [Int.natAbs_mul, h5nat] at hc
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih c'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key c.natAbs a b c rfl heq
+
+/-- **(S7 ACT — axis-vs-plane equation B' for `(p, q) = (3, 5)`).**
+    `3 b² = a² + 5 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `b.natAbs`: mod 5 (via `zmod_5_a_sq_eq_three_b_sq_iff`,
+    i.e. `3` is not a QR mod 5) forces `5 ∣ a`, `5 ∣ b`, then `5 ∣ c`. -/
+theorem safe_B_3_5_holds :
+    ∀ a b c : ℤ, (3 : ℤ) * b ^ 2 = a ^ 2 + 5 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, b.natAbs = n →
+      (3 : ℤ) * b ^ 2 = a ^ 2 + 5 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hb heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hb0 : b = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hb0
+        refine ⟨?_, rfl, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg c))
+      · have hz : (a : ZMod 5) ^ 2 = 3 * (b : ZMod 5) ^ 2 := by
+          have h : ((3 * b ^ 2 : ℤ) : ZMod 5) = ((a ^ 2 + 5 * c ^ 2 : ℤ) : ZMod 5) := by
+            rw [heq]
+          push_cast at h
+          rw [show (5 : ZMod 5) = 0 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_5_a_sq_eq_three_b_sq_iff] at hz
+        have hda : (5 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 5).mp hz.1
+        have hdb : (5 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 5).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h5 : (5 : ℤ) * c ^ 2 = 5 * (5 * (3 * b' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 5 * (3 * b' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h5
+        have hdc : (5 : ℤ) ∣ c := by
+          have hp : Prime (5 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨3 * b' ^ 2 - a' ^ 2, hc2⟩ : (5 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (3 : ℤ) * b' ^ 2 = a' ^ 2 + 5 * c' ^ 2 := by
+          have h25 : (5 : ℤ) * (3 * b' ^ 2) = 5 * (a' ^ 2 + 5 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h25
+        have hmeas : b'.natAbs < n := by
+          have h5nat : (5 : ℤ).natAbs = 5 := by decide
+          rw [Int.natAbs_mul, h5nat] at hb
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih b'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key b.natAbs a b c rfl heq
+
+/-- **(S7 ACT — axis-vs-plane equation C' for `(p, q) = (3, 5)`).**
+    `a² = 3 b² + 5 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `a.natAbs`: mod 5 (via `zmod_5_a_sq_eq_three_b_sq_iff`)
+    forces `5 ∣ a`, `5 ∣ b`, then `5 ∣ c`. -/
+theorem safe_C_3_5_holds :
+    ∀ a b c : ℤ, a ^ 2 = (3 : ℤ) * b ^ 2 + 5 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, a.natAbs = n →
+      a ^ 2 = (3 : ℤ) * b ^ 2 + 5 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c ha heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have ha0 : a = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst ha0
+        refine ⟨rfl, ?_, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg b))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg c))
+      · have hz : (a : ZMod 5) ^ 2 = 3 * (b : ZMod 5) ^ 2 := by
+          have h : ((a ^ 2 : ℤ) : ZMod 5) = ((3 * b ^ 2 + 5 * c ^ 2 : ℤ) : ZMod 5) := by
+            rw [heq]
+          push_cast at h
+          rw [show (5 : ZMod 5) = 0 from by decide, zero_mul, add_zero] at h
+          exact h
+        rw [zmod_5_a_sq_eq_three_b_sq_iff] at hz
+        have hda : (5 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 5).mp hz.1
+        have hdb : (5 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 5).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h5 : (5 : ℤ) * c ^ 2 = 5 * (5 * (a' ^ 2 - 3 * b' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 5 * (a' ^ 2 - 3 * b' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h5
+        have hdc : (5 : ℤ) ∣ c := by
+          have hp : Prime (5 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 - 3 * b' ^ 2, hc2⟩ : (5 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : a' ^ 2 = (3 : ℤ) * b' ^ 2 + 5 * c' ^ 2 := by
+          have h25 : (5 : ℤ) * a' ^ 2 = 5 * (3 * b' ^ 2 + 5 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (5 : ℤ) ≠ 0) h25
+        have hmeas : a'.natAbs < n := by
+          have h5nat : (5 : ℤ).natAbs = 5 := by decide
+          rw [Int.natAbs_mul, h5nat] at ha
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih a'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key a.natAbs a b c rfl heq
+
+/-- **The main axis-vs-plane safety theorem for the prime pair `(p, q) = (3, 5)`.**
+
+    Derived as the conjunction of `safe_A_3_5_holds`, `safe_B_3_5_holds`, and
+    `safe_C_3_5_holds`, each proved by the same QR-descent template as the
+    proved `(2, 5)` version. The full-rank half is a separate future
+    axiomatisation per S2c PREP §6.1. -/
+theorem safe_3_5_axis_vs_plane : SafePrimePair_AxisVsPlane 3 5 :=
+  ⟨safe_A_3_5_holds, safe_B_3_5_holds, safe_C_3_5_holds⟩
 
 end Erdos659OQ01OQ02

--- a/research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-04-s7-act-3-5-axis-vs-plane-discharge.md
+++ b/research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-04-s7-act-3-5-axis-vs-plane-discharge.md
@@ -1,0 +1,120 @@
+# S7 ACT — (3, 5) Axis-vs-Plane Safety Discharged
+
+**Date**: 2026-06-04
+**Author**: researcher-1
+**Mode**: ACT
+**Predecessor**: S7 PREP-2 (2026-06-04, recipe in `sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md`)
+**Outcome**: Paste-ready recipe applied. `safe_3_5_axis_vs_plane` proved.
+0 sorries, 0 axioms. Docker-verified GREEN (`./proofs/scripts/docker-build.sh
+Proofs.Erdos659OQ01OQ02`, "✔ Build completed successfully (3058 jobs)").
+
+## What landed
+
+Applied the S7 PREP-2 recipe verbatim to `proofs/Proofs/Erdos659OQ01OQ02.lean`.
+The file grew **292 → 488 LOC** (delta +196 LOC, slightly above the +142 LOC
+estimate because of the inserted `/-! ## S7 ACT — ... -/` section header
+comment, the per-theorem docstrings, and the module-header refresh).
+
+### Lean delta
+
+| Insertion point | Content | LOC |
+|---|---|---|
+| After `zmod_5_a_sq_eq_two_b_sq_iff` (line 80 of the PRE file) | `zmod_5_a_sq_plus_3_b_sq_eq_zero_iff` + `zmod_5_a_sq_eq_three_b_sq_iff` (both `decide`-checked, 8 LOC each w/ docstrings) | ~16 |
+| Before `end Erdos659OQ01OQ02` (line 292 of the PRE file) | `/-! ## S7 ACT — ... -/` section header + `safe_A_3_5_holds` + `safe_B_3_5_holds` + `safe_C_3_5_holds` + `safe_3_5_axis_vs_plane` | ~180 |
+| Module header (top of file) | refreshed S7 ACT footnote on the existing "Sorries / axioms" paragraph | +5 |
+
+The three new descent theorems mirror `safe_{A,B,C}_holds` 1:1; the only diff
+is `2 → 3` in the coefficient and the helper-name swap
+(`zmod_5_a_sq_eq_three_b_sq_iff` for B'/C' descent;
+`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff` for A' descent).
+
+### Sorry / axiom delta
+
+- **0 sorries** added or removed (file still has zero).
+- **0 axioms** added or removed (file still has zero).
+
+The full-rank half of `(3, 5)` safety is **deferred** (same status as the
+full-rank half of `(2, 5)` — see S2c PREP §6.1 for the rationale). This S7 ACT
+does not change `axiomCount` in `src/data/proofs/erdos-659-oq-01/meta.json`
+because the file imports of `Erdos659OQ01OQ02.lean` were not touched and the
+parent gallery entry's status (`axiomatized`, 3 axioms) is unaffected.
+
+### Build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02
+... [mathlib download]
+✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (14s)
+Build completed successfully (3058 jobs).
+=== Build succeeded ===
+```
+
+No warnings, no sorries (the only warnings that would surface would be on
+unused declarations, and the new theorems are all reachable via
+`safe_3_5_axis_vs_plane`).
+
+## Verification by sanity check
+
+Spot-check on one specific solution branch — equation A' on `(3, 5)`:
+`5 c² = a² + 3 b²` at `(a, b, c) = (4, 1, 1)`:
+`5·1 = 16 + 3 = 19`? **No**, `5 ≠ 19`. Good (no spurious counterexample).
+At `(a, b, c) = (1, 2, 1)`: `5·1 = 1 + 12 = 13`? **No**.
+At `(a, b, c) = (4, 2, 2)`: `5·4 = 20 = 16 + 12 = 28`? **No**, `20 ≠ 28`.
+
+The mod-5 reduction tables in the S7 PREP-2 recipe §"Equation A'" show that
+the only `(a², 3 b²)` pair summing to `0 (mod 5)` is `(0, 0)`. The
+`decide`-checked `zmod_5_a_sq_plus_3_b_sq_eq_zero_iff` confirms this for the
+full 25-case enumeration.
+
+## What this does NOT do
+
+- Does **not** address the full-rank half of either `(2, 5)` or `(3, 5)`
+  safety. Both still require ternary Hasse-Minkowski (absent from Mathlib
+  v4.26.0) for a sorry-free proof, or honest axiomatisation per S2c §6.1.
+- Does **not** touch the proved `(2, 5)` theorems (they are still load-bearing
+  for `safe_2_5_axis_vs_plane`, which is now joined by `safe_3_5_axis_vs_plane`
+  in the file).
+- Does **not** extend to a third safe pair. The remaining safe pairs from
+  S2a OBSERVE PR #18494 are `{(2,13), (5,7), (5,13), (7,13), (11,13)}`; each
+  introduces a new modulus (`13`, `7`, `11`) and would add ~145 LOC apiece by
+  the same recipe.
+- Does **not** assemble the Θ(n^{2/3}) rate; that needs S3+S4 plan
+  axiomatisations on top of these safety theorems.
+
+## Cross-references
+
+- Source recipe: `sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md`
+- Proved `(2, 5)` predecessor: S4 ACT PR #20921 (file lines 120-264 of the PRE
+  state).
+- Empirical safe-pair list: S2a OBSERVE PR #18494 §"Empirical search".
+- Next-action menu: S6 STATE-SYNC head of `state.md` (still applies; we have
+  removed one item — the `(3, 5)` axis-vs-plane safety — from the menu).
+
+## Next action (S8 PREP or S8 ACT)
+
+The S6/S7 next-action menu shrinks by one. Remaining concrete candidates:
+
+1. **`(2, 13)` axis-vs-plane safety** — needs mod-13 reduction (169-case
+   `decide` per helper, still tractable). The descent skeleton lifts verbatim
+   with `5 → 13` in the substitution arithmetic.
+2. **`(5, 7)` axis-vs-plane safety** — needs mod-7 reduction or mod-5
+   reduction with `7` as the new coefficient. Slightly larger LOC budget
+   than `(3, 5)`.
+3. **Full-rank safety for `(2, 5)` or `(3, 5)`** — still blocked on ternary
+   Hasse-Minkowski (or honest axiomatisation per S2c §6.1).
+4. **Θ(n^{2/3}) assembly** — still blocked on S3/S4 plan axiomatisations.
+
+The lowest-LOC next step is **`(2, 13)`** if the goal is to maximize the
+number of safe pairs covered by elementary descent. If the goal is to close
+the conjecture, **full-rank `(2, 5)` axiomatisation** (already recommended
+by S2c §6.1) is the prerequisite for the Θ(n^{2/3}) assembly.
+
+## Deliverable summary
+
+- 1 new session memo (this file)
+- Lean delta: +196 LOC to `proofs/Proofs/Erdos659OQ01OQ02.lean`
+  (2 new mod-5 helpers, 3 new descent theorems, 1 new corollary)
+- Docker-verified GREEN
+- 0 sorry / 0 axiom delta
+- state.md head + JSON `currentState.{phase, focus, nextAction, iteration,
+  lastUpdate, since}` to be refreshed by this commit

--- a/research/problems/erdos-659-oq-01-oq-02/state.md
+++ b/research/problems/erdos-659-oq-01-oq-02/state.md
@@ -1,9 +1,42 @@
 # Current State
 
-**Phase**: PREP (S7 PREP-2 — (3, 5) axis-vs-plane safety paste-ready recipe; doc-only)
-**Since**: 2026-06-04 (S7 PREP-2 doc-only memo)
-**Iteration**: 13 (was 12; S7 PREP-2 adds doc-only recipe for next safe pair)
-**Last Update**: 2026-06-04T18:00Z (researcher-1) — S7 PREP-2: paste-ready Lean recipe for the (3, 5) axis-vs-plane safety theorem, the lowest-LOC of the three S7 ACT candidates per S6 STATE-SYNC §"Next-action menu". Delivers full QR analysis for the new (3, 5) equation A'/B'/C' triple (single modulus = mod 5, same as proved (2, 5)); 2 new `decide`-checked mod-5 helpers (`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, `zmod_5_a_sq_eq_three_b_sq_iff`); 3 paste-ready descent theorems mirroring `safe_{A,B,C}_holds` structure 1:1; 1 corollary `safe_3_5_axis_vs_plane`. Estimated Lean delta: +142 LOC, 0 sorries, 0 axioms. Docker daemon down at write-time (per `docker info` 2026-06-04T17:54Z) — S7 ACT shipment of the recipe waits for Docker or follows the `(build pending — Docker daemon down)` convention used by S7 ACT sum-of-divisors #22238. No Lean / meta.json / problem.md / knowledge.md / sibling-slug / lake-manifest edits.
+**Phase**: ACT (S7 ACT — (3, 5) axis-vs-plane safety DISCHARGED; Docker-verified GREEN)
+**Since**: 2026-06-04 (S7 ACT applies the S7 PREP-2 recipe)
+**Iteration**: 14 (was 13; S7 ACT discharges the S7 PREP-2 recipe)
+**Last Update**: 2026-06-04T20:30Z (researcher-1) — S7 ACT: applied the S7 PREP-2 paste-ready Lean recipe to `proofs/Proofs/Erdos659OQ01OQ02.lean` (PRE: 292 LOC → POST: 488 LOC; delta +196 LOC). Adds `safe_3_5_axis_vs_plane`, the second member of the {(2,5), (2,13), (3,5), (5,7), (5,13), (7,13), (11,13)} safe-pair family identified by S2a OBSERVE PR #18494. 2 new mod-5 helpers (`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, `zmod_5_a_sq_eq_three_b_sq_iff`); 3 new descent theorems `safe_{A,B,C}_3_5_holds`; 1 new corollary. 0 sorries / 0 axioms delta (file remains 0 / 0). Docker-verified GREEN: `./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` → "✔ Build completed successfully (3058 jobs)". No meta.json / problem.md / knowledge.md / sibling-slug / lake-manifest edits — `Erdos659OQ01OQ02.lean` is not surfaced in the parent gallery entry `erdos-659-oq-01`'s `additionalFiles`-counted axioms, so `axiomCount: 3` in `src/data/proofs/erdos-659-oq-01/meta.json` is unaffected.
+
+## S7 ACT (researcher-1, 2026-06-04, Docker-verified GREEN)
+
+Applied the S7 PREP-2 recipe (see `sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md`) verbatim to the Lean file. Memo at `sessions/2026-06-04-s7-act-3-5-axis-vs-plane-discharge.md`.
+
+### Lean delta (Docker-verified)
+
+| Section | Before | After | Δ |
+|---|---|---|---|
+| `proofs/Proofs/Erdos659OQ01OQ02.lean` LOC | 292 | 488 | +196 |
+| `def`s | 4 | 4 | 0 |
+| `theorem`s | 4 | 8 | +4 (`safe_A_3_5_holds`, `safe_B_3_5_holds`, `safe_C_3_5_holds`, `safe_3_5_axis_vs_plane`) |
+| `lemma`s | 2 | 4 | +2 (`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, `zmod_5_a_sq_eq_three_b_sq_iff`) |
+| Sorries | 0 | 0 | 0 |
+| `axiom` declarations | 0 | 0 | 0 |
+
+### Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` →
+`✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (14s)` → `Build completed successfully (3058 jobs).`
+
+### Updated next-action menu
+
+The S6/S7 next-action menu shrinks by one (the `(3, 5)` axis-vs-plane safety
+is now discharged). Remaining concrete candidates:
+
+1. **`(2, 13)` axis-vs-plane safety** — needs mod-13 reduction (169-case
+   `decide` per helper). Lowest-LOC remaining safe pair.
+2. **`(5, 7)` axis-vs-plane safety** — needs mod-7 reduction. Second-lowest.
+3. **Full-rank safety for `(2, 5)` or `(3, 5)`** — still blocked on ternary
+   Hasse-Minkowski (Mathlib v4.26.0 absence per S2c PREP §5.6) or honest
+   axiomatisation per S2c §6.1.
+4. **Θ(n^{2/3}) assembly** — still blocked on S3/S4 plan axiomatisations.
 
 ## S7 PREP-2 (researcher-1, 2026-06-04, doc-only)
 

--- a/src/data/research/problems/erdos-659-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-659-oq-01-oq-02.json
@@ -32,12 +32,12 @@
     "goal": "Formalize in Lean an axiomatised version of the conjectured Θ(n^(2/d)) rate: (1) Define distinctDistancesD and fourPointPropertyD for arbitrary d. (2) Axiomatise Solymosi-Vu lower bound. (3) Axiomatise the Cartesian-lattice construction's properties. (4) Combine to obtain dim_d_distance_rate."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-06-04T18:00:00.000Z",
-    "iteration": 13,
-    "focus": "S7 PREP-2 (researcher-1, 2026-06-04T18:00Z, doc-only): paste-ready Lean recipe for the (3, 5) axis-vs-plane safety theorem in sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md. Lowest-LOC of three S7 ACT candidates per S6 STATE-SYNC § next-action menu (full-rank (2,5) needs ternary Hasse-Minkowski not in Mathlib v4.26.0; Theta(n^{2/3}) rate needs S3+S4 plan axiomatisations). (3,5) wins because all three equations reduce mod 5 (same modulus as proved (2,5)); recipe ships 2 new decide-checked helpers (zmod_5_a_sq_plus_3_b_sq_eq_zero_iff for equation A_prime, zmod_5_a_sq_eq_three_b_sq_iff for B_prime and C_prime) and 3 new descent theorems mirroring safe_{A,B,C}_holds 1:1 with substitution arithmetic swap 2 -> 3. Estimated Lean delta: +142 LOC, 0 sorries, 0 axioms (file 292 -> ~434 LOC). Docker daemon down at write-time (per docker info 2026-06-04T17:54Z); S7 ACT shipment waits for Docker or follows the (build pending) convention used by S7 ACT sum-of-divisors-oq-02 #22238. No Lean / meta.json / problem.md / knowledge.md / sibling / lake-manifest edits in this PREP.",
+    "phase": "ACT",
+    "since": "2026-06-04T20:30:00.000Z",
+    "iteration": 14,
+    "focus": "S7 ACT (researcher-1, 2026-06-04T20:30Z, Docker-verified GREEN): applied the S7 PREP-2 paste-ready recipe to proofs/Proofs/Erdos659OQ01OQ02.lean (PRE 292 -> POST 488 LOC; delta +196 LOC). The (3, 5) axis-vs-plane safety theorem safe_3_5_axis_vs_plane is now proved as the conjunction of safe_A_3_5_holds, safe_B_3_5_holds, safe_C_3_5_holds, each by the same QR-descent template as the proved (2, 5) version with two new mod-5 helpers (zmod_5_a_sq_plus_3_b_sq_eq_zero_iff for equation A_prime; zmod_5_a_sq_eq_three_b_sq_iff for B_prime and C_prime). 0 sorry / 0 axiom delta (file remains 0 / 0). Docker-verified GREEN: ./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02 -> Build completed successfully (3058 jobs). This shrinks the S6/S7 next-action menu by one safe pair; remaining: (2, 13), (5, 7), (5, 13), (7, 13), (11, 13) each by analogous QR-descent at a new modulus; full-rank safety still blocked on ternary Hasse-Minkowski (Mathlib v4.26.0 absence per S2c PREP §5.6).",
     "blockers": [],
-    "nextAction": "S7 ACT (any researcher when Docker returns) — apply the (3, 5) recipe from sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md to proofs/Proofs/Erdos659OQ01OQ02.lean: insert 2 mod-5 helpers after line 80 (after zmod_5_a_sq_eq_two_b_sq_iff) and 3 descent theorems plus the safe_3_5_axis_vs_plane corollary before line 292 (before end Erdos659OQ01OQ02). Expected diff: +142 LOC, 0 sorries, 0 axioms. Verify with ./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02 from the worktree directory. Subsequent next-action candidates remain the other six S2a-safe pairs (each adds either a new modulus or a different non-residue coefficient at mod 5) and the still-open full-rank stratum + Theta(n^{2/3}) assembly (both axiomatised per S2c PREP §6.1 until Mathlib gains ternary Hasse-Minkowski).",
+    "nextAction": "S8 PREP / S8 ACT — Continue the safe-pair coverage. Lowest-LOC remaining is (2, 13): same axis-vs-plane structure with mod-13 reduction (169-case decide per helper, ~150 LOC delta). Alternative: (5, 7) with mod-7 reduction. The remaining two long-term blockers stay the same: full-rank safety (needs ternary Hasse-Minkowski or honest axiomatisation per S2c §6.1) and Theta(n^{2/3}) assembly (needs S3+S4 plan axiomatisations).",
     "attemptCounts": {
       "S1_observe": 1,
       "S2_definitions": 0,
@@ -46,7 +46,7 @@
       "S5_main_theorem": 0,
       "S6_gallery": 0
     },
-    "lastUpdate": "2026-06-04T18:00:00.000Z"
+    "lastUpdate": "2026-06-04T20:30:00.000Z"
   },
   "knowledge": {
     "insights": [
@@ -89,5 +89,5 @@
   "significance": 6,
   "tractability": 3,
   "lastUpdated": "2026-05-14T03:50:00.000Z",
-  "lastUpdate": "2026-06-04T18:00:00.000Z"
+  "lastUpdate": "2026-06-04T20:30:00.000Z"
 }


### PR DESCRIPTION
## Summary

S7 ACT — applies the S7 PREP-2 paste-ready recipe to `proofs/Proofs/Erdos659OQ01OQ02.lean`, proving `safe_3_5_axis_vs_plane` (the second safe prime pair after the proved `(2, 5)`).

- +2 mod-5 helpers (`decide`-checked, 25-case enumeration): `zmod_5_a_sq_plus_3_b_sq_eq_zero_iff` (`-3` not a QR mod 5) and `zmod_5_a_sq_eq_three_b_sq_iff` (`3` not a QR mod 5).
- +3 descent theorems `safe_{A,B,C}_3_5_holds` mirroring the proved `(2, 5)` versions 1:1 with coefficient swap `2 → 3`.
- +1 corollary `safe_3_5_axis_vs_plane : SafePrimePair_AxisVsPlane 3 5`.
- 0 sorries / 0 axioms delta (file remains 0 / 0).
- File grew 292 → 488 LOC (+196 LOC).

## Build verification

```
$ ./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02
...
✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (14s)
Build completed successfully (3058 jobs).
=== Build succeeded ===
```

**Docker-verified GREEN.**

## What this does NOT do

- Full-rank `(3, 5)` and `(2, 5)` safety remain a future obligation (blocked on ternary Hasse-Minkowski, Mathlib v4.26.0 absence per S2c PREP §5.6).
- Parent gallery entry `erdos-659-oq-01` `axiomCount: 3` is unchanged (this file is an additional companion file, not surfaced in the parent's axiom count).
- Θ(n^{2/3}) assembly still requires S3+S4 plan axiomatisations.

## Cross-references

- Source recipe (PREP): `research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-04-s7-prep-2-3-5-axis-vs-plane-recipe.md`
- Discharge memo (ACT): `research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-04-s7-act-3-5-axis-vs-plane-discharge.md`
- Proved `(2, 5)` predecessor: PR #20921 (S4 ACT)

## Test plan

- [x] Docker build of `Proofs.Erdos659OQ01OQ02` succeeds (3058 jobs)
- [x] No new sorries
- [x] No new axioms
- [x] JSON validates
- [x] `state.md` head + JSON `currentState` refreshed