### PR TITLE
fix(meta): elementary-quadratic-reciprocity-oq-03-oq-02 sync meta+leanFile counts (223→224, 16→14)

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json
@@ -18,9 +18,9 @@
     "badge": "wip",
     "sorries": 0,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 14,
     "defCount": 4,
-    "lineCount": 223,
+    "lineCount": 224,
     "dateAdded": "2026-03-28",
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
     "mathlib_version": "4.26.0",
@@ -97,9 +97,9 @@
       "Mathlib.NumberTheory.LegendreSymbol.JacobiSymbol"
     ],
     "namespace": "KroneckerSymbol",
-    "lineCount": 223,
+    "lineCount": 224,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 4,
     "path": "Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Fix

Sync the `meta` block and `leanFile` block in `src/data/proofs/elementary-quadratic-reciprocity-oq-03-oq-02/meta.json` to match the canonical counts produced by `scripts/research/enrich-research.ts`.

## Evidence

**Before** (stale, in both `meta` and `leanFile` blocks):
- `lineCount`: 223
- `theoremCount`: 16

**After** (matches the source):
- `lineCount`: 224
- `theoremCount`: 14

Verified via the canonical counters used by `scripts/research/enrich-research.ts`:

```
$ python3 -c "print(len(open('proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean').read().split('\n')))"
224
$ grep -cE "^(theorem|lemma) " proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
14
$ grep -cE "^axiom " proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
0
$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ02.lean
4
```

The file declares 14 theorems via `^theorem ` (no `^lemma ` declarations); the previous count of 16 was stale relative to the current source. `axiomCount` (0) and `defCount` / `definitionCount` (4) already matched.

---
Automated fix by lean-mechanic agent.