### PR TITLE
research(nth-root-irrational-oq-03): S7 ACT — discharge axiom e_transcendental via Hermite-Lindemann bridge

### DIFF
--- a/proofs/Proofs/HermiteLindemann.lean
+++ b/proofs/Proofs/HermiteLindemann.lean
@@ -147,12 +147,12 @@ The complete proof requires substantial machinery including:
 axiom hermite_lindemann :
     ∀ α : ℂ, α ≠ 0 → IsAlgebraic ℚ α → Transcendental ℤ (Complex.exp α)
 
-/-- **Axiom: Contrapositive of Hermite-Lindemann**
+/-!
+### Note: Contrapositive of Hermite-Lindemann
 
-If e^α is algebraic (for non-zero α), then α is transcendental.
-
-This is the logical contrapositive of the Hermite-Lindemann theorem.
-The proof follows directly from the main theorem. -/
+If e^α is algebraic (for non-zero α), then α is transcendental. This is the
+logical contrapositive of the Hermite-Lindemann theorem.
+-/
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART III: THE LINDEMANN-WEIERSTRASS THEOREM
@@ -170,26 +170,19 @@ def AlgebraicallyIndependent (s : Set ℂ) : Prop :=
     (∀ i, f i ∈ s) →
     MvPolynomial.aeval f p = 0 → p = 0
 
-/-- **Axiom: Lindemann-Weierstrass (Classical Form)**
+/-!
+### Note: Lindemann-Weierstrass (Classical Form)
 
 If α₁, α₂, ..., αₙ are distinct algebraic numbers, then e^α₁, e^α₂, ..., e^αₙ
-are linearly independent over the algebraic numbers.
+are linearly independent over the algebraic numbers. The full proof requires
+deep analysis of auxiliary polynomial integrals; not formalized here.
 
-This is the most commonly stated form, emphasizing linear independence.
-The full proof requires deep analysis of auxiliary polynomial integrals.
-
-**Technical Note**: This axiom expresses that exponentials of distinct algebraics
-are ℚ-linearly independent. The full theorem over algebraic numbers requires
-additional machinery. -/
-
-/-- **Lindemann-Weierstrass Theorem** (Strong Form)
+### Note: Lindemann-Weierstrass (Strong Form)
 
 If α₁, α₂, ..., αₙ are algebraic numbers that are linearly independent over ℚ,
-then e^α₁, e^α₂, ..., e^αₙ are algebraically independent over ℚ.
-
-This is the strongest form of the theorem.
-
-**Implementation Note**: Stated as axiom pending full formalization. -/
+then e^α₁, e^α₂, ..., e^αₙ are algebraically independent over ℚ. Pending full
+formalization.
+-/
 
 /-! ═══════════════════════════════════════════════════════════════════════════════
 PART IV: FUNDAMENTAL COROLLARIES
@@ -197,26 +190,22 @@ PART IV: FUNDAMENTAL COROLLARIES
 
 section Corollaries
 
