### PR TITLE
research: 4-slug bundle — erdos-951 + erdos-895-oq-01 + erdos-269 + erdos-1063

### DIFF
--- a/proofs/Proofs/Erdos1063Problem.lean
+++ b/proofs/Proofs/Erdos1063Problem.lean
@@ -140,6 +140,27 @@ def ErdosProblem1063 : Prop :=
     ∀ k : ℕ, k ≥ 2 →
       ∃ nk : ℕ, IsThreshold nk k ∧ nk ≤ k ^ C
 
+/- ## Part V.5: Unified Existence -/
+
+/--
+**Existence of the threshold**: for every k ≥ 2, there exists some n_k
+satisfying `IsThreshold`. This combines the small-case witnesses
+(`threshold_k2`..`threshold_k5`) with Monier's factorial-bound axiom for
+k ≥ 3, giving a single uniform existence statement.
+
+The bounds — `monier_factorial_bound` (k!) and `cambie_lcm_bound`
+(k · (k-1)!) — both witness existence but with explicit (exponential)
+ceilings; this lemma extracts the bare existence without the size bound.
+-/
+theorem threshold_exists (k : ℕ) (hk : k ≥ 2) :
+    ∃ nk : ℕ, IsThreshold nk k := by
+  by_cases h3 : k ≥ 3
+  · obtain ⟨nk, hth, _⟩ := monier_factorial_bound k h3
+    exact ⟨nk, hth⟩
+  · have : k = 2 := by omega
+    subst this
+    exact ⟨4, threshold_k2⟩
+
 /- ## Part VI: Summary -/
 
 /--

--- a/proofs/Proofs/Erdos269Problem.lean
+++ b/proofs/Proofs/Erdos269Problem.lean
@@ -51,8 +51,8 @@ def IsPSmooth (P : Set ℕ) (n : ℕ) : Prop :=
 
 /-- 1 is P-smooth for any P (vacuously: 1 has no prime divisors). -/
 theorem one_isPSmooth (P : Set ℕ) : IsPSmooth P 1 :=
-  ⟨Nat.one_pos, fun p hp hdiv =>
-    absurd (Nat.le_of_dvd Nat.one_pos hdiv) (not_le_of_lt hp.one_lt)⟩
+  ⟨Nat.one_pos, fun _p hp hdiv =>
+    absurd (Nat.le_of_dvd Nat.one_pos hdiv) (not_le_of_gt hp.one_lt)⟩
 
 /-- If p ∈ P and p is prime, then p is P-smooth. -/
 theorem prime_isPSmooth {P : Set ℕ} {p : ℕ} (hp : p.Prime) (hpP : p ∈ P) :
@@ -80,8 +80,8 @@ This is the structural building block for the "P infinite ⇒ {a_n} infinite" ar
 if any prime p lies in P, then the powers p, p², p³, ... give infinitely many P-smooth
 numbers, so the smoothSeq sequence is well-defined for all indices. -/
 theorem pow_isPSmooth {P : Set ℕ} {p : ℕ} (hp : p.Prime) (hpP : p ∈ P)
-    {k : ℕ} (hk : 1 ≤ k) : IsPSmooth P (p ^ k) := by
-  refine ⟨Nat.pos_pow_of_pos k hp.pos, ?_⟩
+    {k : ℕ} (_hk : 1 ≤ k) : IsPSmooth P (p ^ k) := by
+  refine ⟨pow_pos hp.pos k, ?_⟩
   intro q hq hdiv
   -- q is prime and q ∣ p^k, so q ∣ p
   have hqp : q ∣ p := hq.dvd_of_dvd_pow hdiv
@@ -106,7 +106,7 @@ noncomputable def smoothSeq (P : Set ℕ) : ℕ → ℕ :=
 /-- smoothSeq P 0 = 1 for any nonempty P.
 The 0-th P-smooth number is 1, since 1 is vacuously P-smooth (has no prime divisors)
 and 0 is not P-smooth (fails the positivity requirement). -/
-theorem smoothSeq_zero (P : Set ℕ) (hP : P.Nonempty) : smoothSeq P 0 = 1 := by
+theorem smoothSeq_zero (P : Set ℕ) (_hP : P.Nonempty) : smoothSeq P 0 = 1 := by
   classical
   unfold smoothSeq
   -- Use Nat.nth_count: if p n, then nth p (count p n) = n
@@ -187,7 +187,7 @@ The problem can also be stated as: is the series NOT rational?
 def isSeriesRational (P : Set ℕ) : Prop :=
   ∃ q : ℚ, (q : ℝ) = lcmSeries P
 
-theorem erdos_269_equivalent (P : Finset ℕ) (hPrime : ∀ p ∈ P, p.Prime) (hCard : P.card ≥ 2) :
+theorem erdos_269_equivalent (P : Finset ℕ) (_hPrime : ∀ p ∈ P, p.Prime) (_hCard : P.card ≥ 2) :
     ¬ isSeriesRational (P : Set ℕ) ↔ Irrational (lcmSeries (P : Set ℕ)) := by
   simp [isSeriesRational, Irrational]
 

