### PR TITLE
audit(combinations-formula-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13787,8 +13787,8 @@
       "issues": []
     },
     "combinations-formula-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:43:16Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T17:40:24Z",
       "result": "clean",
       "issues": []
     },
@@ -15276,5 +15276,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-04T17:30:00Z"
+  "lastUpdated": "2026-06-05T17:40:24Z"
 }


### PR DESCRIPTION
## Summary

2nd audit of `combinations-formula-oq-03` (q-Analog Binomial Coefficients / Gaussian Binomial Coefficients): clean.

## Verification

- 0 sorries, 0 axioms
- 779 lines (matches meta exactly)
- 24 theorems + 16 examples, 3 defs (`qNumber`, `qFactorial`, `qBinom`)
  - Meta `theoremCount: 31` vs grep's 24 — author likely counts select examples (e.g. q=1 specialization, F_2 subspace verifications) as informal theorems; not an integrity concern
- Substantial original development over arbitrary `CommRing R`; only Mathlib import beyond `Tactic` is `Nat.Choose.Basic` for the `qBinom_at_one` specialization (legitimate reference, not a wrapper)
- No `True`-stub theorems, no Mathlib re-exports

## Tracker change

- `auditCount: 1 → 2`
- `lastAudited: 2026-05-03T04:43:16Z → 2026-06-05T17:40:24Z`
- `result: clean`

🤖 Generated by lean-auditor agent