### PR TITLE
research(weak-goldbach-oq-03): S8 ACT — axiom elimination vinogradov + helfgott_explicit (7→5, build pending)

### DIFF
--- a/proofs/Proofs/WeakGoldbach.lean
+++ b/proofs/Proofs/WeakGoldbach.lean
@@ -254,12 +254,25 @@ theorem binary_implies_weak (h : BinaryGoldbachConjecture) : WeakGoldbachConject
 
 /-! ## Axiomatized Results -/
 
-/-- Vinogradov (1937): sufficiently large odd numbers are sums of 3 primes -/
-axiom vinogradov_ternary_goldbach :
-    ∃ N₀ : ℕ, ∀ n : ℕ, n > N₀ → Odd n → IsSumOfThreePrimes n
+/-- Helfgott (2013): the weak Goldbach conjecture is true.
 
-/-- Helfgott (2013): the weak Goldbach conjecture is true -/
+    This is the deep result: every odd `n > 5` is a sum of three primes.
+    It is the single load-bearing assumption that the historical
+    `vinogradov_ternary_goldbach` (1937) and `helfgott_explicit_bound`
+    are now derived from (as theorems, below). -/
 axiom helfgott_weak_goldbach : WeakGoldbachConjecture
+
+/-- Vinogradov (1937): sufficiently large odd numbers are sums of 3 primes.
+
+    **S8 ACT (axiom-elimination):** Originally axiomatized; now derived
+    from the stronger `helfgott_weak_goldbach` (which is unconditional
+    for all `n > 5`). Take `N₀ := 5`; the existential is then satisfied
+    by Helfgott's theorem applied pointwise. The underlying mathematical
+    assumption is unchanged — Vinogradov is *implied by* Helfgott's
+    1933 conditional result strengthened to the unconditional form. -/
+theorem vinogradov_ternary_goldbach :
+    ∃ N₀ : ℕ, ∀ n : ℕ, n > N₀ → Odd n → IsSumOfThreePrimes n :=
+  ⟨5, helfgott_weak_goldbach⟩
 
 /-- Every odd n > 5 is sum of three primes -/
 theorem weak_goldbach (n : ℕ) (hn : n > 5) (hodd : Odd n) :
@@ -601,11 +614,17 @@ def twinPrimeConstant : ℝ := 0.6601618158
 
 /-- Helfgott's explicit bound: all odd n > 5 are sums of three primes.
     The computational part verified odd n ≤ 8.875 × 10³⁰.
-    The analytic part (improved Vinogradov) handled n > 8.875 × 10³⁰. -/
-axiom helfgott_explicit_bound :
-    -- The threshold N₀ in Vinogradov's theorem is at most 8.875 × 10³⁰
-    -- This is small enough to check computationally below
-    ∀ n : ℕ, n > 5 → Odd n → IsSumOfThreePrimes n
+    The analytic part (improved Vinogradov) handled n > 8.875 × 10³⁰.
+
+    **S8 ACT (axiom-elimination):** Originally axiomatized; now derived
+    from `helfgott_weak_goldbach`, since the statement here is
+    syntactically `WeakGoldbachConjecture` unfolded. The threshold
+    `8.875 × 10³⁰` from Helfgott's 2013 paper is not a separate
+    mathematical assumption — it is the *content* of the unconditional
+    main theorem. The underlying assumption set is unchanged. -/
+theorem helfgott_explicit_bound :
+    ∀ n : ℕ, n > 5 → Odd n → IsSumOfThreePrimes n :=
+  helfgott_weak_goldbach
 
 /-- The Levy conjecture (1963): every odd integer > 5 can be written as
     p + 2q where p, q are primes. Stronger than weak Goldbach. -/

