### PR TITLE
audit(binomial-theorem-oq-01-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -982,9 +982,9 @@
       "result": "clean"
     },
     "binomial-theorem-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:29:46Z",
+      "lastAudited": "2026-06-09T20:57:44Z",
       "result": "clean"
     },
     "binomial-theorem-oq-02": {


### PR DESCRIPTION
## Audit Result: CLEAN (4th audit)

**Proof**: `binomial-theorem-oq-01-oq-01` — Newton's Generalized Binomial Theorem via Analytic Function Theory
**Status**: verified / badge: mathlib

## Checks Performed

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` declarations, 0 structure-encoded assumptions | ✓ |
| True stubs | — | none | ✓ |
| definitionCount | 1 | 1 (`noncomputable def genBinom`) | ✓ |
| theoremCount | 17 | 17 theorems | ✓ |
| lineCount | 220 | 220 | ✓ |

## Narrative Integrity

- **Tier B classification** (Mathlib bridge): badge `"mathlib"` is correct. `binomial_series_analytic` at line 55–57 wraps `Real.one_add_rpow_hasFPowerSeriesOnBall_zero` for the core analytic convergence.
- **Delegation transparency**: description mentions "power series analyticity via Mathlib"; `mathlibDependencies` enumerates the wrapped theorem with module; `assumptions` field explicitly states "Core analytic convergence derived from Mathlib Real.one_add_rpow_hasFPowerSeriesOnBall_zero".
- **Original contributions** correctly scoped to coefficient-level results (ODE recurrence, uniqueness, absorption identity, half-integer coefficients) — not the Mathlib-provided analyticity.
- No "first formalization" / "we proved" overclaiming.

## Change

Tracker bump only: \`auditCount\` 3 → 4, \`lastAudited\` → 2026-06-09T20:57:44Z, result remains clean.

---
Discovered during routine gallery integrity audit. No fix required.