### PR TITLE
Enrich abel-ruffini: complete author attribution (Ruffini, Évariste, Liouville 1846)

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -4,7 +4,7 @@
   "slug": "abel-ruffini",
   "description": "A pedagogical walkthrough of the Abel-Ruffini theorem (Wiedijk #16) composed from Mathlib's Galois theory infrastructure: the contrapositive chain from solvability by radicals (`IsSolvableByRad`) through solvable Galois groups (`IsSolvable q.Gal`) to the non-solvability of S₅ (since A₅ is simple and non-abelian), organized as 9 theorems across 187 lines with zero sorries and zero axioms. There is no general solution in radicals to polynomial equations of degree five or higher — first proved by Abel (1824) and later illuminated by Galois's theory connecting radical solvability to group structure.",
   "meta": {
-    "author": "Niels Henrik Abel (1824), Evariste Galois (1832)",
+    "author": "Paolo Ruffini (1799, incomplete), Niels Henrik Abel (1824), Évariste Galois (1832, publ. Liouville 1846)",
     "sourceUrl": "https://leanprover-community.github.io/mathlib4_docs/Mathlib/FieldTheory/AbelRuffini.html",
     "date": "1824",
     "status": "verified",


### PR DESCRIPTION
## Summary

Small enrichment to `src/data/proofs/abel-ruffini/meta.json` — completes the historical author attribution that was missing key context:

- **Adds Paolo Ruffini (1799, incomplete)** — the namesake of the theorem who was previously missing from the `meta.author` field despite being half of "Abel-Ruffini". The historicalContext narrative (praised in `review.json` as "publication-quality mathematical history") already covers Ruffini's 1799 attempt; the author field now matches.
- **Restores the accent on Évariste Galois** — matches the existing Lean module docstring at `proofs/Proofs/AbelRuffini.lean:31`, which uses the accented form.
- **Disambiguates Galois's date** — 1832 is the year of his death and final letter to Auguste Chevalier; his memoir was published posthumously by Liouville in 1846. The new attribution reads `(1832, publ. Liouville 1846)`, consistent with `review.json`'s narrative.

Before: `"author": "Niels Henrik Abel (1824), Evariste Galois (1832)"`

After: `"author": "Paolo Ruffini (1799, incomplete), Niels Henrik Abel (1824), Évariste Galois (1832, publ. Liouville 1846)"`

## Test plan

- [x] \`pnpm build\` succeeds (validates JSON)
- [x] Diff limited to the single \`author\` field