--- a/research/problems/weak-goldbach-oq-03/sessions/2026-06-10-s8-act-vinogradov-helfgott-explicit-discharge.md
+++ b/research/problems/weak-goldbach-oq-03/sessions/2026-06-10-s8-act-vinogradov-helfgott-explicit-discharge.md
@@ -1,0 +1,171 @@
+# S8 ACT — Axiom-elimination second pass (vinogradov_ternary_goldbach + helfgott_explicit_bound)
+
+**Author:** researcher-1
+**Timestamp:** 2026-06-10
+**Phase:** S8 ACT — execute the discharges sketched by S6 PREP and S7 PREP
+**Iteration:** 8
+**Builds on:**
+- S6 PREP (PR #18368, merged): sketched the 1-line discharge of
+  `vinogradov_ternary_goldbach` from `helfgott_weak_goldbach`.
+- S7 PREP (PR #18504, merged): projected post-discharge axiomCount of
+  5, identifying `vinogradov_ternary_goldbach` and `helfgott_explicit_bound`
+  as the two "historical-attribution" axioms ready for immediate ACT.
+- S5 ACT (PR #18265, merged): set the precedent — `ramare_six_primes`
+  and `tao_five_primes` axiom → theorem via `helfgott_weak_goldbach`.
+
+## §1. What changed in `proofs/Proofs/WeakGoldbach.lean`
+
+**Reorder + 2 axiom → theorem conversions.**
+
+### §1.1. Helfgott moved above Vinogradov (lines 255-282)
+
+Original order:
+```lean
+axiom vinogradov_ternary_goldbach : ∃ N₀, ∀ n > N₀, Odd n → IsSumOfThreePrimes n
+axiom helfgott_weak_goldbach : WeakGoldbachConjecture
+```
+
+New order:
+```lean
+axiom helfgott_weak_goldbach : WeakGoldbachConjecture
+theorem vinogradov_ternary_goldbach :
+    ∃ N₀ : ℕ, ∀ n : ℕ, n > N₀ → Odd n → IsSumOfThreePrimes n :=
+  ⟨5, helfgott_weak_goldbach⟩
+```
+
+Reordering is necessary so the derivation typechecks
+(`helfgott_weak_goldbach` must be in scope when `vinogradov_ternary_goldbach`
+is stated). Net structural change: 1 axiom block moved up; 1 theorem
+block below it; docstring updates explain the derivation path.
+
+### §1.2. Helfgott explicit bound (lines ~605-620)
+
+Original:
+```lean
+axiom helfgott_explicit_bound :
+    -- The threshold N₀ in Vinogradov's theorem is at most 8.875 × 10³⁰
+    -- This is small enough to check computationally below
+    ∀ n : ℕ, n > 5 → Odd n → IsSumOfThreePrimes n
+```
+
+The statement is **syntactically** `WeakGoldbachConjecture` unfolded.
+Replacement:
+```lean
+theorem helfgott_explicit_bound :
+    ∀ n : ℕ, n > 5 → Odd n → IsSumOfThreePrimes n :=
+  helfgott_weak_goldbach
+```
+
+The narrative comments about the `8.875 × 10³⁰` threshold are preserved
+in the docstring.
+
+## §2. Why these two axioms specifically
+
+Of the 7 pre-S8 axioms, these are the only ones whose statement is a
+**strict logical consequence** of `helfgott_weak_goldbach`'s statement:
+
+| Axiom | Statement shape | Derivable from Helfgott? |
+|-------|-----------------|--------------------------|
+| `vinogradov_ternary_goldbach` | `∃ N₀, ∀ n > N₀, …` | YES — take `N₀ := 5` |
+| `helfgott_weak_goldbach` | `∀ n > 5, …` | (this is the load-bearing axiom) |
+| `circle_method_asymptotic` | `r₃(n) ∼ S(n)·n²/2log³n` | NO — quantitative bound, not in Helfgott |
+| `schnirelmann_basis_theorem` | density > 0 → basis | NO — generic combinatorics, Mathlib TODO |
+| `chen_theorem` | even n = p + P₂ | NO — different statement (binary, not ternary) |
+| `binary_goldbach_verified` | binary n ≤ 4·10¹⁸ | NO — about binary Goldbach |
+| `helfgott_explicit_bound` | `∀ n > 5, …` | YES — *literally* `WeakGoldbachConjecture` |
+
+The five non-derivable axioms are the practical floor for this slug
+per S7 PREP §4.6 and S8 PREP-1 §11 / S8 PREP-2 §11.
+
+## §3. Honest scope
+
+* **The underlying mathematical assumption set is unchanged.** Both
+  new theorems still depend transitively on `helfgott_weak_goldbach`,
+  which remains axiomatized. The reduction is purely in the file's
+  *explicit `axiom` declarations*, from 7 to 5.
+* **No mathematical advance.** The proofs are routine logical
+  consequences of an already-axiomatized stronger result. Per
+  `researcher.md`'s axiom-elimination priority and the S5 precedent
+  (PR #18265), this is real progress on the *axiom-surface integrity*
+  axis but does not introduce new mathematical content.
+* **The remaining 5 axioms are genuinely distinct deep claims.** No
+  further axiom can be discharged from inside the slug without doing
+  real new mathematics (e.g., the Schnirelmann basis theorem proof
+  outlined in S8 PREP-1 §2).
+* **Build status will be reported in the PR description** under the
+  documented "build pending — parent drift cluster" convention (cf.
+  S2 #18068, S3 #18108, S5 #18265). The two `theorem` derivations
+  themselves are trivial type-checks; any build failure will be in
+  the pre-existing drift around `exponentialSumOverPrimes`,
+  `representationCount_pos_iff`, `singular_series_positive` per state.md
+  S2 audit (lines 248-258).
+
+## §4. Counts delta
+
+| Field | Before S8 ACT | After S8 ACT | Delta |
+|-------|---------------|--------------|-------|
+| `axiomCount` | 7 | 5 | −2 |
+| `theoremCount` | 29 | 31 | +2 |
+| `lineCount` | 661 | 680 | +19 |
+| `definitionCount` | 15 | 15 | 0 |
+| Sorries | 0 | 0 | 0 |
+
+## §5. Files modified
+
+- `proofs/Proofs/WeakGoldbach.lean` (661 → 680 lines; 2 axioms → 2
+  theorems; helfgott_weak_goldbach moved above
+  vinogradov_ternary_goldbach).
+- `research/problems/weak-goldbach-oq-03/state.md` (S8 ACT section,
+  session history, current focus).
+- `research/problems/weak-goldbach-oq-03/sessions/2026-06-10-s8-act-vinogradov-helfgott-explicit-discharge.md` (this file).
+- `src/data/proofs/weak-goldbach/meta.json` (description, assumptions,
+  axiomCount, theoremCount, lineCount, leanFile.*).
+
+## §6. Next iteration candidates (S9+)
+
+The 5 remaining axioms have no further trivial-discharge path. The
+realistic next steps:
+
+- **S9 (Approach D-phase-1)**: Schnirelmann sumset inequality
+  `σ(A+B) ≥ σ(A) + σ(B) − σ(A)σ(B)` from `Mathlib.Combinatorics.Schnirelmann`.
+  Per S8 PREP-1 §2.1, ~250-350 LOC; per S8 PREP-2 §7, this is the
+  dominant cost step. Discharges nothing on its own; sets up S10.
+- **S10 (Approach D-phase-2)**: Combine Steps B (induction), C
+  (Mathlib already has it per S8 PREP-2 §2), D (basis from density),
+  + Multiset bridge into a discharge of `schnirelmann_basis_theorem`.
+  ~125-190 LOC per S8 PREP-2 §8.2.
+
+Both Approach D phases are *real new mathematics* unlike S5/S8's
+historical-corollary discharges. They would also be Mathlib
+upstream-PR candidates (the module docstring explicitly TODOs
+Schnirelmann's theorem).
+
+The other 4 axioms (`helfgott_weak_goldbach`, `circle_method_asymptotic`,
+`chen_theorem`, `binary_goldbach_verified`) are the long-term aspirational
+limit — multi-year formalization efforts.
+
+## §7. Anti-targets (this S8 ACT explicitly does NOT do)
+
+1. **Does not touch the other 5 axioms** (Helfgott, circle method,
+   Schnirelmann basis, Chen, binary verified). All require real
+   new mathematics or computation that is out of S8 ACT scope.
+2. **Does not begin Approach D** (Schnirelmann sumset inequality).
+   That is the S9 target per the PREP-2 §8 ordering.
+3. **Does not address parent-file drift** (`exponentialSumOverPrimes`
+   needing `noncomputable`, `representationCount_pos_iff` Mathlib
+   signature change, `singular_series_positive` `positivity` failure).
+   Per state.md S2 audit those are Mechanic concerns, not researcher.
+4. **Does not run a fresh full lake build** outside the docker
+   wrapper. Builds for `Proofs.WeakGoldbach` are slow (~10-15 min
+   with cache) and known to fail on parent drift unrelated to S8 ACT's
+   surgical changes.
+
+## §8. References
+
+* S6 PREP session note: `2026-05-12-s6-prep-vinogradov-helfgott-reduction.md` (PR #18368).
+* S7 PREP session note: `2026-05-12-s7-prep-axiom-redundancy-audit.md` (PR #18504).
+* S8 PREP-1: `2026-05-13-s8-prep-schnirelmann-basis-discharge-roadmap.md` (PR #18552).
+* S8 PREP-2: `2026-05-13-s8-prep-2-mathlib-bearer-audit.md` (PR #18670).
+* S5 ACT (precedent for axiom → theorem via Helfgott): PR #18265 (merged).
+* Helfgott, H. A. (2013). Major arcs / Minor arcs for Goldbach's problem.
+  arXiv:1305.2897, arXiv:1205.5252.

--- a/research/problems/weak-goldbach-oq-03/state.md
+++ b/research/problems/weak-goldbach-oq-03/state.md
@@ -1,20 +1,39 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-05-12 (S4)
-**Iteration**: 4
+**Since**: 2026-06-10 (S8)
+**Iteration**: 8
 
 ## Current Focus
 
-S4 (researcher-1, 2026-05-12): Approach C — small-range kernel-verified
-binary Goldbach. Added `binary_goldbach_verified_small` theorem covering
-`n ≤ 30` via `interval_cases + decide`, sitting alongside the existing
-axiom `binary_goldbach_verified` (Oliveira e Silva 2013 verification up
-to `4 × 10^18`). Genuine kernel verification of 14 even cases
-(n ∈ {4, 6, …, 30}); odd cases discharged by `Even n` being False. ~22
-lines (theorem + docstring) added; 0 new axioms; 0 new sorries; axiom
-count unchanged at 9 (the new theorem is companion content, not an axiom
-replacement).
+S8 (researcher-1, 2026-06-10): ACT — Axiom elimination, second pass.
+Discharged the two remaining historical-attribution axioms that are
+provable corollaries of `helfgott_weak_goldbach`:
+
+- `vinogradov_ternary_goldbach` (axiom → theorem): `∃ N₀, ∀ n > N₀,
+  Odd n → IsSumOfThreePrimes n`. Take `N₀ := 5`; Helfgott's theorem
+  satisfies the pointwise claim.
+- `helfgott_explicit_bound` (axiom → theorem): `∀ n > 5, Odd n →
+  IsSumOfThreePrimes n`. This is *syntactically* `WeakGoldbachConjecture`
+  unfolded; one-line proof `:= helfgott_weak_goldbach`.
+
+Also reordered: `helfgott_weak_goldbach` moved above
+`vinogradov_ternary_goldbach` so that the latter's derivation
+typechecks.
+
+The underlying mathematical assumption set is **unchanged** — both new
+theorems depend transitively on `helfgott_weak_goldbach`, which remains
+axiomatized. The reduction is in the file's *explicit `axiom`
+declarations*, from 7 to 5, matching the S7 PREP §4.6 projection
+("5 irreducible axioms" after S6+S7 ACT). The remaining 5 axioms
+(`helfgott_weak_goldbach`, `circle_method_asymptotic`,
+`schnirelmann_basis_theorem`, `chen_theorem`, `binary_goldbach_verified`)
+are genuinely distinct deep results — the practical floor for the
+slug per S7 PREP and S8 PREP-1/PREP-2.
+
+Counts: `axiomCount` 7 → 5; `lineCount` 661 → 680 (+19 net: -8 axiom
+lines, +27 theorem+docstring lines); `theoremCount` 29 → 31; `sorries`
+0 (unchanged); `definitionCount` 15 (unchanged).
 
 ## Session History
 
@@ -32,7 +51,23 @@ replacement).
 - S4 (researcher-1): Approach C — small-range kernel-verified binary
   Goldbach for `n ≤ 30`. Theorem `binary_goldbach_verified_small`
   proves the same claim shape as the axiom but for the kernel-tractable
-  initial segment. Build pending.
+  initial segment. Merged #18189.
+- S5 (researcher-5): Axiom elimination — `ramare_six_primes` and
+  `tao_five_primes` upgraded from `axiom` to `theorem` proved from
+  `helfgott_weak_goldbach`. axiomCount 9 → 7. Merged #18265.
+- S6 PREP (researcher-?): doc-only — `vinogradov_ternary_goldbach`
+  1-line discharge sketch from `helfgott_weak_goldbach`. Merged #18368.
+- S7 PREP (researcher-?): doc-only — axiom redundancy audit projecting
+  post-S6+S7-ACT census of 5 irreducible axioms. Merged #18504.
+- S8 PREP-1 (researcher-12): doc-only — Schnirelmann basis theorem
+  4-step discharge roadmap. Merged #18552.
+- S8 PREP-2 (researcher-4): doc-only — Mathlib v4.26.0 bearer audit
+  revealing Step C is already a Mathlib theorem. Merged #18670.
+- S8 ACT (researcher-1, this iteration): Axiom elimination —
+  `vinogradov_ternary_goldbach` and `helfgott_explicit_bound` upgraded
+  from `axiom` to `theorem` proved from `helfgott_weak_goldbach`.
+  axiomCount 7 → 5. Build pending under the documented parent-drift
+  precedent.
 
 ## Earlier Plan (S1, kept for context)
 

--- a/src/data/proofs/weak-goldbach/meta.json
+++ b/src/data/proofs/weak-goldbach/meta.json
@@ -2,7 +2,7 @@
   "id": "weak-goldbach",
   "title": "Weak Goldbach Conjecture (Ternary Goldbach)",
   "slug": "weak-goldbach",
-  "description": "Formalizes the Weak Goldbach Conjecture (proved by Helfgott 2013): every odd integer >5 is a sum of three primes. Axiomatizes Vinogradov's circle method, Helfgott's proof, Schnirelmann density, and Chen's theorem. Proves structural reductions: binary Goldbach implies ternary, Lévy's conjecture verified for small cases. Ramaré's 6-prime bound and Tao's 5-prime bound are now theorems proved from helfgott_weak_goldbach (S5 axiom elimination). 28 theorems, 7 axioms.",
+  "description": "Formalizes the Weak Goldbach Conjecture (proved by Helfgott 2013): every odd integer >5 is a sum of three primes. Axiomatizes Helfgott's proof, the circle-method asymptotic, Schnirelmann's basis theorem, Chen's theorem, and Oliveira e Silva's binary Goldbach verification. Proves structural reductions: binary Goldbach implies ternary, Lévy's conjecture verified for small cases. Ramaré's 6-prime bound and Tao's 5-prime bound are theorems proved from helfgott_weak_goldbach (S5 axiom elimination); Vinogradov's 1937 theorem and Helfgott's explicit bound are theorems proved from helfgott_weak_goldbach (S8 axiom elimination). 31 theorems, 5 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-02-15",
@@ -18,10 +18,10 @@
     "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 7,
-    "assumptions": "7 axioms for deep analytic number theory results: vinogradov_ternary_goldbach (Vinogradov 1937: every sufficiently large odd number is sum of 3 primes), helfgott_weak_goldbach (Helfgott 2013: proved unconditionally for all odd n>5), circle_method_asymptotic (circle method asymptotic formula for ternary representations), schnirelmann_basis_theorem (every dense enough set is an additive basis), chen_theorem (Chen 1973: every sufficiently large even n = p + P₂), binary_goldbach_verified (verified for n ≤ 4·10¹⁸), helfgott_explicit_bound (Helfgott's explicit bound). S5 ACT (2026-05-12, researcher-5) reduced the explicit axiomCount from 9 to 7 by upgrading ramare_six_primes (Ramaré 1995: every even n ≥ 4 is sum of ≤ 6 primes) and tao_five_primes (Tao 2014: every odd n > 1 is sum of ≤ 5 primes) from `axiom` declarations to `theorem`s proved from helfgott_weak_goldbach. The underlying assumption set is unchanged — both new theorems still depend transitively on helfgott_weak_goldbach — but they no longer appear as separate axiomatic claims. Also: 2 theorem-level True stubs upgraded in S3 (vinogradov_minor_arc_bound and linnik_goldbach_representations now bear modest typed content via Nat.primeCounting bounds).",
-    "lineCount": 661,
-    "theoremCount": 29,
+    "axiomCount": 5,
+    "assumptions": "5 axioms for deep analytic number theory results: helfgott_weak_goldbach (Helfgott 2013: proved unconditionally for all odd n>5 — the central load-bearing assumption), circle_method_asymptotic (circle method asymptotic formula for ternary representations), schnirelmann_basis_theorem (every dense enough set is an additive basis), chen_theorem (Chen 1973: every sufficiently large even n = p + P₂), binary_goldbach_verified (Oliveira e Silva 2013: verified for n ≤ 4·10¹⁸). S5 ACT (2026-05-12, researcher-5) reduced the explicit axiomCount from 9 to 7 by upgrading ramare_six_primes (Ramaré 1995: every even n ≥ 4 is sum of ≤ 6 primes) and tao_five_primes (Tao 2014: every odd n > 1 is sum of ≤ 5 primes) from `axiom` declarations to `theorem`s proved from helfgott_weak_goldbach. S8 ACT (2026-06-10) reduced 7 → 5 by upgrading vinogradov_ternary_goldbach (∃ N₀, ∀ n > N₀, Odd n → IsSumOfThreePrimes n — Helfgott gives this with N₀ := 5) and helfgott_explicit_bound (∀ n > 5, Odd n → IsSumOfThreePrimes n — literally WeakGoldbachConjecture unfolded) from `axiom` to `theorem` proved from helfgott_weak_goldbach. The underlying assumption set is unchanged — all four S5/S8 new theorems depend transitively on helfgott_weak_goldbach — but they no longer appear as separate axiomatic claims. Also: 2 theorem-level True stubs upgraded in S3 (vinogradov_minor_arc_bound and linnik_goldbach_representations now bear modest typed content via Nat.primeCounting bounds).",
+    "lineCount": 680,
+    "theoremCount": 31,
     "definitionCount": 15,
     "originalContributions": [
       "WeakGoldbachConjecture: formal statement — ∀ n odd, n > 5 → ∃ p q r prime, n = p+q+r",
@@ -139,7 +139,7 @@
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures the mathematical landscape around the Weak Goldbach Conjecture: its statement, an algorithmic decision procedure for any finite case, a fully proved structural reduction from binary to ternary Goldbach, the circle method infrastructure, Schnirelmann density theory, Chen's theorem, and the Lévy conjecture. The 9 axioms represent Helfgott's 2013 proof and its historical predecessors — results whose deep analytic proofs await future Lean formalization.",
+    "summary": "This formalization captures the mathematical landscape around the Weak Goldbach Conjecture: its statement, an algorithmic decision procedure for any finite case, a fully proved structural reduction from binary to ternary Goldbach, the circle method infrastructure, Schnirelmann density theory, Chen's theorem, and the Lévy conjecture. The 5 remaining axioms represent Helfgott's 2013 proof and the deepest analytic/computational ingredients (circle-method asymptotic, Schnirelmann basis theorem, Chen's theorem, Oliveira e Silva's binary-Goldbach verification) — results whose proofs await future Lean formalization. The four originally-declared corollaries of Helfgott (Vinogradov 1937, Ramaré 1995 6-prime, Tao 2012 5-prime, helfgott_explicit_bound) are now theorems derived from helfgott_weak_goldbach.",
     "implications": "Helfgott's 2013 resolution of Weak Goldbach is a landmark achievement in analytic number theory — the culmination of 271 years since Goldbach's original conjecture. The circle method infrastructure formalized here (exponential sums over primes, singular series, major/minor arc decomposition) is the same machinery underlying the prime number theorem, Dirichlet's theorem on primes in arithmetic progressions, and Waring's problem. Formalizing these analytic tools in Lean would yield a powerful library for quantitative prime distribution theory. The cascade Schnirelmann → Ramaré → Tao → Helfgott illustrates how additive number theory progresses through increasingly sharp analytic bounds combined with computational verification.",
     "openQuestions": [
       "Binary (Strong) Goldbach Conjecture: every even n > 2 is a sum of two primes — verified to 4×10¹⁸ computationally (Oliveira e Silva 2013) but unproved in general; the deepest open problem in additive number theory.",
@@ -150,9 +150,9 @@
   },
   "leanFile": {
     "namespace": "WeakGoldbach",
-    "lineCount": 661,
-    "axiomCount": 7,
-    "theoremCount": 29,
+    "lineCount": 680,
+    "axiomCount": 5,
+    "theoremCount": 31,
     "definitionCount": 15,
     "path": "Proofs/WeakGoldbach.lean",
     "sorries": 0

--- a/src/data/research/problems/weak-goldbach-oq-03.json
+++ b/src/data/research/problems/weak-goldbach-oq-03.json
@@ -39,15 +39,15 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-12T19:25:00.000Z",
-    "iteration": 5,
-    "focus": "S5 (researcher-5, 2026-05-12): Axiom elimination via Helfgott corollaries. Upgraded `ramare_six_primes` and `tao_five_primes` from `axiom` declarations to `theorem` proofs derived from `helfgott_weak_goldbach`. For Ramaré (every even n ≥ 4 = sum of ≤ 6 primes): n ≥ 10 case uses Helfgott on n-3 then prepends 3 (4 primes); small cases n ∈ {4, 6, 8} via [2,2], [3,3], [3,5]. For Tao (every odd n > 1 = sum of ≤ 5 primes): n > 5 case is Helfgott directly (3 primes ≤ 5); small cases n ∈ {3, 5} via singletons. Counts: lineCount 543 → 627, axiomCount 9 → 7, theoremCount (broad) 26 → 28. Underlying assumption set unchanged (still depends on helfgott_weak_goldbach), but file's explicit axiom surface reduced. Skipped S4 (Approach C small-range) — already in flight as open PR #18189. Build pending under documented precedent (parent Mathlib drift in Vinogradov section).",
+    "since": "2026-06-10T00:00:00.000Z",
+    "iteration": 8,
+    "focus": "S8 ACT (researcher-1, 2026-06-10): Axiom elimination second pass. Discharged the two remaining historical-attribution axioms that are provable corollaries of `helfgott_weak_goldbach`: (1) `vinogradov_ternary_goldbach` (∃ N₀, ∀ n > N₀, Odd n → IsSumOfThreePrimes n) — take N₀ := 5; Helfgott satisfies the pointwise claim. (2) `helfgott_explicit_bound` (∀ n > 5, Odd n → IsSumOfThreePrimes n) — literally WeakGoldbachConjecture unfolded; one-line proof := helfgott_weak_goldbach. Required reorder so helfgott_weak_goldbach precedes vinogradov_ternary_goldbach. Counts: axiomCount 7 → 5, theoremCount 29 → 31, lineCount 661 → 680 (+19), definitionCount 15, sorries 0. The five remaining axioms (helfgott_weak_goldbach, circle_method_asymptotic, schnirelmann_basis_theorem, chen_theorem, binary_goldbach_verified) are genuinely distinct deep results — the practical floor for this slug per S7 PREP §4.6 and S8 PREP-1/PREP-2. Builds on S6 PREP (#18368), S7 PREP (#18504), S8 PREP-1 (#18552), S8 PREP-2 (#18670). Build pending under documented parent-drift precedent.",
     "blockers": [],
-    "nextAction": "S6 (any researcher): Continue axiom elimination via Helfgott. Next candidate: `vinogradov_ternary_goldbach` (line ~258) — asserts ∃ N₀, ∀ n > N₀, Odd n → IsSumOfThreePrimes n; satisfied by N₀ := 5 via Helfgott. ~5 LOC, brings axiomCount to 6. Or S7: extend PR #18189's small-range kernel range (30 → ~100) via interval_cases + decide. Or S8+ (multi-session): Approach D-phase-1 — Schnirelmann sumset inequality σ(A + B) ≥ α + β − αβ from Mathlib.Combinatorics.Schnirelmann (~600-1000 LOC, 3-6 sessions).",
+    "nextAction": "S9 (any researcher): Begin Approach D — Schnirelmann sumset inequality σ(A+B) ≥ σ(A) + σ(B) − σ(A)σ(B). Per S8 PREP-1 §2.1 and PREP-2 §7, this is ~250-350 LOC, the dominant cost step of the Schnirelmann basis theorem discharge. Mathlib upstream-PR candidate (module docstring explicitly TODOs Schnirelmann's theorem). After S9: S10 combines Step B (induction) + Step C (already a Mathlib theorem per PREP-2 §2) + Step D (combine) + Multiset bridge into a discharge of schnirelmann_basis_theorem (~125-190 LOC). Alternative: defer Approach D and accept axiomCount=5 as the slug's practical floor (per S7 PREP §4.6).",
     "attemptCounts": {
-      "total": 5,
-      "currentApproach": 1,
-      "approachesTried": 3
+      "total": 8,
+      "currentApproach": 2,
+      "approachesTried": 4
     }
   },
   "knowledge": {


### PR DESCRIPTION
## Summary

S8 ACT for `weak-goldbach-oq-03`: axiom elimination, second pass. Two
historical-attribution axioms in `proofs/Proofs/WeakGoldbach.lean` are
upgraded from `axiom` to `theorem`, derived from `helfgott_weak_goldbach`.

- `vinogradov_ternary_goldbach` (∃ N₀, ∀ n > N₀, Odd n → IsSumOfThreePrimes n)
  → `⟨5, helfgott_weak_goldbach⟩`
- `helfgott_explicit_bound` (∀ n > 5, Odd n → IsSumOfThreePrimes n)
  → `helfgott_weak_goldbach` (literally `WeakGoldbachConjecture` unfolded)

Reorder: `helfgott_weak_goldbach` moved above `vinogradov_ternary_goldbach`
so the derivation typechecks.

## Counts delta

| Field | Before | After | Δ |
|-------|--------|-------|---|
| `axiomCount` | 7 | 5 | −2 |
| `theoremCount` | 29 | 31 | +2 |
| `lineCount` | 661 | 680 | +19 |
| `definitionCount` | 15 | 15 | 0 |
| Sorries | 0 | 0 | 0 |

## Honest scope

The underlying mathematical **assumption set is unchanged** — both new
theorems still depend transitively on `helfgott_weak_goldbach`, which
remains axiomatized. The reduction is in the file's *explicit `axiom`
declarations*, from 7 to 5, matching S7 PREP §4.6 projection
("5 irreducible axioms" after S6+S7 ACT).

The remaining 5 axioms (`helfgott_weak_goldbach`,
`circle_method_asymptotic`, `schnirelmann_basis_theorem`, `chen_theorem`,
`binary_goldbach_verified`) are genuinely distinct deep results — the
practical floor for this slug per S7 PREP §4.6 and S8 PREP-1/PREP-2.

Per `researcher.md`: "Reducing axiom counts is more valuable than adding
new theorems." This S8 ACT delivers the same axiom-elimination pattern
as the S5 precedent (PR #18265, `ramare_six_primes` + `tao_five_primes`).

## Build status (pending under documented precedent)

Docker build (`./proofs/scripts/docker-build.sh Proofs.WeakGoldbach`)
exits 1, but **all reported errors are pre-existing parent-file drift**
documented in state.md §S2 (lines 248-258):

- `exponentialSumOverPrimes` (line 283): needs `noncomputable` (Real.pi)
- `representationCount_pos_iff` (lines 299, 304): `Finset.card_pos.mp`
  signature changed in Mathlib
- `singular_series_positive` (line 352): `positivity` cannot prove the
  `⟨1, one_pos⟩` placeholder

All `#check` lines for the touched declarations output cleanly. The two
new theorems' typecheck succeeds before the build crashes on the
unrelated pre-existing errors above.

Same "build pending — Mechanic-targeted" precedent as S2 (#18068), S3
(#18108), S5 (#18265).

## Files changed

- `proofs/Proofs/WeakGoldbach.lean` (661 → 680 lines)
- `src/data/proofs/weak-goldbach/meta.json`
- `src/data/research/problems/weak-goldbach-oq-03.json`
- `research/problems/weak-goldbach-oq-03/state.md`
- `research/problems/weak-goldbach-oq-03/sessions/2026-06-10-s8-act-vinogradov-helfgott-explicit-discharge.md` (new)

## Test plan

- [x] `grep -c "^axiom " proofs/Proofs/WeakGoldbach.lean` returns 5 (was 7)
- [x] Docker build emits `#check` for all relevant declarations; only
      pre-existing drift errors reported
- [ ] Mechanic PR to clean up parent drift — separate concern

## Builds on

- S6 PREP #18368 (vinogradov 1-line discharge sketch)
- S7 PREP #18504 (axiom redundancy audit projecting post-discharge=5)
- S8 PREP-1 #18552 (Schnirelmann basis 4-step roadmap)
- S8 PREP-2 #18670 (Mathlib bearer audit; Step C already in Mathlib)
- S5 ACT #18265 (precedent: ramare + tao axiom → theorem via Helfgott)

🤖 Generated with [Claude Code](https://claude.com/claude-code)