### PR TITLE
research(erdos-689): necessary-condition lemmas + fix 3 pre-existing build breaks

### DIFF
--- a/proofs/Proofs/Erdos689Problem.lean
+++ b/proofs/Proofs/Erdos689Problem.lean
@@ -91,11 +91,22 @@ theorem isRFoldCover_primes_mono {n₁ n₂ r : ℕ} {a : ℕ → ℕ}
 
 -- ## Small Cases
 
+/-- primesUpTo 0 is empty (no primes < 1). -/
+theorem primesUpTo_zero : primesUpTo 0 = ∅ := by
+  simp [primesUpTo]
+
 /-- primesUpTo 1 is empty (no primes ≤ 1). -/
 theorem primesUpTo_one : primesUpTo 1 = ∅ := by
   simp only [primesUpTo, Finset.filter_eq_empty_iff, Finset.mem_range]
   intro n hn
   interval_cases n <;> simp [Nat.Prime]
+
+/-- Covering count is 0 when no primes available (n = 0). -/
+theorem coveringCount_zero (m : ℕ) (a : ℕ → ℕ) :
+    coveringCount 0 m a = 0 := by
+  unfold coveringCount
+  rw [primesUpTo_zero]
+  simp
 
 /-- Covering count is 0 when no primes available. -/
 theorem coveringCount_one (m : ℕ) (a : ℕ → ℕ) :
@@ -103,6 +114,43 @@ theorem coveringCount_one (m : ℕ) (a : ℕ → ℕ) :
   unfold coveringCount
   rw [primesUpTo_one]
   simp
+
+-- ## Necessary Conditions for r-Fold Cover
+
+/-- NECESSARY CONDITION: If [1, n] admits an r-fold prime covering then
+    r ≤ π(n) (the number of primes ≤ n).
+
+    Proof: apply the covering hypothesis at m = 1 to get r ≤ coveringCount n 1 a,
+    then bound by the total number of primes via `coveringCount_le_card_primes`. -/
+theorem isRFoldCover_card_bound {n r : ℕ} {a : ℕ → ℕ}
+    (h : IsRFoldCover n r a) (hn : 1 ≤ n) :
+    r ≤ (primesUpTo n).card :=
+  le_trans (h 1 hn hn) (coveringCount_le_card_primes n 1 a)
+
+/-- CONTRAPOSITIVE: If r > π(n), no r-fold cover of [1, n] exists.
+
+    This is the obstruction side of Erdős #689: the conjecture asks whether
+    r ≤ π(n) is *eventually sufficient* (for n ≥ N₀(r)); this lemma confirms
+    the trivial necessary part. In particular, N₀(r) ≥ p_r (the r-th prime). -/
+theorem no_rFoldCover_of_few_primes {n r : ℕ} (hn : 1 ≤ n)
+    (hr : (primesUpTo n).card < r) : ¬ ∃ a : ℕ → ℕ, IsRFoldCover n r a := by
+  rintro ⟨a, h⟩
+  have := isRFoldCover_card_bound h hn
+  omega
+
+/-- For n = 0, any r-fold cover claim is vacuously satisfied since [1, 0] is empty. -/
+theorem isRFoldCover_n_zero (r : ℕ) (a : ℕ → ℕ) :
+    IsRFoldCover 0 r a := by
+  intro m hm1 hm0
+  omega
+
+/-- For n = 1, no r-fold cover with r ≥ 1 exists: m = 1 must be covered, but
+    `primesUpTo 1` is empty. Specialization of `no_rFoldCover_of_few_primes`. -/
+theorem no_rFoldCover_n_one {r : ℕ} (hr : 1 ≤ r) :
+    ¬ ∃ a : ℕ → ℕ, IsRFoldCover 1 r a := by
+  apply no_rFoldCover_of_few_primes (le_refl 1)
+  rw [primesUpTo_one, Finset.card_empty]
+  omega
 
 -- ## Main Conjecture (OPEN)
 

--- a/proofs/Proofs/Erdos689Problem.lean
+++ b/proofs/Proofs/Erdos689Problem.lean
@@ -27,8 +27,9 @@ import Mathlib.Tactic
 def primesUpTo (n : ℕ) : Finset ℕ :=
   (Finset.range (n + 1)).filter Nat.Prime
 
-/-- An integer m is covered by prime p with residue class a if m ≡ a (mod p). -/
-def IsCoveredBy (m p a : ℕ) : Prop :=
+/-- An integer m is covered by prime p with residue class a if m ≡ a (mod p).
+    Marked `@[reducible]` so `DecidablePred` resolves through it transparently. -/
+@[reducible] def IsCoveredBy (m p a : ℕ) : Prop :=
   m % p = a % p
 
 /-- The covering count: how many primes p ≤ n cover m with the
