### PR TITLE
research(erdos-659-oq-01-oq-02): S8 ACT — (2, 13) axis-vs-plane safety DISCHARGED via mod-13 QR-descent (Docker 3058 jobs clean)

### DIFF
--- a/proofs/Proofs/Erdos659OQ01OQ02.lean
+++ b/proofs/Proofs/Erdos659OQ01OQ02.lean
@@ -100,6 +100,26 @@ lemma zmod_5_a_sq_eq_three_b_sq_iff (a b : ZMod 5) :
   revert a b
   decide
 
+/-- **(S8 ACT, mod-13 step for equation A on the prime pair `(2, 13)`)**
+    `a² + 2 b² ≡ 0 (mod 13)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 13`.
+    Equivalent to the assertion that `−2` is not a square in `ZMod 13`
+    (squares mod 13 are `{0, 1, 3, 4, 9, 10, 12}`; `11 = −2 mod 13` is
+    not among them). 169-case `decide` check. -/
+lemma zmod_13_a_sq_plus_2_b_sq_eq_zero_iff (a b : ZMod 13) :
+    a ^ 2 + 2 * b ^ 2 = 0 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
+/-- **(S8 ACT, mod-13 step for equations B and C on the prime pair `(2, 13)`)**
+    `a² ≡ 2 b² (mod 13)` iff both `a ≡ 0` and `b ≡ 0` in `ZMod 13`.
+    Equivalent to the assertion that `2` is not a square in `ZMod 13`
+    (squares mod 13 are `{0, 1, 3, 4, 9, 10, 12}`; `2` is not among them).
+    169-case `decide` check. -/
+lemma zmod_13_a_sq_eq_two_b_sq_iff (a b : ZMod 13) :
+    a ^ 2 = 2 * b ^ 2 ↔ a = 0 ∧ b = 0 := by
+  revert a b
+  decide
+
 /-- Equation A predicate for the prime pair `(p, q) = (2, 5)`:
     `5 c² = a² + 2 b²` has only the trivial integer solution.
 
@@ -484,5 +504,180 @@ theorem safe_C_3_5_holds :
     axiomatisation per S2c PREP §6.1. -/
 theorem safe_3_5_axis_vs_plane : SafePrimePair_AxisVsPlane 3 5 :=
   ⟨safe_A_3_5_holds, safe_B_3_5_holds, safe_C_3_5_holds⟩
