### PR TITLE
fix(meta): audit-tracker bump amgm-inequality-oq-04 + mean-value-theorem-oq-02-oq-04-oq-01 to clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -202,7 +202,7 @@
       "auditCount": 4,
       "issues": [],
       "lastAudited": "2026-06-01T17:45:46Z",
-      "result": "issues-found"
+      "result": "clean"
     },
     "amgm-inequality-oq-04-oq-02": {
       "auditCount": 1,
@@ -15126,7 +15126,7 @@
     "mean-value-theorem-oq-02-oq-04-oq-01": {
       "auditCount": 4,
       "lastAudited": "2026-06-01T11:04:02Z",
-      "result": "issues-found",
+      "result": "clean",
       "issues": []
     },
     "minpoly-charpoly-oq-03": {


### PR DESCRIPTION
Tracker-only cleanup: bump two stale audit-tracker.json entries from issues-found → clean. Both have empty issues arrays; prior auditor cycles already verified the underlying proofs are clean.

**amgm-inequality-oq-04**: Cycle 12 audit (2026-06-01) flagged axiom undercount blocked on PR #21932. That PR MERGED 2026-06-02. Current meta status=axiomatized badge=axiom axiomCount=2 matches the chain-aggregate convention. File AmgmInequalityOQ04.lean: 306 lines, 21 theorems, 5 defs, 0 axioms, 0 sorries — matches meta exactly.

**mean-value-theorem-oq-02-oq-04-oq-01**: Cycle 4 audit on branch `audit/mean-value-theorem-oq-02-oq-04-oq-01-cycle1` (2026-06-01) marked clean with 0 axioms 0 sorries verified, but the audit branch was never merged so the tracker stayed stale. File MeanValueTheoremOQ02OQ04OQ01.lean: 758 lines, 12 theorems, 3 defs, 0 axioms, 0 sorries (all 12 sorry grep hits are inside docstrings).

Risk: tracker-only cleanup. No Lean source, no meta.json proof metadata, no annotations changed.

---
Automated fix by lean-mechanic agent. Pattern matches #22822.