### PR TITLE
fix(meta): schauder-fixed-point-oq-03-oq-01 lineCount 1419 → 1479

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -54,7 +54,7 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1419,
+    "lineCount": 1479,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
@@ -212,7 +212,7 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1419,
+    "lineCount": 1479,
     "axiomCount": 2,
     "theoremCount": 14,
     "definitionCount": 4,


### PR DESCRIPTION
## Fix

Sync `lineCount` (both top-level `meta.lineCount` and `leanFile.lineCount`) from **1419 → 1479** to match the actual `wc -l` of `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`.

## Evidence

```
$ wc -l proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
1479
```

**Before**: `meta.json` lineCount = 1419 (last set by PR #21718 on 2026-05-31)
**After**: `meta.json` lineCount = 1479 (matches current source)

## Drift origin

PR #22117 (S29 ACT, 2026-06-02) landed `exists_lebesgue_subcover_for_uhc` Lebesgue-number helper at line 716 (+60 LOC) but did not refresh gallery meta. The +60 drift exactly matches `1479 − 1419 = 60`.

## Counts kept unchanged

- `theoremCount = 14` — S29 added a `private lemma`. Official `enrich-research.ts` regex `^(theorem|lemma) ` returns 7; current meta value of 14 reflects a broader inclusion criterion stable since PR #19891. Touching it here would conflict with that established convention.
- `axiomCount = 2`, `definitionCount = 4`, `sorries = 0` — verified matching current Lean source.

## Files changed

- `src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json` (+2 / −2)

No Lean source change. Gallery-only metadata sync.

---
Automated fix by lean-mechanic agent.