### PR TITLE
research(prob-method-second-moment-oq-02): S2-A ACT — generic variance pair-sum decomposition (Docker-verified)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2679,6 +2679,7 @@ import Proofs.ProbMethodExpectation
 import Proofs.ProbMethodExpectationOQ01
 import Proofs.ProbMethodSecondMoment
 import Proofs.ProbMethodSecondMomentOQ01
+import Proofs.ProbMethodSecondMomentOQ02
 import Proofs.ProductOfSegmentsOfChords
 import Proofs.ProductOfSegmentsOfChordsOQ01
 import Proofs.ProductOfSegmentsOfChordsOQ03

--- a/proofs/Proofs/ProbMethodSecondMoment.lean
+++ b/proofs/Proofs/ProbMethodSecondMoment.lean
@@ -182,7 +182,7 @@ theorem paley_zygmund_quantitative {α : Type*} [DecidableEq α] {s : Finset α}
     (1 - θ) ^ 2 * (s.sum f) ^ 2 / s.sum (fun a => f a ^ 2) ≤
       ↑(s.filter (fun a => f a ≥ θ * μ)).card := by
   intro μ
-  rw [div_le_iff hf2_pos]
+  rw [div_le_iff₀ hf2_pos]
   set big := s.filter (fun a => f a ≥ θ * μ) with hbig_def
   have hn_pos : (0 : ℚ) < ↑s.card := Nat.cast_pos.mpr (Finset.Nonempty.card_pos hs)
   have hμ_nn : (0 : ℚ) ≤ μ := div_nonneg (le_of_lt hpos) (le_of_lt hn_pos)
@@ -209,13 +209,12 @@ theorem paley_zygmund_quantitative {α : Type*} [DecidableEq α] {s : Finset α}
             simp only [μ]
             have : (↑s.card : ℚ) ≠ 0 := ne_of_gt hn_pos
             field_simp
-            ring
     linarith
   -- Chain: (1-θ)²·(∑f)² ≤ |big|·∑f²
   calc (1 - θ) ^ 2 * (s.sum f) ^ 2
       = ((1 - θ) * s.sum f) ^ 2 := by ring
     _ ≤ (big.sum f) ^ 2 :=
-        pow_le_pow_left (mul_nonneg (by linarith) (le_of_lt hpos)) hbig_lb 2
+        pow_le_pow_left₀ (mul_nonneg (by linarith) (le_of_lt hpos)) hbig_lb 2
     _ ≤ ↑big.card * big.sum (fun a => f a ^ 2) := sq_sum_le_card_mul_sum_sq big f
     _ ≤ ↑big.card * s.sum (fun a => f a ^ 2) :=
         mul_le_mul_of_nonneg_left

--- a/proofs/Proofs/ProbMethodSecondMomentOQ01.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ01.lean
@@ -128,7 +128,7 @@ theorem paley_zygmund_probability {α : Type*} [DecidableEq α] {s : Finset α}
     (1 - θ) ^ 2 * (s.sum f) ^ 2 / s.sum (fun a => f a ^ 2) ≤
       ↑(s.filter (fun a => θ * (s.sum f / ↑s.card) < f a)).card := by
   have hpz := paley_zygmund_quantitative hs hnn hpos hθ0 hθ1
-  rwa [div_le_iff hf2_pos]
+  rwa [div_le_iff₀ hf2_pos]
 
 /-- At θ = 0, the quantitative PZ reduces to: P[X > 0] · ∑f² ≥ (∑f)².
     This strengthens the qualitative paley_zygmund. -/

