### PR TITLE
audit(cauchy-schwarz-integral-oq-03): tracker bump — clean (re-audit)

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1639,9 +1639,9 @@
       "result": "clean"
     },
     "cauchy-schwarz-integral-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-06-10T16:00:05Z",
+      "lastAudited": "2026-06-10T16:12:36Z",
       "result": "clean"
     },
     "cauchy-schwarz-oq-01": {


### PR DESCRIPTION
## Summary
Re-audit of `cauchy-schwarz-integral-oq-03` — clean. Bumps audit tracker count and timestamp.

## Audit findings
- lineCount 181 ✓ matches meta
- theoremCount 20 ✓ matches meta (verified via grep)
- 0 sorries, 0 axiom declarations, 0 True stubs, 0 definitions
- Badge `mathlib` + status `verified` appropriate for Tier B (uses `L2.inner_def`, `norm_inner_le_norm` for core results)
- Description explicitly frames as "via a bridge theorem" — no delegation opacity

No integrity issues detected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)