### PR TITLE
audit(amgm-inequality-oq-03): clean — tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -145,9 +145,9 @@
       "result": "clean"
     },
     "amgm-inequality-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-10T10:12:21Z",
+      "lastAudited": "2026-06-10T13:55:39Z",
       "result": "clean"
     },
     "amgm-inequality-oq-03-oq-01": {


### PR DESCRIPTION
## Summary

5th clean audit of `amgm-inequality-oq-03` (Power Mean Interpolation: How Do Weighted Power Means Relate to AM and GM?).

All structural counts in `meta.json` match `proofs/Proofs/AmgmInequalityOQ03.lean`:
- `lineCount: 374` ✓
- `theoremCount: 12` ✓ (10 public + 2 private lemmas)
- `definitionCount: 3` ✓ (weightedPowerMean, weightedGeomMean, weightedArithMean)
- `axiomCount: 0`, `sorries: 0`, `structureCount: 0` ✓

## Narrative integrity

- `status: "verified"` / `badge: "original"` are consistent with 0 sorries and 0 axioms.
- Description and `assumptions` field explicitly disclose Mathlib reliance: *"Core building blocks (AM-GM, Jensen, AM ≤ M_p) from Mathlib; original proofs for HM ≤ GM and power mean monotonicity."*
- Mathlib wrappers (`arith_mean_le_power_mean`, `geom_mean_le_arith_mean`, `jensen_pow_ineq`, `geom_mean_le_power_mean_of_one_le`) are one-line `:=` direct calls and labeled as such in surrounding docstrings.
- Original contributions are substantive Lean 4 proofs: HM ≤ GM via inverse AM-GM (`harmonic_mean_le_geom_mean_direct`, ~40 lines), `power_mean_monotone_pos` via Jensen with q = s/r (~45 lines), `power_mean_neg_inv` duality identity, `power_mean_monotone_neg` via dual argument (~50 lines), plus two helper positivity lemmas.
- Open cases (mixed-sign r < 0 < s) are explicitly stated as not formalized in this file.

## Test plan

- [x] `wc -l proofs/Proofs/AmgmInequalityOQ03.lean` → 374
- [x] `grep -c "^axiom " proofs/Proofs/AmgmInequalityOQ03.lean` → 0
- [x] `grep -c "sorry" proofs/Proofs/AmgmInequalityOQ03.lean` → 0
- [x] Counted 12 theorems/lemmas, 3 definitions, 0 structures
- [x] Verified description, assumptions, originalContributions, and tier badge consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)