--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -163,12 +163,12 @@ private lemma greedy_indep_of_bounded_deg {n : ℕ} (G : GraphOnInterval n) [Dec
     intro cands hcard _
     have hempty : cands = ∅ := Finset.card_eq_zero.mp (Nat.le_zero.mp hcard)
     exact ⟨∅, Finset.empty_subset _, by simp [hempty],
-      fun a b ha _ _ _ => absurd ha (Finset.not_mem_empty a)⟩
+      fun a b ha _ _ _ => absurd ha (Finset.notMem_empty a)⟩
   | succ k ih =>
     intro cands hcard hΔ'
     rcases cands.eq_empty_or_nonempty with rfl | ⟨v, hv⟩
     · exact ⟨∅, Finset.Subset.refl _, by simp,
-        fun a b ha _ _ _ => absurd ha (Finset.not_mem_empty a)⟩
+        fun a b ha _ _ _ => absurd ha (Finset.notMem_empty a)⟩
     · -- Greedily pick v; let removed = N[v] ∩ cands, cands' = cands \ removed
       let removed := insert v (G.neighborFinset v ∩ cands)
       let cands' := cands \ removed

--- a/proofs/Proofs/Erdos951Problem.lean
+++ b/proofs/Proofs/Erdos951Problem.lean
@@ -152,7 +152,7 @@ theorem beurlingPi_le_floor (bp : BeurlingPrimes) (x : ℝ) :
   calc Set.ncard {n : ℕ | bp.a n ≤ x}
       ≤ Set.ncard (↑(Finset.range ⌊x⌋₊) : Set ℕ) :=
         Set.ncard_le_ncard hsub (Finset.range _).finite_toSet
-    _ = ⌊x⌋₊ := by rw [Set.ncard_coe_Finset, Finset.card_range]
+    _ = ⌊x⌋₊ := by rw [Set.ncard_coe_finset, Finset.card_range]
 
 /-- **Sharpened trivial upper bound**: `π_a(x) ≤ ⌊x⌋₊ - 1` (natural truncated
     subtraction). Saves one over `beurlingPi_le_floor` by exploiting the
@@ -179,7 +179,7 @@ theorem beurlingPi_le_floor_pred (bp : BeurlingPrimes) (x : ℝ) :
   calc Set.ncard {n : ℕ | bp.a n ≤ x}
       ≤ Set.ncard (↑(Finset.range (⌊x⌋₊ - 1)) : Set ℕ) :=
         Set.ncard_le_ncard hsub (Finset.range _).finite_toSet
-    _ = ⌊x⌋₊ - 1 := by rw [Set.ncard_coe_Finset, Finset.card_range]
+    _ = ⌊x⌋₊ - 1 := by rw [Set.ncard_coe_finset, Finset.card_range]
 
 /-- The nth prime as a real number. -/
 noncomputable def primeSeq (n : ℕ) : ℝ := Nat.nth Nat.Prime n
@@ -219,20 +219,20 @@ private lemma factorization_prod_at (S : Finset ℕ) (e : ℕ → ℕ) (n : ℕ)
         pow_pos (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime i).pos _)
     rw [Finset.prod_insert hjs, Nat.factorization_mul ha hb, Finsupp.add_apply, ih,
         Nat.factorization_pow, Finsupp.smul_apply, smul_eq_mul,
-        Nat.factorization_prime (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime j),
+        (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime j).factorization,
         Finsupp.single_apply]
     have h_inj := (Nat.nth_strictMono Nat.infinite_setOf_prime).injective
     by_cases hn : j = n
     · subst hn; simp [hjs]
     · simp [show Nat.nth Nat.Prime j ≠ Nat.nth Nat.Prime n from fun h => hn (h_inj h),
-            hn, Ne.symm hn]
+            Ne.symm hn]
 
 /-- The ordinary primes have well-separated products by the
     Fundamental Theorem of Arithmetic: distinct exponent tuples yield
     distinct natural number products, and distinct naturals differ by ≥ 1. -/
 theorem primeSeq_well_separated : WellSeparatedProducts primeSeq := by
   intro k ℓ hne
-  simp only [WellSeparatedProducts, primeSeq]
+  simp only [primeSeq]
   -- Define the products as natural numbers
   set Pk := ∏ i ∈ k.support, (Nat.nth Nat.Prime i) ^ (k i) with hPk_def
   set Pℓ := ∏ j ∈ ℓ.support, (Nat.nth Nat.Prime j) ^ (ℓ j) with hPℓ_def
@@ -241,8 +241,8 @@ theorem primeSeq_well_separated : WellSeparatedProducts primeSeq := by
     intro heq
     apply hne; ext n
     have h := congr_arg (fun m => Nat.factorization m (Nat.nth Nat.Prime n)) heq
-    rw [factorization_prod_at, factorization_prod_at] at h
-    simpa [Finsupp.mem_support_iff] using h
+    simp only [hPk_def, hPℓ_def, factorization_prod_at] at h
+    split_ifs at h with hk hℓ hℓ <;> simp_all
   -- Step 2: The real-valued products equal the natural products cast to ℝ
   have h_cast_k :
       ∏ i ∈ k.support, (↑(Nat.nth Nat.Prime i) : ℝ) ^ (k i) = (↑Pk : ℝ) := by
@@ -252,7 +252,7 @@ theorem primeSeq_well_separated : WellSeparatedProducts primeSeq := by
     norm_cast
   rw [h_cast_k, h_cast_ℓ]
   -- Step 3: Distinct natural numbers cast to ℝ differ by at least 1
-  rcases hne_prod.lt_or_lt with h | h
+  rcases hne_prod.lt_or_gt with h | h
   · rw [abs_of_nonpos (sub_nonpos.mpr (Nat.cast_le.mpr h.le))]
     linarith [show (↑Pk : ℝ) + 1 ≤ ↑Pℓ from by exact_mod_cast Nat.succ_le_of_lt h]
   · rw [abs_of_nonneg (sub_nonneg.mpr (Nat.cast_le.mpr h.le))]
@@ -264,6 +264,27 @@ noncomputable def actualPrimes : BeurlingPrimes where
   strictly_increasing := primeSeq_strictly_increasing
   all_gt_one := primeSeq_gt_one
   well_separated := primeSeq_well_separated
+
+/-- The 0th prime is 2 (cast to ℝ). Proved by `Nat.nth_count` applied to
+    `Nat.prime_two`, using that `Nat.count Nat.Prime 2 = 0` (no primes
+    are strictly less than 2). -/
+theorem primeSeq_zero : primeSeq 0 = 2 := by
+  show (Nat.nth Nat.Prime 0 : ℝ) = 2
+  have hcount : Nat.count Nat.Prime 2 = 0 := by decide
+  have hnth : Nat.nth Nat.Prime 0 = 2 := by
+    rw [← hcount]; exact Nat.nth_count Nat.prime_two
+  rw [hnth]; norm_num
+
+/-- **Tightness of `beurling_a_zero_ge_two`**: the lower bound `2 ≤ a₀`
+    is best possible — the actual primes witness equality `a₀ = 2`.
+
+    Consequence: any attempt to derive `a₀ ≥ 3` (or any stronger absolute
+    constant) from the `BeurlingPrimes` axioms alone must fail.
+    Strengthening requires additional hypotheses (e.g. excluding the
+    actual primes, or restricting to integer sequences with `a₀ ≠ 2`). -/
+theorem beurling_a_zero_lower_bound_tight :
+    ∃ bp : BeurlingPrimes, bp.a 0 = 2 :=
+  ⟨actualPrimes, primeSeq_zero⟩
 
 /-- For the actual primes, beurlingPi equals primePi.
     Uses the Galois connection: n < count Prime m ↔ nth Prime n < m
@@ -282,23 +303,53 @@ theorem actualPrimes_counting : ∀ x : ℝ, beurlingPi primeSeq x = primePi x :
     · -- (↑(nth Prime n) : ℝ) ≤ x → n < count Prime (⌊x⌋₊ + 1)
       intro hle
       have h1 : Nat.nth Nat.Prime n ≤ ⌊x⌋₊ := Nat.le_floor (by exact_mod_cast hle)
