### PR TITLE
audit(cayley-hamilton-minpoly-oq-03): sync meta with axiomatized OQ02 companion

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1789,10 +1789,10 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-04T03:58:17Z",
-      "result": "clean"
+      "lastAudited": "2026-06-06T07:48:05Z",
+      "result": "issues-fixed"
     },
     "cayley-hamilton-minpoly-oq-03-oq-01": {
       "auditCount": 2,

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03/meta.json
@@ -7,7 +7,7 @@
     "author": "Formalized in Lean 4 (Mathlib)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Minimal_polynomial_(linear_algebra)#Computation",
     "date": "2026",
-    "status": "verified",
+    "status": "axiomatized",
     "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
     "tags": [
       "linear-algebra",
@@ -78,9 +78,9 @@
         "relationship": "General K-algebra minimal polynomial reduction; provides algebraic foundation"
       }
     ],
-    "axiomCount": 0,
+    "axiomCount": 3,
     "lineCount": 368,
-    "assumptions": "No sorries, no axioms. All 12 theorems fully proved.",
+    "assumptions": "Main proof file (CayleyHamiltonMinpolyOQ03.lean): 0 sorries, 0 axioms — all 12 Krylov theorems fully proved (O(n³) bound). Companion file CayleyHamiltonMinpolyOQ03OQ02.lean adds 3 axioms (`omegaMM`, `omegaMM_two_le`, `omegaMM_lt_three`) declaring the matrix-multiplication exponent ω with its known bounds 2 ≤ ω < 3 (Strassen 1969), as a Layer 3 placeholder for the sibling Keller-Gehrig O(n^ω) question (cayley-hamilton-minpoly-oq-03-oq-02). The Krylov O(n³) result of this entry is unaffected.",
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
     "definitionCount": 1,
@@ -100,12 +100,12 @@
       "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
       {
         "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean",
-        "lineCount": 230,
-        "theorems": 9,
+        "lineCount": 333,
+        "theorems": 11,
         "definitions": 2,
-        "axioms": 0,
+        "axioms": 3,
         "sorries": 0,
-        "description": "Companion file for the sibling open question cayley-hamilton-minpoly-oq-03-oq-02 (Keller-Gehrig O(n^ω) characteristic polynomial). Formalizes Layers 1 + 2 of the three-layer decomposition: structural squared-Krylov sequence T_k := M^(2^k) via repeated squaring with bridge T_k = M^(2^k); correctness bridge M^j = ∏_{i ∈ bitIndices j} T_i via Mathlib's Nat.twoPowSum_bitIndices; vector-level corollaries (squareKrylovProd_mulVec, krylov_in_squareKrylov_range). Layer 3 (complexity) out of scope — Mathlib has no complexity monad and no fast matmul. Namespace MinpolyComplexity.SubcubicKrylov."
+        "description": "Companion file for the sibling open question cayley-hamilton-minpoly-oq-03-oq-02 (Keller-Gehrig O(n^ω) characteristic polynomial). Formalizes Layers 1 + 2 of the three-layer decomposition: structural squared-Krylov sequence T_k := M^(2^k) via repeated squaring with bridge T_k = M^(2^k); correctness bridge M^j = ∏_{i ∈ bitIndices j} T_i via Mathlib's Nat.twoPowSum_bitIndices; vector-level corollaries (squareKrylovProd_mulVec, krylov_in_squareKrylov_range); Layer 2.5 matrix-multiplication factor-count bound (popcount(j) ≤ j); and Layer 3 axiomatized ω placeholder with three axioms (`omegaMM : ℝ`, `omegaMM_two_le : 2 ≤ ω`, `omegaMM_lt_three : ω < 3`) — Mathlib has no complexity monad and no fast matmul, so the O(n^ω) operation count remains deferred. Namespace MinpolyComplexity.SubcubicKrylov."
       }
     ]
   },


### PR DESCRIPTION
## Summary

The recent research commit e0523965e2b (PR #22531) extended `Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` with Layer 2.5 (matvec-count bound) and Layer 3 (axiomatized ω placeholder), introducing **3 new axioms**: `omegaMM : ℝ`, `omegaMM_two_le : 2 ≤ ω`, `omegaMM_lt_three : ω < 3` (Strassen 1969 bounds for the matrix-multiplication exponent).

The Lean source was Docker-verified, and the commit message explicitly flagged the follow-up: *"Next action (S6): gallery promotion with status=axiomatized, listing the 3 ω axioms in the assumptions field."* That follow-up was never applied — the gallery `meta.json` still claimed `status: "verified"`, `axiomCount: 0`, and `"No sorries, no axioms."`, which violates the Axiom Integrity Policy in `CLAUDE.md`:

> Status `verified` requires: 0 sorries, 0 `axiom` declarations, 0 structure-encoded assumptions
> `axiomCount` in meta.json must reflect ALL assumptions: `axiom` declarations + assumption-carrying structure fields

## Changes (meta.json only — no Lean source touched)

| Field | Before | After |
|---|---|---|
| `meta.status` | `"verified"` | `"axiomatized"` |
| `meta.axiomCount` | `0` | `3` |
| `meta.assumptions` | `"No sorries, no axioms. All 12 theorems fully proved."` | Full disclosure of the 3 ω axioms and the note that the Krylov O(n³) result of the main entry is unaffected |
| `leanFile.additionalFiles[1].lineCount` (OQ02) | `230` | `333` |
| `leanFile.additionalFiles[1].theorems` (OQ02) | `9` | `11` |
| `leanFile.additionalFiles[1].axioms` (OQ02) | `0` | `3` |
| `leanFile.additionalFiles[1].description` (OQ02) | Layers 1+2 only | + Layer 2.5 popcount bound + Layer 3 ω axiom enumeration |

Main file `CayleyHamiltonMinpolyOQ03.lean` (368 LOC, 13 theorems, 1 def, 0 sorries, 0 axioms) is unchanged and continues to fully prove the Krylov O(n³) minimal-polynomial result. The 3 axioms live exclusively in the companion file targeting the sibling open question `cayley-hamilton-minpoly-oq-03-oq-02` (Keller-Gehrig O(n^ω) characteristic polynomial).

## Verification

- `grep -n '^axiom' proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` → 3 hits (lines 240, 247, 253)
- `wc -l proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` → 333 lines
- `grep -cE '^(theorem|lemma|protected theorem|protected lemma)' …OQ02.lean` → 11
- No Lean files touched; no rebuild needed.

## Test plan

- [x] meta.json is valid JSON
- [x] All numbers match the Lean source on disk
- [x] Status field follows the table in `CLAUDE.md` (verified → axiomatized when axioms present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)