### PR TITLE
Enrich triangular-reciprocals-oq-02: initial annotations + key-insights pass

### DIFF
--- a/src/data/proofs/triangular-reciprocals-oq-02/annotations.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02/annotations.json
@@ -1,0 +1,173 @@
+[
+  {
+    "id": "ann-header",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 1, "endLine": 28 },
+    "type": "context",
+    "title": "Module Documentation and Proof Outline",
+    "content": "The header introduces the generalized identity $\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)} = \\frac{H_k}{k}$ for every $k \\geq 1$, where $H_k = \\sum_{i=1}^{k} \\frac{1}{i}$ is the $k$-th harmonic number — a one-parameter family containing Leibniz's $k=1$ case as the basepoint. The four-step proof outline (partial fraction, partial sum closed form, tail decay, summability) is exactly the structure of the file: each step becomes a named lemma, and the main theorem composes them. The opening Mathlib `harmonic : ℕ → ℚ` lives in the rationals; the cast to ℝ at the statement boundary follows the sibling `triangular-reciprocals-oq-03` convention so that the irrational sum and rational harmonic numbers coexist in a single `HasSum` statement.",
+    "mathContext": "Main identity: $\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)} = \\frac{H_k}{k}$. The three sanity checks are $H_1/1 = 1$ (Leibniz 1673), $H_2/2 = 3/4$, $H_3/3 = 11/18$ — each verified explicitly at the file's tail. The result is recorded as Gradshteyn-Ryzhik §0.234.2 and is the integer specialization of the digamma identity $\\psi(x+1) - \\psi(1) = \\sum_{n=1}^{\\infty} \\frac{x}{n(n+x)}$ (Abramowitz-Stegun §6.3.5) at $x = k \\in \\mathbb{N}^+$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "harmonic numbers",
+      "telescoping series",
+      "partial fractions",
+      "digamma function",
+      "p-series",
+      "Wiedijk problem 42 (Leibniz k=1 case)"
+    ],
+    "prerequisites": [
+      "real analysis (series convergence)",
+      "Lean 4 Mathlib BigOperators",
+      "rational-to-real coercion conventions"
+    ]
+  },
+  {
+    "id": "ann-imports-namespace",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 29, "endLine": 33 },
+    "type": "technique",
+    "title": "Mathlib Import and Open Namespaces",
+    "content": "The blanket `import Mathlib` is the standard gallery convention for proofs that compose results from across Mathlib (gallery files are not Mathlib-bound, so the stricter ban on `import Mathlib` does not apply here — see CLAUDE.md). The `open` clause brings into scope `Finset` (for `Finset.Icc`, `Finset.sum_Ico_consecutive`, `Finset.sum_Ico_add'`), `BigOperators` (for the `∑ n ∈ S, f n` notation), `Filter` and `Topology` (for `Tendsto`, `atTop`, `𝓝`, `HasSum`), and `Real` (for `Real.deriv_Gamma_nat`-adjacent infrastructure, although the proof avoids the digamma route in favor of the direct telescoping). The namespace `TriangularReciprocalsHarmonic` isolates the four lemmas and main theorem from sibling-proof name clashes (in particular `partial_fraction`, which the alternating-sibling `triangular-reciprocals-oq-03` also defines).",
+    "mathContext": "Namespace and import structure; no mathematical content per se, but the choice of `open Real` is what permits the `Real`-valued `HasSum` statement to coexist with `(harmonic k : ℚ)` via the explicit `((harmonic k : ℚ) : ℝ)` cast.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Lean 4 namespaces",
+      "Mathlib `BigOperators` notation",
+      "Filter library (`Tendsto`, `atTop`, `𝓝`)"
+    ],
+    "prerequisites": [
+      "Lean 4 module system",
+      "Mathlib import conventions for gallery proofs"
+    ]
+  },
+  {
+    "id": "ann-partial-fraction",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 35, "endLine": 49 },
+    "type": "technique",
+    "title": "Lemma 1: Partial Fraction Decomposition",
+    "content": "The decomposition $\\frac{1}{n(n+k)} = \\frac{1}{k}\\left(\\frac{1}{n} - \\frac{1}{n+k}\\right)$ is the engine of the whole proof: it turns a product into a *signed* difference, setting up a sliding-window cancellation when summed over $n$. The factor $\\frac{1}{k}$ is what scales the final sum to $H_k/k$ rather than $H_k$. The proof is one `field_simp; ring` after the three non-zero side conditions ($n \\neq 0$, $k \\neq 0$, $n+k \\neq 0$, the last via `positivity`) are established — a textbook example of how Lean's `field_simp` discharges fraction arithmetic once the denominator hypotheses are in scope. The lemma is lifted verbatim from the alternating sibling `Proofs/TriangularReciprocalGeneralized.lean:133`, exploiting the fact that the algebraic identity is sign-agnostic — only the way the difference is *summed* depends on whether the signs alternate.",
+    "mathContext": "$\\dfrac{1}{n(n+k)} = \\dfrac{1}{k}\\left(\\dfrac{1}{n} - \\dfrac{1}{n+k}\\right)$ for $n, k \\neq 0$. The $\\frac{1}{k}$ prefactor is the source of the $\\frac{1}{k}$ in the main identity's RHS $\\frac{H_k}{k}$. Generalizes the $k=1$ Leibniz decomposition $\\frac{1}{n(n+1)} = \\frac{1}{n} - \\frac{1}{n+1}$, where the prefactor is the trivial $\\frac{1}{1}$ and consecutive terms cancel.",
+    "significance": "key",
+    "relatedConcepts": [
+      "partial fraction decomposition",
+      "Heaviside cover-up method",
+      "Leibniz telescoping",
+      "`field_simp` tactic"
+    ],
+    "prerequisites": [
+      "rational function arithmetic",
+      "Lean 4 `field_simp; ring` discipline",
+      "`positivity` extension"
+    ]
+  },
+  {
+    "id": "ann-partial-sum-closed-form",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 51, "endLine": 132 },
+    "type": "technique",
+    "title": "Lemma 2: Partial Sum Closed Form via Reindexing",
+    "content": "The technical heart of the proof. Starting from $S_N(k) = \\sum_{n=1}^{N} \\frac{1}{n(n+k)}$, applying `partial_fraction` term-by-term and `Finset.sum_sub_distrib` produces $\\frac{1}{k}\\bigl(\\sum_{n=1}^{N} \\frac{1}{n} - \\sum_{n=1}^{N} \\frac{1}{n+k}\\bigr)$. The second sum is reindexed by $m = n + k$ via `Finset.sum_Ico_add'`, transforming $\\sum_{n=1}^{N} \\frac{1}{n+k}$ into $\\sum_{m=k+1}^{N+k} \\frac{1}{m}$, which is exactly $H_{N+k} - H_k$. The two harmonic differences are then identified using `harmonic_eq_sum_Icc` plus `Finset.sum_Ico_consecutive`, and the result drops out as $\\frac{1}{k}(H_k - (H_{N+k} - H_N))$. The internal `have harm_R : ∀ m : ℕ, (harmonic m : ℝ) = ∑ i ∈ Finset.Icc 1 m, 1/(i : ℝ)` is the crucial bridge between Mathlib's rational `harmonic` and the real-valued partial sum — `push_cast` does the heavy lifting after the initial `exact_mod_cast` on `harmonic_eq_sum_Icc`.",
+    "mathContext": "$S_N(k) = \\sum_{n=1}^{N} \\frac{1}{n(n+k)} = \\frac{1}{k}\\bigl(H_k - (H_{N+k} - H_N)\\bigr)$. Equivalently: $S_N(k) = \\frac{1}{k}\\bigl(H_k - \\sum_{j=N+1}^{N+k} \\frac{1}{j}\\bigr)$, exhibiting the *gap-k telescoping* structure: the sliding window cancels the bulk of the harmonic sum, leaving $H_k$ at the start and a vanishing $H_{N+k} - H_N$ tail at the end. The $k=1$ case recovers Leibniz's $S_N(1) = 1 - \\frac{1}{N+1}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "gap-k telescoping",
+      "Finset reindexing (`Finset.sum_Ico_add'`)",
+      "`Finset.sum_Ico_consecutive` decomposition",
+      "rational-to-real cast via `push_cast`",
+      "harmonic numbers as `Finset.Icc` sums"
+    ],
+    "prerequisites": [
+      "Mathlib `Finset.Icc`/`Finset.Ico` interval lemmas",
+      "`harmonic_eq_sum_Icc` identity",
+      "Lean 4 `push_cast` and `exact_mod_cast`"
+    ]
+  },
+  {
+    "id": "ann-tail-to-zero",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 134, "endLine": 179 },
+    "type": "technique",
+    "title": "Lemma 3: Harmonic Tail Decay by Induction on k",
+    "content": "Shows $H_{N+k} - H_N \\to 0$ as $N \\to \\infty$ for any fixed $k$. The proof is by induction on $k$: the base case $k=0$ is trivial (the difference is identically zero), and the successor step uses the identity $H_{N+(k+1)} = H_{N+k} + \\frac{1}{N+k+1}$ (i.e. `harmonic_succ`) to split the difference into $(H_{N+k} - H_N) + \\frac{1}{N+k+1}$. The first summand tends to zero by IH; the second is a shift of $\\frac{1}{N+1}$ by $k$ in the index, so it tends to zero via `tendsto_one_div_add_atTop_nhds_zero_nat` precomposed with `tendsto_add_atTop_nat k`. The proof carefully binds intermediate `have` results with explicit types — the docstring notes this avoided a `ContinuousSMul ℚ≥0` typeclass instability that earlier versions hit. The combinator `ih.add h_term` (adding two zero limits) is the punchline.",
+    "mathContext": "Tail bound: $0 \\leq H_{N+k} - H_N = \\sum_{j=N+1}^{N+k} \\frac{1}{j} \\leq \\frac{k}{N+1} \\to 0$ as $N \\to \\infty$ for fixed $k$. The induction-on-$k$ structure mirrors the recursive definition of `harmonic`: each successor step adds one more vanishing reciprocal, and the sum of $k$ copies of an $o(1)$ sequence is still $o(1)$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Filter.Tendsto (`atTop → 𝓝 0`)",
+      "`tendsto_one_div_add_atTop_nhds_zero_nat`",
+      "induction on the gap parameter",
+      "`harmonic_succ` recurrence",
+      "sum-of-limits combinator (`Tendsto.add`)"
+    ],
+    "prerequisites": [
+      "Mathlib Filter library",
+      "harmonic number recurrence",
+      "limit arithmetic"
+    ]
+  },
+  {
+    "id": "ann-summable",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 181, "endLine": 210 },
+    "type": "technique",
+    "title": "Lemma 4: Summability by p-Series Comparison",
+    "content": "Establishes `Summable (fun n => 1/((n+1)((n+1)+k)))` by dominating the summand by $\\frac{1}{(n+1)^2}$ (since $(n+1)+k \\geq (n+1)$ for $k \\geq 0$) and invoking Mathlib's `summable_one_div_nat_pow.mpr one_lt_two` for the $p$-series at $p=2$ — the Basel-series convergence backbone. The summable-shift `summable_nat_add_iff (f := …) 1` aligns the index $n$ (starting at 0) with the partial-sum convention $n+1$ used in the main theorem. The bound itself is closed by `nlinarith` after `div_le_div_iff₀` normalizes both sides to a polynomial inequality in $n, k$. Comparison test (`Summable.of_nonneg_of_le`) closes the chain.",
+    "mathContext": "Comparison: $\\dfrac{1}{(n+1)((n+1)+k)} \\leq \\dfrac{1}{(n+1)^2}$ since $(n+1)+k \\geq (n+1) > 0$, and $\\sum_{n=0}^{\\infty} \\dfrac{1}{(n+1)^2} = \\frac{\\pi^2}{6}$ converges (Basel/Euler 1735). The comparison is *uniform in $k$* — the summability bound is independent of the shift parameter, which is what allows the main theorem to quantify over all $k \\geq 1$ via a single Summable witness per $k$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "p-series convergence",
+      "Basel problem ($\\zeta(2) = \\pi^2/6$)",
+      "comparison test (`Summable.of_nonneg_of_le`)",
+      "`summable_one_div_nat_pow`",
+      "`summable_nat_add_iff` (index shift)"
+    ],
+    "prerequisites": [
+      "absolute convergence of $\\sum 1/n^p$ for $p>1$",
+      "`positivity` tactic",
+      "`nlinarith` discharge"
+    ]
+  },
+  {
+    "id": "ann-main-theorem",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 212, "endLine": 284 },
+    "type": "insight",
+    "title": "Main Theorem: HasSum of H_k/k",
+    "content": "Combines Lemmas 2–4 to conclude $\\mathrm{HasSum}\\, (\\lambda n.\\ \\frac{1}{(n+1)((n+1)+k)})\\ \\frac{H_k}{k}$. The structural moves: (1) nonnegativity of the summand (clear since denominators are positive) lets us use `hasSum_iff_tendsto_nat_of_nonneg`, reducing `HasSum` to a `Tendsto` statement about partial sums. (2) Align the partial sum over `Finset.range N` (the `hasSum_iff_tendsto_nat_of_nonneg` shape) with the `Finset.Icc 1 N` form used in Lemma 2 via `Finset.sum_Ico_add' 1` — this is the *same* `Finset.sum_Ico_add'` lemma that powers Lemma 2's reindexing, applied at the boundary rather than inside the body. (3) Substitute Lemma 2's closed form. (4) Take the limit: the constant term $H_k/k$ is constant in $N$ (so `tendsto_const_nhds`), and the tail $(H_{N+k} - H_N)/k$ tends to 0 by Lemma 3 composed with `Tendsto.const_mul (1/k)`. (5) `Tendsto.sub` adds the two limits to yield $\\frac{1}{k}(H_k - 0) = H_k/k$. The tsum corollary follows by `HasSum.tsum_eq`. **The whole 70-line proof is glue**: every nontrivial step lives in Lemmas 1–4, and the main theorem is the orchestration.",
+    "mathContext": "Main identity: $\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)} = \\frac{H_k}{k}$ for every $k \\geq 1$. The proof is a *limit + closed-form* sandwich: the closed-form $\\frac{1}{k}(H_k - (H_{N+k} - H_N))$ from Lemma 2 plus the tail decay $H_{N+k} - H_N \\to 0$ from Lemma 3 directly give the limit value $\\frac{H_k}{k}$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "`HasSum` ↔ `Tendsto` of partial sums (`hasSum_iff_tendsto_nat_of_nonneg`)",
+      "limit-of-sum decomposition (`Tendsto.sub`, `Tendsto.const_mul`)",
+      "`HasSum.tsum_eq` corollary",
+      "reindexing at the partial-sum boundary"
+    ],
+    "prerequisites": [
+      "Mathlib `HasSum` API",
+      "Tendsto arithmetic (`add`, `sub`, `const_mul`)",
+      "tsum vs HasSum distinction"
+    ]
+  },
+  {
+    "id": "ann-special-cases",
+    "proofId": "triangular-reciprocals-oq-02",
+    "range": { "startLine": 286, "endLine": 317 },
+    "type": "context",
+    "title": "Special Cases: k = 1 (Leibniz), k = 2, k = 3",
+    "content": "Three closed-form sanity checks: $H_1/1 = 1$, $H_2/2 = 3/4$, $H_3/3 = 11/18$. Each is proved by unfolding `harmonic_succ` (the recurrence $H_{n+1} = H_n + 1/(n+1)$) repeatedly back to `harmonic_zero` $= 0$, then closing with `push_cast; norm_num`. The $k=1$ case is precisely the classical Leibniz identity $\\sum_{n=1}^{\\infty} \\frac{1}{n(n+1)} = 1$ (Leibniz 1673; Wiedijk #42 in its scaled form $\\sum \\frac{2}{n(n+1)} = 2$), confirming that the generalization recovers the basepoint of the family. The $k=2$ and $k=3$ cases serve as concrete arithmetic witnesses that the closed form $H_k/k$ is genuinely $k$-dependent: $H_2/2 = (1 + 1/2)/2 = 3/4 \\neq 1$ shows the identity goes beyond Leibniz, and $H_3/3 = (1 + 1/2 + 1/3)/3 = 11/18$ extends the table. These three triples $(k, H_k, H_k/k) \\in \\{(1,1,1), (2,3/2,3/4), (3,11/6,11/18)\\}$ all check out by direct computation, giving the reader a numerical handle on the symbolic main theorem.",
+    "mathContext": "$H_1/1 = 1$; $H_2/2 = 3/4$; $H_3/3 = 11/18$. More generally $H_k = \\sum_{i=1}^{k} 1/i$ has rational values whose denominators grow like $\\mathrm{lcm}(1, \\ldots, k)$ (Wolstenholme's theorem governs prime-power divisibility properties of these numerators; see the `wolstenholme-theorem` family in the gallery). The sequence $H_k/k$ tends to zero as $k \\to \\infty$, since $H_k \\sim \\ln k$ but $k$ grows faster.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Leibniz identity (1673)",
+      "Wiedijk problem 42",
+      "harmonic-number recurrence (`harmonic_succ`)",
+      "rational arithmetic via `push_cast; norm_num`",
+      "Wolstenholme's theorem (harmonic-number divisibilities)"
+    ],
+    "prerequisites": [
+      "explicit harmonic number values $H_1, H_2, H_3$",
+      "`norm_num` on rational arithmetic"
+    ]
+  }
+]

