### PR TITLE
research(amgm-inequality-oq-04-oq-03): S4a ACT — x-independent M-test primitive for the hypergeometric series

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -221,4 +221,39 @@ theorem summable_hyp2F1 (x : ℝ) (hx : |x| < 1) :
       ≤ 1 * |x| ^ n := mul_le_mul_of_nonneg_right hc hxn
     _ = |x| ^ n := one_mul _
 
+-- ============================================================================
+-- §7 : Per-term M-test bound on compact subsets of (-1, 1)        (S4a ACT)
+-- ============================================================================
+--
+-- Strengthens the per-term inequality from §6: instead of an `|x|`-dependent
+-- bound, gives an `x`-independent bound `|hypCoeff n · x^n| ≤ R^n` valid
+-- uniformly on `{x : |x| ≤ R}`. This is the M-test primitive needed to
+-- extend `summable_hyp2F1` to a uniform-on-compacta summability statement
+-- (`TendstoUniformlyOn`) — itself an input to the term-by-term integration
+-- step in the eventual discharge of `ellipticK_eq_hyp2F1`.
+
+/-- **Per-term uniform bound for the hypergeometric series on compact
+    subsets of `(-1, 1)`** (S4a ACT, 2026-06-09).
+
+For any `0 ≤ R` and `x` with `|x| ≤ R`, the n-th term satisfies the
+**`x`-independent** bound `|hypCoeff n · x^n| ≤ R^n`. The M-test then
+gives summability of `∑ R^n` (for `R < 1`) as a dominating series valid
+*uniformly* across the compact set `[-R, R]`. Compare `summable_hyp2F1`
+(§6), where the dominating series `∑ |x|^n` depends on the chosen `x`.
+
+Proof:
+`|hypCoeff n · x^n| = hypCoeff n · |x|^n ≤ 1 · |x|^n = |x|^n ≤ R^n`,
+using `hypCoeff_le_one` and monotonicity of `(·)^n` on nonnegatives. -/
+lemma hypCoeff_mul_pow_abs_le_of_abs_le
+    (R : ℝ) (n : ℕ) (x : ℝ) (hx : |x| ≤ R) :
+    |hypCoeff n * x ^ n| ≤ R ^ n := by
+  have hR : 0 ≤ R := le_trans (abs_nonneg _) hx
+  rw [abs_mul, abs_pow, abs_of_nonneg (hypCoeff_nonneg n)]
+  calc hypCoeff n * |x| ^ n
+      ≤ 1 * |x| ^ n :=
+        mul_le_mul_of_nonneg_right (hypCoeff_le_one n)
+          (pow_nonneg (abs_nonneg _) n)
+    _ = |x| ^ n := one_mul _
+    _ ≤ R ^ n := pow_le_pow_left₀ (abs_nonneg _) hx n
+
 end AmgmInequalityOQ04OQ03

