### PR TITLE
research(fourier-series-oq-04-oq-01): S14 ACT step-4a/6 — MemLp/eLpNorm measure-bridge corollaries (+30 LOC, 7743 jobs clean)

### DIFF
--- a/proofs/Proofs/FourierSeriesOQ04OQ01.lean
+++ b/proofs/Proofs/FourierSeriesOQ04OQ01.lean
@@ -441,6 +441,36 @@ theorem haarT2_eq_volume : haarT2 = (volume : Measure T2) := by
   simp_rw [key]
   rfl
 
+/-! ## S14 ACT step-4a / step-6 — `MemLp` / `eLpNorm` measure-bridge corollaries
+
+Direct corollaries of `haarT2_eq_volume` (S11 ACT). These paste-ready the S12
+PREP §5 sub-tactics for the eventual S2e ACT close of
+`sphPartialSum_L2_norm_converge`:
+
+- **Step 4a** (`MemLp` lift to volume): convert `MemLp f 2 haarT2` to
+  `MemLp f 2 volume` so that `MemLp.toLp` and the Mathlib engine
+  `hasSum_mFourier_series_L2` (stated over `volume` on `UnitAddTorus`) become
+  invokable on our `haarT2`-stated hypothesis.
+- **Step 6** (`eLpNorm` swap, option-(c) workaround): rewrite the goal's
+  `eLpNorm _ 2 haarT2` to `eLpNorm _ 2 volume` directly, avoiding `Lp`-element
+  transport.
+
+Both are propositional consequences of the measure equality; no new
+analytic content. -/
+
+/-- **`MemLp` measure-bridge** — `f` is in `L^p(haarT2)` iff `f` is in
+    `L^p(volume)` on `𝕋²`. Direct corollary of `haarT2_eq_volume`. -/
+theorem memLp_haarT2_iff_volume (f : T2 → ℂ) (p : ℝ≥0∞) :
+    MemLp f p haarT2 ↔ MemLp f p (volume : Measure T2) := by
+  rw [haarT2_eq_volume]
+
+/-- **`eLpNorm` measure-bridge** — the `L^p` extended norm of `f` against
+    `haarT2` equals the `L^p` extended norm against `volume` on `𝕋²`.
+    Direct corollary of `haarT2_eq_volume`. -/
+theorem eLpNorm_haarT2_eq_volume (f : T2 → ℂ) (p : ℝ≥0∞) :
+    eLpNorm f p haarT2 = eLpNorm f p (volume : Measure T2) := by
+  rw [haarT2_eq_volume]
+
 end
 
 end FourierSeriesOQ04OQ01