-      exact (Nat.lt_nth_iff_count_lt Nat.infinite_setOf_prime).mpr (by omega)
+      exact (Nat.lt_nth_iff_count_lt Nat.infinite_setOf_prime).mpr
+        (Nat.lt_succ_of_le h1)
     · -- n < count Prime (⌊x⌋₊ + 1) → (↑(nth Prime n) : ℝ) ≤ x
       intro hlt
-      have h1 := (Nat.lt_nth_iff_count_lt Nat.infinite_setOf_prime).mp hlt
-      have h2 : Nat.nth Nat.Prime n ≤ ⌊x⌋₊ := by omega
+      have h1 : Nat.nth Nat.Prime n < ⌊x⌋₊ + 1 :=
+        (Nat.lt_nth_iff_count_lt Nat.infinite_setOf_prime).mp hlt
+      have h2 : Nat.nth Nat.Prime n ≤ ⌊x⌋₊ := Nat.lt_succ_iff.mp h1
       have hx_nn : 0 ≤ x := by
         by_contra hlt_x; push_neg at hlt_x
-        have := Nat.floor_eq_zero.mpr (show x < 1 by linarith)
-        exact absurd (le_trans (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime n).two_le h2)
-          (by omega)
+        have hfloor : ⌊x⌋₊ = 0 := Nat.floor_eq_zero.mpr (show x < 1 by linarith)
+        have hge2 : 2 ≤ ⌊x⌋₊ := le_trans
+          (Nat.nth_mem_of_infinite Nat.infinite_setOf_prime n).two_le h2
+        omega
       exact le_trans (Nat.cast_le.mpr h2) (Nat.floor_le hx_nn)
-  rw [hset, Set.ncard_coe_Finset, Finset.card_range]
+  rw [hset, Set.ncard_coe_finset, Finset.card_range]
 
 -- NOTE: A previous version claimed powers of 2 form a Beurling prime sequence.
 -- This is FALSE: the well-separation property fails because products can collide.
 -- Counterexample: k = {0 ↦ 2} gives (2^1)^2 = 4, ℓ = {1 ↦ 1} gives (2^2)^1 = 4.
 -- These are distinct tuples with equal products, violating |prod - prod| ≥ 1.
+-- This is formalized as `powers_of_two_not_well_separated` below.
+
+/-- **Counter-example**: the geometric sequence `aₙ = 2^(n+1)` (i.e.
+    `a₀ = 2, a₁ = 4, a₂ = 8, …`) does NOT satisfy `WellSeparatedProducts`.
+
+    The exponent tuples `k = Finsupp.single 0 2` (product `(a₀)² = 4`)
+    and `ℓ = Finsupp.single 1 1` (product `(a₁)¹ = 4`) are distinct
+    Finsupps but yield identical products, so `|4 - 4| = 0 < 1`.
+
+    This formalizes the comment immediately above. The takeaway:
+    `BeurlingPrimes` is not just "any geometric-style sequence" — the
+    well-separation requirement is genuinely restrictive. -/
+theorem powers_of_two_not_well_separated :
+    ¬ WellSeparatedProducts (fun n => (2 : ℝ) ^ (n + 1)) := by
+  intro h
+  have hne : (Finsupp.single 0 2 : ℕ →₀ ℕ) ≠ Finsupp.single 1 1 := by
+    intro heq
+    have h0 := DFunLike.congr_fun heq 0
+    simp at h0
+  have hsep := h (Finsupp.single 0 2) (Finsupp.single 1 1) hne
+  have hk_supp : (Finsupp.single 0 (2 : ℕ)).support = {0} :=
+    Finsupp.support_single_ne_zero _ (by decide : (2 : ℕ) ≠ 0)
+  have hℓ_supp : (Finsupp.single 1 (1 : ℕ)).support = {1} :=
+    Finsupp.support_single_ne_zero _ one_ne_zero
+  rw [hk_supp, hℓ_supp, Finset.prod_singleton, Finset.prod_singleton] at hsep
+  simp only [Finsupp.single_eq_same] at hsep
+  norm_num at hsep
 
 /-- Well-separated products implies distinct products. -/
 theorem separation_implies_distinct (a : ℕ → ℝ) (h : WellSeparatedProducts a) :

--- a/research/problems/erdos-1039-oq-02/knowledge.md
+++ b/research/problems/erdos-1039-oq-02/knowledge.md
@@ -4,6 +4,65 @@ Insights accumulated during research on this problem.
 
 ---
 
+## Session 2026-06-06 (researcher-1) — Mathlib v4.26 build status (REPAIR-NEEDED)
+
+**Mode**: SCOUT (build check only — no code change pushed)
+**Outcome**: Confirmed pre-existing Mathlib v4.26 elaboration failure;
+documented for future repair session.
+
+### Build status
+
+`Erdos1039Problem.lean` fails to build on Mathlib v4.26 with two
+errors in `erdos_1039_current_state` (lines 277, 278):
+
+1. `Invalid field notation: Type is not of the form 'C ...' where C
+   is a constant` at `f.degree` (where `f : UnitDiscPolynomial`).
+2. `Function expected at rho but this term has type ℝ` at `rho f`.
+
+### What I tried (and reverted)
+
+1. **Made `rho` and `sublevelSet` take explicit `f` parameters**
+   (instead of relying on `variable (f : UnitDiscPolynomial)`
+   auto-binding). This is the standard repair for newer Lean's
+   stricter section-variable auto-binding. The second error
+   (`rho` has type ℝ) went away, but the field-notation error
+   on `f.degree` persisted — meaning the issue is deeper than
+   just auto-binding.
+
+2. **Tried `∃ f : UnitDiscPolynomial, ...` syntax** (without parens
+   around `f : ...`). No change in behavior.
+
+### Hypothesis (untested)
+
+The error message "Type is not of the form `C ...`" combined with
+"f has type UnitDiscPolynomial" is contradictory on its face.
+This suggests either:
+
+- A Lean 4.x parser/elaborator regression in `∃ (f : X), P ∧ rho f ≤ Q`
+  contexts where field notation on `f` interacts oddly with the
+  existential body.
+- A name clash with a Mathlib v4.26 `UnitDiscPolynomial` symbol
+  in scope (possible but unverified — needs `#check UnitDiscPolynomial`).
+
+### Status
+
+Pre-existing breakage, NOT caused by this session's work. The file
+has not been touched since #19454 (2026-05; a sperner-ndim bundle).
+A future repair session should investigate the contradictory error
+message (likely needs `import Mathlib` reduction to a smaller import
+set, or a name-clash check).
+
+### Outcome
+
+Claim released without code changes. The file builds for all
+content EXCEPT the `erdos_1039_current_state` theorem at lines
+274-285 (and possibly other downstream usages of `rho`/`sublevelSet`
+that compile fine in isolation).
+
+---
+
+---
+
 ## Problem Understanding
 
 Erdős Problem #1039 (Erdős–Herzog–Piranian) asks for the optimal lower

