### PR TITLE
audit(picks-theorem-oq-02): tracker bump — clean (3rd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14052,8 +14052,8 @@
       "issues": []
     },
     "picks-theorem-oq-02": {
-      "auditCount": 2,
-      "lastAudited": "2026-05-03T12:17:48Z",
+      "auditCount": 3,
+      "lastAudited": "2026-06-06T08:43:24Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audit of `picks-theorem-oq-02` (status: `verified`, badge: `original`).

## Verification

- `proofs/Proofs/PicksTheoremOQ02.lean`: 245 lines, 13 theorems, 0 axioms, 0 sorries, 0 True stubs — all match meta.json exactly
- No `additionalFiles` or companion files to audit
- `find-targets.ts` integrity check: no issues detected for this entry
- Original work (segment lattice-point counting via gcd; Pick's-theorem edge contribution); uses Mathlib API for `Nat.gcd` / `Finset` but does not wrap any major Mathlib theorem as the main result — `original` badge accurate

No changes to Lean sources or meta.json — tracker entry only.

## Test plan

- [x] Tracker JSON valid
- [x] Lean source counts (axioms / sorries / theorems / lines) match meta.json
- [x] No outstanding integrity issues from `find-targets.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)