### PR TITLE
audit(minpoly-charpoly): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13874,8 +13874,8 @@
       "issues": []
     },
     "minpoly-charpoly": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T19:53:45Z",
       "result": "clean",
       "issues": []
     },
@@ -15282,5 +15282,5 @@
     }
   },
   "version": 1,
-  "lastUpdated": "2026-06-05T19:30:42Z"
+  "lastUpdated": "2026-06-05T19:53:45Z"
 }


### PR DESCRIPTION
## Summary

Re-audit of **minpoly-charpoly** (Minimal Polynomial vs Characteristic Polynomial of Matrices).

## Verification

All counts in `meta.json` match the Lean source `proofs/Proofs/MinpolyCharpoly.lean`:

| Metric | meta.json | Source |
|---|---|---|
| Lines | 246 | 246 ✓ |
| Theorems | 17 | 17 ✓ |
| Definitions | 0 | 0 ✓ |
| Axioms | 0 | 0 ✓ |
| Sorries | 0 | 0 ✓ |

Note: A naive `grep '^theorem'` returns 18, but one match is the text `theorem itself` on line 32 inside the file's opening docstring block (lines 5–47). True count is 17.

- No `True` stub theorems
- No `axiom` declarations
- No structures/classes with assumption-carrying fields
- Status `verified/original` confirmed

## Changes

- Bump `auditCount`: 1 → 2
- Update `lastAudited`: 2026-05-03 → 2026-06-05
- `result`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)