### PR TITLE
research(erdos-396): formalize conjecture as Prop, eliminate placeholder axiom

### DIFF
--- a/proofs/Proofs/Erdos396Problem.lean
+++ b/proofs/Proofs/Erdos396Problem.lean
@@ -17,62 +17,86 @@ Known results:
 Reference: https://erdosproblems.com/396
 -/
 
-import Mathlib.Data.Nat.Basic
-import Mathlib.Data.Nat.Choose.Central
-import Mathlib.Data.Nat.Factorial.Basic
-import Mathlib.Tactic
+import Mathlib
 
 open Nat
 
+namespace Erdos396
+
 /- ## Core Definitions -/
 
-/-- The descending factorial: n(n−1)(n−2)⋯(n−k+1) = n! / (n−k)! -/
--- We use Nat.descFactorial from Mathlib
+/-- The descending product `n · (n−1) · (n−2) ⋯ (n−k)` of length `k+1`.
+    Equal to `Nat.descFactorial n (k+1)`; we re-expose it under a name
+    matching the problem statement for readability. -/
+def descProduct (n k : ℕ) : ℕ :=
+  n.descFactorial (k + 1)
 
-/-- The central binomial coefficient C(2n, n) -/
--- We use Nat.centralBinom from Mathlib
+/-- The descending product equals the standard descending factorial of length `k+1`. -/
+lemma descProduct_eq_descFactorial (n k : ℕ) :
+    descProduct n k = n.descFactorial (k + 1) := rfl
+
+/-- For `k = 0` the descending product collapses to `n` itself. -/
+lemma descProduct_zero (n : ℕ) : descProduct n 0 = n := by
+  simp [descProduct, Nat.descFactorial]
+
+/-- **Erdős Problem #396 (Erdős–Graham).**
+    For every `k`, there exists `n > k` such that
+    `n · (n−1) · (n−2) ⋯ (n−k)` divides the central binomial coefficient `C(2n, n)`.
+
+    The bound `k < n` rules out the vacuous case where the descending product
+    truncates to `0` and divides everything in `ℕ`. -/
+def Conjecture : Prop :=
+  ∀ k : ℕ, ∃ n : ℕ, k < n ∧ descProduct n k ∣ Nat.centralBinom n
 
 /- ## Basic Divisibility Results -/
 
-/-- n+1 always divides C(2n, n), giving the Catalan number C(2n,n)/(n+1).
+/-- `n+1` always divides `C(2n, n)`, yielding the Catalan number `C(2n,n)/(n+1)`.
     This is the fundamental property behind Catalan numbers. -/
 theorem catalan_divisibility (n : ℕ) :
-    (n + 1) ∣ centralBinom n :=
+    (n + 1) ∣ Nat.centralBinom n :=
   Nat.succ_dvd_centralBinom n
 
-/-- n divides C(2n, n) only for specific values of n. -/
-theorem n_divides_rarely :
-    ∃ S : Set ℕ, (∀ n ∈ S, ¬(n ∣ centralBinom n)) ∧
-      -- S has positive upper density (most n do not divide C(2n,n))
-      True :=
-  ⟨∅, fun _ h => absurd h (Set.not_mem_empty _), trivial⟩
+/-- `n` does **not** in general divide `C(2n, n)`. Concrete counterexample:
+    `3 ∤ C(6, 3) = 20`. This shows that the `k = 0` slice of the conjecture
+    is not a triviality — most `n` do not work. -/
+theorem n_not_always_dvd_centralBinom :
+    ∃ n : ℕ, ¬ (n ∣ Nat.centralBinom n) := by
+  refine ⟨3, ?_⟩
+  decide
 
-/- ## Pomerance's Results (2014) -/
+/- ## Witnesses for Small k -/
 
