### PR TITLE
audit(sum-of-kth-powers-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13291,9 +13291,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T15:04:58Z",
+      "lastAudited": "2026-06-09T16:54:20Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-02": {


### PR DESCRIPTION
## Summary

Re-audited gallery entry `sum-of-kth-powers-oq-01` (Unified Faulhaber Formula via Bernoulli Numbers, OQ-01). All claims in `meta.json` verify against the Lean source `Proofs/SumOfKthPowersOQ01.lean`:

- `sorries`: 0 ✓
- `axiomCount`: 0 ✓ (no `axiom` declarations, no structure-encoded assumptions)
- `theoremCount`: 11 ✓ (+ 4 numerical-verification `example`s, excluded by convention)
- `definitionCount`: 0 ✓
- `lineCount`: 193 ✓
- `status`: `"verified"` — appropriate
- `badge`: `"mathlib"` — appropriate (built on `Finset.sum_range_pow`)
- No `True` stubs, no Mathlib-wrapper anti-patterns

`auditCount` bumped 2 → 3.

## Test plan

- [x] meta.json claims cross-checked against Lean source
- [x] grep counts: 0 sorries, 0 axioms, 11 theorems/lemmas, 0 defs, 0 True stubs

Generated with Claude Code