### PR TITLE
fix(meta): erdos-1118-oq-02 sync lineCount (103→104)

### DIFF
--- a/src/data/proofs/erdos-1118-oq-02/meta.json
+++ b/src/data/proofs/erdos-1118-oq-02/meta.json
@@ -19,7 +19,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 103,
+    "lineCount": 104,
     "assumptions": "0 axioms. 0 sorries. All theorems fully proved. The three docstring blocks (Camera-Gol'dberg criterion, SCV differences, plurisubharmonicity) are documentation, not axiom declarations.",
     "dateAdded": "2026-03-30",
     "mathlib_version": "4.26.0",
@@ -112,7 +112,7 @@
       "Mathlib"
     ],
     "namespace": "Erdos1118OQ02",
-    "lineCount": 103,
+    "lineCount": 104,
     "axiomCount": 0,
     "theoremCount": 3,
     "definitionCount": 1,


### PR DESCRIPTION
## Fix

Sync `meta.lineCount` and `leanFile.lineCount` in `src/data/proofs/erdos-1118-oq-02/meta.json` to match actual `proofs/Proofs/Erdos1118OQ02.lean` line count.

## Evidence

**Before**: Both `meta.lineCount` and `leanFile.lineCount` reported `103`.
**After**: Both report `104`, matching `wc -l proofs/Proofs/Erdos1118OQ02.lean` = `104`.

Other counts (`theoremCount: 3`, `axiomCount: 0`, `sorries: 0`) already match the Lean source — no other fields needed adjustment.

---
Automated fix by lean-mechanic agent.
