### PR TITLE
Enrich: Fermat Defect-One benchmark split + Variance of Indicator Sums

### DIFF
--- a/src/data/proofs/fermat-defect-one/meta.json
+++ b/src/data/proofs/fermat-defect-one/meta.json
@@ -104,12 +104,20 @@
       "mathContext": "$\\mathtt{FermatDefectWitness}\\,n\\,a\\,b\\,c$: $2 \\le a \\le b < c \\land \\gcd(\\gcd(a,b),c) = 1 \\land (a^n+b^n+1 = c^n \\lor a^n+b^n = c^n+1)$."
     },
     {
-      "id": "benchmark-n-three",
-      "title": "Verified n=3 Benchmarks (Both Signs)",
+      "id": "benchmark-n-three-raw",
+      "title": "Raw n=3 Witnesses Discharged by native_decide (Both Signs)",
       "startLine": 81,
+      "endLine": 107,
+      "summary": "The two primitive `FermatDefectWitness 3 _ _ _` benchmarks: `fermat_defect_three_neg` ($6^3 + 8^3 + 1 = 9^3$, $\\gcd(6,8,9)=1$) and `fermat_defect_three_pos` ($9^3 + 10^3 = 12^3 + 1$, $\\gcd(9,10,12)=1$). Both proofs follow the identical `refine ⟨?_, ?_, ?_, ?_, ?_⟩` + per-conjunct `native_decide` schema, distinguished only by `left; native_decide` (negative) versus `right; native_decide` (positive) for the final disjunctive branch. This is the gallery's *computational* layer: every claim here is closed by native-code evaluation of decidable predicates on small `Nat` arithmetic.",
+      "mathContext": "Negative: $6^3 + 8^3 + 1 = 216 + 512 + 1 = 729 = 9^3$, primitivity $\\gcd(2,9) = 1$. Positive: $9^3 + 10^3 = 729 + 1000 = 1729 = 1728 + 1 = 12^3 + 1$, primitivity $\\gcd(1,12) = 1$. The positive witness is the Ramanujan-Hardy taxicab number 1729 shifted by one unit."
+    },
+    {
+      "id": "benchmark-n-three-derived",
+      "title": "Derived Existence Corollaries at n=3",
+      "startLine": 109,
       "endLine": 130,
-      "summary": "fermat_defect_three_neg (6^3+8^3+1 = 9^3, gcd(6,8,9)=1) and fermat_defect_three_pos (9^3+10^3 = 12^3+1, gcd(9,10,12)=1), both discharged by native_decide. Derived theorems fermat_defect_three, fermat_defect_three_positive, fermat_defect_three_negative.",
-      "mathContext": "Arithmetic: $216 + 512 + 1 = 729$; $729 + 1000 = 1729 = 1728 + 1$. Primitivity: $\\gcd(2, 9) = 1$, $\\gcd(1, 12) = 1$."
+      "summary": "Three short existential corollaries that consume the raw benchmarks above. `fermat_defect_three : FermatDefectExists 3` is a one-line term-mode anonymous-constructor proof packaging the negative-defect witness. `fermat_defect_three_positive : FermatDefectPositive 3` and `fermat_defect_three_negative : FermatDefectNegative 3` each construct a per-sign existential by re-running the `refine` schema with the explicit witness baked in — together they realise Level 3 of the hierarchy at $n = 3$ (both signs achievable primitively). This is the *logical* layer: the raw benchmarks above are the witnesses, and these corollaries lift them into the existential predicates the headline conjecture quantifies over.",
+      "mathContext": "Level 3 at $n=3$: $\\exists (a,b,c)$ with $a^3 + b^3 + 1 = c^3$ realised by $(6,8,9)$ and $\\exists (a,b,c)$ with $a^3 + b^3 = c^3 + 1$ realised by $(9,10,12)$. The pair $((6,8,9), (9,10,12))$ closes the $n=3$ row of the conjecture's $(n, \\epsilon) \\in \\{3, 4, \\ldots\\} \\times \\{-1, +1\\}$ table."
     },
     {
       "id": "open-conjecture",

--- a/src/data/proofs/prob-method-second-moment-oq-02/annotations.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/annotations.json
@@ -1,0 +1,140 @@
+[
+  {
+    "id": "ann-pmsm-oq02-header",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 1, "endLine": 34 },
+    "type": "context",
+    "title": "Scope: §A of OQ-02 — generic pair-sum form",
+    "content": "The opening docstring fixes the working setting and the slice of OQ-02 this file ships. The headline identity is the bilinear pair-sum form $\\operatorname{Var}\\!\\left(\\sum_{i \\in t} X_i\\right) = \\sum_{(i,j) \\in t \\times t} \\operatorname{Cov}(X_i, X_j)$, which is one Finset diag/offDiag split away from the textbook decomposition $\\sum_i \\operatorname{Var}(X_i) + \\sum_{i \\neq j} \\operatorname{Cov}(X_i, X_j)$. By staying with the pair-sum, the file remains agnostic to whether the user wants the diagonal isolated (independent indicators) or bounded together with the off-diagonal (positively-correlated indicators). The parent OQ-02 deliverable — formalizing the variance computation for subgraph counts in $G(n,p)$ — is sequenced behind this §A as §B (G(n,p) construction) and §C (explicit threshold functions).",
+    "mathContext": "Pair-sum form: $\\operatorname{Var}\\!\\left(\\sum_{i \\in t} X_i\\right) = \\sum_{(i,j) \\in t \\times t} \\operatorname{Cov}(X_i, X_j)$. Textbook form: $= \\sum_{i \\in t} \\operatorname{Var}(X_i) + \\sum_{i \\neq j} \\operatorname{Cov}(X_i, X_j)$.",
+    "significance": "context",
+    "relatedConcepts": [
+      "second moment method",
+      "Paley-Zygmund inequality",
+      "G(n,p) subgraph counting",
+      "Chebyshev's inequality"
+    ],
+    "prerequisites": [
+      "probabilistic method",
+      "covariance as bilinear form",
+      "Finset"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq02-definitions",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 42, "endLine": 59 },
+    "type": "definition",
+    "title": "Counting-measure mean, variance, covariance over a Finset",
+    "content": "The three definitions establish a measure-theory-free framework: a Finset $s : \\mathrm{Finset}\\,\\alpha$ is the sample space with the counting measure, and a `random variable' is just a function $f : \\alpha \\to \\mathbb{Q}$. The mean $\\bar f = \\sum_{a \\in s} f(a) / |s|$ is the arithmetic average; variance is $\\sum_{a \\in s} (f(a) - \\bar f)^2 / |s|$, the mean of the squared deviation; covariance is $\\sum_{a \\in s} (f(a) - \\bar f)(g(a) - \\bar g) / |s|$, the mean of the cross-deviation product. Using $\\mathbb{Q}$ instead of $\\mathbb{R}$ keeps arithmetic exact and avoids placement-of-real-numbers issues; using a Finset (rather than a `Fintype` typeclass instance) keeps the sample space first-class data so the API extends cleanly to subsets.",
+    "mathContext": "$\\bar f := |s|^{-1} \\sum_{a \\in s} f(a)$, $\\operatorname{Var}(f) := |s|^{-1} \\sum_{a \\in s} (f(a) - \\bar f)^2$, $\\operatorname{Cov}(f, g) := |s|^{-1} \\sum_{a \\in s} (f(a) - \\bar f)(g(a) - \\bar g)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "counting measure",
+      "discrete probability space",
+      "centered moments",
+      "rational arithmetic"
+    ],
+    "prerequisites": [
+      "Finset.sum",
+      "Finset.card"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq02-variance-self-cov",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 63, "endLine": 73 },
+    "type": "insight",
+    "title": "Variance = Cov(f, f): the diagonal of the bilinear form",
+    "content": "`variance_eq_covariance_self` records the structural fact that variance is the diagonal value of the symmetric covariance form: $\\operatorname{Var}(f) = \\operatorname{Cov}(f, f)$. The proof is a one-liner — `simp only [variance, covariance, sq]` — because the definitions unfold to the same Finset sum after rewriting $x^2 = x \\cdot x$. This identification is the bridge that lets the final variance-of-sum identity be derived purely from covariance machinery; the variance side never needs its own bilinearity lemmas. Right beside it, `covariance_symm` is the matching symmetry property, proved by congruence under the Finset sum and `ring`.",
+    "mathContext": "$\\operatorname{Var}(f) = \\operatorname{Cov}(f, f)$ and $\\operatorname{Cov}(f, g) = \\operatorname{Cov}(g, f)$ — variance is the diagonal of a symmetric bilinear form on $\\alpha \\to \\mathbb{Q}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "symmetric bilinear form",
+      "quadratic form polarization",
+      "inner product structure"
+    ],
+    "prerequisites": [
+      "symmetric bilinear forms",
+      "polarization identity"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq02-bilinear-api",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 75, "endLine": 94 },
+    "type": "technique",
+    "title": "Bilinearity of covariance: mean_add + ring",
+    "content": "`mean_add` establishes the linearity of expectation in the discrete setting: $\\overline{f + g} = \\bar f + \\bar g$, by `Finset.sum_add_distrib` followed by `add_div`. Bilinearity of covariance then becomes a two-step pattern. First, `covariance_add_left` rewrites the mean of $f_1 + f_2$ via `mean_add` and the Finset sum via `Finset.sum_add_distrib`, then `ring` finishes the per-term algebra because $(f_1 + f_2 - \\overline{f_1} - \\overline{f_2})(g - \\bar g) = (f_1 - \\overline{f_1})(g - \\bar g) + (f_2 - \\overline{f_2})(g - \\bar g)$. Second, `covariance_add_right` is derived from `covariance_add_left` via four applications of `covariance_symm` — symmetry plus left-additivity gives right-additivity for free.",
+    "mathContext": "$\\operatorname{Cov}(f_1 + f_2, g) = \\operatorname{Cov}(f_1, g) + \\operatorname{Cov}(f_2, g)$ and dually in the right slot; the key intermediate step is $\\overline{f_1 + f_2} = \\overline{f_1} + \\overline{f_2}$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "linearity of expectation",
+      "bilinear form additivity",
+      "symmetry trick"
+    ],
+    "prerequisites": [
+      "Finset.sum_add_distrib",
+      "ring tactic"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq02-variance-add",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 98, "endLine": 107 },
+    "type": "concept",
+    "title": "Pair case: Var(f + g) = Var f + Var g + 2·Cov(f, g)",
+    "content": "`variance_add` is the variance-of-pair-sum identity and the smallest case of the headline pair-sum form. The proof routes everything through covariance: rewrite all three variances via `variance_eq_covariance_self`, expand both covariance slots additively via `covariance_add_left` + `covariance_add_right`, then use `covariance_symm` to merge the two cross terms $\\operatorname{Cov}(f, g)$ and $\\operatorname{Cov}(g, f)$ into a single $2 \\cdot \\operatorname{Cov}(f, g)$. The final `ring` closes the algebra. This is the cleanest demonstration that the bilinear API is a complete toolkit — no Finset sum is unfolded directly here.",
+    "mathContext": "$\\operatorname{Var}(f + g) = \\operatorname{Var}(f) + \\operatorname{Var}(g) + 2\\operatorname{Cov}(f, g)$; the cross term is the algebraic obstruction to additivity of variance for dependent variables.",
+    "significance": "key",
+    "relatedConcepts": [
+      "polarization of a quadratic form",
+      "additivity of variance for independent variables",
+      "second moment of a sum"
+    ],
+    "prerequisites": [
+      "covariance bilinearity",
+      "symmetry of covariance"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq02-sum-indexed",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 109, "endLine": 137 },
+    "type": "technique",
+    "title": "Finset induction extends bilinearity to indexed sums",
+    "content": "`covariance_sum_left` lifts left-additivity from the pair case to a Finset-indexed sum: $\\operatorname{Cov}\\!\\left(\\sum_{i \\in t} X_i, g\\right) = \\sum_{i \\in t} \\operatorname{Cov}(X_i, g)$. The proof is `Finset.induction_on t`. The empty case is the subtle one — the LHS reduces to $\\operatorname{Cov}(\\mathbf{0}, g)$, whose mean is zero by `Finset.sum_const_zero`, so the inner sum collapses to zero and matches the empty RHS. The `insert i t` step rewrites the indexed sum via `Finset.sum_insert hi` to expose an $X_i + \\sum_{j \\in t} X_j$ shape, then plugs into `covariance_add_left` and applies the inductive hypothesis. `covariance_sum_right` is then a one-line derivation from `covariance_sum_left` via two symmetry rewrites — the same trick used for `covariance_add_right`.",
+    "mathContext": "$\\operatorname{Cov}\\!\\left(\\sum_{i \\in t} X_i, g\\right) = \\sum_{i \\in t} \\operatorname{Cov}(X_i, g)$ and the dual right-slot identity, by induction on $t$ with `Finset.sum_const_zero` driving the empty case.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Finset.induction_on",
+      "Finset.sum_insert",
+      "lifting pair-additivity to sums"
+    ],
+    "prerequisites": [
+      "Finset induction principle",
+      "decidable equality on the index type"
+    ]
+  },
+  {
+    "id": "ann-pmsm-oq02-pair-sum",
+    "proofId": "prob-method-second-moment-oq-02",
+    "range": { "startLine": 139, "endLine": 152 },
+    "type": "insight",
+    "title": "Headline identity via Finset.sum_product",
+    "content": "`variance_sum_eq_sum_covariance` is the file's headline result. The four-line proof is the cleanest possible composition: (1) rewrite variance as $\\operatorname{Cov}(\\sum_i X_i, \\sum_i X_i)$ via `variance_eq_covariance_self`; (2) expand the left slot via `covariance_sum_left` to produce $\\sum_i \\operatorname{Cov}(X_i, \\sum_j X_j)$; (3) flatten the nested sums via `Finset.sum_product`, which trades a double sum $\\sum_{i \\in t} \\sum_{j \\in t} f(i, j)$ for a single sum over the product Finset $\\sum_{p \\in t \\times t} f(p_1, p_2)$; (4) finish with a `Finset.sum_congr` that applies `covariance_sum_right` pointwise to expand the right slot inside the inner sum. The pair-sum form is preferred over the diag/offDiag form because it leaves the user free to split the index set $t \\times t$ along whichever boundary their application needs.",
+    "mathContext": "$\\operatorname{Var}\\!\\left(\\sum_{i \\in t} X_i\\right) = \\sum_{(i,j) \\in t \\times t} \\operatorname{Cov}(X_i, X_j)$; equivalent to $\\sum_{i} \\operatorname{Var}(X_i) + \\sum_{i \\neq j} \\operatorname{Cov}(X_i, X_j)$ via $t \\times t = \\Delta_t \\sqcup \\operatorname{offDiag}(t)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Finset.sum_product",
+      "diagonal / off-diagonal decomposition",
+      "second moment method",
+      "Paley-Zygmund threshold arguments"
+    ],
+    "prerequisites": [
+      "Finset product",
+      "sum_congr",
+      "Finset.sum_product"
+    ]
+  }
+]

