### PR TITLE
research(erdos-1016): repair build + iteratedLog structural lemmas

### DIFF
--- a/proofs/Proofs/Erdos1016Problem.lean
+++ b/proofs/Proofs/Erdos1016Problem.lean
@@ -42,10 +42,61 @@ noncomputable def pancyclicExcess (n : ℕ) : ℕ :=
 
 /-- The iterated logarithm log*(n): the number of times log₂ must be
     applied to n before the result is ≤ 1. -/
-noncomputable def iteratedLog : ℕ → ℕ
+def iteratedLog : ℕ → ℕ
   | 0 => 0
   | 1 => 0
   | (n + 2) => 1 + iteratedLog (Nat.log 2 (n + 2))
+termination_by n => n
+decreasing_by
+  show Nat.log 2 (n + 2) < n + 1 + 1
+  have hlog_le : Nat.log 2 (n + 2) ≤ n + 2 := Nat.log_le_self 2 (n + 2)
+  -- Strict inequality: equality is impossible because 2^(n+2) > n+2
+  rcases lt_or_eq_of_le hlog_le with hlt | heq
+  · omega
+  · exfalso
+    have h_pow_le : (2 : ℕ) ^ Nat.log 2 (n + 2) ≤ n + 2 :=
+      Nat.pow_log_le_self 2 (by omega)
+    rw [heq] at h_pow_le
+    have h_lt : n + 2 < 2 ^ (n + 2) := Nat.lt_two_pow_self
+    omega
+
+/-! ## Iterated Logarithm Properties
+
+These are pure structural properties of `iteratedLog` (independent of the
+abstract pancyclic model). They characterize the zero fibre and positivity
+of `log*`, which are useful for any downstream formalization that needs to
+reason about the iterated logarithm regardless of which graph encoding is
+adopted for the pancyclic problem itself.
+-/
+
+/-- Defining equation of `iteratedLog` at `0`. -/
+@[simp] theorem iteratedLog_zero : iteratedLog 0 = 0 := by
+  simp [iteratedLog]
+
+/-- Defining equation of `iteratedLog` at `1`. -/
+@[simp] theorem iteratedLog_one : iteratedLog 1 = 0 := by
+  simp [iteratedLog]
+
+/-- Defining recursion of `iteratedLog` at `n + 2`. -/
+theorem iteratedLog_add_two (n : ℕ) :
+    iteratedLog (n + 2) = 1 + iteratedLog (Nat.log 2 (n + 2)) := by
+  simp [iteratedLog]
+
+/-- `iteratedLog n = 0` exactly when `n ≤ 1`. -/
+theorem iteratedLog_eq_zero_iff (n : ℕ) : iteratedLog n = 0 ↔ n ≤ 1 := by
+  match n with
+  | 0 => exact ⟨fun _ => Nat.zero_le _, fun _ => iteratedLog_zero⟩
+  | 1 => exact ⟨fun _ => Nat.le_refl _, fun _ => iteratedLog_one⟩
+  | k + 2 =>
+    refine ⟨fun h => ?_, fun h => ?_⟩
+    · rw [iteratedLog_add_two] at h; omega
+    · omega
+
+/-- `iteratedLog n ≥ 1` whenever `n ≥ 2`. -/
+theorem iteratedLog_pos {n : ℕ} (hn : 2 ≤ n) : 1 ≤ iteratedLog n := by
+  match n, hn with
+  | k + 2, _ =>
+    rw [iteratedLog_add_two]; omega
 
 /- ## Model Flaw and Consequences
 
@@ -116,7 +167,7 @@ theorem hamiltonian_edge_count :
 theorem bondy_quadratic_threshold :
     ∀ n : ℕ, n ≥ 7 → n * n / 4 ≥ n + Nat.log 2 n := by
   intro n hn
-  rcases le_or_lt n 15 with h15 | h16
+  rcases le_or_gt n 15 with h15 | h16
   · -- n ∈ {7,...,15}: compute directly
     interval_cases n <;> native_decide
   · -- n ≥ 16: n²/4 ≥ 2n and log₂ n ≤ n
@@ -124,7 +175,7 @@ theorem bondy_quadratic_threshold :
     have hq : 2 * n ≤ n * n / 4 := by
       have : 4 * (2 * n) ≤ n * n := by nlinarith
       omega
-    have hl : Nat.log 2 n ≤ n := le_of_lt (Nat.log_lt (by omega) (by omega))
+    have hl : Nat.log 2 n ≤ n := Nat.log_le_self 2 n
     omega
 
 /-- Monotonicity: adding edges preserves pancyclicity.

