### PR TITLE
audit(godel-first-incompleteness-oq01-oq-04): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13951,12 +13951,12 @@
       "result": "clean"
     },
     "godel-first-incompleteness-oq01-oq-04": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [
         "missing top-level sorries field"
       ],
-      "lastAudited": "2026-05-03T08:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-05T22:45:06Z",
+      "result": "clean"
     },
     "infinitude-primes-4k3-oq-03": {
       "auditCount": 1,


### PR DESCRIPTION
## Summary

Re-audit of `godel-first-incompleteness-oq01-oq-04` confirms gallery meta.json matches the Lean source for `Proofs/GodelFirstIncompletenessOQ01OQ04.lean`. Tracker-only change: auditCount 1→2, `lastAudited` bumped, prior `issues-fixed` result advances to `clean`.

## Audit findings

| Check | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| Line count | 241 | 241 | ✓ |
| Sorries | 0 | 0 | ✓ |
| Axiom count | 5 | 5 (`Provable`, `d1`, `diagonal_lem`, `neg_G_prov`, `omega_cons`) | ✓ |
| Theorem count | 9 | 9 (`G_spec`, `G_not_provable`, `neg_G_not_provable`, `first_incompleteness`, `G_undecidable`, `prov_fixed_point_exists`, `arb_fixed_point_exists`, `consistency_sentence_exists`, `G_self_reference_fwd`) | ✓ |
| Definition count | 7 | 7 (`Formula`, `neg`, `godelNum`, `Prov`, `G`, `Consistent`, `Complete`) | ✓ |
| Status / Badge | axiomatized / axiom | 5 axiom declarations present | ✓ |

- No True stubs.
- No Mathlib wrappers obscured as `original` — badge `axiom` correctly reflects the axiomatized status.
- No claim drift in title/description (explicitly labeled "axiomatized" with the Diagonal Lemma as Axiom 2).
- Prior 1st audit flagged a missing top-level `sorries` field; that has since been added and the value matches the Lean source (0).

## Test plan

- [x] meta.json line/sorry/axiom/theorem/definition counts cross-checked against Lean source
- [x] axiom declarations enumerated and matched to `assumptions` field narrative
- [x] status/badge consistency verified
- [x] tracker-only diff confirmed (no source/meta edits)

---
Generated during periodic gallery integrity audit.