--- a/src/data/proofs/prob-method-second-moment-oq-02/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/meta.json
@@ -106,5 +106,47 @@
       "summary": "variance_add (pair case), covariance_sum_left/right (extended to Finset-indexed sums by induction), and the headline variance_sum_eq_sum_covariance. The pair-sum form collapses the variance of an arbitrary finite sum into a single Cov-sum over the product Finset t ×ˢ t.",
       "mathContext": "Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) — the bilinear pair-sum form, suitable for diagonal / off-diagonal decomposition by the application."
     }
+  ],
+  "conclusion": {
+    "summary": "Ships §A of OQ-02: the bilinear pair-sum form Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j), fully verified in Lean 4 with Mathlib (0 axioms, 0 sorries, 9 theorems, 3 definitions). The proof builds covariance as a symmetric bilinear form on ℚ-valued functions over a Finset (counting measure), extends bilinearity to Finset-indexed sums by induction, and collapses the variance of a sum to a single Finset.sum over the product index set t ×ˢ t.",
+    "implications": "Establishes the algebraic backbone of the second moment method in a measure-theory-free setting. Any threshold argument that reduces to Var(∑ X i) — Chebyshev concentration for indicator sums, the Paley-Zygmund anti-concentration step, random-graph subgraph-count thresholds — can now be expressed as a single Finset.sum over t ×ˢ t of per-pair covariances, with the diagonal / off-diagonal split deferred to the calling site. The pair-sum form is strictly more convenient than the textbook Var + Cov form for code generation: it removes the need to thread a `Finset.diag_union_offDiag` rewrite through every application.",
+    "openQuestions": [
+      "§B (G(n,p) construction): formalize the canonical G(n,p) random-graph sample space — a Finset of edge-subsets of K_n, weighted by p^|E|·(1-p)^(C(n,2)-|E|) — so that subgraph-count indicator sums X_H = ∑_{H' ≅ H} 1_{H' ⊆ G} can be instantiated against this pair-sum form.",
+      "§C (explicit threshold functions): derive the textbook Var(∑ X i) = ∑ Var(X i) + ∑_{i ≠ j} Cov(X i, X j) form via Finset.diag_union_offDiag, then specialize to G(n,p) subgraph counts to recover threshold functions p* = n^(-1/m(H)) for balanced subgraphs H (Bollobás 1981).",
+      "Generalize the counting-measure setting to weighted Finsets — replacing s.card with ∑_{a ∈ s} w a — to capture non-uniform discrete distributions (e.g. biased coins, weighted bootstrap) without introducing measure theory.",
+      "Bridge to Mathlib's measure-theoretic ProbabilityTheory.variance via a counting-measure adapter, so that gallery-level results can compose with downstream Mathlib probability content."
+    ]
+  },
+  "crossReferences": [
+    {
+      "targetId": "prob-method-second-moment",
+      "relationship": "depends-on",
+      "description": "Parent entry: the second moment method as a probabilistic technique (Chebyshev / Paley-Zygmund). This §A file imports ProbMethodSecondMoment and supplies the variance-of-sums identity that the parent's threshold framework consumes."
+    },
+    {
+      "targetId": "prob-method-second-moment-oq-01",
+      "relationship": "related",
+      "description": "Sibling OQ-01 from the same parent: complementary slice of the second moment method's open-question program. Both files share the discrete Finset-ℚ counting-measure formalism established here."
+    },
+    {
+      "targetId": "prob-method-expectation",
+      "relationship": "depends-on",
+      "description": "Foundational: linearity of expectation (mean_add) is the first-moment ancestor of the bilinearity of covariance used here. Second-moment arguments build on first-moment scaffolding."
+    },
+    {
+      "targetId": "prob-method-applications",
+      "relationship": "used-by",
+      "description": "Subgraph-count threshold arguments in random graphs (Erdős-Rényi G(n,p)) reduce to the pair-sum form proved here. §B / §C of this OQ would directly feed those applications."
+    },
+    {
+      "targetId": "cauchy-schwarz",
+      "relationship": "related",
+      "description": "The Paley-Zygmund inequality (parent) uses Cauchy-Schwarz applied to X · 1_{X > 0}, and the off-diagonal covariance bound in second-moment threshold arguments is itself often a Cauchy-Schwarz step on per-pair covariances."
+    },
+    {
+      "targetId": "prob-method-lovasz-local",
+      "relationship": "related",
+      "description": "Both control dependency structure in probabilistic arguments. The pair-sum form here makes dependencies (off-diagonal covariances) explicit; LLL handles them by dependency-graph structure."
+    }
   ]
 }

