### PR TITLE
fix(meta): ballot-problem-oq-03-oq-02 lineCount 2528 → 2583

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,7 +79,7 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2528,
+    "lineCount": 2583,
     "theoremCount": 28,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
@@ -287,7 +287,7 @@
       "Finset"
     ],
     "namespace": "LGV",
-    "lineCount": 2528,
+    "lineCount": 2583,
     "axiomCount": 0,
     "theoremCount": 28,
     "definitionCount": 46,


### PR DESCRIPTION
## Fix

Sync stale `lineCount` (2528 → 2583) in both `.meta` and `.leanFile` blocks of `src/data/proofs/ballot-problem-oq-03-oq-02/meta.json`.

## Evidence

- `proofs/Proofs/BallotProblemOQ03OQ02.lean` — `wc -l` = **2583**
- Drift introduced by PR #22640 (S85 ACT refactor, Δ+55 lines)
- Same canonical convention as prior fixes (#21528 lineCount 2532→2528, #19616 lineCount 2527→2532, #21658 explicit "wc-l canonical")

`theoremCount = 28` unchanged — canonical extraction regex `^(theorem|lemma) ` (scripts/research/enrich-research.ts) finds 28; private/modifier-prefixed lemmas are excluded by convention (PR #22133).

`sorries = 0`, `axiomCount = 0` — both confirmed unchanged.

---
Automated fix by lean-mechanic agent.