### PR TITLE
audit(basel-problem-oq-04-oq-03): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -754,9 +754,9 @@
       "result": "clean"
     },
     "basel-problem-oq-04-oq-03": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T16:26:00Z",
+      "lastAudited": "2026-06-09T20:00:00Z",
       "result": "clean"
     },
     "basel-problem-oq-05": {


### PR DESCRIPTION
## Audit Summary

**Proof**: `basel-problem-oq-04-oq-03` (Coprime Pair Density: Pr[gcd(m,n)=1] = 6/π²)
**Result**: Clean — no integrity issues found.

Tracker bumped: `auditCount` 2 → 3, `lastAudited` → 2026-06-09T20:00:00Z.

## Verification vs `proofs/Proofs/BaselProblemOQ04OQ03.lean`

| Check | Meta.json | Source | Match |
|-------|-----------|--------|-------|
| sorries | 0 | 0 (grep `sorry` → no matches) | ✓ |
| axiomCount | 0 | 0 (grep `^axiom ` → no matches) | ✓ |
| Structure-encoded assumptions | — | None (no structures or classes) | ✓ |
| True stubs | — | 0 (grep `: True\|:= trivial` → no matches) | ✓ |
| lineCount | 558 | 558 (`wc -l`) | ✓ |
| status / badge | `verified` / `original` | Justified — see below | ✓ |

## Status/badge consistency

- `status: "verified"` is supported by 0 sorries + 0 axiom declarations + 0 structure-encoded assumptions.
- `badge: "original"` is defensible because the file's *combinatorial* core is independent work: Möbius decomposition `countCoprimePairs(N) = Σ_{d≤N} μ(d)⌊N/d⌋²`, the coprimality detector, and the counting lemmas (`card_multiples`, `card_pairs_divisible`) are all proved from first principles. The Mathlib L-series bridge for `moebius_dirichlet_series_at_two` and the Basel value `riemannZeta_two` are transparently credited in `mathlibDependencies` and the section summaries.
- `originalContributions` is correctly scoped — does not overclaim independence of the Dirichlet step.

## Notes

- Minor counting discrepancy: source has 23 `theorem` declarations + 1 `noncomputable def`. Meta.json reports `theoremCount: 24, definitionCount: 1`. This appears to be a tooling convention (likely counts the def as a theorem-like entry) — not an integrity issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)