### PR TITLE
audit(angle-trisection-oq-03-oq-01): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13770,12 +13770,12 @@
       "lastAudited": "2026-06-05T01:34:43Z"
     },
     "angle-trisection-oq-03-oq-01": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [
         "lineCount 123→150, theoremCount 13→12, all 5 section line ranges off by ~10 (file has been edited since enrichment); core integrity claims (verified/0 sorries/0 axioms) hold — fixed in PR"
       ],
-      "result": "issues-fixed",
-      "lastAudited": "2026-05-03T03:37:43Z"
+      "result": "clean",
+      "lastAudited": "2026-06-05T15:48:19Z"
     },
     "area-of-circle-oq-01-oq-03-oq-02": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

- Re-audited `angle-trisection-oq-03-oq-01` (Executable Constructibility Checker for Regular Polygons)
- All meta.json claims match Lean source — no integrity issues
- Tracker bumped from 1→2 audits

## Integrity checks

| Field | meta.json | Lean source | OK |
|-------|-----------|-------------|------|
| lineCount | 150 | 150 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 12 | 12 | ✓ |
| definitionCount | 2 | 2 | ✓ |
| True stubs | n/a | 0 | ✓ |

Tier A classification (verified/original) is accurate. The file uses Mathlib's `Nat.totient` / `decide` / `native_decide` infrastructure but proves its own 12 theorems (correctness of `ngonConstructible`, verified enumeration of 24 polygons up to n=100, all five known Fermat primes constructible). The `assumptions` field honestly notes the import chain includes one π-transcendence axiom for circle-squaring that none of this file's theorems depend on.

## Test plan

- [x] No source-file changes (tracker-only PR)
- [ ] CI green