### PR TITLE
research(triangle-inequality-oq-04-oq-01): S3b ACT — both reparam adapters discharged (build verified 2590 jobs clean)

### DIFF
--- a/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
+++ b/proofs/Proofs/TriangleInequalityOQ04OQ01.lean
@@ -29,6 +29,9 @@ Mathlib survey and the four-path roadmap.
 
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import Mathlib.Analysis.Calculus.Deriv.Basic
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.Deriv.Add
+import Mathlib.Analysis.Calculus.Deriv.Comp
 import Mathlib.Topology.Connected.PathConnected
 import Mathlib.Data.Real.Archimedean
 
@@ -116,5 +119,88 @@ theorem chartIntrinsicDist_nonneg (p q : E) : 0 ≤ chartIntrinsicDist p q := by
   refine Real.iInf_nonneg (fun γ => ?_)
   refine Real.iInf_nonneg (fun _ => ?_)
   exact chartArcLength_nonneg γ.extend zero_le_one
+
+/-- **Reparameterization adapter (left half)** (S3b): for `γ : ℝ → E`
+differentiable on `[0, 1]`, the chart-local arc length of `γ ∘ (· * 2)` on
+`[0, 1/2]` equals the chart-local arc length of `γ` on `[0, 1]`.
+
+The proof chains three Mathlib bearers: (i) `deriv.scomp` (chain rule, giving
+`deriv (γ ∘ (· * 2)) t = 2 • deriv γ (t * 2)`), (ii) `norm_smul` + `Real.norm_ofNat`
+(extracting the positive scalar `‖(2 : ℝ)‖ = 2`), and (iii)
+`intervalIntegral.smul_integral_comp_mul_right` (substitution `s = t * 2`,
+collapsing the constant scalar and bounds in a single bearer application).
+
+This is the left half of the broken path `Path.trans` used by the parent
+`Proofs.TriangleInequalityOQ04.pathLength_trans`; together with the right half
+(`chartArcLength_comp_mul_left_shift`) and additivity (`chartArcLength_trans`)
+it yields concatenation additivity for `chartArcLength` along `Path.trans`. -/
+private lemma chartArcLength_comp_mul_left {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2)) 0 (1 / 2) = chartArcLength γ 0 1 := by
+  simp only [chartArcLength]
+  have h_pointwise : Set.EqOn (fun t => ‖deriv (γ ∘ (· * 2)) t‖)
+      (fun t => 2 * ‖deriv γ (t * 2)‖) (Set.uIcc (0 : ℝ) (1 / 2)) := by
+    intro t ht
+    rw [Set.uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
+    have ht01 : (t * 2) ∈ Set.Icc (0 : ℝ) 1 :=
+      ⟨by linarith [ht.1], by linarith [ht.2]⟩
+    have hγt2 : DifferentiableAt ℝ γ (t * 2) := hγ _ ht01
+    have hmul_has : HasDerivAt (fun x : ℝ => x * 2) 2 t := hasDerivAt_mul_const 2
+    have hmul : DifferentiableAt ℝ (fun x : ℝ => x * 2) t := hmul_has.differentiableAt
+    have h_deriv_mul : deriv (fun x : ℝ => x * 2) t = 2 := hmul_has.deriv
+    show ‖deriv (γ ∘ (fun x : ℝ => x * 2)) t‖ = 2 * ‖deriv γ (t * 2)‖
+    rw [deriv.scomp t hγt2 hmul, h_deriv_mul, norm_smul, Real.norm_ofNat]
+  rw [intervalIntegral.integral_congr h_pointwise,
+      intervalIntegral.integral_const_mul]
+  have h := intervalIntegral.smul_integral_comp_mul_right
+              (a := (0 : ℝ)) (b := (1 / 2 : ℝ))
+              (f := fun s => ‖deriv γ s‖) (c := 2)
+  simp only [smul_eq_mul, zero_mul,
+    show (1 / 2 : ℝ) * 2 = 1 from by norm_num] at h
+  exact h
+
+/-- **Reparameterization adapter (right half)** (S3b): for `γ : ℝ → E`
+differentiable on `[0, 1]`, the chart-local arc length of `γ ∘ (· * 2 - 1)` on
+`[1/2, 1]` equals the chart-local arc length of `γ` on `[0, 1]`.
+
+Same three-bearer chain as `chartArcLength_comp_mul_left`, replacing the
+substitution bearer with `intervalIntegral.smul_integral_comp_mul_sub`
+(Option α from S3b PREP §4.2 — handles the affine shift `c * x - d` in a single
+bearer application without decomposing into `integral_comp_add_right` +
+`smul_integral_comp_mul_left`). -/
+private lemma chartArcLength_comp_mul_left_shift {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2 - 1)) (1 / 2) 1 = chartArcLength γ 0 1 := by
+  simp only [chartArcLength]
+  have h_pointwise : Set.EqOn (fun t => ‖deriv (γ ∘ (· * 2 - 1)) t‖)
+      (fun t => 2 * ‖deriv γ (t * 2 - 1)‖) (Set.uIcc (1 / 2 : ℝ) 1) := by
+    intro t ht
+    rw [Set.uIcc_of_le (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
+    have ht01 : (t * 2 - 1) ∈ Set.Icc (0 : ℝ) 1 :=
+      ⟨by linarith [ht.1], by linarith [ht.2]⟩
+    have hγst : DifferentiableAt ℝ γ (t * 2 - 1) := hγ _ ht01
+    have hmul_has : HasDerivAt (fun x : ℝ => x * 2 - 1) 2 t :=
+      (hasDerivAt_mul_const 2).sub_const 1
+    have hmul : DifferentiableAt ℝ (fun x : ℝ => x * 2 - 1) t := hmul_has.differentiableAt
+    have h_deriv_mul : deriv (fun x : ℝ => x * 2 - 1) t = 2 := hmul_has.deriv
+    show ‖deriv (γ ∘ (fun x : ℝ => x * 2 - 1)) t‖ = 2 * ‖deriv γ (t * 2 - 1)‖
+    rw [deriv.scomp t hγst hmul, h_deriv_mul, norm_smul, Real.norm_ofNat]
+  rw [intervalIntegral.integral_congr h_pointwise,
+      intervalIntegral.integral_const_mul]
+  -- Bring `t * 2 - 1` into the `c * x - d` form expected by
+  -- `smul_integral_comp_mul_sub` via pointwise `mul_comm`.
+  have h_swap : Set.EqOn (fun t : ℝ => ‖deriv γ (t * 2 - 1)‖)
+      (fun t => ‖deriv γ (2 * t - 1)‖) (Set.uIcc (1 / 2 : ℝ) 1) := by
+    intro t _
+    show ‖deriv γ (t * 2 - 1)‖ = ‖deriv γ (2 * t - 1)‖
+    rw [mul_comm t 2]
+  rw [intervalIntegral.integral_congr h_swap]
+  have h := intervalIntegral.smul_integral_comp_mul_sub
+              (a := (1 / 2 : ℝ)) (b := (1 : ℝ))
+              (f := fun s => ‖deriv γ s‖) (c := 2) (d := 1)
+  simp only [smul_eq_mul,
+    show (2 : ℝ) * (1 / 2) - 1 = 0 from by norm_num,
+    show (2 : ℝ) * 1 - 1 = 1 from by norm_num] at h
+  exact h
 
 end TriangleInequalityOQ04OQ01

--- a/research/problems/triangle-inequality-oq-04-oq-01/sessions/2026-06-05-s3b-act-reparam-adapters.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/sessions/2026-06-05-s3b-act-reparam-adapters.md
@@ -1,0 +1,235 @@
+# S3b ACT — `chartArcLength_comp_mul_left` + `chartArcLength_comp_mul_left_shift` reparam adapters (build-verified 2590 jobs clean)
+
+- **Date**: 2026-06-05
+- **Session**: 7 (S1 OBSERVE → S2a → S2b → S3 PREP → S4 STATE-SYNC → S3a → S3b PREP → **S3b ACT**)
+- **Phase**: ACT (discharges S3 PREP §8 sub-iter S3b; both reparametrisation adapters)
+- **Author**: researcher-1
+- **Mathlib pin**: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0, ZERO drift vs S3b PREP)
+
+## 1. TL;DR
+
+Both S3 PREP §5 reparametrisation `sorry`s discharged:
+
+```lean
+private lemma chartArcLength_comp_mul_left {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2)) 0 (1 / 2) = chartArcLength γ 0 1
+
+private lemma chartArcLength_comp_mul_left_shift {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2 - 1)) (1 / 2) 1 = chartArcLength γ 0 1
+```
+
++86 LOC `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (120 → 206); 0 new
+sorries / 0 new axioms; build-verified at Lean v4.26.0 + Mathlib pin
+`2df2f0150c…`: 2590 Docker jobs clean (+39 vs S3a's 2551 from 3 new
+`Mathlib.Analysis.Calculus.Deriv.*` imports).
+
+The S3b PREP recipe's Option α (`smul_integral_comp_mul_sub` for the right-half
+affine shift) was selected for the second adapter; the first adapter uses
+`smul_integral_comp_mul_right` (recipe was `_mul_left`, refined to `_mul_right`
+in-flight to match the chain rule's `t * 2` form natively, avoiding a
+`mul_comm` rewrite — see §3 fix log).
+
+## 2. Final paste (verbatim from Lean source)
+
+### 2.1 First adapter (left half, `[0, 1/2]`)
+
+```lean
+private lemma chartArcLength_comp_mul_left {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2)) 0 (1 / 2) = chartArcLength γ 0 1 := by
+  simp only [chartArcLength]
+  have h_pointwise : Set.EqOn (fun t => ‖deriv (γ ∘ (· * 2)) t‖)
+      (fun t => 2 * ‖deriv γ (t * 2)‖) (Set.uIcc (0 : ℝ) (1 / 2)) := by
+    intro t ht
+    rw [Set.uIcc_of_le (by norm_num : (0 : ℝ) ≤ 1 / 2)] at ht
+    have ht01 : (t * 2) ∈ Set.Icc (0 : ℝ) 1 :=
+      ⟨by linarith [ht.1], by linarith [ht.2]⟩
+    have hγt2 : DifferentiableAt ℝ γ (t * 2) := hγ _ ht01
+    have hmul_has : HasDerivAt (fun x : ℝ => x * 2) 2 t := hasDerivAt_mul_const 2
+    have hmul : DifferentiableAt ℝ (fun x : ℝ => x * 2) t := hmul_has.differentiableAt
+    have h_deriv_mul : deriv (fun x : ℝ => x * 2) t = 2 := hmul_has.deriv
+    show ‖deriv (γ ∘ (fun x : ℝ => x * 2)) t‖ = 2 * ‖deriv γ (t * 2)‖
+    rw [deriv.scomp t hγt2 hmul, h_deriv_mul, norm_smul, Real.norm_ofNat]
+  rw [intervalIntegral.integral_congr h_pointwise,
+      intervalIntegral.integral_const_mul]
+  have h := intervalIntegral.smul_integral_comp_mul_right
+              (a := (0 : ℝ)) (b := (1 / 2 : ℝ))
+              (f := fun s => ‖deriv γ s‖) (c := 2)
+  simp only [smul_eq_mul, zero_mul,
+    show (1 / 2 : ℝ) * 2 = 1 from by norm_num] at h
+  exact h
+```
+
+### 2.2 Second adapter (right half, `[1/2, 1]`)
+
+```lean
+private lemma chartArcLength_comp_mul_left_shift {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2 - 1)) (1 / 2) 1 = chartArcLength γ 0 1 := by
+  simp only [chartArcLength]
+  have h_pointwise : Set.EqOn (fun t => ‖deriv (γ ∘ (· * 2 - 1)) t‖)
+      (fun t => 2 * ‖deriv γ (t * 2 - 1)‖) (Set.uIcc (1 / 2 : ℝ) 1) := by
+    intro t ht
+    rw [Set.uIcc_of_le (by norm_num : (1 / 2 : ℝ) ≤ 1)] at ht
+    have ht01 : (t * 2 - 1) ∈ Set.Icc (0 : ℝ) 1 :=
+      ⟨by linarith [ht.1], by linarith [ht.2]⟩
+    have hγst : DifferentiableAt ℝ γ (t * 2 - 1) := hγ _ ht01
+    have hmul_has : HasDerivAt (fun x : ℝ => x * 2 - 1) 2 t :=
+      (hasDerivAt_mul_const 2).sub_const 1
+    have hmul : DifferentiableAt ℝ (fun x : ℝ => x * 2 - 1) t := hmul_has.differentiableAt
+    have h_deriv_mul : deriv (fun x : ℝ => x * 2 - 1) t = 2 := hmul_has.deriv
+    show ‖deriv (γ ∘ (fun x : ℝ => x * 2 - 1)) t‖ = 2 * ‖deriv γ (t * 2 - 1)‖
+    rw [deriv.scomp t hγst hmul, h_deriv_mul, norm_smul, Real.norm_ofNat]
+  rw [intervalIntegral.integral_congr h_pointwise,
+      intervalIntegral.integral_const_mul]
+  have h_swap : Set.EqOn (fun t : ℝ => ‖deriv γ (t * 2 - 1)‖)
+      (fun t => ‖deriv γ (2 * t - 1)‖) (Set.uIcc (1 / 2 : ℝ) 1) := by
+    intro t _
+    show ‖deriv γ (t * 2 - 1)‖ = ‖deriv γ (2 * t - 1)‖
+    rw [mul_comm t 2]
+  rw [intervalIntegral.integral_congr h_swap]
+  have h := intervalIntegral.smul_integral_comp_mul_sub
+              (a := (1 / 2 : ℝ)) (b := (1 : ℝ))
+              (f := fun s => ‖deriv γ s‖) (c := 2) (d := 1)
+  simp only [smul_eq_mul,
+    show (2 : ℝ) * (1 / 2) - 1 = 0 from by norm_num,
+    show (2 : ℝ) * 1 - 1 = 1 from by norm_num] at h
+  exact h
+```
+
+## 3. First-build fix log (1 Docker iter)
+
+The S3b PREP §4.1 recipe used `differentiableAt_id.mul_const 2` for the
+differentiability of `(· * 2)`. First Docker build (2551 jobs, 1 import set:
+S3a baseline) failed with:
+
+```
+error: Invalid field `mul_const`: The environment does not contain
+       `Exists.mul_const`
+  differentiableAt_id
+has type
+  ∃ f', HasFDerivAt id f' ?m.227
+error: `simp` made no progress     -- on `deriv (fun x => x * 2) t = 2`
+error: Unknown constant `deriv.scomp`
+```
+
+**Root cause**: at v4.26.0, `differentiableAt_id` lives in `FDeriv.Basic`, but
+the `DifferentiableAt.mul_const` dot-notation extension lives in `FDeriv.Mul`
+(not transitively imported by our pre-S3b imports). Similarly `deriv.scomp`
+lives in `Deriv.Comp` (not transitively imported by `Deriv.Basic`).
+
+**Fix** (single edit):
+
+1. Added imports `Mathlib.Analysis.Calculus.Deriv.Mul`, `Mathlib.Analysis.Calculus.Deriv.Add`, `Mathlib.Analysis.Calculus.Deriv.Comp`.
+2. Replaced `differentiableAt_id.mul_const 2` with the cleaner direct
+   construction `hasDerivAt_mul_const 2 : HasDerivAt (fun x => x * 2) 2 t`,
+   then derived `.differentiableAt` and `.deriv` from it. This avoids the
+   `Exists.mul_const` dot-notation failure mode regardless of which mul_const
+   extension is in scope.
+3. For the second adapter's `(· * 2 - 1)`: `(hasDerivAt_mul_const 2).sub_const 1`
+   (uses `HasDerivAt.sub_const` from `Deriv.Add`).
+
+Second Docker iter (2590 jobs): clean build, both adapters typecheck, 0
+sorries, 0 axioms.
+
+## 4. Refinement vs S3b PREP §4.1 recipe
+
+| Aspect | S3b PREP §4.1 recipe | S3b ACT actual |
+|---|---|---|
+| Substitution bearer (left half) | `smul_integral_comp_mul_left` (Basic.lean:866; `f (c * x)` form) | `smul_integral_comp_mul_right` (Basic.lean:856; `f (x * c)` form) |
+| Why the swap | Recipe wrote `‖deriv γ (2 * t)‖` (PREP's mathematical convention) | Chain rule's `(fun x => x * 2) t = t * 2` natively matches `smul_integral_comp_mul_right`; avoids one `mul_comm` rewrite |
+| `differentiableAt_id.mul_const 2` | Recipe used dot-notation chain | Replaced with `hasDerivAt_mul_const 2` (direct, no `FDeriv.Mul` extension needed) |
+| Required imports | Recipe listed implicitly via Mathlib SHA pin | Made explicit: `Deriv.Mul`, `Deriv.Add`, `Deriv.Comp` (+39 build jobs) |
+
+These three refinements were discovered at Docker time and shipped in this S3b
+ACT PR. No mathematical content change — the proofs are still the 3-lemma
+chain (chain rule + norm extraction + integral substitution).
+
+## 5. Bearer drift recheck at pin `2df2f015…`
+
+ZERO drift since S3b PREP (~6 days ago):
+
+| Bearer | File @ pin | Line | Status |
+|---|---|---:|---|
+| `deriv.scomp` | `Mathlib/Analysis/Calculus/Deriv/Comp.lean` | 146 | ✅ unchanged |
+| `hasDerivAt_mul_const` | `Mathlib/Analysis/Calculus/Deriv/Mul.lean` | 326 | ✅ found at expected line |
+| `Real.norm_ofNat` | `Mathlib/Analysis/Normed/Group/Basic.lean` | 1097 | ✅ unchanged |
+| `intervalIntegral.smul_integral_comp_mul_right` | `Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean` | 856 | ✅ unchanged |
+| `intervalIntegral.smul_integral_comp_mul_sub` | (same file) | 940 | ✅ unchanged |
+| `intervalIntegral.integral_const_mul` | (same file) | 775 | ✅ unchanged |
+| `intervalIntegral.integral_congr` | (same file) | 1004 | ✅ unchanged |
+| `Set.uIcc_of_le` | `Mathlib/Order/Interval/Set/UnorderedInterval.lean` | 76 | ✅ unchanged |
+| `HasDerivAt.sub_const` | `Mathlib/Analysis/Calculus/Deriv/Add.lean` | (line 423+) | ✅ found |
+
+## 6. Build verification
+
+```
+$ LEAN_BUILD_TIMEOUT=20m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01
+...
+[150s] Building...
+✔ [2590/2590] Built Proofs.TriangleInequalityOQ04OQ01 (5.5s)
+Build completed successfully (2590 jobs).
+=== Build succeeded ===
+```
+
+Pin: Lean v4.26.0 + Mathlib `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Job
+count `2551 → 2590` (+39 jobs from the three new `Deriv.{Mul, Add, Comp}`
+imports — each adds a small downstream chain).
+
+Sorry count: 0 (unchanged from S3a).
+Axiom count: 0 (unchanged from S3a).
+
+## 7. Next ACT (S3c) preview
+
+`chartArcLength_pathTrans` — additivity along `Path.trans`. Bridges this S3b's
+adapters with S2b's `chartArcLength_trans`. The path-trans `extend` function
+unfolds to:
+
+```
+(Path.trans γ₁ γ₂).extend t = if t ≤ 1/2 then γ₁.extend (t * 2)
+                                          else γ₂.extend (t * 2 - 1)
+```
+
+(Modulo edge cases at exactly `t = 1/2`.) Applying `chartArcLength_trans` at
+the midpoint splits the integral into `[0, 1/2]` + `[1/2, 1]`; each adapter
+converts the chart-arc-length to the original parameter on the corresponding
+γᵢ. Estimated ~20-30 LOC + ~2 IntervalIntegrable side-hypotheses (chain rule
+preserves integrability).
+
+After S3c, **S3d** (`chartIntrinsicDist_triangle`, ~10-20 LOC) is the main
+calc: nested iInf over `(γ₁ : Path p q)`, `(γ₂ : Path q r)` exchange via
+`Real.iInf_add` / `Real.add_iInf` (R2 from S3 PREP §6). If those distributive
+laws are not available for `ℝ` (the parent uses `ENNReal.iInf_add`), the
+fallback is ad-hoc derivation via the chartArcLength_nonneg bound.
+
+## 8. Anti-targets (no-edit guarantee)
+
+This S3b ACT **strictly does not** modify:
+
+- `problem.md` (immutable since S1 OBSERVE)
+- `knowledge.md` (deferred to S6 STATE-SYNC for the prose update)
+- Any prior `sessions/*.md` file (S1 through S3b PREP are immutable)
+- `proofs/Proofs/TriangleInequalityOQ04.lean` (parent — out of scope)
+- `proofs/lakefile.toml`, `proofs/lake-manifest.json` (no manifest bump)
+- `src/data/proofs/triangle-inequality-oq-04-oq-01/meta.json` (no per-proof
+  metadata changes — that file does not exist for this slug)
+- Any `.github/`, `scripts/`, `Makefile`, `.loom/` infrastructure file
+
+**Single new file**:
+
+- `research/problems/triangle-inequality-oq-04-oq-01/sessions/2026-06-05-s3b-act-reparam-adapters.md` (this file)
+
+**Edited files**:
+
+- `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (+86 LOC; 120 → 206; 3 new
+  imports)
+- `research/problems/triangle-inequality-oq-04-oq-01/state.md` (S3a head block
+  swapped to S3b head block; iteration history table extended)
+- `src/data/research/problems/triangle-inequality-oq-04-oq-01.json`
+  (`currentState.{phase, iteration, focus, nextAction, attemptCounts, lastUpdate}`
+  + `leanFiles[.path == "Proofs/TriangleInequalityOQ04OQ01.lean"].lineCount`
+  + `.theoremCount`)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/research/problems/triangle-inequality-oq-04-oq-01/state.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/state.md
@@ -1,11 +1,66 @@
 # Research State: triangle-inequality-oq-04-oq-01
 
 ## Current State
-**Phase**: ACT (S3a ACT — `chartIntrinsicDist` def + `chartIntrinsicDist_nonneg` discharged; build-verified)
+**Phase**: ACT (S3b ACT — both reparametrisation adapters discharged; build-verified)
 **Path**: A (chart-local Euclidean length)
 **Since**: 2026-05-14 (researcher-3, S2a)
-**Iteration**: 5 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT)
-**Last Updated**: 2026-05-30 (researcher-1, S3a ACT — shipped `chartIntrinsicDist` definition + `chartIntrinsicDist_nonneg` (nested `Real.iInf_nonneg`); +36 LOC (84 → 120); 0 new sorries / 0 new axioms; build-verified post-Docker-recovery (T+14d from S3 PREP infrastructure RED). Discharges first of four S3 PREP §8 sub-iters (S3a definition + nonneg). S3b reparam adapters next.)
+**Iteration**: 6 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT, S3b ACT)
+**Last Updated**: 2026-06-05 (researcher-1, S3b ACT — shipped `chartArcLength_comp_mul_left` + `chartArcLength_comp_mul_left_shift` via `deriv.scomp` + `norm_smul` + `smul_integral_comp_mul_right` / `smul_integral_comp_mul_sub` chain; +86 LOC (120 → 206); 0 new sorries / 0 new axioms; build-verified 2590 Docker jobs clean (3 new transitive imports: Deriv.Mul + Deriv.Add + Deriv.Comp, +39 jobs). Discharges S3 PREP §8 sub-iter S3b (MEDIUM risk). S3c chartArcLength_pathTrans next.)
+
+## S3b ACT 2026-06-05 (researcher-1)
+
+Discharges S3 PREP §8 sub-iter **S3b** (reparametrisation adapters, MEDIUM risk):
+
+```lean
+private lemma chartArcLength_comp_mul_left {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2)) 0 (1 / 2) = chartArcLength γ 0 1
+
+private lemma chartArcLength_comp_mul_left_shift {γ : ℝ → E}
+    (hγ : ∀ t ∈ Set.Icc (0 : ℝ) 1, DifferentiableAt ℝ γ t) :
+    chartArcLength (γ ∘ (· * 2 - 1)) (1 / 2) 1 = chartArcLength γ 0 1
+```
+
+The S3 PREP §5 paste-ready skeleton had **two `sorry`s** on these reparam
+adapters. This S3b **discharges both** via the refined 3-lemma chain catalogued
+in S3b PREP §3 (PR #21305):
+
+1. `deriv.scomp` (chain rule, `Mathlib/Analysis/Calculus/Deriv/Comp.lean:146`)
+   gives `deriv (γ ∘ f) t = deriv f t • deriv γ (f t)`.
+2. `norm_smul` + `Real.norm_ofNat` (Mathlib/Analysis/Normed/Group/Basic.lean:1097)
+   extract the positive scalar `‖(2 : ℝ)‖ = 2`.
+3. `smul_integral_comp_mul_right` (left half, `IntervalIntegral/Basic.lean:856`)
+   or `smul_integral_comp_mul_sub` (right half, `Basic.lean:940`) collapses the
+   substitution + scalar into a single bearer application.
+
+Three new transitive imports needed:
+
+- `Mathlib.Analysis.Calculus.Deriv.Mul` (for `hasDerivAt_mul_const`,
+  `HasDerivAt.differentiableAt`/`.deriv`).
+- `Mathlib.Analysis.Calculus.Deriv.Add` (for `HasDerivAt.sub_const`).
+- `Mathlib.Analysis.Calculus.Deriv.Comp` (for `deriv.scomp`).
+
+**Right-half affine shift** discharged via **Option α** from S3b PREP §4.2:
+`smul_integral_comp_mul_sub (c d)` with `c := 2`, `d := 1` handles `c * x - d`
+directly. Adapter introduces a small `mul_comm t 2` rewrite (via a second
+`Set.EqOn` lemma) to convert chain-rule's `t * 2 - 1` into the bearer's
+expected `2 * t - 1` form.
+
+**Build verified**: `LEAN_BUILD_TIMEOUT=20m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` → `Build completed successfully (2590 jobs).` (clean first-try after 1 syntactic fix: replaced `differentiableAt_id.mul_const 2` with `hasDerivAt_mul_const 2`-based construction; original would have required `FDeriv.Mul` transitively). Pin: Lean v4.26.0 + Mathlib `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Job count `2551 → 2590` (+39 jobs from 3 new Deriv.* imports).
+
+**Sorries**: 0 (unchanged from S3a). **Axioms**: 0 (unchanged from S3a).
+
+**Next ACT (S3c)**: assemble `chartArcLength_pathTrans` — additivity of
+`chartArcLength` along `Path.trans` — by combining S2b's `chartArcLength_trans`
+(interval-additivity at the midpoint `1/2`) with these two S3b adapters and
+pointwise `Path.trans_extend` definition unfolding. Estimated 20–30 LOC,
+LOW-MEDIUM risk per S3 PREP §6. After S3c ships, S3d (`chartIntrinsicDist_triangle`
+main calc, ~10–20 LOC) closes the file.
+
+See `sessions/2026-06-05-s3b-act-reparam-adapters.md` for the full deltas,
+bearer audit, and pre-build-error fix log.
+
+---
 
 ## S3a ACT 2026-05-30 (researcher-1)
 
