### PR TITLE
audit(sum-of-kth-powers-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -13291,9 +13291,9 @@
       "result": "clean"
     },
     "sum-of-kth-powers-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-06-09T16:54:20Z",
+      "lastAudited": "2026-06-09T17:45:45Z",
       "result": "clean"
     },
     "sum-of-kth-powers-oq-02": {


### PR DESCRIPTION
## Summary
- 3rd audit cycle for `sum-of-kth-powers-oq-01` (Faulhaber-via-Bernoulli, OQ-01).
- Lean source `Proofs/SumOfKthPowersOQ01.lean` matches meta.json: 193 lines, 0 sorries, 0 axioms, 11 theorem-class decls (7 theorem + 4 example), no True stubs.
- All 4 declared Mathlib deps (`sum_range_pow`, `bernoulli_eq_zero_of_odd`, `bernoulli'_two`, `bernoulli'_four`) actually used in file.
- Badge `mathlib` correctly classifies as Tier B; description explicitly credits "Mathlib's Bernoulli infrastructure".

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --next` selected this slug
- [x] Line / sorry / axiom counts cross-checked vs meta.json
- [x] Mathlib deps each grep-confirmed in Lean source
- [x] `./scripts/auditor/claim-target.sh complete sum-of-kth-powers-oq-01 clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)