--- a/research/problems/erdos-1016/knowledge.md
+++ b/research/problems/erdos-1016/knowledge.md
@@ -70,7 +70,62 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### 2026-06-05 (researcher-1) — Repair build break + iteratedLog structural lemmas
+
+**Mode**: REVISIT
+**Mode of progress**: build-repair + small structural additions
+
+Discovered that `proofs/Proofs/Erdos1016Problem.lean` was broken on `main`:
+
+1. `iteratedLog` was declared `noncomputable def` without a `termination_by`
+   clause. The recursive call is on `Nat.log 2 (n + 2)` which is not a
+   structural subterm of `n`, so Lean's structural-recursion check fails
+   and well-founded recursion is required. Build error:
+   ```
+   error: Proofs/Erdos1016Problem.lean:45:18: fail to show termination for iteratedLog
+   ```
+2. `bondy_quadratic_threshold` used
+   `le_of_lt (Nat.log_lt (by omega) (by omega))` to obtain
+   `Nat.log 2 n ≤ n`. In current Mathlib (v4.26.0), `Nat.log_lt` is the
+   *iff* lemma `Nat.log b n < k ↔ n < b^k`, not a direct propositional
+   witness. Build error:
+   ```
+   error: Proofs/Erdos1016Problem.lean:156:47: Unknown constant `Nat.log_lt`
+   ```
+3. `rcases le_or_lt n 15 with …` triggered a deprecation warning
+   (`le_or_lt` → `le_or_gt`).
+
+**Repairs**:
+
+- Removed `noncomputable` from `iteratedLog` (`Nat.log` is computable) and
+  added an explicit `termination_by n => n` + `decreasing_by` block using
+  `Nat.log_le_self`, `Nat.pow_log_le_self`, and `Nat.lt_two_pow_self` to
+  rule out the `Nat.log 2 (n + 2) = n + 2` equality case.
+- Replaced the broken `Nat.log_lt` line with `Nat.log_le_self 2 n`.
+- Replaced `le_or_lt` with `le_or_gt`.
+
+**New theorems (5)**:
+
+- `iteratedLog_zero : iteratedLog 0 = 0` (`@[simp]`)
+- `iteratedLog_one : iteratedLog 1 = 0` (`@[simp]`)
+- `iteratedLog_add_two : iteratedLog (n+2) = 1 + iteratedLog (Nat.log 2 (n+2))`
+- `iteratedLog_eq_zero_iff : iteratedLog n = 0 ↔ n ≤ 1`
+- `iteratedLog_pos : 2 ≤ n → 1 ≤ iteratedLog n`
+
+These are independent of the documented `IsPancyclic` modelling flaw — they
+characterize the iterated logarithm itself and survive any future redesign
+of the graph-theoretic encoding.
+
+**Verification**: Docker build (`./proofs/scripts/docker-build.sh
+Proofs.Erdos1016Problem`) succeeds cleanly; only a pre-existing
+`unused variable edgeCount` linter warning remains.
+
+**State**: 0 sorries, 0 axioms, 12 theorems, 3 defs, 209 LOC (was 158).
+
+**Next**: Build a corrected `SimpleGraph (Fin n)` based pancyclic model in
+a separate section; the abstract `IsPancyclic` model remains as a
+documented diagnostic scaffold so the relationship between the two
+encodings stays explicit.
 
 ---
 

--- a/research/problems/erdos-1016/state.md
+++ b/research/problems/erdos-1016/state.md
@@ -1,24 +1,34 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T13:43:13.293Z
-**Iteration**: 1
+**Phase**: ACT
+**Since**: 2026-06-05
+**Iteration**: 4
 
 ## Current Focus
 
-Initial exploration of the problem.
+Pure structural properties of `iteratedLog` independent of the abstract
+pancyclic model: characterize the zero fibre and positivity.
 
 ## Active Approach
 
-None yet.
+Add small, model-agnostic arithmetic lemmas about `iteratedLog`. These
+are independent of the documented `IsPancyclic` modelling flaw, so they
+remain valid when (and if) the graph-theoretic encoding is rebuilt on
+top of `SimpleGraph (Fin n)` with `Walk.IsCycle`.
 
 ## Blockers
 
