### PR TITLE
audit(cayley-hamilton-minpoly): clean — tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1741,9 +1741,9 @@
       "result": "clean"
     },
     "cayley-hamilton-minpoly": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:33Z",
+      "lastAudited": "2026-06-10T10:23:29Z",
       "result": "clean"
     },
     "cayley-hamilton-minpoly-oq-01": {


### PR DESCRIPTION
## Summary
4th audit pass on cayley-hamilton-minpoly. All meta.json fields match source.

## Verification
- `lineCount: 447` matches `wc -l Proofs/CayleyHamiltonOQ01.lean`
- `theoremCount: 30` matches `grep -cE "^(theorem|lemma) "`
- `axiomCount: 0` no `^axiom ` declarations
- `sorries: 0` no `sorry` in source
- `definitionCount: 0` no `^def ` declarations
- No structure-encoded assumptions
- No `: True` stub theorems
- `additionalFile` CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean: 0 axioms, 0 sorries
- Status `verified` + badge `mathlib` consistent with 0 sorries + 0 axioms

## Test plan
- [x] Tracker bumped (`auditCount: 3 to 4`, `lastAudited` updated)
- [x] Result: `clean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)