### PR TITLE
audit(erdos-1054-oq-01-fnorm): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13825,8 +13825,8 @@
       "issues": []
     },
     "erdos-1054-oq-01-fnorm": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T04:51:00Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T21:18:45Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audit of `erdos-1054-oq-01-fnorm` — partial-progress formalization of Erdős #1054 OQ-01 via the sigma bound $f(\sigma(m)) \leq m$. All integrity checks pass; tracker bumped to `auditCount: 2`, result `clean`.

## Integrity Checks

- **0 sorries** — meta.json claim matches Lean source
- **0 axioms** — no `axiom` declarations, no assumption-carrying structures
- **49 theorems** — matches meta.json `theoremCount`
- **521 lines** — matches meta.json `lineCount`
- **5 definitions** — matches meta.json `definitionCount`
- **No True stubs** — no `: True :=` or `:= trivial` placeholder theorems
- **Status / badge** — `verified` / `original` consistent with kernel state (Tier A; no axiom or sorry-laden core theorem)
- **Claim scope** — description and conclusion correctly scope the result to $f(\sigma(m)) \leq m$ and density along superabundant σ-values; the full OQ-01 (density-1) is explicitly noted as open
- **Mathlib reliance** — `Nat.divisors` is used as a definitional building block for `partialDivisorSums`, not as a wrapper for the main theorem. Badge `original` (not `mathlib`) is appropriate
- **Open problem framing** — title says "Partial Progress" via "f(n) = o(n) via Sigma Bound"; key insights explicitly distinguish what is proved (sigma bound, σ-subsequence o(n)) from what remains open (density-1 conjecture)

## Test plan

- [x] Tracker JSON valid (single-key diff, count `1→2`, ISO timestamp)
- [x] No other repository state mutated
🤖 Generated with [Claude Code](https://claude.com/claude-code)