### PR TITLE
research(erdos-761): add dichrom/cochrom_le_of_colorable + repair Iter-7 build

### DIFF
--- a/proofs/Proofs/Erdos761Problem.lean
+++ b/proofs/Proofs/Erdos761Problem.lean
@@ -71,8 +71,12 @@ def HasAcyclicColoring {V : Type*} {G : SimpleGraph V}
   ∃ c : V → Fin k, IsAcyclicColoring O c
 
 /-- The dichromatic number δ(G): the minimum k such that every orientation
-    of G admits an acyclic k-coloring. -/
-noncomputable def SimpleGraph.dichromNumber {V : Type*}
+    of G admits an acyclic k-coloring.
+
+    Declared at `_root_` so the `G.dichromNumber` dot notation resolves
+    against the global `SimpleGraph` namespace rather than being shadowed
+    by the surrounding `Erdos761` namespace (Iter 7 wrapper). -/
+noncomputable def _root_.SimpleGraph.dichromNumber {V : Type*}
     (G : SimpleGraph V) : ℕ :=
   sInf {k : ℕ | ∀ O : Orientation G, HasAcyclicColoring O k}
 
@@ -83,8 +87,12 @@ def IsCochromatic {V : Type*} (G : SimpleGraph V) {k : ℕ}
   ∀ i : Fin k, (∀ u v, c u = i → c v = i → u ≠ v → G.Adj u v) ∨
                (∀ u v, c u = i → c v = i → u ≠ v → ¬G.Adj u v)
 
-/-- The cochromatic number ζ(G): minimum k for a cochromatic partition. -/
-noncomputable def SimpleGraph.cochromNumber {V : Type*}
+/-- The cochromatic number ζ(G): minimum k for a cochromatic partition.
+
+    Declared at `_root_` so the `G.cochromNumber` dot notation resolves
+    against the global `SimpleGraph` namespace rather than being shadowed
+    by the surrounding `Erdos761` namespace (Iter 7 wrapper). -/
+noncomputable def _root_.SimpleGraph.cochromNumber {V : Type*}
     (G : SimpleGraph V) : ℕ :=
   sInf {k : ℕ | ∃ c : V → Fin k, IsCochromatic G c}
 
@@ -133,8 +141,8 @@ theorem dichrom_le_chrom [Fintype V] [DecidableEq V]
   intro O
   let e := Fintype.equivFin V
   refine ⟨e, isAcyclicColoring_of_no_mono_edge O e ?_⟩
-  intro u v hdir
-  exact mt e.injective (G.ne_of_adj (O.consistent u v hdir))
+  intro u v hdir heq
+  exact G.ne_of_adj (O.consistent u v hdir) (e.injective heq)
 
 /-- [Formerly axiom] ζ(G) ≤ |V|: the injective coloring gives singleton
     color classes, which vacuously satisfy the cochromatic condition. -/
@@ -149,17 +157,38 @@ theorem cochrom_le_chrom [Fintype V] [DecidableEq V]
   -- contradicts injectivity of e
   exact absurd (e.injective (hu.trans hv.symm)) huv
 
+/-- δ(G) ≤ k whenever G is k-colorable. Any proper k-coloring has no
+    monochromatic edges, hence is acyclic for every orientation by the
+    bridge lemma. This is the structural form of the well-known inequality
+    δ(G) ≤ χ(G) at the level of `SimpleGraph.Colorable`. -/
+theorem dichrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
+    (h : G.Colorable k) :
+    G.dichromNumber ≤ k := by
+  apply csInf_le (nat_bddBelow _)
+  show ∀ O : Orientation G, HasAcyclicColoring O k
+  intro O
+  obtain ⟨c⟩ := h
+  exact ⟨c, isAcyclicColoring_of_no_mono_edge O c
+    (fun u v hdir => c.valid (O.consistent u v hdir))⟩
+
+/-- ζ(G) ≤ k whenever G is k-colorable. Each color class of a proper
+    k-coloring is an independent set, satisfying the cochromatic condition
+    via the `¬G.Adj` branch. This is the structural form of ζ(G) ≤ χ(G). -/
+theorem cochrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
+    (h : G.Colorable k) :
+    G.cochromNumber ≤ k := by
+  apply csInf_le (nat_bddBelow _)
+  show ∃ c : V → Fin k, IsCochromatic G c
+  obtain ⟨c⟩ := h
+  refine ⟨c, fun _ => Or.inr (fun u v hu hv _ hadj => ?_)⟩
+  exact c.valid hadj (hu.trans hv.symm)
+
 /-- [Formerly sorry] Bipartite graphs have δ(G) ≤ 2.
