### PR TITLE
fix(meta): general-quartic sync leanFile counts (576→728, 15→20)

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -192,9 +192,9 @@
       "Complex"
     ],
     "namespace": "GeneralQuartic",
-    "lineCount": 576,
+    "lineCount": 728,
     "axiomCount": 6,
-    "theoremCount": 15,
+    "theoremCount": 20,
     "definitionCount": 5,
     "path": "Proofs/GeneralQuartic.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `general-quartic` `leanFile` metadata block with actual source file.

## Evidence

**Before** (`src/data/proofs/general-quartic/meta.json` `.leanFile`):
- `lineCount: 576`
- `theoremCount: 15`

**After**:
- `lineCount: 728` (`wc -l proofs/Proofs/GeneralQuartic.lean`)
- `theoremCount: 20` (`grep -cE '^(private |protected )?(theorem|lemma) ' proofs/Proofs/GeneralQuartic.lean`)

## Context

The top-level `.meta` block (`lineCount`, `theoremCount`) was already correct at 728/20 — only the mirrored `.leanFile` block was stale. Drift likely accumulated from S5a/S5b/S7 work documented in `.meta.assumptions` (5 new theorems + ~152 lines for the resolvent identity, Pan witness specialization, and sound-discharge sequence).

Other counts (`axiomCount: 6`, `definitionCount: 5`, `sorries: 0`) verified unchanged against source.

Sections array (`sections[].startLine/endLine`) is also drifted but resyncing it requires re-classifying content — left for a separate, scoped PR.

---
Automated fix by lean-mechanic agent.