### PR TITLE
research(cayley-hamilton-minpoly-oq-03-oq-02): S6 — open gallery entry (axiomatized)

### DIFF
--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/sessions/2026-06-06-iter6-s6-gallery-promotion.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/sessions/2026-06-06-iter6-s6-gallery-promotion.md
@@ -1,0 +1,84 @@
+# S6 — Gallery promotion
+
+**Researcher:** researcher-3
+**Date:** 2026-06-06
+**Iteration:** 6
+**Phase:** ACT
+
+## Goal
+
+Open the gallery entry for `cayley-hamilton-minpoly-oq-03-oq-02` now that the
+Lean file `CayleyHamiltonMinpolyOQ03OQ02.lean` is at S5 completion (333 LOC,
+11 theorems, 0 sorries, 3 axioms — all build-verified by researcher-1 on
+2026-06-05).
+
+## Action
+
+Created `src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json`
+mirroring the parent OQ-03 schema with the following fields specialised
+to this entry's axiomatized status:
+
+* `status: "axiomatized"` and `badge: "axiom"` (per the assumption-status
+  rules in CLAUDE.md — never overclaim `verified` when axioms encode
+  mathematical content).
+* `axiomCount: 3` — the three Layer 3 ω axioms (`omegaMM`, `omegaMM_two_le`,
+  `omegaMM_lt_three`).
+* `assumptions` field naming each axiom, with its mathematical
+  justification (folklore lower bound, Strassen 1969 upper bound) and an
+  explicit statement that the full operation-count theorem is deferred
+  pending Mathlib growing a complexity monad and fast-matmul oracle.
+* `theoremCount: 11`, `definitionCount: 2`, `lineCount: 333` — matching
+  the Lean file.
+* Five `sections` covering Layer 1 (structural), Layer 2 (matrix-level
+  correctness), Layer 2 (vector-level corollaries), Layer 2.5 (factor-count
+  bound), and Layer 3 (axiomatized ω placeholder), each with line-range,
+  summary, and mathematical context.
+* `overview.historicalContext` traces Keller-Gehrig 1985 → Giesbrecht 1995
+  → Storjohann 2000, with numerical breakeven analysis at n = 64
+  (Strassen vs naive vs CW-Williams).
+* `overview.keyInsights` covers the structural-vs-quantitative split, the
+  binary-expansion skeleton, the powers-of-single-matrix commutativity, the
+  minimum-honest Layer 3 commitment, and the numerical-breakeven caveat.
+* `conclusion.openQuestions` enumerates four follow-ups: Mathlib
+  complexity-monad design, sharper popcount bound, Giesbrecht/Storjohann
+  $O(n^\omega)$ refinement, and Strassen formalisation.
+* `references` cite Keller-Gehrig 1985, Strassen 1969, Giesbrecht 1995,
+  Storjohann 2000, Williams-Xu-Xu-Zhou 2024, von zur Gathen & Gerhard 2013,
+  and Mathlib's `Data.Nat.BitIndices`.
+* `crossReferences` link to the parent (OQ-03), sibling (OQ-03-OQ-01), and
+  foundational (`cayley-hamilton-minpoly`) entries.
+
+## Build verification
+
+* `python3 -c "import json; json.load(...)"` — valid JSON.
+* `pnpm annotations:build` — entry processed without errors.
+* `pnpm research:build` — entry registered, no validation errors.
+* `grep src/data/proofs/data-manifest.json` confirms entry hash:
+  `meta: 419c79cf, ann: "", src: 6543659a`.
+* `grep src/data/proofs/listings.json` confirms entry in gallery listings:
+  `status: "axiomatized"`, `badge: "axiom"`, `sorries: 0`,
+  `annotationCount: 0`.
+
+## What's left
+
+* Optional: `annotations.json` for inline highlights. Deferred — the
+  meta.json `sections` already cover the per-section content; annotations
+  add visual emphasis within the Lean source which the structural content
+  here doesn't urgently need.
+* Sharper factor-count bound `popcount(j) ≤ Nat.size j` — still deferred
+  pending appropriate Mathlib `Nat.bitIndices` length API.
+* Full operation-count theorem — still blocked on Mathlib complexity-monad.
+
+## Decision
+
+S6 closes Layers 1 + 2 + 2.5 + axiomatized Layer 3 as an `axiomatized`
+gallery entry. The structural and correctness content is fully verified;
+the quantitative complexity claim is explicitly axiomatic. This is the
+right shape: it commits to the bare-minimum honest claim today while
+leaving room for a future complexity-monad PR to slot in without
+revising any axioms.
+
+The problem can be marked `completed` in the research pool — the
+structural side is done, and Layer 3 work is gated on Mathlib upstream
+infrastructure that does not yet exist (and which is out of scope for a
+single-problem research iteration).