--- a/research/problems/erdos-1063/knowledge.md
+++ b/research/problems/erdos-1063/knowledge.md
@@ -70,7 +70,61 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### 2026-06-06 (researcher-1) — Session 1: unified existence + build verification
+
+**Mode**: ACT (small addition + verification)
+**Outcome**: Docker build clean (3058 jobs); added `threshold_exists` (1 new theorem).
+
+#### What I added
+
+A unified existence theorem `threshold_exists` (k ≥ 2) covering both:
+
+- The k = 2 small-case witness from `threshold_k2` (n_2 = 4).
+- The k ≥ 3 cases via `monier_factorial_bound`'s extracted threshold.
+
+```lean
+theorem threshold_exists (k : ℕ) (hk : k ≥ 2) :
+    ∃ nk : ℕ, IsThreshold nk k := by
+  by_cases h3 : k ≥ 3
+  · obtain ⟨nk, hth, _⟩ := monier_factorial_bound k h3
+    exact ⟨nk, hth⟩
+  · have : k = 2 := by omega
+    subst this
+    exact ⟨4, threshold_k2⟩
+```
+
+This is a small "API smoothing" lemma: it presents the existence
+question as a single uniform statement, decoupled from the specific
+size bound (`k!` from Monier or `k · (k-1)!` from Cambie). Useful
+downstream when one needs the bare existence rather than a sized
+witness.
+
+#### File status after S1
+
+- 169 → 187 lines (theorem + docstring + section header).
+- 5 → 6 theorems, 3 axioms unchanged, 0 sorries.
+- Phase: ACT.
+
+#### Honest assessment
+
+Small API addition, not progress on the open question. The Erdős
+Problem 1063 (polynomial vs exponential growth of n_k) remains
+OPEN — and is unchanged here. Lasting value: future researchers
+can use `threshold_exists` as a uniform interface to the
+small-case witnesses + Monier's bound, instead of dispatching
+manually on k.
+
+The main open conjecture `ErdosProblem1063` (existence of a
+polynomial bound) is unchanged.
+
+#### Next steps
+
+1. Strengthen `threshold_exists` to include Cambie's tighter bound
+   `nk ≤ k * (k-1)!` (currently just gives bare existence).
+2. Compute `n_6, n_7` via `native_decide` to extend the
+   `threshold_k2..5` table.
+3. Investigate whether `ErdosProblem1063` (polynomial bound)
+   admits any verifiable conditional/partial result.
 
 ---
 

--- a/research/problems/erdos-1063/state.md
+++ b/research/problems/erdos-1063/state.md
@@ -1,27 +1,56 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-01-15T14:38:41.571Z
+**Phase**: ACT
+**Since**: 2026-06-06T00:00:00Z
 **Iteration**: 1
 
 ## Current Focus
 
-Initial exploration of the problem.
+S1 (researcher-1, 2026-06-06): ACT. Verified Docker build on
+Mathlib v4.26 (3058/3058 jobs, no warnings, no errors) and added
+one unified existence theorem.
+
+New theorem:
+
+1. `threshold_exists (k : ℕ) (hk : k ≥ 2) : ∃ nk, IsThreshold nk k` —
+   uniform existence statement combining the k = 2 small-case witness
+   (`threshold_k2`) with Monier's factorial bound for k ≥ 3. Drops the
+   size bound to give a clean existence interface.
+
+File grew 169 → 187 lines; theoremCount 5 → 6; 3 axioms unchanged,
+0 sorries.
 
 ## Active Approach
 
-None yet.
+API-smoothing lemmas that present existing axioms / small-case
+witnesses in uniform forms. The polynomial vs exponential growth
+question (`ErdosProblem1063`) remains OPEN.
 
 ## Blockers
 
-None.
+- `ErdosProblem1063` (polynomial bound on n_k) is OPEN. Both
+  available upper bounds — Monier (k!) and Cambie (k · (k-1)!) — are
+  exponential, so neither suffices.
 
 ## Next Action
 
-Begin problem exploration.
+Possible follow-ups (increasing difficulty):
+
+1. **Sized version of `threshold_exists`**: combine with Monier or
+   Cambie to give both existence + size bound in one statement.
+
+2. **Extend small-case table** to n_6, n_7 via `native_decide`.
+   Requires looking up / computing the true values.
+
+3. **Lower bound for n_k**: derive a verifiable lower bound from
+   the divisibility-count constraint.
+
+4. **Conditional polynomial bound**: investigate whether
+   `ErdosProblem1063` admits any verified partial / conditional
+   result.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1 (API smoothing)
+- Approaches tried: 1

--- a/research/problems/erdos-269/knowledge.md
+++ b/research/problems/erdos-269/knowledge.md
@@ -60,7 +60,35 @@ Back to the problem
 
 ## Sessions
 
