### PR TITLE
research(researcher-1): STATE-SYNC bundle — 4 problems + 3 prior commits

### DIFF
--- a/research/problems/lagrange-theorem-oq-02-oq-01/state.md
+++ b/research/problems/lagrange-theorem-oq-02-oq-01/state.md
@@ -1,16 +1,18 @@
 # Current State
 
-**Phase**: NEW
-**Since**: 2026-05-04T17:47:35.846Z
+**Phase**: COMPLETED
+**Since**: 2026-06-10T17:00:00.000Z
 **Iteration**: 1
 
 ## Current Focus
 
-Initial exploration of the problem.
+Burnside's Counting Lemma formalized via explicit double-counting.
+Gallery entry verified (`Proofs/LagrangeTheoremOQ02OQ01.lean`, 226 lines,
+6 theorems, 0 axioms, 0 sorries).
 
 ## Active Approach
 
-None yet.
+None — problem solved.
 
 ## Blockers
 
@@ -18,7 +20,7 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+None — completed.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/area-of-circle-oq-05-oq-04.json
+++ b/src/data/research/problems/area-of-circle-oq-05-oq-04.json
@@ -184,7 +184,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.560Z",
-  "lastUpdate": "2026-06-02T13:36:00+00:00",
+  "lastUpdate": "2026-06-10T17:00:00.000Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -224,7 +224,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ01.lean",
-      "lineCount": 164,
+      "lineCount": 163,
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 0,
@@ -235,7 +235,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ01OQ02.lean",
-      "lineCount": 211,
+      "lineCount": 210,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 1,
@@ -246,7 +246,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ01OQ03.lean",
-      "lineCount": 196,
+      "lineCount": 195,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 1,
@@ -257,7 +257,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ02.lean",
-      "lineCount": 83,
+      "lineCount": 82,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
@@ -268,7 +268,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ02OQ01.lean",
-      "lineCount": 420,
+      "lineCount": 419,
       "theoremCount": 11,
       "axiomCount": 5,
       "defCount": 4,
@@ -280,7 +280,7 @@
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03.lean",
       "lineCount": 217,
-      "theoremCount": 14,
+      "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 3,
       "sorryCount": 0,
@@ -290,7 +290,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ02OQ03OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ02OQ03OQ03.lean",
-      "lineCount": 303,
+      "lineCount": 302,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 3,
@@ -301,18 +301,18 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03.lean",
       "filename": "AreaOfCircleOQ01OQ03.lean",
-      "lineCount": 1938,
+      "lineCount": 1937,
       "theoremCount": 52,
       "axiomCount": 0,
       "defCount": 11,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03.lean"
     },
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03Aristotle.lean",
       "filename": "AreaOfCircleOQ01OQ03Aristotle.lean",
-      "lineCount": 101,
+      "lineCount": 100,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -323,7 +323,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ01.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ01.lean",
-      "lineCount": 713,
+      "lineCount": 712,
       "theoremCount": 26,
       "axiomCount": 0,
       "defCount": 3,
@@ -334,11 +334,11 @@
     {
       "path": "Proofs/AreaOfCircleOQ01OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ01OQ03OQ02.lean",
-      "lineCount": 566,
+      "lineCount": 565,
       "theoremCount": 15,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 8,
+      "sorryCount": 6,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ01OQ03OQ02.lean"
     },
@@ -346,7 +346,7 @@
       "path": "Proofs/AreaOfCircleOQ02.lean",
       "filename": "AreaOfCircleOQ02.lean",
       "lineCount": 211,
-      "theoremCount": 17,
+      "theoremCount": 16,
       "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,
@@ -367,7 +367,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ02OQ04.lean",
       "filename": "AreaOfCircleOQ02OQ04.lean",
-      "lineCount": 273,
+      "lineCount": 272,
       "theoremCount": 18,
       "axiomCount": 0,
       "defCount": 3,
@@ -378,7 +378,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ03OQ01.lean",
       "filename": "AreaOfCircleOQ03OQ01.lean",
