### PR TITLE
audit(meta): re-audit buffons-needle-oq-02 clean at HEAD ed21a4b1279

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1373,9 +1373,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T16:43:29Z",
+      "lastAudited": "2026-06-10T18:24:22Z",
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-01": {


### PR DESCRIPTION
## Summary

Gallery integrity re-audit of `buffons-needle-oq-02` (3D Buffon's Noodle: Parallel Planes Formula E = L/(2d)) at HEAD `ed21a4b1279`. Result: **clean**.

## Audit findings

| Check | meta.json | Lean source | Result |
|---|---|---|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 16 | 16 | ✓ |
| definitionCount | 1 | 1 (`buffon3d`) | ✓ |
| lineCount | 262 | 262 | ✓ |
| True stubs | — | 0 | ✓ |
| status="verified" | 0 sorries + 0 axioms (incl. transitive) | Import is `Mathlib` only — no in-project transitive deps | ✓ |
| badge="mathlib" | Heavy Mathlib FTC reliance | Uses `integral_eq_sub_of_hasDerivAt`, `cos_nonneg_of_mem_Icc`, `integral_add_adjacent_intervals` | ✓ |

All 7 listed `originalContributions` present in source:
- `integral_sin_abs_cos` (L108)
- `sphere_average_abs_cos` (L144)
- `buffon3d` def (L160)
- `buffon3d_noodle` (L210)
- `crossing_factor_3d_lt_2d` (L227)
- `buffon3d_lt_buffon2d` (L241)
- `buffon3d_to_buffon2d_ratio` (L253)

## Test plan

- [x] meta.json field consistency vs source counts
- [x] No `sorry` tokens in source
- [x] No `axiom` declarations in source
- [x] Tier classification (Tier A/B boundary; "mathlib" badge conservatively correct)
- [x] All `originalContributions` mapped to source identifiers

🤖 Generated with [Claude Code](https://claude.com/claude-code)