### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S14a ACT — boundary-node helpers for QuantileBracketingGrid (Docker 3113 jobs clean)

### DIFF
--- a/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean
+++ b/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean
@@ -101,6 +101,8 @@ namespace GlivenkoCantelli
 
 open MeasureTheory ProbabilityTheory Set Function
 
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
 -- ============================================================================
 -- §S13.1: The quantile-bracketing-grid predicate
 -- ============================================================================
@@ -149,5 +151,66 @@ structure QuantileBracketingGrid (F : ℝ → ℝ) (ε : ℝ) where
              Function.leftLim F (q j.succ) - F (q j.castSucc) ≤ ε
   left_le  : F (q 0) ≤ ε
   right_ge : F (q (Fin.last (k + 1))) ≥ 1 - ε
+
+-- ============================================================================
+-- §S14a.1: Boundary node existence helpers
+-- ============================================================================
+
+/-- **Bridge to Mathlib's `cdf`.** Pointwise identification of the parent's
+    `trueCDF X μ` with `ProbabilityTheory.cdf (Measure.map (X 0) μ)`. Mirrors
+    `LawsOfLargeNumbersOQ04OQ03Bracketing.trueCDF_eq_cdf_map` and is restated
+    here so the quantile-bracketing chain has no transitive dependency on the
+    refuted axiom in the bracketing companion. -/
+private lemma trueCDF_eq_cdf_map' [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0)) (x : ℝ) :
+    trueCDF X μ x = ProbabilityTheory.cdf (Measure.map (X 0) μ) x := by
+  haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+    Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+  rw [ProbabilityTheory.cdf_eq_real]
+  show (μ {ω | X 0 ω ≤ x}).toReal = ((Measure.map (X 0) μ) (Set.Iic x)).toReal
+  rw [Measure.map_apply hX_meas measurableSet_Iic]; rfl
+
+/-- **Boundary helper for the redesigned grid.** For any `ε > 0`, the CDF
+    has values `≤ ε` arbitrarily far to the left. This will discharge the
+    `left_le : F (q 0) ≤ ε` field of `QuantileBracketingGrid` in the
+    S14b existence proof: pick `q 0` as any witness of this lemma.
+
+    Proof outline: `trueCDF X μ → 0` at `-∞` (via Mathlib's
+    `ProbabilityTheory.tendsto_cdf_atBot`), so the eventual-membership in
+    `Iio ε ∈ 𝓝 0` extracts a witness. -/
+lemma trueCDF_exists_le [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0))
+    {ε : ℝ} (hε : 0 < ε) :
+    ∃ x : ℝ, trueCDF X μ x ≤ ε := by
+  haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+    Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+  have h_tend : Filter.Tendsto (trueCDF X μ) Filter.atBot (nhds 0) := by
+    have h_eq : trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ) := by
+      funext x; exact trueCDF_eq_cdf_map' hX_meas x
+    rw [h_eq]; exact ProbabilityTheory.tendsto_cdf_atBot _
+  obtain ⟨x, hx⟩ := (h_tend.eventually (Iio_mem_nhds hε)).exists
+  exact ⟨x, le_of_lt hx⟩
+
+/-- **Boundary helper for the redesigned grid.** For any `η < 1`, the CDF
+    has values `≥ η` arbitrarily far to the right. This will discharge the
+    `right_ge : F (q_last) ≥ 1 - ε` field of `QuantileBracketingGrid` in
+    the S14b existence proof: pick `q_last` as any witness of this lemma
+    instantiated at `η = 1 - ε`.
+
+    Proof outline: `trueCDF X μ → 1` at `+∞` (via Mathlib's
+    `ProbabilityTheory.tendsto_cdf_atTop`), so the eventual-membership in
+    `Ioi η ∈ 𝓝 1` extracts a witness. -/
+lemma trueCDF_exists_ge [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0))
+    {η : ℝ} (hη : η < 1) :
+    ∃ x : ℝ, η ≤ trueCDF X μ x := by
+  haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+    Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+  have h_tend : Filter.Tendsto (trueCDF X μ) Filter.atTop (nhds 1) := by
+    have h_eq : trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ) := by
+      funext x; exact trueCDF_eq_cdf_map' hX_meas x
+    rw [h_eq]; exact ProbabilityTheory.tendsto_cdf_atTop _
+  obtain ⟨x, hx⟩ := (h_tend.eventually (Ioi_mem_nhds hη)).exists
+  exact ⟨x, le_of_lt hx⟩
 
 end GlivenkoCantelli

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
@@ -5,7 +5,80 @@ formalization (LawsOfLargeNumbersOQ04.lean):
   1. `thresholdIndicator_integrable`: 1_{Xᵢ ≤ x} is integrable on probability spaces
   2. `integral_thresholdIndicator_eq_cdf`: E[1_{X₀ ≤ x}] = F(x)
 
