### PR TITLE
Enrich Variance of Indicator Sums (Generic Decomposition)

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/annotations.json
@@ -1,0 +1,216 @@
+[
+  {
+    "id": "ann-oq02-header",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 1,
+      "endLine": 40
+    },
+    "type": "context",
+    "title": "Discrete Finset-ℚ Setting and OQ-02 Scope",
+    "content": "The file header motivates the bilinear pair-sum form Var(∑ X i) = ∑_{(i,j)} Cov(X i, X j) as the algebraic backbone of any second-moment threshold argument and explains the design choice to stay in the parent file's discrete Finset-ℚ setting. The 'sample space' is a `Finset s`, a 'random variable' is a function `f : α → ℚ`, and expectations are arithmetic averages — `s.sum f / s.card`. This avoids importing `MeasureTheory` while preserving the exact form of every identity used downstream. The `import Mathlib` line brings the full library; `import Proofs.ProbMethodSecondMoment` reuses the parent's namespace and is the canonical entry point for the OQ-02 §A piece.",
+    "mathContext": "Working setting: the sample space is $(s, \\text{counting})$ with $s : \\text{Finset } \\alpha$, random variables are $f : \\alpha \\to \\mathbb{Q}$, and $\\mathbb{E}[f] = \\frac{1}{|s|} \\sum_{a \\in s} f(a)$. No $\\sigma$-algebra; no Lebesgue integration; all identities are pure Finset arithmetic.",
+    "significance": "context",
+    "relatedConcepts": [
+      "discrete probability space",
+      "counting measure",
+      "second moment method",
+      "Erdős-Rényi random graph thresholds"
+    ],
+    "prerequisites": [
+      "Finset",
+      "rational arithmetic",
+      "second moment method (parent: prob-method-second-moment)"
+    ]
+  },
+  {
+    "id": "ann-oq02-definitions",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 42,
+      "endLine": 59
+    },
+    "type": "definition",
+    "title": "Mean, Variance, Covariance",
+    "content": "Three definitions in the counting-measure setting. `mean s f := s.sum f / s.card` is the arithmetic average over `s`. `variance s f := mean s (fun a => (f a - mean s f)^2)` is the mean of the squared deviation from the mean — the standard textbook form, but here expressed via Finset sums rather than integrals. `covariance s f g := mean s (fun a => (f a - mean s f) * (g a - mean s g))` is the bilinear analogue. Note: division by zero is silently handled — when `s.card = 0`, every quantity reduces to `0 / 0 = 0` in ℚ, so all identities downstream still hold without an emptiness hypothesis. This is a feature of working in ℚ rather than dragging through `s.Nonempty` everywhere.",
+    "mathContext": "$\\overline{f} := \\frac{1}{|s|} \\sum_{a \\in s} f(a)$, $\\operatorname{Var}_s(f) := \\frac{1}{|s|} \\sum_{a \\in s} (f(a) - \\overline{f})^2$, $\\operatorname{Cov}_s(f, g) := \\frac{1}{|s|} \\sum_{a \\in s} (f(a) - \\overline{f})(g(a) - \\overline{g})$. All three are well-defined as ℚ-valued expressions; the convention $0/0 = 0$ in Lean keeps statements clean at empty `s`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "arithmetic mean",
+      "squared deviation",
+      "bilinear form",
+      "rational arithmetic convention"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "Finset.card",
+      "rational division"
+    ]
+  },
+  {
+    "id": "ann-oq02-variance-self",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 63,
+      "endLine": 66
+    },
+    "type": "insight",
+    "title": "Variance Is the Diagonal of Covariance",
+    "content": "`variance_eq_covariance_self : variance s f = covariance s f f` is proved by `simp only [variance, covariance, sq]` — unfolding the definitions and rewriting `x^2 = x * x` makes the two expressions syntactically identical. This one-line lemma is load-bearing: every subsequent variance identity is derived by reducing to a covariance identity and applying bilinearity. Conceptually, this re-expresses variance not as an ad-hoc second-order quantity but as the diagonal of the symmetric bilinear form Cov on functions α → ℚ.",
+    "mathContext": "$\\operatorname{Var}(f) = \\operatorname{Cov}(f, f)$ — variance is the diagonal entry of the covariance bilinear form. Equivalently, $(f - \\overline{f})^2 = (f - \\overline{f}) \\cdot (f - \\overline{f})$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bilinear form",
+      "quadratic form",
+      "polarization identity",
+      "inner product on function space"
+    ],
+    "prerequisites": [
+      "square equals self-product (sq)",
+      "definition unfolding"
+    ]
+  },
+  {
+    "id": "ann-oq02-covariance-symm",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 68,
+      "endLine": 73
+    },
+    "type": "technique",
+    "title": "Covariance Symmetry by Pointwise `ring`",
+    "content": "`covariance_symm : covariance s f g = covariance s g f` is proved by reducing to a pointwise identity inside the Finset sum: `Finset.sum_congr rfl (fun a _ => by ring)` does the heavy lifting. The `ring` tactic handles the trivial pointwise equation `(f a - mean s f) * (g a - mean s g) = (g a - mean s g) * (f a - mean s f)`. The `congr 1` step strips off the division by `s.card` and reduces to an equality of sums, which `Finset.sum_congr rfl` then reduces to pointwise equality. This three-line pattern recurs throughout the file: unfold, congr off the denominator, sum_congr to pointwise, ring.",
+    "mathContext": "$\\operatorname{Cov}(f, g) = \\operatorname{Cov}(g, f)$ because the integrand $(f - \\overline{f})(g - \\overline{g})$ is symmetric under swapping $f \\leftrightarrow g$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "symmetric bilinear form",
+      "Finset.sum_congr",
+      "pointwise ring reasoning"
+    ],
+    "prerequisites": [
+      "Finset.sum_congr",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-oq02-mean-add",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 75,
+      "endLine": 78
+    },
+    "type": "technique",
+    "title": "Mean Is Additive (Linearity of Expectation)",
+    "content": "`mean_add : mean s (f + g) = mean s f + mean s g` is the linearity-of-expectation lemma in the discrete setting. The proof is essentially one rewrite chain: `Finset.sum_add_distrib` splits the sum, then `add_div` distributes the denominator. In Mathlib's measure-theoretic library this is `integral_add` and requires integrability hypotheses; in the Finset setting it is a one-liner with no hypotheses because every Finset sum is automatically finite.",
+    "mathContext": "$\\mathbb{E}[f + g] = \\mathbb{E}[f] + \\mathbb{E}[g]$. In Finset form: $\\frac{1}{|s|} \\sum_a (f(a) + g(a)) = \\frac{1}{|s|} \\sum_a f(a) + \\frac{1}{|s|} \\sum_a g(a)$, which holds by `Finset.sum_add_distrib` and `add_div`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "linearity of expectation",
+      "Finset.sum_add_distrib",
+      "additivity"
+    ],
+    "prerequisites": [
+      "Finset.sum_add_distrib",
+      "add_div"
+    ]
+  },
+  {
+    "id": "ann-oq02-covariance-add-left",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 80,
+      "endLine": 94
+    },
+    "type": "technique",
+    "title": "Bilinearity: Additivity in Each Slot",
+    "content": "`covariance_add_left : Cov(f₁ + f₂, g) = Cov(f₁, g) + Cov(f₂, g)` establishes additivity in the first slot of covariance. The proof unfolds, uses `mean_add` to split the inner mean, then merges the two outer sums (`← Finset.sum_add_distrib`) and one denominator (`← add_div`), reducing to the pointwise distributive identity proved by `ring`. The second slot lemma `covariance_add_right` is one rewrite chain away — it routes through `covariance_symm` on both sides. Together with `mean_add`, these two lemmas exhibit Cov as a bilinear form: a symmetric function α → ℚ × α → ℚ → ℚ that is additive in each argument with the other fixed.",
+    "mathContext": "$\\operatorname{Cov}(f_1 + f_2, g) = \\operatorname{Cov}(f_1, g) + \\operatorname{Cov}(f_2, g)$, and by symmetry $\\operatorname{Cov}(f, g_1 + g_2) = \\operatorname{Cov}(f, g_1) + \\operatorname{Cov}(f, g_2)$. The bilinear-form characterization is: Cov is the unique symmetric bilinear form on $\\{f : \\alpha \\to \\mathbb{Q}\\}/\\text{constants}$ whose diagonal is Var.",
+    "significance": "key",
+    "relatedConcepts": [
+      "bilinear form",
+      "additivity",
+      "symmetric bilinear form"
+    ],
+    "prerequisites": [
+      "mean_add",
+      "Finset.sum_add_distrib",
+      "add_div",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-oq02-variance-add",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 98,
+      "endLine": 107
+    },
+    "type": "concept",
+    "title": "Pair Variance: Var(f+g) = Var f + Var g + 2 Cov(f,g)",
+    "content": "`variance_add` is the textbook pair-case of the variance-of-sum identity. The proof is purely algebraic: apply `variance_eq_covariance_self` three times (LHS once, RHS twice), then use `covariance_add_left` followed by two applications of `covariance_add_right` to expand `Cov(f+g, f+g)` into four terms, use `covariance_symm` to identify the cross terms, and close with `ring`. The factor of 2 is exactly the count of cross terms after expanding the bilinear product. This identity generalizes the elementary $(a+b)^2 = a^2 + b^2 + 2ab$ to functions modulo their means.",
+    "mathContext": "$\\operatorname{Var}(f + g) = \\operatorname{Var}(f) + \\operatorname{Var}(g) + 2 \\operatorname{Cov}(f, g)$. Specializing to independent $f, g$ (where $\\operatorname{Cov}(f, g) = 0$): $\\operatorname{Var}(f + g) = \\operatorname{Var}(f) + \\operatorname{Var}(g)$ — the additivity of variance for independent random variables.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polarization identity",
+      "independence",
+      "additivity of variance",
+      "cross term"
+    ],
+    "prerequisites": [
+      "variance_eq_covariance_self",
+      "covariance_add_left",
+      "covariance_add_right",
+      "covariance_symm"
+    ]
+  },
+  {
+    "id": "ann-oq02-covariance-sum-left",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 109,
+      "endLine": 129
+    },
+    "type": "technique",
+    "title": "Bilinearity over Finset-Indexed Sums (Induction)",
+    "content": "`covariance_sum_left` extends bilinearity from pair sums to arbitrary Finset-indexed sums by `Finset.induction_on`. **Empty case**: when `t = ∅`, the indexed sum is the constant-zero function; covariance with the zero function vanishes, and the RHS empty sum is zero. The `simp only [covariance, mean, Finset.sum_const_zero, zero_div, sub_zero, zero_mul]` chain closes it. **Insert case**: when `t = insert i t'`, `Finset.sum_insert hi` splits the inner sum into `X i a + ∑_{j ∈ t'} X j a`, which is a pair sum — `covariance_add_left` peels off `X i`, and the induction hypothesis closes the rest. The `[DecidableEq ι]` instance is needed for `insert` to be well-defined; ℚ-valued targets avoid additive-group hypotheses. The right-slot version `covariance_sum_right` is one application of `covariance_symm` away.",
+    "mathContext": "$\\operatorname{Cov}\\!\\left(\\sum_{i \\in t} X_i,\\, g\\right) = \\sum_{i \\in t} \\operatorname{Cov}(X_i, g)$. The Finset-induction template: $P(\\emptyset)$ (base) + $P(t) \\Rightarrow P(\\text{insert}~i~t)$ for $i \\notin t$ (step). Each step reduces to a pair-sum decomposition via `Finset.sum_insert`.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset induction",
+      "Finset.sum_insert",
+      "extension of bilinearity",
+      "constant-zero function"
+    ],
+    "prerequisites": [
+      "Finset.induction_on",
+      "Finset.sum_insert",
+      "Finset.sum_const_zero",
+      "covariance_add_left"
+    ]
+  },
+  {
+    "id": "ann-oq02-headline",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": {
+      "startLine": 139,
+      "endLine": 152
+    },
+    "type": "insight",
+    "title": "Headline: Var(∑) as a Pair-Sum of Covariances",
+    "content": "The headline identity `variance_sum_eq_sum_covariance` collapses Var(∑_{i ∈ t} X i) into a single Cov-sum indexed by the product Finset `t ×ˢ t`. The proof is a four-rewrite chain: (1) `variance_eq_covariance_self` recasts Var as Cov(∑, ∑); (2) `covariance_sum_left` extracts the outer sum; (3) `Finset.sum_product` rewrites the nested-sum form into a single sum over the product Finset; (4) the inner `Finset.sum_congr` + `covariance_sum_right` extracts the inner sum into the pair. This pair-sum form is the cleanest for applications — the user can split `t ×ˢ t = t.diag ∪ t.offDiag` to recover the textbook decomposition Var(∑) = ∑ Var + ∑_{i≠j} Cov, or apply specific bounds on diagonal/off-diagonal terms (e.g. independence ⇒ off-diagonal vanishes; Erdős-Rényi indicator pairs ⇒ off-diagonal Cov computable explicitly).",
+    "mathContext": "$\\operatorname{Var}\\!\\left(\\sum_{i \\in t} X_i\\right) = \\sum_{(i,j) \\in t \\times t} \\operatorname{Cov}(X_i, X_j)$. The diagonal/off-diagonal split: $\\sum_{(i,j) \\in t \\times t} \\operatorname{Cov}(X_i, X_j) = \\sum_{i \\in t} \\operatorname{Var}(X_i) + \\sum_{i \\ne j} \\operatorname{Cov}(X_i, X_j)$, recovering the textbook form.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_product",
+      "diagonal/off-diagonal decomposition",
+      "second moment method",
+      "subgraph counts in G(n,p)"
+    ],
+    "prerequisites": [
+      "variance_eq_covariance_self",
+      "covariance_sum_left",
+      "covariance_sum_right",
+      "Finset.sum_product"
+    ]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment-oq-02/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/meta.json
@@ -106,5 +106,61 @@
       "summary": "variance_add (pair case), covariance_sum_left/right (extended to Finset-indexed sums by induction), and the headline variance_sum_eq_sum_covariance. The pair-sum form collapses the variance of an arbitrary finite sum into a single Cov-sum over the product Finset t ×ˢ t.",
       "mathContext": "Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) — the bilinear pair-sum form, suitable for diagonal / off-diagonal decomposition by the application."
     }