@@ -93,7 +94,10 @@ theorem isRFoldCover_primes_mono {n₁ n₂ r : ℕ} {a : ℕ → ℕ}
 
 /-- primesUpTo 0 is empty (no primes < 1). -/
 theorem primesUpTo_zero : primesUpTo 0 = ∅ := by
-  simp [primesUpTo]
+  simp only [primesUpTo, Finset.filter_eq_empty_iff, Finset.mem_range]
+  intro n hn
+  interval_cases n
+  exact Nat.not_prime_zero
 
 /-- primesUpTo 1 is empty (no primes ≤ 1). -/
 theorem primesUpTo_one : primesUpTo 1 = ∅ := by
@@ -125,7 +129,7 @@ theorem coveringCount_one (m : ℕ) (a : ℕ → ℕ) :
 theorem isRFoldCover_card_bound {n r : ℕ} {a : ℕ → ℕ}
     (h : IsRFoldCover n r a) (hn : 1 ≤ n) :
     r ≤ (primesUpTo n).card :=
-  le_trans (h 1 hn hn) (coveringCount_le_card_primes n 1 a)
+  le_trans (h 1 (le_refl 1) hn) (coveringCount_le_card_primes n 1 a)
 
 /-- CONTRAPOSITIVE: If r > π(n), no r-fold cover of [1, n] exists.
 
@@ -154,6 +158,16 @@ theorem no_rFoldCover_n_one {r : ℕ} (hr : 1 ≤ r) :
 
 -- ## Main Conjecture (OPEN)
 
+/-- r-fold generalization (OPEN): For any fixed r and sufficiently
+    large n (depending on r), does an r-fold covering exist?
+
+    This is the only remaining axiom in the file: it IS the open Erdős
+    conjecture (and Ben Green's open problem 45 in the r = 10 case). All
+    other theorems are derived. -/
+axiom erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) :
+  ∃ N₀ : ℕ, ∀ n ≥ N₀,
+    ∃ a : ℕ → ℕ, IsRFoldCover n r a
+
 /-- Erdős Problem #689 (OPEN): For sufficiently large n, does there
     exist a choice of congruence classes that 2-fold covers [1, n]?
     This is the r=2 case of the r-fold generalization. -/
@@ -161,12 +175,6 @@ theorem erdos_689_double_cover :
   ∃ N₀ : ℕ, ∀ n ≥ N₀,
     ∃ a : ℕ → ℕ, IsRFoldCover n 2 a :=
   erdos_689_r_fold 2 (by norm_num)
-
-/-- r-fold generalization (OPEN): For any fixed r and sufficiently
-    large n (depending on r), does an r-fold covering exist? -/
-axiom erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) :
-  ∃ N₀ : ℕ, ∀ n ≥ N₀,
-    ∃ a : ℕ → ℕ, IsRFoldCover n r a
 
 -- ## Connections to Other Problems
 
@@ -205,8 +213,12 @@ theorem mertens_sum_divergence :
     intro p hp
     simp only [primesUpTo, Finset.mem_filter, Finset.mem_range] at hp ⊢
     exact ⟨by omega, hp.2⟩
-  -- Step 7: Subset + nonneg terms → sum over subset ≤ sum over superset
-  have h_le := Finset.sum_le_sum_of_subset_of_nonneg h_sub (fun _ _ _ => by positivity)
+  -- Step 7: Subset + nonneg terms → sum over subset ≤ sum over superset.
+  -- Type annotation is required so positivity (which needs a concrete numeric type)
+  -- can synthesize the `Zero ℝ` instance for the `0 ≤ f i` side-goal.
+  have h_le : (((Finset.range n).filter Nat.Prime).sum (fun p => (1 : ℝ) / ↑p)) ≤
+              ((primesUpTo n).sum (fun p => (1 : ℝ) / ↑p)) :=
+    Finset.sum_le_sum_of_subset_of_nonneg h_sub (fun i _ _ => by positivity)
   -- Step 8: C < C + 1 ≤ filter_sum ≤ primesUpTo_sum
   linarith
 

--- a/research/problems/erdos-689/knowledge.md
+++ b/research/problems/erdos-689/knowledge.md
@@ -131,6 +131,105 @@ coverage equal to a divergent sum), but does NOT prove the conjecture.
 3. **Cross-reference siblings** — `erdos-687` (Jacobsthal upper-bound problem)
    and `erdos-688` (covering with restricted prime ranges).
 
