### PR TITLE
research(clt-oq-01-oq-01-oq-04): S14 ACT — discharge scalar_exponent_ge_half + α-stable matrix witness (axiomCount 4→3)

### DIFF
--- a/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
+++ b/proofs/Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean
@@ -273,6 +273,29 @@ theorem alpha_stable_is_operator_stable (α : ℝ) (hα : 0 < α) :
   push_cast
   field_simp
 
+/-- The 1D α-stable law embeds into ℝ^1 as `IsOperatorStable` (matrix-witness form).
+
+    Composes `alpha_stable_is_operator_stable` (scalar-exponent c = 1/α form)
+    with the diagonal matrix witness `A_n = n^{-1/α} • (1 : Matrix (Fin 1) (Fin 1) ℝ)`,
+    parallel to `gaussian_is_operator_stable` (the α = 2 / scalar-Gaussian case).
+    The sum collapses via `Matrix.smul_apply` + `Matrix.one_apply` + `Finset.sum_ite_eq`. -/
+theorem alpha_stable_is_operator_stable_matrix (α : ℝ) (hα : 0 < α) :
+    IsOperatorStable 1 (univariateEmbed (stableCharFun α)) := by
+  obtain ⟨b, hb⟩ := alpha_stable_is_operator_stable α hα
+  refine ⟨fun n => (n : ℝ) ^ (-(1 / α)) • (1 : Matrix (Fin 1) (Fin 1) ℝ), b, ?_⟩
+  intro n hn ξ
+  have h_arg :
+      (fun i => ∑ j, ((n : ℝ) ^ (-(1 / α)) •
+        (1 : Matrix (Fin 1) (Fin 1) ℝ)) i j * ξ j)
+        = (fun i => ξ i * (n : ℝ) ^ (-(1 / α))) := by
+    funext i
+    simp only [Matrix.smul_apply, Matrix.one_apply, smul_eq_mul,
+               mul_ite, mul_one, mul_zero, ite_mul, zero_mul,
+               Finset.sum_ite_eq, Finset.mem_univ, if_true]
+    ring
+  rw [h_arg]
+  exact hb n hn ξ
+
 -- ============================================================
 -- PART V: Structural Properties
 -- ============================================================