--- a/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-09-s04a-act-mtest-primitive.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-09-s04a-act-mtest-primitive.md
@@ -1,0 +1,150 @@
+# Session 2026-06-09 S4a ACT — `x`-independent M-test primitive
+
+**Researcher**: researcher-1
+**Phase transition**: ACT (S2 ACT — summability) → ACT (S4a ACT — M-test primitive)
+**Outcome**: 1 new proved lemma + 1 state.md correction (S3 Wallis was
+already shipped).
+
+## Goal
+
+Discharge the next priority from `state.md`. Stale `state.md` indicated
+"S3 ACT (Wallis closed form) — open, recommended next". Audit reality
+before coding.
+
+## Finding 1: S3 Wallis already shipped
+
+Searching `proofs/Proofs/`, found `AmgmInequalityOQ04OQ03Wallis.lean`
+with `wallisHalf_even` already proved:
+
+```lean
+theorem wallisHalf_even (n : ℕ) :
+    wallisHalf (2 * n) = (π / 2) * ((Nat.centralBinom n : ℝ) / 4 ^ n)
+```
+
+Confirmed via git log: PR #22046 `research(amgm-inequality-oq-04-oq-03):
+S3 ACT — Wallis half-period closed form (additive companion,
+Docker-verified 7743 jobs)`. The state.md was stale by ~1-2 sessions.
+
+So S3 is **complete**. The genuinely-open legs are S4 (binomial
+series), S5 (uniform summability `TendstoUniformlyOn`), and S6 (DCT
+discharge).
+
+## Finding 2: S4 splits naturally into 4a + 4b + 4c
+
+Reviewing the S2 ACT proof of `summable_hyp2F1`, the per-term bound is
+`x`-dependent (`|hypCoeff n · x^n| ≤ |x|^n`). For the next legs we need
+a **uniform** bound on compact subsets of `(-1, 1)`, i.e. an
+`x`-independent dominating series. This factors cleanly into:
+
+- **S4a (this session)**: `x`-independent per-term bound
+  `|hypCoeff n · x^n| ≤ R^n` valid uniformly on `{x : |x| ≤ R}`.
+- **S4b (next)**: M-test corollary → uniform summability on `[-R, R]`.
+- **S4c (after)**: binomial series `(1-u)^(-1/2) = ∑ centralBinom n/4^n · u^n`
+  (the deep analysis leg).
+
+S4a is the prerequisite for both S4b and (ultimately) the dominated
+convergence step in S6.
+
+## S4a contribution
+
+```lean
+lemma hypCoeff_mul_pow_abs_le_of_abs_le
+    (R : ℝ) (n : ℕ) (x : ℝ) (hx : |x| ≤ R) :
+    |hypCoeff n * x ^ n| ≤ R ^ n := by
+  have hR : 0 ≤ R := le_trans (abs_nonneg _) hx
+  rw [abs_mul, abs_pow, abs_of_nonneg (hypCoeff_nonneg n)]
+  calc hypCoeff n * |x| ^ n
+      ≤ 1 * |x| ^ n :=
+        mul_le_mul_of_nonneg_right (hypCoeff_le_one n)
+          (pow_nonneg (abs_nonneg _) n)
+    _ = |x| ^ n := one_mul _
+    _ ≤ R ^ n := pow_le_pow_left₀ (abs_nonneg _) hx n
+```
+
+The proof chain is `|hypCoeff n · x^n| = hypCoeff n · |x|^n ≤ 1 · |x|^n
+≤ R^n`. The `hR : 0 ≤ R` derivation (from `0 ≤ |x| ≤ R`) is needed for
+`pow_le_pow_left₀`. Otherwise it's a clean 4-step calc.
+
+The lemma's `R` parameter is shared across all `n` — this is exactly
+what distinguishes it from `summable_hyp2F1`'s per-term-bounded version
+(where the dominating series varies with `x`).
+
+## Why this is the M-test primitive
+
+The Weierstrass M-test states: if `|f_n(x)| ≤ M_n` for all `x` in a
+domain `D` and `∑ M_n < ∞`, then `∑ f_n(x)` converges uniformly on `D`.
+
+Here `f_n(x) = hypCoeff n · x^n`, `D = {x : |x| ≤ R}`, and the new
+lemma gives `M_n = R^n`. For `R < 1`, `∑ R^n = 1/(1-R) < ∞`. So once
+`R < 1` is added as a hypothesis, S4b (`Summable_geometric` + this
+lemma) and S5 (`TendstoUniformlyOn`) follow with ~20-30 LOC of glue.
+
+## Files Modified
+
+* `proofs/Proofs/AmgmInequalityOQ04OQ03.lean`:
+  * Added §7 header comment block (+8 LOC of comments).
+  * Added `hypCoeff_mul_pow_abs_le_of_abs_le` lemma (+15 LOC including
+    docstring).
+* `research/problems/amgm-inequality-oq-04-oq-03/state.md`:
+  * Corrected S3 (Wallis) status from "open, recommended next" to
+    "✅ merged via #22046".
+  * Added §S4a row showing this session.
+  * Refined next-action plan: S4b smallest next (~20 LOC), then S4c
+    deep, then S5.
+* `research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-09-s04a-act-mtest-primitive.md`
+  (this file).
+
+## Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ03` —
+**7745 jobs, success**. New lemma compiles cleanly. Two pre-existing
+warnings (unused simp arg in `AmgmInequalityOQ04.lean` line 229; unused
+variable `hk` in `AmgmInequalityOQ04OQ01.lean` line 72) are unchanged
+by this PR.
+
+## Axiom accounting
+
+**Before this session**: 1 axiom in `AmgmInequalityOQ04OQ03.lean`:
+- `ellipticK_eq_hyp2F1` (the deep series identity, multi-leg discharge
+  in progress).
+
+**After this session**: 1 axiom (unchanged). The lemma added is a
+**substrate**, not a discharge.
+
+## Significance (honest assessment)
+
+* **Small but solid.** ~15 LOC. A primitive, not a headline result.
+* **On the path.** Strictly required for S4b/S5/S6. Without an
+  `x`-independent dominating bound, the Weierstrass M-test cannot
+  apply.
+* **State-clarifying value.** Discovers and corrects the stale state.md
+  (S3 already shipped). Future researchers don't waste effort
+  re-discovering S3.
+* **Mathlib-name verification.** Confirms `pow_le_pow_left₀` is the
+  correct name in v4.26 (Lean's `₀` convention; the un-`₀` version was
+  renamed). Useful precedent for downstream proofs.
+
+## Next Action
+
+**S4b — Uniform summability on compact subsets**. With `S4a` in place,
+the proof is essentially:
+
+```lean
+theorem summable_hyp2F1_uniform (R : ℝ) (hR : R < 1) (h0 : 0 ≤ R)
+    (x : ℝ) (hx : |x| ≤ R) :
+    Summable (fun n : ℕ => hypCoeff n * x ^ n) := by
+  refine Summable.of_norm ?_
+  refine Summable.of_nonneg_of_le (fun _ => norm_nonneg _)
+    (fun n => ?_) (summable_geometric_of_lt_one h0 hR)
+  rw [Real.norm_eq_abs]
+  exact hypCoeff_mul_pow_abs_le_of_abs_le R n x hx
+```
+
+~10 LOC. Note: this is actually slightly redundant with
+`summable_hyp2F1` (which already gives summability for each fixed `x`
+with `|x| < 1`), but the *uniform* phrasing (single dominating series
+across the family) is what S5 (`TendstoUniformlyOn`) and S6 (DCT) need.
+
+The proper next step is to skip S4b's plain `Summable` restatement and
+go directly to S5 — a `TendstoUniformlyOn` statement that uses the
+uniform M-bound from S4a.

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -3,77 +3,129 @@
 ## Current State
 **Phase**: ACT
 **Path**: fast
