### PR TITLE
audit(cayley-hamilton-minpoly-oq-03): tracker bump — clean (5th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1789,10 +1789,10 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-06T07:48:05Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-06T09:42:35Z",
+      "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-03-oq-01": {
       "auditCount": 2,


### PR DESCRIPTION
## Summary

- 5th gallery audit of `cayley-hamilton-minpoly-oq-03` (Krylov-method O(n³) minimal polynomial)
- Result: **clean** — no actionable integrity issues
- Bumps `audit-tracker.json`: auditCount 4 → 5

## Re-verification details

Re-audited against `origin/main` HEAD `0a6649aa225`:

| File | Theorems | Axioms | Sorries |
|------|----------|--------|---------|
| `CayleyHamiltonMinpolyOQ03.lean` (main) | 13 | 0 | 0 |
| `CayleyHamiltonMinpolyOQ03Aristotle.lean` | 4 | 0 | 0 |
| `CayleyHamiltonMinpolyOQ03OQ02.lean` (sibling OQ-02 companion) | 11 | 3 | 0 |

The 3 axioms in the OQ02 companion declare the matrix-multiplication exponent ω with its known bounds (`omegaMM : ℝ`, `omegaMM_two_le : 2 ≤ ω`, `omegaMM_lt_three : ω < 3`). They support the sibling open question (Keller–Gehrig O(n^ω)), not the main O(n³) Krylov result of this entry.

- `meta.axiomCount=3` matches the chain detection
- `assumptions` field correctly distinguishes the verified main proof from the axiomatized OQ02 sibling-question companion
- `status=verified`, `badge=mathlib` retained (per #22548 audit decision)

The earlier "axiom undercount" signal seen on a stale branch was already resolved by PR #22548 (sync meta with axiomatized OQ02 companion) before this audit ran.

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --issues` returns 0 issues for this proof
- [x] Tracker JSON diff is the single intended entry bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)