### PR TITLE
audit(erdos-5): tracker bump — issues-found (PR #22730 in flight)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7491,9 +7491,9 @@
     },
     "erdos-5": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:17Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-10T04:34:07Z",
+      "result": "issues-found"
     },
     "erdos-5-prime-gaps": {
       "auditCount": 3,


### PR DESCRIPTION
## Audit summary

erdos-5 re-audited; issue persists but a fix is already in flight.

Finding (unchanged from prior audits):
- meta.json claims axiomCount: 3
- Actual: 4 axioms (3 in Erdos5PrimeGaps.lean + 1 in Erdos5Problem.lean)

Fix in flight: #22730 (audit/erdos-5-axiom-count-fix) — OPEN, MERGEABLE. Awaiting deployer merge.

## What this PR changes

Single-line tracker bump in src/data/proofs/audit-tracker.json:
- auditCount: 3 -> 4
- lastAudited: 2026-05-04 -> 2026-06-10
- result: clean -> issues-found

No code or meta.json changes — the actual axiomCount correction lives in #22730.

🤖 Generated with [Claude Code](https://claude.com/claude-code)