### PR TITLE
Enrich Non-Desarguesian Planes (Moulton): mainTheorems + Part V gap annotation

### DIFF
--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/annotations.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/annotations.json
@@ -142,6 +142,30 @@
     ]
   },
   {
+    "id": "ann-part-v-intro-narrative",
+    "proofId": "desargues-theorem-oq-01-oq-01",
+    "range": {
+      "startLine": 212,
+      "endLine": 225
+    },
+    "type": "context",
+    "title": "Part V Intro: The Contradiction Setup Before Any Tactic Fires",
+    "content": "The Part V docstring (lines 212-224) lays out the entire structure of the upcoming contradiction in advance, so a reader can verify the algebra by hand before reading the tactic block. Three keys are stated: (1) The witnesses are $P = (-17, 9)$, $Q = (27, 17)$, $R = (-6, 11)$ — note that $P$ and $R$ have $x \\leq 0$ while $Q$ has $x > 0$, which forces any positive-slope Moulton line through all three to mix the left-branch ($y = mx + b$) and right-branch ($y = \\tfrac{m}{2}x + b$) equations. (2) The two-equation pair from $P$ (left, $9 = m(-17) + b$) and $Q$ (right, $17 = \\tfrac{m}{2}(27) + b$) is recombined to yield $m = 16/61$. (3) Substituting this $m$ into the $R$ equation gives $11 = \\tfrac{725}{61} \\neq \\tfrac{671}{61}$, the numeric contradiction. The docstring also rules out the other cases: negative-slope lines cannot contain PQ (slope $2/11 > 0$) and vertical lines are excluded by distinct x-coordinates — corresponding precisely to the three `by_cases` branches `hv1`, `hm : m ≤ 0`, and `m > 0` in the proof below. This 'pre-flight checklist' makes the tactic block at lines 233-261 a transparent translation of the mathematical content, not a sequence of opaque calls.",
+    "mathContext": "Substituting $m = 16/61$ into $11 = m(-6) + b$ gives $b = 11 + 6 \\cdot \\tfrac{16}{61} = \\tfrac{671 + 96}{61} = \\tfrac{767}{61}$, and then $m \\cdot (-17) + b = \\tfrac{-272 + 767}{61} = \\tfrac{495}{61} \\neq \\tfrac{549}{61} = 9 \\cdot \\tfrac{61}{61}$ — but the docstring's framing prefers the shorter calculation: setting $11 = m(-6) + b$ with $b = 17 + \\tfrac{m}{2}(-27) = 17 - \\tfrac{m \\cdot 27}{2}$ (from $Q$) and $m = 16/61$ gives $b = 17 - \\tfrac{8 \\cdot 27}{61} = \\tfrac{17 \\cdot 61 - 216}{61} = \\tfrac{821}{61}$, and then $m(-6) + b = -\\tfrac{96}{61} + \\tfrac{821}{61} = \\tfrac{725}{61} \\neq \\tfrac{11 \\cdot 61}{61} = \\tfrac{671}{61}$. Either reading exposes the same arithmetic obstruction. The actual proof skips this $b$-elimination by using `linear_combination` to extract two contradictory expressions for $m$ directly.",
+    "significance": "supporting",
+    "prerequisites": [
+      "linear systems in two unknowns",
+      "case analysis on slope sign and verticality",
+      "Moulton plane left/right branch equations"
+    ],
+    "relatedConcepts": [
+      "narrative bridge between definition and proof",
+      "pre-tactic algebraic outline",
+      "three-case structure of desargues_fails",
+      "Lean docstring as proof scaffold"
+    ]
+  },
+  {
     "id": "ann-desargues-fails",
     "proofId": "desargues-theorem-oq-01-oq-01",
     "range": {

--- a/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
+++ b/src/data/proofs/desargues-theorem-oq-01-oq-01/meta.json
@@ -74,6 +74,72 @@
             "Rational-coordinate linear algebra in $\\mathbb{Q}^2$: explicit computation of line intersections via the slope-intercept formulas $y = mx + b$ and $y = m'x + b'$, the cross-product collinearity test $\\det\\!\\begin{pmatrix} x_2 - x_1 & y_2 - y_1 \\\\ x_3 - x_1 & y_3 - y_1 \\end{pmatrix} = 0$, and the numeric witnesses $A = (-2, 3)$, $B = (3, 1)$, $C = (0, 1)$, $A' = (-4, 6)$, $B' = (9, 3)$, $C' = (0, 4)$ that produce the explicit counterexample $P = (-17, 9)$, $Q = (27, 17)$, $R = (-6, 11)$"
         ]
     },
