### PR TITLE
audit(erdos-1001-oq-02-oq-01): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14084,9 +14084,9 @@
       ]
     },
     "erdos-1001-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T14:00:00Z",
-      "result": "issues-fixed",
+      "auditCount": 2,
+      "lastAudited": "2026-06-06T13:12:32Z",
+      "result": "clean",
       "issues": [
         "lineCount was 248 (actual 313); leanFile section was missing — both corrected"
       ]


### PR DESCRIPTION
## Audit Summary

Re-audited gallery integrity for **erdos-1001-oq-02-oq-01** (Sharpness of the O(log N / N) Convergence Rate via Walfisz 1963).

## Verification

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| `sorries` | 4 | 4 | ✓ |
| `axiomCount` | 4 | 4 | ✓ |
| `lineCount` | 313 | 313 | ✓ |
| `theoremCount` | 6 | 6 | ✓ |
| `definitionCount` | 7 | 7 | ✓ |
| True stubs | none | none | ✓ |
| `status` | axiomatized | 4 axioms remain | ✓ |
| `badge` | axiom | appropriate | ✓ |

Axioms verified in source: `totient_sum_mertens_error`, `totient_sum_walfisz_error`, `rangeTotientSum_walfisz_error`, `convergence_rate_sharp`.

Sorries verified in source: `walfisz_rate_isLittleO_mertens_rate`, `walfisz_full_rate_isLittleO_mertens_rate`, `sharp_rate_isLittleO_oq02_rate`, `improvement_factor_tends_to_zero`.

Title and originalContributions accurately scope claims — Walfisz 1963 is properly credited as the sharp-bound input, no overstatement of independent contribution.

## Tracker Update

- auditCount: 1 → 2
- result: issues-fixed → clean
- lastAudited: 2026-05-03 → 2026-06-06

Prior audit's issue (lineCount / leanFile section) was already resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)