### PR TITLE
audit(amgm-inequality-oq-03): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -145,9 +145,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:31Z",
+      "lastAudited": "2026-06-10T10:12:21Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-01": {


### PR DESCRIPTION
## Summary

Verified meta.json claims match the Lean source for the Power Mean Interpolation entry (parent of the negative-monotonicity sub-entry cleared in #22776).

## Integrity checks

| Field | meta.json | Lean file | Match |
|---|---|---|---|
| lineCount | 374 | 374 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 axioms + 0 structure-encoded assumptions | ✓ |
| theoremCount | 12 | 7 theorems + 5 lemmas (incl. 2 private) | ✓ |
| definitionCount | 3 | 3 noncomputable defs | ✓ |
| True stubs | (none claimed) | 0 | ✓ |

## Badge & status

- status `"verified"` valid (0 sorries, 0 axioms, no `True` stubs).
- badge `"original"` appropriate. Mathlib building blocks (`geom_mean_le_arith_mean_weighted`, `arith_mean_le_rpow_mean`, `rpow_arith_mean_le_arith_mean_rpow`, `mul_rpow`) are honestly disclosed in the description, `assumptions` field, and `mathlibDependencies` list. The originalContributions — HM ≤ GM via AM-GM on inverses, the duality identity $M_r(z) = M_{-r}(z^{-1})^{-1}$, and negative-exponent monotonicity via duality — are the synthesis on top of Mathlib infrastructure. Consistent with the "original" badge already accepted on the OQ-01 sub-entry in #22776.

Discovered during gallery integrity audit cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)