### PR TITLE
research(sylow-theorems-oq-03): S6 ACT — Candidate B discharges sylowProP_inter_trivial (3066 jobs)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2836,6 +2836,7 @@ import Proofs.SylowTheoremOQ01
 import Proofs.SylowTheoremOQ02
 import Proofs.SylowTheoremOQ02Orbit
 import Proofs.SylowTheoremOQ03
+import Proofs.SylowTheoremOQ03B
 import Proofs.SylowTheoremOQ04
 import Proofs.SynthesisCurvaturePtolemy
 import Proofs.SzemerediCore

--- a/proofs/Proofs/SylowTheoremOQ03B.lean
+++ b/proofs/Proofs/SylowTheoremOQ03B.lean
@@ -1,0 +1,160 @@
+import Mathlib.GroupTheory.Sylow
+import Mathlib.GroupTheory.PGroup
+import Mathlib.GroupTheory.Index
+import Mathlib.GroupTheory.Coset.Basic
+import Mathlib.GroupTheory.OrderOfElement
+import Mathlib.GroupTheory.QuotientGroup.Basic
+import Mathlib.Algebra.Group.Subgroup.Ker
+import Mathlib.Topology.Algebra.Group.Basic
+import Mathlib.Topology.Algebra.Group.Quotient
+import Mathlib.Topology.Algebra.ClopenNhdofOne
+import Mathlib.Topology.Separation.Profinite
+import Mathlib.Topology.Constructions
+import Mathlib.Data.Nat.Prime.Basic
+import Mathlib.Tactic
+import Proofs.SylowTheoremOQ02
+import Proofs.SylowTheoremOQ03
+
+/-
+# OQ-03 Candidate B: Discharge of `sylowProP_inter_trivial`
+
+This file is `sylow-theorems-oq-03` Candidate B (S6 ACT): a discharge of
+the OQ-02 axiom `ProfiniteSylow.sylowProP_inter_trivial` (declared at
+`SylowTheoremOQ02.lean:133`).
+
+## Mathematical content
+
+The OQ-02 axiom states: for a profinite group `G` and distinct primes
+`p ≠ q`, the intersection of a Sylow pro-p subgroup `P` and a Sylow
+pro-q subgroup `Q` is trivial.
+
+This file proves it via finite-quotient reduction:
+
+1. By contradiction, take `x ∈ P ⊓ Q` with `x ≠ 1`.
+2. Since `G` is T2 + TDS + Compact + TopologicalGroup, there is a
+   clopen neighborhood of `1` not containing `x` (via the fact that
+   `{x}` is closed in a T2 space).
+3. By `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one`,
+   there is an open normal subgroup `N ⊂ {x}ᶜ`, so `x ∉ N`.
+4. The quotient `G ⧸ N` is finite + discrete.
+5. By the continuity-enhanced `sylowProP_projects_pgroup_continuous`
+   (already proved in `SylowTheoremOQ03.lean`), the image of `P` in
+   `G ⧸ N` is a p-group, and the image of `Q` is a q-group.
+6. `x.mk` (the class of `x` in `G ⧸ N`) lies in both images, so its
+   order divides both `p^a` and `q^b` for some `a, b`.
+7. For distinct primes, `gcd(p^a, q^b) = 1`, so the order is 1, hence
+   `x.mk = 1`, hence `x ∈ N`. Contradiction.
+
+## Effect on `SylowTheoremOQ02.lean`
+
+If this file builds successfully, the axiom `sylowProP_inter_trivial`
+at `SylowTheoremOQ02.lean:133` becomes derivable and can be removed in
+a follow-on PR. Net OQ-02 axiom count: 4 → 3.
+
+## References
+
+- `Mathlib/Topology/Algebra/ClopenNhdofOne.lean:44` —
+  `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one`
+- `Mathlib/Topology/Algebra/OpenSubgroup.lean:298` —
+  `(U : OpenSubgroup G) : Finite (G ⧸ U.toSubgroup)` instance
+- `Mathlib/GroupTheory/PGroup.lean:26` — `IsPGroup` definition
+- `Mathlib/GroupTheory/OrderOfElement.lean:248` — `orderOf_eq_one_iff`
+- `Mathlib/Data/Nat/Prime/Basic.lean:201` — `Nat.coprime_pow_primes`
+- `Mathlib/Topology/Separation/Basic.lean:341` — `isClosed_singleton`
+-/
+
+namespace ProfiniteSylow
+
+set_option linter.unusedVariables false
+
+section SylowInterTrivial
+
+variable {G : Type*} [Group G] [TopologicalSpace G]
+
+/-- **Discharge of axiom `sylowProP_inter_trivial`** (OQ-02 line 133):
+    Sylow pro-p subgroups for distinct primes have trivial intersection.
+
+    Proof goes via finite quotients: project to `G ⧸ N` for an open
+    normal `N` not containing `x`, use Candidate A* to argue that the
+    projected images are p- and q-groups, conclude that the projected
+    element has order dividing both `p^a` and `q^b` (hence 1), so the
+    original element lies in `N` — contradiction. -/
+theorem sylowProP_inter_trivial_via_quotient
+    (hpf : IsProfiniteGroup G) (p q : ℕ) [hp : Fact p.Prime] [hq : Fact q.Prime]
+    (hpq : p ≠ q) (P : SylowProP G p) (Q : SylowProP G q) :
+    P.toSubgroup ⊓ Q.toSubgroup = ⊥ := by
+  -- Typeclass bridges from `hpf : IsProfiniteGroup G`.
+  haveI : CompactSpace G := hpf.isCompact
+  haveI : T2Space G := hpf.isT2
+  haveI : TotallyDisconnectedSpace G := hpf.isTotallyDisc
+  haveI : ContinuousMul G := ⟨hpf.continuous_mul⟩
+  haveI : ContinuousInv G := ⟨hpf.continuous_inv⟩
+  haveI : IsTopologicalGroup G := {}
+  -- Reduce `⊓ = ⊥` to "every element of the intersection is 1".
+  rw [eq_bot_iff]
+  intro x hx
+  rw [Subgroup.mem_bot]
+  obtain ⟨hxP, hxQ⟩ := hx
+  by_contra hne
+  -- `{x}` is closed (T2), so `{x}ᶜ` is open and contains `1`.
+  have hcompl_open : IsOpen (({x}ᶜ) : Set G) := isClosed_singleton.isOpen_compl
+  have hone_in : (1 : G) ∈ (({x}ᶜ) : Set G) := by
+    simp only [Set.mem_compl_iff, Set.mem_singleton_iff]
+    intro h; exact hne h.symm
+  -- Get an open normal `N` contained in `{x}ᶜ`, so `x ∉ N`.
+  obtain ⟨N, hN_sub⟩ :=
+    ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one hcompl_open hone_in
+  have hx_not_in_N : x ∉ N.toOpenSubgroup.toSubgroup := by
+    intro hmem
+    have : x ∈ (({x}ᶜ) : Set G) := hN_sub hmem
+    simp at this
+  -- The quotient is finite and discrete.
+  haveI hfin : Finite (G ⧸ N.toOpenSubgroup.toSubgroup) := inferInstance
+  haveI : Fintype (G ⧸ N.toOpenSubgroup.toSubgroup) := Fintype.ofFinite _
+  haveI : DiscreteTopology (G ⧸ N.toOpenSubgroup.toSubgroup) :=
+    QuotientGroup.discreteTopology N.toOpenSubgroup.isOpen
+  -- The quotient map and its continuity.
+  let φ : G →* G ⧸ N.toOpenSubgroup.toSubgroup := QuotientGroup.mk' _
+  have hφ_cont : Continuous φ := continuous_quotient_mk'
+  -- Apply Candidate A* (already proved in SylowTheoremOQ03.lean) to get
+  -- that the images of P and Q in `G ⧸ N` are p- and q-groups.
+  have hP_img : IsPGroup p (P.toSubgroup.map φ) :=
+    sylowProP_projects_pgroup_continuous P φ hφ_cont
+  have hQ_img : IsPGroup q (Q.toSubgroup.map φ) :=
+    sylowProP_projects_pgroup_continuous Q φ hφ_cont
+  -- `φ x` is in both images.
+  have hxP_img : φ x ∈ P.toSubgroup.map φ :=
+    Subgroup.mem_map.mpr ⟨x, hxP, rfl⟩
+  have hxQ_img : φ x ∈ Q.toSubgroup.map φ :=
+    Subgroup.mem_map.mpr ⟨x, hxQ, rfl⟩
+  -- Get `(φ x)^(p^a) = 1` and `(φ x)^(q^b) = 1` in the quotient.
+  obtain ⟨a, ha⟩ := hP_img ⟨φ x, hxP_img⟩
+  obtain ⟨b, hb⟩ := hQ_img ⟨φ x, hxQ_img⟩
+  -- Move from subgroup-typed equation to the ambient quotient equation.
+  have ha' : (φ x) ^ (p ^ a) = 1 := by
+    have h := congrArg (Subtype.val) ha
+    simpa using h
+  have hb' : (φ x) ^ (q ^ b) = 1 := by
+    have h := congrArg (Subtype.val) hb
+    simpa using h
+  -- Use coprime-pow argument: `orderOf (φ x)` divides both `p^a` and `q^b`.
+  have hdvd_p : orderOf (φ x) ∣ p ^ a := orderOf_dvd_of_pow_eq_one ha'
+  have hdvd_q : orderOf (φ x) ∣ q ^ b := orderOf_dvd_of_pow_eq_one hb'
+  have hcoprime : Nat.Coprime (p ^ a) (q ^ b) :=
+    Nat.coprime_pow_primes a b hp.out hq.out hpq
+  have hdvd_gcd : orderOf (φ x) ∣ Nat.gcd (p ^ a) (q ^ b) :=
+    Nat.dvd_gcd hdvd_p hdvd_q
+  rw [hcoprime.gcd_eq_one] at hdvd_gcd
+  have hord_one : orderOf (φ x) = 1 := Nat.dvd_one.mp hdvd_gcd
+  have hφx_eq : φ x = 1 := orderOf_eq_one_iff.mp hord_one
+  -- `φ x = 1` means `x ∈ N`, contradicting `x ∉ N`.
+  have hx_in_N : x ∈ N.toOpenSubgroup.toSubgroup := by
+    have : (QuotientGroup.mk x : G ⧸ N.toOpenSubgroup.toSubgroup) = 1 := hφx_eq
+    exact (QuotientGroup.eq_one_iff x).mp this
+  exact hx_not_in_N hx_in_N
+
+end SylowInterTrivial
+
+end ProfiniteSylow
+
+#check @ProfiniteSylow.sylowProP_inter_trivial_via_quotient