--- a/src/data/proofs/prob-method-second-moment-oq-02/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/meta.json
@@ -99,11 +99,19 @@
       "mathContext": "Variance is the diagonal of the covariance bilinear form: Var(f) = Cov(f, f)."
     },
     {
-      "id": "variance-of-sum",
-      "title": "Variance of a sum (pair-sum form)",
+      "id": "variance-pair-sum",
+      "title": "Pair-case variance of a sum",
       "startLine": 96,
+      "endLine": 108,
+      "summary": "variance_add: Var(f + g) = Var f + Var g + 2·Cov(f, g). Smallest case of the headline pair-sum form, derived by routing through covariance and using the symmetric-bilinear API — no Finset sum is unfolded directly. Demonstrates that the bilinearity lemmas (covariance_add_left, covariance_add_right, covariance_symm) form a complete toolkit for variance arithmetic.",
+      "mathContext": "Var(f + g) = Var(f) + Var(g) + 2·Cov(f, g); the cross term 2·Cov(f, g) is the algebraic obstruction to additivity of variance for dependent variables."
+    },
+    {
+      "id": "variance-indexed-sum",
+      "title": "Headline identity: indexed-sum variance",
+      "startLine": 109,
       "endLine": 153,
-      "summary": "variance_add (pair case), covariance_sum_left/right (extended to Finset-indexed sums by induction), and the headline variance_sum_eq_sum_covariance. The pair-sum form collapses the variance of an arbitrary finite sum into a single Cov-sum over the product Finset t ×ˢ t.",
+      "summary": "covariance_sum_left/right extend bilinearity from the pair case to Finset-indexed sums by Finset induction (empty case via Finset.sum_const_zero, insert case via covariance_add_left + IH). The headline variance_sum_eq_sum_covariance composes self-equality + sum_left + Finset.sum_product + sum_right to collapse the variance of an arbitrary finite sum into a single Cov-sum over the product Finset t ×ˢ t.",
       "mathContext": "Var(∑_{i ∈ t} X i) = ∑_{(i,j) ∈ t ×ˢ t} Cov(X i, X j) — the bilinear pair-sum form, suitable for diagonal / off-diagonal decomposition by the application."
     }
   ],


