### PR TITLE
audit(bezout-identity-oq-03-oq-01-oq-01-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -892,9 +892,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T16:38:31Z",
+      "lastAudited": "2026-06-09T22:15:42Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-02": {


### PR DESCRIPTION
## Summary
- Re-audit of ideal-theoretic CRT (`Proofs/BezoutIdentityOQ03OQ01OQ01OQ01.lean`).
- All meta.json metric claims verified against Lean source: 0 sorries, 0 axioms, 0 structure-encoded assumptions, 9 theorems, 3 noncomputable defs, 160 lines.
- Status `verified` + badge `mathlib` consistent with content (Tier-B Mathlib bridge wrapping `Ideal.quotientInfRingEquivPiQuotient` and `Ideal.quotientInfEquivQuotientProd`).
- `originalContributions` correctly limited to `inf_eq_mul_of_coprime`, `crt_product`, `crt_unique`, `isCoprime_of_coprime_inf` — no overclaim.
- Audit-tracker only; no Lean or gallery content changes.

## Test plan
- [x] `grep -c '\bsorry\b'` → 0
- [x] `grep -c '^axiom '` → 0
- [x] `grep -c '^structure '` → 0
- [x] `^theorem|^lemma` count → 9 (matches `theoremCount: 9`)
- [x] `^def|^noncomputable def` count → 3 (matches `definitionCount: 3`)
- [x] `wc -l` → 160 (matches `lineCount: 160`)
- [x] No `: True :=` stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)