### PR TITLE
audit(central-limit-theorem-oq-04): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1951,9 +1951,9 @@
       "result": "clean"
     },
     "central-limit-theorem-oq-04": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T03:10:00Z",
+      "lastAudited": "2026-06-05T13:29:03Z",
       "result": "clean"
     },
     "cevas-theorem": {


### PR DESCRIPTION
## Summary
- 5th audit of `central-limit-theorem-oq-04`; meta.json fully matches Lean source.
- All integrity checks pass: lineCount 649, sorries 0, axioms 9, theorems 21, definitions 12.
- `status: axiomatized` / `badge: axiom` correctly reflects 9 axioms.

## Notes
- The 9 axioms in source exactly match the `assumptions` text inventory.
- `definitionCount: 12` resolves to 10 (`def` + `noncomputable def`) + 2 `structure` (NCDistribution, CLTStructure). The count is consistent if `structure` is included; flagging here in case a future refactor wants to split these.
- All 10 `originalContributions` claimed as proved exist in source as `theorem` declarations.

## Test plan
- [x] `wc -l` on Lean source = 649 (matches meta)
- [x] `grep -c "^axiom "` = 9 (matches meta)
- [x] `grep -cE "^(theorem|lemma) "` = 21 (matches meta)
- [x] No `\bsorry\b` tokens in code
- [x] No `: True` / `:= trivial` stubs
- [x] Each claimed "proved" theorem name resolves to a top-level theorem

🤖 Generated with [Claude Code](https://claude.com/claude-code)