### PR TITLE
audit(arithmetic-series): clean — tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -514,9 +514,9 @@
       "result": "issues-fixed"
     },
     "arithmetic-series": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-10T06:47:42Z",
+      "lastAudited": "2026-06-10T07:16:40Z",
       "result": "clean"
     },
     "arithmetic-series-oq-00": {


### PR DESCRIPTION
## Summary

- Auditor verified `arithmetic-series` matches its Lean source.
- meta.json: `status: verified`, `badge: mathlib`, `sorries: 0`, `axiomCount: 0`.
- `proofs/Proofs/ArithmeticSeries.lean`: 0 axioms, 0 sorries, 0 True stubs.
- Tier B (Mathlib-backed via `Finset.sum_range_id`) correctly badged.
- `originalContributions` accurately scoped to derived corollaries.

## Test plan

- [x] `grep -c '^axiom '` → 0
- [x] `grep -c 'sorry'` → 0
- [x] True-stub scan → 0
- [x] Tracker entry recorded as clean.