+  ],
+  "conclusion": {
+    "summary": "A complete, axiom-free Lean 4 formalization of the generic variance-of-sum decomposition in the discrete Finset-ℚ setting consistent with the parent file `ProbMethodSecondMoment.lean`. Three definitions (mean, variance, covariance), six API lemmas exhibiting Cov as a symmetric bilinear form and Mean as additive, the pair variance identity Var(f+g) = Var f + Var g + 2 Cov(f,g), the Finset-induction extension to Cov(∑, ·) and Cov(·, ∑), and the headline pair-sum form Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j). 9 theorems, 3 definitions, 153 lines, 0 sorries, 0 axioms — verified against Mathlib 4.26.0.",
+    "implications": "Provides the §A algebraic backbone for the parent second-moment method: any second-moment threshold argument — Chebyshev tail bound, Paley-Zygmund existence bound, or the parent's second_moment_existence — instantiated on a sum of indicators reduces to bounding the pair-covariance sum produced by this file's headline identity. In random-graph applications (Erdős-Rényi G(n,p) subgraph counts, clique thresholds, Hamilton cycle thresholds), the diagonal/off-diagonal split of t ×ˢ t recovers the textbook ∑ Var + ∑_{i≠j} Cov form and isolates the off-diagonal correlations that determine whether the second-moment method succeeds (Var = o((E[X])²)). The result composes directly with `prob-method-second-moment` (Chebyshev, Paley-Zygmund, second_moment_existence) and `prob-method-second-moment-oq-01` (quantitative Paley-Zygmund) — the OQ-02 program ships §A here and defers the G(n,p) construction plus explicit threshold functions to follow-ups (§B, §C).",
+    "openQuestions": [
+      "§B follow-up: rewrite the pair-sum form Var(∑) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) into the textbook ∑_{i ∈ t} Var(X i) + ∑_{i ≠ j} Cov(X i, X j) via `Finset.diag_union_offDiag`.",
+      "§C follow-up: specialize to the indicator case Xᵢ ∈ {0,1} to derive Var(Xᵢ) = E[Xᵢ] · (1 − E[Xᵢ]) and the second-moment-method threshold E[X²]/(E[X])² → 1.",
+      "G(n,p) follow-up: construct the explicit edge-indicator family on the Erdős-Rényi probability space and instantiate the pair-sum form to recover the subgraph-count threshold functions p(n) = n^{-1/m(H)} for arbitrary fixed H.",
+      "Can the entire OQ-02 program be lifted to the measure-theoretic `MeasureTheory.Lp` setting in Mathlib, or is the discrete Finset-ℚ formulation the right long-run home for the gallery's probabilistic-method work?",
+      "Can the bilinear/symmetric Cov API (and the pair-sum form) be contributed upstream to Mathlib's `Mathlib.Probability.Variance`, generalized to suitable measure spaces, where it would replace ad-hoc per-application variance computations?"
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "extends",
+      "description": "Parent of the OQ-02 program. This file (§A) supplies the generic Var(∑) = ∑ Cov pair-sum identity that any application of the parent's Chebyshev, Paley-Zygmund, or second_moment_existence theorems to a sum of indicators ultimately reduces to. Reuses the parent's discrete Finset-ℚ setting and `ProbMethod.SecondMoment` namespace."
+    },
+    {
+      "targetId": "prob-method-second-moment-oq-01",
+      "relationship": "related",
+      "description": "Sibling OQ-01 ships the quantitative Paley-Zygmund threshold; this OQ-02 §A piece supplies the variance computation that feeds Paley-Zygmund. Together they cover the second-moment-method backbone needed for random-graph threshold arguments."
+    },
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "depends-on",
+      "description": "Linearity of expectation (mean_add here) is the foundational first-moment identity. The probabilistic method's expectation phase establishes E[X] > 0; the second-moment phase formalized here bounds Var(X) to conclude X > 0 with positive probability."
+    },
+    {
+      "targetId": "prob-method-applications",
+      "relationship": "feeds",
+      "description": "Applications of the probabilistic method — Ramsey lower bounds, tournament constructions, random-graph thresholds — instantiate the pair-sum form with explicit indicator families and decompose t ×ˢ t into diagonal (variance) and off-diagonal (correlation) terms."
+    }
+  ],
+  "references": [
+    {
+      "authors": ["Alon, Noga", "Spencer, Joel H."],
+      "title": "The Probabilistic Method",
+      "year": "2016",
+      "venue": "Wiley, 4th edition, §4 (The Second Moment)",
+      "note": "Canonical reference for the second-moment-method applications that the pair-sum identity enables: subgraph counts in G(n,p), clique thresholds, distinct sums, and combinatorial existence proofs via variance bounds."
+    },
+    {
+      "authors": ["Erdős, Paul", "Rényi, Alfréd"],
+      "title": "On the evolution of random graphs",
+      "year": "1960",
+      "venue": "Publications of the Mathematical Institute of the Hungarian Academy of Sciences 5, pp. 17-61",
+      "note": "Founding paper of random-graph theory. The threshold functions for subgraph containment in G(n,p) are derived by exactly the second-moment computation that the pair-sum form streamlines."
+    },
+    {
+      "authors": ["Chebyshev, Pafnuty"],
+      "title": "Des valeurs moyennes",
+      "year": "1867",
+      "venue": "Journal de Mathématiques Pures et Appliquées 12, pp. 177-184",
+      "note": "Introduces what is now Chebyshev's inequality. The bilinear additivity of variance — formalized here as variance_add and its Finset-indexed generalization — was implicit in this work and made fully explicit in the 20th-century framing of variance as a quadratic form."
+    }
   ]
 }


