### PR TITLE
research(fermat-defect-one): new gallery entry with verified n=3 benchmarks

### DIFF
--- a/proofs/Proofs/FermatDefectOne.lean
+++ b/proofs/Proofs/FermatDefectOne.lean
@@ -1,0 +1,146 @@
+/-
+  Fermat Defect-One Conjecture
+
+  The Fermat equation $a^n + b^n - c^n = 0$ has no nontrivial solutions for
+  $n > 2$ (Fermat's Last Theorem). This file investigates the very next
+  question: can the "defect" be exactly $\pm 1$?
+
+      $$ | a^n + b^n - c^n | = 1 $$
+
+  A primitive, nontrivial witness is asked for: $2 \le a \le b < c$ and
+  $\gcd(a, b, c) = 1$. To avoid signed-integer coercions, the absolute-value
+  condition is expressed as a disjunction on `Nat`:
+
+      $a^n + b^n + 1 = c^n$    (negative defect: $a^n+b^n-c^n = -1$)
+      $a^n + b^n = c^n + 1$    (positive defect: $a^n+b^n-c^n = +1$)
+
+  Benchmarks at $n = 3$ (both signs are witnessed):
+
+      Negative: $6^3 + 8^3 + 1 = 216 + 512 + 1 = 729 = 9^3$, with $\gcd(6,8,9)=1$.
+      Positive: $9^3 + 10^3 = 729 + 1000 = 1729 = 1728 + 1 = 12^3 + 1$,
+                with $\gcd(9,10,12)=1$.
+
+  The positive-defect witness is a near-cousin of the Ramanujan-Hardy taxicab
+  number 1729 = 1^3 + 12^3 = 9^3 + 10^3.
+
+  Both n=3 benchmarks are discharged in this file by `native_decide`. The
+  headline conjecture for general $n \ge 3$ is left as `sorry`.
+
+  Hierarchy from trivial to sharp (see gallery entry annotations):
+    Level 0: trivial existence ($a = c, b = 1$ for any $n \ge 1$).
+    Level 1: nontrivial defect-one existence ($2 \le a \le b < c$).
+    Level 2: primitive nontrivial existence ($\gcd(a,b,c) = 1$).
+    Level 3: signed primitive existence (both $\pm 1$ witnessed for every $n$).
+
+  Connections:
+    - Fermat's Last Theorem (FLT): the zero-defect case is impossible for $n > 2$.
+    - Fermat-Catalan: $x^p + y^q = z^r$ with $1/p+1/q+1/r < 1$ has finitely many
+      primitive solutions; defect-one is a Pillai-type offset of the diagonal case.
+    - Pillai's conjecture: gaps between perfect powers.
+-/
+
+import Mathlib
+
+namespace FermatDefectOne
+
+/-! ## Predicates -/
+
+/-- A primitive nontrivial Fermat defect-one witness for exponent `n`.
+
+The bounds `2 ≤ a ≤ b < c` exclude the trivial Level-0 collapse
+(`a = 1` or `a = c`). The primitivity condition `gcd (gcd a b) c = 1`
+prevents scaling families from inflating a single solution. The defect
+condition is the Nat-disjunction:
+
+  `a^n + b^n + 1 = c^n` (negative defect, $a^n+b^n-c^n = -1$), OR
+  `a^n + b^n = c^n + 1` (positive defect, $a^n+b^n-c^n = +1$).
+-/
+def FermatDefectWitness (n a b c : Nat) : Prop :=
+  2 ≤ a ∧ a ≤ b ∧ b < c ∧
+  Nat.gcd (Nat.gcd a b) c = 1 ∧
+  (a ^ n + b ^ n + 1 = c ^ n ∨ a ^ n + b ^ n = c ^ n + 1)
+
+/-- Existence of any primitive nontrivial defect-one witness at exponent `n`. -/
+def FermatDefectExists (n : Nat) : Prop :=
+  ∃ a b c : Nat, FermatDefectWitness n a b c
+
+/-- Positive defect: $a^n + b^n - c^n = +1$ (Nat form: `a^n + b^n = c^n + 1`). -/
+def FermatDefectPositive (n : Nat) : Prop :=
+  ∃ a b c : Nat,
+    2 ≤ a ∧ a ≤ b ∧ b < c ∧
+    Nat.gcd (Nat.gcd a b) c = 1 ∧
+    a ^ n + b ^ n = c ^ n + 1
+
+/-- Negative defect: $a^n + b^n - c^n = -1$ (Nat form: `a^n + b^n + 1 = c^n`). -/
+def FermatDefectNegative (n : Nat) : Prop :=
+  ∃ a b c : Nat,
+    2 ≤ a ∧ a ≤ b ∧ b < c ∧
+    Nat.gcd (Nat.gcd a b) c = 1 ∧
+    a ^ n + b ^ n + 1 = c ^ n
+
+/-! ## Verified $n = 3$ benchmarks (both signs) -/
+
+/-- Negative defect at $n = 3$: $6^3 + 8^3 + 1 = 9^3$.
+
+Check: $216 + 512 + 1 = 729 = 9^3$. Primitivity: $\gcd(\gcd(6,8),9) = \gcd(2,9) = 1$.
+Bounds: $2 \le 6 \le 8 < 9$. Discharged by `native_decide`. -/
+theorem fermat_defect_three_neg : FermatDefectWitness 3 6 8 9 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+  · left; native_decide
+
+/-- Positive defect at $n = 3$: $9^3 + 10^3 = 12^3 + 1$.
+
+Check: $729 + 1000 = 1729 = 1728 + 1 = 12^3 + 1$. Primitivity:
+$\gcd(\gcd(9,10),12) = \gcd(1,12) = 1$. Bounds: $2 \le 9 \le 10 < 12$.
+This is the Ramanujan-Hardy taxicab number $1729 = 1^3 + 12^3 = 9^3 + 10^3$
+shifted by one. Discharged by `native_decide`. -/
+theorem fermat_defect_three_pos : FermatDefectWitness 3 9 10 12 := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+  · right; native_decide
+
+/-- $n = 3$ admits a primitive nontrivial defect-one witness. Derived from the
+negative-defect benchmark `fermat_defect_three_neg`. -/
+theorem fermat_defect_three : FermatDefectExists 3 :=
+  ⟨6, 8, 9, fermat_defect_three_neg⟩
+
+/-- Positive-defect existence at $n = 3$, packaged as `FermatDefectPositive`. -/
+theorem fermat_defect_three_positive : FermatDefectPositive 3 := by
+  refine ⟨9, 10, 12, ?_, ?_, ?_, ?_, ?_⟩
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+
+/-- Negative-defect existence at $n = 3$, packaged as `FermatDefectNegative`. -/
+theorem fermat_defect_three_negative : FermatDefectNegative 3 := by
+  refine ⟨6, 8, 9, ?_, ?_, ?_, ?_, ?_⟩
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+  · native_decide
+
+/-! ## Open conjecture: defect-one existence for every $n \ge 3$ -/
+
+/-- **Fermat defect-one conjecture (Level 2).** For every exponent $n \ge 3$,
+there is a primitive nontrivial triple $(a, b, c)$ with $2 \le a \le b < c$,
+$\gcd(a, b, c) = 1$, and $|a^n + b^n - c^n| = 1$.
+
+Status: open. The $n = 3$ case is verified above (both signs witnessed). For
+$n \ge 4$ this is a genuine research conjecture, sitting between Fermat's
+Last Theorem (zero defect impossible) and Pillai-type problems (gaps between
+perfect powers). -/
+theorem fermat_defect_one_exists :
+    ∀ n : Nat, 3 ≤ n → FermatDefectExists n := by
+  sorry
+
+end FermatDefectOne

--- a/src/data/proofs/fermat-defect-one/annotations.json
+++ b/src/data/proofs/fermat-defect-one/annotations.json
@@ -1,0 +1,161 @@
+[
+  {
+    "id": "ann-module-overview",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 1,
+      "endLine": 47
+    },
+    "type": "concept",
+    "title": "Module Overview: The Defect-One Conjecture",
+    "content": "The module docstring introduces the Fermat defect-one conjecture: whether $|a^n + b^n - c^n| = 1$ admits a primitive nontrivial solution for every $n \\ge 3$. FLT rules out the zero-defect case for $n > 2$; this conjecture asks the natural next question. The Nat-only formulation uses a disjunction `a^n + b^n + 1 = c^n ∨ a^n + b^n = c^n + 1` to avoid signed-integer coercions, keeping the predicates decidable. Both signs of the $n = 3$ benchmark are advertised: $6^3 + 8^3 + 1 = 9^3$ (negative) and $9^3 + 10^3 = 12^3 + 1$ (positive — the Ramanujan-Hardy taxicab number 1729 unit-shifted).",
+    "mathContext": "Sharp dichotomy at $n \\ge 3$: FLT says $a^n + b^n - c^n \\ne 0$. The defect-one conjecture says $a^n + b^n - c^n = \\pm 1$ is conjecturally always achieved with $\\gcd(a, b, c) = 1$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat's Last Theorem",
+      "Pillai's conjecture",
+      "Fermat-Catalan conjecture",
+      "taxicab number 1729",
+      "Nat disjunction encoding of absolute value"
+    ],
+    "prerequisites": [
+      "Mathlib import",
+      "Nat arithmetic and Nat.gcd",
+      "Diophantine equations"
+    ]
+  },
+  {
+    "id": "ann-hierarchy",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 18,
+      "endLine": 33
+    },
+    "type": "concept",
+    "title": "Hierarchy: Levels 0–3",
+    "content": "The conjecture has a natural ladder of strength. Level 0 (trivial): $a = c, b = 1$ gives $c^n + 1 - c^n = 1$ for any $n$ — pedagogically illustrates why primitivity matters in Diophantine problems. Level 1: nontrivial existence with $2 \\le a \\le b < c$. Level 2: primitive nontrivial existence (adds $\\gcd(a, b, c) = 1$) — this is the headline. Level 3: signed primitive existence, demanding both signs at every $n$. Level 3 may fail at specific $(n, \\epsilon)$ due to modular obstructions; a refutation would itself be a result.",
+    "mathContext": "Level 2 (headline): $\\forall n \\ge 3,\\; \\exists a, b, c,\\; 2 \\le a \\le b < c \\land \\gcd(a, b, c) = 1 \\land |a^n + b^n - c^n| = 1$. Level 3 strengthens to per-sign existence.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "primitivity convention in Diophantine problems",
+      "modular obstructions",
+      "scaling families"
+    ]
+  },
+  {
+    "id": "ann-predicates",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 49,
+      "endLine": 79
+    },
+    "type": "definition",
+    "title": "Four Predicates Encoding the Conjecture",
+    "content": "`FermatDefectWitness n a b c` is the combined predicate: $2 \\le a \\le b < c$, $\\gcd(\\gcd(a,b),c) = 1$, and the disjunction $a^n + b^n + 1 = c^n \\lor a^n + b^n = c^n + 1$. `FermatDefectExists n := ∃ a b c, FermatDefectWitness n a b c`. The split predicates `FermatDefectPositive n` (only $a^n + b^n = c^n + 1$) and `FermatDefectNegative n` (only $a^n + b^n + 1 = c^n$) isolate each sign for finer-grained Level-3 analysis. All four predicates are `Prop`-valued and decidable on concrete inputs — `decide` and `native_decide` discharge concrete witnesses without algebraic manipulation.",
+    "mathContext": "Disjunction trick: $|a^n+b^n-c^n| = 1$ on $\\mathbb{Z}$ becomes $a^n + b^n + 1 = c^n \\lor a^n + b^n = c^n + 1$ on $\\mathbb{N}$, decidable for each concrete triple.",
+    "significance": "central",
+    "relatedConcepts": [
+      "Nat.gcd",
+      "decidability of Diophantine predicates on Nat",
+      "absolute-value encoding tricks"
+    ]
+  },
+  {
+    "id": "ann-benchmark-neg",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 86,
+      "endLine": 100
+    },
+    "type": "theorem",
+    "title": "Verified n=3 Negative-Defect Benchmark",
+    "content": "`fermat_defect_three_neg : FermatDefectWitness 3 6 8 9`. Arithmetic: $6^3 = 216$, $8^3 = 512$, $9^3 = 729$, so $216 + 512 + 1 = 729$. Bounds: $2 \\le 6 \\le 8 < 9$. Primitivity: $\\gcd(\\gcd(6, 8), 9) = \\gcd(2, 9) = 1$. The disjunction is satisfied by the LEFT disjunct ($a^n + b^n + 1 = c^n$, the negative-defect side). Discharged by `native_decide` after refining the conjunction.",
+    "mathContext": "$6^3 + 8^3 + 1 = 9^3$, i.e., $6^3 + 8^3 - 9^3 = -1$. The negative-defect sibling of the taxicab number 1729 on the other side of $9^3 = 729$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "native_decide tactic",
+      "taxicab number 1729",
+      "n=3 cubic Diophantine equations"
+    ]
+  },
+  {
+    "id": "ann-benchmark-pos",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 102,
+      "endLine": 116
+    },
+    "type": "theorem",
+    "title": "Verified n=3 Positive-Defect Benchmark (Taxicab Shift)",
+    "content": "`fermat_defect_three_pos : FermatDefectWitness 3 9 10 12`. Arithmetic: $9^3 + 10^3 = 729 + 1000 = 1729 = 1728 + 1 = 12^3 + 1$. Bounds: $2 \\le 9 \\le 10 < 12$. Primitivity: $\\gcd(\\gcd(9, 10), 12) = \\gcd(1, 12) = 1$. The disjunction is satisfied by the RIGHT disjunct ($a^n + b^n = c^n + 1$, the positive-defect side). Discharged by `native_decide`. This is the Ramanujan-Hardy taxicab number 1729 = 1^3 + 12^3 = 9^3 + 10^3 shifted by one unit — a charming coincidence that makes the n=3 case memorable.",
+    "mathContext": "$9^3 + 10^3 - 12^3 = 1$. Equivalently $1729 - 12^3 = 1$ — a unit-distance fact about the taxicab number.",
+    "significance": "central",
+    "relatedConcepts": [
+      "taxicab number 1729",
+      "Ramanujan-Hardy anecdote",
+      "native_decide tactic"
+    ]
+  },
+  {
+    "id": "ann-existence-derived",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 118,
+      "endLine": 130
+    },
+    "type": "theorem",
+    "title": "Derived Existence Theorems at n=3",
+    "content": "Three corollaries: `fermat_defect_three : FermatDefectExists 3` packages the negative-defect benchmark as defect-one existence. `fermat_defect_three_positive : FermatDefectPositive 3` and `fermat_defect_three_negative : FermatDefectNegative 3` give per-sign existence at n=3, witnessing Level 3 in this case. All three are short consequences of the two benchmarks.",
+    "mathContext": "Level 3 holds at $n = 3$: both $+1$ and $-1$ defects are realised primitively with $c \\le 12$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Level 3 of the hierarchy",
+      "existential introduction"
+    ]
+  },
+  {
+    "id": "ann-open-conjecture",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 132,
+      "endLine": 146
+    },
+    "type": "theorem",
+    "title": "Headline Open Conjecture (sorry'd)",
+    "content": "`fermat_defect_one_exists : ∀ n : Nat, 3 ≤ n → FermatDefectExists n`. This is the Level-2 headline statement. It is left as a `sorry` — a genuine open mathematical conjecture, not a placeholder for tractable work. The $n = 3$ case is verified above; $n = 4$ and beyond are open. No general construction is known, and the conjecture is expected to require deep machinery (Pillai-type techniques, possibly abc-style effective forms, or Fermat-Catalan-style modular methods). This is the gallery entry's anchor: an honest research target, marked as such.",
+    "mathContext": "$\\forall n \\ge 3,\\; \\exists a, b, c \\in \\mathbb{N},\\; 2 \\le a \\le b < c \\land \\gcd(a, b, c) = 1 \\land |a^n + b^n - c^n| = 1$. Status: open for $n \\ge 4$.",
+    "significance": "central",
+    "relatedConcepts": [
+      "FLT (zero defect ruled out)",
+      "Pillai's conjecture",
+      "Fermat-Catalan conjecture",
+      "abc conjecture",
+      "open Diophantine problems"
+    ],
+    "prerequisites": [
+      "FermatDefectExists definition",
+      "the four predicates above"
+    ]
+  },
+  {
+    "id": "ann-connections",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 30,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Connections to Known Problem Families",
+    "content": "The defect-one conjecture interpolates between three established families. (1) **Fermat's Last Theorem**: FLT rules out defect 0 for $n > 2$; the defect-one conjecture asks the next question. (2) **Fermat-Catalan** ($x^p + y^q = z^r$, $1/p + 1/q + 1/r < 1$): predicts finitely many primitive solutions. The defect-one problem is a unit-offset slice of the diagonal case $p = q = r = n$. (3) **Pillai-type problems** ($a^x - b^y = c$): for fixed $c$, finitely many solutions; the defect-one problem is morally Pillai on a richer set (sum of two powers vs one power). The verified benchmarks at $n = 3$ also tie into Thue / superelliptic territory once one variable is fixed.",
+    "mathContext": "FLT (defect 0 forbidden) → defect-one (this conjecture) → Fermat-Catalan (general exponents, finiteness) → Pillai (perfect-power gaps).",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Fermat's Last Theorem",
+      "Fermat-Catalan conjecture",
+      "Pillai's conjecture",
+      "abc conjecture",
+      "Thue equations",
+      "superelliptic equations"
+    ]
+  }
+]

