### PR TITLE
audit(bezout-identity-oq-03-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -880,9 +880,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:29:46Z",
+      "lastAudited": "2026-06-09T21:23:53Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01": {


### PR DESCRIPTION
## Audit Result: CLEAN (4th audit)

**Proof**: `bezout-identity-oq-03-oq-01` — CRT Ring Isomorphism ℤ/mnℤ ≅ ℤ/mℤ × ℤ/nℤ
**Status**: verified / badge: mathlib

## Checks Performed

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls, 0 structure-encoded assumptions | ✓ |
| True stubs | — | none | ✓ |
| definitionCount | 5 | 5 | ✓ |
| theoremCount | 25 | 25 | ✓ |
| lineCount | 315 | 315 | ✓ |

## Narrative Integrity

- **Tier B classification** (Mathlib bridge): badge `"mathlib"` is correct. `crtRingIso` at line 44 wraps `ZMod.chineseRemainder` for the core ring isomorphism.
- **Delegation transparency**: description says "Wraps Mathlib's ZMod.chineseRemainder"; `mathlibDependencies` enumerates 5 wrapped theorems with modules; `assumptions` field discloses "Core ring isomorphism derived from Mathlib's ZMod.chineseRemainder".
- **Original contributions** correctly scoped to wrapper packaging, orthogonal idempotent decomposition, explicit Bézout-based solution formula, unit characterization, cardinality preservation, and power preservation — not the core CRT isomorphism itself.
- No "first formalization" / "we proved" overclaiming.

## Change

Tracker bump only: `auditCount` 3 → 4, `lastAudited` → 2026-06-09T21:23:53Z, result remains clean.

---
Discovered during routine gallery integrity audit. No fix required.