### PR DESCRIPTION
## Summary

Enrichment pass for `prob-method-second-moment-oq-02` (Variance of Indicator Sums — Generic Decomposition, §A of OQ-02).

The entry started with rich `meta.json` (overview, sections, proofStrategy, keyInsights, mathlibDependencies) but no `annotations.json`, no `conclusion`, no `crossReferences`, and no `references`. This pass closes those gaps.

## Changes

**`annotations.json` (NEW)** — 9 substantive annotations covering every major section of the 153-line Lean file:

1. **Header / OQ-02 scope** (lines 1–40) — motivates discrete Finset-ℚ setting; explains §A vs §B/§C scope.
2. **Mean, variance, covariance definitions** (42–59) — counting-measure formalism, $0/0 = 0$ convention in ℚ.
3. **Variance = Cov(f, f)** (63–66) — the diagonal-of-bilinear-form recasting.
4. **Covariance symmetry by pointwise `ring`** (68–73) — recurring three-line pattern.
5. **Mean is additive** (75–78) — linearity of expectation, no integrability hypothesis needed in Finset setting.
6. **Bilinearity: `covariance_add_left/right`** (80–94) — Cov exhibited as symmetric bilinear form.
7. **`variance_add`: Var(f+g) = Var f + Var g + 2 Cov(f,g)** (98–107) — polarization identity for variance.
8. **`covariance_sum_left` by Finset induction** (109–129) — empty case collapses via `Finset.sum_const_zero`; insert case threads `covariance_add_left` + IH.
9. **Headline: `variance_sum_eq_sum_covariance`** (139–152) — Var(∑) = ∑ Cov over `t ×ˢ t`; explains diagonal/off-diagonal applications.

