### PR TITLE
audit(inverse-galois-oq-01): tracker bump — clean (7th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11956,9 +11956,9 @@
       "result": "clean"
     },
     "inverse-galois-oq-01": {
-      "auditCount": 6,
+      "auditCount": 7,
       "issues": [],
-      "lastAudited": "2026-06-06T15:21:18Z",
+      "lastAudited": "2026-06-06T17:12:51Z",
       "result": "clean"
     },
     "inverse-galois-oq-02": {


### PR DESCRIPTION
## Summary
- Verified all meta.json claims match the Lean source for inverse-galois-oq-01
- No issues found; tracker bumped to auditCount=7 with result `clean`

## Audit Findings
**meta.json claims**: status `axiomatized`, badge `axiom`, sorries=1, axiomCount=1, 723 lines, 40 theorems

**Lean reality** (all consistent):
- InverseGaloisOQ01.lean: 0 axioms, 1 intentional sorry at line 412 (open Inverse Galois Conjecture, clearly disclaimed)
- InverseGaloisA5.lean: 1 axiom (three_dvd_gal_card at line 309 — Dedekind's theorem that 3 divides |Gal|, properly justified)
- AbelRuffiniGaloisExtensions.lean: 0 axioms, 0 sorries
- AbelRuffiniOQ04OQ01.lean: 0 axioms, 0 sorries
- No structure/class-encoded assumptions
- Line count and theorem count match

assumptions field in meta.json accurately enumerates the transitive axiom and intentional sorry.

## Test plan
- [x] claim-target.sh complete inverse-galois-oq-01 clean succeeded
- [x] git diff shows only audit-tracker.json bump