### PR TITLE
fix(meta): erdos-396 sync meta+leanFile to actual Lean source

### DIFF
--- a/src/data/proofs/erdos-396/meta.json
+++ b/src/data/proofs/erdos-396/meta.json
@@ -15,17 +15,17 @@
       "divisibility",
       "open"
     ],
-    "badge": "axiom",
+    "badge": "wip",
     "sorries": 0,
     "erdosNumber": 396,
     "erdosUrl": "https://erdosproblems.com/396",
     "erdosProblemStatus": "open",
-    "axiomCount": 1,
-    "lineCount": 78,
-    "assumptions": "1 axiom: smallest_witness (smallest witness function — axiomatized). 0 sorries.",
+    "axiomCount": 0,
+    "lineCount": 102,
+    "assumptions": "0 axioms, 0 sorries. The conjecture is stated as `Erdos396.Conjecture : Prop` (a definition, not an asserted axiom). Supporting lemmas fully verified: `catalan_divisibility` ((n+1) ∣ C(2n,n)), `n_not_always_dvd_centralBinom` (n=3 counterexample), and explicit witnesses `conjecture_holds_for_zero` and `conjecture_holds_for_one` (n=2). Pomerance's 2014 density results are referenced but not formalized (no density infrastructure imported).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 2,
-    "definitionCount": 0
+    "theoremCount": 6,
+    "definitionCount": 2
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed Problem #396 in their 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory,' asking about the divisibility of central binomial coefficients $\\binom{2n}{n}$ by descending factorial products. The question is motivated by the classical fact that $n+1$ always divides $\\binom{2n}{n}$ (giving the Catalan numbers $C_n = \\binom{2n}{n}/(n+1)$), but $n$ itself rarely divides $\\binom{2n}{n}$. The problem asks how far 'downward' from $n$ one can push simultaneous divisibility.\n\nCarl Pomerance made the most significant progress in 2014. He showed that for any fixed $k$, each individual factor $(n-k)$ divides $\\binom{2n}{n}$ for infinitely many $n$, but the set of such $n$ has upper density less than $1/3$. In contrast, the ascending product $(n+1)(n+2)\\cdots(n+k)$ divides $\\binom{2n}{n}$ with asymptotic density 1 — a striking asymmetry between descending and ascending factorials. The key difficulty lies in the $p$-adic structure: by Kummer's theorem, $\\nu_p(\\binom{2n}{n})$ equals the number of carries when adding $n$ to $n$ in base $p$, and simultaneous divisibility by $n(n-1)\\cdots(n-k)$ places correlated constraints across multiple primes.\n\nThe OEIS sequence A375077 catalogues the smallest witness $n$ for each $k$. The problem remains open: even the existence of a single $n$ for each $k$ is unproved, let alone the natural strengthening that infinitely many witnesses exist.",
@@ -108,11 +108,11 @@
     "opens": [
       "Nat"
     ],
-    "namespace": null,
-    "lineCount": 78,
-    "axiomCount": 1,
-    "theoremCount": 2,
-    "definitionCount": 0,
+    "namespace": "Erdos396",
+    "lineCount": 102,
+    "axiomCount": 0,
+    "theoremCount": 6,
+    "definitionCount": 2,
     "path": "Proofs/Erdos396Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Fix

Synchronize `src/data/proofs/erdos-396/meta.json` with the current state of `proofs/Proofs/Erdos396Problem.lean`. Both the `meta` and `leanFile` blocks were behind the actual source — the file has been substantially rewritten since the meta was last updated.

## Evidence

**Before** (both blocks)
- `lineCount`: 78
- `theoremCount`: 2
- `definitionCount`: 0
- `axiomCount`: 1
- `leanFile.namespace`: `null`
- `badge`: `"axiom"`
- `assumptions`: claims a `smallest_witness` axiom that no longer exists in the file

**After** (both blocks)
- `lineCount`: 102
- `theoremCount`: 6
- `definitionCount`: 2
- `axiomCount`: 0
- `leanFile.namespace`: `"Erdos396"`
- `badge`: `"wip"` (no axioms remain)
- `assumptions`: rewritten to describe the actual current state — the open conjecture is stated as a `Prop` definition only, with verified supporting lemmas

## Verification

```
wc -l proofs/Proofs/Erdos396Problem.lean                       → 102
grep -cE '^(theorem|lemma|@\[.*\] (theorem|lemma)) ' ...       → 6
grep -cE '^(def|noncomputable def|structure|class) ' ...       → 2
grep -cE '^axiom ' proofs/Proofs/Erdos396Problem.lean          → 0
```

The current 6 theorems/lemmas: `descProduct_eq_descFactorial`, `descProduct_zero`, `catalan_divisibility`, `n_not_always_dvd_centralBinom`, `conjecture_holds_for_zero`, `conjecture_holds_for_one`. The 2 definitions: `descProduct`, `Conjecture`.

## Scope

This is a counts-sync fix only. Narrative fields (`proofStrategy`, `sections[*].summary`, `sections[*].endLine`, `conclusion.summary`) still describe the prior file structure (referencing the removed `smallest_witness` axiom and `n_divides_rarely` placeholder). That rewrite is enrichment work and out of scope for this PR.

---
Automated fix by lean-mechanic agent.