### PR TITLE
Enrich abel-ruffini: complete abel-ruffini-galois-extensions cross-ref

### DIFF
--- a/src/data/proofs/abel-ruffini/meta.json
+++ b/src/data/proofs/abel-ruffini/meta.json
@@ -711,7 +711,7 @@
     {
       "targetId": "abel-ruffini-galois-extensions",
       "relationship": "extended-by",
-      "description": "Provides the complete solvability classification for symmetric groups: S₀–S₄ are solvable (proved explicitly), Sₙ solvable iff n ≤ 4 (bidirectional theorem), A₅ simple. Directly fills the gap noted in this entry where S₂, S₃, S₄ lacked Mathlib instances"
+      "description": "Provides the complete solvability classification for symmetric groups: $S_0$–$S_4$ are solvable (proved explicitly via the derived series $S_4 \\supset A_4 \\supset V_4 \\supset \\{e\\}$), $S_n$ solvable iff $n \\leq 4$ (the bidirectional theorem `symmetric_solvable_iff`), $A_5$ simple, and non-commutativity witnesses for $S_3$, $S_4$, $S_5$, $A_4$, $A_5$. Directly fills the gap noted in this entry's open questions where Mathlib instances `IsSolvable (Equiv.Perm (Fin n))` for $n = 2, 3, 4$ were missing at time of writing — `abel-ruffini-galois-extensions` discharges them by `inferInstance` (small commutative cases) and explicit derived-series unrolling. The companion entry also formalizes the alternating analogue (`alternating_solvable_iff`: $A_n$ solvable iff $n \\leq 4$) and verifies concrete group orders $|S_7| = 5040$, $|S_8| = 40320$, $|A_7| = 2520$, $|A_8| = 20160$ via `native_decide`. 59 theorems across 534 lines, 0 axioms, 0 sorries — the structural complement to this entry's contrapositive synthesis."
     },
     {
       "targetId": "abel-ruffini-oq-04",


### PR DESCRIPTION
## Summary

Expanded the `abel-ruffini-galois-extensions` cross-reference description in `src/data/proofs/abel-ruffini/meta.json` from 253 chars to ~1100 chars. The previous text ended mid-sentence at "lacked Mathlib instances" without a period — the shortest of all 103 cross-references in the entry.

## Changes

The expanded description now:
- Names the bidirectional theorem `symmetric_solvable_iff`
- Spells out the derived series $S_4 \supset A_4 \supset V_4 \supset \{e\}$ explicitly
- Lists the missing Mathlib `IsSolvable (Equiv.Perm (Fin n))` instances filled for n=2,3,4 via `inferInstance` + explicit derived-series unrolling
- Names the alternating analogue `alternating_solvable_iff` ($A_n$ solvable iff $n \leq 4$)
- Cites concrete `native_decide` group-order verifications: $|S_7|=5040$, $|S_8|=40320$, $|A_7|=2520$, $|A_8|=20160$
- Anchors with companion entry scale: 59 theorems, 534 lines, 0 axioms, 0 sorries

## Quality scope

abel-ruffini was already at quality 100 with 7 passes; this targets the single shortest cross-reference in the entry (the next-shortest sibling at 269 chars and all others ≥274 chars end with proper terminal punctuation).

## Verification

- JSON validates with `python3 -m json.tool` ✓
- Build-time enrichment scan (`tsx scripts/build-data-enrichment.ts`) processed all 1983 entries without abel-ruffini error ✓
- Single one-line description edit; no schema or structural changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)