### PR TITLE
audit(triangular-reciprocals-oq-02): clean — tracker entry

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15302,6 +15302,12 @@
       "lastAudited": "2026-06-10T09:07:09Z",
       "result": "clean",
       "issues": []
+    },
+    "triangular-reciprocals-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-10T15:21:06Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Summary
- Marks `triangular-reciprocals-oq-02` as audited clean in `audit-tracker.json`.
- All meta.json counts verified against `proofs/Proofs/TriangularReciprocalsOQ02.lean`: 318 lines, 9 theorems, 0 axioms, 0 sorries, 0 defs.
- No True stubs, no Mathlib wrapper theorems. Status `verified` / badge `original` is accurate.

## Test plan
- [x] Counts cross-checked (`grep -cE '^(theorem|lemma) '`, `^axiom`, `sorry`, `^def`).
- [x] Lean file line count matches `lineCount: 318`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)