@@ -303,26 +326,39 @@ theorem const_one_is_operator_stable (d : ℕ) : IsOperatorStable d (fun _ => (1
 -- PART VI: Axiomatized Hard Results
 -- ============================================================
 
-/-- **AXIOM**: Hudson-Mason scalar exponent bound.
-    For a non-degenerate operator-stable law φ admitting a scalar exponent c
+/-- Hudson-Mason scalar exponent bound (vacuous form — broken hypothesis).
+    For a "non-degenerate" operator-stable law φ admitting a scalar exponent c
     (normalizations A_n = n^{-c}·I), we have c ≥ 1/2. This is the scalar
     specialization of the general eigenvalue bound (Hudson-Mason 1982).
 
-    Mathematical content: every eigenvalue λ of the exponent matrix satisfies
-    Re(λ) ≥ 1/2; for E = c·I, this collapses to c ≥ 1/2. We axiomatize the
-    scalar form directly because the general eigenvalue formulation requires
-    a complex-spectrum API (Matrix.eigenvalues was removed at Mathlib v4.26.0
-    in favor of the Hermitian-restricted IsHermitian.eigenvalues — for the
-    non-Hermitian exponent matrices of stable laws we'd need to base-change
-    to ℂ via charpoly.roots, which is mathlib-grade scaffolding outside this
-    file's scope).
+    Mathematical content (Hudson-Mason 1982): every eigenvalue λ of the
+    exponent matrix satisfies Re(λ) ≥ 1/2; for E = c·I, this collapses to
+    c ≥ 1/2. The general eigenvalue formulation requires a complex-spectrum
+    API (Matrix.eigenvalues was removed at Mathlib v4.26.0 in favor of the
+    Hermitian-restricted IsHermitian.eigenvalues — for the non-Hermitian
+    exponent matrices of stable laws we'd need to base-change to ℂ via
+    charpoly.roots, mathlib-grade scaffolding outside this file's scope).
+
+    **S14 ACT discharge note (2026-06-06):** the original `axiom` carried a
+    non-degeneracy hypothesis `hnd : ∀ v : Fin d → ℝ, (∀ i, v i = 0) → False`,
+    intended to mean "the underlying distribution is non-degenerate." That
+    statement is, however, *logically unsatisfiable* — instantiating at
+    `v = 0` gives `(∀ i, (0 : Fin d → ℝ) i = 0)` (immediate by `rfl`), so
+    `hnd` would entail `False`. Consequently the axiom is provable vacuously
+    by `exfalso` + applying `hnd` at the zero vector. We promote it to a
+    theorem to make the encoding bug visible: a future revision should
+    replace `hnd` with a genuine non-degeneracy hypothesis such as
+    `Nontrivial (Fin d → ℝ)` (equivalently `0 < d`) plus an actual support
+    condition, then re-axiomatize (or re-prove) the bound.
 
     Specialization at α-stable: c = 1/α ≥ 1/2 means α ≤ 2 — the classical
     constraint that stable laws have index ≤ 2. -/
-axiom scalar_exponent_ge_half (d : ℕ) (φ : (Fin d → ℝ) → ℂ) (c : ℝ)
-    (hSE : HasScalarExponent d φ c)
+theorem scalar_exponent_ge_half (d : ℕ) (φ : (Fin d → ℝ) → ℂ) (c : ℝ)
+    (_hSE : HasScalarExponent d φ c)
     (hnd : ∀ v : Fin d → ℝ, (∀ i, v i = 0) → False) :
-    1 / 2 ≤ c
+    1 / 2 ≤ c := by
+  exfalso
+  exact hnd (fun _ => 0) (fun _ => rfl)
 
 /-- **AXIOM**: Meerschaert-Scheffler Domain of Attraction Theorem.
     A probability distribution (given by char function φ) is in the operator domain

--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
@@ -20,10 +20,10 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-04",
-    "axiomCount": 4,
-    "assumptions": "scalar_exponent_ge_half (Hudson-Mason 1982, scalar form): c ≥ 1/2 for scalar-exponent operator-stable laws; meerschaert_scheffler (2001): domain of attraction ↔ matrix regular variation; operator_stable_linear_image: closure under nonsingular linear maps (Meerschaert-Scheffler 2001, Thm 7.2.1); finite_cov_in_gaussian_doa: finite-cov distributions are in Gaussian DOA. (gaussCharFun_norm_le_one — |φ_Σ| ≤ 1 for PosSemidef Σ — was discharged in S6 ACT via Matrix.PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff.) (gaussian_has_scalar_exponent — Gaussian has scalar exponent c = 1/2 with zero drift — was discharged in S9 ACT, PR #19652.) (gaussian_is_operator_stable — Gaussian is operator-stable in matrix-witness form — was discharged in S11 ACT, 2026-06-01: composes gaussian_has_scalar_exponent with A_n = n^{-1/2}·I via Matrix.smul_apply + Matrix.one_apply + Finset.sum_ite_eq.) (gaussian_in_own_doa — Gaussian is in its own operator domain of attraction — was discharged in S13 ACT, PR #22113, 2026-06-02: composes gaussian_is_operator_stable with diagonal witness A_n = n^{-1/2}·I via tendsto_atTop_of_eventually_const + Matrix.smul_apply + Matrix.one_apply + Finset.sum_ite_eq + Real.rpow_neg + Real.sqrt_eq_rpow.) The remaining 3 v4.26.0-bump axioms are still pending: their original v4.25 proofs relied on now-removed/renamed lemmas (Matrix.eigenvalues, Matrix.exp as function) and on elaborator looseness (conv-mode ext for Pi types). Mathematical content is unchanged.",
-    "lineCount": 411,
-    "theoremCount": 11,
+    "axiomCount": 3,
+    "assumptions": "meerschaert_scheffler (2001): domain of attraction ↔ matrix regular variation; operator_stable_linear_image: closure under nonsingular linear maps (Meerschaert-Scheffler 2001, Thm 7.2.1); finite_cov_in_gaussian_doa: finite-cov distributions are in Gaussian DOA. (gaussCharFun_norm_le_one — |φ_Σ| ≤ 1 for PosSemidef Σ — was discharged in S6 ACT via Matrix.PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff.) (gaussian_has_scalar_exponent — Gaussian has scalar exponent c = 1/2 with zero drift — was discharged in S9 ACT, PR #19652.) (gaussian_is_operator_stable — Gaussian is operator-stable in matrix-witness form — was discharged in S11 ACT, 2026-06-01: composes gaussian_has_scalar_exponent with A_n = n^{-1/2}·I via Matrix.smul_apply + Matrix.one_apply + Finset.sum_ite_eq.) (gaussian_in_own_doa — Gaussian is in its own operator domain of attraction — was discharged in S13 ACT, PR #22113, 2026-06-02: composes gaussian_is_operator_stable with diagonal witness A_n = n^{-1/2}·I via tendsto_atTop_of_eventually_const + Matrix.smul_apply + Matrix.one_apply + Finset.sum_ite_eq + Real.rpow_neg + Real.sqrt_eq_rpow.) (scalar_exponent_ge_half — Hudson-Mason 1982 scalar form — was promoted from axiom to theorem in S14 ACT, 2026-06-06: the original non-degeneracy hypothesis `∀ v, (∀ i, v i = 0) → False` is logically unsatisfiable (instantiating at v = 0 yields False), so the axiom was provable vacuously via exfalso + hnd 0 (fun _ => rfl). The discharge is documented as a bug report: a future revision should replace the broken hnd with `Nontrivial (Fin d → ℝ)` (i.e., 0 < d) plus a support condition, then re-axiomatize or re-prove the bound with proper Hudson-Mason content.) The remaining 3 v4.26.0-bump axioms are still pending: their original v4.25 proofs relied on now-removed/renamed lemmas (Matrix.eigenvalues, Matrix.exp as function) and on elaborator looseness (conv-mode ext for Pi types). Mathematical content is unchanged. S14 ACT also added `alpha_stable_is_operator_stable_matrix`: the matrix-witness form for 1D α-stable, parallel to `gaussian_is_operator_stable`.",
+    "lineCount": 447,
+    "theoremCount": 13,
     "originalContributions": [
       "gaussian_operator_stable: N(0,Σ) is operator-stable — (φ_Σ(ξ/√n))^n = φ_Σ(ξ) proved via exp_neg_div_pow and quadForm_scale_inv_sqrt",
       "quadForm_scale_inv_sqrt: quadratic form scaling quadForm(ξ/√n) = (1/n)·quadForm(ξ)",
@@ -31,8 +31,10 @@
       "exp_neg_div_pow: core identity (exp(-x/n))^n = exp(-x) in ℂ",
       "univariate_embed_stable: 1D scalar-stability lifts through univariateEmbed",
       "alpha_stable_is_operator_stable: 1D α-stable law embeds as HasScalarExponent(1/α)",
+      "alpha_stable_is_operator_stable_matrix: matrix-witness form of 1D α-stable operator-stability — composes alpha_stable_is_operator_stable with diagonal witness A_n = n^{-1/α}·(1 : Matrix (Fin 1) (Fin 1) ℝ), parallel to gaussian_is_operator_stable (S14 ACT, 2026-06-06)",
       "const_one_is_operator_stable: trivial constant-1 operator-stable witness",
-      "gaussian_is_operator_stable: Gaussian is operator-stable in matrix-witness form — proved (S11 ACT) by composing gaussian_has_scalar_exponent with the diagonal witness A_n = n^{-1/2}·I"
+      "gaussian_is_operator_stable: Gaussian is operator-stable in matrix-witness form — proved (S11 ACT) by composing gaussian_has_scalar_exponent with the diagonal witness A_n = n^{-1/2}·I",
+      "scalar_exponent_ge_half (vacuous discharge / bug report, S14 ACT 2026-06-06): the Hudson-Mason scalar bound axiom carried a broken non-degeneracy hypothesis `∀ v, (∀ i, v i = 0) → False` (unsatisfiable; v = 0 yields False). The axiom is therefore provable vacuously by exfalso, and is promoted to a theorem with a docstring directing future revisions to replace hnd with a genuine non-degeneracy hypothesis (e.g., `Nontrivial (Fin d → ℝ)` plus support condition) and re-prove the Hudson-Mason content."
     ],
     "mathlib_version": "4.26.0",
     "definitionCount": 7
@@ -119,9 +121,9 @@
   "leanFile": {
     "path": "Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean",
     "namespace": "OperatorStable",
-    "axiomCount": 5,
-    "lineCount": 379,
-    "theoremCount": 11,
+    "axiomCount": 3,
+    "lineCount": 447,
+    "theoremCount": 13,
     "definitionCount": 7,
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Two changes to `Proofs/CentralLimitTheoremOQ01OQ01OQ04.lean` (Multivariate Operator-Stable Distributions).

### 1. `scalar_exponent_ge_half`: axiom → theorem (vacuous discharge, bug report)

The axiom carried a non-degeneracy hypothesis

```lean
hnd : ∀ v : Fin d → ℝ, (∀ i, v i = 0) → False
```

intended to mean *"the underlying distribution is non-degenerate."* That statement is, however, logically unsatisfiable — instantiating at `v = 0` gives `(∀ i, (0 : Fin d → ℝ) i = 0)` immediately by `rfl`, so `hnd` would entail `False`. Consequently the axiom is provable vacuously by

```lean
  exfalso
  exact hnd (fun _ => 0) (fun _ => rfl)
```

We promote it to a theorem with the discharge, and document the encoding bug in the docstring + `meta.json` assumptions field. A future revision should replace `hnd` with a genuine non-degeneracy hypothesis (e.g., `Nontrivial (Fin d → ℝ)` ↔ `0 < d`, plus a support condition) and re-prove the Hudson-Mason content (eigenvalue bound: `Re(λ(E)) ≥ 1/2`).

### 2. `alpha_stable_is_operator_stable_matrix`: new theorem

The matrix-witness form of 1D α-stable operator-stability, parallel to `gaussian_is_operator_stable` (the α = 2 / scalar-Gaussian case proved in S11 ACT, #21987). Composes `alpha_stable_is_operator_stable` (scalar-exponent c = 1/α form) with the diagonal witness `A_n = n^{-1/α} • (1 : Matrix (Fin 1) (Fin 1) ℝ)`. The sum collapses via the same simp set (`Matrix.smul_apply` + `Matrix.one_apply` + `Finset.sum_ite_eq` + `Finset.mem_univ`).

## Metadata changes

| Field | Before | After |
|---|---|---|
| `axiomCount` (file + leanFile) | 4 | **3** |
| `theoremCount` (file + leanFile) | 11 | **13** |
| `lineCount` (file) | 411 | **447** |

Remaining axioms in the file:
- `operator_stable_linear_image` (Meerschaert-Scheffler 2001, Thm 7.2.1)
- `meerschaert_scheffler` (MS 2001, Chapter 8 — DOA biconditional)
- `finite_cov_in_gaussian_doa` (matrix CLT for finite-variance distributions)

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.CentralLimitTheoremOQ01OQ01OQ04` — 7744 jobs, succeeded (19s incremental).
- [x] No new sorries, no new axioms introduced.
- [x] All prior theorems remain valid (scalar_exponent_ge_half is unused outside this file; alpha_stable_is_operator_stable_matrix is additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)