--- a/research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-09-s14-act-memlp-elpnorm-bridges.md
+++ b/research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-09-s14-act-memlp-elpnorm-bridges.md
@@ -1,0 +1,167 @@
+# S14 ACT — `MemLp` / `eLpNorm` measure-bridge corollaries (step-4a / step-6 mini-helpers)
+
+**Date**: 2026-06-09
+**Researcher**: researcher-11
+**Mode**: ACT (Lean delta; small public-API mini-helpers)
+**Outcome**: SHIPPED — two sorry-free / axiom-free public theorems built clean
+  on Docker `lean4-arm64:v4.26.0`, 7743 jobs, exit 0, zero new warnings.
+  Sorry surface unchanged (still the single pre-existing
+  `sphPartialSum_L2_norm_converge` placeholder at line 148).
+
+## What I did
+
+Followed up the S13 SCOUT verify (2026-06-06, researcher-1) with a focused
+ACT shipping the two mini-helpers naturally factored out of the S12 PREP §5
+tactic skeleton — the `MemLp` lift (step 4a) and the `eLpNorm` swap (step
+6) — as standalone named lemmas. Both are direct corollaries of S11's
+`haarT2_eq_volume` and compile by a single `rw [haarT2_eq_volume]` tactic.
+This factoring makes the S15 ACT (the eventual recipe close) paste-ready:
+instead of inlining `rw [haarT2_eq_volume]` inside the
+`sphPartialSum_L2_norm_converge` proof body, the next ACT can write
+`(memLp_haarT2_iff_volume f 2).mp hf` to obtain the volume-domain `MemLp`
+and `rw [eLpNorm_haarT2_eq_volume]` to swap the goal's measure — cleaner
+separation of the measure-equality lift from the analytic content.
+
+### Code shipped
+
+```lean
+/-! ## S14 ACT step-4a / step-6 — `MemLp` / `eLpNorm` measure-bridge corollaries
+
+Direct corollaries of `haarT2_eq_volume` (S11 ACT). These paste-ready the S12
+PREP §5 sub-tactics for the eventual S2e ACT close of
+`sphPartialSum_L2_norm_converge`:
+
+- **Step 4a** (`MemLp` lift to volume): convert `MemLp f 2 haarT2` to
+  `MemLp f 2 volume` so that `MemLp.toLp` and the Mathlib engine
+  `hasSum_mFourier_series_L2` (stated over `volume` on `UnitAddTorus`) become
+  invokable on our `haarT2`-stated hypothesis.
+- **Step 6** (`eLpNorm` swap, option-(c) workaround): rewrite the goal's
+  `eLpNorm _ 2 haarT2` to `eLpNorm _ 2 volume` directly, avoiding `Lp`-element
+  transport.
+
+Both are propositional consequences of the measure equality; no new
+analytic content. -/
+
+/-- **`MemLp` measure-bridge** — `f` is in `L^p(haarT2)` iff `f` is in
+    `L^p(volume)` on `𝕋²`. Direct corollary of `haarT2_eq_volume`. -/
+theorem memLp_haarT2_iff_volume (f : T2 → ℂ) (p : ℝ≥0∞) :
+    MemLp f p haarT2 ↔ MemLp f p (volume : Measure T2) := by
+  rw [haarT2_eq_volume]
+
+/-- **`eLpNorm` measure-bridge** — the `L^p` extended norm of `f` against
+    `haarT2` equals the `L^p` extended norm against `volume` on `𝕋²`.
+    Direct corollary of `haarT2_eq_volume`. -/
+theorem eLpNorm_haarT2_eq_volume (f : T2 → ℂ) (p : ℝ≥0∞) :
+    eLpNorm f p haarT2 = eLpNorm f p (volume : Measure T2) := by
+  rw [haarT2_eq_volume]
+```
+
+Both proofs are 2 LOC each (a single `rw [haarT2_eq_volume]` tactic). The
+`rw` works because both `MemLp` and `eLpNorm` are stated as functions *of
+the measure*, so propagating the equality through the function-position
+discharges the goal directly.
+
+### Why this is a step forward (not just a re-cosmetic of S11)
+
+S11 shipped `haarT2_eq_volume` itself; that lemma is the measure identity.
+But its two natural *consumption patterns* — `MemLp` lift and `eLpNorm`
+rewrite — both require a small additional adapter step:
+
+- `MemLp f p haarT2 → MemLp f p volume` is not `Eq.mp` of the measure
+  equality (the types `Measure T2` are the same; only the proposition
+  arguments differ). `rw [haarT2_eq_volume]` rewrites the hypothesis's
+  `haarT2` to `volume` — straightforward but worth a named lemma.
+- `eLpNorm f p haarT2 = eLpNorm f p volume` likewise unfolds to the
+  rewrite, but having it as a named identity means it can fire as
+  `simp [eLpNorm_haarT2_eq_volume]` or `exact eLpNorm_haarT2_eq_volume f 2`
+  rather than requiring the consumer to know the underlying measure
+  identity.
+
+This matches the S9/S10/S11 mini-ACT pattern (each ACT ships exactly one
+small named helper or pair of mutually-bound helpers) and keeps each PR
+self-contained.
+
+## Build result
+
+```
+[180s] Building...
+⚠ [7743/7743] Built Proofs.FourierSeriesOQ04OQ01 (123s)
+warning: Proofs/FourierSeriesOQ04OQ01.lean:148:8: declaration uses 'sorry'
+Build completed successfully (7743 jobs).
+=== Build succeeded ===
+```
+
+- 7743 jobs total (cache hit 7727/7727 = 100% on Mathlib; ~123s for the
+  one local file rebuild).
+- 0 errors. Single expected sorry warning at line 148 — exactly the
+  pre-existing `sphPartialSum_L2_norm_converge` placeholder; sorry surface
+  unchanged.
+- No new warnings introduced by the two new theorems.
+- Confirms both proofs typecheck and the `rw [haarT2_eq_volume]` tactic
+  fires cleanly under both `MemLp` and `eLpNorm`'s elaboration paths.
+
+## File diff summary
+
+- `proofs/Proofs/FourierSeriesOQ04OQ01.lean` — 446 → 476 lines (+30
+  including section docstring); 12 → 14 theorems
+  (`memLp_haarT2_iff_volume`, `eLpNorm_haarT2_eq_volume`); 1 → 1 sorries
+  (unchanged); 1 → 1 axioms (unchanged); 5 → 5 definitions.
+- `src/data/proofs/fourier-series-oq-04-oq-01/meta.json` — `lineCount`
+  446 → 476, `theoremCount` 12 → 14 (both fields, top-level + meta);
+  `originalContributions` extended with the new combined entry covering
+  both new theorems.
+- `research/problems/fourier-series-oq-04-oq-01/state.md` — header bump
+  iter 12 → 13; phase PREP → ACT; new "Last Update" describing the S14
+  contribution; S13 SCOUT verify moved to Previous Status.
+
+## Race / rebase risk
+
+- Branch: `research/fourier-oq04-oq01-s14-act-memlp-elpnorm-bridges` off
+  `origin/main` (head `ac12868a924`).
+- Concurrent slug activity: 0 open PRs on this slug at branch creation
+  time (verified by `gh pr list --state open --search
+  "fourier-series-oq-04-oq-01"`).
+- Mathlib pin unchanged since 2026-05-17 (commit `ecb47b35601`); the S13
+  SCOUT verify of 2026-06-06 confirmed cache + signatures stable.
+- Rebase risk: low — the only Lean file touched is the slug's main file
+  and the diff is purely additive (no edits to existing theorems).
+
+## Next iteration
+
+**S15 ACT** — close `sphPartialSum_L2_norm_converge` using the now-named
+S14 helpers + S9 cofinality + S10 finset-sum bridge + Mathlib engine
+`hasSum_mFourier_series_L2`. The remaining S12 PREP §5 scope after S14 is
+steps 4b + 4c + 5 + 6, estimated at 15-25 LOC (down from the S12 PREP
+projection of 18-35 LOC for the full 4a+4b+4c+5+6 close).
+
+Sub-task ordering for S15:
+1. **(4a — paste-ready)** lift `MemLp f 2 haarT2 → MemLp f 2 volume` via
+   `(memLp_haarT2_iff_volume f 2).mp hf` and obtain `f̂ :=
+   (memLp_haarT2_iff_volume f 2).mp hf |>.toLp`.
+2. **(4c)** identify `multiFourierCoeff f k = mFourierCoeff f̂ k` via
+   `integral_congr_measure` on the `haarT2 → volume` switch + the
+   character identity `mFourier k x = fourier (k 0) (x 0) * fourier (k 1)
+   (x 1)` (verify whether Mathlib already has this as `mFourier_apply` or
+   equivalent).
+3. **(4b)** apply `Lp.coeFn_finset_sum` (Mathlib direct lemma on `volume`)
+   to bridge the inner-sum coeFn; the S10 `coeFn_finset_sum_haarT2` may
+   still be needed if any pre-`haarT2 → volume` finset-sum survives.
+4. **(5)** cite `hasSum_mFourier_series_L2 f̂` and combine with S9's
+   `latticeDisc_eventually_supset` cofinality witness via
+   `HasSum.tendsto_atTop_of_cofinal`.
+5. **(6 — paste-ready)** close the `eLpNorm`-form goal via `rw
+   [eLpNorm_haarT2_eq_volume]; exact …` chained with `Lp.norm_def` /
+   `Tendsto.toReal` at 0.
+
+## Files modified
+
+- `proofs/Proofs/FourierSeriesOQ04OQ01.lean` — +30 lines (2 new public
+  theorems + section docstring).
+- `src/data/proofs/fourier-series-oq-04-oq-01/meta.json` — `lineCount`,
+  `theoremCount`, `originalContributions` synced.
+- `research/problems/fourier-series-oq-04-oq-01/state.md` — header bump +
+  S14 ACT entry.
+- `research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-09-s14-act-memlp-elpnorm-bridges.md`
+  — this file.
+
+No new axioms. No new sorries. One small Lean delta + doc sync.

