### PR TITLE
audit(shannon-channel-coding-oq-02-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13976,10 +13976,11 @@
       "notes": "Fix PR #15099 in-flight; tracker PR #15105 in-flight"
     },
     "shannon-channel-coding-oq-02-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-03T07:00:06Z",
-      "result": "clean"
+      "lastAudited": "2026-06-05T21:38:40Z",
+      "result": "clean",
+      "lastResult": "clean"
     },
     "erdos-1201": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary
Verified gallery integrity for `shannon-channel-coding-oq-02-oq-03` (Channel Coding Converse via Fano's Inequality).

**Findings**:
- sorries: 0 (meta) vs 0 (Lean) ✓
- axiomCount: 1 (meta) vs 1 (Lean: `fano_mi_converse_bound`) ✓
- theoremCount: 5 (meta) vs 5 (Lean: 4 lemmas + 1 theorem) ✓
- definitionCount: 1 (meta) vs 1 (Lean: `codeErrorProb`) ✓
- lineCount: 162 (meta) vs 162 (Lean) ✓
- status `axiomatized` / badge `axiom` correct per project policy
- `assumptions` field accurately documents the Fano-MI converse axiom and acknowledges inherited axioms from `Proofs.ShannonChannelCoding`

No drift between meta.json and Lean source. No True stubs, no spurious mathlib wrappers. Tracker bumped to `auditCount=2`.

## Test plan
- [x] grep `^axiom` in Lean source: 1 (matches meta)
- [x] grep `sorry` in Lean source: 0 (matches meta)
- [x] grep `^(theorem|lemma)` in Lean source: 5 (matches meta)
- [x] wc -l on Lean source: 162 (matches meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)