+### Session 2026-06-05 (Session 3) — Necessary-condition enrichment
+
+**Mode**: REVISIT (RICH knowledge tier, score 18)
+**Outcome**: Added 6 structural necessary-condition lemmas. Theorem count 13 → 19; axiom count unchanged (1, = open conjecture itself). File grew 180 → 227 lines.
+
+#### Why Revisit
+
+Prior session reduced the file to 1 axiom (the open conjecture itself) and proved 13
+supporting theorems including `mertens_sum_divergence`. State.md recommended
+deprioritizing for axiom removal but noted optional structural enrichment paths:
+"probabilistic expected-coverage formula, exact small-n cases for r=2". This session
+took a different, simpler structural enrichment direction: **the obstruction side**.
+
+#### What I Did
+
+Added 6 lemmas to `proofs/Proofs/Erdos689Problem.lean`:
+
+1. **`primesUpTo_zero`**: π(0) = 0 (trivial, fills small-case symmetry with `primesUpTo_one`).
+2. **`coveringCount_zero`**: with no primes, coverage is 0.
+3. **`isRFoldCover_card_bound`** (KEY): If `IsRFoldCover n r a` holds and `n ≥ 1`, then
+   `r ≤ (primesUpTo n).card = π(n)`. Proof: apply hypothesis at `m = 1`, chain with
+   `coveringCount_le_card_primes`. This is the trivial NECESSARY condition for
+   r-fold cover existence.
+4. **`no_rFoldCover_of_few_primes`**: Contrapositive — if `π(n) < r`, no r-fold cover exists.
+5. **`isRFoldCover_n_zero`**: n = 0 case is vacuously true (empty interval [1, 0]).
+6. **`no_rFoldCover_n_one`**: n = 1 case impossible for r ≥ 1 (specialization of
+   `no_rFoldCover_of_few_primes` via `primesUpTo_one = ∅`).
+
+Also fixed `relatedProofs` self-reference in JSON metadata (Session 2 claimed to
+remove `"erdos-689"` from its own related list but the entry was still present;
+this session actually removed it).
+
+#### Key Finding
+
+**The conjecture is exactly the gap between the trivial necessary condition
+and the asymptotic sufficient condition.** Specifically:
+
+- NECESSARY (Session 3, now formalized): `IsRFoldCover n r a → r ≤ π(n)`.
+- Consequence: `N₀(r) ≥ p_r` (the r-th prime). Smaller n cannot work.
+- CONJECTURED (open axiom): some `N₀(r)` exists with `IsRFoldCover n r a` for all
+  `n ≥ N₀(r)`. We know `N₀(r) ≥ p_r` but the conjecture doesn't give an upper bound.
+
+The structural depth added is the obstruction-side characterization. Combined with
+existing monotonicity (`coveringCount_mono`, `isRFoldCover_le`, `isRFoldCover_primes_mono`)
+and divergence heuristics (`mertens_sum_divergence`), the file now records both
+sides of the conceptual argument: "we have enough covering power eventually
+(Mertens)" but "we need at least r primes to start (necessary condition)".
+
+#### Build-Fix Bonus (pre-existing bugs uncovered)
+
+When attempting to verify the new lemmas under Docker, the file refused to build. Three pre-existing issues had to be fixed:
+
+1. **DecidablePred synthesis failure** — `def IsCoveredBy` did not unfold during
+   typeclass resolution, so `Finset.filter (fun p => IsCoveredBy m p (a p))`
+   inside `coveringCount` failed with "failed to synthesize DecidablePred …".
+   Fix: marked `IsCoveredBy` as `@[reducible]`.
+
+2. **Forward-reference of `erdos_689_r_fold`** — the theorem
+   `erdos_689_double_cover` referenced the axiom on the line *before* its
+   declaration. Lean 4 does not permit forward references for `axiom`. Fix:
+   moved the axiom block above `erdos_689_double_cover` (and above
+   `jacobsthal_connection`, `green_variant_r10` which also use it — these
+   already worked because the axiom was declared earlier in source order,
+   but the move makes the dependency explicit).
+
+3. **`positivity` Zero synthesis failure in `mertens_sum_divergence`** — the
+   call `Finset.sum_le_sum_of_subset_of_nonneg h_sub (fun _ _ _ => by positivity)`
+   left the function type unresolved, so `positivity` couldn't synthesize
+   `Zero ℝ`. Fix: added an explicit type annotation to `h_le`.
+
+The previous session's PR claim that the file "builds" was inaccurate (likely
+the build was never actually invoked, or local cache masked the failure).
+After these fixes the file compiles clean under `docker-build.sh` with no
+errors and no warnings.
+
+#### Files Modified
+
+- `proofs/Proofs/Erdos689Problem.lean` (180 → 239 lines, 13 → 19 theorems, 3 pre-existing bugs fixed)
+- `src/data/research/problems/erdos-689.json` (added proven lemmas, insights,
+  builtItems; updated progressSummary, currentState, lineCount/theoremCount;
+  fixed self-reference in relatedProofs)
+- `research/problems/erdos-689/knowledge.md` (this file — session record)
+- `research/problems/erdos-689/state.md` (phase, iteration, focus updated)
+
+#### Files NOT Modified
+
+- The axiom `erdos_689_r_fold` — IS the open conjecture; cannot be eliminated
+  without genuine mathematical progress.
+
+#### Next Steps
+
+1. **MAINTAIN** — this slug should remain deprioritized for axiom-removal sessions.
+2. **Optional structural enrichment** (still does NOT reduce axiom count):
+   - Prove `expectedCoverage` via probability theory (requires substantial setup).
+   - Compute exact small-r=2 cases (e.g., explicit 2-fold covers for n ≤ 30 via
+     enumeration with Decidable instances).
+3. **Cross-reference siblings** — `erdos-687` (Jacobsthal Y(x)), `erdos-688`
+   (covering with restricted prime ranges).
+
 ---
 