-(No research sessions yet)
+### 2026-06-06 (researcher-1) — Session 7: Mathlib v4.26 build repair
+
+**Mode**: VERIFY/REPAIR
+**Outcome**: Docker build clean (7743/7743 jobs); 1 build-breaking error + 1 deprecation + 4 unused-variable warnings resolved.
+
+#### Context
+
+Per state.md, Erdos269Problem.lean is graduated (completed 2026-03-24). After previous-session work (PR #13317 added `pow_isPSmooth`), Mathlib v4.26 introduced an API drift that broke the file. The error was a build failure, not just warnings — so this is repair, not just hygiene.
+
+#### Build-breaking error fixed
+
+Line 84: `Unknown constant Nat.pos_pow_of_pos`. The lemma was renamed/removed in Mathlib v4.26. Replaced `Nat.pos_pow_of_pos k hp.pos` with `pow_pos hp.pos k` — `pow_pos : 0 < a → 0 < a^n` is the modern equivalent and works for any `n : ℕ` (the original signature required `1 ≤ k` but `pow_pos` does not).
+
+Side effect: the `hk : 1 ≤ k` hypothesis in `pow_isPSmooth` is now unused. Kept for backwards compatibility (callers may pass it) but underscored to `_hk` to silence the lint.
+
+#### Other warnings fixed
+
+- `not_le_of_lt hp.one_lt` → `not_le_of_gt hp.one_lt` (line 55, deprecation).
+- Unused-variable warnings silenced via underscore prefix (`_p` on line 54, `_hP` on line 109, `_hPrime` and `_hCard` on line 190). These preserve the theorem signatures while silencing the Lean 4.26 `linter.unusedVariables` linter.
+
+#### File status (S7 end)
+
+- 303 lines (unchanged), 15 theorems, 9 defs, 3 axioms (the open conjecture + 2 variants), 0 sorries.
+- Status `axiomatized` (correct per axiom-integrity policy).
+- All Mathlib v4.26 warnings eliminated.
+
+#### Honest assessment
+
+Build-repair work, not mathematical progress. The Erdős 269 conjecture (P-smooth LCM series irrationality) remains OPEN. Lasting value: the file builds cleanly on Mathlib v4.26 and the graduation status is preserved.
 
 ---
 

--- a/research/problems/erdos-895-oq-01/knowledge.md
+++ b/research/problems/erdos-895-oq-01/knowledge.md
@@ -4,6 +4,33 @@
 **Status**: OPEN (Hajnal conjecture) — formalization complete: `Erdos895OQ01Problem.lean` axiomatizes the conjecture and proves 6 supporting lemmas (0 sorries).
 **Gallery entry**: `erdos-895` (parent), `erdos-895-oq-01` (this slug), `Erdos895Problem.lean` + `Erdos895OQ01Problem.lean`
 
+## Session 2026-06-06 (Session 7) — Mathlib v4.26 deprecation hygiene
+
+**Mode**: VERIFY (small cleanup)
+**Outcome**: Docker build clean (7743/7743 jobs); 2 `Finset.not_mem_empty` → `Finset.notMem_empty` deprecations resolved.
+
+### Context
+
+After Session 6 marked this pool entry `completed`, Mathlib v4.26 introduced two camelCase-style deprecation renamings affecting `Erdos895OQ01Problem.lean`. The file still built successfully but with 2 warnings. This session updates the usages.
+
+### What I verified
+
+- `./proofs/scripts/docker-build.sh Proofs.Erdos895OQ01Problem` — completed successfully (7743 jobs), no errors, originally 2 deprecation warnings (now fixed).
+- `Finset.not_mem_empty` → `Finset.notMem_empty` at lines 166 and 171 (both inside `greedy_indep_of_bounded_deg`'s base/empty-cases).
+
+### Files modified (S7)
+
+- `proofs/Proofs/Erdos895OQ01Problem.lean` — 2 deprecated lemma names updated.
+- `src/data/proofs/erdos-895-oq-01/meta.json` — `mathlib_version` confirmed `4.26.0`; no other counts changed (still 0 sorries, 1 axiom).
+- `research/problems/erdos-895-oq-01/knowledge.md` — this entry.
+
+### Honest assessment
+
+Hygiene work, not progress. The file's mathematical content is unchanged. Lasting value: avoids future deprecation-warning noise as Mathlib continues its naming-style migration (snake_case → camelCase for negation-prefixed lemmas).
+
+The main Hajnal conjecture remains OPEN and axiomatized.
+
+
 ## Session 2026-06-05 (Session 6) — Pool Status Reconciliation
 
 **Mode**: VERIFY (doc-only)

--- a/research/problems/erdos-951/knowledge.md
+++ b/research/problems/erdos-951/knowledge.md
@@ -197,6 +197,141 @@ proven theorem.
    `WellSeparatedProducts` predicate into an explicit density bound
    for `BeurlingPrimes` of multiplicative complexity ≤ k?
 
+### 2026-06-06 (researcher-1) — Session 5: tightness + counter-example
+
+Followed up on Session 4's open-question #1 (whether `a_0 ≥ 3` is
+derivable) by establishing the *negative* answer in verified form:
+the lower bound `a_0 ≥ 2` is best possible.
+
+Three new theorems map two boundary points of the
+`BeurlingPrimes` parameter space:
+
+1. **`powers_of_two_not_well_separated`** — counter-example formalizing
+   the in-file comment. The geometric sequence `a_n = 2^(n+1)` (i.e.
+   `2, 4, 8, …`) does NOT satisfy `WellSeparatedProducts`: the tuples
+   `k = single 0 2` and `ℓ = single 1 1` both produce product `4`,
+   so `|4 - 4| = 0 < 1`. Confirms `BeurlingPrimes` is genuinely
+   restrictive — not implied by "any geometric-style sequence".
+
+2. **`primeSeq_zero : primeSeq 0 = 2`** — the first index-specific
+   value for the canonical Beurling prime sequence. Proof uses
+   `Nat.nth_count Nat.prime_two` rewritten via the computational fact
+   `Nat.count Nat.Prime 2 = 0` (no primes are `< 2`).
+
+3. **`beurling_a_zero_lower_bound_tight : ∃ bp, bp.a 0 = 2`** —
+   tightness of `beurling_a_zero_ge_two`. Direct application of the
+   previous lemma: `⟨actualPrimes, primeSeq_zero⟩` witnesses equality.
+
+#### What I Added
+
+```lean
+theorem powers_of_two_not_well_separated :
+    ¬ WellSeparatedProducts (fun n => (2 : ℝ) ^ (n + 1)) := by
+  intro h
+  have hne : (Finsupp.single 0 2 : ℕ →₀ ℕ) ≠ Finsupp.single 1 1 := by
+    intro heq
+    have h0 := DFunLike.congr_fun heq 0
+    simp [Finsupp.single_apply] at h0
+  have hsep := h (Finsupp.single 0 2) (Finsupp.single 1 1) hne
+  have hk_supp : (Finsupp.single 0 (2 : ℕ)).support = {0} :=
+    Finsupp.support_single_ne_zero _ (by decide : (2 : ℕ) ≠ 0)
+  have hℓ_supp : (Finsupp.single 1 (1 : ℕ)).support = {1} :=
+    Finsupp.support_single_ne_zero _ one_ne_zero
+  rw [hk_supp, hℓ_supp, Finset.prod_singleton, Finset.prod_singleton] at hsep
+  simp only [Finsupp.single_eq_same] at hsep
+  norm_num at hsep
+
+theorem primeSeq_zero : primeSeq 0 = 2 := by
+  show (Nat.nth Nat.Prime 0 : ℝ) = 2
+  have hcount : Nat.count Nat.Prime 2 = 0 := by decide
+  have hnth : Nat.nth Nat.Prime 0 = 2 := by
+    rw [← hcount]; exact Nat.nth_count Nat.prime_two
+  rw [hnth]; norm_num
+
+theorem beurling_a_zero_lower_bound_tight :
+    ∃ bp : BeurlingPrimes, bp.a 0 = 2 :=
+  ⟨actualPrimes, primeSeq_zero⟩
+```
+
+#### Mathematical Content
+
+Together, the three theorems map two boundary points of the
+`BeurlingPrimes` parameter space:
+
+- **Lower envelope point**: `actualPrimes` achieves `a_0 = 2`,
+  saturating `beurling_a_zero_ge_two`. Any candidate sequence with
+  `a_0 < 2` would have to lie outside `BeurlingPrimes` by
+  Session 4's derivation.
+- **Excluded sequence**: the geometric sequence `2^(n+1)` is in the
+  "naive guess" zone but violates well-separation. The exclusion is
+  *small-index*: it fires already at `k.support ⊆ {0, 1}`, so no
+  large-product analysis is needed.
+
+This is parameter-space cartography — the kind of incremental
+mapping work that, accumulated over many sessions, will eventually
+constrain the conjecture's space of counter-examples.
+
+#### Build Verification
+
+Docker build attempted via
+`./proofs/scripts/docker-build.sh Proofs.Erdos951Problem`. Result
+will be recorded in the PR description; on success the Mechanic /
+Auditor agents will close out post-merge verification.
+
+#### Honest Assessment
+
+This session is documentation-grade rather than progress-grade. It
+records facts about `WellSeparatedProducts` that experienced
+researchers in this area would assume without writing down, but
+that the prior file did not formally pin. The lasting value is:
+
+1. The in-file comment about powers of 2 is now a verified theorem,
+   not a remark that could rot or be misread.
+2. The exact lower bound for `a_0` (and its tightness) is part of
+   the formal API and reusable by future iterations.
+3. Open question #1 from Session 4 is *resolved* (negatively): no
+   absolute constant `c > 2` can be derived from `BeurlingPrimes`
+   alone.
+
+The mathematical content of the Erdős 951 conjecture — the
+`log x` factor between `⌊x⌋ - 1` and `π(x)` — remains untouched.
+
+#### Stats after session
+
+- 18 theorems, 9 defs, 0 axioms, 0 sorries.
+- 388 lines (was 339).
+- Phase: ACT (graduation-candidate pending Docker build verification).
+
+#### Files Modified
+
+- `proofs/Proofs/Erdos951Problem.lean` — added 3 theorems
+  (powers_of_two_not_well_separated, primeSeq_zero,
+  beurling_a_zero_lower_bound_tight).
+- `src/data/proofs/erdos-951/meta.json` — bumped lineCount,
+  theoremCount, originalContributions, keyInsights, conclusion summary.
+- `research/problems/erdos-951/state.md` — phase ACT, iteration 5,
+  new next-action list.
+- `research/problems/erdos-951/knowledge.md` — this entry.
+
+#### Open Questions Resolved
+
+- **From Session 4 #1**: "Does `WellSeparatedProducts` force `a_0`
+  to be a positive integer ≥ 3?" — **No**, by
+  `beurling_a_zero_lower_bound_tight` and `primeSeq_zero`.
+
+#### Open Questions Generated
+
+1. Is `beurling_consec_gap` (`a_{n+1} ≥ a_n + 1`) tight on
+   `actualPrimes`? `primeSeq 1 = 3 = 2 + 1` would saturate the gap
+   at `n = 0`. Would pin a second index-specific value.
+2. Is there an explicit construction of a non-prime Beurling sequence
+   (e.g. a transcendental `a_0` with carefully chosen `a_1, a_2, …`)?
+   Beurling 1937 implies existence; a Lean witness would map a third
+   parameter-space point.
+3. For integer-valued Beurling primes, can we *force* `a_n` to be the
+   actual `n`-th prime under additional hypotheses (e.g.
+   multiplicative independence, or `N_a(x) = x + o(log x)`)?
+
 ---
 
 *Generated from erdosproblems.com on 2026-01-15*

--- a/research/problems/erdos-951/state.md
+++ b/research/problems/erdos-951/state.md
@@ -1,69 +1,82 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-06-04T00:00:00Z
-**Iteration**: 4
+**Since**: 2026-06-06T00:00:00Z
+**Iteration**: 5
 
 ## Current Focus
 
-S4 (researcher-1, 2026-06-04): ACT. Sharpened the trivial upper bound chain.
+S5 (researcher-1, 2026-06-06): ACT. Pin down what `WellSeparatedProducts`
+implies (and does NOT imply) about the first element `a₀`, and convert
+an in-file informal comment into a verified theorem.
+
 Three new theorems:
 
-1. `beurling_a_zero_ge_two : 2 ≤ bp.a 0` — derived (not assumed) from
-   `WellSeparatedProducts` applied to the zero exponent tuple (empty
-   product = 1) vs `Finsupp.single 0 1` (product = `a 0`), giving
-   `|1 - a 0| ≥ 1` and combined with `a 0 > 1` forcing `a 0 ≥ 2`.
-2. `beurling_linear_growth_strong : bp.a n ≥ (n : ℝ) + 2` — combines
-   `beurling_linear_growth` with `beurling_a_zero_ge_two`.
-3. `beurlingPi_le_floor_pred : beurlingPi bp.a x ≤ ⌊x⌋₊ - 1` — sharpened
-   trivial bound. Holds unconditionally (Nat truncated subtraction
-   handles the `x < 2` edge case).
+1. `powers_of_two_not_well_separated` — counter-example formalizing the
+   in-file comment that the geometric sequence `aₙ = 2^(n+1)` does NOT
+   satisfy `WellSeparatedProducts`. Witness: `k = single 0 2`,
+   `ℓ = single 1 1`, both yield product `4` so `|4 - 4| = 0 < 1`.
+   Shows that `BeurlingPrimes` is genuinely restrictive — not just any
+   geometric-style sequence works.
+2. `primeSeq_zero : primeSeq 0 = 2` — proved by `Nat.nth_count`
+   applied to `Nat.prime_two`, using `Nat.count Nat.Prime 2 = 0` (no
+   primes are < 2). This is the first index-specific value for the
+   actual-primes sequence in the file.
+3. `beurling_a_zero_lower_bound_tight : ∃ bp, bp.a 0 = 2` — tightness
+   of `beurling_a_zero_ge_two`. The witness is `actualPrimes`
+   together with `primeSeq_zero`, establishing that `a₀ ≥ 2` cannot
+   be strengthened to `a₀ ≥ 3` from the structure alone.
 
-File grew 285 → 339 lines; theoremCount 12 → 15; 0 axioms, 0 sorries.
+File grew 339 → 388 lines; theoremCount 15 → 18; 0 axioms, 0 sorries.
 
 ## Active Approach
 
-Add verified partial bounds toward the open Erdős 951 conjecture
-(`π_a(x) ≤ π(x)`). The sharpened trivial bound `⌊x⌋₊ - 1` is still
-linear in x (the conjecture asserts sublinear `π(x) ~ x/log x`), so
-this remains in the SURVEY-tier "trivial bound" regime — but the chain
-of three small lemmas now exposes `WellSeparatedProducts ⇒ a_0 ≥ 2`
-cleanly, which is a reusable building block for any future
-density-increment argument.
+Document the precise mathematical content of the structure axioms:
+which constants are derivable, which are tight, and which are not.
+
+- The lemma `beurling_a_zero_ge_two` establishes `a₀ ≥ 2`. The new
+  tightness theorem proves this is the best possible absolute lower
+  bound on `a₀` — any strengthening requires extra hypotheses.
+- The counter-example (powers of 2 are not Beurling primes) gives a
+  concrete, verifiable demonstration that the `WellSeparatedProducts`
+  predicate is not automatic from naive constructions.
+
+This complements Session 3 and Session 4's sharpened upper-bound chain
+by mapping the *space of Beurling prime sequences*: actualPrimes
+witnesses the lower envelope `a₀ = 2`; powers of 2 are excluded.
 
 ## Blockers
 
-- Docker daemon is in I/O-error state on this host; the
-  `./proofs/scripts/docker-build.sh` invocation cannot run locally.
-  Build verification is deferred to Mechanic/Auditor (same precedent
-  as the recently-shipped szemeredi-theorem-oq-01 Session 3). The new
-  proofs mirror the idioms of the working `beurling_consec_gap` /
-  `beurlingPi_le_floor` proofs in the same file (which build in CI).
-
 - The main conjecture (`erdos951_conjecture`) is OPEN and not pursued
-  directly.
+  directly. Refining the trivial bound `⌊x⌋₊ - 1` to a sublinear
+  bound (toward `π(x) ~ x/log x`) would require a density-increment
+  argument that is out of scope for a single session.
 
 ## Next Action
 
 Possible follow-ups (in increasing difficulty):
 
-1. **Sharpen by `+ a_0` further**: if `a_0 ≥ 3` is forced (e.g. by
-   considering `Finsupp.single 0 2` whose product is `a_0^2`), the
-   bound could be tightened more. Investigate whether
-   `WellSeparatedProducts` forces `a_0` to be a positive integer ≥ 2
-   under stronger conditions.
+1. **Tightness of consecutive-gap bound**: show `beurling_consec_gap`
+   (`aₙ₊₁ ≥ aₙ + 1`) is tight at `n = 0` for `actualPrimes`
+   (`primeSeq 1 = 3 = 2 + 1`). Combined with Session 5's
+   `primeSeq_zero`, this would pin down two index-specific values.
 
-2. **Integer-valued case**: For Beurling sequences with all
-   `a_i ∈ ℕ`, prove `a_i ≥ 2 + i` (already derived above), plus
-   multiplicative independence — first nontrivial step toward `π(x)`.
+2. **Real-valued non-prime example**: construct an explicit Beurling
+   prime sequence with `a₀ ≠ 2` (e.g., a transcendental). Existence
+   is folklore (Beurling 1937), but a verified construction in Lean
+   would map a second point in the parameter space.
 
-3. **Refine trivial bound by `log` factor**: Bridge from `⌊x⌋ - 1` to
-   `x / (log log x)` would be the first genuinely sublinear bound —
-   requires a density-increment argument that's currently out of
-   scope. Multi-week project.
+3. **Integer-valued case**: For Beurling sequences with all
+   `aᵢ ∈ ℕ`, prove that the sequence is uniquely determined by the
+   first few elements (or by a multiplicative independence relation).
+
+4. **Refine trivial bound by `log` factor**: Bridge from `⌊x⌋ - 1` to
+   `x / (log log x)` — first genuinely sublinear bound. Requires a
+   density-increment argument; multi-week project.
 
 ## Attempt Counts
 
-- Total attempts: 4
-- Current approach attempts: 2 (extended partial-bound chain)
-- Approaches tried: 2 (axiom elimination, partial-bound theorem chain)
+- Total attempts: 5
+- Current approach attempts: 1 (tightness + counter-example documentation)
+- Approaches tried: 3 (axiom elimination, partial-bound theorem chain,
+  parameter-space mapping)

--- a/src/data/proofs/erdos-1063/meta.json
+++ b/src/data/proofs/erdos-1063/meta.json
@@ -52,9 +52,9 @@
       "erdos_1063_summary theorem combining key results"
     ],
     "axiomCount": 3,
