### PR TITLE
research(cantor-diagonalization-oq-01-oq-02): S3 ACT — 5 axiom-free contrapositive corollaries

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean
@@ -308,4 +308,54 @@ theorem ch_independent_of_large_cardinals :
     RelativelyConsistent (HasMeasurable ∧ ¬CH) :=
   measurable_independent_of_ch
 
+/-
+═══════════════════════════════════════════════════════════════════════════════
+PART IX: CONTRAPOSITIVE COROLLARIES (CH/GCH BLOCK FORCING AXIOMS)
+═══════════════════════════════════════════════════════════════════════════════
+
+These five corollaries are pure consequences of theorems already in this file —
+no new axioms, no new definitions, no Mathlib infrastructure beyond what
+`mm_implies_not_ch`, `ma_implies_not_ch`, `gch_implies_ch`, and
+`Cardinal.aleph_lt_aleph` already provide. They connect Parts IV (Forcing
+Axioms ⇒ ¬CH) and VII (GCH) by recording the contrapositives:
+
+  CH → ¬MM,   CH → ¬MA,   GCH → ¬MM,   GCH → ¬MA,
+
+plus a quantitative refinement that Martin's Maximum forces the continuum
+strictly above ℵ₁ (which is the precise sense in which MM refutes CH).
+
+The mathematical content is implicit in Parts IV/VII; making the
+contrapositives explicit clarifies the four-way logical structure
+{CH, ¬CH} × {MM/MA, ¬MM/¬MA} that any forcing-axiom-aware reader needs.
+-/
+
+/-- **Corollary** (contrapositive of `mm_implies_not_ch`): CH rules out
+    Martin's Maximum. If 2^ℵ₀ = ℵ₁, then 2^ℵ₀ ≠ ℵ₂. -/
+theorem ch_implies_not_mm (hch : CH) : ¬MartinsMaximum :=
+  fun hmm => mm_implies_not_ch hmm hch
+
+/-- **Corollary** (contrapositive of `ma_implies_not_ch`): CH rules out
+    Martin's Axiom. If 2^ℵ₀ = ℵ₁, then 2^ℵ₀ < ℵ₂. -/
+theorem ch_implies_not_ma (hch : CH) : ¬MartinsAxiom :=
+  fun hma => ma_implies_not_ch hma hch
+
+/-- **Corollary**: GCH rules out Martin's Maximum (composing `gch_implies_ch`
+    with `ch_implies_not_mm`). Under GCH, 2^ℵ₀ = ℵ₁ ≠ ℵ₂. -/
+theorem gch_implies_not_mm (h : GCH) : ¬MartinsMaximum :=
+  ch_implies_not_mm (gch_implies_ch h)
+
+/-- **Corollary**: GCH rules out Martin's Axiom (composing `gch_implies_ch`
+    with `ch_implies_not_ma`). Under GCH, 2^ℵ₀ = ℵ₁ < ℵ₂. -/
+theorem gch_implies_not_ma (h : GCH) : ¬MartinsAxiom :=
+  ch_implies_not_ma (gch_implies_ch h)
+
+/-- **Quantitative refinement of `mm_implies_not_ch`**: under Martin's Maximum,
+    the continuum strictly exceeds ℵ₁ (since MM pins it to ℵ₂ > ℵ₁). This is
+    the cardinal-arithmetic content behind MM ⇒ ¬CH. -/
+theorem mm_continuum_gt_aleph_one (hmm : MartinsMaximum) :
+    Cardinal.aleph 1 < (2 : Cardinal.{0}) ^ ℵ₀ := by
+  unfold MartinsMaximum at hmm
+  rw [hmm]
+  exact Cardinal.aleph_lt_aleph.mpr (by norm_num)
+
 end CantorDiagOQ01OQ02

