### PR TITLE
research: 4-slug bundle — central-limit-theorem + e-transcendental-oq-03 + erdos-761 (S9 ACT) + fourier-series-oq-04-oq-01 (S13 SCOUT)

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
@@ -246,7 +246,7 @@ theorem univariate_embed_stable (φ : ℝ → ℂ) (c : ℝ)
       (φ (t * (n : ℝ) ^ (-c))) ^ n = φ t) :
     HasScalarExponent 1 (univariateEmbed φ) c := by
   refine ⟨fun _ _ => 0, fun n hn ξ => ?_⟩
-  simp only [univariateEmbed, vecInner, Pi.zero_apply, zero_mul,
+  simp only [univariateEmbed, vecInner, zero_mul,
              Finset.sum_const_zero, ofReal_zero, mul_zero, Complex.exp_zero, mul_one]
   exact hstable n hn (ξ 0)
 
@@ -402,7 +402,7 @@ axiom finite_cov_in_gaussian_doa (d : ℕ) (Sg : Matrix (Fin d) (Fin d) ℝ)
     (hSg : Matrix.PosSemidef Sg)
     (φ : (Fin d → ℝ) → ℂ)
     (hφ_char : φ (fun _ => 0) = 1)
-    (hφ_cov : ∃ (hφ_reg : True),
+    (hφ_cov : ∃ (_hφ_reg : True),
       Filter.Tendsto (fun ξ : Fin d → ℝ => φ ξ) (nhds 0) (nhds 1)) :
     ∃ ψ : (Fin d → ℝ) → ℂ, InOperatorDomainOfAttraction d φ ψ
 

--- a/proofs/Proofs/ETranscendentalOQ03.lean
+++ b/proofs/Proofs/ETranscendentalOQ03.lean
@@ -3,7 +3,7 @@ import Mathlib.NumberTheory.Transcendental.Liouville.LiouvilleWith
 import Mathlib.NumberTheory.DiophantineApproximation.Basic
 import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 import Mathlib.RingTheory.Algebraic.Basic
-import Mathlib.Data.Real.Irrational
+import Mathlib.NumberTheory.Real.Irrational
 import Mathlib.Tactic
 import Proofs.eTranscendental
 

--- a/proofs/Proofs/Erdos761Problem.lean
+++ b/proofs/Proofs/Erdos761Problem.lean
@@ -183,6 +183,29 @@ theorem cochrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
   refine ⟨c, fun _ => Or.inr (fun u v hu hv _ hadj => ?_)⟩
   exact c.valid hadj (hu.trans hv.symm)
 
+/-- δ(G) ≤ χ(G) lifted from the ℕ-valued `Colorable n` interface to
+    Mathlib's ℕ∞-valued `SimpleGraph.chromaticNumber`.
+
+    Mathlib defines `G.chromaticNumber := ⨅ n ∈ {n | G.Colorable n}, (n : ℕ∞)`.
+    `le_iInf₂` reduces the goal to: for every `n` with `G.Colorable n`,
+    `(G.dichromNumber : ℕ∞) ≤ (n : ℕ∞)`. That follows by casting the ℕ-valued
+    `dichrom_le_of_colorable G hcol : G.dichromNumber ≤ n` to ℕ∞.
+
+    The bound is vacuous when `G.chromaticNumber = ⊤` (e.g. infinite
+    graphs of unbounded chromatic number); for finite `V` it agrees with
+    the natural inequality δ(G) ≤ χ(G). -/
+theorem dichrom_le_chromaticNumber (G : SimpleGraph V) :
+    (G.dichromNumber : ℕ∞) ≤ G.chromaticNumber := by
+  refine le_iInf₂ fun n hcol => ?_
+  exact_mod_cast dichrom_le_of_colorable G hcol
+
+/-- ζ(G) ≤ χ(G) lifted to Mathlib's ℕ∞-valued `SimpleGraph.chromaticNumber`.
+    Mirror of `dichrom_le_chromaticNumber` via `cochrom_le_of_colorable`. -/
+theorem cochrom_le_chromaticNumber (G : SimpleGraph V) :
+    (G.cochromNumber : ℕ∞) ≤ G.chromaticNumber := by
+  refine le_iInf₂ fun n hcol => ?_
+  exact_mod_cast cochrom_le_of_colorable G hcol
+
 /-- [Formerly sorry] Bipartite graphs have δ(G) ≤ 2.
     Direct corollary of `dichrom_le_of_colorable` at k = 2. -/
 theorem bipartite_dichrom_le_two (G : SimpleGraph V)

--- a/research/problems/erdos-761/knowledge.md
+++ b/research/problems/erdos-761/knowledge.md
@@ -172,4 +172,66 @@ since the original drift was discovered on 2026-04-27.
 
 ---
 
+### Session 2026-06-06 — Iter 9: ℕ∞ lifts to Mathlib's chromaticNumber (researcher-1)
+
+**Mode**: REVISIT (RICH score 50)
+**Outcome**: PROGRESS — realized the two Iter 9 candidate lemmas
+predicted by Iter 8's state.md, lifting δ(G) ≤ χ(G) and ζ(G) ≤ χ(G)
+from the ℕ-valued `Colorable n` interface to Mathlib's ℕ∞-valued
+`SimpleGraph.chromaticNumber`.
+
+**What I Did**
+
+Added two structural lemmas to `proofs/Proofs/Erdos761Problem.lean`,
+inserted after `cochrom_le_of_colorable` (the `_of_colorable` siblings)
+and before `bipartite_dichrom_le_two`:
+
+- `dichrom_le_chromaticNumber (G : SimpleGraph V) :
+   (G.dichromNumber : ℕ∞) ≤ G.chromaticNumber` — 3-line proof.
+   Reduces via `le_iInf₂` against Mathlib's
+   `chromaticNumber := ⨅ n ∈ setOf G.Colorable, (n : ℕ∞)` to the
+   per-`n` bound `(G.dichromNumber : ℕ∞) ≤ (n : ℕ∞)` whenever
+   `G.Colorable n`. That follows by casting the ℕ-valued
+   `dichrom_le_of_colorable` to ℕ∞.
+- `cochrom_le_chromaticNumber (G : SimpleGraph V) :
+   (G.cochromNumber : ℕ∞) ≤ G.chromaticNumber` — mirror lift via
+   `cochrom_le_of_colorable`. Identical 3-line structure.
+
+The bound is vacuous when `G.chromaticNumber = ⊤` (graphs of
+unbounded chromatic number — possible for infinite `V`) and agrees
+with the natural δ(G), ζ(G) ≤ χ(G) on every finitely-chromatic
+graph. The Iter 8 prediction noted "needs a `WithTop`-aware csInf
+manipulation" but in practice `le_iInf₂` handles the ℕ∞ side
+without an explicit `⊤` case split — Mathlib's chromaticNumber is
+already expressed as an iInf so the inequality lifts uniformly.
+
+**Why this is the right next step**
+
+This is exactly the lemma the gallery's chromatic-number ecosystem
+wants: every other Erdős entry that quantifies chromatic constraints
+(e.g. erdos-705, erdos-922, erdos-629) uses Mathlib's
+`G.chromaticNumber : ℕ∞`, not the ad-hoc per-file ℕ definitions.
+Without the ℕ∞ lift, the file's δ/ζ bounds could not chain with
+anything in the broader gallery — they were "stuck" at the
+`Colorable n` interface. With Iter 9, an external proof that has
+`G.chromaticNumber ≤ k` can directly conclude δ(G), ζ(G) ≤ k via the
+standard `(·: ℕ∞)` cast.
+
+**Files Modified This Session**
+
+- `proofs/Proofs/Erdos761Problem.lean`: +23 lines (291 → 314).
+   theoremCount 8 → 10 (added two ℕ∞-lifts; no other changes).
+- `src/data/proofs/erdos-761/meta.json`: lineCount 291 → 314;
+   theoremCount 8 → 10; assumptions text updated to list the two new
+   theorems.
+- `research/problems/erdos-761/knowledge.md`, `state.md`: this entry.
+
+**Build Status**: Docker build of `Proofs.Erdos761Problem` to be
+confirmed in this session (Iter 8 took 12s after Mathlib cache prime
+under `lean4-arm64:v4.26.0`).
+
+**Sorry/Axiom Count: 2 (unchanged, both OPEN conjectures)**
+
+---
+
 *Generated from erdosproblems.com on 2026-01-15*

--- a/research/problems/erdos-761/state.md
+++ b/research/problems/erdos-761/state.md
@@ -1,34 +1,33 @@
 # Current State
 
-**Phase**: ACT (axiom-side work continues; structural lemmas extended)
+**Phase**: ACT (ℕ∞-side lifts realized; structural lemma surface widened)
 **Path**: full
 **Since**: 2026-04-27 (BLOCKED), 2026-05-08 (UNBLOCKED — Iter 7),
-           2026-06-05 (Iter 8 — this PR)
-**Last Updated**: 2026-06-05 (Iteration 8, researcher-1)
-**Iteration**: 8
+           2026-06-05 (Iter 8), 2026-06-06 (Iter 9 — this PR)
+**Last Updated**: 2026-06-06 (Iteration 9, researcher-1)
+**Iteration**: 9
 
 ## Current Focus
 
-**Iter 8 (this PR)**: Added the two structural lemmas predicted by
-Iter 7's state.md as the next actions:
+**Iter 9 (this PR)**: Realized the two next-action lemmas predicted by
+Iter 8's state.md, lifting the ℕ-valued χ-bounds to Mathlib's
+`SimpleGraph.chromaticNumber : ℕ∞`.
 
-1. `dichrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
-    (h : G.Colorable k) : G.dichromNumber ≤ k` — generalizes
-    `bipartite_dichrom_le_two`. Direct application of
-    `isAcyclicColoring_of_no_mono_edge` to any proper k-coloring,
-    which has no monochromatic edges.
-2. `cochrom_le_of_colorable (G : SimpleGraph V) {k : ℕ}
-    (h : G.Colorable k) : G.cochromNumber ≤ k` — mirror lemma for
-    the cochromatic side. Each color class of a proper k-coloring
-    is an independent set, satisfying the `¬G.Adj` branch of
-    `IsCochromatic`.
+1. `dichrom_le_chromaticNumber (G : SimpleGraph V) :
+    (G.dichromNumber : ℕ∞) ≤ G.chromaticNumber` — proved via
+    `le_iInf₂` on Mathlib's `⨅ n ∈ setOf G.Colorable, (n : ℕ∞)`
+    definition, then `exact_mod_cast` of `dichrom_le_of_colorable`.
+    The bound is vacuous when `G.chromaticNumber = ⊤` and agrees
+    with δ(G) ≤ χ(G) on every finitely-chromatic graph.
+2. `cochrom_le_chromaticNumber (G : SimpleGraph V) :
+    (G.cochromNumber : ℕ∞) ≤ G.chromaticNumber` — mirror lift via
+    `cochrom_le_of_colorable`.
 
-`bipartite_dichrom_le_two` was then refactored from a 7-line `by`
-proof into a 1-line corollary of `dichrom_le_of_colorable`. No new
-axioms, no sorries.
+Both are 3-line `le_iInf₂` + cast proofs. No new axioms, no sorries,
+no changes to definitions or the open-conjecture axioms.
 
-**2 axioms remain** in `proofs/Proofs/Erdos761Problem.lean` (283 lines,
-8 theorems, 6 defs, 1 private lemma, 0 sorries on this PR):
+**2 axioms remain** in `proofs/Proofs/Erdos761Problem.lean` (314 lines,
+10 theorems, 6 defs, 1 private lemma, 0 sorries on this PR):
 
 1. `erdos_761_question1` (Erdős–Neumann-Lara) — must a graph with
    large chromatic number have large dichromatic number? OPEN.
@@ -52,29 +51,37 @@ Both are genuinely open questions and remain as axioms.
   (state.md said "Build pending"); the wrapper itself introduced a
   fresh dot-notation breakage on every `G.dichromNumber` /
   `G.cochromNumber` call.
-- **Iter 8** (2026-06-05, researcher-1, this PR): (a) added
-  `dichrom_le_of_colorable` + `cochrom_le_of_colorable` (the
-  structural ℕ-valued χ-bounds); (b) simplified
-  `bipartite_dichrom_le_two` to a corollary; (c) repaired the Iter-7
-  wrapper by switching the two `SimpleGraph.X` defs to `_root_.`
-  form; (d) repaired Mathlib 4.26 `Equiv.injective` drift at lines
-  145 & 232 (`mt e.injective` → direct λ). lineCount 262 → 291.
+- **Iter 8** (2026-06-05, researcher-1): (a) added
+  `dichrom_le_of_colorable` + `cochrom_le_of_colorable`; (b)
+  simplified `bipartite_dichrom_le_two` to a corollary; (c)
+  repaired the Iter-7 wrapper via `_root_.` defs; (d) repaired
+  Mathlib 4.26 `Equiv.injective` drift. lineCount 262 → 291.
   theoremCount 7 → 8. First successful Docker build since 2026-04-27.
+- **Iter 9** (2026-06-06, researcher-1, this PR): lifted the two
+  `_of_colorable` bounds to Mathlib's `SimpleGraph.chromaticNumber :
+  ℕ∞` via `le_iInf₂`. lineCount 291 → 314. theoremCount 8 → 10.
+  Both proofs are 3 lines; bound is vacuous when chromaticNumber = ⊤.
 
 ## Active Approach (next sessions)
 
-Both Iter 7 predictions (S6 research drafts) are now realized. Future
-sessions should turn to:
+The two ℕ∞ lifts are now in. Remaining work to widen the structural
+surface around δ(G) and ζ(G):
 
-- **Iter 9 candidate** — `dichrom_le_chromaticNumber` lifting the new
-  `dichrom_le_of_colorable` bound to `G.chromaticNumber : ℕ∞`. This
-  needs a `WithTop`-aware csInf manipulation. Roughly ~10 lines.
-- Mirror `cochrom_le_chromaticNumber` similarly. ~10 lines.
-- Optionally, a lemma `cochrom_le_dichrom_aux` or any sharp boundary
-  result that connects `dichromNumber` to `cochromNumber` directly
-  (currently we only have both ≤ |V|, both ≤ k for k-colorable, plus
-  `dichrom_mono`). Anything that compares δ and ζ structurally would
-  be new theory.
+- **Iter 10 candidate** — `cochrom_le_dichrom_via_clique` or an analogue
+  comparing δ(G) and ζ(G) directly. Currently we have both bounded by
+  χ(G) and both bounded by |V|, plus `dichrom_mono` for δ under
+  subgraph inclusion. No lemma relates δ and ζ. The classical
+  inequality ζ(G) ≤ δ(G) follows from observing that an acyclic
+  k-coloring's classes induce DAG subgraphs, whose underlying
+  undirected graphs are either cliques or have a missing edge — but
+  this is not immediate from the definitions and may need a stronger
+  acyclic-coloring lemma first. Out of scope for a single iteration.
+- **Iter 10 alternate** — `cochrom_mono` analogue to `dichrom_mono`:
+  ζ(H) ≤ ζ(G) for H ⊆ G. The cochromatic property restricts cleanly
+  to subgraphs (an induced clique stays a clique; an induced
+  independent set stays independent), so this should be ~15 lines.
+- **Iter 10 alternate** — `dichrom_le_one_of_edgeless`: δ(G) ≤ 1 when
+  G has no edges (any 1-coloring is vacuously acyclic). 5-line lemma.
 
 All three are independent of the two open axioms.
 
@@ -84,21 +91,22 @@ None.
 
 ## Next Action
 
-**Iter 9**: lift `dichrom_le_of_colorable` to `G.chromaticNumber`
-(Mathlib's `ℕ∞`-valued chromatic number). Look for an existing
-Mathlib bridge `Colorable n ↔ chromaticNumber ≤ n` to keep the new
-lemma short.
+**Iter 10**: `cochrom_mono` (ζ monotone under subgraph inclusion) —
+mirrors `dichrom_mono` but does not need the orientation-extension
+machinery; cochromatic colorings restrict directly. Estimated ~15
+lines.
 
 ## Attempt Counts
 
-- Total attempts: 8
-- Current approach attempts: 1 (Iter 8 structural lemmas, this PR)
+- Total attempts: 9
+- Current approach attempts: 1 (Iter 9 ℕ∞ lifts, this PR)
 - Approaches tried: drift discovery (Iter 6); namespace wrapper
-  unblock (Iter 7); structural χ-bounds (Iter 8).
+  unblock (Iter 7); structural ℕ-valued χ-bounds (Iter 8); ℕ∞ lifts
+  to Mathlib chromaticNumber (Iter 9).
 
 ## References
 
-- `proofs/Proofs/Erdos761Problem.lean` — main file (283 lines, 8
+- `proofs/Proofs/Erdos761Problem.lean` — main file (314 lines, 10
   theorems, 6 defs, 1 private lemma, 2 axioms, 0 sorries).
 - `src/data/proofs/erdos-761/meta.json` — gallery integration.
 - Neumann-Lara 1982: "The dichromatic number of a digraph",

--- a/research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-06-s13-scout-verify-build-clean.md
+++ b/research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-06-s13-scout-verify-build-clean.md
@@ -1,0 +1,77 @@
+# S13 SCOUT verify — build clean at current Mathlib pin
+
+**Date**: 2026-06-06
+**Researcher**: researcher-1
+**Mode**: SCOUT (doc-only build verification; no Lean delta)
+**Outcome**: VERIFIED — S11 ACT + S12 PREP baseline remains buildable
+  at current Mathlib v4.26.0 cache; the 18-35 LOC S13 ACT budget
+  predicted by S12 PREP §5 remains tractable.
+
+## What I did
+
+1. Claimed `fourier-series-oq-04-oq-01` (knowledge score 50, RICH, MODERATE+
+   tier depth-first selection).
+2. Ran `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ04OQ01`
+   on `lean4-arm64:v4.26.0` against the shared `lean-mathlib-cache`
+   Docker volume.
+3. Confirmed the build completes cleanly with the expected sorry
+   warning at line 148 (`sphPartialSum_L2_norm_converge`).
+
+## Build result
+
+```
+[180s] Building...
+⚠ [7743/7743] Replayed Proofs.FourierSeriesOQ04OQ01
+warning: Proofs/FourierSeriesOQ04OQ01.lean:148:8: declaration uses 'sorry'
+Build completed successfully (7743 jobs).
+=== Build succeeded ===
+```
+
+- 7743 jobs total (mostly cached replays — Mathlib cache hit was 100%
+  on the 7727 file cache).
+- 0 errors. Single expected sorry warning at line 148, exactly the
+  pre-existing `sphPartialSum_L2_norm_converge` placeholder for the
+  Mathlib-gap-bound Plancherel-on-T² L²-norm convergence.
+- Sorry surface identical to the last verified build (S11 ACT,
+  2026-05-31; sessions/2026-05-31-s11-act-step1-contingency-haart2-volume.md).
+- No new warnings introduced by Mathlib pin updates since S11 ACT.
+
+## Why this matters
+
+The state.md §1 had been at iter 11 since 2026-06-01's S12 PREP audit.
+S12 cataloged 4 Mathlib API entries (`mFourier`, `mFourierLp`,
+`mFourierCoeff`, `hasSum_mFourier_series_L2`) at pinned commit
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Five days have elapsed.
+Without a verification build, we could not confidently invoke the
+18-35 LOC S13 ACT budget — any silent Mathlib drift would invalidate
+the cataloged signatures and reset the budget estimate.
+
+This iteration confirms:
+- The pinned commit's API surface is still load-bearing (build clean).
+- The S11 ACT `haarT2_eq_volume` bridge still typechecks.
+- The S9 cofinality + S10 `coeFn_finset_sum_haarT2` helpers still
+  elaborate. (Implicit: any drift in their bearer set would surface
+  as build errors here.)
+- The `sphPartialSum_L2_norm_converge` sorry remains the lone sorry
+  in the file. No regressions.
+
+## Next action
+
+**S14 ACT** — execute the S12 PREP §5 tactic skeleton against the live
+file. Per S12 budget projection: 18-35 LOC closing the single sorry at
+line 148, via the option (c) `eLpNorm` swap workaround on top of the
+S9/S10/S11 ACT bearers. The recipe (S7 audit §4 steps 4 + 5 + 6) is
+fully paste-ready in the S12 memo. Estimated 2-3 Docker iterations
+for tactic adjustment.
+
+This SCOUT clears the gate for that ACT to proceed against a verified
+baseline rather than a stale pin assumption.
+
+## Files modified
+
+- `research/problems/fourier-series-oq-04-oq-01/state.md` — header bump
+  iter 11 → 12, S13 SCOUT entry added, S12 status section retitled.
+- `research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-06-s13-scout-verify-build-clean.md`
+  — this file.
+
+No Lean delta. No new axioms. No new sorries. Doc-only iteration.

--- a/research/problems/fourier-series-oq-04-oq-01/state.md
+++ b/research/problems/fourier-series-oq-04-oq-01/state.md
@@ -1,10 +1,14 @@
 # Research State: fourier-series-oq-04-oq-01
 
 ## Current State
-**Phase**: PREP (S12 doc-only Mathlib v4.26.0 API audit + tactic skeleton)
-**Since**: 2026-06-01 (S12 PREP — researcher-1)
-**Iteration**: 11
-**Last Update**: 2026-06-01 (researcher-1) — **S12 PREP Mathlib API audit**: doc-only PREP cataloging v4.26.0 signatures for `mFourier`, `mFourierLp`, `mFourierCoeff`, `hasSum_mFourier_series_L2` (all confirmed via `~/GitHub/mathlib4` at pinned commit `2df2f0150c`). Identifies the **measure-cast obstacle** between `Lp ℂ 2 volume` (Mathlib engine output type) and `Lp ℂ 2 haarT2` (our stated machinery) and proposes the workaround: **option (c) `eLpNorm` swap** — rewrite `haarT2 → volume` directly in the goal's `eLpNorm` arguments using `haarT2_eq_volume` (S11 ACT), avoiding any `Lp`-element transport. Mathlib does NOT expose `Lp.congr_measure` / `Lp.cast_of_eq_measure`. With option (c), the S13 ACT budget shrinks from 25-45 LOC to **18-35 LOC**. Step 1 setup confirmed no-op (`import Mathlib` already pulls `AddCircleMulti`). Full tactic skeleton with `sorry` holes drafted in S12 memo §5. See `sessions/2026-06-01-s12-prep-mathlib-api-audit.md`.
+**Phase**: PREP (S12 audit verified; build clean at current Mathlib pin)
+**Since**: 2026-06-01 (S12 PREP — researcher-1); 2026-06-06 (S13 SCOUT verify — researcher-1)
+**Iteration**: 12
+**Last Update**: 2026-06-06 (researcher-1) — **S13 SCOUT verify** (doc-only): re-built `Proofs.FourierSeriesOQ04OQ01` under `lean4-arm64:v4.26.0` Docker against current Mathlib cache to confirm the S11 ACT (`haarT2_eq_volume`) and S12 PREP (Mathlib API audit) deliverables still hold. **7743 jobs, exit 0, zero errors, single expected `sphPartialSum_L2_norm_converge` sorry warning at line 148** — identical sorry surface as the last verified build (S11 ACT, 2026-05-31, worktree HEAD `~e36a09a3`). No Mathlib pin bump or signature drift across the 4 S12-cataloged API entries (`mFourier`, `mFourierLp`, `mFourierCoeff`, `hasSum_mFourier_series_L2`). The 18-35 LOC S13 ACT budget remains tractable on this baseline. No Lean delta this iteration; doc-only state.md bump. See `sessions/2026-06-06-s13-scout-verify-build-clean.md`.
+
+## Previous Status — S12 PREP Mathlib API audit (2026-06-01, researcher-1)
+
+**S12 PREP**: doc-only PREP cataloging v4.26.0 signatures for `mFourier`, `mFourierLp`, `mFourierCoeff`, `hasSum_mFourier_series_L2` (all confirmed via `~/GitHub/mathlib4` at pinned commit `2df2f0150c`). Identifies the **measure-cast obstacle** between `Lp ℂ 2 volume` (Mathlib engine output type) and `Lp ℂ 2 haarT2` (our stated machinery) and proposes the workaround: **option (c) `eLpNorm` swap** — rewrite `haarT2 → volume` directly in the goal's `eLpNorm` arguments using `haarT2_eq_volume` (S11 ACT), avoiding any `Lp`-element transport. Mathlib does NOT expose `Lp.congr_measure` / `Lp.cast_of_eq_measure`. With option (c), the S13 ACT budget shrinks from 25-45 LOC to **18-35 LOC**. Step 1 setup confirmed no-op (`import Mathlib` already pulls `AddCircleMulti`). Full tactic skeleton with `sorry` holes drafted in S12 memo §5. See `sessions/2026-06-01-s12-prep-mathlib-api-audit.md`.
 
 ## Previous Status — S11 ACT step-1-contingency (2026-05-31, researcher-1, MERGED PR #21611)
 

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -38,10 +38,10 @@
       }
     ],
     "axiomCount": 2,
-    "lineCount": 291,
-    "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`; SimpleGraph.dichromNumber and SimpleGraph.cochromNumber are declared with `_root_.` prefix so dot notation `G.dichromNumber` continues to resolve. Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, dichrom_le_of_colorable, cochrom_le_of_colorable, bipartite_dichrom_le_two (now a 1-line corollary of dichrom_le_of_colorable), dichrom_mono, acyclic_orientation_exists.",
+    "lineCount": 314,
+    "assumptions": "2 axioms: erdos_761_question1 (OPEN), erdos_761_question2 (OPEN). Eliminated complete_dichrom (incorrect formula). Fixed IsAcyclicColoring definition from 'no monochromatic directed edge' to correct 'no monochromatic directed cycle' (Neumann-Lara 1982). Wrapped all declarations in `namespace Erdos761` to resolve the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`; SimpleGraph.dichromNumber and SimpleGraph.cochromNumber are declared with `_root_.` prefix so dot notation `G.dichromNumber` continues to resolve. Proved: isAcyclicColoring_of_no_mono_edge, dichrom_le_chrom, cochrom_le_chrom, dichrom_le_of_colorable, cochrom_le_of_colorable, dichrom_le_chromaticNumber, cochrom_le_chromaticNumber (Iter 9: ℕ∞ lifts to Mathlib's `SimpleGraph.chromaticNumber`), bipartite_dichrom_le_two (now a 1-line corollary of dichrom_le_of_colorable), dichrom_mono, acyclic_orientation_exists.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 7,
     "additionalFiles": [
       "Proofs/Stubs/Erdos761Aristotle.lean"
@@ -129,9 +129,9 @@
       "SimpleGraph"
     ],
     "namespace": "Erdos761",
-    "lineCount": 291,
+    "lineCount": 314,
     "axiomCount": 2,
-    "theoremCount": 8,
+    "theoremCount": 10,
     "definitionCount": 7,
     "path": "Proofs/Erdos761Problem.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

4-slug bundle: SCOUT verification + lint hygiene + Iter 9 ℕ∞ lift work + S13 SCOUT verify on a second Fourier slug.

### Slug 1: `central-limit-theorem-oq-01-oq-01-oq-04` (S13 verification)

SCOUT-mode verification + small lint hygiene on `CentralLimitTheoremOQ01OQ01OQ04.lean`.

**Context.** S13 ACT (researcher-1, 2026-06-02, PR/session pre-merge) shipped an `axiom → theorem` swap for `gaussian_in_own_doa` (+32 LOC, axiomCount 5→4) but flagged itself as "build-pending under Docker corrupted-blob INFRA blocker". This session verifies the predecessor's work on a recovered Docker environment.

**What I did.**
1. **Build verification**: `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ01OQ01OQ04` completes cleanly on Mathlib v4.26 — **7744 jobs, 0 errors**. The S13 ACT predecessor's projected post-state is verified: 411 lines, 12 theorems, 4 axioms, 0 sorries.
2. **Lint hygiene** (2 minor edits, no proof-content change):
   - Line 249: removed unused `Pi.zero_apply` from a `simp only [...]` list.
   - Line 405: renamed unused-binder `hφ_reg : True` (inside an existential placeholder) to `_hφ_reg`.

### Slug 2: `e-transcendental-oq-03` (import update)

SCOUT-mode update of a deprecated Mathlib import.

### Slug 3: `erdos-761` (Iter 9 ACT — ℕ∞ lifts)

Realizes both Iter 9 candidate lemmas predicted by Iter 8's `state.md`.

**What I did.** Added in `proofs/Proofs/Erdos761Problem.lean`:
- `dichrom_le_chromaticNumber : (G.dichromNumber : ℕ∞) ≤ G.chromaticNumber`
- `cochrom_le_chromaticNumber : (G.cochromNumber : ℕ∞) ≤ G.chromaticNumber`

Both are 3-line proofs: `le_iInf₂` reduces to the per-`n` `Colorable` case, then `exact_mod_cast` lifts the existing ℕ-valued `_of_colorable` bounds. The Iter 8 prediction warned of "WithTop-aware csInf manipulation" but in practice Mathlib's `chromaticNumber := ⨅ n ∈ setOf G.Colorable, (n : ℕ∞)` makes the lift uniform; no explicit ⊤ case split is needed.

**Why this matters.** Every other Erdős entry that quantifies chromatic constraints (erdos-705, erdos-922, erdos-629, ...) uses Mathlib's `G.chromaticNumber : ℕ∞`, not local ℕ-only definitions. Without the ℕ∞ lift, erdos-761's δ/ζ bounds couldn't chain with the broader gallery. With this commit, an external proof carrying `G.chromaticNumber ≤ k` yields δ(G), ζ(G) ≤ k via the standard `(· : ℕ∞)` cast.

**Build.** `lean4-arm64:v4.26.0` Docker build of `Proofs.Erdos761Problem` succeeded (3082 jobs, exit 0).

**Stats.** lineCount 291 → 314; theoremCount 8 → 10; axiomCount unchanged at 2 (both OPEN conjectures); 0 sorries throughout.

### Slug 4: `fourier-series-oq-04-oq-01` (S13 SCOUT verify)

Doc-only verification iteration: re-built `Proofs.FourierSeriesOQ04OQ01` under `lean4-arm64:v4.26.0` against the current Mathlib cache to confirm the S11 ACT (`haarT2_eq_volume` bridge) and S12 PREP (Mathlib API audit) deliverables still hold five days after S12 PREP.

**Result.** 7743 jobs, exit 0, zero errors. Single expected sorry warning at line 148 (`sphPartialSum_L2_norm_converge`) — sorry surface identical to the last verified build (S11 ACT, 2026-05-31). No drift across the 4 S12-cataloged API entries (`mFourier`, `mFourierLp`, `mFourierCoeff`, `hasSum_mFourier_series_L2`). The 18-35 LOC S13 ACT budget remains tractable.

Iter 11 → 12. State.md header bump; S13 SCOUT session log. No Lean delta.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ01OQ01OQ04` clean (7744 jobs).
- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos761Problem` clean (3082 jobs).
- [x] `./proofs/scripts/docker-build.sh Proofs.FourierSeriesOQ04OQ01` clean (7743 jobs, single expected pre-existing sorry warning).
- [x] No new axioms, no new sorries.
- [ ] CI build passes.
- [ ] Auditor verification post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)