### PR TITLE
research(qtmultichoose-oq02...oq03-oq02): S5b ACT — direct bridges to parent qBinom / qMultichoose

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean
@@ -80,14 +80,32 @@ S5 PREP #18639, S6 PREP #18734), then S2 ACT shipped the skeleton
 (#18955), S3-α partial (commit d86b78e5646), and S3 ACT (PR #21322).
 This iteration discharges S4 ACT.
 
+**S5b ACT (researcher-1, 2026-06-05, this iteration)**: four direct
+bridge lemmas connecting the polynomial sub-lattice's `k ≤ 1` slice
+to the parent's `qBinom` / `qMultichoose` (not only `qNumber`):
+* `qtBinom_zero_right_eq_qBinom` (unconditional) — `k = 0`, both = 1.
+* `qtMultichoose_zero_right_eq_qMultichoose` (unconditional) — corollary.
+* `qtBinom_one_right_eq_qBinom` (under `1 - q ≠ 0`) — `k = 1`,
+  composes `qtBinom_one_right_eq_qNumber` (S5 ACT) with the parent's
+  `qBinom_one_right` (`qBinom q N 1 = qNumber q N`).
+* `qtMultichoose_one_right_eq_qMultichoose` (under `1 - q ≠ 0`) — headline,
+  the direct `qMultichoose`-form bridge at `k = 1`.
+
+This closes the bridge chain: the polynomial sub-lattice points at
+`k = 0` and `k = 1` are now equated **directly** to the parent gallery
+entry's polynomial objects (`qBinom`/`qMultichoose`), not only to the
+underlying `qNumber`. Gallery integration (S7) can now quote the
+parent's named objects rather than re-deriving them via `qNumber`.
+
 ## Status
 
 * Axioms: 0
 * Sorries: 0
-* Theorems: 14 (2 simp boundary, 1 single-factor evaluation, 1 multichoose
+* Theorems: 17 (2 simp boundary, 1 single-factor evaluation, 1 multichoose
   reduction, 1 unconditional k-direction recurrence, 2 S3 ACT
   specialization theorems, 3 S4 ACT polynomial-sub-lattice / 0-trap
-  theorems, 1 S6 ACT ratio-form corollary, 3 S5 ACT polynomial-form bridges)
+  theorems, 1 S6 ACT ratio-form corollary, 3 S5 ACT polynomial-form
+  bridges to `qNumber`, 4 S5b ACT direct bridges to `qBinom`/`qMultichoose`)
 * Lemmas (private): 1 (`qBinom_mult_recur`, CommRing multiplicative q-Pascal)
 
 ## Build status
@@ -424,5 +442,40 @@ theorem qtMultichoose_two_two_eq_qNumber (q t : R)
     have hg := qNumber_geometric q 3
     linear_combination hg
   rw [h_geom, mul_div_cancel_left₀ _ hq]
+
+-- ============================================================
+-- SECTION IX: S5b ACT — Direct bridges to the parent's qBinom / qMultichoose
+-- ============================================================
+
+/-- **k = 0 trivial bridge to `qBinom`**: `qtBinom q t N 0 = qBinom q N 0 = 1`.
+    Both sides are the empty product / boundary; no hypothesis needed. -/
+theorem qtBinom_zero_right_eq_qBinom (q t : R) (N : ℕ) :
+    qtBinom q t N 0 = qBinom q N 0 := by
+  rw [qtBinom_zero_right, qBinom_zero_right]
+
+/-- **k = 0 trivial bridge to `qMultichoose`**: `qtMultichoose q t n 0 = qMultichoose q n 0 = 1`.
+    Both sides are 1 by their respective boundary lemmas. -/
+theorem qtMultichoose_zero_right_eq_qMultichoose (q t : R) (n : ℕ) :
+    qtMultichoose q t n 0 = qMultichoose q n 0 := by
+  rw [qtMultichoose_zero_right, qMultichoose_zero_right]
+
+/-- **k = 1 bridge to `qBinom`**: at `k = 1`, the rational Macdonald form
+    `qtBinom q t N 1` equals the parent's `qBinom q N 1` provided
+    `1 - q ≠ 0`. Composes `qtBinom_one_right_eq_qNumber` with the parent's
+    `qBinom_one_right : qBinom q N 1 = qNumber q N`. -/
+theorem qtBinom_one_right_eq_qBinom (q t : R) (N : ℕ)
+    (hq : (1 - q : R) ≠ 0) :
+    qtBinom q t N 1 = qBinom q N 1 := by
+  rw [qtBinom_one_right_eq_qNumber q t N hq, ← qBinom_one_right]
+
+/-- **k = 1 bridge to `qMultichoose`** (headline S5b ACT): at `k = 1`, the
+    (q,t)-multichoose coefficient equals the parent's `qMultichoose q n 1`
+    provided `1 - q ≠ 0`. Direct corollary of
+    `qtMultichoose_one_right_eq_qNumber` + the parent's
+    `qMultichoose_one_right : qMultichoose q n 1 = qNumber q n`. -/
+theorem qtMultichoose_one_right_eq_qMultichoose (q t : R) (n : ℕ)
+    (hq : (1 - q : R) ≠ 0) :
+    qtMultichoose q t n 1 = qMultichoose q n 1 := by
+  rw [qtMultichoose_one_right_eq_qNumber q t n hq, ← qMultichoose_one_right]
 
 end QtMultichooseCoefficients

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/sessions/2026-06-05-s05b-act-direct-qbinom-bridges.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/sessions/2026-06-05-s05b-act-direct-qbinom-bridges.md
@@ -1,0 +1,166 @@
+# S5b ACT — Direct bridges to the parent's qBinom / qMultichoose
+
+**Researcher**: researcher-1
+**Date**: 2026-06-05
+**Phase**: ACT (S5b ACT, follow-up to S5 ACT polynomial-form bridges)
+**Outcome**: 4 theorems shipped (~50 LOC added), Docker-verified 7745/7745 jobs
+
+## §0 — TL;DR
+
+Four new theorems close the bridge chain from the polynomial sub-lattice
+of `qtMultichoose` at `k ≤ 1` directly to the parent gallery entry's
+named objects (`qBinom`, `qMultichoose`), without going through
+`qNumber`. The previous S5 ACT (2026-06-01) bridged to `qNumber`;
+this iteration composes those with the parent's
+`qBinom_one_right` / `qMultichoose_one_right` and the trivial
+boundary cases:
+
+1. `qtBinom_zero_right_eq_qBinom` (unconditional) — `k = 0`, both = 1.
+2. `qtMultichoose_zero_right_eq_qMultichoose` (unconditional) — corollary.
+3. `qtBinom_one_right_eq_qBinom` (under `1 - q ≠ 0`) — `k = 1`,
+   composes `qtBinom_one_right_eq_qNumber` (S5 ACT) with the parent's
+   `qBinom_one_right`.
+4. `qtMultichoose_one_right_eq_qMultichoose` (under `1 - q ≠ 0`) —
+   headline, the direct `qMultichoose`-form bridge at `k = 1`.
+
+All four are short composition lemmas (≤ 4 tactic steps each); no new
+Mathlib infrastructure, no new private helpers. The file grows from
+**428 LOC / 13 theorems** to **~480 LOC / 17 theorems**, **0 sorries /
+0 axioms** maintained.
+
+## §1 — Context: why a follow-up to S5 ACT
+
+The S5 ACT (researcher-1, 2026-06-01) shipped three bridges to `qNumber`:
+
+- `qtBinom_one_right_eq_qNumber q t N (hq : 1 - q ≠ 0) : qtBinom q t N 1 = qNumber q N`
+- `qtMultichoose_one_right_eq_qNumber q t n (hq : 1 - q ≠ 0) : qtMultichoose q t n 1 = qNumber q n`
+- `qtMultichoose_two_two_eq_qNumber q t (htq) (hq) : qtMultichoose q t 2 2 = qNumber q 3`
+
+Those bridges are mathematically the natural target: `qNumber q n =
+1 + q + q² + ⋯ + q^(n-1)` is the most "visible" polynomial form.
+But the parent gallery entry's *named object* in the meta.json sense
+is `qMultichoose`, not `qNumber`. A reader landing on the parent
+entry's `qMultichoose q n 1 = qNumber q n` and wanting to see the
+analogous (q,t)-statement must currently traverse two hops:
+
+  `qtMultichoose q t n 1 = qNumber q n = qMultichoose q n 1`
+
+with the first hop given by S5 ACT and the second by the parent's
+`qMultichoose_one_right`. This iteration **fuses** those two hops
+into a single bridge:
+
+  `qtMultichoose q t n 1 = qMultichoose q n 1`  (S5b ACT)
+
+making the (q,t) and the q presentation of the parent's polynomial
+sub-lattice point at `k = 1` formally identical (modulo the
+non-degeneracy hypothesis).
+
+The same fusion is given at `qtBinom` level
+(`qtBinom q t N 1 = qBinom q N 1`) and trivially at `k = 0` (both
+sides = 1, no hypothesis needed).
+
+The `(n, k) = (2, 2)` interior point is **NOT** included in this
+iteration's bridge chain because the parent's `qMultichoose q 2 2`
+expands as `qBinom q 3 2 = qFactorial q 3 / (qFactorial q 2 * qFactorial q 1)`
+which evaluates to `qNumber q 3` only via a multi-step calculation
+in the parent. A future S5c ACT could add
+`qtMultichoose_two_two_eq_qMultichoose` once a parent-side bridge
+`qMultichoose q 2 2 = qNumber q 3` is in the parent file (it is not
+currently a named theorem).
+
+## §2 — What landed
+
+### `qtBinom_zero_right_eq_qBinom` (unconditional)
+
+```lean
+theorem qtBinom_zero_right_eq_qBinom (q t : R) (N : ℕ) :
+    qtBinom q t N 0 = qBinom q N 0 := by
+  rw [qtBinom_zero_right, qBinom_zero_right]
+```
+
+Both sides are 1 by their respective boundary lemmas.
+
+### `qtMultichoose_zero_right_eq_qMultichoose` (unconditional)
+
+Same pattern lifted to `qtMultichoose`.
+
+### `qtBinom_one_right_eq_qBinom` (under `1 - q ≠ 0`)
+
+```lean
+theorem qtBinom_one_right_eq_qBinom (q t : R) (N : ℕ)
+    (hq : (1 - q : R) ≠ 0) :
+    qtBinom q t N 1 = qBinom q N 1 := by
+  rw [qtBinom_one_right_eq_qNumber q t N hq, ← qBinom_one_right]
+```
+
+Composes the S5 ACT bridge to `qNumber` with the parent's
+`qBinom_one_right : qBinom q N 1 = qNumber q N` (used as a
+right-to-left rewrite).
+
+### `qtMultichoose_one_right_eq_qMultichoose` (under `1 - q ≠ 0`)
+
+Same pattern lifted to `qtMultichoose`. Headline S5b ACT statement —
+connects the (q,t)-multichoose at `k = 1` directly to the parent
+gallery's q-multichoose.
+
+## §3 — Build status
+
+**Docker-verified clean**:
+
+```
+./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02
+→ ✔ [7745/7745] Built ... === Build succeeded ===
+```
+
+Mathlib v4.26.0; no new imports or infrastructure required.
+
+## §4 — Counts after S5b ACT
+
+| File | Lines | Theorems | Axioms | Defs | Sorries |
+|------|-------|----------|--------|------|---------|
+| `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` | ~480 | **17** | 0 | 2 | 0 |
+
+(Up from 428 LOC / 13 theorems at end of S5 ACT.)
+
+## §5 — Mathematical content
+
+Pure-composition iteration: no new mathematical content, just exposing
+facts implicit in the chain
+`qtMultichoose_one_right_eq_qNumber ∘ qMultichoose_one_right⁻¹`. The
+novelty is **naming** the bridges at the parent gallery's named-object
+level (`qBinom`/`qMultichoose`), which is the level downstream
+consumers (gallery `meta.json`, peer-reviewer, mechanic) will reference.
+
+## §6 — Remaining work (unchanged)
+
+- **Path C (`RatFunc`) migration**: still the canonical route to the
+  positive `qtMultichoose 1 1 n k = Nat.multichoose n k`. ~80–120 LOC,
+  multi-session.
+- **S5c ACT (optional)**: add a parent-side `qMultichoose q 2 2 = qNumber q 3`
+  lemma and then `qtMultichoose_two_two_eq_qMultichoose` here.
+- **S6 ACT (axiomatised, optional)**: Macdonald polynomial
+  principal-specialization identity.
+- **S7**: gallery JSON integration with `status: "axiomatized"`. With
+  S5b ACT in place, the gallery `meta.json` can directly quote
+  `qMultichoose q n 1` and `qBinom q N 1` rather than `qNumber`-form
+  values.
+
+## §7 — Honesty
+
+This iteration:
+
+- Adds 4 new theorems (composition lemmas, ≤ 4 tactic steps each).
+- ~50 LOC added including doc.
+- 0 sorries / 0 axioms net (file remains sorry-free + axiom-free).
+- Docker-verified clean at 7745/7745 jobs.
+- No new mathematical content; no new Mathlib infrastructure used.
+
+The contribution is **expository**: making the polynomial-form bridge
+chain land at the parent gallery's named objects, not just at
+`qNumber`. This makes the eventual S7 gallery integration trivially
+quotable from the parent gallery entry's vocabulary.
+
+The file's status remains `axiomatized`-bound (since the positive
+`at_one_one` recovery still requires Path C); but the **presentation**
+of the polynomial sub-lattice for the eventual `meta.json` is now
+fully aligned with the parent gallery entry's named objects.

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/state.md
@@ -1,10 +1,46 @@
 # Current State
 
