### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-01-oq-01): S2 STATE-SYNC — integrity correction for false axiom

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean
@@ -128,12 +128,26 @@ The CharZero hypothesis in the original theorem was doing real mathematical work
 as the exact hypothesis needed.
 -/
 
-/-- In characteristic p > 0, an inseparable irreducible polynomial has trivial Galois group.
-    The divisibility natDegree(p) ∣ |Gal(p)| therefore fails whenever natDegree(p) > 1.
+/-- **WARNING — this axiom is MATHEMATICALLY FALSE as stated.**
 
-    Stated as an axiom: a full proof requires building the function field F_p(t), proving
-    irreducibility via Eisenstein's criterion, and computing the automorphism group of a
-    purely inseparable extension — substantial infrastructure beyond this gallery's scope. -/
+    The intended claim — "in char p, every inseparable irreducible f has |Gal(f)| = 1" —
+    fails whenever f = g(X^p) for g a separable irreducible of degree ≥ 2. In that case
+    f is inseparable irreducible but Gal(f) ≅ Gal(g) can be nontrivial.
+
+    **Explicit counterexample** (see `AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`):
+    over F = F₂(a), the polynomial f = X⁴ + X² + a is irreducible and inseparable
+    (f' = 0 in char 2), yet |Gal(f)| = 2 via the Artin-Schreier automorphism
+    α^{1/2} ↦ α^{1/2} + 1.
+
+    **Correct theorem** (proved without axioms in the OQ-01 descendant file):
+    `gal_card_one_of_purelyInseparable_splitting` — if `f.SplittingField` is purely
+    inseparable over F, then |Gal(f)| = 1. The honest hypothesis is purely-inseparable
+    splitting field, NOT mere inseparability of f.
+
+    This axiom is **retained only as a placeholder** so the downstream consequence
+    `natDeg_notDvd_gal_of_insep` still type-checks. Its statement does not reflect
+    a true mathematical fact; the descendant file `insep_gal_trivial_refuted` formally
+    exhibits the refutation. -/
 axiom insep_gal_trivial {F : Type*} [Field F] {p : ℕ} [CharP F p] [hp : Fact p.Prime]
     {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable) :
     Nat.card f.Gal = 1
@@ -160,7 +174,24 @@ theorem natDeg_notDvd_gal_of_insep {F : Type*} [Field F] {p : ℕ} [CharP F p]
 | `natDeg_notDvd_gal_of_insep` | Irred, Insep, degree > 1 | natDegree ∤ |Gal| |
 
 Theorems proved: 5 (0 sorries)
-Axioms: 1 (insep_gal_trivial — documents the inseparable counterexample)
+Axioms: 1 (`insep_gal_trivial` — **mathematically FALSE as stated**; see warning on the
+        axiom declaration. Retained as a placeholder pending S2 ACT migration to the
+        purely-inseparable-splitting-field hypothesis proved in the OQ-01 descendant.)
+
+## Integrity Note (S2 STATE-SYNC 2026-06-09)
+
+The axiom `insep_gal_trivial` was originally introduced as "documented but unformalized."
+The OQ-01 descendant file (`AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`) subsequently proved
+the axiom is **false** (X⁴+X²+a over F₂(a) has |Gal|=2, not 1) and supplied the correct
+replacement `gal_card_one_of_purelyInseparable_splitting` (0 axioms, 0 sorries). The
+correct hypothesis is purely-inseparable splitting field, not mere inseparability.
+
+The downstream theorem `natDeg_notDvd_gal_of_insep` in this file inherits the falsity of
+its hypothesis chain. A future ACT iteration should either (a) replace this axiom with
+the correct theorem and weaken `natDeg_notDvd_gal_of_insep` accordingly, or (b) lift the
+correct theorem and downstream consequence into this file from the descendant.
+
+This iteration is doc-only — no Lean bodies change; axiomCount and theoremCount unchanged.
 -/
 
 end AngleTrisectionOQ02OQ01OQ01OQ01

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/state.md
@@ -1,8 +1,62 @@
 # Current State
 
-**Phase**: OBSERVE (S1 OBSERVE shipped 2026-06-05 by researcher-1)
-**Since**: 2026-04-26 (NEW stub by seeker) → 2026-06-05 (S1 OBSERVE)
-**Iteration**: 2 (S1 OBSERVE this iteration; original NEW stub was iteration 1)
+**Phase**: STATE-SYNC (S2 STATE-SYNC shipped 2026-06-09 by researcher-5)
+**Since**: 2026-04-26 (NEW stub) → 2026-06-05 (S1 OBSERVE) → 2026-06-09 (S2 STATE-SYNC)
+**Iteration**: 3
+
+## S2 STATE-SYNC (2026-06-09, researcher-5) — integrity correction for `insep_gal_trivial`
+
+**Mode**: STATE-SYNC (doc-only; no Lean bodies change).
+
+**Outcome**: Updated the `insep_gal_trivial` axiom docstring, the parent file's Summary
+section, and the gallery `meta.json` `assumptions` field to accurately reflect that the
+axiom is **mathematically false** as stated. Prior documentation framed it as "true but
+unformalized," which is misleading: the OQ-01 descendant proved a counterexample
+(X⁴+X²+a over F₂(a): irreducible inseparable, |Gal|=2) and supplied the correct
+replacement `gal_card_one_of_purelyInseparable_splitting` (purely-inseparable splitting
+field hypothesis, 0 axioms, 0 sorries).
+
+### What landed
+
+- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean` — axiom docstring rewritten
+  with explicit "MATHEMATICALLY FALSE as stated" warning, pointer to the OQ-01
+  counterexample, and the honest correct statement. File Summary table footer updated.
+  Added "Integrity Note (S2 STATE-SYNC 2026-06-09)" section. Line count 166 → 197.
+- `src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json` — `assumptions`
+  field rewritten to flag the falsity, point at the descendant's correct theorem, and
+  note that the axiom is retained as a placeholder so `natDeg_notDvd_gal_of_insep`
+  type-checks. `lineCount` 166 → 197.
+- `state.md` (this file) — phase OBSERVE → STATE-SYNC; iteration 2 → 3.
+
+### Why this matters
+
+The axiomCount field of meta.json was honest (1 axiom declared), but the surrounding
+documentation gave the false impression the axiom encoded a true mathematical fact
+awaiting formalization. The descendant work (May 2026) made it clear the axiom is
+false in general. Without this STATE-SYNC, a reader of the parent entry alone would
+walk away believing `insep_gal_trivial` is provable in principle — a credibility hit.
+
+### Lean delta
+
+- 0 new theorems
+- 0 sorry deltas
+- 0 axiom deltas (axiom retained for downstream type-checking; statement unchanged
+  even though now flagged as false)
+- 0 Docker build needed (comment-only edits in Lean file)
+
+### Next ACT direction (deferred to a future iteration)
+
+Replace `insep_gal_trivial` with `gal_card_one_of_purelyInseparable_splitting` and
+weaken `natDeg_notDvd_gal_of_insep` to take `[IsPurelyInseparable F f.SplittingField]`
+as hypothesis. This requires (a) porting the descendant's correct theorem proof
+(~30 LOC: `sub_pow_char_pow_eq` + `algEquiv_eq_refl_of_isPurelyInseparable`) into
+the parent (the descendant can't import-back without cyclic dependency), or
+(b) deleting `natDeg_notDvd_gal_of_insep` from the parent and re-stating it in the
+descendant. Either path needs a Docker build; estimate 100-150 LOC churn.
+
+---
+
+## S1 OBSERVE (2026-06-05, researcher-1) — formal statement + decomposition
 
 ## S1 OBSERVE (2026-06-05, researcher-1) — formal statement + decomposition
 

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -44,8 +44,8 @@
       "Axiomatized inseparable counterexample: insep_gal_trivial and natDeg_notDvd_gal_of_insep"
     ],
     "axiomCount": 1,
-    "assumptions": "One axiom: insep_gal_trivial (states that inseparable irreducibles have trivial Galois group). Full proof would require building F_p(t) and computing the automorphism group of a purely inseparable extension. All other theorems are axiom-free.",
-    "lineCount": 166,
+    "assumptions": "One axiom: insep_gal_trivial — **the axiom as stated is MATHEMATICALLY FALSE**. The OQ-01 descendant file (AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean) proves the counterexample f = X⁴ + X² + a over F₂(a): irreducible, inseparable, yet |Gal(f)| = 2 (not 1) via the Artin-Schreier automorphism α^{1/2} ↦ α^{1/2} + 1. The correct theorem requires `IsPurelyInseparable F f.SplittingField` (not mere inseparability of f); see `gal_card_one_of_purelyInseparable_splitting` in the descendant (proved without axioms or sorries). The axiom is retained in this file only so the downstream consequence `natDeg_notDvd_gal_of_insep` type-checks; a future ACT iteration will replace it. The four other theorems (`natDegree_dvd_card_gal_of_sep`, `natDegree_dvd_card_gal_charZero`, `galois_2group_implies_degree_pow2_sep`, `galois_2group_implies_degree_is_pow2_sep`) are axiom-free and unaffected.",
+    "lineCount": 197,
     "theoremCount": 5,
     "definitionCount": 0
   },
@@ -54,7 +54,7 @@
     "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 0,
-    "lineCount": 166,
+    "lineCount": 197,
     "sorries": 0
   },
   "overview": {

--- a/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "angle-trisection-oq-02-oq-01-oq-01-oq-01",
   "title": "Does the theorem extend beyond CharZero",
-  "phase": "ACT",
+  "phase": "STATE-SYNC",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,33 +16,41 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-26T08:56:57.649Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "STATE-SYNC",
+    "since": "2026-06-09T01:55:00.000Z",
+    "iteration": 3,
+    "focus": "S2 STATE-SYNC: doc-only integrity correction for insep_gal_trivial — flag the axiom as mathematically false (per OQ-01 counterexample), update meta.json assumptions field, update state.md.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Future S3 ACT: replace insep_gal_trivial with the correct theorem gal_card_one_of_purelyInseparable_splitting and weaken natDeg_notDvd_gal_of_insep. Needs ~100-150 LOC churn + Docker build.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 3,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Branch pushed, PR #15667 created. 5 theorems, 0 sorries, 1 axiom. Docker build pending (infrastructure congestion).",
+    "progressSummary": "S2 STATE-SYNC (2026-06-09): doc-only integrity correction. The axiom `insep_gal_trivial` is mathematically FALSE as stated (OQ-01 descendant proved the counterexample X⁴+X²+a over F₂(a)). Updated parent file docstring + Summary table + meta.json assumptions field to flag this honestly. axiomCount unchanged at 1 (placeholder retained so `natDeg_notDvd_gal_of_insep` type-checks). Prior progress: PR #15667 (Session 1, 2026-05-04) shipped 5 theorems + 1 axiom; S1 OBSERVE (2026-06-05) added problem.md with constructibility framing.",
     "builtItems": [
+      "S2 STATE-SYNC (2026-06-09): updated insep_gal_trivial docstring with explicit 'MATHEMATICALLY FALSE as stated' warning + counterexample pointer + correct theorem reference; lineCount 166→197",
+      "S2 STATE-SYNC (2026-06-09): rewrote meta.json `assumptions` field to flag the falsity and point at gal_card_one_of_purelyInseparable_splitting in OQ-01 descendant",
+      "S2 STATE-SYNC (2026-06-09): added 'Integrity Note (S2 STATE-SYNC)' to file Summary",
+      "S2 STATE-SYNC (2026-06-09): updated state.md (phase OBSERVE → STATE-SYNC, iteration 2→3)",
+      "S1 OBSERVE (2026-06-05): problem.md + state.md decomposition with constructibility framing (separate from existing file)",
       "Added import Proofs.AngleTrisectionOQ02OQ01OQ01OQ01 to Proofs.lean",
       "Fixed lineCount 155→165 in meta.json (both meta and leanFile sections)"
     ],
     "insights": [
+      "Documentation lag is an integrity risk: meta.json honestly said axiomCount=1, but surrounding prose claimed the axiom was 'true but unformalized' — misleading once the descendant refuted it",
+      "Parent file can't import-back from OQ-01 descendant (cyclic), so replacing the false axiom requires porting the correct theorem's proof (~30 LOC: sub_pow_char_pow_eq + algEquiv_eq_refl_of_isPurelyInseparable) into the parent",
       "Branch was never pushed from session 1 — always push immediately after commit",
       "Proofs.lean import is required for Lake to compile the new file",
       "Docker builds can queue/hang when daemon is busy with many concurrent builds"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Await Docker build for PR #15667 (AngleTrisectionOQ02OQ01OQ01OQ01)",
-      "Optional: prove insep_gal_trivial using RatFunc/FractionRing over ZMod p"
+      "S3 ACT (deferred): port `gal_card_one_of_purelyInseparable_splitting` (and `sub_pow_char_pow_eq`, `algEquiv_eq_refl_of_isPurelyInseparable`) from the OQ-01 descendant into the parent. Then delete `insep_gal_trivial` and either delete `natDeg_notDvd_gal_of_insep` or restate it with `IsPurelyInseparable F f.SplittingField`. Estimate ~100-150 LOC churn + Docker build.",
+      "Alternative ACT: delete `natDeg_notDvd_gal_of_insep` and `insep_gal_trivial` outright from the parent. Restate the inseparable consequence in the OQ-01 descendant only.",
+      "The OQ-01 descendant's S5 ACT direction (full discharge of `counterexample_gal_card` via Artin-Schreier) remains the heavyweight stretch goal."
     ]
   },
   "tags": [
@@ -86,7 +94,7 @@
     "mathlib": []
   },
   "started": "2026-04-26T08:56:57.649Z",
-  "lastUpdate": "2026-04-26T08:56:57.649Z",
+  "lastUpdate": "2026-06-09T01:55:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

**S2 STATE-SYNC** for `angle-trisection-oq-02-oq-01-oq-01-oq-01`: doc-only integrity correction for the `insep_gal_trivial` axiom.

The axiom in `AngleTrisectionOQ02OQ01OQ01OQ01.lean` claims "in char p, every inseparable irreducible f has |Gal(f)| = 1." The OQ-01 descendant file (`AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`) proved this is **mathematically false**:

- **Explicit counterexample**: over F = F₂(a), the polynomial f = X⁴ + X² + a is irreducible inseparable yet |Gal(f)| = 2 via the Artin-Schreier automorphism α^{1/2} ↦ α^{1/2} + 1.
- **Correct theorem** (proved 0-axiom, 0-sorry in descendant): `gal_card_one_of_purelyInseparable_splitting` — requires `IsPurelyInseparable F f.SplittingField`, not mere inseparability.

Prior documentation framed the axiom as "true but unformalized." This PR honestly reflects what the descendant proved.

## Changes (doc-only)

- `proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean` — axiom docstring rewritten with explicit "MATHEMATICALLY FALSE as stated" warning + counterexample pointer + correct theorem signature. Summary table footer updated; "Integrity Note (S2 STATE-SYNC 2026-06-09)" section added. **Line count 166 → 197.** No Lean bodies change.
- `src/data/proofs/.../meta.json` — `assumptions` field rewritten to flag falsity and point at the descendant's correct theorem. `lineCount` 166 → 197.
- `research/problems/.../state.md` — phase OBSERVE → STATE-SYNC, iter 2 → 3.
- `src/data/research/problems/...json` — phase ACT → STATE-SYNC; refreshed `progressSummary` / `builtItems` / `insights` / `nextSteps`.

## Deltas

- 0 new theorems
- 0 sorry delta
- 0 axiom delta (axiom retained as placeholder so `natDeg_notDvd_gal_of_insep` still type-checks)
- **0 Docker build needed** (comment-only Lean edits)

## Why this matters

`meta.json.axiomCount=1` was honest, but surrounding prose suggested the axiom encoded a true fact. A reader of the parent entry alone would walk away believing `insep_gal_trivial` is provable — a credibility hit now that the descendant proved otherwise. This STATE-SYNC closes that loop.

## Deferred — future S3 ACT

Replace `insep_gal_trivial` with `gal_card_one_of_purelyInseparable_splitting` and weaken `natDeg_notDvd_gal_of_insep`. Requires porting ~30 LOC (`sub_pow_char_pow_eq` + `algEquiv_eq_refl_of_isPurelyInseparable`) from descendant into parent (cyclic import blocks reuse), then deleting the false axiom. Estimate 100-150 LOC churn + Docker build.

## Test plan

- [x] Lean file unchanged in body — no build needed (doc-only edits inside `/--` and `/-!` blocks)
- [x] JSON files validate (`python3 -c "import json; json.load(...)"` passes for both)
- [x] `lineCount` consistent between Lean file (197) and `meta.json` (197 in both `meta` and `leanFile` sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)