### PR TITLE
Aristotle: adopt Harmonic StatementOnly file format + enforce in preprocessor

### DIFF
--- a/proofs/Proofs/SumOfOddsStatementOnly.lean
+++ b/proofs/Proofs/SumOfOddsStatementOnly.lean
@@ -1,0 +1,66 @@
+/-
+Sum of the first n odd natural numbers.
+
+Statement: For every natural number n,
+    1 + 3 + 5 + ... + (2n - 1) = n²
+
+Formally: ∑ k ∈ Finset.range n, (2 * k + 1) = n ^ 2.
+
+This is the classic arithmetic identity due to Pythagoras (the "gnomon"
+argument: each successive odd number completes a larger square).  It is
+used here as a small, well-known sanity check for the Harmonic
+`StatementOnly_*.lean` Aristotle submission format.
+
+Answer: n²
+-/
+
+import Mathlib
+
+open scoped BigOperators
+open scoped Nat
+open scoped Classical
+
+set_option maxHeartbeats 0
+set_option maxRecDepth 4000
+set_option synthInstance.maxHeartbeats 20000
+set_option synthInstance.maxSize 128
+set_option pp.fullNames true
+set_option pp.structureInstances true
+set_option relaxedAutoImplicit false
+set_option autoImplicit false
+set_option pp.coercions.types true
+set_option pp.funBinderTypes true
+set_option pp.letVarTypes true
+set_option pp.piBinderTypes true
+set_option linter.all false
+
+noncomputable section
+
+namespace SumOfOddsStatement
+
+/--
+The sum of the first `n` odd natural numbers equals `n ^ 2`.
+
+This is a classic identity (Pythagoras' gnomon argument):
+`1 + 3 + 5 + ... + (2 n - 1) = n²`.
+
+Included here as a documented example of the Harmonic
+`StatementOnly_*.lean` file format used for Aristotle submissions:
+- single informal `/-` block at the top of the file,
+- standard `set_option` block (verbatim from Harmonic),
+- `noncomputable section` wrapper,
+- exactly one theorem statement (proof body left as a hole),
+- optional `-- Proof attempt:` scaffolding (Rivin pattern).
+-/
+theorem sum_of_first_n_odds (n : ℕ) :
+    ∑ k ∈ Finset.range n, (2 * k + 1) = n ^ 2 := by
+  sorry
+
+-- Proof attempt: a sketch of the expected argument. Aristotle is free to
+-- ignore this; it exists only to seed the MCTS prior.
+-- 1. Induct on n. The base case n = 0 is `Finset.sum_range_zero` and `0 ^ 2 = 0`.
+-- 2. For the step, use `Finset.sum_range_succ` to peel off the (n+1)-th term:
+--      ∑ k ∈ range (n+1), (2 k + 1) = (∑ k ∈ range n, (2 k + 1)) + (2 n + 1).
+--    Apply the IH and `ring` to conclude `n ^ 2 + (2 n + 1) = (n + 1) ^ 2`.
+
+end SumOfOddsStatement

--- a/scripts/aristotle/find-candidates.sh
+++ b/scripts/aristotle/find-candidates.sh
@@ -9,12 +9,16 @@
 #   ./find-candidates.sh --json       # Output as JSON
 #   ./find-candidates.sh --tier1-only # Return only companion files (Tier 1)
 #
-# Two-tier candidate system:
-#   Tier 1 (preferred): *Aristotle.lean companion files
+# Three-tier candidate system:
+#   Tier 0 (highest priority): *StatementOnly.lean files (Harmonic format)
+#     - One theorem per file with informal /- problem block and standard set_option block
+#     - Mirrors Harmonic's HarmonicLean/StatementOnly_*.lean convention
+#     - Score = theorem_sorries only
+#   Tier 1: *Aristotle.lean companion files
 #     - Purpose-built for Aristotle: only routine lemma sorries, no axioms
 #     - Created by Researchers alongside main proof files
 #     - Score = theorem_sorries only (no axiom penalty)
-#   Tier 2 (fallback): Research output files (non-Erdos, non-Test, non-Aristotle)
+#   Tier 2 (fallback): Research output files (non-Erdos, non-Test, non-Aristotle, non-StatementOnly)
 #     - Researcher-produced files with complete definitions and routine lemma sorries
 #     - Score = theorem_sorries only
 #
@@ -109,7 +113,7 @@ get_blocked_files() {
 }
 
 # Analyze a single file. Returns score -1 for hard rejects.
-# Args: file, tier (1 or 2)
+# Args: file, tier (0, 1 or 2)
 analyze_file() {
     local file="$1"
     local tier="${2:-2}"
@@ -200,6 +204,18 @@ main() {
 
     local candidate_data=()
 
+    # Tier 0: StatementOnly files (*StatementOnly.lean) — Harmonic format
+    local tier0_files=()
+    while IFS= read -r f; do
+        tier0_files+=("$f")
+    done < <(find "$PROOFS_DIR" -name "*StatementOnly.lean" -type f 2>/dev/null | sort)
+
+    if [[ ${#tier0_files[@]} -gt 0 ]]; then
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && candidate_data+=("$line")
+        done < <(collect_candidates 0 "$submitted_files" "$blocked_files" "${tier0_files[@]}")
+    fi
+
     # Tier 1: Companion files (*Aristotle.lean)
     local tier1_files=()
     while IFS= read -r f; do
@@ -218,7 +234,7 @@ main() {
         while IFS= read -r f; do
             tier2_files+=("$f")
         done < <(find "$PROOFS_DIR" -name "*.lean" -type f \
-            ! -name "Erdos*" ! -name "Test*" ! -name "*Aristotle.lean" \
+            ! -name "Erdos*" ! -name "Test*" ! -name "*Aristotle.lean" ! -name "*StatementOnly.lean" \
             2>/dev/null | sort)
 
         if [[ ${#tier2_files[@]} -gt 0 ]]; then
@@ -265,6 +281,12 @@ main() {
             else
                 echo ","
             fi
+            # companion_file is true for Tier 0 (StatementOnly) AND Tier 1 (Aristotle).
+            # Both are purpose-built files for Aristotle submission.
+            local companion_flag="false"
+            if [[ "$tier" -eq 0 || "$tier" -eq 1 ]]; then
+                companion_flag="true"
+            fi
             cat <<EOF
   {
     "file": "proofs/Proofs/${name}.lean",
@@ -274,7 +296,7 @@ main() {
     "theorem_sorries": $thm,
     "score": $score,
     "tier": $tier,
-    "companion_file": $([ "$tier" -eq 1 ] && echo "true" || echo "false")
+    "companion_file": $companion_flag
   }
 EOF
         done <<< "$sorted_data"
@@ -289,20 +311,27 @@ EOF
         while IFS='|' read -r name total def axiom thm score tier; do
             [[ -z "$name" ]] && continue
             local tier_label
-            [[ "$tier" -eq 1 ]] && tier_label="T1" || tier_label="T2"
+            case "$tier" in
+                0) tier_label="T0" ;;
+                1) tier_label="T1" ;;
+                *) tier_label="T2" ;;
+            esac
             printf "%-40s %5s %8d %8d %8d %8d\n" "$name" "$tier_label" "$total" "$def" "$axiom" "$score"
         done <<< "$sorted_data"
 
-        local total_count tier1_count tier2_count
+        local total_count tier0_count tier1_count tier2_count
         total_count=$(echo "$sorted_data" | grep -c '|' 2>/dev/null; true)
+        tier0_count=$(echo "$sorted_data" | grep -c '|0$' 2>/dev/null; true)
         tier1_count=$(echo "$sorted_data" | grep -c '|1$' 2>/dev/null; true)
         tier2_count=$(echo "$sorted_data" | grep -c '|2$' 2>/dev/null; true)
         total_count="${total_count:-0}"
+        tier0_count="${tier0_count:-0}"
         tier1_count="${tier1_count:-0}"
         tier2_count="${tier2_count:-0}"
         echo ""
-        echo "Total candidates: $total_count (T1 companion: $tier1_count, T2 regular: $tier2_count)"
-        echo "T1 companion files are preferred. T2 research output files are fallback when T1 slots exhausted."
+        echo "Total candidates: $total_count (T0 statement-only: $tier0_count, T1 companion: $tier1_count, T2 regular: $tier2_count)"
+        echo "T0 StatementOnly files (Harmonic format) have top priority. T1 companion files are next."
+        echo "T2 research output files are fallback when T0+T1 slots exhausted."
         echo "Best candidates have low score (few sorries, no def sorries)"
     fi
 }

--- a/scripts/aristotle/preprocess-for-aristotle.sh
+++ b/scripts/aristotle/preprocess-for-aristotle.sh
@@ -4,11 +4,19 @@
 #
 # Takes a Lean file, creates a preprocessed temp copy with:
 #   - /-! docstrings converted to /- (Aristotle parser compat)
+#   - Standard Harmonic-style set_option block injected after imports if missing
+#     (applies to all files; idempotent if already present)
+#
+# Additional checks for *StatementOnly.lean files (Harmonic format):
+#   - Warns if there is no /- informal-problem block at the top of the file
+#   - Rejects (exit 1) if the file has more than one top-level
+#     `theorem|lemma ... := by sorry` (Harmonic recommends one theorem per submission)
 #
 # Rejects (exit 1):
 #   - Files with definition sorries (unfixable, blocks dependent theorems)
 #   - Files where ALL sorries are placeholder "True" theorems (no value)
 #   - Files with zero sorries after preprocessing (nothing to prove)
+#   - *StatementOnly.lean files with multiple top-level theorem/lemma sorries
 #
 # Output:
 #   Last line of stdout = path to preprocessed temp file
@@ -36,6 +44,13 @@ if [[ ! -f "$INPUT_FILE" ]]; then
     exit 1
 fi
 
+# Detect whether this file follows the Harmonic StatementOnly convention.
+# Convention: filename ends with StatementOnly.lean (e.g. FooStatementOnly.lean)
+IS_STATEMENT_ONLY=false
+if [[ "$(basename "$INPUT_FILE")" == *StatementOnly.lean ]]; then
+    IS_STATEMENT_ONLY=true
+fi
+
 # Helper: count grep matches safely (grep -c exits 1 on 0 matches)
 count_matches() {
     grep -cE "$1" "$2" 2>/dev/null || true
@@ -58,6 +73,25 @@ true_thm_sorry=$(count_matches "^(theorem|lemma)[[:space:]].*:[[:space:]]*True[[
 if [[ "$total_thm_sorry" -gt 0 && "$total_thm_sorry" -eq "$true_thm_sorry" ]]; then
     echo "REJECT: All $total_thm_sorry theorem sorries are placeholder 'True' theorems (no value)" >&2
     exit 1
+fi
+
+# StatementOnly: enforce one theorem-with-sorry per file.
+# A "theorem/lemma sorry" is a top-level declaration that ends with `sorry`,
+# which we approximate by `theorem|lemma ... := by sorry` (the canonical form
+# Harmonic uses). We also allow the bare-term form `:= sorry`.
+if [[ "$IS_STATEMENT_ONLY" == true ]]; then
+    multi_sorry_count=$(count_matches "^(theorem|lemma)[[:space:]].*:=[[:space:]]*(by[[:space:]]+)?sorry[[:space:]]*$" "$INPUT_FILE")
+    # Fall back to the broader pattern if the strict form turned up zero — this
+    # covers multi-line declarations where `:= by sorry` is on its own line.
+    if [[ "$multi_sorry_count" -eq 0 ]]; then
+        multi_sorry_count="$total_thm_sorry"
+    fi
+    if [[ "$multi_sorry_count" -gt 1 ]]; then
+        echo "REJECT: multi-sorry file (Harmonic recommends one theorem per submission)" >&2
+        echo "  Found $multi_sorry_count theorem/lemma sorries in $(basename "$INPUT_FILE")" >&2
+        grep -nE "^(theorem|lemma)[[:space:]].*sorry" "$INPUT_FILE" >&2 || true
+        exit 1
+    fi
 fi
 
 # --- Create preprocessed copy ---
@@ -84,6 +118,80 @@ if [[ "$docstring_count" -gt 0 ]]; then
     mv "$tmp_file.tmp" "$tmp_file"
     echo "PREPROCESS: Converted $docstring_count /-! docstrings to /-" >&2
     changes_made=$((changes_made + docstring_count))
+fi
+
+# Transform 2: Inject the standard Harmonic set_option block if absent.
+# Detection: we look for `set_option maxHeartbeats 0` as the canonical marker
+# (it is the most important option in the block and the most likely to be
+# missing).  If absent, we insert the full block after the last `import` line
+# and before any `namespace`/`open`/`set_option`/`noncomputable section` lines.
+if ! grep -qE "^set_option[[:space:]]+maxHeartbeats[[:space:]]+0([[:space:]]|$)" "$tmp_file"; then
+    # Locate the last `import` line. If there is none, insert at the top of the
+    # file (line 0 — i.e. as a leading block).
+    last_import_line=$(grep -nE "^import[[:space:]]" "$tmp_file" | tail -1 | cut -d: -f1 || true)
+    insert_after="${last_import_line:-0}"
+
+    # Write the set_option block to a sidecar file so we can read it from
+    # awk without dealing with multi-line shell quoting (awk -v rejects
+    # embedded newlines in variable values).
+    block_file="$tmp_dir/.set_option_block"
+    cat > "$block_file" <<'BLOCK_EOF'
+
+set_option maxHeartbeats 0
+set_option maxRecDepth 4000
+set_option synthInstance.maxHeartbeats 20000
+set_option synthInstance.maxSize 128
+set_option pp.fullNames true
+set_option pp.structureInstances true
+set_option relaxedAutoImplicit false
+set_option autoImplicit false
+set_option pp.coercions.types true
+set_option pp.funBinderTypes true
+set_option pp.letVarTypes true
+set_option pp.piBinderTypes true
+set_option linter.all false
+BLOCK_EOF
+
+    awk -v insert_after="$insert_after" -v block_file="$block_file" '
+        BEGIN {
+            block = ""
+            while ((getline line < block_file) > 0) {
+                block = block line "\n"
+            }
+            close(block_file)
+        }
+        { print }
+        NR == insert_after {
+            # Strip the trailing newline added by the loop above so we do not
+            # produce a stray blank line at the end of the block.
+            sub(/\n$/, "", block)
+            print block
+        }
+    ' "$tmp_file" > "$tmp_file.tmp"
+    mv "$tmp_file.tmp" "$tmp_file"
+    rm -f "$block_file"
+    echo "PREPROCESS: Injected standard set_option block after line $insert_after" >&2
+    changes_made=$((changes_made + 1))
+fi
+
+# Warn (don't reject) if there is no informal-problem `/-` block at the top.
+# "At the top" = before the first declaration (import/namespace/open/theorem/
+# def/etc.). We look for a `/-` (but not `/-!`) opening sequence in the first
+# few non-blank lines.
+has_informal_block=false
+# Scan up to the first 80 lines for an early `/-` block opener that precedes
+# the first import. We accept any `/-` on a line by itself or starting a line.
+first_decl_line=$(grep -nE "^(import|namespace|open|theorem|lemma|def|axiom|structure|class|instance|inductive|abbrev|noncomputable[[:space:]]+section|section)" "$tmp_file" | head -1 | cut -d: -f1 || true)
+if [[ -z "$first_decl_line" ]]; then
+    first_decl_line=80
+fi
+# Look at lines 1..first_decl_line for `/-` (not `/-!`)
+if awk -v limit="$first_decl_line" 'NR <= limit && /^[[:space:]]*\/-([^!]|$)/ { found=1; exit } END { exit !found }' "$tmp_file"; then
+    has_informal_block=true
+fi
+
+if [[ "$has_informal_block" != true ]]; then
+    echo "PREPROCESS: WARN no informal-problem block at top" >&2
 fi
 
 # --- Post-preprocessing validation ---

--- a/scripts/aristotle/submit-batch.sh
+++ b/scripts/aristotle/submit-batch.sh
@@ -12,8 +12,9 @@
 #   ARISTOTLE_API_KEY - Required for submission
 #   ARISTOTLE_TARGET  - Target number of active jobs (default 10)
 #
-# Submission order: Tier 1 companion files (*Aristotle.lean) first,
-# then Tier 2 research output files to fill remaining slots.
+# Submission order: Tier 0 StatementOnly files (*StatementOnly.lean) first,
+# then Tier 1 companion files (*Aristotle.lean), then Tier 2 research output
+# files to fill remaining slots.
 #
 
 set -euo pipefail
@@ -51,8 +52,8 @@ while [[ $# -gt 0 ]]; do
             echo "  --target N   Maintain N active jobs (default: 10)"
             echo "  --dry-run    Show what would be submitted"
             echo ""
-            echo "Submission order: Tier 1 companion files (*Aristotle.lean) first,"
-            echo "then Tier 2 research output files to fill remaining slots."
+            echo "Submission order: Tier 0 StatementOnly files (*StatementOnly.lean) first,"
+            echo "then Tier 1 companion files (*Aristotle.lean), then Tier 2 research files."
             exit 0
             ;;
         *) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -166,8 +167,12 @@ submit_file() {
 
     local is_companion=false
     [[ "$file" == *Aristotle.lean ]] && is_companion=true
+    local is_statement_only=false
+    [[ "$file" == *StatementOnly.lean ]] && is_statement_only=true
 
-    if [[ "$is_companion" == true ]]; then
+    if [[ "$is_statement_only" == true ]]; then
+        echo -e "${BLUE}Submitting [T0 statement-only]:${NC} $file"
+    elif [[ "$is_companion" == true ]]; then
         echo -e "${BLUE}Submitting [T1 companion]:${NC} $file"
     else
         echo -e "${BLUE}Submitting [T2 regular]:${NC} $file"
@@ -254,8 +259,21 @@ submit_file() {
     local tmp_file=$(mktemp)
     local preprocessed_flag="false"
     [[ -n "$preprocess_log" ]] && preprocessed_flag="true"
+    # companion_file flag captures both T0 (statement-only) and T1 (companion)
+    # files — both are purpose-built Aristotle submissions.
     local companion_flag="false"
-    [[ "$is_companion" == true ]] && companion_flag="true"
+    if [[ "$is_companion" == true || "$is_statement_only" == true ]]; then
+        companion_flag="true"
+    fi
+    local submission_tier="T2"
+    local submission_note="Batch submission (T2)"
+    if [[ "$is_statement_only" == true ]]; then
+        submission_tier="T0"
+        submission_note="StatementOnly submission (T0)"
+    elif [[ "$is_companion" == true ]]; then
+        submission_tier="T1"
+        submission_note="Companion file submission (T1)"
+    fi
 
     jq --arg pid "$project_id" \
        --arg file "$file" \
@@ -264,6 +282,8 @@ submit_file() {
        --argjson preprocessed "$preprocessed_flag" \
        --arg preprocess_log "${preprocess_log:-}" \
        --argjson companion "$companion_flag" \
+       --arg tier "$submission_tier" \
+       --arg note "$submission_note" \
        '.jobs += [{
          project_id: $pid,
          file: $file,
@@ -273,7 +293,8 @@ submit_file() {
          preprocessed: $preprocessed,
          preprocessing_log: (if $preprocess_log != "" then $preprocess_log else null end),
          companion_file: $companion,
-         notes: (if $companion then "Companion file submission (T1)" else "Batch submission (T2)" end)
+         tier: $tier,
+         notes: $note
        }]' "$JOBS_FILE" > "$tmp_file" && mv "$tmp_file" "$JOBS_FILE"
 
     # Create completion signal for daemon stats tracking
@@ -358,8 +379,9 @@ main() {
     echo "Will submit: $to_submit files"
     echo ""
 
-    # Get best candidates — two-tier system:
-    # Tier 1 (companion *Aristotle.lean files) come first, then Tier 2 (regular files)
+    # Get best candidates — three-tier system:
+    # Tier 0 (*StatementOnly.lean) first, then Tier 1 (companion *Aristotle.lean),
+    # then Tier 2 (regular files). Ordering is enforced by find-candidates.sh.
     local candidates
     candidates=$("$FIND_CANDIDATES" --json --best "$to_submit" 2>/dev/null)
 
@@ -368,12 +390,14 @@ main() {
         return 0
     fi
 
+    local tier0_count
+    tier0_count=$(echo "$candidates" | jq '[.[] | select(.tier == 0)] | length')
     local tier1_count
     tier1_count=$(echo "$candidates" | jq '[.[] | select(.tier == 1)] | length')
     local tier2_count
     tier2_count=$(echo "$candidates" | jq '[.[] | select(.tier == 2)] | length')
 
-    echo "Candidates: $tier1_count Tier 1 companion files + $tier2_count Tier 2 regular files"
+    echo "Candidates: $tier0_count Tier 0 StatementOnly + $tier1_count Tier 1 companion + $tier2_count Tier 2 regular files"
     echo ""
 
     # Submit each candidate (already sorted: T1 first, then T2)


### PR DESCRIPTION
## Summary

Introduces the Harmonic `StatementOnly_*.lean` (we use the suffix form `*StatementOnly.lean`) convention as a new Tier 0 submission class for Aristotle.

- **Preprocessor** (`scripts/aristotle/preprocess-for-aristotle.sh`):
  - Injects the standard 13-line Harmonic `set_option` block after the last `import` line when `set_option maxHeartbeats 0` is absent (idempotent).
  - Emits `PREPROCESS: WARN no informal-problem block at top` when there is no leading `/-` (not `/-!`) block before the first declaration.
  - For files matching `*StatementOnly.lean` **only**: detects more than one top-level `theorem|lemma ... := by sorry` and exits non-zero with `REJECT: multi-sorry file (Harmonic recommends one theorem per submission)`.
  - Existing `*Aristotle.lean` and regular `.lean` flows are unchanged (single-theorem rejection is gated by filename match).
- **Candidate selector** (`scripts/aristotle/find-candidates.sh`):
  - New Tier 0 collects `*StatementOnly.lean` files ahead of Tier 1 (`*Aristotle.lean`) and Tier 2 (regular).
  - JSON output gains `tier: 0` with `companion_file: true` for these files; table output shows `T0` in the tier column.
  - Tier 2 file collection now also excludes `*StatementOnly.lean` to avoid double-counting.
- **Submitter** (`scripts/aristotle/submit-batch.sh`):
  - Logs `Submitting [T0 statement-only]: <file>` for Tier 0.
  - `aristotle-jobs.json` rows now include a `tier` field (`T0` / `T1` / `T2`) and tier-aware notes.
- **Pilot file** (`proofs/Proofs/SumOfOddsStatementOnly.lean`):
  - Documents the new format using a classic arithmetic identity ($\sum_{k=0}^{n-1}(2k+1)=n^2$).
  - Includes the informal `/-` problem block, the verbatim `set_option` block, `noncomputable section`, exactly one `theorem` with `sorry`, and a Rivin-pattern `-- Proof attempt:` scaffold. Passes the new preprocessor with zero warnings.

## Test plan

- [x] `preprocess-for-aristotle.sh proofs/Proofs/SumOfOddsStatementOnly.lean` exits 0 with `PREPROCESS: No changes needed` and `Result has 1 sorries to attempt`.
- [x] Hand-crafted multi-sorry `*StatementOnly.lean` is rejected with `REJECT: multi-sorry file ...` and non-zero exit.
- [x] Same-content `*Aristotle.lean` file is accepted (backward compat) and the standard `set_option` block is injected after the last import.
- [x] Idempotency: re-running preprocessor on the pilot file produces `No changes needed`.
- [x] `find-candidates.sh --tier1-only --json | jq '[.[] | select(.tier == 0)]'` returns the pilot file with `tier: 0` and `companion_file: true`.
- [x] Table mode shows `SumOfOddsStatementOnly  T0  1  0  0  1` and summary line reads `Total candidates: 204 (T0 statement-only: 1, T1 companion: 203, T2 regular: 0)`.
- [x] No regression: existing 203 `*Aristotle.lean` candidates still appear at Tier 1.

Closes #22468

🤖 Generated with [Claude Code](https://claude.com/claude-code)