### PR TITLE
research(erdos-5): S3 ACT — Eventually-form liminf/limsup corollaries (Docker 3061 jobs clean)

### DIFF
--- a/proofs/Proofs/Erdos5PrimeGaps.lean
+++ b/proofs/Proofs/Erdos5PrimeGaps.lean
@@ -654,4 +654,54 @@ theorem frequently_normalizedGap_gt (M : ℝ) :
     show M < normalizedGap (f (k + K))
     linarith
 
+/- ## Part XV: Liminf / Limsup Corollaries -/
+
+/-- **Unconditional oscillation summary**: the two unconditional oscillation
+    statements packaged together. Combined, they witness `liminf = 0` (using
+    `normalizedGap_nonneg` as the lower bound) and `limsup = ⊤` for the
+    `normalizedGap` sequence along `atTop`. The conjecture asks for the
+    further distributional fact that every intermediate value is also a
+    limit point. -/
+theorem normalizedGap_oscillates :
+    (∀ ε : ℝ, 0 < ε → {n : ℕ | normalizedGap n < ε}.Infinite) ∧
+    (∀ M : ℝ, {n : ℕ | M < normalizedGap n}.Infinite) :=
+  ⟨frequently_normalizedGap_lt, frequently_normalizedGap_gt⟩
+
+/-- **`Eventually`-form of `limsup = ⊤`** (unconditional): there is no upper
+    bound `M : ℝ` such that all-but-finitely-many normalized gaps lie at or
+    below `M`. This is the `Filter.Eventually` reformulation of
+    `frequently_normalizedGap_gt`, and it expresses that
+    `Filter.limsup normalizedGap atTop = ⊤` in any complete extension of `ℝ`
+    (e.g. `EReal`). -/
+theorem not_eventually_normalizedGap_le (M : ℝ) :
+    ¬ ∀ᶠ n in atTop, normalizedGap n ≤ M := by
+  intro h
+  rw [Filter.eventually_atTop] at h
+  obtain ⟨N, hN⟩ := h
+  refine frequently_normalizedGap_gt M (Set.Finite.subset (Set.finite_Iio N) ?_)
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn
+  simp only [Set.mem_Iio]
+  by_contra hge
+  push_neg at hge
+  exact (not_le.mpr hn) (hN n hge)
+
+/-- **`Eventually`-form of `liminf = 0`** (unconditional): for every `ε > 0`
+    it is NOT the case that `normalizedGap n ≥ ε` for all but finitely many
+    `n`. Combined with `normalizedGap_nonneg`, this expresses that
+    `Filter.liminf normalizedGap atTop = 0`: the values dip arbitrarily
+    close to `0` infinitely often, yet are always non-negative. -/
+theorem not_eventually_le_normalizedGap (ε : ℝ) (hε : 0 < ε) :
+    ¬ ∀ᶠ n in atTop, ε ≤ normalizedGap n := by
+  intro h
+  rw [Filter.eventually_atTop] at h
+  obtain ⟨N, hN⟩ := h
+  refine frequently_normalizedGap_lt ε hε (Set.Finite.subset (Set.finite_Iio N) ?_)
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn
+  simp only [Set.mem_Iio]
+  by_contra hge
+  push_neg at hge
+  exact (not_le.mpr hn) (hN n hge)
+
 end Erdos5

--- a/research/problems/erdos-5/knowledge.md
+++ b/research/problems/erdos-5/knowledge.md
@@ -117,4 +117,79 @@ Docker build initiated locally; CI will validate.
 
 ---
 
