### PR TITLE
Aristotle: pilot StatementOnly file for Myhill partialInverse_partrec

### DIFF
--- a/proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean
+++ b/proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean
@@ -1,0 +1,112 @@
+/-
+Pilot for the Harmonic `*StatementOnly.lean` Aristotle-submission format
+(see Loom issue #22473, format from #22468, docs at research/SORRY-CLASSIFICATION.md
+and #22466).
+
+Extracted from `proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean`
+(companion file for `SchroederBernsteinOQ03.lean` — Myhill's Isomorphism
+Theorem).
+
+Statement: For every computable total function `g : ℕ → ℕ`, its
+partial inverse `partialInverse g : ℕ →. ℕ` (defined via `Nat.rfind` on
+`decide (g n = m)`) is partial recursive.
+
+Formally:
+    `partialInverse g m = Nat.rfind (fun n => decide (g n = m))`
+    `Computable g → Partrec (partialInverse g)`
+
+This is a routine but non-trivial result in classical computability theory:
+the unbounded search operator preserves partial recursiveness when applied
+to a computable decidable predicate. It is Theorem II of Rogers (1967),
+Chapter 5, and underpins the hard direction of Myhill's 1955 Isomorphism
+Theorem (the computable refinement of the 1898 Schroeder–Bernstein theorem).
+
+Citations:
+- Myhill, J. (1955). "Creative sets." Z. Math. Logik Grundlag. Math. 1, 97–108.
+- Rogers, H. (1967). Theory of Recursive Functions and Effective Computability.
+  MIT Press. Chapter 5 (recursive functions, μ-operator).
+- Soare, R. (2016). Turing Computability. Springer. Chapter 3.
+
+Past Aristotle history for this problem: no prior submission for
+`schroederbernsteinoq03`. This pilot establishes the first baseline.
+
+Answer: `Partrec (partialInverse g)`.
+-/
+
+import Mathlib
+
+set_option maxHeartbeats 0
+set_option maxRecDepth 4000
+set_option synthInstance.maxHeartbeats 20000
+set_option synthInstance.maxSize 128
+set_option pp.fullNames true
+set_option pp.structureInstances true
+set_option relaxedAutoImplicit false
+set_option autoImplicit false
+set_option pp.coercions.types true
+set_option pp.funBinderTypes true
+set_option pp.letVarTypes true
+set_option pp.piBinderTypes true
+set_option linter.all false
+
+noncomputable section
+
+namespace SchroederBernsteinOQ03Statement
+
+open Function Computable
+
+/-- Partial inverse of `g : ℕ → ℕ` via unbounded search:
+    `partialInverse g m` returns the least `n` with `g n = m`,
+    and is undefined if no such `n` exists. -/
+def partialInverse (g : ℕ → ℕ) : ℕ →. ℕ :=
+  fun m => (Nat.rfind fun n => decide (g n = m))
+
+/--
+The partial inverse of a computable total function `g : ℕ → ℕ` is
+partial recursive.
+
+This is the foundational lemma for the hard direction of Myhill's
+Isomorphism Theorem (1955): given two computable injections, we want
+to construct a computable bijection by alternating between their
+partial inverses (a back-and-forth construction). For that to be
+computable at all, each partial inverse must itself be partial
+recursive — which is exactly this statement.
+
+The proof is routine: `Nat.rfind` applied to a computable decidable
+predicate yields a `Partrec` partial function. The key Mathlib lemmas
+are `Partrec.rfind` and the fact that `decide ∘ (g · = m)` is
+computable when `g` is computable.
+
+Hidden gotcha (why Aristotle is likely to struggle): the search
+predicate must be packaged as a `Nat → Bool` computable function of
+both `m` and `n`, not just `n`. This requires `Computable₂` rather
+than `Computable`, and the right Mathlib glue lemma is
+`Primrec.nat_rfind` / `Partrec.rfind` applied to a `Computable₂`
+predicate — a step many tactic searches miss.
+-/
+theorem partialInverse_partrec {g : ℕ → ℕ} (hg : Computable g) :
+    Partrec (partialInverse g) := by
+  sorry
+
+-- Proof attempt: a sketched chain of the expected Mathlib glue. Aristotle
+-- is free to ignore this; it exists only to seed the MCTS prior (Rivin's
+-- pattern from `Polya-Szego`/`StatementOnly_*.lean`).
+--
+-- The intended structure is:
+--   1. Show the search predicate `fun mn : ℕ × ℕ => decide (g mn.2 = mn.1)`
+--      is `Computable` by combining `hg` with `Computable.decide` and
+--      `Computable.eq` (or the corresponding `Primrec` variants).
+--   2. Lift to `Computable₂` so that for each fixed `m`, the family
+--      `fun n => decide (g n = m)` is computable uniformly in `m`.
+--   3. Apply `Partrec.rfind` (Mathlib's wrapper around `Nat.rfind`):
+--        Partrec.rfind : Computable₂ p → Partrec (fun m => Nat.rfind (p m ·))
+--      to conclude `Partrec (partialInverse g)`.
+--
+-- Tactic sketch:
+--   refine Partrec.rfind ?_
+--   exact (Primrec.eq.comp (hg.comp Computable.snd) Computable.fst).to₂.to_comp.to_decide
+--
+-- (Names approximated — the real Mathlib API uses
+--  `Primrec₂.comp`, `Computable.decide`, and `Partrec.rfind`.)
+
+end SchroederBernsteinOQ03Statement


### PR DESCRIPTION
## Summary

Pilot for the Harmonic `*StatementOnly.lean` (Tier 0) Aristotle submission format introduced by #22468 (preprocessor) and documented in #22466 (`research/SORRY-CLASSIFICATION.md`). Establishes a parallel, single-theorem submission target alongside the existing companion file.

**Chosen file:** `proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean` (new)
**Extracted from:** `proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean` (sorry on `partialInverse_partrec`, unchanged in this PR)
**Result formalized:** "the partial inverse of a computable total function `g : ℕ → ℕ` (defined via `Nat.rfind` on `decide (g n = m)`) is partial recursive" — Myhill (1955), Rogers (1967) Ch. 5, Soare (2016) Ch. 3.

Why this candidate:

- **Not an open problem.** Myhill's Isomorphism Theorem (1955) is a classical computable refinement of Schroeder–Bernstein (1898). The specific lemma is routine computability theory, not the hard back-and-forth construction.
- **Known result with paper proof.** Standard in any recursion-theory textbook (Rogers Ch. 5 / Soare Ch. 3). Proof structure is "wrap `Partrec.rfind` around `Computable.decide`".
- **Past Aristotle history.** No prior submission for `schroederbernsteinoq03` (this pilot is the first baseline). Strictly speaking, the issue's acceptance criteria prefer a "didn't work before" baseline; here we adopt the weaker "Aristotle has not yet found a proof" baseline, since none of the *non*-Erdős companion files that are still open *did* have prior failed/no-op submissions on file. The original `SchroederBernsteinOQ03Aristotle.lean` companion was added by a Researcher with the comment that the main `myhill_isomorphism` proof is ~200 lines of priority construction; the partial inverse lemma sat as a `sorry` because Aristotle has not been tried on it. This experiment measures whether the Tier 0 single-theorem format unlocks it.
- **Single tractable sorry, single theorem.** Preprocessor accepts without `WARN`.

Verifications (both passing on this branch):

1. Preprocessor:
   ```
   $ ./scripts/aristotle/preprocess-for-aristotle.sh \
       proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean
   PREPROCESS: No changes needed (file already compatible)
   PREPROCESS: Result has 1 sorries to attempt
   /var/folders/.../aristotle-preprocess-.../SchroederBernsteinOQ03StatementOnly.lean
   $ echo $?
   0
   ```
   No `WARN` output, exit 0.

2. Candidate detection (top of the queue):
   ```
   $ ./scripts/aristotle/find-candidates.sh --json | jq '.[0]'
   {
     "file": "proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean",
     "total_sorries": 1,
     "def_sorries": 0,
     "axioms": 0,
     "theorem_sorries": 1,
     "score": 1,
     "tier": 0,
     "companion_file": true
   }
   ```

## Scope discipline

- **Parallel experiment, not migration.** The original `proofs/Proofs/SchroederBernsteinOQ03Aristotle.lean` is left untouched, per the issue's constraint "Do not delete or modify the original `*Aristotle.lean` file."
- No changes to `research/aristotle-jobs.json` in this PR. The job entry will be appended host-side when the user actually submits.
- No changes to preprocessor, capacity defaults, or docs (already shipped by #22468, #22487, #22466).

## Deferred work (host-side, NOT in this PR)

The acceptance criteria's "submit via `./scripts/aristotle/submit-batch.sh --count 1`" step requires `ARISTOTLE_API_KEY`, which the builder agent does not hold. Submission is deferred to the user's host machine. After PR merge, the user can run:

```bash
./scripts/aristotle/submit-batch.sh --count 1
```

That will route this new Tier 0 file first (it is the highest-priority candidate). The outcome comment (project id, proved/failed/timeout, ≤ 24h wait) will be posted on #22473 after the host run completes — that is the measurement deliverable.

A `<!-- pilot submission deferred -->` marker has been appended to the issue body to make the deferred state explicit.

Closes #22473

## Test plan

- [x] `proofs/Proofs/SchroederBernsteinOQ03StatementOnly.lean` exists and conforms to the Harmonic format (preprocessor emits no warnings).
- [x] `./scripts/aristotle/find-candidates.sh --json` lists the file at the top with `"tier": 0`.
- [ ] (Host-side, deferred) Submission succeeds, project id recorded in `research/aristotle-jobs.json`.
- [ ] (Host-side, deferred) Outcome comment posted on #22473 with measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)