--- a/proofs/Proofs/ProbMethodSecondMomentOQ02.lean
+++ b/proofs/Proofs/ProbMethodSecondMomentOQ02.lean
@@ -1,0 +1,153 @@
+/-
+  Variance of Sums (Second Moment Method — Generic Decomposition)
+
+  The variance computation for indicator sums, in the discrete Finset-ℚ
+  setting consistent with `ProbMethodSecondMoment.lean`.
+
+  The headline identity is the bilinear pair-sum form
+
+      Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j),
+
+  which a follow-up PR can split into the textbook decomposition
+
+      Var(∑_{i ∈ t} X i) = ∑_{i ∈ t} Var(X i) + ∑_{i ≠ j} Cov(X i, X j)
+
+  via `Finset.diag_union_offDiag`.
+
+  This is the algebraic backbone of any second-moment threshold argument:
+  applying Chebyshev / Paley-Zygmund (the parent file) to a sum of
+  indicators reduces to a per-pair covariance computation. The identity
+  itself is purely algebraic — no indicator hypothesis is required.
+
+  Working setting (matches parent): the "sample space" is a Finset `s`
+  with counting measure, and a "random variable" is `f : α → ℚ`. Means
+  and (co)variances are defined over ℚ via Finset sums and cardinalities,
+  avoiding measure theory.
+
+  Open question OQ-02 (parent: prob-method-second-moment):
+  "Can the variance computation for indicator sums be formalized
+  generically to handle subgraph counting in G(n,p) and derive specific
+  threshold functions?" This file ships §A: the generic pair-sum form of
+  variance and the bilinear/symmetric API needed to instantiate it. The
+  G(n,p) construction and explicit threshold functions are follow-up
+  scope (see state.md "Sequence A / §B / §C").
+-/
+import Mathlib
+import Proofs.ProbMethodSecondMoment
+
+set_option linter.unusedVariables false
+
+namespace ProbMethod.SecondMoment
+
+/-! ## Mean, variance, and covariance over a Finset
+
+We work with ℚ-valued functions on a Finset `s`. The mean is the
+arithmetic average; variance is the mean of the squared deviation;
+covariance is the bilinear analogue.
+-/
+
+/-- Arithmetic mean of `f : α → ℚ` on a Finset `s`. -/
+def mean {α : Type*} (s : Finset α) (f : α → ℚ) : ℚ :=
+  s.sum f / s.card
+
+/-- Variance of `f` on `s`: mean of `(f − mean f)²`. -/
+def variance {α : Type*} (s : Finset α) (f : α → ℚ) : ℚ :=
+  s.sum (fun a => (f a - mean s f) ^ 2) / s.card
+
+/-- Covariance of `f` and `g` on `s`: mean of `(f − mean f) · (g − mean g)`. -/
+def covariance {α : Type*} (s : Finset α) (f g : α → ℚ) : ℚ :=
+  s.sum (fun a => (f a - mean s f) * (g a - mean s g)) / s.card
+
+/-! ## Basic identities: symmetry and additivity -/
+
+/-- Variance is the covariance of `f` with itself. -/
+theorem variance_eq_covariance_self {α : Type*} (s : Finset α) (f : α → ℚ) :
+    variance s f = covariance s f f := by
+  simp only [variance, covariance, sq]
+
+/-- Covariance is symmetric. -/
+theorem covariance_symm {α : Type*} (s : Finset α) (f g : α → ℚ) :
+    covariance s f g = covariance s g f := by
+  simp only [covariance]
+  congr 1
+  exact Finset.sum_congr rfl (fun a _ => by ring)
+
+/-- The mean is additive. -/
+theorem mean_add {α : Type*} (s : Finset α) (f g : α → ℚ) :
+    mean s (fun a => f a + g a) = mean s f + mean s g := by
+  simp only [mean, Finset.sum_add_distrib, add_div]
+
+/-- Covariance is additive in its first slot. -/
+theorem covariance_add_left {α : Type*} (s : Finset α) (f₁ f₂ g : α → ℚ) :
+    covariance s (fun a => f₁ a + f₂ a) g =
+      covariance s f₁ g + covariance s f₂ g := by
+  simp only [covariance, mean_add]
+  rw [← add_div, ← Finset.sum_add_distrib]
+  congr 1
+  exact Finset.sum_congr rfl (fun a _ => by ring)
+
+/-- Covariance is additive in its second slot. -/
+theorem covariance_add_right {α : Type*} (s : Finset α) (f g₁ g₂ : α → ℚ) :
+    covariance s f (fun a => g₁ a + g₂ a) =
+      covariance s f g₁ + covariance s f g₂ := by
+  rw [covariance_symm, covariance_add_left,
+      covariance_symm s f g₁, covariance_symm s f g₂]
+
+/-! ## Variance of a sum -/
+
+/-- Variance of a pair sum:
+    `Var(f + g) = Var f + Var g + 2 · Cov(f, g)`. -/
+theorem variance_add {α : Type*} (s : Finset α) (f g : α → ℚ) :
+    variance s (fun a => f a + g a) =
+      variance s f + variance s g + 2 * covariance s f g := by
+  rw [variance_eq_covariance_self s (fun a => f a + g a),
+      variance_eq_covariance_self s f, variance_eq_covariance_self s g,
+      covariance_add_left, covariance_add_right, covariance_add_right,
+      covariance_symm s g f]
+  ring
+
+/-- Covariance of a Finset-indexed sum (first slot). -/
+theorem covariance_sum_left {α ι : Type*} [DecidableEq ι] (s : Finset α)
+    (t : Finset ι) (X : ι → α → ℚ) (g : α → ℚ) :
+    covariance s (fun a => t.sum (fun i => X i a)) g =
+      t.sum (fun i => covariance s (X i) g) := by
+  induction t using Finset.induction_on with
+  | empty =>
+    -- LHS: covariance s (fun a => 0) g = 0; RHS: empty sum = 0.
+    have hzero :
+        (fun a : α => (∅ : Finset ι).sum (fun i => X i a)) = (fun _ : α => (0 : ℚ)) := by
+      funext a; simp
+    rw [hzero, Finset.sum_empty]
+    -- covariance s (fun _ => 0) g = 0
+    simp only [covariance, mean, Finset.sum_const_zero, zero_div, sub_zero, zero_mul]
+  | @insert i t hi ih =>
+    have hpoint :
+        (fun a : α => (insert i t).sum (fun j => X j a)) =
+          (fun a : α => X i a + t.sum (fun j => X j a)) := by
+      funext a
+      rw [Finset.sum_insert hi]
+    rw [hpoint, covariance_add_left, ih, Finset.sum_insert hi]
+
+/-- Covariance of a Finset-indexed sum (second slot). -/
+theorem covariance_sum_right {α ι : Type*} [DecidableEq ι] (s : Finset α)
+    (t : Finset ι) (f : α → ℚ) (Y : ι → α → ℚ) :
+    covariance s f (fun a => t.sum (fun j => Y j a)) =
+      t.sum (fun j => covariance s f (Y j)) := by
+  rw [covariance_symm, covariance_sum_left]
+  exact Finset.sum_congr rfl (fun j _ => covariance_symm _ _ _)
+
+/-- **Pair-sum form** of the variance decomposition: the variance of a
+finite sum equals the double sum of covariances over all index pairs.
+
+This is the cleanest algebraic form and directly serves the second-moment
+method: applying Chebyshev / Paley-Zygmund to `∑ X i` reduces to bounding
+the pair-covariance sum, which for independent indicators collapses to a
+diagonal `∑ Var(X i)` plus zero off-diagonal terms. -/
+theorem variance_sum_eq_sum_covariance {α ι : Type*} [DecidableEq ι]
+    (s : Finset α) (t : Finset ι) (X : ι → α → ℚ) :
+    variance s (fun a => t.sum (fun i => X i a)) =
+      (t ×ˢ t).sum (fun p => covariance s (X p.1) (X p.2)) := by
+  rw [variance_eq_covariance_self, covariance_sum_left, Finset.sum_product]
+  exact Finset.sum_congr rfl (fun i _ => covariance_sum_right _ _ _ _)
+
+end ProbMethod.SecondMoment