--- a/research/problems/cantor-diagonalization-oq-01-oq-02/sessions/2026-06-09-s03-act-contrapositive-corollaries.md
+++ b/research/problems/cantor-diagonalization-oq-01-oq-02/sessions/2026-06-09-s03-act-contrapositive-corollaries.md
@@ -1,0 +1,108 @@
+# S3 ACT — Contrapositive Corollaries Bridging Parts IV and VII
+
+**Date**: 2026-06-09
+**Author**: researcher-4
+**Phase**: ACT (additive — pure consequences of existing theorems)
+**Iteration**: 3 (after S2 ACT 2026-06-05 API-drift repair)
+**Mode**: ACT — file is Docker-clean at HEAD (3061/3061 jobs, re-verified at the
+start of this iteration). Adds 5 axiom-free corollaries; no theorem touched,
+no axiom touched, no definition touched.
+
+## Outcome
+
+`proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean` grows **306 → 361 LOC**
+(+55, of which ~30 are docstrings/section header and ~25 are theorem
+statements + proofs). **5 new theorems**; **0 new axioms**, **0 new
+definitions**, **0 sorries closed** (file already had 0), **0 axioms
+eliminated**. Re-Docker-verified clean post-edit.
+
+## What was added (PART IX)
+
+A new `PART IX: CONTRAPOSITIVE COROLLARIES` section between the existing
+PART VIII summary and `end CantorDiagOQ01OQ02`. Each corollary is a one-line
+or two-line proof composing pre-existing theorems:
+
+| New theorem | Type | Proof (1-line) |
+|---|---|---|
+| `ch_implies_not_mm` | `CH → ¬MartinsMaximum` | `fun hmm => mm_implies_not_ch hmm hch` |
+| `ch_implies_not_ma` | `CH → ¬MartinsAxiom` | `fun hma => ma_implies_not_ch hma hch` |
+| `gch_implies_not_mm` | `GCH → ¬MartinsMaximum` | `ch_implies_not_mm (gch_implies_ch h)` |
+| `gch_implies_not_ma` | `GCH → ¬MartinsAxiom` | `ch_implies_not_ma (gch_implies_ch h)` |
+| `mm_continuum_gt_aleph_one` | `MM → ℵ₁ < 2^ℵ₀` | `rw [hmm]; exact Cardinal.aleph_lt_aleph.mpr (by norm_num)` |
+
+The first four are exactly the contrapositives of `mm_implies_not_ch` and
+`ma_implies_not_ch` (Part IV), optionally pre-composed with `gch_implies_ch`
+(Part VII). The fifth records the quantitative refinement: MM does not only
+refute CH (`2^ℵ₀ ≠ ℵ₁`) — it forces the continuum strictly above ℵ₁
+(`ℵ₁ < 2^ℵ₀`), which is the cardinal-arithmetic content underlying MM ⇒ ¬CH.
+
+## Why this matters (mathematical motivation)
+
+Before S3 the file proved the implications
+
+  MM ⇒ ¬CH,    MA ⇒ ¬CH,    GCH ⇒ CH
+
+but did not record the four-corner logical structure that a forcing-axiom-aware
+reader would expect:
+
+```
+   CH   ─→ ¬MM, ¬MA       (now: ch_implies_not_mm, ch_implies_not_ma)
+   GCH  ─→ CH ─→ ¬MM, ¬MA  (now: gch_implies_not_mm, gch_implies_not_ma)
+```
+
+In particular `gch_implies_not_mm` is the formal statement that the Woodin
+Ultimate-L target (GCH) is **incompatible** with Foreman-Magidor-Shelah's
+forcing axiom (MM). This is a folklore observation, but in a Lean file
+purporting to map the large-cardinal/CH landscape it is the natural
+explicit corollary.
+
+## What did NOT change
+
+- **0 new axioms.** All 7 deep set-theoretic axioms (Lévy-Solovay × 4,
+  mm_consistent, ma_consistent, ultimate_l_implies_ch_consistent) retained.
+- **0 new definitions.** All 10 defs (IsStrongLimit, IsRegular,
+  IsInaccessible, IsMeasurable, HasInaccessible, HasMeasurable,
+  MartinsAxiom, MartinsMaximum, UltimateLConjecture, GCH) retained.
+- **All 14 pre-existing theorems retained**, unchanged.
+- **Status `axiomatized` unchanged.** The 5 new corollaries are pure
+  composition of existing-file theorems; they neither add nor remove
+  set-theoretic assumptions.
+
+## Counts after S3 ACT
+
+| File | Lines | Theorems | Axioms | Defs | Sorries |
+|------|-------|----------|--------|------|---------|
+| `CantorDiagonalizationOQ01OQ02.lean` | **361** | **19** (+5) | 7 | 10 | 0 |
+
+(Up from 311 LOC / 14 theorems pre-S3.)
+
+## Build status
+
+**Docker pre-check (pre-edit, HEAD ac12868a924)**:
+`./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ01OQ02`
+→ `Build completed successfully (3061 jobs).` → `=== Build succeeded ===`
+
+**Docker post-edit (this iteration)**:
+Same command, post-edit, identical exit code, 3061 jobs. See in-PR log
+`/tmp/r4-build-s3.log` artifact.
+
+## Honesty
+
+This iteration is **pure surface enrichment**: 0 sorries closed, 0 axioms
+eliminated, 0 mathematical claims strengthened beyond what the file already
+proved. The value is making **explicit** five logical-corollary entry points
+that the original file left implicit:
+
+- before S3, a reader asking "what does CH say about MM?" had to chase
+  `mm_implies_not_ch` and apply `mt`/`fun hmm => ...` themselves;
+- after S3, `ch_implies_not_mm` is a directly-citable lemma in the namespace.
+
+This is a typical "tighten the API surface" iteration for a mature gallery
+file. No drama, no new mathematics — just five clean compositions and the
+section header explaining why they are there.
+
+The Continuum Hypothesis question — "is CH decided by large cardinal
+axioms?" — is unchanged: **partially** (standard large cardinals: no, by
+Lévy-Solovay; forcing axioms: yes, by Foreman-Magidor-Shelah; Ultimate-L:
+open). The S3 corollaries simply re-state that "yes, by Foreman-Magidor-
+Shelah" in contrapositive form.

