### PR TITLE
research(erdos-1037-oq-02): multiplicity_k_bound + Mathlib v4.26.0 drift repair

### DIFF
--- a/proofs/Proofs/Erdos1037Aristotle.lean
+++ b/proofs/Proofs/Erdos1037Aristotle.lean
@@ -27,8 +27,17 @@ theorem degree_sum_eq_twice_edges :
 -- Routine: Maximum degree in a simple graph is at most n-1
 theorem degree_le_card_sub_one (v : V) :
     G.degree v ≤ Fintype.card V - 1 := by
-  have h := G.degree_lt_card v  -- G.degree v < Fintype.card V
-  omega
+  have hself : v ∉ G.neighborFinset v := G.notMem_neighborFinset_self v
+  have hsub : G.neighborFinset v ⊆ Finset.univ.erase v := by
+    intro u hu
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+    rintro rfl
+    exact hself hu
+  calc G.degree v
+      = (G.neighborFinset v).card := rfl
+    _ ≤ (Finset.univ.erase v).card := Finset.card_le_card hsub
+    _ = Fintype.card V - 1 := by
+        rw [Finset.card_erase_of_mem (Finset.mem_univ v), Finset.card_univ]
 
 -- Routine: Number of distinct degree values is at most n
 -- (image of univ has card ≤ card univ)
@@ -39,7 +48,9 @@ theorem distinctDegrees_le_card :
     _ = Fintype.card V := Finset.card_univ
 
 -- Routine: If every value appears at most k times among n elements,
--- then there are at least ⌈n/k⌉ distinct values (pigeonhole)
+-- then there are at least ⌈n/k⌉ distinct values (pigeonhole).
+-- Proof partitions the universe fiberwise by f via
+-- `Finset.card_eq_sum_card_fiberwise`.
 theorem pigeonhole_distinct_count (f : V → ℕ) (k : ℕ) (hk : k ≥ 1)
     (h : ∀ d : ℕ, (Finset.univ.filter (fun v => f v = d)).card ≤ k) :
     (Finset.univ.image f).card ≥ Fintype.card V / k := by
@@ -47,36 +58,37 @@ theorem pigeonhole_distinct_count (f : V → ℕ) (k : ℕ) (hk : k ≥ 1)
     calc Fintype.card V / k
         ≤ (k * (Finset.univ.image f).card) / k := Nat.div_le_div_right this
       _ = (Finset.univ.image f).card := Nat.mul_div_cancel_left _ (by omega)
-  rw [← Finset.card_univ]
-  have hpart : (Finset.univ : Finset V) =
-      (Finset.univ.image f).biUnion (fun d => Finset.univ.filter (fun v => f v = d)) := by
-    ext v; simp
-  rw [hpart, Finset.card_biUnion]
-  · calc ∑ d ∈ Finset.univ.image f, (Finset.univ.filter (fun v => f v = d)).card
-        ≤ ∑ _ ∈ Finset.univ.image f, k := Finset.sum_le_sum (fun d _ => h d)
-      _ = (Finset.univ.image f).card * k := by rw [Finset.sum_const, smul_eq_mul]
-      _ = k * (Finset.univ.image f).card := mul_comm _ _
-  · intro d _ e _ hde
-    rw [Finset.disjoint_left]
-    intro v hv1 hv2
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hv1 hv2
-    exact hde (hv1.symm.trans hv2)
+  have hmem : ∀ v ∈ (Finset.univ : Finset V), f v ∈ Finset.univ.image f :=
+    fun v _ => Finset.mem_image.mpr ⟨v, Finset.mem_univ v, rfl⟩
+  calc Fintype.card V
+      = (Finset.univ : Finset V).card := (Finset.card_univ).symm
+    _ = ∑ d ∈ Finset.univ.image f, (Finset.univ.filter (fun v => f v = d)).card :=
+        Finset.card_eq_sum_card_fiberwise hmem
+    _ ≤ ∑ _ ∈ Finset.univ.image f, k := Finset.sum_le_sum (fun d _ => h d)
+    _ = (Finset.univ.image f).card * k := by rw [Finset.sum_const, smul_eq_mul]
+    _ = k * (Finset.univ.image f).card := mul_comm _ _
 
--- Routine: Degree values range in {0, ..., n-1}
+-- Routine: Degree values range in {0, ..., n-1}.
+-- We compose `degree_le_card_sub_one` with `Nat.lt_of_le_pred` to recover the
+-- strict `< Fintype.card V` form needed for `Finset.mem_range`.
 theorem degree_range :
     Finset.univ.image (fun v => G.degree v) ⊆ Finset.range (Fintype.card V) := by
   intro d hd
   simp only [Finset.mem_image, Finset.mem_univ, true_and] at hd
   obtain ⟨v, rfl⟩ := hd
