### PR TITLE
audit(cevas-theorem-oq-01-oq-03): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14058,10 +14058,10 @@
       "issues": []
     },
     "cevas-theorem-oq-01-oq-03": {
-      "auditCount": 1,
+      "auditCount": 2,
       "issues": [],
-      "lastAudited": "2026-05-03T12:00:00Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-06T02:10:27Z",
+      "result": "clean"
     },
     "pac-learning-bounds-oq-01-oq-01": {
       "auditCount": 1,


### PR DESCRIPTION
## Audit Summary

Verified `cevas-theorem-oq-01-oq-03` (Routh's Theorem for general parameters d, e, f ∈ (0,1)).

| Field | meta.json | Lean source |
|---|---|---|
| lineCount | 230 | 230 ✓ |
| theoremCount | 19 | 19 ✓ |
| definitionCount | 6 | 6 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 (no `axiom` declarations; no assumption-carrying structures) ✓ |
| status / badge | verified / original | Tier A — appropriate ✓ |

- No `True`-stub theorems.
- Parent file `Proofs/CevasTheoremOQ01.lean` provides every referenced symbol (`signedArea`, `routhRatio`, `routh_zero_iff_ceva`, `routh_medial_thirds`, `medians_ceva`, `affineComb`, `lineThrough`, `cevaCondition`).
- Mathlib is used only for tactics (`nlinarith`, `field_simp`, `ring`, `positivity`, `norm_num`); no Mathlib theorem supplies the core argument — the Routh identity is established directly from explicit vertex formulas + `field_simp; ring`. No Mathlib wrapper / delegation-opacity concerns.

Result: **clean**. Tracker bumped `auditCount` 1 → 2, `lastAudited` set to 2026-06-06T02:10:27Z, `result` set to `clean`.

---
Discovered during gallery integrity audit.