### PR TITLE
audit(buffons-needle-oq-01-oq-01-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1355,9 +1355,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01-oq-01": {
-      "auditCount": 2,
+      "auditCount": 3,
       "issues": [],
-      "lastAudited": "2026-05-03T16:29:46Z",
+      "lastAudited": "2026-06-09T20:25:47Z",
       "result": "clean"
     },
     "buffons-needle-oq-01-oq-01-oq-04": {


### PR DESCRIPTION
## Summary
3rd audit of `buffons-needle-oq-01-oq-01-oq-01` — clean. Verified meta claims match the Lean source.

- **Lean source**: `proofs/Proofs/BuffonsNeedleOQ01OQ01OQ01.lean`
- **Lines**: 223 (matches meta)
- **Axioms**: 0 (matches `axiomCount: 0`)
  - The lone `^axiom ` grep hit is inside a `/- ... -/` docstring code block, not a declaration
- **Sorries**: 0 (matches `sorries: 0`)
- **Theorems**: 7 (matches `theoremCount: 7`): `planarArcLength_eq`, `planarCurveArcLength_nonneg`, `buffon_noodle_smooth_theorem`, `smooth_shape_independence_free`, `smooth_expected_crossings_nonneg_free`, `smooth_crossings_mono_free`, `straight_line_axiom_free`
- **Definitions**: 1 (matches `definitionCount: 1`): `planarCurveArcLength`
- **Status**: `verified` / `original` — file has no axioms, no sorries, no structure-encoded assumptions

Tracker entry bumped 2 → 3.

## Test plan
- [x] Verified Lean source line count, axiom count, sorry count
- [x] Cross-checked theorem and definition counts vs `meta.json`
- [x] Confirmed no structure-encoded assumptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)