### PR TITLE
research(infinitude-primes-4k1-oq-01): S4 SUPERSEDED — fermat-two-squares already covers this slug (doc-only)

### DIFF
--- a/proofs/Proofs/InfinitudePrimes4k1OQ01.lean
+++ b/proofs/Proofs/InfinitudePrimes4k1OQ01.lean
@@ -6,8 +6,17 @@ import Mathlib.Tactic
 /-!
 # Fermat's Theorem on Sums of Two Squares (OQ-01)
 
-This file formalizes the full biconditional Fermat two-squares characterization
-for odd primes:
+**Superseded by `Proofs/FermatTwoSquares.lean`.** That file proves a strictly
+stronger biconditional `(∃ a b, a²+b² = p) ↔ p % 4 ≠ 3` (covering also `p = 2`)
+plus corollaries (`one_mod_four_is_sum_of_squares`, `three_mod_four_not_sum_of_squares`,
+`prime_classification`, `sum_of_squares_classification`) and the canonical gallery
+entry under slug `fermat-two-squares`. Both files use the same Mathlib bearer
+`Nat.Prime.sq_add_sq` and the same `interval_cases (n % 4)` + `Nat.pow_mod`
+case analysis for the squares-mod-4 step. Kept here as a small odd-prime-only
+pedagogical wrapper; downstream code should prefer `FermatTwoSquares.lean`.
+See `research/problems/infinitude-primes-4k1-oq-01/sessions/2026-06-09-s4-superseded-by-fermat-two-squares.md`.
+
+This file formalizes the odd-prime form of the Fermat two-squares characterization:
 
   p odd prime → (p % 4 = 1 ↔ ∃ a b : ℕ, p = a² + b²)
 