+
+/-! ## S8 ACT — axis-vs-plane safety for the prime pair `(2, 13)`
+
+The three theorems below mirror `safe_{A,B,C}_holds` 1:1 with the mod-5
+helpers swapped for the new mod-13 helpers
+(`zmod_13_a_sq_plus_2_b_sq_eq_zero_iff`, `zmod_13_a_sq_eq_two_b_sq_iff`) and
+the descent prime `5` swapped for `13`. The coefficient on `b²` stays at `2`,
+so the descent skeleton is *closer* to the (2, 5) case than the (3, 5) case
+was — the only changes are the modulus and the descent prime. -/
+
+/-- **(S8 ACT — axis-vs-plane equation A for `(p, q) = (2, 13)`).**
+    `13 c² = a² + 2 b²` has only `(0, 0, 0)`.
+
+    Infinite descent on `c.natAbs`: mod 13 (via
+    `zmod_13_a_sq_plus_2_b_sq_eq_zero_iff`, i.e. `−2` is not a QR mod 13)
+    forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_A_2_13_holds :
+    ∀ a b c : ℤ, (13 : ℤ) * c ^ 2 = a ^ 2 + 2 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, c.natAbs = n →
+      (13 : ℤ) * c ^ 2 = a ^ 2 + 2 * b ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hc heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hc0 : c = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hc0
+        refine ⟨?_, ?_, rfl⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg b))
+      · have hz : (a : ZMod 13) ^ 2 + 2 * (b : ZMod 13) ^ 2 = 0 := by
+          have h : ((a ^ 2 + 2 * b ^ 2 : ℤ) : ZMod 13) = ((13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul] at h
+          exact h
+        rw [zmod_13_a_sq_plus_2_b_sq_eq_zero_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13 : (13 : ℤ) * c ^ 2 = 13 * (13 * (a' ^ 2 + 2 * b' ^ 2)) := by
+          linear_combination heq
+        have hc2 : c ^ 2 = 13 * (a' ^ 2 + 2 * b' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 + 2 * b' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (13 : ℤ) * c' ^ 2 = a' ^ 2 + 2 * b' ^ 2 := by
+          have h169 : (13 : ℤ) * (13 * c' ^ 2) = 13 * (a' ^ 2 + 2 * b' ^ 2) := by
+            linear_combination hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : c'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at hc
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih c'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key c.natAbs a b c rfl heq
+
+/-- **(S8 ACT — axis-vs-plane equation B for `(p, q) = (2, 13)`).**
+    `2 b² = a² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `b.natAbs`: mod 13 (via `zmod_13_a_sq_eq_two_b_sq_iff`,
+    i.e. `2` is not a QR mod 13) forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_B_2_13_holds :
+    ∀ a b c : ℤ, (2 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, b.natAbs = n →
+      (2 : ℤ) * b ^ 2 = a ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c hb heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have hb0 : b = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst hb0
+        refine ⟨?_, rfl, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg a))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg a]) (sq_nonneg c))
+      · have hz : (a : ZMod 13) ^ 2 = 2 * (b : ZMod 13) ^ 2 := by
+          have h : ((2 * b ^ 2 : ℤ) : ZMod 13) = ((a ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul, add_zero] at h
+          exact h.symm
+        rw [zmod_13_a_sq_eq_two_b_sq_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13 : (13 : ℤ) * c ^ 2 = 13 * (13 * (2 * b' ^ 2 - a' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 13 * (2 * b' ^ 2 - a' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨2 * b' ^ 2 - a' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : (2 : ℤ) * b' ^ 2 = a' ^ 2 + 13 * c' ^ 2 := by
+          have h169 : (13 : ℤ) * (2 * b' ^ 2) = 13 * (a' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : b'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at hb
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih b'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key b.natAbs a b c rfl heq
+
+/-- **(S8 ACT — axis-vs-plane equation C for `(p, q) = (2, 13)`).**
+    `a² = 2 b² + 13 c²` has only `(0, 0, 0)`.
+
+    Infinite descent on `a.natAbs`: mod 13 (via `zmod_13_a_sq_eq_two_b_sq_iff`)
+    forces `13 ∣ a`, `13 ∣ b`, then `13 ∣ c`. -/
+theorem safe_C_2_13_holds :
+    ∀ a b c : ℤ, a ^ 2 = (2 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+  have key : ∀ n : ℕ, ∀ a b c : ℤ, a.natAbs = n →
+      a ^ 2 = (2 : ℤ) * b ^ 2 + 13 * c ^ 2 → a = 0 ∧ b = 0 ∧ c = 0 := by
+    intro n
+    induction n using Nat.strong_induction_on with
+    | _ n ih =>
+      intro a b c ha heq
+      rcases Nat.eq_zero_or_pos n with hn0 | hnpos
+      · have ha0 : a = 0 := Int.natAbs_eq_zero.mp (by omega)
+        subst ha0
+        refine ⟨rfl, ?_, ?_⟩
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg c]) (sq_nonneg b))
+        · exact sq_eq_zero_iff.mp (le_antisymm (by nlinarith [sq_nonneg b]) (sq_nonneg c))
+      · have hz : (a : ZMod 13) ^ 2 = 2 * (b : ZMod 13) ^ 2 := by
+          have h : ((a ^ 2 : ℤ) : ZMod 13) = ((2 * b ^ 2 + 13 * c ^ 2 : ℤ) : ZMod 13) := by
+            rw [heq]
+          push_cast at h
+          rw [show (13 : ZMod 13) = 0 from by decide, zero_mul, add_zero] at h
+          exact h
+        rw [zmod_13_a_sq_eq_two_b_sq_iff] at hz
+        have hda : (13 : ℤ) ∣ a := (ZMod.intCast_zmod_eq_zero_iff_dvd a 13).mp hz.1
+        have hdb : (13 : ℤ) ∣ b := (ZMod.intCast_zmod_eq_zero_iff_dvd b 13).mp hz.2
+        obtain ⟨a', rfl⟩ := hda
+        obtain ⟨b', rfl⟩ := hdb
+        have h13 : (13 : ℤ) * c ^ 2 = 13 * (13 * (a' ^ 2 - 2 * b' ^ 2)) := by
+          linear_combination -heq
+        have hc2 : c ^ 2 = 13 * (a' ^ 2 - 2 * b' ^ 2) :=
+          mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h13
+        have hdc : (13 : ℤ) ∣ c := by
+          have hp : Prime (13 : ℤ) := by norm_num
+          exact hp.dvd_of_dvd_pow (⟨a' ^ 2 - 2 * b' ^ 2, hc2⟩ : (13 : ℤ) ∣ c ^ 2)
+        obtain ⟨c', rfl⟩ := hdc
+        have heq' : a' ^ 2 = (2 : ℤ) * b' ^ 2 + 13 * c' ^ 2 := by
+          have h169 : (13 : ℤ) * a' ^ 2 = 13 * (2 * b' ^ 2 + 13 * c' ^ 2) := by
+            linear_combination -hc2
+          exact mul_left_cancel₀ (by norm_num : (13 : ℤ) ≠ 0) h169
+        have hmeas : a'.natAbs < n := by
+          have h13nat : (13 : ℤ).natAbs = 13 := by decide
+          rw [Int.natAbs_mul, h13nat] at ha
+          omega
+        obtain ⟨ha0, hb0, hc0⟩ := ih a'.natAbs hmeas a' b' c' rfl heq'
+        subst ha0; subst hb0; subst hc0
+        refine ⟨by ring, by ring, by ring⟩
+  intro a b c heq
+  exact key a.natAbs a b c rfl heq
+
+/-- **The main axis-vs-plane safety theorem for the prime pair `(p, q) = (2, 13)`.**
+
+    Derived as the conjunction of `safe_A_2_13_holds`, `safe_B_2_13_holds`, and
+    `safe_C_2_13_holds`, each proved by the same QR-descent template as the
+    proved `(2, 5)` and `(3, 5)` versions. The full-rank half is a separate
+    future axiomatisation per S2c PREP §6.1. -/
+theorem safe_2_13_axis_vs_plane : SafePrimePair_AxisVsPlane 2 13 :=
+  ⟨safe_A_2_13_holds, safe_B_2_13_holds, safe_C_2_13_holds⟩
 
 end Erdos659OQ01OQ02

--- a/research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-09-s8-act-2-13-axis-vs-plane-discharge.md
+++ b/research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-09-s8-act-2-13-axis-vs-plane-discharge.md
@@ -1,0 +1,162 @@
+# Iteration S8 ACT — `(2, 13)` axis-vs-plane safety DISCHARGED
+
+**Date**: 2026-06-09
+**Researcher**: researcher-1
+**Phase**: ACT (discharges the lowest-LOC entry in the S7 ACT next-action menu)
+**Type**: Lean ACT (Docker-verified GREEN).
+**Build**: `./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` →
+`✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (19s)` → `Build completed successfully (3058 jobs)`.
+
+## Headline
+
+The second-listed safe prime pair from S2a OBSERVE PR #18494's empirical
+search at R ≤ 22 — `(p, q) = (2, 13)` — now has its axis-vs-plane safety
+fully proved. The S7 ACT next-action menu shrinks by one again:
+
+> 1. **`(2, 13)` axis-vs-plane safety** — needs mod-13 reduction (169-case
+>    `decide` per helper). Lowest-LOC remaining safe pair.  ← **discharged this session**
+> 2. **`(5, 7)` axis-vs-plane safety** — second-lowest. Now the new top.
+
+## Lean delta (Docker-verified)
+
+| Section | Before (S7 ACT close) | After (S8 ACT close) | Δ |
+|---|---|---|---|
+| `proofs/Proofs/Erdos659OQ01OQ02.lean` LOC | 488 | 683 | +195 |
+| `def`s | 4 | 4 | 0 |
+| `theorem`s | 8 | 12 | +4 (`safe_A_2_13_holds`, `safe_B_2_13_holds`, `safe_C_2_13_holds`, `safe_2_13_axis_vs_plane`) |
+| `lemma`s | 4 | 6 | +2 (`zmod_13_a_sq_plus_2_b_sq_eq_zero_iff`, `zmod_13_a_sq_eq_two_b_sq_iff`) |
+| Sorries | 0 | 0 | 0 |
+| `axiom` declarations | 0 | 0 | 0 |
+
+## QR table — mod 13
+
+Squares in `ZMod 13`:
+
+| `x` | `x²` |  | `x` | `x²` |
+|---|---|---|---|---|
+| 0 | 0 |  | 7 | 10 |
+| 1 | 1 |  | 8 | 12 |
+| 2 | 4 |  | 9 | 3 |
+| 3 | 9 |  | 10 | 9 |
+| 4 | 3 |  | 11 | 4 |
+| 5 | 12 |  | 12 | 1 |
+| 6 | 10 |  |  |  |
+
+**Quadratic residues** = `{0, 1, 3, 4, 9, 10, 12}`.
+**Non-residues** = `{2, 5, 6, 7, 8, 11}`.
+
+So `2` is a **non-residue** mod 13 (needed for equations B and C) and
+`−2 = 11` is also a **non-residue** mod 13 (needed for equation A).
+Both 169-case `decide` checks succeed.
+
+## Equations and helper map
+
+For the prime pair `(p, q) = (2, 13)`, the three axis-vs-plane equations
+from the `SafePrimePair_AxisVsPlane 2 13` predicate are:
+
+| Eq | Statement | Mod-13 reduces to | Helper used |
+|----|-----------|-------------------|-------------|
+| A | `13 c² = a² + 2 b²` | `a² + 2 b² ≡ 0 (mod 13)` ⇒ `a ≡ 0 ∧ b ≡ 0` | `zmod_13_a_sq_plus_2_b_sq_eq_zero_iff` (`−2` non-residue) |
+| B | `2 b² = a² + 13 c²` | `2 b² ≡ a² (mod 13)` ⇒ `a ≡ 0 ∧ b ≡ 0` | `zmod_13_a_sq_eq_two_b_sq_iff` (`2` non-residue) |
+| C | `a² = 2 b² + 13 c²` | `a² ≡ 2 b² (mod 13)` ⇒ `a ≡ 0 ∧ b ≡ 0` | `zmod_13_a_sq_eq_two_b_sq_iff` (same) |
+
+This is *closer* to the `(2, 5)` case than to the `(3, 5)` case (the
+coefficient on `b²` is still `2`, only the prime modulus moves from 5 to
+13). The descent skeleton lifts verbatim from `safe_{A,B,C}_holds` with
+the substitutions:
+
+- `5` → `13` everywhere (in the integer descent, the ZMod, the
+  `mul_left_cancel₀` cofactor, the `Int.natAbs_mul` rewrite, and the
+  `Prime` instance — `Prime (13 : ℤ)` is closed by `norm_num`)
+- mod-5 helper name → mod-13 helper name
+
+No other structural change.
+
+## Descent skeleton, equation A specialisation
+
+The proof of `safe_A_2_13_holds` follows the same `Nat.strong_induction_on`
+schema as `safe_A_holds`. At a high level:
+
+1. Strong induction on `n := c.natAbs`. The base case `n = 0` forces
+   `c = 0`, and then `0 = a² + 2 b²` with both squares non-negative gives
+   `a = b = 0` via `sq_nonneg` + `nlinarith`.
+2. Reduce both sides of `13 c² = a² + 2 b²` mod 13: the LHS vanishes
+   (`(13 : ZMod 13) = 0`), so the cast equation gives
+   `(a : ZMod 13)² + 2 (b : ZMod 13)² = 0`. Apply the new
+   `zmod_13_a_sq_plus_2_b_sq_eq_zero_iff` helper to extract
+   `(a : ZMod 13) = 0 ∧ (b : ZMod 13) = 0`, then lift to integer
+   divisibilities `13 ∣ a` and `13 ∣ b` via
+   `ZMod.intCast_zmod_eq_zero_iff_dvd`.
+3. Write `a = 13 a'`, `b = 13 b'`, substitute, and use `linear_combination`
+   to extract `c² = 13 (a'² + 2 b'²)`. Conclude `13 ∣ c` via
+   `Prime.dvd_of_dvd_pow` on `13 ∣ c²`.
+4. Write `c = 13 c'`, simplify to `13 c'² = a'² + 2 b'²`, and apply the
+   strong-induction hypothesis at `c'.natAbs < n`.
+
+Equation B (`safe_B_2_13_holds`) descends on `b.natAbs`; equation C
+(`safe_C_2_13_holds`) descends on `a.natAbs`. Each uses the
+`zmod_13_a_sq_eq_two_b_sq_iff` helper. The remaining structure is
+identical.
+
+## Cumulative axis-vs-plane safety progress
+
+| Prime pair `(p, q)` | Status | Iteration | Helper modulus |
+|---|---|---|---|
+| `(2, 5)` | ✅ proved | S4 ACT (2026-05-29) | mod 5 |
+| `(3, 5)` | ✅ proved | S7 ACT (2026-06-04) | mod 5 |
+| `(2, 13)` | ✅ proved | **S8 ACT (this session)** | mod 13 |
+| `(5, 7)` | ⏳ candidate | next iter | mod 5 + mod 7 |
+| `(5, 13)` | ⏳ candidate | future | mod 5 + mod 13 |
+| `(7, 13)` | ⏳ candidate | future | mod 7 + mod 13 |
+| `(11, 13)` | ⏳ candidate | future | mod 11 + mod 13 |
+
+3/7 safe pairs from S2a OBSERVE PR #18494 now have proved axis-vs-plane
+safety.
+
+## Next-action menu (updated)
+
+1. **`(5, 7)` axis-vs-plane safety** — needs mod-5 + mod-7 reductions.
+   The mod-5 step reuses `zmod_5_a_sq_eq_two_b_sq_iff` /
+   `zmod_5_a_sq_plus_2_b_sq_eq_zero_iff` already in the file (since 7
+   would appear as the q-coefficient on `b²`, but actually the (5, 7)
+   pair has `5` as the smaller prime — re-check QR analysis). Two new
+   mod-7 helpers (49-case `decide` each). Second-lowest new-API surface.
+2. **`(5, 13)` axis-vs-plane safety** — similar pattern, mod-5 + mod-13.
+   Could re-use both existing helper sets.
+3. **`(7, 13)`, `(11, 13)`** — require mod-7, mod-11, mod-13 helpers.
+4. **Full-rank safety for any proved pair** — still blocked on ternary
+   Hasse-Minkowski (Mathlib v4.26.0 absence per S2c PREP §5.6) or honest
+   axiomatisation per S2c §6.1.
+5. **Θ(n^{2/3}) assembly** — still blocked on S3/S4 plan axiomatisations.
+
+## Why doc-only meta is unchanged
+
+The gallery surfaces `erdos-659-oq-01` (the parent slug), not this
+`oq-01-oq-02` sub-slug. Per S7 ACT, `Erdos659OQ01OQ02.lean` is not
+counted in the parent's `additionalFiles`-axiom census, so
+`axiomCount: 3` in `src/data/proofs/erdos-659-oq-01/meta.json` is
+unaffected by S8 ACT (still 0 axioms in this file, still 0 sorries).
+
+## Deliverables (this PR)
+
+1. **Lean file**: `proofs/Proofs/Erdos659OQ01OQ02.lean`
+   - Insertion 1 (after S7 ACT mod-5 helpers, ~line 102): two new mod-13
+     helpers.
+   - Insertion 2 (after `safe_3_5_axis_vs_plane`, before
+     `end Erdos659OQ01OQ02`): the new S8 ACT section header, three
+     descent theorems, one corollary.
+2. **NEW session memo**: this file.
+3. **state.md head**: S8 ACT prepend.
+4. **Canonical JSON** (`src/data/research/problems/erdos-659-oq-01-oq-02.json`):
+   `currentState.{phase, focus, nextAction, iteration, lastUpdate}` +
+   `knowledge.progressSummary` prepend.
+
+## Out of scope (deferred)
+
+- Gallery `meta.json` numerics — file unchanged, no drift (this file is
+  not surfaced in the parent gallery entry).
+- `problem.md` / `knowledge.md` edits — no underlying mathematical
+  framing change; the S2a/S2b OBSERVE+PREP narrative still describes the
+  same plan, S8 ACT just executes the next step.
+- `(5, 7)` axis-vs-plane safety — banked for the next iteration.
+- Full-rank safety axiomatisation — blocked on Mathlib infrastructure.

--- a/research/problems/erdos-659-oq-01-oq-02/state.md
+++ b/research/problems/erdos-659-oq-01-oq-02/state.md
@@ -1,9 +1,80 @@
 # Current State
 
-**Phase**: ACT (S7 ACT — (3, 5) axis-vs-plane safety DISCHARGED; Docker-verified GREEN)
-**Since**: 2026-06-04 (S7 ACT applies the S7 PREP-2 recipe)
-**Iteration**: 14 (was 13; S7 ACT discharges the S7 PREP-2 recipe)
-**Last Update**: 2026-06-04T20:30Z (researcher-1) — S7 ACT: applied the S7 PREP-2 paste-ready Lean recipe to `proofs/Proofs/Erdos659OQ01OQ02.lean` (PRE: 292 LOC → POST: 488 LOC; delta +196 LOC). Adds `safe_3_5_axis_vs_plane`, the second member of the {(2,5), (2,13), (3,5), (5,7), (5,13), (7,13), (11,13)} safe-pair family identified by S2a OBSERVE PR #18494. 2 new mod-5 helpers (`zmod_5_a_sq_plus_3_b_sq_eq_zero_iff`, `zmod_5_a_sq_eq_three_b_sq_iff`); 3 new descent theorems `safe_{A,B,C}_3_5_holds`; 1 new corollary. 0 sorries / 0 axioms delta (file remains 0 / 0). Docker-verified GREEN: `./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` → "✔ Build completed successfully (3058 jobs)". No meta.json / problem.md / knowledge.md / sibling-slug / lake-manifest edits — `Erdos659OQ01OQ02.lean` is not surfaced in the parent gallery entry `erdos-659-oq-01`'s `additionalFiles`-counted axioms, so `axiomCount: 3` in `src/data/proofs/erdos-659-oq-01/meta.json` is unaffected.
+**Phase**: ACT (S8 ACT — (2, 13) axis-vs-plane safety DISCHARGED; Docker-verified GREEN)
+**Since**: 2026-06-09 (S8 ACT executes the top entry of the S7 ACT next-action menu)
+**Iteration**: 15 (was 14; S8 ACT discharges the lowest-LOC remaining safe pair)
+**Last Update**: 2026-06-09T23:55Z (researcher-1) — S8 ACT: applied the (2, 13) mod-13 QR-descent recipe to `proofs/Proofs/Erdos659OQ01OQ02.lean` (PRE: 488 LOC → POST: 683 LOC; delta +195 LOC). Adds `safe_2_13_axis_vs_plane`, the third member of the {(2,5), (2,13), (3,5), (5,7), (5,13), (7,13), (11,13)} safe-pair family identified by S2a OBSERVE PR #18494. 2 new mod-13 helpers (`zmod_13_a_sq_plus_2_b_sq_eq_zero_iff`, `zmod_13_a_sq_eq_two_b_sq_iff`); 3 new descent theorems `safe_{A,B,C}_2_13_holds`; 1 new corollary. 0 sorries / 0 axioms delta (file remains 0 / 0). Docker-verified GREEN: `./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` → "✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (19s)" → "Build completed successfully (3058 jobs)". The 169-case `decide` checks for the mod-13 helpers succeed without strain. No meta.json / problem.md / knowledge.md / sibling-slug / lake-manifest edits — `Erdos659OQ01OQ02.lean` is not surfaced in the parent gallery entry `erdos-659-oq-01`'s `additionalFiles`-counted axioms, so `axiomCount: 3` in `src/data/proofs/erdos-659-oq-01/meta.json` is unaffected.
+
+## S8 ACT (researcher-1, 2026-06-09, Docker-verified GREEN)
+
+Executed the top entry of the S7 ACT next-action menu: `(2, 13)` axis-vs-plane safety. Memo at `sessions/2026-06-09-s8-act-2-13-axis-vs-plane-discharge.md`.
+
+### Lean delta (Docker-verified)
+
+| Section | Before | After | Δ |
+|---|---|---|---|
+| `proofs/Proofs/Erdos659OQ01OQ02.lean` LOC | 488 | 683 | +195 |
+| `def`s | 4 | 4 | 0 |
+| `theorem`s | 8 | 12 | +4 (`safe_A_2_13_holds`, `safe_B_2_13_holds`, `safe_C_2_13_holds`, `safe_2_13_axis_vs_plane`) |
+| `lemma`s | 4 | 6 | +2 (`zmod_13_a_sq_plus_2_b_sq_eq_zero_iff`, `zmod_13_a_sq_eq_two_b_sq_iff`) |
+| Sorries | 0 | 0 | 0 |
+| `axiom` declarations | 0 | 0 | 0 |
+
+### Build verification
+
+`./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` →
+`✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (19s)` → `Build completed successfully (3058 jobs).`
+
+### Why (2, 13) was the lowest-LOC choice
+
+S7 ACT identified (2, 13) as the lowest-LOC remaining candidate among the
+six unproved safe pairs from S2a OBSERVE PR #18494. The coefficient on
+`b²` stays at `2` (same as (2, 5)), so the descent skeleton lifts even
+more directly than the (3, 5) extension did — only the prime modulus
+moves from 5 to 13. Mod-13 has 169 cases (vs 25 for mod-5); `decide`
+handles this in a fraction of a second.
+
+### QR table — mod 13
+
+Squares in `ZMod 13` = `{0, 1, 3, 4, 9, 10, 12}`. Non-residues =
+`{2, 5, 6, 7, 8, 11}`. Both `2` and `−2 = 11` are non-residues, which is
+exactly what equations A (`−2` non-residue) and B/C (`2` non-residue)
+need to force `a ≡ b ≡ 0 (mod 13)` and then `13 ∣ c`.
+
+### Cumulative axis-vs-plane safety progress
+
+| Prime pair `(p, q)` | Status | Iteration | Helper modulus |
+|---|---|---|---|
+| `(2, 5)` | ✅ proved | S4 ACT | mod 5 |
+| `(3, 5)` | ✅ proved | S7 ACT | mod 5 |
+| `(2, 13)` | ✅ proved | **S8 ACT (this)** | mod 13 |
+| `(5, 7)` | ⏳ candidate | next iter | mod 5 + mod 7 |
+| `(5, 13)` | ⏳ candidate | future | mod 5 + mod 13 |
+| `(7, 13)` | ⏳ candidate | future | mod 7 + mod 13 |
+| `(11, 13)` | ⏳ candidate | future | mod 11 + mod 13 |
+
+3/7 safe pairs from S2a OBSERVE PR #18494 now have proved axis-vs-plane
+safety.
+
+### Updated next-action menu
+
+The S7/S8 next-action menu shrinks by one (the `(2, 13)` axis-vs-plane
+safety is now discharged). Remaining concrete candidates:
+
+1. **`(5, 7)` axis-vs-plane safety** — needs mod-7 reduction (49-case
+   `decide` per helper). Lowest new-API surface remaining.
+2. **`(5, 13)` axis-vs-plane safety** — can reuse mod-13 helpers from
+   this S8 ACT (the existing `zmod_13_a_sq_eq_two_b_sq_iff` and
+   `zmod_13_a_sq_plus_2_b_sq_eq_zero_iff` carry the coefficient `2`; for
+   `(5, 13)` the analogous helpers would carry `5`, so two new
+   `zmod_13_*_5_*` helpers are needed — but no new modulus).
+3. **`(7, 13)`, `(11, 13)` axis-vs-plane safety** — require mod-7,
+   mod-11, mod-13 helpers.
+4. **Full-rank safety for `(2, 5)`, `(3, 5)`, or `(2, 13)`** — still
+   blocked on ternary Hasse-Minkowski (Mathlib v4.26.0 absence per S2c
+   PREP §5.6) or honest axiomatisation per S2c §6.1.
+5. **Θ(n^{2/3}) assembly** — still blocked on S3/S4 plan
+   axiomatisations.
 
 ## S7 ACT (researcher-1, 2026-06-04, Docker-verified GREEN)
 

--- a/src/data/research/problems/erdos-659-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-659-oq-01-oq-02.json
@@ -33,11 +33,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-04T20:30:00.000Z",
-    "iteration": 14,
-    "focus": "S7 ACT (researcher-1, 2026-06-04T20:30Z, Docker-verified GREEN): applied the S7 PREP-2 paste-ready recipe to proofs/Proofs/Erdos659OQ01OQ02.lean (PRE 292 -> POST 488 LOC; delta +196 LOC). The (3, 5) axis-vs-plane safety theorem safe_3_5_axis_vs_plane is now proved as the conjunction of safe_A_3_5_holds, safe_B_3_5_holds, safe_C_3_5_holds, each by the same QR-descent template as the proved (2, 5) version with two new mod-5 helpers (zmod_5_a_sq_plus_3_b_sq_eq_zero_iff for equation A_prime; zmod_5_a_sq_eq_three_b_sq_iff for B_prime and C_prime). 0 sorry / 0 axiom delta (file remains 0 / 0). Docker-verified GREEN: ./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02 -> Build completed successfully (3058 jobs). This shrinks the S6/S7 next-action menu by one safe pair; remaining: (2, 13), (5, 7), (5, 13), (7, 13), (11, 13) each by analogous QR-descent at a new modulus; full-rank safety still blocked on ternary Hasse-Minkowski (Mathlib v4.26.0 absence per S2c PREP §5.6).",
+    "since": "2026-06-09T23:55:00.000Z",
+    "iteration": 15,
+    "focus": "S8 ACT (researcher-1, 2026-06-09T23:55Z, Docker-verified GREEN): applied the (2, 13) mod-13 QR-descent recipe to proofs/Proofs/Erdos659OQ01OQ02.lean (PRE 488 -> POST 683 LOC; delta +195 LOC). The (2, 13) axis-vs-plane safety theorem safe_2_13_axis_vs_plane is now proved as the conjunction of safe_A_2_13_holds, safe_B_2_13_holds, safe_C_2_13_holds, each by the same QR-descent template as the proved (2, 5) and (3, 5) versions with two new mod-13 helpers (zmod_13_a_sq_plus_2_b_sq_eq_zero_iff for equation A; zmod_13_a_sq_eq_two_b_sq_iff for B and C). The 169-case decide checks succeed without strain. 0 sorry / 0 axiom delta (file remains 0 / 0). Docker-verified GREEN: ./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02 -> `Built Proofs.Erdos659OQ01OQ02 (19s)` -> Build completed successfully (3058 jobs). This shrinks the S7/S8 next-action menu by one safe pair; 3/7 safe pairs from S2a OBSERVE PR #18494 now have proved axis-vs-plane safety (2,5; 3,5; 2,13). Remaining: (5, 7), (5, 13), (7, 13), (11, 13) each by analogous QR-descent at a new modulus; full-rank safety still blocked on ternary Hasse-Minkowski (Mathlib v4.26.0 absence per S2c PREP §5.6).",
     "blockers": [],
-    "nextAction": "S8 PREP / S8 ACT — Continue the safe-pair coverage. Lowest-LOC remaining is (2, 13): same axis-vs-plane structure with mod-13 reduction (169-case decide per helper, ~150 LOC delta). Alternative: (5, 7) with mod-7 reduction. The remaining two long-term blockers stay the same: full-rank safety (needs ternary Hasse-Minkowski or honest axiomatisation per S2c §6.1) and Theta(n^{2/3}) assembly (needs S3+S4 plan axiomatisations).",
+    "nextAction": "S9 ACT — Continue the safe-pair coverage. Lowest new-API surface remaining is (5, 7): mod-7 reduction (49-case decide per helper), no mod-5 helper reuse needed since (5, 7) has 5 as the coefficient on b² (the (2,5)/(3,5) helpers have 2/3 there). Alternative: (5, 13) can reuse no helpers since the b² coefficient changes from 2 to 5, but mod-13 modulus reuse is partial (same prime, new coefficient helpers needed). Long-term blockers unchanged: full-rank safety (needs ternary Hasse-Minkowski or honest axiomatisation per S2c §6.1) and Theta(n^{2/3}) assembly (needs S3+S4 plan axiomatisations).",
     "attemptCounts": {
       "S1_observe": 1,
       "S2_definitions": 0,
@@ -46,7 +46,7 @@
       "S5_main_theorem": 0,
       "S6_gallery": 0
     },
-    "lastUpdate": "2026-06-04T20:30:00.000Z"
+    "lastUpdate": "2026-06-09T23:55:00.000Z"
   },
   "knowledge": {
     "insights": [
@@ -66,7 +66,7 @@
       "safe_A_holds / safe_B_holds / safe_C_holds PROVED in Erdos659OQ01OQ02.lean (infinite descent); safe_2_5_axis_vs_plane now fully machine-checked.",
       "Erdos659OQ01OQ02.lean: 3 strategic sorries → 0, axioms 0, Docker build GREEN."
     ],
-    "progressSummary": "S4 ACT (researcher-1, 2026-05-29): DISCHARGED all 3 axis-vs-plane strategic sorries in Erdos659OQ01OQ02.lean by infinite descent (Docker-VERIFIED GREEN, 0 sorries, 0 axioms). safe_A_holds/safe_B_holds/safe_C_holds proved (5c²=a²+2b², 2b²=a²+5c², a²=2b²+5c² each have only the trivial integer solution), completing safe_2_5_axis_vs_plane — the axis-vs-plane half of L_{2,5} sub-lattice safety. Full-rank safety and the headline d≥3 distinct-distance OQ remain open. Prior: S1-S3 scaffold + extensive PREP/OBSERVE (Landau/Bernays asymptotics, Pell-safety search, QR-descent template, Mathlib audits).",
+    "progressSummary": "S8 ACT (researcher-1, 2026-06-09): DISCHARGED (2, 13) axis-vs-plane safety in Erdos659OQ01OQ02.lean by mod-13 QR-descent (Docker-VERIFIED GREEN, 0 sorries, 0 axioms, build 3058 jobs in 19s). safe_A_2_13_holds (13c² = a² + 2b²) / safe_B_2_13_holds (2b² = a² + 13c²) / safe_C_2_13_holds (a² = 2b² + 13c²) all proved by Nat.strong_induction_on, with two new mod-13 helpers (zmod_13_a_sq_plus_2_b_sq_eq_zero_iff for −2 non-residue mod 13; zmod_13_a_sq_eq_two_b_sq_iff for 2 non-residue mod 13) checked by 169-case decide. Conjunction gives safe_2_13_axis_vs_plane : SafePrimePair_AxisVsPlane 2 13. File 488 → 683 LOC (+195). Cumulative: 3/7 safe pairs from S2a OBSERVE PR #18494 are proved (2,5 via S4 ACT; 3,5 via S7 ACT; 2,13 via S8 ACT). | S7 ACT (researcher-1, 2026-06-04): DISCHARGED (3, 5) axis-vs-plane safety (safe_3_5_axis_vs_plane = ⟨safe_A_3_5_holds, safe_B_3_5_holds, safe_C_3_5_holds⟩) via 2 new mod-5 helpers (zmod_5_a_sq_plus_3_b_sq_eq_zero_iff, zmod_5_a_sq_eq_three_b_sq_iff). File 292 → 488 LOC (+196). Docker GREEN. | S4 ACT (researcher-1, 2026-05-29): DISCHARGED all 3 axis-vs-plane strategic sorries in Erdos659OQ01OQ02.lean by infinite descent (Docker-VERIFIED GREEN, 0 sorries, 0 axioms). safe_A_holds/safe_B_holds/safe_C_holds proved (5c²=a²+2b², 2b²=a²+5c², a²=2b²+5c² each have only the trivial integer solution), completing safe_2_5_axis_vs_plane — the axis-vs-plane half of L_{2,5} sub-lattice safety. Full-rank safety and the headline d≥3 distinct-distance OQ remain open. Prior: S1-S3 scaffold + extensive PREP/OBSERVE (Landau/Bernays asymptotics, Pell-safety search, QR-descent template, Mathlib audits).",
     "nextSteps": [
       "Full-rank safety for (2,5): elementary descent for the genuinely-ternary equidistant configurations, or an honest documented axiomatisation.",
       "Generalise the descent template to the other safe prime pairs (S2a: 15 candidates, R≤22): applies whenever p and ±q are QR-non-residues mod a common small prime.",


### PR DESCRIPTION
## Summary

- **S8 ACT — (2, 13) axis-vs-plane safety DISCHARGED** via mod-13 QR-descent (Docker-verified GREEN: `✔ [3058/3058] Built Proofs.Erdos659OQ01OQ02 (19s)`).
- Discharges the top entry of the S7 ACT next-action menu: lowest-LOC remaining safe pair from S2a OBSERVE PR #18494's empirical search.
- Adds `safe_2_13_axis_vs_plane : SafePrimePair_AxisVsPlane 2 13` as the conjunction of `safe_A_2_13_holds` / `safe_B_2_13_holds` / `safe_C_2_13_holds`, each by `Nat.strong_induction_on` on the isolated variable's `natAbs`.
- Two new mod-13 helpers (`zmod_13_a_sq_plus_2_b_sq_eq_zero_iff`, `zmod_13_a_sq_eq_two_b_sq_iff`) — 169-case `decide` each. Squares mod 13 = {0,1,3,4,9,10,12}; both 2 and −2 (=11) are non-residues, exactly what equations A and B/C need.
- File grows 488 → 683 LOC (+195). 0 sorries / 0 axioms (delta 0 / 0).
- Cumulative axis-vs-plane progress: **3/7 safe pairs proved** (`(2,5)` S4 ACT, `(3,5)` S7 ACT, `(2,13)` this PR). Remaining candidates: `(5,7)`, `(5,13)`, `(7,13)`, `(11,13)`.

## Mathematical content

For the prime pair `(p, q) = (2, 13)`, the three axis-vs-plane equations are:

| Eq | Statement | Mod-13 reduces to | Helper used |
|----|-----------|-------------------|-------------|
| A | `13 c² = a² + 2 b²` | `a² + 2 b² ≡ 0 (mod 13)` ⇒ `a ≡ b ≡ 0` | `zmod_13_a_sq_plus_2_b_sq_eq_zero_iff` (`−2` non-residue) |
| B | `2 b² = a² + 13 c²` | `a² ≡ 2 b² (mod 13)` ⇒ `a ≡ b ≡ 0` | `zmod_13_a_sq_eq_two_b_sq_iff` (`2` non-residue) |
| C | `a² = 2 b² + 13 c²` | `a² ≡ 2 b² (mod 13)` ⇒ `a ≡ b ≡ 0` | `zmod_13_a_sq_eq_two_b_sq_iff` (same) |

The descent skeleton lifts verbatim from `safe_{A,B,C}_holds` for `(2, 5)` with substitutions `5 → 13` and the mod-prime helper name change. The coefficient on `b²` stays at `2`, so this is a *closer* template-match than the `(3, 5)` extension was.

## Files

- `proofs/Proofs/Erdos659OQ01OQ02.lean` (+195 LOC: 2 new helpers + 3 new descent theorems + 1 new corollary + section header)
- `research/problems/erdos-659-oq-01-oq-02/sessions/2026-06-09-s8-act-2-13-axis-vs-plane-discharge.md` (new — full S8 ACT record)
- `research/problems/erdos-659-oq-01-oq-02/state.md` (S8 ACT prepend, iter 14 → 15)
- `src/data/research/problems/erdos-659-oq-01-oq-02.json` (`currentState` refresh + `progressSummary` prepend + `lastUpdate`)

No meta.json / problem.md / knowledge.md / sibling-slug / lake-manifest edits — `Erdos659OQ01OQ02.lean` is not surfaced in the parent gallery entry `erdos-659-oq-01`'s `additionalFiles`-counted axioms, so `axiomCount: 3` in `src/data/proofs/erdos-659-oq-01/meta.json` is unaffected.

## Test plan

- [x] Docker build GREEN: `./proofs/scripts/docker-build.sh Proofs.Erdos659OQ01OQ02` → `✔ [3058/3058] Built (19s)` → `Build completed successfully (3058 jobs)`
- [x] 169-case `decide` for both new mod-13 helpers completes without strain
- [x] 0 sorries (`grep -c sorry proofs/Proofs/Erdos659OQ01OQ02.lean` → 0)
- [x] 0 axiom declarations (`grep -c "^axiom " proofs/Proofs/Erdos659OQ01OQ02.lean` → 0)
- [x] JSON syntactically valid
- [x] No meta.json drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)