--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -1,0 +1,208 @@
+{
+  "id": "fermat-defect-one",
+  "title": "Fermat Defect-One Conjecture",
+  "slug": "fermat-defect-one",
+  "description": "The Fermat defect-one conjecture asks whether $|a^n + b^n - c^n| = 1$ admits a primitive nontrivial solution ($2 \\le a \\le b < c$, $\\gcd(a,b,c) = 1$) for every $n \\ge 3$ — the natural follow-up to Fermat's Last Theorem, which rules out the zero-defect case. Both signs of the defect are verified at $n = 3$: $6^3 + 8^3 + 1 = 9^3$ (negative) and $9^3 + 10^3 = 12^3 + 1$ (positive, a near-cousin of the Ramanujan-Hardy taxicab number 1729). The headline statement for all $n \\ge 3$ is left as an open conjecture (sorry placeholder).",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-09",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/FermatDefectOne.lean",
+    "tags": [
+      "number-theory",
+      "diophantine",
+      "fermat",
+      "open-conjecture",
+      "pillai",
+      "fermat-catalan",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 1,
+    "dateAdded": "2026-06-09",
+    "axiomCount": 0,
+    "assumptions": "1 sorry on the headline conjecture `fermat_defect_one_exists : ∀ n : Nat, 3 ≤ n → FermatDefectExists n`. This is a genuine open mathematical conjecture (a Pillai-type diophantine problem) — the sorry marks the absence of a proof for all n ≥ 4, not a placeholder for tractable work. The n=3 case is fully verified for both signs via `native_decide` (no assumptions). 0 axiom declarations and 0 structure-encoded assumptions; the sorry is the only open mathematical assumption in the file.",
+    "lineCount": 146,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "originalContributions": [
+      "FermatDefectWitness, FermatDefectExists, FermatDefectPositive, FermatDefectNegative: four Nat-only predicates expressing |a^n + b^n - c^n| = 1 via a disjunction avoiding signed-integer coercions",
+      "fermat_defect_three_neg: verified primitive negative-defect witness 6^3 + 8^3 + 1 = 9^3 (gcd(6,8,9)=1) via native_decide",
+      "fermat_defect_three_pos: verified primitive positive-defect witness 9^3 + 10^3 = 12^3 + 1 (gcd(9,10,12)=1) via native_decide — the taxicab number 1729 shifted by one",
+      "fermat_defect_three: derived defect-one existence at n=3 from the negative-defect benchmark",
+      "fermat_defect_one_exists: headline open conjecture stated as a sorry'd target for all n ≥ 3"
+    ]
+  },
+  "overview": {
+    "historicalContext": "Fermat's Last Theorem (1637 marginal note, proved by Wiles in 1995) asserts that $a^n + b^n = c^n$ has no positive integer solutions for $n > 2$. This rules out the zero-defect case $a^n + b^n - c^n = 0$. The natural sharpening — can the defect be exactly $\\pm 1$? — sits in the tradition of Pillai's conjecture (gaps between perfect powers) and the Fermat-Catalan conjecture (finitely many primitive solutions to $x^p + y^q = z^r$ with $1/p+1/q+1/r < 1$). The $n = 3$ positive-defect witness $9^3 + 10^3 = 12^3 + 1 = 1729$ is a unit-shift of Ramanujan and Hardy's famous taxicab number $1729 = 1^3 + 12^3 = 9^3 + 10^3$, the smallest number expressible as a sum of two cubes in two distinct ways. The negative-defect witness $6^3 + 8^3 = 9^3 - 1$ is its sibling on the other side of $9^3$. That both signs are realised at the very first nontrivial exponent makes the conjecture concrete and pedagogically rich, while the absence of any general construction for $n \\ge 4$ keeps it genuinely open.",
+    "problemStatement": "For every integer $n \\ge 3$, do there exist positive integers $a, b, c$ with\n\n$$2 \\le a \\le b < c, \\quad \\gcd(a, b, c) = 1, \\quad |a^n + b^n - c^n| = 1?$$\n\nOn `Nat`, the absolute-value condition is expressed as a disjunction:\n\n$$a^n + b^n + 1 = c^n \\qquad \\text{(negative defect, } a^n+b^n-c^n = -1\\text{)}$$\n\n$$a^n + b^n = c^n + 1 \\qquad \\text{(positive defect, } a^n+b^n-c^n = +1\\text{).}$$\n\nLevel 0 (trivial): $a = c$, $b = 1$ gives $c^n + 1 - c^n = 1$ for any $n$. Excluding this is the role of the bounds $2 \\le a$ and $a \\le b < c$. Level 2 (primitive) is the version stated above. Level 3 strengthens to demanding both signs at every $n$.",
+    "text": "A 146-line Lean 4 file with 4 definitions, 6 theorems, 0 axioms, and 1 sorry (the headline open conjecture). The four predicates package the defect-one condition as a Nat disjunction. Both signs of the n=3 benchmark are verified by `native_decide`: the negative-defect witness $6^3 + 8^3 + 1 = 9^3$ and the positive-defect witness $9^3 + 10^3 = 12^3 + 1$. The headline `fermat_defect_one_exists : ∀ n ≥ 3, FermatDefectExists n` is left as a sorry'd target. Status: axiomatized (the sorry is a genuine open mathematical assumption, not a placeholder for tractable work).",
+    "proofStrategy": "Hierarchy of statements from trivial to sharp:\n\n**Level 0 (trivial existence)**: For every $n \\ge 1$, take $a = c$, $b = 1$: $c^n + 1 - c^n = 1$. Excluded by demanding $2 \\le a$ and $a \\le b < c$.\n\n**Level 1 (nontrivial defect-one existence)**: For every $n \\ge 3$, there exist $2 \\le a \\le b < c$ with $|a^n + b^n - c^n| = 1$.\n\n**Level 2 (primitive nontrivial existence)**: As Level 1, but additionally $\\gcd(a, b, c) = 1$. This is the headline statement.\n\n**Level 3 (signed primitive existence)**: For every $n \\ge 3$ and every $\\epsilon \\in \\{-1, +1\\}$, a primitive witness exists. Possibly false at some $(n, \\epsilon)$ (a refutation would itself be a result).\n\nThe $n = 3$ benchmarks are discharged by `native_decide` after refining the witness conjunction. The arithmetic is small: $6^3 = 216$, $8^3 = 512$, $9^3 = 729$, so $6^3 + 8^3 + 1 = 729$; and $9^3 + 10^3 = 729 + 1000 = 1729 = 1728 + 1 = 12^3 + 1$. The gcd-reduction $\\gcd(\\gcd(6, 8), 9) = \\gcd(2, 9) = 1$ and $\\gcd(\\gcd(9, 10), 12) = \\gcd(1, 12) = 1$ are also computational. No general construction is known for $n \\ge 4$; the open conjecture is a Pillai-type statement and is expected to require deep machinery from Diophantine geometry.",
+    "keyInsights": [
+      "**Defect hierarchy:** FLT rules out defect 0 for $n > 2$. The defect-one conjecture asks the very next question. Pillai-type intuition suggests only finitely many solutions are possible for each fixed pair $(n, \\epsilon)$, but the question is whether at least one exists for every $n$.",
+      "**Primitivity matters:** Without $\\gcd(a, b, c) = 1$, any single solution at exponent $n$ scales to infinitely many — but the scaled triples are not new mathematics. The primitivity demand is the standard way to rule out this triviality, mirroring the convention in Fermat-Catalan and abc-style problems.",
+      "**Why $a \\ge 2$ and $a \\ne c$:** The constraint $a = 1$ collapses to $1 + b^n - c^n = \\pm 1$, i.e., $b^n = c^n$ or $b^n + 2 = c^n$ — both pin $b, c$ very tightly. The constraint $a = c$ gives the Level-0 triviality $c^n + b^n - c^n = b^n = 1$, i.e., $b = 1$. These are not the spirit of the problem.",
+      "**Taxicab connection:** $9^3 + 10^3 = 1729 = 1^3 + 12^3$ is the smallest positive integer expressible as a sum of two cubes in two distinct ways (Ramanujan-Hardy). The defect-one positive witness $9^3 + 10^3 - 12^3 = 1$ is therefore the assertion that $1729 - 12^3 = 1$ — a unit-distance fact about the taxicab number. The negative-defect witness $6^3 + 8^3 - 9^3 = -1$ is its mirror on the other side of $9^3 = 729$.",
+      "**Nat-only formulation:** Stating $|a^n + b^n - c^n| = 1$ on `ℤ` requires signed coercion; on `Nat` it splits into the disjunction $a^n + b^n + 1 = c^n \\lor a^n + b^n = c^n + 1$. This keeps the predicate decidable and lets `native_decide` close concrete witnesses without algebraic manipulation.",
+      "**Search structure:** For each $n$, a bounded search over $a \\le b < c \\le N$ with mod-$p$ pre-filters is tractable for small $n$ and small $N$. The minimal-witness function $M(n)$ — the smallest $c$ for which a primitive witness exists — is finite where the conjecture holds; $M(3) \\le 9$ from the negative-defect benchmark."
+    ],
+    "prerequisites": [
+      "Basic arithmetic on `Nat` and `Nat.gcd`",
+      "The `decide` and `native_decide` tactics in Lean 4",
+      "Diophantine equations and the Fermat equation $a^n + b^n = c^n$",
+      "Pillai's conjecture (background context)",
+      "Fermat-Catalan conjecture (background context)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "imports-and-overview",
+      "title": "Imports and Module Overview",
+      "startLine": 1,
+      "endLine": 47,
+      "summary": "Module docstring introducing the defect-one conjecture, the Nat disjunction trick, the n=3 benchmarks for both signs, and connections to FLT, Pillai, and Fermat-Catalan.",
+      "mathContext": "$|a^n + b^n - c^n| = 1$ encoded on $\\mathbb{N}$ as $a^n + b^n + 1 = c^n \\lor a^n + b^n = c^n + 1$."
+    },
+    {
+      "id": "predicates",
+      "title": "Four Predicates",
+      "startLine": 49,
+      "endLine": 79,
+      "summary": "Definitions of FermatDefectWitness (combined signs, with bounds and gcd primitivity), FermatDefectExists (existence over witnesses), FermatDefectPositive (a^n + b^n = c^n + 1), and FermatDefectNegative (a^n + b^n + 1 = c^n).",
+      "mathContext": "$\\mathtt{FermatDefectWitness}\\,n\\,a\\,b\\,c$: $2 \\le a \\le b < c \\land \\gcd(\\gcd(a,b),c) = 1 \\land (a^n+b^n+1 = c^n \\lor a^n+b^n = c^n+1)$."
+    },
+    {
+      "id": "benchmark-n-three",
+      "title": "Verified n=3 Benchmarks (Both Signs)",
+      "startLine": 81,
+      "endLine": 130,
+      "summary": "fermat_defect_three_neg (6^3+8^3+1 = 9^3, gcd(6,8,9)=1) and fermat_defect_three_pos (9^3+10^3 = 12^3+1, gcd(9,10,12)=1), both discharged by native_decide. Derived theorems fermat_defect_three, fermat_defect_three_positive, fermat_defect_three_negative.",
+      "mathContext": "Arithmetic: $216 + 512 + 1 = 729$; $729 + 1000 = 1729 = 1728 + 1$. Primitivity: $\\gcd(2, 9) = 1$, $\\gcd(1, 12) = 1$."
+    },
+    {
+      "id": "open-conjecture",
+      "title": "Open Conjecture: Defect-One Existence for All n ≥ 3",
+      "startLine": 132,
+      "endLine": 146,
+      "summary": "fermat_defect_one_exists : ∀ n ≥ 3, FermatDefectExists n. Headline statement, left as a sorry'd target. The n=3 case is verified above; n ≥ 4 is genuinely open.",
+      "mathContext": "$\\forall n \\ge 3,\\; \\exists a, b, c \\in \\mathbb{N},\\; 2 \\le a \\le b < c \\land \\gcd(a,b,c) = 1 \\land |a^n + b^n - c^n| = 1$."
+    }
+  ],
+  "crossReferences": [
+    {
+      "targetId": "fermats-last-theorem",
+      "relationship": "complementary",
+      "description": "Fermat's Last Theorem rules out the zero-defect case $a^n + b^n = c^n$ for $n > 2$. The defect-one conjecture asks the natural next question: can the defect be exactly $\\pm 1$? Together they form a sharp dichotomy at $n \\ge 3$ — defect 0 forbidden, defect $\\pm 1$ conjecturally always realisable."
+    },
+    {
+      "targetId": "fermat-two-squares",
+      "relationship": "related",
+      "description": "Fermat's two-squares theorem is the other Fermat-named Diophantine statement formalized in the gallery. Both stem from Fermat's marginal notes and concern integer representations involving small powers; the defect-one conjecture cousins the two-squares characterization in spirit, though it lives at higher exponent."
+    },
+    {
+      "targetId": "pythagorean-theorem",
+      "relationship": "foundational",
+      "description": "Pythagoras's theorem $a^2 + b^2 = c^2$ at $n = 2$ has infinitely many primitive solutions (Pythagorean triples). FLT shows defect 0 fails for $n > 2$; the defect-one conjecture asks whether something just one unit away is always available. The trio $n = 2$ rich / $n > 2$ zero defect empty / $n \\ge 3$ defect-one conjecturally always present sketches the arithmetic geography of low-power Diophantine equations."
+    },
+    {
+      "targetId": "pythagorean-triples",
+      "relationship": "related",
+      "description": "Pythagorean triples classify $a^2 + b^2 = c^2$. The defect-one conjecture is the higher-exponent analogue of asking 'how close can $a^n + b^n$ come to $c^n$?' — at $n = 2$ infinitely many exact hits; at $n \\ge 3$ no exact hits but conjecturally always within one."
+    }
+  ],
+  "conclusion": {
+    "summary": "The Fermat defect-one conjecture is a concrete, clean Diophantine question sitting one unit away from Fermat's Last Theorem. It has small primitive witnesses at $n = 3$ for both signs of the defect — including a unit-shift of the Ramanujan-Hardy taxicab number 1729 — but is genuinely open for $n \\ge 4$. This gallery entry formalizes the predicates, verifies the $n = 3$ benchmarks via `native_decide`, and states the open conjecture as a `sorry`'d target.",
+    "implications": "**Why it matters**\n\n1. **Sharp dichotomy with FLT.** FLT pins the defect $a^n + b^n - c^n$ to be either zero (only at $n \\le 2$) or at least one unit away (for $n > 2$). The defect-one conjecture asks whether 'one unit away' is achieved, sharpening FLT from a non-existence statement into a structural one.\n\n2. **Pillai-style content.** Pillai's conjecture (gaps between perfect powers) is the closest classical relative. The defect-one problem is a richer Pillai problem — sums of two powers versus one power — and any progress on it would inform Pillai-type techniques.\n\n3. **Fermat-Catalan adjacency.** The Fermat-Catalan conjecture predicts only finitely many primitive solutions to $x^p + y^q = z^r$ with $1/p+1/q+1/r < 1$. The defect-one problem fixes $p = q = r = n$ and adds a unit offset; it's a parametric slice of the broader Fermat-Catalan landscape.\n\n4. **Search tractability.** Strong modular pre-filters make bounded searches at small $n$ feasible. Computational follow-ups (per-$n$ search) are filed as separate issues.\n\n5. **Failure mode is interesting.** A specific $(n, \\epsilon)$ at which Level 3 fails would itself be a result — a modular-arithmetic obstruction would tie the defect-one problem back to congruence-class structure of $n$-th-power residues.",
+    "openQuestions": [
+      "Does Level 2 hold for all $n \\ge 3$? (The headline conjecture.) No general construction is known for $n \\ge 4$; small searches at $n = 4, 5, 6, \\ldots$ are the natural first probe.",
+      "Does Level 3 hold? — i.e., are BOTH signs realised at every $n \\ge 3$? At $n = 3$ yes; for general $n$ a modular obstruction might rule out one sign at specific $n$.",
+      "Asymptotic of $M(n)$: does $M(n) \\to \\infty$ as $n \\to \\infty$? Is $M(n) = O(\\mathrm{poly}(n))$? Pillai-style intuition suggests $M(n) \\to \\infty$ at least.",
+      "Bounded-nonexistence theorems: for fixed $n$ and bound $N$, prove $|a^n + b^n - c^n| \\ne 1$ for all $2 \\le a \\le b < c \\le N$ — a `decide`-style 'no small witness' result that would tighten lower bounds on $M(n)$.",
+      "Connections to abc: does the abc conjecture (or its effective forms) imply finiteness of primitive defect-one solutions for each fixed $n \\ge 4$?"
+    ]
+  },
+  "references": [
+    {
+      "authors": "Wiles, Andrew",
+      "title": "Modular elliptic curves and Fermat's Last Theorem",
+      "year": "1995",
+      "venue": "Annals of Mathematics 141(3): 443-551",
+      "note": "Proof that every semistable elliptic curve over Q is modular, which combined with Frey-Ribet proves FLT. FLT rules out the zero-defect case; the defect-one conjecture is the natural follow-up question."
+    },
+    {
+      "authors": "Hardy, G. H.",
+      "title": "Ramanujan: Twelve Lectures on Subjects Suggested by His Life and Work",
+      "year": "1940",
+      "venue": "Cambridge University Press",
+      "note": "Recounts the taxicab anecdote: 1729 is the smallest number expressible as a sum of two cubes in two distinct ways ($1^3 + 12^3 = 9^3 + 10^3$). The positive-defect witness $9^3 + 10^3 - 12^3 = 1$ is a unit-distance fact about 1729."
+    },
+    {
+      "authors": "Waldschmidt, Michel",
+      "title": "Perfect powers: Pillai's works and their developments",
+      "year": "2009",
+      "venue": "Combinatorial number theory and additive group theory (CRM Barcelona, Birkhäuser)",
+      "note": "Survey of Pillai-type problems on perfect powers and their gaps. The defect-one problem is morally a Pillai-type question on a richer set (sum of two powers vs. one power)."
+    },
+    {
+      "authors": "Darmon, Henri; Granville, Andrew",
+      "title": "On the equations $z^m = F(x, y)$ and $Ax^p + By^q = Cz^r$",
+      "year": "1995",
+      "venue": "Bulletin of the London Mathematical Society 27(6): 513-543",
+      "note": "Foundational paper on the Fermat-Catalan equation. The defect-one problem at exponent $n$ is a unit-offset Fermat-Catalan equation in the diagonal case $p = q = r = n$."
+    },
+    {
+      "authors": "Pillai, S. S.",
+      "title": "On $a^x - b^y = c$",
+      "year": "1936",
+      "venue": "Journal of the Indian Mathematical Society 2: 119-122",
+      "note": "Original Pillai conjecture on gaps between perfect powers — for fixed $c$, the equation $a^x - b^y = c$ has only finitely many solutions. The defect-one problem inherits Pillai's finiteness intuition while asking the existence question for each fixed $n$."
+    },
+    {
+      "authors": "Frits Beukers",
+      "title": "The Diophantine equation $Ax^p + By^q = Cz^r$",
+      "year": "1998",
+      "venue": "Duke Mathematical Journal 91(1): 61-88",
+      "note": "Modern analytic-Diophantine treatment of the generalized Fermat-Catalan equation; informs the modular-arithmetic obstructions that may govern Level 3 (per-sign existence)."
+    }
+  ],
+  "leanFile": {
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [],
+    "namespace": "FermatDefectOne",
+    "lineCount": 146,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 4,
+    "path": "Proofs/FermatDefectOne.lean",
+    "sorries": 1
+  },
+  "mainTheorems": [
+    {
+      "name": "fermat_defect_three_neg",
+      "type": "core",
+      "description": "Verified primitive negative-defect witness at n=3: 6^3 + 8^3 + 1 = 9^3, gcd(6,8,9)=1, 2 ≤ 6 ≤ 8 < 9.",
+      "leanType": "FermatDefectWitness 3 6 8 9"
+    },
+    {
+      "name": "fermat_defect_three_pos",
+      "type": "core",
+      "description": "Verified primitive positive-defect witness at n=3: 9^3 + 10^3 = 12^3 + 1, gcd(9,10,12)=1, 2 ≤ 9 ≤ 10 < 12. The taxicab number 1729 shifted by one.",
+      "leanType": "FermatDefectWitness 3 9 10 12"
+    },
+    {
+      "name": "fermat_defect_three",
+      "type": "derived",
+      "description": "Defect-one existence at n=3, packaged from the negative-defect benchmark.",
+      "leanType": "FermatDefectExists 3"
+    },
+    {
+      "name": "fermat_defect_one_exists",
+      "type": "headline",
+      "description": "Headline open conjecture (sorry'd): for every n ≥ 3, there exists a primitive nontrivial defect-one witness.",
+      "leanType": "∀ n : Nat, 3 ≤ n → FermatDefectExists n"
+    }
+  ],
+  "sorries": 1
+}


