### PR TITLE
audit(erdos-554): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7913,9 +7913,9 @@
     },
     "erdos-554": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T00:38:10Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-06-05T08:09:54Z",
+      "result": "clean",
       "issues": [
         "phantom contributions in originalContributions: triangle_ramsey_exponential, triangle_ramsey_upper, oddCycle_ramsey_upper, oddCycle_ramsey_lower (docstrings only, not declared)"
       ]


### PR DESCRIPTION
## Summary

Re-audited **erdos-554** (Erdős Problem #554: Odd Cycle vs Triangle Ramsey Numbers — Erdős-Graham 1981, OPEN).

All meta.json counts match the Lean source exactly:

| Field | meta.json | Lean source |
|---|---|---|
| lineCount | 128 | 128 |
| axiomCount | 3 | 3 (`ramseyNumber`, `two_color_odd_cycle`, `two_color_triangle`) |
| theoremCount | 2 | 2 (`two_color_pentagon_ratio`, `pentagon_is_special_case`) |
| definitionCount | 5 | 5 |
| sorries | 0 | 0 |
| True stubs | — | 0 |

- `status: axiomatized` and `badge: axiom` are correct for an open Erdős-Graham 1981 conjecture with 3 axioms.
- `originalContributions` list only declarations that actually exist in the file (the previously-flagged phantom contributions remain resolved).
- `assumptions` field correctly enumerates the 3 axioms and 0 sorries.

## Test plan

- [x] meta.json/Lean counts cross-checked via grep
- [x] No new integrity issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)