### PR TITLE
audit(inverse-galois-oq-01): tracker bump — clean (6th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11956,10 +11956,10 @@
       "result": "clean"
     },
     "inverse-galois-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T14:08:20Z",
-      "result": "issues-fixed"
+      "lastAudited": "2026-06-06T15:21:18Z",
+      "result": "clean"
     },
     "inverse-galois-oq-02": {
       "auditCount": 6,


### PR DESCRIPTION
## Audit Summary

Verified `InverseGaloisOQ01.lean` and transitively-imported companion files. All meta.json claims confirmed.

### Verified facts

| Claim | Found | Status |
|---|---|---|
| 723 lines | 723 | OK |
| 40 theorems | 40 | OK |
| 1 definition | 1 (`quotient_galois_equiv`, noncomputable) | OK |
| 0 axioms in main file | 0 | OK |
| 1 sorry (intentional IGP conjecture) | 1 at line 412 | OK |
| 1 transitive axiom in InverseGaloisA5 (`three_dvd_gal_card`) | 1 at line 309 | OK |
| AbelRuffiniGaloisExtensions axiom-free | 0 axioms, 0 sorries | OK |
| AbelRuffiniOQ04OQ01 axiom-free | 0 axioms, 0 sorries | OK |
| Status `axiomatized`, badge `axiom` | matches 1-axiom total | OK |
| No True stubs / Mathlib wrappers | clean | OK |

No issues found — tracker bump only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)