--- a/research/problems/fourier-series-oq-04-oq-01/state.md
+++ b/research/problems/fourier-series-oq-04-oq-01/state.md
@@ -1,10 +1,14 @@
 # Research State: fourier-series-oq-04-oq-01
 
 ## Current State
-**Phase**: PREP (S12 audit verified; build clean at current Mathlib pin)
-**Since**: 2026-06-01 (S12 PREP — researcher-1); 2026-06-06 (S13 SCOUT verify — researcher-1)
-**Iteration**: 12
-**Last Update**: 2026-06-06 (researcher-1) — **S13 SCOUT verify** (doc-only): re-built `Proofs.FourierSeriesOQ04OQ01` under `lean4-arm64:v4.26.0` Docker against current Mathlib cache to confirm the S11 ACT (`haarT2_eq_volume`) and S12 PREP (Mathlib API audit) deliverables still hold. **7743 jobs, exit 0, zero errors, single expected `sphPartialSum_L2_norm_converge` sorry warning at line 148** — identical sorry surface as the last verified build (S11 ACT, 2026-05-31, worktree HEAD `~e36a09a3`). No Mathlib pin bump or signature drift across the 4 S12-cataloged API entries (`mFourier`, `mFourierLp`, `mFourierCoeff`, `hasSum_mFourier_series_L2`). The 18-35 LOC S13 ACT budget remains tractable on this baseline. No Lean delta this iteration; doc-only state.md bump. See `sessions/2026-06-06-s13-scout-verify-build-clean.md`.
+**Phase**: ACT (S14 step-4a/6 measure-bridge corollaries shipped; build clean)
+**Since**: 2026-06-09 (S14 ACT — researcher-11)
+**Iteration**: 13
+**Last Update**: 2026-06-09 (researcher-11) — **S14 ACT step-4a/6 measure-bridge corollaries** (Lean delta): added two sorry-free, axiom-free **public** corollaries of `haarT2_eq_volume` (S11) — `memLp_haarT2_iff_volume` (the step-4a `MemLp` lift `MemLp f p haarT2 ↔ MemLp f p volume`) and `eLpNorm_haarT2_eq_volume` (the step-6 `eLpNorm` swap `eLpNorm f p haarT2 = eLpNorm f p volume`). Both compile via a single-tactic `rw [haarT2_eq_volume]`, propagating the measure equality through `MemLp`/`eLpNorm`'s function-of-measure signatures. **Build verified**: Docker `lean4-arm64:v4.26.0`, 7743 jobs, exit 0, zero new warnings; only the pre-existing `sphPartialSum_L2_norm_converge` sorry at line 148 remains (sorry surface unchanged). File: `Proofs/FourierSeriesOQ04OQ01.lean` (446 → 476 lines, 12 → 14 theorems; +2 sorry-free public theorems in a new "S14 ACT step-4a / step-6" section). Gallery meta-json line/theorem counts synced; `originalContributions` extended. These paste-ready the S12 PREP §5 sub-tactics for the eventual S2e ACT close — the next ACT can call `(memLp_haarT2_iff_volume f 2).mp hf` to obtain the volume-domain `MemLp` and `rw [eLpNorm_haarT2_eq_volume]` to swap the goal's measure. See `sessions/2026-06-09-s14-act-memlp-elpnorm-bridges.md`.
+
+## Previous Status — S13 SCOUT verify build-clean (2026-06-06, researcher-1)
+
+**S13 SCOUT verify**: doc-only build verification under `lean4-arm64:v4.26.0` Docker — confirmed the S11 ACT (`haarT2_eq_volume`) and S12 PREP (Mathlib API audit) baseline still holds at current Mathlib cache. **7743 jobs, exit 0, zero errors, single expected `sphPartialSum_L2_norm_converge` sorry warning at line 148** — identical sorry surface as the last verified build (S11 ACT, 2026-05-31, worktree HEAD `~e36a09a3`). No Mathlib pin bump or signature drift across the 4 S12-cataloged API entries (`mFourier`, `mFourierLp`, `mFourierCoeff`, `hasSum_mFourier_series_L2`). The 18-35 LOC closing budget remains tractable on this baseline. See `sessions/2026-06-06-s13-scout-verify-build-clean.md`.
 
 ## Previous Status — S12 PREP Mathlib API audit (2026-06-01, researcher-1)
 

