### PR TITLE
fix(central-limit-theorem-oq-04): repair orphan docstrings so file builds

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ04.lean
@@ -447,8 +447,7 @@ on the space of centered distributions with variance 1.
 noncomputable def freeRenormalization (μ : NCDistribution) : NCDistribution :=
   dilate (1 / Real.sqrt 2) (freeConv μ μ)
 
-/-- The semicircle is a FIXED POINT of the free renormalization map:
-    T(w) = w. -/
+-- The semicircle is a FIXED POINT of the free renormalization map: T(w) = w.
 
 /-- Structural verification: the free cumulants are preserved under
     renormalization for the semicircle (κ₂ check). -/
@@ -608,13 +607,13 @@ def bernoulliNC : NCDistribution where
   moment := fun n => if n % 2 = 0 then 1 else 0
   moment_zero := by simp
 
-/-- Boolean cumulants: the simplest cumulant family.
-    For the Boolean CLT, the Boolean cumulants satisfy:
-    βₙ(μ ⊎ ν) = βₙ(μ) + βₙ(ν) using interval partitions.
-
-    Note: Boolean cumulants are not developed further in this file.
-    The CLTStructure framework above would accommodate a Boolean
-    CLT instance with bernoulliNC as the limit law. -/
+-- Boolean cumulants: the simplest cumulant family.
+-- For the Boolean CLT, the Boolean cumulants satisfy:
+-- βₙ(μ ⊎ ν) = βₙ(μ) + βₙ(ν) using interval partitions.
+--
+-- Note: Boolean cumulants are not developed further in this file.
+-- The CLTStructure framework above would accommodate a Boolean
+-- CLT instance with bernoulliNC as the limit law.
 
 /-- Summary: The answer to "How does the topological perspective extend?"
 


### PR DESCRIPTION
## Summary

`Proofs/CentralLimitTheoremOQ04.lean` was failing to Docker-build on `main` because of two orphan `/-- ... -/` docstrings without theorem bodies (the parser then emits \`unexpected token '/--'; expected 'lemma'\`).

- Line 451: standalone \"The semicircle is a FIXED POINT\" docstring, sitting between `freeRenormalization` and `semicircle_renorm_cumulant_two`. Converted to a `--` line comment.
- Lines 611–617: the \"Boolean cumulants\" paragraph docstring before the file's final \"Summary\" `/--` block. Converted to `--` line comments.

No theorem, axiom, or definition content changes. Same parser pattern repaired in `Erdos1037Problem.lean` via #22509 (now merged).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ04` — Build completed successfully (3060 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)