### PR TITLE
audit(bezout-identity-oq-03-oq-01-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -886,9 +886,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:38:31Z",
+      "lastAudited": "2026-06-10T00:59:36Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01-oq-01-oq-01": {


### PR DESCRIPTION
## Summary

- Audit target: `bezout-identity-oq-03-oq-01-oq-01` (k-fold Chinese Remainder Theorem)
- Result: **clean** — all integrity checks pass
- File: `proofs/Proofs/BezoutIdentityOQ03OQ01OQ01.lean` (249 lines)

## Integrity Checks

| Check | meta.json | Lean source | Status |
|-------|-----------|-------------|--------|
| Axioms | 0 | 0 | OK |
| Sorries | 0 | 0 | OK |
| Theorems | 14 | 14 | OK |
| Definitions | 8 | 8 | OK |
| Line count | 249 | 249 | OK |
| True stubs | — | none | OK |
| Structure-encoded assumptions | — | none | OK |
| Badge `mathlib` | matches Mathlib bridge usage (`ZMod.chineseRemainder`) | OK |

## Test plan

- [x] `grep -c "^axiom "` on Lean source → 0
- [x] `grep -c "sorry"` on Lean source → 0
- [x] Theorem/def counts match meta.json
- [x] No `True` stubs or `:= trivial` placeholders
- [x] No structure-encoded assumption fields

Discovered during gallery integrity audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)