### PR TITLE
audit(ramsey-r4k): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13898,8 +13898,8 @@
       "issues": []
     },
     "ramsey-r4k": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T18:44:25Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- Re-audited `ramsey-r4k` (2nd audit, last 2026-05-03).
- Source: `proofs/Proofs/RamseyR4k.lean` — 587 lines, 30 theorem/lemma, 4 def, 0 `sorry`, 0 `axiom`, no `structure`/`class`, no `True` stubs.
- All meta.json claims match: `sorries=0`, `axiomCount=0`, `lineCount=587`, `theoremCount=30`, `definitionCount=4`, status `verified/original`.
- No issues found; `auditCount` 1 → 2.

## Test plan
- [x] `wc -l proofs/Proofs/RamseyR4k.lean` → 587
- [x] `grep -c "^axiom "` → 0
- [x] `grep "sorry"` → none
- [x] `grep -cE "^theorem |^lemma "` → 30
- [x] `grep -cE "^def "` → 4
- [x] No structure-encoded assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)