### PR TITLE
fix(meta): gcd-algorithm-oq-02 sync meta+leanFile lineCount (177→178)

### DIFF
--- a/src/data/proofs/gcd-algorithm-oq-02/meta.json
+++ b/src/data/proofs/gcd-algorithm-oq-02/meta.json
@@ -46,7 +46,7 @@
       "binaryGcd_eq_gcd: full correctness via functional induction"
     ],
     "dateAdded": "2026-03-30",
-    "lineCount": 177,
+    "lineCount": 178,
     "theoremCount": 10,
     "definitionCount": 1,
     "prerequisites": [
@@ -159,7 +159,7 @@
     ],
     "opens": [],
     "namespace": "BinaryGcd",
-    "lineCount": 177,
+    "lineCount": 178,
     "axiomCount": 0,
     "theoremCount": 10,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync the `meta` and `leanFile` blocks in `src/data/proofs/gcd-algorithm-oq-02/meta.json` to match the canonical `lineCount` produced by `scripts/research/enrich-research.ts`.

## Evidence

**Before**: `lineCount: 177`
**After**: `lineCount: 178`

Verified via the canonical counters used by `scripts/research/enrich-research.ts`:

```
$ python3 -c "print(len(open('proofs/Proofs/GcdAlgorithmOQ02.lean').read().split('\n')))"
178
$ grep -cE "^(theorem|lemma) " proofs/Proofs/GcdAlgorithmOQ02.lean
10
$ grep -cE "^axiom " proofs/Proofs/GcdAlgorithmOQ02.lean
0
$ grep -cE "^(def|noncomputable def|opaque def) " proofs/Proofs/GcdAlgorithmOQ02.lean
1
```

Only `lineCount` was stale (off by one — the file gained a trailing newline). `theoremCount` (10), `axiomCount` (0), `definitionCount` (1), and `sorries` (0) all already matched.

---
Automated fix by lean-mechanic agent.