--- a/research/problems/prob-method-second-moment-oq-02/sessions/2026-06-09-s2a-variance-decomp.md
+++ b/research/problems/prob-method-second-moment-oq-02/sessions/2026-06-09-s2a-variance-decomp.md
@@ -1,0 +1,102 @@
+# 2026-06-09 — S2-A ACT: generic variance decomposition (Docker-clean)
+
+**Researcher**: researcher-7
+**Phase**: S2 ACT (was: S2 ACT ready post-S1g 27-day stall)
+**Cycle**: PREP → ACT — first Lean code on this slug after seven doc-only PRs
+(S1, S1b, S1c, S1d, S1e, S1f, S1g; 2026-05-12 → 2026-05-13)
+
+## What shipped
+
+`proofs/Proofs/ProbMethodSecondMomentOQ02.lean` — 153 lines, 9 theorems,
+3 definitions, **0 sorries, 0 axioms, Docker 7744 jobs clean**.
+
+Plus pre-existing Mathlib drift fixes to the parent (`div_le_iff` →
+`div_le_iff₀`, `pow_le_pow_left` → `pow_le_pow_left₀`, drop redundant
+`ring` after `field_simp`) — needed to make this file's parent import
+build at the current Mathlib snapshot `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`
+checkout of pin `v4.26.0`.
+
+## Headline identity
+
+For ℚ-valued functions `X : ι → α → ℚ` on a Finset `s` (counting-measure
+sample space) and an index Finset `t : Finset ι`:
+
+    Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j)
+
+(`variance_sum_eq_sum_covariance`). This is the pair-sum form of the
+textbook decomposition
+
+    Var(∑) = ∑ Var + ∑_{i ≠ j} Cov,
+
+deferred to a follow-up via `Finset.diag_union_offDiag`.
+
+## Theorem inventory
+
+| # | Name | Statement | Notes |
+|---|------|-----------|-------|
+| 1 | `variance_eq_covariance_self` | Var(f) = Cov(f, f) | `simp only [sq]` |
+| 2 | `covariance_symm` | Cov(f, g) = Cov(g, f) | `ring` per summand |
+| 3 | `mean_add` | mean (f + g) = mean f + mean g | linearity of `Finset.sum` |
+| 4 | `covariance_add_left` | Cov(f₁+f₂, g) = Cov(f₁, g) + Cov(f₂, g) | bilinearity |
+| 5 | `covariance_add_right` | Cov(f, g₁+g₂) = Cov(f, g₁) + Cov(f, g₂) | by symmetry |
+| 6 | `variance_add` | Var(f+g) = Var f + Var g + 2·Cov(f, g) | pair case |
+| 7 | `covariance_sum_left` | Cov(∑_t X, g) = ∑_t Cov(X i, g) | Finset induction |
+| 8 | `covariance_sum_right` | Cov(f, ∑_t Y) = ∑_t Cov(f, Y j) | by symmetry |
+| 9 | `variance_sum_eq_sum_covariance` | Var(∑_t X) = ∑_{t ×ˢ t} Cov | **headline**, via `Finset.sum_product` |
+
+Definitions: `mean`, `variance`, `covariance` (all over a Finset `s`,
+ℚ-valued, counting-measure).
+
+## Pinned Mathlib bearers (re-verified 2026-06-09)
+
+| Bearer | Path (Mathlib SHA `2df2f01…`) | Used by |
+|---|---|---|
+| `Finset.sum_add_distrib` | Mathlib.Algebra.BigOperators.Group.Finset.Basic | mean_add, covariance_add_left |
+| `Finset.sum_product` | Mathlib.Algebra.BigOperators.Group.Finset.Sigma:81 | variance_sum_eq_sum_covariance |
+| `Finset.sum_insert` | Mathlib.Algebra.BigOperators.Group.Finset.Defs | covariance_sum_left induction |
+| `Finset.sum_const_zero` | Mathlib.Algebra.BigOperators.Finsupp.Basic | empty case of covariance_sum_left |
+| `div_le_iff₀` | Mathlib.Algebra.Order.Field.Basic (was `div_le_iff` pre-snapshot) | parent fix |
+| `pow_le_pow_left₀` | Mathlib.Algebra.Order.GroupWithZero.Basic:470 (was `pow_le_pow_left` pre-snapshot) | parent fix |
+
+## Scope discipline
+
+Single Lean file added (`ProbMethodSecondMomentOQ02.lean`); single
+import line added to `proofs/Proofs.lean`; single new gallery directory
+`src/data/proofs/prob-method-second-moment-oq-02/` with one `meta.json`.
+Plus the two-line drift fix to the parent + OQ-01 (3 lines total). No
+other files touched.
+
+## Follow-up scope (out of this PR)
+
+- **§A.2 diag/offDiag split**: `variance_sum_eq_diag_plus_offDiag` —
+  one Finset.diag_union_offDiag application on the pair-sum form.
+  Independent of any new Mathlib infrastructure; ~15 LOC.
+- **§A.3 `variance_indicator` collapse**: for f a ∈ {0,1}, simplify
+  Var(f) = mean f − (mean f)². Pure algebra (~15 LOC), independent
+  of §A.1 pair-sum.
+- **§B G(n,p) construction**: defer until S1d's `PMF.ofFintype`
+  bearer is re-verified at current pin (S1d's `Fintype.sum_pow_mul_eq_add_pow`
+  cite was confirmed by S1g — but at T-27d, worth a fresh check).
+- **§C Paley-Zygmund route**: parent's `paley_zygmund_quantitative`
+  already provides the discrete-Finset Paley-Zygmund. The OQ-01 file
+  exposes the probability form. So §C may be already in place for
+  the threshold-function downstream — to be evaluated when §B lands.
+
+## Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.ProbMethodSecondMomentOQ02`
+finished in ~3 minutes wall-clock with 7744 successful jobs after
+the parent-drift fixes. No warnings. The build cache downloaded
+7727 Mathlib oleans; only ~17 oleans rebuilt locally
+(`ProbMethodSecondMoment`, `ProbMethodSecondMomentOQ01`, and the
+new `ProbMethodSecondMomentOQ02`).
+
+## State delta
+
+- Iteration: 2 → 3
+- Phase: S2 ACT ready → **S2-A ACT complete** (S2-B = diag/offDiag
+  split, S2-C = §B G(n,p), S2-D = §C Paley-Zygmund evaluation)
+- Files added: 1 Lean + 1 meta.json + 1 session note + this state edit
+- Files modified: parent (3 lines drift fix) + OQ-01 (1 line drift fix)
+  + Proofs.lean (1 import line)
+- Total LOC delta: +153 Lean (new file) + 5 drift-fix lines = +158 Lean

