### PR TITLE
fix(meta): cantor-diag-oq01oq02 sync leanFile counts (306→361, 14→19)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json
@@ -162,9 +162,9 @@
       "ContinuumHypothesis"
     ],
     "namespace": "CantorDiagOQ01OQ02",
-    "lineCount": 306,
+    "lineCount": 361,
     "axiomCount": 7,
-    "theoremCount": 14,
+    "theoremCount": 19,
     "definitionCount": 10,
     "path": "Proofs/CantorDiagonalizationOQ01OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync drifted `leanFile.lineCount` and `leanFile.theoremCount` in `src/data/proofs/cantor-diagonalization-oq-01-oq-02/meta.json` to match the actual `proofs/Proofs/CantorDiagonalizationOQ01OQ02.lean` source.

## Evidence

| Field         | Was | Now | Source |
|---------------|----:|----:|--------|
| lineCount     | 306 | 361 | wc -l → 361 |
| theoremCount  | 14  | 19  | grep '^(theorem|lemma) ' → 19 |
| axiomCount    | 7   | 7   | unchanged (already correct) |
| definitionCount | 10 | 10 | unchanged (already correct) |
| sorries       | 0   | 0   | unchanged (already correct) |

The top-level meta block in this file was already in sync (lineCount 361, theoremCount 19); the drift was confined to the duplicate leanFile block at the bottom. Pure positive-delta sync — no semantic claims affected.

## Detection

Drift scan against the canonical counter at scripts/research/enrich-research.ts:144, adjusted to use wc -l line convention (gallery convention, not split('\n').length).

---
Automated fix by lean-mechanic agent (cycle v188).