--- a/research/problems/cantor-diagonalization-oq-01-oq-02/state.md
+++ b/research/problems/cantor-diagonalization-oq-01-oq-02/state.md
@@ -1,10 +1,34 @@
 # Current State
 
-**Phase**: ACT (Docker-verified clean after Mathlib API drift repair, 2026-06-05)
-**Since**: 2026-04-26 (S1 ACT initial formalization) → 2026-06-05 (S2 ACT API drift repair)
-**Iteration**: 2
+**Phase**: ACT (Docker-verified clean after S3 contrapositive corollaries, 2026-06-09)
+**Since**: 2026-04-26 (S1 ACT initial formalization) → 2026-06-05 (S2 ACT API drift repair) → 2026-06-09 (S3 ACT contrapositive corollaries)
+**Iteration**: 3
 
-`proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean` is **311 LOC** with **14 theorems**, 7 axioms (all deep set-theoretic results), 10 defs, 0 sorries. **Docker-verified 3061/3061 jobs on 2026-06-05** after a one-iteration API drift repair (April 2026 → June 2026 Mathlib changes).
+`proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean` is **361 LOC** with **19 theorems** (+5 in S3), 7 axioms (unchanged), 10 defs (unchanged), 0 sorries. **Docker-verified 3061/3061 jobs on 2026-06-09** both pre- and post-edit.
+
+## S3 ACT (2026-06-09, researcher-4) — Contrapositive corollaries (PART IX)
+
+**Mode**: ACT (pure surface enrichment; file pre-built clean, post-built clean).
+
+**Outcome**: +55 LOC (306 → 361). **+5 theorems** (14 → 19). **0 new axioms, 0 new defs, 0 sorries closed.**
+
+### New theorems (PART IX)
+
+| Theorem | Type | Role |
+|---|---|---|
+| `ch_implies_not_mm` | `CH → ¬MartinsMaximum` | Contrapositive of `mm_implies_not_ch` |
+| `ch_implies_not_ma` | `CH → ¬MartinsAxiom` | Contrapositive of `ma_implies_not_ch` |
+| `gch_implies_not_mm` | `GCH → ¬MartinsMaximum` | Composes `gch_implies_ch` with `ch_implies_not_mm` |
+| `gch_implies_not_ma` | `GCH → ¬MartinsAxiom` | Composes `gch_implies_ch` with `ch_implies_not_ma` |
+| `mm_continuum_gt_aleph_one` | `MM → ℵ₁ < 2^ℵ₀` | Quantitative refinement of MM ⇒ ¬CH |
+
+These connect Parts IV (forcing axioms ⇒ ¬CH) and VII (GCH ⇒ CH) by recording the four-corner logical structure {CH, ¬CH} × {MM/MA, ¬MM/¬MA} explicitly. The quantitative refinement records the cardinal-arithmetic content (ℵ₁ < ℵ₂) underlying MM ⇒ ¬CH.
+
+### Build status
+
+**Docker pre-check (pre-edit, HEAD ac12868a924)**: `Build completed successfully (3061 jobs)`. **Docker post-edit**: same — 3061 jobs.
+
+## S2 ACT (2026-06-05, researcher-1) — Mathlib API drift repair
 
 ## S2 ACT (2026-06-05, researcher-1) — Mathlib API drift repair
 
@@ -67,6 +91,6 @@ Pure API-drift repair iteration. No new mathematical content; the focus is keepi
 
 ## Attempt Counts
 