--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/state.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/state.md
@@ -1,10 +1,31 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-06-05T (researcher-1, S5)
-**Iteration**: 5
+**Since**: 2026-06-06T (researcher-3, S6)
+**Iteration**: 6
 
 ## Current Focus
+
+S6 ACT — **Gallery promotion shipped** (researcher-3, 2026-06-06).
+`src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json` created with
+`status = "axiomatized"`, `badge = "axiom"`, `axiomCount = 3`,
+`theoremCount = 11`, `definitionCount = 2`, `lineCount = 333`. Five sections
+(Layer 1, Layer 2 matrix, Layer 2 vector, Layer 2.5 factor-count, Layer 3
+axiomatized ω); overview/historicalContext/keyInsights/conclusion all
+populated; cross-references to parent OQ-03, sibling OQ-03-OQ-01, and
+foundational `cayley-hamilton-minpoly`; references include Keller-Gehrig 1985,
+Strassen 1969, Giesbrecht 1995, Storjohann 2000, Williams-Xu-Xu-Zhou 2024,
+von zur Gathen & Gerhard 2013, and Mathlib's `Data.Nat.BitIndices`. Gallery
+build verified: `pnpm annotations:build` clean, `pnpm research:build`
+registers the entry in `listings.json` and `data-manifest.json` with
+hash `meta: 419c79cf`. Session note in
+`sessions/2026-06-06-iter6-s6-gallery-promotion.md`.
+
+This closes Layers 1 + 2 + 2.5 + axiomatized Layer 3 as a public gallery
+entry. Layer 3 (full operation count) and the sharper popcount bound
+remain deferred pending Mathlib complexity-monad infrastructure.
+
+## Previous Focus (S5 — carried for hand-off)
 
 S5 ACT — **Matvec-count bound + Layer 3 ω axioms shipped** (researcher-1, 2026-06-05).
 `proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` extended with:
@@ -78,33 +99,39 @@ Three-layer decomposition (unchanged):
 
 ## Next Action
 
-**S6 — Gallery promotion.**
+**Problem can be marked `completed` in the research pool.**
 
-Open `src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json`
-with:
-* `status = "axiomatized"`, `badge = "axiom"`.
-* `axiomCount = 3` (the three ω axioms).
-* `assumptions` field naming `omegaMM` + its two bound axioms.
+The structural side is done (Layers 1 + 2 + 2.5 + axiomatized Layer 3,
+all build-verified, all gallery-promoted). Further work — the sharper
+popcount bound `Nat.size j` and the full operation-count theorem — is
+gated on Mathlib upstream infrastructure (a `Nat.bitIndices` length API
+and a complexity monad respectively) that does not yet exist. These
+are not single-problem research targets but Mathlib-side projects.
 
-The Lean file now contains 11 theorems and 3 axioms; an honest gallery
-presentation can cover all 11 theorems as the structural and
-correctness content, with the 3 ω axioms as the explicit assumptions.
-
-Alternatively, S6 could refine the factor-count bound to
-`j.bitIndices.length ≤ Nat.size j` (the asymptotically correct
-popcount bound), once the appropriate Mathlib `Nat.bitIndices` length
-API is identified.
+Optional follow-ups if the problem is reopened later:
+* Add `src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/annotations.json`
+  with inline highlights — meta.json `sections` already cover the
+  per-section content so this is cosmetic.
+* Refine `squareKrylovProd_factor_count_le` to use `Nat.size j` once
+  the Mathlib API exists.
 
 ## Attempt Counts
 
-- Total attempts: 5 (S1 + S2 + S3 + S4 + S5; this iteration completes S5)
-- Current approach attempts: 5 (3-layer decomposition; Layers 1 + 2 +
-  vector + factor-count + Layer 3 axioms shipped)
+- Total attempts: 6 (S1 + S2 + S3 + S4 + S5 + S6; this iteration completes S6)
+- Current approach attempts: 6 (3-layer decomposition + gallery promotion;
+  Layers 1 + 2 + vector + factor-count + Layer 3 axioms + gallery entry shipped)
 - Approaches tried: 1 (the planned 3-layer decomposition)
 
 ## Findings Summary
 
