### PR TITLE
audit(pac-learning-bounds-oq-01-oq-01): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14064,8 +14064,8 @@
       "result": "clean"
     },
     "pac-learning-bounds-oq-01-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T12:17:48Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-06T10:23:34Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

Re-audited `pac-learning-bounds-oq-01-oq-01` (VC dimension of interval classifiers on ℕ). All integrity checks pass — tracker bumped.

## Verification

Checked `src/data/proofs/pac-learning-bounds-oq-01-oq-01/meta.json` vs `proofs/Proofs/PACLearningOQ01OQ01.lean`:

| Field | meta.json | source |
|-------|-----------|--------|
| lineCount | 162 | 162 ✓ |
| sorries | 0 | 0 ✓ |
| axiomCount | 0 | 0 ✓ |
| theoremCount | 4 | 4 ✓ |
| definitionCount | 2 | 2 ✓ |
| True stubs | n/a | 0 ✓ |

- `status: "verified"` consistent with 0 sorries / 0 axioms / 0 structure-encoded assumptions.
- `badge: "original"` appropriate: `mathlibDependencies` are basic Finset/Nat/omega infrastructure — the core convexity obstruction argument is genuinely Lean-authored, not a Mathlib wrapper.

## Test plan

- [x] meta.json field counts match Lean source
- [x] No `axiom` declarations
- [x] No `True`-stub theorems
- [x] Tracker `auditCount: 1 → 2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)