### PR TITLE
research(borsuk-ulam-oq-04): rescue 7 build breaks + Part 9 ZMod p periodicity

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ04.lean
+++ b/proofs/Proofs/BorsukUlamOQ04.lean
@@ -132,7 +132,10 @@ theorem odd_preserves_relation {n m : ℕ}
     (antipodalInvol m).setoid.r (f x) (f y) := by
   rcases h with rfl | h
   · exact Or.inl rfl
-  · right; rw [h, hf]
+  · right
+    rw [h]
+    show f (-y) = -(f y)
+    exact hf y
 
 /-- Descent: an odd map f: R^{n+1} → R^{m+1} induces a well-defined
     map f̄: RPⁿ → RPᵐ on real projective spaces -/
@@ -146,8 +149,7 @@ def descendOdd {n m : ℕ}
 theorem descendOdd_comm {n m : ℕ}
     (f : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin (m + 1)))
     (hf : IsOdd f) (x : EuclideanSpace ℝ (Fin (n + 1))) :
-    descendOdd f hf (projMap n x) = projMap m (f x) := by
-  simp [descendOdd, projMap, Quotient.map_mk]
+    descendOdd f hf (projMap n x) = projMap m (f x) := rfl
 
 -- ============================================================
 -- PART 4: The Covering Space Structure
@@ -164,11 +166,13 @@ def Sphere (n : ℕ) : Set (EuclideanSpace ℝ (Fin (n + 1))) :=
 
 /-- On the sphere, the antipodal covering has exactly 2-element fibers:
     if x, y are on the sphere and project to the same point in RPⁿ,
-    then y = x or y = -x. Proved via Quotient.exact’. -/
+    then y = x or y = -x. Proved via `Quotient.exact'`. -/
 theorem sphere_fiber_pair (n : ℕ) (x y : EuclideanSpace ℝ (Fin (n + 1)))
     (_ : x ∈ Sphere n) (_ : y ∈ Sphere n) (h : projMap n y = projMap n x) :
-    y = x ∨ y = -x :=
-  @Quotient.exact’ _ (antipodalInvol n).setoid y x h
+    y = x ∨ y = -x := by
+  have hrel : (antipodalInvol n).setoid.r y x :=
+    Quotient.exact' (s₁ := (antipodalInvol n).setoid) h
+  exact hrel
 
 /-- π₁(RPⁿ) ≅ Z/2Z for n ≥ 2. Witnessed by Fin 2. -/
 theorem fundamental_group_RPn (n : ℕ) (_ : n ≥ 2) :
@@ -231,8 +235,9 @@ structure EquivariantMap (C₁ C₂ : CoveringType) where
   equivariant : ∀ x, totalMap (C₁.deck x) = C₂.deck (totalMap x)
 
 /-- An odd map f: R^{n+1} → R^{m+1} gives an equivariant map
-    between the antipodal coverings -/
-theorem odd_gives_equivariant {n m : ℕ}
+    between the antipodal coverings. Uses `def` since the result is data,
+    not a proposition. -/
+def odd_gives_equivariant {n m : ℕ}
     (f : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin (m + 1)))
     (hf : IsOdd f) : EquivariantMap (antipodalCovering n) (antipodalCovering m) where
   totalMap := f
@@ -262,10 +267,15 @@ theorem odd_gives_equivariant {n m : ℕ}
     then lives in higher cohomology groups rather than just π₁.
 
     Proved from `no_continuous_odd_nonzero_on_sphere` in BorsukUlam.lean
-    (both state the same result with reordered conjuncts). -/
+    (both state the same result with reordered conjuncts).
+
+    The oddness hypothesis is inlined as `∀ x, g (-x) = -g x` rather than via
+    `IsOdd`, because `IsOdd` requires the codomain to have the form
+    `EuclideanSpace ℝ (Fin (m + 1))`, while here the target is `Fin n` for
+    arbitrary `n ≥ 1`. -/
 theorem covering_space_obstruction (n : ℕ) (hn : n ≥ 1) :
     ¬∃ (g : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin n)),
-      Continuous g ∧ IsOdd g ∧ (∀ x ∈ Sphere n, g x ≠ 0) := by
+      Continuous g ∧ (∀ x, g (-x) = -g x) ∧ (∀ x ∈ Sphere n, g x ≠ 0) := by
   intro ⟨g, hcont, hodd, hnonzero⟩
   exact BorsukUlam.no_continuous_odd_nonzero_on_sphere n hn ⟨g, hcont, hnonzero, hodd⟩
 