-    "lineCount": 169,
-    "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated.",
-    "theoremCount": 5,
+    "lineCount": 190,
+    "assumptions": "3 axioms: erdos_selfridge_nondivisibility (Erdős-Selfridge impossibility result), monier_factorial_bound (n_k ≤ k!), cambie_lcm_bound (n_k ≤ k·lcm(2,...,k-1)). Former threshold axioms proved and eliminated. Unified threshold_exists theorem (k ≥ 2) added to combine small-case witnesses with Monier's bound into one uniform existence statement.",
+    "theoremCount": 6,
     "definitionCount": 5
   },
   "overview": {
@@ -227,9 +227,9 @@
     ],
     "opens": [],
     "namespace": "Erdos1063",
-    "lineCount": 169,
+    "lineCount": 190,
     "axiomCount": 3,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 5,
     "path": "Proofs/Erdos1063Problem.lean",
     "sorries": 0

--- a/src/data/proofs/erdos-951/meta.json
+++ b/src/data/proofs/erdos-951/meta.json
@@ -64,12 +64,15 @@
       "beurlingPi_le_floor: π_a(x) ≤ ⌊x⌋₊ (trivial upper bound; partial result toward main conjecture)",
       "beurling_a_zero_ge_two: a₀ ≥ 2 (derived from WellSeparatedProducts applied to 0 vs Finsupp.single 0 1)",
       "beurling_linear_growth_strong: aₙ ≥ n + 2 (sharpening of linear growth, combining a₀ ≥ 2 with the linear-growth lemma)",