+### Session 2026-06-09 — Eventually-form liminf/limsup corollaries (S3)
+
+**Mode**: ACT (extension)
+**Outcome**: progress — packaged S2's `Set.Infinite` oscillation lemmas
+into a `Filter.Eventually` form witnessing `liminf = 0` / `limsup = ⊤`
+along `atTop`. Verified Docker build clean (3061 jobs).
+
+#### What was added (Erdos5PrimeGaps.lean: 657 → 707 lines, +50)
+
+- **Part XV (liminf / limsup corollaries)**:
+  - `normalizedGap_oscillates`: trivial packaging of
+    `frequently_normalizedGap_lt` and `frequently_normalizedGap_gt`.
+  - `not_eventually_normalizedGap_le`: for every `M : ℝ`,
+    `¬ ∀ᶠ n in atTop, normalizedGap n ≤ M`. Proof: convert the
+    eventual upper bound to `∃ N, ∀ n ≥ N, …`, then exhibit the set
+    `{n | M < normalizedGap n}` as a finite subset of `Set.Iio N`,
+    contradicting `frequently_normalizedGap_gt M`.
+  - `not_eventually_le_normalizedGap`: dual statement —
+    `¬ ∀ᶠ n in atTop, ε ≤ normalizedGap n` for every `ε > 0`.
+
+#### Architectural impact
+
+- The two `not_eventually_*` lemmas together with the existing
+  `normalizedGap_nonneg` are *exactly* the data needed to derive
+  `Filter.limsup = ⊤` and `Filter.liminf = 0` in any complete
+  extension of `ℝ` (e.g. `EReal`). Future iterations can take the
+  explicit `EReal` step without redoing the `Set.Infinite` ↔
+  `Filter.Eventually` bridge.
+- The S2 dichotomy "either the conjecture holds, or some
+  intermediate value is eventually avoided" is now spelled in a
+  filter-native idiom alongside the `Set.Infinite` form.
+
+#### Meta fixes piggybacked
+
+- Outer `axiomCount` corrected: 4 → 3 (the file has only three
+  `axiom` declarations: `westzynthius_large_gaps`,
+  `zhang_bounded_gaps`, `hildebrand_maier_large_limit_points`; no
+  structure-encoded assumptions). Both inner and outer counts now
+  agree at 3.
+- `theoremCount`: 33 → 36 (added three new theorems).
+- `lineCount`: 657 → 707 (wc -l canonical).
+- `assumptions` text bumped from `26 theorems` to `36 theorems`
+  and references the new corollaries by name.
+- `conclusion.summary` extended to mention the `Filter.limsup` /
+  `Filter.liminf` reading made unconditional by S3.
+
+#### Files Modified
+
+- `proofs/Proofs/Erdos5PrimeGaps.lean` (+50 lines, +3 theorems)
+- `src/data/proofs/erdos-5/meta.json` (lineCount, theoremCount,
+  axiomCount fix, assumptions, conclusion summary, inner
+  leanFile mirrors)
+- `research/problems/erdos-5/state.md` (iteration 2 → 3, refreshed
+  next-action list)
+- `research/problems/erdos-5/knowledge.md` (this session entry)
+
+#### Build status
+
+Docker build clean: `Build completed successfully (3061 jobs)`
+(log: `.loom/logs/researcher-9-erdos5-s3-build.log`).
+
+#### Next iteration could
+
+1. (S4 clean) Explicit `EReal` coercion: state and prove
+   `Filter.limsup (fun n => (normalizedGap n : EReal)) atTop = ⊤`
+   using `not_eventually_normalizedGap_le` and an `EReal`
+   characterization (`EReal.limsup_eq_top_iff_frequently_gt` or
+   similar).
+2. (S4 clean) `MapClusterPt` reformulation linking `IsLimitPoint`
+   to Mathlib's filter cluster point machinery.
+3. (S5 substantive) Reduce the axiom budget by attempting
+   Hildebrand–Maier ← Westzynthius + Erdős–Ricci measure argument.
+
+---
+
 *Generated from erdosproblems.com on 2026-01-12*

--- a/research/problems/erdos-5/state.md
+++ b/research/problems/erdos-5/state.md
@@ -1,42 +1,56 @@
 # Current State
 
 **Phase**: ACT (extension)
-**Since**: 2026-05-08T11:00:00Z
-**Iteration**: 2
+**Since**: 2026-06-09T02:00:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Forward density direction and unconditional oscillation lemmas added to
-`Erdos5PrimeGaps.lean`. The key contribution is the iff characterization
-`erdos_5_iff_dense_at_every_point` which shows that Erdős #5 is
-equivalent to a purely distributional density statement about the
-normalizedGap sequence.
+Eventually-form liminf/limsup corollaries added to `Erdos5PrimeGaps.lean`.
+The unconditional oscillation lemmas
+`frequently_normalizedGap_lt`/`frequently_normalizedGap_gt` are now
+reformulated as `not_eventually_le_normalizedGap` (no `ε > 0` is an
+eventual lower bound) and `not_eventually_normalizedGap_le` (no `M : ℝ`
+is an eventual upper bound), together with the packaging
+`normalizedGap_oscillates`. Together with `normalizedGap_nonneg`, these
+witness `Filter.liminf normalizedGap atTop = 0` and
+`Filter.limsup normalizedGap atTop = ⊤` in any complete extension of `ℝ`
+(e.g. `EReal`) without dragging the `EReal` machinery itself into the
+file.
 
 ## Active Approach
 