+    "mainTheorems": [
+        {
+            "name": "desargues_fails",
+            "type": "core",
+            "description": "The Moulton counterexample's central negative result: the three intersection points P=(-17,9), Q=(27,17), R=(-6,11) are not Moulton-collinear, even though triangles ABC and A'B'C' are in perspective from O=(0,0). Three-case proof: vertical excluded by distinct x-coordinates; m≤0 excluded since hP'−hQ' forces 44m=8>0; m>0 collapses to the system 11m=2 and 61m=16, whose linarith inconsistency (122≠176) closes the goal.",
+            "leanType": "¬ MoultonCollinear P_pt Q_pt R_pt",
+            "line": 233,
+            "endLine": 261
+        },
+        {
+            "name": "moulton_counterexample",
+            "type": "core",
+            "description": "The full Desargues-failure certificate as a single 21-component conjunction: three perspectivity-from-O facts (collinear_OAA', collinear_OBB', collinear_OCC'), eighteen incidence facts (P on AB/A'B', Q on BC/B'C', R on CA/C'A' with all six endpoint memberships), and desargues_fails. Term-mode anonymous-constructor proof. Packages the entire counterexample as one machine-checkable theorem statement asserting the negation of Desargues's theorem in the Moulton plane.",
+            "leanType": "MoultonCollinear O_pt A_pt A'_pt ∧ MoultonCollinear O_pt B_pt B'_pt ∧ MoultonCollinear O_pt C_pt C'_pt ∧ … ∧ ¬ MoultonCollinear P_pt Q_pt R_pt",
+            "line": 268,
+            "endLine": 296
+        },
+        {
+            "name": "onMoultonLine",
+            "type": "definition",
+            "description": "The piecewise Moulton line predicate. For slope m ≤ 0: ordinary line y = mx + b. For m > 0 with x ≤ 0 (left half-plane): also y = mx + b. For m > 0 with x > 0 (right half-plane): y = (m/2)x + b. The bend at x = 0 is continuous since both pieces give y = b there. This is the minimal perturbation of Euclidean lines that breaks Desargues while preserving every affine plane axiom (two points determine a unique line, two non-parallel lines meet, parallel postulate).",
+            "leanType": "(m b : ℝ) → (P : ℝ × ℝ) → Prop",
+            "line": 54,
+            "endLine": 58
+        },
+        {
+            "name": "MoultonCollinear",
+            "type": "definition",
+            "description": "Three-point Moulton collinearity: either all three points share an x-coordinate (vertical line) or they all lie on some non-vertical Moulton line specified by left-slope m and intercept b. The disjunction is critical: vertical lines are not in the range of onMoultonLine since they have undefined slope, so they need separate treatment. This shape directly drives the three-case structure of desargues_fails: vertical, m ≤ 0, m > 0.",
+            "leanType": "(P Q R : ℝ × ℝ) → Prop",
+            "line": 60,
+            "endLine": 64
+        },
+        {
+            "name": "collinear_OAA'",
+            "type": "supporting",
+            "description": "First perspectivity-from-O fact. Line OA has slope -3/2 ≤ 0, so it is an ordinary Moulton line (the bending only affects positive slopes). norm_num closes each of the three incidence checks O, A, A' under the negative-slope branch.",
+            "leanType": "MoultonCollinear O_pt A_pt A'_pt",
+            "line": 110,
+            "endLine": 117
+        },
+        {
+            "name": "collinear_OBB'",
+            "type": "supporting",
+            "description": "Second perspectivity-from-O fact, and the one where Moulton bending becomes operationally visible inside the perspectivity hypothesis: line OB has left-slope 2/3 > 0. O = (0,0) is on the seam (onML_pos_left, since 0 ≤ 0), while B = (3,1) and B' = (9,3) are on the right half (onML_pos_right with right-slope 1/3). All three incidence checks discharge by norm_num.",
+            "leanType": "MoultonCollinear O_pt B_pt B'_pt",
+            "line": 119,
+            "endLine": 125
+        },
+        {
+            "name": "collinear_OCC'",
+            "type": "supporting",
+            "description": "Third perspectivity-from-O fact, dispatched by the vertical-line branch of MoultonCollinear: O, C, C' all have x = 0. This is the case where the disjunctive structure of MoultonCollinear (vertical OR non-vertical Moulton line) is genuinely needed — no single non-vertical Moulton line could contain all three points.",
+            "leanType": "MoultonCollinear O_pt C_pt C'_pt",
+            "line": 127,
+            "endLine": 129
+        },
+        {
+            "name": "PQR_x_distinct",
+            "type": "supporting",
+            "description": "Excludes the vertical case from desargues_fails. The three intersection points P=(-17,9), Q=(27,17), R=(-6,11) have pairwise distinct x-coordinates (-17 ≠ 27 ≠ -6 ≠ -17), so no vertical Moulton line can contain all three. This lemma is what the vertical branch of desargues_fails dispatches against, leaving only the genuine algebraic case (m ≤ 0 or m > 0) for the linarith / linear_combination machinery.",
+            "leanType": "P_pt.1 ≠ Q_pt.1 ∧ P_pt.1 ≠ R_pt.1 ∧ Q_pt.1 ≠ R_pt.1",
+            "line": 227,
+            "endLine": 229
+        }
+    ],
     "sections": [
         {
             "id": "moulton-line-definition",


### PR DESCRIPTION
## Enrichment pass for `desargues-theorem-oq-01-oq-01`

Two targeted improvements to the Moulton-plane counterexample entry.

### 1. Added `mainTheorems` array (8 entries)
The entry was missing the structural `mainTheorems` field. The new array exposes the key user-facing results so the gallery's theorem-level navigation works:

- `desargues_fails` (core, lines 233-261) — the central negative result
- `moulton_counterexample` (core, lines 268-296) — the full 21-component certificate
- `onMoultonLine` (definition, lines 54-58) — the piecewise predicate
- `MoultonCollinear` (definition, lines 60-64) — the disjunctive collinearity predicate
- `collinear_OAA'` / `collinear_OBB'` / `collinear_OCC'` (supporting) — the three perspectivity facts
- `PQR_x_distinct` (supporting, lines 227-229) — vertical-case excluder for the main proof

Each entry carries `leanType`, line range, and a substantive description matching the gallery pattern.

### 2. Closed annotation coverage gap (lines 212-225)
Previously `ann-intersection-points` ended at line 210 and `ann-desargues-fails` began at line 226, leaving the 13-line Part V intro docstring unannotated. The new `ann-part-v-intro-narrative` covers this gap and maps each docstring claim (P/Q/R coordinates → left/right branch split → `m = 16/61` → numeric contradiction `725/61 ≠ 671/61`) to the corresponding `by_cases` branch at lines 233-261.

### Quality after pass
- All 10 annotations have `mathContext`, `significance`, `relatedConcepts`, `prerequisites`
- Line coverage extends from 1 to 296 (only blank separator lines uncovered)
- `mainTheorems` brings the entry to parity with mature gallery entries

### Verification
`pnpm build` passes (1m 43s, 0 errors). Lean file unchanged; integrity preserved (0 sorries, 0 axioms, 0 structure-encoded assumptions).

## Test plan
- [x] JSON validation (jq parse) passes for both files
- [x] `pnpm build` succeeds end-to-end
- [x] Only `desargues-theorem-oq-01-oq-01/` files modified in this commit
- [x] No Lean source modifications

Note: This PR was force-pushed over a stale prior commit on the shared `feature/enricher-1` branch; the new HEAD `cac712da14b` is the only commit relevant to review.