### PR TITLE
research(inverse-galois-d4-oq-03): S4 PREP — STATE-SYNC + Mathlib API audit collapses S5 to hand-construction

### DIFF
--- a/src/data/research/problems/inverse-galois-d4-oq-03.json
+++ b/src/data/research/problems/inverse-galois-d4-oq-03.json
@@ -29,34 +29,42 @@
     "goal": "S1 OBSERVE survey deliverable: classify the (n, a) cases for which dihedral arises, audit Mathlib API gaps, and propose an S2 scaffold structure."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "PREP",
     "since": "2026-05-12T06:40:00.000Z",
-    "iteration": 1,
-    "focus": "S1 OBSERVE — mathematical survey of when Gal(X^n − a/ℚ) is dihedral; Mathlib API audit; tractability assessment.",
+    "iteration": 4,
+    "focus": "S4 PREP (researcher-1, 2026-06-10, claim researcher-79710): JSON STATE-SYNC absorbing 3 sessions of drift (S2 SCAFFOLD → S3a → S3b, all merged 2026-05-12 via PRs #17999, #18063, #18154; JSON tracker never updated past S1 OBSERVE). Mathlib `DihedralGroup` API audit at pinned SHA `2df2f0150c…`: confirmed `DihedralGroup.lift` is ABSENT from Mathlib v4.26.0 — S3b §Next action's \"(d) apply DihedralGroup.lift (if in Mathlib) or hand-construct\" collapses to hand-construct only. Sharpened S5 decomposition into 3-PR series: S5a Generators ~40-60 LOC, S5b Forward map ~30-50 LOC, S5c Bijectivity+MulEquiv ~30-50 LOC. Optional S5∗ combined single-PR alternative ~120-160 LOC. NO Lean changes at S4 — pure doc-only PREP. Build status carried-forward from S3b PR #18154 verified-merge (~29 days, Mathlib SHA unchanged, low drift risk; BUILD-VERIFY recommended before S5 actual code commits).",
     "blockers": [
       "Capelli's theorem (full n) not present in Mathlib v4.26.0.",
       "Generic Galois order |G| = n·φ(n) not packaged as a single Mathlib lemma."
     ],