-/-- Pomerance: for any k ≥ 0, infinitely many n satisfy (n−k) | C(2n, n) -/
-/-- Pomerance: the set of n with (n−k) | C(2n, n) has upper density < 1/3.
-    The measure-theoretic statement requires density infrastructure;
-    the existential structure here is a placeholder. -/
-/-
-  Pomerance: the upper density of {n : (n−k) | C(2n,n)} is less than 1/3.
-  Measure-theoretic statement requires density infrastructure.
--/
+/-- For `k = 0`, the conjecture holds with `n = 2`:
+    `Nat.descFactorial 2 1 = 2` and `Nat.centralBinom 2 = C(4, 2) = 6`,
+    so the descending product divides the central binomial coefficient. -/
+theorem conjecture_holds_for_zero :
+    ∃ n : ℕ, 0 < n ∧ descProduct n 0 ∣ Nat.centralBinom n := by
+  refine ⟨2, by decide, ?_⟩
+  decide
 
-/-
-  Pomerance: the set {n : ∏_{i=1}^{k}(n+i) | C(2n,n)} has asymptotic density 1.
-  Measure-theoretic statement requires density infrastructure.
--/
+/-- For `k = 1`, the value `n = 2` is also a witness:
+    `2 · 1 = 2 ∣ 6 = C(4, 2)`. -/
+theorem conjecture_holds_for_one :
+    ∃ n : ℕ, 1 < n ∧ descProduct n 1 ∣ Nat.centralBinom n := by
+  refine ⟨2, by decide, ?_⟩
+  decide
 
-/- ## The Erdős–Graham Conjecture -/
+/- ## Pomerance's Results (2014)
 
-/-- Erdős Problem 396: For every k, there exists n such that
-    n · (n−1) · ⋯ · (n−k) divides C(2n, n) -/
+  Pomerance: for any `k ≥ 0`, infinitely many `n` satisfy `(n−k) | C(2n,n)`,
+  and the set of such `n` has upper density `< 1/3`.
+  Pomerance: the set `{n : ∏_{i=1}^{k}(n+i) | C(2n,n)}` has asymptotic density 1.
+  Measure-theoretic statements require density infrastructure not yet present here. -/
+
 /- ## Computational Evidence -/
 
-/-- Small cases: the smallest n for each k (OEIS A375077)
-    k=0: n=2 (since 2 | C(4,2) = 6)
-    k=1: n=3 (since 3·2 | C(6,3) = 20? No — 6 ∤ 20)
-    Actually k=1: need n(n-1) | C(2n,n), e.g. n=4: 4·3=12 | C(8,4)=70? No
-    These are non-trivial to find. -/
-axiom smallest_witness : ℕ → ℕ
-/-- The conjecture implies infinitely many witnesses for each k -/
+/-- The smallest `k = 0` witness `n = 2` checks out: `C(4, 2) = 6`. -/
+example : Nat.centralBinom 2 = 6 := by decide
+
+/-- `3 ∤ C(6, 3) = 20`, demonstrating that `n ∣ C(2n, n)` is not universal. -/
+example : ¬ (3 ∣ Nat.centralBinom 3) := by decide
+
+/-- The next `k = 0` witness after `n = 2` is `n = 6`: `6 ∣ C(12, 6) = 924`. -/
+example : 6 ∣ Nat.centralBinom 6 := by decide
+
+end Erdos396

--- a/research/problems/erdos-396/state.md
+++ b/research/problems/erdos-396/state.md
@@ -1,27 +1,32 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-13T02:35:40.568Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-06-05T01:55:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Conjecture is now formalized as a `Prop` and the placeholder axiom is gone.
 
 ## Active Approach
 
-None yet.
+Formalization-first: state the conjecture as `Erdos396.Conjecture`, prove
+small-`k` witnesses by `decide`, and document the Pomerance density results
+that block deeper progress.
 
 ## Blockers
 
-None.
+- Pomerance's density theorems require asymptotic-density infrastructure
+  that is not yet present in Mathlib in a usable form.
 
 ## Next Action
 
-Begin problem exploration.
+Search for the smallest `k = 2` witness empirically (no `n ∈ [3, 13]` works),
+or attempt to express the conjecture via the identity
+`Nat.descFactorial n (k+1) = (k+1)! * n.choose (k+1)`.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2

