### PR TITLE
fix(meta): derangements-convergence-oq-03 sync meta+leanFile counts (88→89, 2→1)

### DIFF
--- a/src/data/proofs/derangements-convergence-oq-03/meta.json
+++ b/src/data/proofs/derangements-convergence-oq-03/meta.json
@@ -22,8 +22,8 @@
     "axiomCount": 0,
     "assumptions": "No assumptions. The theorem is fully machine-checked. The proof delegates the rate bound to derangements_convergence_rate from DerangementsConvergence.lean, which establishes |D(n)/n! - e⁻¹| ≤ 1/(n+1)! via the alternating series estimation theorem.",
     "dateAdded": "2026-04-24",
-    "lineCount": 88,
-    "theoremCount": 2,
+    "lineCount": 89,
+    "theoremCount": 1,
     "definitionCount": 0,
     "originalContributions": [
       "derangements_eq_round (PROVED): For n ≥ 2, (numDerangements n : ℤ) = round(n! · rexp(-1))",
@@ -179,9 +179,9 @@
       "Topology"
     ],
     "namespace": "DerangementsConvergenceOQ03",
-    "lineCount": 88,
+    "lineCount": 89,
     "axiomCount": 0,
-    "theoremCount": 2,
+    "theoremCount": 1,
     "substantiveTheoremCount": 1,
     "duplicateTheorems": 0,
     "definitionCount": 0,


### PR DESCRIPTION
## Fix

Sync the `meta` block and `leanFile` block in `src/data/proofs/derangements-convergence-oq-03/meta.json` to match the canonical counts produced by `scripts/research/enrich-research.ts`.

## Evidence

**Before** (stale, in both `meta` and `leanFile` blocks):
- `lineCount`: 88
- `theoremCount`: 2

**After** (matches the source):
- `lineCount`: 89
- `theoremCount`: 1

Verified via the canonical counters used by `scripts/research/enrich-research.ts`:

```
$ python3 -c "print(len(open('proofs/Proofs/DerangementsConvergenceOQ03.lean').read().split('\n')))"
89
$ grep -cE "^(theorem|lemma) " proofs/Proofs/DerangementsConvergenceOQ03.lean
1
$ grep -cE "^axiom " proofs/Proofs/DerangementsConvergenceOQ03.lean
0
$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/DerangementsConvergenceOQ03.lean
0
```

The previous `theoremCount: 2` counted the `private lemma factorial_mul_one_div_factorial_succ` (line 37), which the canonical extractor excludes — its regex anchors on `^theorem ` / `^lemma `, so `private lemma` is not matched. The `leanFile.substantiveTheoremCount: 1` was already accurate.

`axiomCount` (0) and `definitionCount` (0) already matched the file — no changes there.

---
Automated fix by lean-mechanic agent.