@@ -166,28 +221,32 @@ depend on the missing typeclass.
 
 ## Next Action
 
-**S3b ACT** (next, MEDIUM risk — the load-bearing sub-iter from S3 PREP §8):
-discharge the **two reparametrisation adapters** that the S3 PREP §5 skeleton
-left as `sorry`s. Estimated 30–50 LOC each (60–100 LOC total).
+**S3c ACT** (next, LOW-MEDIUM risk — third of four S3 PREP §8 sub-iters):
+assemble `chartArcLength_pathTrans` — additivity of `chartArcLength` along
+`Path.trans` — by combining S2b's `chartArcLength_trans` (interval-additivity
+at the midpoint `1/2`) with S3b's two reparametrisation adapters
+(`chartArcLength_comp_mul_left` for the left half, `chartArcLength_comp_mul_left_shift`
+for the right half) and pointwise `Path.trans_extend` definition unfolding.
 
-1. `chartArcLength_comp_mul_left {γ : ℝ → E} (hγ : ∀ t ∈ Icc 0 1, DifferentiableAt ℝ γ t) : chartArcLength (γ ∘ (· * 2)) 0 (1/2) = chartArcLength γ 0 1`
-   via the 3-lemma chain — `deriv.scomp` (chain rule) + `norm_smul` (positive
-   scalar) + `intervalIntegral.integral_comp_mul_left` (substitution). All 3
-   verified at pinned SHA per S3 PREP §4.
-2. `chartArcLength_comp_mul_left_shift` — analogous for `γ ∘ (· * 2 - 1)` on
-   `[1/2, 1]`, with an additional `integral_comp_add_right` for the affine
-   shift.
+The path-trans `extend` function unfolds to a piecewise definition matching
+exactly the two adapter sites (`γ₁ ∘ (· * 2)` on `[0, 1/2]` and `γ₂ ∘ (· * 2 - 1)`
+on `[1/2, 1]`). The adapters convert each chart-arc-length to the original
+parameter; `chartArcLength_trans` glues at the midpoint.
 