-- Total attempts: 2 (S1 ACT 2026-04-26 + S2 ACT 2026-06-05)
-- Current approach attempts: 1 (API drift repair, this iteration)
-- Approaches tried: 2 (S1: initial formalisation; S2: API drift repair)
+- Total attempts: 3 (S1 ACT 2026-04-26 + S2 ACT 2026-06-05 + S3 ACT 2026-06-09)
+- Current approach attempts: 1 (contrapositive corollaries, this iteration)
+- Approaches tried: 3 (S1: initial formalisation; S2: API drift repair; S3: contrapositive corollaries)

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -21,9 +21,9 @@
     "erdosNumber": null,
     "axiomCount": 7,
     "assumptions": "7 axioms: levy_solovay_inaccessible_ch (Lévy-Solovay 1967: inaccessible + CH consistent), levy_solovay_inaccessible_not_ch (Lévy-Solovay 1967: inaccessible + ¬CH consistent), levy_solovay_measurable_ch (Lévy-Solovay: measurable + CH consistent), levy_solovay_measurable_not_ch (Lévy-Solovay: measurable + ¬CH consistent), mm_consistent (Foreman-Magidor-Shelah 1988: MM consistent with ZFC+supercompact), ma_consistent (Martin-Solovay: MA consistent with ZFC), ultimate_l_implies_ch_consistent (Woodin program: open).",
-    "lineCount": 306,
+    "lineCount": 361,
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 19,
     "originalContributions": [
       "IsStrongLimit definition: ∀ λ < κ, 2^λ < κ",
       "IsRegular definition: κ.ord.cof.card = κ",
@@ -45,7 +45,12 @@
       "GCH definition: ∀ n : ℕ, 2^ℵₙ = ℵₙ₊₁",
       "gch_implies_ch theorem: GCH → CH proved by specializing n=0 (simp + Cardinal.aleph_zero)",
       "gch_decides_all_aleph theorem: GCH gives exact value of all higher continua",
-      "gch_continuum_below_aleph_add_two theorem: GCH → 2^ℵₙ < ℵₙ₊₂ (Cardinal.aleph_lt.mpr + omega)"
+      "gch_continuum_below_aleph_add_two theorem: GCH → 2^ℵₙ < ℵₙ₊₂ (Cardinal.aleph_lt.mpr + omega)",
+      "ch_implies_not_mm theorem: CH → ¬MM (contrapositive of mm_implies_not_ch)",
+      "ch_implies_not_ma theorem: CH → ¬MA (contrapositive of ma_implies_not_ch)",
+      "gch_implies_not_mm theorem: GCH → ¬MM (composes gch_implies_ch with ch_implies_not_mm)",
+      "gch_implies_not_ma theorem: GCH → ¬MA (composes gch_implies_ch with ch_implies_not_ma)",
+      "mm_continuum_gt_aleph_one theorem: MM → ℵ₁ < 2^ℵ₀ (quantitative refinement)"
     ],
     "definitionCount": 10
   },
@@ -120,13 +125,21 @@
       "id": "summary",
       "title": "Summary Theorems",
       "startLine": 283,
-      "endLine": 306,
+      "endLine": 309,
       "summary": "large_cardinals_and_ch_summary and ch_independent_of_large_cardinals combining the main results.",
       "mathContext": "Standard large cardinals leave CH independent; MM decides ¬CH; GCH decides all continua."
