### PR TITLE
audit(infinitude-primes-4k3-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13959,12 +13959,12 @@
       "result": "issues-fixed"
     },
     "infinitude-primes-4k3-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [
         "lineCount stale 100->103 in meta and leanFile blocks"
       ],
-      "lastAudited": "2026-05-03T08:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-05T22:41:40Z",
+      "result": "clean"
     },
     "angle-trisection-oq-03-oq-02": {
       "auditCount": 5,


### PR DESCRIPTION
## Summary
Second audit pass over `infinitude-primes-4k3-oq-03` (`Proofs/InfinitudePrimes4k3OQ03.lean`). All meta fields match the Lean source on disk; no fixes needed.

Tracker: `auditCount` 1→2, `lastAudited` → 2026-06-05T22:41:40Z, `result` issues-fixed→clean.

## Verification
| Meta field | Claimed | Found |
|---|---|---|
| theoremCount | 4 | 4 ✓ |
| axiomCount | 0 | 0 ✓ |
| newAxiomCount | 0 | 0 ✓ |
| definitionCount | 0 | 0 ✓ |
| sorries | 0 | 0 ✓ |
| lineCount | 103 | 103 ✓ |
| status / badge | verified / original | verified / original ✓ |

- 0 `axiom` declarations, 0 `opaque` declarations, 0 structure-encoded assumptions
- No `True` stubs; no `:= Mathlib.…` re-export shells
- Theorems re-export sibling gallery proofs `InfinitudePrimes4k1` / `InfinitudePrimes4k3` (original gallery construction, not Mathlib wrappers) — `original` badge stands.

## Test plan
- [x] `git diff` clean except tracker bump
- [x] `wc -l`, `grep` counts match meta.json
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)