### PR TITLE
audit(cramers-rule-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2192,9 +2192,9 @@
       "result": "clean"
     },
     "cramers-rule-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:38:30Z",
+      "lastAudited": "2026-06-09T21:47:57Z",
       "result": "clean"
     },
     "cramers-rule-oq-01-oq-02": {


### PR DESCRIPTION
## Audit Result: CLEAN (4th audit)

**Proof**: `cramers-rule-oq-01` — Cayley-Hamilton as a Corollary of Cramer's Rule
**Status**: verified / badge: mathlib

## Checks Performed

| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls, 0 structure-encoded assumptions | ✓ |
| True stubs | — | none | ✓ |
| definitionCount | 0 | 0 | ✓ |
| theoremCount | 13 | 13 | ✓ |
| lineCount | 282 | 282 | ✓ |

## Narrative Integrity

- **Tier B classification** (Mathlib bridge): badge `"mathlib"` is correct. Core results use `Matrix.mul_adjugate` (line 78), `Matrix.adjugate_mul` (lines 83, 111), and `Matrix.matPolyEquiv_charmatrix` (line 136) — all direct Mathlib calls.
- **Delegation transparency**: description frames as Cayley-Hamilton "follows as a direct corollary of the adjugate identity at the heart of Cramer's Rule"; `mathlibDependencies` enumerates 5 wrapped theorems with modules; `assumptions` discloses "derived from Mathlib's adjugate_mul, charmatrix_det_eq_charpoly, and matPolyEquiv".
- **Original contributions** correctly scoped to the explicit derivation chain (adjugate → charmatrix → matPolyEquiv → eval) and the capstone `cramer_implies_cayley_hamilton` — not the underlying Mathlib results.
- No "first formalization" / "we proved" overclaiming.

## Change

Tracker bump only: `auditCount` 3 → 4, `lastAudited` → 2026-06-09T21:47:57Z, result remains clean.

---
Discovered during routine gallery integrity audit. No fix required.