### PR TITLE
research(burnside-counting-oq-01): S2 ACT — discharge coloringSetoid + coloringQuotientFintype (axioms 4 → 2, Docker 3058 jobs clean)

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -346,12 +346,29 @@ axiom fixed_point_sum_binary_4 :
   Fintype.card { c : Coloring 4 2 // IsFixedByRotation 2 c } +
   Fintype.card { c : Coloring 4 2 // IsFixedByRotation 3 c } = 24
 
-/-- The equivalence relation on colorings by rotation. -/
-axiom coloringSetoid (n k : ℕ) [NeZero n] : Setoid (Coloring n k)
+/-- The equivalence relation on colorings by rotation.
+    Derived from `AddAction.orbitRel` (replacing the prior axiom): two
+    colorings are equivalent iff one is a rotation (in `ZMod n`) of the
+    other. -/
+def coloringSetoid (n k : ℕ) [NeZero n] : Setoid (Coloring n k) :=
+  AddAction.orbitRel (ZMod n) (Coloring n k)
 
-/-- The quotient of colorings by rotation has a Fintype instance. -/
-axiom coloringQuotientFintype (n k : ℕ) [NeZero n] :
-    Fintype (Quotient (@coloringSetoid n k _))
+/-- The orbit relation on colorings is decidable: two colorings are in
+    the same orbit iff `∃ r : ZMod n, r +ᵥ b = a`, which is decidable
+    because `ZMod n` is a `Fintype` and equality of colorings is
+    decidable (`Fin n → Fin k` has decidable equality). -/
+instance coloringSetoid_decidableRel (n k : ℕ) [NeZero n] :
+    DecidableRel (coloringSetoid n k).r := fun a b =>
+  decidable_of_iff (∃ x : ZMod n, x +ᵥ b = a) AddAction.mem_orbit_iff.symm
+
+/-- The quotient of colorings by rotation has a Fintype instance,
+    derived via `Quotient.fintype` from the finite carrier `Coloring n k`
+    and the decidable orbit relation above.  Replaces the prior axiom. -/
+def coloringQuotientFintype (n k : ℕ) [NeZero n] :
+    Fintype (Quotient (@coloringSetoid n k _)) := by
+  letI : Setoid (Coloring n k) := coloringSetoid n k
+  haveI : DecidableRel (α := Coloring n k) (· ≈ ·) := coloringSetoid_decidableRel n k
+  exact Quotient.fintype _
 
 /-- **Binary Necklaces of Length 4**:
     There are exactly 6 distinct binary necklaces of length 4.

--- a/research/problems/burnside-counting-oq-01/sessions/2026-06-09-s2-act-orbitrel-bridge.md
+++ b/research/problems/burnside-counting-oq-01/sessions/2026-06-09-s2-act-orbitrel-bridge.md
@@ -1,0 +1,200 @@
+# S2 ACT — `coloringSetoid` + `coloringQuotientFintype` discharged via `AddAction.orbitRel`
+
+**Date**: 2026-06-09
+**Researcher**: researcher-1
+**Type**: ACT — axiom discharges, Docker-verified.
+**Scope**: Discharge the two abstract group-action API axioms
+(`coloringSetoid`, `coloringQuotientFintype`) that S1b STATE-SYNC pinned
+as the highest-priority next deliverable. Reduces `BurnsideCounting.lean`
+from 4 axioms to 2.
+
+## §1 Result
+
+`BurnsideCounting.lean`: 370 → 387 LOC, axioms 4 → 2, theorems 7 → 7,
+defs 7 → 9 (+`coloringSetoid`, +`coloringQuotientFintype`; the new
+`coloringSetoid_decidableRel` is an `instance`, not a `def`). Sorries:
+0 → 0. Docker: 3058 / 3058 jobs clean (same job count as S1 — the
+new declarations all compile against the cached prefix).
+
+Axioms remaining: `fixed_point_sum_binary_4` (S3 candidate via
+`native_decide`) and `binary_necklaces_4` (S4 candidate via
+`burnside_lemma`).
+
+## §2 Surprise: no `Multiplicative` bridge needed
+
+S1b STATE-SYNC §2 pinned an `AddAction → MulAction` bridge as the S2
+plan:
+
+> The S2 ACT needs to bridge `AddAction (ZMod n) → MulAction (Multiplicative (ZMod n))`
+> so that `orbitRel.Quotient (Multiplicative (ZMod n)) (Coloring n k)` is
+> a defined type and `coloringSetoid` becomes `MulAction.orbitRel _ _`.
+
+That plan was over-engineered for the actual goal of discharging the
+*setoid* axiom. Direct check against `Mathlib/GroupTheory/GroupAction/Defs.lean`
+(line 279) shows:
+
+```lean
+/-- The relation 'in the same orbit'. -/
+@[to_additive /-- The relation 'in the same orbit'. -/]
+def orbitRel : Setoid α where
+  r a b := a ∈ orbit G b
+  iseqv := ⟨mem_orbit_self, ..., ...⟩
+```
+
+`orbitRel` carries `@[to_additive]`, so `AddAction.orbitRel (G : Type*) (α : Type*) [AddMonoid G] [AddAction G α] : Setoid α`
+exists directly. The discharge collapses to a 2-line `def`:
+
+```lean
+def coloringSetoid (n k : ℕ) [NeZero n] : Setoid (Coloring n k) :=
+  AddAction.orbitRel (ZMod n) (Coloring n k)
+```
+
+The `Multiplicative` bridge would only become necessary downstream in S4
+when *applying* `burnside_lemma` (which is stated in `MulAction` form).
+For the setoid axiom alone, it was unnecessary scaffolding.
+
+## §3 The `Fintype` instance
+
+For the quotient `Fintype`, `Quotient.fintype` (`Mathlib/Data/Fintype/Basic.lean:163`)
+requires:
+
+```lean
+instance Quotient.fintype [Fintype α] (s : Setoid α)
+    [DecidableRel ((· ≈ ·) : α → α → Prop)] : Fintype (Quotient s)
+```
+
+So we need (1) `Fintype (Coloring n k)` — automatic, since
+`Coloring n k = Fin n → Fin k` and Lean's `Pi.fintype` handles
+`Fin n → Fin k`; (2) decidability of the orbit equivalence relation.
+
+The relation unfolds: `a ≈ b` in our setoid = `(coloringSetoid n k).r a b`
+= `a ∈ AddAction.orbit (ZMod n) b`. By `AddAction.mem_orbit_iff`
+(`@[to_additive]` on `MulAction.mem_orbit_iff` at `Defs.lean:54`), that's
+`∃ x : ZMod n, x +ᵥ b = a`. Since `ZMod n` is `Fintype` for
+`[NeZero n]` and `Coloring n k` has decidable equality (Pi over finite
+indices), `Fintype.decidableExistsFintype` discharges it.
+
+Implementation:
+
+```lean
+instance coloringSetoid_decidableRel (n k : ℕ) [NeZero n] :
+    DecidableRel (coloringSetoid n k).r := fun a b =>
+  decidable_of_iff (∃ x : ZMod n, x +ᵥ b = a) AddAction.mem_orbit_iff.symm
+
+def coloringQuotientFintype (n k : ℕ) [NeZero n] :
+    Fintype (Quotient (@coloringSetoid n k _)) := by
+  letI : Setoid (Coloring n k) := coloringSetoid n k
+  haveI : DecidableRel (α := Coloring n k) (· ≈ ·) := coloringSetoid_decidableRel n k
+  exact Quotient.fintype _
+```
+
+The `letI` + `haveI` dance is needed because `Quotient.fintype` looks
+up `(· ≈ ·)` via the `HasEquiv` instance derived from the in-scope
+`Setoid`. With `letI` providing the setoid, `(· ≈ ·)` resolves to
+`(coloringSetoid n k).r`, and the explicit `haveI` provides the
+matching `DecidableRel` instance for instance search to find.
+
+## §4 Why this didn't break `binary_necklaces_4`
+
+The third remaining axiom (`binary_necklaces_4`) references both
+discharged symbols explicitly:
+
+```lean
+axiom binary_necklaces_4 :
+  @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6
+```
+
+Both names continue to resolve: `coloringSetoid` was `axiom` →
+`def`, `coloringQuotientFintype` was `axiom` → `def`. Both have the
+same signature as before, so the explicit `@`-application call site is
+unchanged. The `binary_necklaces_4` axiom is now stating that
+`Fintype.card (Quotient (AddAction.orbitRel (ZMod 4) (Coloring 4 2))) = 6`
+(with the specific Fintype instance derived from `Quotient.fintype`),
+which is a strictly stronger / more concrete statement than the old
+one over abstract axiomatic setoid + Fintype — and still axiomatic
+until S4 wires it through `burnside_lemma`.
+
+## §5 Build verification
+
+```
+$ ./proofs/scripts/docker-build.sh Proofs.BurnsideCounting
+...
+✔ [3058/3058] Built Proofs.BurnsideCounting (35s)
+Build completed successfully (3058 jobs).
+```
+
+Three `linter.unusedSimpArgs` warnings in pre-existing code at lines
+77, 299, 301 (`rotatedIndex_zero`, `period2_count` — both untouched by
+this PR). No new warnings introduced. No new sorries. No new axioms.
+
+## §6 Files modified
+
+1. `proofs/Proofs/BurnsideCounting.lean` (UPDATE):
+   - Lines 349–354: replaced 2 axioms (`coloringSetoid`,
+     `coloringQuotientFintype`) with a `def` + `instance` + `def` block
+     (~25 LOC including docstrings). Net +17 LOC.
+2. `src/data/proofs/burnside-counting/meta.json` (UPDATE):
+   - `axiomCount`: 4 → 2
+   - `lineCount`: 370 → 387
+   - `definitionCount`: 7 → 9
+   - `assumptions`: rewritten to list the 2 remaining axioms + note S1
+     and S2 discharges
+   - `originalContributions`: +3 entries (coloringSetoid,
+     coloringSetoid_decidableRel, coloringQuotientFintype)
+   - `proofStrategy`: updated to reflect S2 progress
+   - `openQuestions`: trimmed to just the S3/S4 + Polya/dihedral items
+   - Mirror in `.leanFile` block: `lineCount`, `axiomCount`,
+     `definitionCount` synced
+3. `research/problems/burnside-counting-oq-01/state.md` (UPDATE):
+   - Head phase + iteration + Last Updated bumped to S2 ACT / 2 / 2026-06-09
+   - Lean inventory section recounted
+   - Axiom inventory restructured into "remaining (after S2)" +
+     "discharged in earlier iterations"
+   - What's Next narrowed to S3 / S4 specifically
+   - Session Log: new top entry for this iteration
+4. `research/problems/burnside-counting-oq-01/sessions/2026-06-09-s2-act-orbitrel-bridge.md`
+   (NEW, this file).
+5. `src/data/research/problems/burnside-counting-oq-01.json`:
+   - `currentState.phase`: OBSERVE → ACT
+   - `currentState.iteration`: 1 → 2
+   - `knowledge.progressSummary`, `knowledge.builtItems`,
+     `knowledge.insights`, `knowledge.nextSteps`: synced with this
+     iteration's deliverables.
+
+## §7 Race / saturation
+
+```
+$ gh pr list --search "burnside-counting-oq-01 in:title" --state open
+(no open PRs)
+```
+
+0 open PRs on slug at PR-creation time.
+
+## §8 Honest scope
+
+* **Discharges**: 2 axioms (`coloringSetoid`, `coloringQuotientFintype`).
+* **Does NOT discharge**: `fixed_point_sum_binary_4` (S3) or
+  `binary_necklaces_4` (S4). Both remain explicit axioms.
+* **Does NOT** ship the `Multiplicative`-bridge that S1b STATE-SYNC
+  pinned — that work turned out to be unnecessary for these two
+  specific axioms, but may still be useful for S4's `burnside_lemma`
+  application. The S1b STATE-SYNC §2.1 bearer-API pin is therefore
+  partially superseded (still relevant for S4, no longer relevant for
+  S2).
+* **Does NOT** modify any other parent gallery file, any sibling proof
+  file, or any test infrastructure.
+* No new sorries. No new axioms. No new `lake-manifest.json` touches.
+
+## §9 References
+
+* Predecessor PRs: #21148 (S1 ACT, 2026-05-30), S1b STATE-SYNC PR
+  (2026-06-03, doc-only).
+* Mathlib v4.26.0 anchors:
+  - `Mathlib/GroupTheory/GroupAction/Defs.lean:279-284` —
+    `@[to_additive] def orbitRel`.
+  - `Mathlib/GroupTheory/GroupAction/Defs.lean:54-55` —
+    `@[to_additive] theorem mem_orbit_iff`.
+  - `Mathlib/Data/Fintype/Basic.lean:163-165` —
+    `instance Quotient.fintype`.
+* Companion file `BurnsideCountingOQ03OQ03.lean` (sibling slug) sketches
+  the `MulAction` connection chain; S4 may revisit it.

--- a/research/problems/burnside-counting-oq-01/state.md
+++ b/research/problems/burnside-counting-oq-01/state.md
@@ -1,21 +1,23 @@
 # Research State: burnside-counting-oq-01
 
-**Phase**: S1 ACT — rotatedIndex_add discharged (axiom → theorem); S1b STATE-SYNC adds S2 ACT bearer-API pin + Docker / disk blocker note
-**Owner**: researcher-1 (S1 ACT 2026-05-30; S1b STATE-SYNC 2026-06-03)
-**Iteration**: 1 (S1b is a sub-step, not a fresh iteration)
-**Last Updated**: 2026-06-03Z
-**Branch**: `research/burnside-counting-oq-01-s1-discharge-axiom` (merged) → `research/burnside-counting-oq-01-s1b-state-sync-*` (this SYNC)
+**Phase**: S2 ACT — `coloringSetoid` + `coloringQuotientFintype` discharged (axioms → derived from `AddAction.orbitRel` + `Quotient.fintype`)
+**Owner**: researcher-1 (S1 ACT 2026-05-30; S1b STATE-SYNC 2026-06-03; **S2 ACT 2026-06-09**)
+**Iteration**: 2 (S2 is a fresh iteration after S1 / S1b)
+**Last Updated**: 2026-06-09Z
+**Branch**: `research/burnside-counting-oq-01-s1-discharge-axiom` (merged) → `research/burnside-counting-oq-01-s1b-state-sync-*` (merged) → `research/burnside-counting-oq-01-s2-act-orbitrel-bridge-*` (this PR)
 
-## Lean file inventory (post S1, Docker-verified)
+## Lean file inventory (post S2, Docker-verified)
 
 ```
 File:        proofs/Proofs/BurnsideCounting.lean
-Lines:       370 (was 255 at S0)
-Theorems:    7 (was 6; rotatedIndex_add promoted from axiom to theorem)
-Definitions: 7 (unchanged)
+Lines:       387 (was 370 at S1; +17 LOC for S2 ACT)
+Theorems:    7 (unchanged)
+Definitions: 9 (was 7; +coloringSetoid def, +coloringQuotientFintype def;
+                 coloringSetoid_decidableRel instance also added)
 Sorries:     0
-Axioms:      4 (was 5; fixed_point_sum_binary_4, coloringSetoid,
-                 coloringQuotientFintype, binary_necklaces_4 remain)
+Axioms:      2 (was 4 at S1; fixed_point_sum_binary_4 and binary_necklaces_4
+                 remain; coloringSetoid and coloringQuotientFintype
+                 discharged this PR)
 Build:       ✔ Docker 3058/3058 jobs clean
 ```
 
@@ -61,44 +63,50 @@ case-split. Materializing both case splits by hand brings each leaf
 to a linear identity that omega *does* close (when invoked via the
 three Nat-mod auxiliaries).
 
-## Axiom inventory (after S1)
+## Axiom inventory (after S2)
 
-The remaining 4 axioms in `BurnsideCounting.lean` are *content* axioms,
-not modular-arithmetic infrastructure:
+The remaining 2 axioms in `BurnsideCounting.lean` are both *content*
+axioms about the specific binary 4-necklace computation:
 
 1. `fixed_point_sum_binary_4` (Part IV) — the `|Fix(0)| + |Fix(1)| +
    |Fix(2)| + |Fix(3)| = 24` computation. Discharge candidate: route
    through `native_decide` once `IsFixedByRotation` is fully decidable
    in the rotation/coloring API.
-2. `coloringSetoid` (Part IV) — the orbit equivalence relation for
-   colorings under rotation. Discharge candidate: derive from
-   `MulAction.orbitRel` once the `AddAction (ZMod n)` ↔
-   `MulAction (Multiplicative (ZMod n))` bridge is built.
-3. `coloringQuotientFintype` (Part IV) — `Fintype` instance for the
-   coloring quotient. Discharge candidate: standard once `coloringSetoid`
-   is concrete.
-4. `binary_necklaces_4` (Part IV) — the headline `= 6` necklace count.
+2. `binary_necklaces_4` (Part IV) — the headline `= 6` necklace count.
    Discharge candidate: combine `burnside_lemma` +
    `fixed_point_sum_binary_4` + `|ZMod 4| = 4`.
 
-S1 discharged the *infrastructure* axiom (the modular-arithmetic
-composition law). The remaining 4 are about the abstract group-action
-API + the concrete computation, sitting one bridge-build away from full
-discharge.
+### Axioms discharged in earlier iterations
 
-## What's Next (S2+ priority)
+- **S1 (PR #21148)**: `rotatedIndex_add` — modular-arithmetic
+  composition law for rotations. Proved unconditionally via
+  `ZMod.val_add` + an 8-leaf case enumeration.
+- **S2 (this PR)**: `coloringSetoid` — orbit equivalence relation.
+  Derived as `AddAction.orbitRel (ZMod n) (Coloring n k)`. The actual
+  bridge is simpler than the S1b STATE-SYNC plan suggested: Mathlib's
+  `orbitRel` is `@[to_additive]`, so `AddAction.orbitRel` exists
+  directly — no `Multiplicative`-bridge needed.
+- **S2 (this PR)**: `coloringQuotientFintype` — `Fintype` instance for
+  the coloring quotient. Derived via `Quotient.fintype` from finite
+  `Coloring n k = Fin n → Fin k` and a new decidable-orbit-relation
+  instance `coloringSetoid_decidableRel` (each orbit membership reduces
+  to `∃ x : ZMod n, x +ᵥ b = a`, decidable by
+  `Fintype.decidableExistsFintype`).
 
-1. **S2 (highest priority)**: build the `AddAction → MulAction` bridge for
-   `ZMod n` acting on `Coloring n k`, via `Multiplicative (ZMod n)`. This
-   would let `coloringSetoid` be derived rather than axiomatized, and
-   unblock `binary_necklaces_4` via `burnside_lemma`. The companion file
-   `BurnsideCountingOQ03OQ03.lean` already sketches this connection
-   chain explicitly.
-2. **S3**: discharge `fixed_point_sum_binary_4` via `native_decide`
+## What's Next (S3+ priority)
+
+1. **S3**: discharge `fixed_point_sum_binary_4` via `native_decide`
    (provided `IsFixedByRotation` is decidable, which it is — there is
    an `instance` at line ~218 of `BurnsideCounting.lean`).
-3. **S4**: combine S2 + S3 to discharge `binary_necklaces_4` and reach
-   the `verified` badge for the entire file.
+2. **S4**: combine S3 with `burnside_lemma` to discharge
+   `binary_necklaces_4` and reach the `verified` badge for the entire
+   file. With `coloringSetoid` now `= AddAction.orbitRel (ZMod n) (Coloring n k)`,
+   `Quotient (coloringSetoid n k) = AddAction.orbitRel.Quotient (ZMod n) (Coloring n k)`,
+   which is exactly the orbit-quotient type that `burnside_lemma` (in its
+   `MulAction` form) would consume after a `Multiplicative`-bridge. For
+   S4, the cleanest path is either (a) restate `burnside_lemma` in
+   `AddAction` form using `to_additive` lemmas, or (b) build the
+   `Multiplicative` bridge for the orbit equivalence specifically.
 
 ## Verified Mathlib API (used in S1 proof)
 
@@ -117,6 +125,27 @@ All names re-verified against `leanprover-community/mathlib4` HEAD before
 writing.
 
 ## Session Log
+
+- **2026-06-09 (S2 ACT, researcher-1)**: ACT — discharged `coloringSetoid`
+  and `coloringQuotientFintype` axioms. File 370 → 387 LOC (+17),
+  axioms 4 → 2, definitions 7 → 9 (+coloringSetoid def, +coloringQuotientFintype def,
+  +coloringSetoid_decidableRel instance). Approach: instead of building
+  the `Multiplicative (ZMod n)` bridge that the S1b STATE-SYNC pinned,
+  observed that Mathlib's `orbitRel` carries `@[to_additive]`, so
+  `AddAction.orbitRel (ZMod n) (Coloring n k)` is directly available.
+  `coloringSetoid` is now a 2-line `def` aliasing this. For Fintype on
+  the quotient, registered a `DecidableRel (coloringSetoid n k).r`
+  instance using `decidable_of_iff` + `AddAction.mem_orbit_iff` +
+  `Fintype.decidableExistsFintype` (membership in orbit reduces to a
+  finite ∃ over `ZMod n`), then `coloringQuotientFintype` is
+  `Quotient.fintype` applied with the setoid + decidability in scope
+  via `letI`/`haveI`. Build verified with
+  `./proofs/scripts/docker-build.sh Proofs.BurnsideCounting` →
+  3058 / 3058 jobs clean (3 pre-existing simpArgs warnings in untouched
+  code at lines 77, 299, 301). meta.json sync: lineCount 370 → 387,
+  axiomCount 4 → 2, definitionCount 7 → 9, assumptions text rewritten,
+  3 new originalContributions added, openQuestions trimmed (now lists
+  just S3 + S4 + Polya + dihedral generalizations).
 
 - **2026-06-03 (S1b STATE-SYNC, researcher-1)**: doc-only — confirmed
   4-day bearer byte-stability (`BurnsideCounting.lean` SHA1 `5879ade40b5…`,

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -20,11 +20,11 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 4,
-    "assumptions": "4 axioms: fixed_point_sum_binary_4 (computed fixed-point sum = 24), coloringSetoid (orbit equivalence relation), coloringQuotientFintype (fintype instance for quotient), binary_necklaces_4 (6 distinct binary 4-necklaces). The earlier rotatedIndex_add axiom (modular-arithmetic composition law for rotations) was discharged to a fully-proved theorem in the burnside-counting-oq-01 S1 iteration (Docker 3058 jobs clean).",
-    "lineCount": 370,
+    "axiomCount": 2,
+    "assumptions": "2 axioms: fixed_point_sum_binary_4 (computed fixed-point sum = 24) and binary_necklaces_4 (6 distinct binary 4-necklaces). The earlier rotatedIndex_add axiom (modular-arithmetic composition law, discharged in S1 / PR #21148) and the coloringSetoid + coloringQuotientFintype axioms (orbit-equivalence relation and quotient Fintype, discharged in S2 ACT via AddAction.orbitRel + Quotient.fintype with a decidable-orbit-relation instance) are now fully proved.",
+    "lineCount": 387,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "originalContributions": [
       "burnside_lemma: Burnside orbit-counting theorem from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
       "rotateColoring: ZMod n acts on colorings by cyclic rotation",
@@ -33,14 +33,17 @@
       "binary_4_colorings_count: Coloring 4 2 has 16 elements",
       "constant_coloring_count: exactly k constant colorings for n positions with k colors",
       "period2_count: 4 binary colorings of length 4 with period dividing 2",
-      "IsFixedByRotation: decidable predicate for fixed colorings"
+      "IsFixedByRotation: decidable predicate for fixed colorings",
+      "coloringSetoid: orbit-equivalence relation on colorings, derived from AddAction.orbitRel (ZMod n) (Coloring n k) (previously axiomatized; discharged in S2 ACT)",
+      "coloringSetoid_decidableRel: DecidableRel instance for the orbit relation, via Fintype.decidableExistsFintype on ZMod n and decidable equality of Fin n → Fin k colorings",
+      "coloringQuotientFintype: Fintype instance for the quotient by rotation, via Quotient.fintype + the decidable-orbit-relation instance (previously axiomatized; discharged in S2 ACT)"
     ]
   },
   "overview": {
     "historicalContext": "Burnside's lemma (also called the Cauchy-Frobenius lemma or orbit-counting theorem) has a tangled attribution history. Cauchy stated an equivalent result in 1845 in his work on permutation groups. Frobenius reproved and generalized it in 1887 using character theory. William Burnside included it in his influential 1897 textbook *Theory of Groups of Finite Order*, where its accessibility made it the standard reference — even though Burnside himself acknowledged Frobenius's priority. The lemma became a cornerstone of Pólya's 1937 enumeration theory, which extended it to weighted counting (the Pólya enumeration theorem). Applications span chemistry (counting isomers of molecules with rotational symmetry), combinatorics (counting graphs, tilings, and colorings up to symmetry), and coding theory. For binary necklaces of length $n$ under $\\mathbb{Z}/n\\mathbb{Z}$ rotation, the formula gives the $n$-th necklace number. For $n=4$: $\\frac{1}{4}(16 + 2 + 4 + 2) = 6$, matching the 6 equivalence classes $\\{0000\\}, \\{1111\\}, \\{0001,0010,0100,1000\\}, \\{0011,0110,1001,1100\\}, \\{0101,1010\\}, \\{0111,1011,1101,1110\\}$.\n\nThe practical impact of Burnside's lemma (and its Pólya extension) has been enormous in chemistry. In 1937, George Pólya applied the weighted version to count structural isomers of organic molecules: the number of distinct alkanes $\\text{C}_n\\text{H}_{2n+2}$ up to structural isomorphism, counting isomers of benzene derivatives with different substituents, and computing the generating function for all molecular structures with given atom counts. The Pólya enumeration theorem replaced case-by-case enumeration with an elegant formula involving the *cycle index* $Z(G; p_1, \\ldots, p_k) = \\frac{1}{|G|}\\sum_{g\\in G} p_1^{c_1(g)}\\cdots p_k^{c_k(g)}$, where $c_j(g)$ is the number of $j$-cycles of $g$. For $\\mathbb{Z}/4\\mathbb{Z}$: $Z = \\frac{1}{4}(p_1^4 + p_2^2 + 2p_4)$; substituting $p_k = b^k + w^k$ gives $\\frac{1}{4}((b+w)^4 + (b^2+w^2)^2 + 2(b^4+w^4)) = b^4 + b^3w + 2b^2w^2 + bw^3 + w^4$ — six terms for 6 binary 4-necklaces.\n\nIn coding theory, Burnside's lemma counts **cyclic codes**: binary linear codes of length $n$ closed under cyclic shifts. These are fixed points of the cyclic group $\\mathbb{Z}/n\\mathbb{Z}$ acting on $\\mathbb{F}_2^n$, and their count is given by the necklace formula. The connection to CRC codes (cyclic redundancy checks) — used in virtually all digital communication — makes Burnside's counting a foundational tool of modern information theory.\n\nThe OEIS sequence A000029 gives the number of binary necklaces of length $n$ (under rotation and reflection) and A000116 under rotation only. For $n=4$: 6 (our computed answer), for $n=8$: 36, for $n=10$: 78. These grow as $2^n/n$ asymptotically, which follows from Burnside's lemma applied to the cyclic group.",
     "problemStatement": "Apply Mathlib's MulAction orbit-counting theorem (Burnside's lemma) to count distinct colorings under group symmetry, specifically: how many distinct binary necklaces of length 4 exist?",
     "text": "Burnside's lemma: |X/G| × |G| = Σ_{g∈G} |Fix(g)|. For binary 4-necklaces under Z_4 rotation: |Fix(id)| = 16, |Fix(rot₁)| = 2, |Fix(rot₂)| = 4, |Fix(rot₃)| = 2, sum = 24, so |X/G| = 24/4 = 6 distinct necklaces.",
-    "proofStrategy": "Part I directly applies MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group from Mathlib. Part II defines the ZMod n action on colorings by rotation and establishes its AddAction structure (using rotatedIndex for the explicit formula). Part III provides concrete counting lemmas: all 16 binary colorings, the 2 constant ones, and the 4 period-2 ones. The 5 axioms cover modular arithmetic details (rotatedIndex_add), the specific fixed-point computation (fixed_point_sum_binary_4), and the setoid/quotient structure needed for the necklace count.",
+    "proofStrategy": "Part I directly applies MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group from Mathlib. Part II defines the ZMod n action on colorings by rotation and establishes its AddAction structure (using rotatedIndex for the explicit formula). Part III provides concrete counting lemmas: all 16 binary colorings, the 2 constant ones, and the 4 period-2 ones. After S2 ACT, the orbit-equivalence relation coloringSetoid and quotient Fintype coloringQuotientFintype are derived from AddAction.orbitRel + Quotient.fintype (no longer axiomatized). The remaining 2 axioms cover the specific fixed-point computation (fixed_point_sum_binary_4, discharge candidate: native_decide) and the headline 6-necklace count (binary_necklaces_4, discharge candidate: burnside_lemma + fixed_point_sum_binary_4 + |ZMod 4| = 4).",
     "keyInsights": [
       "Burnside's lemma is in Mathlib as `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` — the Lean proof is a one-line wrapper, with all content coming from Mathlib's group theory library",
       "The `AddAction (ZMod n) (Coloring n k)` instance uses the formula $c \\mapsto (i \\mapsto c(i - r))$ for rotation by $r$. The subtraction $(i + n - r) \\bmod n$ is computed in $\\mathbb{N}$ to avoid underflow, making `rotatedIndex_add` a natural-number modular arithmetic identity that needs careful case analysis",
@@ -60,18 +63,18 @@
     "summary": "Burnside's lemma is formalized from Mathlib and applied to the classic necklace counting problem. The key mathematical content — the orbit-counting formula — is proved. The application to binary 4-necklaces is axiomatized pending formal proof of modular arithmetic details.",
     "implications": "This formalization demonstrates the two-layer structure of applying abstract Mathlib theorems to concrete problems: (1) the abstract `burnside_lemma` wraps `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` with zero proof effort; (2) the concrete application requires defining the specific action (cyclic rotation), verifying it satisfies the `AddAction` axioms, and computing fixed-point cardinalities for each group element. The fully verified lemmas (`rotatedIndex_zero`, `rotatedIndex_add`, `binary_4_colorings_count`, `constant_coloring_count`, `period2_count`) show that both the modular-arithmetic infrastructure and the fixed-point counting are elementarily decidable — the remaining 4 axioms are a bridge-building problem between Mathlib's multiplicative and additive group-action APIs. Once that bridge is built (via a `MulAction` instance from the `AddAction` + `AddCommGroup (ZMod n)`, e.g. through `Multiplicative (ZMod n)`), all remaining axioms collapse to `native_decide` or Mathlib lemmas. Burnside's lemma underlies Pólya enumeration (used in chemical isomer counting, OEIS necklace sequences), and this formalization provides the scaffolding for a full Pólya cycle index theorem in Lean 4.",
     "openQuestions": [
-      "Prove fixed_point_sum_binary_4 via native_decide",
-      "Bridge AddAction (ZMod n) ↔ MulAction (Multiplicative (ZMod n)) so coloringSetoid and coloringQuotientFintype can be derived (not axiomatized) and binary_necklaces_4 follows from burnside_lemma",
+      "Prove fixed_point_sum_binary_4 via native_decide (S3 candidate)",
+      "Discharge binary_necklaces_4 from burnside_lemma + fixed_point_sum_binary_4 + |ZMod 4| = 4 (S4 candidate)",
       "Generalize to Polya enumeration: weighted counting by color frequency",
       "Extend to dihedral group D_n (necklaces with flip symmetry)"
     ]
   },
   "leanFile": {
     "namespace": "BurnsideCounting",
-    "lineCount": 370,
-    "axiomCount": 4,
+    "lineCount": 387,
+    "axiomCount": 2,
     "theoremCount": 7,
-    "definitionCount": 7,
+    "definitionCount": 9,
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0
   },

--- a/src/data/research/problems/burnside-counting-oq-01.json
+++ b/src/data/research/problems/burnside-counting-oq-01.json
@@ -27,34 +27,42 @@
     "goal": "Prove the `rotatedIndex_add` composition theorem for the existing `ZMod n`/`Fin n` definition without adding new axioms or sorries."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-03T07:05:01-07:00",
-    "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "iteration": 2,
+    "focus": "S2 ACT: discharged coloringSetoid and coloringQuotientFintype axioms via AddAction.orbitRel + Quotient.fintype.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "S3 candidate: discharge fixed_point_sum_binary_4 via native_decide. S4 candidate: discharge binary_necklaces_4 via burnside_lemma + Multiplicative bridge or AddAction-form Burnside.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "OBSERVE: Local docs and the parent proof identify `rotatedIndex_add` as an axiomatized modular-arithmetic composition law in `Proofs/BurnsideCounting.lean`. No OQ-specific Lean proof attempt is recorded in the local state.",
-    "builtItems": [],
+    "progressSummary": "ACT (S2): BurnsideCounting.lean reduced from 4 axioms to 2 by deriving coloringSetoid as AddAction.orbitRel (ZMod n) (Coloring n k) and coloringQuotientFintype via Quotient.fintype + a new DecidableRel instance for orbit membership. Docker 3058/3058 jobs clean. Approach: used the @[to_additive] tag on Mathlib orbitRel (no Multiplicative bridge needed for the setoid axiom).",
+    "builtItems": [
+      "coloringSetoid: def (was axiom) in BurnsideCounting.lean:353 — Setoid (Coloring n k) := AddAction.orbitRel (ZMod n) (Coloring n k)",
+      "coloringSetoid_decidableRel: instance in BurnsideCounting.lean:361 — DecidableRel (coloringSetoid n k).r via decidable_of_iff + AddAction.mem_orbit_iff.symm + Fintype.decidableExistsFintype",
+      "coloringQuotientFintype: def (was axiom) in BurnsideCounting.lean:368 — Fintype (Quotient (coloringSetoid n k)) via Quotient.fintype with letI/haveI for setoid + DecidableRel"
+    ],
     "insights": [
       "The actual source theorem uses `ZMod n` rotations and `Fin n` indices, not bare natural-number rotation parameters.",
       "`rotatedIndex n r i` computes `((i.val + n - (r.val % n)) % n)` to model subtraction modulo `n` in `Nat`.",
       "`cyclicAddActionOnColorings.add_vadd` depends directly on `rotatedIndex_add`.",
-      "Discharging this OQ removes one parent-file axiom, but the overall Burnside-counting entry remains axiomatized until the other four parent axioms are also proved."
+      "Discharging this OQ removes one parent-file axiom, but the overall Burnside-counting entry remains axiomatized until the other four parent axioms are also proved.",
+      "Mathlib orbitRel carries @[to_additive], so AddAction.orbitRel exists directly — the Multiplicative-bridge sketched in the S1b STATE-SYNC plan was unnecessary for the setoid axiom",
+      "Decidability of the orbit relation on Coloring n k reduces to ∃ x : ZMod n, x +ᵥ b = a via AddAction.mem_orbit_iff, then discharged by Fintype.decidableExistsFintype (ZMod n is Fintype, Fin n → Fin k has DecidableEq)",
+      "Quotient.fintype requires the setoid in scope before resolving the DecidableRel on (· ≈ ·); pattern: letI := <setoid>; haveI : DecidableRel (· ≈ ·) := <inst>; exact Quotient.fintype _",
+      "S4 (binary_necklaces_4) still needs a bridge to burnside_lemma (MulAction form) — the Multiplicative bridge from S1b STATE-SYNC §2.1 remains the candidate path"
     ],
     "mathlibGaps": [
       "No confirmed missing Mathlib theorem is documented locally; the expected work is controlling `Nat` subtraction/modulo arithmetic or recasting the argument through `ZMod`/`Fin` lemmas."
     ],
     "nextSteps": [
-      "Reproduce the exact parent theorem in a Lean scratch or feature file and unfold `rotatedIndex`.",
-      "Try a `simp`/`omega` route using `Nat.add_mod`, `Nat.sub_mod`, and `ZMod.val_lt`; if that stalls, move the calculation into `ZMod n` before returning to `Fin n` equality.",
-      "Only after a compiling proof exists, replace the parent axiom and refresh proof metadata."
+      "S3: discharge fixed_point_sum_binary_4 via native_decide. IsFixedByRotation is already decidable (instance at BurnsideCounting.lean:329); the 4 subtype cardinalities should compute.",
+      "S4: discharge binary_necklaces_4. Cleanest route is (a) bridge AddAction.orbitRel.Quotient to MulAction.orbitRel.Quotient via Multiplicative (ZMod n), or (b) use to_additive on burnside_lemma to produce an AddAction-form variant directly applicable to the cyclicAddActionOnColorings instance.",
+      "Optional S5: investigate whether the 3 simpArgs-linter warnings at lines 77/299/301 are worth a separate cleanup (untouched in this PR; pre-existing)."
     ],
     "markdown": "# Knowledge Base: burnside-counting-oq-01\n\n## Problem Understanding\n\nThe target is the parent-file axiom `rotatedIndex_add` in `Proofs/BurnsideCounting.lean`. The source definition is:\n\n```lean\ndef rotatedIndex (n : Nat) [NeZero n] (r : ZMod n) (i : Fin n) : Fin n :=\n  { val := ((i : Nat) + n - (r.val % n)) % n\n    isLt := Nat.mod_lt _ (NeZero.pos n) }\n```\n\nThe theorem to prove is that composing two rotations of this form equals rotation by the sum in `ZMod n`:\n\n```lean\nrotatedIndex n s (rotatedIndex n r i) = rotatedIndex n (r + s) i\n```\n\n## Source Evidence\n\n`Proofs/BurnsideCounting.lean` proves `rotatedIndex_zero`, but states `rotatedIndex_add` as an axiom. The `cyclicAddActionOnColorings` instance uses this axiom to satisfy `add_vadd`. Parent metadata also lists `rotatedIndex_add` as one of five assumptions in the Burnside-counting gallery proof.\n\n## Current Status\n\nThe research state is still OBSERVE with zero recorded attempts. No local session file records a failed tactic path or a completed Lean proof for this OQ.\n\n## Useful Facts\n\n- The index formula is subtraction modulo `n` implemented in `Nat`: `i + n - r.val`, then `% n`.\n- Equality of `Fin n` values should reduce to a modular arithmetic identity on the underlying natural values.\n- The parent proof already has `[NeZero n]`, so `0 < n` is available as `NeZero.pos n`.\n\n## Next Work\n\nStart from the exact source signature, unfold `rotatedIndex`, and test whether `simp` plus `omega` can close the `Nat` modulo identity. If direct `Nat.sub` arithmetic is brittle, prove the rotation law in `ZMod n` first and transfer it back to the `Fin n` index representation.\n"
   },
@@ -84,10 +92,10 @@
     {
       "path": "Proofs/BurnsideCounting.lean",
       "filename": "BurnsideCounting.lean",
-      "lineCount": 256,
+      "lineCount": 387,
       "theoremCount": 6,
-      "axiomCount": 5,
-      "defCount": 6,
+      "axiomCount": 2,
+      "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BurnsideCounting.lean"
@@ -125,5 +133,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BurnsideCountingOQ03OQ03.lean"
     }
-  ]
+  ],
+  "lastUpdate": "2026-06-09T20:50:00Z"
 }


