### PR TITLE
research(erdos-840): S2 ACT — discharge unordered_pairs_card sorry via swap-bijection

### DIFF
--- a/proofs/Proofs/Erdos840Aristotle.lean
+++ b/proofs/Proofs/Erdos840Aristotle.lean
@@ -122,12 +122,61 @@ lemma sidon_distinct_sums (A : Finset ℕ) (hS : IsSidon' A)
   ## Section 3: Sumset Size Bounds
 -/
 
-/-- The number of unordered pairs from A is C(|A|, 2).
-    Proof: the map (a,b) ↦ {a,b} bijects strict pairs with 2-element subsets,
-    and there are A.card.choose 2 such subsets by Finset.card_powersetLen.
-    This is a standard combinatorial identity. -/
+/-- The number of strict pairs (a, b) ∈ A × A with a < b is C(|A|, 2).
+
+    Proof strategy (swap-bijection argument, avoiding 2-element subsets):
+    Let L = strict-lt pairs, G = strict-gt pairs. Then
+      * L ∪ G = offDiag (= ≠-pairs), disjoint
+      * |L| = |G| via the swap bijection (a, b) ↦ (b, a)
+      * |offDiag| = |A| * (|A| - 1) by `card_ordered_pairs`
+    Hence 2 * |L| = |A| * (|A| - 1) = 2 * C(|A|, 2) by `two_mul_choose_two`,
+    so |L| = C(|A|, 2). -/
 theorem unordered_pairs_card (A : Finset ℕ) :
-    ((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2 := by sorry
+    ((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2 := by
+  set L := (A ×ˢ A).filter (fun p : ℕ × ℕ => p.1 < p.2) with hL_def
+  set G := (A ×ˢ A).filter (fun p : ℕ × ℕ => p.2 < p.1) with hG_def
+  -- Disjointness: a < b and b < a cannot both hold
+  have h_disj : Disjoint L G := by
+    rw [Finset.disjoint_left]
+    rintro p hLp hGp
+    simp only [hL_def, hG_def, Finset.mem_filter] at hLp hGp
+    omega
+  -- L ∪ G coincides with the ≠-filter, whose card is given by `card_ordered_pairs`
+  have h_union_card : (L ∪ G).card = A.card * (A.card - 1) := by
+    have h_eq : L ∪ G = (A ×ˢ A).filter (fun p : ℕ × ℕ => p.1 ≠ p.2) := by
+      ext p
+      simp only [hL_def, hG_def, Finset.mem_union, Finset.mem_filter]
+      constructor
+      · rintro (⟨h1, h2⟩ | ⟨h1, h2⟩) <;> exact ⟨h1, by omega⟩
+      · rintro ⟨h1, h2⟩
+        rcases Nat.lt_or_gt_of_ne h2 with hlt | hgt
+        · exact Or.inl ⟨h1, hlt⟩
+        · exact Or.inr ⟨h1, hgt⟩
+    rw [h_eq, card_ordered_pairs]
+  -- Swap bijection: G is the image of L under (a, b) ↦ (b, a)
+  have h_swap_inj : Function.Injective (fun p : ℕ × ℕ => (p.2, p.1)) := by
+    rintro ⟨a, b⟩ ⟨c, d⟩ h
+    simp only [Prod.mk.injEq] at h
+    exact Prod.ext h.2 h.1
+  have h_G_eq : G = L.image (fun p : ℕ × ℕ => (p.2, p.1)) := by
+    ext ⟨a, b⟩
+    simp only [hG_def, hL_def, Finset.mem_filter, Finset.mem_product,
+               Finset.mem_image]
+    constructor
+    · rintro ⟨⟨ha, hb⟩, hgt⟩
+      exact ⟨(b, a), ⟨⟨hb, ha⟩, hgt⟩, rfl⟩
+    · rintro ⟨⟨c, d⟩, ⟨⟨hc, hd⟩, hlt⟩, h_eq⟩
+      obtain ⟨h_d_a, h_c_b⟩ : d = a ∧ c = b := Prod.mk.inj h_eq
+      subst h_d_a; subst h_c_b
+      exact ⟨⟨hd, hc⟩, hlt⟩
+  have h_card_eq : G.card = L.card := by
+    rw [h_G_eq]; exact Finset.card_image_of_injective L h_swap_inj
+  -- Combine: 2 * |L| = |A| * (|A| - 1) = 2 * choose 2
+  have h_two_L : 2 * L.card = A.card * (A.card - 1) := by
+    rw [Finset.card_union_of_disjoint h_disj, h_card_eq] at h_union_card
+    omega
+  have h_two_choose := two_mul_choose_two A.card
+  omega
 
 /-- Sumset is nonempty when A is nonempty -/
 lemma sumset_nonempty (A : Finset ℕ) (hA : A.Nonempty) : (sumset' A).Nonempty := by

--- a/research/problems/erdos-840/state.md
+++ b/research/problems/erdos-840/state.md
@@ -1,0 +1,125 @@
+# Current State
+
+**Phase**: ACT (S2 ACT shipped 2026-06-09 by researcher-5)
+**Since**: 2026-04-21 (S1 ACT — initial formalization) → 2026-06-09 (S2 ACT)
+**Iteration**: 2
+
+## S2 ACT (2026-06-09, researcher-5) — discharge `unordered_pairs_card` sorry
+
+**Mode**: ACT (Lean sorry → proven theorem).
+
+**Outcome**: Replaced the `sorry` on `unordered_pairs_card` in
+`Erdos840Aristotle.lean` with a complete proof via the swap-bijection argument.
+
+### Mathematical content
+
+Goal: `((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2`
+
+Proof sketch (~50 LOC):
+
+1. Let `L` = strict-lt pairs, `G` = strict-gt pairs.
+2. `L ∪ G` coincides with `(A ×ˢ A).filter (· ≠ ·)` and is disjoint, so
+   `|L ∪ G| = |L| + |G|`.
+3. By the already-proven `card_ordered_pairs`,
+   `|(A ×ˢ A).filter (· ≠ ·)| = |A| * (|A| - 1)`.
+4. Swap bijection `(a, b) ↦ (b, a)`: `G = L.image swap`, swap is injective,
+   so `|G| = |L|`.
+5. Therefore `2 * |L| = |A| * (|A| - 1)`.
+6. By the already-proven (private) `two_mul_choose_two`,
+   `2 * A.card.choose 2 = |A| * (|A| - 1)`.
+7. `omega` closes: `|L| = A.card.choose 2`.
+
+### Why this proof, not the powersetCard-bijection route
+
+The natural alternative is to biject lt-pairs with 2-element subsets of `A`
+and use `Finset.card_powersetCard`. That route requires reasoning about
+`Finset` extensionality on doubletons (`{a, b} = {c, d}` with `a<b, c<d`
+implies `a=c, b=d`), which is hairier in Lean 4 than the symmetric-counting
+argument above. The chosen proof reuses two lemmas already proven in this
+file (`card_ordered_pairs`, `two_mul_choose_two`) — no new infrastructure.
+
+### What landed
+
+- `proofs/Proofs/Erdos840Aristotle.lean` — `unordered_pairs_card` replaces
+  `:= by sorry` with the full ~50-LOC proof; doc-comment rewritten to
+  describe the swap-bijection strategy. Sorry count 2 → 1 (only
+  `sidon_card_le_sqrt` remains).
+- `src/data/research/problems/erdos-840.json` — phase ACT (iter 1) → ACT (iter 2);
+  refreshed `progressSummary` / `builtItems` / `insights` / `nextSteps`.
+- `src/data/proofs/erdos-840/meta.json` (if present) — refresh `sorryCount`
+  and `theoremCount`.
+- `state.md` (this new file) — initial creation; phase ACT, iter 2.
+
+### Docker build status
+
+**Docker build: PASSED** (7743 jobs, 388s build of `Proofs.Erdos840Aristotle`).
+Only one warning: `Erdos840Aristotle.lean:240:8: declaration uses 'sorry'`,
+which is the remaining `sidon_card_le_sqrt` we explicitly defer. The new
+`unordered_pairs_card` proof compiles cleanly.
+
+Final file size: 193 → 242 lines (+49 lines for the proof body).
+
+### Lean delta
+
+- 0 new theorems by signature (the sorry was already declared as a `theorem`)
+- 1 sorry discharged (`unordered_pairs_card` was the cleaner of the two
+  remaining sorries in the Aristotle file)
+- 0 new axioms
+- Net: −1 sorry in `Erdos840Aristotle.lean`
+
+### Remaining sorries / axioms
+
+**Aristotle file** (1 sorry remaining):
+- `sidon_card_le_sqrt` (line 191): `|A| ≤ √(2N) + 1` for Sidon `A ⊆ {1..N}`.
+  Proof requires the "distinct differences" argument: the C(k,2) positive
+  differences lie in {1, …, N-1}, giving k*(k-1)/2 ≤ N-1, hence the bound.
+  This needs `IsSidon → distinct differences` (substantive) and
+  `Real.sqrt` arithmetic to invert the quadratic — heavier than this S2 step.
+
+**Problem file** (8 axioms, unchanged):
+- `sidon_sumset_card`, `erdos_freud_lower_bound`, `construction_is_quasi_sidon`,
+  `erdos_freud_upper_bound`, `pikhurko_upper_bound`, `pikhurko_constant_approx`,
+  `sidon_set_upper_bound`, `sidon_set_exists` — all research-level results
+  correctly axiomatized per the gallery's axiomatization policy.
+
+## Active Approach
+
+Continue closing Aristotle-file sorries via direct Lean proofs that don't
+depend on research-level results.
+
+## Blockers
+
+- `sidon_card_le_sqrt` needs an intermediate "Sidon ⇒ distinct differences"
+  lemma plus `Real.sqrt` quadratic inversion. ~80-120 LOC; deferred.
+
+## Next Action
+
+**S3 ACT (future)**: prove `sidon_card_le_sqrt` via differences-argument:
+
+```lean
+theorem sidon_card_le_sqrt (A : Finset ℕ) (N : ℕ) (hN : N ≥ 1)
+    (hA : ∀ a ∈ A, a ≤ N) (hS : IsSidon' A) :
+    (A.card : ℝ) ≤ Real.sqrt (2 * N) + 1 := by
+  -- Step 1: define differences set D = {a - b : a, b ∈ A, b < a}
+  -- Step 2: show D has cardinality C(|A|, 2) (Sidon distinctness)
+  -- Step 3: D ⊆ Finset.Icc 1 N
+  -- Step 4: C(|A|, 2) ≤ N, i.e. k*(k-1)/2 ≤ N
+  -- Step 5: solve quadratic: k ≤ √(2N) + 1
+```
+
+Expected ~100-150 LOC + Docker build.
+
+## Honesty
+
+This S2 ACT iteration eliminates one sorry from the Aristotle file via a
+self-contained proof that reuses two lemmas already established in the same
+file. The proof is not novel mathematics — it is a standard "double counting
+of ordered pairs vs unordered pairs" argument that any combinatorics text
+states in one line. The contribution is the careful Lean encoding, especially
+the `Finset.image` + injectivity bridge for the swap bijection.
+
+Mathlib likely has this identity under a different name (some variant of
+`Finset.card_powersetCard`-derived); I did not attempt to track it down
+because the local-reuse proof is ~50 LOC and self-contained, and the
+gallery's policy prefers self-contained Aristotle helpers over chained
+Mathlib invocations for clarity.

--- a/src/data/research/problems/erdos-840.json
+++ b/src/data/research/problems/erdos-840.json
@@ -33,15 +33,15 @@
       "Bijection proof for unordered_pairs_card requires complex Finset quotient argument (kept as axiom)",
       "Main bounds (Erdős-Freud, Pikhurko) are research-level — correctly axiomatized"
     ],
-    "nextAction": "Claim new problem; consider contributing unordered_pairs_card proof",
+    "nextAction": "S3 ACT (future): prove sidon_card_le_sqrt via differences argument (|D| = C(|A|,2), D ⊆ {1..N-1}, ⟹ k ≤ √(2N) + 1). ~100-150 LOC.",
     "attemptCounts": {
-      "total": 1,
+      "total": 2,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: All 15 sorries eliminated. Both files build with 0 sorries. Aristotle file: 2 axioms (bijection, Sidon bound). Problem file: 8 axioms (known research results). Fixed mathematically false bound sqrt(N)+1 → sqrt(2N)+1.",
+    "progressSummary": "S2 ACT (2026-06-09): discharged unordered_pairs_card sorry via swap-bijection (~50 LOC; reuses card_ordered_pairs + two_mul_choose_two). Aristotle file sorry count 2 → 1; only sidon_card_le_sqrt remains. Problem file unchanged (8 research-level axioms). Prior S1 ACT (2026-04-21): eliminated all original 15 sorries, fixed false sqrt(N)+1 → sqrt(2N)+1.",
     "builtItems": [
       "mem_sumset: a+b ∈ sumset' A when a,b ∈ A (Erdos840Aristotle.lean:60-63)",
       "two_mul_mem_sumset: 2*a ∈ sumset' A when a ∈ A (Erdos840Aristotle.lean:65-69)",
@@ -54,6 +54,7 @@
       "two_div_sqrt3_gt_one: 2/sqrt(3) > 1 via fraction arithmetic (Erdos840Aristotle.lean:125-133)",
       "Fixed IsSidon syntax: ∀ a₁ ∈ A, ∀ a₂ ∈ A, ... (Erdos840Problem.lean:51-53)",
       "Fixed bounds_gap proof: Real.pi_lt_d2 replaces broken exact? (Erdos840Problem.lean:210)",
+      "S2 ACT (2026-06-09): unordered_pairs_card discharged via swap-bijection (~50 LOC, Erdos840Aristotle.lean:129-181). Replaces sorry with full proof reusing card_ordered_pairs + two_mul_choose_two. Strategy: L ∪ G = offDiag (disjoint), |L| = |G| via swap injection, so 2|L| = |A|*(|A|-1) = 2*C(|A|,2).",
       "triangular_eq_choose_plus: n*(n+1)/2 = C(n,2)+n — proved via two_mul_choose_two + Nat.div_mul_cancel + calc chain + omega (Erdos840Aristotle.lean:46-68)",
       "card_ordered_pairs: |{(a,b)∈A×A : a≠b}| = |A|*(|A|-1) — proved via offDiag + case split + ring/omega (Erdos840Aristotle.lean:71-85)",
       "choose_two_formula: C(n,2) = n*(n-1)/2 — proved via two_mul_choose_two + omega (Erdos840Aristotle.lean:41-43)",
@@ -69,7 +70,8 @@
       "omega fails when calc chain uses m+1+1 form but goal has m+2 — fix by keeping calc in m+1+1 form throughout to match hnn1 exactly",
       "Finset.offDiag_card gives n*n-n form, not n*(n-1) — case split + ring + omega needed to bridge the gap",
       "Sidon bound sqrt(N)+1 is mathematically FALSE for large N — correct bound from differences argument is sqrt(2N)+1",
-      "For nat division: establish A = 2*B via ring/linarith, then omega derives A/2 = B"
+      "For nat division: establish A = 2*B via ring/linarith, then omega derives A/2 = B",
+      "unordered_pairs_card has a clean swap-bijection proof reusing card_ordered_pairs + two_mul_choose_two; the powersetCard-bijection route hits Finset doubleton extensionality (hairier)"
     ],
     "mathlibGaps": [
       "No direct Mathlib theorem for Sidon set cardinality bound |A| ≤ √N + O(1)",
@@ -77,9 +79,8 @@
       "triangular_eq_choose_plus and choose_two_formula: omega fails on Nat truncated division"
     ],
     "nextSteps": [
-      "Try proving unordered_pairs_card via Finset.card_image_of_injective with canonical pair ordering",
-      "Consider proving sidon_card_le_sqrt via the differences argument C(k,2) ≤ N-1 implies k ≤ sqrt(2N)+1",
-      "Submit remaining 2 HARD axioms (unordered_pairs_card, sidon_card_le_sqrt) to Aristotle"
+      "S3 ACT: prove sidon_card_le_sqrt via the differences argument. Steps: (1) define differences set D ⊆ Finset.range N; (2) prove IsSidon ⟹ distinct differences ⟹ |D| = C(|A|,2); (3) D ⊆ {1..N-1} ⟹ C(k,2) ≤ N-1 ⟹ k*(k-1) ≤ 2(N-1) ⟹ k ≤ sqrt(2N)+1.",
+      "Mathlib gap: the differences-set Sidon bound is not in Mathlib; this contribution would be a standalone, ~100-150 LOC."
     ],
     "markdown": "# Knowledge Base: erdos-840\n\n## Problem\nErdős Problem #840: quasi-Sidon subsets A ⊆ {1,...,N} with |A+A| = (1+o(1))C(|A|,2).\nOpen since 1981. Known: 1.15√N ≤ f(N) ≤ 1.86√N.\n\n## Session 2026-04-21\nBuilt supporting infrastructure. Both files compile with acceptable sorries.\n"
   },


### PR DESCRIPTION
## Summary

**S2 ACT** for `erdos-840` (Quasi-Sidon Subsets): discharges the
`unordered_pairs_card` sorry in `Erdos840Aristotle.lean` via a swap-bijection
argument. Sorry count in the Aristotle file: 2 → 1.

## Proof (~50 LOC, reuses existing lemmas)

Goal: `((A ×ˢ A).filter fun p => p.1 < p.2).card = A.card.choose 2`

Strategy:

1. Let `L` = strict-lt pairs, `G` = strict-gt pairs.
2. `L ∪ G = (A ×ˢ A).filter (· ≠ ·)`, disjoint.
3. `card_ordered_pairs` (already proven): `|≠-filter| = |A| * (|A| - 1)`.
4. Swap `(a, b) ↦ (b, a)` is injective; `G = L.image swap`; so `|G| = |L|`
   via `Finset.card_image_of_injective`.
5. `2 * |L| = |A| * (|A| - 1)`.
6. `two_mul_choose_two` (already proven): `2 * C(|A|, 2) = |A| * (|A| - 1)`.
7. `omega` closes: `|L| = C(|A|, 2)`.

**Why this proof, not the powersetCard-bijection route**: the natural alternative
bijects lt-pairs with 2-element subsets and uses `Finset.card_powersetCard`. That
requires reasoning about `Finset` doubleton extensionality (`{a, b} = {c, d}` with
`a<b, c<d` implies `a=c, b=d`), which is hairier in Lean 4 than the
symmetric-counting argument above. The chosen proof reuses two lemmas already
established in this file — no new infrastructure.

## Docker build

**PASSED**: `./proofs/scripts/docker-build.sh Proofs.Erdos840Aristotle` (7743 jobs, 388s).

Only warning: `Erdos840Aristotle.lean:240:8: declaration uses 'sorry'` — the
remaining `sidon_card_le_sqrt`, explicitly deferred to S3 ACT.

## Deltas

- **Sorry**: Aristotle file 2 → 1 (only `sidon_card_le_sqrt` remains).
- **Axioms**: unchanged (Problem file still has 8 research-level axioms).
- **Line count**: `Erdos840Aristotle.lean` 193 → 242 (+49 LOC).

## Files

- `proofs/Proofs/Erdos840Aristotle.lean` — replaces `:= by sorry` on
  `unordered_pairs_card` (~50 LOC proof body); doc-comment rewritten to
  describe the swap-bijection strategy.
- `src/data/research/problems/erdos-840.json` — phase ACT (iter 1) → ACT (iter 2);
  refreshed `progressSummary`, `builtItems`, `insights`, `nextSteps`.
- `research/problems/erdos-840/state.md` — new tracker file (phase ACT, iter 2).

## Deferred — S3 ACT

Prove `sidon_card_le_sqrt` (`|A| ≤ √(2N) + 1` for Sidon `A ⊆ {1..N}`) via the
differences argument:

```
1. D = {a - b : a, b ∈ A, b < a} ⊆ Finset.Icc 1 (N - 1)
2. IsSidon ⟹ distinct differences ⟹ |D| = C(|A|, 2)
3. C(|A|, 2) ≤ N - 1 ⟹ |A| * (|A| - 1) ≤ 2(N - 1) ⟹ |A| ≤ √(2N) + 1
```

Estimate ~100-150 LOC + Docker build.

## Test plan

- [x] Docker build passes (7743 jobs, only the deferred sidon_card_le_sqrt warning).
- [x] JSON files validate (`python3 -c "import json; json.load(...)"`).
- [x] Line count delta matches: file 193 → 242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)