### PR TITLE
audit(erdos-32): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -6105,8 +6105,8 @@
     },
     "erdos-32": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T03:22:32Z",
+      "auditCount": 5,
+      "lastAudited": "2026-06-05T15:35:38Z",
       "result": "clean"
     },
     "erdos-320": {


### PR DESCRIPTION
## Summary

5th audit of `erdos-32` (Erdős Problem #32: Additive Complements of Primes) — **clean**.

### Verified meta.json claims match Lean source

| Claim | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 (`erdos_log_squared`, `kolountzakis_log_loglog`, `ruzsa_lower_bound`) | ✓ |
| lineCount | 264 | 264 | ✓ |
| theoremCount | 3 | 3 | ✓ |
| definitionCount | 12 | 12 | ✓ |
| status | axiomatized | 3 axioms present | ✓ |
| badge | axiom | appropriate | ✓ |

### Narrative integrity

- No True stubs
- `originalContributions` properly label axiomatizations as such
- `assumptions` field transparent: "3 axioms: erdos_log_squared, kolountzakis_log_loglog, ruzsa_lower_bound. 0 sorries."
- `erdos_32_summary` theorem combines axiom statements via `⟨erdos_log_squared, kolountzakis_log_loglog, ruzsa_lower_bound⟩` — transparently shows axiom dependency

## Test plan
- [x] sorry count matches (0)
- [x] axiom count matches (3)
- [x] line count matches (264)
- [x] no True stubs
- [x] status/badge appropriate for axiomatized proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)