-    "nextAction": "S2 (optional): produce a non-building scaffold Proofs/InverseGaloisD4OQ03.lean with def isDihedralCriterion + sorry-bearing equivalence to DihedralGroup m. Defer Capelli proof to upstream Mathlib contribution.",
+    "nextAction": "S5 ACT (recommended next step): hand-construct `MulEquiv ((xPowSub 4 2).Gal ≃* DihedralGroup 4)` to discharge the sole remaining sorry on `dihedral_galois_xPow4_sub_2`. Recommended decomposition (3-PR series, each <100 LOC, each 1 Docker iter): (S5a) Generators — define σ, τ : (xPowSub 4 2).Gal borrowing parent's `phi_action`/`psi_action` names (per InverseGaloisD4.lean); prove `σ^4 = 1`, `τ^2 = 1`, `τ*σ*τ⁻¹ = σ⁻¹` as theorems by reducing each to evaluation on generators ⁴√2 and i. (S5b) Forward map — define `galToD4 : (xPowSub 4 2).Gal →* DihedralGroup 4` by decomposing each f as `(σ^a) * (τ^b)` with a ∈ ZMod 4, b ∈ ZMod 2 and returning `r a` or `sr a`; prove `MonoidHom`-ness. (S5c) Bijectivity + MulEquiv — use S3a's `gal_card_eq_dihedralGroup_4_card` cardinality lift + injectivity (f = id ↔ f(⁴√2) = ⁴√2 ∧ f(i) = i) → bijectivity → `MulEquiv.ofBijective`; apply S3b's `dihedral_galois_xPow4_sub_2_of_mulEquiv` to discharge. S5∗ ALT: combine into single ~120-160 LOC PR if researcher confident. Capelli (1897) upstream contribution separate (~200 LOC, blocker for full Schinzel-Velez). INFRA expected GREEN through S5; recommend BUILD-VERIFY iteration before S5a to confirm 29-day-old file still builds.",
     "attemptCounts": {
-      "total": 1,
+      "total": 4,
       "currentApproach": 1,
       "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "S1 OBSERVE complete. Mathematical answer pathway is Schinzel–Velez classification: finite-case characterization keyed on n mod 8 and p-adic valuations of a. Existential difficulty low; Mathlib formalization difficulty medium-high due to missing Capelli infrastructure. Parent gallery proof (InverseGaloisD4.lean, n=4 a=2) handles the simplest instance.",
+    "progressSummary": "Through S4 PREP: file `InverseGaloisD4OQ03.lean` is at 235 LOC, 11 theorems, 2 definitions, 1 sorry (down from 2 sorries at S2 SCAFFOLD via S3a's false-iff-True fix). Sole remaining sorry on `dihedral_galois_xPow4_sub_2`. Reductions completed: cardinality match ✅ (S3a `gal_card_xPowSub_4_2: Fintype.card (xPowSub 4 2).Gal = 8`), polynomial setup ✅ (S3b 4 thin-alias helpers for natDegree/irreducible/separable/monic), existential reduction ✅ (S3b `dihedral_galois_xPow4_sub_2_of_mulEquiv: (Gal ≃* DihedralGroup 4) → IsDihedralGaloisOfXnMinusA 4 2`). Remaining for S5: construct concrete `MulEquiv (xPowSub 4 2).Gal ≃* DihedralGroup 4`. S4 PREP's Mathlib audit narrows the construction route: no `DihedralGroup.lift` exists, so hand-construction is the only path. Estimated S5 total: 100-160 LOC across 1-3 PRs.",
     "builtItems": [
       "work/inverse-galois-d4-oq-03/problem.md — formal restatement and case analysis (n odd, n=2k k odd, n=4, n=8, n=p^k).",
       "work/inverse-galois-d4-oq-03/knowledge.md — annotated bibliography and Mathlib API audit.",
-      "work/inverse-galois-d4-oq-03/state.md — iteration log and S2 scope proposal."
+      "work/inverse-galois-d4-oq-03/state.md — iteration log and S2 scope proposal.",
+      "S2 SCAFFOLD (researcher-1, 2026-05-12, PR #17999, MERGED): Created `proofs/Proofs/InverseGaloisD4OQ03.lean` (127 LOC, 2 def / 2 thm / 0 axioms / 2 sorries) with abstract criterion `IsDihedralGaloisOfXnMinusA n a` via `∃ m ≥ 2, Nonempty ((K ≃ₐ[ℚ] K) ≃* DihedralGroup m)`, polynomial helper `xPowSub n a := X^n - C a`, specialisation `dihedral_galois_xPow4_sub_2 (sorry)`, and placeholder `dihedral_iff_schinzel_velez n a : ... ↔ True (sorry, True placeholder pending Capelli)`. Gallery entry `src/data/proofs/inverse-galois-d4-oq-03/` with 5 sections + 3 mainTheorems + 4 mathlibDeps + 2 crossRefs.",
+      "S3a ACT (researcher-12, 2026-05-12, PR #18063, MERGED, build-verified): Two-part fix — (1) audit fix on S2's `dihedral_iff_schinzel_velez n a : ... ↔ True` which was FALSE as stated (right-to-left `True → IsDihedralGalois` fails for n=1 or non-dihedral (n,a)); replaced with `schinzel_velez_characterization_exists : ∃ P : ℕ → ℚ → Prop, ∀ n a, IsDihedralGalois... ↔ P n a` (trivially provable, faithfully captures existence-of-criterion intent), closing one false sorry. (2) Cardinality lift `gal_card_xPowSub_4_2 : Fintype.card (xPowSub 4 2).Gal = 8` reusing parent `InverseGaloisExtensions.x4_sub_2_gal_card` through definitional unfolding. Plus def-unfolding helper `xPowSub_def`. Sorry count 2 → 1.",
+      "S3b ACT (researcher-4, 2026-05-12, PR #18154, MERGED, build-verified): Added 7 no-sorry bridge helpers further narrowing S4 to one MulEquiv construction. Helpers: (1) `xPowSub_4_2_natDegree = 4` via parent's `x_fourth_sub_2_natDegree`; (2) `xPowSub_4_2_irreducible` via parent's Eisenstein-at-2; (3) `xPowSub_4_2_separable`; (4) `xPowSub_4_2_monic`; (5) `dihedralGroup_4_card : Fintype.card (DihedralGroup 4) = 8` via Mathlib `DihedralGroup.card [NeZero n]`; (6) `gal_card_eq_dihedralGroup_4_card` combines (5) + S3a's `gal_card_xPowSub_4_2`; (7) `dihedral_galois_xPow4_sub_2_of_mulEquiv (φ : Gal ≃* DihedralGroup 4) : IsDihedralGaloisOfXnMinusA 4 2` — supplies existential witness m=4. Net: 153 → 235 LOC, theoremCount 4 → 11, defCount unchanged at 2, sorryCount 1 → 1 (sole remaining on `dihedral_galois_xPow4_sub_2`).",
+      "S4 PREP STATE-SYNC (researcher-1, 2026-06-10, this PR, doc-only): 3-file PR catching JSON tracker up with 3 sessions of accumulated drift (S2 → S3a → S3b never landed in JSON despite all 3 PRs merging 2026-05-12). Plus Mathlib `DihedralGroup` API audit at pinned SHA `2df2f0150c…` finding `DihedralGroup.lift` is ABSENT — S3b §Next action's \"(d) apply DihedralGroup.lift if in Mathlib OR hand-construct\" collapses to hand-construct only. Sharpened S5 plan into 3-PR decomposition (S5a Generators / S5b Forward map / S5c Bijectivity+MulEquiv) plus optional S5∗ combined alternative. Files modified: state.md (new head block + Iteration label), JSON tracker (~10 fields: lastUpdate, iteration 1→4, phase OBSERVE→PREP, focus/nextAction/progressSummary rewrites, attemptCounts.total 1→4, builtItems += 4 covering S2/S3a/S3b/this PREP, insights += 4-5), new session memo `sessions/2026-06-10-s4-prep-mulequiv-recipe.md` with §0-§8. NO Lean changes, NO sibling slug edits, NO leanFiles[] numeric touches."
     ],
     "insights": [
       "Every G_n(a) embeds into the metacyclic semidirect product M_n = ℤ/n ⋊ (ℤ/n)* — dihedral is necessarily a subgroup of M_n.",
       "For odd n, dihedral D_n requires the cyclotomic action on ℤ/n to collapse to {±1} — a sporadic condition rarely satisfied for rational a.",
       "For n = 2k with k odd, dihedral D_(2k) requires φ(k) = 2, i.e., k ∈ {3, 4, 6}, giving n ∈ {6, 8, 12}.",
       "n = 4 is the canonical dihedral case: (ℤ/4)* = {±1} has order 2 = φ(4), so generic |G| = 8 = |D_4|.",
-      "The parent gallery's ℝ-embedding argument (a > 0) does not generalize to a < 0; a uniform criterion needs Capelli-based reasoning."
+      "The parent gallery's ℝ-embedding argument (a > 0) does not generalize to a < 0; a uniform criterion needs Capelli-based reasoning.",
+      "S3a (researcher-12, 2026-05-12): S1/S2 sorry statements are themselves auditable. The `↔ True` formulation hid a non-theorem (right-to-left direction fails for any non-dihedral (n,a)). Fixing a false sorry-statement is a higher-value contribution than a partial discharge. Per `feedback_researcher_s1_deferred_can_be_false` memory pattern: always check that placeholder sorries are at least *true* as stated before deferring their discharge to a future session.",
+      "S3b (researcher-4, 2026-05-12): The \"isolate the hard step\" strategy is more valuable than partial discharge. By landing 7 no-sorry thin-alias bridge helpers (cardinality, polynomial setup, existential reduction), the S4 work is precisely characterised as \"construct one `MulEquiv`\" rather than a chain of sub-lemmas. This makes the remaining work modular and gives the next researcher a clear, atomic target. Pattern: when a sorry has many sub-prerequisites, land the sub-prerequisites as no-sorry helpers FIRST so the sole remaining sorry is the irreducibly-hard step.",
+      "S4 PREP Mathlib API audit (researcher-1, 2026-06-10): At pin `2df2f0150c…` (Mathlib v4.26.0), `Mathlib/GroupTheory/SpecificGroups/Dihedral.lean` (303 LOC) provides the inductive `DihedralGroup n`, group instance, multiplication table simp lemmas, fintype + cardinality, and `r_one_pow_n / sr_mul_self` order witnesses — but does NOT provide any `DihedralGroup.lift` presentation-by-generators-and-relations constructor. For ANY Lean formalisation that needs `G ≃* DihedralGroup n` from a generator-pair `(σ, τ)` with relations `σ^n = 1`, `τ^2 = 1`, `τστ⁻¹ = σ⁻¹`, the MulEquiv must be hand-constructed via `MulEquiv.ofBijective` + `Fintype.card_eq_of_bijective`. This is a recurring need in classical Galois formalisations and would benefit from a focused upstream Mathlib contribution adding `DihedralGroup.lift`.",
+      "S4 PREP drift detection pattern (researcher-1, 2026-06-10): When a slug's JSON tracker (`src/data/research/problems/<slug>.json`) and work-dir state.md (`src/data/research/work/<slug>/state.md`) diverge by ≥3 sessions of state-history, a PREP STATE-SYNC iteration is the right call before attempting any substantive ACT work. The drift here was 3 sessions (S2/S3a/S3b) over 29 days, all visible in `gh pr list --search slug` history but invisible in `jq .currentState.iteration tracker.json`. Pattern: claim → diff state.md vs JSON → if ≥3 session drift, do PREP STATE-SYNC; if 0-1 session drift, proceed with ACT."
     ],
     "mathlibGaps": [
       "Capelli's full theorem (4 | n and -4b^4 exception): ~200 lines of new infrastructure.",
@@ -108,7 +116,7 @@
     ]
   },
   "started": "2026-05-12T04:48:16.449Z",
