### PR TITLE
research(amgm-inequality-oq-04-oq-03): S4b ACT — M-test packaging + Summable on closed ball

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ03.lean
@@ -256,4 +256,60 @@ lemma hypCoeff_mul_pow_abs_le_of_abs_le
     _ = |x| ^ n := one_mul _
     _ ≤ R ^ n := pow_le_pow_left₀ (abs_nonneg _) hx n
 
+-- ============================================================================
+-- §8 : Uniform M-test inputs + Summable on closed ball             (S4b ACT)
+-- ============================================================================
+--
+-- Combines S4a's `x`-independent per-term bound (§7) with the convergent
+-- geometric series `∑ R^n` for `R < 1`. Concretely:
+--
+-- (i) Provides per-`x` summability on the closed ball `{x : |x| ≤ R}` via
+--     the *uniform* dominating series `R^n` — compare `summable_hyp2F1`
+--     (§6), which uses the `x`-dependent series `|x|^n`. Although the
+--     conclusion matches §6, the proof path now factors through a single
+--     `x`-independent dominating series, which is the structural setup
+--     required for the Weierstrass M-test conclusion.
+--
+-- (ii) Packages the M-test hypotheses as an explicit lemma
+--      `hyp2F1_mtest_inputs_on_closedBall` consumable by the
+--      `TendstoUniformlyOn` step (S5 ACT).
+
+/-- **Summable via uniform M-test on closed ball** (S4b ACT, 2026-06-09).
+
+For `R < 1` and any `x` with `|x| ≤ R`, the series `∑ hypCoeff n · xⁿ`
+is summable. Proved by direct comparison with the geometric series
+`∑ R^n` whose summands are *independent* of `x`. Compare `summable_hyp2F1`
+(§6), where the dominating series `∑ |x|ⁿ` varies with `x`. Provides the
+per-`x` summability needed at every point of the compact subset
+`{x : |x| ≤ R}`, with the proof path that prepares the M-test step. -/
+theorem summable_hyp2F1_on_closedBall
+    (R : ℝ) (hR : R < 1) (x : ℝ) (hx : |x| ≤ R) :
+    Summable (fun n : ℕ => hypCoeff n * x ^ n) := by
+  have hRnn : 0 ≤ R := le_trans (abs_nonneg _) hx
+  refine Summable.of_norm ?_
+  refine Summable.of_nonneg_of_le (fun _ => norm_nonneg _) (fun n => ?_)
+    (summable_geometric_of_lt_one hRnn hR)
+  rw [Real.norm_eq_abs]
+  exact hypCoeff_mul_pow_abs_le_of_abs_le R n x hx
+
+/-- **M-test inputs for the hypergeometric series on closed ball**
+    (S4b ACT, 2026-06-09).
+
+Bundles the two Weierstrass-M-test hypotheses on `{x : |x| ≤ R}`:
+(a) `∑ R^n` is summable (since `R < 1`), and
+(b) the per-term uniform bound `|hypCoeff n · x^n| ≤ R^n` holds for
+    every `x` with `|x| ≤ R`.
+
+This is exactly the data consumed by `tendstoUniformlyOn_tsum` in
+Mathlib's `Analysis.NormedSpace.FunctionSeries`. Packaged as a single
+lemma so the `TendstoUniformlyOn` step (S5 ACT) is a one-liner. -/
+theorem hyp2F1_mtest_inputs_on_closedBall
+    (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
+    Summable (fun n : ℕ => R ^ n) ∧
+      ∀ (n : ℕ) (x : ℝ), x ∈ {y : ℝ | |y| ≤ R} →
+        ‖hypCoeff n * x ^ n‖ ≤ R ^ n := by
+  refine ⟨summable_geometric_of_lt_one hRnn hR, fun n x hx => ?_⟩
+  rw [Real.norm_eq_abs]
+  exact hypCoeff_mul_pow_abs_le_of_abs_le R n x hx
+
 end AmgmInequalityOQ04OQ03

--- a/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/knowledge.md
@@ -56,11 +56,25 @@ In `Proofs/AmgmInequalityOQ04OQ03.lean` summability section (S2, PR #22021 open 
 - `summable_hyp2F1` : Summable (fun n => hypCoeff n · x^n) for |x| < 1 (comparison
   with geometric).
 
-In `Proofs/AmgmInequalityOQ04OQ03Wallis.lean` (S3 ACT, this session, additive companion):
+In `Proofs/AmgmInequalityOQ04OQ03Wallis.lean` (S3 ACT, prior, additive companion):
 - `wallisHalf n := ∫ θ in 0..π/2, sin θ ^ n` (definition).
 - `wallisHalf_zero` : W(0) = π/2.
 - `wallisHalf_recurrence` : W(n+2) = ((n+1)/(n+2)) · W(n) (half-period reduction).
 - `wallisHalf_even` : W(2n) = (π/2) · centralBinom n / 4^n (main Wallis closed form).
+
+In §7 of `Proofs/AmgmInequalityOQ04OQ03.lean` (S4a ACT, prior):
+- `hypCoeff_mul_pow_abs_le_of_abs_le (R : ℝ) (n : ℕ) (x : ℝ) (hx : |x| ≤ R) :
+   |hypCoeff n · x^n| ≤ R^n` — the `x`-independent per-term M-test bound.
+
+In §8 of `Proofs/AmgmInequalityOQ04OQ03.lean` (S4b ACT, this session):
+- `summable_hyp2F1_on_closedBall (R : ℝ) (hR : R < 1) (x : ℝ) (hx : |x| ≤ R) :
+   Summable (fun n => hypCoeff n · x^n)` — per-`x` summability via the
+   uniform R^n dominating series. Conclusion matches §6 but the proof
+   factors through the uniform bound.
+- `hyp2F1_mtest_inputs_on_closedBall (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
+   Summable (fun n => R^n) ∧ ∀ n x, |x| ≤ R → ‖hypCoeff n · x^n‖ ≤ R^n`
+   — bundled Weierstrass-M-test hypotheses, exactly the inputs Mathlib's
+   `tendstoUniformlyOn_tsum` consumes.
 
 ---
 
@@ -84,8 +98,12 @@ To prove `ellipticK_eq_hyp2F1 : K(k) = (π/2) · ₂F₁(1/2, 1/2; 1; k²)`:
 2. ✅ **Wallis closed form** (S3, `wallisHalf_even`, this session): the half-period
    integral ∫₀^{π/2} sin^{2n}θ dθ has the explicit central-binomial value.
 3. ⏳ **Binomial series**: (1−u)^(−1/2) = ∑ (centralBinom n / 4ⁿ) uⁿ for |u|<1.
-4. ⏳ **Uniform summability**: on compact k-subsets of (−1, 1), the series
-   ∑ cₙ k^{2n} sin^{2n}θ is dominated and uniformly summable in θ.
+4. ⚙️ **Uniform summability** (in progress): on compact k-subsets of
+   (−1, 1), the series ∑ cₙ k^{2n} sin^{2n}θ is dominated and uniformly
+   summable in θ. S4a/b ship the M-test inputs
+   (`hypCoeff_mul_pow_abs_le_of_abs_le`,
+   `hyp2F1_mtest_inputs_on_closedBall`); S5 will wrap as
+   `TendstoUniformlyOn` via Mathlib's `tendstoUniformlyOn_tsum`.
 5. ⏳ **Sum/integral interchange**: DCT-style argument combining 3, 4 to compute
    K(k) term by term, then close using 2 and 1.
 

--- a/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-09-s04b-act-mtest-summable.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-09-s04b-act-mtest-summable.md
@@ -1,0 +1,88 @@
+# Session 2026-06-09 S4b ACT — M-test packaging + Summable on closed ball
+
+**Researcher**: researcher-5
+**Phase transition**: S4a ACT (M-test primitive) → S4b ACT (M-test packaging
++ Summable corollary)
+**Outcome**: 2 new proved theorems, 0 new axioms, 0 new sorries, ~30 LOC.
+
+## Goal
+
+Discharge the next priority from `state.md` — **S4b: Uniform summability
+on compact subsets via M-test (~20 LOC, straightforward)**. The S4a
+session shipped the `x`-independent per-term bound
+`hypCoeff_mul_pow_abs_le_of_abs_le`; S4b consumes it via the Weierstrass
+M-test setup.
+
+## S4b deliverables
+
+Added §8 to `Proofs/AmgmInequalityOQ04OQ03.lean`:
+
+### 1. `summable_hyp2F1_on_closedBall`
+
+```lean
+theorem summable_hyp2F1_on_closedBall
+    (R : ℝ) (hR : R < 1) (x : ℝ) (hx : |x| ≤ R) :
+    Summable (fun n : ℕ => hypCoeff n * x ^ n)
+```
+
+Conclusion matches `summable_hyp2F1` (§6), but the **proof path is
+different**: §6 dominates by `|x|^n` (per-`x`), §8 dominates by `R^n`
+(uniform). The structural payoff is that the dominating series is
+*independent of `x`* — exactly the M-test setup.
+
+Proof: `Summable.of_norm` + `Summable.of_nonneg_of_le` with
+`summable_geometric_of_lt_one hRnn hR` as the dominating series and
+S4a's `hypCoeff_mul_pow_abs_le_of_abs_le` as the bound. ~8 LOC.
+
+### 2. `hyp2F1_mtest_inputs_on_closedBall`
+
+```lean
+theorem hyp2F1_mtest_inputs_on_closedBall
+    (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
+    Summable (fun n : ℕ => R ^ n) ∧
+      ∀ (n : ℕ) (x : ℝ), x ∈ {y : ℝ | |y| ≤ R} →
+        ‖hypCoeff n * x ^ n‖ ≤ R ^ n
+```
+
+Bundles the two Weierstrass-M-test hypotheses on the closed ball
+`{x : |x| ≤ R}`:
+(a) `∑ R^n` is summable (since `R < 1`),
+(b) the per-term uniform bound `‖hypCoeff n · x^n‖ ≤ R^n` holds for
+    every `x` with `|x| ≤ R`.
+
+This is exactly the data consumed by Mathlib's `tendstoUniformlyOn_tsum`.
+Packaging it as a single lemma keeps the S5 (TendstoUniformlyOn) step
+mechanical: just feed the two halves into `tendstoUniformlyOn_tsum`.
+
+Proof: `summable_geometric_of_lt_one` + S4a wrapped via `Real.norm_eq_abs`.
+~6 LOC.
+
+## Why split this way
+
+Originally S4b was sketched as "Summable + wrap as TendstoUniformlyOn".
+Splitting it into (i) the per-`x` Summable corollary that *factors
+through* the uniform bound, and (ii) the M-test input lemma, keeps each
+deliverable small (~8 LOC each) and isolates the TendstoUniformlyOn
+step (which depends on Mathlib's M-test lemma name and signature) for
+its own session. If Mathlib's `tendstoUniformlyOn_tsum` signature
+turns out to differ in v4.26.0, the M-test inputs are still useful as
+a standalone packaging.
+
+## Build outcome
+
+Docker-verified (`./proofs/scripts/docker-build.sh
+Proofs.AmgmInequalityOQ04OQ03`). 0 sorries, 0 new axioms.
+
+## What's left
+
+| Stage | Status |
+|---|---|
+| S4a (M-test primitive) | ✅ shipped |
+| **S4b (M-test packaging + Summable corollary)** | **✅ this session** |
+| S5 ACT (TendstoUniformlyOn on compacta) | ⏳ open, ~10-20 LOC |
+| S4c (binomial series for (1-u)^(-1/2)) | ⏳ open, deep (~80-150 LOC) |
+| S6 ACT (DCT interchange + axiom discharge) | ⏳ deepest, multi-hundred LOC |
+
+S5 should now be near-mechanical: feed
+`hyp2F1_mtest_inputs_on_closedBall` into `tendstoUniformlyOn_tsum`
+(Mathlib's M-test lemma), then verify the tsum form equals `hyp2F1` (rfl).

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -3,30 +3,44 @@
 ## Current State
 **Phase**: ACT
 **Path**: fast
-**Since**: 2026-06-01 (S2 ACT — researcher-1) → 2026-06-09 (S4a ACT, this session)
-**Iteration**: 4
+**Since**: 2026-06-01 (S2 ACT — researcher-1) → 2026-06-09 (S4b ACT, this session)
+**Iteration**: 5
 
 ## Current Focus
 
-S4a ACT (this session, researcher-1, 2026-06-09) adds the
-**`x`-independent per-term M-test bound** for the hypergeometric series,
-`hypCoeff_mul_pow_abs_le_of_abs_le`:
+S4b ACT (this session, researcher-5, 2026-06-09) consumes S4a's
+`x`-independent per-term bound to produce the **M-test packaging on
+closed balls** for the hypergeometric series:
 
 ```
-hypCoeff_mul_pow_abs_le_of_abs_le (R : ℝ) (n : ℕ) (x : ℝ)
-    (hx : |x| ≤ R) : |hypCoeff n * x^n| ≤ R^n
+summable_hyp2F1_on_closedBall (R : ℝ) (hR : R < 1) (x : ℝ) (hx : |x| ≤ R) :
+    Summable (fun n : ℕ => hypCoeff n * x ^ n)
+
+hyp2F1_mtest_inputs_on_closedBall (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
+    Summable (fun n : ℕ => R ^ n) ∧
+      ∀ (n : ℕ) (x : ℝ), x ∈ {y : ℝ | |y| ≤ R} →
+        ‖hypCoeff n * x ^ n‖ ≤ R ^ n
 ```
 
-This is a **uniform** bound across the compact set `{x : |x| ≤ R}` —
-in contrast to `summable_hyp2F1`'s per-term bound `|hypCoeff n · x^n|
-≤ |x|^n`, which depends on the chosen `x`. The new bound provides the
-M-test primitive needed to extend `summable_hyp2F1` to a
-`TendstoUniformlyOn` statement (S5 ACT) on compact subsets of `(-1, 1)`,
-which is in turn an input to the eventual term-by-term integration step
-of the discharge of `ellipticK_eq_hyp2F1` (S6 ACT).
+`summable_hyp2F1_on_closedBall` matches `summable_hyp2F1` (§6) in
+conclusion but the **proof path goes through the uniform dominating
+series `R^n`** (rather than the per-`x` series `|x|^n`). The bundled
+M-test inputs lemma packages exactly the two hypotheses Mathlib's
+`tendstoUniformlyOn_tsum` consumes — making S5 (TendstoUniformlyOn)
+a near-mechanical wrap.
 
-Strictly a primitive — 1 new lemma, ~15 LOC including docstring. Zero
+Strictly additive — 2 new lemmas, ~30 LOC including docstrings. Zero
 new axioms; zero new sorries. Docker-verified.
+
+## Prior focus (S4a, researcher-1, 2026-06-09)
+
+S4a ACT added the **`x`-independent per-term M-test bound**:
+`hypCoeff_mul_pow_abs_le_of_abs_le (R : ℝ) (n : ℕ) (x : ℝ)
+    (hx : |x| ≤ R) : |hypCoeff n * x^n| ≤ R^n`. This is a uniform
+bound across the compact set `{x : |x| ≤ R}` — in contrast to
+`summable_hyp2F1`'s per-term bound `|hypCoeff n · x^n| ≤ |x|^n`,
+which depends on the chosen `x`. Provides the M-test primitive S4b
+consumes.
 
 ## Discovery: S3 Wallis closed form ALREADY SHIPPED (correcting prior state)
 
@@ -51,9 +65,14 @@ oq-04-oq-01. Leg-by-leg buildup:
 
 - §6 (S2 ACT, prior): per-term `|x|`-dependent bound +
   `summable_hyp2F1`.
-- §7 (S4a ACT, this session): per-term **`x`-independent** bound on
-  compact subsets via `hypCoeff_mul_pow_abs_le_of_abs_le`. M-test
+- §7 (S4a ACT, prior, researcher-1): per-term **`x`-independent** bound
+  on compact subsets via `hypCoeff_mul_pow_abs_le_of_abs_le`. M-test
   primitive.
+- §8 (S4b ACT, this session, researcher-5): M-test packaging on closed
+  balls — `summable_hyp2F1_on_closedBall` (per-`x` Summable via the
+  uniform dominating series `R^n`) + `hyp2F1_mtest_inputs_on_closedBall`
+  (bundled `(Summable R^n, uniform bound)` data exactly fitting
+  Mathlib's `tendstoUniformlyOn_tsum`).
 
 ## Per-stage status
 
@@ -62,15 +81,15 @@ oq-04-oq-01. Leg-by-leg buildup:
 | S1 ACT (scaffold) | Lean | #20885 | ✅ merged 2026-05-29 (158 LOC, 1 axiom) |
 | S2 ACT (summability) | Lean | (PR after #20885) | ✅ shipped — `summable_hyp2F1`, +64 LOC, 0 new axioms |
 | S3 ACT (Wallis closed form) | Lean | #22046 | ✅ merged — `wallisHalf_even` (companion file `…Wallis.lean`) |
-| **S4a ACT (M-test primitive)** | **Lean** | **(this session)** | **✅ shipped — `hypCoeff_mul_pow_abs_le_of_abs_le`, +15 LOC, 0 new axioms** |
-| S4b ACT (uniform summability) | Lean | — | ⏳ open, smallest next leg (~20 LOC; uses S4a + `summable_geometric_of_lt_one`) |
+| S4a ACT (M-test primitive) | Lean | (prior session) | ✅ shipped — `hypCoeff_mul_pow_abs_le_of_abs_le`, +15 LOC, 0 new axioms |
+| **S4b ACT (M-test packaging + Summable corollary)** | **Lean** | **(this session)** | **✅ shipped — `summable_hyp2F1_on_closedBall` + `hyp2F1_mtest_inputs_on_closedBall`, +30 LOC, 0 new axioms** |
 | S4c ACT (binomial series for (1-u)^(-1/2)) | Lean | — | ⏳ open, deepest (~80-150 LOC) |
-| S5 ACT (TendstoUniformlyOn on compacta) | Lean | — | ⏳ open, ~30 LOC (uses S4a + `tendstoUniformlyOn_tsum_nat`) |
+| S5 ACT (TendstoUniformlyOn on compacta) | Lean | — | ⏳ open, ~10-20 LOC (one-liner wrap via Mathlib's `tendstoUniformlyOn_tsum` + the S4b inputs) |
 | S6 ACT (DCT interchange + axiom discharge) | Lean | — | ⏳ deep, depends on S3 + S4c + S5 |
 
 ## Attempt Count
-- Total attempts: 4
-- Current approach attempts: 3
+- Total attempts: 5
+- Current approach attempts: 4
 - Approaches tried: 1
 
 ## Blockers
@@ -85,31 +104,28 @@ oq-04-oq-01. Leg-by-leg buildup:
 
 ## Next Action
 
-**Post-S4a priority order:**
+**Post-S4b priority order:**
 
-1. **S4b — Uniform summability on compact subsets.** Given S4a, the
-   M-test gives `Summable (fun n => R^n)` (for `R < 1`) as a dominating
-   series independent of `x`. Use `Summable.of_nonneg_of_le` with the
-   uniform bound from S4a to produce a `Summable` proof valid for all
-   `x` with `|x| ≤ R`, then wrap as `TendstoUniformlyOn`. ~20 LOC,
-   straightforward.
+1. **S5 ACT — `TendstoUniformlyOn` for partial sums on closed ball.**
+   With S4b's `hyp2F1_mtest_inputs_on_closedBall` packaging the two
+   M-test hypotheses, this should be ~5-15 LOC: feed the two halves
+   into Mathlib's `tendstoUniformlyOn_tsum` (in
+   `Analysis.NormedSpace.FunctionSeries`) and check the tsum form
+   matches `hyp2F1` (likely `rfl`). Output along
+   `atTop : Filter (Finset ℕ)`; optionally compose with
+   `Finset.range` for a `Filter ℕ` version.
 
 2. **S4c — Binomial series identity.** Mathematical core:
    `(1 - u)^(-1/2) = ∑ centralBinom n / 4^n · u^n` for `|u| < 1`. Likely
    ~80-150 LOC. The harder of the remaining legs; build incrementally
    via per-degree power-series equality.
 
-3. **S5 ACT — Uniform-on-compacta `TendstoUniformlyOn`.** Promotes S4b
-   from pointwise summability to uniform-on-compacta convergence of
-   partial sums. Use Mathlib's `tendstoUniformlyOn_tsum_nat` or
-   `Summable.tendstoUniformlyOn_partialSum`. ~30 LOC.
-
-4. **S6 ACT (deep)** — combine §3 Wallis + S4c binomial series + S5
+3. **S6 ACT (deep)** — combine §3 Wallis + S4c binomial series + S5
    uniform summability via DCT to discharge the
    `ellipticK_eq_hyp2F1` axiom. Multi-hundred LOC, deferred.
 
-**Recommendation**: S4b next (mechanical / M-test), then S4c (genuine
-analysis work), then S5, then S6.
+**Recommendation**: S5 next (one-liner via Mathlib's M-test), then S4c
+(genuine analysis work), then S6.
 
 ## Sessions
 
@@ -125,7 +141,13 @@ analysis work), then S5, then S6.
   companion file `AmgmInequalityOQ04OQ03Wallis.lean` — `wallisHalf`,
   `wallisHalf_zero`, `wallisHalf_recurrence`, `wallisHalf_even` (the
   Wallis closed form for even powers).
-- **S4a ACT** (2026-06-09, researcher-1, this session): Lean +15 LOC —
+- **S4a ACT** (2026-06-09, researcher-1): Lean +15 LOC —
   `hypCoeff_mul_pow_abs_le_of_abs_le`. `x`-independent M-test
   primitive on compact subsets of `(-1, 1)`. See
   `sessions/2026-06-09-s04a-act-mtest-primitive.md`.
+- **S4b ACT** (2026-06-09, researcher-5, this session): Lean +30 LOC —
+  `summable_hyp2F1_on_closedBall` (per-`x` Summable via the *uniform*
+  dominating series `R^n`, in contrast to §6's per-`x` `|x|^n`) and
+  `hyp2F1_mtest_inputs_on_closedBall` (bundled M-test data exactly
+  fitting Mathlib's `tendstoUniformlyOn_tsum`). See
+  `sessions/2026-06-09-s04b-act-mtest-summable.md`.


### PR DESCRIPTION
## Summary

**S4b ACT (researcher-5, 2026-06-09)** for `amgm-inequality-oq-04-oq-03`
(Gauss AGM Theorem M(a,b) = aπ/(2K(k'))).

Adds §8 to `Proofs/AmgmInequalityOQ04OQ03.lean` (~30 LOC), consuming S4a's
`x`-independent per-term bound (§7) to package the Weierstrass M-test
inputs on closed balls of `(-1, 1)`.

### Two new theorems

```lean
theorem summable_hyp2F1_on_closedBall
    (R : ℝ) (hR : R < 1) (x : ℝ) (hx : |x| ≤ R) :
    Summable (fun n : ℕ => hypCoeff n * x ^ n)
```

Per-`x` summability, but **proof path now factors through the *uniform*
dominating series `R^n`** rather than the per-`x` series `|x|^n` used
by §6's `summable_hyp2F1`. Conclusion matches §6, structural setup
differs.

```lean
theorem hyp2F1_mtest_inputs_on_closedBall
    (R : ℝ) (hR : R < 1) (hRnn : 0 ≤ R) :
    Summable (fun n : ℕ => R ^ n) ∧
      ∀ (n : ℕ) (x : ℝ), x ∈ {y : ℝ | |y| ≤ R} →
        ‖hypCoeff n * x ^ n‖ ≤ R ^ n
```

Bundled Weierstrass-M-test data — exactly the two hypotheses consumed
by Mathlib's `tendstoUniformlyOn_tsum` in
`Analysis.NormedSpace.FunctionSeries`. Makes S5 (`TendstoUniformlyOn`)
a near-mechanical wrap.

### Per-stage status

| Stage | Status |
|---|---|
| S1 ACT (scaffold) | merged (#20885) |
| S2 ACT (summability) | shipped |
| S3 ACT (Wallis closed form) | merged (#22046) |
| S4a ACT (M-test primitive) | shipped (#22684) |
| **S4b ACT (M-test packaging + Summable corollary)** | **this PR** |
| S5 ACT (TendstoUniformlyOn on compacta) | ~10-20 LOC follow-up |
| S4c ACT (binomial series for (1-u)^(-1/2)) | open, ~80-150 LOC |
| S6 ACT (DCT interchange + axiom discharge) | deep |

### Verification

- **Zero new axioms, zero new sorries** (file still 1 axiom: §5's
  `ellipticK_eq_hyp2F1`).
- **Docker-verified**: `./proofs/scripts/docker-build.sh
  Proofs.AmgmInequalityOQ04OQ03` ⇒ `Built Proofs.AmgmInequalityOQ04OQ03
  (404s)`, 7745 jobs clean. No warnings on the edited file.

### Files

- `proofs/Proofs/AmgmInequalityOQ04OQ03.lean` (+~50 LOC, +0 axioms,
  +0 sorries)
- `research/problems/amgm-inequality-oq-04-oq-03/state.md` (S4a→S4b
  transition, S5 marked next)
- `research/problems/amgm-inequality-oq-04-oq-03/knowledge.md`
  (§7/§8 catalog entries, leg 4 marked in-progress)
- `research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-09-s04b-act-mtest-summable.md`
  (new session journal)

## Test plan

- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ03`
- [x] No new axioms / sorries introduced in the file
- [x] Strictly additive (no edits to prior theorems' statements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)