### PR TITLE
research(erdos-1210): S2 REFUTATION — n=5,A={4} falsifies literal axiom

### DIFF
--- a/proofs/Proofs/Erdos1210Problem.lean
+++ b/proofs/Proofs/Erdos1210Problem.lean
@@ -34,7 +34,7 @@ This is an open conjecture of Erdős. The inequality asserts that primes are
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.GCD.Basic
 import Mathlib.Data.Finset.Basic
-import Mathlib.Algebra.BigOperators.Group.Finset
+import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 import Mathlib.Data.Real.Basic
 import Mathlib.Tactic
 
@@ -107,19 +107,18 @@ theorem primesBelow_sum_nonneg (n : ℕ) :
   apply Finset.sum_nonneg
   intro p hp
   simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
-  apply div_nonneg one_nonneg
+  apply div_nonneg zero_le_one
   have : (p : ℝ) < n := by exact_mod_cast hp.1
   linarith
 
 /-- The prime sum is positive for n ≥ 3 (since 1/(n-2) > 0). -/
 theorem primesBelow_sum_pos {n : ℕ} (hn : 3 ≤ n) :
     0 < ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
-  apply Finset.sum_pos (primesBelow_nonempty hn)
+  refine Finset.sum_pos ?_ (primesBelow_nonempty hn)
   intro p hp
   simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
-  apply div_pos one_pos
-  have : (p : ℝ) < n := by exact_mod_cast hp.1
-  linarith
+  have hpn : (p : ℝ) < n := by exact_mod_cast hp.1
+  exact _root_.div_pos one_pos (by linarith)
 
 /-
 ## The Main Conjecture (Open)
@@ -161,7 +160,7 @@ theorem erdos_1210_prime_singleton (n : ℕ) (hn : 3 ≤ n) (p : ℕ)
         apply Finset.sum_le_sum_of_subset_of_nonneg (by simp [hp_mem])
         intro q hq _
         simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hq
-        apply div_nonneg one_nonneg
+        apply div_nonneg zero_le_one
         have : (q : ℝ) < n := by exact_mod_cast hq.1
         linarith
 