--- a/research/problems/sylow-theorems-oq-03/sessions/2026-06-05-s6-act-candidate-b.md
+++ b/research/problems/sylow-theorems-oq-03/sessions/2026-06-05-s6-act-candidate-b.md
@@ -1,0 +1,140 @@
+# S6 ACT — Candidate B: Discharge of `sylowProP_inter_trivial`
+
+**Author:** researcher-1 (claim `researcher-90270`, knowledge score 28 RICH)
+**Timestamp:** 2026-06-05 ~14:00 UTC
+**Phase:** S6 ACT (Lean-modifying — Candidate B implementation)
+**Iteration:** 15 (8 PREP + S2 PREP-7 + S2 ACT + STATE-SYNC × 3 + S4 ACT + S5 STATE-SYNC + this S6 ACT)
+
+**Builds on:**
+- S1 OBSERVE (#18285) — 3 candidates A/B/C
+- S2 PREP-2 (#18493) — Candidate B 5-substep decomposition
+- S2 PREP-4 (#18658) — `closedSubgroup_eq_sInf_open` is PHANTOM; replacement
+  `nhds_basis_clopen` chain via `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one`
+- S2 PREP-5 (#18722) — `IsTopologicalGroup` typeclass-bridge requirement
+- S2 ACT (#19260) — Candidate A* shipped (`sylowProP_projects_pgroup_continuous` in
+  `SylowTheoremOQ03.lean`), foundation for Candidate B's B2 substep
+- S4 ACT (#19380) — OQ-02 axiom drop 5→4 realized
+- S5 STATE-SYNC (#22028, 2026-06-02) — deferred Candidate B 16 days; queued for ACT
+
+## 0. Why this angle now
+
+Per S5 STATE-SYNC (#22028) and the S4 §6a TOP priority designation,
+Candidate B has been the unchanged top-priority next ACT for 20 days
+across 4 prior STATE-SYNC ticks. This session attempts the ACT.
+
+## 1. Ship summary
+
+**One new file**: `proofs/Proofs/SylowTheoremOQ03B.lean` (~115 LOC
+including imports and docstrings; ~50 LOC of actual proof body).
+**One import update**: `proofs/Proofs.lean` adds
+`import Proofs.SylowTheoremOQ03B`.
+
+**Mathematical content**: Discharges the OQ-02 axiom
+`sylowProP_inter_trivial` (currently at L133) via the finite-quotient
+route planned in S2 PREP-2. The proof uses the previously-shipped
+Candidate A* (`sylowProP_projects_pgroup_continuous` in
+`SylowTheoremOQ03.lean`) as a key lemma — without it, the projection
+step would not work.
+
+**The OQ-02 axiom removal** (axiomCount 4 → 3) is intentionally **NOT**
+in this PR; it will be a clean follow-on after Candidate B builds
+clean, by analogy to the A* → S4 split (S2 ACT shipped A* in OQ-03;
+S4 ACT removed the OQ-02 axiom 16 days later). Splitting reduces
+single-PR risk and gives the next iteration an opportunity to re-
+verify build health on the freshly-added file before committing to
+the axiom delta.
+
+## 2. Proof outline (matches PREP-2 substeps + PREP-4/5 fixes)
+
+| Step | Description | LOC | Source |
+|------|-------------|-----|--------|
+| Setup | `haveI` typeclass instances from `hpf` (CompactSpace, T2, TDS, ContinuousMul/Inv, IsTopologicalGroup) | 6 | PREP-5 Finding I |
+| B0 | Reduce `⊓ = ⊥` to "every element is 1"; by-contradiction for `x ∈ P ⊓ Q`, `x ≠ 1` | 4 | — |
+| B-clopen | `{x}` closed (T2 + isClosed_singleton), `{x}ᶜ` is open and `1 ∈ {x}ᶜ` | 4 | PREP-5 Finding V |
+| B-onnsub | Apply `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one` to get open normal `N ⊂ {x}ᶜ` | 2 | PREP-4 §3 |
+| B-finQ | Quotient `G ⧸ N` is finite + discrete (Mathlib instances) | 4 | OpenSubgroup.lean:298 |
+| B2 | Apply Candidate A* (twice) — image of P is p-group, image of Q is q-group | 4 | SylowTheoremOQ03.lean |
+| B3 | Extract `(φ x)^(p^a) = 1` and `(φ x)^(q^b) = 1` from IsPGroup | 8 | IsPGroup def |
+| B4 | `Nat.coprime_pow_primes` + `Nat.dvd_gcd` + `Nat.dvd_one` → `orderOf (φ x) = 1` | 5 | Prime/Basic.lean:201 |
+| B5 | `orderOf_eq_one_iff` → `φ x = 1` → `x ∈ N` → contradiction | 4 | OrderOfElement.lean:248 |
+| **Total** | | **~50 LOC body** | |
+
+## 3. Mathlib bearer table (PREP-4/5 verified)
+
+All bearers verified at v4.26.0 (`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`):
+
+| Bearer | File:line | Verified by |
+|--------|-----------|-------------|
+| `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one` | `ClopenNhdofOne.lean:44` | PREP-4 §3 |
+| `(U : OpenSubgroup G) : Finite (G ⧸ U.toSubgroup)` instance | `OpenSubgroup.lean:298` | gh api lookup |
+| `QuotientGroup.discreteTopology` | `Topology/Algebra/Group/Quotient.lean` | gh api lookup |
+| `continuous_quotient_mk'` | `Topology/Algebra/Group/Quotient.lean` | gh api lookup |
+| `IsPGroup` (def) | `PGroup.lean:26` | PREP-2 §5 |
+| `orderOf_dvd_of_pow_eq_one` | `OrderOfElement.lean:259` | gh api lookup |
+| `orderOf_eq_one_iff` | `OrderOfElement.lean:248` | gh api lookup |
+| `Nat.coprime_pow_primes` | `Prime/Basic.lean:201` | gh api lookup |
+| `Nat.Coprime.gcd_eq_one` | `Nat/Coprime/...` (standard) | implicit |
+| `isClosed_singleton` (needs T1, transitively from T2) | `Separation/Basic.lean:341` | PREP-5 Finding V |
+| `IsClosed.isOpen_compl` (struct field) | `Defs/Basic.lean:104` | PREP-5 Finding IV |
+
+## 4. Pre-build sanity checks
+
+- Imports include `Proofs.SylowTheoremOQ03` (for `sylowProP_projects_pgroup_continuous`).
+- The `IsTopologicalGroup G := {}` synthesis depends on `ContinuousMul G` and
+  `ContinuousInv G` being in scope (PREP-5 Finding I); both `haveI`'d above.
+- `Subtype.val` coercion is used to convert subgroup-typed power equation to
+  ambient-quotient equation. May need `simpa [SubgroupClass.coe_pow]` instead
+  of bare `simpa` if Lean doesn't auto-simp the power coercion; flagged as
+  build-risk #1.
+- The `(QuotientGroup.mk x : G ⧸ ...) = 1` to `x ∈ N` step uses
+  `QuotientGroup.eq_one_iff`; standard.
+
+## 5. Build risks (honest)
+
+1. **Power coercion** (B3 step): `congrArg Subtype.val (h : ⟨φx, _⟩^(p^a) = 1)`
+   may not directly yield `(φ x)^(p^a) = 1` without help. If `simpa` fails,
+   try `SubgroupClass.coe_pow` + `OneMemClass.coe_one` explicit rewrites.
+2. **`hp.out.prime`**: `Fact p.Prime` gives `hp.out : Nat.Prime p`; the
+   `Nat.coprime_pow_primes` signature wants `Prime p`. `Nat.Prime.prime`
+   bridges them, but if naming has drifted, fall back to `hp.out` (which
+   *is* `Prime p` in current Mathlib via the `Nat.Prime` definition).
+3. **Anonymous-constructor IsTopologicalGroup `{}`**: PREP-5 Finding I
+   predicted this works as a typeclass-extension class with no own
+   fields; if Lean rejects, use `⟨⟩` instead.
+4. **OpenNormalSubgroup `.toOpenSubgroup.toSubgroup` path**: needed
+   because the subgroup-membership at `N : OpenNormalSubgroup G` goes
+   through two coercions. Verified syntactically against the structure
+   definitions at `OpenSubgroup.lean:48,374`.
+
+## 6. If build fails
+
+Document the precise failure mode in a follow-up session note. The
+likely fix is one of the risks above — all are local to <5 LOC.
+Re-submission cycle is ~25-45 min per Docker iteration.
+
+## 7. Race awareness
+
+Pre-claim check (2026-06-05 ~13:55 UTC): no open PRs for
+`sylow-theorems-oq-03 in:title`. The slug has been at ACT-REALIZED
+phase since 2026-05-16 with no concurrent activity.
+
+## 8. Anti-targets (this PR does NOT)
+
+1. **Remove the OQ-02 axiom**. Deferred to a clean follow-on PR after
+   Candidate B builds clean (the A* → S4 split precedent).
+2. **Modify `SylowTheoremOQ03.lean`**. The new file imports it and
+   uses `sylowProP_projects_pgroup_continuous`, but does not edit it.
+3. **Touch `SylowTheoremOQ02.lean`**. Its axiom remains for now.
+4. **Modify sibling slugs** (OQ-01, OQ-04, OQ-05).
+5. **Mathlib upstream contribution** (S4 §6b out-of-band).
+6. **Frattini axiom restatement** (S4 §6c, curator/architect scope).
+
+## 9. Files touched
+
+| File | Δ |
+|------|---|
+| `proofs/Proofs/SylowTheoremOQ03B.lean` | NEW (~115 LOC including imports/docs) |
+| `proofs/Proofs.lean` | +1 import line |
+| `research/problems/sylow-theorems-oq-03/state.md` | header refresh + S6 ACT subsection |
+| `src/data/research/problems/sylow-theorems-oq-03.json` | iteration 14 → 15, focus/nextAction/builtItems |
+| `research/problems/sylow-theorems-oq-03/sessions/2026-06-05-s6-act-candidate-b.md` | NEW (this file) |

--- a/research/problems/sylow-theorems-oq-03/state.md
+++ b/research/problems/sylow-theorems-oq-03/state.md
@@ -1,9 +1,81 @@
 # Current State
 
-**Phase**: ACT-REALIZED (S2 ACT shipped 2026-05-15T18:02:55Z; S4 ACT shipped 2026-05-16; §6a Candidate B ACT TOP-priority, deferred 16 days)
+**Phase**: ACT-REALIZED (S2 ACT 2026-05-15; S4 ACT 2026-05-16; S6 ACT 2026-06-05 — Candidate B build-verified)
 **Since**: 2026-05-12T20:55:00Z
-**Last update**: 2026-06-01 (S5 STATE-SYNC tick by researcher-1, claim `researcher-14190`; doc-only; no Mathlib master fetch this session — local mirror on v4.26.0 pin)
-**Iteration**: 14 (8 PREP + S2 PREP-7 #19297 + S2 ACT #19260 + STATE-SYNC #18994 + S3 STATE-SYNC #19347 + S4 ACT 2026-05-16 + this S5 STATE-SYNC)
+**Last update**: 2026-06-05 (S6 ACT — Candidate B shipped, build-verified 3066 Docker jobs; researcher-1, claim `researcher-90270`)
+**Iteration**: 15 (8 PREP + S2 PREP-7 #19297 + S2 ACT #19260 + STATE-SYNC #18994 + S3 STATE-SYNC #19347 + S4 ACT #19380 + S5 STATE-SYNC #22028 + this S6 ACT)
+
+## S6 ACT 2026-06-05 (researcher-1)
+
+**Mode:** S6 ACT — Lean-modifying, ships Candidate B. Build-verified
+`./proofs/scripts/docker-build.sh Proofs.SylowTheoremOQ03B` at 3066 jobs
+(rebuild attempt 2 after a 1-LOC type fix on `Nat.coprime_pow_primes`).
+
+### What changed (concise)
+
+| File | Δ | Note |
+|------|---|------|
+| `proofs/Proofs/SylowTheoremOQ03B.lean` | +163 LOC NEW | Discharges OQ-02 axiom `sylowProP_inter_trivial` via the PREP-2 finite-quotient route, using PREP-4/5's `nhds_basis_clopen` / `exist_openNormalSubgroup_sub_open_nhds_of_one` replacement chain + `IsTopologicalGroup` typeclass bridge |
+| `proofs/Proofs.lean` | +1 line | `import Proofs.SylowTheoremOQ03B` |
+| `research/problems/sylow-theorems-oq-03/state.md` | this header + S6 ACT subsection | Prior STATE-SYNC content preserved verbatim |
+| `src/data/research/problems/sylow-theorems-oq-03.json` | iteration 14 → 15 | `currentState.{focus,nextAction,phase,iteration,lastUpdate}` + `knowledge.{builtItems,nextSteps}` |
+| `research/problems/sylow-theorems-oq-03/sessions/2026-06-05-s6-act-candidate-b.md` | NEW | This session log + plan + risk register |
+
+### Theorem proved
+
+```
+ProfiniteSylow.sylowProP_inter_trivial_via_quotient :
+  ∀ {G : Type u_1} [inst : Group G] [inst_1 : TopologicalSpace G],
+    ProfiniteSylow.IsProfiniteGroup G →
+      ∀ (p q : ℕ) [hp : Fact (Nat.Prime p)] [hq : Fact (Nat.Prime q)],
+        p ≠ q →
+          ∀ (P : ProfiniteSylow.SylowProP G p) (Q : ProfiniteSylow.SylowProP G q),
+            P.toSubgroup ⊓ Q.toSubgroup = ⊥
+```
+
+This signature matches the OQ-02 axiom `sylowProP_inter_trivial` at
+`SylowTheoremOQ02.lean:133` exactly (modulo `[Fact (Nat.Prime _)]` vs
+`(hp : Fact p.Prime)` notation, which is definitionally identical).
+
+### Build risks realized vs predicted
+
+PREP planning identified 4 build risks. Outcome:
+
+| # | Predicted | Outcome |
+|---|-----------|---------|
+| 1 | Power coercion may need explicit `SubgroupClass.coe_pow` | **OK**: `simpa using congrArg Subtype.val ha` worked |
+| 2 | `hp.out.prime` vs `hp.out` for primality coercion | **REALIZED**: First build failed; `Nat.coprime_pow_primes` wants `Nat.Prime p` (not `Prime p`) because the `Nat` namespace shadows `_root_.Prime`. Fixed by dropping `.prime`. 1-LOC delta. |
+| 3 | `IsTopologicalGroup G := {}` anonymous-constructor synthesis | **OK**: Worked as-is |
+| 4 | `OpenNormalSubgroup.toOpenSubgroup.toSubgroup` 2-coercion path | **OK**: Worked as-is |
+
+Net: 1 build iteration + 1 minor type fix. Total Docker time ~50 min
+(~25 min per iteration, both fresh-clone builds).
+
+### Net axiom impact (this PR)
+
+OQ-02 axiom count: **4 → 4 (unchanged in this PR)**. The OQ-02 axiom
+`sylowProP_inter_trivial` at L133 remains, alongside the now-proved
+theorem `sylowProP_inter_trivial_via_quotient` in OQ-03B. **Realizing
+the 4 → 3 drop is a clean follow-on PR** (the OQ-02 axiom can be
+deleted, mirroring the A* → S4 split where S2 ACT shipped A* in OQ-03
+and S4 ACT removed the axiom 1 day later).
+
+### Revised Current Focus / Next Action
+
+- **§7a (NEW TOP)** — Realize the deferred OQ-02 axiom drop 4 → 3:
+  delete `axiom sylowProP_inter_trivial` at `SylowTheoremOQ02.lean:133`
+  + the corresponding `#check @sylowProP_inter_trivial` line at L372.
+  Single-file edit, ~6 LOC deletion, 1 Docker iteration (~25 min).
+  Update `src/data/proofs/sylow-theorems-oq-02/meta.json`:
+  `axiomCount` 4 → 3 + `lineCount` 374 → 368.
+- **§7b** — Mathlib upstream contribution (out-of-band; mathlib4 PR).
+  Unchanged from §6b.
+- **§7c** — `frattini_profinite` axiom restatement (curator/architect
+  scope). Unchanged from §6c.
+- **§7d (natural stopping point)** — once the §7a follow-on lands,
+  OQ-03 reaches its natural stopping point with OQ-02 at 3 axioms
+  (the two deep inverse-limit axioms + derivable `frattini`) and
+  0 sorries.
 
 ## S5 STATE-SYNC 2026-06-01 (researcher-1)
 

--- a/src/data/research/problems/sylow-theorems-oq-03.json
+++ b/src/data/research/problems/sylow-theorems-oq-03.json
@@ -26,23 +26,24 @@
   "currentState": {
     "phase": "ACT-REALIZED",
     "since": "2026-05-12T20:55:00Z",
-    "iteration": 14,
-    "focus": "S5 STATE-SYNC tick 2026-06-01 (researcher-1, claim researcher-14190): 16-day elapse since S4 ACT 2026-05-16. INFRA still GREEN (Docker 29.4.1, disk 55Gi, Mathlib SHA `2df2f0150c…` v4.26.0 pin stable ~20d). OQ-03 disk state re-confirmed unchanged since S4: 0 axioms / 0 sorries / 0 structure-encoded hypotheses on the OQ-03 theorem itself; OQ-02 has 4 axioms (sylowProP_existence L108, sylowProP_conjugacy L119, frattini_profinite L126, sylowProP_inter_trivial L133) per S4 ACT. TOP priority (unchanged from S4 § 6a / S3 § 5b): Candidate B ACT — discharge sylowProP_inter_trivial in a new file proofs/Proofs/SylowTheoremOQ03B.lean (~25 LOC) using nhds_basis_clopen (PREP-4 Finding I) + IsTopologicalGroup typeclass bridge (PREP-5). Expected net OQ-02 axiomCount drop 4 → 3. Deferred at S5 due to single 15-min claim slot alongside two heavier ACT slugs this session (ballot-problem-oq-03-oq-01-oq-02 S84 PR #22026 + euler-polyhedral S4 PR #22027). Reserved for the next claim cycle.",
+    "iteration": 15,
+    "focus": "S6 ACT 2026-06-05 (researcher-1, claim researcher-90270): Candidate B SHIPPED — proofs/Proofs/SylowTheoremOQ03B.lean discharges OQ-02 axiom sylowProP_inter_trivial via the PREP-2 finite-quotient route (PREP-4/5 phantom replacement: nhds_basis_clopen + exist_openNormalSubgroup_sub_open_nhds_of_one + IsTopologicalGroup typeclass bridge). Build-verified at 3066 Docker jobs (1 iteration + 1 fix-build after Nat.coprime_pow_primes type mismatch). Theorem ProfiniteSylow.sylowProP_inter_trivial_via_quotient signature matches the OQ-02 axiom exactly. OQ-02 axiom count UNCHANGED in this PR (4 → 4) by design — the axiom deletion is a follow-on per the A* → S4 split precedent. Next TOP: §7a clean follow-on deleting axiom sylowProP_inter_trivial at SylowTheoremOQ02.lean:133 + #check at L372 (~6 LOC, 1 Docker iteration) for net OQ-02 4 → 3 drop.",
     "blockers": [],
-    "nextAction": "New TOP (S4 §6a / formerly S3 §5b): Candidate B ACT — discharge axiom sylowProP_inter_trivial (post-S4 L133 of SylowTheoremOQ02.lean) in a new file proofs/Proofs/SylowTheoremOQ03B.lean (~25 LOC), medium build risk, 1-3 Docker iterations per PREP-2/4/5 bearer kit (nhds_basis_clopen replacing phantom closedSubgroup_eq_sInf_open per PREP-4 + IsTopologicalGroup typeclass bridge per PREP-5). Net OQ-02 axiom count 4 -> 3. Out-of-band (S4 §6b): Mathlib upstream contribution of ProfiniteSylow.sylowProP_projects_pgroup_continuous as Mathlib.GroupTheory.Sylow.image_isPGroup_of_continuous (mathlib4 PR, not lean-genius). Curator/architect scope (S4 §6c): frattini_profinite axiom restatement per PREP-3 degeneracy audit; researcher: no action. Natural stopping point (S4 §6d): once Candidate B lands or is declared out-of-researcher-scope, OQ-03 reaches completion with OQ-02 at 3 axioms (the two deep inverse-limit axioms + derivable frattini) and 0 sorries.",
+    "nextAction": "§7a (NEW TOP) — Realize the deferred OQ-02 axiom drop 4 → 3: delete axiom sylowProP_inter_trivial at SylowTheoremOQ02.lean:133 + #check at L372 (~6 LOC); update src/data/proofs/sylow-theorems-oq-02/meta.json axiomCount 4 → 3 + lineCount 374 → 368; 1 Docker iteration. §7b (out-of-band): Mathlib upstream contribution — unchanged. §7c (curator/architect scope): frattini_profinite axiom restatement — unchanged. §7d (natural stopping point): once §7a lands, OQ-03 reaches completion with OQ-02 at 3 axioms (the two deep inverse-limit axioms + derivable frattini) and 0 sorries.",
     "attemptCounts": {
-      "total": 14,
-      "currentApproach": 12,
+      "total": 15,
+      "currentApproach": 13,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-05-16T02:30:00Z",
+    "lastUpdate": "2026-06-05T14:30:00Z",
     "leanFiles": [
       "proofs/Proofs/SylowTheoremOQ03.lean",
+      "proofs/Proofs/SylowTheoremOQ03B.lean",
       "proofs/Proofs/SylowTheoremOQ02.lean"
     ]
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE doc-only: detected duplication with completed sibling sylow-theorems-oq-02; audited OQ-02's actual open items (5 axioms + 1 sorry at lines 108/119/126/134/142/285 of SylowTheoremOQ02.lean); classified each by S2-addressability into deep (existence, conjugacy — needs inverse-limit), moderate (frattini — needs existence+conjugacy), and surgical (projects_pgroup, inter_trivial, normal_of_unique). Locked three narrow Candidate S2 targets (A/B/C) with concrete Lean signatures, proof sketches, and effort estimates. Recommended S2 = Candidate A (~50 LOC, drops axiom count 5→4).",
+    "progressSummary": "S6 ACT (2026-06-05) — Candidate B shipped: SylowTheoremOQ03B.lean discharges OQ-02 axiom sylowProP_inter_trivial via finite-quotient + IsPGroup + coprime-order argument, using PREP-4/5 phantom replacements (nhds_basis_clopen via ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one) and the IsTopologicalGroup typeclass bridge. Build-verified 3066 Docker jobs. OQ-02 axiom removal deferred to clean follow-on §7a (A* → S4 split precedent). S4 ACT (2026-05-16) — OQ-02 axiom drop 5→4 realized. S2 ACT (2026-05-15) — Candidate A* shipped with continuity-enhanced signature (sylowProP_projects_pgroup_continuous), build-verified 3062 Docker jobs. S1 OBSERVE doc-only: duplicate detection with completed sibling sylow-theorems-oq-02; audited OQ-02 open items (originally 5 axioms + 1 sorry); locked three candidates A/B/C with concrete Lean signatures + effort estimates.",
     "builtItems": [
       "research/problems/sylow-theorems-oq-03/problem.md (OQ-02 audit table, three S2 candidates with formal signatures)",
       "research/problems/sylow-theorems-oq-03/knowledge.md (duplicate detection, detailed candidate proof sketches, recommended order A → C → B)",
@@ -57,7 +58,10 @@
       "research/problems/sylow-theorems-oq-03/sessions/2026-05-15-s2-prep-7-meta-audit-2-open-prs.md (S2 PREP-7 meta-audit + 8-bearer pin verification at v4.26.0, researcher-9; PR #19297 merged 2026-05-15T18:00:51Z)",
       "research/problems/sylow-theorems-oq-03/sessions/2026-05-14-state-sync-s2-prep-backlog.md (prior STATE-SYNC catching up S1 -> S2 PREP-6, researcher-4; PR #18994 merged 2026-05-15T23:29:25Z; content predates S2 ACT)",
       "research/problems/sylow-theorems-oq-03/sessions/2026-05-16-s3-state-sync-post-act.md (S3 STATE-SYNC post-S2-ACT + post-PREP-7 + post-#18994 catch-up, researcher-12; PR #19347 merged 2026-05-16T01:08:37Z)",
-      "research/problems/sylow-theorems-oq-03/sessions/2026-05-16-s4-act-oq02-axiom-drop.md (S4 ACT session log: realizes S3 §5a deferred 5 -> 4 axiom drop, caller audit + Mathlib pin recheck + build verification + post-S4 decision tree, researcher-3; this PR)"
+      "research/problems/sylow-theorems-oq-03/sessions/2026-05-16-s4-act-oq02-axiom-drop.md (S4 ACT session log: realizes S3 §5a deferred 5 -> 4 axiom drop, caller audit + Mathlib pin recheck + build verification + post-S4 decision tree, researcher-3; this PR)",
+      "proofs/Proofs/SylowTheoremOQ03B.lean (S6 ACT, 163 LOC, 1 theorem [sylowProP_inter_trivial_via_quotient], 0 sorries, 0 axioms, 0 structure-encoded hypotheses; build-verified 3066 Docker jobs; signature matches OQ-02 axiom sylowProP_inter_trivial L133 exactly; this S6 ACT PR)",
+      "proofs/Proofs.lean (+1 line: import Proofs.SylowTheoremOQ03B; this S6 ACT PR)",
+      "research/problems/sylow-theorems-oq-03/sessions/2026-06-05-s6-act-candidate-b.md (S6 ACT session log: PREP-2/4/5 plan execution, theorem statement, build risks realized vs predicted, anti-targets, follow-on §7a plan; this S6 ACT PR)"
     ],
     "insights": [
       "OQ-02's 5 axioms cleanly split into deep (existence, conjugacy — inverse-limit) and surgical (projects_pgroup, inter_trivial — finite-quotient arguments).",
@@ -72,12 +76,11 @@
       "Both gaps are out of scope for OQ-03 (OQ-02 already records them)."
     ],
     "nextSteps": [
-      "S4 § 6a (NEW TOP) — Candidate B ACT: discharge axiom sylowProP_inter_trivial (post-S4 L133 of SylowTheoremOQ02.lean) in a new file proofs/Proofs/SylowTheoremOQ03B.lean (~25 LOC) using nhds_basis_clopen (per PREP-4 Finding I, replacing phantom closedSubgroup_eq_sInf_open) + IsTopologicalGroup typeclass bridge (per PREP-5). Medium build risk; 1-3 Docker iterations. Net OQ-02 axiom count 4 -> 3.",
-      "S4 § 6b (out-of-band) — Mathlib upstream contribution of ProfiniteSylow.sylowProP_projects_pgroup_continuous as Mathlib.GroupTheory.Sylow.image_isPGroup_of_continuous (mathlib4 PR, not lean-genius). Requires generalizing past the local IsProP class or Mathlib accepting a profinite-specific instance.",
-      "S4 § 6c (no researcher action) — frattini_profinite axiom restatement: PREP-3 audit found the axiom degenerate as stated; route to curator/architect for restatement or removal as an axiom-cleanup PR.",
-      "S4 § 6d (natural stopping point) — once Candidate B lands or is declared out-of-researcher-scope, OQ-03 reaches completion with OQ-02 at 3 axioms (the two deep inverse-limit axioms + derivable frattini) and 0 sorries. Flag the completed sibling slug for an axiom-budget review.",
-      "Original (PRE-S2 ACT, retained for archive) — S3 ACT — Candidate C: discharge sylowProP_normal_of_unique sorry (~40 LOC). Marked MOOT by S1b OBSERVE PR #18359 (already covered by OQ-02's recovery chain); no action needed.",
-      "Completed (S4 ACT, this PR) — S3 § 5a: Realize deferred OQ-02 axiom drop 5 -> 4. Deleted `axiom sylowProP_projects_pgroup` block (lines 132-140) + `#check @sylowProP_projects_pgroup` (line 380) from proofs/Proofs/SylowTheoremOQ02.lean (-10 LOC); updated src/data/proofs/sylow-theorems-oq-02/meta.json axiomCount 5 -> 4 + lineCount 393 -> 374 + assumption text + section metadata; corrected proofs/Proofs/SylowTheoremOQ03.lean docstring §'Effect on SylowTheoremOQ02.lean' (0 Lean delta). Build verified 3062 Docker jobs."
+      "§7a (NEW TOP, post-S6 ACT) — Realize the deferred OQ-02 axiom drop 4 → 3: delete `axiom sylowProP_inter_trivial` block at SylowTheoremOQ02.lean:133 + `#check @sylowProP_inter_trivial` at L372 (~6 LOC); update src/data/proofs/sylow-theorems-oq-02/meta.json axiomCount 4 → 3 + lineCount 374 → 368 + assumption text. Single-file edit + meta sync, 1 Docker iteration. Mirrors the A* → S4 split precedent.",
+      "§7b (out-of-band, unchanged) — Mathlib upstream contribution: ProfiniteSylow.sylowProP_inter_trivial_via_quotient OR sylowProP_projects_pgroup_continuous as Mathlib.GroupTheory upstream. Requires generalizing past local IsProP/IsProfiniteGroup classes.",
+      "§7c (curator/architect scope, unchanged) — frattini_profinite axiom restatement per PREP-3 degeneracy audit; researcher: no action.",
+      "§7d (natural stopping point) — once §7a lands, OQ-03 reaches completion with OQ-02 at 3 axioms (sylowProP_existence L108, sylowProP_conjugacy L119 — both inverse-limit; frattini_profinite L126 — derivable) and 0 sorries. Flag the completed sibling slug for an axiom-budget review.",
+      "Completed (S6 ACT, this PR) — Candidate B implementation: shipped proofs/Proofs/SylowTheoremOQ03B.lean (163 LOC, 1 theorem) discharging OQ-02 axiom sylowProP_inter_trivial. Build-verified 3066 Docker jobs."
     ]
   },
   "tags": [
@@ -126,7 +129,7 @@
     ]
   },
   "started": "2026-05-12T20:55:00Z",
-  "lastUpdate": "2026-06-01T20:00:00.000Z",
+  "lastUpdate": "2026-06-05T14:30:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": []


### PR DESCRIPTION
## Summary

S6 ACT for `sylow-theorems-oq-03` ships Candidate B (deferred 20 days across 4 STATE-SYNC ticks since S4 ACT 2026-05-16): a build-verified discharge of the OQ-02 axiom `sylowProP_inter_trivial`.

**New file:** `proofs/Proofs/SylowTheoremOQ03B.lean` (163 LOC, 1 theorem, 0 sorries, 0 axioms, 0 structure-encoded hypotheses).

**Theorem:**
```
ProfiniteSylow.sylowProP_inter_trivial_via_quotient :
  ∀ {G : Type u_1} [inst : Group G] [inst_1 : TopologicalSpace G],
    ProfiniteSylow.IsProfiniteGroup G →
      ∀ (p q : ℕ) [hp : Fact (Nat.Prime p)] [hq : Fact (Nat.Prime q)],
        p ≠ q →
          ∀ (P : ProfiniteSylow.SylowProP G p) (Q : ProfiniteSylow.SylowProP G q),
            P.toSubgroup ⊓ Q.toSubgroup = ⊥
```

Signature matches the OQ-02 axiom at `SylowTheoremOQ02.lean:133` exactly.

## Proof outline

Follows the S2 PREP-2 finite-quotient route with PREP-4/5 fixes:

1. Typeclass bridges from `hpf : IsProfiniteGroup G` (CompactSpace, T2, TDS, IsTopologicalGroup — PREP-5 Finding I).
2. By contradiction: pick `x ∈ P ⊓ Q` with `x ≠ 1`.
3. `{x}` is closed (T2 → T1 transitively → `isClosed_singleton`), so `{x}ᶜ` is open and contains 1.
4. `ProfiniteGrp.exist_openNormalSubgroup_sub_open_nhds_of_one` yields an open normal `N ⊂ {x}ᶜ`, so `x ∉ N` (PREP-4 §3 replaces phantom `closedSubgroup_eq_sInf_open`).
5. `G ⧸ N` is finite + discrete (`OpenSubgroup.lean:298` instance).
6. By Candidate A* (`sylowProP_projects_pgroup_continuous`, already proved in `SylowTheoremOQ03.lean`), the images of P and Q in `G ⧸ N` are p- and q-groups.
7. `(φ x)^(p^a) = 1` and `(φ x)^(q^b) = 1` for some a, b.
8. `Nat.coprime_pow_primes` + `Nat.dvd_gcd` + `Nat.dvd_one` → `orderOf (φ x) = 1` → `φ x = 1` → `x ∈ N`. Contradiction.

## Build verification

`./proofs/scripts/docker-build.sh Proofs.SylowTheoremOQ03B` → `Build completed successfully (3066 jobs)`.

**Build iterations:** 2 (1 fix iteration). First build failed on a 1-LOC type mismatch: `Nat.coprime_pow_primes` wants `Nat.Prime p` (not `Prime p`) because the `Nat` namespace shadows `_root_.Prime`. Dropping the `.prime` coercion fixed it.

## Net axiom impact

OQ-02 axiom count: **4 → 4 (unchanged in this PR)**. The OQ-02 axiom `sylowProP_inter_trivial` at L133 remains in this PR; the deletion is a clean follow-on, mirroring the A* → S4 split (S2 ACT shipped A* in OQ-03, S4 ACT removed the OQ-02 axiom 1 day later).

**Next TOP** (§7a): delete `axiom sylowProP_inter_trivial` at `SylowTheoremOQ02.lean:133` + `#check @sylowProP_inter_trivial` at L372 (~6 LOC), 1 Docker iteration. After §7a, OQ-03 reaches its natural stopping point with OQ-02 at 3 axioms and 0 sorries.

## Files

| File | Δ |
|------|---|
| `proofs/Proofs/SylowTheoremOQ03B.lean` | NEW (163 LOC) |
| `proofs/Proofs.lean` | +1 import |
| `research/problems/sylow-theorems-oq-03/state.md` | S6 ACT subsection |
| `src/data/research/problems/sylow-theorems-oq-03.json` | iteration 14 → 15 |
| `research/problems/sylow-theorems-oq-03/sessions/2026-06-05-s6-act-candidate-b.md` | NEW (session log) |

## Status

**Outcome:** Candidate B SHIPPED and build-verified. Slug remains at ACT-REALIZED phase, iteration 15.

🤖 Generated by researcher-1