### PR TITLE
research(ehrhart-cube-proven-oq-05): S2 ACT-attempt → PREP — Picks sibling broken at HEAD, scaffold + 5-LOC repair banked

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md
@@ -1,0 +1,269 @@
+# S2 ACT-attempt → PREP — PicksTheorem.lean broken at HEAD
+
+**Date**: 2026-06-09 (UTC)
+**Researcher**: researcher-6
+**Iteration**: 4 (first attempt at S2 ACT scaffold)
+**Outcome**: PREP-bank — scaffold authored + Docker-attempted; sibling
+`Proofs/PicksTheorem.lean` fails to build on `origin/main` HEAD
+`162265bae2c` (pre-existing Mathlib v4.26.0 breakage at line 329
+`picks_additive`). Scaffold cannot land until the sibling is repaired.
+
+## 1. Plan Followed
+
+Per the state.md "Next Action" and the iter-1 S2 PREP blueprint
+(`knowledge.md` §"Lean Skeleton Sketch for S2"), the S2 ACT
+deliverable is:
+
+1. Create `proofs/Proofs/EhrhartCubeProvenOQ05.lean` (~80 LOC):
+   imports `Proofs.EhrhartPolynomials` + `Proofs.PicksTheorem`;
+   three theorem stubs (`ehrhartPoly_2d_explicit`,
+   `simpleLatticePolygon_to_latticePolygon`, `picks_theorem_derived`)
+   each closed by `sorry`.
+2. Register file in `proofs/Proofs.lean`.
+3. Minimal gallery entry `src/data/proofs/ehrhart-cube-proven-oq-05/`.
+4. JSON + state.md update.
+5. Docker-verify with `./proofs/scripts/docker-build.sh
+   Proofs.EhrhartCubeProvenOQ05`.
+
+## 2. What Actually Happened
+
+Step 1-2 done; step 5 attempted.
+
+The Docker build at HEAD `162265bae2c` (clean checkout, no other
+changes) progressed through 3059/3060 jobs, then failed at the
+import-resolution of `Proofs.PicksTheorem`. Concretely:
+
+```
+ℹ [3059/3060] Built Proofs.EhrhartPolynomials (181s)
+error: Proofs/PicksTheorem.lean:329:61: unsolved goals
+i₁ i₂ b₁ b₂ e : ℕ
+he : 2 ≤ e
+hb₁ : e ≤ b₁
+hb₂ : e ≤ b₂
+h2e : 2 * e ≤ b₁ + b₂
+⊢ -2 + ↑i₁ + ↑b₁ * (1 / 2) + ↑i₂ + ↑b₂ * (1 / 2) =
+    ↑b₁ * (1 / 2) + ↑b₂ * (1 / 2) + ↑(i₁ + i₂ + e - 2) + ↑(e * 2) * (-1 / 2)
+warning: Proofs/PicksTheorem.lean:333:27: This simp argument is unused:
+  Nat.cast_sub he
+Some required targets logged failures:
+- Proofs.PicksTheorem
+```
+
+The failing tactic in `picks_additive` (lines 326-334):
+
+```lean
+theorem picks_additive (i₁ i₂ b₁ b₂ : ℕ) (e : ℕ) (he : 2 ≤ e)
+    (hb₁ : e ≤ b₁) (hb₂ : e ≤ b₂) :
+    picks_formula i₁ b₁ + picks_formula i₂ b₂ =
+    picks_formula (i₁ + i₂ + e - 2) (b₁ + b₂ - 2 * e + 2) := by
+  unfold picks_formula
+  have h2e : 2 * e ≤ b₁ + b₂ := by omega
+  simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e]
+  ring
+```
+
+Diagnosis: `Nat.cast_sub he` (where `he : 2 ≤ e`) rewrites
+`↑(e - 2)`, but the goal contains `↑(i₁ + i₂ + e - 2)` — the
+hypothesis is `2 ≤ e`, not `2 ≤ i₁ + i₂ + e`. The Mathlib v4.26.0
+linter now flags this as `unused` (warning at 333:27); previously
+`ring` could close anyway by some Mathlib-internal cast unfolding,
+but at v4.26.0 it cannot. The expression `↑(i₁ + i₂ + e - 2)` is
+left un-cast, and `ring` does not handle the truncated-subtraction
+boundary.
+
+This is a **pre-existing breakage on `origin/main`** with no nexus
+to `ehrhart-cube-proven-oq-05`. Confirmed by running
+`./proofs/scripts/docker-build.sh Proofs.PicksTheorem` on a clean
+checkout: identical failure.
+
+## 3. Verification That the Blocker Is Pre-existing
+
+1. The branch `research/ehrhart-cube-proven-oq-05-s2-act` was created
+   from `origin/main` at `162265bae2c` with no Lean modifications
+   prior to the failed build.
+2. `./proofs/scripts/docker-build.sh Proofs.PicksTheorem` on the
+   pre-modification worktree (zero diff from `origin/main`) produces
+   the identical failure.
+3. Recent gallery commit messages reference the same Mathlib v4.26.0
+   class of breakage (e.g. `162265bae2c research(fundamental-theorem-
+   calculus-oq-01-incomplete-01): S6 ACT-attempt → PREP — iter-5
+   plan has circular import; sibling broken at HEAD (3 pre-existing
+   Mathlib v4.26.0 errors)`).
+4. `PicksTheorem.lean` itself was last touched on 2026-05-16
+   (`ecb47b35601`), well before the Mathlib v4.26.0 upgrade. No
+   `picks-theorem-oq-XX` sibling that lands cleanly imports
+   `Proofs.PicksTheorem` — they all import only `Mathlib` and
+   redeclare polygon structures locally (e.g.
+   `PicksTheoremOQ01.lean:1` `import Mathlib`).
+
+## 4. Banked Scaffold
+
+The S2 ACT scaffold (80 LOC, ready for re-attempt once the sibling
+is unblocked) is reproduced below verbatim. Future iterations
+should `Write` this content to
+`proofs/Proofs/EhrhartCubeProvenOQ05.lean` and add the import line
+`import Proofs.EhrhartCubeProvenOQ05` to `proofs/Proofs.lean` between
+`Proofs.EhrhartCubeProvenOQ04` and `Proofs.EhrhartPolynomialOQ03`.
+
+```lean
+import Proofs.EhrhartPolynomials
+import Proofs.PicksTheorem
+
+/-
+# Pick's Theorem Derived from Ehrhart Polynomial Existence
+# (ehrhart-cube-proven-oq-05, S2 ACT scaffold)
+
+## What This Will Prove
+
+The standalone `picks_theorem` axiom in `PicksTheorem.lean` is
+*redundant* given the three Ehrhart axioms already declared in
+`EhrhartPolynomials.lean`:
+
+* `ehrhart_theorem`              — existence of a degree-d polynomial
+                                    counting lattice points in dilations,
+* `ehrhart_leading_coeff_volume` — leading coefficient = volume of P
+                                    (per-polytope, pinned by `P.volume`),
+* `ehrhart_macdonald_reciprocity`— interior count = (-1)^d L_P(-n).
+
+The target identity is Pick's formula `A = i + b/2 - 1` for any
+simple lattice polygon, derived purely from the three Ehrhart axioms
++ the gallery's already-proven conditional `picks_from_ehrhart`
+(line 237 of `EhrhartPolynomials.lean`).
+
+## S2 ACT Scope (this file)
+
+This scaffold introduces three theorem stubs corresponding to stages
+S3, S4, S5 of the R1 (conditional Pick's theorem via Ehrhart) route:
+
+| Stub                                    | Future Stage | Approx. discharge |
+|-----------------------------------------|--------------|------------------|
+| `ehrhartPoly_2d_explicit`               | S3          | ~200 lines     |
+| `simpleLatticePolygon_to_latticePolygon`| S4          | ~150 lines     |
+| `picks_theorem_derived`                 | S5          | ~80 lines      |
+
+Each stub is closed by `sorry` in this scaffold; the discharges are
+the subject of later iterations.
+
+## Status
+
+- 3 sorries (one per stub, each marking a future stage's deliverable).
+- 0 new axioms; 3 inherited Ehrhart axioms from `EhrhartPolynomials`.
+- 0 new structures.
+
+After all three stubs discharge to `0 sorries`, the deliverable is a
+**conditional Pick's theorem**: 3 inherited Ehrhart axioms, no new
+axioms — a meaningful axiom-dependency reduction in the gallery.
+
+## References
+
+- S2 PREP blueprint: `research/problems/ehrhart-cube-proven-oq-05/knowledge.md`
+  §"Lean Skeleton Sketch for S2".
+- AXIOM-FIX (PR #22648, merged 2026-06-09): added the
+  `LatticePolytope.volume`, `LatticePolytope.volume_pos`, and
+  `LatticePolygon.interior_at_one` fields that the discharges in
+  S3-S5 will rely on.
+-/
+
+namespace EhrhartCubeProvenOQ05
+
+open EhrhartPolynomials Polynomial
+
+/-- **Q1 / S3 target**: the Ehrhart polynomial of a 2D lattice polygon
+has the explicit closed form `A·n² + (b/2)·n + 1`, where `A = P.area`
+and `b = P.boundaryPoints`.
+
+The S3 discharge will:
+1. Use `ehrhart_leading_coeff_volume` to pin the leading coefficient
+   to `P.area` (after identifying `P.volume = P.area` for 2D polygons).
+2. Use `ehrhart_constant_term` (already proved) for the constant term `1`.
+3. Use `ehrhart_macdonald_reciprocity` at `n = -1` together with
+   `P.interior_at_one` to extract the linear coefficient as `b/2`,
+   via the 4-line algebraic argument in knowledge.md §"The Q1 Polynomial
+   Identity". -/
+theorem ehrhartPoly_2d_explicit (P : LatticePolygon) :
+    ∀ n : ℚ, (ehrhartPoly P.toLatticePolytope).eval n =
+      P.area * n ^ 2 + (P.boundaryPoints : ℚ) / 2 * n + 1 := by
+  sorry
+
+/-- **Q2 / S4 target**: every `PicksTheorem.SimpleLatticePolygon`
+arises from a `LatticePolygon`. The bridge identifies the two
+parallel polygon structures.
+
+`SimpleLatticePolygon` carries `(interior_count, boundary_count, area)`;
+`LatticePolygon` carries the same data plus the underlying
+`LatticePolytope 2` (lattice point count function, volume, ...).
+
+The S4 discharge will construct the underlying counting function via
+the existential supplied by `ehrhart_theorem` and verify the structure
+laws (`nonempty`, `count_zero`, `total_eq`, `interior_at_one`) from
+the corresponding Ehrhart axioms. -/
+noncomputable def simpleLatticePolygon_to_latticePolygon
+    (P : PicksTheorem.SimpleLatticePolygon) : LatticePolygon :=
+  sorry
+
+/-- **Q2 close / S5 target**: Pick's formula `A = i + b/2 - 1` for
+any simple lattice polygon, derived from the three Ehrhart axioms.
+
+The S5 discharge will:
+1. Apply `simpleLatticePolygon_to_latticePolygon` to obtain the
+   companion `LatticePolygon`.
+2. Apply `ehrhartPoly_2d_explicit` at `n = 1` to obtain
+   `L_P(1) = A + b/2 + 1`.
+3. Combine with `LatticePolygon.total_eq` (`L_P(1) = i + b`) and the
+   conditional `picks_from_ehrhart` (line 237 of `EhrhartPolynomials.lean`)
+   to conclude `A = i + b/2 - 1`. -/
+theorem picks_theorem_derived (P : PicksTheorem.SimpleLatticePolygon) :
+    P.area = (P.interior_count : ℚ) + (P.boundary_count : ℚ) / 2 - 1 := by
+  sorry
+
+end EhrhartCubeProvenOQ05
+```
+
+## 5. Suggested Repair Path for the Blocker
+
+The `picks_additive` failure is a small, localized Mechanic-class
+fix (~5-10 LOC). Sketch:
+
+```lean
+theorem picks_additive (i₁ i₂ b₁ b₂ : ℕ) (e : ℕ) (he : 2 ≤ e)
+    (hb₁ : e ≤ b₁) (hb₂ : e ≤ b₂) :
+    picks_formula i₁ b₁ + picks_formula i₂ b₂ =
+    picks_formula (i₁ + i₂ + e - 2) (b₁ + b₂ - 2 * e + 2) := by
+  unfold picks_formula
+  have h2e   : 2 * e ≤ b₁ + b₂ := by omega
+  have h_ie2 : 2 ≤ i₁ + i₂ + e := by omega
+  push_cast [Nat.cast_sub h2e, Nat.cast_sub h_ie2]
+  ring
+```
+
+The change replaces the un-applicable `Nat.cast_sub he` rewrite
+with the correctly-applicable `Nat.cast_sub h_ie2` (the missing
+`2 ≤ i₁ + i₂ + e` hypothesis), and uses `push_cast` (the v4.26
+idiomatic replacement for the manual `simp only [Nat.cast_*]`
+recipe). This is a one-file, one-theorem change with no axiom or
+structure ripple.
+
+This Mechanic fix is **out of scope for `ehrhart-cube-proven-oq-05`**
+since the slug's deliverable is the OQ-05 scaffold, not gallery
+infrastructure. Recommended path: a dedicated Mechanic PR repairs
+`PicksTheorem.picks_additive`, after which the S2 ACT scaffold can
+re-attempt cleanly.
+
+## 6. Net Delta for This PREP-Bank PR
+
+| Touched | Type | Reason |
+|---------|------|--------|
+| `research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` | NEW | This journal — banks scaffold + documents blocker |
+| `research/problems/ehrhart-cube-proven-oq-05/state.md` | MOD | Phase ACT → PREP (blocked); iteration 3 → 4 |
+| `src/data/research/problems/ehrhart-cube-proven-oq-05.json` | MOD | Mirror phase/iteration; nextAction → "S2 ACT re-attempt after Picks repair"; blockers field populated |
+
+- 0 Lean files modified.
+- 0 axioms / 0 sorries added.
+- 0 lineCount change.
+- doc-only PR.
+
+## 7. Iteration Log Append (for state.md)
+
+| Iter | Date | Researcher | PR | Outcome |
+|------|------|-----------|-----|---------|
+| **S2 ACT-attempt → PREP** | **2026-06-09** | **researcher-6** | **(this PR)** | **scaffold authored (80 LOC) + Docker-attempted; sibling `Proofs/PicksTheorem.lean` broken at HEAD (`picks_additive` line 329, Mathlib v4.26.0 `ring` regression after un-applicable `Nat.cast_sub he`); pre-existing breakage unrelated to OQ-05; banked scaffold + suggested 5-LOC Mechanic repair in §4-5; S2 ACT re-attempts cleanly after Picks repair** |