@@ -174,5 +173,74 @@ theorem erdos_1210_singleton_bounded (n : ℕ) (hn : 3 ≤ n) (k : ℕ) (hk1 : 1
     (fun a ha b hb hab => by simp only [Finset.mem_singleton] at ha hb; omega)
   simp only [Finset.sum_singleton] at hle
   exact hle
+
+/-
+## Counterexample: The Literal Statement Is FALSE
+
+The literal axiom `erdos_1210` above is **unsound** as transcribed: there is a
+concrete (n, A) for which the hypotheses are satisfied but the inequality
+FAILS. The minimal witness is n = 5, A = {4}:
+
+  - 4 ∈ [1, 5), so `ValidSubset 5 {4}` holds.
+  - A = {4} is trivially pairwise coprime (singleton, vacuous condition).
+  - ∑_{a ∈ {4}} 1/(5 - a) = 1/(5-4) = 1.
+  - primesBelow 5 = {2, 3}, so ∑_{p < 5 prime} 1/(5 - p) = 1/3 + 1/2 = 5/6.
+  - 1 > 5/6, so the conjectured bound fails.
+
+The theorem `erdos_1210_literal_counterexample` below proves this in machine-
+checked form. It does not invoke the bad axiom (to avoid deriving False and
+destabilizing downstream uses), but its statement is direct evidence that
+`erdos_1210` cannot be a theorem of any consistent extension of ZFC + Lean.
+
+### Interpretation
+
+The transcribed conjecture either:
+  (a) requires unstated constraints on A (e.g., A ⊆ (n/2, n) or a > √n), or
+  (b) uses different weights (e.g., 1/a instead of 1/(n-a)), or
+  (c) was misrecorded in the source database.
+
+Two open follow-ups:
+  1. **Locate originals** [Er77c, Er80] to recover the intended hypothesis.
+  2. **Revise the axiom** to a verified or correctly-stated form. The current
+     axiom should be replaced (the four consequence theorems above are then
+     vacuous and should be removed/refactored).
+-/
+
+/-- `primesBelow 5 = {2, 3}` (decidable equality of concrete Finsets). -/
+theorem primesBelow_five : primesBelow 5 = ({2, 3} : Finset ℕ) := by
+  unfold primesBelow
+  decide
+
+/-- The weighted sum over primes below 5 equals 5/6. -/
+theorem primesBelow_five_sum :
+    ∑ p ∈ primesBelow 5, (1 : ℝ) / ((5 : ℝ) - p) = 5 / 6 := by
+  rw [primesBelow_five]
+  have h23 : (2 : ℕ) ∉ ({3} : Finset ℕ) := by decide
+  rw [show ({2, 3} : Finset ℕ) = insert 2 {3} from rfl,
+      Finset.sum_insert h23, Finset.sum_singleton]
+  norm_num
+
+/-- `{4}` satisfies the hypotheses of `erdos_1210` at n = 5. -/
+theorem singleton_four_valid_at_five :
+    ValidSubset 5 ({4} : Finset ℕ) ∧ PairwiseCoprime ({4} : Finset ℕ) := by
+  refine ⟨?_, ?_⟩
+  · intro a ha
+    simp only [Finset.mem_singleton] at ha
+    subst ha
+    exact ⟨by norm_num, by norm_num⟩
+  · intro a ha b hb hab
+    simp only [Finset.mem_singleton] at ha hb
+    omega
+
+/-- **Counterexample to `erdos_1210` (as literally stated)**.
+
+    At n = 5, A = {4}, the A-sum (= 1) STRICTLY EXCEEDS the prime-sum (= 5/6).
+    All hypotheses of `erdos_1210` are satisfied (see
+    `singleton_four_valid_at_five`), but the conclusion fails. -/
+theorem erdos_1210_literal_counterexample :
+    (∑ p ∈ primesBelow 5, (1 : ℝ) / ((5 : ℝ) - p)) <
+      ∑ a ∈ ({4} : Finset ℕ), (1 : ℝ) / ((5 : ℝ) - a) := by
+  rw [primesBelow_five_sum, Finset.sum_singleton]
+  norm_num
 
 end Erdos1210

--- a/research/problems/erdos-1210/knowledge.md
+++ b/research/problems/erdos-1210/knowledge.md
@@ -47,16 +47,73 @@ i.e., does the set of primes below $n$ maximize this weighted harmonic sum over 
 - PR #15117 open
 
 #### Key Findings
-- Full statement: primes below n maximize ∑ 1/(n-a) over pairwise coprime A ⊆ {1,...,n-1}
-- Structural constraint: pairwise coprime sets have ≤1 even element
-- The conjecture is tight: A = {primes < n} achieves equality
-- No elementary proof known; likely needs Mertens-type analytic estimates
+- Full statement (as transcribed): primes below n maximize ∑ 1/(n-a) over
+  pairwise coprime A ⊆ {1,...,n-1}. (REFUTED in S2 below.)
+- Structural constraint: pairwise coprime sets have ≤1 even element.
+- (CLAIMED) The conjecture is tight at A = {primes < n}. (REFUTED in S2.)
+- No elementary proof known; likely needs Mertens-type analytic estimates.
 
 #### Next Steps
 - Verify Lean file builds (Docker)
 - Investigate exchange argument: swapping non-prime for nearby prime
 - Explore computational verification for small n ≤ 20
 - Asymptotic: ∑_{p<n} 1/(n-p) ~ ? as n → ∞
+
+### Session 2026-06-09 (Session 2) — researcher-6
+
+**Mode**: ITERATION
+**Outcome**: STATEMENT-REVISION-NEEDED — literal axiom REFUTED by counterexample at n = 5, A = {4}.
+
+#### What Was Done
+- Discovered that the literal axiom `erdos_1210` (as currently formalized) is
+  **unsound**: A = {4} at n = 5 satisfies all hypotheses but violates the
+  conclusion.
+- Added four machine-checked theorems to `proofs/Proofs/Erdos1210Problem.lean`:
+  - `primesBelow_five` — primesBelow 5 = {2, 3} by `decide`.
+  - `primesBelow_five_sum` — prime sum equals 5/6.
+  - `singleton_four_valid_at_five` — {4} is a valid pairwise-coprime subset.
+  - `erdos_1210_literal_counterexample` — the prime sum is strictly less than
+    the {4}-sum, refuting the axiom's conclusion.
+- Documented the discrepancy in a `## Counterexample: The Literal Statement Is
+  FALSE` block, with two interpretation hypotheses (missing hypothesis like
+  `a > n/2`; or a different weight like `1/a`).
+- Did NOT derive False from the bad axiom (kept the file consistent so any
+  future repair retains the existing structure).
+- Updated import path `Mathlib.Algebra.BigOperators.Group.Finset` → `.Basic`
+  to match current Mathlib layout.
+
+#### Counterexample Detail
+- n = 5, A = {4}:
+  - ValidSubset 5 {4}: 1 ≤ 4 ∧ 4 < 5 ✓
+  - PairwiseCoprime {4}: singleton, vacuous ✓
+  - LHS = 1/(5-4) = 1
+  - primesBelow 5 = {2, 3}; RHS = 1/3 + 1/2 = 5/6
+  - 1 > 5/6 — REFUTATION
+
+- Additional sub-n=10 counterexamples (informal): A = {1} at n = 5
+  (LHS = 1/4 < 5/6 OK), A = {1, 2} at n = 3 (LHS = 1/2 + 1 = 3/2 vs RHS = 1).
+
+#### Plausible Reinterpretations
+- **Hypothesis (a)** A ⊆ [√n, n) or A ⊆ (n/2, n). At n=5 with a ≥ √5 ≈ 2.24,
+  {4} still violates (LHS = 1, RHS = 5/6). At n=5 with a > n/2 = 2.5, same
+  issue. Neither matches.
+- **Hypothesis (b)** Weight is 1/a (not 1/(n-a)). At n = 5 with a ≥ 2:
+  - {2, 3}: 1/2 + 1/3 = 5/6 = ∑ 1/p ✓ (equality)
+  - {3, 4}: 1/3 + 1/4 = 7/12 < 5/6 ✓
+  - {4}: 1/4 < 5/6 ✓
+  No counterexample found in this restricted regime. Likely candidate for the
+  intended statement, but requires source-text confirmation.
+- **Hypothesis (c)** The inequality direction is reversed. At n = 5 with
+  A = {1}, LHS = 1/4 < 5/6 = RHS, refuting this direction too.
+
+#### Next Steps (S3)
+- Locate the Erdős source ([Er77c], [Er80]) to recover the intended statement.
+- Once the correct statement is known, replace the unsound axiom with the
+  corrected statement (or with a verified theorem if provable).
+- Refactor or remove the four consequence theorems that depend on the current
+  axiom.
+- Possibly downgrade gallery `status` from `axiomatized` →
+  `formalized-pending-statement-revision`.
 
 ---
 

--- a/research/problems/erdos-1210/state.md
+++ b/research/problems/erdos-1210/state.md
@@ -1,27 +1,55 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-04-16T17:10:06.887Z
-**Iteration**: 1
+**Phase**: STATEMENT_REVISION_NEEDED
+**Since**: 2026-06-09T20:35:00Z
+**Iteration**: 2
 
 ## Current Focus
 
-Initial exploration of the problem.
+Discovered the transcribed axiom `erdos_1210` is **unsound** as literally
+stated. Adding machine-checked counterexample and flagging the formalization
+for statement-revision.
 
 ## Active Approach
 
-None yet.
+S2 COUNTEREXAMPLE — Construct a concrete witness (n = 5, A = {4}) where the
+hypotheses of `erdos_1210` hold but the conclusion fails. Verify in Lean.
+
+## Findings (S2)
+
+The transcribed statement
+`∑_{a ∈ A} 1/(n-a) ≤ ∑_{p < n, p prime} 1/(n-p)`
+admits the following counterexample at n = 5:
+
+- A = {4} trivially satisfies `ValidSubset 5 A` (1 ≤ 4 < 5) and
+  `PairwiseCoprime A` (singleton).
+- LHS = 1/(5-4) = 1.
+- RHS = 1/(5-2) + 1/(5-3) = 1/3 + 1/2 = 5/6 ≈ 0.833.
+- 1 > 5/6, so the conjectured inequality FAILS.
+
+Hence the existing `axiom erdos_1210` and its four consequence theorems are
+unsound and should be refactored once the intended Erdős statement is
+recovered from [Er77c] / [Er80].
 
 ## Blockers
 
-None.
+- Source-text access: cannot directly fetch the original Erdős papers
+  ([Er77c] Erdős 1977c, [Er80] Erdős 1980) to recover the unstated hypothesis
+  (e.g., a > n/2, a > √n, or a different weight like 1/a).
+- Without the corrected statement, the axiom cannot be replaced — only flagged.
 
 ## Next Action
 
-Begin problem exploration.
+S3 — A future iteration should:
+  1. Locate the Erdős source for problem 1210 (likely contains the missing
+     hypothesis).
+  2. Replace the unsound axiom with the corrected statement (or with a verified
+     theorem if the corrected version is provable).
+  3. Refactor or remove the four consequence theorems that depend on the
+     current axiom.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1 (S2 counterexample)
+- Approaches tried: 2 (S1 formalization → axiomatization; S2 falsification)


### PR DESCRIPTION
## Summary

- **Discovery**: The literal `axiom erdos_1210` in `proofs/Proofs/Erdos1210Problem.lean` is **unsound**. The minimal counterexample is `n = 5`, `A = {4}`: hypotheses hold (`1 ≤ 4 < 5`, singleton trivially pairwise coprime), but `LHS = 1/(5-4) = 1 > 5/6 = 1/3 + 1/2 = ∑ 1/(5-p)` for `p ∈ primesBelow 5 = {2,3}`.
- **Contribution**: Four machine-checked theorems documenting the counterexample (`primesBelow_five`, `primesBelow_five_sum`, `singleton_four_valid_at_five`, `erdos_1210_literal_counterexample`).
- **Stability**: The unsound axiom is **NOT** deleted in this PR — the file remains consistent. A future iteration should locate the original Erdős source ([Er77c], [Er80]) and replace the axiom with the correctly-stated theorem.

## Counterexample Math

| Object | Value |
|---|---|
| n | 5 |
| A | {4} |
| ValidSubset 5 A | 1 ≤ 4 < 5 |
| PairwiseCoprime A | singleton — vacuous |
| ∑_{a ∈ A} 1/(5-a) | 1/1 = 1 |
| primesBelow 5 | {2, 3} |
| ∑_{p ∈ primesBelow 5} 1/(5-p) | 1/3 + 1/2 = 5/6 |
| Conclusion | 1 > 5/6 — REFUTES |

## Plausible Reinterpretations

- **(a)** Different constraint on A (e.g., a > n/2, a ≥ √n). At n=5, A={4} still violates with a > n/2 = 2.5, so this is not enough.
- **(b)** Different weight: 1/a instead of 1/(n-a). At n=5 with a ≥ 2, sanity-checked subsets ({2,3}, {3,4}, {4}) satisfy the bound with equality at primes — likely the intended statement.
- **(c)** Direction reversed (≥ instead of ≤). At n=5, A={1}: LHS = 1/4 < 5/6 = RHS — refutes this too.

Recovery of the original source is needed to commit to a reinterpretation.

## Files Changed

- proofs/Proofs/Erdos1210Problem.lean — adds counterexample section + 4 theorems; incidental Mathlib drift fixes (import path, Finset.sum_pos arg order, one_nonneg → zero_le_one, qualify _root_.div_pos).
- research/problems/erdos-1210/state.md — phase NEW → STATEMENT_REVISION_NEEDED.
- research/problems/erdos-1210/knowledge.md — Session 2 entry documenting the refutation.

## Test plan

- [x] Docker build verified: ./proofs/scripts/docker-build.sh Proofs.Erdos1210Problem — succeeds (warning: unused hn in pre-existing erdos_1210_prime_singleton).
- [x] Counterexample arithmetic re-checked twice by hand and once symbolically in Lean.
- [ ] (Future S3) Locate Erdős source; replace axiom; downgrade gallery status if needed.

Generated with Claude Code (https://claude.com/claude-code)