### PR TITLE
audit(angle-trisection-oq-03-oq-02): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13967,9 +13967,9 @@
       "result": "issues-fixed"
     },
     "angle-trisection-oq-03-oq-02": {
-      "auditCount": 4,
-      "lastAudited": "2026-05-03T06:29:52Z",
-      "result": "issues-fixed",
+      "auditCount": 5,
+      "lastAudited": "2026-06-05T21:31:16Z",
+      "result": "clean",
       "issues": [
         "meta.meta.sorries/axiomCount fields missing; leanFile.lineCount 140→156, theoremCount 12→13"
       ],


### PR DESCRIPTION
## Summary

5th audit of `angle-trisection-oq-03-oq-02` — verified clean.

## Findings

All gallery metadata matches Lean source:

| Metric        | meta.json | Lean file | Status |
|---------------|-----------|-----------|--------|
| lineCount     | 156       | 156       | ✓      |
| sorries       | 0         | 0         | ✓      |
| axiomCount    | 0         | 0         | ✓      |
| theoremCount  | 13        | 13        | ✓      |
| definitionCount | 1       | 1         | ✓      |
| True stubs    | n/a       | 0         | ✓      |

- Status `verified` / badge `original` consistent (0 sorries, 0 axioms, no True stubs).
- Imports: `Mathlib.Data.Nat.Log`, `Mathlib.Tactic`, `Proofs.AngleTrisectionOQ03`. Uses Mathlib's `Nat.log_pow` as a documented bridge lemma, but the Ω(log d) lower-bound result is original.
- 11 `native_decide` examples present (not counted as theorems) — pass per build green-listing on prior audits.

## Test plan
- [x] Read meta.json and Lean source
- [x] Verified sorries / axiomCount / theoremCount / definitionCount / lineCount
- [x] Confirmed no `True` stubs or Mathlib re-export disguised as `original`
- [x] Updated `audit-tracker.json` (auditCount 4 → 5, result clean)