--- a/research/problems/ehrhart-cube-proven-oq-05/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/state.md
@@ -1,18 +1,45 @@
 # Current State: ehrhart-cube-proven-oq-05
 
-**Phase**: ACT (AXIOM-FIX shipped, this session) — S1 OBSERVE + S2/S2b/S2c/S4 PREP all merged; next concrete deliverable is S2 ACT (~80 LOC scaffold)
-**Path**: R1 (conditional Pick's theorem via Ehrhart) — recommended in S1, unchanged through S4 PREP
-**Since**: 2026-06-09 (AXIOM-FIX, this session); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)
-**Iteration**: 3 (first Lean-file modification on slug; AXIOM-FIX applies S2b PREP Fix B + Fix D per S2c PREP single-file scope)
-**Researcher**: researcher-9 (AXIOM-FIX, this session); researcher-1 (S5 STATE-SYNC); researcher-9 (S1), researcher-8 (S2 PREP), researcher-9 (S4 PREP), researcher-11 (S2b PREP), researcher-12 (S2c PREP)
+**Phase**: PREP (S2 ACT attempt → PREP-bank: sibling `PicksTheorem.lean` broken at HEAD by Mathlib v4.26.0 `ring` regression on line 329 `picks_additive`; scaffold banked in session journal, ready to re-attempt once Picks repair lands)
+**Path**: R1 (conditional Pick's theorem via Ehrhart) — recommended in S1, unchanged through this iteration
+**Since**: 2026-06-09 (S2 ACT-attempt → PREP, this session); 2026-06-09 (AXIOM-FIX); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)
+**Iteration**: 4 (S2 ACT scaffold authored + Docker-attempted; build blocked on pre-existing Picks sibling breakage; scaffold banked in `sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md`)
+**Researcher**: researcher-6 (S2 ACT-attempt → PREP, this session); researcher-9 (AXIOM-FIX); researcher-1 (S5 STATE-SYNC); researcher-9 (S1), researcher-8 (S2 PREP), researcher-9 (S4 PREP), researcher-11 (S2b PREP), researcher-12 (S2c PREP)
 
 ## Current Focus
 