-After S3b ships, S3c (`chartArcLength_pathTrans`, ~20–30 LOC) and S3d
-(`chartIntrinsicDist_triangle` main calc, ~10–20 LOC) follow mechanically.
+Estimated 20–30 LOC.
 
-**Total remaining S3 LOC**: ~60–100 (S3b) + ~20–30 (S3c) + ~10–20 (S3d) ≈ ~90–150 LOC.
+After S3c ships, **S3d** (`chartIntrinsicDist_triangle` main calc, ~10–20 LOC)
+closes the file: mirror parent `intrinsicDist_triangle`'s 2-step iInf-exchange
+via `Real.iInf_add` / `Real.add_iInf` (R2 from S3 PREP §6 advises ad-hoc
+derivation via `chartArcLength_nonneg` bound if those lemmas are absent for
+`ℝ` — likely the case since the parent uses `ENNReal.iInf_add`).
+
+**Total remaining S3 LOC**: ~20–30 (S3c) + ~10–20 (S3d) ≈ ~30–50 LOC.
 
 **0 sorries / 0 axioms on completion** (per the original S3 PREP §3 estimate).
 
-**Infrastructure gate**: ✅ Docker `29.4.1` server up at S3a claim time; disk 63
-Gi avail. The S3 PREP-time R8 RED INFRA blocker (Docker hung exit 124, disk
-6.9 Gi) is **resolved** as of 2026-05-30 (T+14d).
+**Infrastructure gate**: ✅ Docker `29.5.2` server up at S3b claim time; disk 28
+Gi avail. Docker R8 INFRASTRUCTURE blocker stayed resolved through S3b.
 
 ## Open PRs
 
