### PR TITLE
audit(inverse-galois-f20): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13862,8 +13862,8 @@
       "issues": []
     },
     "inverse-galois-f20": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T20:08:34Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
- 2nd audit of `inverse-galois-f20` (status `verified/original`) — clean.
- Verified meta.json against `proofs/Proofs/InverseGaloisF20.lean`:
  - 27 theorems (matches)
  - 0 sorries (matches)
  - 0 axioms (matches)
  - 0 structure-encoded assumptions
  - 529 lines (matches)
- Bumps `auditCount` 1 → 2 in `src/data/proofs/audit-tracker.json`.

## Test plan
- [x] `grep -cE "^(theorem|lemma) " proofs/Proofs/InverseGaloisF20.lean` → 27
- [x] `grep -c "sorry" proofs/Proofs/InverseGaloisF20.lean` → 0
- [x] `grep -c "^axiom " proofs/Proofs/InverseGaloisF20.lean` → 0
- [x] `wc -l proofs/Proofs/InverseGaloisF20.lean` → 529
- [x] No `structure`/`class` declarations encoding assumptions