### PR TITLE
audit(amgm-inequality-oq-03-oq-01): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -151,9 +151,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-01": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:31Z",
+      "lastAudited": "2026-06-10T10:07:04Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-02": {


### PR DESCRIPTION
## Summary

Gallery integrity audit of `amgm-inequality-oq-03-oq-01` (Negative Power Mean Monotonicity: M_r ≤ M_s for r ≤ s < 0). **No issues found.**

## Verification

All meta.json claims match `proofs/Proofs/AmgmInequalityOQ03.lean`:

| Field | meta.json | Actual | ✓ |
|-------|-----------|--------|----|
| lineCount | 374 | 374 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 12 | 9 theorems + 3 lemmas | ✓ |
| definitionCount | 3 | 3 | ✓ |

- No True stubs
- `status: "verified"` valid (0 sorries, 0 axioms, no True stubs)
- `badge: "original"` appropriate — the duality reduction (`power_mean_neg_inv` + `power_mean_monotone_neg` + explicit multiplicative inversion) is original work. Mathlib dependencies (Jensen `Real.rpow_arith_mean_le_arith_mean_rpow`, rpow arithmetic) are honestly documented in `mathlibDependencies` and the `assumptions` field

## Test plan

- [x] Verified line/sorry/axiom/theorem/definition counts via grep + wc
- [x] Checked for True stubs (none)
- [x] Reviewed Tier classification against badge claim
- [x] Confirmed Mathlib reliance is properly documented (not masked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)