### PR DESCRIPTION
## Summary

Adds the **Fermat defect-one conjecture** as a new gallery entry: does

$$|a^n + b^n - c^n| = 1$$

admit a primitive nontrivial solution ($2 \le a \le b < c$, $\gcd(a,b,c) = 1$) for every $n \ge 3$? FLT rules out the zero-defect case for $n > 2$; this conjecture asks the natural next question.

## Verified theorems at n = 3 (both signs)

Discharged by `native_decide` (`decide` was not attempted given the size of $9^3, 10^3, 12^3$; `native_decide` succeeded on the first try):

- `fermat_defect_three_neg : FermatDefectWitness 3 6 8 9` — because $6^3 + 8^3 + 1 = 216 + 512 + 1 = 729 = 9^3$, with $\gcd(6,8,9) = 1$ and bounds $2 \le 6 \le 8 < 9$. **Negative-defect** branch of the disjunction.
- `fermat_defect_three_pos : FermatDefectWitness 3 9 10 12` — because $9^3 + 10^3 = 729 + 1000 = 1729 = 1728 + 1 = 12^3 + 1$, with $\gcd(9,10,12) = 1$ and bounds $2 \le 9 \le 10 < 12$. **Positive-defect** branch (Ramanujan–Hardy taxicab number 1729 shifted by one).
- Derived existence theorems: `fermat_defect_three`, `fermat_defect_three_positive`, `fermat_defect_three_negative`.

