### PR TITLE
audit(erdos-5): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -7491,9 +7491,9 @@
     },
     "erdos-5": {
       "agentId": "auditor-cycle-20-batch",
-      "auditCount": 4,
-      "lastAudited": "2026-06-10T05:19:16Z",
-      "result": "issues-found"
+      "auditCount": 5,
+      "lastAudited": "2026-06-10T06:57:17Z",
+      "result": "clean"
     },
     "erdos-5-prime-gaps": {
       "auditCount": 3,


### PR DESCRIPTION
## Summary

- Re-audit of `erdos-5` confirms all integrity claims match the Lean sources following commit 3b0ccc44377 (#22730) which corrected `axiomCount` from 3 → 4.
- Tracker moves erdos-5 from `issues-found` (auditCount 4, 2026-06-10T05:19:16Z) to `clean` (auditCount 5).
- `npx tsx scripts/auditor/find-targets.ts --issues` now returns 0 targets gallery-wide.

## Verification

| Field | meta.json | Actual (Lean) | Status |
|-------|-----------|---------------|--------|
| Top-level `axiomCount` | 4 | 3 (Erdos5PrimeGaps.lean) + 1 (Erdos5Problem.lean companion) = 4 | ✓ |
| `leanFile.axiomCount` | 3 | 3 (main file only) | ✓ |
| `sorries` | 0 | 0 across both files | ✓ |
| `status` / `badge` | axiomatized / axiom | axiom-bearing proof | ✓ |

Axioms detected:
- `Erdos5PrimeGaps.lean` — `westzynthius_large_gaps`, `zhang_bounded_gaps`, `hildebrand_maier_large_limit_points`
- `Erdos5Problem.lean` — `gaps_unbounded`

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts --issues` → 0 targets
- [x] `grep -c "^axiom " proofs/Proofs/Erdos5PrimeGaps.lean` → 3
- [x] `grep -c "^axiom " proofs/Proofs/Erdos5Problem.lean` → 1
- [x] `grep -c "\bsorry\b"` across both files → 0

Discovered during scheduled 20-minute auditor iteration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)