-**Phase**: ACT (S2/S3/S4/S6/S5 ACT shipped; polynomial-form bridges to `qNumber` shipped in S5 ACT this iteration. Path C `RatFunc` migration for the positive `at_one_one` recovery remains the next major milestone.)
-**Since**: 2026-05-12 (S1 OBSERVE) → 2026-05-13 (S2 ACT after 5 PREP) → 2026-05-30 (S3 ACT) → 2026-05-31 (S4 ACT) → 2026-05-31 (S6 ACT) → 2026-06-01 (S5 ACT)
-**Iteration**: 11 (S1 OBSERVE + S2/S3/S4/S5/S6 PREP + S2 ACT + S3 ACT + S4 ACT + S6 ACT + S5 ACT)
+**Phase**: ACT (S2/S3/S4/S6/S5/S5b ACT shipped; direct bridges to parent `qBinom`/`qMultichoose` shipped in S5b ACT this iteration. Path C `RatFunc` migration for the positive `at_one_one` recovery remains the next major milestone.)
+**Since**: 2026-05-12 (S1 OBSERVE) → 2026-05-13 (S2 ACT after 5 PREP) → 2026-05-30 (S3 ACT) → 2026-05-31 (S4 ACT) → 2026-05-31 (S6 ACT) → 2026-06-01 (S5 ACT) → 2026-06-05 (S5b ACT)
+**Iteration**: 12 (S1 OBSERVE + S2/S3/S4/S5/S6 PREP + S2 ACT + S3 ACT + S4 ACT + S6 ACT + S5 ACT + S5b ACT)
 
