### PR TITLE
audit(buffons-needle-oq-02-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14042,8 +14042,8 @@
       "issues": []
     },
     "buffons-needle-oq-02-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T09:26:47Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-05T23:36:59Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Audit summary

2nd audit of `buffons-needle-oq-02-oq-03` (Abstract Cauchy-Crofton Formula). All meta.json structural claims verified against `proofs/Proofs/BuffonsNeedleOQ02OQ03.lean`.

## Verification

| Field | Meta | Source | Match |
|---|---|---|---|
| lineCount | 285 | 285 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 3 | 3 | ✓ |
| theoremCount | 27 | 27 | ✓ |
| definitionCount | 7 | 7 | ✓ |
| status | axiomatized | (3 axioms) | ✓ |
| badge | axiom | axiom | ✓ |

**Axioms (3):**
- `kinematicMeasure` (L97) — invariant measure on AffineHyperplane n
- `cauchy_crofton_segment` (L102) — single-segment expected crossings = αₙ · length
- `crossing_integrable` (L108) — crossing indicator integrable wrt kinematicMeasure

**Theorems/lemmas (27):**
- 18 with `^theorem`/`^lemma` anchor (e.g. `cauchy_crofton_polygonal`, `crofton_*`, `crossingFactor_{four,five,pos,succ_succ_lt}`, dimension comparisons)
- 9 with `@[simp] lemma` prefix: `crossingFactor_{zero,one,two,three,rec}`, `totalCrossings_{nil,cons}`, `totalLength_{nil,cons}`

**Definitions (7):** 2 abbrev (`AffineHyperplane`, `LineSegment`) + 5 noncomputable def (`LineSegment.length`, `LineSegment.crossing`, `crossingFactor`, `totalCrossings`, `totalLength`)

No issues found. Bumping auditCount 1→2, lastAudited → 2026-06-05.

## Test plan
- [x] meta.json values match Lean source counts
- [x] Status axiomatized honest (3 axioms present)
- [x] No structure-encoded assumptions
- [ ] Build verification deferred (Docker wrapper required; clean tracker bump only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)