### PR TITLE
research(greens-theorem-oq-01-oq-02): add pathLineIntegral_neg_field

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/GreensTheoremOQ01OQ02.lean
@@ -91,6 +91,26 @@ lemma pathLineIntegral_swap_endpoints
   unfold pathLineIntegral
   exact integral_symm a b
 
+/-- **Vector-field-negation symmetry**: negating both `P` and `Q` (the components
+    of the vector field) negates the path line integral.
+
+    No integrability hypothesis is required — the unconditional
+    `intervalIntegral.integral_neg` does the work, since negating each integrand
+    coefficient pointwise commutes with integration regardless of integrability.
+    Combined with `pathLineIntegral_swap_endpoints`, this gives the basic
+    "Klein four" symmetry group of the line integral under (a) parameter
+    reversal and (b) vector-field sign flip; in particular, reversing
+    *both* simultaneously is the identity. -/
+lemma pathLineIntegral_neg_field
+    (P Q : ℝ × ℝ → ℝ) (γx γy γx' γy' : ℝ → ℝ) (a b : ℝ) :
+    pathLineIntegral (fun p => -P p) (fun p => -Q p) γx γy γx' γy' a b =
+      - pathLineIntegral P Q γx γy γx' γy' a b := by
+  unfold pathLineIntegral
+  rw [← intervalIntegral.integral_neg]
+  apply integral_congr
+  intro t _
+  ring
+
 /-!
 ## Part II: Edge Specializations (Bridge to OQ-01)
 

--- a/src/data/proofs/greens-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-02/meta.json
@@ -21,18 +21,19 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Green%27s_theorem",
     "dateAdded": "2026-05-08",
     "axiomCount": 1,
-    "lineCount": 227,
+    "lineCount": 247,
     "assumptions": "1 own axiom: greens_theorem_smooth_boundary — the planar Green's theorem for a parametrized piecewise-smooth, positively-oriented, simple closed curve bounding a measurable region. This packages the open Mathlib gap: there is no first-class statement that takes a parametrized boundary γ : [a,b] → ℝ² and a region D and asserts ∮_γ (P dx + Q dy) = ∬_D (∂Q/∂x − ∂P/∂y). Mathlib has Stokes' theorem in higher generality via differential forms on manifolds, but the specifically planar Green statement is not packaged in this form. The path-integral side is fully proved (no axioms): `pathLineIntegral` is defined directly via `intervalIntegral`, and the rectangular case is recovered by the bridge lemma `pathLineIntegral_rect_boundary_eq_rectLineIntegral`.",
     "mathlib_version": "4.26.0",
     "originalContributions": [
       "pathLineIntegral: a definition of the line integral along a parametric plane curve, expressed entirely in terms of Mathlib's intervalIntegral (no axioms)",
       "pathLineIntegral_swap_endpoints: orientation-reversal lemma via integral_symm — traversing the curve backwards negates the integral",
+      "pathLineIntegral_neg_field: vector-field-negation symmetry — negating (P, Q) negates the integral; together with pathLineIntegral_swap_endpoints this gives the Klein four symmetry under parameter reversal × field sign flip",
       "pathLineIntegral_horizontal_segment / pathLineIntegral_vertical_segment: edge specializations connecting the smooth-curve formulation to OQ-01's rectLineIntegral",
       "rectBoundaryPathIntegral: explicit four-edge counterclockwise parametrization of the rectangle boundary, each edge a smooth line segment",
       "pathLineIntegral_rect_boundary_eq_rectLineIntegral: bridge theorem proving the smooth-curve framework agrees with OQ-01's rectangular formulation on the nose",
       "greens_theorem_smooth_boundary (axiomatized): isolates the open Mathlib gap as a single axiom — the parametrized planar Green identity for a piecewise-smooth Jordan curve plus measurable region"
     ],
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 2
   },
   "crossReferences": [


### PR DESCRIPTION
## Summary

- **Added 1 new lemma** `pathLineIntegral_neg_field`: negating the vector field (P, Q) ↦ (−P, −Q) negates the line integral. No integrability hypothesis required.
- **Docker build verified** (`Proofs.GreensTheoremOQ01OQ02` ✓ 51s build, 0 errors, 0 warnings).

Counts: **6 theorems, 2 definitions, 1 axiom, 0 sorries, 247 LOC** (was 5T / 2D / 1A / 0S / 227 LOC).

## Mathematical content

Together with the existing `pathLineIntegral_swap_endpoints` (parameter reversal), this completes the basic "Klein four" symmetry group of the line integral under:

- (a) parameter reversal a ↔ b   →  ×(−1)
- (b) field sign flip (P, Q) ↦ (−P, −Q)   →  ×(−1)

Doing both simultaneously is the identity — the standard textbook sanity check that orientation conventions don't accidentally double-flip the sign. The proof uses unconditional `intervalIntegral.integral_neg` (no integrability hypothesis needed because the integrand transformation is pointwise).

```lean
lemma pathLineIntegral_neg_field
    (P Q : ℝ × ℝ → ℝ) (γx γy γx' γy' : ℝ → ℝ) (a b : ℝ) :
    pathLineIntegral (fun p => -P p) (fun p => -Q p) γx γy γx' γy' a b =
      - pathLineIntegral P Q γx γy γx' γy' a b := by
  unfold pathLineIntegral
  rw [← intervalIntegral.integral_neg]
  apply integral_congr
  intro t _
  ring
```

## Test plan

- [x] Docker build of `Proofs.GreensTheoremOQ01OQ02` succeeds.
- [x] meta.json `lineCount`/`theoremCount` updated (6T / 247 LOC).
- [x] `originalContributions` extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)