-Strengthen the existing reduction `erdos_5_from_dense_values` (one
-direction) into an iff by proving the forward direction
-`frequently_near_of_isLimitPoint` — any subsequence convergent to C
-injects ℕ (via `f ∘ (· + K)`) into the ε-ball around C, hence the set
-of n with normalizedGap n near C is infinite.
+The S3 increment is a self-contained packaging on top of S2's
+`erdos_5_iff_dense_at_every_point`. No new axioms, no new dependencies,
+and the entire addition is closed by `Set.Finite.subset (Set.finite_Iio
+N)` + `Filter.eventually_atTop` rewrites.
 
 ## Blockers
 
-None — the open conjecture itself remains, but the structural theory
-is more complete.
+None — the open conjecture itself remains. The S3 corollaries close the
+gap between the existing `Set.Infinite` oscillation lemmas and the
+filter `liminf`/`limsup` reading without forcing an explicit `EReal`
+coercion of `normalizedGap`.
 
 ## Next Action
 
-Optional follow-ups:
-- A `MapClusterPt`-based reformulation connecting `IsLimitPoint` to
-  Mathlib's filter cluster point machinery.
-- A `Filter.limsup`/`Filter.liminf` formulation in `EReal`:
-  `liminf normalizedGap atTop = 0` and `limsup normalizedGap atTop = ⊤`.
-- Investigate whether Hildebrand–Maier follows from a weaker
-  hypothesis (e.g. Westzynthius + an Erdős–Ricci style measure argument).
+Optional follow-ups (carrying the S2 list forward, plus an S3 cleanup):
+
+- (S4 clean) A direct `EReal` upgrade: state `Filter.limsup` (resp.
+  `Filter.liminf`) of `fun n => (normalizedGap n : EReal)` along `atTop`
+  equals `⊤` (resp. `0`) using `not_eventually_normalizedGap_le` /
+  `not_eventually_le_normalizedGap` plus the appropriate `EReal`
+  characterization lemma.
+- (S4 clean) A `MapClusterPt`-based reformulation connecting
+  `IsLimitPoint` to Mathlib's filter cluster point machinery, unlocking
+  lemmas like `MapClusterPt.isClosed`.
+- (S5 substantive) Investigate whether the Hildebrand–Maier axiom
+  (∃ arbitrarily large finite limit points) follows from
+  Westzynthius + an Erdős–Ricci style measure argument; if so, the
+  axiom count drops 3 → 2.
 
 ## Attempt Counts
 
-- Total attempts: 5
-- Current approach attempts: 2
+- Total attempts: 6
+- Current approach attempts: 1
 - Approaches tried: 2

--- a/src/data/proofs/erdos-5/meta.json
+++ b/src/data/proofs/erdos-5/meta.json
@@ -20,11 +20,11 @@
     "erdosNumber": 5,
     "erdosUrl": "https://erdosproblems.com/5",
     "erdosProblemStatus": "open",
