### PR TITLE
fix(meta): erdos-5-prime-gaps sync meta+leanFile counts (657→708, 33→36)

### DIFF
--- a/src/data/proofs/erdos-5-prime-gaps/meta.json
+++ b/src/data/proofs/erdos-5-prime-gaps/meta.json
@@ -21,8 +21,8 @@
     "dateAdded": "2026-04-02",
     "axiomCount": 3,
     "assumptions": "3 axioms for deep analytic number theory results: westzynthius_large_gaps (Westzynthius 1931: arbitrarily large prime gaps exist, i.e., ∞ ∈ S), zhang_bounded_gaps (Zhang 2013: ∃H, infinitely many prime gaps ≤ H, i.e., 0 ∈ S via bounded gaps), hildebrand_maier_large_limit_points (Hildebrand-Maier: S contains arbitrarily large finite values). The full conjecture S = [0,∞) remains open.",
-    "lineCount": 657,
-    "theoremCount": 33,
+    "lineCount": 708,
+    "theoremCount": 36,
     "definitionCount": 9,
     "originalContributions": [
       "nthPrime: nth prime function (0-indexed, via Mathlib's Nat.nth)",
@@ -69,9 +69,9 @@
   },
   "leanFile": {
     "namespace": "Erdos5",
-    "lineCount": 657,
+    "lineCount": 708,
     "axiomCount": 3,
-    "theoremCount": 33,
+    "theoremCount": 36,
     "definitionCount": 9,
     "path": "Proofs/Erdos5PrimeGaps.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync the top-level `meta` block and the `leanFile` block in `src/data/proofs/erdos-5-prime-gaps/meta.json` to match the current Lean source `proofs/Proofs/Erdos5PrimeGaps.lean`.

## Evidence

**Before** (stale, in both `meta` and `leanFile` blocks):
- `lineCount`: 657
- `theoremCount`: 33

**After** (matches the source):
- `lineCount`: 708
- `theoremCount`: 36

Verified via the canonical counters used by `scripts/research/enrich-research.ts`:

```
$ python3 -c "print(len(open('proofs/Proofs/Erdos5PrimeGaps.lean').read().split('\n')))"
708
$ grep -cE "^(theorem|lemma) " proofs/Proofs/Erdos5PrimeGaps.lean
36
$ grep -cE "^axiom " proofs/Proofs/Erdos5PrimeGaps.lean
3
```

`axiomCount` (3) and `definitionCount` (9) already matched the file — no changes needed there.

---
Automated fix by lean-mechanic agent (cantor-pattern leanFile drift sync).