### PR TITLE
audit(angle-trisection-oq-02-oq-01-oq-02-incomplete-01): tracker bump — clean (6th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -289,9 +289,9 @@
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-01-oq-02-incomplete-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T12:00:00Z",
+      "lastAudited": "2026-06-06T04:52:10Z",
       "result": "clean"
     },
     "angle-trisection-oq-02-oq-02": {


### PR DESCRIPTION
## Summary

Re-verified gallery integrity for `angle-trisection-oq-02-oq-01-oq-02-incomplete-01` against `proofs/Proofs/AngleTrisectionOQ02OQ01OQ02Incomplete01.lean` at HEAD `811ecfa0df6`. All meta.json claims match the Lean source. No drift detected. Tracker bumped (auditCount 4 → 5, lastAudited refreshed).

## Verification

| Field | meta.json | Lean source | Match |
|---|---|---|---|
| `sorries` | 0 | 0 (4 grep matches all in comments) | ✓ |
| `axiomCount` | 0 | 0 | ✓ |
| `theoremCount` | 22 | 22 (16 public + 6 private) | ✓ |
| `definitionCount` | 2 | 2 (1 `def` + 1 `inductive`) | ✓ |
| `lineCount` | 639 | 639 | ✓ |
| `status` / `badge` | `verified` / `original` | Tier A (no sorries, no axioms, no True stubs) | ✓ |

Aristotle companion `AngleTrisectionOQ02OQ01OQ02Incomplete01Aristotle.lean`: 0 axioms, 0 sorries.

Mathlib dependencies properly credited (Eisenstein, Gauss's lemma, minpoly tools) — main theorem result `not_constructible_of_bad_degree` and the three concrete impossibilities (angle trisection, cube doubling, regular 7-gon) are derived independently via the tower-degree induction `isConstructible_algebraic_degree`, so `original` badge is appropriate.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --stats` clean
- [x] Tracker diff inspected — only `auditCount` and `lastAudited` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)