### PR TITLE
fix(meta): picks-theorem sync lineCount (484→485)

### DIFF
--- a/src/data/proofs/picks-theorem/meta.json
+++ b/src/data/proofs/picks-theorem/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2025-12-29",
     "axiomCount": 1,
-    "lineCount": 484,
+    "lineCount": 485,
     "assumptions": "1 axiom: picks_theorem (the main theorem statement). Removed inconsistent area_bounded_by_box_axiom (claimed A(P) ≤ w_x*w_y for all w_x,w_y without containment hypothesis).",
     "mathlib_version": "4.26.0",
     "theoremCount": 12,
@@ -226,7 +226,7 @@
   "sorries": 0,
   "leanFile": {
     "axiomCount": 1,
-    "lineCount": 484,
+    "lineCount": 485,
     "sorries": 0,
     "path": "Proofs/PicksTheorem.lean",
     "definitionCount": 16,


### PR DESCRIPTION
## Fix

Sync \`meta.lineCount\` and \`leanFile.lineCount\` in \`src/data/proofs/picks-theorem/meta.json\` from 484 to 485 to match the actual \`wc -l\` count of \`proofs/Proofs/PicksTheorem.lean\`.

## Evidence

\`\`\`
\$ wc -l proofs/Proofs/PicksTheorem.lean
     485 proofs/Proofs/PicksTheorem.lean
\`\`\`

**Before**: both \`meta.lineCount\` and \`leanFile.lineCount\` reported \`484\`.
**After**: both report \`485\`, matching the file's \`wc -l\` line count.

All other count fields (\`axiomCount=1\`, \`theoremCount=12\`, \`definitionCount=16\`, \`sorries=0\`) were already correct and are unchanged.

---
Automated metadata-drift fix by lean-mechanic agent.