### PR TITLE
Enrich euler-identity-oq-01-oq-04: §0 motivation annotation + 6th keyInsight + 2 openQuestions + 2 crossRefs

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-04/annotations.json
@@ -22,6 +22,28 @@
     ]
   },
   {
+    "id": "eioq01x4-ann-01b",
+    "proofId": "euler-identity-oq-01-oq-04",
+    "range": { "startLine": 74, "endLine": 94 },
+    "type": "context",
+    "title": "§0 Motivation: Why a Bridge Lemma Is Needed at All",
+    "content": "The §0 section docstring (lines 76-93) lays out the two Periodic.lift constructions that motivate the bridge: `AddCircle.toCircle` (general T parameter, defined as `(scaled_exp_map_periodic T).lift` and yielding `Circle.exp ((2π/T) * x)` on representatives) versus `Real.Angle.toCircle` (T = 2π specialization, defined as `Circle.periodic_exp.lift` and yielding `Circle.exp x` on representatives by `rfl`). A casual reader might assume these are the same function — and at T = 2π they ARE, but only propositionally. The cited Mathlib reference (`SpecialFunctions/Complex/Circle.lean:168` in v4.26.0) pins down exactly which bearer `homeomorphCircle'` uses: `Real.Angle.toCircle`. The design choice this file makes — using `AddCircle.toCircle` as the canonical forward map of the new `≃+` — is what forces the bridge: we want the named `≃+` to compose with the general `AddCircle.toCircle_*` lemma family (`toCircle_zero`, `toCircle_add`, `injective_toCircle`), so we cannot just adopt `Real.Angle.toCircle` as the forward map.",
+    "mathContext": "Choice of canonical bearer: $\\text{AddCircle.toCircle}_T$ (parameterized over $T$) vs $\\text{Real.Angle.toCircle}$ (fixed at $T = 2\\pi$). The former is the natural target for general-$T$ lemma reuse; the latter is what Mathlib's existing $\\text{homeomorphCircle}'$ uses internally.",
+    "significance": "context",
+    "relatedConcepts": [
+      "Periodic.lift",
+      "scaled_exp_map_periodic",
+      "Circle.periodic_exp",
+      "canonical bearer choice",
+      "definitional vs propositional equality"
+    ],
+    "prerequisites": [
+      "Mathlib.Topology.Instances.AddCircle.Defs (AddCircle.toCircle definition)",
+      "Mathlib.Analysis.SpecialFunctions.Complex.Circle (Real.Angle.toCircle, homeomorphCircle')",
+      "Periodic functions and their quotient lifts"
+    ]
+  },
+  {
     "id": "eioq01x4-ann-02",
     "proofId": "euler-identity-oq-01-oq-04",
     "range": { "startLine": 95, "endLine": 104 },

--- a/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
@@ -98,7 +98,8 @@
       "The subtle obstruction: `AddCircle.toCircle` (general `T`) and `Real.Angle.toCircle` (the `T = 2π` specialization) are *propositionally* but *not definitionally* equal. The former goes through `(scaled_exp_map_periodic T).lift` which evaluates to `Circle.exp ((2π/T) * x)` on representatives; the latter goes through `Circle.periodic_exp.lift` directly. At `T = 2π`, the `2π/2π = 1` reduction collapses them — but it's a `div_self` step, not `rfl`. A small `QuotientAddGroup.induction_on` proof bridges them.",
       "Choice of forward map: we use `AddCircle.toCircle` (the canonical/general quotient bearer) rather than `Real.Angle.toCircle`, even though `homeomorphCircle'` uses the latter. This matches the convention in the sibling `EulerIdentityOQ01OQ01OQ01.lean` which works in terms of `circleMap : ℝ → ℂ` (analogous to `AddCircle.toCircle` lifted), and means the `≃+` packaging composes cleanly with other `AddCircle.toCircle_*` lemmas in Mathlib (`toCircle_zero`, `toCircle_add`, `injective_toCircle`).",
       "The `Additive` wrapper is a type alias (`Additive α := α`), so `Additive.ofMul` and `Additive.toMul` are `rfl`-equalities, and `Add (Additive α)` is implemented as `Mul α` underneath. This is why `map_add'` reduces to `AddCircle.toCircle_add` + `rfl`: the multiplicative homomorphism law and the additive homomorphism law are literally the same proposition through the type alias.",
-      "Sibling complementarity: `EulerIdentityOQ01OQ01OQ01.lean` proves the underlying claim for the project's own `circleMap : ℝ → ℂ` packaged as `circleHom : Multiplicative ℝ →* ℂˣ`. This file is the *companion* on Mathlib's quotient side: `AddCircle (2π) ≃+ Additive Circle`. The two together exhibit `S^1` as a 1-parameter Lie group from both the universal cover and the quotient perspective."
+      "Sibling complementarity: `EulerIdentityOQ01OQ01OQ01.lean` proves the underlying claim for the project's own `circleMap : ℝ → ℂ` packaged as `circleHom : Multiplicative ℝ →* ℂˣ`. This file is the *companion* on Mathlib's quotient side: `AddCircle (2π) ≃+ Additive Circle`. The two together exhibit `S^1` as a 1-parameter Lie group from both the universal cover and the quotient perspective.",
+      "Two-tactic interplay (the craft detail): the AddEquiv proof navigates the `AddCircle.toCircle` ↔ `Real.Angle.toCircle` ↔ `homeomorphCircle'.toFun` chain using two *different* tactics in succession. First, `rw [addCircle_toCircle_eq_angle_toCircle]` discharges the *propositional* gap (the `2π/2π = 1` reduction) between `AddCircle.toCircle` and `Real.Angle.toCircle`. Then `change` discharges the *definitional* identity between `Real.Angle.toCircle` and `homeomorphCircle'.toFun` (which holds because Mathlib's `homeomorphCircle'` was constructed with `@[simps]` and unfolds to `Real.Angle.toCircle` by `rfl`). Mixing `rw` (for propositional steps) and `change` (for definitional steps) is the right pattern when a proof crosses two different kinds of equality — a `rw` for a `change` would fail (no equality to rewrite); a `change` for a `rw` would fail (not definitionally equal). Both are needed and they cannot be swapped."
     ]
   },
   "sections": [
@@ -140,7 +141,9 @@
     "implications": "Closes the OQ-04 question posed in `euler-identity-oq-01`: yes, the Euler-formula scaffolding extends to the named additive-group isomorphism `AddCircle (2 * π) ≃+ Additive Circle`. The two @[simp] API lemmas make this isomorphism usable as a rewrite tool in downstream proofs about `AddCircle` and `Circle`. Together with the sibling file `EulerIdentityOQ01OQ01OQ01.lean` (which constructs the analogous `circleHom : Multiplicative ℝ →* ℂˣ` from the project's own `circleMap`), the gallery now exhibits $S^1$ as a 1-parameter Lie group from both the universal-cover perspective (`circleHom`) and the quotient perspective (`addCircleEquivAdditiveCircle`).",
     "openQuestions": [
       "Should this `≃+` be upstreamed to Mathlib? The construction is mechanical and the missing-definition gap is small; the main barrier is choosing the canonical bearer (`AddCircle.toCircle` vs `Real.Angle.toCircle`) for the forward map.",
-      "Can the construction be generalized to arbitrary `T > 0`, packaging `AddCircle T ≃+ Additive Circle` for all positive periods (the forward map being `t ↦ exp(2π i t / T)`)? Mathlib's `AddCircle.toCircle` is already parameterized this way; only the bridge lemma changes."
+      "Can the construction be generalized to arbitrary `T > 0`, packaging `AddCircle T ≃+ Additive Circle` for all positive periods (the forward map being `t ↦ exp(2π i t / T)`)? Mathlib's `AddCircle.toCircle` is already parameterized this way; only the bridge lemma changes.",
+      "Can this be lifted to a `LieGroup`-isomorphism rather than just an `AddEquiv`? `AddCircle (2π)` and `Circle` both already have Mathlib `LieGroup` (or at least `TopologicalGroup` + smooth-manifold) structure; the next step would be a `≃L` (continuous-linear / Lie isomorphism) that records the smooth structure, not just the topology and algebra. This would let downstream Lie-theory proofs cite the canonical $S^1 \\cong \\mathbb{R}/2\\pi\\mathbb{Z}$ as a single LieGroup isomorphism.",
+      "Does the dual character lattice $\\widehat{S^1} \\cong \\mathbb{Z}$ (a foundational Fourier-analytic identity) follow cleanly from this `≃+`? Pontryagin duality says $\\widehat{\\mathbb{R}/2\\pi\\mathbb{Z}} \\cong (2\\pi\\mathbb{Z})^{\\vee} \\cong \\mathbb{Z}$; transporting along this `≃+` should give the character-by-integer indexing $\\chi_n(\\theta) = e^{in\\theta}$ used throughout harmonic analysis on the circle. Mathlib has the duality theory but the explicit character lattice isomorphism would be a small follow-up."
     ]
   },
   "references": {
@@ -174,6 +177,16 @@
       "type": "related",
       "id": "euler-identity-oq-01",
       "description": "The parent open-question slug. OQ-04 specifically asks for the AddCircle ≃+ Additive Circle packaging that this file delivers."
+    },
+    {
+      "type": "depends-on",
+      "id": "euler-identity-oq-01-oq-01",
+      "description": "Axiom-elimination intermediate: that file removes the axiom dependency from EulerIdentityOQ01, putting Euler's formula on an axiom-free footing. This file inherits that axiom-free status — the construction here uses 0 axioms because the upstream Mathlib pieces (AddCircle.toCircle, homeomorphCircle', toCircle_add) are all axiom-free, and the chain back through the sibling formalizations preserves that."
+    },
+    {
+      "type": "related",
+      "id": "euler-identity",
+      "description": "Great-grandparent: the original point identity $e^{i\\pi} + 1 = 0$ that motivates the entire OQ-01 lineage. This file delivers the structural generalization: the same Euler exponential $t \\mapsto e^{it}$ that produces $e^{i\\pi} = -1$ at $t = \\pi$ is the carrier of the additive-group isomorphism $\\mathbb{R}/2\\pi\\mathbb{Z} \\simeq_+ S^1$."
     }
   ],
   "leanFile": {


### PR DESCRIPTION
## Summary

Enrichment pass for `euler-identity-oq-01-oq-04` (S¹ as an Additive Group: AddCircle (2π) ≃+ Additive Circle).

### Changes

**annotations.json** (+1 annotation, 5 → 6)
- New `eioq01x4-ann-01b` covering lines 74–94 (the §0 section docstring + namespace declaration that motivates the bridge lemma). Previously a gap between ann-01 (lines 1–73) and ann-02 (lines 95–104). Explains the deliberate choice to keep `AddCircle.toCircle` as the canonical forward map even though `homeomorphCircle'` internally uses `Real.Angle.toCircle` — and why that choice is what forces the bridge.

**meta.json — overview.keyInsights** (+1 insight, 5 → 6)
- New insight on the **`rw`/`change` two-tactic interplay** in the AddEquiv proof: `rw [addCircle_toCircle_eq_angle_toCircle]` discharges the *propositional* `2π/2π = 1` gap; `change` discharges the *definitional* `Real.Angle.toCircle = homeomorphCircle'.toFun` identity (which holds by `@[simps]` unfolding). The two tactics target different kinds of equality and cannot be swapped — a craft detail visible in the proof source (lines 136, 147–148).

**meta.json — conclusion.openQuestions** (+2 questions, 2 → 4)
- LieGroup-isomorphism upgrade: lift this `AddEquiv` to a `≃L` that records the smooth structure on `AddCircle (2π)` and `Circle`, not just the topology + algebra.
- Pontryagin character lattice: derive $\widehat{S^1} \cong \mathbb{Z}$ explicitly by transporting along this `≃+`, giving the integer-indexed character family $\chi_n(\theta) = e^{in\theta}$ from harmonic analysis on the circle.

**meta.json — crossReferences** (+2 entries, 2 → 4, aligning with `relatedProblems`)
- Added `euler-identity-oq-01-oq-01` (axiom-elimination ancestor — explains why this file inherits 0-axiom status).
- Added `euler-identity` (the great-grandparent point identity $e^{i\pi} + 1 = 0$ — the same Euler exponential carrying both the point identity at $t = \pi$ and the structural isomorphism $\mathbb{R}/2\pi\mathbb{Z} \simeq_+ S^1$).

### Build status

JSON parses cleanly; the build's enrichment phase (which reads every proof's meta + annotations JSON) ran over all 1971 problems including this one with no errors. The `tsc not found` / `better-sqlite3` rebuild failures observed are worktree-environment issues (native-module rebuild against Node 26), structurally unrelated to this content change.

## Test plan

- [x] JSON valid (\`node -e \"JSON.parse(...)\"\` on both files)
- [x] Build enrichment phase processes the file without error
- [ ] Page renders on the live site after deploy
- [ ] crossReferences resolve to actual gallery slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)