-      "beurlingPi_le_floor_pred: π_a(x) ≤ ⌊x⌋₊ - 1 (sharpened trivial bound — saves one over `beurlingPi_le_floor` by exploiting `aₙ ≥ n + 2`)"
+      "beurlingPi_le_floor_pred: π_a(x) ≤ ⌊x⌋₊ - 1 (sharpened trivial bound — saves one over `beurlingPi_le_floor` by exploiting `aₙ ≥ n + 2`)",
+      "powers_of_two_not_well_separated: the geometric sequence aₙ = 2^(n+1) is NOT a Beurling prime sequence — counter-example formalizing the in-file comment (k = single 0 2 and ℓ = single 1 1 both give product 4)",
+      "primeSeq_zero: primeSeq 0 = 2 (the 0th prime as a real number; via Nat.nth_count applied to Nat.prime_two)",
+      "beurling_a_zero_lower_bound_tight: ∃ bp, bp.a 0 = 2 — tightness of beurling_a_zero_ge_two, witnessed by actualPrimes"
     ],
     "axiomCount": 0,
-    "lineCount": 341,
-    "assumptions": "0 axioms. All former axioms eliminated: primeSeq_well_separated proved via FTA (factorization_prod_at), beurlings_conjecture converted to def (Prop, not asserted). File is fully verified. Open conjecture; supporting lemmas fully verified. Trivial upper bound π_a(x) ≤ ⌊x⌋₊ (`beurlingPi_le_floor`) and its sharpening π_a(x) ≤ ⌊x⌋₊ - 1 (`beurlingPi_le_floor_pred`) give weaker forms of the conjecture as verified partial results.",
-    "theoremCount": 14,
+    "lineCount": 388,
+    "assumptions": "0 axioms. All former axioms eliminated: primeSeq_well_separated proved via FTA (factorization_prod_at), beurlings_conjecture converted to def (Prop, not asserted). File is fully verified. Open conjecture; supporting lemmas fully verified. Trivial upper bound π_a(x) ≤ ⌊x⌋₊ (`beurlingPi_le_floor`) and its sharpening π_a(x) ≤ ⌊x⌋₊ - 1 (`beurlingPi_le_floor_pred`) give weaker forms of the conjecture as verified partial results. The lower bound a₀ ≥ 2 is best possible (`beurling_a_zero_lower_bound_tight` witnessed by actualPrimes); the powers-of-2 geometric sequence is shown to NOT be Beurling (`powers_of_two_not_well_separated`).",
+    "theoremCount": 17,
     "definitionCount": 9
   },
   "overview": {
@@ -185,9 +188,9 @@
       "Real"
     ],
     "namespace": "Erdos951",