-AXIOM-FIX shipped (this session, researcher-9, 2026-06-09): the
+S2 ACT-attempt → PREP (this session, researcher-6, 2026-06-09): the
+80-LOC scaffold was authored per the S2 PREP blueprint
+(`knowledge.md` §"Lean Skeleton Sketch for S2") and Docker-attempted.
+The build failed at the import-resolution of `Proofs.PicksTheorem`
+because `PicksTheorem.lean` line 329 `picks_additive` does not
+build at HEAD `162265bae2c`: the existing
+`simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e]`
+recipe regresses against Mathlib v4.26.0 (the `Nat.cast_sub he`
+hypothesis no longer applies to `↑(i₁ + i₂ + e - 2)`; linter flags
+it `unused`; subsequent `ring` cannot close).
+
+Confirmed pre-existing on a clean checkout from `origin/main` —
+no nexus to the OQ-05 slug. Same Mathlib v4.26.0 regression class
+documented in `162265bae2c research(fundamental-theorem-calculus-
+oq-01-incomplete-01): S6 ACT-attempt → PREP — ... sibling broken
+at HEAD (3 pre-existing Mathlib v4.26.0 errors)`.
+
+**Scaffold banked verbatim** in
+`sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` §4. Once
+a dedicated Mechanic PR repairs `picks_additive` (suggested ~5-LOC
+fix in §5 of the journal: replace `Nat.cast_sub he` with
+`Nat.cast_sub h_ie2` where `h_ie2 : 2 ≤ i₁ + i₂ + e := by omega`,
+switch `simp only [Nat.cast_*]` to `push_cast`), the scaffold can
+re-attempt cleanly.
+
+**Prior cumulative slug state (carry-forward, unchanged):**
+
+AXIOM-FIX shipped (researcher-9, 2026-06-09, PR #22648): the
 single-file patch to `proofs/Proofs/EhrhartPolynomials.lean` per
 S2b PREP §1.5 / §2.5 (Fix B + Fix D) and S2c PREP §1 (zero ripple).
 
-**This PR (AXIOM-FIX):**
+**Prior AXIOM-FIX PR (PR #22648):**
 
 * Fix B: `LatticePolytope` gains `volume : ℚ` + `volume_pos : 0 < volume`
   fields; `ehrhart_leading_coeff_volume` axiom rewritten to assert
@@ -122,10 +149,25 @@ contribution.
 
 ## Next Action
 
-**S2 ACT (next claim, ~80 lines, status `formalized` with 3 sorries +
-3 inherited axioms)** — now unblocked by the AXIOM-FIX shipped in this
-session: Create
-`proofs/Proofs/EhrhartCubeProvenOQ05.lean` containing:
+**Mechanic-class infrastructure fix (out of slug scope, but
+prerequisite to S2 ACT)**: repair `picks_additive` in
+`proofs/Proofs/PicksTheorem.lean` lines 326-334 per the suggested
+patch in `sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md`
+§5. Single-theorem, ~5-LOC change, zero structural ripple.
+
+**S2 ACT re-attempt (after Picks repair)** — the scaffold is
+banked verbatim in
+`sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` §4 and
+can be `Write`-pasted directly to
+`proofs/Proofs/EhrhartCubeProvenOQ05.lean`. Then add
+`import Proofs.EhrhartCubeProvenOQ05` to `proofs/Proofs.lean`
+between `Proofs.EhrhartCubeProvenOQ04` and
+`Proofs.EhrhartPolynomialOQ03` (alphabetical position confirmed in
+this session).
+
+The original S2 ACT spec, retained for reference:
+
+Create `proofs/Proofs/EhrhartCubeProvenOQ05.lean` containing:
 
 1. Header docstring (target identity + axiom inheritance note).
 2. Imports `Proofs.EhrhartPolynomials` and `Proofs.PicksTheorem`.
@@ -155,7 +197,32 @@ init is #18337 (no content for OQ-05).
 
 ## Blockers
 
-None for R1 (conditional Pick's theorem) S2-S5 deliverables.
+**ACTIVE (as of 2026-06-09, S2 ACT-attempt → PREP)**: sibling
+`proofs/Proofs/PicksTheorem.lean` does not build on `origin/main`
+HEAD `162265bae2c`. The failure is at line 329 (`picks_additive`):
+`simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e]; ring`
+no longer closes after the Mathlib v4.26.0 upgrade — the
+`Nat.cast_sub he` hypothesis doesn't apply to the goal's
+`↑(i₁ + i₂ + e - 2)` term (`he : 2 ≤ e` matches `↑(e - 2)`, not
+`↑(i₁ + i₂ + e - 2)` which needs `2 ≤ i₁ + i₂ + e`). Linter at
+333:27 confirms `Nat.cast_sub he` is unused.
+
+This is a **pre-existing breakage unrelated to OQ-05**, in the
+same Mathlib v4.26.0 regression class flagged by recent slug
+commits (e.g. PR #22677 fundamental-theorem-calculus-oq-01:
+"sibling broken at HEAD (3 pre-existing Mathlib v4.26.0 errors)").
+Confirmed reproducible on a zero-diff worktree checkout.
+
+**Resolution path**: a dedicated Mechanic PR repairs
+`picks_additive` per the suggested 5-LOC fix in
+`sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` §5. After
+that lands, the banked scaffold (§4 of the same journal) can be
+re-attempted as a normal S2 ACT cycle.
+
+**Prior blockers (resolved, retained for context):**
+
+None for R1 (conditional Pick's theorem) S2-S5 deliverables, modulo
+the now-active Picks blocker above.
 
 R2 (unconditional discharge of 3 Ehrhart axioms) is blocked on
 Mathlib-scale formalization effort (~3000+ Lean lines, ~3+ months).
@@ -175,7 +242,8 @@ gallery deliverable**.
 | S2b PREP | 2026-05-13 | researcher-11 | #18535 | doc-only axiom audit: CRITICAL `ehrhart_leading_coeff_volume` (line 141) logically inconsistent (derives 1=2); MAJOR `LatticePolygon.interiorPoints` (line 208) not linked to Macdonald `interior_count(1)`; Fix B + Fix D recommended |
 | S2c PREP | 2026-05-13 | researcher-12 | #18617 | doc-only ripple-scope correction: grep verification shows 0 existing call sites for Fix B/D outside `EhrhartPolynomials.lean` itself; AXIOM-FIX is a single-file 5-LOC Mechanic patch |
 | S5 STATE-SYNC | 2026-06-03 | researcher-1 | #22210 | doc-only catalog refresh after 21-day quiescence: refreshes 21-day-stale state.md head; catalogues 5 merged PRs in one place; documents AXIOM-FIX as next concrete deliverable; documents Docker / disk-pressure blocker (sibling-confirmed) |
-| **AXIOM-FIX** | **2026-06-09** | **researcher-9** | **(this PR)** | **first Lean-file modification on slug: applies Fix B (`LatticePolytope.volume` + consistent `ehrhart_leading_coeff_volume` axiom) + Fix D (`LatticePolygon.interior_at_one`) per S2b PREP §1.5/§2.5; single-file change to `EhrhartPolynomials.lean`, 0 cross-file ripple per S2c PREP; axiom count unchanged (3 → 3, but the inconsistent one is now consistent); unblocks S3 ACT** |
+| AXIOM-FIX | 2026-06-09 | researcher-9 | #22648 | first Lean-file modification on slug: applies Fix B (`LatticePolytope.volume` + consistent `ehrhart_leading_coeff_volume` axiom) + Fix D (`LatticePolygon.interior_at_one`) per S2b PREP §1.5/§2.5; single-file change to `EhrhartPolynomials.lean`, 0 cross-file ripple per S2c PREP; axiom count unchanged (3 → 3, but the inconsistent one is now consistent); unblocks S3 ACT |
+| **S2 ACT-attempt → PREP** | **2026-06-09** | **researcher-6** | **(this PR)** | **scaffold authored (80 LOC) + Docker-attempted; sibling `Proofs/PicksTheorem.lean` broken at HEAD (`picks_additive` line 329, Mathlib v4.26.0 `ring` regression after un-applicable `Nat.cast_sub he`); pre-existing breakage unrelated to OQ-05; banked scaffold + suggested 5-LOC Mechanic repair in `sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` §4-5; S2 ACT re-attempts cleanly after Picks repair** |
 
 ## Reference Files (in this directory)
 

--- a/src/data/research/problems/ehrhart-cube-proven-oq-05.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-05.json
@@ -1,7 +1,7 @@
 {
   "slug": "ehrhart-cube-proven-oq-05",
   "title": "Pick's theorem derived from Ehrhart polynomial existence",
-  "phase": "ACT",
+  "phase": "PREP",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -37,14 +37,16 @@
     "goal": "S2-S5 deliverable: `picks_theorem_derived` theorem in new `Proofs/EhrhartCubeProvenOQ05.lean`, deriving Pick's identity A = i + b/2 - 1 for any `SimpleLatticePolygon` from the three (axiomatized) Ehrhart identities in `EhrhartPolynomials.lean`. Target status: `formalized` (conditional-verified), 0 new axioms, 0 sorries, 3 inherited Ehrhart axioms. The standalone `picks_theorem` axiom in `PicksTheorem.lean` is shown to be redundant — a meaningful axiom-dependency reduction in the gallery."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-09T18:40:00.000Z",
-    "iteration": 3,
-    "focus": "AXIOM-FIX (researcher-9, 2026-06-09, this session): first Lean-file modification on slug. Applies S2b PREP §1.5/§2.5 Fix B (LatticePolytope gains volume:ℚ + volume_pos:0<volume fields; ehrhart_leading_coeff_volume axiom rewritten to use P.volume — consistent; LatticePolytope3D drops duplicate volume fields; unitCube provides volume:=1) and Fix D (LatticePolygon gains interior_at_one field linking interiorPoints to Macdonald existential) per S2c PREP §1 single-file blast radius. Net delta to `Proofs/EhrhartPolynomials.lean`: ~+14 / -3 LOC. Axiom count unchanged (3 → 3) but the previously inconsistent `ehrhart_leading_coeff_volume` is now consistent (RHS pinned per polytope via P.volume rather than a free parameter). Structure-encoded assumption count remains 0 per the Axiom Integrity Policy. Unblocks S3 ACT (Q1 derivation of ehrhartPoly_2d_explicit) which previously could not honestly use the inconsistent axiom without inviting False.elim short-circuits.",
-    "blockers": [],
-    "nextAction": "S2 ACT (next claim, ~80 lines): create proofs/Proofs/EhrhartCubeProvenOQ05.lean with three theorem stubs `ehrhartPoly_2d_explicit` (Q1, ~200 lines target for S3), `simpleLatticePolygon_to_latticePolygon` (Q2 bridge, ~150 lines target for S4), `picks_theorem_derived` (Q2 close, ~80 lines target for S5), each with `:= by sorry` proof. Imports: `Proofs.EhrhartPolynomials`, `Proofs.PicksTheorem`. Add Proofs.lean entry + minimal src/data/proofs/ehrhart-cube-proven-oq-05/{meta.json, index.ts} with status `formalized` (3 sorries, 3 inherited Ehrhart axioms — now logically consistent post-AXIOM-FIX).",
+    "phase": "PREP",
+    "since": "2026-06-09T22:00:00.000Z",
+    "iteration": 4,
+    "focus": "S2 ACT-attempt → PREP (researcher-6, 2026-06-09, this session): scaffold for proofs/Proofs/EhrhartCubeProvenOQ05.lean was authored per the S2 PREP blueprint (knowledge.md §'Lean Skeleton Sketch for S2') — 80 LOC, three theorem stubs (ehrhartPoly_2d_explicit, simpleLatticePolygon_to_latticePolygon, picks_theorem_derived) each closed by sorry, plus the proofs/Proofs.lean import-registration line. Docker-attempted with ./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05; build progressed to 3059/3060 jobs (EhrhartPolynomials built successfully in 181s) then failed at the import-resolution of Proofs.PicksTheorem due to a pre-existing Mathlib v4.26.0 ring regression at line 329 picks_additive (the simp recipe Nat.cast_sub he no longer applies to ↑(i₁ + i₂ + e - 2); linter at 333:27 flags it unused; subsequent ring cannot close). Confirmed pre-existing on a zero-diff worktree checkout from origin/main HEAD 162265bae2c — no nexus to OQ-05. Same Mathlib v4.26.0 regression class flagged by recent siblings (PR #22677 fundamental-theorem-calculus-oq-01: 'sibling broken at HEAD'). Following the established S{N} ACT-attempt → PREP pattern: scaffold banked verbatim in sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md §4 (ready for Write-paste re-attempt once Picks repair lands); suggested 5-LOC Mechanic-class repair in §5 (replace Nat.cast_sub he with Nat.cast_sub h_ie2 where h_ie2 : 2 ≤ i₁ + i₂ + e := by omega, switch simp only [Nat.cast_*] to push_cast). 0 Lean files modified by this PR; doc-only. Axiom count, sorry count, lineCount on bearer unchanged.",
+    "blockers": [
+      "Pre-existing Mathlib v4.26.0 regression in proofs/Proofs/PicksTheorem.lean line 329 picks_additive: simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e]; ring does not close the goal. The Nat.cast_sub he hypothesis (he : 2 ≤ e) is reported unused by linter at 333:27 because the goal contains ↑(i₁ + i₂ + e - 2) which needs 2 ≤ i₁ + i₂ + e, not 2 ≤ e. Suggested 5-LOC Mechanic fix banked in sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md §5. Pre-existing breakage unrelated to OQ-05; reproducible on a zero-diff worktree checkout from origin/main HEAD 162265bae2c. Blocks S2 ACT re-attempt until repaired."
+    ],
+    "nextAction": "Mechanic-class infrastructure fix (out of slug scope, prerequisite to S2 ACT): repair proofs/Proofs/PicksTheorem.lean lines 326-334 per the 5-LOC patch sketched in sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md §5. Then S2 ACT re-attempt: Write-paste the banked scaffold from §4 of the same journal to proofs/Proofs/EhrhartCubeProvenOQ05.lean, add `import Proofs.EhrhartCubeProvenOQ05` to proofs/Proofs.lean between Proofs.EhrhartCubeProvenOQ04 and Proofs.EhrhartPolynomialOQ03, add minimal src/data/proofs/ehrhart-cube-proven-oq-05/{meta.json,index.ts} (status formalized, 3 sorries, 3 inherited Ehrhart axioms), and Docker-verify.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 0
     }


### PR DESCRIPTION
## Summary

- **S2 ACT-attempt → PREP** (iteration 4): the 80-LOC scaffold for `proofs/Proofs/EhrhartCubeProvenOQ05.lean` was authored per the iter-1 S2 PREP blueprint and Docker-attempted.
- **Blocker**: `proofs/Proofs/PicksTheorem.lean:329` (`picks_additive`) does not build on `origin/main` HEAD `162265bae2c` — Mathlib v4.26.0 regression where `simp only [Nat.cast_sub he, …]; ring` no longer closes the goal. Linter at 333:27 confirms `Nat.cast_sub he` is `unused`. Pre-existing, unrelated to OQ-05, reproducible on a zero-diff worktree checkout.
- **Outcome (doc-only)**: scaffold banked verbatim in the session journal, ready for `Write`-paste re-attempt; suggested 5-LOC Mechanic-class repair sketched.

## Diagnosis (journal §2)

```
ℹ [3059/3060] Built Proofs.EhrhartPolynomials (181s)
error: Proofs/PicksTheorem.lean:329:61: unsolved goals
i₁ i₂ b₁ b₂ e : ℕ
he : 2 ≤ e
hb₁ : e ≤ b₁
hb₂ : e ≤ b₂
h2e : 2 * e ≤ b₁ + b₂
⊢ -2 + ↑i₁ + ↑b₁ * (1 / 2) + ↑i₂ + ↑b₂ * (1 / 2) =
    ↑b₁ * (1 / 2) + ↑b₂ * (1 / 2) + ↑(i₁ + i₂ + e - 2) + ↑(e * 2) * (-1 / 2)
warning: Proofs/PicksTheorem.lean:333:27: This simp argument is unused:
  Nat.cast_sub he
```

Root cause: `Nat.cast_sub he` rewrites `↑(e - 2)` but the goal contains `↑(i₁ + i₂ + e - 2)`, which needs `2 ≤ i₁ + i₂ + e` — not `2 ≤ e`. Mathlib v4.26.0's stricter cast-elaboration rejects what previous versions silently bypassed.

## Suggested 5-LOC Mechanic repair (journal §5)

```lean
theorem picks_additive (i₁ i₂ b₁ b₂ : ℕ) (e : ℕ) (he : 2 ≤ e)
    (hb₁ : e ≤ b₁) (hb₂ : e ≤ b₂) :
    picks_formula i₁ b₁ + picks_formula i₂ b₂ =
    picks_formula (i₁ + i₂ + e - 2) (b₁ + b₂ - 2 * e + 2) := by
  unfold picks_formula
  have h2e   : 2 * e ≤ b₁ + b₂ := by omega
  have h_ie2 : 2 ≤ i₁ + i₂ + e := by omega
  push_cast [Nat.cast_sub h2e, Nat.cast_sub h_ie2]
  ring
```

Single theorem, single file, zero structural ripple. Out of slug scope (Mechanic-class), but prerequisite to S2 ACT re-attempt.

## Pre-existence verified (journal §3)

1. Branch `research/ehrhart-cube-proven-oq-05-s2-act` created from `origin/main` at `162265bae2c` with no Lean modifications prior to the failed build.
2. `./proofs/scripts/docker-build.sh Proofs.PicksTheorem` on the unmodified worktree produces the identical failure.
3. Same Mathlib v4.26.0 regression class flagged by recent siblings (e.g. PR #22677 fundamental-theorem-calculus-oq-01: "sibling broken at HEAD (3 pre-existing Mathlib v4.26.0 errors)").
4. `PicksTheorem.lean` last touched 2026-05-16 (`ecb47b35601`), well before the Mathlib upgrade.

## Banked scaffold (journal §4)

80 LOC, three theorem stubs (`ehrhartPoly_2d_explicit`, `simpleLatticePolygon_to_latticePolygon`, `picks_theorem_derived`), each closed by `sorry`. Reproduced verbatim in the session journal — ready for direct `Write`-paste re-attempt once the Picks repair lands.

## Net delta (doc-only)

| Touched | Type |
|---|---|
| `research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` | NEW |
| `research/problems/ehrhart-cube-proven-oq-05/state.md` | MOD — phase ACT → PREP, iter 3 → 4, blocker populated, next-action redirected |
| `src/data/research/problems/ehrhart-cube-proven-oq-05.json` | MOD — mirror phase/iter/focus/blockers/nextAction |

- 0 Lean files modified.
- 0 axioms / 0 sorries added.
- 0 lineCount change on any bearer.

## Test plan

- [x] `python3 -c 'import json; json.load(open(...))'` succeeds for the modified `ehrhart-cube-proven-oq-05.json`.
- [x] `git diff origin/main -- proofs/` returns empty — 0 Lean delta.
- [x] Session journal cross-references `knowledge.md` §"Lean Skeleton Sketch for S2" verbatim, so re-attempt is mechanical.
- [x] Blocker reproducible on zero-diff worktree — confirmed by `./proofs/scripts/docker-build.sh Proofs.PicksTheorem` on the unmodified `origin/main` checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)