--- a/src/data/proofs/triangular-reciprocals-oq-02/meta.json
+++ b/src/data/proofs/triangular-reciprocals-oq-02/meta.json
@@ -85,7 +85,9 @@
       "The tail H_{N+k} - H_N is bounded above by k/(N+1) since each of its k terms is at most 1/(N+1), so the tail vanishes for any fixed k; the proof structures this as an induction on k",
       "Mathlib's `harmonic : ℕ → ℚ` lives in ℚ but the series is real; the cast site is at the statement level (harmonic k : ℝ), with push_cast bridging inside lemmas — this matches the sibling `triangular-reciprocals-oq-03` convention",
       "Reindexing via `Finset.sum_Ico_add'` is the same lemma harmonic_eq_sum_Icc uses internally, so the harmonic differences fall out without manual index gymnastics",
-      "The Aristotle companion file exposes only the supporting lemmas (partial_fraction, tail_to_zero, summability) — not the main HasSum — keeping the open-question identity out of the automated proof-search loop"
+      "The Aristotle companion file exposes only the supporting lemmas (partial_fraction, tail_to_zero, summability) — not the main HasSum — keeping the open-question identity out of the automated proof-search loop",
+      "The proof exhibits a *uniform-in-k* summability bound: the comparison $\\frac{1}{(n+1)((n+1)+k)} \\le \\frac{1}{(n+1)^2}$ uses no information about $k$ beyond $k \\geq 0$, so Lemma 4 returns a single Summable witness per $k$ derivable from the Basel $\\zeta(2)$ machinery. This is what makes the main theorem's quantification over arbitrary $k \\geq 1$ logistically clean — no separate convergence proof per shift",
+      "The relation $H_k/k \\sim (\\ln k)/k$ as $k \\to \\infty$ means the partial sums $\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)}$ themselves vanish for large $k$. This is consistent with the digamma reformulation $H_k/k = (\\psi(k+1) + \\gamma)/k$ and Euler's asymptotic $\\psi(x) \\sim \\ln x - 1/(2x) - \\sum_{j\\geq 1} B_{2j}/(2j x^{2j})$ — the sum over $n$ behaves like a logarithmic decay in the shift parameter $k$"
     ],
     "prerequisites": [
       "Real analysis (series, partial fractions, summability)",
@@ -168,15 +170,32 @@
       "targetId": "basel-problem",
       "relationship": "related",
       "description": "Summability of 1/(n(n+k)) is established by comparison with ∑1/n² (Basel). Both express rational-coefficient series with closed forms — Basel gets π²/6, this gets H_k/k."
+    },
+    {
+      "targetId": "wolstenholme-theorem",
+      "relationship": "related",
+      "description": "Wolstenholme's theorem (1862): for any prime $p \\geq 5$, $H_{p-1}/1 \\equiv 0 \\pmod{p^2}$ when written as a rational $a/b$ in lowest terms. **Number-theoretic counterpart** of the analytic identity here: this entry computes the *real-analytic* value of $\\sum 1/(n(n+k)) = H_k/k$, while Wolstenholme controls the $p$-adic structure of the numerators of $H_k$ at primes $p$ dividing $k+1$. Reading both together: the same harmonic numbers $H_k$ appearing as the closed form of the present series carry highly non-trivial prime-power divisibilities — $H_k/k$ is rational with denominator dividing $k \\cdot \\mathrm{lcm}(1, \\ldots, k)$, and Wolstenholme's congruence sharpens which primes can appear in the numerator. The connection is methodological: the `harmonic_succ` recurrence the special-cases lemmas use to compute $H_1, H_2, H_3$ explicitly is the same recurrence Wolstenholme-style $p$-adic arguments analyze symbolically."
+    },
+    {
+      "targetId": "basel-problem-oq-01",
+      "relationship": "uses",
+      "description": "Sibling of `basel-problem` that supplies the Basel-series convergence ($\\sum 1/n^2 < \\infty$) used in Lemma 4 as the *uniform-in-k* upper bound for summability. The comparison $\\frac{1}{(n+1)((n+1)+k)} \\leq \\frac{1}{(n+1)^2}$ in Lemma 4 makes the entire summability question of this entry rest on `summable_one_div_nat_pow` at $p = 2$ — the formal Lean expression of Euler's 1735 Basel theorem. The reverse direction (using harmonic-number identities to *compute* Basel) is the route of Euler's original calculation (Bernoulli's $\\int_0^1 \\ln(1-x)/x\\, dx$ approach); the present entry uses Basel as an *input* rather than reproving it."
+    },
+    {
+      "targetId": "harmonic-divergence-oq-01",
+      "relationship": "complementary",
+      "description": "Companion to `harmonic-divergence` already cross-referenced. **Divergence-vs-convergence pairing**: the harmonic series $\\sum 1/n$ diverges (Oresme c. 1350, Bernoulli 1689) but its *truncated tails* $H_{N+k} - H_N$ for fixed $k$ vanish (Lemma 3 here), and the *gap-k difference series* $\\sum 1/(n(n+k))$ converges precisely *because* the harmonic tail decays. The two results are the qualitative-vs-quantitative twin theorems: harmonic-divergence shows the partial sums $H_N \\to \\infty$; this entry shows the truncated-tail differences $H_{N+k} - H_N \\to 0$ at the rate $\\Theta(k/N)$. Together they bound the local-vs-global behavior of the harmonic numbers."
     }
   ],
   "conclusion": {
     "summary": "The generalized identity ∑_{n=1}^∞ 1/(n(n+k)) = H_k/k is fully verified in Lean 4 (Mathlib v4.26.0) with 0 sorries and 0 axioms. The proof closes the open question OQ-02 of the triangular-reciprocals series and demonstrates that the partial-fraction + harmonic-telescoping technique scales cleanly from k=1 (Leibniz) to arbitrary k.",
-    "implications": "This result provides the analytic backbone for several follow-ups: (1) digamma reformulation (H_k/k = (ψ(k+1) + γ)/k) via `Real.deriv_Gamma_nat`, (2) extension to non-integer k via the digamma series, and (3) connection to the alternating sibling's transcendental closed forms. Recovers Leibniz as the k=1 case and exposes the harmonic numbers as the natural one-parameter family.",
+    "implications": "This result provides the analytic backbone for several follow-ups: (1) digamma reformulation (H_k/k = (ψ(k+1) + γ)/k) via `Real.deriv_Gamma_nat`, (2) extension to non-integer k via the digamma series, and (3) connection to the alternating sibling's transcendental closed forms. Recovers Leibniz as the k=1 case and exposes the harmonic numbers as the natural one-parameter family. The gap-$k$ telescoping structure (Lemma 2) generalizes Leibniz's $k=1$ consecutive-term cancellation to a sliding window of width $k$, exposing a unified telescoping mechanism that also underlies sums of the form $\\sum 1/((n+a)(n+b))$ for any integer offsets — a structural observation that connects this entry to the broader class of *generalized telescoping series* (Knuth-Graham-Patashnik §2.6) and to digamma-function identities. Cross-cutting with the `triangular-reciprocals-oq-03` alternating sibling: the *same* `partial_fraction` lemma feeds both proofs, but the convergence theory bifurcates — the non-alternating case here uses positive-summand $p$-series comparison, while the alternating sibling requires Abel-summation machinery (axiomatized in that entry) since the analogous closed form features a logarithm rather than a rational harmonic number.",
     "openQuestions": [
       "Derive the digamma reformulation (ψ(k+1) + γ)/k as a corollary via Real.deriv_Gamma_nat",
       "Extend to non-integer real x ≥ 0 via the digamma series ψ(x+1) = -γ + ∑ x/(n(n+x))",
-      "Combine with the alternating sibling to get a Catalan-type series ∑(-1)^{n+1}/(n(n+k))"
+      "Combine with the alternating sibling to get a Catalan-type series ∑(-1)^{n+1}/(n(n+k))",
+      "Quantify the rate of convergence: the closed form gives $|\\sum_{n=1}^{\\infty} \\frac{1}{n(n+k)} - S_N(k)| = \\frac{1}{k}(H_{N+k} - H_N) \\leq \\frac{1}{N+1}$ uniformly in $k$ — formalize this as a Mathlib-style truncation error bound for the partial sums",
+      "Use the gap-$k$ telescoping structure to prove the analogous identity over a general DVR or Dedekind domain: for $\\alpha, \\beta$ algebraic integers with $\\beta \\neq 0$, when does $\\sum 1/(\\alpha + n\\beta)(\\alpha + (n+k)\\beta) = (\\sum_{i=1}^{k} 1/(\\alpha + i\\beta))/(k\\beta)$ hold?"
     ]
   },
   "leanFile": {


### PR DESCRIPTION
## Summary

First enrichment pass on the freshly-added gallery entry `triangular-reciprocals-oq-02` (created by #22782). The entry covers $\sum_{n=1}^{\infty} \frac{1}{n(n+k)} = H_k/k$ — the harmonic-number generalization of Leibniz's $k=1$ identity.

### `annotations.json` (new, 8 annotations)

Covers the full 318-line proof with line-range-aligned annotations, each carrying `content`, `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`:

| ID | Lines | Title |
|----|-------|-------|
| `ann-header` | 1–28 | Module Documentation and Proof Outline |
| `ann-imports-namespace` | 29–33 | Mathlib Import and Open Namespaces |
| `ann-partial-fraction` | 35–49 | Lemma 1: Partial Fraction Decomposition |
| `ann-partial-sum-closed-form` | 51–132 | Lemma 2: Partial Sum Closed Form via Reindexing |
| `ann-tail-to-zero` | 134–179 | Lemma 3: Harmonic Tail Decay by Induction on k |
| `ann-summable` | 181–210 | Lemma 4: Summability by p-Series Comparison |
| `ann-main-theorem` | 212–284 | Main Theorem: HasSum of H_k/k |
| `ann-special-cases` | 286–317 | Special Cases: k = 1 (Leibniz), k = 2, k = 3 |

### `meta.json` updates

- `keyInsights`: 5 → 7 (uniform-in-$k$ summability bound; $H_k/k \sim \ln(k)/k$ asymptotic linking to the digamma series)
- `openQuestions`: 3 → 5 (truncation error bound $\le \frac{1}{N+1}$ uniformly in $k$; DVR/Dedekind-domain generalization)
- `crossReferences`: 5 → 8 — added:
  - `wolstenholme-theorem` (p-adic structure of $H_k$ numerators)
  - `basel-problem-oq-01` (the summability backbone used in Lemma 4)
  - `harmonic-divergence-oq-01` (divergence-vs-convergence twin)
- `conclusion.implications` expanded with the gap-$k$ telescoping connection and the analytic/transcendental bifurcation with the alternating sibling `triangular-reciprocals-oq-03`.

## Test plan

- [x] JSON validated (`json.load` for both files)
- [x] Full `pnpm build` succeeded (in foreground; second background run terminated to avoid duplication)
- [x] All 8 cross-reference target proof IDs verified to exist in `src/data/proofs/`
- [x] No build-generated annotation artifacts staged (only `triangular-reciprocals-oq-02/`)
- [x] All annotations carry every required field per role spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)