### PR TITLE
audit(inverse-galois): tracker bump — clean (8th audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11950,9 +11950,9 @@
       "result": "clean"
     },
     "inverse-galois": {
-      "auditCount": 7,
+      "auditCount": 8,
       "issues": [],
-      "lastAudited": "2026-05-03T15:04:09Z",
+      "lastAudited": "2026-06-06T18:03:26Z",
       "result": "clean"
     },
     "inverse-galois-oq-01": {


### PR DESCRIPTION
## Audit Summary

8th audit of the **Inverse Galois Problem** parent gallery entry. Result: **clean**.

### Verified claims match Lean source

- **axiomCount: 5** — 4 axioms in InverseGalois.lean (inverse_galois_problem_open_conjecture, abelian_realizable, shafarevich_theorem, symmetric_group_realizable) + 1 in InverseGaloisA5.lean (three_dvd_gal_card); all names match meta.json
- **sorries: 0** — all "sorry" matches are docstring references, not proof terms
- **status "axiomatized" / badge "axiom"** — correctly labels axiomatized statements (Shafarevich, Kronecker-Weber, Hilbert irreducibility, Dedekind)
- No True stubs, no structure-encoded assumptions
- All 7 listed Lean files exist with expected sorry/axiom counts

### Note

Minor stale descriptive line counts (description says 5879 lines / 1882; actual 6131 / 1877). Not material to audit-critical fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)