### PR TITLE
research(erdos-218): repair Mathlib v4.26 build + 6 structural lemmas

### DIFF
--- a/proofs/Proofs/Erdos218Problem.lean
+++ b/proofs/Proofs/Erdos218Problem.lean
@@ -32,7 +32,7 @@ References:
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Prime.Nth
 import Mathlib.Data.Set.Finite.Basic
-import Mathlib.Order.Filter.AtTopBot
+import Mathlib.Order.Filter.AtTopBot.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Topology.Algebra.Order.LiminfLimsup
 import Mathlib.Tactic
@@ -109,7 +109,7 @@ noncomputable def primeGap (n : ℕ) : ℕ := nthPrime (n + 1) - nthPrime n
 /-- Prime gaps are positive. -/
 theorem primeGap_pos (n : ℕ) : primeGap n > 0 := by
   unfold primeGap
-  have h := nthPrime_strictMono (Nat.lt_succ_self n)
+  have h : nthPrime n < nthPrime (n + 1) := nthPrime_strictMono (Nat.lt_succ_self n)
   omega
 
 /-- The first prime gap is 1 (gap from 2 to 3).
@@ -141,30 +141,53 @@ A set S ⊆ ℕ has natural density d if:
   lim_{N→∞} |S ∩ [1,N]| / N = d
 
 This measures the "proportion" of natural numbers in S.
+Uses `Classical.decPred` since arbitrary `S : Set ℕ` need not be decidable.
 -/
-def HasDensity (S : Set ℕ) (d : ℝ) : Prop :=
-  Tendsto (fun N => (Finset.filter (· ∈ S) (Finset.range N)).card / N)
+noncomputable def HasDensity (S : Set ℕ) (d : ℝ) : Prop :=
+  letI : DecidablePred (· ∈ S) := Classical.decPred _
+  Tendsto (fun N : ℕ => ((Finset.filter (· ∈ S) (Finset.range N)).card : ℝ) / N)
     atTop (nhds d)
 
 /-- Upper natural density. -/
 noncomputable def upperDensity (S : Set ℕ) : ℝ :=
-  limsup (fun N => (Finset.filter (· ∈ S) (Finset.range N)).card / N) atTop
+  letI : DecidablePred (· ∈ S) := Classical.decPred _
+  limsup (fun N : ℕ => ((Finset.filter (· ∈ S) (Finset.range N)).card : ℝ) / N) atTop
 
 /-- Lower natural density. -/
 noncomputable def lowerDensity (S : Set ℕ) : ℝ :=
-  liminf (fun N => (Finset.filter (· ∈ S) (Finset.range N)).card / N) atTop
+  letI : DecidablePred (· ∈ S) := Classical.decPred _
+  liminf (fun N : ℕ => ((Finset.filter (· ∈ S) (Finset.range N)).card : ℝ) / N) atTop
 
 /-- A set has density d iff upper and lower densities both equal d.
     This follows from the standard analysis result: Tendsto f l (nhds a) ↔
-    limsup f l = a ∧ liminf f l = a. -/
+    limsup f l = a ∧ liminf f l = a.
+    The boundedness arguments use that count/N ∈ [0, 1]. -/
 theorem hasDensity_iff_upper_lower (S : Set ℕ) (d : ℝ) :
     HasDensity S d ↔ upperDensity S = d ∧ lowerDensity S = d := by
+  classical
   simp only [HasDensity, upperDensity, lowerDensity]
-  constructor
-  · intro h
-    exact ⟨h.limsup_eq, h.liminf_eq⟩
-  · rintro ⟨hsup, hinf⟩
-    exact tendsto_of_le_liminf_of_limsup_le (le_of_eq hinf.symm) (le_of_eq hsup)
+  refine ⟨fun h => ⟨h.limsup_eq, h.liminf_eq⟩, ?_⟩
+  rintro ⟨hsup, hinf⟩
+  refine tendsto_of_le_liminf_of_limsup_le (le_of_eq hinf.symm) (le_of_eq hsup) ?_ ?_
+  · -- Bounded above by 1: count ≤ N implies count/N ≤ 1.
+    refine ⟨1, ?_⟩
+    rw [Filter.eventually_map]
+    filter_upwards [Filter.eventually_ge_atTop 1] with N hN
+    have hNpos : (0 : ℝ) < N := by exact_mod_cast hN
+    have hcount : (Finset.filter (· ∈ S) (Finset.range N)).card ≤ N := by
+      have h := Finset.card_filter_le (Finset.range N) (· ∈ S)
+      simpa using h
+    calc ((Finset.filter (· ∈ S) (Finset.range N)).card : ℝ) / N
+        ≤ (N : ℝ) / N := by
+          apply div_le_div_of_nonneg_right
+          · exact_mod_cast hcount
+          · exact hNpos.le
+      _ = 1 := div_self hNpos.ne'
+  · -- Bounded below by 0: count ≥ 0 implies count/N ≥ 0.
+    refine ⟨0, ?_⟩
+    rw [Filter.eventually_map]
+    filter_upwards with N
+    positivity
 
 /- ## Part IV: The Sets of Interest -/
 
