### PR TITLE
audit(feuerbachs-theorem-oq-02): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -11315,9 +11315,9 @@
       "result": "clean"
     },
     "feuerbachs-theorem-oq-02": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:26:00Z",
+      "lastAudited": "2026-06-09T19:57:05Z",
       "result": "clean"
     },
     "feuerbachs-theorem-oq-05": {


### PR DESCRIPTION
## Summary
- 4th audit of `feuerbachs-theorem-oq-02`, no issues found
- Verified meta.json claims against `proofs/Proofs/FeuerbachsTheoremOQ02.lean`:
  - 1 axiom (`feuerbach_3d_fails_general`) matches `axiomCount: 1`
  - 0 actual sorries (only `sorry` occurrence is in a comment at line 494) matches `sorries: 0`
  - 769 lines exact match with `lineCount: 769`
  - `status: axiomatized` + `badge: axiom` accurate (1 axiomatized open conjecture)

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --next` confirmed target
- [x] Verified axiom/sorry counts in source file
- [x] Tracker bumped `auditCount: 3 → 4`, `lastAudited` updated