### PR TITLE
audit(erdos-1006-oq-04): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13807,8 +13807,8 @@
       ]
     },
     "erdos-1006-oq-04": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:44:08Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T17:48:25Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-verified gallery integrity for **erdos-1006-oq-04** (Erdős #1006 OQ04: DAG Structure of the Coloring Orientation).

- **Main file** `Proofs/Erdos1006OQ04.lean`: 193 lines, 15 theorems, 0 sorries, 0 axioms
- **Companion** `Proofs/Erdos1006OQ04Decidability.lean`: 115 lines, 4 theorems + 1 definition + 1 instance, 0 sorries, 0 axioms
- Status `verified` / badge `original` — accurate
- All numeric meta fields match Lean source

### Minor finding (doc-level, not blocking)

`conclusion.summary` says "11 theorems proved" while `meta.theoremCount` (and actual count) is 15. The four additional structural theorems (`coloringOrientation_trans`, `coloringOrientation_arc_irrefl`, `coloringOrientation_arc_ne`, `coloring_same_color_not_adj`, lines 136–156) sit in Part V but aren't described in the section summary. This is narrative drift, not integrity — a future enrichment pass could refresh the conclusion text and Part V description.

## Test plan

- [x] `meta.json` numerics match Lean source
- [x] Companion file accounted for in `additionalFiles`
- [x] Status / badge accurately reflect 0-sorry, 0-axiom state
- [x] No `True` stubs or Mathlib trivial wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)