### PR TITLE
audit(bezout-identity-oq-03-oq-01-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -886,9 +886,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-09T22:51:31Z",
+      "lastAudited": "2026-06-09T22:56:04Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -886,9 +886,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-06-09T22:56:04Z",
+      "lastAudited": "2026-06-09T23:17:15Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01-oq-01": {

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -886,9 +886,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:38:31Z",
+      "lastAudited": "2026-06-09T22:51:31Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Summary
- Re-audit of `bezout-identity-oq-03-oq-01-oq-01` (k-fold Chinese Remainder Theorem)
- All integrity checks pass — no issues, tracker bumped clean
- `auditCount: 3 → 4`, `lastAudited: 2026-05-03 → 2026-06-09`

## Integrity checks
| Check | Result |
|-------|--------|
| Sorry count | 0 (matches `meta.sorries`) |
| Axiom declarations | 0 (matches `meta.axiomCount`) |
| True stubs | 0 |
| Theorem count | 14 (matches `meta.theoremCount`) |
| Badge tier | Tier B `mathlib` (builds on `ZMod.chineseRemainder`) |
| Mathlib attribution | Description openly credits 2-fold CRT |
| `originalContributions` scope | Limited to k-fold induction, `CRTProd`, totient corollary |
| Title qualifier | "k-fold CRT" — no overclaim |

## Test plan
- [x] grep sorry / axiom on Lean file
- [x] No True stubs detected
- [x] meta.json counts align with file enumeration
- [x] Tier B badge `mathlib` matches Mathlib reliance for core 2-fold step

🤖 Generated with [Claude Code](https://claude.com/claude-code)