### PR TITLE
fix(meta): erdos-689 sync leanFile counts (179→240, 13→19)

### DIFF
--- a/src/data/proofs/erdos-689/meta.json
+++ b/src/data/proofs/erdos-689/meta.json
@@ -20,11 +20,11 @@
     "erdosUrl": "https://erdosproblems.com/689",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 179,
+    "lineCount": 240,
     "assumptions": "1 axiom: erdos_689_r_fold (OPEN conjecture, general r-fold covering). All other results derived: erdos_689_double_cover (r=2), green_variant_r10 (r=10), jacobsthal_connection (r=1 via Filter.eventually_atTop).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 13,
-    "definitionCount": 4
+    "theoremCount": 19,
+    "definitionCount": 3
   },
   "sections": [
     {
@@ -113,10 +113,10 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 179,
+    "lineCount": 240,
     "axiomCount": 1,
-    "theoremCount": 13,
-    "definitionCount": 4,
+    "theoremCount": 19,
+    "definitionCount": 3,
     "path": "Proofs/Erdos689Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Custom drift scan (canonical extractor in `scripts/research/enrich-research.ts:144`) found `src/data/proofs/erdos-689/meta.json` out of sync with `proofs/Proofs/Erdos689Problem.lean`:

| Field | Claimed | Actual | Δ |
|---|---:|---:|---:|
| `lineCount` | 179 | 240 | +61 |
| `theoremCount` | 13 | 19 | +6 |
| `definitionCount` | 4 | 3 | -1 |
| `axiomCount` | 1 | 1 | ✓ |
| `sorries` | 0 | 0 | ✓ |

Both the `meta` and `leanFile` substructures were updated to match the canonical line-prefix counter.

Status (`axiomatized`) and badge (`axiom`) remain correct — 1 axiom present (`erdos_689_r_fold`, the open r-fold covering conjecture), 0 sorries.

## Test plan
- [x] JSON validates (`node -e "JSON.parse(...)"`)
- [x] Counts match canonical extractor used by `scripts/research/enrich-research.ts`
- [x] Imports / opens / namespace unchanged (no other drift)

🤖 Generated with [Claude Code](https://claude.com/claude-code)