### PR TITLE
Enrich abel-ruffini-galois-extensions-oq-05-oq-01: type + description on mainTheorems

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-05-oq-01/meta.json
@@ -567,57 +567,75 @@
   "mainTheorems": [
     {
       "name": "cyclic_realizable",
+      "type": "supporting",
+      "line": 65,
       "statement": "∀ n > 0: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = n",
       "significance": "Recap wrapper around InverseGaloisProblem.cyclic_group_realizable (Dirichlet + Galois fixed fields)",
-      "line": 65
+      "description": "**Cyclic group case (re-export).** Wraps `InverseGaloisProblem.cyclic_group_realizable` to expose the cyclic-realizability statement inside this file's namespace. The witness construction uses Dirichlet's theorem on primes in arithmetic progression (find a prime $p \\equiv 1 \\pmod n$) followed by the fixed field of the index-$n$ subgroup $H \\leq (\\mathbb{Z}/p)^\\times \\cong \\mathrm{Gal}(\\mathbb{Q}(\\zeta_p)/\\mathbb{Q})$; the resulting $K = \\mathbb{Q}(\\zeta_p)^H$ has $\\mathrm{Gal}(K/\\mathbb{Q}) \\cong \\mathbb{Z}/n\\mathbb{Z}$ via `IsGalois.normalAutEquivQuotient`. This is the *constructive* anchor that makes the Mathlib-feasibility claim for the cyclic case concrete (0 sorries, 0 axioms in the underlying `InverseGalois.lean` definition)."
     },
     {
       "name": "zmod_coprime_crt",
+      "type": "supporting",
+      "line": 85,
       "statement": "Coprime m n → (ZMod (m*n) ≃+ ZMod m × ZMod n)",
       "significance": "The algebraic tool making the coprime reduction work (extracts the additive iso from ZMod.chineseRemainder)",
-      "line": 85
+      "description": "**CRT algebraic kernel.** Extracts the additive isomorphism $\\mathbb{Z}/(mn)\\mathbb{Z} \\cong \\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ from Mathlib's `ZMod.chineseRemainder` (a ring isomorphism). The downward casting `.toAddEquiv` discards the multiplicative structure that the cyclic-realizability argument does not need. This is the algebraic content that justifies the reduction *coprime cyclic product $\\Rightarrow$ single cyclic of product order*, which `coprime_product_cyclic_realizable` then turns into a Galois-realization statement."
     },
     {
       "name": "coprime_product_cyclic_realizable",
+      "type": "key",
+      "line": 91,
       "statement": "When gcd(m,n)=1: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = m*n",
       "significance": "Key new result: coprime abelian product reduced to cyclic via CRT",
-      "line": 91
+      "description": "**Key new result of this file.** When $\\gcd(m, n) = 1$, the abelian product $\\mathbb{Z}/m\\mathbb{Z} \\times \\mathbb{Z}/n\\mathbb{Z}$ is *itself* cyclic of order $mn$ (CRT, via `zmod_coprime_crt`), so the same cyclotomic fixed-field construction that realizes $\\mathbb{Z}/(mn)\\mathbb{Z}$ also realizes the product. This reduces the coprime abelian case to the cyclic case (`cyclic_realizable`) *without* the linear-disjointness machinery (`galois_compositum_product` axiom) that the same-prime case $\\mathbb{Z}/p\\mathbb{Z} \\times \\mathbb{Z}/p\\mathbb{Z}$ requires — a 0-axiom contribution to the abelian feasibility frontier. **Why coprime alone suffices**: distinct primes $m, n$ make $\\mathbb{Z}/m \\times \\mathbb{Z}/n$ structurally isomorphic to the larger cyclic $\\mathbb{Z}/(mn)$, so no compositum theory is needed at all."
     },
     {
       "name": "z2z3_realizable",
+      "type": "supporting",
+      "line": 101,
       "statement": "∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = 6",
       "significance": "Concrete instance: ℤ/2 × ℤ/3 ≅ ℤ/6 realizable (gcd(2,3) = 1)",
-      "line": 101
+      "description": "**Concrete CRT instance at smallest non-trivial coprime case.** $\\mathbb{Z}/2 \\times \\mathbb{Z}/3 \\cong \\mathbb{Z}/6$ (cyclic of order 6) is realized by the fixed-field-of-cyclotomic construction at any prime $p \\equiv 1 \\pmod 6$ — e.g. $p = 7$, giving $K = \\mathbb{Q}(\\zeta_7)^{H_2}$ where $H_2 \\leq (\\mathbb{Z}/7)^\\times \\cong \\mathbb{Z}/6$ is the index-6 subgroup (trivial), i.e. $K = \\mathbb{Q}(\\zeta_7)$ with $|\\mathrm{Gal}| = 6$. Discharged by `coprime_product_cyclic_realizable 2 3` with `norm_num`-checked positivity and coprimality."
     },
     {
       "name": "z5z7_realizable",
+      "type": "supporting",
+      "line": 108,
       "statement": "∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = 35",
       "significance": "Concrete instance: ℤ/5 × ℤ/7 ≅ ℤ/35 realizable (gcd(5,7) = 1)",
-      "line": 108
+      "description": "**Concrete CRT instance at a larger coprime case.** $\\mathbb{Z}/5 \\times \\mathbb{Z}/7 \\cong \\mathbb{Z}/35$ is realized by a cyclotomic-fixed-field construction at any prime $p \\equiv 1 \\pmod{35}$ — e.g. $p = 71$, giving a subfield $K \\subset \\mathbb{Q}(\\zeta_{71})$ with $|\\mathrm{Gal}(K/\\mathbb{Q})| = 35$. Demonstrates that the coprime-reduction trick scales beyond the toy $\\mathbb{Z}/6$ case to arbitrary coprime products, including ones whose moduli are themselves odd primes (genuinely non-trivial structurally)."
     },
     {
       "name": "galois_compositum_product",
+      "type": "core",
+      "line": 141,
       "statement": "Axiom: Galois extensions with coprime group orders → product Galois group on compositum",
       "significance": "Single axiom precisely identifying the Mathlib gap for the abelian case",
-      "line": 141
+      "description": "**The single axiom of this file — the precise Mathlib gap for the general abelian case.** For two Galois extensions $K_1, K_2 / \\mathbb{Q}$ with coprime Galois group orders, the compositum $K_1 K_2$ is Galois over $\\mathbb{Q}$ with $\\mathrm{Gal}(K_1 K_2 / \\mathbb{Q}) \\cong \\mathrm{Gal}(K_1 / \\mathbb{Q}) \\times \\mathrm{Gal}(K_2 / \\mathbb{Q})$. The mathematical justification proceeds via linear disjointness from coprime conductors (unramified-at-each-other's-primes argument), then the standard Galois-correspondence product formula. **Why this axiom is honest**: Mathlib 2026 lacks (i) the conductor theory for subfields of cyclotomic extensions, (ii) the linear-disjointness-from-coprime-conductor criterion, and (iii) the compositum-Galois-group product formula at the abstract level. Closing these gaps is estimated at ~500 LOC of algebraic number theory. The axiom is the *single* assumption blocking a general-abelian-case proof; the same-prime $\\mathbb{Z}/p \\times \\mathbb{Z}/p$ obstruction (which CRT cannot reduce away) is the only non-CRT-reducible piece, and `galois_compositum_product` is exactly the missing tool for it."
     },
     {
       "name": "s3_realizable_via_cubic",
+      "type": "supporting",
+      "line": 165,
       "statement": "∃ K Galois/ℚ, Sym(Fin 3) ≃* Gal(K/ℚ)",
       "significance": "S₃ realizable by direct cubic construction (non-Shafarevich)",
-      "line": 165
+      "description": "**Non-abelian solvable example, realized ad-hoc rather than via Shafarevich.** $S_3 \\cong \\mathrm{Gal}(\\mathbb{Q}(\\sqrt[3]{2}, \\omega)/\\mathbb{Q})$ where $\\omega = e^{2\\pi i / 3}$, via the splitting field of $X^3 - 2$ (irreducible over $\\mathbb{Q}$ by Eisenstein at $p = 2$, splitting field of degree 6 = 3 \\cdot 2 = |S_3|$). Delegates to `InverseGaloisProblem.s3_realizable`, a direct polynomial construction that does *not* invoke the embedding-problem / class-field-theory machinery Shafarevich would require for a uniform proof. **Pedagogical point**: individual non-abelian solvable groups admit explicit polynomial witnesses, but the *uniform* statement (every solvable group realizable) needs Shafarevich's machinery, which Mathlib 2026 does not yet have."
     },
     {
       "name": "s3_is_solvable",
+      "type": "supporting",
+      "line": 173,
       "statement": "IsSolvable (Equiv.Perm (Fin 3))",
       "significance": "S₃ solvable via derived series S₃ ⊃ A₃ ⊃ {1} (delegates to symmetric_solvable_of_le_four)",
-      "line": 173
+      "description": "**Solvability typeclass for $S_3$.** $S_3$ is solvable via the derived series $S_3 \\supset A_3 \\cong \\mathbb{Z}/3 \\supset \\{e\\}$ with abelian quotients $S_3/A_3 \\cong \\mathbb{Z}/2$ and $A_3/\\{e\\} \\cong \\mathbb{Z}/3$. The proof delegates to `AbelRuffiniGaloisExtensions.symmetric_solvable_of_le_four` with `norm_num` discharging the inequality $3 \\leq 4$. This supplies the `IsSolvable` instance that `s3_realizable_via_cubic` needs to fit inside the Shafarevich-feasibility framework: every realized group must first be shown solvable, then Shafarevich (or here, a polynomial-specific construction) delivers the field."
     },
     {
       "name": "shafarevich_cyclic_case_proved",
+      "type": "core",
+      "line": 195,
       "statement": "∀ n > 0: ∃ K Galois/ℚ, IsCyclic Gal(K/ℚ) ∧ |Gal(K/ℚ)| = n",
       "significance": "Summary theorem restating the cyclic case as the formal status report's main result",
-      "line": 195
+      "description": "**Headline summary theorem.** Restates the cyclic case as this file's formal status report: every $\\mathbb{Z}/n\\mathbb{Z}$ is realizable as a Galois group over $\\mathbb{Q}$ — *unconditionally*, with 0 axioms, via the explicit cyclotomic-fixed-field construction in `InverseGalois.lean`. This is the *achieved* fragment of Shafarevich's theorem; the file's contribution is sharpening exactly *what part* of the full Shafarevich statement is currently provable in Mathlib (cyclic ✅, coprime products ✅, general abelian ⚠️ 1 axiom, general solvable ❌ ~5000+ LOC), with this theorem as the unambiguous core deliverable."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary

The 9 `mainTheorems` entries in `abel-ruffini-galois-extensions-oq-05-oq-01/meta.json` had `name`, `statement`, `significance`, and `line` but were missing the `type` and `description` fields the gallery uses for badge rendering and reader-facing prose. This PR fills both gaps.

Companion to PR #22387 (same enrichment on `abel-ruffini-galois-extensions`) and the in-flight PR #22361 commit *"add line numbers and types to mainTheorems"* on the parent sibling `abel-ruffini-galois-extensions-oq-05`.

### Type assignments (following parent-file convention)

- **`core`**: `galois_compositum_product` (the single axiom — Mathlib gap statement) and `shafarevich_cyclic_case_proved` (headline summary theorem)
- **`key`**: `coprime_product_cyclic_realizable` (the file's main new result — coprime abelian reduction via CRT, 0 axioms)
- **`supporting`**: re-exports (`cyclic_realizable`), algebraic helpers (`zmod_coprime_crt`), concrete instances (`z2z3_realizable`, `z5z7_realizable`), the cubic non-Shafarevich `s3_realizable_via_cubic` example, and the `s3_is_solvable` helper

Each description fact-checks against the Lean file's docstrings and explains *why* each theorem holds the structural role its name suggests — making the file's "cyclic ✅ / coprime products ✅ / general abelian ⚠️ / general solvable ❌" status report navigable per-theorem.

## Test plan

- [x] Line numbers verified against `proofs/Proofs/AbelRuffiniGaloisExtensionsOQ05OQ01.lean` (all 9 match — 65, 85, 91, 101, 108, 141, 165, 173, 195)
- [x] JSON validates (Python `json.load`)
- [x] No structural changes — `name`, `statement`, `significance` all preserved alongside new `type` and `description`