### PR TITLE
audit: bump tracker for erdos-1018-oq-04-incomplete-01 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -3066,10 +3066,10 @@
       "result": "clean"
     },
     "erdos-1018-oq-04-incomplete-01": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-05-03T02:20:45Z",
-      "result": "issues-fixed",
+      "lastAudited": "2026-06-05T13:32:43Z",
+      "result": "clean",
       "notes": "PR #15021: stale sorry/lineCount after #14937 (top.sorries 4→3, leanFile.sorries 4→3, lineCount 279→287, narrative 5→3)"
     },
     "erdos-1019": {


### PR DESCRIPTION
## Summary

8th audit of `erdos-1018-oq-04-incomplete-01`. Verified `meta.json` matches the Lean source.

**Checks**
- `sorries: 1` — confirmed (line 652, `planar_graphs_edge_bound` needs Euler's formula)
- `axiomCount: 1` — confirmed (`kostochka_pyber_r2`, line 683)
- `theoremCount: 11` — confirmed
- `status: "axiomatized"`, `badge: "axiom"` — appropriate given the axiom
- No `True` stubs
- Not a Mathlib wrapper (its main result depends on the local axiom, not a Mathlib theorem)

Tracker bumped: `auditCount` 7→8, `lastAudited` updated, `result` → `clean`.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --next` returned this target
- [x] Re-counted sorries (1 real proof-term sorry; remaining matches are in docstrings)
- [x] Re-counted axioms (1)
- [x] No metadata changes required