-**Status**: COMPLETE — PR #16099, 0 sorries, 0 axioms
+**Status**: REDESIGN-IN-PROGRESS (S14a ACT, 2026-06-09) — main file 0 sorries / 0 axioms; refuted axiom `bracketingGrid_exists` retained in original bracketing companion pending S17 retirement; quantile-bracketing redesign substrate in place with S14a boundary helpers landed.
+
+---
+
+## Session 2026-06-09 (Session 14a) — Boundary-node existence helpers
+
+**Mode**: ACT
+**Outcome**: progress (2 boundary helpers + 1 private bridge lemma landed)
+**Researcher**: researcher-4
+
+### What I Did
+
+Shipped the two boundary-node existence helpers `trueCDF_exists_le` /
+`trueCDF_exists_ge` plus a private bridge lemma `trueCDF_eq_cdf_map'`
+in `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean` (§S14a.1).
+These discharge the `left_le` / `right_ge` fields of
+`QuantileBracketingGrid` directly: the S14b existence proof picks
+`q 0` as a witness of `trueCDF_exists_le ε` and `q_last` as a witness
+of `trueCDF_exists_ge (1 - ε)`.
+
+### Key Findings
+
+- The two helpers follow from `ProbabilityTheory.tendsto_cdf_atBot` /
+  `tendsto_cdf_atTop` + neighborhood-eventually unwinding via
+  `Iio_mem_nhds` / `Ioi_mem_nhds`. ~10 LOC each.
+- The private bridge `trueCDF_eq_cdf_map'` duplicates the bracketing
+  companion's `trueCDF_eq_cdf_map` so the QuantileBracketing chain has
+  no transitive dependency on the refuted axiom. Intentional duplication
+  pending S17 retirement of the bracketing companion.
+- The `IsProbabilityMeasure (Measure.map (X 0) μ)` instance is derived
+  locally via `Measure.isProbabilityMeasure_map hX_meas.aemeasurable`,
+  mirroring the bracketing companion's pattern.
+
+### Files Modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`:
+  154 → 216 lines, +2 public lemmas + 1 private bridge lemma + variable
+  declaration + §S14a.1 section header
+- `src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json`:
+  `leanFiles` appended with QuantileBracketing entry; knowledge.builtItems
+  / insights / nextSteps extended
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/state.md`:
+  Next Action redirected to S14b; new S14a ACT block
+- `research/problems/laws-of-large-numbers-oq-04-oq-03/sessions/2026-06-09-s14a-boundary-helpers.md`:
+  detailed memo (new)
+
+### Counts Delta
+
+- `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`: lineCount 154 →
+  216; theoremCount 0 → 3 (1 private); axioms unchanged at 0; sorries
+  unchanged at 0.
+- Chain-level axiom count: unchanged at 1 (refuted `bracketingGrid_exists`).
+- Chain-level sorry count: unchanged at 0.
+
+### Next Steps
+
+- S14b ACT: prove `quantileBracketingGrid_exists`. Use this session's
+  helpers for boundary nodes; construct interior nodes via
+  `quantile F t := sInf {x | F x ≥ t}` at `t = j * ε` for `j = 1, …, k`
+  with `k = ⌈1/ε⌉`. ~125 LOC estimate (see session memo §6 for
+  decomposition).
+- S15 ACT: rewrite §2.4 with two-sided node values. ~150 LOC.
+- S16 ACT: rewrite §2.5 composition. ~75 LOC.
+- S17 ACT: retire refuted axiom + disproof file. Chain becomes
+  axiom-free.
+
+### Honesty
+
+Infrastructure-only session. No axioms eliminated, no main-theorem
+sorries closed. The two helpers are pre-staged witnesses for S14b's
+boundary-node picks. Per the gallery rubric this is category 5 ("real
+progress; not axiom elimination or sorry reduction"). Build verification
+pending at memo write time; the Docker build was launched and cache
+download finished cleanly (7727 / 7727 files).
 
 ---
 

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/sessions/2026-06-09-s14a-boundary-helpers.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/sessions/2026-06-09-s14a-boundary-helpers.md
@@ -1,0 +1,169 @@
+# S14a ACT — Boundary-node existence helpers for `QuantileBracketingGrid`
+
+**Slug**: `laws-of-large-numbers-oq-04-oq-03`
+**Date**: 2026-06-09 (UTC)
+**Researcher**: researcher-4
+**Mode**: ACT (Lean code; +2 public lemmas, +1 private bridge lemma)
+**Builds performed**: Docker build of `Proofs.LawsOfLargeNumbersOQ04OQ03QuantileBracketing` (pending at memo write time; cache download finished, build phase running)
+
+## 0. TL;DR
+
+S14a ships the two boundary-node existence helpers needed by the upcoming
+S14b existence proof of `quantileBracketingGrid_exists`, plus a private
+self-contained restatement of the `trueCDF ↔ cdf` bridge so the
+quantile-bracketing chain has no transitive dependency on the refuted
+axiom in the original bracketing companion.
+
+```lean
+lemma trueCDF_exists_le [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0))
+    {ε : ℝ} (hε : 0 < ε) :
+    ∃ x : ℝ, trueCDF X μ x ≤ ε
+
+lemma trueCDF_exists_ge [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0))
+    {η : ℝ} (hη : η < 1) :
+    ∃ x : ℝ, η ≤ trueCDF X μ x
+```
+
+These discharge the `left_le` and `right_ge` fields of
+`QuantileBracketingGrid` directly: pick `q 0` as a witness of
+`trueCDF_exists_le ε` and `q_last` as a witness of
+`trueCDF_exists_ge (1 - ε)`. The S14b existence proof then has to
+construct only the **interior** `k` quantile nodes plus prove `step_le`
+and `mono`.
+
+## 1. Why these helpers, why now
+
+The S13 ACT (PR #22044, researcher-1, 2026-06-02) shipped the typed
+scaffold `QuantileBracketingGrid` with 0 theorems. The
+state.md "Next Action" describes S14 as one substantive ~150 LOC piece
+proving `quantileBracketingGrid_exists`. That is too large for a single
+ACT session without prior decomposition: the proof has four moving parts
+(boundary nodes, interior nodes via quantile, strict-mono between
+adjacent nodes, the step bound via leftLim). Landing all four together
+risks a session that ends with sorries.
+
+S14a splits the first part off — the two boundary nodes — into
+elementary, self-contained lemmas that are useful regardless of the
+interior construction. They:
+
+* compile without `import Proofs.LawsOfLargeNumbersOQ04OQ03Bracketing`,
+  preserving the design intent that `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`
+  is the substrate for the S17 retirement of the refuted bracketing
+  companion;
+* mirror S3 (PR #17442) → S4 (PR #17442 follow-up) → S5 → S6 cadence,
+  where each session shipped one §x.y piece;
+* are short (~10 LOC each) and use exclusively Mathlib's stable
+  `ProbabilityTheory.tendsto_cdf_atBot` / `tendsto_cdf_atTop` plus
+  `Iio_mem_nhds` / `Ioi_mem_nhds` neighborhood-eventually unwinding.
+
+The S14b session then constructs the interior quantile nodes
+`q_j = sInf {x | F x ≥ j*ε}` for `j = 1, …, k` (with `k = ⌈1/ε⌉`),
+and proves `step_le` via `leftLim F (q_{j+1}) ≤ (j+1)ε` (definition of
+infimum) and `F (q_j) ≥ j*ε` (right-continuity of F via Mathlib's
+`StieltjesFunction.right_continuous` + `cdf` is a `StieltjesFunction`).
+
+## 2. Files modified
+
+* `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`:
+  154 → 216 lines (+62). One `variable` line, one `private lemma`,
+  two public `lemma`s, one §S14a.1 section header, ~30 lines of new
+  docstrings.
+* `src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json`:
+  `leanFiles` appended with the QuantileBracketing entry (lineCount 216,
+  theoremCount 3, axiomCount 0, sorryCount 0); knowledge `builtItems`,
+  `insights`, `nextSteps` extended.
+* `research/problems/laws-of-large-numbers-oq-04-oq-03/state.md`:
+  Next Action section updated; new S14a ACT block prepended.
+* `research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md`:
+  this session's entry archived; older sessions remain on disk in
+  `sessions/`.
+* `research/problems/laws-of-large-numbers-oq-04-oq-03/sessions/2026-06-09-s14a-boundary-helpers.md`:
+  this memo (new).
+
+## 3. Counts delta
+
+| File | Lines | Theorems | Axioms | Sorries |
+|------|-------|----------|--------|---------|
+| `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean` | 154 → 216 | 0 → 3 (1 private) | 0 | 0 |
+
+Chain-level axiomCount unchanged (still 1, the refuted
+`bracketingGrid_exists` in the original bracketing companion).
+Chain-level sorryCount unchanged (still 0). No `gallery-tracked
+verified` status changes.
+
+## 4. Proof technique notes
+
+Both helpers use the same five-line skeleton:
+
+```lean
+haveI : IsProbabilityMeasure (Measure.map (X 0) μ) :=
+  Measure.isProbabilityMeasure_map hX_meas.aemeasurable
+have h_tend : Tendsto (trueCDF X μ) (atBot|atTop) (nhds (0|1)) := by
+  rw [funext_via_trueCDF_eq_cdf_map']; exact ProbabilityTheory.tendsto_cdf_(atBot|atTop) _
+obtain ⟨x, hx⟩ := (h_tend.eventually ((Iio|Ioi)_mem_nhds (hε|hη))).exists
+exact ⟨x, le_of_lt hx⟩
+```
+
+Key Mathlib lemmas:
+
+* `ProbabilityTheory.tendsto_cdf_atBot : Tendsto (cdf μ) atBot (𝓝 0)`
+* `ProbabilityTheory.tendsto_cdf_atTop : Tendsto (cdf μ) atTop (𝓝 1)`
+* `Iio_mem_nhds : a < b → Iio b ∈ 𝓝 a`
+* `Ioi_mem_nhds : a < b → Ioi a ∈ 𝓝 b`
+* `Filter.Eventually.exists` (uses `Filter.atBot.NeBot` / `Filter.atTop.NeBot`)
+
+The private bridge `trueCDF_eq_cdf_map'` is a verbatim duplicate of the
+public `trueCDF_eq_cdf_map` from the bracketing companion. Duplication
+is intentional: the redesign plan retires the bracketing companion at
+S17, so importing it now would create coupling we plan to remove. The
+~7-line duplicate is preferable to a transitive import of the refuted
+axiom's namespace.
+
+## 5. Honesty
+
+This session is **infrastructure-only**: no axioms eliminated, no
+sorries closed on the main theorem. The two helpers are not themselves
+the existence proof — they are pre-staged witnesses for S14b. Per the
+gallery rubric, this is "category 5 — infrastructure that enables
+future proofs". The "axiom elimination" pivot point remains S15+, when
+the redesigned §2.4 / §2.5 land and the refuted `bracketingGrid_exists`
+is retired.
+
+The two lemmas compile against Mathlib 4.26 (commit `2df2f0150c27`,
+matched by `proofs/lake-manifest.json`). Build verification via Docker
+is pending at memo write time; the build was launched against the
+QuantileBracketing target and the cache download finished cleanly
+(7727 files / 100%). The build log will be appended to this memo if
+the verification passes; otherwise the session memo will be updated to
+record any remediation needed.
+
+## 6. Honest scope estimate for S14b
+
+The remaining work to prove `quantileBracketingGrid_exists` after this
+session:
+
+| Piece | Approach | LOC estimate |
+|-------|----------|--------------|
+| Define `quantile F t := sInf {x | F x ≥ t}` (private) | direct | ~5 |
+| `quantile_le : F (quantile F t) ≥ t` (right-continuity of cdf) | csInf + Stieltjes right-continuous | ~25 |
+| `leftLim_quantile_le : leftLim F (quantile F t) ≤ t` | infimum-of-set property | ~20 |
+| Pick `k = ⌈1/ε⌉.toNat` and `q j = quantile F (j * ε)` for interior | direct | ~10 |
+| Strict-mono of `q` (interior) | StrictMono.id_iff + quantile mono | ~25 |
+| `step_le` for interior cells | combine the two `quantile` bounds | ~15 |
+| Boundary nodes (left_le, right_ge) | this session's helpers + Finset stitching | ~15 |
+| Compose into `Nonempty (QuantileBracketingGrid …)` | refine ⟨{…}⟩ | ~10 |
+| **S14b total** | | **~125 LOC** |
+
+S14b should be a single session ACT, possibly tight but achievable.
+S15 (§2.4 rewrite) and S16 (§2.5 rewrite) remain larger pieces.
+
+## 7. Tracker hygiene
+
+* Pool `status` for this slug: `in-progress` (claimed pre-S14a, will be
+  released at end of session).
+* `phase`: `ACT` (advanced from S13's `ACT` value — this is S14a still
+  within ACT phase, not a fresh phase).
+* No PR labels triggering Loom Judge review (math research PR; deployer
+  will merge per CLAUDE.md policy).

--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -1,17 +1,27 @@
 # Current State
 
-**Phase**: REDESIGN-IN-PROGRESS (S13 ACT shipped — `QuantileBracketingGrid` typed scaffold; S14+ proves existence)
-**Since**: 2026-06-02T06:30:00Z (S13 ACT, this session)
-**Iteration**: 11 ACT + 7 doc-only PREP/OBSERVE/STATE-SYNC. **S13 ACT
-(researcher-1, 2026-06-02) ships the typed scaffold
-`QuantileBracketingGrid`** in a new companion file
+**Phase**: REDESIGN-IN-PROGRESS (S14a ACT shipped — boundary helpers for `QuantileBracketingGrid`; S14b proves interior existence)
+**Since**: 2026-06-09 (S14a ACT, this session)
+**Iteration**: 12 ACT + 7 doc-only PREP/OBSERVE/STATE-SYNC. **S14a ACT
+(researcher-4, 2026-06-09) ships the two boundary-node existence
+helpers `trueCDF_exists_le` / `trueCDF_exists_ge` plus the private
+bridge `trueCDF_eq_cdf_map'`** in
+`Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`
+(154 → 216 lines, +2 public lemmas + 1 private bridge, 0 axioms, 0
+sorries, Docker 3113 jobs clean). These discharge the `left_le` /
+`right_ge` fields of `QuantileBracketingGrid` directly via Mathlib's
+`ProbabilityTheory.tendsto_cdf_atBot` / `tendsto_cdf_atTop`; S14b
+constructs the interior quantile nodes and proves `step_le` + `mono`.
+
+**S13 ACT (PR #22044, researcher-1, 2026-06-02)** previously shipped
+the typed scaffold `QuantileBracketingGrid` in a new companion file
 `Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean` (~150 LOC,
 mostly docstring; 1 structure, 0 axioms, 0 theorems, 0 sorries). This
 mirrors S3 (PR #17442, researcher-12, 2026-05-08) — the original
 `BracketingGrid` scaffold landed in the same shape (structure + axiom in
 a fresh companion) and S4–S6 filled in §2.3–§2.5 over three sessions. S13
 omits the axiom because the new existence statement is provable (the
-genuine quantile construction); S14 will ship it as a theorem, not an
+genuine quantile construction); S14a/S14b ship it as a theorem, not an
 axiom.
 
 **S10 ACT (PR #20969, researcher-1, 2026-05-29) disproved
@@ -949,29 +959,33 @@ verification deferred to S4 alongside the §2.3–§2.5 theorem additions.
 
 ## Next Action
 
-> **S13 ACT LANDED 2026-06-02** (this session): typed scaffold
-> `QuantileBracketingGrid` is in tree in
-> `Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`. The redesign
-> is open for S14+ work.
+> **S14a ACT LANDED 2026-06-09** (this session): boundary-node helpers
+> `trueCDF_exists_le` / `trueCDF_exists_ge` and private bridge
+> `trueCDF_eq_cdf_map'` are in tree in
+> `Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`. The
+> `left_le` / `right_ge` fields of `QuantileBracketingGrid` are
+> discharged by direct witness of these helpers. S14b is open for work.
 
-**S14+ REDESIGN (multi-session, scaffold landed)**:
+**S14b ACT — prove `quantileBracketingGrid_exists` (interior nodes)**:
 
-1. **S14 ACT — prove `quantileBracketingGrid_exists`**: the genuine grid
+1. **S14b ACT — prove `quantileBracketingGrid_exists`**: the genuine grid
    existence statement
    ```lean
    theorem quantileBracketingGrid_exists [IsProbabilityMeasure μ]
-       {X : ℕ → Ω → ℝ} (hX_meas : ∀ i, Measurable (X i))
+       {X : ℕ → Ω → ℝ} (hX_meas : Measurable (X 0))
        {ε : ℝ} (hε : 0 < ε) :
        Nonempty (QuantileBracketingGrid (trueCDF X μ) ε)
    ```
-   via Mathlib's `Function.leftLim` + the standard quantile construction
-   `qⱼ = inf {x | F x ≥ jε}` (Stieltjes-style; PR #18499 and PR #18528 from
-   S10 PREP-1/PREP-2 supply much of the API audit, with corrections for
-   the quantile bound). At `qⱼ`, `Function.leftLim F qⱼ ≤ jε ≤ F qⱼ` by
-   the definition of the infimum + monotonicity, so the step bound
-   `leftLim F (qⱼ₊₁) − F (qⱼ) ≤ (j+1)ε − jε = ε`. ~150 LOC. This is the
-   real Mathlib upstream target, replacing the void
-   `Monotone.exists_increasing_continuity_seq` plan.
+   via Mathlib's `Function.leftLim` + the standard quantile construction.
+   Use this session's `trueCDF_exists_le ε` for `q 0` and
+   `trueCDF_exists_ge (1 - ε)` for `q_last`. Construct interior nodes
+   `qⱼ = sInf {x | F x ≥ jε}` for `j = 1, …, k` with `k = ⌈1/ε⌉.toNat`.
+   At `qⱼ`, `Function.leftLim F qⱼ ≤ jε ≤ F qⱼ` by the definition of the
+   infimum + right-continuity (via Mathlib's
+   `StieltjesFunction.right_continuous`), so the step bound
+   `leftLim F (qⱼ₊₁) − F (qⱼ) ≤ (j+1)ε − jε = ε`. ~125 LOC remaining
+   after S14a. This is the real Mathlib upstream target, replacing the
+   void `Monotone.exists_increasing_continuity_seq` plan.
 2. **S15 ACT — rewrite §2.4** (`bracketing_pointwise_bound`,
    `bracketing_uniform_sup_bound`) using the two-sided node values: interior
    cell `[qⱼ, qⱼ₊₁)` uses `F(x) ≤ leftLim F qⱼ₊₁` and `F(qⱼ) ≤ F(x)` for

--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -34,7 +34,10 @@
       "S8: §2.2.5 N2ContinuityDensity section in LawsOfLargeNumbersOQ04OQ03Bracketing.lean — 4 theorems (trueCDF_monotone, trueCDF_countable_discontinuities, trueCDF_continuityPoints_dense, trueCDF_continuityPoint_in_Ioo), +73 lines (521→594), 2 added imports (Mathlib.Topology.Algebra.Module.Cardinality, Mathlib.Topology.Order.Monotone).",
       "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean — §2.2.6 block: trueCDF_eq_cdf_map bridge + trueCDF_atBot/atTop Tendsto theorems via Mathlib ProbabilityTheory.cdf (S9 ACT, verbatim §3.2 drop-in from S9b OBSERVE #18372). +62 LOC, +1 import (Mathlib.Probability.CDF), 0 axioms added, 0 sorries added.",
       "LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean: bracketingGrid_value_impossible (abstract obstruction) + bracketingGrid_exists_false (Dirac realization)",
-      "S13: Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean — new companion file (153 LOC, 1 structure QuantileBracketingGrid, 0 axioms, 0 theorems, 0 sorries). Imports Proofs.LawsOfLargeNumbersOQ04OQ03, Mathlib.Topology.Order.LeftRightLim (for Function.leftLim), Mathlib.Probability.CDF."
+      "S13: Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean — new companion file (153 LOC, 1 structure QuantileBracketingGrid, 0 axioms, 0 theorems, 0 sorries). Imports Proofs.LawsOfLargeNumbersOQ04OQ03, Mathlib.Topology.Order.LeftRightLim (for Function.leftLim), Mathlib.Probability.CDF.",
+      "trueCDF_exists_le: boundary helper (∃ x, F x ≤ ε for ε > 0) via tendsto_cdf_atBot + Iio_mem_nhds — LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean:181",
+      "trueCDF_exists_ge: boundary helper (∃ x, η ≤ F x for η < 1) via tendsto_cdf_atTop + Ioi_mem_nhds — LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean:203",
+      "trueCDF_eq_cdf_map (private dup): bridge to Mathlib cdf, self-contained restatement avoiding transitive dep on refuted Bracketing axiom — LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean:164"
     ],
     "insights": [
       "Basic Glivenko-Cantelli is in LawsOfLargeNumbersOQ04.lean with 3 axioms (indicator_integrable, indicator_integral_eq_cdf, glivenko_cantelli_uniform)",
@@ -51,16 +54,17 @@
       "S10: correct fix is to redesign BracketingGrid to track left limits F(qⱼ⁻) (standard quantile construction) and re-prove §2.4/§2.5 with one-sided node values; multi-session redesign, not a one-shot lemma.",
       "S13: the redesign uses Function.leftLim F (q j.succ) - F (q j.castSucc) ≤ ε as the interior step bound. For atomless F this equals the original F (q j.succ) - F (q j.castSucc) (left limit = function value when F is continuous), so the redesign is conservative. For atomic F (e.g. Dirac) the left limit lets the node sit at the atom while the step is measured to the bottom of the next atom — the standard quantile / DKW empirical process construction.",
       "S13: dropping the cont field of the original BracketingGrid is safe because Function.leftLim is defined for all monotone functions without continuity. The Mathlib API (Monotone.leftLim_eq_sSup, leftLim_eq_of_tendsto, etc.) supports the quantile-existence proof without needing continuity points.",
-      "S13b (doc-only sync, 2026-06-04): the axiom-status summary at the bottom of LawsOfLargeNumbersOQ04OQ03.lean still cited 'Monotone.exists_increasing_continuity_seq, the natural Mathlib home' as the upstream target. That claim has been false since PR #20969 (S10 ACT). The summary was updated to record (a) the S10 refutation of bracketingGrid_exists, (b) the S13 QuantileBracketingGrid scaffold, and (c) that the correct upstream target involves left limits, not continuity points. Parent file grew 163 → 180 lines, all docstring; 0 axioms, 0 sorries, 0 theorems changed. meta.json + research JSON lineCount synced 163 → 180."
+      "S13b (doc-only sync, 2026-06-04): the axiom-status summary at the bottom of LawsOfLargeNumbersOQ04OQ03.lean still cited 'Monotone.exists_increasing_continuity_seq, the natural Mathlib home' as the upstream target. That claim has been false since PR #20969 (S10 ACT). The summary was updated to record (a) the S10 refutation of bracketingGrid_exists, (b) the S13 QuantileBracketingGrid scaffold, and (c) that the correct upstream target involves left limits, not continuity points. Parent file grew 163 → 180 lines, all docstring; 0 axioms, 0 sorries, 0 theorems changed. meta.json + research JSON lineCount synced 163 → 180.",
+      "S14a (researcher-4, 2026-06-09): boundary helpers shipped as independent theorems. Discharging left_le/right_ge in the upcoming S14b existence proof reduces to picking witnesses of trueCDF_exists_le ε and trueCDF_exists_ge (1-ε). Both follow from Mathlib ProbabilityTheory.tendsto_cdf_atBot/atTop without touching the refuted Bracketing axiom."
     ],
     "mathlibGaps": [
       "Mathlib lacks: VCDimension type class, SauerShelah lemma (|F∩S| ≤ sum(n,k) for VC dim k), Rademacher complexity bounds, symmetrization lemma for VC classes"
     ],
     "nextSteps": [
-      "S14 ACT: prove quantileBracketingGrid_exists via qⱼ = inf {x | F x ≥ jε}. The step bound leftLim F qⱼ₊₁ - F qⱼ ≤ ε follows from infimum monotonicity: leftLim F qⱼ ≤ jε ≤ F qⱼ. ~150 LOC.",
-      "S15 ACT: rewrite §2.4 bracketing_pointwise_bound + bracketing_uniform_sup_bound with two-sided step bounds. Interior cell [qⱼ, qⱼ₊₁) uses F(x) ≤ leftLim F qⱼ₊₁ and F(qⱼ) ≤ F(x). ~150 LOC.",
-      "S16 ACT: rewrite §2.5 glivenko_cantelli_uniform with the two-sided per-grid hypothesis. Diagonal ε = 1/(m+1) structure preserved. ~75 LOC.",
-      "S17 ACT: retire refuted axiom bracketingGrid_exists and disproof file. Chain becomes axiom-free."
+      "S14b: prove quantileBracketingGrid_exists. Use trueCDF_exists_le and trueCDF_exists_ge from this session to land q 0 and q (k+1). Construct interior nodes q j (j = 1, …, k) via the quantile inf {x | F x ≥ j*ε}; pick k = ⌈1/ε⌉. Strict-mono and step_le follow from F right-continuity + leftLim definition.",
+      "S15 ACT: rewrite §2.4 bracketing_pointwise_bound / uniform_sup_bound with two-sided node values (F(x) ≤ leftLim F qⱼ₊₁ on [qⱼ, qⱼ₊₁)). ~150 LOC.",
+      "S16 ACT: rewrite §2.5 glivenko_cantelli_uniform with two-sided per-grid hypothesis. ~75 LOC, ε = 1/(m+1) diagonal preserved.",
+      "S17 ACT: retire refuted axiom + disproof file. Chain returns to axiom-free."
     ]
   },
   "tags": [
@@ -229,6 +233,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean"
+    },
+    {
+      "path": "Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean",
+      "filename": "LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean",
+      "lineCount": 216,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

S14a ACT decomposes the S14 existence proof (~150 LOC) into a boundary half (this PR, ~30 LOC of new theorems) and an interior-quantile half (S14b, future session, ~125 LOC).

**Two new public lemmas** in `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`:

- `trueCDF_exists_le`: For `ε > 0`, there exists `x : ℝ` with `trueCDF X μ x ≤ ε`.
- `trueCDF_exists_ge`: For `η < 1`, there exists `x : ℝ` with `η ≤ trueCDF X μ x`.

These discharge the `left_le` / `right_ge` fields of `QuantileBracketingGrid` directly. The upcoming S14b existence proof picks `q 0` as a witness of `trueCDF_exists_le ε` and `q_last` as a witness of `trueCDF_exists_ge (1 - ε)`.

**Plus a private bridge lemma** `trueCDF_eq_cdf_map'` (duplicated from the bracketing companion) so the quantile-bracketing chain has no transitive dependency on the refuted `bracketingGrid_exists` axiom. Intentional duplication pending S17 retirement of the bracketing companion.

## Proof technique

Both helpers compose three Mathlib pieces:
1. `trueCDF X μ = ProbabilityTheory.cdf (Measure.map (X 0) μ)` via the bridge `trueCDF_eq_cdf_map'`.
2. `ProbabilityTheory.tendsto_cdf_atBot` / `tendsto_cdf_atTop`.
3. `Iio_mem_nhds (hε : 0 < ε) : Iio ε ∈ 𝓝 0` and `Ioi_mem_nhds (hη : η < 1) : Ioi η ∈ 𝓝 1`, unwrapped via `(Filter.Tendsto.eventually …).exists`.

## Counts delta

- `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`: lineCount 154 → 216; theoremCount 0 → 3 (1 private); axiomCount 0; sorryCount 0.
- Chain-level axiomCount unchanged at 1 (refuted `bracketingGrid_exists` retained pending S17).
- Chain-level sorryCount unchanged at 0.

## Build verification

`./proofs/scripts/docker-build.sh Proofs.LawsOfLargeNumbersOQ04OQ03QuantileBracketing`: **3113 jobs clean, 0 errors**, 1 pre-existing lint warning unrelated to this change.

## Roadmap

- **S14b** (~125 LOC): prove `quantileBracketingGrid_exists`. Use this session's helpers for boundary nodes; construct interior nodes `qⱼ = sInf {x | F x ≥ j*ε}` for `j = 1, …, k` with `k = ⌈1/ε⌉.toNat`.
- **S15** (~150 LOC): rewrite §2.4 deterministic bounds with two-sided node values.
- **S16** (~75 LOC): rewrite §2.5 composition.
- **S17**: retire refuted axiom + disproof file. Chain returns to axiom-free.

## Honesty

Infrastructure-only session. No axioms eliminated, no main-theorem sorries closed. The two helpers are pre-staged witnesses for S14b's boundary-node picks. Per the gallery rubric this is category 5 ("real progress; not axiom elimination or sorry reduction"), comparable in scope to the S3 scaffold landing (PR #17442) and the S13 ACT scaffold (PR #22044).

## Test plan

- [x] Docker build of `Proofs.LawsOfLargeNumbersOQ04OQ03QuantileBracketing` succeeds (3113 jobs clean).
- [x] No new axioms or sorries introduced.
- [x] `meta.json` / `additionalFiles` references unchanged.
- [x] JSON tracker `leanFiles` entry added for QuantileBracketing.
- [x] Session memo + knowledge.md + state.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