+    },
+    {
+      "id": "contrapositive-corollaries",
+      "title": "Contrapositive Corollaries (CH/GCH ⇒ ¬MM/¬MA)",
+      "startLine": 311,
+      "endLine": 360,
+      "summary": "Five axiom-free corollaries that connect Parts IV and VII: ch_implies_not_mm, ch_implies_not_ma, gch_implies_not_mm, gch_implies_not_ma, mm_continuum_gt_aleph_one.",
+      "mathContext": "From $\\text{MM} \\Rightarrow \\neg\\text{CH}$ and $\\text{MA} \\Rightarrow \\neg\\text{CH}$ (Part IV), the contrapositives $\\text{CH} \\Rightarrow \\neg\\text{MM}$ and $\\text{CH} \\Rightarrow \\neg\\text{MA}$ follow directly; composing with $\\text{GCH} \\Rightarrow \\text{CH}$ (Part VII) gives the four-corner logical structure linking CH/GCH and the forcing axioms. The quantitative refinement $\\text{MM} \\Rightarrow \\aleph_1 < 2^{\\aleph_0}$ records the cardinal-arithmetic content."
     }
   ],
   "conclusion": {
-    "summary": "Formalizes the large cardinal landscape around CH: standard large cardinals leave CH undecided (Lévy-Solovay, axiomatized), while forcing axioms (MM, MA) decide ¬CH (proved). Adds GCH section: defines GCH (2^ℵₙ = ℵₙ₊₁), proves GCH → CH and structural consequences. 0 sorries, 7 axioms, 14 theorems.",
+    "summary": "Formalizes the large cardinal landscape around CH: standard large cardinals leave CH undecided (Lévy-Solovay, axiomatized), while forcing axioms (MM, MA) decide ¬CH (proved). Adds GCH section: defines GCH (2^ℵₙ = ℵₙ₊₁), proves GCH → CH and structural consequences. 0 sorries, 7 axioms, 19 theorems (5 contrapositive corollaries added in S3 connecting Parts IV and VII).",
     "implications": "The formalization clarifies the precise boundary: set-theoretic 'size' axioms (large cardinals) don't decide CH, but 'saturation' axioms (forcing axioms) do. GCH is the ultimate strengthening and is the target of Woodin's program.",
     "openQuestions": [
       "Does the Woodin Ultimate-L program succeed in settling CH canonically as true?",


### PR DESCRIPTION
## Summary

Adds **PART IX** to `proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean`, bridging Parts IV (forcing axioms ⇒ ¬CH) and VII (GCH ⇒ CH) with five explicit corollaries that were previously implicit in the file. **Pure additions** — no theorem touched, no axiom touched, no definition touched.

## New theorems

| Theorem | Type | Role |
|---|---|---|
| `ch_implies_not_mm` | `CH → ¬MartinsMaximum` | Contrapositive of `mm_implies_not_ch` |
| `ch_implies_not_ma` | `CH → ¬MartinsAxiom` | Contrapositive of `ma_implies_not_ch` |
| `gch_implies_not_mm` | `GCH → ¬MartinsMaximum` | Composes `gch_implies_ch` with `ch_implies_not_mm` |
| `gch_implies_not_ma` | `GCH → ¬MartinsAxiom` | Composes `gch_implies_ch` with `ch_implies_not_ma` |
| `mm_continuum_gt_aleph_one` | `MM → ℵ₁ < 2^ℵ₀` | Quantitative refinement of `mm_implies_not_ch` |

Each proof is a one- or two-line composition of pre-existing file theorems.

## Why

The original file recorded the implications `MM ⇒ ¬CH`, `MA ⇒ ¬CH`, `GCH ⇒ CH`, but left the four-corner logical structure `{CH, ¬CH} × {MM/MA, ¬MM/¬MA}` as exercises for the reader. Making these contrapositives explicit gives directly-citable lemma names for the natural follow-up questions, and `gch_implies_not_mm` in particular records the folklore fact that **the Woodin Ultimate-L target (GCH) is incompatible with the Foreman-Magidor-Shelah forcing axiom (MM)** — worth a Lean lemma name in a file purporting to map the large-cardinal/CH landscape.

## Counts after S3

| File | Lines | Theorems | Axioms | Defs | Sorries |
|---|---|---|---|---|---|
| `CantorDiagonalizationOQ01OQ02.lean` | **361** (+55) | **19** (+5) | 7 (unchanged) | 10 (unchanged) | 0 |

- **0 new axioms.** All 7 deep set-theoretic axioms (Lévy-Solovay × 4, mm_consistent, ma_consistent, ultimate_l_implies_ch_consistent) retained unchanged.
- **0 new definitions.** All 10 defs retained unchanged.
- **All 14 pre-existing theorems retained**, unchanged.

## Build

**Docker pre-check (pre-edit, HEAD ac12868a924)**:
```
./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ01OQ02
→ Build completed successfully (3061 jobs).
→ === Build succeeded ===
```

**Docker post-edit (this PR)**: identical — 3061 jobs, clean.

## Status

`status: axiomatized` unchanged. The 5 new corollaries are pure compositions of existing-file theorems; they neither add nor remove set-theoretic assumptions. The Continuum Hypothesis question — "is CH decided by large cardinal axioms?" — remains answered the same way: standard large cardinals: no, by Lévy-Solovay; forcing axioms: yes, by Foreman-Magidor-Shelah; Ultimate-L: open. S3 simply re-states "yes, by Foreman-Magidor-Shelah" in contrapositive form.

## Test plan

- [x] Docker pre-check (pre-edit): 3061/3061 jobs clean
- [x] Docker post-edit: 3061/3061 jobs clean
- [x] State / session report updated
- [x] meta.json `theoremCount` 14 → 19, `lineCount` 306 → 361, new `originalContributions` entries, new `sections.contrapositive-corollaries` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)