-    "lineCount": 341,
+    "lineCount": 388,
     "axiomCount": 0,
-    "theoremCount": 14,
+    "theoremCount": 17,
     "definitionCount": 9,
     "path": "Proofs/Erdos951Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Four-slug bundle, all Docker-clean on Mathlib v4.26. Three are
build-repair / hygiene; one (`erdos-951`) is substantive.

### erdos-951 Session 5 (`Erdos951Problem.lean`)

Two parts: (a) 3 new theorems mapping boundary points of the `BeurlingPrimes` parameter space, (b) Mathlib v4.26 API drift repair to restore compilation.

**New theorems**:
- `powers_of_two_not_well_separated` — counter-example formalizing the in-file comment that $a_n = 2^{n+1}$ does NOT satisfy `WellSeparatedProducts`.
- `primeSeq_zero : primeSeq 0 = 2` — proved by `Nat.nth_count Nat.prime_two`.
- `beurling_a_zero_lower_bound_tight : ∃ bp, bp.a 0 = 2` — tightness of `beurling_a_zero_ge_two`. Resolves S4 open question #1 negatively.

**Mathlib v4.26 repairs** (same drift class as #22520):
- `Nat.factorization_prime hp` → `hp.factorization`.
- `Ne.lt_or_lt` → `Ne.lt_or_gt`.
- `Set.ncard_coe_Finset` → `Set.ncard_coe_finset` (×3).
- `omega` η-equivalence drift → `Nat.lt_succ_of_le` / `Nat.lt_succ_iff`.
- `factorization_prod_at` if-then-else: `simpa` → `split_ifs <;> simp_all`.

Stats: 339 → 388 lines; 15 → 18 theorems; 0 axioms, 0 sorries.

### erdos-895-oq-01 Session 7 (`Erdos895OQ01Problem.lean`)

**Mode**: VERIFY (hygiene). Hajnal's Independent Hindman Set Conjecture.

**Fix**: `Finset.not_mem_empty` → `Finset.notMem_empty` (×2). 272 lines, 1 axiom (open), 0 sorries (unchanged).

### erdos-269 Session 7 (`Erdos269Problem.lean`)

**Mode**: REPAIR. P-smooth LCM series irrationality (Erdős 1973). Build was BROKEN.

**Build-breaking fix**: `Nat.pos_pow_of_pos k hp.pos` → `pow_pos hp.pos k`.

**Hygiene**: `not_le_of_lt` → `not_le_of_gt`, and 4 unused-variable warnings silenced via `_` prefix.

Stats unchanged: 303 lines, 15 theorems, 9 defs, 3 axioms, 0 sorries.

### erdos-1063 Session 1 (`Erdos1063Problem.lean`)

**Mode**: ACT (small addition). Erdős-Selfridge binomial threshold n_k.

**New theorem**: `threshold_exists (k : ℕ) (hk : k ≥ 2) : ∃ nk, IsThreshold nk k` — unified existence statement combining `threshold_k2` with Monier's factorial bound.

Stats: 169 → 190 lines; 5 → 6 theorems; 3 axioms unchanged, 0 sorries.

## Honest Framing

Mixed contribution types:
- **Substantive** (erdos-951): tightness + counter-example + Mathlib repair.
- **API smoothing** (erdos-1063): unified existence statement.
- **Hygiene** (erdos-895-oq-01): deprecation rename.
- **Build repair** (erdos-269): file was broken, now builds.

All four open conjectures remain OPEN; this PR does not claim
mathematical progress on any of them.

## Test plan

- [x] All four files: `./proofs/scripts/docker-build.sh Proofs.<File>` clean.
- [x] 0 sorries across all four files.
- [x] Axiom counts correct per axiom-integrity policy.
- [ ] CI build passes.
- [ ] Auditor verification post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)