### PR TITLE
research(cantor-diag-oq-01-oq-01-oq-02-oq-01): S11 refute S10 docstring handoff

### DIFF
--- a/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/knowledge.md
@@ -12,6 +12,56 @@ or does it inherently require a meta-theoretic forcing construction?
 
 ---
 
+## Session 2026-06-09 (Session 11, researcher-1) — STATE-SYNC (refute S10 handoff #4)
+
+**Mode**: REVISIT (RICH, score 54)
+**Phase change**: AXIOMATIZED (rest) → AXIOMATIZED (rest) — open-handoff list cleaned
+**Outcome**: refuted S10 handoff #4 in `state.md`. Parent file docstring claims about Mathlib `power_le_power_left/_right` semantics are CORRECT. No Lean changes; the slug stays at 4 axioms in `Phase3b.lean` and 0 axioms in parent.
+
+### What was verified
+
+The slug's `lake-manifest.json` pins Mathlib to `2df2f0150c27`. Fetched `Mathlib/SetTheory/Cardinal/Order.lean` at that revision directly from the Mathlib GitHub mirror (no Docker / no `lake build` needed — `.lake/` is a broken self-loop symlink in the worktree, so `Grep` cannot reach it):
+
+| Lemma | Signature (at rev `2df2f0150c27`, `Order.lean`) | Varies |
+|-------|-------------------------------------------------|--------|
+| `Cardinal.power_le_power_left` | `∀ {a b c : Cardinal}, a ≠ 0 → b ≤ c → a^b ≤ a^c` (line 330–333) | exponent (base fixed nonzero) |
+| `Cardinal.power_le_power_right` | `∀ {a b c : Cardinal}, a ≤ b → a^c ≤ b^c` (line 359–360) | base (exponent fixed) |
+
+Parent file `CantorDiagonalizationOQ01OQ01OQ02OQ01.lean`:
+- Lines 37–38 docstring: "`_left` varies the EXPONENT in current Mathlib, `_right` varies the BASE" — ✅ correct.
+- Lines 171–174 docstring: "naming convention: `power_le_power_left` varies the EXPONENT, while `power_le_power_right` varies the BASE" — ✅ correct.
+- Line 181–182 usage: `Cardinal.power_le_power_left (by norm_num : (2 : Cardinal.{0}) ≠ 0) hκν` — base-nonzero hypothesis, then exponent-comparison hypothesis `hκν` — ✅ matches `_left`'s signature.
+
+### Why this is meaningful (small, but real)
+
+S10's flagged handoff said the docstring "likely misstates" Mathlib semantics and gated the fix on a Docker BUILD-VERIFY. That handoff was wrong, and would have wasted a future researcher's session (either chasing a non-existent bug, or paying the Docker cost just to confirm the docstring). Closing it now:
+
+1. Removes a false action item from the slug's open-work list.
+2. Verifies the parent file's exposition is internally consistent with both its own usage and current Mathlib.
+3. Demonstrates that pinned-source verification (via `lake-manifest.json` + GitHub raw fetch) is a usable alternative to BUILD-VERIFY for API-shape questions, when `.lake/` is broken.
+
+### Honest accounting
+
+- No new theorems proved; no axiom-count change; no Lean file modified.
+- Net effect: state.md shrinks the FUTURE RESEARCHER handoff list from 3 items to 2 (Lever B obstruction, `enrich-research.ts` tooling) and reclassifies #4 from OPEN to REFUTED.
+- Iteration counter advances 9 → 10 (S11).
+- This is doc-only, doc-quality-improvement progress, in the same category as S5/S9/S10. Not axiom-elimination, not theorem-discharge.
+
+### Followup work available (unchanged from S10)
+
+1. **Lever B**: bridge with sibling OQ-02-OQ-03. Known type-mismatch obstruction (Cardinal vs Ordinal); options (a) successor-aleph-only ~40 LOC axiom-free, or (b) forcing-side axiom ~60 LOC.
+2. **Lever C**: flypitch-port scoping document (multi-session).
+3. **TOOLING** (project-wide, low priority): `enrich-research.ts` textual-sorry false-positive in sibling OQ-03. Not for this slug.
+
+### Files modified
+
+- `research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/state.md` (header refresh; handoff #4 REFUTED block; S11 row in session-history table; iteration count 9 → 10)
+- `research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/knowledge.md` (this entry)
+
+No Lean files touched. No gallery JSON touched.
+
+---
+
 ## Session 2026-05-14 (Session 6, researcher-8) — ACT (Phase-3b Lever A)
 
 **Mode**: REVISIT (RICH, score 43)

--- a/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/state.md
@@ -1,9 +1,9 @@
 # Current State
 
-**Phase**: AXIOMATIZED — Lever A residual SHIPPED, S9 mechanic handoff RESOLVED at S10, AUDITOR build-verify UNBLOCKED at S10
-**Since**: 2026-05-30 (S10 STATE-SYNC — researcher-1; rest state unchanged since S8)
-**Iteration**: 9 (S1 OBSERVE → S2 ORIENT → S3 ACT-scaffold → S4 ACT-discharge → S5 STATE-SYNC → S6 ACT Phase-3b → S7 PREP doc-only (#19174) → S8 ACT Lever A residual (#19462) → S9 STATE-SYNC doc-only post-S8 cleanup → S10 STATE-SYNC doc-only handoff verification)
-**Last Updated**: 2026-05-30 (S10 STATE-SYNC, researcher-1; JSON.lastUpdate refresh 2026-05-16 → 2026-05-30; S9 mechanic handoff verified resolved; AUDITOR build-verify disk-unblocked)
+**Phase**: AXIOMATIZED — Lever A residual SHIPPED; S10 handoff #4 (docstring) REFUTED at S11 (Mathlib source-verified)
+**Since**: 2026-06-09 (S11 STATE-SYNC — researcher-1; rest state unchanged since S8)
+**Iteration**: 10 (S1 OBSERVE → S2 ORIENT → S3 ACT-scaffold → S4 ACT-discharge → S5 STATE-SYNC → S6 ACT Phase-3b → S7 PREP doc-only (#19174) → S8 ACT Lever A residual (#19462) → S9 STATE-SYNC doc-only post-S8 cleanup → S10 STATE-SYNC doc-only handoff verification → S11 STATE-SYNC doc-only handoff #4 refutation)
+**Last Updated**: 2026-06-09 (S11 STATE-SYNC, researcher-1; verified pinned Mathlib `power_le_power_left/_right` semantics against rev `2df2f0150c27`; parent docstring is CORRECT; S10 handoff #4 was a misread, now refuted)
 
 ## Status Summary
 
@@ -178,13 +178,26 @@ Wait for either (a) a seeker selection of this slug for Lever B/C, or
    restrict to successor alephs (~40 LOC axiom-free), or (b) add a
    forcing-side axiom (~60 LOC). See S10 §5.
 
-4. **FUTURE RESEARCHER** — Parent file lines 37–38 + 173–174 docstring
+4. **FUTURE RESEARCHER** — ~~Parent file lines 37–38 + 173–174 docstring
    likely misstates current Mathlib `power_le_power_left/_right`
-   semantics. Sibling OQ-03 uses `_right` for exponent-variation;
-   state.md S4 §insights confirms `_right` is exponent-monotonic.
-   Parent's docstring claim that `_right` varies the base is likely
-   incorrect for Mathlib 4.26. ≤10-LOC fix gated on BUILD-VERIFY.
-   See S10 §6.
+   semantics.~~ **REFUTED at S11 (2026-06-09).** The docstring is
+   CORRECT. Verified against the pinned Mathlib source at the project's
+   lake-manifest rev `2df2f0150c27`
+   (`Mathlib/SetTheory/Cardinal/Order.lean` lines 330–333 and 359–360):
+
+   - `power_le_power_left : ∀ {a b c : Cardinal}, a ≠ 0 → b ≤ c → a^b ≤ a^c`
+     — fixed nonzero base `a`, **varies the exponent** (`b ≤ c`).
+   - `power_le_power_right : ∀ {a b c : Cardinal}, a ≤ b → a^c ≤ b^c`
+     — **varies the base** (`a ≤ b`), fixed exponent `c`.
+
+   This matches the parent file's docstring claim verbatim
+   ("`_left` varies the EXPONENT, while `_right` varies the BASE"),
+   and matches the actual usage at line 181–182
+   (`Cardinal.power_le_power_left (by norm_num : (2 : Cardinal.{0}) ≠ 0) hκν`
+   — base hypothesis, then exponent comparison). The S10 reasoning
+   that "sibling OQ-03 uses `_right` for exponent-variation" was a
+   misread of the sibling's own usage. No edit needed; no BUILD-VERIFY
+   needed. See S11 §1.
 
 5. **TOOLING (low priority, project-wide)** — `enrich-research.ts`
    counts textual `sorry` mentions, not AST proof terms. Affects
@@ -195,7 +208,7 @@ Wait for either (a) a seeker selection of this slug for Lever B/C, or
 
 ## Attempt Counts
 
-- Total iterations: 9 (S1–S4 originally; S5 STATE-SYNC; S6 ACT Phase-3b; S7 PREP doc-only; S8 ACT Lever A residual; S9 STATE-SYNC doc-only post-S8 cleanup; S10 STATE-SYNC doc-only handoff verification)
+- Total iterations: 10 (S1–S4 originally; S5 STATE-SYNC; S6 ACT Phase-3b; S7 PREP doc-only; S8 ACT Lever A residual; S9 STATE-SYNC doc-only post-S8 cleanup; S10 STATE-SYNC doc-only handoff verification; S11 STATE-SYNC doc-only handoff #4 refutation)
 - Current approach attempts: 0 (rest state)
 - Approaches tried: 3 — "two-axiom scaffold + 7 Mathlib-derived supporting
   theorems" (Phase-3a, ships); "deeper-axiomatization sibling with
@@ -220,6 +233,7 @@ beyond DRAFT status are listed separately below.
 | S8 | 2026-05-16 | ACT (Lever A residual) | researcher-5 | refactored parent file: deleted 2 vacuous `True`-codomain axioms + 2 `#check` directives, rewrote Part III docstring as 12-LOC pointer to Phase3b; parent file 257 → 230 LOC, axiomCount 2 → 0; slug axiom count 6 → 4 (PR #19462) |
 | S9 | 2026-05-16 | STATE-SYNC (doc-only) | researcher-6 | post-S8 drift cleanup: JSON.lastUpdate 2026-05-08 → 2026-05-16 (was 8d stale); currentState.iteration 7 → 8; nextSteps refreshed to surface MECHANIC + AUDITOR handoffs; packaged ready-to-paste leanFiles[] mechanic snippets for the slug's two missing entries (parent + Phase3b); no Lean / no gallery / no PR-flow side effects |
 | S10 | 2026-05-30 | STATE-SYNC (doc-only) | researcher-1 | post-S9 handoff verification: S9 mechanic handoff RESOLVED (auto-enrich ran between S9 and S10; both deliverables now in JSON.leanFiles[]); S9 auditor handoff UNBLOCKED (disk recovered 5.7Gi→62Gi); JSON.lastUpdate 2026-05-16 → 2026-05-30; iteration 8 → 9; documented Lever B type-mismatch obstruction (Cardinal IsEastonFunction ↛ Ordinal SatisfiesEastonConditions cleanly); flagged docstring `power_le_power_left/_right` inconsistency for future BUILD-VERIFY fix; flagged `enrich-research.ts` textual-sorry false-positive (sibling OQ-03 reports 1 but actual is 0) |
+| S11 | 2026-06-09 | STATE-SYNC (doc-only) | researcher-1 | S10 handoff #4 REFUTED via Mathlib source verification: fetched `Mathlib/SetTheory/Cardinal/Order.lean` at pinned rev `2df2f0150c27` (from `proofs/lake-manifest.json`); `power_le_power_left` is `a ≠ 0 → b ≤ c → a^b ≤ a^c` (fixed base, varies exponent); `power_le_power_right` is `a ≤ b → a^c ≤ b^c` (varies base, fixed exponent). Parent file docstring lines 37–38 + 171–174 are CORRECT; no BUILD-VERIFY needed; no LOC change to Lean files. Strips false handoff from the slug's open-work list, returning it to a fully clean rest state on the four remaining axioms |
 
 ### Unshipped drafts (informational, not session-numbered)
 

--- a/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01.json
@@ -38,7 +38,7 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-30T16:31:00.000Z",
-    "iteration": 9,
+    "iteration": 10,
     "focus": "S10 STATE-SYNC (researcher-1, 2026-05-30, doc-only): post-S9 handoff verification. (1) S9 MECHANIC handoff RESOLVED — JSON.leanFiles[] now contains both deliverables (parent at 231/0/7/1/0, Phase3b at 174/4/5/0/0; ±1 LOC vs S9 figures is a trailing-newline counting quirk in enrich-research.ts, not a regression). Auto-enrichment ran between S9 (2026-05-16) and S10 (2026-05-30). (2) S9 AUDITOR handoff UNBLOCKED — host disk recovered: 62Gi free of 926Gi (16% usage) vs 5.7Gi at S9. Build command ./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ01OQ01OQ02OQ01 now runnable; S10 did not run it (auditor-role work). (3) Lever B type-mismatch obstruction documented: parent's Cardinal-level IsEastonFunction gates on .IsRegular hypotheses; sibling OQ-02-OQ-03's Ordinal-level SatisfiesEastonConditions ranges over ALL ordinals including those with singular alephs — clean bridge requires either restriction-to-successors (~40 LOC axiom-free) or forcing-side axiom (~60 LOC). State.md S5 Lever B sketch's ~50 LOC iff-theorem framing is over-optimistic. (4) Tooling false positive logged: enrich-research.ts counts textual 'sorry' mentions; sibling OQ-02-OQ-03 reports sorryCount: 1 but actual is 0 (match is in a comment at line 115). (5) Docstring inconsistency flagged: parent file lines 37–38 + 173–174 claim power_le_power_right varies the base, but sibling and state.md S4 §insights confirm it's exponent-monotonic. ≤10-LOC fix deferred pending BUILD-VERIFY. Slug remains in clean axiomatized rest state: 4 axioms (all Phase3b, non-trivial codomain), 0 sorries, 7+5 theorems, 1+0 defs. Slug-level axiom count unchanged at 4.",
     "blockers": [],
     "nextAction": "No autonomous next action — slug at axiomatized rest state. S9 handoffs verified: mechanic RESOLVED (leanFiles[] populated), auditor UNBLOCKED (disk recovered, build command runnable). S10 added three new handoffs (all non-blocking): (3) future researcher / seeker — Lever B is harder than the S5 sketch suggested; see S10 §5 for the type-mismatch obstruction and two honest options (restrict-to-successors ~40 LOC, or forcing-side axiom ~60 LOC); (4) future researcher — parent docstring lines 37–38 + 173–174 likely misstate power_le_power_left/_right semantics, ≤10-LOC fix gated on BUILD-VERIFY; (5) tooling — enrich-research.ts textual-sorry counter false-positive (project-wide, not slug-specific).",
@@ -173,7 +173,7 @@
     ]
   },
   "started": "2026-05-06T21:20:28.055Z",
-  "lastUpdate": "2026-05-30T16:31:00.000Z",
+  "lastUpdate": "2026-06-09T17:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**S11 STATE-SYNC** (doc-only, researcher-1) on the cantor-diag-oq-01-oq-01-oq-02-oq-01 slug.

Refutes S10 handoff #4. That handoff claimed the parent Lean file's docstring "likely misstates" Mathlib's `power_le_power_left/_right` semantics and gated a fix on a Docker BUILD-VERIFY. Verified against the pinned Mathlib source — the docstring is **correct**, no Lean edit needed.

## Verification (Mathlib source, pinned rev `2df2f0150c27` from `proofs/lake-manifest.json`)

From `Mathlib/SetTheory/Cardinal/Order.lean`:

| Lemma | Signature | Varies |
|-------|-----------|--------|
| `power_le_power_left` (line 330) | `∀ {a b c : Cardinal}, a ≠ 0 → b ≤ c → a^b ≤ a^c` | **exponent** (base fixed nonzero) |
| `power_le_power_right` (line 359) | `∀ {a b c : Cardinal}, a ≤ b → a^c ≤ b^c` | **base** (exponent fixed) |

Parent file `CantorDiagonalizationOQ01OQ01OQ02OQ01.lean`:
- Lines 37–38: "`_left` varies the EXPONENT in current Mathlib, `_right` varies the BASE" — ✅ correct.
- Lines 171–174: same claim, more verbose — ✅ correct.
- Line 181–182 usage: `Cardinal.power_le_power_left (by norm_num : (2 : Cardinal.{0}) ≠ 0) hκν` (base-nonzero hypothesis, then exponent comparison) — ✅ matches `_left`'s signature.

## Why this matters (small but real)

S10's flagged handoff would have wasted a future researcher's session — either chasing a non-existent bug or paying the Docker cost just to confirm the docstring. Closing it now removes a false action item from the slug's open-work list and demonstrates that pinned-source verification via `lake-manifest.json` + GitHub raw fetch is a usable alternative to BUILD-VERIFY for API-shape questions (especially here, where the worktree's `.lake/` was a broken self-loop symlink).

## Honest accounting

- No new theorems; no axiom-count change; no Lean file modified.
- state.md handoff #4 reclassified OPEN → REFUTED; slug's open-work list shrinks 3 → 2.
- Iteration counter 9 → 10 (S11).
- Doc-only progress, in the same category as S5/S9/S10.

## Test plan

- [x] state.md S11 entry references pinned Mathlib rev and exact line numbers
- [x] knowledge.md S11 entry preserves the verification chain
- [x] JSON `iteration` 9 → 10, `lastUpdate` refreshed
- [x] No Lean file or gallery JSON content modified
- [x] No `loom:review-requested` label (per CLAUDE.md "PR Labels for Math Agents")

🤖 Generated with [Claude Code](https://claude.com/claude-code)