### PR TITLE
audit(sum-of-kth-powers-oq-04): tracker bump — clean (4th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13303,9 +13303,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers-oq-04": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T14:04:10Z",
+      "lastAudited": "2026-06-06T13:19:30Z",
       "result": "clean"
     },
     "sylow-theorem": {


### PR DESCRIPTION
## Summary

4th audit of `sum-of-kth-powers-oq-04` (Euler-Maclaurin Asymptotics for Power Sums). All integrity-checklist items pass.

## Verification

| Claim | meta.json | Lean source | ✓ |
|---|---|---|---|
| Main file lineCount | 254 | 254 | ✓ |
| Main file sorries | 0 | 0 | ✓ |
| Main file axiomCount | 0 | 0 | ✓ |
| theoremCount | 10 | 5 public + 5 private | ✓ |
| definitionCount | 1 | `powerSumRatio` | ✓ |
| Companion sorries | "2 routine sorries" | `low_degree_poly_ratio_tendsto_zero`, `monic_sub_pow_natDegree_lt` | ✓ |
| status / badge | `formalized` / `wip` | appropriate (companion has sorries) | ✓ |
| Mathlib dependency framing | building blocks (Faulhaber + Bernoulli) | leading-coeff lemma proved locally via `coeff_bernoulli` | ✓ |

`originalContributions` items map to actual theorems (`powerSumRatio` def, `gauss_sum_rat`, `powerSumRatio_k0`, `powerSumRatio_k1`, `powerSumRatio_tendsto`).

## Notes

- Section `startLine`/`endLine` ranges drifted relative to file growth (e.g. `main-theorem` section claims 52–68 but `powerSumRatio_tendsto` is at line 190). Cosmetic only — does not affect any integrity claim. Deferred to next enrichment pass.

## Test plan

- [x] Verified main-file sorry/axiom counts via grep
- [x] Verified companion-file sorry names match assumptions field
- [x] Confirmed all `originalContributions` entries exist in source
- [x] Confirmed status/badge consistent with sorry distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)