### PR TITLE
Enrich Fermat Defect-One: line-range accuracy + tactic annotation

### DIFF
--- a/src/data/proofs/fermat-defect-one/annotations.json
+++ b/src/data/proofs/fermat-defect-one/annotations.json
@@ -4,7 +4,7 @@
     "proofId": "fermat-defect-one",
     "range": {
       "startLine": 1,
-      "endLine": 47
+      "endLine": 40
     },
     "type": "concept",
     "title": "Module Overview: The Defect-One Conjecture",
@@ -28,7 +28,7 @@
     "id": "ann-hierarchy",
     "proofId": "fermat-defect-one",
     "range": {
-      "startLine": 18,
+      "startLine": 29,
       "endLine": 33
     },
     "type": "concept",
@@ -46,7 +46,7 @@
     "id": "ann-predicates",
     "proofId": "fermat-defect-one",
     "range": {
-      "startLine": 49,
+      "startLine": 46,
       "endLine": 79
     },
     "type": "definition",
@@ -64,8 +64,8 @@
     "id": "ann-benchmark-neg",
     "proofId": "fermat-defect-one",
     "range": {
-      "startLine": 86,
-      "endLine": 100
+      "startLine": 83,
+      "endLine": 93
     },
     "type": "theorem",
     "title": "Verified n=3 Negative-Defect Benchmark",
@@ -82,8 +82,8 @@
     "id": "ann-benchmark-pos",
     "proofId": "fermat-defect-one",
     "range": {
-      "startLine": 102,
-      "endLine": 116
+      "startLine": 95,
+      "endLine": 107
     },
     "type": "theorem",
     "title": "Verified n=3 Positive-Defect Benchmark (Taxicab Shift)",
@@ -100,7 +100,7 @@
     "id": "ann-existence-derived",
     "proofId": "fermat-defect-one",
     "range": {
-      "startLine": 118,
+      "startLine": 109,
       "endLine": 130
     },
     "type": "theorem",
