### PR TITLE
audit(zsqrtd-neg-two): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13904,8 +13904,8 @@
       "issues": []
     },
     "zsqrtd-neg-two": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T18:18:18Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audited **zsqrtd-neg-two** (ℤ[√−2] Euclidean domain, x²+2y² representations). Source matches meta.json claims exactly — bumping tracker.

## Verification

| Check | Claimed | Actual | ✓ |
|---|---|---|---|
| Lines | 476 | 476 | ✓ |
| Theorems/lemmas | 20 | 20 | ✓ |
| Definitions | 1 | 1 (abbrev `ZsqrtNegTwo`) | ✓ |
| Sorries | 0 | 0 | ✓ |
| Axioms | 0 | 0 | ✓ |
| True stubs | n/a | 0 | ✓ |
| Status / badge | verified / original | appropriate | ✓ |

No Mathlib-wrapper red flags. Genuine Lean 4 formalization of the classical Fermat/Euler/Gauss results via Euclidean structure on ℤ[√−2] (Mathlib `Zsqrtd` library) plus the quadratic-residue / Legendre-symbol splitting argument.

Previous audit: 2026-05-03 (clean). This is the 2nd audit.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` — zsqrtd-neg-two no longer top after merge
- [x] No source files touched; only `src/data/proofs/audit-tracker.json` updated