--- a/research/problems/prob-method-second-moment-oq-02/state.md
+++ b/research/problems/prob-method-second-moment-oq-02/state.md
@@ -1,17 +1,36 @@
 # Research State: prob-method-second-moment-oq-02
 
 ## Current State
-**Phase**: S2 ACT (PREP complete: S1g pinned Route C Mathlib bearer);
-no Lean code yet
+**Phase**: S2-A ACT complete — generic variance decomposition shipped
+in `proofs/Proofs/ProbMethodSecondMomentOQ02.lean` (153 LOC, 9 thms,
+3 defs, 0 sorries, 0 axioms, Docker 7744 jobs clean). Headline identity
+Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) (`variance_sum_eq_sum_covariance`).
 **Path**: fast
 **Since**: 2026-05-12T13:53:31-07:00
-**Iteration**: 2 (catch-up STATE-SYNC absorbing 7 merged S1/S1b/S1c/
-S1d/S1e/S1f/S1g doc-only PRs from 2026-05-12 / 2026-05-13 +
-27-day post-S1g drift; this PR is doc-only state.md refresh, no
-sessions/* added, no Lean diff)
-**Last Updated**: 2026-06-09 (researcher-1; doc-only iter 1 → 2
-STATE-SYNC catching up state.md after 27-day drift since
-S1g PREP / 2026-05-13)
+**Iteration**: 3 (S2-A ACT — first Lean code on the slug, post-7
+doc-only PRs and a 27-day stall on S2 ACT)
+**Last Updated**: 2026-06-09 (researcher-7; S2-A ACT ships the pair-sum
+form via Finset.sum_product; S2-B diag/offDiag split deferred, §B G(n,p)
+and §C Paley-Zygmund evaluation also deferred — see follow-up scope
+in `sessions/2026-06-09-s2a-variance-decomp.md`)
+
+## S2-A drift fixes (parent + OQ-01)
+
+The S2-A ACT PR additionally bundles 5 lines of Mathlib-snapshot-drift
+fixes that were blocking the parent build at SHA `2df2f0150c275ad…`:
+
+- `Proofs/ProbMethodSecondMoment.lean:185` — `div_le_iff` → `div_le_iff₀`
+- `Proofs/ProbMethodSecondMoment.lean:212` — drop redundant `ring`
+  after `field_simp` (the simp normal form now closes the goal)
+- `Proofs/ProbMethodSecondMoment.lean:218` — `pow_le_pow_left` →
+  `pow_le_pow_left₀`
+- `Proofs/ProbMethodSecondMomentOQ01.lean:131` — `div_le_iff` →
+  `div_le_iff₀`
+
+Without these fixes the parent file's `paley_zygmund_quantitative`
+proof fails at SHA `2df2f01…` checkout of pin `v4.26.0`. The Mathlib
+deprecation cycle moved `div_le_iff` / `pow_le_pow_left` to the `₀`
+variants on this snapshot.
 
 ## Catch-up STATE-SYNC ledger (this PR, 2026-06-09, researcher-1)
 

--- a/src/data/proofs/prob-method-second-moment-oq-02/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/meta.json
@@ -1,0 +1,110 @@
+{
+  "id": "prob-method-second-moment-oq-02",
+  "title": "Variance of Indicator Sums (Generic Decomposition)",
+  "slug": "prob-method-second-moment-oq-02",
+  "description": "Generic pair-sum decomposition of variance: Var(∑ Xᵢ) = ∑_{(i,j) ∈ t ×ˢ t} Cov(Xᵢ, Xⱼ). This is §A of OQ-02 — the algebraic backbone any second-moment threshold argument reduces to, in the discrete Finset-ℚ setting consistent with the parent.",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-09",
+    "status": "verified",
+    "proofRepoPath": "Proofs/ProbMethodSecondMomentOQ02.lean",
+    "tags": [
+      "probability",
+      "combinatorics",
+      "second-moment-method",
+      "variance",
+      "covariance"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "dateAdded": "2026-06-09",
+    "axiomCount": 0,
+    "lineCount": 153,
+    "theoremCount": 9,
+    "definitionCount": 3,
+    "assumptions": "None. 0 axioms, 0 sorries. Fully verified in Lean 4 with Mathlib.",
+    "originalContributions": [
+      "variance_sum_eq_sum_covariance: Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) — the pair-sum form, headline identity",
+      "variance_add: Var(f + g) = Var f + Var g + 2 · Cov(f, g)",
+      "covariance_add_left / covariance_add_right: bilinearity of covariance",
+      "covariance_sum_left / covariance_sum_right: extends bilinearity to Finset-indexed sums",
+      "covariance_symm: covariance is symmetric",
+      "variance_eq_covariance_self: variance is the covariance of f with itself",
+      "Definitions: mean, variance, covariance for ℚ-valued functions on a Finset (counting-measure)"
+    ],
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.sum_add_distrib",
+        "description": "Linearity of finite sum: ∑ (f + g) = ∑ f + ∑ g",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset"
+      },
+      {
+        "theorem": "Finset.sum_product",
+        "description": "Sum over a product set decomposes into nested sums: ∑ x ∈ s ×ˢ t, f x = ∑ a ∈ s, ∑ b ∈ t, f (a, b)",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Sigma"
+      },
+      {
+        "theorem": "Finset.sum_insert",
+        "description": "Decomposition of sum over `insert i t` when i ∉ t — drives the induction in covariance_sum_left",
+        "module": "Mathlib.Algebra.BigOperators.Group.Finset.Defs"
+      },
+      {
+        "theorem": "Finset.induction_on",
+        "description": "Finset induction (empty / insert) — drives covariance_sum_left",
+        "module": "Mathlib.Data.Finset.Basic"
+      }
+    ],
+    "mathlib_version": "4.26.0"
+  },
+  "overview": {
+    "historicalContext": "The variance-of-sums identity Var(∑ Xᵢ) = ∑ Var(Xᵢ) + ∑_{i ≠ j} Cov(Xᵢ, Xⱼ) — equivalently, the bilinear pair-sum form ∑_{(i,j)} Cov(Xᵢ, Xⱼ) — is the algebraic backbone of the second moment method, especially in probabilistic combinatorics. It was implicit in Chebyshev's 1867 work and made fully explicit by the 20th-century formalization of variance and covariance as bilinear forms. The identity is purely algebraic, requiring no probability axioms beyond linearity of expectation and the definition Cov(X, Y) = E[XY] − E[X]E[Y]. Its workhorse status in Erdős-Rényi random-graph threshold arguments (subgraph counts, chromatic-number bounds, Hamilton cycles) makes it indispensable to the field; see Alon–Spencer §4 for representative applications.",
+    "problemStatement": "For ℚ-valued functions X : ι → α → ℚ on a Finset α with counting measure, and an index Finset t : Finset ι, prove the bilinear variance-of-sum identity\n\n  Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j).\n\nThis is the discrete, measure-theory-free form §A of OQ-02 (parent: prob-method-second-moment). The textbook decomposition Var(∑) = ∑ Var + ∑_{i≠j} Cov is one Finset diag/offDiag split away from the pair-sum form, deferred to a follow-up PR.",
+    "text": "Proves the variance-of-sums decomposition in the discrete Finset-ℚ setting consistent with the parent file ProbMethodSecondMoment.lean. The proof is elementary: define mean, variance, covariance via Finset sums and cardinalities; verify the bilinear/symmetric API (mean_add, covariance_symm, covariance_add_left/right, variance_add); extend bilinearity to Finset-indexed sums by Finset induction (covariance_sum_left/right); collapse to the pair-sum form via Finset.sum_product.",
+    "proofStrategy": "Five layers:\n\n1. **Definitions**: mean s f = (s.sum f) / s.card; variance s f = mean (fun a => (f a − mean s f)^2); covariance s f g = mean (fun a => (f a − mean s f) · (g a − mean s g)).\n\n2. **Self-equality**: variance_eq_covariance_self — variance is covariance of f with itself, by `sq` definition.\n\n3. **Bilinear / symmetric API**: covariance_symm by `Finset.sum_congr` + `ring`; mean_add by `Finset.sum_add_distrib` + `add_div`; covariance_add_left by combining mean_add, `Finset.sum_add_distrib`, and `ring`; covariance_add_right by symmetry.\n\n4. **Sum-indexed bilinearity**: covariance_sum_left by Finset induction — empty case collapses to covariance s (fun _ => 0) g = 0 via Finset.sum_const_zero; insert case reuses covariance_add_left.\n\n5. **Pair-sum form**: variance_sum_eq_sum_covariance — apply variance_eq_covariance_self, then covariance_sum_left in slot 1 and covariance_sum_right in slot 2, then collapse with Finset.sum_product to a single sum over t ×ˢ t.",
+    "keyInsights": [
+      "**Bilinearity is the point**: variance-of-sum splits because covariance is a bilinear, symmetric form on the space of functions α → ℚ. Once additivity in both slots and the self-equality variance = Cov(f, f) are established, the indexed pair-sum form follows by routine sum manipulation.",
+      "**The pair-sum form is the cleanest**: Var(∑) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) hides the diagonal/off-diagonal split. For applications (independent indicators → off-diagonal vanishes; pairwise-positively-correlated indicators → off-diagonal bounds Cauchy-Schwarz), the user instantiates the pair-sum form and decomposes the index set as they see fit.",
+      "**Discrete setting avoids measure theory**: with ℚ-valued functions on a Finset and counting measure, all expectations are arithmetic averages and the identity reduces to Finset.sum manipulations. No σ-algebra machinery is needed for the algebraic content of the second moment method.",
+      "**Finset induction handles the indexed sums**: covariance_sum_left is proved by induction on the index Finset t. The empty case collapses via Finset.sum_const_zero (the constant-zero function has zero mean and zero covariance with anything); the insert case threads through covariance_add_left.",
+      "**Indicator hypothesis is not load-bearing for §A**: the bilinear decomposition holds for any ℚ-valued functions. The indicator constraint Xᵢ ∈ {0,1} only matters when one wants to simplify Var(Xᵢ) = E[Xᵢ] − E[Xᵢ]², which is a §B / §C concern (covered by parent's qualitative paley_zygmund or by a follow-up `variance_indicator` lemma)."
+    ],
+    "prerequisites": [
+      "Finset.sum and Finset induction",
+      "Linearity of finite sums (Finset.sum_add_distrib)",
+      "Product Finsets and Finset.sum_product",
+      "Second moment method (parent entry: ProbMethodSecondMoment)"
+    ]
+  },
+  "sections": [
+    {
+      "id": "header",
+      "title": "File header and imports",
+      "startLine": 1,
+      "endLine": 35,
+      "summary": "States the headline identity Var(∑ X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j), motivates the discrete Finset-ℚ working setting, and explains how this §A piece fits into the broader OQ-02 program (G(n,p), Paley-Zygmund routes deferred to follow-ups). Imports Mathlib and the parent ProbMethodSecondMoment."
+    },
+    {
+      "id": "definitions",
+      "title": "Mean, variance, covariance",
+      "startLine": 36,
+      "endLine": 60,
+      "summary": "Three definitions over ℚ-valued functions on a Finset: mean (arithmetic average), variance (mean of squared deviation), covariance (mean of cross-deviation product). Counting-measure formalism — no measure theory required."
+    },
+    {
+      "id": "basic-identities",
+      "title": "Bilinear / symmetric API",
+      "startLine": 61,
+      "endLine": 95,
+      "summary": "variance_eq_covariance_self, covariance_symm, mean_add, covariance_add_left, covariance_add_right. These four/five lemmas exhibit covariance as a symmetric bilinear form and prove that mean distributes over addition. Together they form a minimal API for downstream algebra.",
+      "mathContext": "Variance is the diagonal of the covariance bilinear form: Var(f) = Cov(f, f)."
+    },
+    {
+      "id": "variance-of-sum",
+      "title": "Variance of a sum (pair-sum form)",
+      "startLine": 96,
+      "endLine": 153,
+      "summary": "variance_add (pair case), covariance_sum_left/right (extended to Finset-indexed sums by induction), and the headline variance_sum_eq_sum_covariance. The pair-sum form collapses the variance of an arbitrary finite sum into a single Cov-sum over the product Finset t ×ˢ t.",
+      "mathContext": "Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) — the bilinear pair-sum form, suitable for diagonal / off-diagonal decomposition by the application."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

§A of OQ-02 (parent: `prob-method-second-moment`): ships the bilinear pair-sum form of the variance of a Finset-indexed sum in the discrete Finset-ℚ formalism consistent with the parent.

**Headline identity** (`variance_sum_eq_sum_covariance`):

  Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j)

First Lean code on this slug after seven doc-only PRs (S1, S1b, S1c, S1d, S1e, S1f, S1g; 2026-05-12 → 2026-05-13) and a 27-day stall on S2 ACT.

## Lean delta — `proofs/Proofs/ProbMethodSecondMomentOQ02.lean`

- **153 LOC, 0 sorries, 0 axioms**
- **3 definitions**: `mean`, `variance`, `covariance` (all ℚ-valued, Finset-based)
- **9 theorems**:
  1. `variance_eq_covariance_self`
  2. `covariance_symm`
  3. `mean_add`
  4. `covariance_add_left`  (bilinearity slot 1)
  5. `covariance_add_right` (bilinearity slot 2)
  6. `variance_add`  (pair case: Var(f+g) = Var f + Var g + 2·Cov(f, g))
  7. `covariance_sum_left`   (Finset-indexed bilinearity, slot 1)
  8. `covariance_sum_right`  (Finset-indexed bilinearity, slot 2)
  9. `variance_sum_eq_sum_covariance`  (**headline** pair-sum identity)
- **Docker build**: 7744 jobs clean (`./proofs/scripts/docker-build.sh Proofs.ProbMethodSecondMomentOQ02`)

## Bundled drift fixes — parent + OQ-01

The current Mathlib snapshot at SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (checkout of pin `v4.26.0`) deprecates `div_le_iff` → `div_le_iff₀` and `pow_le_pow_left` → `pow_le_pow_left₀`. The parent `ProbMethodSecondMoment.lean` and `ProbMethodSecondMomentOQ01.lean` both broke on these. 5 line-level fixes:

- `ProbMethodSecondMoment.lean:185` — `div_le_iff` → `div_le_iff₀`
- `ProbMethodSecondMoment.lean:212` — drop redundant `ring` after `field_simp` (simp normal form now closes the goal)
- `ProbMethodSecondMoment.lean:218` — `pow_le_pow_left` → `pow_le_pow_left₀`
- `ProbMethodSecondMomentOQ01.lean:131` — `div_le_iff` → `div_le_iff₀`

Without these, the parent imports fail and the new OQ-02 file can't be Docker-verified. Included in-PR so that the verification chain is re-attainable end-to-end at the current Mathlib snapshot.

## Gallery

- `src/data/proofs/prob-method-second-moment-oq-02/meta.json` — status: verified, badge: original, 0 axioms, 0 sorries, lineCount: 153, theoremCount: 9, definitionCount: 3, mathlib_version: 4.26.0.

## State / sessions

- `research/problems/prob-method-second-moment-oq-02/state.md` — Iteration 2 → 3, Phase "S2 ACT ready" → "S2-A ACT complete".
- `research/problems/prob-method-second-moment-oq-02/sessions/2026-06-09-s2a-variance-decomp.md` — full session ledger (theorem inventory, pinned Mathlib bearers re-verified at current SHA, follow-up scope).

## Follow-up scope (out of this PR)

- **§A.2 diag/offDiag split** (`variance_sum_eq_diag_plus_offDiag`) — one `Finset.diag_union_offDiag` application on the pair-sum form. ~15 LOC.
- **§A.3 `variance_indicator` collapse** (f a ∈ {0,1} ⇒ Var f = mean f − (mean f)²). Pure algebra ~15 LOC, independent of §A.1.
- **§B G(n,p) construction** — defer until S1d's `PMF.ofFintype` bearer is re-verified at current pin.
- **§C Paley-Zygmund evaluation** — parent's `paley_zygmund_quantitative` may already cover the threshold-function downstream once §B lands.

## Test plan

- [x] Docker-build `Proofs.ProbMethodSecondMomentOQ02` → 7744 jobs clean
- [x] Re-verify Mathlib bearers (`Finset.sum_product`, `Finset.sum_add_distrib`, `Finset.sum_const_zero`, `Finset.sum_insert`) at SHA `2df2f01…`
- [x] No axioms, no sorries in new file (`grep -cE '^axiom |sorry' = 0`)
- [x] gallery meta.json fields consistent with file stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)