### PR TITLE
research: Tier 3 open-conjecture infrastructure + Fermat defect-one adoption

### DIFF
--- a/proofs/Proofs/FermatDefectOneAristotle.lean
+++ b/proofs/Proofs/FermatDefectOneAristotle.lean
@@ -1,0 +1,76 @@
+/-
+  Aristotle targets for Fermat Defect-One Conjecture
+  Bounded-search lemmas for automated proof search.
+  See FermatDefectOne.lean for the main formalization and the open headline
+  conjecture `fermat_defect_one_exists`.
+
+  These targets are scoped to small bounds that Aristotle can realistically
+  chip at. None of them is the headline conjecture; the headline stays a
+  sorry in the main file and is registered as a Tier-3 open-conjecture target
+  in research/open-conjectures.json.
+
+  Three bounded-search targets:
+
+    witness_n_eq_4_bounded_50    -- "Does n=4 admit a witness with c ≤ 50?"
+    witness_n_eq_5_bounded_50    -- "Does n=5 admit a witness with c ≤ 50?"
+    no_witness_n_eq_4_below_20   -- "Bounded-nonexistence at n=4, c ≤ 20."
+
+  Each is a theorem sorry (NOT an axiom). Aristotle can attempt these
+  immediately; any one that succeeds ships as a verified `native_decide`
+  witness lemma. The bounded-nonexistence target is a `decide`-style "no
+  small witness" lower bound on M(n).
+
+  These statements are intentionally narrow so the MCTS search can succeed
+  on at least the no-witness target via `decide` / `native_decide`. If a
+  bounded witness exists, the existence statement may also be decidable
+  via the same tactic.
+-/
+import Mathlib
+import Proofs.FermatDefectOne
+
+namespace FermatDefectOne
+
+/-! ## Bounded-witness existence targets
+
+These are *existence* statements with explicit bounds on `c`. If a primitive
+witness exists at the given `(n, bound)`, Aristotle should produce it; if no
+such witness exists, the statement is false (and the target is dropped from
+the registry — see `research/SORRY-CLASSIFICATION.md` Tier-3 policy).
+
+Both `n = 4` and `n = 5` bounded-witness targets are *open* — no small witness
+is known and we are explicitly attempting them.
+-/
+
+/-- Bounded witness at $n = 4$, $c \le 50$. Open: no primitive nontrivial
+witness at $n = 4$ is currently known at any bound. -/
+theorem witness_n_eq_4_bounded_50 :
+    ∃ a b c : Nat, c ≤ 50 ∧ FermatDefectWitness 4 a b c := by
+  sorry
+
+/-- Bounded witness at $n = 5$, $c \le 50$. Open: no primitive nontrivial
+witness at $n = 5$ is currently known at any bound. -/
+theorem witness_n_eq_5_bounded_50 :
+    ∃ a b c : Nat, c ≤ 50 ∧ FermatDefectWitness 5 a b c := by
+  sorry
+
+/-! ## Bounded-nonexistence targets
+
+A bounded-nonexistence statement at $(n, N)$ asserts that no primitive
+nontrivial defect-one witness exists with $c \le N$. This is a `decide`-style
+claim with a finite search space.
+
+A successful proof at $(4, 20)$ would push the minimal-witness function
+$M(4) \ge 21$ (if it is finite), and the same template generalizes to other
+$(n, N)$ pairs.
+-/
+
+/-- Bounded nonexistence at $n = 4$, $c \le 20$: no primitive nontrivial
+defect-one witness exists with $c$ at most 20. Discharge candidate:
+`decide` / `native_decide` over the finite search space. -/
+theorem no_witness_n_eq_4_below_20 :
+    ∀ a b c : Nat,
+      2 ≤ a → a ≤ b → b < c → c ≤ 20 →
+      ¬ FermatDefectWitness 4 a b c := by
+  sorry
+
+end FermatDefectOne

--- a/research/PROBLEMS-STRUCTURE.md
+++ b/research/PROBLEMS-STRUCTURE.md
@@ -1,0 +1,134 @@
+# research/problems/&lt;slug&gt;/ — substrate for the OODA loop
+
+This document defines the file layout for an actively-attempted research target
+under `research/problems/<slug>/`. The Erdős-problem convention (one
+`problem.md` per `erdos-N-oq-K`) is the prior art; this document generalizes
+that convention for non-Erdős targets and adds the `claims/`, `notes/`, and
+`links/` subdirectories that turn a problem entry into a working OODA-loop
+substrate.
+
+See issue #22628 for context and rationale.
+
+## Layout
+
+```
+research/problems/<slug>/
+  problem.md            # statement, current state, attack-vector menu
+  claims/               # one file per researcher (or Aristotle) attempt
+    YYYY-MM-DD-<vector>-<short-tag>.md
+    ...
+  notes/                # curated cross-claim insights (less frequently updated)
+    leads.md
+    dead-ends.md
+    open-sub-conjectures.md
+  links/                # pointers into the rest of the repo
+    lean-files.md       # which proofs/Proofs/*.lean files instantiate / depend on this
+    gallery.md          # which src/data/proofs/<slug>/ entries reference this
+```
+
+The `<slug>` matches the gallery slug exactly (e.g., `fermat-defect-one`
+matches `src/data/proofs/fermat-defect-one/`). For Erdős problems the legacy
+convention `erdos-<N>-oq-<K>` is retained; new non-Erdős targets use the
+gallery slug.
+
+## problem.md
+
+The top-level file is a working brief. It must contain at minimum:
+
+1. **Statement** — formal Lean statement and a plain-language version.
+2. **Current state** — what is known, what is open, citations.
+3. **Attack vectors** — a numbered menu the next iteration can choose from.
+   Each vector should be named (one of: `witness-search`, `modular-obstruction`,
+   `parameterization`, `reduction`, `structural-lemma`, `literature-reading`,
+   `other`) so claim files can reference it.
+4. **Connections** — neighboring problems, both in the gallery and in the
+   literature.
+
+Style is functional; this is a working file, not a publication artifact.
+
+## claims/
+
+A `claims/` file records **one attempt**, success or failure. Negative results
+are first-class — the whole point of writing them down is so the next
+iteration does not redo the same dead end.
+
+File naming: `YYYY-MM-DD-<vector>-<short-tag>.md`, e.g.
+
+```
+2026-06-10-mod3-obstruction-n4.md
+2026-06-12-witness-search-n5-bound500.md
+2026-06-14-thue-reduction-n3.md
+```
+
+Required sections inside a claim file:
+
+```markdown
+# Claim — <short title>
+
+- **Vector attempted**: one of (witness-search | modular-obstruction |
+  parameterization | reduction | structural-lemma | literature-reading | other)
+- **Date**: YYYY-MM-DD
+- **Author**: (agent id or human)
+- **Status**: succeeded | failed | inconclusive | partial
+
+## What was tried
+
+(concrete: search bound, prime modulus, parameterization family,
+Lean file path, literature reference)
+
+## What happened
+
+(witness found / no witness in bound / obstruction found / no obstruction /
+lemma proved / lemma failed / paper located)
+
+## What this suggests for next iteration
+
+(actionable: try larger bound, try different prime, write Lean lemma X,
+read paper Y, abandon this vector)
+```
+
+Aristotle's wrapper auto-generates a stub claim file (vector `aristotle-mcts`)
+via `scripts/aristotle/write-run-artifact.sh` whenever it completes a run on
+the target. Researchers can promote these stubs into curated claims; they do
+not need to be hand-written from scratch.
+
+## notes/
+
+Three optional curated files. These survive after individual claim files age
+out. Updated less frequently (weekly at most) and only when an insight is
+durable enough that future iterations will want to know it.
+
+- `leads.md` — promising directions not yet attempted.
+- `dead-ends.md` — vectors known not to work, with brief justifications.
+- `open-sub-conjectures.md` — smaller open conjectures discovered along the way.
+
+## links/
+
+Two pointer files that keep the problem entry in sync with the rest of the
+repository:
+
+- `lean-files.md` — `proofs/Proofs/*.lean` files that instantiate or depend on
+  the problem.
+- `gallery.md` — `src/data/proofs/<slug>/` entries that reference it.
+
+These are short lists; they exist so that an agent picking up the slug for the
+first time can find the surrounding code without grepping.
+
+## Lifecycle
+
+A `research/problems/<slug>/` entry exists exactly when:
+
+1. The corresponding `src/data/proofs/<slug>/meta.json` has
+   `researchStatus: "actively-attempting"`, OR
+2. The slug is listed in `research/open-conjectures.json` (Tier-3 registry).
+
+When either condition is dropped (e.g., the conjecture is proven, abandoned, or
+demoted to `input`), the problem directory remains for historical reference but
+is no longer updated.
+
+## Relationship to existing Erdős convention
+
+The `research/problems/erdos-<N>-oq-<K>/` directories pre-date this document.
+Existing Erdős entries continue to follow their established convention; the
+new `claims/`, `notes/`, `links/` subdirectories are optional additions, not
+retroactive requirements.

