### PR TITLE
audit(angle-trisection-oq-04-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13916,9 +13916,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-04-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-03T08:00:00Z",
+      "lastAudited": "2026-06-05T23:06:26Z",
       "result": "clean"
     },
     "angle-trisection-oq-04-oq-04": {


### PR DESCRIPTION
## Summary

2nd audit of `angle-trisection-oq-04-oq-03` (Pierpont prime criterion for neusis constructibility). **Result: clean.** meta.json claims match Lean source exactly.

## Verification

**Main file** `proofs/Proofs/AngleTrisectionOQ04OQ03.lean` (328 lines):
- 54 theorem/lemma/example declarations → matches `theoremCount: 54`
- 2 `def` declarations → matches `definitionCount: 2`
- 0 `axiom` declarations → matches `axiomCount: 0`
- 0 sorries → matches `sorries: 0`
- 0 True-stub theorems

**Additional file** `proofs/Proofs/AngleTrisectionOQ04.lean` (599 lines, imported):
- 0 `axiom`, 0 `opaque` declarations
- 0 sorries
- File-internal self-declaration confirms "Axioms: 0, Sorries: 0" (lines 595–596)
- Docstring at L196 mentions "axiomatized" for Mohr-Mascheroni, but `mohr_mascheroni` at L215 is actually proved by `rfl` — no actual axiom

Status `verified` / badge `original` accurately reflects the formalization.

## Tracker change

- `auditCount`: 1 → 2
- `lastAudited`: 2026-05-03T08:00:00Z → 2026-06-05T23:06:26Z
- `result`: clean (unchanged)

## Test plan

- [x] grep theorems → 54
- [x] grep axiom/opaque → 0 (both files)
- [x] grep sorry → 0 (both files)
- [x] grep True stubs → 0
- [ ] CI build passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)