### PR TITLE
audit(erdos-1001-oq-02-oq-01): tracker bump — clean (3rd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14084,8 +14084,8 @@
       ]
     },
     "erdos-1001-oq-02-oq-01": {
-      "auditCount": 2,
-      "lastAudited": "2026-06-06T13:12:32Z",
+      "auditCount": 3,
+      "lastAudited": "2026-06-06T14:22:00Z",
       "result": "clean",
       "issues": [
         "lineCount was 248 (actual 313); leanFile section was missing — both corrected"


### PR DESCRIPTION
## Summary

Re-audit (3rd) of `erdos-1001-oq-02-oq-01` (Erdős #1001 OQ-02-OQ-01: Sharpness of the O(log N / N) Rate). Result: **clean**.

## Findings

- **4 axiom declarations** in `Proofs/Erdos1001OQ02OQ01.lean` (matches `meta.axiomCount = 4`):
  `totient_sum_mertens_error`, `totient_sum_walfisz_error`, `rangeTotientSum_walfisz_error`, `convergence_rate_sharp`
- **4 sorries** at lines 148, 162, 248, 280 — all `rpow` asymptotic comparisons declared as Aristotle candidates (matches `meta.sorries = 4`)
- 0 `True` stubs / placeholder theorems
- Status `axiomatized` + badge `axiom` consistent with an axiom-bearing open-question file
- Companion file `Erdos1001OQ02OQ01Aristotle.lean`: 4 supporting-lemma sorries, 0 axioms — correct Aristotle companion pattern

## Test plan

- [x] `grep -c "^axiom "` confirms 4 axioms
- [x] Sorries cross-checked against meta.json declaration
- [x] `lineCount` matches actual file length (313)
- [x] Tracker bumped to `auditCount = 3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)