--- a/research/SORRY-CLASSIFICATION.md
+++ b/research/SORRY-CLASSIFICATION.md
@@ -8,6 +8,14 @@ This guide helps decide **what to send to Aristotle** (proof search tool), NOT w
 - **Claude** → Strategic reasoning, creative approaches, attempting OPEN problems
 - **Aristotle** → Tactical proof search for results with KNOWN proofs
 
+> **Policy update (2026-06-09, issue #22628):** Open conjectures we are
+> actively attacking now have a Tier-3 slot in the candidate pipeline. The
+> prior default of *"convert the headline sorry to an `axiom` so Aristotle skips
+> it"* is **reversed for actively-attempted targets**. See the new
+> [Tier 3: open-conjecture targets](#tier-3-open-conjecture-targets-rate-limited-long-haul)
+> and [Open conjectures: when to use Tier 3 vs `axiom`](#open-conjectures-when-to-use-tier-3-vs-axiom)
+> sections below.
+
 ## Classification Tiers (for Aristotle Submission)
 
 ### TRIVIAL (Minutes)
@@ -685,6 +693,160 @@ If you have an existing `*Aristotle.lean` companion file with N sorries:
 
 Do not delete the original `*Aristotle.lean` companion file until the StatementOnly
 submissions have succeeded — keep it as a fallback.
+
+## Tier 3: open-conjecture targets (rate-limited, long-haul)
+
+> **Added 2026-06-09 by issue #22628.**
+
+The candidate pipeline (`scripts/aristotle/find-candidates.sh`) recognizes a
+fourth tier in addition to T0 / T1 / T2:
+
+| Tier | Source | Purpose | Cadence |
+|------|--------|---------|---------|
+| T0 | `*StatementOnly.lean` | One-theorem-per-file Harmonic submissions | every run |
+| T1 | `*Aristotle.lean` | Multi-sorry companion files (legacy fallback) | every run |
+| T2 | `proofs/Proofs/*.lean` | Routine research output | every run |
+| **T3** | `research/open-conjectures.json` | **Open conjectures we are actively attacking** | **rate-limited (default 7d)** |
+
+### What makes a target Tier 3
+
+A Tier-3 target is a specific theorem in a specific Lean file whose proof is
+genuinely open — no published proof exists. Tier-3 targets are listed in
+`research/open-conjectures.json`. Each entry specifies:
+
+```jsonc
+{
+  "slug": "fermat-defect-one",
+  "file": "proofs/Proofs/FermatDefectOne.lean",
+  "theorem": "fermat_defect_one_exists",
+  "kind": "headline",
+  "attackVectors": ["witness-search", "modular-obstruction", "..."],
+  "cadence": "7d",       // optional, defaults to registry-wide default
+  "budget": "4h",        // optional, max runtime per attempt
+  "problemDir": "research/problems/fermat-defect-one"
+}
+```
+
+### Tier-3 scheduling differs from T0/T1/T2
+
+- **Rate-limited.** The pipeline emits a Tier-3 candidate only when the most
+  recent attempt under `research/aristotle-runs/<slug>/` is older than the
+  per-target cadence. Default cadence is 7 days.
+- **Failures DO NOT block.** Unlike T0/T1/T2 — where two failed jobs without
+  intervening file edits mark the file as `blocked` — Tier-3 failures only
+  consume rate-limit budget. The point of T3 is iteration, not single-shot
+  success.
+- **Per-run artifacts.** Every Tier-3 attempt (success or failure) writes a
+  `research/aristotle-runs/<slug>/<timestamp>/` directory containing
+  `config.json`, `transcript.log`, optional `final-state.lean`, and
+  `summary.md`. The artifact-writing helper is
+  `scripts/aristotle/write-run-artifact.sh`.
+- **Opt-in.** If `research/open-conjectures.json` does not exist, Tier-3
+  contributes zero candidates and the pipeline behavior is identical to the
+  prior three-tier system. There is no automatic upgrade.
+
+### Artifact directory schema
+
+```
+research/aristotle-runs/<slug>/<YYYY-MM-DDTHH-MMZ>/
+  config.json          # tier, status, Aristotle version, timestamp
+  transcript.log       # full Aristotle output (stdout/stderr)
+  final-state.lean     # proof state when the run ended (optional)
+  summary.md           # one-paragraph human-readable summary
+```
+
+The artifact dir doubles as the **memory layer** for the OODA loop: the next
+run on the same slug reads prior `summary.md` files to avoid repeating dead
+ends. (Reading prior summaries is a follow-up — the storage is the prerequisite
+and is shipped now.)
+
+### OODA-loop substrate: `research/problems/<slug>/`
+
+Every Tier-3 slug should have a corresponding `research/problems/<slug>/`
+directory with the layout defined in
+[`research/PROBLEMS-STRUCTURE.md`](./PROBLEMS-STRUCTURE.md). At minimum:
+
+```
+research/problems/<slug>/
+  problem.md           # statement, current state, attack-vector menu
+  claims/              # one file per attempt (success or failure)
+  notes/               # curated cross-claim insights
+  links/               # pointers to lean-files and gallery entries
+```
+
+When the Aristotle wrapper completes a Tier-3 run, `write-run-artifact.sh`
+drops a stub claim file in `research/problems/<slug>/claims/` so that the
+Aristotle agent and the Researcher agent share the same memory.
+
+## Open conjectures: when to use Tier 3 vs `axiom`
+
+> **Policy reversal (2026-06-09, issue #22628).**
+
+There are now **two valid stances** for an open conjecture in a proof file,
+and the choice is no longer driven by queue hygiene.
+
+### Stance A — Tier 3: actively attempting
+
+Use this when you intend the system to *attempt* the conjecture.
+
+```lean
+/-- Headline open conjecture. -/
+theorem fermat_defect_one_exists :
+    ∀ n : Nat, 3 ≤ n → FermatDefectExists n := by
+  sorry
+```
+
+- Keep the conjecture as a `sorry` (NOT an `axiom`).
+- Add the file + theorem to `research/open-conjectures.json`.
+- Create `research/problems/<slug>/problem.md` with the attack-vector menu.
+- Set `researchStatus: "actively-attempting"` in
+  `src/data/proofs/<slug>/meta.json`.
+- Status remains `"axiomatized"` — the open `sorry` is still an assumption
+  (per the Axiom Integrity Policy). `researchStatus` is metadata about the
+  stance, not a license to under-count assumptions.
+
+### Stance B — `axiom`: accepted as input
+
+Use this when the conjecture is a foundational assumption that supports
+downstream proofs but you do NOT plan to attempt it.
+
+```lean
+/-- Accepted as input. -/
+axiom riemann_hypothesis : ∀ s : ℂ, ...
+```
+
+- The conjecture becomes an `axiom`; Aristotle and the candidate pipeline
+  skip it.
+- The downstream proofs in the file proceed normally on the assumption.
+- `researchStatus: "input"` (or absent) in `src/data/proofs/<slug>/meta.json`.
+
+### Choosing between Stance A and Stance B
+
+| Question | Choose Tier 3 (A) | Choose `axiom` (B) |
+|---|---|---|
+| Are we attempting this? | yes | no |
+| Are there small / tractable instances? | yes | no |
+| Is the conjecture downstream of axiomatic prerequisites we accept (e.g., RH)? | no | yes |
+| Does failure to make progress matter? | no — that's the system learning its limits | yes — it would invalidate downstream results |
+
+**Either stance is honest.** Stance A says "we are trying"; Stance B says "we
+are not trying right now". The old default — convert headline sorries to axioms
+purely to keep the queue clean — produced a third, dishonest stance ("we have
+declared this off-limits to avoid running into it again"). That third stance is
+deprecated. Pick A or B and document the choice.
+
+### Migrating an existing axiom-headline to Tier 3
+
+If you previously converted an open-conjecture sorry to an `axiom` purely for
+queue hygiene and you want to attempt it again:
+
+1. Convert the `axiom foo : ...` back to `theorem foo : ... := by sorry`.
+2. Add the entry to `research/open-conjectures.json`.
+3. Create / update `research/problems/<slug>/`.
+4. Update `src/data/proofs/<slug>/meta.json` (set `researchStatus`,
+   `researchTargets`, keep `status: "axiomatized"`).
+5. Confirm the candidate pipeline emits the new Tier-3 entry:
+   `./scripts/aristotle/find-candidates.sh | grep '<basename>'`.
 
 ## Citations
 

--- a/research/aristotle-runs/.gitkeep
+++ b/research/aristotle-runs/.gitkeep
@@ -1,0 +1,13 @@
+# Aristotle run artifacts
+
+This directory holds per-run artifacts written by
+`scripts/aristotle/write-run-artifact.sh` after each Aristotle attempt on a
+Tier-3 (open-conjecture) target. See `research/SORRY-CLASSIFICATION.md` for
+the schema and policy.
+
+Layout:
+  research/aristotle-runs/<slug>/<YYYY-MM-DDTHH-MMZ>/
+    config.json
+    transcript.log
+    final-state.lean   (optional)
+    summary.md

--- a/research/open-conjectures.json
+++ b/research/open-conjectures.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./open-conjectures.schema.json",
+  "version": "1.0",
+  "description": "Registry of Tier-3 open-conjecture targets for the Aristotle pipeline. Each entry marks a specific theorem in a Lean file as an actively-attempted open conjecture: rate-limited submissions, longer per-job budgets, failures do NOT block further attempts. See research/SORRY-CLASSIFICATION.md (Tier 3 section) for the policy.",
+  "defaults": {
+    "cadence": "7d",
+    "budget": "4h",
+    "minHoursBetweenAttempts": 168
+  },
+  "targets": [
+    {
+      "slug": "fermat-defect-one",
+      "file": "proofs/Proofs/FermatDefectOne.lean",
+      "theorem": "fermat_defect_one_exists",
+      "kind": "headline",
+      "attackVectors": [
+        "witness-search",
+        "modular-obstruction",
+        "parameterization",
+        "reduction",
+        "structural-lemma"
+      ],
+      "cadence": "7d",
+      "budget": "4h",
+      "problemDir": "research/problems/fermat-defect-one",
+      "notes": "Headline open conjecture: for every n >= 3, a primitive nontrivial |a^n + b^n - c^n| = 1 witness exists. Stays as `sorry` (NOT axiomatized) — explicitly attempted by the system. n=3 already verified for both signs in the same file."
+    }
+  ]
+}

--- a/research/problems/fermat-defect-one/links/gallery.md
+++ b/research/problems/fermat-defect-one/links/gallery.md
@@ -1,0 +1,8 @@
+# Gallery entries for fermat-defect-one
+
+- `src/data/proofs/fermat-defect-one/meta.json` — gallery entry. Carries
+  `researchStatus: "actively-attempting"` and a `researchTargets` array
+  pointing at the headline and the bounded-search companion targets.
+- Cross-references: `fermats-last-theorem`, `fermat-two-squares`,
+  `pythagorean-theorem`, `pythagorean-triples` (see `crossReferences` in
+  `meta.json`).

--- a/research/problems/fermat-defect-one/links/lean-files.md
+++ b/research/problems/fermat-defect-one/links/lean-files.md
@@ -1,0 +1,12 @@
+# Lean files for fermat-defect-one
+
+- `proofs/Proofs/FermatDefectOne.lean` — main formalization. Contains:
+  - The four predicates (`FermatDefectWitness`, `FermatDefectExists`,
+    `FermatDefectPositive`, `FermatDefectNegative`).
+  - Verified $n = 3$ benchmarks (both signs) via `native_decide`.
+  - Headline open conjecture `fermat_defect_one_exists` (sorry — Tier 3).
+- `proofs/Proofs/FermatDefectOneAristotle.lean` — companion file with three
+  bounded-search targets Aristotle can attempt immediately:
+  - `witness_n_eq_4_bounded_50`
+  - `witness_n_eq_5_bounded_50`
+  - `no_witness_n_eq_4_below_20`

--- a/research/problems/fermat-defect-one/notes/dead-ends.md
+++ b/research/problems/fermat-defect-one/notes/dead-ends.md
@@ -1,0 +1,6 @@
+# Dead ends — fermat-defect-one
+
+Vectors known not to work, with brief justifications. Update this file when a
+claim closes off a direction definitively.
+
+(No dead ends recorded yet — seeded 2026-06-09 by issue #22628.)

--- a/research/problems/fermat-defect-one/notes/leads.md
+++ b/research/problems/fermat-defect-one/notes/leads.md
@@ -1,0 +1,15 @@
+# Leads — fermat-defect-one
+
+Curated list of promising directions not yet attempted. Add to this file when
+a claim suggests a new angle worth recording across iterations.
+
+- Bounded witness search at $n = 4$: even an exhaustive search to $c \le 100$
+  has not been documented in this repository. A single positive hit clears
+  the exponent.
+- Modular sieving by $p = 3, 5, 7$ should drastically shrink the bounded
+  search space before evaluating the defect condition itself.
+- The $n = 3$ positive-defect witness is structurally linked to the taxicab
+  number 1729. Investigate whether the same structural family (sums of two
+  cubes with two representations) has higher-power analogues.
+
+(Seeded 2026-06-09 by issue #22628. Curate as claims accumulate.)

--- a/research/problems/fermat-defect-one/notes/open-sub-conjectures.md
+++ b/research/problems/fermat-defect-one/notes/open-sub-conjectures.md
@@ -1,0 +1,15 @@
+# Open sub-conjectures — fermat-defect-one
+
+Smaller open conjectures discovered along the way that may be tractable on
+their own.
+
+- **$M(n)$ asymptotics.** Does $M(n) \to \infty$ as $n \to \infty$? Is
+  $M(n) = O(\mathrm{poly}(n))$? Even a weak bound would be publishable.
+- **Per-sign Level 3.** Are both signs of the defect realised at every
+  $n \ge 3$? At $n = 3$ yes; for general $n$ open. A modular-arithmetic
+  obstruction would rule out one sign at specific $n$.
+- **abc consequence.** Does the abc conjecture (or its effective forms)
+  imply finiteness of primitive defect-one solutions for each fixed
+  $n \ge 4$?
+
+(Seeded 2026-06-09 by issue #22628.)

--- a/research/problems/fermat-defect-one/problem.md
+++ b/research/problems/fermat-defect-one/problem.md
@@ -1,0 +1,155 @@
+# Problem: Fermat Defect-One Conjecture
+
+**Slug**: fermat-defect-one
+**Created**: 2026-06-09
+**Status**: Actively attempting (Tier 3)
+**Gallery**: `src/data/proofs/fermat-defect-one/`
+**Lean source**: `proofs/Proofs/FermatDefectOne.lean`
+**Aristotle companion**: `proofs/Proofs/FermatDefectOneAristotle.lean`
+**Source**: issues #22620, #22628
+
+## Problem Statement
+
+### Formal Statement (Level 2)
+
+For every integer $n \ge 3$, there exist positive integers $a, b, c$ with
+
+$$2 \le a \le b < c, \quad \gcd(a, b, c) = 1, \quad |a^n + b^n - c^n| = 1.$$
+
+On `Nat`, the absolute-value condition splits into a disjunction:
+
+- $a^n + b^n + 1 = c^n$ (negative defect: $a^n + b^n - c^n = -1$)
+- $a^n + b^n = c^n + 1$ (positive defect: $a^n + b^n - c^n = +1$)
+
+```lean
+theorem fermat_defect_one_exists :
+    ∀ n : Nat, 3 ≤ n → FermatDefectExists n := by
+  sorry
+```
+
+### Plain Language
+
+Fermat's Last Theorem (Wiles, 1995) says $a^n + b^n - c^n = 0$ has no
+nontrivial integer solutions for $n > 2$. The defect-one conjecture asks the
+next question: can the defect be exactly $\pm 1$? At $n = 3$ both signs are
+witnessed by small primitive triples; for $n \ge 4$ no general construction
+is known.
+
+### Statement Hierarchy
+
+- **Level 0** (trivial): $a = c$, $b = 1$ gives $c^n + 1 - c^n = 1$ for any $n$.
+  Excluded by demanding $2 \le a$ and $a \le b < c$.
+- **Level 1** (nontrivial defect-one existence): for every $n \ge 3$,
+  $2 \le a \le b < c$ with $|a^n + b^n - c^n| = 1$.
+- **Level 2** (primitive nontrivial existence): Level 1 plus $\gcd(a, b, c) = 1$.
+  **This is the headline.**
+- **Level 3** (signed primitive existence): for every $n \ge 3$ and every
+  $\epsilon \in \{-1, +1\}$, a primitive witness with that sign exists. May
+  fail at some $(n, \epsilon)$ — a refutation would itself be a result.
+
+## Known Witnesses (verified)
+
+Both signs are verified at $n = 3$ via `native_decide` in
+`proofs/Proofs/FermatDefectOne.lean`:
+
+| Sign | Triple $(a, b, c)$ | Arithmetic | gcd |
+|------|-------------------|------------|-----|
+| Negative ($a^n + b^n + 1 = c^n$) | $(6, 8, 9)$ | $216 + 512 + 1 = 729$ | $\gcd(2, 9) = 1$ |
+| Positive ($a^n + b^n = c^n + 1$) | $(9, 10, 12)$ | $729 + 1000 = 1729 = 1728 + 1$ | $\gcd(1, 12) = 1$ |
+
+The positive-defect witness is a unit-shift of the Ramanujan-Hardy taxicab
+number $1729 = 1^3 + 12^3 = 9^3 + 10^3$.
+
+No primitive nontrivial defect-one witness is currently known at $n \ge 4$.
+
+## Attack Vectors
+
+A claim file in `claims/` should pick exactly one vector (named exactly as
+below) and document what was tried, what happened, and what to try next. See
+`research/PROBLEMS-STRUCTURE.md` for the claim-file format.
+
+### 1. `witness-search` — bounded search for $n = 4, 5, 6, \ldots$
+
+For each fixed $n$, enumerate $(a, b, c)$ with $2 \le a \le b < c \le N$,
+filter by mod-$p$ pre-tests, and check the defect condition. A single
+primitive witness at any $(n, N)$ ships as a verified `native_decide` theorem
+of the form
+
+```lean
+theorem fermat_defect_witness_n_<k> : FermatDefectWitness <k> <a> <b> <c>
+```
+
+and clears that exponent off the open list. Aristotle companion targets
+(see `proofs/Proofs/FermatDefectOneAristotle.lean`):
+
+- `witness_n_eq_4_bounded_50` — does $n = 4$ admit a witness with $c \le 50$?
+- `witness_n_eq_5_bounded_50` — does $n = 5$ admit a witness with $c \le 50$?
+
+### 2. `modular-obstruction` — Level 3 refutation candidates
+
+For each candidate $(n, \epsilon)$, check whether some prime $p$ obstructs all
+solutions: $a^n + b^n \pm 1 \equiv c^n \pmod{p}$ for all $(a, b, c)$. A
+Level-3 refutation at any specific $(n, \epsilon)$ is itself a publishable
+result. Typical targets: $n \in \{4, 5, 6, 8, 10\}$, $p \in \{3, 5, 7, 11, 13\}$.
+
+### 3. `parameterization` — polynomial families
+
+Search for families $(a(t), b(t), c(t)) \in \mathbb{Z}[t]^3$ with
+$a(t)^n + b(t)^n - c(t)^n \equiv \pm 1$ identically. One such family proves
+the conjecture for infinitely many witnesses at the given $n$ in a single
+shot. Sub-attacks: linear, quadratic, and cubic parameterizations; reuse of
+the $n = 3$ benchmark structure.
+
+### 4. `reduction` — Thue / Fermat-Catalan
+
+Does the conjecture (or its negation at specific $n$) follow from known
+finiteness results applied in a particular regime? The Fermat-Catalan
+equation $x^p + y^q = z^r$ with $1/p + 1/q + 1/r < 1$ has finitely many
+primitive solutions (conjectured); the defect-one problem at exponent $n$ is
+a unit-offset diagonal slice.
+
+### 5. `structural-lemma` — asymptotic $M(n)$
+
+Let $M(n) = \min \{c : \exists\, (a, b) \text{ with } 2 \le a \le b < c,
+\gcd(a, b, c) = 1, |a^n + b^n - c^n| = 1\}$ when this set is non-empty. Any
+bound $M(n) = O(n^k)$ (or even $M(n) \le f(n)$ for an explicit $f$) would
+be a publishable result.
+
+Bounded-nonexistence theorems contribute lower bounds on $M(n)$. The
+Aristotle companion exposes:
+
+- `no_witness_n_eq_4_below_20` — proves $M(4) \ge 21$ if $M(4)$ is finite.
+
+## Connections
+
+| Target | Relationship |
+|---|---|
+| Fermat's Last Theorem (FLT) | Zero defect impossible at $n > 2$; defect-one asks whether the very next defect is realised. |
+| Pillai's conjecture | Finiteness of solutions to $a^x - b^y = c$ for fixed $c$. Defect-one is a richer Pillai-type question. |
+| Fermat-Catalan conjecture | $x^p + y^q = z^r$ with $1/p + 1/q + 1/r < 1$ has finitely many primitives. Defect-one at exponent $n$ is the unit-offset diagonal $p = q = r = n$. |
+| Thue equations | Finiteness for $F(x, y) = c$ with $F$ irreducible. Relevant to vector 4. |
+| Taxicab number 1729 | The $n = 3$ positive-defect witness $9^3 + 10^3 - 12^3 = 1$ is a unit-distance fact about $1729 = 1^3 + 12^3 = 9^3 + 10^3$. |
+
+## References
+
+- Wiles, "Modular elliptic curves and Fermat's Last Theorem" (1995).
+- Pillai, "On $a^x - b^y = c$" (1936).
+- Darmon and Granville, "On the equations $z^m = F(x, y)$ and $Ax^p + By^q = Cz^r$" (1995).
+- Beukers, "The Diophantine equation $Ax^p + By^q = Cz^r$" (1998).
+- Waldschmidt, "Perfect powers: Pillai's works and their developments" (2009) —
+  [PDF](https://webusers.imj-prg.fr/~michel.waldschmidt/articles/pdf/PerfectPowers.pdf).
+- Hardy, "Ramanujan: Twelve Lectures…" (1940) — taxicab anecdote.
+
+## Sub-issues
+
+Each attack vector is tracked as its own follow-up issue (filed under
+`loom:curated`):
+
+- #22635 — `witness-search` at $n = 4$, $c \le 1000$.
+- #22636 — `modular-obstruction` (Level 3) at $n = 4, 5, 6$.
+- #22637 — `parameterization` (polynomial families).
+- #22638 — `reduction` (Thue / Fermat-Catalan).
+
+Each sub-issue should produce either a verified Lean theorem (positive
+result) or a curated claim file in `claims/` (negative result). Both outcomes
+count as progress.

--- a/scripts/aristotle/find-candidates.sh
+++ b/scripts/aristotle/find-candidates.sh
@@ -9,7 +9,7 @@
 #   ./find-candidates.sh --json       # Output as JSON
 #   ./find-candidates.sh --tier1-only # Return only companion files (Tier 1)
 #
-# Three-tier candidate system:
+# Four-tier candidate system:
 #   Tier 0 (highest priority): *StatementOnly.lean files (Harmonic format)
 #     - One theorem per file with informal /- problem block and standard set_option block
 #     - Mirrors Harmonic's HarmonicLean/StatementOnly_*.lean convention
@@ -21,6 +21,12 @@
 #   Tier 2 (fallback): Research output files (non-Erdos, non-Test, non-Aristotle, non-StatementOnly)
 #     - Researcher-produced files with complete definitions and routine lemma sorries
 #     - Score = theorem_sorries only
+#   Tier 3 (opt-in, rate-limited): Open-conjecture targets from research/open-conjectures.json
+#     - Long-haul research targets — the headline conjecture STAYS a sorry; the system attempts it
+#     - Failures DO NOT block future attempts; the registry enforces a per-file cadence (default 7d)
+#     - Returned only when the per-target cadence allows another attempt
+#     - If research/open-conjectures.json does not exist, Tier 3 is silent and overall behavior
+#       is identical to the prior three-tier system.
 #
 # Candidates are files that:
 #   - Have theorem/lemma sorries (something to prove)
@@ -35,6 +41,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PROOFS_DIR="$PROJECT_ROOT/proofs/Proofs"
 JOBS_FILE="$PROJECT_ROOT/research/aristotle-jobs.json"
+OPEN_CONJ_REGISTRY="$PROJECT_ROOT/research/open-conjectures.json"
+ARISTOTLE_RUNS_DIR="$PROJECT_ROOT/research/aristotle-runs"
 
 # Parse arguments
 COUNT_ONLY=false
@@ -194,6 +202,127 @@ collect_candidates() {
     done
 }
 
+# ---------------------------------------------------------------------------
+# Tier 3: open-conjecture registry helpers
+#
+# Tier 3 targets are opt-in via research/open-conjectures.json. Each entry has
+# a per-file `cadence` (default 7d). A target is eligible for re-submission iff
+# its most recent attempt artifact (research/aristotle-runs/<slug>/<ts>/) is
+# older than the cadence — or no attempt exists yet.
+#
+# Failures DO NOT block Tier 3 candidates. This is intentional: the whole point
+# of Tier 3 is to keep trying hard problems, not single-shot them and give up.
+# ---------------------------------------------------------------------------
+
+# Returns 0 (success) if the registry is present, non-zero otherwise.
+tier3_registry_present() {
+    [[ -f "$OPEN_CONJ_REGISTRY" ]]
+}
+
+# Print one basename (no .lean) per line for every file referenced by the
+# Tier-3 registry. Used to suppress duplicate Tier-2 emissions for files that
+# are also Tier-3 targets — a Tier-3 entry takes precedence so the routine
+# blocked/submitted filters do not silence the long-haul target.
+tier3_registered_basenames() {
+    tier3_registry_present || return 0
+    jq -r '.targets[]? | .file' "$OPEN_CONJ_REGISTRY" 2>/dev/null \
+        | while IFS= read -r rel; do
+            [[ -z "$rel" ]] && continue
+            basename "$rel" .lean
+        done | sort -u
+}
+
+# Parse a cadence string like "7d" / "12h" / "30m" into seconds. Defaults to
+# 604800 (7 days) on parse failure.
+cadence_to_seconds() {
+    local cad="$1"
+    if [[ -z "$cad" ]]; then
+        echo 604800
+        return
+    fi
+    local n="${cad%[a-zA-Z]*}"
+    local unit="${cad##*[0-9]}"
+    if [[ ! "$n" =~ ^[0-9]+$ ]]; then
+        echo 604800
+        return
+    fi
+    case "$unit" in
+        s) echo "$n" ;;
+        m) echo $((n * 60)) ;;
+        h) echo $((n * 3600)) ;;
+        d) echo $((n * 86400)) ;;
+        w) echo $((n * 604800)) ;;
+        *) echo 604800 ;;
+    esac
+}
+
+# Print the epoch-seconds of the most recent artifact directory for a given
+# Tier-3 slug, or 0 if none exists.
+tier3_last_attempt_epoch() {
+    local slug="$1"
+    local dir="$ARISTOTLE_RUNS_DIR/$slug"
+    [[ -d "$dir" ]] || { echo 0; return; }
+    # Artifact subdirs are timestamp-named (e.g., 2026-06-10T03-15Z). Use mtime
+    # of the most recently-created subdir as the attempt epoch.
+    local latest
+    latest=$(find "$dir" -mindepth 1 -maxdepth 1 -type d \
+        -exec stat -f '%m' {} \; 2>/dev/null \
+        || find "$dir" -mindepth 1 -maxdepth 1 -type d \
+        -exec stat -c '%Y' {} \; 2>/dev/null \
+        || echo "")
+    if [[ -z "$latest" ]]; then
+        echo 0
+        return
+    fi
+    # Highest mtime among subdirs is the most recent attempt.
+    echo "$latest" | sort -n | tail -1
+}
+
+# Collect Tier-3 candidates from the open-conjectures registry. Emits the same
+# pipe-delimited format as collect_candidates() for the main pipeline.
+collect_tier3_candidates() {
+    tier3_registry_present || return 0
+
+    local default_cadence
+    default_cadence=$(jq -r '.defaults.cadence // "7d"' "$OPEN_CONJ_REGISTRY" 2>/dev/null || echo "7d")
+
+    local now_epoch
+    now_epoch=$(date +%s)
+
+    # Iterate registry entries
+    jq -r '.targets[]? | [.slug, .file, (.cadence // ""), .theorem] | @tsv' \
+        "$OPEN_CONJ_REGISTRY" 2>/dev/null | while IFS=$'\t' read -r slug rel_file cadence theorem; do
+        [[ -z "$slug" ]] && continue
+        [[ -z "$rel_file" ]] && continue
+
+        local abs_file="$PROJECT_ROOT/$rel_file"
+        [[ -f "$abs_file" ]] || continue
+
+        local effective_cadence="${cadence:-$default_cadence}"
+        local cad_secs
+        cad_secs=$(cadence_to_seconds "$effective_cadence")
+
+        local last_epoch
+        last_epoch=$(tier3_last_attempt_epoch "$slug")
+
+        local elapsed=$((now_epoch - last_epoch))
+        # If most recent attempt is within the cadence window, skip.
+        if [[ "$last_epoch" -gt 0 && "$elapsed" -lt "$cad_secs" ]]; then
+            continue
+        fi
+
+        # Analyze the file (tier 3). Score is theorem_sorries.
+        local analysis
+        analysis=$(analyze_file "$abs_file" 3)
+        local score
+        score=$(echo "$analysis" | cut -d'|' -f6)
+        # Skip hard rejects (definition sorries or all-True placeholders).
+        [[ "$score" -eq -1 ]] && continue
+
+        echo "$analysis"
+    done
+}
+
 # Main logic
 main() {
     local submitted_files
@@ -228,10 +357,21 @@ main() {
         done < <(collect_candidates 1 "$submitted_files" "$blocked_files" "${tier1_files[@]}")
     fi
 
-    # Tier 2: Regular proof files (unless --tier1-only)
+    # Tier 2: Regular proof files (unless --tier1-only).
+    # Files registered as Tier-3 open-conjecture targets are excluded from
+    # Tier 2 so the same file is not emitted twice (and so the Tier-2
+    # blocked/submitted filters do not silence a long-haul T3 target).
     if [[ "$TIER1_ONLY" != true ]]; then
+        local tier3_basenames
+        tier3_basenames=$(tier3_registered_basenames)
+
         local tier2_files=()
         while IFS= read -r f; do
+            local bn
+            bn=$(basename "$f" .lean)
+            if [[ -n "$tier3_basenames" ]] && echo "$tier3_basenames" | grep -q "^${bn}$"; then
+                continue
+            fi
             tier2_files+=("$f")
         done < <(find "$PROOFS_DIR" -name "*.lean" -type f \
             ! -name "Erdos*" ! -name "Test*" ! -name "*Aristotle.lean" ! -name "*StatementOnly.lean" \
@@ -242,6 +382,15 @@ main() {
                 [[ -n "$line" ]] && candidate_data+=("$line")
             done < <(collect_candidates 2 "$submitted_files" "$blocked_files" "${tier2_files[@]}")
         fi
+    fi
+
+    # Tier 3: Open-conjecture registry (opt-in, rate-limited, no submitted/blocked filters)
+    # Tier-3 entries are gated by cadence rather than the success/failure status
+    # of prior jobs. The whole point is to keep attempting — failures DO NOT block.
+    if [[ "$TIER1_ONLY" != true ]]; then
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && candidate_data+=("$line")
+        done < <(collect_tier3_candidates)
     fi
 
     if [[ ${#candidate_data[@]} -eq 0 ]]; then
@@ -314,24 +463,29 @@ EOF
             case "$tier" in
                 0) tier_label="T0" ;;
                 1) tier_label="T1" ;;
+                2) tier_label="T2" ;;
+                3) tier_label="T3" ;;
                 *) tier_label="T2" ;;
             esac
             printf "%-40s %5s %8d %8d %8d %8d\n" "$name" "$tier_label" "$total" "$def" "$axiom" "$score"
         done <<< "$sorted_data"
 
-        local total_count tier0_count tier1_count tier2_count
+        local total_count tier0_count tier1_count tier2_count tier3_count
         total_count=$(echo "$sorted_data" | grep -c '|' 2>/dev/null; true)
         tier0_count=$(echo "$sorted_data" | grep -c '|0$' 2>/dev/null; true)
         tier1_count=$(echo "$sorted_data" | grep -c '|1$' 2>/dev/null; true)
         tier2_count=$(echo "$sorted_data" | grep -c '|2$' 2>/dev/null; true)
+        tier3_count=$(echo "$sorted_data" | grep -c '|3$' 2>/dev/null; true)
         total_count="${total_count:-0}"
         tier0_count="${tier0_count:-0}"
         tier1_count="${tier1_count:-0}"
         tier2_count="${tier2_count:-0}"
+        tier3_count="${tier3_count:-0}"
         echo ""
-        echo "Total candidates: $total_count (T0 statement-only: $tier0_count, T1 companion: $tier1_count, T2 regular: $tier2_count)"
+        echo "Total candidates: $total_count (T0 statement-only: $tier0_count, T1 companion: $tier1_count, T2 regular: $tier2_count, T3 open-conjecture: $tier3_count)"
         echo "T0 StatementOnly files (Harmonic format) have top priority. T1 companion files are next."
         echo "T2 research output files are fallback when T0+T1 slots exhausted."
+        echo "T3 open-conjecture targets (research/open-conjectures.json) are rate-limited long-haul attempts."
         echo "Best candidates have low score (few sorries, no def sorries)"
     fi
 }

--- a/scripts/aristotle/write-run-artifact.sh
+++ b/scripts/aristotle/write-run-artifact.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+#
+# write-run-artifact.sh - Persist an Aristotle attempt's outputs as a research
+# artifact under research/aristotle-runs/<slug>/<timestamp>/.
+#
+# This is the storage half of the "memory layer for the OODA loop" defined in
+# issue #22628. The Aristotle wrapper calls this script after each attempt
+# (success OR failure) on a Tier-3 target, so prior attempts remain inspectable
+# by future runs and by the Researcher agent.
+#
+# Usage:
+#   write-run-artifact.sh \
+#       --slug <slug>             # e.g., fermat-defect-one
+#       --tier <0|1|2|3>           # tier from find-candidates.sh
+#       --status <success|failure|partial|skipped>
+#       --transcript <path>        # full Aristotle output (will be copied)
+#       [--final-state <path>]     # optional: proof state when the run ended
+#       [--summary <text>]         # optional: one-paragraph human summary
+#       [--config-json <path>]     # optional: extra config to merge into config.json
+#
+# Artifact directory layout:
+#   research/aristotle-runs/<slug>/<YYYY-MM-DDTHH-MMZ>/
+#     config.json          # tier, timeout, Aristotle version, slug, status
+#     transcript.log       # full Aristotle output
+#     final-state.lean     # proof state when the run ended (optional)
+#     summary.md           # one-paragraph human-readable summary
+#
+# Notes:
+#   - This is a thin storage helper. It does NOT submit anything to Aristotle.
+#   - It is safe to call repeatedly; each invocation creates a new timestamp dir.
+#   - The output of this script is the absolute path of the created artifact dir
+#     (printed on stdout). Callers can pipe this into downstream tooling.
+#
+# Exit codes:
+#   0 — artifact written successfully
+#   1 — usage error (missing required flags)
+#   2 — transcript not readable
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+ARISTOTLE_RUNS_DIR="$PROJECT_ROOT/research/aristotle-runs"
+
+SLUG=""
+TIER=""
+STATUS=""
+TRANSCRIPT=""
+FINAL_STATE=""
+SUMMARY=""
+CONFIG_JSON=""
+
+usage() {
+    sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --slug) SLUG="$2"; shift 2 ;;
+        --tier) TIER="$2"; shift 2 ;;
+        --status) STATUS="$2"; shift 2 ;;
+        --transcript) TRANSCRIPT="$2"; shift 2 ;;
+        --final-state) FINAL_STATE="$2"; shift 2 ;;
+        --summary) SUMMARY="$2"; shift 2 ;;
+        --config-json) CONFIG_JSON="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+[[ -z "$SLUG" ]] && { echo "ERROR: --slug is required" >&2; usage; }
+[[ -z "$TIER" ]] && { echo "ERROR: --tier is required" >&2; usage; }
+[[ -z "$STATUS" ]] && { echo "ERROR: --status is required" >&2; usage; }
+[[ -z "$TRANSCRIPT" ]] && { echo "ERROR: --transcript is required" >&2; usage; }
+[[ -r "$TRANSCRIPT" ]] || { echo "ERROR: transcript not readable: $TRANSCRIPT" >&2; exit 2; }
+
+TIMESTAMP=$(date -u +'%Y-%m-%dT%H-%MZ')
+ARTIFACT_DIR="$ARISTOTLE_RUNS_DIR/$SLUG/$TIMESTAMP"
+mkdir -p "$ARTIFACT_DIR"
+
+# Write config.json
+ARISTOTLE_VERSION="${ARISTOTLE_VERSION:-unknown}"
+TIMEOUT_HINT="${ARISTOTLE_TIMEOUT:-unset}"
+cat > "$ARTIFACT_DIR/config.json" <<EOF
+{
+  "slug": "$SLUG",
+  "tier": $TIER,
+  "status": "$STATUS",
+  "timestamp": "$(date -u +'%Y-%m-%dT%H:%M:%SZ')",
+  "aristotleVersion": "$ARISTOTLE_VERSION",
+  "timeoutHint": "$TIMEOUT_HINT"
+}
+EOF
+
+# Merge in optional extra config (best-effort; falls back to bare config.json)
+if [[ -n "$CONFIG_JSON" && -r "$CONFIG_JSON" ]]; then
+    if command -v jq >/dev/null 2>&1; then
+        jq -s '.[0] * .[1]' "$ARTIFACT_DIR/config.json" "$CONFIG_JSON" \
+            > "$ARTIFACT_DIR/config.json.tmp" \
+            && mv "$ARTIFACT_DIR/config.json.tmp" "$ARTIFACT_DIR/config.json"
+    fi
+fi
+
+# Copy transcript (best-effort gzip if file is large)
+cp "$TRANSCRIPT" "$ARTIFACT_DIR/transcript.log"
+
+# Copy final-state if provided
+if [[ -n "$FINAL_STATE" && -r "$FINAL_STATE" ]]; then
+    cp "$FINAL_STATE" "$ARTIFACT_DIR/final-state.lean"
+fi
+
+# Write summary.md
+SUMMARY_TEXT="${SUMMARY:-No summary provided. (Set --summary to record what was tried, what stuck, and what to try next.)}"
+cat > "$ARTIFACT_DIR/summary.md" <<EOF
+# Aristotle attempt — $SLUG — $TIMESTAMP
+
+- **Slug**: $SLUG
+- **Tier**: $TIER
+- **Status**: $STATUS
+- **Aristotle version**: $ARISTOTLE_VERSION
+
+## Summary
+
+$SUMMARY_TEXT
+
+## Artifacts
+
+- \`config.json\` — run configuration (tier, status, Aristotle version)
+- \`transcript.log\` — full Aristotle output (stdout/stderr)
+$(if [[ -f "$ARTIFACT_DIR/final-state.lean" ]]; then echo "- \`final-state.lean\` — proof state when the run ended"; fi)
+
+EOF
+
+# If the slug has a research/problems/<slug>/ directory, drop a stub claim file.
+# This is the Aristotle <-> Researcher coupling described in #22628 section 5.
+PROBLEM_DIR="$PROJECT_ROOT/research/problems/$SLUG"
+if [[ -d "$PROBLEM_DIR" ]]; then
+    CLAIMS_DIR="$PROBLEM_DIR/claims"
+    mkdir -p "$CLAIMS_DIR"
+    CLAIM_FILE="$CLAIMS_DIR/$(date -u +'%Y-%m-%d')-aristotle-${STATUS}-${TIMESTAMP}.md"
+    cat > "$CLAIM_FILE" <<EOF
+# Claim — Aristotle attempt $TIMESTAMP
+
+- **Vector attempted**: \`aristotle-mcts\` (automated)
+- **Date**: $(date -u +'%Y-%m-%d')
+- **Status**: $STATUS
+
+## What was tried
+
+Aristotle MCTS proof search on Tier-3 target \`$SLUG\`.
+
+## What happened
+
+$STATUS — see \`research/aristotle-runs/$SLUG/$TIMESTAMP/\` for full transcript and config.
+
+## What this suggests for next iteration
+
+(Auto-generated stub; the Researcher agent should curate this when it picks up the slug next.)
+EOF
+fi
+
+echo "$ARTIFACT_DIR"

--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -25,6 +25,35 @@
     "lineCount": 146,
     "theoremCount": 6,
     "definitionCount": 4,
+    "researchStatus": "actively-attempting",
+    "researchTargets": [
+      {
+        "name": "fermat_defect_one_exists",
+        "kind": "headline",
+        "attackVectors": [
+          "witness-search",
+          "modular-obstruction",
+          "parameterization",
+          "reduction",
+          "structural-lemma"
+        ]
+      },
+      {
+        "name": "witness_n_eq_4_bounded_50",
+        "kind": "bounded-search",
+        "attackVectors": ["witness-search"]
+      },
+      {
+        "name": "witness_n_eq_5_bounded_50",
+        "kind": "bounded-search",
+        "attackVectors": ["witness-search"]
+      },
+      {
+        "name": "no_witness_n_eq_4_below_20",
+        "kind": "bounded-search",
+        "attackVectors": ["witness-search", "structural-lemma"]
+      }
+    ],
     "originalContributions": [
       "FermatDefectWitness, FermatDefectExists, FermatDefectPositive, FermatDefectNegative: four Nat-only predicates expressing |a^n + b^n - c^n| = 1 via a disjunction avoiding signed-integer coercions",
       "fermat_defect_three_neg: verified primitive negative-defect witness 6^3 + 8^3 + 1 = 9^3 (gcd(6,8,9)=1) via native_decide",

--- a/src/pages/ProofPage.tsx
+++ b/src/pages/ProofPage.tsx
@@ -199,6 +199,20 @@ export function ProofPage() {
           >
             {proof.meta.status}
           </span>
+          {/*
+            TODO(22628): full "active research status" banner.
+            Should link to research/problems/<slug>/, list the most recent
+            claim files, and surface open sub-conjectures. For now we render
+            a minimal badge so the meta-schema extension has a visible effect.
+          */}
+          {proof.meta.researchStatus === 'actively-attempting' && (
+            <span
+              className="px-2 py-0.5 rounded text-xs font-medium bg-purple-500/20 text-purple-300"
+              title="This entry's open assumptions are actively being attacked by the research pipeline. See research/open-conjectures.json and research/problems/<slug>/ for current attack vectors."
+            >
+              actively attempting
+            </span>
+          )}
           <span>{annotations.length} annotations</span>
         </div>
 

--- a/src/types/proof.ts
+++ b/src/types/proof.ts
@@ -319,6 +319,30 @@ export const ERDOS_PROBLEMS: Record<number, string> = {
 }
 
 /**
+ * A specific theorem / sorry being actively attacked by the research pipeline.
+ *
+ * Surfaced in the gallery for entries with
+ * `meta.researchStatus = "actively-attempting"`. Schema introduced by
+ * issue #22628 (research infrastructure for open-conjecture attempts).
+ */
+export interface ResearchTarget {
+  /** Theorem name in the linked Lean file (e.g., "fermat_defect_one_exists"). */
+  name: string
+  /**
+   * Role of this target within the proof file:
+   * - `"headline"` — the main open conjecture
+   * - `"bounded-search"` — a finite-budget version Aristotle might prove now
+   * - `"supporting"` — a lemma in service of the headline
+   */
+  kind?: 'headline' | 'bounded-search' | 'supporting' | string
+  /**
+   * Attack-vector menu we plan to apply. Vector names match
+   * `research/PROBLEMS-STRUCTURE.md` and the `claims/` filename convention.
+   */
+  attackVectors?: string[]
+}
+
+/**
  * A theorem or lemma imported from Mathlib
  */
 export interface MathlibDependency {
@@ -358,6 +382,33 @@ export interface ProofMeta {
   hilbertNumber?: number
   /** Millennium Prize Problem identifier if applicable */
   millenniumProblem?: MillenniumProblem
+
+  /**
+   * Research stance for the open assumptions in this proof.
+   *
+   * - `"input"` (default when absent): assumptions are accepted as background,
+   *   not actively attacked. Equivalent to prior behavior.
+   * - `"actively-attempting"`: at least one sorry / axiom is a Tier-3 target
+   *   in `research/open-conjectures.json`. Gallery may render a banner.
+   * - `"abandoned"`: the conjecture was previously attempted but no current
+   *   attack is in flight (review for demotion to `"input"` after 90 days
+   *   of no activity).
+   *
+   * NOTE: this does NOT change how axioms are counted (per AXIOM INTEGRITY
+   * POLICY). It is metadata about our research stance, not the assumption count.
+   *
+   * Backwards-compatible legacy values such as `"ongoing"` are tolerated by
+   * the gallery build pipeline; new entries should use one of the three
+   * canonical states above.
+   */
+  researchStatus?: 'input' | 'actively-attempting' | 'abandoned' | string
+
+  /**
+   * Which specific theorems / sorries we are attacking. Each entry references
+   * a theorem name in the linked Lean file and the attack-vector menu we plan
+   * to apply. Read by the gallery's "active research status" banner.
+   */
+  researchTargets?: ResearchTarget[]
 
   // Erdős Problems fields
   /** Erdős problem number from erdosproblems.com */


### PR DESCRIPTION
Closes #22628.

## Summary

Implements Phase 1 + Phase 2 of #22628 — a first-class workflow for attempting hard open conjectures rather than axiomatizing them away. The headline `fermat_defect_one_exists` stays a `sorry`, per the user's framing.

## Phase 1 — system-level infrastructure

- `research/open-conjectures.json`: Tier-3 registry. Each entry has `{slug, file, theorem, attackVectors[], cadence, budget}`. Opt-in — if absent, the pipeline is unchanged.
- `scripts/aristotle/find-candidates.sh`: new Tier 3 (rate-limited, long-haul). Cadence-gated (default 7d). **Failures DO NOT block.** Tier-3 targets are excluded from Tier 2 to avoid double-emission.
- `scripts/aristotle/write-run-artifact.sh`: persists each Aristotle attempt to `research/aristotle-runs/<slug>/<YYYY-MM-DDTHH-MMZ>/{config.json, transcript.log, final-state.lean?, summary.md}`. Drops a stub claim file when the slug has an OODA-loop substrate.
- `research/PROBLEMS-STRUCTURE.md`: documents the `research/problems/<slug>/{problem.md, claims/, notes/, links/}` substrate for non-Erdős targets.
- `research/SORRY-CLASSIFICATION.md`: policy reversal — open conjectures we are actively attacking stay as `sorry`, NOT `axiom`.
- `src/types/proof.ts`: extends `ProofMeta` with optional `researchStatus` and `researchTargets`. Backwards-compatible.
- `src/pages/ProofPage.tsx`: minimal stub badge for `researchStatus = "actively-attempting"`. `TODO(22628)` marker for the full banner.

## Phase 2 — Fermat defect-one adoption

- `proofs/Proofs/FermatDefectOneAristotle.lean`: companion file with three bounded-search targets (all theorem sorries, no axioms): `witness_n_eq_4_bounded_50`, `witness_n_eq_5_bounded_50`, `no_witness_n_eq_4_below_20`.
- `research/open-conjectures.json`: registers `fermat_defect_one_exists` as the first Tier-3 target.
- `research/problems/fermat-defect-one/`: full OODA-loop substrate with the 5-vector attack menu.
- `src/data/proofs/fermat-defect-one/meta.json`: `researchStatus: actively-attempting` + `researchTargets[]`.

The headline `fermat_defect_one_exists` STAYS A SORRY. Not converted to axiom.

## Sub-issues filed

- #22635 — witness search at n=4, c ≤ 1000
- #22636 — modular obstructions Level 3 at n = 4, 5, 6
- #22637 — polynomial parameterization search
- #22638 — Thue / Fermat-Catalan reduction attempt

## Smoke test

`./scripts/aristotle/find-candidates.sh --count`:
- pre-change (no edits, no registry): 376
- post-change with registry: 377
- post-change without registry (mv'd out): 377

The +1 net change is the new `FermatDefectOneAristotle.lean`. The registry's net contribution is 0 (T3 adds +1, T2 suppression removes −1). Backwards compatibility verified.

## Out of scope (Phase 3, not in this PR)

- Wiring the Aristotle wrapper to call `write-run-artifact.sh` on every run.
- Reading prior `summary.md` files as input to the next attempt.
- Full gallery UI banner.

## Axiom Integrity Policy

Untouched. `researchStatus` is metadata about our research stance, not a license to under-count assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
