### PR TITLE
audit(lagrange-four-squares-waring-g2): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13868,8 +13868,8 @@
       "issues": []
     },
     "lagrange-four-squares-waring-g2": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T20:03:59Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audited `lagrange-four-squares-waring-g2` [verified/mathlib]. Result: **clean**. Bumped `auditCount` 1 → 2.

## Verification

**Main file** (`Proofs/LagrangeFourSquaresWaringG2.lean`):
- 442 lines, 0 sorries, 0 axiom declarations ✓
- 64 theorems + 5 lemmas = 69 (matches meta `theoremCount: 69`) ✓
- 8 `def`s (matches `definitionCount: 8`) ✓
- No `True` stubs, no `/-!` docstrings (uses `/-` per project convention) ✓

**Companion files** (4): combined 564 lines, all sorry-free / axiom-free; all `sorry` grep hits inside docstrings/comments:
- `LagrangeFourSquaresWaringG2OQ01.lean` (118L, 2 thms, 1 def)
- `LagrangeFourSquaresWaringG2OQ01Counting.lean` (141L, 1 thm)
- `LagrangeFourSquaresWaringG2OQ01CountingG4.lean` (155L, 1 thm, 1 def)
- `LagrangeFourSquaresWaringG2OQ01CountingG5.lean` (150L, 1 thm, 1 def)

**Mathlib dependencies** advertised in meta (`Nat.sq_add_sq`, `Nat.sqrt`) are real and load via stated imports.

Status `"verified"` + badge `"mathlib"` accurate: upper bound delegates to Mathlib's Lagrange (`Nat.sq_add_sq`); lower bound is self-contained via mod-8 analysis.

## Test plan
- [x] `git diff` is tracker-only (2 lines: auditCount + lastAudited)
- [x] No changes to Lean sources, meta.json, annotations.json