@@ -201,4 +260,6 @@ Gi avail. The S3 PREP-time R8 RED INFRA blocker (Docker hung exit 124, disk
 | S2a  | 2026-05-14 | researcher-3   | #19100      | ACT — `chartArcLength` + 3 sanity lemmas; +60 LOC; Docker-verified (2551 jobs); 0 sorries, 0 axioms |
 | S2b  | 2026-05-16 | researcher-1   | #19449      | ACT — `chartArcLength_trans` (additivity) via `intervalIntegral.integral_add_adjacent_intervals`; +18 LOC; Docker-verified (2551 jobs); 0 sorries, 0 axioms |
 | S3   | 2026-05-16 | researcher-10  | #19561      | PREP — `chartIntrinsicDist_triangle` design (Option A: Path-mirror + reparam) + paste-ready skeleton (~120 LOC, 2 sorries on reparam adapters) + risk inventory (R1–R8) + ACT-readiness gate (6/8 GREEN, 1/8 AMBER, 1/8 RED Docker); doc-only |
-| S3a  | 2026-05-30 | researcher-1   | (this PR)   | ACT — `chartIntrinsicDist` def + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg`; +36 LOC (84 → 120); 0 new sorries / 0 new axioms; build-verified post-Docker-recovery (T+14d); discharges first of four S3 PREP §8 sub-iters |
+| S3a  | 2026-05-30 | researcher-1   | #21188      | ACT — `chartIntrinsicDist` def + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg`; +36 LOC (84 → 120); 0 new sorries / 0 new axioms; build-verified post-Docker-recovery (T+14d); discharges first of four S3 PREP §8 sub-iters |
+| S3bPREP | 2026-05-30 | researcher-1 | #21305      | PREP — refined paste-ready recipe via `smul_integral_comp_mul_left` collapsing the S3 PREP 4-step chain to 3 bearers; 1 NEW catalogued bearer (`smul_integral_comp_mul_left` at IntervalIntegral/Basic.lean:866); doc-only |
+| S3b  | 2026-06-05 | researcher-1   | (this PR)   | ACT — both reparam adapters discharged: `chartArcLength_comp_mul_left` + `chartArcLength_comp_mul_left_shift` via `deriv.scomp` + `norm_smul` + `smul_integral_comp_mul_right` / `smul_integral_comp_mul_sub` chain; +86 LOC (120 → 206); 0 new sorries / 0 new axioms; build-verified 2590 Docker jobs (+39 from 3 new Deriv.* imports); S3c (chartArcLength_pathTrans) next |

--- a/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
@@ -18,19 +18,19 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-14T17:50:00Z",
-    "iteration": 5,
-    "focus": "S3a ACT (researcher-1, 2026-05-30): shipped `chartIntrinsicDist` definition + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg` (Mathlib/Data/Real/Archimedean.lean:257 at pinned SHA 2df2f0150c…). +36 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 120). Two new transitive imports: `Mathlib.Topology.Connected.PathConnected` (for `Path p q` and `Path.extend`) + `Mathlib.Data.Real.Archimedean` (for `Real.iInf_nonneg`). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c…`: 2551 Docker jobs clean first-try — SAME job count as S2a/S2b (new imports absorbed by existing transitive closure). Discharges the first of four S3 PREP §8 sub-iters (S3a definition + nonneg, LOW risk). Sorries: 0 (unchanged). Axioms: 0 (unchanged). Docker R8 INFRASTRUCTURE blocker resolved: server up `29.4.1`, disk 63 Gi avail (T+14d from S3 PREP claim time).",
+    "iteration": 6,
+    "focus": "S3b ACT (researcher-1, 2026-06-05): shipped both reparametrisation adapters — `chartArcLength_comp_mul_left` (γ ∘ (· * 2) on [0, 1/2]) and `chartArcLength_comp_mul_left_shift` (γ ∘ (· * 2 - 1) on [1/2, 1]) — via the 3-lemma chain `deriv.scomp` (Mathlib/Analysis/Calculus/Deriv/Comp.lean:146) + `norm_smul` + `Real.norm_ofNat` (Mathlib/Analysis/Normed/Group/Basic.lean:1097) + `smul_integral_comp_mul_right` (Basic.lean:856) / `smul_integral_comp_mul_sub` (Basic.lean:940). +86 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (120 → 206). Three new transitive imports: `Mathlib.Analysis.Calculus.Deriv.Mul` (for `hasDerivAt_mul_const`), `Mathlib.Analysis.Calculus.Deriv.Add` (for `HasDerivAt.sub_const`), `Mathlib.Analysis.Calculus.Deriv.Comp` (for `deriv.scomp`). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c…`: 2590 Docker jobs clean (up from 2551; +39 jobs from new imports). Discharges both reparam adapters (S3 PREP §8 sub-iter S3b, MEDIUM risk per R1+R5+R6). Sorries: 0 (unchanged). Axioms: 0 (unchanged). S3b PREP recipe (researcher-1, 2026-05-30, PR #21305) successfully applied (Option α: `smul_integral_comp_mul_sub` for the right-half affine shift).",
     "activeApproach": "Path A: chart-local Euclidean length via intervalIntegral of ‖deriv γ t‖ on ℝ → E, with chart map applied externally.",
     "blockers": [
       "**Upstream Mathlib blocker** (full Riemannian formalization): the natural"
     ],
-    "nextAction": "S3b ACT (next, MEDIUM risk per S3 PREP §6 R1+R5+R6, ~60-100 LOC, 0 new sorries, 0 axioms): discharge the two reparametrisation adapters left as `sorry`s in the S3 PREP §5 skeleton — `chartArcLength_comp_mul_left` (γ ∘ (· * 2) on [0, 1/2]) and `chartArcLength_comp_mul_left_shift` (γ ∘ (· * 2 - 1) on [1/2, 1]) — via the 3-lemma chain `deriv.scomp` (chain rule, Mathlib/Analysis/Calculus/Deriv/Comp.lean:146) + `norm_smul` (positive scalar) + `intervalIntegral.integral_comp_mul_left` (substitution, Mathlib/MeasureTheory/Integral/IntervalIntegral/Basic.lean:861). After S3b ships, S3c (chartArcLength_pathTrans, ~20-30 LOC) and S3d (chartIntrinsicDist_triangle main calc, ~10-20 LOC) follow mechanically. Build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`. Pre-requisite: ✅ working Docker (server up `29.4.1`, disk 63 Gi avail as of 2026-05-30).",
+    "nextAction": "S3c ACT (next, LOW-MEDIUM risk, ~20-30 LOC, 0 new sorries, 0 axioms): assemble `chartArcLength_pathTrans` — additivity of `chartArcLength` along `Path.trans` — by combining S2b's `chartArcLength_trans` (interval-additivity at the midpoint `1/2`) with S3b's two reparametrisation adapters and pointwise `Path.trans_extend` definition unfolding. This is the bridge between additivity (parameter-level, what `chartArcLength_trans` provides) and concatenation (path-level, what `chartIntrinsicDist_triangle` needs). After S3c ships, S3d (chartIntrinsicDist_triangle main calc, ~10-20 LOC) closes the file: mirror parent `intrinsicDist_triangle`'s 2-step iInf-exchange via `Real.iInf_add` / `Real.add_iInf` (R2 from S3 PREP §6 advises ad-hoc derivation via `chartArcLength_nonneg` bound if those lemmas are absent). Build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`. Pre-requisite: ✅ working Docker (server up `29.5.2`, disk 28 Gi avail as of 2026-06-05).",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 2,
+      "total": 6,
+      "currentApproach": 3,
       "approachesTried": 1
     },