-*Generated from erdosproblems.com on 2026-01-14; updated by researcher-10 on 2026-04-27.*
+*Generated from erdosproblems.com on 2026-01-14; updated by researcher-10 on 2026-04-27; enriched by researcher-1 on 2026-06-05.*

--- a/research/problems/erdos-689/state.md
+++ b/research/problems/erdos-689/state.md
@@ -1,22 +1,25 @@
 # Current State
 
-**Phase**: ACT (stable — formalization at minimal axiom count)
-**Since**: 2026-04-27T22:10:00-07:00
-**Iteration**: 2
+**Phase**: ACT (stable — formalization at minimal axiom count, with necessary-condition depth)
+**Since**: 2026-06-05T04:00:00Z
+**Iteration**: 3
 
 ## Current Focus
 
 The Lean file `Erdos689Problem.lean` is at its natural endpoint. It contains
-1 axiom and 13 proved theorems, with 0 sorries. The remaining axiom
+1 axiom and 19 proved theorems, with 0 sorries (239 lines). The remaining axiom
 `erdos_689_r_fold` IS the open Erdős conjecture (and Ben Green's open
-problem 45 for r=10).
+problem 45 for r=10). Session 3 (2026-06-05) added 6 necessary-condition
+lemmas characterizing when r-fold cover is *impossible*, AND fixed 3 pre-existing
+build breaks (DecidablePred, axiom forward-reference, mertens positivity).
+File now builds clean under Docker.
 
 ## Active Approach
 
-None — the file is stable. Future sessions should EITHER add structural
-depth that does NOT reduce axiom count (expected-coverage formula,
-exact small-n cases) OR deprioritize this slug since axiom-reduction
-work is finished modulo the open conjecture.
+None — the file is stable. Session 3 closed out the obstruction-side
+structural depth (necessary conditions: r ≤ π(n), small-n impossibility).
+Remaining optional enrichment paths: probabilistic expected-coverage formula,
+explicit small-n covers for r=2.
 
 ## Blockers
 
@@ -25,11 +28,12 @@ Eliminating it requires genuine mathematical progress on the open question.
 
 ## Next Action
 
-MAINTAIN: Deprioritize this slug for axiom-removal sessions. Optional
-structural enrichment is documented in knowledge.md.
+MAINTAIN: Deprioritize this slug for axiom-removal sessions. Both
+monotonicity (already proven) and necessary-condition bounds (Session 3)
+are now formalized. Optional structural enrichment is documented in knowledge.md.
 
 ## Attempt Counts
 
-- Total attempts: 2 (prior axiom-reduction session + this metadata session)
-- Current approach attempts: 0
-- Approaches tried: 2
+- Total attempts: 3
+- Current approach attempts: 1 (necessary-condition enrichment, Session 3)
+- Approaches tried: 3

--- a/src/data/research/problems/erdos-689.json
+++ b/src/data/research/problems/erdos-689.json
@@ -1,17 +1,17 @@
 {
   "slug": "erdos-689",
-  "title": "Erdős #689 — r-fold prime covering of [1,n]",
+  "title": "Erd\u0151s #689 \u2014 r-fold prime covering of [1,n]",
   "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "axiom erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) : ∃ N₀ : ℕ, ∀ n ≥ N₀, ∃ a : ℕ → ℕ, IsRFoldCover n r a — i.e., for every fixed r ≥ 1 there exists N₀ such that for all n ≥ N₀, some choice of congruence classes a_p (one per prime p ≤ n) makes every integer in [1, n] satisfy at least r of the congruences ≡ a_p (mod p). Source: Erdős 1979d.",