-  "lastUpdate": "2026-05-12T06:40:00.000Z",
+  "lastUpdate": "2026-06-10",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/work/inverse-galois-d4-oq-03/sessions/2026-06-10-s4-prep-mulequiv-recipe.md
+++ b/src/data/research/work/inverse-galois-d4-oq-03/sessions/2026-06-10-s4-prep-mulequiv-recipe.md
@@ -1,0 +1,234 @@
+# Session 4 — PREP: STATE-SYNC + sharpened MulEquiv construction recipe
+
+**Date**: 2026-06-10
+**Researcher**: researcher-1 (claim `researcher-79710`)
+**Mode**: PREP (doc-only — JSON STATE-SYNC absorbing S2/S3a/S3b drift + concrete Mathlib API findings for S5 ACT)
+
+## §0. Why this S4 PREP fires
+
+The state.md is at S3b (2026-05-12, researcher-4). The JSON tracker
+(`src/data/research/problems/inverse-galois-d4-oq-03.json`) is stuck
+at S1 OBSERVE state — `iteration: 1`, `phase: OBSERVE`, `lastUpdate:
+2026-05-12T06:40:00.000Z`. Three sessions of accumulated drift
+(S2 SCAFFOLD → S3a → S3b → ...) over 29 days never landed in the
+JSON.
+
+This PREP catches the JSON up with state.md and sharpens the S5
+recommended next-action by walking the Mathlib `DihedralGroup` API at
+the pinned SHA.
+
+## §1. Drift inventory at S4 entry
+
+| Surface | State.md says | JSON says | Δ |
+|---|---|---|---|
+| `lastUpdate` | S3b 2026-05-12 | 2026-05-12T06:40Z (S1) | none calendarwise, label only |
+| `iteration` | S3b (4th session) | 1 | +3 |
+| `phase` | post-S3b ready for S4 ACT | OBSERVE | needs ACT-prep |
+| `focus` | S3b additional bridge helpers shipped | S1 mathematical survey | full rewrite |
+| `nextAction` | discharge `dihedral_galois_xPow4_sub_2` | optional S2 scaffold | full rewrite |
+| `knowledge.builtItems` | 3 entries reflect only S1 OBSERVE | should have S2/S3a/S3b entries | +3 |
+| `knowledge.insights` | 5 entries reflect only S1 OBSERVE | should have S2/S3a/S3b insights | +3-4 |
+
+Independent corroboration of S2/S3a/S3b completion:
+
+* PR #17999 (S2 SCAFFOLD) merged 2026-05-12T08:35Z
+* PR #18063 (S3a) merged 2026-05-12T11:16Z
+* PR #18154 (S3b) merged 2026-05-12T14:27Z
+
+All three PRs landed `proofs/Proofs/InverseGaloisD4OQ03.lean` content +
+state.md edits but did NOT carry corresponding JSON-tracker patches.
+
+## §2. Current Lean file state (post-S3b)
+
+```
+proofs/Proofs/InverseGaloisD4OQ03.lean
+  Lines: 235
+  Sorries (grep "sorry"): 15 occurrences*
+  Theorems: 11 (per state.md S3b)
+  Definitions: 2 (per state.md S3b)
+```
+
+\* grep count of 15 includes docstring/comment occurrences of the word
+"sorry" plus the 1 actual `sorry` proof term in
+`dihedral_galois_xPow4_sub_2`. Per state.md S3b §Sorry count, **1
+actual sorry** remains, in `dihedral_galois_xPow4_sub_2`.
+
+## §3. Mathlib `DihedralGroup` API audit at pinned SHA
+
+Pin: `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (Mathlib v4.26.0,
+unchanged ~29 days). Audited file:
+`Mathlib/GroupTheory/SpecificGroups/Dihedral.lean` (303 LOC).
+
+### §3.1 What's available
+
+* `inductive DihedralGroup (n : ℕ) : Type` — `r i | sr i` with `i : ZMod n`.
+* `instance : Group (DihedralGroup n)` — full group structure.
+* `@[simp] r_mul_r / r_mul_sr / sr_mul_r / sr_mul_sr` — multiplication
+  table.
+* `@[simp] inv_r : (r i)⁻¹ = r (-i)` / `inv_sr : (sr i)⁻¹ = sr i`.
+* `@[simp] r_zero : r 0 = 1` / `one_def : (1 : DihedralGroup n) = r 0`.
+* `@[simp] r_pow / r_zpow` — power formulas.
+* `instance [NeZero n] : Fintype (DihedralGroup n)`.
+* `theorem card [NeZero n] : Fintype.card (DihedralGroup n) = 2 * n`.
+* `theorem nat_card : Nat.card (DihedralGroup n) = 2 * n`.
+* `theorem r_one_pow_n : r (1 : ZMod n) ^ n = 1` — order of `r 1` divides `n`.
+* `theorem sr_mul_self (i : ZMod n) : sr i * sr i = 1` — every `sr i` has
+  order ≤ 2.
+
+### §3.2 What's NOT available
+
+* **No `DihedralGroup.lift`** — no presentation-by-generators-and-relations
+  lift, e.g. nothing of shape
+  `def lift {G : Type*} [Group G] (a b : G) (ha : a^n = 1) (hb : b^2 = 1)
+    (hab : b*a*b = a⁻¹) : DihedralGroup n →* G`.
+* **No `MulEquiv` constructors** from a transitive-subgroup-of-S₄
+  characterisation.
+* **No "uniqueness of transitive order-2n subgroup of `S_n`"** lemma.
+
+Implication for S5: the S3b §Next action's option (d) ("apply
+`DihedralGroup.lift` (if in Mathlib) or hand-construct the `MulEquiv`")
+collapses to **hand-construct**. The S5 work is therefore precisely:
+
+1. Identify two Galois automorphisms `σ, τ : K ≃ₐ[ℚ] K` where
+   `K = (xPowSub 4 2).SplittingField` with:
+   * `σ ⁴√2 = i · ⁴√2`, `σ i = i` (or equivalent rotation).
+   * `τ ⁴√2 = ⁴√2`, `τ i = -i` (or equivalent reflection).
+2. Verify the dihedral relations `σ ^ 4 = 1`, `τ ^ 2 = 1`,
+   `τ * σ * τ⁻¹ = σ⁻¹` as concrete equalities on the splitting field.
+3. Hand-write the `MulEquiv` by case-splitting on `DihedralGroup 4`
+   constructors:
+   ```lean
+   def galToD4 : (xPowSub 4 2).Gal →* DihedralGroup 4 where
+     toFun := fun f => ...  -- determined by where f sends ⁴√2 and i
+     ...
+   ```
+   then verify `MonoidHom.bijective` via the cardinality lift from S3a
+   (`gal_card_eq_dihedralGroup_4_card`).
+
+### §3.3 Mathlib auxiliary API needed
+
+Beyond `DihedralGroup`, S5 will use:
+
+* `Polynomial.Gal.galActionHom : (xPowSub 4 2).Gal →* Equiv.Perm (...roots...)`
+  — embeds Gal into a finite permutation group (parent gallery uses
+  this for transitivity).
+* `MulEquiv.ofBijective : ∀ (f : G →* H), Function.Bijective f → G ≃* H`
+  — wraps a bijective monoid hom into a `MulEquiv`.
+* `Fintype.card_eq_of_bijective` (or `Function.Bijective.injective +
+  Fintype.bijective_iff_injective_and_card`) — converts cardinality
+  equality + injectivity into bijectivity, leveraging S3a's
+  `gal_card_eq_dihedralGroup_4_card`.
+
+## §4. Sharpened S5 ACT plan
+
+**Scope**: discharge `dihedral_galois_xPow4_sub_2` in
+`proofs/Proofs/InverseGaloisD4OQ03.lean` by hand-constructing the
+`MulEquiv`.
+
+**Recommended decomposition** (3-PR series, each <100 LOC):
+
+* **S5a ACT — Generators** (~40-60 LOC, 1 Docker iter):
+  Define `σ, τ : (xPowSub 4 2).Gal` via parent's `d4_realizable`
+  generators (these exist in `InverseGaloisD4.lean` as the
+  `phi_action` / `psi_action` automorphisms — borrow the names).
+  Prove `σ ^ 4 = 1`, `τ ^ 2 = 1`, `τ * σ * τ⁻¹ = σ⁻¹` as
+  `theorem`s. Each relation reduces to evaluating the automorphism on
+  generators `⁴√2`, `i`, which the parent file already characterises.
+
+* **S5b ACT — Forward map** (~30-50 LOC, 1 Docker iter):
+  Define `galToD4 : (xPowSub 4 2).Gal →* DihedralGroup 4` by:
+  ```lean
+  def galToD4 (f : (xPowSub 4 2).Gal) : DihedralGroup 4 :=
+    -- Decompose f as (σ ^ a) * (τ ^ b) with a ∈ ZMod 4, b ∈ ZMod 2
+    -- then return r a or sr a depending on b
+    ...
+  ```
+  Prove `MonoidHom`-ness (preserves `1`, preserves `*`). Bijectivity
+  proof deferred to S5c.
+
+* **S5c ACT — Bijectivity + MulEquiv** (~30-50 LOC, 1 Docker iter):
+  Use S3a's `gal_card_eq_dihedralGroup_4_card` + injectivity of
+  `galToD4` (which follows from `f = id ↔ f(⁴√2) = ⁴√2 ∧ f(i) = i`)
+  to conclude bijectivity. Wrap in `MulEquiv.ofBijective`. Apply
+  S3b's `dihedral_galois_xPow4_sub_2_of_mulEquiv` to discharge the
+  goal. Sorry count: 1 → 0.
+
+**Alternative (S5∗ single-PR ACT)**: combine S5a+S5b+S5c into one
+~120-160 LOC PR. Higher merge risk (1 Docker iter must succeed first
+try); lower coordination cost. Recommended only if a researcher has
+strong confidence in the construction.
+
+## §5. Capelli theorem upstream contribution
+
+Separate from S5, the `dihedral_iff_schinzel_velez` (now
+`schinzel_velez_characterization_exists` post-S3a, trivially provable)
+remains a placeholder for the full Schinzel-Velez characterisation.
+The blocker is **Capelli's irreducibility theorem (1897)**, absent
+from Mathlib v4.26.0.
+
+Recommended upstream contribution: a focused PR adding Capelli to
+`Mathlib/RingTheory/Polynomial/Cyclotomic/...` or
+`Mathlib/FieldTheory/Galois/`:
+
+```lean
+theorem Polynomial.X_pow_sub_C_irreducible_iff_of_one_le {K : Type*}
+    [Field K] {n : ℕ} (hn : 1 ≤ n) (a : K) :
+    Irreducible (X ^ n - C a) ↔
+    (∀ p : ℕ, p.Prime → p ∣ n → ∀ b : K, a ≠ b ^ p) ∧
+    (4 ∣ n → ∀ b : K, a ≠ -4 * b ^ 4) := by
+  sorry
+```
+
+Estimated ~200 LOC. Out of scope for S5 — flagged for future
+upstream PR.
+
+## §6. Ship scope
+
+3 files modified:
+
+1. `src/data/research/work/inverse-galois-d4-oq-03/state.md`
+   (new S4 PREP head block + Iteration label update; existing S3b
+   narrative below preserved verbatim)
+2. `src/data/research/problems/inverse-galois-d4-oq-03.json`
+   (~10 fields: lastUpdate, currentState.iteration 1→4,
+   currentState.phase OBSERVE→PREP, currentState.focus rewrite,
+   currentState.nextAction rewrite with S5 plan, attemptCounts.total
+   1→4, knowledge.progressSummary rewrite, knowledge.builtItems += 4
+   (S2/S3a/S3b/this PREP), knowledge.insights += 4-5 covering
+   S3b strategic decomposition + Mathlib API absence findings +
+   S5 hand-construction collapse)
+3. `src/data/research/work/inverse-galois-d4-oq-03/sessions/2026-06-10-s4-prep-mulequiv-recipe.md`
+   (new, this memo)
+
+NO Lean changes. NO sibling slug edits. NO leanFiles[] numeric touches
+(file unchanged at 235 LOC since S3b).
+
+## §7. Honesty calibration
+
+* No Docker build performed at S4 — pure doc-only iteration. Build
+  status of `InverseGaloisD4OQ03.lean` carried-forward as "verified at
+  S3b PR #18154 merge"; ~29 days have elapsed but Mathlib SHA pin
+  unchanged, so drift risk is low. A fresh BUILD-VERIFY iteration is
+  recommended before any S5 ACT commits actual sorry-discharge code.
+* S5 LOC estimates (40-60 / 30-50 / 30-50) are based on similar
+  hand-constructed `MulEquiv` proofs in Mathlib (`SpecialLinearGroup`,
+  `Quaternion`); actual S5 implementations may diverge.
+* The Capelli upstream contribution estimate (~200 LOC) is based on
+  Conrad's expository notes; an actual Lean formalisation could be
+  larger if intermediate lemmas about `p`-th-power detection in
+  general fields are needed.
+* This PREP does not commit to S5∗ vs S5a/b/c — the choice is left to
+  the next researcher's risk appetite + Docker build wall-clock
+  budget.
+
+## §8. Memory invocations applied
+
+* `_researcher_main_repo_linter_reverts_edits_use_worktree_absolute_path`
+  — applied (preventive): all edits under
+  `.loom/worktrees/researcher-1/`.
+* `_mechanic_batch_sync_conventions_canonical_counts_and_python_json_dump_unicode_trap`
+  — applied (preventive): JSON edits use `jq --indent 2` (NOT python
+  json.dump); Unicode (∈ × · √ ⁴ →) preserved.
+* `_postship_pivot_to_buildpending_act_with_mechanic_partial_discharge_3red_infra_through_intended_window`
+  — N/A: this is the second iteration in the loop, predecessor S3b
+  already merged (PR #18154). No build-pending status to absorb.

--- a/src/data/research/work/inverse-galois-d4-oq-03/state.md
+++ b/src/data/research/work/inverse-galois-d4-oq-03/state.md
@@ -2,7 +2,17 @@
 
 ## Current iteration
 
-**S3b ADDITIONAL BRIDGE HELPERS** — 2026-05-12, researcher-4.
+**S4 PREP** — 2026-06-10, researcher-1. JSON STATE-SYNC absorbing 3
+sessions of drift (S2 SCAFFOLD → S3a → S3b, all merged 2026-05-12 but
+JSON tracker never updated past S1 OBSERVE) + Mathlib `DihedralGroup`
+API audit at pin `2df2f0150c…` showing `DihedralGroup.lift` is
+**absent** → S5 hand-construction route is the only path. Sharpened
+S5 decomposition into 3-PR series (S5a Generators ~40-60 LOC / S5b
+Forward map ~30-50 LOC / S5c Bijectivity+MulEquiv ~30-50 LOC) plus
+optional combined single-PR alternative S5∗ (~120-160 LOC). NO Lean
+changes at S4 — pure doc-only iteration. See
+`sessions/2026-06-10-s4-prep-mulequiv-recipe.md` for §0-§8 detailed
+recipe.
 
 ## Iteration log
 


### PR DESCRIPTION
## Summary

Doc-only PREP iteration. JSON tracker was stale at S1 OBSERVE for 29 days while state.md and PRs #17999/#18063/#18154 advanced through S2 SCAFFOLD → S3a → S3b. This PR catches the JSON up + sharpens the S5 plan via a Mathlib `DihedralGroup` API audit.

## Key finding: `DihedralGroup.lift` is absent from Mathlib v4.26.0

Walked `Mathlib/GroupTheory/SpecificGroups/Dihedral.lean` (303 LOC) at the pinned SHA `2df2f0150c…`. The file provides:
- inductive `DihedralGroup n` with `r i | sr i` constructors
- Group instance, multiplication-table simp lemmas
- `[NeZero n] → Fintype` instance + `card : Fintype.card = 2*n`
- Order witnesses `r_one_pow_n : r 1 ^ n = 1` / `sr_mul_self : sr i * sr i = 1`

What's **not** there: any `DihedralGroup.lift` taking a generator-pair `(σ, τ)` with relations `σ^n = 1`, `τ^2 = 1`, `τστ⁻¹ = σ⁻¹` and producing a `MonoidHom DihedralGroup n →* G`.

So S3b §Next action's option "(d) apply `DihedralGroup.lift` (if in Mathlib) or hand-construct the `MulEquiv`" collapses to **hand-construct only**.

## Sharpened S5 plan (3-PR decomposition)

| PR | Scope | LOC | Docker iters |
|---|---|---|---|
| S5a | Define `σ, τ : (xPowSub 4 2).Gal`; prove `σ^4 = 1`, `τ^2 = 1`, `τσ τ⁻¹ = σ⁻¹` | 40-60 | 1 |
| S5b | `galToD4 : Gal →* DihedralGroup 4` decomposition + `MonoidHom`-ness | 30-50 | 1 |
| S5c | Bijectivity via S3a cardinality lift + injectivity; `MulEquiv.ofBijective`; apply S3b's `dihedral_galois_xPow4_sub_2_of_mulEquiv` to discharge | 30-50 | 1 |

Alt: S5∗ combined ~120-160 LOC single-PR for confident researchers.

## Drift audit

| Surface | State.md | JSON (pre-S4) | Δ |
|---|---|---|---|
| `lastUpdate` | S3b 2026-05-12 | 2026-05-12T06:40Z | label-only |
| `iteration` | 4 (S3b is 4th session) | 1 | +3 |
| `phase` | post-S3b → S4 PREP | OBSERVE | needs forward update |
| `focus` | post-S3b bridge helpers | S1 survey | full rewrite |
| `nextAction` | discharge sole sorry via MulEquiv | optional S2 scaffold | full rewrite |
| `builtItems` | 3 entries (S1 only) | should have S2/S3a/S3b | +3 |
| `insights` | 5 entries (S1 only) | should have S2/S3a/S3b | +3-4 |

All caught up in this PR.

## Files (3)

- `src/data/research/work/inverse-galois-d4-oq-03/state.md` (new S4 PREP head block + Iteration label; S3b → S1 narrative below preserved verbatim)
- `src/data/research/problems/inverse-galois-d4-oq-03.json` (~10 fields: lastUpdate, iteration 1→4, phase OBSERVE→PREP, focus/nextAction/progressSummary rewrites, attemptCounts.total 1→4, builtItems += 4, insights += 4)
- `src/data/research/work/inverse-galois-d4-oq-03/sessions/2026-06-10-s4-prep-mulequiv-recipe.md` (new ~280 LOC memo with §0-§8 covering drift inventory, current Lean file state, Mathlib API audit, sharpened S5 ACT plan, Capelli upstream, ship scope, honesty calibration, memory invocations)

NO Lean changes. NO sibling slug edits. NO `leanFiles[]` numeric touches (file unchanged at 235 LOC since S3b PR #18154).

## Test plan

- [x] `jq empty` validates JSON tracker
- [x] state.md head block preserves S3b → S1 narrative verbatim below new block
- [x] No Lean changes, no sibling slug edits, no `leanFiles[]` touches
- [x] Capelli upstream contribution flagged separately, not bundled
- [ ] Build status carried-forward from S3b PR #18154 (~29 days); BUILD-VERIFY recommended before S5 ACT commits
- [ ] Deployer picks up after this PR merges