-None.
+None for `iteratedLog` lemmas.
+
+The pancyclic excess content remains blocked by the documented model
+flaw — see the file header. Real Bondy/Griffin/GKW bounds need a
+`SimpleGraph (Fin n)` reformulation (≈200 LOC).
 
 ## Next Action
 
-Begin problem exploration.
+After this iteration: consider a corrected `SimpleGraph` based model
+in a separate file or section, leaving the current abstract model as
+a diagnostic scaffold.
 
 ## Attempt Counts
 

--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -234,9 +234,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 158,
+    "lineCount": 209,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 12,
     "definitionCount": 3,
     "path": "Proofs/Erdos1016Problem.lean",
     "sorries": 0

--- a/src/data/research/problems/erdos-1016.json
+++ b/src/data/research/problems/erdos-1016.json
@@ -29,11 +29,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-01-15T13:43:13.293Z",
-    "iteration": 3,
-    "focus": "Metadata backfill aligned with the zero-axiom model-diagnostic proof file.",
+    "since": "2026-06-05T00:00:00Z",
+    "iteration": 4,
+    "focus": "Pure structural lemmas about iteratedLog and a repair of the pre-existing build break.",
     "blockers": [],
-    "nextAction": "Replace the abstract `hasCycleOfLength` model with real graph-cycle infrastructure before pursuing Bondy/Griffin/GKW bounds.",
+    "nextAction": "Build a corrected SimpleGraph (Fin n) based pancyclic model in a separate section; the abstract IsPancyclic model remains as a documented diagnostic scaffold.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 0A (false axioms removed due to model flaw), 8T proved, 0S. Model flaw documented: IsPancyclic disconnects edges from cycles.",
+    "progressSummary": "ACT: Fixed pre-existing build break on main (iteratedLog missing termination_by/decreasing_by, bondy_quadratic_threshold mis-using Nat.log_lt iff as direct witness, le_or_lt deprecation). Added 5 model-independent iteratedLog structural lemmas (zero/one/add_two as defining equations; eq_zero_iff and pos as characterizations). Now 12T, 0A, 0S, 209 LOC. Verified by Docker build.",
     "builtItems": [
       "theorem hamiltonian_edge_count: pancyclicExcess n ≥ 0 (trivial for ℕ)",
       "theorem pancyclic_monotone: IsPancyclic independent of edgeCount",
@@ -51,7 +51,12 @@
         "type": "axiom-elimination",
         "description": "Proved n²/4 ≥ n + log₂ n for n ≥ 7 — small cases by native_decide, large by nlinarith + Nat.log_lt"
       },
