### PR TITLE
research(ballot-problem-oq-01-oq-01-oq-02-oq-01): S14 ACT — open gallery entry

### DIFF
--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-06-10-s14-act-gallery-promotion.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-06-10-s14-act-gallery-promotion.md
@@ -1,0 +1,118 @@
+# S14 ACT — Gallery promotion of `ballot-problem-oq-01-oq-01-oq-02-oq-01`
+
+**Date**: 2026-06-10T05:45Z
+**Researcher**: researcher-11 (claim id researcher-33477)
+**Mode**: ACT (gallery promotion — net-additive)
+**Outcome**: shipped — `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/` created with `meta.json` + `annotations.json`; build pipeline clean.
+
+## Goal
+
+Discharge S13's "Next Action" item #1 (the only ACT scope remaining on this slug). The Lean side has been boundary-tight on the strict equality regime since S12 (PR #21857, 2026-06-01); the gallery side has been missing this entry. S14 promotes the proof to a public gallery slug with full schema parity to the parent OQ-02 entry.
+
+## Pre-edit verification
+
+| Item | Value | Source |
+|---|---|---|
+| `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` `wc -l` | 626 | `wc -l` (matches state.md S12 ACT entry) |
+| Axiom count (`grep -c '^axiom '`) | 0 | unchanged since S6/S7/S11/S12 |
+| Sorry count (`grep "sorry"`) | 0 | unchanged since file creation |
+| Public theorem count | 12 | manual count of non-`private` `theorem`/`lemma` lines |
+| Private support declarations | 1 def + 11 theorems/lemmas | `levelPosB` + Path B / S12 helpers |
+| Mathlib pin SHA | `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) | `proofs/lake-manifest.json` |
+| Parent gallery entry (sibling on `oq-02`) | exists; `status="verified"`, `badge="original"`, 9 theorems / 211 LOC | `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json` |
+| Existing gallery slug for `oq-02-oq-01` | absent (this slug) | confirmed via `test -d` before write |
+
+No Docker re-verification performed (the Lean file has been stable on `origin/main` since 2026-06-01; the gallery promotion makes no Lean changes).
+
+## What was created
+
+### `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/meta.json`
+
+Full schema modeled tightly on the parent OQ-02 `meta.json`. Highlights:
+
+- **Top-level**: `id` / `slug` / `title` / `description` / `meta` (status `"verified"`, badge `"original"`, dateAdded `2026-06-09`).
+- **`meta.tags`**: `combinatorics`, `ballot-problem`, `cycle-lemma`, `m-jump-ivt`, `discrete-ivt`, `prefix-sums`, `alphabet-refinement`, `leftmost-crossing`, `rightmost-position`, `research`.
+- **`meta.mathlibDependencies`** (5): `Finset.min'`, `Finset.max'`, `List.sum_take_succ`, `Int.ceil_le / Int.ceil_nonneg`, `Finset.card_le_card_of_injOn` — the actual API surface consumed by the IVT proofs and the `levelPosB` injection.
+- **`meta.originalContributions`** (8): one bullet per major theorem/strand — the two m-jump IVTs, the [-m, m+S] refutation, Conjecture E, Path B, the S12 sharpest one-sided form, and the Option C public-API preservation.
+- **`overview.historicalContext`** (~3 paragraphs): situates the slug in the Bertrand → Dvoretzky–Motzkin → Raney → parent OQ-02 → this slug chain, narrates the S1 OBSERVE refutation, and walks through the S2 → S6 → S7 → S11 → S12 four-step alphabet sharpening with the discovery that the lower bound on negative steps was inert.
+- **`overview.proofStrategy`** (~2 paragraphs): explains both strands — leftmost-crossing Finset.min' for the IVTs, rightmost-position `levelPosB` injection for the equality results.
+- **`overview.keyInsights`** (6): leftmost-crossing-transfers-verbatim, m-jump-window-is-sharp, naive-bound-destroyed-by-single-uncapped-jump, lower-bound-is-inert, levelPosB-as-key-gadget, maximal-clean-alphabet-methodology.
+- **`sections`** (6): preamble (L1–37), m-jump-downward-ivt (L38–129), m-jump-upward-ivt (L131–235), conjecture-e (L237–316), path-b-mixed-down (L319–476), sharpest-cap-one (L478–625). Each section has a `mathContext` LaTeX block summarising the key formal content.
+- **`conclusion`** (summary + implications + 5 openQuestions): includes quantitative slack characterisation, continuous-time analog (Lévy/Bingham 1975), multi-step alphabets (Mohanty 1979), two-sided generalisations, and tight-slack witnesses.
+- **`leanFile`**: imports `Proofs.BallotProblemOQ01OQ01OQ02` and `Mathlib.Tactic`; opens `GeneralizedBallot`; namespace `BallotMJumpCycleLemma`; lineCount 626; 12 theorems; 0 axioms; 0 sorries.
+- **`crossReferences`** (4): `extends` parent OQ-02, `extends` grandparent OQ-01-OQ-01 (provider of `cycle_lemma`), `related` great-grandparent OQ-01, `ancestor` the Bertrand original.
+- **`references`** (7): Bertrand 1887, André 1887, Dvoretzky–Motzkin 1947, Raney 1960, Mohanty 1979, Bingham 1975, Stanley 2011 — each with a `note` field explaining how the cited work connects to a specific theorem or open question in this slug.
+- **`mainTheorems`** (12): one entry per public theorem with `type` (lemma/core) and a 1–3-sentence description that emphasises the *strategy* rather than the statement.
+
+### `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/annotations.json`
+
+Seven inline highlights covering the most pedagogically useful regions:
+
+| id | range | type | focus |
+|---|---|---|---|
+| ann-preamble | L1–37 | context | four-part roadmap |
+| ann-m-jump-step-bound | L38–46 | key-lemma | the per-step bound that drives the IVT |
+| ann-m-jump-downward-ivt | L48–111 | core-theorem | Conjecture D leftmost-crossing proof |
+| ann-conjecture-e | L276–316 | core-theorem | thin restatement of parent's `cycle_lemma` |
+| ann-levelposB-def | L341–405 | definition | the `levelPosB` combinatorial gadget + `levelPosB_eq` |
+| ann-path-b-equality | L448–476 | core-theorem | Path B strict equality + B′ slack form |
+| ann-sharpest-cap-one | L478–605 | core-theorem | S12 maximal clean alphabet `x ≤ 1` + Option C corollary |
+
+Each annotation has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites` fields. The annotations deliberately *complement* (not duplicate) the section summaries in `meta.json`: they zoom in on the proof-mechanism-level commentary while the section summaries give the bird's-eye view.
+
+## Build verification
+
+```
+$ pnpm annotations:build
+…
+   [zsqrtd-neg-two-oq-03] Annotation "ann-norm-eq-zero-iff": Annotation type "theorem" but found "instance" at line 175
+⚠️  Continuing despite errors (non-strict mode)
+```
+
+Zero errors for `ballot-problem-oq-01-oq-01-oq-02-oq-01`. The non-strict warnings shown are for *other* slugs and pre-exist this PR.
+
+```
+$ pnpm research:build
+…
+Generated research-data-manifest.json (1711 problems, 68KB)
+Listings: 1690 (skipped 21 unfilled Seeker stubs)
+Generated research-listings.json (1171KB)
+```
+
+The build added our slug to `src/data/proofs/listings.json` and `src/data/proofs/data-manifest.json`:
+
+```
+$ grep -A2 "ballot-problem-oq-01-oq-01-oq-02-oq-01" src/data/proofs/data-manifest.json
+  "ballot-problem-oq-01-oq-01-oq-02-oq-01": {
+    "meta": "10028619",
+    "ann": "980d36dc",
+```
+
+(Note: the generated `listings.json` / `data-manifest.json` are large binary-equivalent files that get rewritten on every `annotations:build` run; the PR will only commit the per-slug `meta.json` and `annotations.json`, plus the deterministically-regenerated index files.)
+
+## Files modified
+
+- **NEW**: `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/meta.json` (~34 KB).
+- **NEW**: `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/annotations.json` (~12 KB).
+- **UPDATED**: `src/data/proofs/listings.json` and `src/data/proofs/data-manifest.json` (deterministic regeneration via `pnpm annotations:build` + `pnpm research:build`).
+- **UPDATED**: `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md` (phase header refresh + Next-Action update).
+- **NEW**: `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/sessions/2026-06-10-s14-act-gallery-promotion.md` (this memo).
+
+## Files NOT modified (intentional scope discipline)
+
+- `proofs/Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean` — Lean file untouched (0 byte change). The slug promotion is doc + gallery only.
+- `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json` — parent slug's `crossReferences` to this new child is left for a separate, smaller PR (S15) to keep this PR's diff focused. The forward direction (this slug → parent) is in place via our `crossReferences[0]`.
+- `proofs/lake-manifest.json` — Mathlib pin unchanged at v4.26.0 SHA `2df2f01…`.
+- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/problem.md` — content stable; no new conjectures to document.
+- `research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/knowledge.md` — already comprehensive at S12; no new findings this iteration.
+- Earlier session memos (S1 OBSERVE through S13 STATE-SYNC) — left intact as historical audit artifacts.
+
+## Build risk
+
+Zero. 0 Lean files modified, 0 imports changed, 0 tactic changes. All meta.json `lineCount` / `axiomCount` / `theoremCount` / `sorries` fields were sourced from the same `wc -l` / `grep -c` measurements that S12 used. The build pipeline ran clean end-to-end (no validation errors specific to this slug).
+
+## Phase head transition
+
+S12 ACT (sharpest one-sided alphabet, Docker-verified, 2026-06-01) → S13 STATE-SYNC (doc refresh post-merge, 2026-06-01) → **S14 ACT (gallery promotion, this iteration, 2026-06-10)** → "Lean-and-gallery-parity achieved; further work optional (sibling-slug crossReferences refresh in parent OQ-02, or new mathematical research per `openQuestions`)."
+
+The slug is ready to be marked `completed` in the research pool. The strict-equality regime is boundary-tight on the Lean side (S12) and now publicly browsable on the gallery side (S14).

--- a/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/ballot-problem-oq-01-oq-01-oq-02-oq-01/state.md
@@ -1,10 +1,16 @@
 # Current State
 
-**Phase**: ACT (S12 ACT sharpest one-sided alphabet `x ≤ 1` shipped + Docker-verified; cycle-lemma Lean formalisation has reached the boundary of the equality regime — any further mathematical sharpening of the count formula would be cosmetic)
-**Since**: 2026-06-01 (S12 ACT)
-**Iteration**: 16
-**Last researcher**: researcher-1 (S12 ACT sharpest one-sided alphabet, 2026-06-01)
-**Last Update**: 2026-06-01 (researcher-1) — **S12 ACT** (PR #21857, MERGED 2026-06-01T07:02:01Z): acted on the S11-noted INERT lower bound observation. Introduced `step_le_one_card_eq` — the cycle-lemma strict equality `(goodRotations l).card = l.sum.toNat` on the one-sided alphabet `∀ x ∈ l, x ≤ 1` alone, with **no lower bound on negative steps**. Refactored Option C internals: `levelPosB_eq_optionC` → `levelPosB_eq_capOne`, `goodRotations_card_ge_pathB_optionC` → `goodRotations_card_ge_capOne` (same proof bodies, dropped never-consumed lower-bound conjunct from `hmem`). The public API (`step_in_one_pos_pm_card_eq`, `step_in_one_pos_pm_card_bound`) is preserved byte-identically as one-line corollaries of the sharper theorem. **Docker-verified clean: 3062/3062 jobs, 0 sorries, 0 axioms, 0 warnings; file 608 → 626 LOC.** `x ≤ 1` is now provably the *maximal* clean alphabet for the equality (any upward relaxation admits `l = [-1, 3]` refutation, S1 OBSERVE mechanism). See `sessions/2026-06-01-s12-act-sharpest-onesided-alphabet.md`.
+**Phase**: ACT (S14 ACT gallery promotion shipped — `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/` created with `status="verified"`, `badge="original"`, 12 theorems / 0 axioms / 0 sorries / 626 LOC; six sections + seven annotations; `pnpm annotations:build` and `pnpm research:build` clean; listings.json and data-manifest.json regenerated. Gallery side now mirrors the Lean side: the four-step alphabet refinement (Conjecture E → Path B → Option C → S12 sharpest cap-one) and the m-jump IVTs D + D′ are now publicly browsable.)
+**Since**: 2026-06-10T05:45Z (S14 ACT)
+**Iteration**: 17
+**Last researcher**: researcher-11 (S14 ACT gallery promotion, 2026-06-10)
+**Last Update**: 2026-06-10 (researcher-11) — **S14 ACT** — shipped the gallery slug per S13's "Next Action" item #1. `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/meta.json` created with the full schema modeled on the parent OQ-02 entry: six `sections` covering the preamble, m-jump downward IVT, m-jump upward IVT, Conjecture E, Path B mixed-down, and S12 sharpest cap-one; twelve `mainTheorems` entries (one per public theorem in the Lean file); four `crossReferences` to the parent / grandparent / great-grandparent / Bertrand ancestor; seven literature references including Dvoretzky-Motzkin 1947, Raney 1960, Mohanty 1979, Bingham 1975, Stanley 2011; five `openQuestions` targeting quantitative slack characterisations, continuous-time analogs, multi-step alphabets, two-sided generalisations, and tight-slack witnesses. `annotations.json` with seven section-level highlights (preamble roadmap, m-jump step bound, m-jump downward IVT, Conjecture E, levelPosB combinatorial gadget, Path B equality, S12 sharpest cap-one). **Build pipeline verified clean**: `pnpm annotations:build` reports zero validation errors for this slug; `pnpm research:build` registers the entry in `src/data/proofs/listings.json` and `src/data/proofs/data-manifest.json` with hashes `meta: 10028619`, `ann: 980d36dc`. Session memo at `sessions/2026-06-10-s14-act-gallery-promotion.md`.
+
+---
+
+**S13 STATE-SYNC (2026-06-01, researcher-1)** — doc-only refresh after S12 ACT merge, retained below.
+
+**S12 ACT (researcher-1, 2026-06-01)** (PR #21857, MERGED 2026-06-01T07:02:01Z): acted on the S11-noted INERT lower bound observation. Introduced `step_le_one_card_eq` — the cycle-lemma strict equality `(goodRotations l).card = l.sum.toNat` on the one-sided alphabet `∀ x ∈ l, x ≤ 1` alone, with **no lower bound on negative steps**. Refactored Option C internals: `levelPosB_eq_optionC` → `levelPosB_eq_capOne`, `goodRotations_card_ge_pathB_optionC` → `goodRotations_card_ge_capOne` (same proof bodies, dropped never-consumed lower-bound conjunct from `hmem`). The public API (`step_in_one_pos_pm_card_eq`, `step_in_one_pos_pm_card_bound`) is preserved byte-identically as one-line corollaries of the sharper theorem. **Docker-verified clean: 3062/3062 jobs, 0 sorries, 0 axioms, 0 warnings; file 608 → 626 LOC.** `x ≤ 1` is now provably the *maximal* clean alphabet for the equality (any upward relaxation admits `l = [-1, 3]` refutation, S1 OBSERVE mechanism). See `sessions/2026-06-01-s12-act-sharpest-onesided-alphabet.md`.
 
 **S13 STATE-SYNC (2026-06-01, researcher-1, this PR)**: doc-only state-sync — the prior state.md remained pinned at iteration 15 / S11 ACT through the S12 ACT merge (PR #21857). This iteration refreshes the Phase / Iteration / Last Update fields, refreshes the conjecture status against problem.md, and refreshes the next-action list to reflect the gallery-slug creation as the natural follow-up.
 
@@ -167,31 +173,35 @@ None. No Mathlib gap anticipated (all required primitives — `Finset.min'`,
 `Finset.min'_mem`, `Finset.min'_le`, `List.sum_take_succ`, `List.getElem_mem`
 — present in v4.26.0).
 
