### PR TITLE
Enrich abel-ruffini: add endLine to mainTheorems

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -632,63 +632,72 @@
         "type": "wrapper",
         "description": "If α is solvable by radicals and root of irreducible q, then Gal(q) is solvable",
         "leanType": "(α : E) → (q : Polynomial F) → Irreducible q → aeval α q = 0 → IsSolvableByRad F α → IsSolvable q.Gal",
-        "line": 64
+        "line": 64,
+        "endLine": 67
       },
       {
         "name": "symmetric_group_not_solvable",
         "type": "bridge",
         "description": "Sₙ is not solvable for n ≥ 5 (ℕ-to-Cardinal type coercion bridge)",
         "leanType": "(n : ℕ) → 5 ≤ n → ¬ IsSolvable (Equiv.Perm (Fin n))",
-        "line": 79
+        "line": 79,
+        "endLine": 84
       },
       {
         "name": "not_solvable_by_rad_of_not_solvable_gal",
         "type": "synthesis",
         "description": "Contrapositive of galois_bridge: non-solvable Gal(q) implies α not solvable by radicals",
         "leanType": "(α : E) → (q : Polynomial F) → Irreducible q → aeval α q = 0 → ¬ IsSolvable q.Gal → ¬ IsSolvableByRad F α",
-        "line": 145
+        "line": 145,
+        "endLine": 149
       },
       {
         "name": "s5_not_solvable",
         "type": "specialization",
         "description": "S₅ specialization of symmetric_group_not_solvable at n = 5 via le_rfl",
         "leanType": "¬ IsSolvable (Equiv.Perm (Fin 5))",
-        "line": 87
+        "line": 87,
+        "endLine": 88
       },
       {
         "name": "s6_not_solvable",
         "type": "specialization",
         "description": "S₆ specialization of symmetric_group_not_solvable at n = 6 via omega",
         "leanType": "¬ IsSolvable (Equiv.Perm (Fin 6))",
-        "line": 91
+        "line": 91,
+        "endLine": 92
       },
       {
         "name": "a5_is_simple",
         "type": "wrapper",
         "description": "One-line wrapper of Mathlib's alternatingGroup.isSimpleGroup_five — the structural reason the derived series of S₅ stalls at A₅",
         "leanType": "IsSimpleGroup (alternatingGroup (Fin 5))",
-        "line": 97
+        "line": 97,
+        "endLine": 98
       },
       {
         "name": "s0_solvable",
         "type": "instance",
         "description": "S₀ (permutations of empty type) is solvable — discharged by inferInstance",
         "leanType": "IsSolvable (Equiv.Perm (Fin 0))",
-        "line": 115
+        "line": 115,
+        "endLine": 115
       },
       {
         "name": "s1_solvable",
         "type": "instance",
         "description": "S₁ (permutations of one element) is solvable — discharged by inferInstance",
         "leanType": "IsSolvable (Equiv.Perm (Fin 1))",
-        "line": 118
+        "line": 118,
+        "endLine": 118
       },
       {
         "name": "exists_quintic",
         "type": "witness",
         "description": "Trivial existence: ∃ degree-5 polynomial over ℚ (witness X⁵); the substantive analogue ∃ irreducible q with Gal(q) ≅ S₅ is proved in abel-ruffini-oq-04-oq-01",
         "leanType": "∃ p : Polynomial ℚ, p.natDegree = 5",
-        "line": 132
+        "line": 132,
+        "endLine": 135
       }
     ],
     "path": "Proofs/AbelRuffini.lean",
@@ -1620,63 +1629,72 @@
       "type": "core",
       "description": "Abel-Ruffini contrapositive: if the Galois group of an irreducible polynomial is not solvable, then its roots are not solvable by radicals",
       "leanType": "(α : E) → (q : Polynomial F) → Irreducible q → aeval α q = 0 → ¬ IsSolvable q.Gal → ¬ IsSolvableByRad F α",
