### PR TITLE
fix(minpoly-charpoly-oq-03): repair MinpolyCharpolyOQ03.lean build errors (Docker 3059 jobs clean)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03.lean
@@ -228,7 +228,7 @@ this file (sub-OQs `oq-03-oq-01` through `oq-03-oq-04`).
 theorem rational_canonical_form_exists
     {n : Type*} [Fintype n] [DecidableEq n] (M : Matrix n n F) :
     ∃ c : InvariantFactorChain F,
-      c.prodFactors = M.charpoly ∧ c.lastFactor = M.minpoly := by
+      c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M := by
   sorry
 
 /-! ## Part 3: Unconditional structural lemmas
@@ -376,7 +376,7 @@ private theorem lastFactor_eq_getElem_pred
       have hpos : 0 < c.factors.length := length_pos_of_ne_nil h
       omega) := by
   show c.factors.getLast?.getD 1 = _
-  rw [List.getLast?_eq_getLast h]
+  rw [List.getLast?_eq_some_getLast h]
   -- Now: `(some (c.factors.getLast h)).getD 1 = c.factors[...]`
   show c.factors.getLast h = _
   exact List.getLast_eq_getElem h
@@ -540,9 +540,17 @@ noncomputable def InvariantFactorChain.firstFactor
 private theorem firstFactor_eq_getElem_zero
     (c : InvariantFactorChain F) (h : c.factors ≠ []) :
     c.firstFactor = c.factors[0]'(length_pos_of_ne_nil h) := by
-  rcases hl : c.factors with _ | ⟨a, t⟩
-  · exact absurd hl h
-  · rfl
+  -- Factor out the list-only fact to a fresh universally-quantified
+  -- variable `l`, sidestepping the `rcases hl : c.factors`
+  -- generalize-over-dependent-getElem-proof failure.
+  -- See `MinpolyCharpolyOQ03.lean` build error history at S13 ACT.
+  have key : ∀ (l : List F[X]) (h0 : l ≠ []),
+      l.head?.getD 1 = l[0]'(length_pos_of_ne_nil h0) := by
+    intro l h0
+    cases l with
+    | nil => exact absurd rfl h0
+    | cons a t => rfl
+  exact key c.factors h
 
 /-- The first factor of a nonempty invariant-factor chain is a member
     of the chain. Mirror of `lastFactor_mem`. -/


### PR DESCRIPTION
## Summary

Three pre-existing issues in `Proofs/MinpolyCharpolyOQ03.lean` discovered
when Docker-verifying the file at HEAD. State.md noted "Build-pending per
S2/S3/S4/S5/S13 convention (Docker daemon in I/O-error state on this
host)" — these issues had been merged on the build-pending convention
but never actually verified.

### Errors fixed

**1. `M.minpoly` → `minpoly F M`** (line 231, S14 strong-form upgrade)

Lean's dot notation routed `M : Matrix n n F` to `Function.minpoly`
(since `Matrix` is definitionally a function), which does not exist.
Mathlib's `minpoly` lives at root-namespace and takes the coefficient
ring explicitly: `minpoly F M : F[X]`.

Original error:
```
error: Proofs/MinpolyCharpolyOQ03.lean:231:52: Invalid field `minpoly`:
       The environment does not contain `Function.minpoly`
```

**2. `firstFactor_eq_getElem_zero` rcases-generalize failure** (lines 540-545, S13 firstFactor mirror)

The proof `rcases hl : c.factors with _ | ⟨a, t⟩` tried to abstract
`c.factors` over a goal that contained
`c.factors[0]'(length_pos_of_ne_nil h)` — the dependent proof in the
indexed access made the generalization type-incorrect
(`∀ (x : List F[X]), c.firstFactor = x[0]` has no proof that
`0 < x.length`).

Original error:
```
error: Proofs/MinpolyCharpolyOQ03.lean:543:2: Tactic `generalize` failed:
       result is not type correct
  ∀ (x : List F[X]), c.firstFactor = x[0]
```

Refactored to factor the list-only fact through a fresh universally-
quantified variable `l`, which sidesteps the `c.factors` substitution
entirely:

```lean
private theorem firstFactor_eq_getElem_zero
    (c : InvariantFactorChain F) (h : c.factors ≠ []) :
    c.firstFactor = c.factors[0]'(length_pos_of_ne_nil h) := by
  have key : ∀ (l : List F[X]) (h0 : l ≠ []),
      l.head?.getD 1 = l[0]'(length_pos_of_ne_nil h0) := by
    intro l h0
    cases l with
    | nil => exact absurd rfl h0
    | cons a t => rfl
  exact key c.factors h
```

**3. Deprecated `List.getLast?_eq_getLast` → `List.getLast?_eq_some_getLast`** (line 379)

API rename in Mathlib v4.26.0. Was emitting a deprecation warning at
S4 `lastFactor_eq_getElem_pred`.

### Net change

- 2 statement-level fixes + 1 proof refactor + 1 deprecation rename.
- Zero new sorries (the file still has its single S1 placeholder `sorry`
  on `rational_canonical_form_exists`, line 232).
- Zero new axioms. No new imports.

### Verification

Docker-verified: `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03`
⇒ `Built Proofs.MinpolyCharpolyOQ03 (39s)`, **3059 jobs clean**. Only
warning is the expected `declaration uses 'sorry'` on
`rational_canonical_form_exists`.

This clears the "build-pending" status from S13/S14 (see state.md
sessions log).

## Test plan

- [x] Docker build passes: `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03`
- [x] No new axioms / sorries introduced (file still 1 sorry: S1 placeholder)
- [x] All three original errors resolved
- [x] Strictly additive style: zero edits to any other theorem statement
- [x] Pre-existing S1 sorry preserved (`rational_canonical_form_exists`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)