--- a/src/data/research/problems/erdos-396.json
+++ b/src/data/research/problems/erdos-396.json
@@ -17,32 +17,44 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-18T11:20:09Z",
-    "iteration": 2,
-    "focus": "Surveyed central-binomial formalization and placeholder axiom surface.",
+    "since": "2026-06-05T01:55:00Z",
+    "iteration": 3,
+    "focus": "Stated Erdős–Graham conjecture as a Prop using descFactorial, eliminated meaningless placeholder axiom, proved k=0 and k=1 witnesses.",
     "blockers": [],
-    "nextAction": "State the descending-factorial divisibility conjecture as a real Prop before adding witness claims.",
+    "nextAction": "Attempt k=2 witness (smallest n with n(n-1)(n-2) | C(2n,n) is non-obvious; search up to ~50) or prove descProduct/centralBinom identities that reduce the conjecture to a Pomerance-style density argument.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 2 theorems, 1 axiom, 0 sorries. Lean proves Catalan divisibility and a trivial rarity placeholder; the Erdos-Graham/Pomerance material is comment-only and smallest_witness has no specification.",
+    "progressSummary": "FORMALIZED: 4 theorems, 2 lemmas, 2 defs, 3 examples, 0 axioms, 0 sorries. The Erdős–Graham descending-factorial conjecture is now a Prop (Erdos396.Conjecture). k=0 and k=1 cases proved with n=2. Placeholder smallest_witness axiom removed (axiom count 1→0). Counterexample 3∤C(6,3)=20 demonstrates the k=0 slice is non-trivial.",
     "builtItems": [
       "Confirmed catalan_divisibility uses Nat.succ_dvd_centralBinom.",
       "Confirmed n_divides_rarely is an empty-set/True witness, not a density theorem.",
-      "Confirmed smallest_witness is the only axiom and currently has no stated witness property."
+      "Confirmed smallest_witness is the only axiom and currently has no stated witness property.",
+      "Defined descProduct n k = n.descFactorial (k+1) matching the problem statement ∏_{i=0..k}(n-i).",
+      "Stated Erdos396.Conjecture : ∀ k, ∃ n > k, descProduct n k ∣ centralBinom n.",
+      "Proved conjecture_holds_for_zero and conjecture_holds_for_one (both witness n=2) via decide.",
+      "Proved n_not_always_dvd_centralBinom with counterexample n=3 (since 3∤20=C(6,3)).",
+      "Eliminated placeholder axiom smallest_witness (had no specification, contributed no math content).",
+      "Replaced True-tautology theorem n_divides_rarely with the real counterexample n_not_always_dvd_centralBinom."
     ],
     "insights": [
       "The descending-factorial conjecture is not yet formalized as a theorem or definition beyond comments.",
       "Pomerance density results are not represented in Lean.",
-      "The next useful metadata-aligned step is to define the product/divisibility predicate before naming witnesses."
+      "The next useful metadata-aligned step is to define the product/divisibility predicate before naming witnesses.",
+      "Pomerance (2014) proves the k=0 statement (set of n with n∣C(2n,n) is infinite, upper density <1/3); formalizing this requires the upper-density infrastructure not yet present.",
+      "The Nat-truncated subtraction in Nat.descFactorial forces a k<n side condition; otherwise descFactorial n (k+1)=0 trivially divides anything.",
+      "n=2 is a small simultaneous witness for both k=0 and k=1: descFactorial 2 1 = 2 and descFactorial 2 2 = 2*1 = 2, both divide centralBinom 2 = 6.",
+      "Empirical search up to n=13 finds no k=2 witness (n(n-1)(n-2)∤C(2n,n) for n∈[3,13]). Pomerance does not give an explicit upper bound on the smallest k=2 witness."
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Define a predicate for prod_{i=0}^k (n-i) | centralBinom n and state the main conjecture as a Prop."
+      "Search for the smallest k=2 witness empirically (extend small-case computation past n=13).",
+      "Express the conjecture via the identity descFactorial n (k+1) = (k+1)! * n.choose (k+1) to expose the factorial/binomial structure.",
+      "Add a companion file targeting Aristotle with routine descFactorial/choose identities; main conjecture remains open."
     ],
     "markdown": "# Erdős #396 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nIs it true that for every $k$ there exists $n$ such that\\[\\prod_{0\\leq i\\leq k}(n-i) \\mid \\binom{2n}{n}?\\]\n\n\n\nErd\\H{o}s and Graham write that $n+1$ always divides $\\binom{2n}{n}$ (indeed $\\frac{1}{n+1}\\binom{2n}{n}$ is the $n$th Catalan number), but it is quite rare that $n$ divides $\\binom{2n}{n}$.\n\nPomerance \\cite{Po14} has shown that for any $k\\geq 0$ there are infinitely many $n$ such that $n-k\\mid\\binom{2n}{n}$, although the set of such $n$ has upper density $<1/3$. Pomerance also shows that the set of $n$ such that\\[\\prod_{1\\leq i\\leq k}(n+i)\\mid \\binom{2n}{n}\\]has density $1$.\n\nThe smallest $n$ for each $k$ are listed as A375077 on the OEIS.\n\n\n\n\nReferences\n\n\n[Po14] Pomerance, C., Divisors of the middle binomial coefficient. American Mathematical Monthly (2014).\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #3\n- Problem #395\n- Problem #397\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- ErGr80\n- Po14\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-13*\n"
   },
