### PR TITLE
research(spherical-law-of-cosines-oq-05): S4 ACT — strict monotonicity + S2 build fixes (Docker-verified)

### DIFF
--- a/proofs/Proofs/SphericalLawOfCosinesOQ05.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ05.lean
@@ -324,7 +324,6 @@ theorem inner_projectPerp_eq_sin_sin_cos_angleC (t : SphericalTriangle) :
       simp only [SphericalTriangle.angleC, dif_neg h_not_deg]
     rw [h_angle_eq, Real.cos_arccos h_div_ge h_div_le, ← h_normA, ← h_normB]
     field_simp
-    ring
 
 /-- **Trigonometric form of the spherical law of cosines.** Combines the parent's
 `spherical_law_of_cosines_trig` (projection-inner-product form) with the bridge
@@ -568,8 +567,9 @@ theorem haversine_eq_zero_iff_of_mem_Icc {θ : ℝ}
     haversine θ = 0 ↔ θ = 0 := by
   have h0_mem : (0 : ℝ) ∈ Set.Icc (0 : ℝ) π :=
     ⟨le_refl 0, Real.pi_pos.le⟩
-  rw [show (0 : ℝ) = haversine 0 from haversine_zero.symm]
-  exact haversine_eq_haversine_iff_eq hθ h0_mem
+  have h := haversine_eq_haversine_iff_eq hθ h0_mem
+  rw [haversine_zero] at h
+  exact h
 
 /- ## Part X: Summary
 

--- a/proofs/Proofs/SphericalLawOfCosinesOQ05.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ05.lean
@@ -228,7 +228,7 @@ cross-term vanishes on both sides.
 
 This conversion is deferred to S2. -/
 
-/-- **Haversine formula for a spherical triangle.**
+/- **Haversine formula for a spherical triangle.**
 
 For any spherical triangle with sides `a := t.sideB`, `b := t.sideA`,
 `c := t.sideC` and dihedral angle `C := t.angleC` at vertex `t.C`,
@@ -281,10 +281,7 @@ theorem inner_projectPerp_eq_sin_sin_cos_angleC (t : SphericalTriangle) :
   · -- Degenerate branch: cos t.angleC = 1 (cos 0), but the cross-term sin·sin still
     -- vanishes because one of the sines is 0.
     have h_angle_zero : t.angleC = 0 := by
-      unfold SphericalTriangle.angleC
-      split_ifs with h
-      · rfl
-      · exact absurd h_deg h
+      simp only [SphericalTriangle.angleC, dif_pos h_deg]
     rw [h_angle_zero, Real.cos_zero, mul_one]
     rcases h_deg with hA0 | hB0
     · have h_zeroA : projectPerp t.A t.C = 0 := norm_eq_zero.mp hA0
@@ -317,17 +314,14 @@ theorem inner_projectPerp_eq_sin_sin_cos_angleC (t : SphericalTriangle) :
     have h_div_ge :
         -1 ≤ (@inner ℝ Vec3 _ (projectPerp t.A t.C) (projectPerp t.B t.C)) /
               (‖projectPerp t.A t.C‖ * ‖projectPerp t.B t.C‖) := by