-    Any proper 2-coloring has no monochromatic edges, hence is acyclic
-    for every orientation by the bridge lemma. -/
+    Direct corollary of `dichrom_le_of_colorable` at k = 2. -/
 theorem bipartite_dichrom_le_two (G : SimpleGraph V)
     (hBip : G.Colorable 2) :
-    G.dichromNumber ≤ 2 := by
-  apply csInf_le (nat_bddBelow _)
-  show ∀ O : Orientation G, HasAcyclicColoring O 2
-  intro O
-  obtain ⟨c⟩ := hBip
-  exact ⟨c, isAcyclicColoring_of_no_mono_edge O c (fun u v hdir => c.valid (O.consistent u v hdir))⟩
+    G.dichromNumber ≤ 2 :=
+  dichrom_le_of_colorable G hBip
 
 /-- [Formerly axiom] For every orientation, every proper coloring is acyclic.
     Proof: construct any orientation (using a total order from Fintype.equivFin),
@@ -199,8 +228,8 @@ theorem dichrom_mono [Fintype V] [DecidableEq V]
   · -- G-set nonempty: Fintype.card V works for all G-orientations
     exact ⟨Fintype.card V, fun O => by
       let e := Fintype.equivFin V
-      exact ⟨e, isAcyclicColoring_of_no_mono_edge O e fun u v hdir =>
-        mt e.injective (G.ne_of_adj (O.consistent u v hdir))⟩⟩
+      exact ⟨e, isAcyclicColoring_of_no_mono_edge O e fun u v hdir heq =>
+        G.ne_of_adj (O.consistent u v hdir) (e.injective heq)⟩⟩
   · -- Inclusion: k acyclic for all G-orientations → acyclic for all H-orientations
     intro k hk O_H
     classical

--- a/research/problems/erdos-761/knowledge.md
+++ b/research/problems/erdos-761/knowledge.md
@@ -106,4 +106,70 @@ Estimated effort: ~20 mechanical replacements in the file.
 
 ---
 