-      "lineCount": 233,
+      "lineCount": 232,
       "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 1,
@@ -389,18 +389,18 @@
     {
       "path": "Proofs/AreaOfCircleOQ03OQ02.lean",
       "filename": "AreaOfCircleOQ03OQ02.lean",
-      "lineCount": 103,
+      "lineCount": 102,
       "theoremCount": 10,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AreaOfCircleOQ03OQ02.lean"
     },
     {
       "path": "Proofs/AreaOfCircleOQ03OQ02OQ02.lean",
       "filename": "AreaOfCircleOQ03OQ02OQ02.lean",
-      "lineCount": 205,
+      "lineCount": 204,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,
@@ -411,7 +411,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ03OQ02OQ02OQ01.lean",
       "filename": "AreaOfCircleOQ03OQ02OQ02OQ01.lean",
-      "lineCount": 255,
+      "lineCount": 254,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 2,
@@ -422,7 +422,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ03OQ03.lean",
       "filename": "AreaOfCircleOQ03OQ03.lean",
-      "lineCount": 191,
+      "lineCount": 190,
       "theoremCount": 14,
       "axiomCount": 0,
       "defCount": 0,
@@ -433,7 +433,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ03OQ03OQ02.lean",
       "filename": "AreaOfCircleOQ03OQ03OQ02.lean",
-      "lineCount": 190,
+      "lineCount": 189,
       "theoremCount": 12,
       "axiomCount": 0,
       "defCount": 1,
@@ -444,7 +444,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ05.lean",
       "filename": "AreaOfCircleOQ05.lean",
-      "lineCount": 133,
+      "lineCount": 132,
       "theoremCount": 4,
       "axiomCount": 0,
       "defCount": 0,
@@ -456,7 +456,7 @@
       "path": "Proofs/AreaOfCircleOQ05OQ01.lean",
       "filename": "AreaOfCircleOQ05OQ01.lean",
       "lineCount": 231,
-      "theoremCount": 10,
+      "theoremCount": 9,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -466,7 +466,7 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ01Aristotle.lean",
       "filename": "AreaOfCircleOQ05OQ01Aristotle.lean",
-      "lineCount": 78,
+      "lineCount": 77,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
@@ -478,7 +478,7 @@
       "path": "Proofs/AreaOfCircleOQ05OQ02.lean",
       "filename": "AreaOfCircleOQ05OQ02.lean",
       "lineCount": 189,
-      "theoremCount": 3,
+      "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
@@ -488,8 +488,8 @@
     {
       "path": "Proofs/AreaOfCircleOQ05OQ04.lean",
       "filename": "AreaOfCircleOQ05OQ04.lean",
-      "lineCount": 204,
-      "theoremCount": 3,
+      "lineCount": 1114,
+      "theoremCount": 28,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,

--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "lagrange-theorem-oq-02-oq-01",
   "title": "Formalize Burnside's counting lemma directly from orbit-stabilizer: |X/G| = (...",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -29,26 +29,26 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 0 sorries, 0 axioms. Explicit double-counting bijection (g,x,g\u2022x=x) \u21a6 (x,g,g\u2022x=x) proved via rfl. Burnside derived from orbit-stabilizer. PR submitted.",
+    "progressSummary": "COMPLETED: 0 sorries, 0 axioms. Explicit double-counting bijection (g,x,g•x=x) ↦ (x,g,g•x=x) proved via rfl. Burnside derived from orbit-stabilizer. PR submitted.",
     "builtItems": [
       "sigma_fixedBy_equiv_sigma_stabilizer: Equiv with rfl proofs in LagrangeTheoremOQ02OQ01.lean:33",
-      "sum_card_fixedBy_eq_sum_card_stabilizer: \u03a3_g|Fix|=\u03a3_x|Stab| via card_sigma in :56",
-      "stabilizer_smul_equiv: Stab(g\u2022x)\u2243Stab(x) via conjugation in :80",
-      "stabilizer_card_eq_of_orbit: |Stab(g\u2022x)|=|Stab(x)| in :107",
+      "sum_card_fixedBy_eq_sum_card_stabilizer: Σ_g|Fix|=Σ_x|Stab| via card_sigma in :56",
+      "stabilizer_smul_equiv: Stab(g•x)≃Stab(x) via conjugation in :80",
+      "stabilizer_card_eq_of_orbit: |Stab(g•x)|=|Stab(x)| in :107",
       "sum_card_stabilizer_orbit: each orbit contributes |G| in :116",
       "burnside_from_orbit_stabilizer: Burnside from orbit-stabilizer in :143",
-      "burnside_divides: |G|\u2223\u03a3|Fix(g)| in :164",
+      "burnside_divides: |G|∣Σ|Fix(g)| in :164",
       "lagrange_orbitstab_burnside_chain: chain statement in :175"
     ],
     "insights": [
-      "Double-counting bijection sigma_fixedBy_equiv_sigma_stabilizer has rfl left/right inverses \u2014 definitional isomorphism",
-      "Stabilizer conjugation h \u21a6 g\u207b\u00b9hg proves Stab(g\u2022x) \u2243 Stab(x) explicitly via 4-step rw chain",
-      "Each orbit contributes exactly |G| to \u03a3_x|Stab(x)|: orbit-invariance of |Stab| + orbit-stabilizer",
+      "Double-counting bijection sigma_fixedBy_equiv_sigma_stabilizer has rfl left/right inverses — definitional isomorphism",
+      "Stabilizer conjugation h ↦ g⁻¹hg proves Stab(g•x) ≃ Stab(x) explicitly via 4-step rw chain",
+      "Each orbit contributes exactly |G| to Σ_x|Stab(x)|: orbit-invariance of |Stab| + orbit-stabilizer",
       "burnside_from_orbit_stabilizer: two uses of double-counting identity make the derivation structure transparent"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "oq-01: prove orbit partition sum \u03a3_x|Stab(x)|=|X/G||G| without using Mathlib Burnside",
+      "oq-01: prove orbit partition sum Σ_x|Stab(x)|=|X/G||G| without using Mathlib Burnside",
       "oq-02: generalize double-counting bijection to monoid actions"
     ]
   },
@@ -69,14 +69,14 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.846Z",
-  "lastUpdate": "2026-05-04T17:47:35.846Z",
+  "lastUpdate": "2026-06-10T17:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/LagrangeTheorem.lean",
       "filename": "LagrangeTheorem.lean",
-      "lineCount": 223,
+      "lineCount": 222,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
@@ -87,7 +87,7 @@
     {
       "path": "Proofs/LagrangeTheoremOQ01.lean",
       "filename": "LagrangeTheoremOQ01.lean",
-      "lineCount": 142,
+      "lineCount": 141,
       "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 0,
@@ -98,7 +98,7 @@
     {
       "path": "Proofs/LagrangeTheoremOQ02.lean",
       "filename": "LagrangeTheoremOQ02.lean",
-      "lineCount": 208,
+      "lineCount": 207,
       "theoremCount": 15,
       "axiomCount": 0,
       "defCount": 1,
@@ -107,9 +107,20 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02.lean"
     },
     {
+      "path": "Proofs/LagrangeTheoremOQ02OQ01.lean",
+      "filename": "LagrangeTheoremOQ02OQ01.lean",
+      "lineCount": 226,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeTheoremOQ02OQ01.lean"
+    },
+    {
       "path": "Proofs/LagrangeTheoremOQ03.lean",
       "filename": "LagrangeTheoremOQ03.lean",
-      "lineCount": 374,
+      "lineCount": 373,
       "theoremCount": 27,
       "axiomCount": 2,
       "defCount": 1,
@@ -120,7 +131,7 @@
     {
       "path": "Proofs/LagrangeTheoremOQ05.lean",
       "filename": "LagrangeTheoremOQ05.lean",
-      "lineCount": 114,
+      "lineCount": 113,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 1,

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "laws-of-large-numbers-oq-01-oq-01",
   "title": "Can the converse (slln_necessity) be proved in Mathlib",
-  "phase": "NEW",
+  "phase": "COMPLETED",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-05-05T02:57:44.816Z",
     "iteration": 1,
     "focus": "Initial exploration of the problem.",
@@ -71,14 +71,14 @@
     "mathlib": []
   },
   "started": "2026-05-05T02:57:44.815Z",
-  "lastUpdate": "2026-05-05T02:57:44.815Z",
+  "lastUpdate": "2026-06-10T17:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/LawsOfLargeNumbers.lean",
       "filename": "LawsOfLargeNumbers.lean",
-      "lineCount": 397,
+      "lineCount": 396,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 3,
@@ -89,7 +89,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01.lean",
-      "lineCount": 404,
+      "lineCount": 403,
       "theoremCount": 13,
       "axiomCount": 1,
       "defCount": 0,
@@ -100,20 +100,31 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean",
       "filename": "LawsOfLargeNumbersOQ01Aristotle.lean",
-      "lineCount": 724,
+      "lineCount": 723,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },
     {
+      "path": "Proofs/LawsOfLargeNumbersOQ01OQ01.lean",
+      "filename": "LawsOfLargeNumbersOQ01OQ01.lean",
+      "lineCount": 74,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01OQ01.lean"
+    },
+    {
       "path": "Proofs/LawsOfLargeNumbersOQ02.lean",
       "filename": "LawsOfLargeNumbersOQ02.lean",
-      "lineCount": 339,
-      "theoremCount": 8,
-      "axiomCount": 3,
+      "lineCount": 356,
+      "theoremCount": 9,
+      "axiomCount": 2,
       "defCount": 2,
       "sorryCount": 0,
       "isAristotle": false,
@@ -122,7 +133,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ03.lean",
       "filename": "LawsOfLargeNumbersOQ03.lean",
-      "lineCount": 405,
+      "lineCount": 404,
       "theoremCount": 9,
       "axiomCount": 4,
       "defCount": 5,
@@ -133,11 +144,11 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ03Aristotle.lean",
       "filename": "LawsOfLargeNumbersOQ03Aristotle.lean",
-      "lineCount": 72,
+      "lineCount": 71,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean"
     },

--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -87,14 +87,14 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.846Z",
-  "lastUpdate": "2026-06-02T06:30:00.000Z",
+  "lastUpdate": "2026-06-10T17:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/LawsOfLargeNumbers.lean",
       "filename": "LawsOfLargeNumbers.lean",
-      "lineCount": 397,
+      "lineCount": 396,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 3,
@@ -105,7 +105,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01.lean",
-      "lineCount": 404,
+      "lineCount": 403,
       "theoremCount": 13,
       "axiomCount": 1,
       "defCount": 0,
@@ -116,18 +116,18 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean",
       "filename": "LawsOfLargeNumbersOQ01Aristotle.lean",
-      "lineCount": 724,
+      "lineCount": 723,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 2,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ01.lean",
-      "lineCount": 75,
+      "lineCount": 74,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
@@ -138,7 +138,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ02.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ02.lean",
-      "lineCount": 345,
+      "lineCount": 344,
       "theoremCount": 10,
       "axiomCount": 3,
       "defCount": 1,
@@ -149,7 +149,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ03.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ03.lean",
-      "lineCount": 99,
+      "lineCount": 98,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
@@ -160,7 +160,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ02.lean",
       "filename": "LawsOfLargeNumbersOQ02.lean",
-      "lineCount": 357,
+      "lineCount": 356,
       "theoremCount": 9,
       "axiomCount": 2,
       "defCount": 2,
@@ -171,7 +171,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ03.lean",
       "filename": "LawsOfLargeNumbersOQ03.lean",
-      "lineCount": 405,
+      "lineCount": 404,
       "theoremCount": 9,
       "axiomCount": 4,
       "defCount": 5,
@@ -182,18 +182,18 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ03Aristotle.lean",
       "filename": "LawsOfLargeNumbersOQ03Aristotle.lean",
-      "lineCount": 72,
+      "lineCount": 71,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean"
     },
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
       "filename": "LawsOfLargeNumbersOQ04.lean",
-      "lineCount": 229,
+      "lineCount": 228,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 3,
@@ -215,7 +215,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
-      "lineCount": 673,
+      "lineCount": 672,
       "theoremCount": 11,
       "axiomCount": 2,
       "defCount": 0,
@@ -226,7 +226,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean",
-      "lineCount": 151,
+      "lineCount": 150,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -238,7 +238,7 @@
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean",
       "lineCount": 216,
-      "theoremCount": 3,
+      "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Bundled state-sync PR for researcher-1's accumulated unmerged commits on `feature/researcher-1`. All commits are doc-only metadata syncs (no Lean changes) bringing research problem JSONs in line with the actual file/gallery state.

## Commits

1. **0f93eaa** — `research(greens-theorem-oq-01-oq-01-oq-02-oq-01): S11 STATE-SYNC — Docker recovery (blocker cleared)`
2. **9f39a93** — `research(bertrands-postulate-oq-01): S1 OBSERVE — directory creation + Cramér chain audit`
3. **126daeb** — `research(euler-identity-oq-01-oq-04): Iter 4 ACT-3 — Docker build verified + gallery shipped`
4. **7b983a1** — `research(laws-of-large-numbers-oq-01-oq-01): STATE-SYNC meta drift` *(this session)*
5. **813b4ab** — `research(lagrange-theorem-oq-02-oq-01): STATE-SYNC meta drift` *(this session)*
6. **9ca3e13** — `research(laws-of-large-numbers-oq-04-oq-03): STATE-SYNC leanFiles drift` *(this session)*
7. **7fb8e50** — `research(area-of-circle-oq-05-oq-04): STATE-SYNC leanFiles drift` *(this session)*

## This Session — Highlights

| Problem | Status | Key drift fixed |
|---------|--------|-----------------|
| `laws-of-large-numbers-oq-01-oq-01` | → COMPLETED | Missing `OQ01OQ01.lean`, OQ01Aristotle `sorry` 2→0, OQ03Aristotle `sorry` 1→0, OQ02 `axiom` 3→2 |
| `lagrange-theorem-oq-02-oq-01` | → COMPLETED | Missing `OQ02OQ01.lean` (226L Burnside), state.md Phase NEW→COMPLETED |
| `laws-of-large-numbers-oq-04-oq-03` | active (narrative preserved) | leanFiles `sorry`/`thm`/`axiom`/`lines` re-counted |
| `area-of-circle-oq-05-oq-04` | active (narrative preserved) | **`OQ05OQ04.lean` 204→1114L, 3→28 thm** (S6 ACT shipped, untracked); `OQ01OQ03` `sorry` 1→0; `OQ01OQ03OQ02` `sorry` 8→6 |

Recurring pattern across all 4 problems: `lineCount` off by −1 (trailing-newline / line-count-script style). Several stale `sorryCount` and `theoremCount` fields that hadn't been resynced after live commits.

Galleries (`src/data/proofs/.../meta.json`) were already correct as `verified` where applicable; only the research-problem JSONs had stale fields.

## Verification

```
node -e "...strip block+line comments..." → sorries in code
grep -cE '^(theorem|lemma)\s'             → theoremCount
grep -cE '^(def|noncomputable def)\s'     → defCount
grep -cE '^axiom\s'                       → axiomCount
wc -l                                     → lineCount
```

`isAristotle` set from filename suffix (`*Aristotle.lean`).

## Status

**Outcome**: state-sync only (doc-only, no Lean changes)
**Completed**: 2 problems (laws-of-large-numbers-oq-01-oq-01, lagrange-theorem-oq-02-oq-01)
**Active**: 2 problems updated with leanFiles drift fixes; narrative preserved

🤖 Generated by researcher-1