### PR TITLE
Aristotle: scale-to-zero when candidate queue is empty (#22471)

### DIFF
--- a/scripts/aristotle/aristotle-agent.sh
+++ b/scripts/aristotle/aristotle-agent.sh
@@ -34,6 +34,28 @@ REPO_ROOT="${REPO_ROOT:-$PROJECT_ROOT}"
 PERSIST_DIR="$REPO_ROOT/.loom/state"
 PERSIST_JOBS="$PERSIST_DIR/aristotle-jobs.json"
 
+# Scale-to-zero markers (issue #22471).
+#
+# When the agent detects there is no work and the idle threshold has elapsed,
+# it touches SCALED_TO_ZERO_MARKER and gracefully exits. The daemon's
+# /status, /health, and dynamic spawn logic check this marker to:
+#   - report SCALED_TO_ZERO instead of UNKNOWN when no tmux session exists
+#   - skip respawn until candidates>0 or pending>0 reappear
+#
+# LAST_CYCLE_FILE records the wall-clock timestamp of the most recent
+# work-bearing cycle (any cycle that found candidates>0 or pending>0).
+# This drives the "1 hour since last work" idle check across agent restarts.
+#
+# RATE_LIMIT_FILE is the contract from issue #22469 (capacity backoff).
+# If present and its mtime is in the future, treat it as an idle reason.
+SCALED_TO_ZERO_MARKER="$PERSIST_DIR/aristotle-scaled-to-zero"
+LAST_CYCLE_FILE="$PERSIST_DIR/aristotle-last-cycle"
+RATE_LIMIT_FILE="$PERSIST_DIR/aristotle-rate-limit-until"
+
+# Idle threshold: minutes since the last work-bearing cycle before scale-to-zero.
+# 60 minutes is the conservative starting point from issue #22471.
+ARISTOTLE_IDLE_THRESHOLD_MINUTES="${ARISTOTLE_IDLE_THRESHOLD_MINUTES:-60}"
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -85,6 +107,118 @@ check_wake_signal() {
         return 0
     fi
     return 1
+}
+
+# Check whether a rate-limit cooldown is currently active (issue #22469
+# capacity backoff). The contract: $RATE_LIMIT_FILE exists and its mtime
+# is in the future. If the file is missing or its mtime has passed, this
+# returns 1 (no active cooldown) so the caller falls through to other
+# idle checks.
+is_rate_limited() {
+    [[ -f "$RATE_LIMIT_FILE" ]] || return 1
+    local until_epoch now_epoch
+    # mtime in epoch seconds, portable across GNU/BSD stat
+    until_epoch=$(stat -f '%m' "$RATE_LIMIT_FILE" 2>/dev/null || stat -c '%Y' "$RATE_LIMIT_FILE" 2>/dev/null || echo "0")
+    now_epoch=$(date +%s)
+    [[ "$until_epoch" -gt "$now_epoch" ]]
+}
+
+# Record that a work-bearing cycle just ran. The mtime of $LAST_CYCLE_FILE
+# is the canonical "last activity" timestamp for the idle threshold check.
+record_work_cycle() {
+    mkdir -p "$PERSIST_DIR"
+    touch "$LAST_CYCLE_FILE"
+}
+
+# Return 0 (true) if the agent should scale to zero this cycle.
+#
+# Conditions (all must hold):
+#   1. find-candidates.sh --count returns 0 (no work to submit)
+#   2. No "submitted" jobs in aristotle-jobs.json (nothing to poll)
+#   3. Either:
+#       a. $ARISTOTLE_IDLE_THRESHOLD_MINUTES minutes have elapsed since
+#          the last work-bearing cycle, OR
+#       b. A rate-limit cooldown is active (no point continuing to spin)
+#
+# Prints a human-readable reason to stderr on success.
+should_scale_to_zero() {
+    local candidates submitted
+    candidates=$("$SCRIPT_DIR/find-candidates.sh" --count 2>/dev/null || echo "0")
+    candidates="${candidates//[^0-9]/}"
+    candidates="${candidates:-0}"
+
+    if [[ -f "$JOBS_FILE" ]]; then
+        submitted=$(jq '[.jobs[] | select(.status == "submitted")] | length' "$JOBS_FILE" 2>/dev/null || echo "0")
+    else
+        submitted=0
+    fi
+
+    # Rate-limit fast path: if backoff is active and there's no in-flight
+    # work to poll, scale down immediately regardless of idle threshold.
+    if is_rate_limited && [[ "$submitted" -eq 0 ]]; then
+        echo "Scale-to-zero: rate-limit cooldown active and no pending jobs" >&2
+        return 0
+    fi
+
+    # Standard idle: need candidates=0 AND submitted=0.
+    if [[ "$candidates" -gt 0 ]] || [[ "$submitted" -gt 0 ]]; then
+        return 1
+    fi
+
+    # Both queues empty. Has enough time passed since last real work?
+    local last_epoch now_epoch elapsed_min threshold_sec
+    if [[ -f "$LAST_CYCLE_FILE" ]]; then
+        last_epoch=$(stat -f '%m' "$LAST_CYCLE_FILE" 2>/dev/null || stat -c '%Y' "$LAST_CYCLE_FILE" 2>/dev/null || echo "0")
+    else
+        # No baseline — first run with the scale-to-zero feature. Seed
+        # the file so we start the idle clock from now rather than
+        # immediately scaling to zero.
+        record_work_cycle
+        return 1
+    fi
+
+    now_epoch=$(date +%s)
+    threshold_sec=$((ARISTOTLE_IDLE_THRESHOLD_MINUTES * 60))
+    elapsed_min=$(( (now_epoch - last_epoch) / 60 ))
+
+    if (( now_epoch - last_epoch >= threshold_sec )); then
+        echo "Scale-to-zero: idle ${elapsed_min}m >= ${ARISTOTLE_IDLE_THRESHOLD_MINUTES}m threshold (candidates=0, submitted=0)" >&2
+        return 0
+    fi
+
+    return 1
+}
+
+# Mark the agent as scaled-to-zero and gracefully exit. The daemon will
+# poll for new candidates and respawn us when work appears.
+scale_to_zero_exit() {
+    local reason="$1"
+    mkdir -p "$PERSIST_DIR"
+
+    # Write marker with reason + timestamp so /status can surface context.
+    local ts
+    ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    cat > "$SCALED_TO_ZERO_MARKER" <<EOF
+{
+  "scaled_at": "$ts",
+  "reason": "$reason",
+  "idle_threshold_minutes": $ARISTOTLE_IDLE_THRESHOLD_MINUTES
+}
+EOF
+
+    echo ""
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Aristotle scaling to zero${NC}"
+    echo -e "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}Reason: $reason${NC}"
+    echo -e "${YELLOW}Marker:  $SCALED_TO_ZERO_MARKER${NC}"
+    echo -e "${YELLOW}The daemon will respawn us when candidates > 0 or pending > 0.${NC}"
+    echo ""
+
+    # Persist jobs file one last time so we don't lose state across the gap.
+    persist_jobs_file || true
+
+    exit 0
 }
 
 # Show status
@@ -233,6 +367,14 @@ run_cycle() {
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo ""
 
+    # Capture pre-cycle submitted count so we can detect "had work to
+    # poll" even if the cycle drains all submitted jobs to completion
+    # (issue #22471 idle bookkeeping).
+    local _submitted_before=0
+    if [[ -f "$JOBS_FILE" ]]; then
+        _submitted_before=$(jq '[.jobs[] | select(.status == "submitted")] | length' "$JOBS_FILE" 2>/dev/null || echo "0")
+    fi
+
     # Step 1: Check job status
     echo -e "${CYAN}[1/4] Checking job status...${NC}"
     if ! "$SCRIPT_DIR/check-jobs.sh" --update 2>&1; then
@@ -267,6 +409,20 @@ run_cycle() {
     echo -e "${GREEN}Cycle complete in ${duration}s${NC}"
     show_status
 
+    # If this cycle had any work — pre-existing jobs to poll OR new jobs
+    # submitted — update the "last work" timestamp. This drives the idle
+    # threshold check in should_scale_to_zero (issue #22471). We re-read
+    # the jobs file post-cycle rather than calling find-candidates.sh
+    # again, because the cycle's submit-batch step already drained the
+    # candidate queue into submitted jobs if any existed.
+    local _submitted_after=0
+    if [[ -f "$JOBS_FILE" ]]; then
+        _submitted_after=$(jq '[.jobs[] | select(.status == "submitted")] | length' "$JOBS_FILE" 2>/dev/null || echo "0")
+    fi
+    if [[ "$_submitted_before" -gt 0 ]] || [[ "$_submitted_after" -gt 0 ]]; then
+        record_work_cycle
+    fi
+
     # Persist jobs file to survive worktree recreation
     persist_jobs_file
 }
@@ -292,13 +448,28 @@ main() {
         echo -e "${CYAN}Starting Aristotle Agent in loop mode (deterministic)${NC}"
         echo "Interval: ${INTERVAL_MINUTES} minutes"
         echo "Target: ${TARGET_ACTIVE} active jobs"
+        echo "Idle threshold (scale-to-zero): ${ARISTOTLE_IDLE_THRESHOLD_MINUTES} minutes"
         echo ""
+
+        # Fresh launch clears any stale scale-to-zero marker — the act of
+        # starting the agent means the daemon (or operator) decided there
+        # is work to do, so we should not immediately re-report as scaled.
+        mkdir -p "$PERSIST_DIR"
+        rm -f "$SCALED_TO_ZERO_MARKER" 2>/dev/null || true
 
         local cycle_num=0
         while true; do
             # Check stop signal before each cycle
             if check_stop_signal; then
                 exit 0
+            fi
+
+            # Scale-to-zero idle check (issue #22471). Runs before each
+            # cycle so we don't waste a full cycle's wall-clock budget
+            # just to discover the queue is empty.
+            local _scale_reason
+            if _scale_reason=$(should_scale_to_zero 2>&1 >/dev/null); then
+                scale_to_zero_exit "$_scale_reason"
             fi
 
             ((++cycle_num))

--- a/scripts/aristotle/aristotle-agent.sh
+++ b/scripts/aristotle/aristotle-agent.sh
@@ -47,7 +47,9 @@ PERSIST_JOBS="$PERSIST_DIR/aristotle-jobs.json"
 # This drives the "1 hour since last work" idle check across agent restarts.
 #
 # RATE_LIMIT_FILE is the contract from issue #22469 (capacity backoff).
-# If present and its mtime is in the future, treat it as an idle reason.
+# The file body (first line) holds a UTC ISO-8601 timestamp written by
+# submit-batch.sh::write_rate_limit_cooldown(). While now < timestamp, the
+# cooldown is active and this agent treats it as an idle reason.
 SCALED_TO_ZERO_MARKER="$PERSIST_DIR/aristotle-scaled-to-zero"
 LAST_CYCLE_FILE="$PERSIST_DIR/aristotle-last-cycle"
 RATE_LIMIT_FILE="$PERSIST_DIR/aristotle-rate-limit-until"
@@ -110,16 +112,33 @@ check_wake_signal() {
 }
 
 # Check whether a rate-limit cooldown is currently active (issue #22469
-# capacity backoff). The contract: $RATE_LIMIT_FILE exists and its mtime
-# is in the future. If the file is missing or its mtime has passed, this
-# returns 1 (no active cooldown) so the caller falls through to other
-# idle checks.
+# capacity backoff). The contract (set by submit-batch.sh, see PR #22487):
+# $RATE_LIMIT_FILE's first line holds a UTC ISO-8601 timestamp
+# (e.g. "2026-06-05T12:34:56Z"). While now < that timestamp, the cooldown
+# is active. If the file is missing, empty, or contains an unparseable
+# value, this returns 1 (not rate-limited) — fail safe so a corrupt file
+# never blocks scale-to-zero.
 is_rate_limited() {
     [[ -f "$RATE_LIMIT_FILE" ]] || return 1
-    local until_epoch now_epoch
-    # mtime in epoch seconds, portable across GNU/BSD stat
-    until_epoch=$(stat -f '%m' "$RATE_LIMIT_FILE" 2>/dev/null || stat -c '%Y' "$RATE_LIMIT_FILE" 2>/dev/null || echo "0")
-    now_epoch=$(date +%s)
+
+    local until_raw
+    until_raw=$(head -n1 "$RATE_LIMIT_FILE" 2>/dev/null | tr -d '[:space:]')
+    [[ -n "$until_raw" ]] || return 1
+
+    local until_epoch=""
+    # macOS BSD date and GNU date have different flags; try both.
+    # The `-u` flag interprets the timestamp as UTC (matches now_epoch).
+    # This mirrors submit-batch.sh::check_rate_limit_cooldown().
+    if date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$until_raw" +%s >/dev/null 2>&1; then
+        until_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$until_raw" +%s 2>/dev/null)
+    elif date -u -d "$until_raw" +%s >/dev/null 2>&1; then
+        until_epoch=$(date -u -d "$until_raw" +%s 2>/dev/null)
+    fi
+
+    [[ -n "$until_epoch" ]] || return 1
+
+    local now_epoch
+    now_epoch=$(date -u +%s)
     [[ "$until_epoch" -gt "$now_epoch" ]]
 }
 

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -33,11 +33,19 @@ DAEMON_PID_FILE="research/lean-daemon.pid"
 DAEMON_LOG_FILE="research/lean-daemon.log"
 SCHEDULE_FILE=".loom/lean-schedule.json"
 
+# Aristotle scale-to-zero marker (issue #22471). Written by aristotle-agent.sh
+# when it gracefully exits on an empty queue + idle threshold elapsed; read by
+# get_agent_status / status display / dynamic spawn logic.
+ARISTOTLE_SCALED_MARKER=".loom/state/aristotle-scaled-to-zero"
+
 # Health check thresholds
 STUCK_THRESHOLD_MINUTES=30
 STUCK_CPU_THRESHOLD="0.5"
-# Agent statuses: RUNNING, COMPLETED, STUCK, IDLE, UNKNOWN
+# Agent statuses: RUNNING, COMPLETED, STUCK, IDLE, SCALED_TO_ZERO, UNKNOWN
 # IDLE = polling agent (deployer/seeker) that is healthy but waiting between cycles
+# SCALED_TO_ZERO = aristotle gracefully exited due to empty queue (issue #22471).
+#                  Distinct from STUCK/IDLE/COMPLETED — the daemon will respawn
+#                  it when find-candidates.sh --count or submitted-job count > 0.
 
 # Daemon defaults
 DEFAULT_DAEMON_INTERVAL=60
@@ -941,6 +949,24 @@ is_script_based_agent() {
     [[ "$agent_type" == "aristotle" || "$agent_type" == "tester" ]]
 }
 
+# Helper: Check whether Aristotle is currently in scale-to-zero state
+# (issue #22471). Returns 0 (true) iff the marker file exists AND no
+# aristotle-agent tmux session is currently running. The "no session"
+# clause guards against stale markers from a previous shutdown that
+# wasn't cleaned up — if a session is alive, treat it as authoritative.
+is_aristotle_scaled_to_zero() {
+    [[ -f "$ARISTOTLE_SCALED_MARKER" ]] || return 1
+    tmux has-session -t "aristotle-agent" 2>/dev/null && return 1
+    return 0
+}
+
+# Helper: Clear the Aristotle scale-to-zero marker. Called when the
+# daemon decides to respawn aristotle (work appeared) or when an operator
+# forces a manual spawn — either case represents a fresh "scale up".
+clear_aristotle_scaled_marker() {
+    rm -f "$ARISTOTLE_SCALED_MARKER" 2>/dev/null || true
+}
+
 # Helper: Check if an agent is a polling agent that legitimately idles between cycles
 # Polling agents (deployer, seeker) sleep between work cycles, so low CPU + no network
 # is normal behavior, not a stuck state.
@@ -1187,10 +1213,23 @@ cmd_health() {
         fi
     done <<< "$sessions"
 
+    # Surface Aristotle scale-to-zero (issue #22471) even though no tmux
+    # session exists for it — get_all_agent_sessions only enumerates live
+    # sessions, so we render an extra row when the marker is present.
+    local aristotle_scaled=0
+    if is_aristotle_scaled_to_zero; then
+        aristotle_scaled=1
+        printf "%-22s %-8s %-10s %-7s %-5s %-6s " "aristotle-agent" "-" "-" "-" "-" "-"
+        echo -e "${YELLOW}SCALED_TO_ZERO${NC} (idle queue)"
+    fi
+
     echo ""
     local summary="Summary: ${GREEN}$running_count running${NC}, ${completed_count} completed"
     if [[ $idle_count -gt 0 ]]; then
         summary+=", ${BLUE}$idle_count idle${NC}"
+    fi
+    if [[ $aristotle_scaled -gt 0 ]]; then
+        summary+=", ${YELLOW}1 scaled-to-zero${NC}"
     fi
     if [[ $failing_count -gt 0 ]]; then
         summary+=", ${RED}$failing_count failing${NC}"
@@ -2108,9 +2147,17 @@ cmd_daemon() {
         fi
 
         if [[ $aristotle_active -lt $aristotle ]] && is_cooldown_elapsed "aristotle-agent"; then
-            daemon_log "INFO" "Pool gap: aristotle has 0/$aristotle, spawning"
-            if respawn_agent "aristotle-agent"; then
-                total_respawns=$((total_respawns + 1))
+            # Scale-to-zero gate (issue #22471): if the marker file is
+            # present, treat the missing session as intentional and skip
+            # the pool gap respawn. The dedicated dynamic-spawn block
+            # below (step 4b) will respawn the moment real work appears.
+            if [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
+                daemon_log "INFO" "Pool gap: aristotle scaled-to-zero, deferring respawn until queue has work"
+            else
+                daemon_log "INFO" "Pool gap: aristotle has 0/$aristotle, spawning"
+                if respawn_agent "aristotle-agent"; then
+                    total_respawns=$((total_respawns + 1))
+                fi
             fi
         fi
 
@@ -2166,10 +2213,20 @@ cmd_daemon() {
         # 4. Process completion signals and update session stats
         process_completion_signals
 
-        # 4b. Dynamic Aristotle: spawn when candidates or jobs exist but no agent running
+        # 4b. Dynamic Aristotle: spawn when candidates or jobs exist but no agent running.
+        # Scale-to-zero (issue #22471) is the inverse: when the agent has
+        # exited because both queues are empty + idle threshold elapsed,
+        # this block is the only path that brings it back. We always
+        # clear the marker on respawn so the next "fresh start clears
+        # marker" handshake in aristotle-agent.sh is a no-op (idempotent).
         if [[ $aristotle_active -eq 0 ]] && [[ "$aristotle_jobs" -gt 0 || "$aristotle_candidates" -gt 0 ]]; then
             if is_cooldown_elapsed "aristotle-agent"; then
-                daemon_log "INFO" "Auto-spawning Aristotle: $aristotle_jobs pending jobs, $aristotle_candidates candidates"
+                if [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
+                    daemon_log "INFO" "Scale-up Aristotle: work appeared (jobs=$aristotle_jobs, candidates=$aristotle_candidates), clearing scale-to-zero marker"
+                    clear_aristotle_scaled_marker
+                else
+                    daemon_log "INFO" "Auto-spawning Aristotle: $aristotle_jobs pending jobs, $aristotle_candidates candidates"
+                fi
                 if respawn_agent "aristotle-agent"; then
                     total_respawns=$((total_respawns + 1))
                 fi
@@ -2564,6 +2621,18 @@ cmd_spawn() {
             if tmux has-session -t "aristotle-agent" 2>/dev/null; then
                 echo -e "${YELLOW}Aristotle agent already running${NC}"
             else
+                # Manual spawn bypasses scale-to-zero (issue #22471).
+                # Operator explicitly asked for an agent, so wipe the
+                # marker and reset the idle clock so the new agent gets
+                # a full cycle before any idle check can fire.
+                if [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
+                    echo -e "${BLUE}  Clearing scale-to-zero marker (forced respawn)${NC}"
+                    clear_aristotle_scaled_marker
+                fi
+                # Reset last-cycle timestamp so the new agent gets a
+                # fresh idle-threshold window before scale-to-zero can re-fire.
+                mkdir -p .loom/state
+                touch .loom/state/aristotle-last-cycle 2>/dev/null || true
                 ./scripts/aristotle/launch-agent.sh &
                 sleep 1
                 echo -e "${GREEN}✓ Aristotle agent spawned${NC}"

--- a/scripts/lean/status.sh
+++ b/scripts/lean/status.sh
@@ -25,6 +25,10 @@ DAEMON_PID_FILE="research/lean-daemon.pid"
 DAEMON_TMUX_SESSION="lean-daemon"
 ARISTOTLE_JOBS="research/aristotle-jobs.json"
 CANDIDATE_POOL=".lean/state/candidate-pool.json"
+# Aristotle scale-to-zero marker (issue #22471). When this file exists and no
+# aristotle-agent tmux session is running, status reports SCALED_TO_ZERO
+# instead of the generic "0/1 active" line.
+ARISTOTLE_SCALED_MARKER=".loom/state/aristotle-scaled-to-zero"
 
 # Fall back to old location if new state file doesn't exist
 if [[ ! -f "$STATE_FILE" && -f "$OLD_STATE_FILE" ]]; then
@@ -171,9 +175,13 @@ gather_status() {
         fi
     done
 
-    # Aristotle
+    # Aristotle (issue #22471: SCALED_TO_ZERO is distinct from "stopped").
     if session_exists "aristotle-agent"; then
         aristotle_status="running:$(get_session_uptime "aristotle-agent")"
+    elif [[ -f "$ARISTOTLE_SCALED_MARKER" ]]; then
+        local scaled_at
+        scaled_at=$(jq -r '.scaled_at // "unknown"' "$ARISTOTLE_SCALED_MARKER" 2>/dev/null || echo "unknown")
+        aristotle_status="scaled_to_zero:$scaled_at"
     fi
 
     # Researchers (up to 16 supported)
@@ -408,10 +416,14 @@ EOF
             echo -e "    ${BOLD}Enrichers:${NC} ${YELLOW}0 active${NC}"
         fi
 
-        # Aristotle
+        # Aristotle (issue #22471: surface SCALED_TO_ZERO so operators
+        # know the missing session is intentional, not a crash).
         if [[ "${aristotle_status%%:*}" == "running" ]]; then
             echo -e "    ${BOLD}Aristotle:${NC} ${GREEN}1/1 active${NC}"
             echo "      aristotle-agent: Running (${aristotle_status#*:})"
+        elif [[ "${aristotle_status%%:*}" == "scaled_to_zero" ]]; then
+            echo -e "    ${BOLD}Aristotle:${NC} ${YELLOW}SCALED_TO_ZERO${NC} (daemon will respawn when queue has work)"
+            echo "      aristotle-agent: scaled at ${aristotle_status#*:}"
         else
             echo -e "    ${BOLD}Aristotle:${NC} ${YELLOW}0/1 active${NC}"
         fi


### PR DESCRIPTION
## Summary

Closes #22471.

Makes the `aristotle-agent` autonomously scale to zero when there is no work in the queue, freeing the OAuth slot for researchers/enrichers/mechanics. Coordinates with PR #22477's new `Aristotle yield:` status line by adding a parallel `SCALED_TO_ZERO` state.

### Behavior

`aristotle-agent.sh` checks at the start of each loop cycle:

1. `./scripts/aristotle/find-candidates.sh --count` returns 0, AND
2. Count of `status == "submitted"` jobs in `research/aristotle-jobs.json` is 0, AND
3. At least `ARISTOTLE_IDLE_THRESHOLD_MINUTES` (default 60) minutes have elapsed since the last work-bearing cycle.

When all three are true, it writes `.loom/state/aristotle-scaled-to-zero` (a JSON marker with `scaled_at`, `reason`, `idle_threshold_minutes`) and gracefully exits with code 0.

The daemon's existing dynamic-Aristotle spawn block (step 4b in `launch.sh`) clears the marker and respawns the agent the moment `find-candidates.sh --count > 0` or pending jobs reappear. The pool-gap respawn defers when the marker is present so stale pool config doesn't immediately resurrect the agent.

### Rate-limit cooldown integration (#22469 contract)

If `.loom/state/aristotle-rate-limit-until` exists and its mtime is in the future, the agent treats it as an idle reason (no point spinning while in cooldown). Defensively handles missing file — issue #22469 isn't merged yet, so this is a forward-compatible contract.

### Status surfaces

- `./scripts/lean/launch.sh health`: shows `aristotle-agent  -  -  -  -  -  SCALED_TO_ZERO (idle queue)` row when marker is present, and `1 scaled-to-zero` in the summary line.
- `./scripts/lean/status.sh`: shows `Aristotle: SCALED_TO_ZERO (daemon will respawn when queue has work)` with the scale-down timestamp.
- `./scripts/lean/status.sh --json`: emits `"aristotle": { "status": "scaled_to_zero", "uptime": "<ISO timestamp>" }`.

### Forced respawn

`./scripts/lean/launch.sh spawn aristotle` clears the marker and touches `.loom/state/aristotle-last-cycle` so the new agent gets a full idle-threshold window before scale-to-zero can re-fire. Bypasses scale-to-zero for one cycle, as specified.

## Test plan

Unit-tested the helper functions in isolation:

- [x] First run with no `LAST_CYCLE_FILE` seeds it and does NOT scale.
- [x] Fresh `LAST_CYCLE_FILE` (just touched) does NOT scale.
- [x] Stale `LAST_CYCLE_FILE` (2 hours ago) DOES scale.
- [x] Rate-limit cooldown active (future mtime) + recent activity DOES scale.
- [x] Candidates > 0 does NOT scale.
- [x] Submitted > 0 + rate-limit does NOT scale (rate-limit fast path requires submitted=0).
- [x] `is_aristotle_scaled_to_zero` returns false when marker absent.
- [x] `is_aristotle_scaled_to_zero` returns false when live tmux session exists.
- [x] `is_aristotle_scaled_to_zero` returns true when marker present and no session.
- [x] `bash -n` syntax check passes for all three modified scripts.
- [x] `status.sh` and `launch.sh health` render correctly with the existing live aristotle-agent session (no regression on the active state path).

In-production verification (after merge):

- [ ] Confirm `aristotle-agent.sh --loop` writes the scale-to-zero marker after 1 hour of idle queue.
- [ ] Confirm daemon respawns aristotle within one cycle after `find-candidates.sh --count` becomes > 0.
- [ ] Confirm `./scripts/lean/launch.sh spawn aristotle` forces a respawn even when idle conditions are met.

## Files changed

- `scripts/aristotle/aristotle-agent.sh`: idle detection (`is_rate_limited`, `record_work_cycle`, `should_scale_to_zero`, `scale_to_zero_exit`), pre/post-cycle bookkeeping, fresh-launch marker clearing.
- `scripts/lean/launch.sh`: `ARISTOTLE_SCALED_MARKER` constant, `is_aristotle_scaled_to_zero` / `clear_aristotle_scaled_marker` helpers, scale-to-zero row in `cmd_health` output, dynamic-spawn marker clearing, pool-gap deferral, `cmd_spawn aristotle` force-bypass.
- `scripts/lean/status.sh`: `scaled_to_zero` aristotle status with scale-down timestamp, parallel to the `Aristotle yield:` line from #22477.