@@ -138,11 +138,54 @@
     ]
   },
   {
+    "id": "ann-tactic-pattern",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 87,
+      "endLine": 93
+    },
+    "type": "technique",
+    "title": "Tactic Pattern: refine + native_decide on Conjunctions",
+    "content": "Each benchmark's proof obligation is a 5-fold conjunction `2 ≤ a ∧ a ≤ b ∧ b < c ∧ gcd_condition ∧ disjunct`. The proof uses `refine ⟨?_, ?_, ?_, ?_, ?_⟩` to introduce five named goals (one per conjunct), then discharges each with `native_decide`. The disjunct goal is handled with `left; native_decide` (negative defect, $a^n + b^n + 1 = c^n$) or `right; native_decide` (positive defect, $a^n + b^n = c^n + 1$) to pick the correct branch before reducing. This pattern is the canonical Lean 4 idiom for closing concrete-witness goals over decidable predicates: structurally decompose the conjunction, computationally close each leaf. `native_decide` reduces to native-code evaluation (faster than the kernel-level `decide`) and is appropriate here because the arithmetic involves $9^3 = 729$ and $12^3 = 1728$ — large enough that kernel reduction would be slow.",
+    "mathContext": "Decomposition: $P_1 \\land P_2 \\land P_3 \\land P_4 \\land (Q_- \\lor Q_+) \\;\\Leftarrow\\; (P_1, P_2, P_3, P_4, Q_\\pm)$ with $\\pm$ picked by `left`/`right`. All five components are decidable on `Nat`.",
+    "significance": "technical",
+    "relatedConcepts": [
+      "refine tactic and anonymous constructor",
+      "native_decide vs decide",
+      "decidability of conjunctions",
+      "left/right for disjunction elimination",
+      "Lean 4 proof-by-evaluation idioms"
+    ],
+    "prerequisites": [
+      "Lean 4 tactic mode",
+      "anonymous constructor syntax ⟨ ⟩",
+      "decidable propositions"
+    ]
+  },
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "fermat-defect-one",
+    "range": {
+      "startLine": 42,
+      "endLine": 44
+    },
+    "type": "context",
+    "title": "Imports and Namespace",
+    "content": "`import Mathlib` pulls in the full Mathlib library — needed for `Nat.gcd`, the `decide`/`native_decide` infrastructure, and standard arithmetic lemmas. The whole file lives in `namespace FermatDefectOne`, so the four predicates and six theorems are exposed as `FermatDefectOne.FermatDefectWitness`, `FermatDefectOne.fermat_defect_three_neg`, etc. Gallery convention: a single `import Mathlib` is preferred over piecemeal imports for self-contained gallery entries; this is distinct from Mathlib-bound files (`mathlib-contribution` skill), which are required to use targeted imports.",
+    "mathContext": "Namespace prefix: `FermatDefectOne.*` for all exported names. Mathlib provides `Nat.gcd` and decidability instances.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Mathlib import conventions",
+      "namespace conventions in Lean 4",
+      "gallery vs mathlib-bound style"
+    ]
+  },
+  {
     "id": "ann-connections",
     "proofId": "fermat-defect-one",
     "range": {
-      "startLine": 30,
-      "endLine": 45
+      "startLine": 35,
+      "endLine": 39
     },
     "type": "concept",
     "title": "Connections to Known Problem Families",

--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -44,7 +44,8 @@
       "**Why $a \\ge 2$ and $a \\ne c$:** The constraint $a = 1$ collapses to $1 + b^n - c^n = \\pm 1$, i.e., $b^n = c^n$ or $b^n + 2 = c^n$ — both pin $b, c$ very tightly. The constraint $a = c$ gives the Level-0 triviality $c^n + b^n - c^n = b^n = 1$, i.e., $b = 1$. These are not the spirit of the problem.",
       "**Taxicab connection:** $9^3 + 10^3 = 1729 = 1^3 + 12^3$ is the smallest positive integer expressible as a sum of two cubes in two distinct ways (Ramanujan-Hardy). The defect-one positive witness $9^3 + 10^3 - 12^3 = 1$ is therefore the assertion that $1729 - 12^3 = 1$ — a unit-distance fact about the taxicab number. The negative-defect witness $6^3 + 8^3 - 9^3 = -1$ is its mirror on the other side of $9^3 = 729$.",
       "**Nat-only formulation:** Stating $|a^n + b^n - c^n| = 1$ on `ℤ` requires signed coercion; on `Nat` it splits into the disjunction $a^n + b^n + 1 = c^n \\lor a^n + b^n = c^n + 1$. This keeps the predicate decidable and lets `native_decide` close concrete witnesses without algebraic manipulation.",
-      "**Search structure:** For each $n$, a bounded search over $a \\le b < c \\le N$ with mod-$p$ pre-filters is tractable for small $n$ and small $N$. The minimal-witness function $M(n)$ — the smallest $c$ for which a primitive witness exists — is finite where the conjecture holds; $M(3) \\le 9$ from the negative-defect benchmark."
+      "**Search structure:** For each $n$, a bounded search over $a \\le b < c \\le N$ with mod-$p$ pre-filters is tractable for small $n$ and small $N$. The minimal-witness function $M(n)$ — the smallest $c$ for which a primitive witness exists — is finite where the conjecture holds; $M(3) \\le 9$ from the negative-defect benchmark.",
+      "**Decidability as a research lever:** Because the four predicates are decidable on `Nat` (each concrete triple reduces to integer arithmetic), `native_decide` closes any concrete witness goal at any exponent $n$ where the cubes/powers fit in machine integers. This means progress on small-$n$ cases is purely a search problem: every candidate $(a, b, c)$ can be checked mechanically, and the gallery can absorb new verified $(n, \\epsilon)$ benchmarks as one-line theorems. The bottleneck is exponential growth of $c^n$, not theorem-proving — pinning a witness at $n = 4$ would close another row of the conjecture's table without any new tactic infrastructure."
     ],
     "prerequisites": [
       "Basic arithmetic on `Nat` and `Nat.gcd`",
@@ -59,14 +60,14 @@
       "id": "imports-and-overview",
       "title": "Imports and Module Overview",
       "startLine": 1,
-      "endLine": 47,
-      "summary": "Module docstring introducing the defect-one conjecture, the Nat disjunction trick, the n=3 benchmarks for both signs, and connections to FLT, Pillai, and Fermat-Catalan.",
+      "endLine": 44,
+      "summary": "Module docstring (lines 1–40) introducing the defect-one conjecture, the Nat disjunction trick, the n=3 benchmarks for both signs, and connections to FLT, Pillai, and Fermat-Catalan; followed by `import Mathlib` (line 42) and `namespace FermatDefectOne` (line 44).",
       "mathContext": "$|a^n + b^n - c^n| = 1$ encoded on $\\mathbb{N}$ as $a^n + b^n + 1 = c^n \\lor a^n + b^n = c^n + 1$."
     },
     {
       "id": "predicates",
       "title": "Four Predicates",
-      "startLine": 49,
+      "startLine": 46,
       "endLine": 79,
       "summary": "Definitions of FermatDefectWitness (combined signs, with bounds and gcd primitivity), FermatDefectExists (existence over witnesses), FermatDefectPositive (a^n + b^n = c^n + 1), and FermatDefectNegative (a^n + b^n + 1 = c^n).",
       "mathContext": "$\\mathtt{FermatDefectWitness}\\,n\\,a\\,b\\,c$: $2 \\le a \\le b < c \\land \\gcd(\\gcd(a,b),c) = 1 \\land (a^n+b^n+1 = c^n \\lor a^n+b^n = c^n+1)$."


### PR DESCRIPTION
## Summary

Enrichment pass for `fermat-defect-one` focused on **line-range accuracy** (so UI highlighting matches actual code positions) and **filling an uncovered tactic-pattern gap**.

### Changes

**`annotations.json`**
- Corrected line ranges on 7 existing annotations to match the actual Lean file positions (`ann-module-overview`, `ann-hierarchy`, `ann-connections`, `ann-predicates`, `ann-benchmark-neg`, `ann-benchmark-pos`, `ann-existence-derived`).
- Added `ann-tactic-pattern` — explains the `refine ⟨?_, ?_, ?_, ?_, ?_⟩` + `native_decide` decomposition pattern that closes both `n=3` benchmarks, including the `left;`/`right;` branch-pick for the disjunction.
- Added `ann-imports-namespace` — covers `import Mathlib` and `namespace FermatDefectOne`, noting the gallery-vs-mathlib-bound import convention.

**`meta.json`**
- Fixed line ranges on `sections[0]` (imports-and-overview: 1–47 → 1–44) and `sections[1]` (predicates: 49–79 → 46–79) to match the Lean file.
- Added a seventh `keyInsights` entry on **decidability as a research lever**: because the four predicates are decidable on `Nat`, small-$n$ witness-finding reduces to a pure search problem and the gallery can absorb new verified $(n, \epsilon)$ benchmarks as one-line theorems with no new tactic infrastructure.

### Axiom integrity check

No changes to `axiomCount` / `status` / `badge`. The entry remains `axiomatized` with 1 sorry on the headline conjecture `fermat_defect_one_exists` (genuine open mathematical assumption for $n \ge 4$); 0 axiom declarations; 0 structure-encoded assumptions. The $n=3$ benchmarks remain fully verified via `native_decide`.

## Test plan

- [x] `node -e "JSON.parse(...)"` validates both files
- [x] Enrichment summary stage of `pnpm build` completed (tsc unavailable in worktree — `node_modules` not installed, unrelated to this change)
- [x] Line ranges verified against `proofs/Proofs/FermatDefectOne.lean` (146 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)