### PR TITLE
docs(aristotle): per-sorry MCP prove() workflow for researchers

### DIFF
--- a/.lean/roles/researcher.md
+++ b/.lean/roles/researcher.md
@@ -275,9 +275,10 @@ end ErdosN
 
 ### Use Aristotle Strategically
 
-- **TRIVIAL sorries**: Try manually first
-- **HARD sorries**: Add to companion file (`ErdosNAristotle.lean`) — the Aristotle agent will detect and submit it automatically
-- **OPEN sorries**: Work manually - Aristotle can't help with unsolved problems
+- **TRIVIAL sorries**: Try manually first — faster to write yourself than to round-trip through Aristotle
+- **HARD sorries**: **Preferred path is per-sorry MCP `prove()` (see "Per-sorry Aristotle (MCP) usage" below)**. The legacy multi-sorry `*Aristotle.lean` companion-file pipeline is deprecated for new work but remains available as a fallback; existing companion files are not being deleted in this transition.
+- **OPEN sorries**: Work manually — Aristotle can't help with unsolved problems (it will spin on the server until it times out)
+- **Definition sorries**: Never submit — Aristotle skips `def ... := by sorry` entirely. Complete the definition first, then submit downstream theorem sorries.
 
 ### Aristotle MCP (interactive proving)
 
@@ -353,6 +354,122 @@ trivial `prove()` returns a project id. The batch pipeline
 `retrieve-integrate.sh`) is unchanged and remains the right path for
 companion-file fleets — the MCP route is additive, for in-session
 interactive proving.