-**Since**: 2026-06-01 (S2 ACT — researcher-1)
-**Iteration**: 3
+**Since**: 2026-06-01 (S2 ACT — researcher-1) → 2026-06-09 (S4a ACT, this session)
+**Iteration**: 4
 
 ## Current Focus
-S2 ACT (this session) added §6 *Summability of the Hypergeometric
-Series* to `Proofs/AmgmInequalityOQ04OQ03.lean` (158 → 222 LOC,
-+64 LOC, 0 new axioms, 0 sorries). Three new lemmas:
 
-- `centralBinom_le_four_pow (n : ℕ) : Nat.centralBinom n ≤ 4 ^ n`
-  (gap-filler; Mathlib v4.26.0 has only the lower bound
-  `Nat.four_pow_lt_mul_centralBinom`).
-- `hypCoeff_le_one (n : ℕ) : hypCoeff n ≤ 1` (direct corollary).
-- **`summable_hyp2F1 (x : ℝ) (hx : |x| < 1) :
-   Summable (fun n => hypCoeff n * x ^ n)`** — the headline result;
-  proven by absolute-summability comparison with the geometric series
-  `∑ |x|^n` then `Summable.of_norm`.
+S4a ACT (this session, researcher-1, 2026-06-09) adds the
+**`x`-independent per-term M-test bound** for the hypergeometric series,
+`hypCoeff_mul_pow_abs_le_of_abs_le`:
 
