### PR TITLE
audit(erdos-770): fix theoremCount drift 80→74 (4th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -9509,11 +9509,11 @@
       "issues": []
     },
     "erdos-770": {
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T08:10:00Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-05T23:28:23Z",
       "result": "issues-fixed",
       "issues": [
-        "theoremCount 80→74: meta.meta.theoremCount and leanFile.theoremCount overcounted by 6 after PR #15094 merged"
+        "theoremCount 80→74: meta.meta.theoremCount and leanFile.theoremCount overcounted by 6 — FIXED in this audit cycle"
       ]
     },
     "erdos-771": {

--- a/src/data/proofs/erdos-770/meta.json
+++ b/src/data/proofs/erdos-770/meta.json
@@ -59,7 +59,7 @@
     "lineCount": 550,
     "assumptions": "2 axioms: erdos_770_q1 (density of {n : hMinK n = p} exists for each prime p — OPEN), erdos_770_q3 (hMinK n = p when p is the largest prime with (p-1)|n, for large n — OPEN). Q2 (h(n) unbounded) is fully proved via hMinK_unbounded. 74 theorems, 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 80,
+    "theoremCount": 74,
     "definitionCount": 2
   },
   "sections": [
@@ -209,7 +209,7 @@
     "namespace": null,
     "lineCount": 550,
     "axiomCount": 2,
-    "theoremCount": 80,
+    "theoremCount": 74,
     "definitionCount": 2,
     "path": "Proofs/Erdos770Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Re-audited **erdos-770** (Erdős Problem #770: Mutual Coprimality of k^n − 1).

- **Result**: issues-fixed (auditCount 3 → 4)
- **Risk**: LOW (cosmetic count mismatch; integrity-critical fields all match)

## Audit Findings vs meta.json

| Field | Claimed | Actual | Match |
|------:|:-------:|:------:|:-----:|
| status | axiomatized | 2 axioms exist | ✓ |
| badge | axiom | (consistent with axiomatized) | ✓ |
| sorries | 0 | 0 (grep -nE `\bsorry\b`) | ✓ |
| axiomCount | 2 | 2 (`erdos_770_q1`, `erdos_770_q3`) | ✓ |
| definitionCount | 2 | 2 (`gcdPowerSeq`, `hMinK`) | ✓ |
| lineCount | 550 | 550 | ✓ |
| theoremCount | **80** | **74** | ✗ → **fixed** |

## What I Fixed

The audit-tracker had documented this exact theoremCount drift from PR #15094 era but never actually corrected meta.json:

```diff
-    "theoremCount": 80,
+    "theoremCount": 74,
```

Two occurrences: `meta.meta.theoremCount` (line 62) and `meta.leanFile.theoremCount` (line 212). The free-text `meta.assumptions` field already stated the correct count ("74 theorems, 0 sorries") — only the structured numeric fields were stale.

## Tier Classification

**Tier C — Scaffold / axiomatized**: The two `axiom` declarations encode Q1 (density existence for each prime p) and Q3 (dominant-prime characterization of hMinK) as OPEN. Q2 (h(n) unbounded) is fully proved via `hMinK_unbounded`. Badge `axiom` is correct.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` confirms tracker delta
- [x] `git diff` confirms minimal change (2 files, 5 insertions, 5 deletions)
- [x] `grep -cE "^theorem |^lemma " proofs/Proofs/Erdos770Problem.lean` = 74

🤖 Generated with [Claude Code](https://claude.com/claude-code)