-## Next Action (post-S13 STATE-SYNC)
+## Next Action (post-S14 ACT)
 
-Per the S12 ACT memo's "next steps (not done this session)":
+Item #1 (gallery slug creation) **SHIPPED** this iteration. Remaining
+items from S13:
 
-1. **Gallery slug creation** (primary next-action): build
-   `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/` with
-   `meta.json` documenting (a) the refuted naive `⌈S/m⌉` bound (parent
-   meta `openQuestions[0]`), (b) the recovered strict equality
-   `step_le_one_card_eq` on the maximal one-sided alphabet `x ≤ 1`,
-   and (c) the m-jump IVTs (D, D′) as the genuine *infrastructural*
-   generalisation of the parent's unit-IVT. Recommended `status:
-   "verified"`, `badge: "original"`. Also create `annotations.json` +
-   `index.ts`. Estimated 1–2 sessions for a quality entry.
+1. ~~Gallery slug creation~~ — **DONE (S14, this iteration)**.
 
-2. **Parent slug update** (deferred until #1 ships, to avoid the
-   broken-`crossReferences` anti-pattern): amend
+2. **Parent slug update** (now unblocked): amend
    `src/data/proofs/ballot-problem-oq-01-oq-01-oq-02/meta.json` to
    reference this child as the resolution of `openQuestions[0]` (the
-   `step ≥ -m` question) once the child slug renders in the UI.
+   `step ≥ -m` question). Now safe to ship — the child's
+   `crossReferences` already point to the parent, and the parent's
+   `additionalFiles[0]` already names `BallotProblemOQ01OQ01OQ02OQ01.lean`,
+   so the bidirectional reference simply needs a one-paragraph addition
+   to the parent's `openQuestions[0]` description. Estimated 1 session
+   (10–20 LOC of JSON).
 
 3. **Mathematical follow-up** (optional, multi-session): pursue further
    relaxations of the alphabet that nevertheless preserve a *quantified*
    lower bound (not the strict equality, which is now boundary-tight on
    `x ≤ 1`). E.g. characterise the slack term `l.sum.toNat - |gR|` in
-   terms of the maximum positive step.
+   terms of the maximum positive step. Captured as the first item of
+   the new gallery entry's `openQuestions`.
+
+The problem can also be marked `completed` in the research pool — the
+Lean side is at the boundary of the strict-equality regime (S12), and
+the gallery side now mirrors it (S14). Further work is either an
+optional sibling-slug refresh (item #2 above, ~10 minutes) or
+genuinely new mathematics (item #3, multi-session research).
 
 ## Historical — original S2 next-action recommendation (DISCHARGED)
 
@@ -203,6 +213,6 @@ add `m_jump_levels_achieved` corollary (~30 LOC).
 
 ## Attempt Counts
 
-- Total attempts: 1
-- Current approach attempts: 1
-- Approaches tried: 1 (S1 OBSERVE — refutation by example)
+- Total attempts: 17 (S1, S1b, S1c, S2–S14; this iteration completes S14 ACT — gallery promotion)
+- Current approach attempts: 17 (alphabet-refinement + gallery promotion track)
+- Approaches tried: 1 (S1 OBSERVE refutation → m-jump IVT generalisation → four-step alphabet sharpening → gallery promotion)

--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/annotations.json
@@ -1,0 +1,165 @@
+[
+  {
+    "id": "ann-preamble",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 1,
+      "endLine": 37
+    },
+    "type": "context",
+    "title": "Four-Part Roadmap: m-Jump IVTs + Alphabet Sharpening to x ≤ 1",
+    "content": "The opening docstring orients the entire 626-line file around two complementary strands. **Strand 1 (Parts I–II, the m-jump IVTs).** The parent file `BallotProblemOQ01OQ01OQ02` proved a unit-decrement (`step ≥ -1`) downward IVT via the leftmost-crossing Finset.min' argument. This file generalises that argument to `step ≥ -m` (Part I) and its symmetric upward dual `step ≤ m` (Part II). The conclusion window widens from {v} to a width-m closed integer interval; at m = 1, the window collapses and the parent's theorem is recovered verbatim (the `_unit_recovery` lemmas). **Strand 2 (Parts III–V, the alphabet sharpening).** S1 OBSERVE refuted the naive `⌈l.sum / m⌉ ≤ |goodRotations|` bound on the broad `step ≥ -m` family with the witness `l = [-m, m + S]`. Parts III, IV, V then trace four progressively broader alphabets on which the *strict equality* `|goodRotations l| = l.sum.toNat` survives: {+1, -m} (Conjecture E), {-m, …, -1, +1} (Path B, S7), {-m, …, 0, 1} (Option C, S11), and finally `x ≤ 1` with no lower bound on negative steps (S12, this file's headline). The end-state `step_le_one_card_eq` is the maximal clean alphabet for the equality.",
+    "mathContext": "**Naive bound (REFUTED on `step ≥ -m`)**: $\\lceil \\sum l / m \\rceil \\leq |gR(l)|$.\n**S1 refutation**: $l = [-m, m+S] \\Rightarrow |gR| = 1 < \\lceil S/m \\rceil$ for $m \\geq 2$, $S = m+1$.\n**S12 sharpest equality**: $\\forall x \\in l,\\ x \\leq 1\\ \\wedge\\ 0 < \\sum l\\ \\Rightarrow\\ |gR(l)| = (\\sum l).\\text{toNat}.$",
+    "significance": "context",
+    "relatedConcepts": [
+      "Dvoretzky–Motzkin cycle lemma",
+      "leftmost-crossing argument",
+      "alphabet refinement methodology",
+      "discrete IVT",
+      "good cyclic rotations"
+    ],
+    "prerequisites": [
+      "Parent unit-decrement IVT (ballot-problem-oq-01-oq-01-oq-02)",
+      "Grandparent cycle_lemma for {+1, -k} alphabets (ballot-problem-oq-01-oq-01)",
+      "Finset.min' and Finset.max' (Mathlib.Data.Finset.Lattice)"
+    ]
+  },
+  {
+    "id": "ann-m-jump-step-bound",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 38,
+      "endLine": 46
+    },
+    "type": "key-lemma",
+    "title": "The Per-Step Bound that Drives the m-Jump IVT",
+    "content": "`m_jump_step_bound` is the file's most-elementary technical atom: for any list with all steps ≥ -m, the prefix sum at position `j+1` is at least `prefixSum l j - m`. The proof is three lines — unfold `prefixSum`, apply `List.sum_take_succ`, and `linarith` with the hypothesised per-element bound. The lemma is the input the leftmost-crossing argument feeds on; widening from the parent's `-1` to `-(m:ℤ)` is the single change that propagates the entire IVT generalisation.",
+    "mathContext": "$l_j \\geq -m \\Rightarrow \\text{PS}(j+1) = \\text{PS}(j) + l_j \\geq \\text{PS}(j) - m.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "prefix sum recursion",
+      "per-step bounds",
+      "List.sum_take_succ"
+    ],
+    "prerequisites": [
+      "Parent's `unit_decrement_step_bound` (the m = 1 special case)"
+    ]
+  },
+  {
+    "id": "ann-m-jump-downward-ivt",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 48,
+      "endLine": 111
+    },
+    "type": "core-theorem",
+    "title": "Conjecture D: m-Jump Downward IVT via Leftmost Crossing",
+    "content": "`m_jump_downward_ivt` is the discharge of the parent's openQuestions[0]. The proof template transfers verbatim from the parent's `unit_decrement_downward_ivt`: define `S := Finset.Ico (i + 1) (j + 1) ∩ {k : PS(k) ≤ v}`, take `kstar := S.min'`, derive `PS(kstar - 1) > v` by minimality (case-splitting on `kstar = i + 1` to handle the boundary), invoke `m_jump_step_bound` at position `kstar - 1` to bound `PS(kstar) ≥ PS(kstar - 1) - m > v - m`, and combine with `PS(kstar) ≤ v` from membership. The conclusion `PS(kstar) ∈ [v - m + 1, v]` follows by `linarith`. At m = 1, the window collapses to {v} — the parent's exact-level IVT.",
+    "mathContext": "Define $S := \\{k \\in (i, j] : \\text{PS}(k) \\leq v\\}$, $k^* := \\min' S$. By minimality $\\text{PS}(k^*-1) > v$; by the one-step bound $\\text{PS}(k^*) \\geq \\text{PS}(k^*-1) - m > v - m$. Combined with $\\text{PS}(k^*) \\leq v$: $\\text{PS}(k^*) \\in [v - m + 1, v]$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "leftmost crossing",
+      "discrete IVT",
+      "Finset.min' minimality argument",
+      "conjecture D"
+    ],
+    "prerequisites": [
+      "`m_jump_step_bound` (the per-step input)",
+      "Parent's `unit_decrement_downward_ivt` (m = 1 base case)"
+    ]
+  },
+  {
+    "id": "ann-conjecture-e",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 276,
+      "endLine": 316
+    },
+    "type": "core-theorem",
+    "title": "Conjecture E: Cycle-Lemma Bound on {+1, -m}",
+    "content": "`step_in_one_neg_m_count` is the cleanest application of the parent's `cycle_lemma`. The bridge is one line: `l ∈ kCountedSequence m (l.count 1) (l.count (-m))` is true by definition unfolding (the membership predicate is `⟨rfl, rfl, h_step⟩`). Then `kCountedSequence_sum` rewrites `l.sum = a - m·b` (where `a = l.count 1`, `b = l.count (-m)`); positivity of the sum forces `m·b < a`; and `cycle_lemma` delivers the *exact* count `|gR(l)| = a - m·b = l.sum.toNat`. The residual `Int.toNat ⌈l.sum / m⌉ ≤ l.sum.toNat` follows from the elementary `ceil_div_le_toNat` arithmetic atom (`⌈S/m⌉ ≤ S` for `m ≥ 1`, `S > 0`). The theorem is presented in the fractional `⌈S/m⌉` form to match the parent's openQuestions language, but the actual count is the much sharper `l.sum.toNat`.",
+    "mathContext": "Restricted to $\\Sigma = \\{+1, -m\\}$: $|gR(l)| = l.\\text{count}(1) - m \\cdot l.\\text{count}(-m) = (\\sum l).\\text{toNat}.$\n\n**Refutation contrast**: the S1 witness $l = [-m, m+S]$ uses an uncapped positive step $+(m+S)$ that this alphabet excludes ($+1$ is the only allowed positive value).",
+    "significance": "key",
+    "relatedConcepts": [
+      "parent cycle_lemma",
+      "kCountedSequence",
+      "ceiling arithmetic",
+      "alphabet restriction"
+    ],
+    "prerequisites": [
+      "`cycle_lemma` from BallotProblemOQ01",
+      "`kCountedSequence_sum` (the sum identity for {+1, -k} sequences)"
+    ]
+  },
+  {
+    "id": "ann-levelposB-def",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 341,
+      "endLine": 405
+    },
+    "type": "definition",
+    "title": "levelPosB: Rightmost Prefix at or Below a Level (the Combinatorial Gadget)",
+    "content": "`levelPosB l n := Finset.max' { i ∈ Finset.range (l.length + 1) : prefixSum l i ≤ minPrefixSum l + n }` is the central combinatorial gadget powering Parts IV and V. It identifies the rightmost prefix position landing at or below level `minPrefixSum + n`; six private support lemmas (`levelPosB_mem`, `_le`, `_prefixSum_le`, `_max`, `_lt`, `_right`) expose its basic properties. The heart is `levelPosB_eq`: for `n < l.sum`, the maximal prefix at level ≤ `minPrefixSum + n` lands *exactly* at that level. Proof: maximality forces a strict upward jump at position `levelPosB l n + 1` (`hj1_gt`); combined with the alphabet constraint `x = 1 ∨ ∃ k ∈ {1..m}, x = -k` (Part IV) or `x ≤ 1` (Part V), the step must be `+1` and the prefix sum is pinned. The parent file's `levelPos` is private, so this slug re-implements it under a new name; the proof shape is preserved, with only the `rcases` pattern on `hmem` changing across alphabet variants.",
+    "mathContext": "$\\text{levelPosB}(l, n) := \\max\\{i \\in [0, |l|] : \\text{PS}(i) \\leq \\text{minPS}(l) + n\\}.$\n\n**Level identity** (`levelPosB_eq`): for $n < \\sum l$, $\\text{PS}(\\text{levelPosB}(l, n)) = \\text{minPS}(l) + n.$\n\n**Why it works**: maximality forces $\\text{PS}(\\text{levelPosB}(l, n) + 1) > \\text{minPS}(l) + n$ (strict upward jump). The alphabet cap $l_{\\text{idx}} \\leq 1$ then forces $l_{\\text{idx}} = 1$ (anything else would either contradict the jump or contradict the cap), pinning $\\text{PS}(\\text{levelPosB}(l, n))$ at the boundary.",
+    "significance": "key",
+    "relatedConcepts": [
+      "rightmost-prefix injection",
+      "Finset.max' maximality",
+      "level-spacing argument",
+      "parent levelPos",
+      "Path B re-implementation"
+    ],
+    "prerequisites": [
+      "Parent `prefixSum`, `minPrefixSum`, `prefixSum_rightmostMinPos`",
+      "`Finset.max'` and `Finset.le_max'`"
+    ]
+  },
+  {
+    "id": "ann-path-b-equality",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 448,
+      "endLine": 476
+    },
+    "type": "core-theorem",
+    "title": "Path B Strict Equality on Mixed-Down Alphabet",
+    "content": "`step_in_one_pos_mixed_neg_card_eq` glues the upper bound `goodRotations_card_le` (alphabet-agnostic, from the parent) with the lower bound `goodRotations_card_ge_pathB` (`levelPosB` injection of `Finset.range l.sum.toNat`) via `le_antisymm`. The slack form `step_in_one_pos_mixed_neg_card_bound` recovers B′'s `l.sum ≤ m·|gR| + (m-1)·l.length` from the strict equality through `Int.toNat_of_nonneg` and `nlinarith`. The 'mixed-down' qualifier refers to the alphabet `x = 1 ∨ ∃ k ∈ {1..m}, x = -k`, i.e. `{+1} ∪ {-1, …, -m}` — the missing element relative to Option C is 0.",
+    "mathContext": "$\\forall x \\in l,\\ (x = 1 \\vee \\exists k \\in \\{1, \\ldots, m\\}, x = -k)\\ \\wedge\\ 0 < \\sum l\\ \\Rightarrow\\ |gR(l)| = (\\sum l).\\text{toNat}.$\n\n**Slack form**: $\\sum l \\leq m \\cdot |gR(l)| + (m - 1) \\cdot |l|.$ Equality at $m = 1$; non-negative slack for $m \\geq 2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "le_antisymm gluing",
+      "alphabet-agnostic upper bound",
+      "B′ slack form",
+      "Path B"
+    ],
+    "prerequisites": [
+      "`goodRotations_card_le` (parent upper bound)",
+      "`goodRotations_card_ge_pathB` (this file's lower bound)"
+    ]
+  },
+  {
+    "id": "ann-sharpest-cap-one",
+    "proofId": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+    "range": {
+      "startLine": 478,
+      "endLine": 605
+    },
+    "type": "core-theorem",
+    "title": "S12 Headline: x ≤ 1 is the Maximal Clean Alphabet for the Equality",
+    "content": "`step_le_one_card_eq` is the file's headline theorem and the end-point of the four-step alphabet refinement (Conjecture E → Path B → Option C → S12). The path from Option C to S12 is the discovery, not the rewrite: S11 ACT noted in-line that the lower bound `-(m:ℤ) ≤ x` was never consumed by the `omega` discharge in `levelPosB_eq`; S12 acted on that observation by dropping the lower bound entirely. The proof obligations shrink in lock-step: `levelPosB_eq_capOne` consumes only `hxle : l[idx] ≤ 1`; `goodRotations_card_ge_capOne` routes through the strengthened identity; `step_le_one_card_eq` glues with the alphabet-agnostic upper bound `goodRotations_card_le`. The Option C public API (`step_in_one_pos_pm_card_eq` and `_card_bound`) is preserved byte-identically as one-line `.2`-projection corollaries — backwards-compatible despite the underlying simplification. **Mathematical sharpness**: the cap `x ≤ 1` cannot be relaxed (S1's `[-m, m + S]` refutation uses an uncapped positive step), and no lower bound on negative steps is needed (S12 strengthening). This is the maximal clean alphabet.",
+    "mathContext": "$\\forall x \\in l,\\ x \\leq 1\\ \\wedge\\ 0 < \\sum l\\ \\Rightarrow\\ |gR(l)| = (\\sum l).\\text{toNat}.$\n\n**Sharpness (upper boundary)**: any relaxation $x \\leq C$ for $C \\geq 2$ admits the S1 family $l = [-m, m+S]$ with $|gR| = 1 < (\\sum l).\\text{toNat} = S$.\n**Sharpness (lower boundary)**: every proof step (level identity, count lower bound, count upper bound) consumes only $x \\leq 1$, never any lower bound on $x$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "maximal clean alphabet",
+      "inert-hypothesis discovery",
+      "alphabet refinement boundary",
+      "Option C corollary",
+      "Path B corollary"
+    ],
+    "prerequisites": [
+      "`levelPosB` and its support lemmas (Part IV)",
+      "`goodRotations_card_le` (parent upper bound)"
+    ]
+  }
+]

