### PR TITLE
audit(picks-theorem-oq-03-product): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13892,8 +13892,8 @@
       "issues": []
     },
     "picks-theorem-oq-03-product": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T18:59:56Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audited `picks-theorem-oq-03-product` (Ehrhart Product Formulas, Quasipolynomials, Valuation Properties). Result: **clean**.

## Verification

- `grep -c sorry` → 0
- `grep -c '^axiom '` → 0
- 57 theorems / 13 definitions (12 `def` + 1 `structure QuasiPoly`)
- 604 lines (matches `meta.json`)
- `QuasiPoly.period_pos : 0 < period` — discharged by `norm_num` at both instantiations (`poly_as_quasi`, `half_segment_quasi`). Not a structure-encoded assumption.

## Skipped

- `ramsey-r4k` — blocked by open PR #22453.

## Tracker

`auditCount`: 1 → 2, `lastAudited`: 2026-06-05T18:59:56Z, `result`: clean.