### PR TITLE
Enrich Abel-Ruffini: Part VI threshold annotation sibling cross-references

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.json
+++ b/src/data/proofs/abel-ruffini/annotations.json
@@ -562,7 +562,11 @@
       "measure-theoretic vs structural threshold",
       "inverse-galois-f20 (solvable degree-5 witness)",
       "keyInsight #22 (Hilbert irreducibility)",
-      "keyInsight #34 (Bhargava-Shankar-Tsimerman)"
+      "keyInsight #34 (Bhargava-Shankar-Tsimerman)",
+      "abel-ruffini-galois-extensions (sibling companion: complete $S_n$ classification for $n \\leq 4$ via Klein-four chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$)",
+      "abel-ruffini-oq-04-oq-02 (companion: instance build-out for $S_2, S_3, S_4$ via `solvable_of_ker_le_range` and Klein-four normality)",
+      "derived length $\\text{dl}(S_4) = 3$ vs $\\text{dl}(S_5) = \\infty$ (the quantitative form of the threshold)",
+      "$A_5 \\cong \\text{PSL}(2, 5) \\cong I$ icosahedral correspondence (Klein 1884)"
     ]
   },
   {


### PR DESCRIPTION
## Summary

Targeted enrichment pass on `abel-ruffini` (quality 100, passes 7).

Extends the `ann-part-vi-threshold` annotation (Part VI: Why Degree 5 Is the Exact Threshold, lines 151–163) with four new cross-references in `relatedConcepts`:

- **`abel-ruffini-galois-extensions` sibling companion** — explicit pointer to the comprehensive companion entry that proves the complete $S_n$ classification for $n \leq 4$ via the Klein-four chain $\{e\} \trianglelefteq V_4 \trianglelefteq A_4 \trianglelefteq S_4$
- **`abel-ruffini-oq-04-oq-02` companion** — instance build-out for $S_2, S_3, S_4$ via `solvable_of_ker_le_range` and Klein-four normality
- **Derived length quantitative threshold** — `$\text{dl}(S_4) = 3$ vs $\text{dl}(S_5) = \infty$`, making the threshold a numerical statement, not just structural
- **Klein 1884 icosahedral correspondence** — `$A_5 \cong \text{PSL}(2, 5) \cong I$`, the geometric face already alluded to in the annotation content but not previously named in `relatedConcepts`

These additions surface existing content from the annotation body and from cross-linked gallery entries into the navigable cross-reference list.

## Test plan
- [x] `jq empty annotations.json` — JSON syntactically valid
- [x] `tsc -b` — TypeScript build passes (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)