### PR TITLE
audit(cayley-hamilton-reduction): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1866,9 +1866,9 @@
       "result": "clean"
     },
     "cayley-hamilton-reduction": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:32Z",
+      "lastAudited": "2026-06-10T06:27:03Z",
       "result": "clean"
     },
     "cayley-hamilton-reduction-oq-01": {


### PR DESCRIPTION
## Summary

Gallery integrity audit of `cayley-hamilton-reduction` — **clean**.

All meta.json fields verified against `proofs/Proofs/CayleyHamiltonOQ02.lean`:

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 20 | 20 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| lineCount | 358 | 358 | ✓ |

No True stubs detected. Badge `mathlib` is correct (Tier B: relies on `Matrix.aeval_self_charpoly` from Mathlib). `originalContributions` accurately describe what is independently proved (polynomial reduction, degree bounds, congruence, annihilator structure, partial sum reduction, nilpotent/idempotent special cases).

## Test plan
- [x] sorry/axiom/theorem/def counts match Lean source
- [x] No True stubs
- [x] Badge/status alignment correct for Tier B

🤖 Generated with [Claude Code](https://claude.com/claude-code)