### PR TITLE
Enrich Abel-Ruffini Galois Extensions: extend solvability-preservation cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions/annotations.json
@@ -178,7 +178,12 @@
       "Hall subgroup",
       "derived length inequality",
       "semidirect product",
-      "Feit-Thompson theorem"
+      "Feit-Thompson theorem",
+      "hereditary class / formation theory",
+      "Mathlib `MulEquiv.surjective`",
+      "abel-ruffini-galois-extensions-oq-04 (Jordan-Hölder uniqueness consumer)",
+      "inverse-galois-a5 (concrete realization consumer)",
+      "$\\text{dl}(G) \\leq \\text{dl}(N) + \\text{dl}(G/N)$ — additive bound from the extension theorem"
     ],
     "prerequisites": [
       "derived series",
@@ -187,7 +192,9 @@
       "typeclass inference in Lean",
       "image of a subgroup under a homomorphism",
       "split extension / semidirect product",
-      "Galois correspondence between subfields and subgroups"
+      "Galois correspondence between subfields and subgroups",
+      "`MulEquiv` (multiplicative group isomorphism) in Mathlib",
+      "instance-derivation rules for `IsSolvable` quotients and subgroups"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Targeted enrichment pass on `abel-ruffini-galois-extensions` (quality 100, passes 4).

Extends the `arg-solvability-preservation` annotation (Part IX, lines 330–347) with concrete cross-references that connect this annotation to the broader gallery and to the file's Mathlib infrastructure:

**Added to `relatedConcepts` (5 new):**
- `hereditary class / formation theory` — names the abstract closure pattern (subgroup, quotient, isomorphism) that makes the three `inferInstance`/`solvable_of_surjective` proofs one-liners
- `Mathlib MulEquiv.surjective` — the underlying coercion that `solvable_of_mul_equiv` uses
- `abel-ruffini-galois-extensions-oq-04 (Jordan-Hölder uniqueness consumer)` — downstream gallery entry that builds on this file's preservation theorems
- `inverse-galois-a5 (concrete realization consumer)` — downstream entry that consumes `card_a5 = 60` and the non-solvability cascade
- `dl(G) ≤ dl(N) + dl(G/N) — additive bound from the extension theorem` — quantitative form of the Schreier splicing, exposed for reuse

**Added to `prerequisites` (2 new):**
- `MulEquiv` (multiplicative group isomorphism) in Mathlib
- instance-derivation rules for `IsSolvable` quotients and subgroups

## Test plan
- [x] `jq empty annotations.json` — JSON syntactically valid
- [x] `tsc -b` — TypeScript build passes
- [x] `pnpm annotations:build` — annotations build step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)