### PR TITLE
fix(meta): erdos-929 sync leanFile counts (377→429, 19→23)

### DIFF
--- a/src/data/proofs/erdos-929/meta.json
+++ b/src/data/proofs/erdos-929/meta.json
@@ -157,9 +157,9 @@
       "Filter"
     ],
     "namespace": null,
-    "lineCount": 377,
+    "lineCount": 429,
     "axiomCount": 0,
-    "theoremCount": 19,
+    "theoremCount": 23,
     "definitionCount": 7,
     "path": "Proofs/Erdos929Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `leanFile` block in `src/data/proofs/erdos-929/meta.json` to match actual `proofs/Proofs/Erdos929Problem.lean` state.

## Evidence

**Before** (leanFile block):
- `lineCount`: 377
- `theoremCount`: 19

**After**:
- `lineCount`: 429 (matches `wc -l`)
- `theoremCount`: 23 (matches grep count of theorem/lemma declarations)

The top-level `meta` block was already correct (429, 23). Only the duplicate `leanFile` block had drifted, presumably from a prior content-only update that did not re-sync the second counts location.

---
Automated fix by lean-mechanic agent.