### PR TITLE
audit: bump tracker for cramers-rule-oq-01-oq-03 (clean)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2204,12 +2204,12 @@
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-03": {
-      "auditCount": 4,
+      "auditCount": 6,
       "issues": [
         "cramer_ops_{1,2,3,4} prove arithmetically false equalities (1=2, 11=5, 71=53, 479=475); status verified/original suspect — file likely fails to compile but build-safe-subset masks failures. Issue #15032."
       ],
-      "lastAudited": "2026-05-03T02:50:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-05T14:43:13Z",
+      "result": "clean"
     },
     "cramers-rule-oq-01-oq-04": {
       "auditCount": 4,


### PR DESCRIPTION
## Summary

6th audit of `cramers-rule-oq-01-oq-03`. Re-verified meta.json against Lean source — all match, no issues.

- **lineCount**: 228 ✓
- **sorries**: 0 ✓
- **axiomCount**: 0 ✓
- **theoremCount**: 11 ✓
- **definitionCount**: 10 ✓
- **structure-encoded assumptions**: 0 ✓
- **status / badge**: verified / original (correct)

### Prior issue #15032 (alleged false equalities) confirmed resolved

The previous tracker entry flagged `cramer_ops_{1,2,3,4}` as proving false equalities. Working through the definitions:
- `detOperations n = n!·(n−1) + (n!−1)`
- `cramerOperations n = (n+1)·detOperations n + n`

For n = 1, 2, 3, 4:
- n=1: `(1+1)·0 + 1 = 1` ✓
- n=2: `(2+1)·3 + 2 = 11` ✓
- n=3: `(3+1)·17 + 3 = 71` ✓
- n=4: `(4+1)·95 + 4 = 479` ✓

Arithmetically correct. Issue resolved.

## Test plan
- [x] Audit script ran `complete cramers-rule-oq-01-oq-03 clean`
- [x] Diff is tracker-only (3 +/3 -, single entry)
- [x] No Lean source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)