### PR TITLE
audit(cayley-hamilton-minpoly-oq-02-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1759,9 +1759,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:38:32Z",
+      "lastAudited": "2026-06-10T01:12:17Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-02-oq-01-oq-01": {


### PR DESCRIPTION
## Summary

Audit of `cayley-hamilton-minpoly-oq-02-oq-01` — clean, tracker bump only.

## Findings

- 0 sorries, 0 axioms, 0 True stubs (matches `meta.json`)
- 9 theorems, 1 definition (matches counts)
- Badge `mathlib` correctly classifies this as a Tier B Mathlib-bridge formalization
- Core invariance result derives from Mathlib's `minpoly.algEquiv_eq` and `minpoly.algHom_eq`
- `originalContributions` properly scopes the novel work to the `conjAlgEquiv` construction connecting abstract minpoly theory to concrete matrix similarity

## Test plan

- [x] `grep -c sorry` → 0
- [x] `grep -c '^axiom '` → 0
- [x] No `True` stubs
- [x] Counts in meta.json match Lean source

🤖 Generated with [Claude Code](https://claude.com/claude-code)