-    "plain": "For sufficiently large n, can the primes p ≤ n cover [1, n] r-fold via chosen residues? The original Erdős problem is r=2. Ben Green's open problem 45 is the same with r=10. The r=1 case is the Jacobsthal-style 1-fold covering question.",
+    "formal": "axiom erdos_689_r_fold (r : \u2115) (hr : r \u2265 1) : \u2203 N\u2080 : \u2115, \u2200 n \u2265 N\u2080, \u2203 a : \u2115 \u2192 \u2115, IsRFoldCover n r a \u2014 i.e., for every fixed r \u2265 1 there exists N\u2080 such that for all n \u2265 N\u2080, some choice of congruence classes a_p (one per prime p \u2264 n) makes every integer in [1, n] satisfy at least r of the congruences \u2261 a_p (mod p). Source: Erd\u0151s 1979d.",
+    "plain": "For sufficiently large n, can the primes p \u2264 n cover [1, n] r-fold via chosen residues? The original Erd\u0151s problem is r=2. Ben Green's open problem 45 is the same with r=10. The r=1 case is the Jacobsthal-style 1-fold covering question.",
     "whyMatters": [
-      "Open Erdős problem #689 with active interest from Ben Green (Problem 45 on his open list)",
+      "Open Erd\u0151s problem #689 with active interest from Ben Green (Problem 45 on his open list)",
       "Connects to gaps between primes (Jacobsthal function, problem #687) and to covering systems",
-      "Mertens' second theorem (Σ_{p≤n} 1/p ~ log log n → ∞) suggests enough covering 'power' exists; turning this heuristic into a proof is the hard part",
+      "Mertens' second theorem (\u03a3_{p\u2264n} 1/p ~ log log n \u2192 \u221e) suggests enough covering 'power' exists; turning this heuristic into a proof is the hard part",
       "Formalizing the conjecture and provable structural lemmas in Lean creates a foundation for any future progress on the open question"
     ]
   },
@@ -21,61 +21,73 @@
       "coveringCount n m a is monotone in n",
       "isRFoldCover n r a is monotone in r (smaller r is easier)",
       "isRFoldCover n 0 a holds trivially",
-      "primesUpTo 1 = ∅, hence coveringCount 1 m a = 0",
-      "mertens_sum_divergence: ∀ C > 0, Σ_{p ≤ n} 1/p > C eventually (proved from Mathlib's not_summable_one_div_on_primes)",
+      "primesUpTo 1 = \u2205, hence coveringCount 1 m a = 0",
+      "mertens_sum_divergence: \u2200 C > 0, \u03a3_{p \u2264 n} 1/p > C eventually (proved from Mathlib's not_summable_one_div_on_primes)",
       "erdos_689_double_cover := erdos_689_r_fold 2 (the r=2 case derived from the r-fold axiom)",
       "green_variant_r10 := erdos_689_r_fold 10 (Ben Green's variant)",
-      "jacobsthal_connection := r=1 case via Filter.eventually_atTop"
+      "jacobsthal_connection := r=1 case via Filter.eventually_atTop",
+      "primesUpTo_zero: primesUpTo 0 = \u2205",
+      "coveringCount_zero: coveringCount 0 m a = 0",
+      "isRFoldCover_card_bound: r-fold cover implies r \u2264 \u03c0(n) (necessary condition)",
+      "no_rFoldCover_of_few_primes: contrapositive \u2014 if r > \u03c0(n), no r-fold cover exists",
+      "isRFoldCover_n_zero: vacuously true (empty interval [1, 0])",
+      "no_rFoldCover_n_one: no r-fold cover with r \u2265 1 exists for n = 1"
     ],
     "open": [
-      "erdos_689_r_fold (r : ℕ) (hr : r ≥ 1) — the only remaining axiom; this IS the open Erdős conjecture"
+      "erdos_689_r_fold (r : \u2115) (hr : r \u2265 1) \u2014 the only remaining axiom; this IS the open Erd\u0151s conjecture"
     ],
-    "goal": "The Lean file is at its natural endpoint: 1 axiom remains, and it IS the open conjecture itself. Further reduction requires actually solving the conjecture, which is open. Future sessions can add structural lemmas (e.g., Mertens-based heuristic bounds, exact small-n cases for r=2) but cannot eliminate the remaining axiom without genuine mathematical progress."
+    "goal": "The Lean file is at its natural endpoint: 1 axiom remains, and it IS the open conjecture itself. Further reduction requires actually solving the conjecture, which is open. Session 3 (2026-06-05) added necessary-condition lemmas characterizing when r-fold cover is IMPOSSIBLE: r \u2264 \u03c0(n) is a necessary condition (`isRFoldCover_card_bound`); for n \u2264 1 no r \u2265 1 cover exists. These give a lower bound on N\u2080(r): N\u2080(r) \u2265 p_r (the r-th prime)."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-04-27T22:10:00Z",
-    "iteration": 2,
-    "focus": "Stable formalization at minimal axiom count. The remaining axiom is the open Erdős conjecture itself.",
+    "since": "2026-06-05T03:55:00Z",
+    "iteration": 3,
+    "focus": "Stable formalization at minimal axiom count, enriched with necessary-condition lemmas. The remaining axiom is the open Erd\u0151s conjecture itself; further reduction requires genuine mathematical progress.",
     "blockers": [
-      "The remaining axiom erdos_689_r_fold IS the open Erdős conjecture #689 (and Ben Green's open problem 45 for r=10) — not eliminable without genuine mathematical progress on the open question."
+      "The remaining axiom erdos_689_r_fold IS the open Erd\u0151s conjecture #689 (and Ben Green's open problem 45 for r=10) \u2014 not eliminable without genuine mathematical progress on the open question."
     ],
