### PR TITLE
audit(erdos-1054-oq-02): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13945,9 +13945,9 @@
       "result": "clean"
     },
     "erdos-1054-oq-02": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-03T08:00:00Z",
+      "lastAudited": "2026-06-05T22:50:38Z",
       "result": "clean"
     },
     "godel-first-incompleteness-oq01-oq-04": {


### PR DESCRIPTION
## Summary

Second audit of `erdos-1054-oq-02` [verified/original]. Result: clean.

## Verification

- 17 theorems, 3 defs, 0 axioms, 0 opaque, 0 sorries
- 307 lines (matches meta `lineCount` and `theoremCount`)
- No `True` stubs or Mathlib wrappers
- `goldbach_implies_representable` is a genuine existential witness, not a stub
- `goldbach_witness_N` series uses `native_decide`; `witnesses_6_to_20` uses `fin_cases` + `native_decide` for all 15 cases

## Changes

`audit-tracker.json`:
- `auditCount`: 1 → 2
- `lastAudited`: 2026-05-03T08:00:00Z → 2026-06-05T22:50:38Z
- `result`: clean (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)