### PR TITLE
fix(meta): erdos-1210 sync leanFile counts (178→246, 11→15)

### DIFF
--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -23,9 +23,9 @@
     "erdosProblemStatus": "open",
     "axiomCount": 1,
     "assumptions": "1 axiom: erdos_1210 (the main conjecture: primes maximize ∑ 1/(n-a) among pairwise coprime subsets of [1,n)). All 11 structural theorems are fully proved.",
-    "lineCount": 178,
+    "lineCount": 246,
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 3
   },
   "overview": {
@@ -110,9 +110,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos1210",
-    "lineCount": 178,
+    "lineCount": 246,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 15,
     "definitionCount": 3,
     "path": "Proofs/Erdos1210Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync stale leanFile.lineCount and leanFile.theoremCount for erdos-1210 to match current state of proofs/Proofs/Erdos1210Problem.lean.

## Evidence

Before (meta.json):
- meta.lineCount / leanFile.lineCount: 178
- meta.theoremCount / leanFile.theoremCount: 11

After (verified against source):
- lineCount: 246 (wc -l proofs/Proofs/Erdos1210Problem.lean)
- theoremCount: 15 (15 theorem/lemma declarations including 4 newly-added: primesBelow_five, primesBelow_five_sum, singleton_four_valid_at_five, erdos_1210_literal_counterexample)

No change to axiomCount (1), definitionCount (3), or sorries (0) -- those remain accurate.

---
Automated fix by lean-mechanic agent.