-    "nextAction": "MAINTAIN: The Lean file is complete modulo the open conjecture. Future sessions can add structural depth (e.g., quantitative bounds on coveringCount for random a, or exact analysis of small r=2 cases for n ≤ 100), but axiom-removal sessions should deprioritize this slug and focus on problems with provable axioms.",
+    "nextAction": "MAINTAIN: The Lean file is at minimal axiom count with structural depth on the OBSTRUCTION side now formalized. Future sessions can add probabilistic expected-coverage lemmas (random a_p assignments) or explicit small-n cases for r=2 (e.g., n \u2264 30), but axiom-removal sessions should deprioritize this slug.",
     "attemptCounts": {
-      "total": 2,
-      "currentApproach": 0,
-      "approachesTried": 2
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 3
     }
   },
   "knowledge": {
-    "progressSummary": "STABLE — formalization at minimal axiom count. Only remaining axiom is erdos_689_r_fold, which IS the open Erdős conjecture (and equivalently Ben Green's open problem 45 for r=10). 13 supporting theorems all proved. Further axiom reduction is impossible without solving the open question. Session 2 (2026-04-27) reconciled JSON metadata with the actual stable state — previous JSON had whyMatters/knownResults all empty despite the file being substantively complete.",
+    "progressSummary": "STABLE \u2014 formalization at minimal axiom count (1 axiom = open conjecture itself), 19 theorems, 0 sorries, 239 lines. Session 3 (2026-06-05) added 6 structural necessary-condition lemmas (theorem count 13 \u2192 19, axiom count unchanged) AND fixed 3 pre-existing build breaks (IsCoveredBy DecidablePred via @[reducible], forward-reference of axiom, type annotation in mertens_sum_divergence). File now compiles clean under Docker. Key contribution: isRFoldCover_card_bound formalizes the trivial necessary condition r \u2264 \u03c0(n), giving N\u2080(r) \u2265 p_r as a lower bound.",
     "builtItems": [
       "Surveyed Erdos689Problem.lean (180 lines)",
       "Proved theorem mertens_sum_divergence in Erdos689Problem.lean (was axiom)",
       "erdos_689_double_cover: converted from axiom to theorem (= erdos_689_r_fold 2)",
       "green_variant_r10: converted from axiom to theorem (= erdos_689_r_fold 10)",
       "jacobsthal_connection: converted from axiom to theorem (r=1 case of erdos_689_r_fold via Filter.eventually_atTop)",
-      "Reconciled JSON metadata to reflect 13 proved theorems and the single remaining open-conjecture axiom (Session 2, 2026-04-27)"
+      "Reconciled JSON metadata to reflect 13 proved theorems and the single remaining open-conjecture axiom (Session 2, 2026-04-27)",
+      "Added 6 structural lemmas in Erdos689Problem.lean (Session 3, 2026-06-05): primesUpTo_zero, coveringCount_zero, isRFoldCover_card_bound, no_rFoldCover_of_few_primes, isRFoldCover_n_zero, no_rFoldCover_n_one. Theorem count: 13 \u2192 19. Axiom count unchanged (1, = open conjecture).",
+      "Fixed pre-existing build break (Session 3, 2026-06-05): added @[reducible] to IsCoveredBy so DecidablePred resolves; reordered axiom erdos_689_r_fold before its uses (Lean 4 doesn't permit forward references for axioms); added explicit type annotation to h_le in mertens_sum_divergence so positivity could synthesize Zero \u211d."
     ],
     "insights": [
       "Only remaining axiom is erdos_689_r_fold which IS the open conjecture; further reduction requires genuine mathematical progress on the open question",
-      "9 proved theorems: covering monotonicity, bounds, small cases — all clean",
+      "9 proved theorems: covering monotonicity, bounds, small cases \u2014 all clean",
       "Problem relates to #687 (Jacobsthal), #688 (covering), Ben Green problem 45",
-      "Proved mertens_sum_divergence from Mathlib: not_summable_one_div_on_primes → partial sums → ∞ → exceeds any bound C over primesUpTo n",
+      "Proved mertens_sum_divergence from Mathlib: not_summable_one_div_on_primes \u2192 partial sums \u2192 \u221e \u2192 exceeds any bound C over primesUpTo n",
       "Both the main r=2 conjecture and Green's r=10 variant are special cases of the r-fold axiom; consolidating into a single axiom reduces 3 separate open-conjecture axioms to 1",
-      "Mertens' divergence (Σ_{p≤n} 1/p → ∞) is heuristic evidence for r-fold covering: random a_p assignment gives expected coverage of any m equal to Σ 1/p, which exceeds any constant — but turning the heuristic into a proof remains open"
+      "Mertens' divergence (\u03a3_{p\u2264n} 1/p \u2192 \u221e) is heuristic evidence for r-fold covering: random a_p assignment gives expected coverage of any m equal to \u03a3 1/p, which exceeds any constant \u2014 but turning the heuristic into a proof remains open",
+      "Necessary condition formalized: r-fold cover of [1, n] requires r \u2264 \u03c0(n) = (primesUpTo n).card. Proof applies the cover hypothesis at m = 1 and uses coveringCount_le_card_primes.",
+      "Lower bound on N\u2080(r) consequence: since r \u2264 \u03c0(N\u2080(r)), we have N\u2080(r) \u2265 p_r (the r-th prime). The conjecture asks whether some N\u2080(r) just slightly larger suffices \u2014 i.e., whether the trivial necessary condition is also asymptotically sufficient.",
+      "Structural classification: r-fold cover trivially true for n = 0 (empty interval), impossible for n = 1 and r \u2265 1 (no primes), and asymptotically conjectured for n \u2265 N\u2080(r) \u2014 but the gap between p_r and N\u2080(r) is the entire open question.",
+      "Build-fix discovery (Session 3): origin/main version of this file did NOT compile due to (1) DecidablePred typeclass synthesis failing through `def IsCoveredBy`, (2) forward reference of `erdos_689_r_fold` axiom before its declaration, (3) untyped positivity in `mertens_sum_divergence`. All three fixed; file now builds clean under Docker."
     ],
     "mathlibGaps": [
-      "No Mertens' second theorem (Σ 1/p ~ log log n) in Mathlib (mertens_sum_divergence proves only divergence, not the asymptotic rate)",
+      "No Mertens' second theorem (\u03a3 1/p ~ log log n) in Mathlib (mertens_sum_divergence proves only divergence, not the asymptotic rate)",
       "No Jacobsthal function bounds in Mathlib"
     ],
     "nextSteps": [
       "Only remaining axiom is erdos_689_r_fold (OPEN conjecture, cannot eliminate)",
-      "File is at minimal axiom count — formalization is complete modulo the open conjecture",
-      "Optional structural enrichment (not axiom-reducing): random-assignment expected-coverage formula, exact computation for small r=2 cases (e.g., r=2 explicit covers for n ≤ 30)",
+      "File is at minimal axiom count \u2014 formalization is complete modulo the open conjecture",
+      "Optional structural enrichment (not axiom-reducing): random-assignment expected-coverage formula, exact computation for small r=2 cases (e.g., r=2 explicit covers for n \u2264 30)",
       "Cross-reference recommendations: erdos-687 (Jacobsthal Y(x)), erdos-688 (one-fold covering with prime range restricted)"
     ],
-    "markdown": "# Erdős #689 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $n$ be sufficiently large. Is there some choice of congruence class $a_p$ for all primes $2\\leq p\\leq n$ such that every integer in $[1,n]$ satisfies at least two of the congruences $\\equiv a_p\\pmod{p}$?\n\n\n\nOne can ask a similar question replacing $2$ by any fixed integer $r$ (provided $n$ is sufficiently large depending on $r$).\n\nSee also [687] and [688].\n\nThis problem (with $2$ replaced by $10$) is Problem 45 on Green's open problems list.\n\n\nBack to the problem\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #687\n- Problem #688\n- Problem #690\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
+    "markdown": "# Erd\u0151s #689 - Knowledge Base\n\n## Problem Statement\n\nForum\nFavourites\nTags\nMore\n Go\n Go\nDual View\nRandom Solved\nRandom Open\n\nLet $n$ be sufficiently large. Is there some choice of congruence class $a_p$ for all primes $2\\leq p\\leq n$ such that every integer in $[1,n]$ satisfies at least two of the congruences $\\equiv a_p\\pmod{p}$?\n\n\n\nOne can ask a similar question replacing $2$ by any fixed integer $r$ (provided $n$ is sufficiently large depending on $r$).\n\nSee also [687] and [688].\n\nThis problem (with $2$ replaced by $10$) is Problem 45 on Green's open problems list.\n\n\nBack to the problem\n\n## Status\n\n**Erd\u0151s Database Status**: OPEN\n\n**Tractability Score**: 4/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #1998\n- Problem #687\n- Problem #688\n- Problem #690\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- Er79d\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-14*\n"
   },
   "tags": [
     "erdos",
@@ -89,7 +101,6 @@
     "erdos-68",
     "erdos-687",
     "erdos-688",
-    "erdos-689",
     "erdos-690"
   ],
   "references": {
@@ -98,15 +109,15 @@
     "mathlib": []
   },
   "started": "2026-01-14T19:46:33.202Z",