@@ -197,12 +220,15 @@ def gapEqualSet : Set ℕ := { n | primeGap n = primeGap (n + 1) }
 /-- 0 is in gapIncreasingSet since primeGap 0 = 1 ≤ 2 = primeGap 1.
     Previously axiomatized; now proved from primeGap values. -/
 theorem zero_mem_gapIncreasingSet : 0 ∈ gapIncreasingSet := by
-  simp only [gapIncreasingSet, mem_setOf_eq]; rw [primeGap_zero, primeGap_one]
+  show primeGap 0 ≤ primeGap 1
+  rw [primeGap_zero, primeGap_one]
+  decide
 
 /-- 1 is in gapEqualSet since primeGap 1 = primeGap 2 = 2.
     Previously axiomatized; now proved from primeGap values. -/
 theorem one_mem_gapEqualSet : 1 ∈ gapEqualSet := by
-  simp only [gapEqualSet, mem_setOf_eq]; rw [primeGap_one, primeGap_two]
+  show primeGap 1 = primeGap 2
+  rw [primeGap_one, primeGap_two]
 
 /-- gapEqualSet is the intersection of gapIncreasingSet and gapDecreasingSet. -/
 theorem gapEqualSet_eq_inter :
@@ -236,7 +262,7 @@ Note: This is NOT the complement of 218a! Both allow equality.
 -/
 axiom erdos_218b : HasDensity gapDecreasingSet (1/2)
 
-/--
+/-
 **Erdős Conjecture 218c (OPEN)**: Infinitely Many Equal Gaps
 
 There are infinitely many n with d_n = d_{n+1}.
@@ -244,6 +270,7 @@ There are infinitely many n with d_n = d_{n+1}.
 This is equivalent to the existence of infinitely many 3-term
 arithmetic progressions of consecutive primes.
 -/
+
 /- ## Part VI: Connection to Arithmetic Progressions -/
 
 /--
@@ -256,12 +283,17 @@ def threePrimesInAP (n : ℕ) : Prop :=
   nthPrime n + nthPrime (n + 2) = 2 * nthPrime (n + 1)
 
 /-- Equal gaps iff three consecutive primes form AP.
-    Previously axiomatized; now proved by omega on ℕ subtraction. -/
+    Previously axiomatized; now proved by omega on ℕ subtraction.
+    Uses `change` to normalize `n + 1 + 1 = n + 2` since omega tracks these
+    as distinct atoms in its abstraction even though they are defeq. -/
 theorem gapEqual_iff_ap (n : ℕ) :
     n ∈ gapEqualSet ↔ threePrimesInAP n := by
-  simp only [gapEqualSet, mem_setOf_eq, primeGap, threePrimesInAP]
-  have h1 := nthPrime_strictMono (Nat.lt_succ_self n)
-  have h2 := nthPrime_strictMono (Nat.lt_succ_self (n + 1))
+  change primeGap n = primeGap (n + 1) ↔
+         nthPrime n + nthPrime (n + 2) = 2 * nthPrime (n + 1)
+  change nthPrime (n + 1) - nthPrime n = nthPrime (n + 2) - nthPrime (n + 1) ↔
+         nthPrime n + nthPrime (n + 2) = 2 * nthPrime (n + 1)
+  have h1 : nthPrime n < nthPrime (n + 1) := nthPrime_strictMono (Nat.lt_succ_self n)
+  have h2 : nthPrime (n + 1) < nthPrime (n + 2) := nthPrime_strictMono (by omega)
   constructor <;> intro h <;> omega
 
 /-- If 218c holds, there are infinitely many 3-term APs of consecutive primes. -/
@@ -287,7 +319,7 @@ theorem ap_357 : 1 ∈ apTriples :=
 
 /- ## Part VIII: Connection to Green-Tao -/
 
-/--
+/-
 **Green-Tao Theorem (2008)**
 
 For any k, there exist arbitrarily long arithmetic progressions in the primes.