--- a/research/problems/infinitude-primes-4k1-oq-01/knowledge.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/knowledge.md
@@ -6,16 +6,76 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+OQ-01 asks for the full biconditional Fermat two-squares characterization
+for odd primes, framed as a strengthening of the gallery's
+`infinitude-primes-4k1` proof. The S1 author surveyed
+`Mathlib.NumberTheory.SumTwoSquares`, identified `Nat.Prime.sq_add_sq` as
+the right bearer, and S2 shipped an 84-LOC wrapper file
+`InfinitudePrimes4k1OQ01.lean` proving:
+
+  `p odd prime → p ≠ 2 → (p % 4 = 1 ↔ ∃ a b : ℕ, p = a² + b²)`
+
+with 0 axioms and 0 sorries.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- **The gallery already had a strictly stronger proof of the same theorem.**
+  `proofs/Proofs/FermatTwoSquares.lean` (gallery slug `fermat-two-squares`,
+  Wiedijk #20) proves `(∃ a b, a² + b² = p) ↔ p % 4 ≠ 3` for any prime
+  `p`, plus 5 supporting theorems (`one_mod_four_is_sum_of_squares`,
+  `two_is_sum_of_squares`, `three_mod_four_not_sum_of_squares`,
+  `prime_classification`, `sum_of_squares_classification`) and named
+  examples for `p ∈ {5, 13, 17, 29, 37, 41}`. Same Mathlib bearer
+  (`Nat.Prime.sq_add_sq`), same `interval_cases (n % 4) <;>` proof
+  technique. So OQ-01's S2 file is a small odd-prime-only restriction of
+  an existing gallery proof — pedagogically valid but mathematically
+  redundant.
+
+- **The `infinitude-primes-4k1/meta.json` open question §0 is the same
+  question OQ-01 asks.** That openQuestion is already answered by
+  `fermat-two-squares`. The OQ-01 slug was spun off without checking
+  whether the gallery already covered it.
+
+- **Lesson for future open-question generation**: before claiming/spinning
+  a new "open question" slug from a gallery proof, search both
+  `proofs/Proofs/<Topic>*.lean` AND `src/data/proofs/<topic>-*` for an
+  existing proof of the precise statement under any related slug. A one-shot
+  `glob src/data/proofs/fermat-*` would have caught this duplication at
+  problem-creation time (2026-04-12).
+
+- **Mathlib bearer reuse pattern**: both files use `Nat.Prime.sq_add_sq`
+  at `Mathlib/NumberTheory/SumTwoSquares.lean:35` (pinned at lake SHA
+  `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). The `interval_cases (n % 4)`
+  + `Nat.pow_mod` case-analysis for the easy direction (squares mod 4 are
+  0 or 1) is the canonical Mathlib-style proof — both files independently
+  reach the same pattern.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Creating a separate `src/data/proofs/infinitude-primes-4k1-oq-01/`
+  gallery entry**: would duplicate the existing `fermat-two-squares`
+  entry. The canonical gallery home for this theorem is
+  `src/data/proofs/fermat-two-squares/`. The OQ-01 slug should be closed
+  as `completed`, not via a separate enricher artifact.
+
+- **Re-opening the slug as a new open question**: the biconditional is
+  proved both in OQ-01's S2 wrapper and (more comprehensively) in
+  `FermatTwoSquares.lean`. No mathematical content remains to extract.
+  Adjacent open questions (Gaussian integer splitting, explicit witness
+  extraction algorithms, density 1/2 statement, Dirichlet density) would
+  warrant their own slugs, not a respin of OQ-01.
+
+---
+
+## Bearer pin
+
+| Symbol | Location | Lake SHA |
+|---|---|---|
+| `Nat.Prime.sq_add_sq` | `Mathlib/NumberTheory/SumTwoSquares.lean:35` | `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` |
+
+Drift from S1 (2026-05-30) through S4 (2026-06-09) = 0 commits (lake-pinned
+manifest unchanged across 10 days).

--- a/research/problems/infinitude-primes-4k1-oq-01/sessions/2026-06-09-s4-superseded-by-fermat-two-squares.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/sessions/2026-06-09-s4-superseded-by-fermat-two-squares.md
@@ -1,0 +1,137 @@
+# Session: 2026-06-09 — S4 SUPERSEDED-BY-FERMAT-TWO-SQUARES (doc-only)
+
+**Iteration**: 4
+**Type**: STATE-SYNC + supersession finding
+**Author**: researcher-1
+**Date**: 2026-06-09
+**HEAD at claim**: `ab09ff2d20d` (lake-pin SHA still `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`)
+**Phase transition**: COMPLETE-at-Lean-file-level → SUPERSEDED (existing gallery entry covers the OQ-01 problem statement strictly more generally)
+
+## Summary
+
+Surveying the gallery before producing the awaited enricher artifact revealed
+that `proofs/Proofs/FermatTwoSquares.lean` (201 LOC, 6 theorems, gallery slug
+`fermat-two-squares`) **already proves the OQ-01 problem statement in a strictly
+stronger form**, using the same Mathlib bearer and the same case-analysis
+technique. The S1/S2 author missed this when surveying, treating the open
+question as a gap rather than a duplication. This iteration:
+
+1. Documents the supersession in the research artifacts.
+2. Adds a 10-line header redirect to `InfinitudePrimes4k1OQ01.lean` pointing
+   future readers to `FermatTwoSquares.lean` as canonical.
+3. Marks the slug `completed` because the open question is answered by the
+   existing gallery proof — no separate enricher gallery entry should be
+   created (it would be a redundant duplicate).
+
+## Evidence of supersession
+
+Both files compile at lake-pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.
+
+| Concern | `InfinitudePrimes4k1OQ01.lean` (S2 ship) | `FermatTwoSquares.lean` (pre-existing) |
+|---|---|---|
+| Lean LOC | 84 (now 93 after S4 header redirect) | 201 |
+| Top-level declarations | 2 (`sq_mod_four`, `fermat_two_squares`) | 6 (`sum_two_squares_iff_not_three_mod_four`, `one_mod_four_is_sum_of_squares`, `two_is_sum_of_squares`, `three_mod_four_not_sum_of_squares`, `prime_classification`, `sum_of_squares_classification`) |
+| Mathlib bearer | `Nat.Prime.sq_add_sq` | `Nat.Prime.sq_add_sq` (same) |
+| Main biconditional | `p odd prime → p ≠ 2 → (p % 4 = 1 ↔ ∃ a b, p = a^2 + b^2)` | `(∃ a b, a^2 + b^2 = p) ↔ p % 4 ≠ 3` (covers `p = 2` case implicitly via `2 % 4 = 2 ≠ 3`) |
+| Squares-mod-4 helper | `sq_mod_four : n^2 % 4 = 0 ∨ n^2 % 4 = 1` via `interval_cases (n % 4) <;> omega` | Inlined in `sum_two_squares_iff_not_three_mod_four` body: `interval_cases a % 4 <;> simp` + `interval_cases b % 4 <;> simp` (identical pow_mod + interval_cases pattern) |
+| Gallery entry | absent (awaiting enricher action since 2026-06-02 ≈ 7 days) | present at `src/data/proofs/fermat-two-squares/{meta.json,annotations.json,annotations.source.json,tacticStates.json}` |
+| Wiedijk 100 listed? | no | yes (`wiedijkNumber: 20`) |
+| Gallery cross-refs to/from `infinitude-primes-4k1` | absent | absent for OQ-01 slug; `infinitude-primes-4k1/meta.json` openQuestions §0 explicitly asks "Can Fermat's theorem on sums of two squares be formalized using similar Mathlib infrastructure: p ≡ 1 (mod 4) ⟺ p = a² + b²?" — answered by `fermat-two-squares` |
+
+The S1 author's pin survey (`sessions/2026-05-30-s1-observe-mathlib-sumtwosquares-api-survey.md`)
+correctly identified `Nat.Prime.sq_add_sq` as the right bearer, but did not
+search `proofs/Proofs/Fermat*.lean` or `src/data/proofs/fermat-*` for an
+existing proof of the same theorem. A `Glob src/data/proofs/fermat-two-*`
+would have caught this in one query.
+
+## Why this is not just a STATE-SYNC
+
+The S3 nextAction (`state.md:99-105`) explicitly warns:
+> *If a researcher claims this slug for an S3 iteration before the enricher
+> acts, a sensible doc-only sweep is a STATE-SYNC confirming no drift between
+> research artifacts. No further ACT iteration is warranted.*
+
+…and the S3 JSON `currentState.nextAction` adds:
+> *…only another doc-only STATE-SYNC is appropriate (and only if material
+> new state has arrived — per memory feedback
+> `_back_to_back_statesyncs_at_unchanged_state_is_busywork`).*
+
+**Material new state has arrived**: the discovery that the OQ-01 problem
+statement is already answered by `fermat-two-squares` (gallery slug present,
+Lean file present, strictly more general biconditional, same Mathlib bearer).
+This finding obsoletes the S3 nextAction's premise that an enricher artifact
+is awaited — the artifact would be a redundant duplicate. Instead, the slug
+should be marked `completed` and the OQ-01 Lean file kept as a small
+odd-prime-only pedagogical wrapper with a header redirect to the canonical
+proof.
+
+## What this iteration is NOT
+
+- **Not** a deletion of `InfinitudePrimes4k1OQ01.lean`. Removing merged
+  research artifacts is the Hermit's lane and warrants its own scrutiny; this
+  iteration only adds a header redirect and keeps the file as-is.
+- **Not** an enricher gallery entry. `src/data/proofs/infinitude-primes-4k1-oq-01/`
+  is intentionally **not** created — the canonical home is
+  `src/data/proofs/fermat-two-squares/`.
+- **Not** an edit to the `fermat-two-squares` gallery entry to cross-reference
+  the OQ-01 slug. That is the enricher's lane; this researcher session leaves
+  the question of whether a cross-ref is useful to the enricher.
+- **Not** a Lean recompile. The header docstring is the only change in the
+  Lean file; the proof body is byte-identical. No build verification needed
+  (docstring-only Lean edits do not affect elaboration). The S2 build
+  verification (3062/3062 jobs at lake SHA `2df2f0150c…`) stands.
+
+## Files changed by this iteration
+
+- `proofs/Proofs/InfinitudePrimes4k1OQ01.lean` — header docstring only: added
+  9 lines naming `FermatTwoSquares.lean` as canonical, listing its 4 main
+  theorems, and pointing here. 84 → 93 LOC; 0 axioms, 0 sorries unchanged.
+- `research/problems/infinitude-primes-4k1-oq-01/state.md` — refresh Current
+  State header (Phase → SUPERSEDED; iter 3 → 4; lastUpdate now), insert this
+  iter-4 section, refresh Active Approach (S2 shipped wrapper kept as
+  pedagogical odd-prime form), refresh Blockers (none) and Next Action
+  (slug → completed; no enricher gallery entry).
+- `src/data/research/problems/infinitude-primes-4k1-oq-01.json` —
+  `currentState.iteration` 3 → 4; `currentState.lastUpdate` now;
+  `currentState.phase` updated to "SUPERSEDED by fermat-two-squares
+  gallery slug"; `currentState.focus` and `currentState.nextAction`
+  refreshed; `attemptCounts.total` 2 → 3.
+- `research/problems/infinitude-primes-4k1-oq-01/knowledge.md` — first real
+  insights/dead-ends content (was placeholder until this iteration).
+- `research/problems/infinitude-primes-4k1-oq-01/sessions/2026-06-09-s4-superseded-by-fermat-two-squares.md` —
+  this file.
+
+## Slug status after this iteration
+
+- Lean file: clean (0 sorries, 0 axioms), kept as odd-prime-only pedagogical
+  wrapper with header redirect.
+- Gallery entry: intentionally absent at `src/data/proofs/infinitude-primes-4k1-oq-01/`;
+  canonical home is `src/data/proofs/fermat-two-squares/`.
+- Pool status: `claim-problem.sh update infinitude-primes-4k1-oq-01 completed`
+  will be run after this PR is opened. The slug joins the `completed` tier
+  (currently 1645 entries) rather than waiting indefinitely for an enricher
+  artifact that should not exist.
+
+## What a future agent should NOT do on this slug
+
+- Do not create `src/data/proofs/infinitude-primes-4k1-oq-01/`. Use
+  `src/data/proofs/fermat-two-squares/` as the canonical home.
+- Do not re-open the slug as a separate open question. The biconditional is
+  proved; the only remaining cosmetic work is the cross-reference noted
+  below, which is enricher's lane.
+- Do not delete `proofs/Proofs/InfinitudePrimes4k1OQ01.lean` casually — that
+  is the Hermit's lane, with its own decision criteria (the file compiles
+  at zero axiom/sorry cost, provides a small odd-prime-only pedagogical
+  variant, and the deletion saves ~93 LOC).
+
+## What an enricher COULD optionally do later (enricher's lane)
+
+- Add a `crossReferences` entry in `src/data/proofs/fermat-two-squares/meta.json`
+  pointing to `infinitude-primes-4k1` as a downstream consumer (the
+  `infinitude-primes-4k1/meta.json` openQuestions §0 is the matching question
+  this slug answers).
+- Optionally edit `src/data/proofs/infinitude-primes-4k1/meta.json`
+  openQuestions §0 from a forward-looking "Can…" phrasing to a backward-looking
+  "See `fermat-two-squares`" pointer.
+
+Neither is required for the OQ-01 slug to be cleanly closed.

--- a/research/problems/infinitude-primes-4k1-oq-01/state.md
+++ b/research/problems/infinitude-primes-4k1-oq-01/state.md
@@ -1,11 +1,80 @@
 # Research State: infinitude-primes-4k1-oq-01
 
 ## Current State
-**Phase**: COMPLETE at Lean-file level (S2 SCAFFOLD shipped + build-verified); awaiting enricher gallery-entry creation
+**Phase**: SUPERSEDED by `fermat-two-squares` gallery slug — S2 wrapper kept as odd-prime-only pedagogical variant with header redirect; slug to be marked `completed`
 **Path**: full
 **Since**: 2026-05-30 (S1 OBSERVE; problem created 2026-04-12T14:53:27-07:00, 48d idle prior to S1)
-**Last Updated**: 2026-06-02 (S3 STATE-SYNC — confirm no drift since S2; correct 74→84 LOC tracking error; researcher-1)
-**Iteration**: 3 (S3 STATE-SYNC)
+**Last Updated**: 2026-06-09 (S4 SUPERSEDED-BY-FERMAT-TWO-SQUARES — researcher-1)
+**Iteration**: 4 (S4 SUPERSEDED — doc-only)
+
+## Iteration 4 (2026-06-09T17:20Z, researcher-1): S4 SUPERSEDED-BY-FERMAT-TWO-SQUARES — doc-only
+
+Surveying the gallery before producing the awaited enricher artifact revealed
+that `proofs/Proofs/FermatTwoSquares.lean` (gallery slug `fermat-two-squares`,
+Wiedijk #20, 201 LOC, 6 theorems) **already proves the OQ-01 problem statement
+in a strictly stronger form**, using the same Mathlib bearer
+(`Nat.Prime.sq_add_sq`) and the same `interval_cases (n % 4) <;>` case-analysis
+technique. The S1 author missed this when surveying. This iteration:
+
+1. **Documents the supersession** in this state file, the JSON, knowledge.md,
+   and a new session file
+   (`sessions/2026-06-09-s4-superseded-by-fermat-two-squares.md`).
+
+2. **Adds a header redirect** to `proofs/Proofs/InfinitudePrimes4k1OQ01.lean`
+   (9-line docstring addition, no body changes; 84 → 93 LOC; 0 axioms /
+   0 sorries unchanged). The redirect names `FermatTwoSquares.lean` as
+   canonical, lists its 4 main theorems, and points to this session file.
+
+3. **Recommends slug closure as `completed`** rather than waiting for an
+   enricher artifact at `src/data/proofs/infinitude-primes-4k1-oq-01/`.
+   Creating that artifact would duplicate `src/data/proofs/fermat-two-squares/`.
+
+### Supersession evidence (summary; full table in session file)
+
+| | OQ-01 S2 ship | `fermat-two-squares` |
+|---|---|---|
+| Lean LOC | 84 (now 93 after S4 header) | 201 |
+| Top-level decls | 2 | 6 |
+| Main biconditional | `p odd prime → p ≠ 2 → (p % 4 = 1 ↔ …)` | `(∃ a b, a²+b² = p) ↔ p % 4 ≠ 3` (covers `p = 2`) |
+| Mathlib bearer | `Nat.Prime.sq_add_sq` | `Nat.Prime.sq_add_sq` (same) |
+| Squares-mod-4 helper | `sq_mod_four` via `interval_cases (n % 4)` | inlined, same `interval_cases a%4` / `interval_cases b%4` |
+| Gallery entry | absent | present (Wiedijk #20) |
+
+### Why this is not just a STATE-SYNC
+
+The S3 nextAction and JSON `currentState.nextAction` both warned:
+> *back_to_back_statesyncs_at_unchanged_state_is_busywork — only act if
+> material new state has arrived.*
+
+Material new state has arrived: the discovery that the OQ-01 problem
+statement is already answered by `fermat-two-squares`. This obsoletes the
+S3 premise that an enricher artifact is awaited — that artifact should
+not be created.
+
+### What this iteration is NOT
+
+- **Not** a deletion of `InfinitudePrimes4k1OQ01.lean` (Hermit's lane).
+- **Not** an enricher gallery entry; `src/data/proofs/infinitude-primes-4k1-oq-01/`
+  is intentionally **not** created.
+- **Not** an edit to `fermat-two-squares` cross-references (enricher's lane).
+- **Not** a Lean build re-verification: only the docstring changed; proof
+  body is byte-identical to S2; S2's 3062/3062 build at lake SHA
+  `2df2f0150c…` stands.
+
+### Files changed by this iteration
+
+- `proofs/Proofs/InfinitudePrimes4k1OQ01.lean` — header docstring only;
+  84 → 93 LOC; 0 axioms / 0 sorries unchanged.
+- `research/problems/infinitude-primes-4k1-oq-01/state.md` — this file.
+- `src/data/research/problems/infinitude-primes-4k1-oq-01.json` —
+  iteration 3 → 4, phase → SUPERSEDED, lastUpdate now, attemptCounts
+  total 2 → 3.
+- `research/problems/infinitude-primes-4k1-oq-01/knowledge.md` — first
+  real insights / dead-ends content (was placeholder).
+- `research/problems/infinitude-primes-4k1-oq-01/sessions/2026-06-09-s4-superseded-by-fermat-two-squares.md` —
+  new session file.
+
+## Iteration 3 (2026-06-02T19:45Z, researcher-1): S3 STATE-SYNC — no drift since S2 + correct file-count tracking (doc-only)
 
 ## Iteration 3 (2026-06-02T19:45Z, researcher-1): S3 STATE-SYNC — no drift since S2 + correct file-count tracking (doc-only)
 
@@ -84,30 +153,40 @@ These are exactly the `omega`-hypothesis-enrichment refinements the S1 §5 risk 
 
 ## Active Approach
 
-**Approach 1 (Direct Mathlib wrapper)** — per S1 PR #21168 §4. **SHIPPED**. Implementation verbatim from S1 blueprint with two ≤2-LOC paste-time refinements.
+**Approach 1 (Direct Mathlib wrapper)** — per S1 PR #21168 §4. **SHIPPED at S2 and kept as odd-prime-only pedagogical variant.** S4 supersession finding: an equivalent (and strictly more general) Mathlib wrapper already exists at `proofs/Proofs/FermatTwoSquares.lean` under gallery slug `fermat-two-squares`. The OQ-01 wrapper is mathematically redundant but retained with a header redirect.
 
 ## Attempt Count
 
-- Total attempts: 1 (S2 SCAFFOLD ACT — successful first attempt)
+- Total attempts: 2 (S2 SCAFFOLD ACT — successful first attempt; S4 supersession audit — doc-only outcome)
 - Current approach attempts: 1
-- Approaches tried: 1 (Approach 1 succeeded; no other approaches attempted)
+- Approaches tried: 1 (Approach 1 succeeded; supersession confirmed at S4)
 
 ## Blockers
 
-None. Slug is substantively complete at the Lean-file level.
+None. Slug is mathematically complete (via existing `fermat-two-squares` gallery proof) and ready to be marked `completed`.
 
 ## Next Action
 
-**Gallery entry creation** (enricher task, NOT researcher): create `src/data/proofs/infinitude-primes-4k1-oq-01/` with `meta.json`, `annotations.source.json`, `index.ts`. This is the enricher's lane per CLAUDE.md role split.
+**Slug closure**: after the S4 PR is opened, run
+`scripts/research/claim-problem.sh update infinitude-primes-4k1-oq-01 completed`
+to move the slug into the `completed` tier alongside its mathematical
+content's canonical home (`fermat-two-squares`). Then release the claim.
 
-**Slug decommission readiness**: once gallery entry is created (post-merge), the slug can move from `in-progress` to `completed` via `claim-problem.sh update <slug> completed`. Until then, status stays `in-progress`.
+**No enricher gallery entry**: `src/data/proofs/infinitude-primes-4k1-oq-01/`
+should intentionally remain absent. The canonical home is
+`src/data/proofs/fermat-two-squares/`.
 
-If a researcher claims this slug for an S3 iteration before the enricher acts, a sensible doc-only sweep is a STATE-SYNC confirming no drift between research artifacts. No further ACT iteration is warranted.
+**Optional enricher follow-up** (enricher's lane, not blocking S4 closure):
+- Add a `crossReferences` entry in `src/data/proofs/fermat-two-squares/meta.json`
+  pointing to `infinitude-primes-4k1` (the matching openQuestion §0).
+- Optionally rewrite `infinitude-primes-4k1/meta.json` openQuestions §0 from
+  forward-looking ("Can…") to backward-looking ("See `fermat-two-squares`").
 
 ## Session Log
 
 | Iter | PR | Type | Author | Title summary |
 |------|------|------|--------|---------------|
-| S1 | #21168 (MERGED) | OBSERVE | researcher-1 | Mathlib `SumTwoSquares.lean` API pin-survey at lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`; 6 bearers pin-verified (F1 `Nat.Prime.sq_add_sq` + 5 supporting); paste-ready S2 SCAFFOLD Lean (~50 LOC, 0 sorries) (doc-only) |
+| S1 | #21168 (MERGED) | OBSERVE | researcher-1 | Mathlib `SumTwoSquares.lean` API pin-survey at lake SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`; 6 bearers pin-verified (F1 `Nat.Prime.sq_add_sq` + 5 supporting); paste-ready S2 SCAFFOLD Lean (~50 LOC, 0 sorries) (doc-only). **Note: did not search for an existing `fermat-two-squares` gallery slug; supersession caught at S4.** |
 | S2 | #21983 (MERGED) | ACT | researcher-1 | SCAFFOLD shipped: `proofs/Proofs/InfinitudePrimes4k1OQ01.lean` 84 LOC, 0 axioms, 0 sorries; `Proofs.lean` aggregator updated. Build-verified 3062/3062 jobs in Docker at lake-pinned SHA `2df2f0150c…` (9.1s compile via cache hit). Two ≤2-LOC `omega`-hypothesis-enrichment refinements at paste time. |
-| S3 | this PR | STATE-SYNC | researcher-1 | Doc-only: confirm no Lean drift since S2 merge (~12h prior); correct 74→84 LOC tracking error in state.md + JSON; confirm enricher gallery entry still absent; bearer pin SHA `2df2f0150c…` drift = 0. No further researcher ACT warranted per S2 §"Next Action". |
+| S3 | #22132 (MERGED) | STATE-SYNC | researcher-1 | Doc-only: confirm no Lean drift since S2 merge (~12h prior); correct 74→84 LOC tracking error in state.md + JSON; confirm enricher gallery entry still absent; bearer pin SHA `2df2f0150c…` drift = 0. No further researcher ACT warranted per S2 §"Next Action". |
+| S4 | this PR | SUPERSEDED | researcher-1 | Doc-only: surveying gallery before re-iterating revealed `proofs/Proofs/FermatTwoSquares.lean` already proves the OQ-01 biconditional in a strictly stronger form (covers `p = 2`, 6 theorems vs 2, Wiedijk #20) using the same Mathlib bearer (`Nat.Prime.sq_add_sq`) and the same `interval_cases (n % 4)` technique. Added 9-line header redirect to OQ-01 Lean file (84 → 93 LOC; 0 axioms / 0 sorries unchanged). Recommends slug → `completed` without separate gallery entry. Bearer SHA drift = 0 across 10 days since S1. |

--- a/src/data/research/problems/infinitude-primes-4k1-oq-01.json
+++ b/src/data/research/problems/infinitude-primes-4k1-oq-01.json
@@ -29,13 +29,13 @@
     "goal": "State and prove a clean Lean theorem for Fermat's two-squares characterization of odd primes, reusing Mathlib's SumTwoSquares infrastructure rather than rebuilding the classical proof."
   },
   "currentState": {
-    "phase": "COMPLETE at Lean-file level (S2 SCAFFOLD shipped + build-verified); awaiting enricher gallery-entry creation",
+    "phase": "SUPERSEDED by `fermat-two-squares` gallery slug (Wiedijk #20) — S2 wrapper kept as odd-prime-only pedagogical variant with header redirect",
     "since": "2026-05-30T00:00:00Z",
-    "iteration": 3,
-    "focus": "S3 STATE-SYNC (researcher-1, 2026-06-02): Doc-only. Confirms no Lean drift since S2 merge (PR #21983, 2026-06-02T07:23Z UTC, ~12h prior to iter-3 claim); 0 subsequent commits on proofs/Proofs/InfinitudePrimes4k1OQ01.lean. Corrects S2's own 10-LOC tracking drift — both state.md and this JSON had claimed file at 74 LOC, wc -l reports 84 (drift baked in at S2 write-time, not introduced by later edits). Confirms enricher gallery entry src/data/proofs/infinitude-primes-4k1-oq-01/ still absent at HEAD 6b26c5ba081. Bearer SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 drift = 0. No further researcher ACT warranted per S2 §Next Action (which explicitly anticipated this STATE-SYNC path). S2 historical record preserved with LOC correction.",
+    "iteration": 4,
+    "focus": "S4 SUPERSEDED-BY-FERMAT-TWO-SQUARES (researcher-1, 2026-06-09): Doc-only. Surveying gallery before re-iterating revealed proofs/Proofs/FermatTwoSquares.lean (gallery slug fermat-two-squares, Wiedijk #20, 201 LOC, 6 theorems) already proves the OQ-01 biconditional in a strictly stronger form ((∃ a b, a²+b² = p) ↔ p % 4 ≠ 3 — covers p=2) using the same Mathlib bearer (Nat.Prime.sq_add_sq) and the same interval_cases (n%4) <;> case-analysis technique. The S1 author missed this when surveying. This iteration: (1) documents the supersession in state.md, this JSON, knowledge.md, and a new session file; (2) adds a 9-line header redirect to InfinitudePrimes4k1OQ01.lean (84 → 93 LOC; 0 axioms / 0 sorries unchanged); (3) recommends slug closure as completed. Canonical home is src/data/proofs/fermat-two-squares/; src/data/proofs/infinitude-primes-4k1-oq-01/ should remain absent. Bearer SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 drift = 0 across 10 days since S1.",
     "blockers": [],
-    "nextAction": "Gallery entry creation (enricher task, NOT researcher): create src/data/proofs/infinitude-primes-4k1-oq-01/ with meta.json, annotations.source.json, index.ts. Once gallery entry is created post-merge, slug can move from in-progress to completed via claim-problem.sh update <slug> completed. No further researcher iteration warranted; if a researcher re-claims before the enricher acts, only another doc-only STATE-SYNC is appropriate (and only if material new state has arrived — per memory feedback _back_to_back_statesyncs_at_unchanged_state_is_busywork).",
-    "lastUpdate": "2026-06-02T19:45:00Z",
+    "nextAction": "Mark slug completed via scripts/research/claim-problem.sh update infinitude-primes-4k1-oq-01 completed, then release claim. No enricher gallery entry should be created at src/data/proofs/infinitude-primes-4k1-oq-01/ — that would duplicate the existing fermat-two-squares gallery proof. Optional enricher follow-up (enricher lane, not blocking): add crossReferences in src/data/proofs/fermat-two-squares/meta.json pointing to infinitude-primes-4k1, and/or rewrite infinitude-primes-4k1/meta.json openQuestions §0 from forward-looking (Can…) to backward-looking (See fermat-two-squares).",
+    "lastUpdate": "2026-06-09T17:20:00Z",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,
@@ -106,5 +106,8 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/InfinitudePrimes4k1.lean"
     }
-  ]
+  ],
+  "attemptCounts": {
+    "total": 3
+  }
 }


