### PR TITLE
research(chinese-remainder-non-coprime-oq-04): add Dirichlet rational form

### DIFF
--- a/proofs/Proofs/ChineseRemainderNonCoprimeOQ04.lean
+++ b/proofs/Proofs/ChineseRemainderNonCoprimeOQ04.lean
@@ -121,6 +121,32 @@ theorem nearest_integer_bound (α : ℝ) :
   use ⌊α + 1 / 2⌋
   rw [abs_le]; constructor <;> linarith [Int.floor_le (α + 1/2), Int.lt_floor_add_one (α + 1/2)]
 
+/-- **Dirichlet's theorem (rational form)**: for every α ∈ ℝ and N ≥ 1, there is a
+    rational p/q with 1 ≤ q ≤ N such that |α − p/q| < 1/(qN).
+
+    This is the textbook reformulation of `dirichlet_approximation` — dividing the
+    bound |qα − p| < 1/N by q (positive) yields the standard "1/(qN)" form, which
+    immediately implies the weaker classical |α − p/q| < 1/q² (since 1/(qN) ≤ 1/q²
+    whenever q ≤ N). The rational form is the standard input to Diophantine
+    approximation refinements (e.g., Liouville-style irrationality lower bounds and
+    the convergents of continued fractions). -/
+theorem dirichlet_approximation_rational (α : ℝ) (N : ℕ) (hN : 0 < N) :
+    ∃ p : ℤ, ∃ q : ℕ, 1 ≤ q ∧ q ≤ N ∧
+      |α - (↑p : ℝ) / (↑q : ℝ)| < 1 / ((↑q : ℝ) * (↑N : ℝ)) := by
+  obtain ⟨p, q, hq1, hqN, hbound⟩ := dirichlet_approximation α N hN
+  refine ⟨p, q, hq1, hqN, ?_⟩
+  have hq_pos : (0 : ℝ) < q := Nat.cast_pos.mpr hq1
+  have hN_pos : (0 : ℝ) < N := Nat.cast_pos.mpr hN
+  -- Rewrite α − p/q = (qα − p)/q, then |·/q| = |·|/q.
+  rw [show α - (↑p : ℝ) / ↑q = ((↑q : ℝ) * α - ↑p) / ↑q from by field_simp]
+  rw [abs_div, abs_of_pos hq_pos]
+  -- Goal: |qα − p| / q < 1 / (q * N). Multiply both sides by q*N (positive).
+  rw [div_lt_div_iff₀ hq_pos (mul_pos hq_pos hN_pos)]
+  -- From hbound : |qα − p| < 1/N, get |qα − p|·N < 1, then close by nlinarith.
+  have hbound' : |(↑q : ℝ) * α - ↑p| * (↑N : ℝ) < 1 := by
+    rw [← lt_div_iff₀ hN_pos]; exact hbound
+  nlinarith
+
 /-!
 ## Part 4: Lattice Point Theorem
 -/

--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -21,9 +21,9 @@
     "badge": "mathlib",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "defCount": 2,
-    "lineCount": 239,
+    "lineCount": 265,
     "mathlibDependencies": [
       {
         "theorem": "Fintype.exists_ne_map_eq_of_card_lt",
@@ -48,6 +48,7 @@
     ],
     "originalContributions": [
       "Full pigeonhole proof of Dirichlet's approximation theorem via fractional part binning (binFn : Fin(N+1) → Fin(N))",
+      "Rational form of Dirichlet's theorem: |α − p/q| < 1/(qN) (dirichlet_approximation_rational), the textbook formulation that immediately implies the classical |α − p/q| < 1/q² bound and feeds into continued-fraction / Liouville-style refinements",
       "Stern-Brocot mediant property: mediant lies strictly between input fractions",
       "Farey neighbor ordering: determinant 1 implies strict ordering",
       "Lattice point existence: half-open interval of length m contains a multiple of m",


### PR DESCRIPTION
## Summary

- **Added 1 new theorem** `dirichlet_approximation_rational`: the textbook rational form of Dirichlet's approximation theorem (|α − p/q| < 1/(qN)), derived as a direct corollary of the existing `dirichlet_approximation` (|qα − p| < 1/N).
- **Docker build verified** (`Proofs.ChineseRemainderNonCoprimeOQ04` ✓ 51s build, 0 errors, 0 warnings).

Counts: **16 theorems, 2 definitions, 0 axioms, 0 sorries, 265 LOC** (was 15T / 2D / 0A / 0S / 239 LOC).

## Mathematical content

The rational form |α − p/q| < 1/(qN) is the standard textbook formulation. It is equivalent to the integer form already proved here (dividing by q > 0), but it's the version that:
1. Immediately implies the classical |α − p/q| < 1/q² (since 1/(qN) ≤ 1/q² when q ≤ N).
2. Feeds directly into continued-fraction convergent theory.
3. Sets up Hurwitz's improvement (constant 1/√5, achieved by φ — already defined here).
4. Underlies Liouville-style irrationality lower bounds for algebraic numbers.

```lean
theorem dirichlet_approximation_rational (α : ℝ) (N : ℕ) (hN : 0 < N) :
    ∃ p : ℤ, ∃ q : ℕ, 1 ≤ q ∧ q ≤ N ∧
      |α - (↑p : ℝ) / (↑q : ℝ)| < 1 / ((↑q : ℝ) * (↑N : ℝ)) := by
  obtain ⟨p, q, hq1, hqN, hbound⟩ := dirichlet_approximation α N hN
  refine ⟨p, q, hq1, hqN, ?_⟩
  have hq_pos : (0 : ℝ) < q := Nat.cast_pos.mpr hq1
  have hN_pos : (0 : ℝ) < N := Nat.cast_pos.mpr hN
  rw [show α - (↑p : ℝ) / ↑q = ((↑q : ℝ) * α - ↑p) / ↑q from by field_simp]
  rw [abs_div, abs_of_pos hq_pos]
  rw [div_lt_div_iff₀ hq_pos (mul_pos hq_pos hN_pos)]
  have hbound' : |(↑q : ℝ) * α - ↑p| * (↑N : ℝ) < 1 := by
    rw [← lt_div_iff₀ hN_pos]; exact hbound
  nlinarith
```

## Test plan

- [x] Docker build of `Proofs.ChineseRemainderNonCoprimeOQ04` succeeds (0 errors, 0 warnings).
- [x] meta.json `lineCount`/`theoremCount` updated (16T / 265 LOC).
- [x] `originalContributions` extended with the rational form contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)