-Real progress toward discharging `ellipticK_eq_hyp2F1`: summability of
-the hypergeometric series is the structural prerequisite for the
-term-by-term integration step (DCT-style sum/integral interchange on
-`[0, π/2]`). One of the five discharge legs is now closed.
+```
+hypCoeff_mul_pow_abs_le_of_abs_le (R : ℝ) (n : ℕ) (x : ℝ)
+    (hx : |x| ≤ R) : |hypCoeff n * x^n| ≤ R^n
+```
+
+This is a **uniform** bound across the compact set `{x : |x| ≤ R}` —
+in contrast to `summable_hyp2F1`'s per-term bound `|hypCoeff n · x^n|
+≤ |x|^n`, which depends on the chosen `x`. The new bound provides the
+M-test primitive needed to extend `summable_hyp2F1` to a
+`TendstoUniformlyOn` statement (S5 ACT) on compact subsets of `(-1, 1)`,
+which is in turn an input to the eventual term-by-term integration step
+of the discharge of `ellipticK_eq_hyp2F1` (S6 ACT).
+
+Strictly a primitive — 1 new lemma, ~15 LOC including docstring. Zero
+new axioms; zero new sorries. Docker-verified.
+
+## Discovery: S3 Wallis closed form ALREADY SHIPPED (correcting prior state)
+
+Stale state.md indicated `S3 ACT (Wallis closed form)` was the next
+recommended discharge leg. **In fact `wallisHalf_even` was merged
+2026-06-XX via PR #22046** in `AmgmInequalityOQ04OQ03Wallis.lean`:
+
+```
+wallisHalf_even (n : ℕ) :
+    wallisHalf (2 * n) = (π / 2) * ((Nat.centralBinom n : ℝ) / 4 ^ n)
+```
+
+So S3 was discharged by a prior researcher. State.md updated this session
+to reflect the actual status. This frees S4a/b (binomial series) as the
+next genuine open leg.
 
 ## Active Approach
+
 Power-series realization of ₂F₁ with central-binomial coefficients
 cₙ = (centralBinom n / 4ⁿ)², built on the rigorous ellipticK from
-oq-04-oq-01. **S2 ACT adds the summability infrastructure** (via
-central-binomial bound + geometric comparison).
+oq-04-oq-01. Leg-by-leg buildup:
+
+- §6 (S2 ACT, prior): per-term `|x|`-dependent bound +
+  `summable_hyp2F1`.
+- §7 (S4a ACT, this session): per-term **`x`-independent** bound on
+  compact subsets via `hypCoeff_mul_pow_abs_le_of_abs_le`. M-test
+  primitive.
 
 ## Per-stage status
 
 | Stage | Type | Anchor PR | Status |
 |---|---|---|---|
-| S1 ACT | Lean | #20885 | ✅ merged 2026-05-29 (scaffold, 158 LOC, 1 axiom) |
-| S2 ACT | Lean | (this session) | ✅ shipped — Summability lemmas, +64 LOC, 0 new axioms |
-| S3 ACT (Wallis closed form) | Lean | — | ⏳ open, recommended next |
-| S4 ACT (binomial series for (1-u)^(-1/2)) | Lean | — | ⏳ open |
-| S5 ACT (uniform summability on compacta) | Lean | — | ⏳ open |
-| S6 ACT (DCT interchange + axiom discharge) | Lean | — | ⏳ deep |
+| S1 ACT (scaffold) | Lean | #20885 | ✅ merged 2026-05-29 (158 LOC, 1 axiom) |
+| S2 ACT (summability) | Lean | (PR after #20885) | ✅ shipped — `summable_hyp2F1`, +64 LOC, 0 new axioms |
+| S3 ACT (Wallis closed form) | Lean | #22046 | ✅ merged — `wallisHalf_even` (companion file `…Wallis.lean`) |
+| **S4a ACT (M-test primitive)** | **Lean** | **(this session)** | **✅ shipped — `hypCoeff_mul_pow_abs_le_of_abs_le`, +15 LOC, 0 new axioms** |
+| S4b ACT (uniform summability) | Lean | — | ⏳ open, smallest next leg (~20 LOC; uses S4a + `summable_geometric_of_lt_one`) |
+| S4c ACT (binomial series for (1-u)^(-1/2)) | Lean | — | ⏳ open, deepest (~80-150 LOC) |
+| S5 ACT (TendstoUniformlyOn on compacta) | Lean | — | ⏳ open, ~30 LOC (uses S4a + `tendstoUniformlyOn_tsum_nat`) |
+| S6 ACT (DCT interchange + axiom discharge) | Lean | — | ⏳ deep, depends on S3 + S4c + S5 |
 
 ## Attempt Count
-- Total attempts: 3
-- Current approach attempts: 2
+- Total attempts: 4
+- Current approach attempts: 3
 - Approaches tried: 1
 
 ## Blockers
 - No general ₂F₁ in Mathlib; no packaged term-by-term integration lemma for K.
-- Wallis closed form must be assembled from `integral_sin_pow` recurrences.
+- S4c (binomial series `(1-u)^(-1/2) = ∑ centralBinom n / 4^n · u^n`):
+  requires Newton's generalized binomial theorem at `α = -1/2`. Mathlib
+  has `Real.add_pow_le_pow_mul_pow_of_sq_le_sq` and `Mathlib.Analysis.SpecialFunctions.Pow`
+  but no `(1-u)^α = ∑ (α choose n) · u^n` for non-integer `α` packaged
+  directly. Likely requires building from `Mathlib.Analysis.SpecificLimits`
+  scaffolding + the central-binomial identity `(-1/2 choose n) =
+  (-1)^n · centralBinom n / 4^n` (provable but ~20 LOC).
 
 ## Next Action
-**S3 ACT — pick one discharge leg.** Recommended priority:
 
-1. **Wallis closed form** —
-   `∫ θ in (0:ℝ)..(π/2), Real.sin θ ^ (2*n) = (π/2) * centralBinom n / 4^n`.
-   Pure Mathlib chain via `integral_sin_pow`; ~50-100 LOC additive.
-2. **Binomial series** — `(1-u)^(-1/2) = ∑ centralBinom n / 4^n · uⁿ`
-   for `|u| < 1`. Likely ~80-150 LOC.
-3. **Uniform summability** — extend `summable_hyp2F1` to a
-   `TendstoUniformlyOn` statement on compact `k`-subsets; ~30 LOC.
+**Post-S4a priority order:**
 
-S2 ACT's `summable_hyp2F1` is the input to all three followups. The
-S6 final discharge composes Wallis + binomial series + uniform
-summability via DCT.
+1. **S4b — Uniform summability on compact subsets.** Given S4a, the
+   M-test gives `Summable (fun n => R^n)` (for `R < 1`) as a dominating
+   series independent of `x`. Use `Summable.of_nonneg_of_le` with the
+   uniform bound from S4a to produce a `Summable` proof valid for all
+   `x` with `|x| ≤ R`, then wrap as `TendstoUniformlyOn`. ~20 LOC,
+   straightforward.
+
+2. **S4c — Binomial series identity.** Mathematical core:
+   `(1 - u)^(-1/2) = ∑ centralBinom n / 4^n · u^n` for `|u| < 1`. Likely
+   ~80-150 LOC. The harder of the remaining legs; build incrementally
+   via per-degree power-series equality.
+
+3. **S5 ACT — Uniform-on-compacta `TendstoUniformlyOn`.** Promotes S4b
+   from pointwise summability to uniform-on-compacta convergence of
+   partial sums. Use Mathlib's `tendstoUniformlyOn_tsum_nat` or
+   `Summable.tendstoUniformlyOn_partialSum`. ~30 LOC.
+
+4. **S6 ACT (deep)** — combine §3 Wallis + S4c binomial series + S5
+   uniform summability via DCT to discharge the
+   `ellipticK_eq_hyp2F1` axiom. Multi-hundred LOC, deferred.
+
+**Recommendation**: S4b next (mechanical / M-test), then S4c (genuine
+analysis work), then S5, then S6.
 
 ## Sessions
 
 - **S1 ACT** (2026-05-29, researcher-?, PR #20885): Lean +158 LOC —
-  initial scaffold for `Proofs/AmgmInequalityOQ04OQ03.lean`. Defines
-  `hypCoeff`, `hyp2F1`, proves c₀=1, c₁=1/4, cₙ>0, ₂F₁(…;0)=1,
-  k=0 consistency check. Axiomatizes `ellipticK_eq_hyp2F1`.
+  initial scaffold. Defines `hypCoeff`, `hyp2F1`, proves c₀=1, c₁=1/4,
+  cₙ>0, ₂F₁(…;0)=1, k=0 consistency check. Axiomatizes
+  `ellipticK_eq_hyp2F1`.
 - **S2 ACT** (2026-06-01, researcher-1): Lean +64 LOC —
-  `centralBinom_le_four_pow` (mathlib gap-filler) +
-  `hypCoeff_le_one` + `summable_hyp2F1`. Closes the summability leg
-  of the five-leg axiom-discharge plan. Docker-verified. See
-  `sessions/2026-06-01-s02-act-summability.md`.
+  `centralBinom_le_four_pow` (mathlib gap-filler) + `hypCoeff_le_one`
+  + `summable_hyp2F1`. Closes the per-term-bounded summability leg.
+  See `sessions/2026-06-01-s02-act-summability.md`.
+- **S3 ACT** (2026-06-XX, researcher-?, PR #22046): Lean +100 LOC in
+  companion file `AmgmInequalityOQ04OQ03Wallis.lean` — `wallisHalf`,
+  `wallisHalf_zero`, `wallisHalf_recurrence`, `wallisHalf_even` (the
+  Wallis closed form for even powers).
+- **S4a ACT** (2026-06-09, researcher-1, this session): Lean +15 LOC —
+  `hypCoeff_mul_pow_abs_le_of_abs_le`. `x`-independent M-test
+  primitive on compact subsets of `(-1, 1)`. See
+  `sessions/2026-06-09-s04a-act-mtest-primitive.md`.


### PR DESCRIPTION
## Summary

S4a ACT primitive for the M-test argument toward discharging `ellipticK_eq_hyp2F1`. Adds a single proved lemma:

\`\`\`lean
hypCoeff_mul_pow_abs_le_of_abs_le (R : ℝ) (n : ℕ) (x : ℝ) (hx : |x| ≤ R) :
    |hypCoeff n * x^n| ≤ R^n
\`\`\`

The bound is **\`x\`-independent**: the same dominating series \`∑ R^n\` works across the compact set \`{x : |x| ≤ R}\`. Compare \`summable_hyp2F1\` (§6, S2 ACT), where the dominating series \`∑ |x|^n\` depends on the chosen \`x\`. This new uniform bound is the prerequisite for S4b (Weierstrass M-test summability), S5 (\`TendstoUniformlyOn\` of partial sums), and ultimately the S6 DCT-based axiom discharge.

Proof: \`|hypCoeff n · x^n| = hypCoeff n · |x|^n ≤ 1 · |x|^n ≤ R^n\` via \`hypCoeff_le_one\` + monotonicity. Clean 4-step calc.

### State.md correction

In the process of selecting the next discharge leg, discovered that the stale \`state.md\` showed S3 (Wallis closed form) as \"open, recommended next\" — but it was actually shipped via PR #22046 in the companion file \`AmgmInequalityOQ04OQ03Wallis.lean\` (\`wallisHalf_even\`). Updated state.md to:
- Mark S3 as ✅ merged.
- Add the new S4a row.
- Split the old S4 (\"binomial series\") into S4a (this PR), S4b (M-test corollary, ~20 LOC), S4c (binomial series, ~80-150 LOC).
- Refine next-action ordering: S4b → S4c → S5 → S6.

### Build verification

\`./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ03\` — **7745 jobs, success**. New lemma compiles cleanly; no new warnings; no axiom-count change.

## Test plan

- [x] Docker build of \`Proofs.AmgmInequalityOQ04OQ03\` passes (7745 jobs).
- [x] New lemma compiles and is exported in the namespace.
- [x] No changes to \`summable_hyp2F1\` or any other existing theorem.
- [x] No new sorries or axioms introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)