+
+### Per-sorry Aristotle (MCP) usage
+
+This is the **preferred** in-session workflow for hard supporting lemmas.
+It supersedes the legacy "create a multi-sorry `*Aristotle.lean` companion
+file and wait for the batch agent" pattern for *new* work. (Existing
+companion files keep working; do not delete them in passing.)
+
+The flow is conversational and per-sorry: classify the sorry, submit
+**one snippet** via `prove()`, record the project id, **continue other
+work**, poll, integrate. This mirrors Harmonic's iterative pattern from
+the Aristotle paper (§4) and the Polya–Szego study where this approach
+produced 80/80.
+
+#### When to call `prove()`
+
+Call it as soon as you hit a sorry that classifies as **HARD** per
+[`research/SORRY-CLASSIFICATION.md`](../../research/SORRY-CLASSIFICATION.md):
+
+- The result is **known in the literature** (paper, textbook, Mathlib
+  lemma you can name but haven't located) and
+- The proof requires **no creative insight from you** — only tactical
+  search and bookkeeping.
+
+Typical fits: monotonicity, cardinality bounds, standard inequalities,
+named theorems, computational lemmas that should "just go through".
+
+#### When NOT to call `prove()`
+
+| Classification | Why not | What to do instead |
+|----------------|---------|--------------------|
+| **TRIVIAL** | Round-tripping through Aristotle is slower than writing the 1–3 line tactic yourself | Write it manually (`simp`, `omega`, `linarith`, `decide`, `Finset.card_*`, etc.) |
+| **OPEN** | Aristotle has no proof in its training distribution; MCTS will spin until the server-side cap or the cooldown kicks in | Work on it yourself; that is **the mission** |
+| **DEF SORRY** (`def foo : T := by sorry`) | Aristotle skips definition sorries entirely — submitting wastes a slot | Complete the definition first, *then* submit the downstream theorem sorries |
+| **Sorry inside an axiom** | Axioms are skipped; restate as `theorem ... := by sorry` if you want it attempted | Convert `axiom` → `theorem ... := by sorry` if it really is provable |
+
+#### Pattern (recommended)
+
+1. **Extract** the sorry as a self-contained snippet. Include just the
+   `theorem` / `lemma` statement, its `by` block, and the local
+   variable hypotheses it actually mentions. Do not paste the whole
+   surrounding file.
+2. **List minimal `context_files`**. Include the file that *defines the
+   sorry's symbols* and at most one or two of its direct dependency
+   files. Aristotle pays (in time and credit) for everything it loads
+   — passing the whole project measurably slows search and is a common
+   mistake. If the snippet only uses Mathlib, omit `context_files`
+   entirely.
+3. **Submit async**: `prove(snippet, context_files=[...], wait=False)`
+   and capture the returned `project_id`.
+4. **Record the project id** in a per-session scratch file so you don't
+   lose it across restarts (project results cache for 30 days
+   server-side, but re-submitting the same snippet is the safety net
+   if you do lose the id):
+
+   ```bash
+   mkdir -p .loom/state/aristotle-mcp
+   SCRATCH=".loom/state/aristotle-mcp/$(date -u +%Y%m%dT%H%M%SZ)-$$.jsonl"
+   echo '{"project_id":"<id>","problem":"<problem-id>","sorry":"<short-tag>","submitted":"'"$(date -u +%FT%TZ)"'"}' >> "$SCRATCH"
+   ```
+
+5. **Continue other work**. Pick up a different sorry, refactor, write
+   docs, work on the OPEN main conjecture. Do **not** block the
+   session on a single Aristotle call.
+6. **Poll every ~10 minutes** with `check_proof(project_id)`. Faster
+   polling burns API calls; slower wastes wall-clock. Ten minutes is
+   the cadence the `septract/lean-aristotle-mcp` README recommends.
+7. **Integrate** when status is `SUCCEEDED`: paste the returned code,
+   rebuild via `./proofs/scripts/docker-build.sh Proofs.<YourProof>`,
+   and verify. On `FAILED` or timeout, either rewrite the snippet
+   (better statement, smaller context) and resubmit, or fall back to
+   manually proving it.
+
+#### Concurrency cap
+
+**At most 3 concurrent per-sorry `prove()` submissions per researcher.**
+The Aristotle server cap is shared with the bulk pipeline, and exceeding
+it triggers 429 responses that propagate into a cooldown.
+
+Before submitting, check the cooldown file from #22487:
+
+```bash
+COOLDOWN=".loom/state/aristotle-rate-limit-until"
+if [ -f "$COOLDOWN" ] && [ "$(cat "$COOLDOWN")" -gt "$(date +%s)" ]; then
+  echo "Aristotle is rate-limited until $(date -r "$(cat "$COOLDOWN")"). Skip prove() this cycle."
+  # work on other things — write the proof yourself, refactor, do the OPEN problem
+fi
+```
+
+Also check the scale-to-zero marker from #22486
+(`.loom/state/aristotle-scaled-to-zero`); if present, the queue is empty
+and you should not submit fresh per-sorry work without confirming the
+batch agent is back up.
+
+Count your own in-flight submissions by reading the per-session scratch
+files; if you already have 3 unfinished `prove()` calls, finish polling
+those before submitting another.
+
+#### Deprecation of hand-curated `*Aristotle.lean` companion files
+
+Going forward, **do not hand-curate new multi-sorry `*Aristotle.lean`
+companion files**. The MCTS proof search Aristotle uses is conditioned
+on *proof state + history + informal statement* per sorry, so bundling
+many unrelated sorries into one file dilutes the search budget. New
+work has exactly two supported routes:
+
+1. **Per-sorry interactive**: `prove()` via MCP (this section). Best
+   for in-session work on a single hard supporting lemma.
+2. **Single-theorem batch**: a `*StatementOnly.lean` file (one theorem,
+   informal-proof docstring, full imports) for end-of-session
+   submission to the batch pipeline. See `research/SORRY-CLASSIFICATION.md`
+   §"Harmonic Submission Format (recommended)" for the file template.
+
+Existing `*Aristotle.lean` files keep working — the batch agent still
+picks them up as a fallback — but they are no longer the recommended
+shape for new submissions.
 
 ## Step 4: Update Knowledge
 

--- a/research/SORRY-CLASSIFICATION.md
+++ b/research/SORRY-CLASSIFICATION.md
@@ -77,6 +77,81 @@ theorem erdos_340 (ε : ℝ) (hε : ε > 0) :
 
 **Aristotle spun on Erdős #340** because NO proof exists. That's for US to discover!
 
+## Decision Tree: which tool handles which sorry?
+
+When you hit a `sorry`, walk this tree before deciding what to do with it:
+
+```
+                       ┌──────────────────────────────┐
+                       │   You hit a `sorry`. What    │
+                       │   kind of declaration is it? │
+                       └──────────────┬───────────────┘
+                                      │
+              ┌───────────────────────┼────────────────────────┐
+              │                       │                        │
+              ▼                       ▼                        ▼
+        def f := by sorry      theorem/lemma             axiom foo : ...
+        (DEF SORRY)            (classify by tier)        (no body to fill)
+              │                       │                        │
+              ▼                       ▼                        ▼
+        Aristotle SKIPS         Classify the sorry:       Aristotle SKIPS.
+        these entirely.         TRIVIAL / HARD / OPEN     Convert to
+        Complete the def         (see tier table above)   `theorem ... := by sorry`
+        yourself first.                 │                  if you want it attempted.
+                                        │
+                ┌───────────────────────┼───────────────────────┐
+                │                       │                       │
+                ▼                       ▼                       ▼
+            TRIVIAL                   HARD                   OPEN
+        (1-10 min if you           (known result,        (unsolved
+         just write it)             paper exists,         conjecture,
+                │                   no creative           creative
+                │                   insight needed)       insight
+                │                       │                 required)
+                ▼                       ▼                     ▼
+        Write it yourself.    ┌─────────────────────┐   YOU work on it
+        Round-tripping        │ In a researcher     │   manually.
+        through Aristotle     │ session right now?  │   This is the
+        is slower than        └─────────┬───────────┘   MISSION — do not
+        `simp`/`omega`/                  │              submit to
+        `linarith`/                      │              Aristotle.
+        `decide`.            ┌───────────┴────────────┐
+                             │                        │
+                             ▼                        ▼
+                          YES                       NO
+                    (in-session,                 (end of session,
+                     interactive)                 batched cleanup)
+                             │                        │
+                             ▼                        ▼
+                ┌────────────────────────┐  ┌──────────────────────┐
+                │ MCP `prove()` per-     │  │ `*StatementOnly.lean`│
+                │ sorry (preferred)      │  │ single-theorem file  │
+                │                        │  │ for the batch        │
+                │ - extract snippet      │  │ pipeline             │
+                │ - minimal context_files│  │                      │
+                │ - async, poll ~10 min  │  │ (Harmonic format,    │
+                │ - max 3 concurrent     │  │  see section below)  │
+                │   per researcher       │  │                      │
+                └────────────────────────┘  └──────────────────────┘
+```
+
+**Quick rules of thumb:**
+
+| Sorry kind | Tool |
+|-----------|------|
+| `def f := by sorry` | You — Aristotle skips |
+| `axiom foo : ...` | You (or convert to `theorem ... := by sorry` first) |
+| TRIVIAL theorem sorry | You — faster than the round trip |
+| HARD theorem sorry, mid-session | MCP `prove()` (per-sorry, async) |
+| HARD theorem sorry, end-of-session batch | `*StatementOnly.lean` + batch pipeline |
+| OPEN theorem sorry | You — that's the research |
+
+**Hand-curated multi-sorry `*Aristotle.lean` companion files are
+DEPRECATED for new work** — the MCTS proof search is conditioned per
+sorry, so batching unrelated sorries dilutes the search budget. Existing
+companion files remain a working fallback; the batch agent still picks
+them up.
+
 ## Aristotle Companion Files (DEPRECATED — early multi-sorry pattern)
 
 > **Status (2026-06-05):** This multi-sorry companion-file pattern is **superseded** by the


### PR DESCRIPTION
## Summary

Updates researcher role documentation so researchers proactively call MCP `prove()` per-sorry on HARD supporting lemmas instead of hand-curating multi-sorry `*Aristotle.lean` companion files. This implements the Harmonic-style iterative pattern from the Aristotle paper §4 and brings the prompt in line with the per-sorry MCP capability vendored in #22470.

No code changes — this is documentation that shapes agent behavior via prompts.

## Changes

- **`.lean/roles/researcher.md`**: new `### Per-sorry Aristotle (MCP) usage` subsection adjacent to (and explicitly extending) the existing `### Aristotle MCP (interactive proving)` section from #22470. Covers:
  - **When to call `prove()`**: HARD sorries per the existing tier table (known result, paper exists, no creative insight required).
  - **When NOT to call `prove()`**: TRIVIAL (faster yourself), OPEN (will spin), definition sorries (Aristotle skips), axioms (Aristotle skips).
  - **Pattern**: extract snippet, list minimal `context_files`, async `prove()`, record `project_id` in per-session scratch under `.loom/state/aristotle-mcp/`, continue other work, poll every ~10 min, integrate on `SUCCEEDED`.
  - **Cap**: at most 3 concurrent per-sorry submissions per researcher. Honors the cooldown file at `.loom/state/aristotle-rate-limit-until` (#22487) and the scale-to-zero marker at `.loom/state/aristotle-scaled-to-zero` (#22486).
  - **Deprecation**: explicitly deprecates hand-curating *new* multi-sorry `*Aristotle.lean` companion files. Existing companion files keep working as a fallback (not deleted in this issue). New work uses per-sorry MCP `prove()` or single-theorem `*StatementOnly.lean` for batch submission.
- Also updated the short "Use Aristotle Strategically" bullets earlier in the file so the per-sorry MCP path is now the preferred route for HARD sorries, with the companion-file pipeline noted as the deprecated fallback. Added a definition-sorry bullet so researchers don't burn a slot on unprovable `def` sorries.
- **`research/SORRY-CLASSIFICATION.md`**: new `## Decision Tree: which tool handles which sorry?` section right after "The Key Insight". ASCII diagram showing the def-sorry / theorem-sorry / axiom branches and routing theorem sorries by tier and session context to Claude, MCP `prove()`, or the `*StatementOnly.lean` batch path. Followed by a "Quick rules of thumb" table for the impatient reader.

## Coordination with prerequisites

- **#22466** (Harmonic format adoption in SORRY-CLASSIFICATION): decision tree references the "Harmonic Submission Format (recommended)" section already in this doc; terminology matches.
- **#22470** (MCP vendored at `.mcp.json`, `### Aristotle MCP (interactive proving)` section already in researcher.md): the new section sits immediately after that one and extends it rather than contradicting it. The earlier section keeps the tool overview and the smoke-test instructions; the new section adds the per-sorry pattern, cap, and deprecation policy.
- **#22468** (StatementOnly format + preprocessor + Tier 0 in find-candidates): decision tree's batch branch points at `*StatementOnly.lean` as the supported batch shape for new work.
- **#22487** (cooldown file at `.loom/state/aristotle-rate-limit-until`): cap section shows the exact pre-submit check.
- **#22486** (scale-to-zero marker at `.loom/state/aristotle-scaled-to-zero`): cap section advises checking the marker before fresh submissions.

## Test plan

- [x] `grep -A 3 "Per-sorry Aristotle (MCP) usage" .lean/roles/researcher.md` returns the new section.
- [x] `grep -A 2 "Decision Tree" research/SORRY-CLASSIFICATION.md` returns the decision-tree section.
- [x] `git status scripts/aristotle/find-candidates.sh scripts/aristotle/submit-batch.sh` shows no modifications — batch pipeline scripts untouched.
- [x] Two files changed, only documentation.
- [ ] Reviewer: confirm the new section reads coherently after the existing `### Aristotle MCP (interactive proving)` section.
- [ ] Reviewer: confirm the ASCII decision tree renders legibly in GitHub markdown (it's intentionally inside a fenced block to preserve alignment).

Closes #22472

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>