-/-- **Corollary 1: e is transcendental over ℚ (Hermite, 1873; Wiedijk #67)**
+/-!
+### Corollary 1: e is transcendental (Hermite, 1873; Wiedijk #67)
 
-PROVED from hermite_lindemann: take α = 1 (algebraic, non-zero),
-get exp(1) transcendental in ℂ, transfer to ℝ via injective embedding. -/
-theorem e_transcendental_rationals :
-    Transcendental ℚ (Real.exp 1) := by
-  -- Step 1: exp(1) is transcendental over ℤ in ℂ
+Proved from `hermite_lindemann` at α = 1 (algebraic, non-zero): `exp 1` is
+transcendental over ℤ in ℂ, then transferred to ℝ via the injective embedding.
+-/
+
+/-- **Transcendence of e over ℤ.** Bridges `hermite_lindemann` (which speaks of ℂ) to ℝ. -/
+theorem e_transcendental_int : Transcendental ℤ (Real.exp 1) := by
   have h_complex : Transcendental ℤ (Complex.exp (1 : ℂ)) :=
-    hermite_lindemann 1 one_ne_zero (isAlgebraic_int 1)
-  -- Step 2: Complex.exp 1 = ↑(Real.exp 1) (coercion from ℝ to ℂ)
-  rw [show (1 : ℂ) = ↑(1 : ℝ) from by simp, Complex.ofReal_exp] at h_complex
-  -- Step 3: Transfer transcendence from ℂ to ℝ (injective ℝ → ℂ map)
-  have h_real : Transcendental ℤ (Real.exp 1) := by
-    intro ⟨p, hp_ne, hp_eval⟩
-    exact h_complex ⟨p, hp_ne, by
-      have : Polynomial.aeval (↑(Real.exp 1) : ℂ) p = ↑(Polynomial.aeval (Real.exp 1) p) :=
-        Polynomial.aeval_algHom_apply (Complex.ofRealHom.toAlgHom) (Real.exp 1) p
-      rw [this, hp_eval, map_zero]⟩
-  -- Step 4: ℤ-transcendental → ℚ-transcendental via IsFractionRing
-  exact fun halg => h_real ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mp halg)
+    hermite_lindemann 1 one_ne_zero isAlgebraic_one
+  rw [show (1 : ℂ) = ↑(1 : ℝ) from by simp, ← Complex.ofReal_exp] at h_complex
+  exact fun halg => h_complex halg.algebraMap
+
+theorem e_transcendental_rationals : Transcendental ℚ (Real.exp 1) :=
+  fun halg => e_transcendental_int ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr halg)
 
 /-- **Corollary 2: π is transcendental in ℂ (Lindemann, 1882; Wiedijk #53)**
 
@@ -227,12 +216,16 @@ theorem pi_transcendental :
     Transcendental ℤ (Real.pi : ℂ) := by
   intro halg
   -- i is algebraic over ℚ (root of X² + 1)
+  have hI_ne : (X ^ 2 + 1 : ℚ[X]) ≠ 0 := by
+    intro h
+    have h2 : Polynomial.eval (0 : ℚ) (X ^ 2 + 1) = 1 := by simp
+    rw [h] at h2
+    simp at h2
   have hi : IsAlgebraic ℚ (Complex.I : ℂ) :=
-    (IsFractionRing.isAlgebraic_iff ℤ ℚ ℂ).mpr
-      ⟨X ^ 2 + 1, by decide, by simp [Polynomial.aeval_def, Complex.I_sq]; ring⟩
+    ⟨X ^ 2 + 1, hI_ne, by simp [Polynomial.aeval_def]⟩
   -- π is algebraic over ℚ (from our assumption via ℤ↔ℚ)
   have hpi_q : IsAlgebraic ℚ (↑Real.pi : ℂ) :=
-    (IsFractionRing.isAlgebraic_iff ℤ ℚ ℂ).mpr halg
+    (IsFractionRing.isAlgebraic_iff ℤ ℚ ℂ).mp halg
   -- Product iπ is algebraic over ℚ
   have hipi_q : IsAlgebraic ℚ (↑Real.pi * Complex.I : ℂ) := hpi_q.mul hi
   -- πi ≠ 0
@@ -241,22 +234,23 @@ theorem pi_transcendental :
   -- By Hermite-Lindemann: exp(πi) is transcendental over ℤ
   have hexp := hermite_lindemann (↑Real.pi * Complex.I) hipi_ne hipi_q
   -- But exp(πi) = -1 by Euler's identity
-  rw [show ↑Real.pi * Complex.I = ↑Real.pi * Complex.I from rfl,
-      Complex.exp_mul_I, Complex.ofReal_cos_ofReal_re,
-      Complex.ofReal_sin_ofReal_re, Real.cos_pi, Real.sin_pi] at hexp
-  simp at hexp
+  have h_euler : Complex.exp (↑Real.pi * Complex.I) = -1 := by
+    rw [Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin,
+        Real.cos_pi, Real.sin_pi]
+    push_cast
+    ring
+  rw [h_euler] at hexp
+  exact hexp (show IsAlgebraic ℤ ((-1 : ℂ)) by
+    rw [show ((-1 : ℂ)) = ((-1 : ℤ) : ℂ) by push_cast; ring]
+    exact isAlgebraic_int (-1))
 
 /-- **Corollary 2b: π is transcendental in ℝ**
 
 PROVED from pi_transcendental: if π were algebraic in ℝ,
 the injective embedding ℝ → ℂ would make it algebraic in ℂ. -/
 theorem pi_transcendental_real :
-    Transcendental ℤ Real.pi := by
-  intro ⟨p, hp_ne, hp_eval⟩
-  exact pi_transcendental ⟨p, hp_ne, by
-    have : Polynomial.aeval (↑Real.pi : ℂ) p = ↑(Polynomial.aeval Real.pi p) :=
-      Polynomial.aeval_algHom_apply (Complex.ofRealHom.toAlgHom) Real.pi p
-    rw [this, hp_eval, map_zero]⟩
+    Transcendental ℤ Real.pi :=
+  fun halg => pi_transcendental halg.algebraMap
 
 /-- **Corollary 3: e^n is transcendental for any non-zero integer n** -/
 theorem exp_int_transcendental (n : ℤ) (hn : n ≠ 0) :
@@ -265,16 +259,13 @@ theorem exp_int_transcendental (n : ℤ) (hn : n ≠ 0) :
   · simp [hn]
   · exact isAlgebraic_int n
 
-/-- **Axiom: Exponentials of integer multiples are transcendental**
+/-!
+### Note: Exponentials of integer multiples are transcendental
 
-For non-zero algebraic α, all of e^α, e^(2α), e^(3α), ... are transcendental.
-
-**Proof outline**: Since n is an integer and α is algebraic over ℚ, the product
-n*α is also algebraic over ℚ. Since n ≠ 0 and α ≠ 0, we have n*α ≠ 0.
-By Hermite-Lindemann, e^(n*α) is transcendental.
-
-**Why axiomatized**: Requires the fact that the product of algebraic numbers
-is algebraic, which needs IsAlgebraic.mul from Mathlib's algebraic number API. -/
+For non-zero algebraic α, all of e^α, e^(2α), e^(3α), ... are transcendental,
+which follows directly from `hermite_lindemann` once `IsAlgebraic.mul` is used to
+witness `n * α` algebraic; no separate statement is needed here.
+-/
 
 end Corollaries
 
@@ -284,29 +275,21 @@ PART V: APPLICATIONS
 
 section Applications
 
-/-- **Axiom: Squaring the Circle is Impossible**
+/-!
+### Note: Squaring the Circle is Impossible
 
-Since π is transcendental, √π is also transcendental.
+Since π is transcendental, √π is also transcendental (if √π were algebraic,
+then (√π)² = π would be algebraic, contradicting `pi_transcendental_real`).
+Consequence: a square with the same area as a given circle cannot be
+constructed with compass and straightedge.
 
-**Proof outline**: If √π were algebraic, then (√π)² = π would be algebraic
-(as the product of algebraic numbers is algebraic). But we know π is
-transcendental by pi_transcendental_real. Contradiction!
+### Note: e is not rational
 
-**Consequence**: Transcendental numbers are not constructible with compass
-and straightedge, so the ancient problem of constructing a square with the
-same area as a given circle is impossible. -/
-
-/-- **Axiom: e is not rational**
-
-e is not equal to any rational number p/q. This is a weaker statement than
-transcendence (every transcendental is irrational, but not vice versa).
-
-**Proof outline**: If e = p/q for integers p, q with q ≠ 0, then e would be
-a root of the polynomial qX - p, making e algebraic. But e is transcendental
-by e_transcendental_rationals. Contradiction!
-
-**Note**: The title refers to non-periodic decimal expansion because rational
-numbers have eventually periodic decimal expansions, and transcendentals don't. -/
+`e_transcendental_int` plus `Transcendental → Irrational` gives that e is not
+equal to any rational number p/q (every transcendental is irrational, but not
+vice versa). Rational numbers have eventually periodic decimal expansions;
+transcendentals don't.
+-/
 
 end Applications
 

--- a/proofs/Proofs/eTranscendental.lean
+++ b/proofs/Proofs/eTranscendental.lean
@@ -4,6 +4,7 @@ import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.Analysis.SpecialFunctions.Complex.Analytic
 import Mathlib.Data.Real.Irrational
 import Mathlib.Data.Complex.ExponentialBounds
+import Proofs.HermiteLindemann
 
 /-!
 # e is Transcendental (Wiedijk #67)
@@ -129,21 +130,19 @@ theorem e_lt_three : Real.exp 1 < 3 := by
 -/
 
 -- ============================================================
--- PART 4: The Main Theorem (Axiomatized)
+-- PART 4: The Main Theorem (derived from Hermite-Lindemann)
 -- ============================================================
 
-/-- **Main Axiom: e is transcendental over ℤ**
+/-- **Main Theorem: e is transcendental over ℤ** (Wiedijk #67).
 
-    This is Wiedijk #67 and follows from Hermite's 1873 proof. The full
-    formalization requires:
-    1. Polynomial arithmetic over ℤ
-    2. Integration by parts for polynomial × exponential
-    3. Careful divisibility analysis mod p
-    4. Asymptotic estimates showing contradiction
+    Derived from `HermiteLindemann.hermite_lindemann` at α = 1: since 1 ≠ 0
+    is algebraic over ℚ, `Complex.exp 1` is transcendental over ℤ; transfer
+    along the embedding ℝ ↪ ℂ gives `Transcendental ℤ (Real.exp 1)`.
 
-    The Lindemann-Weierstrass theorem (a generalization) is not yet in Mathlib.
-    When formalized, this axiom would be replaced by a direct proof. -/
-axiom e_transcendental : Transcendental ℤ (Real.exp 1)
+    The underlying assumption is now `axiom hermite_lindemann` in
+    `Proofs.HermiteLindemann`; this slug no longer carries an independent axiom. -/
+theorem e_transcendental : Transcendental ℤ (Real.exp 1) :=
+  HermiteLindemann.e_transcendental_int
 
 /-- e is transcendental over ℚ.
     Derived from e_transcendental (over ℤ) via IsFractionRing.isAlgebraic_iff:

--- a/research/problems/nth-root-irrational-oq-03/knowledge.md
+++ b/research/problems/nth-root-irrational-oq-03/knowledge.md
@@ -123,3 +123,42 @@ Harder — but isolated. The continued-fraction route is the right strategy. If 
 - **Lean files**: `proofs/Proofs/HermiteLindemann.lean`, `eTranscendental.lean`, `ETranscendentalOQ0{1,2,3}.lean`, `PiTranscendental.lean`
 - **Parent**: `nth-root-irrational` (algebraic irrationality of irreducible-polynomial roots) — orthogonal in technique despite shared "expanding $\Q$" theme
 - **Adjacent transcendence work**: `angle-trisection-cos-20-gal-oq-01-oq-03` (cyclotomic $\Phi_{2p}(-1) = p$, requires algebraic-not-transcendental machinery), `algebraic-numbers-countable-oq-02-oq-04` (countability bounds)
+
+---
+
+## Session 2026-06-05 (Session 7) — S7 ACT — `e_transcendental` axiom discharged via Hermite-Lindemann bridge
+
+**Mode**: REVISIT (knowledge tier RICH at 19 items)
+**Outcome**: progress — local axiom reduction + 5 pre-existing Mathlib v4.26.0 build regressions repaired
+
+### What I Did
+- Discovered `HermiteLindemann.lean:208` already contained `hermite_lindemann 1 one_ne_zero (isAlgebraic_int 1)` — an aspirational derivation of `e_transcendental` that never compiled
+- Audited dependency chain: `eTranscendental.lean` had its own `axiom e_transcendental` (line 147) but the same statement was derivable from `axiom hermite_lindemann`
+- Wrote the bridge `e_transcendental_int : Transcendental ℤ (Real.exp 1)` in `HermiteLindemann.lean` using `IsAlgebraic.algebraMap` (3 lines)
+- Replaced `axiom e_transcendental` with `theorem e_transcendental := HermiteLindemann.e_transcendental_int`
+- Repaired 3 broken theorems in `HermiteLindemann.lean` (Mathlib v4.26.0 API regressions): `e_transcendental_rationals`, `pi_transcendental`, `pi_transcendental_real`
+- Cleaned up 7 dangling `/-- ... -/` aspirational-axiom docstrings → `/-! ... -/` blocks
+
+### Key Findings
+- `IsAlgebraic.algebraMap` (Mathlib/RingTheory/Algebraic/Basic.lean:174) is the right primitive for ℝ→ℂ transcendence transfer — replaces the broken `Polynomial.aeval_algHom_apply (Complex.ofRealHom.toAlgHom)` pattern in 1 line
+- S5b's "flip `.mp` to `.mpr`" applies consistently: `IsFractionRing.isAlgebraic_iff A K x : IsAlgebraic A x ↔ IsAlgebraic K x` so `.mpr` goes ℚ→ℤ
+- The "4 sibling sorries" claim from S1 (Insight 1) is stale — actual sorry count across all 5 sibling files is **0**
+- `HermiteLindemann.lean` was broken on origin/main but unnoticed because `Proofs.lean` builds Mathlib targets lazily; `ETranscendentalOQ03` doesn't import HermiteLindemann so S5c/S5d/S6 all missed the issue
+- `pi_transcendental` and `pi_transcendental_real` (Wiedijk #53) now provide working bridges in addition to the e bridge — orthogonal axiom-reduction targets opened up
+
+### Files Modified
+- `proofs/Proofs/HermiteLindemann.lean` (3 theorems repaired, 1 new theorem, 7 docstring cleanups; 390→373 lines)
+- `proofs/Proofs/eTranscendental.lean` (axiom → theorem, +1 import; 305→304 lines)
+- `src/data/proofs/e-transcendental/meta.json` (leanFile.axiomCount 1→0, theoremCount 12→13)
+- `src/data/proofs/hermite-lindemann/meta.json` (leanFile.theoremCount 4→5, lineCount 390→373)
+- `src/data/research/problems/nth-root-irrational-oq-03.json` (phase OBSERVE→ACT, iteration 7→8, knowledge updates)
+
+### Build verification
+`Proofs.eTranscendental` 3079/3079 jobs ✓; `Proofs.ETranscendentalOQ03` 3085/3085 jobs ✓.
+
+### Next Steps
+- S8 watch tick on PR #28013 (current 169.8h stale, S6 grace period ends ~2026-06-26)
+- S5d.A/B/C continued-fraction-of-e arc remains deferred per S6 grace-period logic
+- S7 follow-up: use repaired `pi_transcendental_real` to discharge `axiom lindemann_theorem` in `PiTranscendental.lean` (requires first fixing PT's pre-existing v4.26.0 build errors — mechanic-class)
+
+See `sessions/2026-06-05-s7-act-e-transcendental-axiom-discharge-via-hermite-lindemann-bridge.md` for full details.

--- a/research/problems/nth-root-irrational-oq-03/sessions/2026-06-05-s7-act-e-transcendental-axiom-discharge-via-hermite-lindemann-bridge.md
+++ b/research/problems/nth-root-irrational-oq-03/sessions/2026-06-05-s7-act-e-transcendental-axiom-discharge-via-hermite-lindemann-bridge.md
@@ -1,0 +1,234 @@
+# S7 ACT — Discharge `axiom e_transcendental` via Hermite-Lindemann bridge
+
+**Researcher**: researcher-5
+**Date**: 2026-06-05T09:30Z
+**Phase**: ACT (axiom reduction)
+**Iteration**: 8
+**Scope**: Lean code change + 2 meta.json edits + state docs
+
+## 1. Mission
+
+Per S6 PREP (2026-06-01), Mathlib PR #28013 threshold-crossing (168h) would
+trigger promotion of S5d.A (CF-of-e formalization). On 2026-06-05, the threshold
+was indeed crossed (169.8h vs 168h), but only by 1.8h — within normal weekly
+variance — and the S6 PREP explicitly extended the grace period to "another
+~3-4 weeks". The proper S5d.A promotion is therefore still deferred to
+~2026-06-26.
+
+This session pursued an **orthogonal axiom-reduction path** identified during
+the dependency audit: discharging `axiom e_transcendental` in
+`eTranscendental.lean` by deriving it from the existing `axiom hermite_lindemann`
+in `HermiteLindemann.lean`. Setting α = 1 in Hermite-Lindemann gives
+transcendence of `Complex.exp 1`, which transfers to `Real.exp 1` via the ℝ↪ℂ
+embedding. This is a structural reduction unrelated to the CF-of-e arc.
+
+## 2. Discoveries
+
+### 2.1 Stale knowledge in slug JSON
+
+`src/data/research/problems/nth-root-irrational-oq-03.json` claimed "4 sibling
+sorries across eTranscendental.lean, ETranscendentalOQ01.lean,
+ETranscendentalOQ02.lean, PiTranscendental.lean" (Insight 1, S1). Direct grep
+at 2026-06-05 confirms **0 sorries** across all 5 sibling files. The sorries
+were discharged in intervening enrichment/research work; the JSON insight is
+stale (S7 leaves it as historical record but no longer actionable).
+
+### 2.2 HermiteLindemann.lean broken on origin/main
+
+Docker-build of `Proofs.HermiteLindemann` at HEAD `da53bdc3c9e` fails with **5
+errors + 4 cascade parse errors** at v4.26.0:
+
+| line | issue | category |
+|------|-------|----------|
+| 216 (orig) | `Complex.ofRealHom.toAlgHom` — `RingHom.toAlgHom` removed v4.26.0 | API regression |
+| 244-246 (orig) | `Complex.ofReal_cos_ofReal_re`/`_sin_ofReal_re` — removed v4.26.0 | API regression |
+| 258 (orig) | `Complex.ofRealHom.toAlgHom` — same as 216 | API regression |
+| 277/297/309 (orig) | cascade parse errors after 258 | parser confusion |
+| 150-155/173-183/185-192 (orig) | dangling `/--` docstrings with no attached declaration | parser strict |
+| 200-203 / 268-277 / 287-309 (orig) | aspirational "Axiom: ..." docstrings, never declared | parser strict |
+| 225 (orig) `pi_transcendental` | `by decide` on `(X^2 + 1 : ℚ[X]) ≠ 0` fails — `Decidable` got stricter v4.26.0 | tactic regression |
+
+S6 PREP (2026-06-01) verified `Proofs.ETranscendentalOQ03` builds clean (3072
+jobs) but did **not** check `Proofs.HermiteLindemann` — OQ03 doesn't import
+HermiteLindemann. This session's bridge requires `import Proofs.HermiteLindemann`
+in `eTranscendental.lean`, so the file must build. All 5+4 errors fixed in §3.
+
+### 2.3 Mathlib API audit at lake-pinned SHA
+
+Confirmed at `gh api repos/leanprover-community/mathlib4/...` (v4.26.0 tag,
+manifest rev `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):
+
+- `IsAlgebraic.algebraMap` (Mathlib/RingTheory/Algebraic/Basic.lean:174) —
+  `{a : S} → IsAlgebraic R a → IsAlgebraic R (algebraMap S A a)`. Provides
+  the ℝ → ℂ algebraicity transfer in 1 line.
+- `Complex.ofReal_exp` — `((Real.exp x : ℝ) : ℂ) = Complex.exp ↑x`. Used `←`
+  direction to rewrite `Complex.exp ↑(1 : ℝ)` to `↑(Real.exp 1)`.
+- `Complex.ofReal_cos` and `Complex.ofReal_sin` — `↑(Real.cos x) = Complex.cos ↑x`
+  etc. Replace the removed `_ofReal_re` variants.
+- `isAlgebraic_one` — `IsAlgebraic R (1 : A)` (Basic.lean:138). Replaces
+  `isAlgebraic_int 1` which failed to elaborate (`?A` ambiguous).
+- `IsFractionRing.isAlgebraic_iff A K x` — `IsAlgebraic A x ↔ IsAlgebraic K x`
+  (Localization/Integral.lean:135). So `.mp : ℤ→ℚ`, `.mpr : ℚ→ℤ`. Matches the
+  S5b "flip `.mp` to `.mpr`" recorded fix at `eTranscendental.lean:152`.
+
+## 3. Lean changes
+
+### 3.1 `proofs/Proofs/HermiteLindemann.lean`
+
+**`e_transcendental_int` (new theorem, replaces broken `e_transcendental_rationals`
+proof)**
+
+```lean
+theorem e_transcendental_int : Transcendental ℤ (Real.exp 1) := by
+  have h_complex : Transcendental ℤ (Complex.exp (1 : ℂ)) :=
+    hermite_lindemann 1 one_ne_zero isAlgebraic_one
+  rw [show (1 : ℂ) = ↑(1 : ℝ) from by simp, ← Complex.ofReal_exp] at h_complex
+  exact fun halg => h_complex halg.algebraMap
+
+theorem e_transcendental_rationals : Transcendental ℚ (Real.exp 1) :=
+  fun halg => e_transcendental_int ((IsFractionRing.isAlgebraic_iff ℤ ℚ ℝ).mpr halg)
+```
+
+Down from 17 lines (broken) to 7 lines (working). `IsAlgebraic.algebraMap`
+substitutes for the entire `Polynomial.aeval_algHom_apply ... Complex.ofRealHom.toAlgHom`
+machinery.
+
+**`pi_transcendental` (repaired)**
+
+Replaced broken `Complex.ofReal_cos_ofReal_re` chain with `Complex.exp_mul_I`
++ `← Complex.ofReal_cos` + `← Complex.ofReal_sin` + `Real.cos_pi` + `Real.sin_pi`
++ `push_cast; ring` for Euler identity. Replaced `by decide` for polynomial
+nonzero with explicit `eval (0 : ℚ)` discharge (`(X^2 + 1).eval 0 = 1`, so if
+the polynomial were zero we'd have `0 = 1`).
+
+**`pi_transcendental_real` (repaired)**
+
+```lean
+theorem pi_transcendental_real : Transcendental ℤ Real.pi :=
+  fun halg => pi_transcendental halg.algebraMap
+```
+
+Same 1-line `IsAlgebraic.algebraMap` shortcut. Down from 6 lines to 2.
+
+**Dangling docstring cleanup**
+
+7 `/-- ... -/` docstrings (for "Axiom: ..." entries never declared) converted
+to `/-! ... -/` doc blocks. No semantic content lost; aspirational axioms
+clearly marked as commentary rather than parse-failed code.
+
+### 3.2 `proofs/Proofs/eTranscendental.lean`
+
+- Added `import Proofs.HermiteLindemann`.
+- Replaced `axiom e_transcendental : Transcendental ℤ (Real.exp 1)` (16 lines
+  of axiom + docstring) with:
+
+```lean
+theorem e_transcendental : Transcendental ℤ (Real.exp 1) :=
+  HermiteLindemann.e_transcendental_int
+```
+
+eTranscendental.lean **local axiom count: 1 → 0**. The downstream
+`e_transcendental_over_rationals`, `e_irrational_axiom`, `e_inv_transcendental_axiom`,
+etc. all continue to use the same name `e_transcendental` (now a theorem) with
+no signature change.
+
+## 4. Build verification
+
+```
+LEAN_BUILD_TIMEOUT=20m ./proofs/scripts/docker-build.sh Proofs.eTranscendental
+→ ⚠ [3079/3079] Built Proofs.eTranscendental (4.5s)
+→ info: e_transcendental : Transcendental ℤ (rexp 1)
+→ Build completed successfully (3079 jobs).
+
+LEAN_BUILD_TIMEOUT=20m ./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ03
+→ ⚠ [3085/3085] Built Proofs.ETranscendentalOQ03 (8.1s)
+→ Build completed successfully (3085 jobs).
+```
+
+Both targets build clean. `e_transcendental` is now a **theorem** at line 144
+(was axiom at line 147 pre-change), as confirmed by the `info:` line from
+`#check e_transcendental` at the bottom of the file.
+
+### 4.1 Out-of-scope build state (pre-existing failures, not regressed)
+
+`Proofs.PiTranscendental` fails at lines 228 (`Unknown identifier irrational_pi`)
+and 285 (type mismatch on `isAlgebraic_algebraMap 1`). `Proofs.ETranscendentalOQ02`
+fails at line 708 (`No goals to be solved`). These were already broken on
+origin/main at HEAD `da53bdc3c9e` and are unaffected by S7 changes. Flagged
+as mechanic-class follow-up.
+
+`Proofs.ETranscendentalOQ01` transitively fails because it imports
+`Proofs.PiTranscendental`. Fixing PT unblocks OQ01.
+
+## 5. Meta.json updates
+
+### `src/data/proofs/e-transcendental/meta.json`
+
+| field | before | after |
+|-------|--------|-------|
+| `leanFile.axiomCount` | 1 | **0** |
+| `leanFile.theoremCount` | 12 | **13** |
+| `leanFile.lineCount` | 305 | 304 |
+
+`meta.status` and `meta.badge` stay `"axiomatized"` / `"axiom"` per Axiom
+Integrity Policy: the slug still **transitively** depends on
+`axiom hermite_lindemann` in the upstream file. The reduction is local-file
+only; total project-wide axiom count is unchanged at 1 (now solely
+`hermite_lindemann`).
+
+### `src/data/proofs/hermite-lindemann/meta.json`
+
+| field | before | after |
+|-------|--------|-------|
+| `leanFile.theoremCount` | 4 | **5** (added `e_transcendental_int`) |
+| `leanFile.lineCount` | 390 | 373 |
+
+## 6. Value assessment
+
+Per the value hierarchy in the research prompt:
+
+1. **Structural theorem** — yes. `e_transcendental` is now a direct consequence
+   of `hermite_lindemann`, making the axiom dependency explicit and shared
+   rather than duplicated. This is exactly the "one reduction > 1000 cases"
+   pattern the prompt highlights.
+2. **Decidable instance** — n/a.
+3. **Lemma on critical path** — `e_transcendental_int` is a reusable bridge
+   for ℂ→ℝ transcendence transfer; will be used again whenever a sibling
+   slug needs `Transcendental ℤ x` from a Hermite-Lindemann-style consequence.
+4. **Side benefit**: HermiteLindemann.lean restored to clean build state.
+   `pi_transcendental` and `pi_transcendental_real` now actually work (was
+   pure decoration before — fail-silent because no caller imported the file).
+
+Non-trivial gain: the discovery that "4 sibling sorries" was stale (0 actual
+sorries), prompting this dependency audit which surfaced the redundant axiom.
+
+## 7. Next steps
+
+1. **S8 (passive watch, primary)**: re-check PR #28013 at next claim of this
+   slug. Threshold crossed 2026-06-05 by 1.8h; S6 grace period ends ~2026-06-26.
+2. **S5d.A/B/C (deferred)**: CF-of-e formalization (280–480 LOC, 3 sub-tasks).
+   Activation criterion: PR #28013 still not merged at 2026-06-26.
+3. **S7 follow-up** (low priority): use `pi_transcendental_real` (now working)
+   to discharge `axiom lindemann_theorem` in `PiTranscendental.lean`. Same
+   `halg.algebraMap` bridge pattern. Would reduce another redundant axiom but
+   requires first fixing PiTranscendental.lean's pre-existing v4.26.0 build
+   errors (out of researcher scope — mechanic-class repair).
+4. **Mechanic flag**: 3 deprecation-linter warnings (Mathlib import paths) in
+   `eTranscendental.lean` and `HermiteLindemann.lean` — `Mathlib.Data.Real.Irrational`
+   → `Mathlib.NumberTheory.Real.Irrational`, `Mathlib.Data.Complex.ExponentialBounds`
+   → `Mathlib.Analysis.Complex.ExponentialBounds`, `Mathlib.Data.Real.Pi.Bounds`
+   → `Mathlib.Analysis.Real.Pi.Bounds`, `Mathlib.Data.Complex.Exponential` →
+   `Mathlib.Analysis.Complex.Exponential`. 4 lines, 2 files, no semantic change.
+
+## 8. Race notes
+
+Pre-action check at 2026-06-05T09:10Z:
+- `find research/claims -name "*.lock" -type d -mmin +120 -exec rm -rf {} \;` → no stale locks
+- `mkdir research/claims/nth-root-irrational-oq-03.lock` → ✓ claimed
+- `gh pr list --state open --head feature/researcher-5` → 0 open PRs (clean branch)
+- `git rev-parse --abbrev-ref HEAD` → `feature/researcher-5` (worktree)
+- `git rebase origin/main` → "Successfully rebased and updated" (clean)
+
+This PR modifies 2 Lean files + 2 meta.json files + 2 problem-state files.
+Counts against the per-session PR cap (not STATE-SYNC — this is a real Lean
+axiom reduction).

--- a/research/problems/nth-root-irrational-oq-03/state.md
+++ b/research/problems/nth-root-irrational-oq-03/state.md
@@ -2,11 +2,61 @@
 
 ## Current State
 
-**Phase**: PREP — S6 watch tick (PR #28013) + CF-of-e Mathlib master rescan (0 new content) + S5c infrastructure build re-verify (3072/3072 clean at HEAD `8bf8a7b3552`). Path C re-evaluation: **no actionable target** — empirical grep confirms no other `LiouvilleWith p (specific-irrational)` axiom anywhere in `proofs/Proofs/`. Strategic posture shifts to Path B (passive watch). PR #28013 staleness 69.8h (warm; 2026-05-29 merge from master reset the clock), well below 168h threshold.
+**Phase**: ACT — S7 (2026-06-05) discharged `axiom e_transcendental` in `eTranscendental.lean` (Wiedijk #67) by deriving it as a theorem from `axiom hermite_lindemann` via a 3-line `IsAlgebraic.algebraMap` bridge. Side benefit: 5 pre-existing Mathlib v4.26.0 build regressions in `HermiteLindemann.lean` (3 broken theorems + 7 dangling docstrings) repaired, restoring `pi_transcendental` and `pi_transcendental_real` (Wiedijk #53) to clean build. Net: eTranscendental.lean local axiom 1→0; HermiteLindemann.lean restored to build-clean. Build verified 3079/3079 jobs. PR #28013 (Mathlib HL upstream) threshold crossed 2026-06-05 (169.8h vs 168h) but S6 grace period (~3-4 weeks after crossing) extends to ~2026-06-26, so S5d.A CF-of-e arc remains deferred. S7 is an orthogonal axiom-reduction path unrelated to the CF-of-e arc.
 **Path**: full
 **Since**: 2026-05-12T13:07:57-07:00 (slug creation by seeker)
-**Last Updated**: 2026-06-01T05:10:00Z (Iteration 7, researcher-1)
-**Iteration**: 7
+**Last Updated**: 2026-06-05T09:30:00Z (Iteration 8, researcher-5)
+**Iteration**: 8
+
+## Iteration 8 (researcher-5, 2026-06-05) — S7 ACT (axiom e_transcendental discharged + HermiteLindemann.lean repaired)
+
+**Outcome**: progress — local axiom reduction in `eTranscendental.lean` (1 → 0) by deriving Wiedijk #67 from the existing `hermite_lindemann` axiom in `HermiteLindemann.lean`. Side benefit: 5 pre-existing Mathlib v4.26.0 build regressions in `HermiteLindemann.lean` repaired, plus 7 dangling docstrings cleaned up — `pi_transcendental` (Wiedijk #53) and `pi_transcendental_real` now build clean (were broken on origin/main, silently because no caller imported the file).
+
+### What I did
+
+- PR #28013 watch tick: head SHA `5abb7c68488…`, `updated_at = 2026-05-29T07:22:48Z` (unchanged from S6). Recomputed staleness at 2026-06-05T09:10Z: **169.8h** — threshold crossed by 1.8h. S6 PREP extended grace period to "~3-4 weeks" after crossing, so S5d.A arc remains deferred until ~2026-06-26.
+- Discovered Mathlib API `IsAlgebraic.algebraMap` (Mathlib/RingTheory/Algebraic/Basic.lean:174) as the replacement primitive for broken `Polynomial.aeval_algHom_apply (Complex.ofRealHom.toAlgHom)` pattern (3 lines vs 17 for the original ℂ→ℝ transcendence transfer).
+- Wrote `HermiteLindemann.e_transcendental_int : Transcendental ℤ (Real.exp 1)` using `hermite_lindemann 1 one_ne_zero isAlgebraic_one`, then `Complex.ofReal_exp` rewrite, then `halg.algebraMap`.
+- Replaced `axiom e_transcendental` in `eTranscendental.lean` with `theorem e_transcendental := HermiteLindemann.e_transcendental_int`. Added `import Proofs.HermiteLindemann`.
+- Repaired `pi_transcendental` (Wiedijk #53): replaced removed `Complex.ofReal_cos_ofReal_re`/`_sin_ofReal_re` with `Complex.ofReal_cos`/`_sin` (in `←` direction); replaced failing `by decide` for `(X^2 + 1 : ℚ[X]) ≠ 0` with explicit `eval (0 : ℚ)` discharge; flipped `.mpr` to `.mp` on the `IsFractionRing.isAlgebraic_iff` calls (consistent with S5b's recorded convention `IsAlgebraic A x ↔ IsAlgebraic K x`).
+- Repaired `pi_transcendental_real` with same `halg.algebraMap` shortcut (6 lines → 2).
+- Cleaned up 7 dangling `/-- ... -/` aspirational-axiom docstrings (no attached declarations) → `/-! ... -/` doc blocks. Pre-existing v4.26.0 parser regression — earlier versions tolerated them; current Lean rejects them as parse errors.
+- Build verification: `Proofs.eTranscendental` 3079/3079 jobs clean; `Proofs.ETranscendentalOQ03` 3085/3085 jobs clean (no regression).
+- Pre-existing build failures NOT introduced by S7 (flagged for mechanic): `Proofs.PiTranscendental:228,285` (unknown `irrational_pi`, type mismatch on `isAlgebraic_algebraMap 1`); `Proofs.ETranscendentalOQ02:708` ("No goals to be solved"); these in turn break `Proofs.ETranscendentalOQ01` transitively.
+
+### Files Modified
+
+- `proofs/Proofs/HermiteLindemann.lean` — 1 new theorem (`e_transcendental_int`), 3 broken theorems repaired, 7 docstring cleanups; 390→373 LOC
+- `proofs/Proofs/eTranscendental.lean` — axiom 1→0, +1 import; 305→304 LOC
+- `src/data/proofs/e-transcendental/meta.json` — leanFile.axiomCount 1→0, theoremCount 12→13, lineCount 305→304
+- `src/data/proofs/hermite-lindemann/meta.json` — leanFile.theoremCount 4→5, lineCount 390→373
+- `research/problems/nth-root-irrational-oq-03/state.md` — this entry + Current State header refresh
+- `research/problems/nth-root-irrational-oq-03/knowledge.md` — session summary entry
+- `research/problems/nth-root-irrational-oq-03/sessions/2026-06-05-s7-act-e-transcendental-axiom-discharge-via-hermite-lindemann-bridge.md` — new full session note
+- `src/data/research/problems/nth-root-irrational-oq-03.json` — phase OBSERVE→ACT, iteration 7→8, 1 new insight, 3 new builtItems, progressSummary + nextSteps refreshed
+
+### Knowledge Added
+
+- **Insights**: 1 new
+  1. `axiom e_transcendental` is locally redundant given `axiom hermite_lindemann`: setting α=1 in HL gives transcendence of `Complex.exp 1`, which transfers to `Real.exp 1` via `IsAlgebraic.algebraMap`. The bridge is 3 lines. The original derivation attempt in `e_transcendental_rationals` (HermiteLindemann.lean:204-219) used `Polynomial.aeval_algHom_apply (Complex.ofRealHom.toAlgHom)` which broke at v4.26.0 (`RingHom.toAlgHom` removed). `IsAlgebraic.algebraMap` from `Mathlib.RingTheory.Algebraic.Basic:174` is the cleaner primitive — replaces the entire aeval-algHom machinery in 1 application.
+
+- **Built items**: 3 new
+  1. `HermiteLindemann.e_transcendental_int : Transcendental ℤ (Real.exp 1)` — the ℂ→ℝ bridge; reusable template for analogous transcendence-transfer slugs.
+  2. `e_transcendental : Transcendental ℤ (Real.exp 1)` — was Wiedijk #67 axiom; now a theorem alias for `HermiteLindemann.e_transcendental_int`.
+  3. `HermiteLindemann.pi_transcendental` and `.pi_transcendental_real` (Wiedijk #53) — pre-existing aspirational proofs, broken on origin/main at v4.26.0, repaired in S7.
+
+- **Risks retired**: HermiteLindemann.lean was a silent ticking bomb — any future research touching it would have hit the same regressions. S7's repair eliminates this hazard.
+
+### Next steps
+
+- **S8 watch (passive)**: re-check PR #28013 at next claim. Current 169.8h stale (just over 168h threshold). S6 grace period ends ~2026-06-26 — if PR not merged by then, promote S5d.A.
+- **S5d.A/B/C (deferred)**: CF-of-e formalization arc; activation criterion ~2026-06-26 + still-no-PR-merge.
+- **S7 follow-up (low priority)**: use `pi_transcendental_real` (now working) to discharge `axiom lindemann_theorem` in `PiTranscendental.lean`. Same `halg.algebraMap` bridge pattern. Blocked by pre-existing v4.26.0 build errors in PiTranscendental.lean (mechanic-class repair needed first).
+- **Mechanic flag**: 4 deprecation linter warnings across `eTranscendental.lean` + `HermiteLindemann.lean` (Mathlib import paths). No semantic change.
+
+### Race notes
+
+Pre-action race check (2026-06-05T09:10Z): 0 stale locks; mkdir lock acquired for slug; 0 open PRs with `nth-root-irrational-oq-03` in title; `feature/researcher-5` clean.
 
 ## Iteration 7 (researcher-1, 2026-06-01) — S6 PREP (PR #28013 watch tick + CF-of-e rescan + S5c build re-verify)
 

--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -208,9 +208,9 @@
       "Polynomial"
     ],
     "namespace": null,
-    "lineCount": 305,
-    "axiomCount": 1,
-    "theoremCount": 12,
+    "lineCount": 304,
+    "axiomCount": 0,
+    "theoremCount": 13,
     "definitionCount": 0,
     "path": "Proofs/eTranscendental.lean",
     "sorries": 0

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -202,9 +202,9 @@
       "ComplexConjugate"
     ],
     "namespace": "HermiteLindemann",
-    "lineCount": 390,
+    "lineCount": 373,
     "axiomCount": 1,
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/HermiteLindemann.lean",
     "sorries": 0

--- a/src/data/research/problems/nth-root-irrational-oq-03.json
+++ b/src/data/research/problems/nth-root-irrational-oq-03.json
@@ -9,9 +9,9 @@
     67
   ],
   "created": "2026-05-12",
-  "lastUpdated": "2026-06-01",
-  "phase": "PREP",
-  "iteration": 7,
+  "lastUpdated": "2026-06-05",
+  "phase": "ACT",
+  "iteration": 8,
   "status": "active",
   "shortDescription": "Hermite-Lindemann (1882): for nonzero algebraic α, e^α is transcendental. Lindemann-Weierstrass (1885): for Q-linearly-independent algebraic α₁..αₙ, the e^αᵢ are algebraically independent over Q. Project status: axiomatized in HermiteLindemann.lean; this slug coordinates bridge work to existing infrastructure rather than re-formalising from scratch.",
   "wiedijkRefs": [
@@ -40,7 +40,8 @@
       "S5b ACT (2026-05-14, researcher-9): parent-file build restored on origin/main via 4 surgical Mathlib v4.26.0 fixes (3 diagnosed in S5a, 1 surfaced after Fix #1 unblocked the namespace). `eTranscendental.lean` and `ETranscendentalOQ03.lean` now build cleanly (3071 jobs). Fix breakdown: (1) add `import Mathlib.RingTheory.Localization.Integral` to `eTranscendental.lean` for `IsFractionRing.isAlgebraic_iff` (lemma moved out of `Algebraic.Basic`'s transitive closure). (2) Replace `isAlgebraic_algebraMap (1 : ℚ)` with `isAlgebraic_one` at `eTranscendental.lean:225` (newer Mathlib elaborator doesn't auto-bridge `algebraMap ℚ ℝ 1` to `(1 : ℝ)`). (3) Replace `irrational_exp_iff.mpr ...` with project-local `e_irrational` at `ETranscendentalOQ03.lean:118` (lemma upstream-removed during Mathlib.Data.Real.Irrational → Mathlib.NumberTheory.Real.Irrational refactor). (4) Flip `.mp` to `.mpr` at `eTranscendental.lean:152` (sole site mismatched with v4.26.0 iff convention `IsAlgebraic A x ↔ IsAlgebraic K x`). Unblocks S5c S2 ACT paste-in for axiomCount 2→1.",
       "S5c ACT (2026-05-16, researcher-12): pasted S5a §3 drafted proof body verbatim into ETranscendentalOQ03.lean, replacing `axiom irrational_liouvilleWith_two` with a `theorem` + the helper `rat_approx_bounded_den_finite`. Added import `Mathlib.NumberTheory.DiophantineApproximation.Basic`. Docker build clean on **first attempt** (3072 jobs, OQ03 file built in 5.8s; `eTranscendental` replayed from cache). None of the S5c PREP §4 robustness fallbacks (Option B/C for `field_simp`, `rpow_natCast`, image-membership refine) were needed — Option A compiled verbatim. `e-transcendental-oq-03/meta.json` axiomCount 2→1. Sharp-upper-bound axiom `e_not_liouvilleWith_gt_two` remains (S5d). Marquee `axiom hermite_lindemann` in HermiteLindemann.lean remains gated on Mathlib PR #28013 (S6). The drafted body + slice-finiteness helper is now a reusable template for analogous LiouvilleWith ACTs.",
       "S5d PREP (2026-05-16, researcher-11): enumerated Mathlib `Algebra.ContinuedFractions.*` + `NumberTheory.DiophantineApproximation.*` API at lake-pinned SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0). Generic CF machinery is fully available: `succ_nth_fib_le_of_nth_den` (Approximations.lean:249), `abs_sub_convs_le` (Approximations.lean:393), `Real.exists_rat_eq_convergent` (Basic.lean:538), `Real.convs_eq_convergent`, `of_partNum_eq_one`/`of_one_le_get?_partDen`. **However the CF expansion of e (Euler's [2;1,2k,1] pattern) is completely absent** — confirmed via 3 independent code searches + full tree filter. Davis's (1978) argument decomposes into 6 steps: steps 3/4/5 (generic machinery) available, steps 1/2 (e-specific input) absent. Direct S5d discharge requires formalising the CF expansion of e from scratch — re-estimated scope 280–480 LOC across 3 sub-tasks (S5d.A `e_continued_fraction_pattern` 150–250 LOC, S5d.B `e_convergent_den_ratio_bounded` 50–80 LOC, S5d.C target axiom 80–150 LOC), not the 150–250 LOC originally estimated. **Recommended hybrid Path B (PR #28013 watch — ~90.93h stale of 168h threshold) + Path C (apply S5c slice-finiteness template to sibling LiouvilleWith-2 slug — ~30–60 LOC ACT) rather than direct S5d ACT.** Also 0 drift on S5c-era bearers (re-pinned at SHA). PR #28013 status unchanged from S5a/S5c records (head SHA `3bafffe27908…`, updated_at `2026-05-12T09:28:36Z`).",
-      "S6 PREP (2026-06-01, researcher-1): 16-day delta watch tick. PR #28013 received exactly one activity since S5d — the 2026-05-29 merge-from-master (head SHA `3bafffe27908…` → `5abb7c68488…`). Recomputed staleness 69.8h (was 90.9h at S5d); the merge reset the clock. `mergeable_state` still `blocked` (24 review comments + 9 issue comments). No new substantive content since 2026-05-08 cluster. Mathlib master rescan since 2026-05-16: 1 CF commit (#37997, generalises det formula `SimpContFract` → `GenContFract`; no e-specific input), 1 toolchain bump (v4.31.0-rc1), 1 doc PR. 0 e-specific additions. S5d's 280–480 LOC re-estimate for S5d.A remains valid. **Path C empirically exhausted**: `grep -rn 'axiom.*[Ll]iouvilleWith' proofs/Proofs/` returns exactly one hit (`e_not_liouvilleWith_gt_two` in the same file as the just-shipped `irrational_liouvilleWith_two` template); no sibling slug carries the analogous-axiom shape. PiTranscendental.lean has only `lindemann_theorem`. S5c infrastructure build-verified clean at HEAD `8bf8a7b3552` (3072/3072 jobs); 0 bearer drift; same 3 deprecation linter warnings as S5c records (Mathlib.Data.Real.Irrational → NumberTheory.Real.Irrational; Mathlib.Data.Complex.ExponentialBounds → Analysis.Complex.ExponentialBounds). Strategic posture shifts to Path B (passive watch) primary; Path A.A deferred."
+      "S6 PREP (2026-06-01, researcher-1): 16-day delta watch tick. PR #28013 received exactly one activity since S5d — the 2026-05-29 merge-from-master (head SHA `3bafffe27908…` → `5abb7c68488…`). Recomputed staleness 69.8h (was 90.9h at S5d); the merge reset the clock. `mergeable_state` still `blocked` (24 review comments + 9 issue comments). No new substantive content since 2026-05-08 cluster. Mathlib master rescan since 2026-05-16: 1 CF commit (#37997, generalises det formula `SimpContFract` → `GenContFract`; no e-specific input), 1 toolchain bump (v4.31.0-rc1), 1 doc PR. 0 e-specific additions. S5d's 280–480 LOC re-estimate for S5d.A remains valid. **Path C empirically exhausted**: `grep -rn 'axiom.*[Ll]iouvilleWith' proofs/Proofs/` returns exactly one hit (`e_not_liouvilleWith_gt_two` in the same file as the just-shipped `irrational_liouvilleWith_two` template); no sibling slug carries the analogous-axiom shape. PiTranscendental.lean has only `lindemann_theorem`. S5c infrastructure build-verified clean at HEAD `8bf8a7b3552` (3072/3072 jobs); 0 bearer drift; same 3 deprecation linter warnings as S5c records (Mathlib.Data.Real.Irrational → NumberTheory.Real.Irrational; Mathlib.Data.Complex.ExponentialBounds → Analysis.Complex.ExponentialBounds). Strategic posture shifts to Path B (passive watch) primary; Path A.A deferred.",
+      "S7 ACT (2026-06-05, researcher-5): discharged axiom e_transcendental in eTranscendental.lean by deriving from axiom hermite_lindemann via halg.algebraMap bridge. ALSO discovered and repaired 5 pre-existing Mathlib v4.26.0 regressions in HermiteLindemann.lean (3 broken theorems + 2 dangling docstrings) blocking the build: (1) e_transcendental_rationals had broken Complex.ofRealHom.toAlgHom call (`RingHom.toAlgHom` removed v4.26.0), (2) pi_transcendental used removed Complex.ofReal_cos_ofReal_re and (X^2+1)≠0 via by-decide, (3) pi_transcendental_real used same Complex.ofRealHom.toAlgHom, (4-6) dangling /-- aspirational axiom docstrings without attached declarations at lines 150/173/185/200/262/281/293. Replaced all broken proofs with halg.algebraMap pattern (3 lines each via IsAlgebraic.algebraMap from Mathlib.RingTheory.Algebraic.Basic:174). Build clean 3079 jobs first attempt. Net effect: eTranscendental.lean axiom 1→0; HermiteLindemann.lean restored to clean build (was failing on origin/main); pi_transcendental and pi_transcendental_real now provide working bridges in addition to e_transcendental_int. S5d.A/B/C continued-fraction-of-e arc still deferred; this is an orthogonal axiom-reduction path."
     ],
     "builtItems": [
       {
@@ -60,18 +61,44 @@
         "signature": "(x : ℝ) (N : ℕ) : {q : ℚ | |x - (q : ℝ)| < 1 / (q.den : ℝ) ^ 2 ∧ q.den ≤ N}.Finite",
         "iteration": 5,
         "summary": "Slice-finiteness helper: the set of good rational approximations to `x` with denominator ≤ N is finite. Used in `irrational_liouvilleWith_two` to derive that good approximations have unbounded denominators. Reusable template for analogous `LiouvilleWith p` ACTs on specific irrationals."
+      },
+      {
+        "name": "e_transcendental_int",
+        "type": "theorem",
+        "file": "proofs/Proofs/HermiteLindemann.lean",
+        "namespace": "HermiteLindemann",
+        "signature": "Transcendental ℤ (Real.exp 1)",
+        "iteration": 8,
+        "summary": "Bridges hermite_lindemann (Complex.exp) to Real.exp via Complex.ofReal_exp rewrite + halg.algebraMap. Discharges axiom e_transcendental in eTranscendental.lean. Reusable template for ℂ→ℝ transcendence transfer."
+      },
+      {
+        "name": "e_transcendental",
+        "type": "theorem (formerly axiom)",
+        "file": "proofs/Proofs/eTranscendental.lean",
+        "namespace": "(top-level)",
+        "signature": "Transcendental ℤ (Real.exp 1)",
+        "iteration": 8,
+        "summary": "Was axiom Wiedijk #67; now derived as HermiteLindemann.e_transcendental_int. axiomCount of e-transcendental slug: 1→0."
+      },
+      {
+        "name": "pi_transcendental (repaired)",
+        "type": "theorem",
+        "file": "proofs/Proofs/HermiteLindemann.lean",
+        "namespace": "HermiteLindemann",
+        "signature": "Transcendental ℤ (Real.pi : ℂ)",
+        "iteration": 8,
+        "summary": "Was broken at v4.26.0 (Complex.ofReal_cos_ofReal_re removed, decide failed); repaired with Complex.ofReal_cos and explicit eval-at-0 nonzero proof. Wiedijk #53."
       }
     ],
-    "progressSummary": "S1 OBSERVE (duplicate-detection survey), S2-S4c PREP chain (Mathlib API audits, 9 doc-only PRs over 14h), S5a PREP (regression discovery + S2 ACT proof body draft), S5b ACT (parent-file build restored via 4 surgical v4.26.0 fixes), S5c PREP (pre-flight bearer audit at lake-pinned SHA), S5c ACT (axiomCount 2→1 via verbatim paste-in of S5a §3 drafted body — first-pass clean Docker build, all S5c PREP §4 fallbacks unused), S5d PREP (CF API enumeration at v4.26.0 — generic CF machinery fully available, but CF expansion of e absent; direct S5d discharge re-estimated 280–480 LOC across 3 sub-tasks, hybrid Path B/C recommended), S6 PREP (16-day delta watch tick: PR #28013 reset its staleness clock on 2026-05-29 merge-from-master, 69.8h stale; Mathlib master 0 new CF-of-e content; Path C empirically exhausted — no sibling slug carries the analogous LiouvilleWith axiom; S5c infrastructure re-verified clean at HEAD 8bf8a7b3552). S5d (sharp upper bound via CF) and S6 (hermite_lindemann via Mathlib PR #28013) are the remaining axioms.",
+    "progressSummary": "S5c ACT (axiomCount 2→1 for OQ03 file). S6 PREP (PR #28013 watch tick). S7 ACT (2026-06-05): orthogonal axiom-reduction path discovered — e_transcendental axiom discharged from hermite_lindemann via 3-line halg.algebraMap bridge; HermiteLindemann.lean fully repaired (was broken pre-existing at v4.26.0); pi_transcendental and pi_transcendental_real now working. eTranscendental.lean axiomCount 1→0. PR #28013 still 169.8h stale (just over 168h threshold).",
     "approachesAttempted": [],
     "knownDeadEnds": [],
     "nextSteps": [
-      "S6 (passive watch, primary stance): re-check Mathlib PR #28013 head SHA + updated_at at next claim. Current staleness 69.8h; threshold 168h; margin 98h. Promote local re-prove if threshold crossed.",
-      "Path C (closed, 2026-06-01): empirical check confirms no sibling slug carries an analogous `LiouvilleWith p (specific-irrational)` axiom. Re-open only if a future enricher/researcher *adds* such an axiom to another file.",
-      "S5d.A/B/C (deferred multi-session arc): if PR #28013 stalls past 168h threshold (~4 days from 2026-05-29 baseline), promote `e_continued_fraction_pattern` from 'deferred' to 'scope this session'. S5d.A — design proof outline (Hermite identity vs direct CF-via-series; 150–250 LOC). S5d.B — `e_convergent_den_ratio_bounded` (50–80 LOC). S5d.C — target axiom (80–150 LOC). Total 280–480 LOC across 3 sessions.",
-      "Mechanic follow-up (out of researcher scope): 3 deprecation linter warnings in `eTranscendental.lean` + `ETranscendentalOQ03.lean` — `Mathlib.Data.Real.Irrational` → `Mathlib.NumberTheory.Real.Irrational`; `Mathlib.Data.Complex.ExponentialBounds` → `Mathlib.Analysis.Complex.ExponentialBounds`. 3 lines, 2 files, no semantic change.",
-      "S5c (researcher-12, 2026-05-16): COMPLETED. axiomCount 2 → 1 via verbatim paste-in of S5a §3 drafted body; Docker-clean first pass (3072 jobs).",
-      "S5b (researcher-9, 2026-05-14): COMPLETED. Parent-file build restored via 4 one-line surgical fixes; both eTranscendental.lean and ETranscendentalOQ03.lean build cleanly (3071 jobs)."
+      "S8 (passive watch, primary): re-check Mathlib PR #28013. Current 169.8h stale, 1.8h over threshold. S6 grace period (~3-4 weeks after threshold crossing) ends ~2026-06-26; promote local CF-of-e re-prove if no progress.",
+      "S5d.A/B/C (deferred): CF expansion of e (Euler [2;1,2k,1]) for e_not_liouvilleWith_gt_two. 280-480 LOC across 3 sub-tasks. Tractability unchanged from S5d.",
+      "S7 follow-up (low priority): consider extending pi_transcendental_real to discharge axiom lindemann_theorem in PiTranscendental.lean via similar bridge. Currently pi-transcendence has 2 independent paths: hermite_lindemann-derived (HermiteLindemann.lean) and lindemann_theorem-axiom (PiTranscendental.lean); the former is now build-clean.",
+      "Mechanic follow-up: PiTranscendental.lean and ETranscendentalOQ02.lean have pre-existing build errors (PT:228,285 unknown irrational_pi/type mismatch; OQ02:708 no goals). Out of researcher scope but flagging.",
+      "ETranscendentalOQ01.lean transitively depends on the broken PiTranscendental.lean. Fixing PT unblocks OQ01."
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary

- **Axiom reduction**: derives `theorem e_transcendental : Transcendental ℤ (Real.exp 1)` (Wiedijk #67) from `axiom hermite_lindemann` at α = 1 via a 3-line `IsAlgebraic.algebraMap` bridge. `eTranscendental.lean` local `axiomCount`: **1 → 0**.
- **Side benefit**: repairs 5 pre-existing Mathlib v4.26.0 build regressions in `HermiteLindemann.lean` (3 broken theorems + 7 dangling `/-- ... -/` docstrings), restoring `pi_transcendental` and `pi_transcendental_real` (Wiedijk #53) to clean build. These were silently broken on `origin/main` because no caller imported `HermiteLindemann` until this PR adds the import to `eTranscendental.lean`.
- **Build verified**: `Proofs.eTranscendental` 3079/3079 jobs ✓ + `Proofs.ETranscendentalOQ03` 3085/3085 jobs ✓.

## Mathematical content

Setting α = 1 ∈ ℂ in Hermite-Lindemann gives `Transcendental ℤ (Complex.exp 1)`. Via the embedding ℝ ↪ ℂ (formalized by `IsAlgebraic.algebraMap` at `Mathlib.RingTheory.Algebraic.Basic:174`), this transfers to `Transcendental ℤ (Real.exp 1)`. The previous attempt at this derivation in `HermiteLindemann.lean:204` used `Polynomial.aeval_algHom_apply (Complex.ofRealHom.toAlgHom)`, but `RingHom.toAlgHom` was removed in Mathlib v4.26.0. `IsAlgebraic.algebraMap` is the cleaner primitive — replaces the entire `aeval ∘ AlgHom` machinery in one application.

The new bridge is:

```lean
theorem e_transcendental_int : Transcendental ℤ (Real.exp 1) := by
  have h_complex : Transcendental ℤ (Complex.exp (1 : ℂ)) :=
    hermite_lindemann 1 one_ne_zero isAlgebraic_one
  rw [show (1 : ℂ) = ↑(1 : ℝ) from by simp, ← Complex.ofReal_exp] at h_complex
  exact fun halg => h_complex halg.algebraMap
```

## What changed

| File | Change |
|------|--------|
| `proofs/Proofs/HermiteLindemann.lean` | 1 new theorem (`e_transcendental_int`), 3 broken theorems repaired (`e_transcendental_rationals`, `pi_transcendental`, `pi_transcendental_real`), 7 dangling docstrings cleaned up; 390→373 LOC |
| `proofs/Proofs/eTranscendental.lean` | `axiom e_transcendental` → `theorem e_transcendental := HermiteLindemann.e_transcendental_int`; +1 import; 305→304 LOC |
| `src/data/proofs/e-transcendental/meta.json` | `leanFile.axiomCount` 1→0, `theoremCount` 12→13, `lineCount` 305→304 |
| `src/data/proofs/hermite-lindemann/meta.json` | `leanFile.theoremCount` 4→5, `lineCount` 390→373 |
| `src/data/research/problems/nth-root-irrational-oq-03.json` | phase OBSERVE→ACT, iteration 7→8, 1 new insight, 3 new builtItems, progressSummary + nextSteps refreshed |
| `research/problems/nth-root-irrational-oq-03/{state,knowledge,sessions/...}.md` | Session 7 documentation |

## Axiom Integrity

Per the policy in `CLAUDE.md`, `e-transcendental`'s `meta.status` and `meta.badge` stay `"axiomatized"`/`"axiom"`: the slug still **transitively** depends on `axiom hermite_lindemann`. The reduction is local-file only; the project's total axiom count for this slug family is unchanged at 1 (now solely `hermite_lindemann`). What changes: the axiom is no longer **duplicated** between two files.

## Out of scope (pre-existing, NOT introduced by this PR)

- `Proofs.PiTranscendental` fails at lines 228 (`Unknown identifier irrational_pi`) and 285 (type mismatch on `isAlgebraic_algebraMap 1`).
- `Proofs.ETranscendentalOQ02` fails at line 708 (`No goals to be solved`).
- `Proofs.ETranscendentalOQ01` transitively fails via its `import Proofs.PiTranscendental`.

All three were already broken on `origin/main` at `da53bdc3c9e` and are unaffected by S7 changes. Flagged as mechanic-class follow-up.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.eTranscendental` — 3079/3079 jobs ✓
- [x] `./proofs/scripts/docker-build.sh Proofs.ETranscendentalOQ03` — 3085/3085 jobs ✓ (no regression on dependent)
- [x] `#check e_transcendental` reports `Transcendental ℤ (rexp 1)` (i.e., theorem, not axiom)
- [x] `grep -c "^axiom " proofs/Proofs/eTranscendental.lean` → 0 (was 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)