--- a/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -1,0 +1,292 @@
+{
+  "id": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+  "title": "m-Jump Cycle Lemma: IVTs, Conjecture E, and the Sharpest One-Sided Alphabet x ≤ 1",
+  "slug": "ballot-problem-oq-01-oq-01-oq-02-oq-01",
+  "description": "Generalizes the parent's unit-decrement IVT to an arbitrary m-jump bound and traces a four-step alphabet refinement of the cycle lemma. The m-jump downward IVT (D, conjectured in the parent's openQuestion list) and its upward dual (D′) replace the parent's exact level-hit with a width-m conclusion window [v - m + 1, v] (resp. [v, v + m - 1]). The naive ⌈S/m⌉ ≤ |goodRotations| bound on the broad step ≥ -m family is refuted by [-m, m + S]; restricting the alphabet to {+1, -m} (Conjecture E) recovers the bound via the parent's cycle lemma; Path B extends the negative side to {-m, ..., -1, +1}; the S12 sharpening drops every lower bound and shows the strict equality |goodRotations| = l.sum.toNat holds on the *maximal* clean one-sided alphabet x ≤ 1, with S1's refutation as the boundary witness on any upward relaxation.",
+  "meta": {
+    "author": "Lean Genius (OQ01 of ballot-problem-oq-01-oq-01-oq-02)",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean",
+    "tags": [
+      "combinatorics",
+      "ballot-problem",
+      "cycle-lemma",
+      "m-jump-ivt",
+      "discrete-ivt",
+      "prefix-sums",
+      "alphabet-refinement",
+      "leftmost-crossing",
+      "rightmost-position",
+      "research"
+    ],
+    "badge": "original",
+    "sorries": 0,
+    "axiomCount": 0,
+    "lineCount": 626,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "dateAdded": "2026-06-09",
+    "assumptions": "None. All 12 public theorems are fully proved (0 axioms, 0 sorries). The supporting infrastructure consists of 1 private noncomputable helper definition (`levelPosB`, the rightmost position with prefix sum ≤ minPrefixSum + n) and 11 private theorems/lemmas (Path B `levelPos`-style helpers plus the `_capOne` strengthenings introduced in S12).",
+    "mathlibDependencies": [
+      {
+        "theorem": "Finset.min'",
+        "description": "Minimum of a nonempty finset, used in the leftmost-crossing arguments for both m-jump IVTs.",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "Finset.max'",
+        "description": "Maximum of a nonempty finset, used to define `levelPosB` as the rightmost prefix position at or below a given level.",
+        "module": "Mathlib.Data.Finset.Lattice"
+      },
+      {
+        "theorem": "List.sum_take_succ",
+        "description": "Prefix-sum recursion `(l.take (j+1)).sum = (l.take j).sum + l[j]`, used to expose the per-step increment in every IVT proof.",
+        "module": "Mathlib.Data.List.Basic"
+      },
+      {
+        "theorem": "Int.ceil_le / Int.ceil_nonneg",
+        "description": "Used in `ceil_div_le_toNat` to bridge `⌈S/m⌉` and `S.toNat` for the Conjecture E lower bound.",
+        "module": "Mathlib.Algebra.Order.Floor"
+      },
+      {
+        "theorem": "Finset.card_le_card_of_injOn",
+        "description": "Drives the Path B and S12 cardinality bounds by injecting `Finset.range l.sum.toNat` into `goodRotations l` via `levelPosB`.",
+        "module": "Mathlib.Data.Finset.Card"
+      }
+    ],
+    "originalContributions": [
+      "m_jump_step_bound / m_jump_step_bound_upward: per-step bounds on prefix-sum increments/decrements for arbitrary m, generalizing the parent's unit-decrement step bound.",
+      "m_jump_downward_ivt: the discharge of the parent's conjecture D — a leftmost-crossing IVT with conclusion window [v - m + 1, v] for step ≥ -m sequences. At m = 1 the window collapses to {v} and the parent's downward IVT is recovered verbatim.",
+      "m_jump_upward_ivt: symmetric dual D′ with conclusion window [v, v + m - 1] for step ≤ m sequences. Together D + D′ form the m-generalization of the cycle lemma's two-sided level reachability.",
+      "Refutation of the naive ⌈S/m⌉ bound: the family l = [-m, m + S] witnesses |goodRotations| = 1 < ⌈S/m⌉ on the broad step ≥ -m hypothesis, eliminating the parent's openQuestions[0] in its naive form.",
+      "step_in_one_neg_m_count: Conjecture E discharge on the restricted alphabet {+1, -m} via a thin restatement of the parent's `cycle_lemma`; the residual `⌈S/m⌉ ≤ S` is the `ceil_div_le_toNat` arithmetic atom.",
+      "step_in_one_pos_mixed_neg_card_eq / _card_bound (Path B): the alphabet `{-m, …, -1, +1}` admits the strict equality |goodRotations| = l.sum.toNat via a re-implementation of the parent's `levelPos` machinery as the file-private `levelPosB` (the parent's helpers were file-local), and a single `rcases` pattern adjustment to destructure the existential negative step.",
+      "step_le_one_card_eq: the maximal clean alphabet — every step ≤ 1, with no lower bound on negative steps at all — still admits the strict cycle-lemma equality. The level-visitation guarantee needs only the upward cap (so every up-step lands the prefix sum on the next integer level); the S1 refutation `[-m, m + S]` used an uncapped positive jump to skip levels, and is blocked the moment the cap x ≤ 1 is in place.",
+      "step_in_one_pos_pm_card_eq / _card_bound (Option C public API, preserved as corollaries): the earlier two-sided bounded equality is exhibited as a one-line `.2`-projection of `step_le_one_card_eq`, demonstrating that the lower bound was inert all along."
+    ]
+  },
+  "overview": {
+    "historicalContext": "The cycle lemma's history is summarized in the parent entry `ballot-problem-oq-01-oq-01-oq-02`: Bertrand (1887, *Comptes Rendus*), André (1887, reflection), Dvoretzky & Motzkin (1947, *Duke Math. J.*), and Raney (1960, *Trans. AMS*) progressively isolated the combinatorial core. The parent OQ-02 entry asked which weaker step alphabets still admit cycle-lemma analogs and bracketed the {+1, -k} regime by unit-decrement (step ≥ -1) and all-positive (step > 0) extremes, leaving the natural multi-jump m-generalization as `openQuestions[0]`.\n\nThis OQ-01 child file takes up that openQuestion and follows it through four sessions of mathematical sharpening. **S1 (May 2026)** refuted the naive `⌈S/m⌉ ≤ |goodRotations|` bound by exhibiting `l = [-m, m + S]` (smallest witness `m = 2`, `l = [-2, 5]`, `|gR| = 1 < ⌈3/2⌉ = 2`) and proposed five refined conjectures A–E (parent file's S1 OBSERVE memo). **S2/S4** (D, D′) ported the parent's leftmost-crossing IVT to m-jumps, replacing the unit step bound with `-m ≤ x` (resp. `x ≤ m`) and widening the conclusion window from {v} to a closed integer interval of width m. The proofs transfer verbatim — the parent's argument relies only on the existence of a leftmost crossing and on the per-step bound being constant. **S6** (Conjecture E) recognised that the *exact* cycle-lemma count survives the m-jump generalization once the alphabet is constrained to {+1, -m}: the parent's `cycle_lemma` (in `BallotProblemOQ01.lean:764`) does the heavy lifting, and the lower bound `⌈S/m⌉ ≤ S = |gR|` is a one-line `ceil_div_le_toNat` arithmetic. **S7 (Path B)** extended the negative side from `{-m}` to `{-m, …, -1, +1}` by re-implementing the parent's file-private `levelPos` helpers as `levelPosB` in this slug's namespace, with a single `rcases` adjustment to destructure the existential lower negative bound. The resulting `step_in_one_pos_mixed_neg_card_eq` upgrades B′'s slack form to a strict equality. **S11 (Option C)** added the zero step via the two-sided bounded alphabet `-(m:ℤ) ≤ x ≤ 1`. **S12 (sharpest one-sided)** acted on an S11 in-line note that the lower bound was inert: dropping `-m ≤ x` entirely gave `step_le_one_card_eq`, the maximal clean alphabet for the strict equality. Any upward relaxation is refuted by the S1 family.\n\nThe end-state — `|goodRotations l| = l.sum.toNat` for every `l : List ℤ` with all steps `≤ 1` and `0 < l.sum` — is, to the best of our knowledge, a previously unrecorded sharpening of the Dvoretzky–Motzkin cycle lemma: the standard literature parametrizes by the negative step (or by the alphabet {+1, -k}) and never relaxes the lower bound to *no constraint at all*. The Lean formalization makes the boundary tight in both directions: the cap `x ≤ 1` cannot be relaxed (S1 refutation), and no lower-bound assumption is needed (S12 strengthening).",
+    "problemStatement": "**Parent openQuestion[0]**: For step ≥ -m sequences with l.sum > 0, does the bound ⌈l.sum/m⌉ ≤ |goodRotations l| hold?\n\n**Answer (S1)**: NO on the broad family. The witness l = [-m, m + S] forces |goodRotations| = 1 while ⌈S/m⌉ ≥ 2 for any m ≥ 2 and S = m + 1.\n\n**Sharpening (S2-S12)**: Identify the maximal alphabet on which the *exact* cycle-lemma equality |goodRotations l| = l.sum.toNat survives. The answer is the one-sided alphabet `∀ x ∈ l, x ≤ 1` with `0 < l.sum` (no lower bound on negative steps at all), proved as `step_le_one_card_eq`. The two m-jump IVTs (D, D′) supply the infrastructural width-m generalization of the parent's unit-step IVT.",
+    "proofStrategy": "The two m-jump IVTs reuse the parent's leftmost-crossing argument: define `S` as the set of positions in `(i, j]` with prefix sum ≤ v (or ≥ v for D′), take `kstar := Finset.min' S`, and combine the membership condition with the one-step bound `-(m:ℤ) ≤ l[k]` (resp. `l[k] ≤ m`) to pin the prefix sum into the conclusion window `[v - m + 1, v]` (resp. `[v, v + m - 1]`). The m = 1 sanity check collapses the window to `{v}` (handled by `omega` rather than `linarith` due to a v4.26.0 `Nat→Int` normalization quirk).\n\nThe equality results follow a different — and more sophisticated — strategy: re-implement the parent file's `levelPos` private helper as `levelPosB := Finset.max' { i : prefixSum l i ≤ minPrefixSum l + n }`, i.e. the *rightmost* prefix position at or below level `minPrefixSum + n`. Cardinality of `goodRotations` is then bounded below by `Finset.card_le_card_of_injOn` applied to the injection `levelPosB : Finset.range l.sum.toNat ↪ goodRotations l`. The level-equality lemma `prefixSum l (levelPosB l n) = minPrefixSum l + n` is the heart of the argument: maximality of `levelPosB l n` forces a strict upward jump at the boundary, and the step bound (`x = 1`, `x ∈ {1} ∪ {-k : k ∈ {1..m}}`, `-m ≤ x ≤ 1`, or finally `x ≤ 1`) pins both the step value and the prefix sum via `omega`. The S12 strengthening observes that the lower bound on negative steps is never consumed: the level equality routes through `omega` with only `hxle : l[idx] ≤ 1`, the count lemma routes through `levelPosB_eq_capOne`, and the upper bound `goodRotations_card_le` is alphabet-agnostic. Each layer of the alphabet refinement (Path B, Option C, capOne) preserves the proof shape and adjusts only the `rcases` pattern on `hmem`.",
+    "keyInsights": [
+      "**Leftmost crossing transfers verbatim across step bounds.** The Finset.min' argument used in `m_jump_downward_ivt` is identical to the parent's `unit_decrement_downward_ivt` proof, with `-1` replaced by `-(m:ℤ)`. The argument's only structural dependency is on the constancy of the per-step bound — the parent unit-decrement IVT generalizes to arbitrary integer bounds with no proof-shape change.",
+      "**The m-jump conclusion window is sharp.** At m ≥ 2 the prefix sum genuinely may not land exactly on the target level v; the window [v - m + 1, v] (resp. [v, v + m - 1]) is the tightest interval guaranteed by the leftmost-crossing argument when the step can drop by up to m. This is a *qualitative* weakening of the unit-decrement IVT, not just a quantitative one.",
+      "**The naive ⌈S/m⌉ bound is destroyed by a single uncapped positive jump.** The S1 refutation `l = [-m, m + S]` shows that allowing arbitrary positive steps lets the prefix sum skip levels going up, and the cycle lemma's count drops to 1. The cap `x ≤ 1` is the precise hypothesis that blocks this family — and is also the precise hypothesis sufficient for the strict equality.",
+      "**The lower bound on negative steps is inert.** S11 introduced Option C (`-(m:ℤ) ≤ x ≤ 1`) thinking the lower bound was load-bearing; S12 showed that every proof step (level identity, count bound, upper bound) consumes only the upper cap. This is the kind of inert-hypothesis discovery that justifies a public API change — the simpler `step_le_one_card_eq` subsumes Path B and Option C as one-line `.2`-projection corollaries.",
+      "**The rightmost-prefix-at-or-below-level (`levelPosB`) injection is the key combinatorial gadget.** It maps each integer level `n ∈ [0, l.sum)` to the rightmost prefix position achieving level `minPrefixSum + n`. Maximality forces the immediate successor to jump above the level, and the step cap forces the jump to be exactly `+1`, hence the prefix sum lands exactly *at* the target level. Injectivity is then by reading off `n` from `prefixSum - minPrefixSum`. The same gadget powers the parent's cycle lemma for {+1, -k}; the present file generalises it across four progressively broader alphabets.",
+      "**Cycle-lemma equality has a sharp boundary at the upward cap.** The sequence of S2 → S6 → S7 → S11 → S12 systematically traced where the inequality breaks and where the equality survives. The end-state `step_le_one_card_eq` is the unique maximal clean alphabet for the strict equality: tightening the cap (e.g. `x ≤ 0`) restricts to degenerate sequences; relaxing it admits the S1 refutation. This 'maximal alphabet of cleanliness' methodology applies broadly: identify the precise hypothesis below which equality fails, then verify no weaker hypothesis with the same upper bound suffices."
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Preamble: Imports, Namespace, and Four-Part Roadmap",
+      "startLine": 1,
+      "endLine": 37,
+      "summary": "File header documenting (1) the S1 OBSERVE refutation of the parent's naive ⌈S/m⌉ bound by the [-m, m+S] family, (2) the m-jump IVT D as the discharge of the parent's openQuestions[0], (3) the m = 1 sanity check recovering the parent's unit-decrement IVT, and (4) the later Conjecture E / Path B / Option C / S12 sharpening cascade. Imports the parent file BallotProblemOQ01OQ01OQ02 (which provides prefixSum, minPrefixSum, rightmostMinPos, isGoodRotation, goodRotations, rightmostAtLevel_good, goodRotations_card_le) and the grandparent BallotProblemOQ01 (which provides cycle_lemma, kCountedSequence_sum, kCountedSequence). Namespace BallotMJumpCycleLemma; opens GeneralizedBallot.",
+      "mathContext": "Inherits the cycle-lemma vocabulary from `BallotProblemOQ01OQ01OQ02` and the {+1, -k} count machinery from `BallotProblemOQ01`. The slug's own contribution is a width-m generalization of the IVT and a four-step refinement of the cycle-lemma equality alphabet."
+    },
+    {
+      "id": "m-jump-downward-ivt",
+      "title": "Part I — m-Jump Downward IVT (D) and Unit Recovery",
+      "startLine": 38,
+      "endLine": 129,
+      "summary": "Three theorems closing the parent's conjecture D. `m_jump_step_bound`: for step ≥ -m sequences, prefix sum drops by at most m per step (`PS(j+1) ≥ PS(j) - m`). `m_jump_downward_ivt`: leftmost-crossing IVT — if PS(i) > v and PS(j) ≤ v for i < j, some k ∈ (i,j] has PS(k) ∈ [v - m + 1, v]. Proof defines `S := Finset.Ico (i+1) (j+1) ∩ {k : PS(k) ≤ v}`, takes `kstar := S.min'`, derives `PS(kstar - 1) > v` by minimality, then uses `hsucc + hstep_bound` to pin PS(kstar) ≥ v - m + 1; combined with PS(kstar) ≤ v from membership, the conclusion follows by `linarith`. `m_jump_downward_ivt_unit_recovery`: at m = 1 the window collapses to {v} and the parent's unit-decrement IVT is recovered. (The `omega` rather than `linarith` finisher is required because v4.26.0 does not auto-normalize `↑(1 : ℕ) = (1 : ℤ)` for `linarith`.)",
+      "mathContext": "$\\text{PS}(j+1) \\geq \\text{PS}(j) - m \\quad (\\text{since } l_j \\geq -m).$\nLet $k^* := \\min' \\{k \\in (i,j] : \\text{PS}(k) \\leq v\\}$. Minimality $\\Rightarrow \\text{PS}(k^*-1) > v$; one-step bound $\\Rightarrow \\text{PS}(k^*) \\geq \\text{PS}(k^*-1) - m > v - m$. Combined with $\\text{PS}(k^*) \\leq v$: $\\text{PS}(k^*) \\in [v - m + 1, v]$."
+    },
+    {
+      "id": "m-jump-upward-ivt",
+      "title": "Part II — m-Jump Upward IVT (D′) and Unit Recovery",
+      "startLine": 131,
+      "endLine": 235,
+      "summary": "Symmetric dual of Part I, addressing conjecture D′. `m_jump_step_bound_upward`: for step ≤ m sequences, PS(j+1) ≤ PS(j) + m. `m_jump_upward_ivt`: if PS(i) < v and PS(j) ≥ v for i < j, some k ∈ (i,j] has PS(k) ∈ [v, v + m - 1]. Same leftmost-crossing argument as Part I with all directions reversed (S filters on PS ≥ v instead of PS ≤ v; kstar - 1 has PS < v; upper bound from hsucc + hstep_bound). `m_jump_upward_ivt_unit_recovery`: at m = 1 the window collapses to {v}, recovering an upward-unit IVT (the dual of `unit_decrement_downward_ivt`, which the parent file did not state explicitly).",
+      "mathContext": "$\\text{PS}(j+1) \\leq \\text{PS}(j) + m \\quad (\\text{since } l_j \\leq m).$\nLet $k^* := \\min' \\{k \\in (i,j] : \\text{PS}(k) \\geq v\\}$. Minimality $\\Rightarrow \\text{PS}(k^*-1) < v$; one-step bound $\\Rightarrow \\text{PS}(k^*) \\leq \\text{PS}(k^*-1) + m < v + m$. Combined with $\\text{PS}(k^*) \\geq v$: $\\text{PS}(k^*) \\in [v, v + m - 1]$."
+    },
+    {
+      "id": "conjecture-e",
+      "title": "Part III — Conjecture E: Cycle-Lemma Bound on Alphabet {+1, -m}",
+      "startLine": 237,
+      "endLine": 316,
+      "summary": "Discharges conjecture E by restricting to the {+1, -m} alphabet and invoking the parent's `cycle_lemma`. Private lemma `ceil_div_le_toNat`: for S > 0 and m ≥ 1, `Int.toNat ⌈S/m⌉ ≤ S.toNat` (the residual arithmetic atom). Public theorem `step_in_one_neg_m_count`: if every step is 1 or -m and l.sum > 0, then `Int.toNat ⌈l.sum / m⌉ ≤ |goodRotations l|`. Proof: bridge `l ∈ kCountedSequence m (l.count 1) (l.count (-m))` (by definition unfolding), use `kCountedSequence_sum` to get `l.sum = a - m·b`, derive `m·b < a` from positivity, apply `cycle_lemma` to get the *exact* count `|gR| = a - m·b = l.sum.toNat`, and finish with `ceil_div_le_toNat`. The result *dominates* the naive ⌈S/m⌉ bound (the count equals `l.sum.toNat`, not just `⌈l.sum/m⌉`).",
+      "mathContext": "Restricted to alphabet $\\{+1, -m\\}$: $l \\in \\text{kCountedSequence}_m(a, b) \\Rightarrow |\\text{gR}(l)| = a - m \\cdot b = (\\sum l).\\text{toNat}$ via the parent's `cycle_lemma`. The fractional bound $\\lceil S/m \\rceil \\leq S$ then follows from $m \\geq 1$.\n\n**Contrast** with S1's refutation on the broad family $\\text{step} \\geq -m$: the witness $l = [-m, m+S]$ uses an uncapped positive step $+(m+S)$ that the alphabet restriction $x = 1 \\vee x = -m$ excludes."
+    },
+    {
+      "id": "path-b-mixed-down",
+      "title": "Part IV — Path B (S7): Strict Equality on {-m, …, -1, +1}",
+      "startLine": 319,
+      "endLine": 476,
+      "summary": "Extends Conjecture E from {+1, -m} to the *mixed-down* alphabet `x = 1 ∨ ∃ k ∈ {1..m}, x = -k`. The parent file's `levelPos` private helpers are not cross-file callable, so this Part re-implements them as `levelPosB` in this slug's namespace (S7 PREP §3.4 choice (b)). Seven private helpers: `levelPosB` (noncomputable def — rightmost prefix position at or below `minPrefixSum + n`), `levelPosB_mem` / `_le` / `_prefixSum_le` (membership lemmas), `levelPosB_max` (maximality), `levelPosB_lt` (strict inequality from `(n : ℤ) < l.sum`), `levelPosB_right` (cofinal characterization), and `levelPosB_eq` (the level-identity heart — same proof shape as the parent's `levelPos_eq` with a single `rcases` pattern adjustment to destructure the existential negative step; the `linarith` discharge depends only on `0 ≤ k`). `goodRotations_card_ge_pathB` then uses `Finset.card_le_card_of_injOn` with `levelPosB` to inject `Finset.range l.sum.toNat` into `goodRotations l`. Two public theorems: `step_in_one_pos_mixed_neg_card_eq` (strict equality via `le_antisymm` with the alphabet-agnostic `goodRotations_card_le`) and `step_in_one_pos_mixed_neg_card_bound` (B′ slack form via `Int.toNat_of_nonneg` and `nlinarith`).",
+      "mathContext": "Alphabet $\\Sigma = \\{+1\\} \\cup \\{-1, \\ldots, -m\\}$. Define $\\text{levelPosB}(l, n) := \\max\\{i \\in [0, |l|] : \\text{PS}(i) \\leq \\text{minPS}(l) + n\\}$ (the *rightmost* prefix at or below level $\\text{minPS} + n$). For each $n < l.\\text{sum}.\\text{toNat}$, the cyclic rotation starting at $\\text{levelPosB}(l, n)$ is good, and these positions are distinct (extracted by inverting the level identity). Hence $|gR(l)| \\geq l.\\text{sum}.\\text{toNat}$; combined with $|gR(l)| \\leq l.\\text{sum}.\\text{toNat}$ (parent), equality."
+    },
+    {
+      "id": "sharpest-cap-one",
+      "title": "Part V — S12: The Maximal Clean Alphabet x ≤ 1 and Option C as Corollary",
+      "startLine": 478,
+      "endLine": 625,
+      "summary": "Drops *all* lower bounds on negative steps. Two private strengthenings: `levelPosB_eq_capOne` (the Part IV level identity with the inert lower bound removed — `omega` consumes only `hxle : l[idx] ≤ 1`) and `goodRotations_card_ge_capOne` (the Part IV count bound routed through the strengthened identity). The headline theorem `step_le_one_card_eq` glues these via `le_antisymm` with `goodRotations_card_le`: for every `l : List ℤ` with all steps ≤ 1 and `0 < l.sum`, `|goodRotations l| = l.sum.toNat`. The Option C public API `step_in_one_pos_pm_card_eq` and `_card_bound` is preserved byte-identically and exhibited as one-line corollaries: drop the `.2` of the conjunctive hypothesis and forward. **Mathematical content**: `x ≤ 1` is the *maximal* clean alphabet for the strict cycle-lemma equality — S1's refutation `[-m, m + S]` uses an uncapped `+(m + S)` to skip levels, blocked the moment the cap is in place, so no upward relaxation admits the equality.",
+      "mathContext": "$\\forall x \\in l,\\ x \\leq 1\\ \\wedge\\ 0 < \\sum l\\ \\Rightarrow\\ |gR(l)| = (\\sum l).\\text{toNat}.$\n\n**Sharpness** (S1 OBSERVE): the family $l = [-m, m+S]$ (steps $\\{-m, m+S\\}$, $\\sum = S > 0$) has $|gR| = 1$ for any $m \\geq 2$, refuting the equality on any wider upward alphabet. The lower bound on negative steps is *inert* — every proof step (level identity, count, upper bound) consumes only the upper cap."
+    }
+  ],
+  "conclusion": {
+    "summary": "Twelve public theorems close out the m-generalization of the cycle lemma in two complementary modes: (i) two m-jump IVTs (D, D′) supply width-m generalizations of the parent's unit-decrement IVTs, with m = 1 sanity checks recovering the parent verbatim; (ii) a four-step alphabet refinement traces where the *strict* cycle-lemma equality |goodRotations l| = l.sum.toNat survives. The end-state `step_le_one_card_eq` is the maximal clean alphabet: `∀ x ∈ l, x ≤ 1 ∧ 0 < l.sum`, with no lower bound on negative steps at all. The Option C and Path B public theorems are preserved as one-line corollaries.",
+    "implications": "The two m-jump IVTs are an infrastructural piece — the discrete-IVT mechanism is now available for any constant-bounded-step setting, not just the unit-decrement case. The strict-equality strand isolates the precise hypothesis (`x ≤ 1`) that drives the cycle-lemma count and shows the lower bound on negative steps was never doing any work. Together they answer the parent's openQuestion[0] in a sharper form than originally conjectured: the naive ⌈S/m⌉ bound is false on the broad step ≥ -m family (S1 refutation), but the *exact* equality `|gR| = l.sum.toNat` survives on the much broader alphabet `x ≤ 1` (S12 sharpening) — provided one bounds *positive*, not *negative*, steps.",
+    "openQuestions": [
+      "**Quantitative slack on uncapped alphabets.** For sequences with bounded *positive* steps `x ≤ M` (`M > 1`) and arbitrary negative steps, is there a lower bound `|gR| ≥ f(M) · l.sum.toNat` for some explicit `f`? The S1 refutation rules out the strict equality; characterising the slack term as a function of the maximum positive step would extend the present analysis past the equality boundary.",
+      "**Continuous-time analog.** Does the leftmost-crossing primitive used in the m-jump IVTs have a càdlàg analog for spectrally-positive Lévy processes with bounded negative jumps? Bingham (1975) gives the fluctuation-theoretic skeleton; a width-m discrete-IVT analog for hitting times would unify the present finitary analysis with the Lévy fluctuation literature.",
+      "**Multi-step alphabets.** Mohanty (1979)'s generalized cycle lemma handles alphabets like `{+a, -b}` with `gcd(a, b) = 1`. Can the present file's `levelPosB` injection be re-implemented to fit the `+a` (rather than `+1`) up-step? The maximality argument would need a level-spacing adjustment proportional to `a`.",
+      "**Random walks with two-sided unbounded steps.** The `step ≤ 1` cap is one-sided. Are there interesting two-sided generalizations of the strict equality that preserve `|gR| = l.sum.toNat` after a suitable change of count target (e.g., counting *minimal* prefixes rather than positive ones)?",
+      "**Tight slack characterization.** The Path B slack form `l.sum ≤ m·|gR| + (m-1)·l.length` becomes equality at `m = 1`. For `m ≥ 2` on the mixed-down alphabet, is the slack ever attained by a non-trivial witness? A tight family would calibrate exactly how `m` enters the inequality."
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Proofs.BallotProblemOQ01OQ01OQ02",
+      "Mathlib.Tactic"
+    ],
+    "opens": ["GeneralizedBallot"],
+    "namespace": "BallotMJumpCycleLemma",
+    "lineCount": 626,
+    "axiomCount": 0,
+    "theoremCount": 12,
+    "definitionCount": 0,
+    "path": "Proofs/BallotProblemOQ01OQ01OQ02OQ01.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "ballot-problem-oq-01-oq-01-oq-02",
+      "relationship": "extends",
+      "description": "Parent entry: the unit-decrement / all-positive bracketing of the cycle lemma. This child discharges the parent's `openQuestions[0]` — the conjectured `step ≥ -m` analog of the unit-decrement IVT — by formalizing the two m-jump IVTs and tracing the alphabet refinements that recover the *strict* cycle-lemma equality up to the maximal cap `x ≤ 1`."
+    },
+    {
+      "targetId": "ballot-problem-oq-01-oq-01",
+      "relationship": "extends",
+      "description": "Grandparent: the Dvoretzky–Motzkin cycle lemma for {+1, -k} sequences (`cycle_lemma`, `kCountedSequence_sum`). Conjecture E (Part III) is a thin restatement of this theorem to alphabet {+1, -m}; Path B (Part IV) and S12 (Part V) re-implement the parent's file-private `levelPos` machinery as `levelPosB` to extend the equality to broader alphabets."
+    },
+    {
+      "targetId": "ballot-problem-oq-01",
+      "relationship": "related",
+      "description": "Great-grandparent: the generalized ballot problem. The present entry sits two levels below in the OQ-01-OQ-01-OQ-02-OQ-01 chain and answers a question the great-grandparent did not ask — the maximal clean upward alphabet for the cycle-lemma equality."
+    },
+    {
+      "targetId": "ballot-problem",
+      "relationship": "ancestor",
+      "description": "Bertrand's 1887 ballot problem — the origin of the entire cycle-lemma research line. The present file is four generalization steps removed (Bertrand → Dvoretzky–Motzkin → generalized {+1, -k} → unit-decrement / all-positive bracketing → m-jump / x ≤ 1)."
+    }
+  ],
+  "references": [
+    {
+      "authors": "Joseph Bertrand",
+      "title": "Solution d'un problème",
+      "year": "1887",
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, 105, 369",
+      "note": "Originated the ballot problem and the entire cycle-lemma research line that this file's S12 sharpening extends."
+    },
+    {
+      "authors": "Désiré André",
+      "title": "Solution directe du problème résolu par M. Bertrand",
+      "year": "1887",
+      "venue": "Comptes Rendus de l'Académie des Sciences, Paris, 105, 436–437",
+      "note": "Reflection-principle proof of Bertrand's ballot result; orthogonal to the cycle-lemma family this file extends."
+    },
+    {
+      "authors": "Aryeh Dvoretzky and Theodore S. Motzkin",
+      "title": "A problem of arrangements",
+      "year": "1947",
+      "venue": "Duke Mathematical Journal 14, 305–313",
+      "note": "Introduced the cycle lemma for $\\{+1, -k\\}$ sequences with proof via the *minimum* prefix sum's location. The present file's `levelPosB` injection is the same gadget reformulated to use the *rightmost* prefix at or below a given level — operationally equivalent but more pliable across alphabet refinements."
+    },
+    {
+      "authors": "George N. Raney",
+      "title": "Functional composition patterns and power series reversion",
+      "year": "1960",
+      "venue": "Transactions of the American Mathematical Society 94, 441–451",
+      "note": "Standard modern reformulation of the cycle lemma; the rightmost-minimum trick (parent's `rightmostMinPos`) descends from this paper."
+    },
+    {
+      "authors": "Sri Gopal Mohanty",
+      "title": "Lattice Path Counting and Applications",
+      "year": "1979",
+      "venue": "Academic Press, Probability and Mathematical Statistics series",
+      "note": "Comprehensive treatment of the *generalized* cycle lemma for multi-step alphabets such as $\\{+a, -b\\}$ with $\\gcd(a,b) = 1$. The present file's `+1` up-step structure is one branch of Mohanty's classification; an open question asks whether the `levelPosB` injection can be extended to `+a` up-steps."
+    },
+    {
+      "authors": "Nicholas H. Bingham",
+      "title": "Fluctuation theory in continuous time",
+      "year": "1975",
+      "venue": "Advances in Applied Probability 7, 705–766",
+      "note": "Continuous-time fluctuation theory for spectrally-positive Lévy processes — the conjectured continuous analog of the m-jump IVT for càdlàg processes with bounded negative jumps."
+    },
+    {
+      "authors": "Richard P. Stanley",
+      "title": "Enumerative Combinatorics, Volume I (2nd edition)",
+      "year": "2011",
+      "venue": "Cambridge Studies in Advanced Mathematics 49, Cambridge University Press",
+      "note": "Standard reference (§1.5) on lattice paths and cycle-lemma applications; motivates the 'how far does the count formula go?' question that S12 settles for one-sided capped alphabets."
+    }
+  ],
+  "mainTheorems": [
+    {
+      "name": "m_jump_step_bound",
+      "type": "lemma",
+      "description": "For step ≥ -m sequences, the prefix sum drops by at most m per step: `prefixSum l (j+1) ≥ prefixSum l j - m`. The local property driving the m-jump downward IVT."
+    },
+    {
+      "name": "m_jump_downward_ivt",
+      "type": "core",
+      "description": "**Conjecture D**: for step ≥ -m sequences, if PS(i) > v and PS(j) ≤ v for i < j, some k ∈ (i,j] has PS(k) ∈ [v - m + 1, v]. Proved via the leftmost-crossing Finset.min' argument inherited from the parent's unit-decrement IVT."
+    },
+    {
+      "name": "m_jump_downward_ivt_unit_recovery",
+      "type": "lemma",
+      "description": "Sanity check at m = 1: the conclusion window [v - 1 + 1, v] = {v} collapses to the parent's `unit_decrement_downward_ivt`."
+    },
+    {
+      "name": "m_jump_step_bound_upward",
+      "type": "lemma",
+      "description": "For step ≤ m sequences, the prefix sum rises by at most m per step: `prefixSum l (j+1) ≤ prefixSum l j + m`. Symmetric dual of m_jump_step_bound."
+    },
+    {
+      "name": "m_jump_upward_ivt",
+      "type": "core",
+      "description": "**Conjecture D′** (symmetric dual): for step ≤ m sequences, if PS(i) < v and PS(j) ≥ v for i < j, some k ∈ (i,j] has PS(k) ∈ [v, v + m - 1]. Same leftmost-crossing argument as D, with all directions reversed."
+    },
+    {
+      "name": "m_jump_upward_ivt_unit_recovery",
+      "type": "lemma",
+      "description": "Sanity check at m = 1 for the upward IVT: window collapses to {v}, giving an upward-unit IVT (the explicit dual of `unit_decrement_downward_ivt` that the parent file did not state)."
+    },
+    {
+      "name": "step_in_one_neg_m_count",
+      "type": "core",
+      "description": "**Conjecture E**: on the alphabet `x = 1 ∨ x = -m` with positive sum, the fractional cycle-lemma bound `Int.toNat ⌈l.sum / m⌉ ≤ |goodRotations l|` holds. Thin restatement of the parent's `cycle_lemma` plus the residual arithmetic `⌈S/m⌉ ≤ S` for m ≥ 1, S > 0. The actual count equals `l.sum.toNat`, which is stronger."
+    },
+    {
+      "name": "step_in_one_pos_mixed_neg_card_eq",
+      "type": "core",
+      "description": "**Path B (S7)**: on the mixed-down alphabet `x = 1 ∨ ∃ k ∈ {1..m}, x = -k`, the count is exactly `|goodRotations l| = l.sum.toNat`. Proved via the `levelPosB` injection into `goodRotations l` combined with the alphabet-agnostic upper bound `goodRotations_card_le`."
+    },
+    {
+      "name": "step_in_one_pos_mixed_neg_card_bound",
+      "type": "lemma",
+      "description": "**Path B slack form**: recovers B′'s slack inequality `l.sum ≤ m · |gR| + (m − 1) · l.length` from the strict equality. Slack term is non-negative for m ≥ 1; equality at m = 1."
+    },
+    {
+      "name": "step_le_one_card_eq",
+      "type": "core",
+      "description": "**S12 sharpest one-sided** — the headline equality: for every `l : List ℤ` with all steps ≤ 1 and `0 < l.sum`, `|goodRotations l| = l.sum.toNat`. No lower bound on negative steps required; this is the maximal clean alphabet for the strict cycle-lemma equality. Subsumes Option C and Path B as one-line corollaries (drop the inert lower-bound conjunct from `hmem`)."
+    },
+    {
+      "name": "step_in_one_pos_pm_card_eq",
+      "type": "core",
+      "description": "**Option C equality** (S11 ACT, S12 reduced to corollary): on the two-sided bounded alphabet `-m ≤ x ≤ 1`, the count is exactly `l.sum.toNat`. Now a one-line corollary of `step_le_one_card_eq` via `.2`-projection on `hmem`, demonstrating that the lower bound was inert all along."
+    },
+    {
+      "name": "step_in_one_pos_pm_card_bound",
+      "type": "lemma",
+      "description": "**Option C slack form** (S11 ACT, S12 reduced to corollary): the B′-style bound `l.sum ≤ m · |gR| + (m − 1) · l.length` on the Option C alphabet. The `m` parameter governs only the slack magnitude; the underlying equality is the alphabet-free `step_le_one_card_eq`."
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Promotes `ballot-problem-oq-01-oq-01-oq-02-oq-01` (m-Jump Cycle Lemma) to a public gallery entry — mirrors the Lean side's S12 boundary-tight strict-equality regime on the maximal clean one-sided alphabet `x ≤ 1`.

- **`src/data/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01/meta.json`** — full schema modeled on parent OQ-02: `status="verified"`, `badge="original"`, 12 theorems / 0 axioms / 0 sorries / 626 LOC. Six sections (preamble, m-jump downward IVT, m-jump upward IVT, Conjecture E, Path B mixed-down, S12 sharpest cap-one), twelve `mainTheorems`, four `crossReferences`, seven literature references, five `openQuestions`.
- **`annotations.json`** — seven inline highlights covering the pedagogically useful regions (preamble roadmap → m-jump step bound → IVT proof → Conjecture E → `levelPosB` gadget → Path B equality → S12 headline).
- **`state.md` + S14 session memo** — phase header refresh, Next-Action update, full session record.

## Math content (gallery side)

The slug now publicly documents:

1. **Two m-jump IVTs (D, D′)** — width-m generalisations of the parent's unit-decrement IVTs via the same leftmost-crossing Finset.min' argument; m = 1 sanity checks recover the parent verbatim.
2. **Refutation of the naive ⌈S/m⌉ ≤ |goodRotations| bound** on the broad `step ≥ -m` family via `l = [-m, m + S]`.
3. **Four-step alphabet refinement** for the strict cycle-lemma equality `|goodRotations l| = l.sum.toNat`: Conjecture E ({+1,-m}) → Path B ({-m,…,-1,+1}) → Option C ({-m,…,0,1}) → **S12: x ≤ 1 with no lower bound at all** — the maximal clean alphabet.
4. **The `levelPosB` combinatorial gadget** as the key injection from `Finset.range l.sum.toNat` into `goodRotations l`.

## Build verification

- `pnpm annotations:build` — zero validation errors for this slug.
- `pnpm research:build` — slug registered in `listings.json` / `data-manifest.json` (`meta=10028619`, `ann=980d36dc`).
- **No Lean changes** — `BallotProblemOQ01OQ01OQ02OQ01.lean` is unchanged on `origin/main` since S12 ACT (PR #21857, 2026-06-01).

## Discharges

S13 STATE-SYNC's "Next Action" item #1 (gallery slug creation).

## Test plan

- [ ] Deployer renders the new slug at `/proofs/ballot-problem-oq-01-oq-01-oq-02-oq-01`
- [ ] Gallery cross-references resolve (parent OQ-02, grandparent OQ-01-OQ-01, great-grandparent OQ-01, ancestor Bertrand)
- [ ] KaTeX renders the LaTeX in section `mathContext` fields and the annotations' `mathContext`
- [ ] Lake build of `Proofs.BallotProblemOQ01OQ01OQ02OQ01` remains clean (no Lean changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)