### PR DESCRIPTION
## Summary

S2 ACT for `burnside-counting-oq-01`. Replaces the `coloringSetoid` and `coloringQuotientFintype` axioms in `Proofs/BurnsideCounting.lean` with derived definitions, reducing the file's axiom count **4 → 2**. Both remaining axioms (`fixed_point_sum_binary_4`, `binary_necklaces_4`) are content axioms about the specific binary 4-necklace computation; S3 / S4 candidates documented.

Predecessor: PR #21148 (S1 ACT, 2026-05-30, same researcher) which discharged `rotatedIndex_add`.

## What's new

### Lean (`proofs/Proofs/BurnsideCounting.lean`, +17 LOC)

**1. `coloringSetoid` — derived from `AddAction.orbitRel`**

```lean
def coloringSetoid (n k : ℕ) [NeZero n] : Setoid (Coloring n k) :=
  AddAction.orbitRel (ZMod n) (Coloring n k)
```

The `Multiplicative`-bridge sketched in the S1b STATE-SYNC plan (§2.1) turned out to be unnecessary for this specific axiom: Mathlib's `orbitRel` (`Mathlib/GroupTheory/GroupAction/Defs.lean:279`) carries `@[to_additive]`, so `AddAction.orbitRel` exists directly.

**2. `coloringSetoid_decidableRel` — orbit relation is decidable**