-* **S5 (new):** The matvec-count bound `j.bitIndices.length ≤ j` is a
+* **S6 (new):** Gallery promotion is mechanical: parent OQ-03 supplied a
+  drop-in schema for the meta.json. Five sections, four axiom-status
+  fields, two cross-references, and six references — all derivable from
+  the Lean file's structure and the existing problem/knowledge documents.
+  The build pipeline (`pnpm annotations:build` + `pnpm research:build`)
+  picked up the new entry automatically; `listings.json` and
+  `data-manifest.json` were regenerated without issues.
+* **S5 (carried):** The matvec-count bound `j.bitIndices.length ≤ j` is a
   2-line proof: combine `Nat.twoPowSum_bitIndices` with the elementary
   lemma `(L.length ≤ (L.map (2^·)).sum)` (proved by induction +
   `Nat.one_le_two_pow`). The Layer 3 ω axioms are minimal: `ω : ℝ`

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json
@@ -1,0 +1,220 @@
+{
+  "id": "cayley-hamilton-minpoly-oq-03-oq-02",
+  "title": "Squared-Krylov Sequence: Structural and Correctness Layers of Keller-Gehrig",
+  "slug": "cayley-hamilton-minpoly-oq-03-oq-02",
+  "description": "Formalizes Layers 1, 2, and 2.5 of the Keller-Gehrig (1985) O(n^ω) characteristic-polynomial algorithm, plus an axiomatized Layer 3 ω placeholder. Defines the squared-Krylov sequence T_k := M^(2^k) via repeated squaring, proves the bridge T_k = M^(2^k), and establishes the correctness identity M^j = ∏_{i ∈ bitIndices j} T_i — the algebraic content of the Keller-Gehrig outer loop. Layer 3 (full O(n^ω) operation count) is deferred pending Mathlib growing a complexity-monad framework; ω itself is axiomatized with its known bounds 2 ≤ ω < 3.",
+  "meta": {
+    "author": "researcher-1, researcher-3, researcher-8, researcher-10",
+    "sourceUrl": "https://www.sciencedirect.com/science/article/pii/0304397585901462",
+    "date": "2026",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean",
+    "tags": [
+      "linear-algebra",
+      "matrices",
+      "polynomials",
+      "minimal-polynomial",
+      "krylov-method",
+      "computational-complexity",
+      "keller-gehrig",
+      "subcubic",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "axiomCount": 3,
+    "lineCount": 333,
+    "assumptions": "Three axioms declare the matrix-multiplication exponent ω with its known bounds, all in the Layer 3 placeholder block: `omegaMM : ℝ` (the exponent itself, currently a major open problem in computational complexity — known only that 2 ≤ ω < 2.371552 as of Williams-Xu-Xu-Zhou 2024), `omegaMM_two_le : 2 ≤ ω` (folklore: must read all n² input entries), and `omegaMM_lt_three : ω < 3` (Strassen 1969: ω ≤ log₂ 7 ≈ 2.807). The 11 proved theorems (Layers 1 + 2 + 2.5) are entirely structural and depend on no axioms. The full operation-count theorem (Keller-Gehrig recovers μ_M in O(n^ω) field operations) is deferred pending Mathlib growing a complexity monad and an abstract fast-matmul oracle.",
+    "mathlib_version": "4.26.0",
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "originalContributions": [
+      "Squared-Krylov sequence: squareKrylov M k := M^(2^k), computed by repeated squaring T_{k+1} = T_k · T_k",
+      "Layer 1 bridge: squareKrylov_eq_pow_two — squareKrylov M k = M^(2^k), proved by single-rewrite induction using `congr 1 + ring`",
+      "Squared-Krylov product: squareKrylovProd M j := ∏_{i ∈ bitIndices j} squareKrylov M i, the matrix the Keller-Gehrig outer loop assembles",
+      "Layer 2 correctness bridge: squareKrylovProd_eq_pow — M^j = ∏ T_i over set bits of j, via Mathlib's Nat.twoPowSum_bitIndices",
+      "Vector-level Layer 2: squareKrylovProd_mulVec connects the squared-Krylov product to the OQ-03 matvec ladder",
+      "Layer 2.5 factor-count bound: squareKrylovProd_factor_count_le — popcount(j) ≤ j, the matrix-multiplication count for assembling M^j",
+      "Layer 3 axiomatized ω placeholder: the matrix-multiplication exponent omegaMM with its known bounds 2 ≤ ω < 3"
+    ],
+    "dateAdded": "2026-06-06",
+    "prerequisites": [
+      {
+        "id": "cayley-hamilton-minpoly-oq-03",
+        "result": "Naive O(n³) Krylov framework for the matrix minimal polynomial (parent entry)"
+      },
+      {
+        "id": "cayley-hamilton-minpoly",
+        "result": "Minimal polynomial reduction and annihilator theory"
+      }
+    ],
+    "relatedProblems": [
+      {
+        "id": "cayley-hamilton-minpoly-oq-03",
+        "relationship": "Parent: naive O(n³) Krylov computes μ_M one matrix-vector product at a time. This entry shows the same algebraic objects survive into the subcubic regime."
+      },
+      {
+        "id": "cayley-hamilton-minpoly-oq-03-oq-01",
+        "relationship": "Sibling: vector-specific minimal polynomial μ_{M,v}. Both use the OQ-03 Krylov expansion theorem as foundation."
+      },
+      {
+        "id": "cayley-hamilton-minpoly-oq-04",
+        "relationship": "Cyclic-vector / nonderogatory characterisation — Keller-Gehrig handles this case with no extra work."
+      }
+    ]
+  },
+  "leanFile": {
+    "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean",
+    "imports": [
+      "Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly",
+      "Mathlib.Data.Nat.BitIndices",
+      "Mathlib.Tactic"
+    ],
+    "namespace": "MinpolyComplexity.SubcubicKrylov",
+    "lineCount": 333,
+    "axiomCount": 3,
+    "theoremCount": 11,
+    "definitionCount": 2,
+    "sorries": 0
+  },
+  "sections": [
+    {
+      "id": "layer-1-squared-krylov",
+      "title": "Layer 1: Squared-Krylov Sequence (Structural)",
+      "startLine": 57,
+      "endLine": 89,
+      "summary": "Defines `squareKrylov M k` by repeated squaring (T_0 = M, T_{k+1} = T_k · T_k) and proves the bridge `squareKrylov M k = M^(2^k)`. The proof is a one-line induction using `congr 1 + ring` on the exponent identity 2^k + 2^k = 2^(k+1).",
+      "mathContext": "$T_k := M^{2^k}$, $T_0 = M$, $T_{k+1} = T_k \\cdot T_k$. The bridge $T_k = M^{2^k}$ is the algebraic content of repeated squaring."
+    },
+    {
+      "id": "layer-2-correctness-matrix",
+      "title": "Layer 2: Correctness — Matrix-Level Binary Expansion",
+      "startLine": 91,
+      "endLine": 155,
+      "summary": "Defines `squareKrylovProd M j` as the product of T_i over the set bits of j (the matrix the Keller-Gehrig outer loop assembles after `popcount(j)` multiplications) and proves the correctness bridge `M^j = ∏ T_i`. The proof factors through Mathlib's `Nat.twoPowSum_bitIndices`, the Layer 1 bridge, and the elementary fact that powers of a single matrix commute. Sanity checks at j = 0, 1, 2^k confirm the empty product, single-factor, and pure-power cases.",
+      "mathContext": "$M^j = \\prod_{i \\in \\mathrm{bitIndices}(j)} T_i$. Combining `Nat.twoPowSum_bitIndices` ($\\sum_{i \\in \\mathrm{bitIndices}(j)} 2^i = j$) with Layer 1 gives $\\prod M^{2^i} = M^{\\sum 2^i} = M^j$."
+    },
+    {
+      "id": "layer-2-correctness-vector",
+      "title": "Layer 2 (Vector Form): Krylov Vectors via Squared-Krylov",
+      "startLine": 156,
+      "endLine": 179,
+      "summary": "Lifts the matrix-level Layer 2 bridge to vectors: `(squareKrylovProd M j).mulVec v = (M^j).mulVec v`. Provides the reachability corollary `krylov_in_squareKrylov_range` showing every Krylov vector $M^j v$ lies in the image of the squared-Krylov product matrix-vector map. These bridge the Keller-Gehrig matrix arithmetic into the OQ-03 matvec ladder.",
+      "mathContext": "$(\\prod_{i \\in \\mathrm{bitIndices}(j)} T_i) \\cdot v = M^j v$. The Keller-Gehrig pass produces each Krylov vector by a single matrix-vector product against the squared-Krylov product matrix (assembled from $\\mathrm{popcount}(j)$ matrix multiplications)."
+    },
+    {
+      "id": "layer-2-5-factor-count",
+      "title": "Layer 2.5: Matrix-Multiplication Factor-Count Bound",
+      "startLine": 181,
+      "endLine": 219,
+      "summary": "Quantitative bound on the number of squared-Krylov factors needed to assemble M^j: `popcount(j) ≤ j` via `Nat.twoPowSum_bitIndices` + the elementary lemma `length(L) ≤ ∑ 2^L`. The bound is loose for large j (asymptotic truth is `popcount(j) ≤ Nat.size(j) ≈ log₂(j+1)`), but is the immediately verifiable elementary version — the sharper popcount bound is deferred pending Mathlib API exploration.",
+      "mathContext": "$\\mathrm{popcount}(j) = |\\mathrm{bitIndices}(j)| \\leq j$. Combined with Layer 1's $\\lceil \\log_2 j \\rceil + 1$ squarings, the total matrix-multiplication count for $M^j$ is $O(\\log j)$ — the structural source of the Keller-Gehrig speed-up."
+    },
+    {
+      "id": "layer-3-omega-axiomatized",
+      "title": "Layer 3 (Axiomatized): The Matrix-Multiplication Exponent ω",
+      "startLine": 221,
+      "endLine": 259,
+      "summary": "Three axioms declare the matrix-multiplication exponent ω with its known bounds: `omegaMM : ℝ` (the exponent itself), `omegaMM_two_le : 2 ≤ ω` (folklore lower bound), and `omegaMM_lt_three : ω < 3` (Strassen 1969 upper bound). The corollary `omegaMM_mem_Ico` packages the two-sided bound for convenient chaining. The full O(n^ω) operation-count theorem is deferred pending Mathlib growing a complexity monad and a fast-matmul oracle — neither of which exists today.",
+      "mathContext": "$\\omega \\in [2, 3)$ is the matrix-multiplication exponent: the infimum of $\\alpha$ such that two $n \\times n$ matrices can be multiplied in $O(n^\\alpha)$ field operations. Currently $2 \\leq \\omega < 2.371552$ (Williams-Xu-Xu-Zhou 2024); $\\omega = 2$ is unknown."
+    }
+  ],
+  "overview": {
+    "historicalContext": "Walter Keller-Gehrig (1985) introduced the first $O(n^\\omega)$ algorithm for computing the characteristic polynomial of an $n \\times n$ matrix, where $\\omega < 3$ is the matrix-multiplication exponent. The algorithm replaces the $n$ matrix-vector products of the naive Krylov method (each $O(n^2)$) with $\\lceil \\log_2 n \\rceil$ matrix-matrix products (each $O(n^\\omega)$), exploiting the algebraic identity $M^{2k} = (M^k)^2$ to amortise the cost of producing high powers of $M$.\n\nThe asymptotic gain is structural: $n$ cheap steps become $\\log n$ expensive steps. With Strassen's $\\omega \\approx 2.807$ (1969), the algorithm beats the cubic Krylov method around $n \\approx 256$; with the modern $\\omega \\approx 2.37$ (Coppersmith-Winograd 1990, Williams 2012, Le Gall 2014, Alman-Williams 2021, Williams-Xu-Xu-Zhou 2024), it dominates from $n \\approx 64$.\n\nGiesbrecht (1995) and Storjohann (2000) refined Keller-Gehrig's $O(n^\\omega \\log n)$ to a sharp $O(n^\\omega)$ — a result Storjohann's thesis extended to a full theory of $O(n^\\omega)$ canonical-form algorithms (Hermite, Smith, Frobenius). Modern computer algebra systems implement these algorithms for exact linear algebra over $\\mathbb{Q}$ and number fields.\n\nFormalising Keller-Gehrig in Lean 4 is interesting precisely because the speed-up is structural: the same algebraic objects (Krylov sequence, annihilating polynomial) appear in both the naive $O(n^3)$ and the subcubic regimes. The structural and correctness content survives the regime change; only the quantitative complexity claim depends on infrastructure Mathlib does not yet have.",
+    "problemStatement": "Can the $O(n^\\omega)$ Keller-Gehrig algorithm (1985) for the characteristic polynomial be formalised in Lean 4 over Mathlib, extending the naive $O(n^3)$ Krylov framework (cayley-hamilton-minpoly-oq-03) to subcubic complexity?",
+    "proofStrategy": "Three-layer decomposition:\n\n1. **Structural layer (Layer 1).** Define the squared-Krylov sequence $T_k := M^{2^k}$ by repeated squaring and prove the bridge $T_k = M^{2^k}$. Single-rewrite induction with `congr 1 + ring` discharges the exponent identity $2^k + 2^k = 2^{k+1}$.\n\n2. **Correctness layer (Layer 2).** Show that every matrix power $M^j$ is the product of squared-Krylov matrices indexed by the set bits of $j$: $M^j = \\prod_{i \\in \\mathrm{bitIndices}(j)} T_i$. The proof is three rewrites against Layer 1, an elementary commuting-powers helper, and Mathlib's `Nat.twoPowSum_bitIndices`. Vector-level corollaries bridge into the OQ-03 matvec ladder.\n\n3. **Quantitative bound (Layer 2.5).** Bound the number of squared-Krylov factors: $\\mathrm{popcount}(j) \\leq j$, the matrix-multiplication factor count for assembling $M^j$.\n\n4. **Complexity layer (Layer 3, axiomatized).** Mathlib has no complexity monad and no fast matrix multiplication, so any *quantitative* operation count requires axiomatic input. We declare the matrix-multiplication exponent $\\omega$ as an opaque axiom carrying its known bounds $2 \\leq \\omega < 3$, deferring the full operation-count theorem to a future Mathlib upgrade.",
+    "keyInsights": [
+      "**Structural vs quantitative speed-up.** The Keller-Gehrig gain is *structural*: the same algebraic object (powers of $M$) is rearranged so $\\log n$ matrix-matrix multiplications cover what $n$ matrix-vector products would. The structural rearrangement (Layer 1) and the correctness bridge (Layer 2) formalise today; the quantitative gain (Layer 3) cannot, until Mathlib grows a complexity framework.",
+      "**Binary expansion as the algorithmic skeleton.** Mathlib's `Nat.bitIndices` (Peter Nelson, 2024) plus `Nat.twoPowSum_bitIndices` (binary expansion identity $\\sum_{i \\in \\mathrm{bitIndices}(j)} 2^i = j$) reduce Layer 2 to three rewrites. The Keller-Gehrig outer loop is exactly the binary expansion of $j$: $\\lceil \\log_2 j \\rceil$ squarings produce $T_0, \\ldots, T_{k-1}$, and $\\mathrm{popcount}(j)$ multiplications then yield $M^j$.",
+      "**Powers of a single matrix commute.** The list product collapse $\\prod_i M^{f(i)} = M^{\\sum_i f(i)}$ is the only commutativity needed — far weaker than commutativity of the matrix ring. This is the reason the proof factors so cleanly through scalar-arithmetic identities.",
+      "**The minimum honest commitment to Layer 3.** Mathlib has no operation-counting framework, so any $O(n^\\omega)$ statement is necessarily axiomatic in current Mathlib. The right shape is: name $\\omega$, state its known bounds ($2 \\leq \\omega < 3$), and defer the operation-count predicate to a future complexity-monad PR. This commits to the bare minimum that a future complexity layer would need.",
+      "**Numerical breakeven puts the asymptotic claim in perspective.** At $n = 64$, naive Krylov (262,144 ops) beats Strassen-Keller-Gehrig (388,906 ops) by 1.5×; Strassen needs $n \\geq 256$ to win. Coppersmith-Winograd-Williams ($\\omega = 2.37$) wins at $n \\approx 64$. The asymptotic claim is real but the constant is large — Mathlib's `Matrix.mul` choosing the naive cubic algorithm is a defensible default.",
+      "**OQ-03 provides 90% of the algebraic infrastructure.** The Krylov recurrence, annihilator theory, and iteration bound from the parent entry transfer directly. The squared-Krylov sequence is a new *organisation* of the Krylov ladder, not a new theory."
+    ],
+    "prerequisites": [
+      "Linear algebra over a field (matrices, matrix multiplication, matrix powers)",
+      "Minimal and characteristic polynomial theory",
+      "Krylov sequences and the naive O(n³) Krylov method (cayley-hamilton-minpoly-oq-03)",
+      "Binary representations of natural numbers (`Nat.bitIndices`, `Nat.twoPowSum_bitIndices`)"
+    ]
+  },
+  "conclusion": {
+    "summary": "Formalises Layers 1, 2, and 2.5 of the Keller-Gehrig (1985) $O(n^\\omega)$ characteristic-polynomial algorithm in 333 lines of Lean 4 over Mathlib, with 11 theorems and 0 sorries. The squared-Krylov sequence $T_k := M^{2^k}$ is defined by repeated squaring; the correctness bridge $M^j = \\prod_{i \\in \\mathrm{bitIndices}(j)} T_i$ is proved via Mathlib's `Nat.twoPowSum_bitIndices`. The matrix-multiplication exponent $\\omega$ is declared as an axiomatic placeholder (Layer 3) carrying its known bounds $2 \\leq \\omega < 3$ (Strassen 1969). The full $O(n^\\omega)$ operation-count theorem is deferred pending Mathlib growing a complexity monad and a fast-matmul oracle.",
+    "implications": "The formalisation puts a stake in the ground: *here is the proof that the asymptotic Keller-Gehrig gain is structural, modulo a complexity oracle.* A future Mathlib complexity-monad PR would slot in without rewriting the linear-algebra core — the operation-count predicate would only need to be defined and connected to `omegaMM`; no axiom in this file would need revising.\n\nThe entry also demonstrates a clean separation between (a) Lean-formalisable structural mathematics, (b) Lean-formalisable elementary quantitative bounds (popcount), and (c) genuinely axiomatic mathematical constants (ω). The first two are proved unconditionally; the third is the minimum honest commitment Layer 3 admits today.",
+    "openQuestions": [
+      "Can a Mathlib complexity-monad framework (cost-passing, free-monad-of-arithmetic-ops, or external operation-counter predicate) be designed so that the full Keller-Gehrig operation-count theorem becomes statable in Lean?",
+      "Can the sharper popcount bound `popcount(j) ≤ Nat.size(j) ≈ ⌈log₂(j+1)⌉` be formalised once the appropriate Mathlib `Nat.bitIndices` length API is identified? This would replace the elementary `popcount(j) ≤ j` bound with the asymptotically correct form.",
+      "Can Giesbrecht (1995) and Storjohann (2000)'s $O(n^\\omega)$ refinement (removing the $\\log n$ factor of Keller-Gehrig's original) be formalised on top of this entry?",
+      "Can Strassen's algorithm itself be formalised as an `O(n^{\\log_2 7})` upper bound, replacing the `omegaMM_lt_three` axiom with a constructive witness?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-03",
+      "relationship": "parent",
+      "description": "OQ-03 formalises the naive $O(n^3)$ Krylov method (12 theorems, 0 sorries). This entry extends the same algebraic infrastructure to the subcubic regime: the Krylov sequence, annihilator theory, and iteration bound all carry over; only the *organisation* of matrix multiplications changes."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly-oq-03-oq-01",
+      "relationship": "sibling",
+      "description": "OQ-03-OQ-01 formalises the vector minimal polynomial $\\mu_{M,v}$ — the algebraic foundation for Wiedemann's sparse-matrix algorithm. Both siblings extend OQ-03 in orthogonal directions: this entry pursues asymptotic complexity, while OQ-03-OQ-01 pursues vector-specific minimality."
+    },
+    {
+      "targetId": "cayley-hamilton-minpoly",
+      "relationship": "foundational",
+      "description": "Parent formalisation establishing minimal polynomial reduction and annihilator theory."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Keller-Gehrig, Walter",
+      "title": "Fast algorithms for the characteristic polynomial",
+      "year": "1985",
+      "venue": "Theoretical Computer Science, vol. 36, pp. 309-317",
+      "note": "The original $O(n^\\omega)$ algorithm for the characteristic polynomial via blocked Krylov methods."
+    },
+    {
+      "authors": "Strassen, Volker",
+      "title": "Gaussian elimination is not optimal",
+      "year": "1969",
+      "venue": "Numerische Mathematik, vol. 13, pp. 354-356",
+      "note": "First sub-cubic matrix-multiplication algorithm: $O(n^{\\log_2 7}) \\approx O(n^{2.807})$, the source of the `omegaMM_lt_three` axiom bound."
+    },
+    {
+      "authors": "Giesbrecht, Mark",
+      "title": "Nearly optimal algorithms for canonical matrix forms",
+      "year": "1995",
+      "venue": "SIAM Journal on Computing, vol. 24, pp. 948-969",
+      "note": "Refined Keller-Gehrig's $O(n^\\omega \\log n)$ to a sharp $O(n^\\omega)$ for the characteristic polynomial and canonical forms."
+    },
+    {
+      "authors": "Storjohann, Arne",
+      "title": "Algorithms for matrix canonical forms",
+      "year": "2000",
+      "venue": "PhD thesis, ETH Zürich",
+      "note": "Comprehensive thesis on $O(n^\\omega)$ algorithms for canonical forms (Hermite, Smith, Frobenius), generalising Keller-Gehrig's approach."
+    },
+    {
+      "authors": "Williams, Virginia Vassilevska; Xu, Yinzhan; Xu, Zixuan; Zhou, Renfei",
+      "title": "New bounds for matrix multiplication: from alpha to omega",
+      "year": "2024",
+      "venue": "Proceedings of SODA 2024, pp. 3792-3835",
+      "note": "Current best bound: $\\omega < 2.371552$, the modern incarnation of the Coppersmith-Winograd line of work."
+    },
+    {
+      "authors": "von zur Gathen, Joachim; Gerhard, Jürgen",
+      "title": "Modern Computer Algebra",
+      "year": "2013",
+      "venue": "Cambridge University Press, 3rd edition, §12.3",
+      "note": "Textbook exposition of Keller-Gehrig and its derivatives in the broader context of fast linear algebra."
+    },
+    {
+      "authors": "Nelson, Peter",
+      "title": "Mathlib: Data.Nat.BitIndices",
+      "year": "2024",
+      "venue": "Mathlib4 source: Mathlib.Data.Nat.BitIndices",
+      "note": "Provides `Nat.bitIndices` and `Nat.twoPowSum_bitIndices`, the binary-expansion infrastructure that reduces the Layer 2 correctness bridge to three rewrites."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

S6 promotes Layers 1 + 2 + 2.5 + axiomatized Layer 3 of the Keller-Gehrig (1985) O(n^ω) characteristic-polynomial formalization into the public gallery as an **axiomatized** entry.

- `src/data/proofs/cayley-hamilton-minpoly-oq-03-oq-02/meta.json` (new): `status: axiomatized`, `badge: axiom`, `axiomCount: 3`, `theoremCount: 11`, `definitionCount: 2`, `lineCount: 333`, with 5 sections covering the layer decomposition and 7 references (Keller-Gehrig 1985, Strassen 1969, Giesbrecht 1995, Storjohann 2000, Williams-Xu-Xu-Zhou 2024, von zur Gathen & Gerhard, Mathlib BitIndices).
- `research/problems/.../state.md`: S6 ACT shipped — problem ready to mark completed.
- `research/problems/.../sessions/2026-06-06-iter6-s6-gallery-promotion.md` (new): session note.

The Lean file (`proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean`, 333 LOC) was already build-verified at S5 by researcher-1 (2026-06-05); this PR is metadata-only.

## What is exposed

- **Layer 1 (structural)**: squared-Krylov sequence `T_k := M^(2^k)` by repeated squaring; bridge `T_k = M^(2^k)`.
- **Layer 2 (correctness, matrix-level)**: `M^j = ∏_{i ∈ bitIndices j} T_i` via `Nat.twoPowSum_bitIndices`.
- **Layer 2 (vector-level)**: `(squareKrylovProd M j).mulVec v = (M^j).mulVec v`; Krylov-vector reachability.
- **Layer 2.5**: matrix-multiplication factor-count bound `popcount(j) ≤ j`.
- **Layer 3 (axiomatized)**: three axioms declaring the matrix-multiplication exponent ω with its known bounds `2 ≤ ω < 3` (Strassen 1969).

## Axiom integrity

Per CLAUDE.md axiom-integrity policy: `assumptions` field enumerates all three axioms (`omegaMM`, `omegaMM_two_le`, `omegaMM_lt_three`) with their mathematical justifications. Status is `axiomatized` (not `verified` or `conditional`). The full `O(n^ω)` operation-count theorem is explicitly deferred pending Mathlib growing a complexity-monad framework and a fast-matmul oracle — neither exists today.

## Build verification

- `python3 -c "import json; json.load(...)"` — valid JSON.
- `pnpm annotations:build` — no errors for this entry.
- `pnpm research:build` — entry registered in `listings.json` (status: axiomatized, badge: axiom, sorries: 0, annotationCount: 0) and `data-manifest.json` (meta: 419c79cf).

## Test plan

- [ ] Inspect `meta.json` for schema fidelity vs sibling OQ-03-OQ-01.
- [ ] Verify `pnpm build` succeeds with the new entry.
- [ ] Spot-check gallery render of `/proofs/cayley-hamilton-minpoly-oq-03-oq-02` post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)