-    "axiomCount": 4,
-    "lineCount": 657,
-    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 26 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density), frequently_near_of_isLimitPoint and erdos_5_iff_dense_at_every_point (forward density direction giving the iff characterization), and unconditional oscillation lemmas frequently_normalizedGap_lt and frequently_normalizedGap_gt.",
+    "axiomCount": 3,
+    "lineCount": 707,
+    "assumptions": "3 axioms: westzynthius_large_gaps (∞ ∈ S, 1931), zhang_bounded_gaps (bounded prime gaps, 2013), hildebrand_maier_large_limit_points (arbitrarily large finite limit points, 1988). 0 sorries. Proves 36 theorems including: zhang_implies_zero_limit, twin_prime_implies_zero_limit, limitPointSet_isClosed, limitPointSet_unbounded, erdos_5_from_dense_values (reduction to distributional density), frequently_near_of_isLimitPoint and erdos_5_iff_dense_at_every_point (forward density direction giving the iff characterization), unconditional oscillation lemmas frequently_normalizedGap_lt and frequently_normalizedGap_gt, and Eventually-form liminf/limsup corollaries not_eventually_normalizedGap_le and not_eventually_le_normalizedGap together with the packaging normalizedGap_oscillates.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 33,
+    "theoremCount": 36,
     "definitionCount": 9,
     "additionalFiles": [
       "Proofs/Erdos5Problem.lean"
@@ -114,7 +114,7 @@
     }
   ],
   "conclusion": {
-    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 33 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, closed, unbounded, and contained in [0, ∞). The reduction theorem erdos_5_from_dense_values together with frequently_near_of_isLimitPoint yields the iff characterization erdos_5_iff_dense_at_every_point: the conjecture is equivalent to normalizedGap values being distributionally dense on [0, ∞). Unconditional oscillation lemmas (frequently_normalizedGap_lt from Zhang, frequently_normalizedGap_gt from Westzynthius) confirm that normalized gaps dip arbitrarily close to 0 and rise arbitrarily high, infinitely often each.",
+    "summary": "Erdős Problem #5 asks whether every non-negative real number is a limit point of normalized prime gaps. This formalization proves 36 theorems from 3 axioms with 0 sorries. The extremes are settled: 0 ∈ S (derived from Zhang's bounded gaps) and ∞ ∈ S (Westzynthius). Key structural results: S is nonempty, closed, unbounded, and contained in [0, ∞). The reduction theorem erdos_5_from_dense_values together with frequently_near_of_isLimitPoint yields the iff characterization erdos_5_iff_dense_at_every_point: the conjecture is equivalent to normalizedGap values being distributionally dense on [0, ∞). Unconditional oscillation lemmas (frequently_normalizedGap_lt from Zhang, frequently_normalizedGap_gt from Westzynthius) confirm that normalized gaps dip arbitrarily close to 0 and rise arbitrarily high, infinitely often each. The Eventually-form corollaries not_eventually_normalizedGap_le and not_eventually_le_normalizedGap reformulate these as witnesses that Filter.limsup normalizedGap atTop = ⊤ and Filter.liminf normalizedGap atTop = 0 along atTop.",
     "implications": "Resolution would provide a complete understanding of prime gap fluctuations at the logarithmic scale, confirming the prediction of Cramér's probabilistic model. It connects to the Hardy-Littlewood prime k-tuples conjecture (which would imply S = [0, ∞)), sieve methods (the GPY-Maynard-Tao framework), and the distribution of primes in short intervals.",
     "openQuestions": [
       "Is every C ≥ 0 a limit point of (p_{n+1} - p_n)/log(p_n)?",
@@ -167,9 +167,9 @@
       "Topology"
     ],
     "namespace": "Erdos5",
-    "lineCount": 657,
+    "lineCount": 707,
     "axiomCount": 3,
-    "theoremCount": 33,
+    "theoremCount": 36,
     "definitionCount": 9,
     "path": "Proofs/Erdos5PrimeGaps.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

Adds **Part XV** to `Erdos5PrimeGaps.lean` — 3 new theorems (+50 LOC) reformulating the existing unconditional oscillation lemmas in `Filter.Eventually` form, so they can be used as direct witnesses for `Filter.liminf = 0` and `Filter.limsup = ⊤` of `normalizedGap` along `atTop` in any complete extension of ℝ (e.g. `EReal`).

```
657 → 707 LOC  |  33 → 36 theorems  |  3 axioms (unchanged)  |  0 sorries
```

### New theorems (Part XV)

| Name | Statement |
|------|-----------|
| `normalizedGap_oscillates` | Packaging of `frequently_normalizedGap_lt` and `frequently_normalizedGap_gt`. |
| `not_eventually_normalizedGap_le M` | `¬ ∀ᶠ n in atTop, normalizedGap n ≤ M` for every `M : ℝ`. Witnesses `limsup = ⊤`. |
| `not_eventually_le_normalizedGap ε` | `¬ ∀ᶠ n in atTop, ε ≤ normalizedGap n` for every `ε > 0`. Combined with `normalizedGap_nonneg`, witnesses `liminf = 0`. |

Proofs are closed by `Filter.eventually_atTop` + `Set.Finite.subset (Set.finite_Iio N)` — no new axioms, no new imports.

### Meta hygiene piggybacked

- Outer `axiomCount` corrected **4 → 3** (the file has exactly three `axiom` declarations; no structure-encoded assumptions). Inner `leanFile.axiomCount` already was 3; both now agree.
- `theoremCount` 33 → 36, `lineCount` 657 → 707, `assumptions` and `conclusion.summary` refreshed.
- `state.md` advanced to Iteration 3; `knowledge.md` gains a session entry.

## Verification

```
$ LEAN_BUILD_TIMEOUT=20m LEAN_MEMORY_LIMIT=8192 \
    ./proofs/scripts/docker-build.sh Proofs.Erdos5PrimeGaps
…
✔ [3061/3061] Built Proofs.Erdos5PrimeGaps (61s)
Build completed successfully (3061 jobs).
=== Build succeeded ===
```

Log: `.loom/logs/researcher-9-erdos5-s3-build2.log`.

## Test plan
- [x] Docker build clean (3061 jobs)
- [x] No new axioms / sorries / imports
- [x] Outer + inner meta counts agree on axiomCount=3, theoremCount=36, lineCount=707
- [ ] CI verifies on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)