### PR TITLE
fix(meta): chinese-remainder-non-coprime-oq-04 sync leanFile counts (239→265, 15→16)

### DIFF
--- a/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
+++ b/src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json
@@ -175,10 +175,10 @@
     ]
   },
   "leanFile": {
-    "lineCount": 239,
+    "lineCount": 265,
     "structureCount": 0,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "lemmaCount": 4,
     "imports": [
       "Mathlib"


### PR DESCRIPTION
## Fix

Sync `leanFile` block in `src/data/proofs/chinese-remainder-non-coprime-oq-04/meta.json` to match actual `proofs/Proofs/ChineseRemainderNonCoprimeOQ04.lean` state.

## Evidence

**Before** (leanFile block):
- `lineCount`: 239
- `theoremCount`: 15

**After**:
- `lineCount`: 265 (matches `wc -l`)
- `theoremCount`: 16 (matches `^(theorem|lemma) ` count)

The top-level `meta` block was already correct (265, 16). Only the duplicate `leanFile` block had drifted from a prior content-only update that did not re-sync the second counts location.

---
Automated fix by lean-mechanic agent.