### PR TITLE
audit(chinese-remainder-constructive): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2045,9 +2045,9 @@
       "result": "clean"
     },
     "chinese-remainder-constructive": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T16:29:46Z",
+      "lastAudited": "2026-06-09T20:15:00Z",
       "result": "clean"
     },
     "chinese-remainder-constructive-oq-03": {


### PR DESCRIPTION
## Summary

5th audit of chinese-remainder-constructive — clean.

Verified meta.json claims against `proofs/Proofs/ChineseRemainderConstructive.lean`:

- **status**: `verified`, **badge**: `mathlib` ✓ (correctly attributes core to Mathlib's `Nat.chineseRemainder`)
- **sorries**: 0 ✓
- **axiomCount**: 0 ✓ (no `axiom` declarations, no assumption-encoding structures)
- **lineCount**: 416 ✓

Tier B classification (formalized using Mathlib theorem) properly reflected in description and originalContributions. No overstatement; original work (constructive witnesses, multi-modulus extensions, Sunzi problem solution, uniqueness) is properly scoped.

No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)