@@ -60,17 +72,17 @@
     "mathlib": []
   },
   "started": "2026-01-13T02:35:40.568Z",
-  "lastUpdate": "2026-05-18T11:20:09Z",
+  "lastUpdate": "2026-06-05T01:55:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos396Problem.lean",
       "filename": "Erdos396Problem.lean",
-      "lineCount": 78,
-      "theoremCount": 2,
-      "axiomCount": 1,
-      "defCount": 0,
+      "lineCount": 102,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos396Problem.lean"


### PR DESCRIPTION
## Summary

Session for **Erdős Problem #396** (descending factorials dividing central binomial coefficients). Phase **ACT**, iteration **3**.

The previous file was a placeholder: 1 axiom with no specification, the main conjecture only present as a comment, and a `True`-tautology theorem standing in for the rarity claim. This PR replaces that surface with a real formal statement and concrete content.

## Progress

- Defined `descProduct n k := n.descFactorial (k+1)` matching the problem's `∏_{i=0..k}(n-i)`.
- Stated **`Erdos396.Conjecture : ∀ k, ∃ n > k, descProduct n k ∣ centralBinom n`** as a `Prop`.
- Proved `conjecture_holds_for_zero` and `conjecture_holds_for_one`, both with witness `n = 2`.
- Replaced the trivially-true `n_divides_rarely` with a real counterexample: `3 ∤ C(6,3) = 20`.
- Removed the no-spec `axiom smallest_witness : ℕ → ℕ` (**axiom count 1 → 0**).
- Added small `decide`-based examples exercising `centralBinom` evaluation.

## Findings

- Pomerance (2014) proves the `k = 0` density statement; formalizing this requires upper-density infrastructure not yet usable in Mathlib here.
- The `Nat`-truncated subtraction in `Nat.descFactorial` forces a `k < n` side condition in the conjecture; otherwise the descending product is `0` and divides everything in `ℕ` trivially.
- Empirically, no `n ∈ [3, 13]` is a `k = 2` witness — Pomerance does not give an explicit upper bound on the smallest `k = 2` witness.

## File Stats (Erdos396Problem.lean)

| Metric | Before | After |
|--------|--------|-------|
| Lines | 78 | 102 |
| Theorems | 2 | 4 |
| Defs | 0 | 2 |
| Axioms | 1 | **0** |
| Sorries | 0 | 0 |

Docker build clean: `Proofs.Erdos396Problem`, 7743 jobs.

## Status

**Outcome**: progress — conjecture is now a real `Prop` with two small-`k` witnesses; the main statement remains open.
**Next Steps**: extend the empirical search for the smallest `k = 2` witness past `n = 13`, or rewrite the conjecture via `Nat.descFactorial_eq_factorial_mul_choose` to expose the `(k+1)! · n.choose (k+1)` structure.

🤖 Generated by researcher-1