### PR TITLE
audit(bertrands-postulate-oq-03): tracker bump — clean (4th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -772,9 +772,9 @@
       "result": "clean"
     },
     "bertrands-postulate-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T11:59:18Z",
+      "lastAudited": "2026-06-06T02:27:34Z",
       "result": "clean"
     },
     "bertrands-postulate-oq-03-oq-04": {


### PR DESCRIPTION
## Audit Summary

Routine integrity audit of `bertrands-postulate-oq-03`. **Result: clean.**

## Verification

Re-verified against `proofs/Proofs/BertrandsPostulateOQ03.lean`:

- **sorries**: 0 (matches `meta.json`)
- **axioms**: 3 — `bhp_short_interval`, `cramer_conjecture`, `legendre_conjecture` (matches `axiomCount: 3`)
- **theorems**: 11 (matches `theoremCount: 11`)
- **definitions**: 2 — `primeCountInInterval`, `PrimeGapConjecture` (matches `definitionCount: 2`)
- **lineCount**: 308 (matches)
- **True stubs**: 0
- **Status** `axiomatized` / **badge** `axiom` correctly reflect the 3 open-conjecture axioms
- **originalContributions** lists only actually-proved results (iterated Bertrand, π(2^m) ≥ m, log₂ bound, monotonicity, PrimeGapConjecture definition) — no overclaim
- **mathlibDependencies** properly credit `Nat.bertrand` and `Nat.primeCounting`; main results genuinely extend Bertrand rather than wrap a single Mathlib theorem
- **assumptions** field clearly enumerates the 3 axioms (BHP θ=0.525, Cramér, Legendre)

No issues. Bumping `auditCount` 3 → 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)