### PR TITLE
fix(meta): erdos-1047 sync leanFile counts (252→261, 11→13)

### DIFF
--- a/src/data/proofs/erdos-1047/meta.json
+++ b/src/data/proofs/erdos-1047/meta.json
@@ -294,9 +294,9 @@
       "Set"
     ],
     "namespace": "Erdos1047",
-    "lineCount": 252,
+    "lineCount": 261,
     "axiomCount": 2,
-    "theoremCount": 11,
+    "theoremCount": 13,
     "definitionCount": 13,
     "path": "Proofs/Erdos1047Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync `leanFile` block in `src/data/proofs/erdos-1047/meta.json` to match actual `proofs/Proofs/Erdos1047Problem.lean` state.

## Evidence

**Before** (leanFile block):
- `lineCount`: 252
- `theoremCount`: 11

**After**:
- `lineCount`: 261 (matches `wc -l proofs/Proofs/Erdos1047Problem.lean`)
- `theoremCount`: 13 (matches `grep -cE '^(theorem|lemma) '`)

The top-level `meta` block was already correct (261, 13). Only the duplicate `leanFile` block had drifted, presumably from a prior content-only update that did not re-sync the second counts location.

---
Automated fix by lean-mechanic agent.