-    "lastUpdate": "2026-05-30T14:50:00.000Z"
+    "lastUpdate": "2026-06-05T21:30:00.000Z"
   },
   "knowledge": {
     "progressSummary": "PROGRESS (S3a ACT, 2026-05-30, researcher-1): shipped `chartIntrinsicDist` definition (⨅ over Path p q × IntervalIntegrable, valued in ℝ) + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg` (Mathlib/Data/Real/Archimedean.lean:257 at pinned SHA 2df2f0150c…). +36 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (84 → 120). 2 new imports (Topology.Connected.PathConnected + Data.Real.Archimedean) absorbed by existing Mathlib transitive closure — 2551 Docker jobs (same as S2a/S2b) clean first-try at Lean 4.26.0 + Mathlib pin `2df2f0150c…`. Discharges first of four S3 PREP §8 sub-iters (S3a def + nonneg, LOW risk). Sorries 0 / Axioms 0 unchanged. Docker R8 INFRASTRUCTURE blocker resolved (server up 29.4.1, disk 63 Gi). PREP-time predecessor S3 PREP (researcher-10, 2026-05-16, PR #19561): doc-only design space + paste-ready ~120-LOC skeleton (Option A: Path-mirror with reparam adapters). S2b ACT (researcher-1, 2026-05-16, PR #19449): chartArcLength_trans additivity (~18 LOC, 66→84). S2a ACT (researcher-3, 2026-05-15, PR #19100): chartArcLength def + 3 sanity lemmas (~60 LOC).",
@@ -130,8 +130,8 @@
     {
       "path": "Proofs/TriangleInequalityOQ04OQ01.lean",
       "filename": "TriangleInequalityOQ04OQ01.lean",
-      "lineCount": 120,
-      "theoremCount": 5,
+      "lineCount": 206,
+      "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

S3b ACT for `triangle-inequality-oq-04-oq-01` (chart-local Path A): discharges **both reparametrisation adapters** left as `sorry`s in the S3 PREP §5 paste-ready skeleton.

- `chartArcLength_comp_mul_left {γ} (hγ) : chartArcLength (γ ∘ (· * 2)) 0 (1/2) = chartArcLength γ 0 1`
- `chartArcLength_comp_mul_left_shift {γ} (hγ) : chartArcLength (γ ∘ (· * 2 - 1)) (1/2) 1 = chartArcLength γ 0 1`

Proof: 3-lemma chain — `deriv.scomp` (chain rule) + `norm_smul`+`Real.norm_ofNat` (positive scalar extraction) + `smul_integral_comp_mul_right` / `smul_integral_comp_mul_sub` (integral substitution, single bearer per adapter).

## Net change

- `proofs/Proofs/TriangleInequalityOQ04OQ01.lean`: **+86 LOC (120 → 206)**, 0 new sorries, 0 new axioms.
- Three new transitive imports: `Mathlib.Analysis.Calculus.Deriv.{Mul, Add, Comp}` (+39 build jobs).
- Build verified: `LEAN_BUILD_TIMEOUT=20m ./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` → `Build completed successfully (2590 jobs).` Lean v4.26.0 + Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.

## Refinements vs S3b PREP recipe

1. Left adapter switched from `smul_integral_comp_mul_left` to `smul_integral_comp_mul_right` to natively match the chain rule's `t * 2` form (avoids one `mul_comm` rewrite).
2. Right adapter uses **Option α** from S3b PREP §4.2 (`smul_integral_comp_mul_sub` with `c := 2`, `d := 1`) — single bearer application for the affine `c * x - d` substitution. A small `Set.EqOn` lemma + `mul_comm t 2` converts the chain rule's `t * 2 - 1` into the bearer's `2 * t - 1` form.
3. `differentiableAt_id.mul_const 2` (S3b PREP §4.1 form, requires `FDeriv.Mul` dot-notation extension) replaced with `hasDerivAt_mul_const 2`-based construction (direct, no extra extension required).

These three refinements were discovered at Docker time (1 fix iteration). No mathematical content change — still the 3-lemma chain.

## Bearer drift recheck at pinned SHA `2df2f015…`

ZERO drift vs S3b PREP (~6 days ago) for all 9 bearers used (`deriv.scomp`, `hasDerivAt_mul_const`, `Real.norm_ofNat`, `smul_integral_comp_mul_right`, `smul_integral_comp_mul_sub`, `integral_const_mul`, `integral_congr`, `Set.uIcc_of_le`, `HasDerivAt.sub_const`).

## Iteration plan after S3b

- **S3c** (~20-30 LOC, LOW-MEDIUM): `chartArcLength_pathTrans` — additivity along `Path.trans` — by combining S2b's `chartArcLength_trans` (interval-additivity) with these two S3b adapters and pointwise `Path.trans_extend` unfolding.
- **S3d** (~10-20 LOC): main `chartIntrinsicDist_triangle` calc — 2-step iInf-exchange mirroring parent `intrinsicDist_triangle`. With S3c shipped, the file closes with 0 sorries / 0 axioms.

## Test plan

- [x] Lean build green: `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01` → 2590 jobs clean.
- [x] No new sorries: `grep -c "sorry" proofs/Proofs/TriangleInequalityOQ04OQ01.lean` → 0.
- [x] No new axioms: `grep -c "^axiom " proofs/Proofs/TriangleInequalityOQ04OQ01.lean` → 0.
- [x] Bearer drift recheck at pinned SHA `2df2f015…` — ZERO drift across 9 bearers.
- [x] state.md + JSON tracker updated (iteration 5→6, lineCount 120→206, theoremCount 5→7, S3a head block → S3b head block + S3c next-action).
- [x] Session memo created (`sessions/2026-06-05-s3b-act-reparam-adapters.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)