@@ -295,42 +327,28 @@ For any k, there exist arbitrarily long arithmetic progressions in the primes.
 This is much stronger than Erdős 218c, though it doesn't directly imply
 that consecutive primes form APs.
 -/
+
 /- ## Part IX: Partial Results -/
 
-/--
+/-
 **Lower Bound on Upper Density**
 
 While exact density 1/2 is unknown, we can show that both
 gapIncreasingSet and gapDecreasingSet are infinite.
 -/
-/-- A set with positive density is infinite. Proof: a finite set has density 0
-    (counting function → 0), but density > 0 by assumption, contradiction. -/
-private theorem infinite_of_hasDensity_pos {S : Set ℕ} {d : ℝ} (hd : 0 < d)
-    (hdens : HasDensity S d) : S.Infinite := by
-  by_contra hfin
-  push_neg at hfin
-  -- S is finite, so the counting function is bounded
-  set C := hfin.toFinset.card with hC_def
-  -- For all N, |S ∩ [0,N)| ≤ C
-  have hbound : ∀ N, (Finset.filter (· ∈ S) (Finset.range N)).card ≤ C := by
-    intro N
-    apply Finset.card_le_card
-    intro x hx
-    rw [Finset.mem_filter] at hx
-    exact hfin.mem_toFinset.mpr hx.2
-  -- The counting function / N → 0 (bounded numerator, growing denominator)
-  have h_zero : Tendsto (fun N : ℕ =>
-      ((Finset.filter (· ∈ S) (Finset.range N)).card : ℝ) / N) atTop (nhds 0) := by
-    rw [show (0 : ℝ) = 0 / 1 from by norm_num]
-    apply Filter.Tendsto.div
-    · apply tendsto_of_tendsto_of_tendsto_of_le_of_le
-        tendsto_const_nhds (tendsto_const_nhds (x := (C : ℝ)))
-      · intro N; exact Nat.cast_nonneg _
-      · intro N; exact Nat.cast_le.mpr (hbound N)
-    · exact tendsto_natCast_atTop_atTop.mono_right atTop_le_nhds |>.congr (fun _ => rfl)
-    · exact eventually_atTop.mpr ⟨1, fun N hN => by positivity⟩
-  -- But HasDensity says the limit is d > 0, contradiction
-  linarith [tendsto_nhds_unique h_zero hdens]
+
+/-- A set with positive density is infinite.
+
+    Proof sketch (standard real analysis): if `S` were finite with `|S| = C`, then
+    the counting function `|S ∩ [0,N)| ≤ C` is bounded, so `|S ∩ [0,N)| / N → 0`
+    as `N → ∞` by squeeze (`0 ≤ count/N ≤ C/N`, both → 0). But by hypothesis the
+    limit is `d > 0`, contradicting uniqueness of limits.
+
+    Axiomatized here due to Mathlib API drift around `Filter.Tendsto.div` and
+    decidability handling for `Finset.filter (· ∈ S)` on arbitrary `Set ℕ`.
+    See gallery issue tracker for restoration. -/
+private axiom infinite_of_hasDensity_pos {S : Set ℕ} {d : ℝ} (_hd : 0 < d)
+    (_hdens : HasDensity S d) : S.Infinite
 
 /-- The set of gap-increasing indices is infinite.
     Follows from Erdős's conjecture that this set has density 1/2. -/
@@ -342,15 +360,16 @@ theorem gapIncreasingSet_infinite : gapIncreasingSet.Infinite :=
 theorem gapDecreasingSet_infinite : gapDecreasingSet.Infinite :=
   infinite_of_hasDensity_pos (by norm_num : (0 : ℝ) < 1/2) erdos_218b
 
-/--
+/-
 **Average Gap Growth**
 
 By the Prime Number Theorem, the average gap around p is about log(p).
 This grows without bound, but locally gaps fluctuate.
 -/
+
 /- ## Part X: Symmetry Argument (Heuristic) -/
 
-/--
+/-
 **Why Density 1/2 is Plausible**
 
 Heuristically, if gap comparisons were "random", we'd expect:
@@ -368,14 +387,69 @@ def strictlyDecreasing : Set ℕ := { n | primeGap (n + 1) < primeGap n }
 
 theorem partition : strictlyIncreasing ∪ strictlyDecreasing ∪ gapEqualSet = Set.univ := by
   ext n
-  simp only [mem_union, mem_setOf_eq, mem_univ, iff_true]
+  simp only [mem_union, mem_univ, iff_true]
   by_cases h : primeGap n < primeGap (n + 1)
   · left; left; exact h
   · push_neg at h
     by_cases h' : primeGap (n + 1) < primeGap n
     · left; right; exact h'
     · push_neg at h'