-      "Proved triangle_pancyclic: sSup ∅ = 0 (defining set empty due to model flaw)"
+      "Proved triangle_pancyclic: sSup ∅ = 0 (defining set empty due to model flaw)",
+      "theorem iteratedLog_zero (simp): iteratedLog 0 = 0",
+      "theorem iteratedLog_one (simp): iteratedLog 1 = 0",
+      "theorem iteratedLog_add_two: iteratedLog (n+2) = 1 + iteratedLog (Nat.log 2 (n+2))",
+      "theorem iteratedLog_eq_zero_iff: iteratedLog n = 0 ↔ n ≤ 1",
+      "theorem iteratedLog_pos: 2 ≤ n → 1 ≤ iteratedLog n"
     ],
     "insights": [
       "hamiltonian_edge_count (pancyclicExcess n ≥ 0) is trivially true for ℕ — eliminated as axiom",
@@ -65,7 +70,13 @@
       "To properly formalize, would need SimpleGraph with Walk.IsCycle and edgeFinset — about 200+ lines of infrastructure",
       "CRITICAL: small_case_4 (pancyclicExcess 4 = 1) is FALSE — pancyclicExcess n = 0 for ALL n≥1",
       "Model flaw: IsPancyclic disconnects edgeCount from hasCycle, making pancyclicExcess trivially 0",
-      "bondy_lower_bound is also FALSE under current model (0+1 < log₂(n-1) for n≥5)"
+      "bondy_lower_bound is also FALSE under current model (0+1 < log₂(n-1) for n≥5)",
+      "Fixed pre-existing build break: iteratedLog needed termination_by/decreasing_by (recursive call on Nat.log 2 (n+2), not a structural subterm of n).",
+      "Decreasing proof uses Nat.log_le_self + Nat.pow_log_le_self + Nat.lt_two_pow_self to rule out the equality case Nat.log 2 (n+2) = n+2.",
+      "Fixed pre-existing build break: bondy_quadratic_threshold used Nat.log_lt as a direct propositional witness, but the current Mathlib lemma is an iff (Nat.log b n < k ↔ n < b^k). Replaced with Nat.log_le_self, which is the direct statement needed.",
+      "Removed noncomputable from iteratedLog: Nat.log is computable and WF recursion is supported for computable defs in Lean 4. This enables decide-style reasoning for callers (though base-case evaluation still requires simp [iteratedLog] because WF recursion equations are propositional, not definitional).",
+      "Replaced deprecated le_or_lt with le_or_gt.",
+      "iteratedLog_eq_zero_iff and iteratedLog_pos are pure structural properties: independent of the abstract IsPancyclic model flaw, so they survive any future redesign of the graph-theoretic encoding."
     ],
     "mathlibGaps": [],
     "nextSteps": [
@@ -93,15 +104,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T13:43:13.294Z",
-  "lastUpdate": "2026-03-26T00:00:00Z",
+  "lastUpdate": "2026-06-05T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1016Problem.lean",
       "filename": "Erdos1016Problem.lean",
-      "lineCount": 159,
-      "theoremCount": 7,
+      "lineCount": 209,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Repair a pre-existing build break on `main` for `proofs/Proofs/Erdos1016Problem.lean`, and add 5 small structural lemmas about `iteratedLog` that are independent of the documented `IsPancyclic` modelling flaw.

## Pre-existing build break (discovered while attempting to extend the file)

Running `./proofs/scripts/docker-build.sh Proofs.Erdos1016Problem` against `main` produces:

1. **Termination failure** — `iteratedLog` is declared `noncomputable def` without a `termination_by` clause. The recursive call is on `Nat.log 2 (n + 2)`, which is not a structural subterm of `n`, so Lean's structural-recursion check fails:
   ```
   error: Proofs/Erdos1016Problem.lean:45:18: fail to show termination for iteratedLog
   ```
2. **`Nat.log_lt` unknown** — `bondy_quadratic_threshold` used `le_of_lt (Nat.log_lt (by omega) (by omega))` to get `Nat.log 2 n ≤ n`. In Mathlib v4.26.0, `Nat.log_lt` is the iff lemma `Nat.log b n < k ↔ n < b^k`, not a direct propositional witness:
   ```
   error: Proofs/Erdos1016Problem.lean:156:47: Unknown constant `Nat.log_lt`
   ```
3. **`le_or_lt` deprecation** — replaced by `le_or_gt`.

## Repairs

- Drop `noncomputable` from `iteratedLog` (`Nat.log` is computable) and add an explicit `termination_by n => n` + `decreasing_by` block using `Nat.log_le_self`, `Nat.pow_log_le_self`, and `Nat.lt_two_pow_self` to rule out the `Nat.log 2 (n + 2) = n + 2` equality case.
- Replace the broken `Nat.log_lt` usage with `Nat.log_le_self 2 n`.
- Replace `le_or_lt` with `le_or_gt`.

## New theorems (5)

All model-independent: they characterize the iterated logarithm itself and survive any future redesign of the abstract pancyclic encoding.

| Theorem | Statement |
|---|---|
| `iteratedLog_zero` (`@[simp]`) | `iteratedLog 0 = 0` |
| `iteratedLog_one` (`@[simp]`) | `iteratedLog 1 = 0` |
| `iteratedLog_add_two` | `iteratedLog (n+2) = 1 + iteratedLog (Nat.log 2 (n+2))` |
| `iteratedLog_eq_zero_iff` | `iteratedLog n = 0 ↔ n ≤ 1` |
| `iteratedLog_pos` | `2 ≤ n → 1 ≤ iteratedLog n` |

## Counts

|  | before | after |
|---|---|---|
| Theorems | 7 | 12 |
| Definitions | 3 | 3 |
| Axioms | 0 | 0 |
| Sorries | 0 | 0 |
| LOC | 158 | 209 |

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1016Problem` succeeds; the only remaining message is the pre-existing `unused variable edgeCount` linter warning on line 33.
- The documented `IsPancyclic` modelling flaw is unchanged — the new lemmas are about `iteratedLog`, not about `pancyclicExcess`.

## Status

**Outcome**: progress (build repair + 5 new theorems)
**Next Steps**: Build a corrected `SimpleGraph (Fin n)` based pancyclic model in a separate section; the abstract `IsPancyclic` model remains as a documented diagnostic scaffold so the relationship between the two encodings stays explicit.

🤖 Generated by researcher-1