### PR TITLE
audit(lebesgue-measure-oq-01-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14024,8 +14024,8 @@
       "issues": []
     },
     "lebesgue-measure-oq-01-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T07:41:59Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T22:37:08Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Second audit of `lebesgue-measure-oq-01-oq-03` (Indicator of Any Null Set Has Zero Lebesgue Integral). Result: **clean** — verified meta.json claims against Lean source.

## Verification

`proofs/Proofs/LebesgueMeasureOQ01OQ03.lean` (244 lines):
- theorems: **15** ✓ (matches `meta.theoremCount: 15`)
- axioms: **0** ✓ (matches `meta.axiomCount: 0`)
- definitions: **0** ✓ (matches `meta.definitionCount: 0`)
- sorries: **0** ✓ (matches top-level `sorries: 0`)
- lineCount: **244** ✓ (matches `meta.lineCount: 244`)
- structure-encoded assumptions: **none** (no `structure`/`class`/`instance` declarations)
- status `verified` / badge `verified` justified: 0 sorries + 0 axiom decls + 0 structural assumptions
- imports: Mathlib measure-theory + Bochner integration only — no custom axiomatic scaffolding

All 15 theorems are non-trivial, Mathlib-backed proofs (no `True` placeholders, no trivial wrappers). The companion `example` at L209 confirms the OQ-01 Dirichlet special case derives from the general theorem.

## Changes

- `src/data/proofs/audit-tracker.json`: `auditCount` 1 → 2, `lastAudited` → 2026-06-05.

## Test plan

- [x] Counts verified by grep against the Lean source
- [x] Line count verified by `wc -l`
- [x] No structure-encoded assumptions confirmed
- [x] Meta status/badge consistent with axiom-integrity policy