### PR TITLE
audit(arithmetic-series): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -514,9 +514,9 @@
       "result": "issues-fixed"
     },
     "arithmetic-series": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:31Z",
+      "lastAudited": "2026-06-10T06:47:42Z",
       "result": "clean"
     },
     "arithmetic-series-oq-00": {


### PR DESCRIPTION
## Summary

Gallery integrity audit #4 for `arithmetic-series` (Wiedijk #68, Gauss's summation formula). All checks pass — no overstated claims, counts match the Lean source.

## Verification

| Check | meta.json | Lean file | Result |
|---|---|---|---|
| Sorries | 0 | 0 | ✓ |
| Axioms | 0 | 0 | ✓ |
| Theorems | 11 | 11 | ✓ |
| Definitions | 1 | 1 | ✓ |
| Lines | 180 | 180 | ✓ |
| True stubs | n/a | 0 | ✓ |

## Tier Classification

**Tier B** — Formalized using Mathlib's `Finset.sum_range_id`. The `mathlib` badge is correctly applied. The description, overview, and Lean module docstring all explicitly credit `Finset.sum_range_id` as the core dependency, so there is no delegation opacity.

## Changes

- `src/data/proofs/audit-tracker.json`: bump `arithmetic-series` audit count 3 → 4, set `lastAudited` to 2026-06-10, result `clean`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)