### PR TITLE
audit(erdos-1006-oq-01-oq-02): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14006,8 +14006,8 @@
       "issues": []
     },
     "erdos-1006-oq-01-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T07:39:34Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T22:22:54Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audited **erdos-1006-oq-01-oq-02** (Cover Graph Recognition).

- 256 lines, 9 theorems, 2 axioms, 4 defs, 0 sorries — all match meta.json
- No True stubs, no Mathlib-wrapper theorems, no structure-encoded assumptions
- Axioms are substantive:
  - `comparability_recognition_in_p` (Golumbic 1977)
  - `cover_graph_recognition_in_p` (the actual open conjecture)
- Status `axiomatized` / badge `axiom` is correct

## Result

`clean` — tracker bumped from auditCount 1 → 2.

## Test plan

- [x] Theorem/axiom/def/sorry counts grepped against meta.json
- [x] Axiom integrity per AXIOM_INTEGRITY policy (no structure-encoded assumptions)
- [x] Status field matches presence of axioms (`axiomatized` for declared axioms)