### PR TITLE
Build arXiv puller script for 1stProof first-batch problems

### DIFF
--- a/research/references/1stproof/README.md
+++ b/research/references/1stproof/README.md
@@ -1,0 +1,62 @@
+# 1stProof Benchmark — local cache
+
+This directory mirrors the **first-batch** problem statements from the
+[First Proof Project](https://1stproof.org/) so that downstream triage and
+`/lean` probes can operate from local files instead of re-fetching the upstream
+LaTeX on every run.
+
+This is a reference cache, **not** a gallery entry — no `proofs/`,
+`src/data/proofs/`, or `research/registry.json` changes are made by the puller.
+
+## Provenance
+
+| Field | Value |
+|-------|-------|
+| Landing page | <https://1stproof.org/first-batch.html> |
+| arXiv id | [2602.05192](https://arxiv.org/abs/2602.05192) |
+| LaTeX source | <https://github.com/1stproof/batch-1/blob/main/First_Proof.tex> |
+| Raw LaTeX | <https://raw.githubusercontent.com/1stproof/batch-1/main/First_Proof.tex> |
+| Last fetch (UTC date) | 2026-06-08 |
+
+The fetch date above is auto-updated by the puller only when the upstream
+LaTeX content actually changes (detected via SHA-256). A no-op re-run leaves
+the date as-is so the directory is fully idempotent.
+
+## Layout
+
+```
+research/references/1stproof/
+  README.md                       <- this file
+  first-batch/
+    first_proof.tex               <- cached upstream LaTeX (verbatim)
+    index.json                    <- {problems: [...]}
+    problems/
+      01-<slug>.md ... 10-<slug>.md
+```
+
+Each problem markdown file contains:
+- short title and area
+- a link back to the upstream source
+- the verbatim LaTeX statement (no transcription / rewording)
+
+## How to refresh
+
+```bash
+./scripts/research/pull-1stproof-first-batch.py
+```
+
+The script is safe to re-run. If the upstream LaTeX has not changed, the
+output is byte-identical to the previous run.
+
+To pin to a specific local copy of the `.tex` (e.g. for reproducibility):
+
+```bash
+./scripts/research/pull-1stproof-first-batch.py --source path/to/First_Proof.tex
+```
+
+## Scope
+
+This cache covers **only** problem-statement retrieval and storage. Triage,
+`/lean` probe orchestration, the June 2026 second-batch window, and any
+trial writeups are tracked separately in the parent issue
+(see the issue referenced in the PR that introduced this directory).

--- a/research/references/1stproof/first-batch/first_proof.tex
+++ b/research/references/1stproof/first-batch/first_proof.tex
@@ -1,0 +1,333 @@
+\documentclass[12pt]{article}
+\usepackage{fullpage}
+
+\usepackage[T1]{fontenc}
+\usepackage[utf8]{inputenc}
+\usepackage{lmodern}
+\usepackage{microtype}
+\usepackage{amsmath,amssymb}
+\usepackage{graphicx}
+\usepackage{booktabs}
+\usepackage{hyperref}
+\usepackage{url}
+\usepackage{color}
+\usepackage{xcolor}
+\usepackage{ulem}
+\usepackage{enumitem}
+\usepackage{marvosym}
+\usepackage{amsfonts}
+
+\usepackage{xcolor}
+
+
+
+\DeclareMathOperator{\vecop}{vec}
+\DeclareMathOperator{\diag}{diag}
+\DeclareMathAlphabet{\catsymbfont}{U}{rsfs}{m}{n}
+\newcommand{\aA}{{\catsymbfont{A}}}
+
+\newcommand{\bR}{\mathbb{R}}
+\newcommand{\co}{\colon}
+\newcommand{\scrS}{\mathscr{S}}
+\newcommand{\aO}{{\catsymbfont{O}}}
+
+
+\title{First Proof}
+\author{ Mohammed Abouzaid\footnote{\Letter\ Corresponding author, Email: abouzaid@stanford.edu}
+\\
+  \textit{Stanford University} 
+  \and
+Andrew J. Blumberg\\
+\textit{Columbia University} 
+\and
+    Martin Hairer \\
+\textit{EPFL and Imperial}
+\and
+Joe Kileel\\
+\textit{University of Texas at Austin}
+\and
+Tamara G. Kolda \\
+\textit{MathSci.ai}
+\and
+Paul D. Nelson\\
+\textit{Aarhus University}
+\and
+Daniel Spielman \\
+\textit{Yale University}
+\and 
+Nikhil Srivastava\footnote{\Letter\ Corresponding author, Email: nikhil@math.berkeley.edu}
+\\
+\textit{University of California, Berkeley}
+\and 
+Rachel Ward\footnote{\Letter\ Corresponding author, Email: rward@math.utexas.edu} \\
+\textit{University of Texas at Austin}
+\and
+Shmuel Weinberger\\
+\textit{University of Chicago}
+\and
+Lauren Williams\footnote{\Letter\ Corresponding author, Email: williams@math.harvard.edu} \\
+\textit{Harvard University}
+}
+\date{\today}
+\begin{document}
+\maketitle
+
+\begin{abstract}
+To assess the ability of current AI systems to correctly answer research-level mathematics questions, we share a set of  ten math questions which have arisen naturally in the research process of the authors.  The questions had not been shared publicly  until now; the answers are known to the authors of the questions but will remain encrypted for a short time.
+\end{abstract}
+
+\newpage 
+
+\section{Introduction}
+
+In baking, the {\it first proof}, or bulk fermentation process, is a crucial step in which one lets the entire batch of dough ferment as one mass, before dividing and shaping it into loaves.  
+  
+This manuscript represents our preliminary efforts to come up with an objective and realistic methodology for assessing the capabilities of AI systems to autonomously solve research-level math questions. After letting these ideas ferment in the community, we hope to be able to produce a more structured benchmark in a few months.
+
+
+One of our primary goals is to develop a sophisticated understanding of the role that AI tools could play in the workflow of professional mathematicians.  While commercial AI systems are undoubtedly already at a level where they are useful tools for mathematicians\footnote{For instance, mathematicians are using AI tools to do literature searches, check manuscripts for  errors, write computer code, and bounce ideas.}, {\bf it is not yet clear where AI systems stand at solving research-level math questions on their own, without an expert in the loop}.  At the moment, most math benchmarks assess the performance of AI systems on math contest questions, an artificial domain that does not reflect the practice of creative mathematics by researchers.  
+
+Evaluation of research capabilities is a challenging task.  As frontier AI systems are now highly capable of searching the literature and translating mathematical questions from one format to another, it is challenging to disentangle problem-solving capabilities from search capabilities when conducting such an assessment.   Our core observation is that an ideal test should involve {\bf research math questions which arose naturally in the process of a mathematician's own research, were subsequently solved by the mathematician, but have not yet been posted to the internet.}  
+
+Towards this end, we present a diverse set of 10 research-level math questions, drawn from the mathematical fields of  algebraic combinatorics, spectral graph theory, algebraic topology, stochastic analysis, symplectic geometry, representation theory, lattices in Lie groups, tensor analysis, and numerical linear algebra, each of which came about naturally in the research process for one of the authors (sometimes together with collaborators).  Each question has been solved by the author(s) of the question with a proof that is roughly five pages or less,  but the answers are not yet posted to the internet.  The page restriction is due to the technical limitations of current publicly available AI systems, and this means that many of the questions on our list are not of sufficient importance to qualify as publishable research on their own, but are smaller components in future publications.
+
+Most of the questions that we have collected are extracted from lemmas arising in larger works whose main results go beyond what current systems are capable of tackling. Significant effort is required to identify such lemmas as crucial steps in these works.   
+
+Before explaining the nature of our evaluation, we will try to be clear about {\bf what math research is}.  Contrary to the popular conception that research is only about finding solutions to well-specified, age-old problems (e.g., Fermat's Last Theorem), most of the important parts of modern research involve  
+figuring out what the question actually is  
+and  
+developing frameworks within which it can be answered.   
+Perelman's proof of the Poincaré conjecture was a stunning achievement.  But in order for it to be possible, Thurston had to develop a new way of thinking about geometric objects and Hamilton had to invent a new kind of dynamics explaining how such objects change.
+
+
+Our `first proof' experiment is focused on the final and most well-specified
+stage of math research, in which the question and frameworks are already
+understood. We do not address the selection of questions to study, the formulation of new definitions, and the development of novel theories. 
+We wish to be clear that our choice of emphasis on proving well-formed statements is
+driven by the judgment that this is a first step; evaluation of the performance
+of frontier systems on the higher-level research tasks above is also essential.
+
+
+
+
+The answers to our set of ten research level math questions have been encrypted and posted to 
+\url{https://1stproof.org}.  
+The authors will release the answers on February 13, 2026. 
+{\bf We invite the community to experiment with our ten questions before the answers are released, and to share their results and observations online.} Ideally, participants should share a complete transcript of their interaction with an AI system. In this process, we hope to gain insight into questions such as: What is an appropriate prompting strategy? What format should an answer take and how should it be graded? Are there data contamination issues we have missed? 
+We hope to use this understanding to design a more formal benchmark. A few months later, we plan to finalize a second set of questions; 
+we are open to devising agreements to test 
+AI models
+on these questions prior to making them public.
+
+
+Unlike other proposed math research benchmarks (see Section~\ref{sec:related}), our question list should not be considered a benchmark in its current form.  For one, our questions are not numerous enough to be considered a benchmark.   By construction, producing research-level math questions with answers which have not yet been published, and whose answers are a certain length, requires substantial human effort. A typical mathematician might create and address 
+a few such questions a year. Additionally,
+we have not specified a formal grading scheme for answers. While we have found correct answers to each of the questions, correct answers are not always  unique ---  there may be  multiple proofs or, alternatively, multiple counterexamples. 
+This makes assessment more challenging, as it must at present be done by a human expert. 
+
+
+
+Compared to previous assessments of AI systems in completing tasks related to mathematical research (discussed in Section~\ref{sec:related} below), to the best of our knowledge, ours is the first  to simultaneously have all of the following features:
+\begin{itemize}[noitemsep]
+    \item The questions are sampled from the true distribution of questions that mathematicians are currently working on. Their answers are proofs, which at present must be graded by humans.
+    \item The answers have never appeared on the internet, in talks, or in any public forum. This eliminates a substantial data contamination problem.  
+    \item The questions are being made public in this document. This means they cannot be reused in the future, but they can be examined by everyone. 
+    \item We allow models unfettered access to outside resources such as Internet searches, bringing them closer to representing real-world assessments.
+\end{itemize}
+
+We ran 
+preliminary tests on many of our ten questions using GPT 5.2 Pro and Gemini 3.0 Deepthink; we briefly discuss our mitigation strategy for data contamination
+in Section~\ref{sec:implementation}.  Our tests indicate that ---  when the system is given one shot to produce the answer --- the best publicly available AI systems struggle to answer many of our questions.  
+In the interest of following a clear protocol, 
+we chose not to iteratively interact with the systems, or even re-run the queries.
+However, we expect that through such interactions we would 
+be able 
+to coax the systems to produce better answers. \\
+
+
+
+\noindent {\bf Conflicts of interest.} 
+No funding was received for the design or implementation of this
+project. None of the authors of this report was employed by or consulted with
+AI companies during the project, nor will they do so while contributing to it.\\
+
+\noindent {\bf Acknowledgment.} We thank the Simons Institute for the Theory of Computing for hosting the organizational meeting of this project in early December 2025, with support from the Director's Opportunity Fund.  PN is supported by a research grant (VIL54509) from VILLUM FONDEN.  This statement reflects author support and does not imply sponsor involvement in the benchmark.
+
+
+\section{The questions}\label{sec:problems}
+
+\begin{enumerate}
+\item Let $\mathbb{T}^3$ be the three dimensional unit size torus and let $\mu$ be the $\Phi^4_3$ measure on the space of distributions $\mathcal{D}'(\mathbb{T}^3)$. Let $\psi : \mathbb{T}^3 \to \mathbb{R}$ be a smooth function that is not identically zero and let $T_\psi : \mathcal{D}'(\mathbb{T}^3) \to \mathcal{D}'(\mathbb{T}^3)$ be the shift map given by $T_\psi(u) = u + \psi$ (with the usual identification of smooth functions as distributions). Are the measures $\mu$ and $T_\psi^* \mu$ equivalent? Here, equivalence of measures is in the sense of having the same null sets and $T_\psi^*$ denotes the pushforward under $T_\psi$.
+
+\item Let \(F\) be a non-archimedean local field with ring of integers \(\mathfrak o\).  Let $N_r$ denote the subgroup of $\mathrm{GL}_{r}(F)$ consisting of upper-triangular unipotent elements.  Let \(\psi:F\to \mathbb C^\times\) be a nontrivial additive character of conductor \(\mathfrak o\), identified in the standard way with a generic character of $N_r$.
+Let \(\Pi\) be a generic irreducible admissible representation of \(\mathrm{GL}_{n + 1}(F)\), realized in its \(\psi^{-1}\)-Whittaker model \(\mathcal W(\Pi,\psi^{-1})\).  Must there exist \(W\in \mathcal W(\Pi,\psi^{-1})\) with the following property?
+
+Let $\pi$ be a generic irreducible admissible representation of \(\mathrm{GL}_{n}(F)\), realized in its $\psi$-Whittaker model \(\mathcal W(\pi,\psi)\).  Let $\mathfrak{q}$ denote the conductor ideal of $\pi$, let \(Q\in F^\times\) be a generator of \(\mathfrak q^{-1}\), and set
+\[
+  u_Q := I_{n+1} + Q\,E_{n,n+1} \in \mathrm{GL}_{n + 1}(F),
+\]
+where \(E_{i, j}\) is the matrix with a \(1\) in the \((i, j)\)-entry and \(0\) elsewhere.  For some \(V\in \mathcal W(\pi,\psi)\), the local Rankin--Selberg integral
+\[
+  \int_{N_n\backslash \mathrm{GL}_{n}(F)} W(\operatorname{diag}(g,1) u_Q)\,V(g)\,|\det g|^{s-\frac12}\,dg
+\]
+is finite and nonzero for all \(s\in\mathbb C\).
+
+\item Let $\lambda=(\lambda_1 > \dots > \lambda_n \geq 0)$ be a partition with distinct parts.  Assume moreover that
+$\lambda$ is {\it restricted}, in the sense that it has a unique part of size $0$ and no part of size $1$.
+Does there exist a nontrivial Markov chain on $S_n(\lambda)$ whose stationary distribution is given by
+$$\frac{F^*_{\mu}(x_1,\dots,x_n; q=1,t)}{P^*_{\lambda}(x_1,\dots,x_n;
+q=1,t)} \text{ for }\mu\in S_n(\lambda)$$
+where $F^*_{\mu}(x_1,\dots,x_n; q,t)$ and
+$P^*_{\lambda}(x_1,\dots,x_n;q,t)$ are the
+interpolation ASEP polynomial and interpolation Macdonald polynomial,
+respectively?  If so, prove that the Markov chain you construct has the
+desired stationary distribution.  By ``nontrivial'' we mean that the
+transition probabilities of the Markov chain should not be described
+using the polynomials $F_{\mu}^*(x_1,\dots,x_n; q,t)$. 
+
+\item Let $p(x)$ and $q(x)$ be two monic polynomials of degree $n$:
+\[
+p(x) = \sum_{k=0}^n a_k x^{n-k} \quad \text{and} \quad q(x) = \sum_{k=0}^n
+b_k x^{n-k}
+\]
+where $a_0 = b_0 = 1$. Define $p \boxplus_n q(x)$ to be the polynomial
+\[
+(p \boxplus_n q)(x) = \sum_{k=0}^n c_k x^{n-k}
+\]
+where the coefficients $c_k$ are given by the formula:
+\[
+c_k = \sum_{i+j=k} \frac{(n-i)! (n-j)!}{n! (n-k)!} a_i b_j
+\]
+for $k = 0, 1, \dots, n$.
+For a monic polynomial $p(x)=\prod_{i\le n}(x- \lambda_i)$, define 
+$$\Phi_n(p):=\sum_{i\le n}(\sum_{j\neq i} \frac1{\lambda_i-\lambda_j})^2$$ and $\Phi_n(p):=\infty$ if $p$ has a multiple root.
+Is it true that if $p(x)$ and $q(x)$ are monic real-rooted polynomials of
+degree $n$, then
+$$\frac1{\Phi_n(p\boxplus_n q)} \ge \frac1{\Phi_n(p)}+\frac1{\Phi_n(q)}?$$
+
+\item Fix a finite group $G$.  Let $\aO$ denote an incomplete transfer
+system associated to an $N_\infty$ operad.  Define the slice
+filtration on the $G$-equivariant stable category adapted to $\aO$ and
+state and prove a characterization of the $\aO$-slice connectivity of
+a connective $G$-spectrum in terms of the geometric fixed points.
+
+\item For a graph $G = (V, E)$, let $G_S = (V, E(S,S))$ denote the graph with the same vertex set, 
+but only the edges between vertices in $S$. Let $L$ be the Laplacian matrix of $G$ and let $L_S$ be the Laplacian of $G_S$. 
+I say that a set of vertices $S$ is $\epsilon$-light if the matrix $\epsilon L - L_S$ is positive semidefinite. 
+Does there exist a constant $c > 0$ so that for every graph $G$ and every $\epsilon$ between $0$ and $1$, $V$ contains an $\epsilon$-light subset $S$ of size at least $c \epsilon |V|$? 
+
+\item Suppose that $\Gamma$ is a uniform lattice in a real semi-simple group, and that $\Gamma$ contains some 2-torsion. Is it possible for $\Gamma$ to be the fundamental group of a compact manifold without boundary whose universal cover is acyclic over the rational numbers $\mathbb{Q}$?
+
+\item   A polyhedral Lagrangian surface $K$ in $\bR^4$ is a finite polyhedral complex all of whose faces are Lagrangians, and which is a topological submanifold of $\bR^4$. A Lagrangian smoothing of $K$ is a Hamiltonian isotopy $K_t$ of smooth Lagrangian submanifolds, parameterised by $(0,1]$, extending to a topological isotopy, parametrised by $[0,1]$, with endpoint $K_0 = K$.
+
+
+Let $K$ be a polyhedral Lagrangian surface with the property that exactly $4$ faces meet at every vertex. Does $K$ necessarily have a Lagrangian smoothing? 
+
+\item Let $n \geq 5$.  
+Let $A^{(1)}, \ldots, A^{(n)} \in \mathbb{R}^{3 \times 4}$ be Zariski-generic.   
+For $\alpha, \beta, \gamma, \delta \in [n]$, construct $Q^{(\alpha \beta \gamma \delta)} \in \mathbb{R}^{3 \times 3 \times 3 \times 3}$ so that its $(i, j, k, \ell)$ entry for $1 \leq i, j, k, \ell \leq 3$ is given by $Q^{(\alpha \beta \gamma \delta)}_{i j k \ell} = \det [A^{(\alpha)}(i, :); A^{(\beta)}(j, :); A^{(\gamma)}(k, :); A^{(\delta)}(\ell, :)]$.
+Here $A(i, :)$ denotes the $i$th row of a matrix $A$, and semicolon denotes vertical concatenation. 
+We are interested in algebraic relations on the set of tensors $\{Q^{(\alpha \beta \gamma \delta)} : \alpha, \beta, \gamma, \delta \in [n] \}$.
+
+More precisely, does there exist a polynomial map $\mathbf{F}: \mathbb{R}^{81n^4} \rightarrow \mathbb{R}^N$ that satisfies the following three properties?
+\smallskip
+\begin{itemize}\setlength\itemsep{0.5em}
+\item The map $\mathbf{F}$ does not depend on $A^{(1)}, \ldots A^{(n)}$. 
+\item The degrees of the coordinate functions of $\mathbf{F}$ do not depend on $n$.
+\item Let $\lambda \in \mathbb{R}^{n \times n \times n \times n}$ satisfy 
+$\lambda_{\alpha \beta \gamma \delta} \neq 0$ for precisely $\alpha, \beta, \gamma, \delta \in [n]$ that are not identical.  Then $\mathbf{F}(\lambda_{\alpha \beta \gamma \delta} Q^{(\alpha \beta \gamma \delta)} : \alpha, \beta, \gamma, \delta \in [n]) = 0$ holds if and only if there exist $u, v, w, x \in (\mathbb{R}^*)^n$ such that $\lambda_{\alpha \beta \gamma \delta} = u_{\alpha} v_{\beta} w_{\gamma} x_{\delta}$ for all $\alpha, \beta, \gamma, \delta \in [n]$ that are not identical. 
+\end{itemize}
+
+\item Given a $d$-way tensor $\mathcal{T} \in \mathbb{R}^{n_1 \times n_2 \times \cdots \times n_d}$ 
+such that the data is unaligned (meaning the tensor $\mathcal{T}$ has missing entries),
+we consider the problem of computing a CP decomposition of rank $r$ where some modes are infinite-dimensional and constrained to be in a Reproducing Kernel Hilbert Space (RKHS). 
+We want to solve this using an alternating optimization approach, and our question is focused on the mode-$k$ subproblem for an infinite-dimensional mode. 
+For the subproblem, then CP factor matrices 
+$A_1, \dots, A_{k-1}, A_{k+1}, \dots, A_d$ are fixed, and we are solving for $A_k$.
+
+Our notation is as follows.
+Let $N = \prod_i n_i$ denote the product of all sizes.
+Let $n \equiv n_k$ be the size of mode $k$, let
+$M = \prod_{i\neq k} n_i$ be the product of all dimensions except $k$, and assume $n \ll M$.
+Since the data are unaligned, this means only a subset of $\mathcal{T}$'s entries are observed, and we let $q \ll N$ denote the number of observed entries.
+We let $T \in \mathbb{R}^{n \times M}$ denote the mode-$k$ unfolding of the tensor $\mathcal{T}$ with all missing entries set to zero.
+The $\vecop$ operations creates a vector from a matrix by stacking its columns,
+and we let $S \in \mathbb{R}^{N \times q}$ denote the selection matrix (a subset of the $N \times N$ identity matrix) such that $S^T \vecop(T)$ selects the $q$ known entries of the tensor $\mathcal{T}$ from the vectorization of its mode-$k$ unfolding.
+We let $Z = A_d \odot \cdots \odot A_{k+1} \odot A_{k-1} \odot \cdots \odot A_1 \in \mathbb{R}^{M \times r}$ be the Khatri-Rao product of the factor matrices corresponding to all modes except mode $k$.
+We let $B = TZ$ denote the MTTKRP of the tensor $\mathcal{T}$ and Khatri-Rao product $Z$.
+
+We assume $A_k = KW$ where
+$K \in \mathbb{R}^{n \times n}$ denotes the psd RKHS kernel matrix for mode $k$.
+The matrix $W$ of size $n \times r$ is the unknown for which we must solve. 
+The system to be solved is
+\begin{equation} 
+	\left[
+    (Z \otimes K)^T S
+    S^T (Z \otimes K)
+    + \lambda (I_r \otimes K) 
+  \right] \vecop(W)
+	= (I_r \otimes K) 
+	\vecop( B ). \nonumber 
+\end{equation}
+Here, $I_r$ denotes the $r \times r$ identity matrix.
+This is a system of size $nr \times nr$
+Using a standard linear solver costs $O(n^3 r^3)$, 
+and explicitly forming the matrix is an additional expense.
+
+Explain how an iterative preconditioned conjugate gradient linear solver can be used to solve this problem more efficiently. Explain the method and choice of preconditioner. Explain in detail how the matrix-vector products are computed and why this works. Provide complexity analysis. 
+We assume $n,r < q \ll N$. Avoid any computation of order $N$.
+
+
+\end{enumerate}
+
+
+\section{Related work}\label{sec:related}
+
+As mentioned earlier, there have been several proposed math research benchmarks.  We discuss a few of them here.
+
+ FrontierMath \cite{frontier} is a benchmark of ``several hundred unpublished, expert-level mathematics problems that take specialists hours to days to solve.''  
+It was funded by OpenAI.  Presently, the FrontierMath problems are private
+(apart from 12 examples that are publicly available). OpenAI has access to a subset of FrontierMath problems  and solutions, and EpochAI has access to the full set of solutions. The FrontierMath problems are structured so that each final answer is an integer or symbolic expression, which makes them automatically gradable, as well as amenable to post-training via reinforcement learning. 
+
+IMProofBench \cite{schmitt2025improofbench} is a broader mathematical proof benchmark, designed to evaluate the ability of AI systems to create research-level mathematical proofs.  The problems are designed to allow for automatic grading of subquestions, but still require human experts to fully verify correctness. 
+ The IMProofBench questions are private. 
+
+The RealMath benchmark for research-level math questions \cite{zhang2025realmath} scrapes (i.e. collects papers automatically from)
+math and computer science categories in \href{https://arxiv.org}{arXiv.org}, skewing toward fields with ``constructive'' theorems like probability and statistics.  It only scrapes questions posted after the ``training data cutoff'' of the AI models being tested, where training data cutoff refers to the final date from which web data was collected and used for training data.  Like FrontierMath, the RealMath questions are designed to facilitate automatic grading, with a final short symbolic or numeric answer. Unlike FrontierMath and IMProofBench, the RealMath questions are public and intended to be refreshed every so often to avoid data contamination. 
+
+
+\section{Implementation details}\label{sec:implementation}
+
+Over the span of a few weeks, we tested roughly 20 research-level math questions using Gemini 3 Pro, GPT-5.1 Pro, and then GPT-5.2 Pro when GPT 5.2 Pro became available. The final selection of questions used the following criteria:
+  \begin{enumerate}[noitemsep]
+  \item Use of the AI system did not reveal the existence of a previous answer to the question that was unknown to the authors.
+  \item A one page statement was sufficient for the systems to ``understand'' the formulation of the question, i.e. it was able to reformulate the question in its own language before starting to answer it. 
+  \item Agreement was reached with the authors of the question to release a human generated proof within the required parameters (length and timeframe).
+ \item No member of the team contributed more than one problem.
+   \end{enumerate}
+The reason for testing more than 10 questions was to probe the ``boundary'' between the types of questions the models can solve and the types of questions beyond their reach.  To minimize data contamination, we turned off the option to share data for training and improving models, but we are aware that data is still retained for 3 days by Google, and 30 days by OpenAI\footnote{According to our reading of the OpenAI \href{https://help.openai.com/en/articles/8983778-chat-and-file-retention-policies-in-chatgpt}{Terms of Service}, a chat can be retained longer than 30 days if the chat has been de-identified and disassociated from the author.  According to our reading of the Gemini \href{https://support.google.com/gemini/answer/13594961}{Terms of Service}, chats reviewed by human reviewers may be retained for up to 3 years.}.  Throughout the process, we have endeavored  to keep the answers to our questions private. We have uploaded encrypted answers to the private repository,  
+\url{https://1stproof.org}.
+We will make the answers publicly available about a week 
+after we release the questions. 
+
+
+\section{Discussion}
+We have presented a set of ten research-level mathematics questions.  
+As mentioned earlier, mathematical research consists of multiple components, including:
+\begin{itemize} [noitemsep]
+\item creating and selecting the questions to study, which will guide and shape the field;
+\item developing novel theories for approaching these questions, including formalizing new definitions and frameworks;
+\item finding answers to the selected questions, and rigorously proving that these answers are correct.
+\end{itemize}
+Our `first proof' experiment is focused on the final, most well-specified, and most measurable stage of mathematical research, that is, finding answers to the selected questions. We do not address the  question of evaluating whether AI systems can reasonably create  questions to study, or develop novel theories. 
+
+We plan to create a second set of questions of the same nature as the ones in Section~\ref{sec:problems} in the coming months, and we are open to devising agreements to test frontier AI systems on the second set of questions before we release them.  We hope that this second set of questions can serve as a form of benchmark for testing the capabilities of AI. 
+
+Beyond the next release, depending on technological developments, we plan to release additional sets of questions by removing some of the artificial constraints we imposed on our chosen questions, such as length, as well as to explore ways of measuring performance along other aspects of the work of research mathematics.
+
+
+\bibliographystyle{plain}
+\bibliography{references}
+
+
+\end{document}

--- a/research/references/1stproof/first-batch/index.json
+++ b/research/references/1stproof/first-batch/index.json
@@ -1,0 +1,83 @@
+{
+  "source": {
+    "landing_page": "https://1stproof.org/first-batch.html",
+    "arxiv_id": "2602.05192",
+    "arxiv_abs_url": "https://arxiv.org/abs/2602.05192",
+    "github_blob_url": "https://github.com/1stproof/batch-1/blob/main/First_Proof.tex",
+    "raw_tex_url": "https://raw.githubusercontent.com/1stproof/batch-1/main/First_Proof.tex",
+    "fetch_date": "2026-06-08",
+    "source_sha256": "970602fcce08525d2b7580cfb0694252e2af26ba31b91c6aa3ae47e80de158a2"
+  },
+  "problems": [
+    {
+      "id": 1,
+      "slug": "phi43-shift-equivalence",
+      "area": "stochastic analysis",
+      "short_title": "Equivalence of shifted Phi^4_3 measures on T^3",
+      "statement_path": "first-batch/problems/01-phi43-shift-equivalence.md"
+    },
+    {
+      "id": 2,
+      "slug": "rankin-selberg-nonvanishing",
+      "area": "representation theory",
+      "short_title": "Nonvanishing local Rankin-Selberg integral on GL_{n+1}",
+      "statement_path": "first-batch/problems/02-rankin-selberg-nonvanishing.md"
+    },
+    {
+      "id": 3,
+      "slug": "interpolation-asep-markov-chain",
+      "area": "algebraic combinatorics",
+      "short_title": "Markov chain for interpolation ASEP / Macdonald ratio",
+      "statement_path": "first-batch/problems/03-interpolation-asep-markov-chain.md"
+    },
+    {
+      "id": 4,
+      "slug": "polynomial-convolution-phi-bound",
+      "area": "spectral graph theory",
+      "short_title": "Boxplus convolution and Phi_n bound for real-rooted polynomials",
+      "statement_path": "first-batch/problems/04-polynomial-convolution-phi-bound.md"
+    },
+    {
+      "id": 5,
+      "slug": "n-infty-slice-filtration",
+      "area": "algebraic topology",
+      "short_title": "O-slice filtration and geometric fixed-point connectivity",
+      "statement_path": "first-batch/problems/05-n-infty-slice-filtration.md"
+    },
+    {
+      "id": 6,
+      "slug": "epsilon-light-laplacian-subset",
+      "area": "spectral graph theory",
+      "short_title": "Existence of epsilon-light vertex subsets of size c*epsilon*|V|",
+      "statement_path": "first-batch/problems/06-epsilon-light-laplacian-subset.md"
+    },
+    {
+      "id": 7,
+      "slug": "uniform-lattice-rational-acyclic-cover",
+      "area": "lattices in Lie groups",
+      "short_title": "Uniform lattice with 2-torsion as pi_1 of Q-acyclic-cover manifold",
+      "statement_path": "first-batch/problems/07-uniform-lattice-rational-acyclic-cover.md"
+    },
+    {
+      "id": 8,
+      "slug": "polyhedral-lagrangian-smoothing",
+      "area": "symplectic geometry",
+      "short_title": "Lagrangian smoothing of 4-valent polyhedral Lagrangian surfaces",
+      "statement_path": "first-batch/problems/08-polyhedral-lagrangian-smoothing.md"
+    },
+    {
+      "id": 9,
+      "slug": "generic-3x4-determinant-tensor-relations",
+      "area": "tensor analysis",
+      "short_title": "Algebraic relations among 3x3x3x3 det-tensors of generic 3x4 matrices",
+      "statement_path": "first-batch/problems/09-generic-3x4-determinant-tensor-relations.md"
+    },
+    {
+      "id": 10,
+      "slug": "cp-rkhs-pcg-mode-subproblem",
+      "area": "numerical linear algebra",
+      "short_title": "Preconditioned CG for RKHS-constrained CP-decomposition mode subproblem",
+      "statement_path": "first-batch/problems/10-cp-rkhs-pcg-mode-subproblem.md"
+    }
+  ]
+}

--- a/research/references/1stproof/first-batch/problems/01-phi43-shift-equivalence.md
+++ b/research/references/1stproof/first-batch/problems/01-phi43-shift-equivalence.md
@@ -1,0 +1,11 @@
+# Problem 1: Equivalence of shifted Phi^4_3 measures on T^3
+
+- **Area:** stochastic analysis
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `phi43-shift-equivalence`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Let $\mathbb{T}^3$ be the three dimensional unit size torus and let $\mu$ be the $\Phi^4_3$ measure on the space of distributions $\mathcal{D}'(\mathbb{T}^3)$. Let $\psi : \mathbb{T}^3 \to \mathbb{R}$ be a smooth function that is not identically zero and let $T_\psi : \mathcal{D}'(\mathbb{T}^3) \to \mathcal{D}'(\mathbb{T}^3)$ be the shift map given by $T_\psi(u) = u + \psi$ (with the usual identification of smooth functions as distributions). Are the measures $\mu$ and $T_\psi^* \mu$ equivalent? Here, equivalence of measures is in the sense of having the same null sets and $T_\psi^*$ denotes the pushforward under $T_\psi$.
+```

--- a/research/references/1stproof/first-batch/problems/02-rankin-selberg-nonvanishing.md
+++ b/research/references/1stproof/first-batch/problems/02-rankin-selberg-nonvanishing.md
@@ -1,0 +1,22 @@
+# Problem 2: Nonvanishing local Rankin-Selberg integral on GL_{n+1}
+
+- **Area:** representation theory
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `rankin-selberg-nonvanishing`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Let \(F\) be a non-archimedean local field with ring of integers \(\mathfrak o\).  Let $N_r$ denote the subgroup of $\mathrm{GL}_{r}(F)$ consisting of upper-triangular unipotent elements.  Let \(\psi:F\to \mathbb C^\times\) be a nontrivial additive character of conductor \(\mathfrak o\), identified in the standard way with a generic character of $N_r$.
+Let \(\Pi\) be a generic irreducible admissible representation of \(\mathrm{GL}_{n + 1}(F)\), realized in its \(\psi^{-1}\)-Whittaker model \(\mathcal W(\Pi,\psi^{-1})\).  Must there exist \(W\in \mathcal W(\Pi,\psi^{-1})\) with the following property?
+
+Let $\pi$ be a generic irreducible admissible representation of \(\mathrm{GL}_{n}(F)\), realized in its $\psi$-Whittaker model \(\mathcal W(\pi,\psi)\).  Let $\mathfrak{q}$ denote the conductor ideal of $\pi$, let \(Q\in F^\times\) be a generator of \(\mathfrak q^{-1}\), and set
+\[
+  u_Q := I_{n+1} + Q\,E_{n,n+1} \in \mathrm{GL}_{n + 1}(F),
+\]
+where \(E_{i, j}\) is the matrix with a \(1\) in the \((i, j)\)-entry and \(0\) elsewhere.  For some \(V\in \mathcal W(\pi,\psi)\), the local Rankin--Selberg integral
+\[
+  \int_{N_n\backslash \mathrm{GL}_{n}(F)} W(\operatorname{diag}(g,1) u_Q)\,V(g)\,|\det g|^{s-\frac12}\,dg
+\]
+is finite and nonzero for all \(s\in\mathbb C\).
+```

--- a/research/references/1stproof/first-batch/problems/03-interpolation-asep-markov-chain.md
+++ b/research/references/1stproof/first-batch/problems/03-interpolation-asep-markov-chain.md
@@ -1,0 +1,22 @@
+# Problem 3: Markov chain for interpolation ASEP / Macdonald ratio
+
+- **Area:** algebraic combinatorics
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `interpolation-asep-markov-chain`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Let $\lambda=(\lambda_1 > \dots > \lambda_n \geq 0)$ be a partition with distinct parts.  Assume moreover that
+$\lambda$ is {\it restricted}, in the sense that it has a unique part of size $0$ and no part of size $1$.
+Does there exist a nontrivial Markov chain on $S_n(\lambda)$ whose stationary distribution is given by
+$$\frac{F^*_{\mu}(x_1,\dots,x_n; q=1,t)}{P^*_{\lambda}(x_1,\dots,x_n;
+q=1,t)} \text{ for }\mu\in S_n(\lambda)$$
+where $F^*_{\mu}(x_1,\dots,x_n; q,t)$ and
+$P^*_{\lambda}(x_1,\dots,x_n;q,t)$ are the
+interpolation ASEP polynomial and interpolation Macdonald polynomial,
+respectively?  If so, prove that the Markov chain you construct has the
+desired stationary distribution.  By ``nontrivial'' we mean that the
+transition probabilities of the Markov chain should not be described
+using the polynomials $F_{\mu}^*(x_1,\dots,x_n; q,t)$.
+```

--- a/research/references/1stproof/first-batch/problems/04-polynomial-convolution-phi-bound.md
+++ b/research/references/1stproof/first-batch/problems/04-polynomial-convolution-phi-bound.md
@@ -1,0 +1,29 @@
+# Problem 4: Boxplus convolution and Phi_n bound for real-rooted polynomials
+
+- **Area:** spectral graph theory
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `polynomial-convolution-phi-bound`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Let $p(x)$ and $q(x)$ be two monic polynomials of degree $n$:
+\[
+p(x) = \sum_{k=0}^n a_k x^{n-k} \quad \text{and} \quad q(x) = \sum_{k=0}^n
+b_k x^{n-k}
+\]
+where $a_0 = b_0 = 1$. Define $p \boxplus_n q(x)$ to be the polynomial
+\[
+(p \boxplus_n q)(x) = \sum_{k=0}^n c_k x^{n-k}
+\]
+where the coefficients $c_k$ are given by the formula:
+\[
+c_k = \sum_{i+j=k} \frac{(n-i)! (n-j)!}{n! (n-k)!} a_i b_j
+\]
+for $k = 0, 1, \dots, n$.
+For a monic polynomial $p(x)=\prod_{i\le n}(x- \lambda_i)$, define 
+$$\Phi_n(p):=\sum_{i\le n}(\sum_{j\neq i} \frac1{\lambda_i-\lambda_j})^2$$ and $\Phi_n(p):=\infty$ if $p$ has a multiple root.
+Is it true that if $p(x)$ and $q(x)$ are monic real-rooted polynomials of
+degree $n$, then
+$$\frac1{\Phi_n(p\boxplus_n q)} \ge \frac1{\Phi_n(p)}+\frac1{\Phi_n(q)}?$$
+```

--- a/research/references/1stproof/first-batch/problems/05-n-infty-slice-filtration.md
+++ b/research/references/1stproof/first-batch/problems/05-n-infty-slice-filtration.md
@@ -1,0 +1,15 @@
+# Problem 5: O-slice filtration and geometric fixed-point connectivity
+
+- **Area:** algebraic topology
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `n-infty-slice-filtration`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Fix a finite group $G$.  Let $\aO$ denote an incomplete transfer
+system associated to an $N_\infty$ operad.  Define the slice
+filtration on the $G$-equivariant stable category adapted to $\aO$ and
+state and prove a characterization of the $\aO$-slice connectivity of
+a connective $G$-spectrum in terms of the geometric fixed points.
+```

--- a/research/references/1stproof/first-batch/problems/06-epsilon-light-laplacian-subset.md
+++ b/research/references/1stproof/first-batch/problems/06-epsilon-light-laplacian-subset.md
@@ -1,0 +1,14 @@
+# Problem 6: Existence of epsilon-light vertex subsets of size c*epsilon*|V|
+
+- **Area:** spectral graph theory
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `epsilon-light-laplacian-subset`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+For a graph $G = (V, E)$, let $G_S = (V, E(S,S))$ denote the graph with the same vertex set, 
+but only the edges between vertices in $S$. Let $L$ be the Laplacian matrix of $G$ and let $L_S$ be the Laplacian of $G_S$. 
+I say that a set of vertices $S$ is $\epsilon$-light if the matrix $\epsilon L - L_S$ is positive semidefinite. 
+Does there exist a constant $c > 0$ so that for every graph $G$ and every $\epsilon$ between $0$ and $1$, $V$ contains an $\epsilon$-light subset $S$ of size at least $c \epsilon |V|$?
+```

--- a/research/references/1stproof/first-batch/problems/07-uniform-lattice-rational-acyclic-cover.md
+++ b/research/references/1stproof/first-batch/problems/07-uniform-lattice-rational-acyclic-cover.md
@@ -1,0 +1,11 @@
+# Problem 7: Uniform lattice with 2-torsion as pi_1 of Q-acyclic-cover manifold
+
+- **Area:** lattices in Lie groups
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `uniform-lattice-rational-acyclic-cover`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Suppose that $\Gamma$ is a uniform lattice in a real semi-simple group, and that $\Gamma$ contains some 2-torsion. Is it possible for $\Gamma$ to be the fundamental group of a compact manifold without boundary whose universal cover is acyclic over the rational numbers $\mathbb{Q}$?
+```

--- a/research/references/1stproof/first-batch/problems/08-polyhedral-lagrangian-smoothing.md
+++ b/research/references/1stproof/first-batch/problems/08-polyhedral-lagrangian-smoothing.md
@@ -1,0 +1,14 @@
+# Problem 8: Lagrangian smoothing of 4-valent polyhedral Lagrangian surfaces
+
+- **Area:** symplectic geometry
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `polyhedral-lagrangian-smoothing`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+A polyhedral Lagrangian surface $K$ in $\bR^4$ is a finite polyhedral complex all of whose faces are Lagrangians, and which is a topological submanifold of $\bR^4$. A Lagrangian smoothing of $K$ is a Hamiltonian isotopy $K_t$ of smooth Lagrangian submanifolds, parameterised by $(0,1]$, extending to a topological isotopy, parametrised by $[0,1]$, with endpoint $K_0 = K$.
+
+
+Let $K$ be a polyhedral Lagrangian surface with the property that exactly $4$ faces meet at every vertex. Does $K$ necessarily have a Lagrangian smoothing?
+```

--- a/research/references/1stproof/first-batch/problems/09-generic-3x4-determinant-tensor-relations.md
+++ b/research/references/1stproof/first-batch/problems/09-generic-3x4-determinant-tensor-relations.md
@@ -1,0 +1,24 @@
+# Problem 9: Algebraic relations among 3x3x3x3 det-tensors of generic 3x4 matrices
+
+- **Area:** tensor analysis
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `generic-3x4-determinant-tensor-relations`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Let $n \geq 5$.  
+Let $A^{(1)}, \ldots, A^{(n)} \in \mathbb{R}^{3 \times 4}$ be Zariski-generic.   
+For $\alpha, \beta, \gamma, \delta \in [n]$, construct $Q^{(\alpha \beta \gamma \delta)} \in \mathbb{R}^{3 \times 3 \times 3 \times 3}$ so that its $(i, j, k, \ell)$ entry for $1 \leq i, j, k, \ell \leq 3$ is given by $Q^{(\alpha \beta \gamma \delta)}_{i j k \ell} = \det [A^{(\alpha)}(i, :); A^{(\beta)}(j, :); A^{(\gamma)}(k, :); A^{(\delta)}(\ell, :)]$.
+Here $A(i, :)$ denotes the $i$th row of a matrix $A$, and semicolon denotes vertical concatenation. 
+We are interested in algebraic relations on the set of tensors $\{Q^{(\alpha \beta \gamma \delta)} : \alpha, \beta, \gamma, \delta \in [n] \}$.
+
+More precisely, does there exist a polynomial map $\mathbf{F}: \mathbb{R}^{81n^4} \rightarrow \mathbb{R}^N$ that satisfies the following three properties?
+\smallskip
+\begin{itemize}\setlength\itemsep{0.5em}
+\item The map $\mathbf{F}$ does not depend on $A^{(1)}, \ldots A^{(n)}$. 
+\item The degrees of the coordinate functions of $\mathbf{F}$ do not depend on $n$.
+\item Let $\lambda \in \mathbb{R}^{n \times n \times n \times n}$ satisfy 
+$\lambda_{\alpha \beta \gamma \delta} \neq 0$ for precisely $\alpha, \beta, \gamma, \delta \in [n]$ that are not identical.  Then $\mathbf{F}(\lambda_{\alpha \beta \gamma \delta} Q^{(\alpha \beta \gamma \delta)} : \alpha, \beta, \gamma, \delta \in [n]) = 0$ holds if and only if there exist $u, v, w, x \in (\mathbb{R}^*)^n$ such that $\lambda_{\alpha \beta \gamma \delta} = u_{\alpha} v_{\beta} w_{\gamma} x_{\delta}$ for all $\alpha, \beta, \gamma, \delta \in [n]$ that are not identical. 
+\end{itemize}
+```

--- a/research/references/1stproof/first-batch/problems/10-cp-rkhs-pcg-mode-subproblem.md
+++ b/research/references/1stproof/first-batch/problems/10-cp-rkhs-pcg-mode-subproblem.md
@@ -1,0 +1,48 @@
+# Problem 10: Preconditioned CG for RKHS-constrained CP-decomposition mode subproblem
+
+- **Area:** numerical linear algebra
+- **Source:** [First_Proof.tex](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex) (arXiv [2602.05192](https://arxiv.org/abs/2602.05192))
+- **Slug:** `cp-rkhs-pcg-mode-subproblem`
+
+## Statement (verbatim LaTeX from upstream)
+
+```latex
+Given a $d$-way tensor $\mathcal{T} \in \mathbb{R}^{n_1 \times n_2 \times \cdots \times n_d}$ 
+such that the data is unaligned (meaning the tensor $\mathcal{T}$ has missing entries),
+we consider the problem of computing a CP decomposition of rank $r$ where some modes are infinite-dimensional and constrained to be in a Reproducing Kernel Hilbert Space (RKHS). 
+We want to solve this using an alternating optimization approach, and our question is focused on the mode-$k$ subproblem for an infinite-dimensional mode. 
+For the subproblem, then CP factor matrices 
+$A_1, \dots, A_{k-1}, A_{k+1}, \dots, A_d$ are fixed, and we are solving for $A_k$.
+
+Our notation is as follows.
+Let $N = \prod_i n_i$ denote the product of all sizes.
+Let $n \equiv n_k$ be the size of mode $k$, let
+$M = \prod_{i\neq k} n_i$ be the product of all dimensions except $k$, and assume $n \ll M$.
+Since the data are unaligned, this means only a subset of $\mathcal{T}$'s entries are observed, and we let $q \ll N$ denote the number of observed entries.
+We let $T \in \mathbb{R}^{n \times M}$ denote the mode-$k$ unfolding of the tensor $\mathcal{T}$ with all missing entries set to zero.
+The $\vecop$ operations creates a vector from a matrix by stacking its columns,
+and we let $S \in \mathbb{R}^{N \times q}$ denote the selection matrix (a subset of the $N \times N$ identity matrix) such that $S^T \vecop(T)$ selects the $q$ known entries of the tensor $\mathcal{T}$ from the vectorization of its mode-$k$ unfolding.
+We let $Z = A_d \odot \cdots \odot A_{k+1} \odot A_{k-1} \odot \cdots \odot A_1 \in \mathbb{R}^{M \times r}$ be the Khatri-Rao product of the factor matrices corresponding to all modes except mode $k$.
+We let $B = TZ$ denote the MTTKRP of the tensor $\mathcal{T}$ and Khatri-Rao product $Z$.
+
+We assume $A_k = KW$ where
+$K \in \mathbb{R}^{n \times n}$ denotes the psd RKHS kernel matrix for mode $k$.
+The matrix $W$ of size $n \times r$ is the unknown for which we must solve. 
+The system to be solved is
+\begin{equation} 
+	\left[
+    (Z \otimes K)^T S
+    S^T (Z \otimes K)
+    + \lambda (I_r \otimes K) 
+  \right] \vecop(W)
+	= (I_r \otimes K) 
+	\vecop( B ). \nonumber 
+\end{equation}
+Here, $I_r$ denotes the $r \times r$ identity matrix.
+This is a system of size $nr \times nr$
+Using a standard linear solver costs $O(n^3 r^3)$, 
+and explicitly forming the matrix is an additional expense.
+
+Explain how an iterative preconditioned conjugate gradient linear solver can be used to solve this problem more efficiently. Explain the method and choice of preconditioner. Explain in detail how the matrix-vector products are computed and why this works. Provide complexity analysis. 
+We assume $n,r < q \ll N$. Avoid any computation of order $N$.
+```

--- a/scripts/research/pull-1stproof-first-batch.py
+++ b/scripts/research/pull-1stproof-first-batch.py
@@ -1,0 +1,442 @@
+#!/usr/bin/env python3
+"""Pull 1stProof first-batch problem statements from GitHub LaTeX source.
+
+The 1stProof benchmark (https://1stproof.org/first-batch.html) publishes 10
+research-level math problems. Statements live in a single LaTeX source file
+on GitHub (1stproof/batch-1, file First_Proof.tex), inside an `enumerate`
+block in `\\section{The questions}`. Each `\\item` is one problem.
+
+Usage:
+    pull-1stproof-first-batch.py                  Pull from the canonical URL
+    pull-1stproof-first-batch.py --source PATH    Use a local .tex file
+    pull-1stproof-first-batch.py --help           Show this help
+
+Output (relative to repo root):
+    research/references/1stproof/
+      README.md
+      first-batch/
+        first_proof.tex                # cached upstream LaTeX
+        index.json                     # {problems: [{id, slug, area, ...}]}
+        problems/
+          01-<slug>.md
+          ...
+          10-<slug>.md
+
+The script is idempotent: re-running with the same source produces identical
+output (modulo the `fetch_date` field in `index.json`, which is bumped only
+when the cached source file content changes).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import json
+import pathlib
+import re
+import sys
+import urllib.request
+
+# Canonical sources.
+RAW_TEX_URL = "https://raw.githubusercontent.com/1stproof/batch-1/main/First_Proof.tex"
+GITHUB_BLOB_URL = "https://github.com/1stproof/batch-1/blob/main/First_Proof.tex"
+ARXIV_ABS_URL = "https://arxiv.org/abs/2602.05192"
+ARXIV_ID = "2602.05192"
+LANDING_URL = "https://1stproof.org/first-batch.html"
+
+# One-line area + slug per problem, in the order the authors used in the paper.
+# These are determined by reading the LaTeX once and recording the topic stated
+# on the landing page next to the matching mathematical content. They are NOT
+# extracted from the LaTeX automatically (the source carries no per-item area
+# tags), so this table is the single hand-maintained mapping. If the upstream
+# source ever reorders or renumbers the problems, this table must be updated.
+PROBLEM_METADATA: list[dict[str, str]] = [
+    {
+        "id": 1,
+        "slug": "phi43-shift-equivalence",
+        "area": "stochastic analysis",
+        "short_title": "Equivalence of shifted Phi^4_3 measures on T^3",
+    },
+    {
+        "id": 2,
+        "slug": "rankin-selberg-nonvanishing",
+        "area": "representation theory",
+        "short_title": "Nonvanishing local Rankin-Selberg integral on GL_{n+1}",
+    },
+    {
+        "id": 3,
+        "slug": "interpolation-asep-markov-chain",
+        "area": "algebraic combinatorics",
+        "short_title": "Markov chain for interpolation ASEP / Macdonald ratio",
+    },
+    {
+        "id": 4,
+        "slug": "polynomial-convolution-phi-bound",
+        "area": "spectral graph theory",
+        "short_title": "Boxplus convolution and Phi_n bound for real-rooted polynomials",
+    },
+    {
+        "id": 5,
+        "slug": "n-infty-slice-filtration",
+        "area": "algebraic topology",
+        "short_title": "O-slice filtration and geometric fixed-point connectivity",
+    },
+    {
+        "id": 6,
+        "slug": "epsilon-light-laplacian-subset",
+        "area": "spectral graph theory",
+        "short_title": "Existence of epsilon-light vertex subsets of size c*epsilon*|V|",
+    },
+    {
+        "id": 7,
+        "slug": "uniform-lattice-rational-acyclic-cover",
+        "area": "lattices in Lie groups",
+        "short_title": "Uniform lattice with 2-torsion as pi_1 of Q-acyclic-cover manifold",
+    },
+    {
+        "id": 8,
+        "slug": "polyhedral-lagrangian-smoothing",
+        "area": "symplectic geometry",
+        "short_title": "Lagrangian smoothing of 4-valent polyhedral Lagrangian surfaces",
+    },
+    {
+        "id": 9,
+        "slug": "generic-3x4-determinant-tensor-relations",
+        "area": "tensor analysis",
+        "short_title": "Algebraic relations among 3x3x3x3 det-tensors of generic 3x4 matrices",
+    },
+    {
+        "id": 10,
+        "slug": "cp-rkhs-pcg-mode-subproblem",
+        "area": "numerical linear algebra",
+        "short_title": "Preconditioned CG for RKHS-constrained CP-decomposition mode subproblem",
+    },
+]
+
+
+def fetch_tex(source: str | None) -> str:
+    """Return LaTeX source text. If source is None, fetch from RAW_TEX_URL."""
+    if source is None:
+        with urllib.request.urlopen(RAW_TEX_URL, timeout=30) as resp:
+            data = resp.read()
+        text = data.decode("utf-8")
+    else:
+        text = pathlib.Path(source).read_text(encoding="utf-8")
+    return text
+
+
+# Regex anchors. We do NOT try to "parse" arbitrary LaTeX; we rely on the very
+# specific structure used by First_Proof.tex:
+#
+#   \section{The questions}\label{sec:problems}
+#
+#   \begin{enumerate}
+#   \item ... problem 1 ...
+#   \item ... problem 2 ...
+#   ...
+#   \item ... problem 10 ...
+#   \end{enumerate}
+#
+# If the upstream file diverges from this structure the script will fail loudly
+# (raise) rather than silently produce garbage.
+SECTION_RE = re.compile(
+    r"\\section\{The questions\}\s*\\label\{sec:problems\}(?P<rest>.*?)\\section\{",
+    re.DOTALL,
+)
+ENUMERATE_RE = re.compile(
+    r"\\begin\{enumerate\}(?P<body>.*?)\\end\{enumerate\}",
+    re.DOTALL,
+)
+
+
+_BEGIN_RE = re.compile(r"\\begin\{([a-zA-Z*]+)\}")
+_END_RE = re.compile(r"\\end\{([a-zA-Z*]+)\}")
+_ITEM_RE = re.compile(r"(?m)^\s*\\item\b")
+
+
+def _split_top_level_items(body: str) -> list[str]:
+    """Split body on `\\item` only when nesting depth is 0.
+
+    A `\\item` inside a nested `\\begin{itemize}...\\end{itemize}` (or any other
+    nested environment) belongs to that inner list, not to the outer
+    `enumerate`. We track depth by walking the string and finding the next
+    `\\begin{...}`, `\\end{...}`, or top-level `\\item` boundary at each step.
+    """
+    # Build a sorted list of (position, kind, span_end) events.
+    events: list[tuple[int, str, int]] = []
+    for m in _BEGIN_RE.finditer(body):
+        events.append((m.start(), "begin", m.end()))
+    for m in _END_RE.finditer(body):
+        events.append((m.start(), "end", m.end()))
+    for m in _ITEM_RE.finditer(body):
+        events.append((m.start(), "item", m.end()))
+    events.sort(key=lambda e: e[0])
+
+    items: list[str] = []
+    depth = 0
+    current_start: int | None = None
+    for pos, kind, end in events:
+        if kind == "begin":
+            depth += 1
+        elif kind == "end":
+            depth -= 1
+        elif kind == "item":
+            if depth == 0:
+                # Close previous item (if any) at this position.
+                if current_start is not None:
+                    items.append(body[current_start:pos].strip())
+                current_start = end  # start of new item body, after `\item`
+    # Close the trailing item: from current_start to end of body.
+    if current_start is not None:
+        items.append(body[current_start:].strip())
+    return items
+
+
+def extract_problem_statements(tex: str) -> list[str]:
+    """Return the list of 10 raw-LaTeX problem statements.
+
+    Raises ValueError if the source doesn't have the expected structure.
+    """
+    section_match = SECTION_RE.search(tex)
+    if section_match is None:
+        raise ValueError(
+            "Could not locate '\\section{The questions}\\label{sec:problems}' "
+            "section in the source. Upstream LaTeX structure may have changed."
+        )
+    enum_match = ENUMERATE_RE.search(section_match.group("rest"))
+    if enum_match is None:
+        raise ValueError(
+            "Found 'The questions' section but no \\begin{enumerate}...\\end{enumerate} "
+            "block inside it. Upstream LaTeX structure may have changed."
+        )
+    body = enum_match.group("body")
+    items = _split_top_level_items(body)
+    items = [it for it in items if it]
+    if len(items) != 10:
+        raise ValueError(
+            f"Expected exactly 10 top-level \\item entries inside the enumerate "
+            f"block, got {len(items)}. Upstream LaTeX structure may have changed."
+        )
+    return items
+
+
+def write_problem_markdown(
+    path: pathlib.Path,
+    meta: dict[str, str],
+    statement_tex: str,
+    *,
+    arxiv_id: str,
+    source_blob_url: str,
+) -> None:
+    """Write a single problem .md file with YAML-like frontmatter + raw LaTeX."""
+    md = (
+        f"# Problem {meta['id']}: {meta['short_title']}\n\n"
+        f"- **Area:** {meta['area']}\n"
+        f"- **Source:** [First_Proof.tex]({source_blob_url}) "
+        f"(arXiv [{arxiv_id}](https://arxiv.org/abs/{arxiv_id}))\n"
+        f"- **Slug:** `{meta['slug']}`\n\n"
+        f"## Statement (verbatim LaTeX from upstream)\n\n"
+        f"```latex\n"
+        f"{statement_tex.rstrip()}\n"
+        f"```\n"
+    )
+    path.write_text(md, encoding="utf-8")
+
+
+def write_index_json(
+    path: pathlib.Path,
+    entries: list[dict[str, object]],
+    *,
+    fetch_date: str,
+    source_sha256: str,
+) -> None:
+    payload = {
+        "source": {
+            "landing_page": LANDING_URL,
+            "arxiv_id": ARXIV_ID,
+            "arxiv_abs_url": ARXIV_ABS_URL,
+            "github_blob_url": GITHUB_BLOB_URL,
+            "raw_tex_url": RAW_TEX_URL,
+            "fetch_date": fetch_date,
+            "source_sha256": source_sha256,
+        },
+        "problems": entries,
+    }
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_readme(path: pathlib.Path, fetch_date: str) -> None:
+    readme = f"""# 1stProof Benchmark — local cache
+
+This directory mirrors the **first-batch** problem statements from the
+[First Proof Project](https://1stproof.org/) so that downstream triage and
+`/lean` probes can operate from local files instead of re-fetching the upstream
+LaTeX on every run.
+
+This is a reference cache, **not** a gallery entry — no `proofs/`,
+`src/data/proofs/`, or `research/registry.json` changes are made by the puller.
+
+## Provenance
+
+| Field | Value |
+|-------|-------|
+| Landing page | <{LANDING_URL}> |
+| arXiv id | [{ARXIV_ID}]({ARXIV_ABS_URL}) |
+| LaTeX source | <{GITHUB_BLOB_URL}> |
+| Raw LaTeX | <{RAW_TEX_URL}> |
+| Last fetch (UTC date) | {fetch_date} |
+
+The fetch date above is auto-updated by the puller only when the upstream
+LaTeX content actually changes (detected via SHA-256). A no-op re-run leaves
+the date as-is so the directory is fully idempotent.
+
+## Layout
+
+```
+research/references/1stproof/
+  README.md                       <- this file
+  first-batch/
+    first_proof.tex               <- cached upstream LaTeX (verbatim)
+    index.json                    <- {{problems: [...]}}
+    problems/
+      01-<slug>.md ... 10-<slug>.md
+```
+
+Each problem markdown file contains:
+- short title and area
+- a link back to the upstream source
+- the verbatim LaTeX statement (no transcription / rewording)
+
+## How to refresh
+
+```bash
+./scripts/research/pull-1stproof-first-batch.py
+```
+
+The script is safe to re-run. If the upstream LaTeX has not changed, the
+output is byte-identical to the previous run.
+
+To pin to a specific local copy of the `.tex` (e.g. for reproducibility):
+
+```bash
+./scripts/research/pull-1stproof-first-batch.py --source path/to/First_Proof.tex
+```
+
+## Scope
+
+This cache covers **only** problem-statement retrieval and storage. Triage,
+`/lean` probe orchestration, the June 2026 second-batch window, and any
+trial writeups are tracked separately in the parent issue
+(see the issue referenced in the PR that introduced this directory).
+"""
+    path.write_text(readme, encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Pull 1stProof first-batch problem statements into research/references/1stproof/."
+    )
+    parser.add_argument(
+        "--source",
+        help="Path to a local copy of First_Proof.tex (default: fetch from GitHub raw).",
+        default=None,
+    )
+    parser.add_argument(
+        "--out-root",
+        help="Repo root to write under (default: auto-detected from this script's location).",
+        default=None,
+    )
+    args = parser.parse_args(argv)
+
+    if args.out_root is not None:
+        repo_root = pathlib.Path(args.out_root).resolve()
+    else:
+        # scripts/research/pull-1stproof-first-batch.py -> repo root is two levels up.
+        repo_root = pathlib.Path(__file__).resolve().parents[2]
+
+    out_dir = repo_root / "research" / "references" / "1stproof"
+    first_batch_dir = out_dir / "first-batch"
+    problems_dir = first_batch_dir / "problems"
+    problems_dir.mkdir(parents=True, exist_ok=True)
+
+    tex = fetch_tex(args.source)
+    source_sha256 = hashlib.sha256(tex.encode("utf-8")).hexdigest()
+
+    cached_tex_path = first_batch_dir / "first_proof.tex"
+    prev_sha = None
+    if cached_tex_path.exists():
+        prev_sha = hashlib.sha256(
+            cached_tex_path.read_bytes()
+        ).hexdigest()
+
+    # Only bump fetch_date when content actually changed.
+    today = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%d")
+    if prev_sha != source_sha256 or not (first_batch_dir / "index.json").exists():
+        fetch_date = today
+    else:
+        # Reuse previous date from index.json if present.
+        try:
+            prev_index = json.loads(
+                (first_batch_dir / "index.json").read_text(encoding="utf-8")
+            )
+            fetch_date = prev_index.get("source", {}).get("fetch_date", today)
+        except Exception:
+            fetch_date = today
+
+    statements = extract_problem_statements(tex)
+    if len(statements) != len(PROBLEM_METADATA):
+        raise ValueError(
+            f"Mismatch between extracted statements ({len(statements)}) and "
+            f"hand-maintained metadata table ({len(PROBLEM_METADATA)})."
+        )
+
+    cached_tex_path.write_text(tex, encoding="utf-8")
+
+    entries: list[dict[str, object]] = []
+    for meta, statement in zip(PROBLEM_METADATA, statements):
+        filename = f"{meta['id']:02d}-{meta['slug']}.md"
+        path = problems_dir / filename
+        write_problem_markdown(
+            path,
+            meta,
+            statement,
+            arxiv_id=ARXIV_ID,
+            source_blob_url=GITHUB_BLOB_URL,
+        )
+        entries.append(
+            {
+                "id": meta["id"],
+                "slug": meta["slug"],
+                "area": meta["area"],
+                "short_title": meta["short_title"],
+                "statement_path": f"first-batch/problems/{filename}",
+            }
+        )
+
+    write_index_json(
+        first_batch_dir / "index.json",
+        entries,
+        fetch_date=fetch_date,
+        source_sha256=source_sha256,
+    )
+    write_readme(out_dir / "README.md", fetch_date)
+
+    print(
+        f"Wrote {len(entries)} problem statements to {first_batch_dir.relative_to(repo_root)}",
+        file=sys.stdout,
+    )
+    print(f"  source sha256: {source_sha256}", file=sys.stdout)
+    print(f"  fetch_date:    {fetch_date}", file=sys.stdout)
+    if prev_sha is not None and prev_sha != source_sha256:
+        print("  upstream content CHANGED since last run", file=sys.stdout)
+    elif prev_sha == source_sha256:
+        print("  upstream content unchanged (idempotent re-run)", file=sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/research/pull-1stproof-first-batch.py` and the resulting
`research/references/1stproof/` cache, mirroring the 10 first-batch problem
statements from the [First Proof Project](https://1stproof.org/first-batch.html)
(arXiv [2602.05192](https://arxiv.org/abs/2602.05192), LaTeX source
[1stproof/batch-1](https://github.com/1stproof/batch-1/blob/main/First_Proof.tex))
so downstream triage and `/lean` probes can work from local files.

Scope is exactly the first sub-task of #21946: retrieval + storage only.
Triage, `/lean` probe orchestration, and the June 2026 second-batch window
remain operator-driven under the parent issue.

## Design

- Depth-aware LaTeX splitter pulls 10 top-level `\item`s out of `\section{The questions}` (problem 9 has a nested `\begin{itemize}`).
- Hand-maintained id/slug/area/short-title table — the LaTeX carries no per-item area tags, so this mapping is the only judgement applied and is documented in-script.
- Idempotent + content-aware: SHA-256s the upstream LaTeX. If unchanged, `fetch_date` is preserved (no spurious diffs). If changed, fetch_date bumps and the puller prints a notice.
- Structural fail-fast: if the upstream LaTeX stops matching the expected shape, the script raises `ValueError`.
- Statements are stored verbatim (no transcription / reformatting / rewording) in fenced LaTeX blocks.

## Files

- `scripts/research/pull-1stproof-first-batch.py` — the puller (executable)
- `research/references/1stproof/README.md` — provenance + how-to-refresh
- `research/references/1stproof/first-batch/first_proof.tex` — cached upstream
- `research/references/1stproof/first-batch/index.json` — id/slug/area/path index + source SHA-256
- `research/references/1stproof/first-batch/problems/01..10-*.md` — verbatim statements

## Acceptance criteria

- [x] Script under `scripts/research/` with `--help` documentation
- [x] Running it produces 10 problem markdown files
- [x] `index.json` lists id, short title, area, statement path
- [x] `README.md` records source URLs, arxiv id, fetch date
- [x] Script is idempotent (verified: second run produced zero `git diff`)
- [x] No network calls at gallery build time
- [x] No changes to `proofs/`, `src/data/proofs/`, or `research/registry.json`
- [x] `pnpm build` succeeds

## Test plan

- [x] Ran script in a clean worktree; 10 markdown files with non-empty statements
- [x] Re-ran script; `git diff` is empty (true idempotence)
- [x] Spot-checked problem 1 (Phi^4_3) and problem 9 (nested itemize) against upstream LaTeX — both match verbatim
- [x] `pnpm build` succeeds

Closes #22605