### PR DESCRIPTION
Two enrichment commits on `feature/enricher-1`. Both target proofs with low quality scores / passes; both are pure data-side additions (no Lean changes).

## Commit 1: `af4d1de0858` — Fermat Defect-One Conjecture
Split benchmark section into raw + derived (4 → 5 sections):
- `benchmark-n-three-raw` (lines 81-107): two `FermatDefectWitness 3 _ _ _` benchmarks discharged by `native_decide`
- `benchmark-n-three-derived` (lines 109-130): three existential corollaries that consume the raw benchmarks
- Distinguishes the computational layer (`native_decide` on small Nat arithmetic) from the logical layer (existential introduction)

## Commit 2: `cdfdc0660ca` — Variance of Indicator Sums (prob-method-second-moment-oq-02)
First enrichment pass — entry previously had only `meta.json`.

- **`annotations.json` (NEW)** — 7 high-quality annotations covering all four sections: scope/header, mean/variance/covariance definitions, variance-as-self-covariance, bilinearity API, pair-sum variance_add, Finset induction for indexed sums, headline `variance_sum_eq_sum_covariance`. Each carries `mathContext` (LaTeX), `significance`, `relatedConcepts`, `prerequisites`.
- **`meta.json` additions**:
  - `conclusion` with summary, implications, and 4 open questions covering the §B / §C / weighted-Finset / Mathlib-bridge follow-ups in the OQ-02 program
  - `crossReferences` to parent `prob-method-second-moment`, sibling `prob-method-second-moment-oq-01`, plus `prob-method-expectation`, `prob-method-applications`, `cauchy-schwarz`, `prob-method-lovasz-local`

All 6 cross-reference targets verified to exist. JSON validated via `jq`. The build's enrichment scanner accepted both entries end-to-end.

## Verification
- `jq empty` on both files — clean
- Build scanner enriched 1711/1971 problems successfully
- All `targetId` values in `crossReferences` resolve to existing gallery directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)