### PR TITLE
fix(meta): audit-tracker bump erdos-24 + erdos-183 to issues-fixed

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -5054,10 +5054,8 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-31T05:52:36Z",
-      "result": "issues-found",
-      "issues": [
-        "sections lineCount drift across all 8 sections (29-241 -> 38-613); leanFile.theoremCount 18->10, definitionCount 14->15"
-      ]
+      "result": "issues-fixed",
+      "issues": []
     },
     "erdos-184": {
       "agentId": "auditor-cycle-20-batch",
@@ -5498,10 +5496,8 @@
       "agentId": "auditor-cycle-20-batch",
       "auditCount": 4,
       "lastAudited": "2026-05-30T08:03:13Z",
-      "result": "issues-found",
-      "issues": [
-        "Section line drift in 4 of 7 sections (main-theorem endLine +9, historical shift -9, generalization shift -16, summary shift -14). Filed #21137."
-      ]
+      "result": "issues-fixed",
+      "issues": []
     },
     "erdos-240": {
       "agentId": "auditor-cycle-20-batch",


### PR DESCRIPTION
## Fix

Bump two stale `audit-tracker.json` entries from `issues-found` → `issues-fixed`. Both underlying issues were already resolved by prior PRs; only the tracker entries lagged.

## Evidence

### erdos-24

- Tracker note: `Section line drift in 4 of 7 sections (main-theorem endLine +9, historical shift -9, generalization shift -16, summary shift -14). Filed #21137.`
- Issue #21137: CLOSED 2026-05-30
- Fix PR #21140: MERGED 2026-05-30 (\`fix(erdos-24): correct section line ranges after content reorg\`)
- Current state: \`Erdos24Problem.lean\` is 245 lines; meta sections (header 1-27, core-defs 41-89, blowup 90-132, main-theorem 133-163, historical 164-174, generalization 175-209, summary 210-245) align with file content.

### erdos-183

- Tracker note: \`sections lineCount drift across all 8 sections (29-241 -> 38-613); leanFile.theoremCount 18->10, definitionCount 14->15\`
- Fix PRs: #21479 (\`fix(meta): erdos-183 realign section line ranges and theorem/def counts\`, MERGED), #22124 (\`fix(meta): erdos-183 status axiomatized→verified + badge axiom→original\`, MERGED)
- Current state: \`Erdos183Problem.lean\` is 770 lines, 13 theorems, 15 defs, 0 axioms, 0 sorries; \`leanFile\` block matches exactly; sections span 37-770.

## Risk

Tracker-only cleanup. No Lean source, no meta.json proof metadata, no annotations changed. Affects only the auditor's bookkeeping signal.

---
Automated fix by lean-mechanic agent.