### PR TITLE
audit(erdos-218): tracker bump — clean (4th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5338,8 +5338,8 @@
     },
     "erdos-218": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-03T20:23:29Z",
+      "auditCount": 4,
+      "lastAudited": "2026-06-06T03:01:18Z",
       "result": "clean"
     },
     "erdos-219": {


### PR DESCRIPTION
## Summary
Re-audited `erdos-218` (Erdős Problem #218: Prime Gap Densities) against current Lean source.

**Findings:** clean
- 3 axioms — matches `axiomCount: 3`
  - `erdos_218a`, `erdos_218b` (the two density-1/2 conjectures)
  - `private infinite_of_hasDensity_pos` (auxiliary, re-axiomatized due to Mathlib v4.26 API drift)
- 0 sorries — matches `sorries: 0`
- 30 theorems/lemmas — matches `theoremCount: 30`
- 12 defs (7 def + 5 noncomputable def) — matches `definitionCount: 12`
- 492 lines — matches `lineCount: 492`
- `status: axiomatized` / `badge: axiom` consistent with structure-encoded assumption policy

Bumps `auditCount` 3 → 4 and refreshes `lastAudited`.