### PR TITLE
audit(erdos-1210): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14012,8 +14012,8 @@
       "issues": []
     },
     "erdos-1210": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T07:39:45Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T22:27:29Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary
Second audit of `erdos-1210` (Pairwise Coprime Subset Sum Inequality, open Erdős conjecture). Verified `proofs/Proofs/Erdos1210Problem.lean` against `src/data/proofs/erdos-1210/meta.json`. All fields match.

## Audit findings
- **Lines:** 178 (meta: 178) ✓
- **Theorems:** 11 (meta: 11) ✓ — `primes_coprime`, `primesBelow_pairwiseCoprime`, `primesBelow_valid`, `primesBelow_nonempty`, `pairwiseCoprime_at_most_one_even`, `primesBelow_sum_nonneg`, `primesBelow_sum_pos`, `erdos_1210_bound`, `erdos_1210_empty`, `erdos_1210_prime_singleton`, `erdos_1210_singleton_bounded`
- **Definitions:** 3 (meta: 3) ✓ — `primesBelow`, `PairwiseCoprime`, `ValidSubset`
- **Axioms:** 1 (meta: 1) ✓ — `erdos_1210` (the open conjecture itself)
- **Sorries:** 0 (meta: 0) ✓
- **True stubs:** 0 ✓
- **Status:** `axiomatized` / badge `axiom` — correct for an open conjecture
- **Assumptions field:** accurately describes the single axiom

No integrity issues. Bumping `auditCount` 1 → 2 and `lastAudited` to 2026-06-05T22:27:29Z.

## Test plan
- [x] Counts in `meta.json` match Lean source
- [x] Axiom and theorem names enumerated and matched
- [x] Status/badge consistent with open-conjecture axiomatization
- [x] No sorries, True stubs, or unstated Mathlib wrappers