### PR TITLE
audit(erdos-1214): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13837,8 +13837,8 @@
       "issues": []
     },
     "erdos-1214": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T20:40:15Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Second audit of `erdos-1214` gallery entry — clean.

## Verification

Re-checked `src/data/proofs/erdos-1214/meta.json` against
`proofs/Proofs/Erdos1214Problem.lean`:

| field | meta | actual |
|---|---|---|
| lineCount | 308 | 308 ✓ |
| theoremCount | 26 | 26 ✓ |
| definitionCount | 1 | 1 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 2 | 2 ✓ |

The single `grep -c sorry` hit is in the docstring text
"Key results proved (no sorry):" at L292 — not a real `sorry`.

Both axioms are bare declarations (no structure-encoded
assumptions, per project Axiom Integrity Policy):
- `corrales_schoof` @ L193
- `zsygmondy` @ L253

Status [axiomatized/axiom] correctly reflects the two assumptions.

## Tracker bump

- `auditCount`: 1 → 2
- `lastAudited`: 2026-06-05T20:39:51Z
- `result`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)