### PR TITLE
Enrich cube-root-3-irrational-oq-02: Schönemann–Eisenstein history + Vahlen–Capelli refinement

### DIFF
--- a/src/data/proofs/cube-root-3-irrational-oq-02/annotations.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02/annotations.json
@@ -22,6 +22,30 @@
     ]
   },
   {
+    "id": "ann-cbrt3oq02-gauss-lemma",
+    "proofId": "cube-root-3-irrational-oq-02",
+    "range": {
+      "startLine": 29,
+      "endLine": 34
+    },
+    "type": "context",
+    "title": "Eisenstein \u2192 Gauss's Lemma \u2192 \u211a-Irreducibility",
+    "content": "The import `Proofs.CubeRoot2IrrationalOQ03` brings in `eisenstein_X_pow_sub_of_sqfree_factor`, which already bundles **Gauss's Lemma** internally. Eisenstein proves irreducibility over \u2124; Gauss's Lemma (Disquisitiones Arithmeticae \u00a742, 1801) bridges to \u211a-irreducibility by showing that a primitive integer polynomial factors over \u211a iff it factors over \u2124. Without Gauss's Lemma, Eisenstein alone would only give \u2124-irreducibility, which is *weaker* than what we need: a \u211a[X] factorization (X\u2212Cq)\u00b7R could come from coefficient denominators clearing. The Mathlib helper handles this bookkeeping under the hood, so the user-facing API gives \u211a-irreducibility directly.",
+    "mathContext": "**Gauss's Lemma**: If $f \\in \\mathbb{Z}[X]$ is primitive (content = 1) and $f = g \\cdot h$ with $g, h \\in \\mathbb{Q}[X]$, then $\\exists$ rational $\\lambda \\neq 0$ with $\\lambda g, \\lambda^{-1} h \\in \\mathbb{Z}[X]$. Equivalently: primitive $f$ is $\\mathbb{Q}$-reducible $\\Leftrightarrow$ $\\mathbb{Z}$-reducible. Combined with Eisenstein (which establishes $\\mathbb{Z}$-irreducibility), this yields $\\mathbb{Q}$-irreducibility.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Gauss's lemma",
+      "content of a polynomial",
+      "primitive polynomial",
+      "\u2124-irreducibility vs \u211a-irreducibility"
+    ],
+    "prerequisites": [
+      "Polynomial.IsPrimitive",
+      "Polynomial.content",
+      "UniqueFactorizationMonoid (for \u2124[X])"
+    ]
+  },
+  {
     "id": "ann-cbrt3oq02-irred",
     "proofId": "cube-root-3-irrational-oq-02",
     "range": {

--- a/src/data/proofs/cube-root-3-irrational-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02/meta.json
@@ -31,7 +31,7 @@
     ]
   },
   "overview": {
-    "historicalContext": "The irrationality of ∛3 was known to ancient mathematicians. The algebraic approach via polynomial irreducibility is due to Eisenstein (1850), who gave a simple sufficient condition for a polynomial over ℤ to be irreducible: if a prime p divides all non-leading coefficients and p² does not divide the constant term, then the polynomial is irreducible over ℤ (and hence over ℚ by Gauss's lemma). For X³−3, the prime p=3 works: 3 | 3 (constant), 9 ∤ 3, 3 ∤ 1 (leading). This gives a systematically algebraic proof of irrationality.",
+    "historicalContext": "The irrationality of ∛3 was known to ancient mathematicians, though the systematic algebraic approach used here is a 19th-century development. The Greek tradition treated each irrational case ad hoc: Theaetetus (c. 369 BC, as reported in Plato's Theaetetus) showed √n is irrational for every non-square integer n ≤ 17 by geometric incommensurability arguments. The cube-root case requires harder integer arithmetic and was likely handled by similar exhaustion.\n\nThe modern algebraic approach via polynomial irreducibility belongs to the Berlin school of the 1840s. **Theodor Schönemann** published the criterion in 1846 (Crelle's Journal 32, p. 100), and **Gotthold Eisenstein** rediscovered and popularized it in his 1850 paper «Über die Irreduktibilität und einige andere Eigenschaften der Gleichung» (Crelle's Journal 39, p. 160–179). Eisenstein, a prodigy who died at 29 in 1852, was a favorite of Gauss; the criterion is sometimes called the Schönemann–Eisenstein theorem.\n\nThe statement: if a prime p divides every non-leading coefficient of an integer polynomial, p does not divide the leading coefficient, and p² does not divide the constant term, then the polynomial is irreducible over ℤ — and hence over ℚ by **Gauss's lemma** (1801, Disquisitiones Arithmeticae §42), which states that a primitive polynomial is ℤ-irreducible iff it is ℚ-irreducible. For X³−3 at p=3: 3 ∣ −3 (constant), 9 ∤ −3, 3 ∤ 1 (leading). Three trivial divisibility checks replace the classical case analysis. The same criterion proves irreducibility of cyclotomic polynomials Φₚ(X) = (Xᵖ−1)/(X−1) at any prime p (after the substitution X ↦ X+1), making Eisenstein indispensable for Galois theory.",
     "problemStatement": "**Open Question OQ-02 from cube-root-3-irrational**:\n\nThe gallery already has `CubeRoot3Irrational.lean` which proves ∛3 is irrational via `irrational_nrt_of_notint_nrt` — an existence argument checking no perfect cube equals 3. The open question: can we give a more algebraically systematic proof using Eisenstein's irreducibility criterion?\n\n**This file answers yes**: X³−3 is irreducible → no rational roots → ∛3 ∉ ℚ.",
     "proofStrategy": "**Three steps:**\n\n1. **Eisenstein irreducibility** (`X3_sub_3_irred`): Apply `eisenstein_X_pow_sub_of_sqfree_factor 3 3 3` from `CubeRoot2IrrationalOQ03`. The prime p=3 divides 3 (constant term) but 9 ∤ 3, and 3 ∤ 1 (leading coefficient). Therefore X³−3 is irreducible over ℚ.\n\n2. **No rational roots** (`X3_sub_3_no_rat_root`): If q:ℚ is a root, then (X−Cq) | (X³−3). By irreducibility, either (X−Cq) is a unit (impossible: natDegree=1≠0) or R is a unit (then natDegree 3 = 1+0 = 1, contradiction). Uses `natDegree_eq_zero_of_isUnit`.\n\n3. **Irrationality** (`cbrt3_irrational_via_eisenstein`): Suppose ∛3 = q ∈ ℚ. Then q³ = 3 (by rpow arithmetic), so q is a root of X³−3. But X³−3 has no rational roots. Contradiction.",
     "keyInsights": [
@@ -39,7 +39,8 @@
       "The irreducibility → no rational roots argument uses `natDegree_eq_zero_of_isUnit` which was already available in the gallery",
       "The rpow arithmetic `((3:ℝ)^(1/3))^3 = 3` uses the same Real.rpow_mul pattern as all the other cube root files",
       "The key advantage over the direct proof: Eisenstein simultaneously shows X³−3 has NO rational roots, not just that ∛3 is not an integer — a strictly stronger algebraic statement",
-      "**The two-case structure is canonical for irreducible polynomials**: The proof of 'irreducible → no roots' uses `Irreducible.isUnit_or_isUnit` to split on which factor is a unit. Case `inl` (X−Cq is a unit) is contradicted by natDegree=1≠0. Case `inr` (cofactor R is a unit) gives natDegree(X³−3) = natDegree(X−Cq) + 0 = 1, contradicting natDegree=3. This two-case pattern is the universal argument: any irreducible polynomial of degree ≥ 2 has no roots in its coefficient field."
+      "**The two-case structure is canonical for irreducible polynomials**: The proof of 'irreducible → no roots' uses `Irreducible.isUnit_or_isUnit` to split on which factor is a unit. Case `inl` (X−Cq is a unit) is contradicted by natDegree=1≠0. Case `inr` (cofactor R is a unit) gives natDegree(X³−3) = natDegree(X−Cq) + 0 = 1, contradicting natDegree=3. This two-case pattern is the universal argument: any irreducible polynomial of degree ≥ 2 has no roots in its coefficient field.",
+      "**Eisenstein's strength over the Rational Root Theorem**: The Rational Root Theorem (test all p/q with p∣3 and q∣1) also disproves rational roots of X³−3, but only ad hoc — it must be reapplied for each new polynomial. Eisenstein proves irreducibility, which automatically rules out roots in *every* algebraic-degree-1 element. This is why Eisenstein is the canonical tool for Galois-theoretic arguments (showing minimal polynomials have a target degree), while the Rational Root Theorem suffices only for the single 'no rational roots' question."
     ],
     "prerequisites": [
       "CubeRoot2IrrationalOQ03.lean: eisenstein_X_pow_sub_of_sqfree_factor general theorem",
@@ -93,26 +94,42 @@
     {
       "targetId": "cube-root-3-irrational",
       "relationship": "extends",
-      "description": "Parent proof using irrational_nrt_of_notint_nrt. This file gives a more algebraic proof via Eisenstein and polynomial irreducibility."
+      "description": "Parent proof using irrational_nrt_of_notint_nrt. This file gives a more algebraic proof via Eisenstein and polynomial irreducibility, proving the strictly stronger statement that X³−3 has no rational roots at all."
     },
     {
-      "targetId": "cube-root-2-irrational-oq-03",
-      "relationship": "depends",
-      "description": "Imports eisenstein_X_pow_sub_of_sqfree_factor from CubeRoot2IrrationalOQ03, which proves the general Eisenstein + minpoly degree theorem."
+      "targetId": "cube-root-2-irrational",
+      "relationship": "thematic",
+      "description": "Sibling cube-root irrationality. The general Eisenstein lemma `eisenstein_X_pow_sub_of_sqfree_factor` used here lives in `CubeRoot2IrrationalOQ03.lean` (no standalone gallery entry yet) — that file proves the same template for X^n−m whenever m has a squarefree prime factor p. ∛2 follows from this template at p=2, m=2."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-01",
+      "relationship": "extends",
+      "description": "Child: builds on X3_sub_3_irred to derive the field extension degree [ℚ(∛3):ℚ] = 3 via `adjoin_nthRoot_finrank`. The irreducibility of X³−3 makes it the minimal polynomial of ∛3 over ℚ (up to monic association), and minimal-polynomial degree equals the field extension degree."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-02",
+      "relationship": "extends",
+      "description": "Child: uses [ℚ(∛3):ℚ] = 3 to prove {1, ∛3, (∛3)²} is ℚ-linearly independent. The minimal-polynomial argument forces any ℚ-linear dependence among {1, α, α²} (where α = ∛3) to come from a degree ≤ 2 annihilating polynomial — but minpoly has degree 3, so no such polynomial exists."
     },
     {
       "targetId": "angle-trisection",
       "relationship": "thematic",
-      "description": "AngleTrisection also uses Eisenstein irreducibility (for 8X³−6X+1) as the key step in proving angle trisection is impossible. Same algebraic technique applied to a different polynomial."
+      "description": "AngleTrisection also uses Eisenstein irreducibility (for 8X³−6X+1, after rescaling X ↦ Y/2 to get Y³−3Y−1, then translating to a form Eisenstein applies to). Same algebraic technique applied to a different polynomial in the impossibility proof — the minimal polynomial of cos(20°) has degree 3 over ℚ, but compass-and-straightedge constructible numbers have minimal-polynomial degree a power of 2."
+    },
+    {
+      "targetId": "abel-ruffini",
+      "relationship": "thematic",
+      "description": "Eisenstein's criterion is the standard tool for constructing irreducible polynomials of arbitrary degree, which are used to exhibit field extensions with prescribed Galois groups. The Abel–Ruffini construction of explicit polynomials of degree 5 with Galois group S₅ (hence unsolvable by radicals) typically begins with an Eisenstein-irreducible quintic."
     }
   ],
   "conclusion": {
     "summary": "∛3 is irrational via the Eisenstein criterion: X³−3 irreducible (Eisenstein at p=3) → no rational roots → ∛3 ∉ ℚ. Three theorems, 0 sorries, 0 axioms.",
-    "implications": "**Algebraic strength**: The Eisenstein approach proves the stronger statement that X³−3 has NO rational roots at all, not just that ∛3 is not an integer. This means 3^(1/3)·ω and 3^(1/3)·ω² (complex cube roots of unity) are also not rational — trivially, but the irreducibility argument handles all roots uniformly.\n\n**Generalizability**: The exact same proof (via eisenstein_X_pow_sub_of_sqfree_factor) works for any X^n − m where m has a prime factor p with p|m but p²∤m. This is the systematic algebraic condition for irrationality of n-th roots.",
+    "implications": "**Algebraic strength**: The Eisenstein approach proves the stronger statement that X³−3 has NO rational roots at all, not just that ∛3 is not an integer. This means 3^(1/3)·ω and 3^(1/3)·ω² (complex cube roots of unity) are also not rational — trivially, but the irreducibility argument handles all roots uniformly. More importantly, irreducibility makes X³−3 the **minimal polynomial** of ∛3 over ℚ, which immediately yields [ℚ(∛3):ℚ] = 3 (formalized in the OQ-01 child file).\n\n**Generalizability**: The exact same proof (via eisenstein_X_pow_sub_of_sqfree_factor) works for any X^n − m where m has a prime factor p with p|m but p²∤m. This is the systematic algebraic condition for irrationality of n-th roots, and underwrites the Mathlib infrastructure for adjoining n-th roots in general.\n\n**Comparison with the Rational Root Theorem**: The Rational Root Theorem gives a quicker disproof of rational roots of X³−3 (test ±1, ±3), but only ad hoc. Eisenstein is the only method that simultaneously proves irreducibility — which is what Galois-theoretic arguments require, since the minimal polynomial of α determines the entire field extension ℚ(α).",
     "openQuestions": [
-      "Can [ℚ(∛3):ℚ] = 3 be derived as a corollary? CubeRoot2IrrationalOQ03 already proves adjoin_nthRoot_finrank 3 3 3 = 3, which gives the field extension degree.",
-      "Is {1, ∛3, (∛3)²} linearly independent over ℚ? This follows from [ℚ(∛3):ℚ] = 3 and would prove ∛3 has degree exactly 3 over ℚ.",
-      "Can the converse be proved: if X^n−m is irreducible over ℚ, then m is not a perfect n-th power?"
+      "Can [ℚ(∛3):ℚ] = 3 be derived as a corollary? Resolved in child `cube-root-3-irrational-oq-02-oq-01` via `adjoin_nthRoot_finrank 3 3 3 = 3`, building directly on `X3_sub_3_irred` proved here.",
+      "Is {1, ∛3, (∛3)²} linearly independent over ℚ? Resolved in child `cube-root-3-irrational-oq-02-oq-02` via a minimal-polynomial degree argument — any ℚ-linear dependence among {1, α, α²} would give a degree-≤2 polynomial vanishing at α = ∛3, contradicting deg(minpoly ℚ ∛3) = 3.",
+      "Can the converse be proved: if X^n−m is irreducible over ℚ, then m is not a perfect n-th power? Half of the converse holds trivially (a perfect n-th power gives a rational root, so X^n−m is reducible by Eisenstein-style descent). The interesting refinement: when is X^n−m irreducible? The full classical answer (Vahlen–Capelli / Lang Algebra VI.9.1): X^n−a is irreducible over a field K iff a is not a p-th power in K for any prime p dividing n, AND when 4∣n, a ∉ −4·K⁴. The 4∣n caveat is essential and historically delicate.",
+      "Does the Eisenstein approach extend to **non-prime** radicands? For example, X^n − 6 is Eisenstein-irreducible at p=2 or p=3 (both work, since 2∣6, 4∤6, and 3∣6, 9∤6). What about X^n − 30? Eisenstein applies at p=2, 3, or 5 — any squarefree m gives an Eisenstein-irreducible X^n − m. The criterion fails for m = 4, 8, 9, 12 (all containing a p² factor); these require Vahlen–Capelli."
     ]
   },
   "leanFile": {
@@ -125,10 +142,28 @@
   },
   "references": [
     {
+      "authors": "T. Schönemann",
+      "title": "Von denjenigen Moduln, welche Potenzen von Primzahlen sind",
+      "year": "1846",
+      "note": "First publication of the irreducibility criterion (Crelle's Journal 32, p. 100), four years before Eisenstein's rediscovery; the criterion is sometimes called the Schönemann–Eisenstein theorem."
+    },
+    {
       "authors": "G. Eisenstein",
-      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung",
+      "title": "Über die Irreductibilität und einige andere Eigenschaften der Gleichung, von welcher die Theilung der ganzen Lemniscate abhängt",
       "year": "1850",
-      "note": "Original Eisenstein irreducibility criterion paper"
+      "note": "Eisenstein's independent presentation (Crelle's Journal 39, p. 160–179), which generalized Schönemann's result and applied it to the lemniscate-division equation; this is the version that became canonical."
+    },
+    {
+      "authors": "C. F. Gauss",
+      "title": "Disquisitiones Arithmeticae",
+      "year": "1801",
+      "note": "§42 contains Gauss's Lemma: a primitive integer polynomial is ℤ-irreducible iff ℚ-irreducible. This is the bridge that makes Eisenstein over ℤ extend to ℚ."
+    },
+    {
+      "authors": "S. Lang",
+      "title": "Algebra (revised 3rd ed.)",
+      "year": "2002",
+      "note": "Chapter VI §9 contains the Vahlen–Capelli theorem characterizing irreducibility of X^n − a in full generality, including the subtle 4∣n case."
     },
     {
       "authors": "Mathlib Contributors",


### PR DESCRIPTION
## Summary
Substantive enrichment pass for `cube-root-3-irrational-oq-02` (∛3 irrationality via Eisenstein criterion).
Branched off `main` (not `feature/enricher-2`) to avoid clobbering still-open PR #22689.

## What changed
- **historicalContext** 530 → ~2200 chars: Theaetetus (c. 369 BC, geometric incommensurability), Schönemann 1846 prior publication (Crelle 32), Eisenstein 1850 (Crelle 39, lemniscate-division motivation), brief biography (died 1852 age 29), Gauss's lemma bridge from ℤ to ℚ, cyclotomic Φ_p application.
- **+1 keyInsight**: Eisenstein vs Rational Root Theorem — same disproof for X³−3 but only Eisenstein gives the irreducibility minimal-polynomial arguments need.
- **+1 annotation** `ann-cbrt3oq02-gauss-lemma` covering the ℤ→ℚ irreducibility bridge handled inside `eisenstein_X_pow_sub_of_sqfree_factor`, with the formal Gauss's-lemma statement in LaTeX.
- **Cross-references:**
  - **Fixed broken ref:** `cube-root-2-irrational-oq-03` (no gallery directory) → `cube-root-2-irrational` with explanation of the Lean-file vs gallery-slug mismatch.
  - **+3 new:** `cube-root-3-irrational-oq-02-oq-01` (field extension child), `cube-root-3-irrational-oq-02-oq-02` (linear independence child), `abel-ruffini` (Eisenstein for S₅ quintic constructions).
- **conclusion.implications** deepened with minimal-polynomial framing and Rational-Root-Theorem comparison.
- **openQuestions** rewritten:
  - Original OQ-01, OQ-02 marked **resolved** in existing children with one-line summaries.
  - Replaced converse placeholder with full **Vahlen–Capelli criterion** statement (Lang VI §9.1) including the 4∣n caveat.
  - Added an extension question on non-prime squarefree radicands.
- **+3 references:** Schönemann 1846 (Crelle 32), Gauss *Disquisitiones* 1801 §42, Lang *Algebra* (rev. 3rd) Ch. VI §9.

## Quality
Heuristic score already saturated at 100/100; this pass adds ≈1700 chars of substantive historical content, 3 cross-refs, 1 annotation, 3 references.

## Test plan
- [x] `jq .` validates both meta.json and annotations.json
- [x] `pnpm annotations:build` succeeds; no new errors for this proof
- [x] Slug confirmed registered in `src/data/proofs/listings.json`

Branch reset note: a background `git reset --hard origin/main` in the worktree wiped my local commit, but the remote push survives (f4e2fdc8fa6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)