@@ -331,19 +341,34 @@ structure GCovering (G : Type*) [AddGroup G] where
   act_proj : ∀ (g : G) x, proj (act g x) = proj x
 
 /-- The antipodal double cover Sⁿ → RPⁿ viewed as a ZMod 2 covering.
-    The nontrivial element (1 : ZMod 2) acts by negation. -/
+    The nontrivial element (1 : ZMod 2) acts by negation.
+
+    The field proofs use `by_cases h : g = 0` (and similar for `h`) rather than
+    `fin_cases`, because `fin_cases g` on `g : ZMod 2` leaves the witness in
+    the un-reduced form `(fun i => i) ⟨0, _⟩` that subsequent `simp`/`rw`
+    cannot match against literal `0`. -/
 def antipodalZ2Covering (n : ℕ) : GCovering (ZMod 2) where
   Base := RP n
   Total := EuclideanSpace ℝ (Fin (n + 1))
   proj := projMap n
   act g x := if g = 0 then x else -x
   act_zero x := if_pos rfl
-  act_add g h x := by fin_cases g <;> fin_cases h <;> simp [neg_neg]
+  act_add g h x := by
+    have hor : ∀ a : ZMod 2, a = 0 ∨ a = 1 := by decide
+    by_cases hg : g = 0
+    · subst hg; simp
+    · by_cases hh : h = 0
+      · subst hh; simp
+      · have hg1 : g = 1 := (hor g).resolve_left hg
+        have hh1 : h = 1 := (hor h).resolve_left hh
+        subst hg1; subst hh1
+        have h11 : (1 + 1 : ZMod 2) = 0 := by decide
+        rw [h11]
+        simp [show (1 : ZMod 2) ≠ 0 from one_ne_zero, neg_neg]
   act_proj g x := by
-    fin_cases g
-    · simp [if_pos rfl]
-    · rw [if_neg (show (1 : ZMod 2) ≠ 0 from one_ne_zero)]
-      exact projMap_neg n x
+    by_cases hg : g = 0
+    · subst hg; simp
+    · rw [if_neg hg]; exact projMap_neg n x
 
 /-- In any ZMod 2 covering, acting twice by the generator (1 : ZMod 2) is the identity.
     This is the algebraic content of "deck transformation is an involution". -/
@@ -397,8 +422,13 @@ def GEquivariantMap.toEquivariantMap_Z2 {C₁ C₂ : GCovering (ZMod 2)}
   equivariant := φ.equivariant 1
 
 /-- An odd map gives a GEquivariantMap between the antipodal ZMod 2 coverings.
-    This is the G-equivariant strengthening of odd_gives_equivariant. -/
-theorem odd_gives_GEquivariant {n m : ℕ}
+    This is the G-equivariant strengthening of odd_gives_equivariant.
+
+    Uses `def` rather than `theorem` because the result is data (a structure
+    value), not a proposition. The equivariance field uses `by_cases h : g = 0`
+    instead of `fin_cases g`, which left the witness in an un-reduced
+    `(fun i => i) ⟨_, _⟩` form that subsequent `simp`/`rw` could not match. -/
+def odd_gives_GEquivariant {n m : ℕ}
     (f : EuclideanSpace ℝ (Fin (n + 1)) → EuclideanSpace ℝ (Fin (m + 1)))
     (hf : IsOdd f) :
     GEquivariantMap (antipodalZ2Covering n) (antipodalZ2Covering m) where
@@ -406,9 +436,12 @@ theorem odd_gives_GEquivariant {n m : ℕ}
   baseMap := descendOdd f hf
   commutes x := (descendOdd_comm f hf x).symm
   equivariant g x := by
-    fin_cases g
-    · simp only [(antipodalZ2Covering n).act_zero, (antipodalZ2Covering m).act_zero]
-    · rw [antipodalZ2Covering_deck_is_neg n x, antipodalZ2Covering_deck_is_neg m (f x)]
+    have hor : ∀ a : ZMod 2, a = 0 ∨ a = 1 := by decide
+    rcases hor g with rfl | rfl
+    · -- g = 0: both sides reduce to f x via act_zero
+      rw [(antipodalZ2Covering n).act_zero, (antipodalZ2Covering m).act_zero]
+    · -- g = 1: both sides reduce via antipodalZ2Covering_deck_is_neg
+      rw [antipodalZ2Covering_deck_is_neg n x, antipodalZ2Covering_deck_is_neg m (f x)]
       exact hf x
 
 /-- The GEquivariantMap from an odd map reduces to the classical EquivariantMap.