## Open conjecture (sorry'd)

```lean
theorem fermat_defect_one_exists :
    ∀ n : Nat, 3 ≤ n → FermatDefectExists n := by sorry
```

This is the headline Level-2 statement. The $n = 3$ case is verified above; $n \ge 4$ is genuinely open.

## Files

- `proofs/Proofs/FermatDefectOne.lean` (146 lines, `import Mathlib`)
  - 4 definitions: `FermatDefectWitness`, `FermatDefectExists`, `FermatDefectPositive`, `FermatDefectNegative`
  - 6 theorems (5 verified + 1 sorry'd headline)
  - 0 axiom declarations, 0 structure-encoded assumptions, 1 sorry
- `src/data/proofs/fermat-defect-one/meta.json` — `status: axiomatized`, `badge: axiom`, `axiomCount: 0`, `sorries: 1`. Per the AXIOM INTEGRITY POLICY, the lone sorry is the only open mathematical assumption (it carries the open conjecture, not a placeholder for tractable work).
- `src/data/proofs/fermat-defect-one/annotations.json` — 8 annotations: module overview, Level 0–3 hierarchy, four predicates, both signed benchmarks, derived existence theorems, the headline open conjecture, connections to FLT / Fermat–Catalan / Pillai.

Cross-references: `fermats-last-theorem` (complementary), `fermat-two-squares`, `pythagorean-theorem`, `pythagorean-triples`.

## Build status

- `./proofs/scripts/docker-build.sh Proofs.FermatDefectOne` succeeds. Only warning is the expected `uses 'sorry'` on `fermat_defect_one_exists`.
- `pnpm build` succeeds with the new gallery entry rendering at `/proofs/fermat-defect-one`.

## Verification of the Nat arithmetic (sanity)

- Negative: $6^3 = 216$, $8^3 = 512$, $9^3 = 729$, $216 + 512 + 1 = 729$ ✓. $\gcd(6, 8) = 2$, $\gcd(2, 9) = 1$ ✓. $2 \le 6 \le 8 < 9$ ✓.
- Positive: $9^3 = 729$, $10^3 = 1000$, $12^3 = 1728$, $729 + 1000 = 1729 = 1728 + 1$ ✓. $\gcd(9, 10) = 1$, $\gcd(1, 12) = 1$ ✓. $2 \le 9 \le 10 < 12$ ✓.

Closes #22620

## Test plan

- [x] Lean file builds via docker wrapper (no errors, expected sorry warning only).
- [x] `pnpm build` succeeds.
- [ ] Reviewer spot-checks the gallery entry renders correctly (`/proofs/fermat-defect-one`).
- [ ] Reviewer confirms the disjunction sides are correctly chosen: `left` for the negative-defect benchmark, `right` for the positive-defect benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)