### PR TITLE
fix(meta): area-of-circle-oq-02 sync theoremCount (16→17)

### DIFF
--- a/src/data/proofs/area-of-circle-oq-02/meta.json
+++ b/src/data/proofs/area-of-circle-oq-02/meta.json
@@ -22,7 +22,7 @@
     "axiomCount": 1,
     "assumptions": "1 axiom: nball_volume_scaling — Vol(Bⁿ(r)) = rⁿ·Vol(Bⁿ(1)). This is a standard measure theory fact requiring careful handling of EuclideanSpace/PiLp volume isomorphism in Mathlib.",
     "lineCount": 211,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 1,
     "originalContributions": [
       "unitBallVolume: definition of Vol(Bⁿ(1)) = πⁿ/² / Γ(n/2+1)",
@@ -103,7 +103,7 @@
     "namespace": "NBallVolume",
     "lineCount": 211,
     "axiomCount": 1,
-    "theoremCount": 16,
+    "theoremCount": 17,
     "definitionCount": 1,
     "path": "Proofs/AreaOfCircleOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

- `src/data/proofs/area-of-circle-oq-02/meta.json` had `theoremCount: 16` in both `meta` and `leanFile` blocks; actual count in `proofs/Proofs/AreaOfCircleOQ02.lean` is **17**.
- `lineCount` (211) and `definitionCount` (1) were already correct.

## Verification

Counted top-level `theorem`/`lemma` declarations (including the one `private lemma`) in the source file:

| # | Name | Line |
|---|------|------|
| 1 | `volume_1ball` | 37 |
| 2 | `volume_2ball` | 43 |
| 3 | `volume_unit_2ball` | 48 |
| 4 | `volume_unit_1ball` | 54 |
| 5 | `unitBallVolume_nonneg` | 75 |
| 6 | `gamma_three_div_two` (private) | 83 |
| 7 | `unitBallVolume_zero` | 90 |
| 8 | `unitBallVolume_one` | 95 |
| 9 | `unitBallVolume_two` | 105 |
| 10 | `unitBallVolume_recurrence` | 119 |
| 11 | `unitBallVolume_three` | 135 |
| 12 | `unitBallVolume_four` | 143 |
| 13 | `area_scaling_2d` | 161 |
| 14 | `nball_volume_zero` | 172 |
| 15 | `nball_generalizes_area_of_circle` | 182 |
| 16 | `unitBallVolume_chain` | 187 |
| 17 | `vol_B5_gt_vol_B4` | 200 |

Total = 17.

## Test plan

- [x] `python -c "import json; json.load(open('src/data/proofs/area-of-circle-oq-02/meta.json'))"` valid JSON
- [x] both `meta.theoremCount` and `leanFile.theoremCount` updated to 17
- [x] no other field changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)