-`proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` is now **428 LOC** with **13 theorems**, 0 sorries, 0 axioms. After S5 ACT (this iteration), it ships: the Macdonald (q,t)-binomial/multichoose definitions, four boundary cases, the unconditional k-direction multiplicative recurrence `qtBinom_succ`, the S3 ACT `at_t_eq_one` substitution (Path A with `q^(j+1) ≠ 1` hypothesis), the S4 ACT polynomial-sub-lattice interior `qtMultichoose_two_two` plus the Field R 0/0 trap formalisation, the S6 ACT ratio-form corollary `qtBinom_succ_div`, and the S5 ACT polynomial-form bridges `qtBinom_one_right_eq_qNumber` / `qtMultichoose_one_right_eq_qNumber` / `qtMultichoose_two_two_eq_qNumber` to the parent's `qNumber`. Per S6 PREP's pivot recommendation, no Pascal-style theorem appears; the k-direction recurrence remains the foundation for the open S5+ Path C work.
+`proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` is now **~480 LOC** with **17 theorems**, 0 sorries, 0 axioms. After S5b ACT (this iteration), it ships: the Macdonald (q,t)-binomial/multichoose definitions, four boundary cases, the unconditional k-direction multiplicative recurrence `qtBinom_succ`, the S3 ACT `at_t_eq_one` substitution (Path A with `q^(j+1) ≠ 1` hypothesis), the S4 ACT polynomial-sub-lattice interior `qtMultichoose_two_two` plus the Field R 0/0 trap formalisation, the S6 ACT ratio-form corollary `qtBinom_succ_div`, the S5 ACT polynomial-form bridges to `qNumber`, **and the S5b ACT direct bridges `qtBinom_zero_right_eq_qBinom` / `qtMultichoose_zero_right_eq_qMultichoose` / `qtBinom_one_right_eq_qBinom` / `qtMultichoose_one_right_eq_qMultichoose` connecting the polynomial sub-lattice `k ≤ 1` slice directly to the parent gallery's named objects**. Per S6 PREP's pivot recommendation, no Pascal-style theorem appears; the k-direction recurrence remains the foundation for the open S5+ Path C work.
+
+## S5b ACT (2026-06-05, researcher-1) — direct bridges to parent qBinom / qMultichoose
+
+**Mode**: ACT (Lean diff; **Docker-verified 7745/7745 jobs**).
+
+**Outcome**: Added 4 theorems (~50 LOC including doc). Discharges the scope-narrowed "polynomial-form bridge to the parent's named objects" follow-up to S5 ACT.
+
+### What landed
+
+1. **`qtBinom_zero_right_eq_qBinom`** (Section IX, unconditional): trivial bridge `qtBinom q t N 0 = qBinom q N 0`, both = 1 by their boundary lemmas.
+2. **`qtMultichoose_zero_right_eq_qMultichoose`** (Section IX, unconditional): same pattern at `qtMultichoose` level.
+3. **`qtBinom_one_right_eq_qBinom`** (Section IX, under `1 - q ≠ 0`): composes `qtBinom_one_right_eq_qNumber` (S5 ACT) with the parent's `qBinom_one_right`. ~3 LOC.
+4. **`qtMultichoose_one_right_eq_qMultichoose`** (Section IX, headline, under `1 - q ≠ 0`): direct `qMultichoose`-form bridge at `k = 1`. ~3 LOC.
+
+### Mathematical content
+
+Pure composition iteration. The novelty is naming the bridges at the parent gallery's named-object level (`qBinom`/`qMultichoose`), the level downstream consumers (gallery `meta.json`, peer-reviewer, mechanic) will reference. The `(2, 2)` interior point is deferred to S5c ACT (needs a parent-side `qMultichoose q 2 2 = qNumber q 3` lemma first).
+
+### Counts after S5b ACT
+
+| File | Lines | Theorems | Axioms | Defs | Sorries |
+|------|-------|----------|--------|------|---------|
+| `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` | **~480** | **17** | 0 | 2 | 0 |
+
+(Up from 428 LOC / 13 theorems at end of S5 ACT.)
+
+### Build status
+
+**Docker-verified clean**: `./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02` → `✔ [7745/7745] Built ... === Build succeeded ===`. Mathlib v4.26.0.
+
+### Remaining work (unchanged from S5 ACT)
+
+- **Path C (`RatFunc`) migration**: still the canonical route to the positive `qtMultichoose 1 1 n k = Nat.multichoose n k`. ~80–120 LOC, multi-session.
+- **S5c ACT (optional)**: add a parent-side `qMultichoose q 2 2 = qNumber q 3` lemma and then `qtMultichoose_two_two_eq_qMultichoose` here.
+- **S6 ACT (axiomatised, optional)**: Macdonald polynomial principal-specialization identity.
+- **S7**: gallery JSON integration with `status: "axiomatized"`. With S5b ACT in place, the gallery `meta.json` can directly quote `qMultichoose q n 1` and `qBinom q N 1` rather than `qNumber`-form values.
 
 ## S5 ACT (2026-06-01, researcher-1) — polynomial-form bridges to qNumber
 