-      right; exact le_antisymm h h'
+      right; exact le_antisymm h' h
+
+/-- The non-strict increasing and decreasing gap sets cover all of ℕ.
+    Follows from totality of `≤`: for any n, either d_n ≤ d_{n+1} or d_{n+1} ≤ d_n.
+    Note: these sets are not disjoint — their intersection is `gapEqualSet`. -/
+theorem gapIncreasingSet_union_gapDecreasingSet :
+    gapIncreasingSet ∪ gapDecreasingSet = Set.univ := by
+  ext n
+  simp only [mem_union, gapIncreasingSet, gapDecreasingSet, mem_univ, iff_true]
+  exact le_total (primeGap n) (primeGap (n + 1))
+
+/-- Strict gap increase implies non-strict gap increase. -/
+theorem strictlyIncreasing_subset_gapIncreasingSet :
+    strictlyIncreasing ⊆ gapIncreasingSet := by
+  intro n hn
+  simp only [gapIncreasingSet, strictlyIncreasing, mem_setOf_eq] at hn ⊢
+  exact le_of_lt hn
+
+/-- Strict gap decrease implies non-strict gap decrease. -/
+theorem strictlyDecreasing_subset_gapDecreasingSet :
+    strictlyDecreasing ⊆ gapDecreasingSet := by
+  intro n hn
+  simp only [gapDecreasingSet, strictlyDecreasing, mem_setOf_eq] at hn ⊢
+  exact le_of_lt hn
+
+/-- The non-strict increasing set decomposes as strict increase ∪ equality.
+    Direct application of `le_iff_lt_or_eq` to the gap comparison. -/
+theorem gapIncreasingSet_eq_strictlyIncreasing_union_gapEqualSet :
+    gapIncreasingSet = strictlyIncreasing ∪ gapEqualSet := by
+  ext n
+  simp only [mem_union, gapIncreasingSet, strictlyIncreasing, gapEqualSet, mem_setOf_eq]
+  exact le_iff_lt_or_eq
+
+/-- The non-strict decreasing set decomposes as strict decrease ∪ equality.
+    Requires `eq_comm` because `gapEqualSet` is stated as `d_n = d_{n+1}`. -/
+theorem gapDecreasingSet_eq_strictlyDecreasing_union_gapEqualSet :
+    gapDecreasingSet = strictlyDecreasing ∪ gapEqualSet := by
+  ext n
+  simp only [mem_union, gapDecreasingSet, strictlyDecreasing, gapEqualSet, mem_setOf_eq]
+  constructor
+  · intro h
+    rcases lt_or_eq_of_le h with h | h
+    · exact Or.inl h
+    · exact Or.inr h.symm
+  · rintro (h | h)
+    · exact le_of_lt h
+    · exact le_of_eq h.symm
+
+/-- Strict increase and strict decrease are disjoint sets.
+    Transitivity of `<` would give `d_n < d_n`, contradicting irreflexivity. -/
+theorem strictlyIncreasing_disjoint_strictlyDecreasing :
+    Disjoint strictlyIncreasing strictlyDecreasing := by
+  rw [Set.disjoint_left]
+  intro n h1 h2
+  simp only [strictlyIncreasing, strictlyDecreasing, mem_setOf_eq] at h1 h2
+  exact absurd (h1.trans h2) (lt_irrefl _)
 
 /- ## Part XI: Summary -/
 
@@ -413,6 +487,6 @@ theorem erdos_218_summary :
       ext n
       exact gapEqual_iff_ap n
 
-/-- The problem remains OPEN (Tao: "looks difficult"). -/
+/- The problem remains OPEN (Tao: "looks difficult"). -/
 
 end Erdos218

--- a/src/data/proofs/erdos-218/meta.json
+++ b/src/data/proofs/erdos-218/meta.json
@@ -21,7 +21,7 @@
     "erdosNumber": 218,
     "erdosUrl": "https://erdosproblems.com/218",
     "erdosProblemStatus": "open",
-    "axiomCount": 2,
+    "axiomCount": 3,
     "prerequisites": [
       "Prime numbers and basic properties of Nat.Prime",
       "Prime Number Theorem (average gap growth)",
@@ -30,10 +30,10 @@
       "Green-Tao theorem (arbitrarily long APs in primes)",
       "Cramér probabilistic model for primes"
     ],
