### PR TITLE
audit(fermat-defect-one): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15284,6 +15284,12 @@
       "lastAudited": "2026-06-06T19:19:39Z",
       "result": "clean",
       "issues": []
+    },
+    "fermat-defect-one": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-09T18:01:29Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary

Gallery integrity audit of `fermat-defect-one`: **clean**.

## Findings

| Check | meta.json | Lean source | Match |
|------|-----------|-------------|------|
| `lineCount` | 146 | 146 | ✓ |
| `axiomCount` | 0 | 0 | ✓ |
| `sorries` | 1 | 1 (line 144 on headline `fermat_defect_one_exists`) | ✓ |
| `theoremCount` | 6 | 6 | ✓ |
| `definitionCount` | 4 | 4 | ✓ |
| `status` | `axiomatized` | 1 sorry on open conjecture | ✓ |
| `badge` | `axiom` | sorry'd headline | ✓ |
| True stubs | — | none | ✓ |
| Narrative tier | Tier C (axiomatized) | accurate | ✓ |

## Narrative review

- Title "Fermat Defect-One Conjecture" does not overclaim.
- Description and `assumptions` explicitly mark the 1 sorry as the headline open conjecture (Pillai-type) — not a placeholder for tractable work.
- n=3 benchmarks are honestly framed as `native_decide` discharges, both signs (negative `6³+8³+1=9³`, positive `9³+10³=12³+1` — taxicab 1729 shifted by one).
- `originalContributions` scopes credit to predicates + verified n=3 benchmarks + sorry'd headline; no inflated claims.
- No Mathlib wrapper masking (file uses `native_decide` arithmetic, not a Mathlib deep theorem for the core result).

## Test plan
- [x] Tracker entry added with `result: clean`
- [x] No meta.json changes required