### PR TITLE
audit(erdos-1056-oq-01): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13831,8 +13831,8 @@
       "issues": []
     },
     "erdos-1056-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T21:04:51Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Second audit of `erdos-1056-oq-01` gallery entry — clean.

## Verification

Re-checked `src/data/proofs/erdos-1056-oq-01/meta.json` against
`proofs/Proofs/Erdos1056OQ01.lean`:

| field | meta | actual |
|---|---|---|
| lineCount | 446 | 446 ✓ |
| theoremCount | 65 | 65 ✓ |
| definitionCount | 10 | 10 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |

No bare `axiom` declarations; no structure/class encoding
assumptions per project Axiom Integrity Policy.

Status [verified/original] correctly reflects the fully-discharged
proof.

## Tracker bump

- `auditCount`: 1 → 2
- `lastAudited`: 2026-06-05T21:04:02Z
- `result`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)