### PR TITLE
audit(cevas-theorem-non-euclidean-oq-02-oq-01): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -14126,8 +14126,8 @@
       "result": "issues-fixed"
     },
     "cevas-theorem-non-euclidean-oq-02-oq-01": {
-      "auditCount": 1,
-      "lastAudited": "2026-05-03T15:00:27Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-06T16:32:04Z",
       "result": "clean",
       "issues": []
     },


### PR DESCRIPTION
## Summary

- 2nd audit pass on `cevas-theorem-non-euclidean-oq-02-oq-01` (Spherical Menelaus via Sin).
- Tracker bump only — no integrity issues found.

## Audit findings

Verified meta.json against `proofs/Proofs/CevasTheoremNonEuclideanOQ02OQ01.lean`:

| Field | Claimed | Actual | Match |
|-------|---------|--------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 11 | 11 | ✓ |
| definitionCount | 4 | 3 noncomputable def + 1 structure = 4 | ✓ |
| lineCount | 340 | 340 | ✓ |
| True stubs | none | none | ✓ |

**Tier classification**: `verified` / `verified` is correct. The main theorem `spherical_menelaus` is independently proved via the reusable `menelaus_algebraic_core` lemma; Mathlib's `Real.sin_neg`, `Real.sin_pos_of_pos_of_lt_pi`, and basic `div_*` lemmas serve only as building blocks. The proof completes the 2×2 matrix (Ceva/Menelaus × Euclidean/Spherical/Hyperbolic).

## Test plan

- [x] Sorry count grep on Lean file
- [x] Axiom count grep on Lean file
- [x] Theorem/lemma count
- [x] Definition + structure count (with `noncomputable def`)
- [x] True-stub detection
- [x] Tier A classification review

🤖 Generated with [Claude Code](https://claude.com/claude-code)