-      rw [le_div_iff h_prod_pos]; linarith [h_cs'.1]
+      rw [le_div_iff₀ h_prod_pos]; linarith [h_cs'.1]
     -- Unfold t.angleC on the non-degenerate branch
     have h_not_deg : ¬ (‖projectPerp t.A t.C‖ = 0 ∨ ‖projectPerp t.B t.C‖ = 0) :=
-      fun h => h.elim hA_ne hB_ne
+      not_or.mpr ⟨hA_ne, hB_ne⟩
     have h_angle_eq : t.angleC = Real.arccos
         ((@inner ℝ Vec3 _ (projectPerp t.A t.C) (projectPerp t.B t.C)) /
          (‖projectPerp t.A t.C‖ * ‖projectPerp t.B t.C‖)) := by
-      unfold SphericalTriangle.angleC
-      split_ifs with h
-      · exact absurd h h_not_deg
-      · rfl
+      simp only [SphericalTriangle.angleC, dif_neg h_not_deg]
     rw [h_angle_eq, Real.cos_arccos h_div_ge h_div_le, ← h_normA, ← h_normB]
     field_simp
     ring
@@ -478,7 +472,106 @@ theorem sideC_eq_great_circle_haversine (t : SphericalTriangle) :
   rw [← haversine_formula t]
   exact sideC_eq_two_arcsin_sqrt_haversine t
 
-/- ## Part VIII: Summary
+/- ## Part IX: Strict monotonicity, injectivity, and navigation uniqueness (S4)
+
+The forward `haversine_formula` (S2) and inverse `eq_two_arcsin_sqrt_haversine`
+(S3) define a navigation pipeline that recovers the great-circle distance
+`c` from `(a, b, C)`. For this pipeline to be unambiguous, the haversine
+must be *injective* on the principal range `[0, π]` of arc-lengths -
+otherwise two different `c` values could produce the same haversine,
+and the inverse step would not be well-defined as a function.
+
+Injectivity follows from strict monotonicity, which in turn follows
+from `Real.strictAntiOn_cos` (strict antitonicity of `cos` on `[0, π]`)
+combined with the half-angle identity `haversine = (1 - cos)/2`.
+
+The downstream corollary `arcLength_eq_of_haversine_eq` lifts the
+injectivity from real arc-lengths to the parent gallery's arc-lengths
+between unit vectors, and `sideC_eq_of_haversine_sideC_eq` records the
+two-spherical-triangles statement: equal haversines for `sideC` imply
+equal `sideC`s. -/
+
+/-- **Strict monotonicity** of `haversine` on the principal range `[0, π]`.
+
+Follows from `Real.strictAntiOn_cos` (strict antitonicity of `cos` on `[0, π]`)
+plus the half-angle identity `haversine = (1 - cos)/2`. -/
+theorem haversine_strictMonoOn_Icc_zero_pi :
+    StrictMonoOn haversine (Set.Icc 0 π) := by
+  intro x hx y hy hxy
+  rw [haversine_eq_one_sub_cos_div_two x, haversine_eq_one_sub_cos_div_two y]
+  have h_cos_lt : Real.cos y < Real.cos x := Real.strictAntiOn_cos hx hy hxy
+  linarith
+
+/-- **Injectivity** of `haversine` on `[0, π]`. The recovery of the
+great-circle distance from its haversine is well-defined. -/
+theorem haversine_injOn_Icc_zero_pi :
+    Set.InjOn haversine (Set.Icc 0 π) :=
+  haversine_strictMonoOn_Icc_zero_pi.injOn
+
+/-- **Order characterisation**: on the principal range `[0, π]`,
+`hav x < hav y ↔ x < y`. -/
+theorem haversine_lt_haversine_iff_lt {x y : ℝ}
+    (hx : x ∈ Set.Icc (0 : ℝ) π) (hy : y ∈ Set.Icc (0 : ℝ) π) :
+    haversine x < haversine y ↔ x < y :=
+  haversine_strictMonoOn_Icc_zero_pi.lt_iff_lt hx hy
+
+/-- **Equality characterisation**: on the principal range `[0, π]`,
+`hav x = hav y ↔ x = y`. -/
+theorem haversine_eq_haversine_iff_eq {x y : ℝ}
+    (hx : x ∈ Set.Icc (0 : ℝ) π) (hy : y ∈ Set.Icc (0 : ℝ) π) :
+    haversine x = haversine y ↔ x = y :=
+  ⟨fun h => haversine_injOn_Icc_zero_pi hx hy h, fun h => by rw [h]⟩
+
+/-- **Generic arc-length injectivity via haversine.** For any four unit
+vectors, equal haversines of the arc-lengths imply equal arc-lengths.
+
+This lifts `haversine_injOn_Icc_zero_pi` from real numbers to the
+parent gallery's arc-lengths, using `arcLength_nonneg` and
+`arcLength_le_pi` to confirm membership in `[0, π]`. -/
+theorem arcLength_eq_of_haversine_eq
+    {u v u' v' : Vec3} (hu : IsUnitVec u) (hv : IsUnitVec v)
+    (hu' : IsUnitVec u') (hv' : IsUnitVec v')
+    (h : haversine (arcLength u v) = haversine (arcLength u' v')) :
+    arcLength u v = arcLength u' v' :=
+  haversine_injOn_Icc_zero_pi
+    ⟨arcLength_nonneg u v hu hv, arcLength_le_pi u v hu hv⟩
+    ⟨arcLength_nonneg u' v' hu' hv', arcLength_le_pi u' v' hu' hv'⟩
+    h
+
+/-- **Two-triangle navigation uniqueness.** If two spherical triangles
+have equal haversines for `sideC`, their `sideC`s are equal.
+
+Formalises the well-definedness of great-circle distance recovery: a
+given haversine value uniquely determines its arc-length on the sphere,
+so the inverse step in the navigation pipeline produces no ambiguity. -/
+theorem sideC_eq_of_haversine_sideC_eq (t₁ t₂ : SphericalTriangle)
+    (h : haversine t₁.sideC = haversine t₂.sideC) :
+    t₁.sideC = t₂.sideC :=
+  arcLength_eq_of_haversine_eq t₁.hA t₁.hB t₂.hA t₂.hB h
+
+/-- **Two-triangle uniqueness for sideA.** -/
+theorem sideA_eq_of_haversine_sideA_eq (t₁ t₂ : SphericalTriangle)
+    (h : haversine t₁.sideA = haversine t₂.sideA) :
+    t₁.sideA = t₂.sideA :=
+  arcLength_eq_of_haversine_eq t₁.hB t₁.hC t₂.hB t₂.hC h
+
+/-- **Two-triangle uniqueness for sideB.** -/
+theorem sideB_eq_of_haversine_sideB_eq (t₁ t₂ : SphericalTriangle)
+    (h : haversine t₁.sideB = haversine t₂.sideB) :
+    t₁.sideB = t₂.sideB :=
+  arcLength_eq_of_haversine_eq t₁.hA t₁.hC t₂.hA t₂.hC h
+
+/-- **Vanishing-haversine characterisation** on the principal range.
+On `[0, π]`, `hav θ = 0 ↔ θ = 0`. -/
+theorem haversine_eq_zero_iff_of_mem_Icc {θ : ℝ}
+    (hθ : θ ∈ Set.Icc (0 : ℝ) π) :
+    haversine θ = 0 ↔ θ = 0 := by
+  have h0_mem : (0 : ℝ) ∈ Set.Icc (0 : ℝ) π :=
+    ⟨le_refl 0, Real.pi_pos.le⟩
+  rw [show (0 : ℝ) = haversine 0 from haversine_zero.symm]
+  exact haversine_eq_haversine_iff_eq hθ h0_mem
+
+/- ## Part X: Summary
 
 | Result                                | Status   |
 |---------------------------------------|----------|
@@ -505,10 +598,19 @@ theorem sideC_eq_great_circle_haversine (t : SphericalTriangle) :
 | `sideA_eq_two_arcsin_sqrt_haversine`  | PROVED (S3) |
 | `sideB_eq_two_arcsin_sqrt_haversine`  | PROVED (S3) |
 | `sideC_eq_great_circle_haversine`     | PROVED (S3) |
+| `haversine_strictMonoOn_Icc_zero_pi`  | PROVED (S4) |
+| `haversine_injOn_Icc_zero_pi`         | PROVED (S4) |
+| `haversine_lt_haversine_iff_lt`       | PROVED (S4) |
+| `haversine_eq_haversine_iff_eq`       | PROVED (S4) |
+| `arcLength_eq_of_haversine_eq`        | PROVED (S4) |
+| `sideC_eq_of_haversine_sideC_eq`      | PROVED (S4) |
+| `sideA_eq_of_haversine_sideA_eq`      | PROVED (S4) |
+| `sideB_eq_of_haversine_sideB_eq`      | PROVED (S4) |
+| `haversine_eq_zero_iff_of_mem_Icc`    | PROVED (S4) |
 
 Axioms: 0
 Sorries: 0
-Proved theorems: 22
+Proved theorems: 31
 Definitions: 1
 -/
 

--- a/research/problems/spherical-law-of-cosines-oq-05/state.md
+++ b/research/problems/spherical-law-of-cosines-oq-05/state.md
@@ -1,9 +1,9 @@
 # Current State
 
-**Phase**: ACT (S3 complete; file extended, 0 sorries, 0 axioms)
-**Since**: 2026-06-03 (S3)
-**Iteration**: 3
-**Last Updated**: 2026-06-03 (researcher-1)
+**Phase**: ACT (S4 complete; file Docker-verified, 0 sorries, 0 axioms, 31 theorems)
+**Since**: 2026-06-10 (S4)
+**Iteration**: 4
+**Last Updated**: 2026-06-10 (researcher-1)
 
 ## Current Focus
 
@@ -34,8 +34,43 @@ unconditionally; record the `SphericalTriangle` version as the open
 
 ## Next Action
 
-S3 **CLOSED**. Added Part VII: inverse haversine formula and the great-circle
-distance navigation identity. File remains sorry-free and axiom-free.
+S4 **CLOSED**. Added Part IX: strict monotonicity, injectivity, and
+navigation uniqueness corollaries. Also fixed pre-existing S2 build issues
+that had silently blocked Docker verification (orphan docstring, split_ifs
+on let-wrapped if, le_div_iff → le_div_iff₀). File is now Docker-verified
+end-to-end for the first time at 31 theorems, 616 lines, 0 sorries, 0 axioms.
+
+S4 deliverables (researcher-1, 2026-06-10):
+
+1. **`haversine_strictMonoOn_Icc_zero_pi`** — `StrictMonoOn haversine
+   (Set.Icc 0 π)`. Proof: rewrite via half-angle identity, apply
+   `Real.strictAntiOn_cos`, close with `linarith`.
+2. **`haversine_injOn_Icc_zero_pi`** — direct corollary via
+   `StrictMonoOn.injOn`.
+3. **`haversine_lt_haversine_iff_lt`** / **`haversine_eq_haversine_iff_eq`**
+   — order/equality characterisations on the principal range via
+   `StrictMonoOn.lt_iff_lt` and the injectivity above.
+4. **`arcLength_eq_of_haversine_eq`** — generic lift to parent gallery's
+   `arcLength` for unit vectors; uses `arcLength_nonneg` and
+   `arcLength_le_pi` to establish `[0, π]`-membership automatically.
+5. **`sideA/B/C_eq_of_haversine_sideA/B/C_eq`** — three two-spherical-triangle
+   uniqueness corollaries; specialisations of (4) to the structure-field
+   sides. Formalises the navigation-pipeline well-definedness directly.
+6. **`haversine_eq_zero_iff_of_mem_Icc`** — vanishing characterisation;
+   useful for boundary-case analysis (zero-length sides).
+
+S4 build-fix deliverables (pre-existing S2 bugs, now resolved):
+
+* Lines 231-245 orphan `/-- ... -/` docstring → regular `/- ... -/` block
+  comment (had no attached declaration, broke parser).
+* Lines 285, 328 `unfold SphericalTriangle.angleC; split_ifs with h` →
+  `simp only [SphericalTriangle.angleC, dif_pos/dif_neg ...]` (split_ifs
+  cannot reach into the `let`-bound `if` in `angleC`'s definition).
+* Line 320 `le_div_iff` → `le_div_iff₀` (Mathlib v4.26 rename).
+* Line 322 `fun h => h.elim hA_ne hB_ne` → `not_or.mpr ⟨hA_ne, hB_ne⟩`
+  (cleaner construction of the `¬ (… ∨ …)` term).
+* Line 333 stray `ring` after `field_simp` removed (field_simp closes
+  the goal completely on this branch).
 
 S3 deliverables (researcher-1, 2026-06-03):
 
@@ -83,29 +118,38 @@ S2 deliverables (researcher-10, 2026-05-12):
    one-line `haversine_formula_algebraic` application with
    `cos_sideC_trig_form` supplying the hypothesis.
 
-S4+ candidates (after S3):
+S5+ candidates (after S4):
 
-* **Quantitative numerical-stability bound** (S4): explicit upper bound on
+* **Quantitative numerical-stability bound** (S5): explicit upper bound on
   the floating-point relative error of `2·arcsin(√·)` vs `arccos(...)` for
   `c → 0`, via `Real.cos` Taylor remainders. Closes the practical motivation
   for the haversine form with formal guarantees.
-* **Latitude/longitude entry point** (S5): define
+* **Latitude/longitude entry point** (S6): define
   `unitVectorOfLatLon : ℝ × ℝ → Vec3` and derive the standard GPS form
   `hav(c) = hav(Δlat) + cos(lat₁)·cos(lat₂)·hav(Δlon)` from the dihedral
   version proved here.
-* **Mathlib contribution** (S6): lift `haversine`, `haversine_formula_algebraic`,
-  `eq_two_arcsin_sqrt_haversine`, and the half-angle identity into
-  `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic`.
-* **Strict monotonicity** (S7): `haversine_strictMonoOn_Icc_zero_pi` would
-  give injectivity of the side-from-haversine recovery.
+* **Mathlib contribution** (S7): lift `haversine`, `haversine_formula_algebraic`,
+  `eq_two_arcsin_sqrt_haversine`, `haversine_strictMonoOn_Icc_zero_pi`, and
+  the half-angle identity into `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic`.
+* **Bijective inverse / Equiv** (S8): package the forward `haversine` and
+  inverse `2·arcsin(√·)` into a `Set.Icc 0 π ≃ Set.Icc 0 1` order
+  isomorphism, making the recovery routine usable as a typed inverse.
 
 ## Attempt Counts
 
-- Total attempts: 3
-- Current approach attempts: 1 (S3 — inverse formula via arcsin)
-- Approaches tried: 3 (S1 split + S2 bridge + S3 inverse)
+- Total attempts: 4
+- Current approach attempts: 1 (S4 — strict monotonicity via Real.strictAntiOn_cos)
+- Approaches tried: 4 (S1 split + S2 bridge + S3 inverse + S4 strict-mono/injOn)
 
 ## Build Status
+
+S4 build: **DOCKER-VERIFIED** (researcher-1, 2026-06-10). Full file
+`Proofs.SphericalLawOfCosinesOQ05` builds successfully in the
+official Docker harness (3059/3059 jobs, 32s compile time after
+Mathlib cache hydrated). This is the first successful Docker build
+of this file — S2 and S3 were marked PROVED but had silent compile
+failures from the orphan docstring, split_ifs, and le_div_iff issues
+listed above.
 
 S3 build: **PENDING**. Worktree's `proofs/.lake` is the recursive
 self-symlink case (confirmed `readlink` shows self-loop); CI is ground truth.
@@ -131,7 +175,7 @@ S1 risk profile:
 
 ## Blockers
 
-None. File is sorry-free and axiom-free after S3.
+None. File is sorry-free, axiom-free, AND Docker-verified after S4.
 
 ## Session log
 
@@ -171,3 +215,29 @@ None. File is sorry-free and axiom-free after S3.
   section; updated conclusion + openQuestions. New annotation
   `ann-inverse-haversine-s3` added. `proofs/Proofs.lean` unchanged
   (import already in place since S1).
+
+* **S4 (researcher-1, 2026-06-10)**: added Part IX — strict monotonicity,
+  injectivity, and navigation uniqueness. Nine new theorems:
+  - `haversine_strictMonoOn_Icc_zero_pi` (StrictMonoOn via Real.strictAntiOn_cos).
+  - `haversine_injOn_Icc_zero_pi` (InjOn corollary).
+  - `haversine_lt_haversine_iff_lt` / `haversine_eq_haversine_iff_eq`
+    (order/equality characterisations on [0, π]).
+  - `arcLength_eq_of_haversine_eq` (generic lift to parent gallery's
+    arcLength for unit vectors).
+  - `sideA/B/C_eq_of_haversine_sideA/B/C_eq` (two-spherical-triangle
+    uniqueness corollaries).
+  - `haversine_eq_zero_iff_of_mem_Icc` (vanishing characterisation).
+
+  Also fixed pre-existing S2 build issues that had silently blocked
+  Docker verification: orphan docstring (line 231), split_ifs on
+  let-wrapped if (lines 285, 328), le_div_iff → le_div_iff₀ (line 320),
+  stray ring after field_simp (line 333), `fun h => h.elim` →
+  `not_or.mpr` (line 322).
+
+  Final state: 616 lines, 31 theorems, 1 definition, 0 sorries,
+  0 axioms, Docker-verified (3059/3059 jobs, 32s compile). Gallery
+  `meta.json` updated: `theoremCount` 22→31, `lineCount` 515→616;
+  added Part IX section + post-S4 summary section; updated conclusion
+  + openQuestions (S4 strict-mono dropped from open list since now
+  closed; added S8 Bijective inverse / Equiv candidate).
+  `proofs/Proofs.lean` unchanged.

--- a/src/data/proofs/spherical-law-of-cosines-oq-05/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-05/meta.json
@@ -22,12 +22,12 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Haversine_formula",
     "dateAdded": "2026-05-12",
     "axiomCount": 0,
-    "lineCount": 515,
-    "assumptions": "None. All 22 theorems proved (0 sorries, 0 axioms). S2 (researcher-10, 2026-05-12) closed the S1 sorry on haversine_formula via the bridge lemma inner_projectPerp_eq_sin_sin_cos_angleC, which converts the parent's projection-inner-product form of the spherical law of cosines into the trigonometric sin(a)·sin(b)·cos(angleC) form. S3 (researcher-1, 2026-06-03) added the inverse haversine formula sideC = 2·arcsin(√(haversine sideC)) (general form for θ ∈ [0, π] plus SphericalTriangle specialisations for sideA, sideB, sideC) and the great-circle distance corollary sideC_eq_great_circle_haversine combining the forward and inverse formulas into the canonical navigation identity.",
+    "lineCount": 616,
+    "assumptions": "None. All 31 theorems proved (0 sorries, 0 axioms). S2 (researcher-10, 2026-05-12) closed the S1 sorry on haversine_formula via the bridge lemma inner_projectPerp_eq_sin_sin_cos_angleC, which converts the parent's projection-inner-product form of the spherical law of cosines into the trigonometric sin(a)·sin(b)·cos(angleC) form. S3 (researcher-1, 2026-06-03) added the inverse haversine formula sideC = 2·arcsin(√(haversine sideC)) (general form for θ ∈ [0, π] plus SphericalTriangle specialisations for sideA, sideB, sideC) and the great-circle distance corollary sideC_eq_great_circle_haversine combining the forward and inverse formulas into the canonical navigation identity. S4 (researcher-1, 2026-06-10) added strict monotonicity haversine_strictMonoOn_Icc_zero_pi (via Real.strictAntiOn_cos), the InjOn corollary haversine_injOn_Icc_zero_pi, order/equality characterisations on [0,π], the generic-Vec3 corollary arcLength_eq_of_haversine_eq, and two-triangle uniqueness statements sideA/B/C_eq_of_haversine_sideA/B/C_eq formalising the well-definedness of great-circle distance recovery. Also fixed pre-existing S2 build issues (orphan docstring, split_ifs on let-wrapped if, le_div_iff → le_div_iff₀): file is now Docker-verified end-to-end for the first time.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 22,
+    "theoremCount": 31,
     "definitionCount": 1,
-    "substantiveTheoremCount": 22
+    "substantiveTheoremCount": 31
   },
   "sections": [
     {
@@ -95,12 +95,20 @@
       "mathContext": "The inverse uses two facts: (1) `sin(θ/2) ≥ 0` on `[0, π/2]`, so `√(sin²(θ/2)) = sin(θ/2)`; (2) `arcsin(sin x) = x` on `[-π/2, π/2]`, and `θ/2 ∈ [0, π/2] ⊆ [-π/2, π/2]` when `θ ∈ [0, π]`. Both branches use only standard Mathlib API (`Real.sin_nonneg_of_nonneg_of_le_pi`, `Real.sqrt_sq`, `Real.arcsin_sin`). The great-circle distance corollary closes the navigation pipeline: given latitudes/longitude-difference, the haversine of the great-circle distance can be computed without going through `arccos` near 1, and the inverse `arcsin(√·)` is well-conditioned because `arcsin` near 0 is well-behaved."
     },
     {
-      "id": "summary-final",
-      "title": "Part VIII: Summary (post-S3)",
+      "id": "strict-mono-injOn",
+      "title": "Part IX: Strict monotonicity, injectivity, and navigation uniqueness (S4)",
       "startLine": 481,
-      "endLine": 514,
-      "summary": "Tabular summary of the file's contents after S3: 22 proved theorems, 0 axioms, 0 sorries, 1 definition, 515 lines.",
-      "mathContext": "Status accounting: this file is `verified` with badge `original`. The S1 algebraic identity, S2 SphericalTriangle bridge, and S3 inverse-formula/navigation corollary together form a complete formalisation of the haversine identity loop."
+      "endLine": 580,
+      "summary": "Establishes strict monotonicity of `haversine` on the principal arc-length range `[0, π]` via `Real.strictAntiOn_cos`, deduces injectivity as a corollary, and records the resulting two-triangle uniqueness statements. Nine new theorems: `haversine_strictMonoOn_Icc_zero_pi`, `haversine_injOn_Icc_zero_pi`, `haversine_lt_haversine_iff_lt`, `haversine_eq_haversine_iff_eq`, the generic-Vec3 corollary `arcLength_eq_of_haversine_eq` (lifting injectivity from real numbers to parent-gallery arc-lengths), the three `sideA/B/C_eq_of_haversine_sideA/B/C_eq` uniqueness statements, and the vanishing characterisation `haversine_eq_zero_iff_of_mem_Icc`.",
+      "mathContext": "Strict monotonicity formalises the navigation pipeline's well-definedness: the forward `haversine_formula` (S2) plus the inverse `eq_two_arcsin_sqrt_haversine` (S3) compute a great-circle distance, and injectivity confirms this distance is uniquely recoverable from its haversine. Mathematically: $\\text{hav}(\\theta) = (1 - \\cos\\theta)/2$, and `cos` is strictly antitone on $[0, \\pi]$, so `haversine` is strictly monotone there. The corollary `arcLength_eq_of_haversine_eq` makes the injectivity directly applicable to arc-lengths between unit vectors, which always lie in $[0, \\pi]$ by `arcLength_nonneg`/`arcLength_le_pi` from the parent file."
+    },
+    {
+      "id": "summary-final",
+      "title": "Part X: Summary (post-S4)",
+      "startLine": 581,
+      "endLine": 615,
+      "summary": "Tabular summary of the file's contents after S4: 31 proved theorems, 0 axioms, 0 sorries, 1 definition, 616 lines.",
+      "mathContext": "Status accounting: this file is `verified` with badge `original`. The S1 algebraic identity, S2 SphericalTriangle bridge, S3 inverse-formula/navigation corollary, and S4 strict-monotonicity/injectivity together form a complete formalisation of the haversine identity loop with full navigation-pipeline well-definedness guarantees."
     }
   ],
   "overview": {
@@ -123,13 +131,12 @@
     ]
   },
   "conclusion": {
-    "summary": "Complete after S3: the forward haversine formula `hav(c) = hav(a−b) + sin(a)·sin(b)·hav(C)` is proved both as an algebraic identity (S1) and for a `SphericalTriangle` (S2 bridge); the inverse `c = 2·arcsin(√(hav c))` is proved on the principal arc-length range `[0, π]` (S3); and the navigation identity `c = 2·arcsin(√(hav(a−b) + sin·sin·hav(C)))` is the composed corollary. 22 theorems, 0 sorries, 0 axioms.",
-    "implications": "The haversine form is the only stable way to compute small great-circle distances in floating-point: at 1 km on Earth's surface ($R \\approx 6371$ km), the standard SLC argument $\\cos a \\cos b + \\sin a \\sin b \\cos C$ differs from 1 by $\\sim 10^{-8}$ — below the resolution of `Real.arccos` near 1 — while $\\text{hav}(c) = \\sin^2(c/2)$ stays well-conditioned because $\\sin^2$ vanishes quadratically rather than $\\cos$ saturating. Formalising the algebraic equivalence (S1's `haversine_formula_algebraic` + `cos_form_of_haversine_formula`) means any Mathlib-formalised algorithm built on the cosine form can be refactored into the haversine form without re-proving correctness. With S3's inverse formula closing the pipeline (`sideC_eq_great_circle_haversine`), the file is now self-contained: a verified end-to-end great-circle distance routine can be written against this file's API without ever calling `Real.arccos`. Methodologically, the file demonstrates a clean three-stage pattern: (S1) algebraic identity (no geometry), (S2) project geometry-to-trigonometry bridge, (S3) numerically stable inverse — isolating the analytic, geometric, and computational content into separate sessions for independent review.",
+    "summary": "Complete after S4: the forward haversine formula `hav(c) = hav(a−b) + sin(a)·sin(b)·hav(C)` is proved both as an algebraic identity (S1) and for a `SphericalTriangle` (S2 bridge); the inverse `c = 2·arcsin(√(hav c))` is proved on the principal arc-length range `[0, π]` (S3); the composed corollary `sideC_eq_great_circle_haversine` is the canonical navigation identity (S3); and strict monotonicity / injectivity of `haversine` on `[0, π]` (S4) formalises the well-definedness of the inverse step. 31 theorems, 0 sorries, 0 axioms. File is now Docker-verified end-to-end — S4 also fixed pre-existing S2 build issues (orphan docstring, split_ifs on let-wrapped if, le_div_iff → le_div_iff₀) that had silently blocked CI verification.",
+    "implications": "The haversine form is the only stable way to compute small great-circle distances in floating-point: at 1 km on Earth's surface ($R \\approx 6371$ km), the standard SLC argument $\\cos a \\cos b + \\sin a \\sin b \\cos C$ differs from 1 by $\\sim 10^{-8}$ — below the resolution of `Real.arccos` near 1 — while $\\text{hav}(c) = \\sin^2(c/2)$ stays well-conditioned because $\\sin^2$ vanishes quadratically rather than $\\cos$ saturating. Formalising the algebraic equivalence (S1's `haversine_formula_algebraic` + `cos_form_of_haversine_formula`) means any Mathlib-formalised algorithm built on the cosine form can be refactored into the haversine form without re-proving correctness. With S3's inverse formula closing the pipeline (`sideC_eq_great_circle_haversine`) and S4's injectivity confirming uniqueness, the file is now self-contained: a verified end-to-end great-circle distance routine can be written against this file's API without ever calling `Real.arccos`, with formal guarantees that the recovered distance is the unique value matching its haversine. Methodologically, the file demonstrates a clean four-stage pattern: (S1) algebraic identity (no geometry), (S2) project geometry-to-trigonometry bridge, (S3) numerically stable inverse, (S4) injectivity + well-definedness — isolating the analytic, geometric, computational, and order-theoretic content into separate sessions for independent review.",
     "openQuestions": [
-      "Lift `haversine`, `haversine_formula_algebraic`, `eq_two_arcsin_sqrt_haversine` to `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic` as a potential upstream contribution (no `Real.haversine` exists at v4.26.0).",
+      "Lift `haversine`, `haversine_formula_algebraic`, `eq_two_arcsin_sqrt_haversine`, `haversine_strictMonoOn_Icc_zero_pi` to `Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic` as a potential upstream contribution (no `Real.haversine` exists at v4.26.0).",
       "Quantify the numerical-stability claim: prove an explicit upper bound on the floating-point relative error of `2·arcsin(√(hav(c)))` vs `arccos(...)` for `c → 0`, with the catastrophic-cancellation analysis made rigorous via `Real.cos` Taylor remainder bounds.",
       "Connect to the spherical law of sines (companion gallery entry `spherical-law-of-sines`) for a unified spherical trigonometry library — derive a haversine analogue of `sin a / sin A = sin b / sin B = sin c / sin C`.",
-      "Strict monotonicity of `haversine` on `[0, π]`: prove `haversine_strictMonoOn_Icc_zero_pi`, which would give injectivity of the side-from-haversine recovery (currently expressed as an equality `sideC = 2·arcsin(√(hav sideC))` only, without explicit injectivity).",
       "Latitude/longitude entry point: define `unitVectorOfLatLon : ℝ × ℝ → Vec3` and prove the standard `hav(c) = hav(Δlat) + cos(lat₁)·cos(lat₂)·hav(Δlon)` form from the dihedral version proved here; would make the GPS-distance application directly usable.",
       "Can the half-angle pattern be packaged as a general Mathlib lemma `numerically_stable_form_of_cos_identity` that, given any identity $\\cos f = g$, produces $\\text{hav}\\,f = (1-g)/2$ automatically?"
     ]


### PR DESCRIPTION
## Summary

**S4 ACT** for `spherical-law-of-cosines-oq-05` (the haversine formula). Adds **Part IX**: strict monotonicity, injectivity, and two-spherical-triangle navigation uniqueness — formalising the well-definedness of great-circle distance recovery in the haversine navigation pipeline (forward `haversine_formula` from S2 → inverse `eq_two_arcsin_sqrt_haversine` from S3).

**Bonus: first end-to-end Docker verification.** While developing S4 I discovered the file had silent build failures dating back to S2 — never caught because S2/S3 sessions ran in worktrees with broken `proofs/.lake` symlinks. This PR fixes those bugs along with adding S4, so the file is Docker-verified for the first time (3059/3059 jobs, 32s compile after Mathlib cache hydration).

## Changes

### S4 additions (Part IX, 9 new theorems)
- `haversine_strictMonoOn_Icc_zero_pi : StrictMonoOn haversine (Set.Icc 0 π)` — proof: rewrite via half-angle identity, apply `Real.strictAntiOn_cos`, close with `linarith`.
- `haversine_injOn_Icc_zero_pi : Set.InjOn haversine (Set.Icc 0 π)` — direct corollary via `StrictMonoOn.injOn`.
- `haversine_lt_haversine_iff_lt` / `haversine_eq_haversine_iff_eq` — order/equality characterisations on the principal range.
- `arcLength_eq_of_haversine_eq` — generic lift of injectivity to parent gallery's `arcLength` between unit vectors.
- `sideA/B/C_eq_of_haversine_sideA/B/C_eq` — three two-spherical-triangle uniqueness corollaries; specialisations to structure fields.
- `haversine_eq_zero_iff_of_mem_Icc` — vanishing characterisation; useful for zero-length sides.

### S2 build fixes (pre-existing, never CI-verified)
- **Orphan docstring** at line 231 — `/-- ... -/` with no attached declaration → `/- ... -/` block comment.
- **`split_ifs` on let-wrapped `if`** at lines 285, 328 — `SphericalTriangle.angleC` uses `let projA := ...` bindings, so raw `unfold + split_ifs` fails. Replaced with the standard `simp only [SphericalTriangle.angleC, dif_pos/dif_neg ...]` pattern used in `LawOfCosinesOQ01OQ01.lean:162`.
- **Mathlib rename** at line 320: `le_div_iff` → `le_div_iff₀`.
- **Stray `ring`** at line 333: `field_simp` already closes the goal on the non-degenerate branch.
- **Cleaner `not_or`** at line 322: `fun h => h.elim hA_ne hB_ne` → `not_or.mpr ⟨hA_ne, hB_ne⟩`.

### Gallery/state metadata
- `meta.json`: theoremCount 22→31, lineCount 515→616, new Part IX section, updated Part X summary, updated conclusion + openQuestions (S4 strict-mono removed from open list).
- `research/problems/spherical-law-of-cosines-oq-05/state.md`: iteration 3→4, Build Status DOCKER-VERIFIED, session log entry for S4, S5+ candidates list.

## File-level state

| | Before S4 | After S4 |
|---|---|---|
| Lines | 515 (claimed) | 616 (verified) |
| Theorems | 22 (claimed) | 31 (verified) |
| Definitions | 1 | 1 |
| Sorries | 0 | 0 |
| Axioms | 0 | 0 |
| Docker build | silently broken | **PASSING** |

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.SphericalLawOfCosinesOQ05` → exit 0, 3059/3059 jobs, 32s
- [x] No new imports
- [x] No new structures or typeclasses
- [x] All S4 theorems use standard Mathlib v4.26.0 API (`Real.strictAntiOn_cos`, `StrictMonoOn.injOn`, `StrictMonoOn.lt_iff_lt`, `not_or.mpr`, `dif_pos`/`dif_neg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)