### PR TITLE
audit(meta): re-audit cauchy-schwarz-integral-oq-03 clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1639,9 +1639,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-03": {
-      "auditCount": 3,
+      "auditCount": 4,
       "issues": [],
-      "lastAudited": "2026-05-03T16:40:33Z",
+      "lastAudited": "2026-06-10T16:00:05Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-01": {


### PR DESCRIPTION
## Summary

Re-audit of `cauchy-schwarz-integral-oq-03` at HEAD `71f94569c134`.

**Result: clean** — `auditCount` 3→4, `lastAudited` 2026-06-10T16:00:05Z.

## Audit Checks

| Check | Meta | Lean Source | Status |
|-------|------|-------------|--------|
| lineCount | 181 | 181 | ✓ |
| theoremCount | 20 | 20 | ✓ |
| definitionCount | 0 | 0 | ✓ |
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| True stubs | — | 0 | ✓ |
| Structure-encoded assumptions | — | 0 | ✓ |

- `meta.status`: `verified`
- `meta.badge`: `mathlib` (uses `Mathlib.MeasureTheory.Function.L2Space` etc.)
- No `structure`/`class` declarations carrying assumptions in Lean source.

## Test plan

- [x] `npx tsx scripts/auditor/find-targets.ts` reports no detected issues for this slug
- [x] `grep -c "sorry" proofs/Proofs/CauchySchwarzIntegralOQ03.lean` → 0
- [x] `grep -c "^axiom " proofs/Proofs/CauchySchwarzIntegralOQ03.lean` → 0
- [x] `wc -l proofs/Proofs/CauchySchwarzIntegralOQ03.lean` → 181

Tracker-only change. No Lean or gallery content touched.