### PR TITLE
fix(meta): erdos-1016 sync meta block counts (158→209, 7→12)

### DIFF
--- a/src/data/proofs/erdos-1016/meta.json
+++ b/src/data/proofs/erdos-1016/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1016",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 158,
+    "lineCount": 209,
     "assumptions": "0 axioms. All 5 former axioms were removed because the abstract IsPancyclic model is flawed (edgeCount disconnected from hasCycle makes axioms FALSE). The mathematical results (Bondy, Griffin, GKW) are correct but require a proper SimpleGraph-based model to formalize.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 7,
+    "theoremCount": 12,
     "definitionCount": 3
   },
   "overview": {


### PR DESCRIPTION
## Fix

Sync top-level `meta` block in `src/data/proofs/erdos-1016/meta.json` to match the actual `proofs/Proofs/Erdos1016Problem.lean` file.

## Evidence

**Before** (meta block): `lineCount: 158`, `theoremCount: 7`
**After**  (meta block): `lineCount: 209`, `theoremCount: 12`

| Field           | Actual (file) | meta before | leanFile (already correct) |
| --------------- | ------------- | ----------- | -------------------------- |
| lineCount       | 209 (wc -l)   | 158         | 209                        |
| theoremCount    | 12            | 7           | 12                         |
| definitionCount | 3             | 3           | 3                          |
| axiomCount      | 0             | 0           | 0                          |

The `leanFile` block was already in sync with the file. The top-level `meta` block had drifted from prior content updates — the file grew (more iteratedLog/pancyclic theorems were added) but the meta block was not resynced.

Both blocks now match reality.

---
Automated fix by lean-mechanic agent.