### PR TITLE
audit(picks-theorem-oq-03-cross-poly): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13880,8 +13880,8 @@
       "issues": []
     },
     "picks-theorem-oq-03-cross-poly": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T19:30:42Z",
       "result": "clean",
       "issues": []
     },
@@ -15282,5 +15282,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-05T17:40:24Z"
+  "lastUpdated": "2026-06-05T19:30:42Z"
 }


### PR DESCRIPTION
## Summary

Re-audit of **picks-theorem-oq-03-cross-poly** (Cross-Polytope Ehrhart Theory: Polynomials, h*-Vectors, and Duality).

## Verification

All counts in `meta.json` match the Lean source `proofs/Proofs/PicksTheoremOQ03CrossPoly.lean`:

| Metric | meta.json | Source |
|---|---|---|
| Lines | 695 | 695 ✓ |
| Theorems | 69 | 69 ✓ |
| Definitions | 12 | 12 ✓ |
| Axioms | 0 | 0 ✓ |
| Sorries | 0 | 0 ✓ |

- No `True` stub theorems
- No `axiom` declarations
- No structures/classes with assumption-carrying fields
- Status `verified/original` confirmed

## Changes

- Bump `auditCount`: 1 → 2
- Update `lastAudited`: 2026-05-03 → 2026-06-05
- `result`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)