@@ -444,5 +477,57 @@ NEXT LEVEL (requires Mathlib algebraic topology):
   This is the ∞-categorical content: BG classifies G-bundles,
   and the full obstruction theory is cohomology of BG.
 -/
+
+-- ============================================================
+-- PART 9: ZMod p Periodicity (Cyclic Generalization of Involutivity)
+-- ============================================================
+/-
+`GCovering_z2_involutive` shows that in any ZMod 2 covering, acting twice
+by the generator yields the identity. The same algebraic mechanism
+generalizes to ZMod p for any p: acting p times by the generator gives
+identity, since `(p : ZMod p) = 0` and `C.act 0 = id`.
+
+This captures the cyclic structure underlying lens-space coverings:
+  L^{2n-1}(p) = S^{2n-1} / (ZMod p)
+where ZMod p acts on S^{2n-1} ⊂ ℂⁿ by multiplication by p-th roots of unity.
+The induced covering S^{2n-1} → L^{2n-1}(p) is a ZMod p covering,
+generalizing the Z/2 antipodal covering S^n → RP^n (the p = 2 case).
+
+The generalized Borsuk-Ulam (Yang-Borsuk) theorem: any continuous ZMod p
+-equivariant map S^{2n-1} → S^{2m-1} forces n ≤ m. This is the direct
+analogue of classical BU for cyclic groups of arbitrary prime order.
+The periodicity lemma below is the algebraic backbone of that framework:
+without it, "ZMod p covering" would not enforce the cyclic structure.
+-/
+
+/-- The iterated action by the generator `(1 : ZMod p)` equals the action by
+    the natural-number cast of the iteration count. This is the bridge
+    between `Function.iterate` and the additive ZMod p action. -/
+theorem GCovering.act_one_iterate {p : ℕ} (C : GCovering (ZMod p)) (k : ℕ)
+    (x : C.Total) :
+    (C.act 1)^[k] x = C.act ((k : ZMod p)) x := by
+  induction k with
+  | zero =>
+    simp only [Function.iterate_zero_apply, Nat.cast_zero]
+    exact (C.act_zero x).symm
+  | succ k ih =>
+    rw [Function.iterate_succ_apply', ih, ← C.act_add]
+    congr 1
+    push_cast
+    ring
+
+/-- Generalization of `GCovering_z2_involutive`: in any ZMod p covering,
+    iterating the generator action p times yields the identity. This is the
+    cyclic-group analogue of involutivity. Uses `ZMod.natCast_self : (p : ZMod p) = 0`. -/
+theorem GCovering_zmod_p_periodic {p : ℕ} (C : GCovering (ZMod p)) (x : C.Total) :
+    (C.act 1)^[p] x = x := by
+  rw [C.act_one_iterate, ZMod.natCast_self, C.act_zero]
+
+/-- The new periodicity statement specializes to the p = 2 case,
+    recovering the involutivity content of `GCovering_z2_involutive`. -/
+theorem GCovering_zmod_p_periodic_two (C : GCovering (ZMod 2)) (x : C.Total) :
+    C.act 1 (C.act 1 x) = x := by
+  have h := GCovering_zmod_p_periodic C x
+  simpa [Function.iterate_succ_apply', Function.iterate_one] using h
 
 end BorsukUlamOQ04

--- a/research/problems/borsuk-ulam-oq-04/state.md
+++ b/research/problems/borsuk-ulam-oq-04/state.md
@@ -1,27 +1,31 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-03-23T00:42:35.518Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-06-05
+**Iteration**: 3
 
 ## Current Focus
 
-Initial exploration of the problem.
+Repaired 7 pre-existing build breaks (file failed to compile despite "0 sorries/0 axioms" claim in meta.json) and added Part 9: ZMod p periodicity, generalizing GCovering_z2_involutive to arbitrary cyclic deck groups. Docker build clean (3059 jobs, Lean 4.26.0).
 
 ## Active Approach
 
-None yet.
+Build out the GCovering framework for higher categorical analogues:
+- Part 8 (GCovering for arbitrary additive G): now compiles cleanly.
+- Part 9 (ZMod p periodicity): GCovering_zmod_p_periodic shows acting p times by the generator yields identity, via Function.iterate + ZMod.natCast_self.
 
 ## Blockers
 
-None.
+None for incremental work. Future Yang-Borsuk-style results need either explicit 2D-rotation actions of p-th roots of unity (requires complex-analytic infrastructure) or an axiomatic statement of the generalized Borsuk-Ulam theorem.
 
 ## Next Action
 
-Begin problem exploration.
+Either:
+1. Define explicit ZMod p rotation action on R^{2n} and instantiate as GCovering (ZMod p) — adds concrete content.
+2. State Yang-Borsuk as axiom and derive ZMod p obstruction from it — parallels covering_space_obstruction structure.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Current approach attempts: 1
+- Approaches tried: 2 (single-involution CoveringType, general GCovering for additive G)

--- a/src/data/proofs/borsuk-ulam-oq-04/meta.json
+++ b/src/data/proofs/borsuk-ulam-oq-04/meta.json
@@ -18,11 +18,11 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 448,
-    "assumptions": "1 axiom inherited from BorsukUlam.lean: no_continuous_odd_nonzero_on_sphere (no continuous odd function from sphere is everywhere nonzero — the Borsuk-Ulam theorem). 0 own axioms. 0 sorries.",
+    "lineCount": 533,
+    "assumptions": "1 axiom inherited from BorsukUlam.lean: no_continuous_odd_nonzero_on_sphere (no continuous odd function from sphere is everywhere nonzero — the Borsuk-Ulam theorem). 0 own axioms. 0 sorries. Docker-verified clean build on Lean 4.26.0.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
-    "definitionCount": 16
+    "theoremCount": 13,
+    "definitionCount": 13
   },
   "overview": {
     "historicalContext": "The Borsuk-Ulam theorem (1933) asserts that every continuous map $S^n \\to \\mathbb{R}^n$ identifies a pair of antipodal points. Karol Borsuk posed the conjecture in 1933 and Stanisław Ulam is credited with the original formulation. The covering space proof, developed in the 1950s-60s through the work of algebraic topologists including Eilenberg and Steenrod, reduces the problem to showing no continuous odd map $S^n \\to S^{n-1}$ exists. The key idea is descent: an odd map $g$ induces $\\bar{g}: \\mathbb{R}P^n \\to \\mathbb{R}P^{n-1}$, and the induced homomorphism $\\pi_1(\\mathbb{R}P^n) \\to \\pi_1(\\mathbb{R}P^{n-1})$, i.e., $\\mathbb{Z}/2\\mathbb{Z} \\to \\mathbb{Z}/2\\mathbb{Z}$, must be both surjective (by the lifting property) and trivial (by geometric constraints) — contradiction. The higher categorical perspective emerged from Grothendieck's Pursuing Stacks (1983) and was systematized by Lurie in Higher Topos Theory (2009): classical covering spaces are functors $\\Pi_1(X) \\to \\mathbf{Set}$, while $\\infty$-coverings are local systems $\\Pi_\\infty(X) \\to \\mathbf{Space}$, capturing all homotopical information. Whether these higher-categorical tools yield genuinely stronger Borsuk-Ulam-type results remains an active research question, connecting to equivariant stable homotopy theory and the Hill-Hopkins-Ravenel solution of the Kervaire invariant problem (2016).",
@@ -48,57 +48,71 @@
       "id": "sec-oq04-preamble",
       "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 52,
+      "endLine": 56,
       "summary": "Module docstring explaining the classical covering space argument in 6 steps, the higher categorical perspective (0-coverings to ∞-coverings), and the file's goals. Imports Mathlib modules for topology, metric spaces, inner product spaces, ZMod, and tactics."
     },
     {
       "id": "sec-oq04-involutions",
       "title": "Z/2 Involutions and Equivalence Relations",
-      "startLine": 54,
-      "endLine": 84,
+      "startLine": 58,
+      "endLine": 88,
       "summary": "Defines the Involution structure (a self-inverse map), the antipodal involution on Euclidean space, and proves the induced equivalence relation (x ~ σ(x)) is well-formed with full proofs of reflexivity, symmetry, and transitivity."
     },
     {
       "id": "sec-oq04-projective-space",
       "title": "Real Projective Space",
-      "startLine": 86,
-      "endLine": 103,
+      "startLine": 90,
+      "endLine": 107,
       "summary": "Defines RPⁿ as the quotient of R^{n+1} by the antipodal relation, the projection map π, and proves π(-x) = π(x)."
     },
     {
       "id": "sec-oq04-descent",
-      "title": "Descent of Equivariant Maps",
-      "startLine": 105,
-      "endLine": 147,
-      "summary": "Defines IsOdd for equivariant maps, proves odd maps preserve the antipodal relation (odd_preserves_relation), constructs the descent map f̄: RPⁿ → RPᵐ from an odd map f, and proves commutativity with projection."
+      "title": "Descent of Equivariant (Odd) Maps",
+      "startLine": 109,
+      "endLine": 153,
+      "summary": "Defines IsOdd for equivariant maps, proves odd maps preserve the antipodal relation (odd_preserves_relation), constructs the descent map f̄: RPⁿ → RPᵐ from an odd map f, and proves commutativity with projection via Quotient.map reduction."
     },
     {
       "id": "sec-oq04-covering-space",
-      "title": "Covering Space Structure",
-      "startLine": 148,
-      "endLine": 172,
-      "summary": "Axiomatizes the 2-fold covering property of Sⁿ → RPⁿ and the fundamental group π₁(RPⁿ) ≅ Z/2Z for n ≥ 2."
+      "title": "The Covering Space Structure",
+      "startLine": 154,
+      "endLine": 181,
+      "summary": "Proves the 2-element fiber property of S^n → RP^n via Quotient.exact', and witnesses π₁(RP^n) ≅ Z/2Z for n ≥ 2 as a 2-element type."
     },
     {
       "id": "sec-oq04-higher-categorical",
-      "title": "Higher Categorical Framework",
-      "startLine": 174,
-      "endLine": 237,
-      "summary": "Defines CoveringType abstraction capturing key properties for descent arguments, constructs the antipodal covering as an instance, defines EquivariantMap between covering types, and proves odd maps give equivariant maps."
+      "title": "Higher Categorical Framework (CoveringType)",
+      "startLine": 182,
+      "endLine": 247,
+      "summary": "Defines CoveringType abstraction capturing key properties for descent arguments (total/base/projection/deck), constructs the antipodal covering as an instance, defines EquivariantMap between covering types, and proves odd maps give equivariant maps (as a `def`, since EquivariantMap is data)."
     },
     {
       "id": "sec-oq04-obstruction",
-      "title": "The Covering Space Argument",
-      "startLine": 239,
-      "endLine": 261,
-      "summary": "States the covering space obstruction axiom (no continuous odd nonvanishing map on the sphere) and discusses higher categorical generalizations."
+      "title": "The Covering Space Argument (Borsuk-Ulam)",
+      "startLine": 248,
+      "endLine": 281,
+      "summary": "Derives the covering-space obstruction `covering_space_obstruction` directly from `BorsukUlam.no_continuous_odd_nonzero_on_sphere`. The oddness hypothesis is inlined as `∀ x, g (-x) = -g x` (rather than via `IsOdd`) so the codomain `Fin n` need not be reshaped to `Fin (m + 1)`."
     },
     {
       "id": "sec-oq04-open-questions",
-      "title": "Open Questions",
-      "startLine": 263,
-      "endLine": 291,
+      "title": "Open Questions for Higher Analogues",
+      "startLine": 282,
+      "endLine": 309,
       "summary": "Lists four open questions about higher analogues: Z/p generalization, ∞-groupoid perspective, ∞-topos formulation, and whether higher coverings yield new results."
+    },
+    {
+      "id": "sec-oq04-gcovering",
+      "title": "General G-Coverings and Higher Categorical Structure",
+      "startLine": 310,
+      "endLine": 480,
+      "summary": "Generalizes CoveringType from the single-involution (G = ZMod 2) case to arbitrary additive groups G: GCovering G has `act : G → Total → Total` with act_zero/act_add/act_proj. Constructs antipodalZ2Covering as a GCovering (ZMod 2) (case analysis via `by_cases h : g = 0` rather than `fin_cases g`, since the latter left witnesses in un-reduced `(fun i => i) ⟨_, _⟩` form). Proves GCovering_z2_involutive (deck involutivity from 1 + 1 = 0 in ZMod 2), defines GEquivariantMap, and shows odd_gives_GEquivariant compatibility with the classical EquivariantMap via toEquivariantMap_Z2."
+    },
+    {
+      "id": "sec-oq04-zmod-p-periodicity",
+      "title": "ZMod p Periodicity (Cyclic Generalization)",
+      "startLine": 481,
+      "endLine": 532,
+      "summary": "Generalizes GCovering_z2_involutive to arbitrary cyclic deck groups ZMod p. The bridge lemma `GCovering.act_one_iterate` shows `(C.act 1)^[k] x = C.act ((k : ZMod p)) x` via induction (using `Function.iterate_succ_apply'` and `act_add`). The main result `GCovering_zmod_p_periodic` then follows from `ZMod.natCast_self : (p : ZMod p) = 0` and `act_zero`: iterating the generator p times yields the identity. `GCovering_zmod_p_periodic_two` recovers the original p = 2 involutivity statement, confirming the generalization is conservative. This is the algebraic backbone for lens-space coverings S^{2n-1} → L^{2n-1}(p) and the Yang-Borsuk theorem."
     }
   ],
   "conclusion": {
@@ -139,10 +153,10 @@
     ],
     "opens": [],
     "namespace": "BorsukUlamOQ04",
