### PR TITLE
audit(abel-ruffini-oq-09): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14000,8 +14000,8 @@
       ]
     },
     "abel-ruffini-oq-09": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T07:39:19Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T22:17:10Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audit of **abel-ruffini-oq-09** (Liouville's Theorem on Integration: The Gaussian Integral is Not Elementary).

## Verification

All counts in `meta.json` match the Lean source `proofs/Proofs/AbelRuffiniOQ09.lean`:

| Metric | meta.json | Source |
|---|---|---|
| Lines | 540 | 540 ✓ |
| Theorems | 24 | 24 ✓ |
| Definitions | 6 | 6 ✓ |
| Axioms | 5 | 5 ✓ |
| Sorries | 0 | 0 ✓ |

**axiomCount=5 decomposition** (matches `assumptions` field):
- 2 `axiom` declarations: `liouville_integration_theorem`, `risch_exp_criterion_gaussian`
- 3 `opaque` predicates: `IsElementaryOver`, `IsLiouvilleForm`, `IsElementaryFn`

**definitionCount=6 decomposition**: 2 `def` (isConst, rischOp) + 3 `opaque` + 1 `class` (DiffField).

- No `True` stub theorems
- `DiffField` class is a type-class definition (algebraic structure interface, not an assumption-carrying axiom set)
- `gaussian_not_elementary` is a fully-proved theorem (not sorry'd); `conclusion.summary` accurately scopes it to "no rational-function antiderivative"; the broader "no elementary antiderivative" remains gated by the two stated axioms
- Status `axiomatized` / badge `axiom` consistent with axiom presence

## Changes

- Bump `auditCount`: 1 → 2
- Update `lastAudited`: 2026-05-03 → 2026-06-05
- `result`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)