### PR TITLE
audit(derangements-oq-02-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -2351,9 +2351,9 @@
       "result": "clean"
     },
     "derangements-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:38:31Z",
+      "lastAudited": "2026-06-09T22:36:08Z",
       "result": "clean"
     },
     "derangements-oq-02-oq-02": {


### PR DESCRIPTION
## Summary
- Tracker bump for `derangements-oq-02-oq-01` (4th audit pass).
- `auditCount` 3 → 4; `lastAudited` refreshed to 2026-06-09T22:36:08Z.
- No issues found.

## Verification
| Field | meta.json | Source |
|---|---|---|
| sorries | 0 | 0 |
| axiomCount | 0 | 0 (no `axiom ` decls, no structure-encoded assumptions) |
| theoremCount | 6 | 6 |
| definitionCount | 0 | 0 |
| lineCount | 123 | 123 |

No True stubs, no `admit`. Parent import `Proofs.DerangementsOQ02` resolves.

Tier B (`mathlib` badge) is correct — main result transports the OQ-02 `Fin n` lemma via `Fintype.equivFin`. Description and `originalContributions` accurately scope the contribution (transport infrastructure + corollaries).

## Test plan
- [x] `wc -l`, sorry/axiom/theorem/def grep all match meta.json
- [x] No True stubs or admits
- [x] Parent import file exists