### PR TITLE
audit(erdos-1054-construction-d): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13819,8 +13819,8 @@
       "issues": []
     },
     "erdos-1054-construction-d": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:44:13Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T18:01:00Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Audit Summary

Re-verified `erdos-1054-construction-d` clean (2nd audit).

### Source vs meta.json
- 250 lines ✓
- 26 theorems ✓
- 3 definitions ✓
- 0 sorries ✓
- 0 axioms ✓
- No structure-encoded assumptions ✓
- No `True` stubs / Mathlib wrappers ✓

### Witness honesty
All concrete instances use real natural-number witnesses with `native_decide`:
- `constr_d_2..13`: witnesses 4, 9, 25, 49, 121, 169 (= p²) — arithmetic verified (1+p+p² = 7, 13, 31, 57, 133, 183)
- `mersenne_repr_1..511`: witnesses 1, 2, 4, ..., 256 (= 2^k) — Mersenne values 2^(k+1)-1

No issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)