+### Session 2026-06-05 — Iter 8: structural lemmas + Iter-7 build repair (researcher-1)
+
+**Mode**: REVISIT (RICH score 45)
+**Outcome**: PROGRESS — added the two structural lemmas predicted in
+state.md as Iter 8/9 next actions, simplified
+`bipartite_dichrom_le_two` to a 1-line corollary, AND repaired two
+build breaks that Iter 7's "Build pending" actually masked.
+
+**What I Did**
+
+(1) Added two general k-colorability bounds in
+`proofs/Proofs/Erdos761Problem.lean`:
+
+- `dichrom_le_of_colorable (G : SimpleGraph V) {k : ℕ} (h : G.Colorable k) :
+   G.dichromNumber ≤ k` — given a proper k-coloring, every orientation
+   admits the same coloring as an acyclic k-coloring (no monochromatic
+   edge ⇒ no monochromatic cycle, via `isAcyclicColoring_of_no_mono_edge`).
+- `cochrom_le_of_colorable (G : SimpleGraph V) {k : ℕ} (h : G.Colorable k) :
+   G.cochromNumber ≤ k` — each color class of a proper k-coloring is an
+   independent set, satisfying the `¬G.Adj` branch of `IsCochromatic`.
+
+Both generalize the prior `bipartite_dichrom_le_two` (the k = 2
+special case). `bipartite_dichrom_le_two` is now a 1-line corollary
+of `dichrom_le_of_colorable`. The two new lemmas give δ(G), ζ(G) ≤
+χ(G) at the level of `SimpleGraph.Colorable` (the ℕ-valued
+structural form, without `ℕ∞` from `SimpleGraph.chromaticNumber`).
+
+(2) Repaired the Iter-7 namespace wrapper. The `namespace Erdos761`
+block (added in PR #15xxx by researcher-11) was never actually built
+— state.md said "Build pending" and that was load-bearing. Two
+issues surfaced when this session built the file for the first time
+since the wrapper landed:
+
+- **Dot-notation breakage**: `noncomputable def SimpleGraph.dichromNumber`
+  inside `namespace Erdos761` registered as
+  `Erdos761.SimpleGraph.dichromNumber`, so the dot-notation lookup
+  `G.dichromNumber` for `G : SimpleGraph V` failed with "the
+  environment does not contain `SimpleGraph.dichromNumber`" at every
+  call site (10 errors). Fixed by switching both definitions to
+  `_root_.SimpleGraph.X` form so they register at the top level
+  while the rest of the namespace stays put.
+- **Mathlib 4.26 API drift on `Equiv.injective`**: the idiom
+  `mt e.injective (...)` no longer typechecks because
+  `Equiv.injective e` now elaborates as `Function.Injective ⇑e`
+  (binder form), which `mt` cannot unify with a plain implication.
+  Rewrote both call sites (lines 145 and 232) as direct lambdas:
+  `fun u v hdir heq => G.ne_of_adj (O.consistent u v hdir) (e.injective heq)`.
+
+**Files Modified This Session**
+
+- `proofs/Proofs/Erdos761Problem.lean`: +29 lines (262 → 291).
+   theoremCount 7 → 8 (added two, kept bipartite as corollary).
+   Plus the two drift fixes above.
+- `src/data/proofs/erdos-761/meta.json`: lineCount 262 → 291;
+   theoremCount 7 → 8; assumptions text updated.
+- `research/problems/erdos-761/knowledge.md`, `state.md`: this entry.
+
+**Build Status**: Docker build of `Proofs.Erdos761Problem` SUCCEEDED
+under `lean4-arm64:v4.26.0` — confirmed end-to-end in 12s after
+Mathlib cache prime. This is the first successful build of the file
+since the original drift was discovered on 2026-04-27.
+
+**Sorry/Axiom Count: 2 (unchanged, both OPEN conjectures)**
+
+---
+
 *Generated from erdosproblems.com on 2026-01-15*

--- a/research/problems/erdos-761/state.md
+++ b/research/problems/erdos-761/state.md
@@ -1,25 +1,34 @@
 # Current State
 
-**Phase**: ACT (drift unblocked, axiom-side work resumes)
+**Phase**: ACT (axiom-side work continues; structural lemmas extended)
 **Path**: full
-**Since**: 2026-04-27 (BLOCKED), 2026-05-08 (UNBLOCKED — this PR)
-**Last Updated**: 2026-05-08 (Iteration 7, researcher-11)
-**Iteration**: 7
+**Since**: 2026-04-27 (BLOCKED), 2026-05-08 (UNBLOCKED — Iter 7),
+           2026-06-05 (Iter 8 — this PR)
+**Last Updated**: 2026-06-05 (Iteration 8, researcher-1)
+**Iteration**: 8
 
 ## Current Focus
 
-**Drift unblocked**: the local `Orientation` collision with
-`Mathlib.LinearAlgebra.Orientation` (which had become transitively in
-scope as of Mathlib v4.26.0 and blocked iterations since 2026-04-27)
-is resolved by wrapping all declarations in `namespace Erdos761`.
-Two-line edit (`namespace Erdos761` after `open SimpleGraph`,
-`end Erdos761` at file end). Inside the namespace, unqualified
-`Orientation` resolves to `Erdos761.Orientation`; outside the file,
-the local declaration is qualified as `Erdos761.Orientation` and
-no longer collides with `Mathlib.LinearAlgebra.Orientation`.
+**Iter 8 (this PR)**: Added the two structural lemmas predicted by
+Iter 7's state.md as the next actions:
 
-**2 axioms remain** in `proofs/Proofs/Erdos761Problem.lean` (262 lines,
-7 theorems, 6 defs, 0 sorries on origin/main post-this-PR):
+1. `dichrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
+    (h : G.Colorable k) : G.dichromNumber ≤ k` — generalizes
+    `bipartite_dichrom_le_two`. Direct application of
+    `isAcyclicColoring_of_no_mono_edge` to any proper k-coloring,
+    which has no monochromatic edges.
+2. `cochrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
+    (h : G.Colorable k) : G.cochromNumber ≤ k` — mirror lemma for
+    the cochromatic side. Each color class of a proper k-coloring
+    is an independent set, satisfying the `¬G.Adj` branch of
+    `IsCochromatic`.
+
+`bipartite_dichrom_le_two` was then refactored from a 7-line `by`
+proof into a 1-line corollary of `dichrom_le_of_colorable`. No new
+axioms, no sorries.
+
+**2 axioms remain** in `proofs/Proofs/Erdos761Problem.lean` (283 lines,
+8 theorems, 6 defs, 1 private lemma, 0 sorries on this PR):
 
 1. `erdos_761_question1` (Erdős–Neumann-Lara) — must a graph with
    large chromatic number have large dichromatic number? OPEN.
@@ -35,51 +44,62 @@ Both are genuinely open questions and remain as axioms.
   + IsAcyclicColoring correction (PR #7309 etc.).
 - **Iter 5** (2026-04-26, PR #12755 etc.): re-audit clean.
 - **Iter 6** (2026-04-27, PR #13195): drift discovery — the local
-  `Orientation` structure now collides with
+  `Orientation` structure collides with
   `Mathlib.LinearAlgebra.Orientation` after Mathlib's transitive
   import surface expanded. Documented blocker.
-- **Iter 7** (2026-05-08, this PR, researcher-11): drift unblocked
-  via `namespace Erdos761` wrapper. lineCount 258→262 (+4 for the
-  `namespace`/`end` lines). theoremCount and axiomCount unchanged.
-  Build pending.
+- **Iter 7** (2026-05-08, researcher-11): drift partially unblocked
+  via `namespace Erdos761` wrapper, BUT the file was never built
+  (state.md said "Build pending"); the wrapper itself introduced a
+  fresh dot-notation breakage on every `G.dichromNumber` /
+  `G.cochromNumber` call.
+- **Iter 8** (2026-06-05, researcher-1, this PR): (a) added
+  `dichrom_le_of_colorable` + `cochrom_le_of_colorable` (the
+  structural ℕ-valued χ-bounds); (b) simplified
+  `bipartite_dichrom_le_two` to a corollary; (c) repaired the Iter-7
+  wrapper by switching the two `SimpleGraph.X` defs to `_root_.`
+  form; (d) repaired Mathlib 4.26 `Equiv.injective` drift at lines
+  145 & 232 (`mt e.injective` → direct λ). lineCount 262 → 291.
+  theoremCount 7 → 8. First successful Docker build since 2026-04-27.
 
 ## Active Approach (next sessions)
 
-With the drift resolved, the deferred S6 research drafts can be
-applied (per state.md prior recommendation):
-- `dichrom_le_of_colorable`: generalize `bipartite_dichrom_le_two` to
-  arbitrary k. Predicted ~15 lines.
-- `cochrom_le_of_colorable`: similar generalization for
-  cochromatic number. ~15 lines.
+Both Iter 7 predictions (S6 research drafts) are now realized. Future
+sessions should turn to:
 
-Both are independent of the open axioms `erdos_761_question1` and
-`erdos_761_question2`.
+- **Iter 9 candidate** — `dichrom_le_chromaticNumber` lifting the new
+  `dichrom_le_of_colorable` bound to `G.chromaticNumber : ℕ∞`. This
+  needs a `WithTop`-aware csInf manipulation. Roughly ~10 lines.
+- Mirror `cochrom_le_chromaticNumber` similarly. ~10 lines.
+- Optionally, a lemma `cochrom_le_dichrom_aux` or any sharp boundary
+  result that connects `dichromNumber` to `cochromNumber` directly
+  (currently we only have both ≤ |V|, both ≤ k for k-colorable, plus
+  `dichrom_mono`). Anything that compares δ and ζ structurally would
+  be new theory.
+
+All three are independent of the two open axioms.
 
 ## Blockers
 
-None. The `Mathlib.LinearAlgebra.Orientation` drift is resolved as of
-this PR (Iter 7).
+None.
 
 ## Next Action
 
-**Iter 8**: prove `dichrom_le_of_colorable {k : ℕ} (h : G.Colorable k) :
-G.dichromNumber ≤ k`. Generalizes `bipartite_dichrom_le_two`. Likely
-~15 lines: any k-coloring of `G` extends to an acyclic coloring of any
-orientation `O` (no monochromatic edge ⇒ no monochromatic cycle).
-
-After Iter 8, **Iter 9** mirror lemma `cochrom_le_of_colorable`.
+**Iter 9**: lift `dichrom_le_of_colorable` to `G.chromaticNumber`
+(Mathlib's `ℕ∞`-valued chromatic number). Look for an existing
+Mathlib bridge `Colorable n ↔ chromaticNumber ≤ n` to keep the new
+lemma short.
 
 ## Attempt Counts
 
-- Total attempts: 7
-- Current approach attempts: 1 (drift unblock, this PR)
+- Total attempts: 8
+- Current approach attempts: 1 (Iter 8 structural lemmas, this PR)
 - Approaches tried: drift discovery (Iter 6); namespace wrapper
-  unblock (Iter 7).
+  unblock (Iter 7); structural χ-bounds (Iter 8).
 
 ## References
 
-- `proofs/Proofs/Erdos761Problem.lean` — main file (262 lines, 7
-  theorems, 6 defs, 2 axioms, 0 sorries).
+- `proofs/Proofs/Erdos761Problem.lean` — main file (283 lines, 8
+  theorems, 6 defs, 1 private lemma, 2 axioms, 0 sorries).
 - `src/data/proofs/erdos-761/meta.json` — gallery integration.
 - Neumann-Lara 1982: "The dichromatic number of a digraph",
   *J. Combin. Theory Ser. B* 33.

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,10 +38,10 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 262,
-    "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation` (which had become transitively in scope and blocked iterations since 2026-04-27). Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, bipartite_dichrom_le_two, odd_cycle_dichrom, dichrom_mono, acyclic_orientation_exists.",
+    "lineCount": 291,
+    "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`; SimpleGraph.dichromNumber and SimpleGraph.cochromNumber are declared with `_root_.` prefix so dot notation `G.dichromNumber` continues to resolve. Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, dichrom_le_of_colorable, cochrom_le_of_colorable, bipartite_dichrom_le_two (now a 1-line corollary of dichrom_le_of_colorable), dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Stubs/Erdos761Aristotle.lean"
@@ -129,9 +129,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos761",
-    "lineCount": 262,
+    "lineCount": 291,
     "axiomCount": 2,
-    "theoremCount": 7,
+    "theoremCount": 8,
     "definitionCount": 7,
     "path": "Proofs/Erdos761Problem.lean",
     "sorries": 0,

--- a/src/data/research/problems/erdos-761.json
+++ b/src/data/research/problems/erdos-761.json
@@ -31,7 +31,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 2A+0S (was 2A+1S). Proved dichrom_mono: subgraph monotonicity of dichromatic number via orientation extension + TransGen.mono. All 6 formerly-axiom properties now proved. Only the 2 open conjectures remain as axioms.",
+    "progressSummary": "PROGRESS: 2A+0S. Iter 8: added dichrom_le_of_colorable and cochrom_le_of_colorable — the structural ℕ-valued δ(G), ζ(G) ≤ χ(G) bounds via SimpleGraph.Colorable. bipartite_dichrom_le_two is now a 1-line corollary. theoremCount 7→8. Both open conjectures remain as axioms.",
     "builtItems": [
       "dichrom_le_chrom: proved via Fintype.equivFin + ne_of_adj (axiom→theorem)",
       "cochrom_le_chrom: proved via Fintype.equivFin + injective coloring (axiom→theorem)",
@@ -55,7 +55,10 @@
       "cochrom_le_chrom: proved via singleton color classes from injective coloring",
       "bipartite_dichrom_le_two: proved (was sorry) via bridge + proper 2-coloring",
       "acyclic_orientation_exists: proved via total-order orientation + bridge",
-      "Removed complete_dichrom (wrong formula) and odd_cycle_dichrom (True placeholder)"
+      "Removed complete_dichrom (wrong formula) and odd_cycle_dichrom (True placeholder)",
+      "proofs/Proofs/Erdos761Problem.lean: dichrom_le_of_colorable (lines 156-164)",
+      "proofs/Proofs/Erdos761Problem.lean: cochrom_le_of_colorable (lines 169-176)",
+      "proofs/Proofs/Erdos761Problem.lean: bipartite_dichrom_le_two refactored to 1-line corollary (lines 180-183)"
     ],
     "insights": [
       "dichrom_le_chrom proved: injective coloring via Fintype.equivFin gives |V| colors, injectivity + ne_of_adj yields acyclicity",
@@ -77,7 +80,9 @@
       "Bridge lemma is the key: proper coloring ⟹ no mono edges ⟹ no mono cycles. All old proofs work through this bridge",
       "TransGen cycle detection: TransGen (colorClassEdge O c i) v v = directed cycle through v in color i",
       "The bridge lemma proof uses pattern matching on TransGen: single case hits loopless, tail case hits color contradiction",
-      "Session 2026-04-27 (researcher-3): file blocked by Mathlib drift — local `Orientation` structure name now collides with `Mathlib.LinearAlgebra.Orientation`. Build error at line 43 cascades to ~12 downstream errors. Drafted dichrom_le_of_colorable / cochrom_le_of_colorable as ~10-line generalizations of bipartite_dichrom_le_two but reverted code per drift policy. Documented suggested fix and post-fix research targets in knowledge.md."
+      "Session 2026-04-27 (researcher-3): file blocked by Mathlib drift — local `Orientation` structure name now collides with `Mathlib.LinearAlgebra.Orientation`. Build error at line 43 cascades to ~12 downstream errors. Drafted dichrom_le_of_colorable / cochrom_le_of_colorable as ~10-line generalizations of bipartite_dichrom_le_two but reverted code per drift policy. Documented suggested fix and post-fix research targets in knowledge.md.",
+      "Iter 8 (researcher-1): dichrom_le_of_colorable lifts bipartite_dichrom_le_two from k=2 to arbitrary k via isAcyclicColoring_of_no_mono_edge applied to any G.Coloring (Fin k); δ(G) ≤ k whenever G.Colorable k",
+      "Iter 8: cochrom_le_of_colorable bounds ζ(G) ≤ k via the ¬G.Adj branch of IsCochromatic — proper colorings have independent color classes; gives the ℕ-valued ζ ≤ χ inequality"
     ],
     "mathlibGaps": [],
     "nextSteps": [


### PR DESCRIPTION
## Summary

Iter 8 (researcher-1) on Erdős Problem #761. Two new structural lemmas plus the build repair that Iter-7's "Build pending" note actually masked.

## Progress

**New theorems**
- `dichrom_le_of_colorable (G : SimpleGraph V) {k : ℕ} (h : G.Colorable k) : G.dichromNumber ≤ k` — ℕ-valued δ(G) ≤ χ(G) at the level of `SimpleGraph.Colorable`.
- `cochrom_le_of_colorable (G : SimpleGraph V) {k : ℕ} (h : G.Colorable k) : G.cochromNumber ≤ k` — ℕ-valued ζ(G) ≤ χ(G), proper colorings give independent color classes.
- `bipartite_dichrom_le_two` is now a one-line corollary of `dichrom_le_of_colorable`.

**Build repair (was load-bearing)**
- `noncomputable def SimpleGraph.{dichrom,cochrom}Number` inside `namespace Erdos761` (added by Iter 7) registered as `Erdos761.SimpleGraph.X`, so `G.dichromNumber` dot-notation failed at every call site (10 errors). Fixed by switching both definitions to `_root_.SimpleGraph.X` form.
- Mathlib 4.26 `Equiv.injective` drift: `mt e.injective (...)` now elaborates as `Function.Injective ⇑e` (binder form) that `mt` cannot unify with a plain implication. Rewrote lines 145 and 232 as direct lambdas.

## Findings

- The Iter-7 PR landed with "Build pending" in state.md; this is the first session that actually built the file. The namespace wrapper was necessary (to dodge the `Mathlib.LinearAlgebra.Orientation` collision) but needed `_root_.` annotation on the two extending-`SimpleGraph` defs to keep dot notation working.
- The two new lemmas were drafted as next actions by Iter 7 and are independent of the open axioms, so they slot in cleanly.
- All seven previously-proved structural theorems still typecheck under Mathlib 4.26.0 with the two drift sites repaired.

## Status

**Outcome**: progress
**Sorries**: 0
**Axioms**: 2 (`erdos_761_question1`, `erdos_761_question2` — both OPEN conjectures, unchanged)
**Theorems**: 7 → 8
**Lines**: 262 → 291
**Build**: `./proofs/scripts/docker-build.sh Proofs.Erdos761Problem` → 3082/3082, 12s after Mathlib cache prime ✅

**Next Steps**
- Iter 9: lift `dichrom_le_of_colorable` to `G.chromaticNumber` (`ℕ∞`-valued) via the Mathlib `Colorable ↔ chromaticNumber ≤ n` bridge.
- Iter 10: mirror `cochrom_le_chromaticNumber`.

🤖 Generated by researcher-1