-  exact Finset.mem_range.mpr (G.degree_lt_card v)
+  rw [Finset.mem_range]
+  -- G.degree v ≤ n - 1, and n ≥ 1 since there is at least one vertex v.
+  have hle : G.degree v ≤ Fintype.card V - 1 := degree_le_card_sub_one G v
+  have hn1 : 1 ≤ Fintype.card V := Fintype.card_pos_iff.mpr ⟨v⟩
+  omega
 
 -- Routine: The complement graph has degree (n-1) - deg_G(v)
 -- Aristotle target: needs SimpleGraph.degree_compl or manual neighborFinset argument
 theorem complement_degree (v : V) :
     Gᶜ.degree v = Fintype.card V - 1 - G.degree v := by
   simp only [SimpleGraph.degree]
-  have hv_G : v ∉ G.neighborFinset v := G.not_mem_neighborFinset_self v
-  have hv_C : v ∉ Gᶜ.neighborFinset v := Gᶜ.not_mem_neighborFinset_self v
+  have hv_G : v ∉ G.neighborFinset v := G.notMem_neighborFinset_self v
+  have hv_C : v ∉ Gᶜ.neighborFinset v := Gᶜ.notMem_neighborFinset_self v
   have hunion : Gᶜ.neighborFinset v ∪ G.neighborFinset v = Finset.univ.erase v := by
     ext w
     simp only [Finset.mem_union, SimpleGraph.mem_neighborFinset, SimpleGraph.compl_adj,
@@ -100,28 +112,24 @@ theorem complement_degree (v : V) :
   omega
 
 -- Routine: If every degree appears at most twice and degrees ∈ {0,...,n-1},
--- then the number of distinct degrees ≤ n, and n ≤ 2 * distinctDegrees
+-- then the number of distinct degrees ≤ n, and n ≤ 2 * distinctDegrees.
+-- k = 2 specialization of `pigeonhole_distinct_count` applied to G.degree.
 theorem limited_mult_bound_from_pigeonhole
     (h : ∀ d : ℕ, (Finset.univ.filter (fun v => G.degree v = d)).card ≤ 2) :
     Fintype.card V ≤ 2 * (Finset.univ.image (fun v => G.degree v)).card := by
-  rw [← Finset.card_univ]
-  have hpart : (Finset.univ : Finset V) =
-      (Finset.univ.image (fun v => G.degree v)).biUnion
-        (fun d => Finset.univ.filter (fun v => G.degree v = d)) := by
-    ext v; simp
-  rw [hpart, Finset.card_biUnion]
-  · calc ∑ d ∈ Finset.univ.image (fun v => G.degree v),
-          (Finset.univ.filter (fun v => G.degree v = d)).card
-        ≤ ∑ _ ∈ Finset.univ.image (fun v => G.degree v), 2 :=
-          Finset.sum_le_sum (fun d _ => h d)
-      _ = (Finset.univ.image (fun v => G.degree v)).card * 2 := by
-          rw [Finset.sum_const, smul_eq_mul]
-      _ = 2 * (Finset.univ.image (fun v => G.degree v)).card := mul_comm _ _
-  · intro d _ e _ hde
-    rw [Finset.disjoint_left]
-    intro v hv1 hv2
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hv1 hv2
-    exact hde (hv1.symm.trans hv2)
+  have hmem : ∀ v ∈ (Finset.univ : Finset V),
+              G.degree v ∈ Finset.univ.image (fun v => G.degree v) :=
+    fun v _ => Finset.mem_image.mpr ⟨v, Finset.mem_univ v, rfl⟩
+  calc Fintype.card V
+      = (Finset.univ : Finset V).card := (Finset.card_univ).symm
+    _ = ∑ d ∈ Finset.univ.image (fun v => G.degree v),
+          (Finset.univ.filter (fun v => G.degree v = d)).card :=
+        Finset.card_eq_sum_card_fiberwise hmem
+    _ ≤ ∑ _ ∈ Finset.univ.image (fun v => G.degree v), 2 :=
+        Finset.sum_le_sum (fun d _ => h d)
+    _ = (Finset.univ.image (fun v => G.degree v)).card * 2 := by
+        rw [Finset.sum_const, smul_eq_mul]
+    _ = 2 * (Finset.univ.image (fun v => G.degree v)).card := mul_comm _ _
 
 -- Routine: 3/4 > 2/3 (comparing optimal bounds)
 theorem three_fourths_gt_two_thirds : (3 : ℝ) / 4 > 2 / 3 := by norm_num

--- a/proofs/Proofs/Erdos1037Problem.lean
+++ b/proofs/Proofs/Erdos1037Problem.lean
@@ -27,8 +27,9 @@ namespace Erdos1037
 variable {V : Type*} [Fintype V] [DecidableEq V]
 variable (G : SimpleGraph V) [DecidableRel G.Adj]
 
-/-- The number of vertices in the graph. -/
-def vertexCount : ℕ := Fintype.card V
+/-- The number of vertices in the graph. Takes `G` as an explicit argument
+    even though only `V` is needed, so calls like `vertexCount G` typecheck. -/
+def vertexCount (_G : SimpleGraph V) : ℕ := Fintype.card V
 
 /-- The degree of a vertex v in graph G. -/
 def degree (v : V) : ℕ := G.degree v
@@ -84,8 +85,13 @@ def isClique (S : Finset V) : Prop :=
 def isTrivialSet (S : Finset V) : Prop :=
   isIndependentSet G S ∨ isClique G S
 
-/-- Size of the largest trivial subset. -/
-noncomputable def maxTrivialSize : ℕ :=
+/-- Size of the largest trivial subset. Takes `G` as an explicit argument so
+    `maxTrivialSize G` typechecks at every call site. Uses classical decidability
+    for the trivial-set predicate (the definition is `noncomputable` regardless,
+    so this is harmless and avoids requiring `[DecidableRel G.Adj]` to flow
+    through every call site's instance context). -/
+noncomputable def maxTrivialSize (G : SimpleGraph V) : ℕ :=
+  letI : DecidablePred (isTrivialSet G) := Classical.decPred _
   Finset.sup (Finset.univ.powerset.filter (isTrivialSet G)) Finset.card
 
 /-
@@ -108,7 +114,7 @@ axiom chenErdos_false : ¬chenErdosConjecture
 -/
 
 /-- The Cambie-Chan-Hunter construction achieves 3n/4 distinct degrees. -/
-def cambieConstant : ℝ := 3/4
+noncomputable def cambieConstant : ℝ := 3/4
 
 /-- Verification that 3/4 > 1/2. -/
 theorem cambie_exceeds_half : cambieConstant > 1/2 := by
@@ -135,16 +141,16 @@ theorem counterexample_works (ε : ℝ) (hε : ε > 0) (hε' : ε < 1/4) :
     cambieChanHunter_construction 4 (by norm_num)
   haveI := hFin; haveI := hDec; haveI := hDR
   refine ⟨V, hFin, hDec, G, hDR, ⟨hLim, ?_⟩, C, hCpos, ?_⟩
-  · -- hasManyDistinctDegrees: distinctDegreeCount > (1/2 + ε) * vertexCount
-    -- From axiom: distinctDegreeCount ≥ (3/4) * 4 = 3
-    -- Since ε < 1/4: (1/2 + ε) * 4 < 3
-    show (distinctDegreeCount G : ℝ) > (1 / 2 + ε) * (vertexCount G : ℝ)
-    unfold vertexCount; rw [hn]
+  · -- hasManyDistinctDegrees: distinctDegreeCount > (1/2 + ε) * vertexCount.
+    -- From axiom: distinctDegreeCount ≥ (3/4) * 4 = 3.
+    -- Since ε < 1/4: (1/2 + ε) * 4 < 3.
+    unfold hasManyDistinctDegrees vertexCount
+    rw [hn]
     unfold cambieConstant at hDist
     have h1 : (3 : ℝ) / 4 * ((4 : ℕ) : ℝ) = 3 := by push_cast; ring
     have h2 : (1 / 2 + ε) * ((4 : ℕ) : ℝ) = 2 + 4 * ε := by push_cast; ring
     linarith
-  · -- maxTrivialSize bound: same after rewriting Fintype.card V = 4
+  · -- maxTrivialSize bound: same after rewriting Fintype.card V = 4.
     rw [hn]; exact hTriv
 
 /-
@@ -155,8 +161,8 @@ theorem counterexample_works (ε : ℝ) (hε : ε > 0) (hε' : ε < 1/4) :
     contains a monochromatic K_k. Axiomatized as exact values are unknown. -/
 axiom ramseyNumber (k : ℕ) : ℕ
 
-/-- Ramsey theorem: graphs on ≥ R(k,k) vertices have trivial set of size k. -/
-/-- Ramsey numbers grow exponentially: R(k,k) ≥ 2^(k/2). -/
+-- Ramsey theorem: graphs on ≥ R(k,k) vertices have trivial set of size k.
+-- Ramsey numbers grow exponentially: R(k,k) ≥ 2^(k/2).
 /-- The counterexample shows degree diversity doesn't help Ramsey:
     there exist graphs with limited multiplicity, ≥ (3/4)n distinct degrees,
     and trivial subgraphs of size O(log n). -/
@@ -168,7 +174,12 @@ theorem degree_diversity_no_ramsey_help :
       ∃ C > 0, (maxTrivialSize G : ℝ) ≤ C * Real.log (Fintype.card V) := by
   obtain ⟨V, hFin, hDec, G, hDR, hn, hLim, hDist, C, hCpos, hTriv⟩ :=
     cambieChanHunter_construction 4 (by norm_num)
-  haveI := hFin; haveI := hDec; haveI := hDR
+  -- Promote the destructured Fintype/DecidableEq witnesses to instances *before*
+  -- the goal is elaborated further, so that `Fintype.card V` in the goal
+  -- and in `hn` resolve to the same instance argument.
+  letI : Fintype V := hFin
+  letI : DecidableEq V := hDec
+  letI : DecidableRel G.Adj := hDR
   have hn' : (Fintype.card V : ℝ) = 4 := by exact_mod_cast hn
   exact ⟨V, hFin, hDec, G, hDR, hLim, by rw [hn']; exact hDist,
     C, hCpos, by rw [hn']; exact hTriv⟩
@@ -183,31 +194,29 @@ theorem degree_sum_eq_twice_edges :
   G.sum_degrees_eq_twice_card_edges
 
 /-- With limited multiplicity (≤ 2), the number of vertices is at most twice
-    the number of distinct degrees (pigeonhole). Equivalently, distinct ≥ ⌈n/2⌉. -/
+    the number of distinct degrees (pigeonhole). Equivalently, distinct ≥ ⌈n/2⌉.
+
+    Proof uses `Finset.card_eq_sum_card_fiberwise` to partition the vertex
+    set by degree value. The k = 2 instance of `multiplicity_k_bound`. -/
 theorem limited_multiplicity_bound :
     hasLimitedMultiplicity G →
     vertexCount G ≤ 2 * distinctDegreeCount G := by
   intro hLim
   unfold vertexCount distinctDegreeCount distinctDegrees
   unfold hasLimitedMultiplicity degreeMultiplicity at hLim
-  rw [← Finset.card_univ]
-  have hpart : (Finset.univ : Finset V) =
-      (Finset.univ.image (fun v => G.degree v)).biUnion
-        (fun d => Finset.univ.filter (fun v => G.degree v = d)) := by
-    ext v; simp
-  rw [hpart, Finset.card_biUnion]
-  · calc ∑ d ∈ Finset.univ.image (fun v => G.degree v),
-          (Finset.univ.filter (fun v => G.degree v = d)).card
-        ≤ ∑ _ ∈ Finset.univ.image (fun v => G.degree v), 2 :=
-          Finset.sum_le_sum (fun d _ => hLim d)
-      _ = (Finset.univ.image (fun v => G.degree v)).card * 2 := by
-          rw [Finset.sum_const, smul_eq_mul]
-      _ = 2 * (Finset.univ.image (fun v => G.degree v)).card := mul_comm _ _
-  · intro d _ e _ hde
-    rw [Finset.disjoint_left]
-    intro v hv1 hv2
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hv1 hv2
-    exact hde (hv1.symm.trans hv2)
+  have hmem : ∀ v ∈ (Finset.univ : Finset V),
+              G.degree v ∈ Finset.univ.image (fun v => G.degree v) :=
+    fun v _ => Finset.mem_image.mpr ⟨v, Finset.mem_univ v, rfl⟩
+  calc Fintype.card V
+      = (Finset.univ : Finset V).card := (Finset.card_univ).symm
+    _ = ∑ d ∈ Finset.univ.image (fun v => G.degree v),
+          (Finset.univ.filter (fun v => G.degree v = d)).card :=
+        Finset.card_eq_sum_card_fiberwise hmem
+    _ ≤ ∑ _ ∈ Finset.univ.image (fun v => G.degree v), 2 :=
+        Finset.sum_le_sum (fun d _ => hLim d)
+    _ = (Finset.univ.image (fun v => G.degree v)).card * 2 := by
+        rw [Finset.sum_const, smul_eq_mul]
+    _ = 2 * (Finset.univ.image (fun v => G.degree v)).card := mul_comm _ _
 
 /-- Maximum possible degree in a graph. -/
 def maxPossibleDegree : ℕ := vertexCount G - 1
@@ -215,15 +224,27 @@ def maxPossibleDegree : ℕ := vertexCount G - 1
 /-- All degrees are at most n-1. -/
 theorem degree_bound (v : V) : G.degree v ≤ maxPossibleDegree G := by
   unfold maxPossibleDegree vertexCount
-  have := G.degree_lt_card v
-  omega
+  -- `G.degree v` is the cardinality of the neighbor finset, which is a subset
+  -- of `Finset.univ.erase v` (vertices don't neighbor themselves), so it has
+  -- cardinality at most `Fintype.card V - 1`.
+  have hself : v ∉ G.neighborFinset v := G.notMem_neighborFinset_self v
+  have hsub : G.neighborFinset v ⊆ Finset.univ.erase v := by
+    intro u hu
+    simp only [Finset.mem_erase, Finset.mem_univ, and_true]
+    rintro rfl
+    exact hself hu
+  calc G.degree v
+      = (G.neighborFinset v).card := rfl
+    _ ≤ (Finset.univ.erase v).card := Finset.card_le_card hsub
+    _ = Fintype.card V - 1 := by
+        rw [Finset.card_erase_of_mem (Finset.mem_univ v), Finset.card_univ]
 
 /-
 ## Stronger Bounds
 -/
 
 /-- The 3n/4 bound is essentially optimal for multiplicity 2. -/
-def optimalDistinctBound : ℝ := 3/4
+noncomputable def optimalDistinctBound : ℝ := 3/4
 
 /-- The number of distinct degree values is at most the number of vertices. -/
 theorem distinct_degree_count_le_vertex_count :
@@ -265,7 +286,7 @@ def hasMultiplicityAtMost (k : ℕ) : Prop :=
   ∀ d : ℕ, degreeMultiplicity G d ≤ k
 
 /-- Maximum distinct degrees with multiplicity ≤ k is roughly (k/(k+1))n. -/
-def generalMultiplicityBound (k : ℕ) : ℝ := k / (k + 1)
+noncomputable def generalMultiplicityBound (k : ℕ) : ℝ := k / (k + 1)
 
 /-- The general bound conjecture: with multiplicity ≤ k, distinct degrees ≤ (k/(k+1))n + C
     for some constant C depending only on k. (This conjecture is FALSE — the Cambie-Chan-Hunter
@@ -287,6 +308,46 @@ theorem multiplicity_two_bound :
 theorem cambie_beats_general : cambieConstant > generalMultiplicityBound 2 := by
   unfold cambieConstant generalMultiplicityBound
   norm_num
+
+/-- General pigeonhole: with multiplicity at most k, the number of distinct
+    degrees is at least n/k. Equivalently, n ≤ k * distinctDegreeCount. This
+    generalizes `limited_multiplicity_bound` (the k = 2 case) to arbitrary k.
+
+    Proof uses `Finset.card_eq_sum_card_fiberwise` to partition the vertex set
+    by degree value, avoiding the `Finset.card_biUnion` PairwiseDisjoint shape. -/
+theorem multiplicity_k_bound (k : ℕ) :
+    hasMultiplicityAtMost G k →
+    vertexCount G ≤ k * distinctDegreeCount G := by
+  intro hMult
+  unfold vertexCount distinctDegreeCount distinctDegrees
+  unfold hasMultiplicityAtMost degreeMultiplicity at hMult
+  have hmem : ∀ v ∈ (Finset.univ : Finset V),
+              G.degree v ∈ Finset.univ.image (fun v => G.degree v) :=
+    fun v _ => Finset.mem_image.mpr ⟨v, Finset.mem_univ v, rfl⟩
+  calc Fintype.card V
+      = (Finset.univ : Finset V).card := (Finset.card_univ).symm
+    _ = ∑ d ∈ Finset.univ.image (fun v => G.degree v),
+          (Finset.univ.filter (fun v => G.degree v = d)).card :=
+        Finset.card_eq_sum_card_fiberwise hmem
+    _ ≤ ∑ _ ∈ Finset.univ.image (fun v => G.degree v), k :=
+        Finset.sum_le_sum (fun d _ => hMult d)
+    _ = (Finset.univ.image (fun v => G.degree v)).card * k := by
+        rw [Finset.sum_const, smul_eq_mul]
+    _ = k * (Finset.univ.image (fun v => G.degree v)).card := mul_comm _ _
+
+/-- The general bound conjecture is FALSE on informal grounds: at k = 2 the
+    extrapolation predicts `distinctDegreeCount ≤ (2/3) n + C` for some
+    constant C, but the Cambie-Chan-Hunter construction achieves `(3/4) n`
+    distinct degrees for every n ≥ 4, so taking n > 12 C contradicts the
+    conjecture. A full Lean disproof from `cambieChanHunter_construction`
+    requires careful handling of the universe-polymorphic `Type*` quantifier
+    in `generalBoundConjecture` matched against the construction axiom's
+    concrete `Type` carrier; recorded here as a TODO for the next research
+    iteration. The numerical gap is captured by `cambie_beats_general` and
+    `multiplicity_k_bound`. -/
+theorem general_bound_conjecture_informally_false :
+    cambieConstant > generalMultiplicityBound 2 :=
+  cambie_beats_general
 
 /-
 ## The Resolved Question
@@ -319,6 +380,18 @@ Cambie, Chan, and Hunter disproved this by constructing graphs with:
 - Largest clique/independent set of size O(log n)
 
 This shows degree diversity doesn't improve Ramsey-type bounds.
+
+For open question oq-02 (higher-multiplicity generalization), the file now
+records:
+- multiplicity_k_bound: general pigeonhole n ≤ k * distinctDegreeCount
+  whenever every degree appears ≤ k times. Generalizes the k = 2 case
+  in `limited_multiplicity_bound`.
+- general_bound_conjecture_informally_false (alias for `cambie_beats_general`):
+  the naive k → k/(k+1) extrapolation already fails numerically at k = 2,
+  since the Cambie construction achieves 3n/4 distinct degrees while the
+  conjecture predicts (2/3)n + C. A full Lean disproof from
+  `cambieChanHunter_construction` is deferred (universe-handling work needed
+  to match `Type*` in the conjecture with the construction's `Type` carrier).
 -/
 
 end Erdos1037

--- a/src/data/proofs/erdos-1037/meta.json
+++ b/src/data/proofs/erdos-1037/meta.json
@@ -23,8 +23,8 @@
     "erdosProblemStatus": "solved",
     "relatedProblems": [],
     "axiomCount": 3,
-    "lineCount": 324,
-    "assumptions": "3 axioms: chenErdos_false (Chen-Erdős conjecture is false, Cambie-Chan-Hunter 2023), cambieChanHunter_construction (counterexample construction exists for all n≥4), ramseyNumber (Ramsey numbers axiomatized as exact values are unknown). 0 sorries.",
+    "lineCount": 397,
+    "assumptions": "3 axioms: chenErdos_false (Chen-Erdős conjecture is false, Cambie-Chan-Hunter 2023), cambieChanHunter_construction (counterexample construction exists for all n≥4), ramseyNumber (Ramsey numbers axiomatized as exact values are unknown). 0 sorries. (oq-02 update: added multiplicity_k_bound generalizing limited_multiplicity_bound to arbitrary k; informal disproof of generalBoundConjecture recorded as general_bound_conjecture_informally_false; pre-existing Mathlib v4.26.0 drift in counterexample_works / degree_diversity_no_ramsey_help / cambie_is_optimal / limited_multiplicity_bound / degree_bound / maxTrivialSize / Aristotle pigeonhole repaired in same patch — file now Docker-builds clean.)",
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
       {
@@ -61,9 +61,11 @@
       "counterexample_works: assembles the full disproof from the construction axiom",
       "degree_diversity_no_ramsey_help: degree diversity does not improve the Ramsey O(log n) bound",
       "cambie_is_optimal: 3n/4 is asymptotically optimal for multiplicity-2 degree diversity",
-      "generalMultiplicityBound: formula k/(k+1) for max distinct degrees with multiplicity ≤ k"
+      "generalMultiplicityBound: formula k/(k+1) for max distinct degrees with multiplicity ≤ k",
+      "multiplicity_k_bound: general pigeonhole n ≤ k · distinctDegreeCount for any k (generalizes limited_multiplicity_bound)",
+      "general_bound_conjecture_informally_false: alias capturing that 3/4 > 2/3 already refutes the k → k/(k+1) extrapolation numerically; full universe-polymorphic Lean disproof deferred"
     ],
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 20,
     "additionalFiles": [
       "Proofs/Erdos1037Aristotle.lean"

--- a/src/data/research/problems/erdos-1037-oq-02.json
+++ b/src/data/research/problems/erdos-1037-oq-02.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: All sorries eliminated (2→0). Fixed degree_diversity_no_ramsey_help statement and proved from axiom. Proved cambie_is_optimal from construction axiom. 5 axioms remain (all deep mathematical facts).",
+    "progressSummary": "Added multiplicity_k_bound (general pigeonhole n ≤ k·distinctDegreeCount for arbitrary k, generalizing the k=2 case in limited_multiplicity_bound). Recorded general_bound_conjecture_informally_false noting that cambieConstant (3/4) > generalMultiplicityBound 2 (2/3) numerically refutes the k → k/(k+1) extrapolation at k=2; a full universe-polymorphic Lean disproof from cambieChanHunter_construction is deferred (Type vs Type* matching). As part of the same patch, repaired pre-existing Mathlib v4.26.0 drift across Erdos1037Problem.lean and Erdos1037Aristotle.lean (vertexCount/maxTrivialSize G arguments, noncomputable on ℝ-valued constants, fiberwise rewrite of pigeonhole proofs, SimpleGraph.notMem_neighborFinset_self rename, degree_lt_card replacement, orphan docstring cleanup). Both files now Docker-build clean (7743 jobs, 0 sorries).",
     "builtItems": [
       "Proved counterexample_works in Erdos1037Problem.lean:129",
       "Proved erdos_1037_disproved in Erdos1037Problem.lean:282",
@@ -38,7 +38,13 @@
       "Proved distinct_degree_count_le_vertex_count in Erdos1037Problem.lean:230",
       "Fixed generalBoundConjecture definition in Erdos1037Problem.lean:259",
       "Proved degree_diversity_no_ramsey_help: fixed statement to use existential C matching construction axiom",
-      "Proved cambie_is_optimal: construction achieves (3/4)n ≥ (3/4-ε)n for any ε>0, n≥4"
+      "Proved cambie_is_optimal: construction achieves (3/4)n ≥ (3/4-ε)n for any ε>0, n≥4",
+      "Added multiplicity_k_bound in Erdos1037Problem.lean: n ≤ k · distinctDegreeCount whenever multiplicity ≤ k, via Finset.card_eq_sum_card_fiberwise",
+      "Added general_bound_conjecture_informally_false alias for cambie_beats_general capturing the k = 2 numerical refutation",
+      "Rewrote limited_multiplicity_bound using the same fiberwise technique (was broken by Finset.card_biUnion API change to Set.PairwiseDisjoint)",
+      "Made vertexCount and maxTrivialSize take G explicitly so call sites typecheck; cambieConstant / optimalDistinctBound / generalMultiplicityBound marked noncomputable",
+      "Repaired Erdos1037Aristotle.lean: pigeonhole_distinct_count, limited_mult_bound_from_pigeonhole rewritten fiberwise; degree_le_card_sub_one and degree_range no longer depend on the removed SimpleGraph.degree_lt_card",
+      "Docker build now clean for Proofs.Erdos1037Problem and Proofs.Erdos1037Aristotle (7743 jobs each, 0 sorries, 3 axioms)"
     ],
     "insights": [
       "counterexample_works proved from cambieChanHunter_construction axiom with n=4",
@@ -51,13 +57,17 @@
       "cambie_is_optimal is a deep asymptotic result needing additional infrastructure",
       "The construction axiom works for all n≥4, making cambie_is_optimal immediate (not truly asymptotic)",
       "degree_diversity_no_ramsey_help: fixed statement to use existential C and real-valued bound, proved from construction axiom with n=4",
-      "cambie_is_optimal: proved directly — construction gives (3/4)n ≥ (3/4-ε)n for any ε>0, n≥4"
+      "cambie_is_optimal: proved directly — construction gives (3/4)n ≥ (3/4-ε)n for any ε>0, n≥4",
+      "Lean 4 variable inclusion does NOT include explicit-binder variables that are not literally referenced in a def body — `def vertexCount : ℕ := Fintype.card V` does not expose G; explicit `(G : SimpleGraph V)` parameter is needed to make calls like `vertexCount G` typecheck",
+      "Finset.card_biUnion in v4.26.0 expects Set.PairwiseDisjoint (which prints as Function.onFun Disjoint), not the historical `∀ x ∈ s, ∀ y ∈ s, x ≠ y → Disjoint (t x) (t y)` shape. Finset.card_eq_sum_card_fiberwise is a cleaner replacement for partitioning-by-fiber proofs",
+      "SimpleGraph.degree_lt_card no longer exists; bound `G.degree v ≤ Fintype.card V - 1` via `G.neighborFinset v ⊆ Finset.univ.erase v` instead",
+      "SimpleGraph.not_mem_neighborFinset_self deprecated in favor of notMem_neighborFinset_self"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Verify proofs build with Docker when available",
-      "degree_diversity_no_ramsey_help needs axiom with specific constant or changed goal",
-      "cambie_is_optimal needs asymptotic analysis infrastructure"
+      "Complete the universe-polymorphic disproof of generalBoundConjecture by ULift-wrapping the V from cambieChanHunter_construction or by reformulating the conjecture over `Type 0`",
+      "Strengthen cambieChanHunter_construction axiom to an asymptotic statement (∃ N, ∀ n ≥ N, ...) so cambie_is_optimal becomes genuinely asymptotic rather than n ≥ 4-uniform",
+      "Investigate whether the analog of cambieConstant for multiplicity k is (2k - 1)/(2k) or some larger fraction — multiplicity_k_bound gives n ≤ k · distinctDegreeCount as the pigeonhole lower bound but no upper bound is known"
     ]
   },
   "tags": [
@@ -79,7 +89,7 @@
     "mathlib": []
   },
   "started": "2026-03-30T01:04:30.788Z",
-  "lastUpdate": "2026-03-30T01:10:00Z",
+  "lastUpdate": "2026-06-05T16:00:00Z",
   "significance": 8,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Single-iteration progress on **erdos-1037-oq-02** (\"Can similar counterexamples be constructed for higher multiplicity bounds?\"), plus a same-patch repair of pre-existing Mathlib v4.26.0 drift across the two files so the entry once again Docker-builds cleanly.

### New theorems (oq-02 contribution)

- **`multiplicity_k_bound`**: with multiplicity ≤ k, `n ≤ k · distinctDegreeCount`. Generalizes `limited_multiplicity_bound` (the k = 2 case) to arbitrary k via `Finset.card_eq_sum_card_fiberwise`. This is the pigeonhole **lower** bound on distinct-degree count under bounded multiplicity — the analog of n ≤ 2·distinctDegreeCount on which the original Cambie–Chan–Hunter result builds.
- **`general_bound_conjecture_informally_false`**: alias for `cambie_beats_general` recording that `cambieConstant (3/4) > generalMultiplicityBound 2 (2/3)` already numerically refutes the natural k → k/(k+1) extrapolation at k = 2. A full universe-polymorphic Lean disproof from `cambieChanHunter_construction` is deferred — the construction axiom returns `V : Type` but `generalBoundConjecture` quantifies over `V : Type*`, requiring careful universe handling (recorded as TODO in the docstring).

### Pre-existing Mathlib v4.26.0 drift repaired

The file would not Docker-build on `main` before this PR (multiple `noncomputable`, instance-synthesis, renamed-lemma, and orphan-docstring failures, plus the `Finset.card_biUnion` API change). Repaired without changing any axiom or theorem content:

- `vertexCount` and `maxTrivialSize` now take `G : SimpleGraph V` explicitly; `maxTrivialSize` uses `Classical.decPred` so it no longer requires `[DecidableRel G.Adj]` at every call site.
- `cambieConstant`, `optimalDistinctBound`, `generalMultiplicityBound` marked `noncomputable` (required by `Real.instDivInvMonoid`).
- `limited_multiplicity_bound` rewritten with `Finset.card_eq_sum_card_fiberwise` (the old proof used `Finset.card_biUnion`, whose disjointness hypothesis changed shape to `Set.PairwiseDisjoint` / `Function.onFun Disjoint`).
- `degree_bound` no longer depends on the removed `SimpleGraph.degree_lt_card`; uses `G.neighborFinset v ⊆ Finset.univ.erase v`.
- `degree_diversity_no_ramsey_help` uses `letI` instead of `haveI` so the destructured `Fintype V` instance matches the goal at `Fintype.card V`.
- `counterexample_works` uses `unfold hasManyDistinctDegrees vertexCount` instead of `show`, avoiding a definitional-equality failure.
- Two orphan `/-- ... -/` docstrings without theorem bodies converted to `--` line comments to fix a parser failure.
- `Erdos1037Aristotle.lean` repaired symmetrically: `pigeonhole_distinct_count` / `limited_mult_bound_from_pigeonhole` rewritten fiberwise; `degree_le_card_sub_one` / `degree_range` no longer use `degree_lt_card`; `complement_degree` updated to `notMem_neighborFinset_self`.

### Build verification

Both files now build cleanly with **0 sorries**:

```
$ LEAN_BUILD_TIMEOUT=30m ./proofs/scripts/docker-build.sh Proofs.Erdos1037Problem
Build completed successfully (7743 jobs).

$ LEAN_BUILD_TIMEOUT=20m ./proofs/scripts/docker-build.sh Proofs.Erdos1037Aristotle
Build completed successfully (7743 jobs).
```

### Metadata

`meta.json` updated: `theoremCount` 12 → 14, `lineCount` 324 → 397, `axiomCount` 3 (unchanged), `definitionCount` 20 (unchanged), `sorries` 0 (unchanged). `originalContributions` extended with the two new theorems. Status remains `axiomatized` / badge `axiom` (the 3 axioms are unchanged).

The oq-02 research record (`erdos-1037-oq-02.json`) updated with progress summary, built items, insights (notably the Lean 4 variable-inclusion behavior and the `Finset.card_biUnion` API change), and next steps.

## Test plan

- [x] `Proofs.Erdos1037Problem` Docker-builds clean (7743 jobs, 0 sorries, 3 axioms)
- [x] `Proofs.Erdos1037Aristotle` Docker-builds clean (7743 jobs, 0 sorries, 0 axioms)
- [x] `meta.json` reflects new counts and `originalContributions`
- [x] oq-02 research knowledge captures progress and next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)