### PR TITLE
audit(erdos-446): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7076,9 +7076,9 @@
     },
     "erdos-446": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T03:18:00Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-06-05T15:21:03Z",
+      "result": "clean",
       "issues": [
         "Phantom axiom narrative: \"Historical axioms: Besicovitch/Erdős\" entry claimed axioms for docstring-only sections; ford section claimed phantom ford_2008_general axiom; delta originalContributions overstated constraints; section line ranges were stale by 10-25 lines."
       ]


### PR DESCRIPTION
## Summary

Re-audited **erdos-446** (Erdős Problem #446: Density of Integers with Divisors in (n,2n)). All meta.json claims match the Lean source.

## Verification

`proofs/Proofs/Erdos446Problem.lean` — 139 lines

| Claim | meta.json | source | Match |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 4 | 4 (delta, deltaR, ford_2008_main, ford_2008_disproof) | ✓ |
| theoremCount | 2 | 2 | ✓ |
| definitionCount | 5 | 5 | ✓ |
| lineCount | 139 | 139 | ✓ |
| structure-encoded assumptions | — | 0 | ✓ |
| `True` stubs | — | 0 | ✓ |
| status | axiomatized | matches 4 stated assumptions | ✓ |

No issues found. Result: **clean**. Tracker bumped to 5th audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)