--- a/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
@@ -15,11 +15,11 @@
       "Topology"
     ],
     "namespace": "FourierSeriesOQ04OQ01",
-    "lineCount": 446,
+    "lineCount": 476,
     "axiomCount": 1,
     "sorries": 1,
     "definitionCount": 5,
-    "theoremCount": 12
+    "theoremCount": 14
   },
   "meta": {
     "author": "Open in mathematics (Stein 1971 ICM; Tao 2002 survey). Formalized statement: Lean Genius contributors.",
@@ -40,8 +40,8 @@
     "sorries": 1,
     "dateAdded": "2026-05-12",
     "axiomCount": 1,
-    "lineCount": 446,
-    "theoremCount": 12,
+    "lineCount": 476,
+    "theoremCount": 14,
     "definitionCount": 5,
     "assumptions": "1 axiom: `carleson_2d_sph` — the open 2D Carleson spherical-summation conjecture on T². 1 sorry: `sphPartialSum_L2_norm_converge` — the unconditional L²-norm convergence statement; provable from Plancherel on T² (Mathlib gap; the orthonormal basis tensor-product structure is implicit but not exposed as a named identity). No other assumptions.",
     "mathlibDependencies": [
@@ -90,7 +90,8 @@
       "latticeDisc_card_le_real (S2-Gauss-real): Real-form qualitative Gauss-circle bound ((latticeDisc R).card : ℝ) ≤ (2|R|+3)² suitable for ℓ¹-majorisation of sphPartialSum",
       "latticeDisc_mem_eventually, latticeDisc_eventually_supset (S2e-cofinality, iter 8): atTop cofinality of latticeDisc — every fixed finite set of lattice points is eventually contained in latticeDisc R as R → ∞; stepping-stone for the Plancherel-tail engine that closes sphPartialSum_L2_norm_converge",
       "coeFn_finset_sum_haarT2 (S2e-step2, iter 9, private helper): inductive `Lp.coeFn_finset_sum`-style helper specialized to `Lp ℂ 2 haarT2` — closes the documented Mathlib gap (no named `Lp.coeFn_finset_sum` / `Finset.coeFn_sum` / `AEEqFun.coeFn_sum` at pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67) via `Finset.induction_on` + `Lp.coeFn_zero` + `Lp.coeFn_add`. Step 2 of the S7 audit §4 ACT recipe for discharging `sphPartialSum_L2_norm_converge`; independent of step 1 (haarT2/volume setup)",
-      "haarT2_eq_volume (S2e-step1-contingency, iter 10): sorry-free, axiom-free measure-equality bridge `haarT2 = (volume : Measure T2)` on `Fin 2 → AddCircle 1`. Combines `AddCircle.volume_eq_smul_haarAddCircle` (1D scaling identity `volume = ENNReal.ofReal T • haarAddCircle`) with `ENNReal.ofReal_one`, `one_smul`, and `volume_pi` (a `rfl` lemma `volume = Measure.pi (fun _ => volume)` on a Pi type). At `T = 1` the scaling is trivial. Discharges step 1 contingency of the S7 audit §4 ACT recipe (haarT2/volume disambiguation) — the Mathlib engine `hasSum_mFourier_series_L2` in `Mathlib.Analysis.Fourier.AddCircleMulti` (verified at pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 / v4.26.0, line 224) is stated over `L²(UnitAddTorus d)` with `volume` measure, so this bridge enables invoking it on our `haarT2`-stated theorems. Sites the rfl-ness of `volume_pi` (Pi.lean:652) and `AddCircle.volume_eq_smul_haarAddCircle` (AddCircle.lean:92)."
+      "haarT2_eq_volume (S2e-step1-contingency, iter 10): sorry-free, axiom-free measure-equality bridge `haarT2 = (volume : Measure T2)` on `Fin 2 → AddCircle 1`. Combines `AddCircle.volume_eq_smul_haarAddCircle` (1D scaling identity `volume = ENNReal.ofReal T • haarAddCircle`) with `ENNReal.ofReal_one`, `one_smul`, and `volume_pi` (a `rfl` lemma `volume = Measure.pi (fun _ => volume)` on a Pi type). At `T = 1` the scaling is trivial. Discharges step 1 contingency of the S7 audit §4 ACT recipe (haarT2/volume disambiguation) — the Mathlib engine `hasSum_mFourier_series_L2` in `Mathlib.Analysis.Fourier.AddCircleMulti` (verified at pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 / v4.26.0, line 224) is stated over `L²(UnitAddTorus d)` with `volume` measure, so this bridge enables invoking it on our `haarT2`-stated theorems. Sites the rfl-ness of `volume_pi` (Pi.lean:652) and `AddCircle.volume_eq_smul_haarAddCircle` (AddCircle.lean:92).",
+      "memLp_haarT2_iff_volume, eLpNorm_haarT2_eq_volume (S14-ACT-step-4a/6 measure-bridge corollaries, iter 13, public): two sorry-free, axiom-free direct corollaries of `haarT2_eq_volume` (S11 ACT) that paste-ready the S12 PREP §5 sub-tactics. `memLp_haarT2_iff_volume` provides the step-4a `MemLp` lift `MemLp f p haarT2 ↔ MemLp f p volume` (so `MemLp.toLp` and the Mathlib engine `hasSum_mFourier_series_L2` become invokable on our `haarT2`-stated hypothesis). `eLpNorm_haarT2_eq_volume` provides the step-6 `eLpNorm` swap `eLpNorm f p haarT2 = eLpNorm f p volume` (the option-(c) workaround, avoiding `Lp`-element transport). Both proofs are single-tactic `rw [haarT2_eq_volume]`, propagating the measure equality through the type-class-resolved `MemLp`/`eLpNorm` definitions."
     ]
   },
   "overview": {


### PR DESCRIPTION
## Summary

S14 ACT mini-step landing **two sorry-free, axiom-free public corollaries** of S11's `haarT2_eq_volume` (PR #21611) that paste-ready the S12 PREP §5 sub-tactics for the eventual S2e ACT close of `sphPartialSum_L2_norm_converge`:

- **`memLp_haarT2_iff_volume`** (step-4a): `MemLp f p haarT2 ↔ MemLp f p volume` — lifts hypothesis to the volume domain so `MemLp.toLp` and the Mathlib engine `hasSum_mFourier_series_L2` (stated over `volume` on `UnitAddTorus`) become invokable.
- **`eLpNorm_haarT2_eq_volume`** (step-6): `eLpNorm f p haarT2 = eLpNorm f p volume` — the option-(c) `eLpNorm` swap workaround from S12 PREP §4.3, avoiding `Lp`-element transport.

Both proofs are single-tactic `rw [haarT2_eq_volume]`, propagating the measure equality through `MemLp`/`eLpNorm`'s function-of-measure signatures. Matches the S9/S10/S11 mini-ACT pattern (one focused PR per recipe step).

**Build verified**: Docker `lean4-arm64:v4.26.0`, 7743 jobs, exit 0, zero new warnings; only the pre-existing `sphPartialSum_L2_norm_converge` sorry at line 148 remains (sorry surface unchanged).

## Changes

| File | Change |
|------|--------|
| `proofs/Proofs/FourierSeriesOQ04OQ01.lean` | 446 → 476 lines, 12 → 14 theorems; +1 new section "S14 ACT step-4a / step-6" |
| `src/data/proofs/fourier-series-oq-04-oq-01/meta.json` | `lineCount` 446 → 476, `theoremCount` 12 → 14, `originalContributions` extended |
| `research/problems/fourier-series-oq-04-oq-01/state.md` | iter 12 → 13, phase PREP → ACT, S14 ACT entry added |
| `research/problems/fourier-series-oq-04-oq-01/sessions/2026-06-09-s14-act-memlp-elpnorm-bridges.md` | new session file |

## Why this is a step forward

S11 shipped `haarT2_eq_volume` itself; that's the measure identity. But its two natural *consumption patterns* — `MemLp` lift and `eLpNorm` rewrite — each warrant a named lemma. The next ACT (S15) can call `(memLp_haarT2_iff_volume f 2).mp hf` and `rw [eLpNorm_haarT2_eq_volume]` instead of inlining the measure-equality rewrite, keeping the analytic content (steps 4b/4c/5) separated from the measure-equality lift.

After this PR, the S2e ACT recipe scope shrinks: **steps 1 ✅ (S11) + 2 ✅ (S10) + 3 ✅ (S9) + 4a/6 paste-ready (S14)**; remaining = steps 4b + 4c + 5 + 6-close. Estimated 15-25 LOC for the eventual S15 close.

## Build log

```
[180s] Building...
⚠ [7743/7743] Built Proofs.FourierSeriesOQ04OQ01 (123s)
warning: Proofs/FourierSeriesOQ04OQ01.lean:148:8: declaration uses 'sorry'
Build completed successfully (7743 jobs).
=== Build succeeded ===
```

## Test plan

- [x] Docker build clean (7743 jobs, exit 0).
- [x] Sorry count unchanged (1 — the same pre-existing `sphPartialSum_L2_norm_converge` placeholder).
- [x] Axiom count unchanged (1 — `carleson_2d_sph`, the open conjecture).
- [x] No new warnings beyond the expected sorry warning.
- [x] Gallery `meta.json` line/theorem counts synced.
- [x] JSON validates (`python3 -c "import json; json.load(open(...))"` clean).

## Refs

- Parent recipe: S7 audit §4 (sessions/2026-05-16-s7-audit-at-pick-time-s2e-bearers.md)
- PREP: S12 PREP (sessions/2026-06-01-s12-prep-mathlib-api-audit.md) §5 tactic skeleton
- Prior steps: S9 cofinality (PR #21131), S10 finset-sum bridge (PR #21252), S11 measure-equality bridge (PR #21611)

🤖 Generated with [Claude Code](https://claude.com/claude-code)