### PR TITLE
audit(shannon-source-coding-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14048,9 +14048,9 @@
       "issues": []
     },
     "shannon-source-coding-oq-03": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T09:34:34Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-06-06T00:27:41Z",
+      "result": "clean",
       "issues": []
     },
     "picks-theorem-oq-02": {


### PR DESCRIPTION
## Audit Summary

Clean 2nd audit of **shannon-source-coding-oq-03** (Asymptotic Equipartition Property).

## Verification

All `meta.json` claims match the Lean source exactly:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| theoremCount | 13 | 13 ✓ (12 public + 1 private `expVal_marginal_product` at L234) |
| definitionCount | 8 | 8 ✓ (7 `def` + 1 `structure DiscreteDist` at L59) |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| lineCount | 476 | 476 ✓ |
| True stubs | n/a | 0 ✓ |
| status | verified | honest ✓ |
| badge | original | honest ✓ |

### Audit gotcha (for future runs)

Naive `grep -cE '^(theorem|lemma)'` misses `private lemma` (1 here at L234). Naive `grep -cE '^(noncomputable )?def'` misses `structure` (1 here at L59 — counted as a definition by the meta). Use:
- theorems: `^(@\[[^]]+\][[:space:]]+)*(private[[:space:]]+)?(theorem|lemma)\b`
- defs: `^(@\[[^]]+\][[:space:]]+)*(noncomputable[[:space:]]+)?(def|structure)\b`

## Tracker

- Original audit: 2026-05-03 (issues-fixed)
- This audit: 2026-06-06 (clean) → `auditCount` 1 → 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)