```lean
instance coloringSetoid_decidableRel (n k : ℕ) [NeZero n] :
    DecidableRel (coloringSetoid n k).r := fun a b =>
  decidable_of_iff (∃ x : ZMod n, x +ᵥ b = a) AddAction.mem_orbit_iff.symm
```

By `AddAction.mem_orbit_iff`, orbit membership reduces to a finite ∃ over `ZMod n`; `Fintype.decidableExistsFintype` discharges it.

**3. `coloringQuotientFintype` — derived from `Quotient.fintype`**

```lean
def coloringQuotientFintype (n k : ℕ) [NeZero n] :
    Fintype (Quotient (@coloringSetoid n k _)) := by
  letI : Setoid (Coloring n k) := coloringSetoid n k
  haveI : DecidableRel (α := Coloring n k) (· ≈ ·) := coloringSetoid_decidableRel n k
  exact Quotient.fintype _
```

The `letI` + `haveI` dance is required because `Quotient.fintype` resolves `(· ≈ ·)` via the in-scope `Setoid`'s `HasEquiv` derivation.

## Build verification

\`./proofs/scripts/docker-build.sh Proofs.BurnsideCounting\` → \`Build completed successfully (3058 jobs)\`.

Only pre-existing \`linter.unusedSimpArgs\` warnings at lines 77, 299, 301 — all in code not touched by this PR (`rotatedIndex_zero`, `period2_count`).

## File inventory (post-S2)

| Metric | Before (S1) | After (S2) |
|---|---|---|
| Lines | 370 | 387 |
| Theorems | 7 | 7 |
| Definitions | 7 | 9 (+`coloringSetoid`, +`coloringQuotientFintype`) |
| Instances | (unchanged) | (+`coloringSetoid_decidableRel`) |
| Axioms | 4 | **2** |
| Sorries | 0 | 0 |
| Docker jobs | 3058 | 3058 |

## Axioms remaining (and discharge candidates)

| # | Axiom | Discharge plan |
|---|-------|----------------|
| 1 | \`fixed_point_sum_binary_4\` | **S3**: \`native_decide\`. \`IsFixedByRotation\` is decidable (\`BurnsideCounting.lean:329\`), and the 4 subtype cardinalities should compute. |
| 2 | \`binary_necklaces_4\` | **S4**: combine \`burnside_lemma\` (MulAction form) + S3 + \`|ZMod 4| = 4\`. Cleanest route is either (a) \`Multiplicative\`-bridge (the S1b STATE-SYNC §2.1 plan is still relevant here), or (b) \`to_additive\` an AddAction-form of \`burnside_lemma\`. |

## Files

- \`proofs/Proofs/BurnsideCounting.lean\` (UPDATE, +17 LOC)
- \`src/data/proofs/burnside-counting/meta.json\` (UPDATE: lineCount 370→387, axiomCount 4→2, definitionCount 7→9, assumptions text rewritten, +3 originalContributions, openQuestions trimmed)
- \`research/problems/burnside-counting-oq-01/state.md\` (UPDATE: head bumped to S2 ACT / iter 2 / 2026-06-09, Lean inventory recounted, Axiom inventory restructured, What's Next narrowed to S3/S4, Session Log appended)
- \`research/problems/burnside-counting-oq-01/sessions/2026-06-09-s2-act-orbitrel-bridge.md\` (NEW)
- \`src/data/research/problems/burnside-counting-oq-01.json\` (UPDATE: phase OBSERVE→ACT, iteration 1→2, knowledge.progressSummary/insights/builtItems/nextSteps synced)

## Test plan

- [x] \`docker-build.sh Proofs.BurnsideCounting\` succeeds (3058 jobs)
- [x] No new sorries (0 → 0)
- [x] Axiom count drops as advertised (4 → 2)
- [x] \`binary_necklaces_4\` still type-checks against the new (now-derived) \`coloringSetoid\` + \`coloringQuotientFintype\`
- [x] state.md, sessions/, meta.json, knowledge JSON synced
- [ ] (Future S3) \`fixed_point_sum_binary_4\` via \`native_decide\`
- [ ] (Future S4) \`binary_necklaces_4\` via \`burnside_lemma\` + AddAction/MulAction bridge

## Predecessor PRs

- #21148 — S1 ACT (rotatedIndex_add discharge, researcher-1, 2026-05-30)
- (S1b STATE-SYNC, doc-only, 2026-06-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)