### PR TITLE
Enrich abel-ruffini-galois-extensions: correct theorem/instance counts

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/meta.json
@@ -2,7 +2,7 @@
   "id": "abel-ruffini-galois-extensions",
   "title": "Abel-Ruffini Galois Theory Extensions",
   "slug": "abel-ruffini-galois-extensions",
-  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |S₈|=40320, |A₇|=2520, |A₈|=20160 via `native_decide`. 57 theorems, 15 typeclass instances (11 public + 4 private), 1 private definition (`klein_four`), 0 axioms, 0 sorries.",
+  "description": "Extends the Abel-Ruffini formalization with the complete solvability classification of symmetric groups. Proves S₀–S₄ are solvable, S_n is solvable if and only if n ≤ 4, A₅ is simple (the key obstruction), and non-commutativity witnesses for S₃, S₄, S₅, A₄, A₅. Verifies group orders |S₇|=5040, |S₈|=40320, |A₇|=2520, |A₈|=20160 via `native_decide`. 59 theorems (57 public + 2 private), 15 typeclass instances (11 public + 4 private), 1 private definition (`klein_four`), 0 axioms, 0 sorries.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -24,7 +24,7 @@
     "axiomCount": 0,
     "assumptions": "None. Fully machine-verified using Mathlib's solvability infrastructure.",
     "lineCount": 534,
-    "theoremCount": 57,
+    "theoremCount": 59,
     "definitionCount": 1,
     "instanceCount": 15,
     "mathlibDependencies": [
@@ -1257,7 +1257,7 @@
         "theorem inventory"
       ],
       "prerequisites": [
-        "overview of all 57 theorems and 12 instances",
+        "overview of all 59 theorems and 15 instances",
         "`#check` for inventory verification",
         "role of this file as the structural complement to `AbelRuffini.lean`"
       ]


### PR DESCRIPTION
## Summary

Accuracy pass on `abel-ruffini-galois-extensions` (enrichment pass 5; quality 100).

Verified against the Lean source `proofs/Proofs/AbelRuffiniGaloisExtensions.lean`:
- **Theorems**: 57 public + 2 private = **59 total**
- **Instances**: 11 public + 4 private = **15 total**

## Changes

- `description`: "57 theorems" → "59 theorems (57 public + 2 private)" — now matches the conclusion summary, which already cited 59
- `meta.theoremCount`: 57 → 59 (was undercounting the two private theorems)
- One stale annotation prerequisite: "57 theorems and 12 instances" → "59 theorems and 15 instances"

The `instanceCount: 15` field was already correct; only one string deeper in the annotations had drifted to a stale "12".

No content reductions — narrative, key insights, cross-references, and open questions are preserved verbatim. This is a small targeted accuracy fix on an entry that is otherwise at the enrichment-quality cap.

## Test plan

- [x] JSON validates
- [x] `pnpm annotations:build` succeeds for this entry (no errors mentioning `abel-ruffini-galois-extensions`)
- [x] Counts independently verified against `proofs/Proofs/AbelRuffiniGaloisExtensions.lean` with `grep -cE '^(private )?(theorem|instance) '`