### PR TITLE
audit(fermat-defect-one): tracker bump — clean (2nd audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15286,8 +15286,8 @@
       "issues": []
     },
     "fermat-defect-one": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-09T18:01:29Z",
+      "auditCount": 2,
+      "lastAudited": "2026-06-09T19:17:59Z",
       "result": "clean",
       "issues": []
     }


### PR DESCRIPTION
## Summary

2nd audit of `fermat-defect-one` — claims verified against `proofs/Proofs/FermatDefectOne.lean`.

## Verification

- 0 `axiom` declarations, 0 structure-encoded assumptions
- 1 sorry on the headline open conjecture `fermat_defect_one_exists : ∀ n ≥ 3, FermatDefectExists n`
- 6 theorems, 4 definitions, 146 lines (all match meta.json)
- n=3 benchmarks (both signs) discharged by `native_decide`:
  - Negative: `fermat_defect_three_neg` — $6^3 + 8^3 + 1 = 9^3$, $\gcd(6,8,9)=1$
  - Positive: `fermat_defect_three_pos` — $9^3 + 10^3 = 12^3 + 1$, $\gcd(9,10,12)=1$ (1729 ± 1)
- Status `axiomatized` / badge `axiom` correctly reflects sorry on a genuine Pillai-type open conjecture (not a tractable placeholder)
- Mathlib import is genuine; predicates and n=3 verifications are original, not wrappers

## Diff

`auditCount: 1 → 2`, `lastAudited` timestamp bumped. No other changes.

## Test plan

- [x] `grep -c "^axiom "` returns 0
- [x] Only sorry is on line 144 (`fermat_defect_one_exists`)
- [x] Theorem/def/line counts match meta.json exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)