Each annotation carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`.

**`meta.json` (UPDATED)** — added:

- `conclusion` with substantive `summary` (theorem/axiom counts, Mathlib 4.26.0), `implications` connecting §A to the parent `second_moment_existence` and Erdős-Rényi threshold applications, and 5 `openQuestions` tracing the §B / §C / G(n,p) / measure-theoretic / Mathlib-upstream roadmap.
- `crossReferences`: parent `prob-method-second-moment` (reuses Finset-ℚ setting + namespace), sibling `prob-method-second-moment-oq-01` (quantitative Paley-Zygmund), `prob-method-expectation` (depends-on linearity of expectation), `prob-method-applications` (feeds Ramsey / random-graph threshold instantiations).
- `references`: Alon–Spencer §4 (Second Moment), Erdős–Rényi 1960 (random-graph evolution), Chebyshev 1867 (original variance framing).

## Axiom Integrity

Verified: 0 axiom declarations, 0 sorries, no structure-encoded assumptions in the Lean source. `status: "verified"` / `badge: "original"` / `axiomCount: 0` remain accurate.

## Test Plan

- [x] JSON validates
- [x] `pnpm build` enrichment phase processes the entry cleanly (build failed at `tsc` due to a pre-existing `better-sqlite3` native-compile env issue in this worktree, unrelated to these changes).
- [x] Entry already present in `listings.json` and `data-manifest.json` — no new wiring needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)