-      "line": 145
+      "line": 145,
+      "endLine": 149
     },
     {
       "name": "galois_bridge",
       "type": "key",
       "description": "Solvability by radicals implies solvable Galois group (Galois's fundamental theorem, from Mathlib)",
       "leanType": "(α : E) → (q : Polynomial F) → Irreducible q → aeval α q = 0 → IsSolvableByRad F α → IsSolvable q.Gal",
-      "line": 64
+      "line": 64,
+      "endLine": 67
     },
     {
       "name": "symmetric_group_not_solvable",
       "type": "key",
       "description": "The symmetric group Sₙ is not solvable for n ≥ 5",
       "leanType": "(n : ℕ) → 5 ≤ n → ¬ IsSolvable (Equiv.Perm (Fin n))",
-      "line": 79
+      "line": 79,
+      "endLine": 84
     },
     {
       "name": "s5_not_solvable",
       "type": "supporting",
       "description": "S₅ is not solvable. Specialization of `symmetric_group_not_solvable` at n = 5 via `le_rfl`",
       "leanType": "¬ IsSolvable (Equiv.Perm (Fin 5))",
-      "line": 87
+      "line": 87,
+      "endLine": 88
     },
     {
       "name": "s6_not_solvable",
       "type": "supporting",
       "description": "S₆ is not solvable. Specialization of `symmetric_group_not_solvable` at n = 6 via `omega`",
       "leanType": "¬ IsSolvable (Equiv.Perm (Fin 6))",
-      "line": 91
+      "line": 91,
+      "endLine": 92
     },
     {
       "name": "a5_is_simple",
       "type": "key",
       "description": "A₅ is a simple group: the structural reason the derived series of S₅ stalls at A₅. Wraps `alternatingGroup.isSimpleGroup_five`",
       "leanType": "IsSimpleGroup (alternatingGroup (Fin 5))",
-      "line": 97
+      "line": 97,
+      "endLine": 98
     },
     {
       "name": "s0_solvable",
       "type": "supporting",
       "description": "S₀ (permutations of the empty type) is solvable — trivial group, found by `inferInstance`",
       "leanType": "IsSolvable (Equiv.Perm (Fin 0))",
-      "line": 115
+      "line": 115,
+      "endLine": 115
     },
     {
       "name": "s1_solvable",
       "type": "supporting",
       "description": "S₁ (permutations of a single element) is solvable — trivial group, found by `inferInstance`",
       "leanType": "IsSolvable (Equiv.Perm (Fin 1))",
-      "line": 118
+      "line": 118,
+      "endLine": 118
     },
     {
       "name": "exists_quintic",
       "type": "supporting",
       "description": "There exists a degree-5 polynomial over ℚ (witness: X⁵). A trivial existence statement; the substantive analogue (∃ irreducible q with Gal(q) ≅ S₅) is proved in `abel-ruffini-oq-04-oq-01` for x⁵ − 4x + 2",
       "leanType": "∃ p : Polynomial ℚ, p.natDegree = 5",
-      "line": 132
+      "line": 132,
+      "endLine": 135
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- Adds `endLine` field alongside the existing `line` (startLine) to all 9 `mainTheorems` entries in `src/data/proofs/abel-ruffini/meta.json`, both in the top-level `mainTheorems` array and inside `leanFile.mainTheorems`.
- Sibling addition to PR #22387, which introduced `line` (startLine) for the corresponding `abel-ruffini-galois-extensions` entry. With both fields present, the gallery UI can fetch a complete source range rather than just an opening line.
- Pure metadata enrichment — no changes to `description`, `leanType`, or any prose fields.

## Verification
Each `endLine` was checked against `proofs/Proofs/AbelRuffini.lean`:

| Theorem | line | endLine |
|---|---|---|
| `galois_bridge` | 64 | 67 |
| `symmetric_group_not_solvable` | 79 | 84 |
| `s5_not_solvable` | 87 | 88 |
| `s6_not_solvable` | 91 | 92 |
| `a5_is_simple` | 97 | 98 |
| `s0_solvable` | 115 | 115 |
| `s1_solvable` | 118 | 118 |
| `exists_quintic` | 132 | 135 |
| `not_solvable_by_rad_of_not_solvable_gal` | 145 | 149 |

The single-line `inferInstance` proofs (`s0_solvable`, `s1_solvable`) correctly have `line == endLine`.

## Test plan
- [x] `python -c "import json; json.load(open('src/data/proofs/abel-ruffini/meta.json'))"` parses cleanly
- [x] `endLine` values cross-checked against the Lean source line ranges
- [x] No prose / description content was modified — diff is +37/-19 lines, additive only

🤖 Generated with [Claude Code](https://claude.com/claude-code)