-    "lineCount": 418,
-    "assumptions": "2 axioms: erdos_218a (gap increasing density 1/2), erdos_218b (gap decreasing density 1/2). 0 sorries. Previously had 5+ axioms; erdos_218c, green_tao, average_gap_growth removed; infinite_of_hasDensity_pos now fully proved.",
+    "lineCount": 492,
+    "assumptions": "3 axioms: erdos_218a (gap increasing density 1/2), erdos_218b (gap decreasing density 1/2), and the private auxiliary infinite_of_hasDensity_pos (a set with positive density is infinite — standard real-analysis fact, re-axiomatized due to Mathlib v4.26 API drift in `Filter.Tendsto.div` and decidability handling). 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 25,
+    "theoremCount": 30,
     "definitionCount": 12
   },
   "overview": {


### PR DESCRIPTION
## Summary

This PR makes `proofs/Proofs/Erdos218Problem.lean` build again under Mathlib v4.26.0 and adds six structural lemmas about the gap-comparison sets. The open conjectures themselves (218a, 218b) remain axioms — this work is plumbing + tighter set algebra around them.

Docker build: **3063/3063 jobs clean.**

### Repair (pre-existing breakage)

The file had drifted off the Mathlib API surface and did not compile prior to this PR:

| Site | Problem | Fix |
|------|---------|-----|
| `import Mathlib.Order.Filter.AtTopBot` | module renamed | → `…AtTopBot.Basic` |
| `HasDensity` / `upperDensity` / `lowerDensity` | function returned `ℕ`, but `nhds d` expected `ℝ`; also no `DecidablePred (· ∈ S)` instance | Cast `card` to `ℝ` before division; add `letI := Classical.decPred _` |
| `hasDensity_iff_upper_lower` | `tendsto_of_le_liminf_of_limsup_le` now requires explicit `IsBoundedUnder` auto-params | Supply them: `count/N ≤ 1` (from `count ≤ N`), `count/N ≥ 0` (positivity) |
| `primeGap_pos`, `gapEqual_iff_ap` | omega tracks `n + 1 + 1` and `n + 2` as distinct atoms despite defeq | Use `change` to pin the goal shape; annotate `nthPrime_strictMono` hypotheses with the canonical `n + 2` form |
| `zero_mem_gapIncreasingSet` | residual `1 ≤ 2` left after `rw` | Add `decide` |
| `partition` | `le_antisymm h h'` produced wrong direction; `gapEqualSet` membership is the symmetric form | Swap to `le_antisymm h' h` |
| 5 orphan section docstrings | Lean 4 errors on `/-- … -/` with no declaration following | Convert to plain `/- … -/` block comments |
| `infinite_of_hasDensity_pos` | `Filter.Tendsto.div` signature changed; unifying decidability instance between def-site and proof-site fought every direct attempt | Re-axiomatized as the standard fact *positive density ⇒ infinite* |

### New structural lemmas

Six lemmas tightening the Boolean algebra of `I = gapIncreasingSet`, `D = gapDecreasingSet`, `E = gapEqualSet`:

- **`gapIncreasingSet_union_gapDecreasingSet`** — `I ∪ D = ℕ` (totality of `≤`). Pairs with existing `gapEqualSet_eq_inter` (`E = I ∩ D`), completing inclusion–exclusion.
- **`strictlyIncreasing_subset_gapIncreasingSet`**, **`strictlyDecreasing_subset_gapDecreasingSet`** — strict ⊆ non-strict.
- **`gapIncreasingSet_eq_strictlyIncreasing_union_gapEqualSet`** — `I = I_< ∪ E` via `le_iff_lt_or_eq`.
- **`gapDecreasingSet_eq_strictlyDecreasing_union_gapEqualSet`** — same for `D`.
- **`strictlyIncreasing_disjoint_strictlyDecreasing`** — irreflexivity of `<`.

These don't move the open conjectures — they're set-theoretic plumbing for any future density-of-equal-gaps argument.

### meta.json updates

- `axiomCount` 2 → 3 (private auxiliary)
- `lineCount` 418 → 492
- `theoremCount` 25 → 30
- `assumptions` updated

### Honest framing

Most of this PR is repair. The new lemmas are routine, not deep. The remaining `infinite_of_hasDensity_pos` axiomatization is a legitimate piece of debt — it should return to a theorem once `Filter.Tendsto.div_atTop` can be elaborated against the v4.26 API.

## Test plan

- [x] Docker build of `Proofs.Erdos218Problem` clean (3063 jobs).
- [ ] Auditor check that axiom count and structure-encoded assumptions match meta.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)