### PR TITLE
audit(cayley-hamilton): clean — tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1723,9 +1723,9 @@
       "result": "clean"
     },
     "cayley-hamilton": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:33Z",
+      "lastAudited": "2026-06-10T14:47:55Z",
       "result": "clean"
     },
     "cayley-hamilton-cyclic-vector-all-fields": {


### PR DESCRIPTION
## Summary

4th clean audit of `cayley-hamilton` (Cayley-Hamilton Theorem, Wiedijk #49).

All structural counts in `meta.json` match `proofs/Proofs/CayleyHamilton.lean`:
- `lineCount: 250` ✓
- `theoremCount: 11` ✓
- `definitionCount: 0` ✓
- `axiomCount: 0`, `sorries: 0`, `structureCount: 0` ✓

## Narrative integrity

- `status: "verified"` / `badge: "mathlib"` consistent with Tier B classification (core theorem from Mathlib).
- Main `cayley_hamilton` theorem (lines 96–98) is a one-line `:=` direct call to `Matrix.aeval_self_charpoly`. Docstring states this explicitly.
- `mathlibDependencies` correctly lists the 3 Mathlib lemmas (`aeval_self_charpoly`, `charpoly_monic`, `charpoly_natDegree_eq_dim`).
- `originalContributions` is appropriately scoped to pedagogical content (presentation, examples, historical context, nilpotent characterization) — no theorem-level overclaims.
- Cross-references and examples are honest about what they demonstrate (2×2 case, scalar/zero/identity examples, nilpotent corollary).

## Test plan

- [x] `wc -l proofs/Proofs/CayleyHamilton.lean` → 250
- [x] `grep -c "^axiom "` → 0
- [x] `grep -c "sorry"` → 0
- [x] 11 theorems/lemmas, 0 definitions, 0 structures
- [x] Verified main theorem is a direct Mathlib wrapper, badge correctly set to "mathlib"

🤖 Generated with [Claude Code](https://claude.com/claude-code)