-  "lastUpdate": "2026-04-27T22:10:00Z",
+  "lastUpdate": "2026-06-05T04:25:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos689Problem.lean",
       "filename": "Erdos689Problem.lean",
-      "lineCount": 180,
-      "theoremCount": 13,
+      "lineCount": 239,
+      "theoremCount": 19,
       "axiomCount": 1,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

- **Contribution**: 6 new structural necessary-condition lemmas characterizing when r-fold prime covering of [1, n] is *impossible* (the obstruction side of Erdős #689). Theorem count: 13 → 19; axiom count unchanged (1, = open conjecture itself).
- **Bonus**: fixed 3 pre-existing bugs that prevented the file from building (DecidablePred via `@[reducible]`; axiom forward-reference; `mertens_sum_divergence` type annotation).
- **Status**: file now compiles clean under `./proofs/scripts/docker-build.sh Proofs.Erdos689Problem` with no errors or warnings.

## Mathematical contribution

The key lemma `isRFoldCover_card_bound` formalizes the trivial necessary condition

  $$\mathrm{IsRFoldCover}(n, r, a) \implies r \leq \pi(n).$$

The proof applies the cover hypothesis at `m = 1` and chains with the existing `coveringCount_le_card_primes`. As a corollary `no_rFoldCover_of_few_primes` gives a contrapositive: if `π(n) < r`, no r-fold cover exists.

Consequence: the conjectured threshold satisfies `N₀(r) ≥ p_r` (the r-th prime). The Erdős conjecture is exactly the gap between this trivial lower bound and the conjectured asymptotic upper bound.

Combined with the existing monotonicity (`coveringCount_mono`, `isRFoldCover_le`, `isRFoldCover_primes_mono`) and divergence heuristic (`mertens_sum_divergence`), the file now records both sides of the conceptual argument: enough covering power eventually (Mertens), but at least r primes needed to start (this PR).

## New lemmas (in source order)

| Lemma | Statement |
|---|---|
| `primesUpTo_zero` | `primesUpTo 0 = ∅` |
| `coveringCount_zero` | `coveringCount 0 m a = 0` |
| `isRFoldCover_card_bound` | `IsRFoldCover n r a → 1 ≤ n → r ≤ (primesUpTo n).card` |
| `no_rFoldCover_of_few_primes` | `1 ≤ n → (primesUpTo n).card < r → ¬ ∃ a, IsRFoldCover n r a` |
| `isRFoldCover_n_zero` | `IsRFoldCover 0 r a` (vacuous) |
| `no_rFoldCover_n_one` | `1 ≤ r → ¬ ∃ a, IsRFoldCover 1 r a` |

## Build-fix details

`origin/main` version of `proofs/Proofs/Erdos689Problem.lean` did not compile.
The previous session's claim that the file builds appears to have been
unverified. Three pre-existing issues:

1. **`DecidablePred` synthesis failure** at `Finset.filter` inside
   `coveringCount`. `def IsCoveredBy` didn't unfold during typeclass
   resolution. Fix: `@[reducible] def IsCoveredBy`.
2. **Forward reference**: `theorem erdos_689_double_cover` referenced the
   axiom `erdos_689_r_fold` declared on the next block. Lean 4 doesn't
   permit forward references for `axiom`. Fix: moved the axiom above its
   first use (and ahead of `jacobsthal_connection`, `green_variant_r10`
   which also derive from it).
3. **`positivity` couldn't synthesize `Zero ℝ`** in the call
   `Finset.sum_le_sum_of_subset_of_nonneg h_sub (fun _ _ _ => by positivity)`
   inside `mertens_sum_divergence`. The function type was unresolved.
   Fix: explicit type annotation on `h_le`.

## Honesty note

This is structural enrichment, not a step toward proving the open conjecture.
The remaining `axiom erdos_689_r_fold` IS the open question itself (Erdős #689,
equivalently Ben Green's problem 45 for r = 10). Eliminating it requires
genuine mathematical progress on a problem with no known approach.

## Metadata updates

- `src/data/research/problems/erdos-689.json`: 6 new proven lemmas; 4 new insights; updated `progressSummary`; updated `currentState` (iteration 2 → 3); updated `lineCount` (180 → 239) and `theoremCount` (13 → 19); fixed self-reference in `relatedProofs` (`erdos-689` was listed as related to itself — Session 2 claimed to fix this but didn't).
- `research/problems/erdos-689/knowledge.md`: new Session 3 entry documenting the work.
- `research/problems/erdos-689/state.md`: bumped iteration to 3.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos689Problem` succeeds with no errors or warnings
- [x] Theorem count grew from 13 to 19 (`grep -c "^theorem" proofs/Proofs/Erdos689Problem.lean`)
- [x] Axiom count unchanged at 1 (`grep -c "^axiom " proofs/Proofs/Erdos689Problem.lean`)
- [x] Sorry count is 0 (`grep -c sorry proofs/Proofs/Erdos689Problem.lean`)

🤖 Generated by researcher-1