@@ -179,6 +215,7 @@ Pending. Per CLAUDE.md never invoke `lake build` directly. The file's five lemma
 | 9    | ACT      | merged | researcher-1  | 2026-05-31           | `2026-05-31-s04-act-polynomial-sublattice-and-field-trap.md`      | (S4 ACT) — `qtMultichoose_two_two` (polynomial sub-lattice interior) + `qtBinom_at_one_one_eq_zero` + `qtMultichoose_at_one_one_eq_zero` (Field 0/0 trap formalised). File 229 → ~313 LOC; 0 sorries / 0 axioms net. |
 | 10   | ACT      | merged | researcher-1  | 2026-05-31           | `2026-05-31-s06-act-ratio-identity-corollary.md`                  | (S6 ACT) — `qtBinom_succ_div` (k-direction telescoping ratio identity corollary of `qtBinom_succ`). File ~313 → 348 LOC; 0 sorries / 0 axioms net; Docker-verified 7745/7745. |
 | 11   | ACT      | TBD    | researcher-1  | 2026-06-01           | `2026-06-01-s05-act-polynomial-form-bridges.md`                   | (S5 ACT) — `qtBinom_one_right_eq_qNumber` + `qtMultichoose_one_right_eq_qNumber` + `qtMultichoose_two_two_eq_qNumber` (polynomial-form bridges of S4 ACT polynomial sub-lattice to parent's `qNumber`). File 348 → 428 LOC; 0 sorries / 0 axioms net; Docker-verified 7745/7745. |
+| 12   | ACT      | TBD    | researcher-1  | 2026-06-05           | `2026-06-05-s05b-act-direct-qbinom-bridges.md`                    | (S5b ACT) — `qtBinom_zero_right_eq_qBinom` + `qtMultichoose_zero_right_eq_qMultichoose` + `qtBinom_one_right_eq_qBinom` + `qtMultichoose_one_right_eq_qMultichoose` (direct bridges from polynomial sub-lattice `k ≤ 1` slice to parent gallery's named objects). File 428 → ~480 LOC; 0 sorries / 0 axioms net; Docker-verified 7745/7745. |
 
 ## Current Focus
 


### PR DESCRIPTION
## Summary

S5b ACT for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02` (the (q,t)-deformation of qMultichoose). Adds **4 direct polynomial-form bridge theorems** that compose the S5 ACT `qNumber`-form bridges with the parent gallery entry's `qBinom_one_right` / `qMultichoose_one_right`, so the polynomial sub-lattice `k ≤ 1` slice is now equated **directly** to the parent's named objects.

## What landed

- `qtBinom_zero_right_eq_qBinom` (unconditional) — `k = 0`, both = 1.
- `qtMultichoose_zero_right_eq_qMultichoose` (unconditional) — corollary.
- `qtBinom_one_right_eq_qBinom` (under `1 - q ≠ 0`) — `k = 1`, composes `qtBinom_one_right_eq_qNumber` with the parent's `qBinom_one_right`.
- `qtMultichoose_one_right_eq_qMultichoose` (under `1 - q ≠ 0`) — headline, the direct `qMultichoose`-form bridge at `k = 1`.

Plus session memo `2026-06-05-s05b-act-direct-qbinom-bridges.md` and `state.md` update.

## Stats

| File | Before | After |
|------|--------|-------|
| `ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` | 428 LOC / 13 thms | ~480 LOC / 17 thms |

0 sorries, 0 axioms net (file remains sorry-free and axiom-free).

## Test plan

- [x] Docker-verified clean: \`./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02\` → \`✔ [7745/7745] Built ... === Build succeeded ===\`.
- [x] No new \`import\` or Mathlib infrastructure required.
- [x] No new private helpers; all new theorems are ≤ 4-tactic-step compositions of existing lemmas.

## Why this is useful

The previous S5 ACT (#22010) bridged the polynomial sub-lattice points to \`qNumber\` (= \`1 + q + q² + ⋯\`). But the parent gallery entry's *named object* is \`qMultichoose\`, not \`qNumber\`. This iteration fuses the two-hop chain \`qtMultichoose → qNumber → qMultichoose\` into a single named bridge, so the eventual gallery \`meta.json\` can directly quote \`qMultichoose q n 1\` rather than going through \`qNumber\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)