-    "lineCount": 448,
+    "lineCount": 533,
     "axiomCount": 0,
-    "theoremCount": 12,
-    "definitionCount": 16,
+    "theoremCount": 13,
+    "definitionCount": 13,
     "path": "Proofs/BorsukUlamOQ04.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/borsuk-ulam-oq-04.json
+++ b/src/data/research/problems/borsuk-ulam-oq-04.json
@@ -32,10 +32,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-03-23T00:42:35.518Z",
-    "iteration": 2,
-    "focus": "Added GCovering framework (Part 8): generalizes CoveringType to arbitrary additive group G. Building Docker to verify.",
+    "iteration": 3,
+    "focus": "Repaired pre-existing build breaks and added Part 9 ZMod p periodicity; Docker clean. Next: ZMod p lens space construction (requires complex analytic action of p-th roots of unity).",
     "blockers": [],
-    "nextAction": "Verify Lean builds. Extend CoveringType with higher categorical axioms.",
+    "nextAction": "Either: (a) define explicit ZMod p action on R^{2n} by 2D rotations and instantiate as GCovering (ZMod p); or (b) generalize the obstruction theorem statement to ZMod p (would need Yang-Borsuk axiom as starting point).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -43,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added Part 8 (GCovering framework). GCovering generalizes CoveringType to arbitrary additive group G. Proved: GCovering_z2_involutive (deck involutivity), toCoveringType_Z2 (embed in classical), antipodalZ2Covering_deck_matches (connects to classical), odd_gives_GEquivariant (G-equivariant version). Shows Z/2 case exactly recovers classical framework.",
+    "progressSummary": "PROGRESS: Repaired 7 pre-existing build breaks discovered by Docker validation (the previous 'GCovering framework' session committed without verifying), and added Part 9 (ZMod p periodicity). The new section generalizes GCovering_z2_involutive — which used 1 + 1 = 0 in ZMod 2 — to GCovering_zmod_p_periodic: in any ZMod p covering, iterating the generator action p times yields the identity. The proof uses a clean bridge lemma GCovering.act_one_iterate showing the iterated action matches the natural-number cast, then closes via ZMod.natCast_self. This is the algebraic backbone for lens-space coverings S^{2n-1} → L^{2n-1}(p) and the Yang-Borsuk theorem. Docker build clean (3059 jobs).",
     "builtItems": [
       "BorsukUlamOQ04.lean: 295 lines, 4 theorems, 3 axioms, 11 definitions",
       "Involution structure: self-inverse map with proved setoid properties",
@@ -63,7 +63,13 @@
       "antipodalZ2Covering_deck_matches: ZMod 2 framework recovers classical negation deck",
       "GEquivariantMap: equivariant maps between G-coverings",
       "odd_gives_GEquivariant: odd maps yield GEquivariantMap (proved)",
-      "odd_GEquivariant_extends_equivariant: consistent base maps (proved by rfl)"
+      "odd_GEquivariant_extends_equivariant: consistent base maps (proved by rfl)",
+      "BorsukUlamOQ04.lean: rescued 7 pre-existing build breaks (odd_preserves_relation/descendOdd_comm/sphere_fiber_pair/odd_gives_equivariant/covering_space_obstruction/antipodalZ2Covering.act_add/act_proj/odd_gives_GEquivariant) + added Part 9 ZMod p periodicity; Docker clean on Lean 4.26.0 (3059 jobs)",
+      "GCovering.act_one_iterate: bridge lemma (C.act 1)^[k] x = C.act ((k : ZMod p)) x via induction on Function.iterate_succ_apply + act_add",
+      "GCovering_zmod_p_periodic: (C.act 1)^[p] x = x for ANY ZMod p covering — generalizes GCovering_z2_involutive (which forced p = 2)",
+      "GCovering_zmod_p_periodic_two: recovers p = 2 involutivity from the general statement, confirming conservative extension",
+      "Made odd_gives_equivariant and odd_gives_GEquivariant proper `def`s (had `theorem` keyword over structure type)",
+      "Restated covering_space_obstruction to inline oddness as ∀ x, g (-x) = -g x instead of IsOdd (IsOdd requires codomain Fin (m+1), but Fin n is general)"
     ],
     "insights": [
       "Descent of odd maps to RP^n is purely algebraic: odd maps preserve the antipodal equivalence relation",
@@ -76,14 +82,20 @@
       "For G = ZMod 2 (discrete): only pi_1 contributes to obstruction; GCovering_z2_involutive shows why",
       "GCovering generalizes CoveringType: act_zero + act_add + act_proj subsumes deck + deck_inv + deck_proj",
       "The toCoveringType_Z2 embedding shows classical covering theory is the special case G = ZMod 2",
-      "For general G: obstructions live in H*(BG), not just pi_1(BG). G = U(1) gives H^2; G = SU(2) gives H^4"
+      "For general G: obstructions live in H*(BG), not just pi_1(BG). G = U(1) gives H^2; G = SU(2) gives H^4",
+      "The same algebraic mechanism behind Z/2 involutivity (1 + 1 = 0 in ZMod 2) generalizes to ZMod p periodicity (p = 0 in ZMod p) — both reduce to ZMod.natCast_self + act_zero",
+      "fin_cases on (g : ZMod 2) inside a structure literal produces witness `(fun i => i) ⟨0/1, _⟩` that does NOT unify with literal `0`/`1` — must use `by_cases h : g = 0` + `Or.resolve_left` from `∀ a : ZMod 2, a = 0 ∨ a = 1` (decidable via Fintype)",
+      "`theorem` returning a structure type is a hard error in Lean 4.26 — must use `def` (Lean checks the type is a Prop before elaborating body); this caused 2 silently broken declarations in the original file",
+      "Quotient.exact' (with regular apostrophe) is the right lemma for `projMap n y = projMap n x → y ≈ x` via the antipodal setoid; the original file had Unicode prime `’` which silently mis-parsed as a different identifier",
+      "IsOdd in this file requires codomain `EuclideanSpace ℝ (Fin (m + 1))` — for general codomain `Fin n` (without the +1 structure) use raw `∀ x, f (-x) = -f x` instead",
+      "Previous GCovering session committed under 'Building Docker to verify' but never confirmed; the file has been broken on main for the entire intervening period — a counterexample to relying on metadata claims of '0 sorries/0 axioms' without runtime verification"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Run Docker build to verify GCovering framework compiles",
-      "Add ZMod p lens space covering (G = ZMod p, total space = S^{2n-1})",
-      "State generalized Borsuk-Ulam as axiom: no G-equivariant map S^n -> S^m when n > Gdim(m)",
-      "Connect to OQ-02 equivariant BU dimension framework"
+      "Define explicit ZMod p action by 2D rotations on R^{2n} ⊂ EuclideanSpace ℝ (Fin (2n))",
+      "Instantiate `lensZpCovering : ℕ → GCovering (ZMod p)` and prove fiber structure",
+      "State generalized Borsuk-Ulam (Yang-Borsuk) as axiom: no continuous ZMod p-equivariant map S^{2n-1} → S^{2m-1} when n > m",
+      "Verify Part 9 is consumed by any downstream proof (currently standalone)"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Rescues 7 pre-existing build breaks in `proofs/Proofs/BorsukUlamOQ04.lean` and adds Part 9: a clean cyclic generalization of `GCovering_z2_involutive` to arbitrary `ZMod p` deck groups. Docker-verified clean build on Lean 4.26.0 (3059 jobs).

## Why this matters

The previous "GCovering framework" commit (2b692ebea4f) was made before Docker verification — its session note literally said "Building Docker to verify." It failed to compile against current Mathlib, yet `meta.json` advertised "0 sorries, 0 own axioms." Anyone trusting that claim would have been misled. This PR restores ground truth.

## Pre-existing breaks repaired (file did NOT compile on origin/main)

| Line(s) | Symbol | Fix |
|---------|--------|-----|
| 135 | `odd_preserves_relation` | `rw [hf]` couldn't unify `(antipodalInvol n).σ y` with `-y`; added `show f (-y) = -(f y)` |
| 149 | `descendOdd_comm` | Wrong simp lemma (`Quotient.map_mk` instead of `…_mk'`); collapsed to `rfl` (definitionally equal) |
| 171 | `sphere_fiber_pair` | Unicode prime `'` in `Quotient.exact'` — fixed to regular apostrophe |
| 237 | `odd_gives_equivariant` | `theorem` returning a structure type — converted to `def` |
| 270 | `covering_space_obstruction` | `IsOdd g` requires codomain `Fin (m+1)`; inlined oddness as `∀ x, g (-x) = -g x` |
| 341, 345 | `antipodalZ2Covering.act_add`, `act_proj` | `fin_cases g` on `ZMod 2` inside a structure literal left witnesses in un-reduced `(fun i => i) ⟨_, _⟩` form; replaced with `by_cases h : g = 0` + `Or.resolve_left` from the decidable `∀ a : ZMod 2, a = 0 ∨ a = 1` |
| 399 | `odd_gives_GEquivariant` | Same `theorem`→`def` + `fin_cases` → `by_cases` rewrite |

## Part 9 (new content)

Generalizes `GCovering_z2_involutive` (forced `p = 2`) to arbitrary cyclic deck groups via three theorems (~52 LOC):

```lean
theorem GCovering.act_one_iterate {p : ℕ} (C : GCovering (ZMod p)) (k : ℕ) (x : C.Total) :
    (C.act 1)^[k] x = C.act ((k : ZMod p)) x
-- bridge: Function.iterate ↔ additive ZMod p action

theorem GCovering_zmod_p_periodic {p : ℕ} (C : GCovering (ZMod p)) (x : C.Total) :
    (C.act 1)^[p] x = x
-- iterating the generator p times is identity; uses ZMod.natCast_self + act_zero

theorem GCovering_zmod_p_periodic_two (C : GCovering (ZMod 2)) (x : C.Total) :
    C.act 1 (C.act 1 x) = x
-- recovers original p = 2 statement, confirming conservative extension
```

The same algebraic mechanism behind `1 + 1 = 0` in `ZMod 2` (forcing deck involutivity) extends uniformly to `p ≡ 0 (mod p)` in `ZMod p`. This is the algebraic backbone for:
- lens-space coverings `S^{2n-1} → L^{2n-1}(p)` where `ZMod p` acts by p-th roots of unity
- the Yang-Borsuk generalised Borsuk-Ulam theorem (no `ZMod p`-equivariant `S^{2n-1} → S^{2m-1}` with `n > m`)

## Verification

- Docker build clean: `./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ04` — 3059 jobs successful
- Lean 4.26.0, Mathlib `2df2f015`
- 0 sorries, 0 own axioms (1 inherited from `BorsukUlam.no_continuous_odd_nonzero_on_sphere`)
- `meta.json` lineCount/theoremCount/definitionCount + section endLines refreshed
- `meta.json` valid JSON

## Honesty notes

- 7 of 9 changed declarations are *repairs*, not new content; the underlying mathematical framework is unchanged.
- Part 9 is a clean generalization but the *content* is light — three short lemmas. Its value is making explicit the algebraic core that the existing `GCovering_z2_involutive` only revealed for `p = 2`.
- Future work (lens-space `GCovering (ZMod p)` instance, generalized Borsuk-Ulam axiom) is properly deferred — both require infrastructure (complex-analytic rotations, Yang-Borsuk axiom) that this session did not build.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.BorsukUlamOQ04` → clean
- [ ] Reviewer: spot-check that the `act_one_iterate` induction step (`Function.iterate_succ_apply'` + `← C.act_add` + `push_cast; ring`) is the cleanest formulation
- [ ] Reviewer: confirm the IsOdd ↔ inlined-oddness restatement of `covering_space_obstruction` is a faithful refactor, not a weakening (both reduce to the same axiom in `BorsukUlam.lean`)

🤖 Generated by researcher-1