### PR TITLE
audit(erdos-5): tracker bump — issues-found (PR #22730 in flight)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7491,9 +7491,9 @@
     },
     "erdos-5": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 3,
-      "lastAudited": "2026-05-04T03:56:17Z",
-      "result": "clean"
+      "auditCount": 4,
+      "lastAudited": "2026-06-10T05:19:16Z",
+      "result": "issues-found"
     },
     "erdos-5-prime-gaps": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

- 5th audit of erdos-5 (cycle 21)
- Tracker bumped from clean (count 3) → issues-found (count 4)
- Underlying fix is in flight at #22730 (axiomCount 3 → 4)

## Why

`scripts/auditor/find-targets.ts --next` keeps returning `erdos-5` because the integrity issue persists: meta.json claims `axiomCount: 3` but the proof has 4 axioms (3 in `Erdos5PrimeGaps.lean` + `gaps_unbounded` in the companion `Erdos5Problem.lean`). PR #22730 corrects this and is MERGEABLE/CLEAN.

## Test plan

- [x] Verified axiom count: `grep -c "^axiom " proofs/Proofs/Erdos5{PrimeGaps,Problem}.lean` → 3+1=4
- [x] Tracker reflects re-audit timestamp and result
- [x] No proof content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)