### PR TITLE
audit(prob-method-second-moment-oq-02): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15290,6 +15290,12 @@
       "lastAudited": "2026-06-09T19:17:59Z",
       "result": "clean",
       "issues": []
+    },
+    "prob-method-second-moment-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-10T01:52:32Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Audited `prob-method-second-moment-oq-02` (variance of indicator sums — generic pair-sum decomposition).
- Result: **clean**. 0 sorries, 0 axioms, 0 True stubs, no Mathlib wrappers.
- All meta.json claims verified against `proofs/Proofs/ProbMethodSecondMomentOQ02.lean` (3 defs, 9 theorems, 153 lines).
- Docker build green (7744 jobs, Mathlib v4.26.0).

## Test plan
- [x] `npx tsx scripts/auditor/find-targets.ts --stats` (queue confirmed)
- [x] sorry/axiom/True grep against Lean source (none)
- [x] theorem/def count matches meta.json
- [x] `./proofs/scripts/docker-build.sh Proofs.ProbMethodSecondMomentOQ02` succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)