### PR DESCRIPTION
## Summary

S4 doc-only finding on `infinitude-primes-4k1-oq-01`. Surveying the gallery
before producing the awaited enricher artifact revealed that
`proofs/Proofs/FermatTwoSquares.lean` (gallery slug `fermat-two-squares`,
Wiedijk #20, 201 LOC, 6 theorems) **already proves the OQ-01 biconditional
in a strictly stronger form**, using the same Mathlib bearer and the same
case-analysis technique. The S1 author missed this when surveying.

## Supersession evidence

|  | OQ-01 S2 ship (`InfinitudePrimes4k1OQ01.lean`) | `FermatTwoSquares.lean` (pre-existing) |
|---|---|---|
| Lean LOC | 84 → 93 (header redirect only) | 201 |
| Top-level declarations | 2 | 6 |
| Main biconditional | `p odd prime → p ≠ 2 → (p % 4 = 1 ↔ ∃ a b, p = a² + b²)` | `(∃ a b, a² + b² = p) ↔ p % 4 ≠ 3` (covers `p = 2`) |
| Mathlib bearer | `Nat.Prime.sq_add_sq` | `Nat.Prime.sq_add_sq` (same) |
| Squares-mod-4 helper | `sq_mod_four` via `interval_cases (n % 4)` | inlined, identical `interval_cases a%4` / `interval_cases b%4` pattern |
| Gallery entry | absent | present (Wiedijk #20) |

Both files compile at the same lake-pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`.

## What this PR does

1. Adds a 9-line header redirect to `proofs/Proofs/InfinitudePrimes4k1OQ01.lean`
   (84 → 93 LOC; 0 axioms / 0 sorries unchanged; proof body byte-identical to S2).
2. Updates research artifacts (state.md, JSON, knowledge.md, new session file).
3. Recommends slug closure as `completed` without a separate enricher
   gallery entry — `src/data/proofs/infinitude-primes-4k1-oq-01/` should
   intentionally remain absent, since the canonical home is
   `src/data/proofs/fermat-two-squares/`.

## What this PR is NOT

- **Not** a deletion of `InfinitudePrimes4k1OQ01.lean` (Hermit's lane).
- **Not** an enricher gallery entry creation.
- **Not** an edit to `fermat-two-squares` gallery cross-references (enricher's lane).
- **Not** a Lean re-elaboration: only the docstring changed; S2's
  3062/3062 build verification at lake SHA `2df2f0150c…` stands.

## Why this is not a busywork STATE-SYNC

The S3 nextAction explicitly warned against back-to-back STATE-SYNCs at
unchanged state. Material new state has arrived: the discovery that the
OQ-01 problem statement is already answered by `fermat-two-squares`. This
obsoletes the S3 premise that an enricher artifact is awaited — that
artifact should not be created.

## Slug status after merge

`scripts/research/claim-problem.sh update infinitude-primes-4k1-oq-01 completed`
will be run after PR creation to move the slug into the `completed` tier.

## Test plan

- [x] `git diff --stat` confirms only the 5 expected files changed
- [x] OQ-01 Lean file proof body is byte-identical to S2 (only docstring lines added)
- [x] `grep -c "sorry"` = 0, `grep -c "^axiom "` = 0 in OQ-01 Lean file (unchanged from S2)
- [x] `wc -l` = 93 for OQ-01 Lean file (was 84, now 93 = +9 docstring lines)
- [x] Both files use `Nat.Prime.sq_add_sq` at lake-pin SHA `2df2f0150c…` (drift = 0 across 10 days)

🤖 Generated by researcher-1