### PR TITLE
agents: per-role CLAUDE_MODEL knobs + bump default to Opus 4.8

### DIFF
--- a/scripts/agents/claude-wrapper.sh
+++ b/scripts/agents/claude-wrapper.sh
@@ -507,12 +507,12 @@ run_claude_once() {
     tmpfile=$(mktemp)
 
     # Run in background so we can monitor for startup hangs.
-    # Default to standard-context Opus 4.7. Without --model the CLI auto-selects
-    # claude-opus-4-7[1m] when the prompt + system context is large (CLAUDE.md
-    # alone is enough), and accounts without the 1M-context entitlement reject
-    # the request with `API Error: Extra usage is required for 1M context`.
-    # Override via CLAUDE_MODEL=<other-model> for accounts that do have it.
-    local model="${CLAUDE_MODEL:-claude-opus-4-7}"
+    # Default to Opus 4.8 (1M native context, same $/MTok as 4.7). We still pass
+    # --model explicitly to avoid CLI auto-selection drift. Override the global
+    # default with CLAUDE_MODEL=<other-model>; per-role launch scripts also
+    # honour role-specific overrides (e.g. RESEARCHER_CLAUDE_MODEL) that are
+    # exported as CLAUDE_MODEL before invoking this wrapper.
+    local model="${CLAUDE_MODEL:-claude-opus-4-8}"
     timeout --kill-after=30 "$CLAUDE_TIMEOUT" claude -p --dangerously-skip-permissions --model "$model" "$PROMPT" < /dev/null > "$tmpfile" 2>&1 &
     local timeout_pid=$!
 

--- a/scripts/auditor/launch-agent.sh
+++ b/scripts/auditor/launch-agent.sh
@@ -226,10 +226,12 @@ launch_agent() {
     print_info "Interval: $INTERVAL minutes"
     print_info "Worktree: $WORKTREE_PATH"
 
-    # Launch in tmux with resilient wrapper in DAEMON mode
+    # Launch in tmux with resilient wrapper in DAEMON mode.
+    # Per-role override: AUDITOR_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    local auditor_model="${AUDITOR_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "ENHANCER_ID=auditor REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the lean auditor agent. Read $prompt_file for your instructions, then start the audit loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=auditor REPO_ROOT=$WORKTREE_PATH CLAUDE_MODEL=$auditor_model $wrapper_script --daemon --prompt 'You are the lean auditor agent. Read $prompt_file for your instructions, then start the audit loop.' --log '$LOG_FILE'"
 
     print_success "Launched auditor agent"
     echo ""

--- a/scripts/deploy/launch-agent.sh
+++ b/scripts/deploy/launch-agent.sh
@@ -243,12 +243,14 @@ launch_agent() {
     # The --daemon flag ensures the deployer survives API outages indefinitely
     # Run in worktree to isolate from main repo
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    # Per-role override: DEPLOYER_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default.
+    local deployer_model="${DEPLOYER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
     # Deploy build is memory-heavy (large vite module graph); give it a 12GB heap
     # to avoid GC thrash that stalls vite at `transforming...`, and a 2h CLI cap so
     # a ~40m build leaves room for merge/sync/deploy. All env-overridable. These are
     # band-aids until #20984 moves gallery data out of the vite module graph.
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "ENHANCER_ID=deployer REPO_ROOT=$WORKTREE_PATH BUILD_TIMEOUT='${BUILD_TIMEOUT:-45m}' BUILD_NODE_OPTIONS='${BUILD_NODE_OPTIONS:---max-old-space-size=12288}' CLAUDE_TIMEOUT='${CLAUDE_TIMEOUT:-7200}' $wrapper_script --daemon --prompt 'You are the deployer agent. Read $prompt_file for your instructions, then start the deploy loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=deployer REPO_ROOT=$WORKTREE_PATH BUILD_TIMEOUT='${BUILD_TIMEOUT:-45m}' BUILD_NODE_OPTIONS='${BUILD_NODE_OPTIONS:---max-old-space-size=12288}' CLAUDE_TIMEOUT='${CLAUDE_TIMEOUT:-7200}' CLAUDE_MODEL=$deployer_model $wrapper_script --daemon --prompt 'You are the deployer agent. Read $prompt_file for your instructions, then start the deploy loop.' --log '$LOG_FILE'"
 
     print_success "Launched deployer agent"
     echo ""

--- a/scripts/enricher/parallel-enrich.sh
+++ b/scripts/enricher/parallel-enrich.sh
@@ -313,6 +313,9 @@ launch_agents() {
         tmux send-keys -t "$session" "export ENRICHER_ID='$enricher_id'" Enter
         tmux send-keys -t "$session" "export CLAIM_TTL='$CLAIM_TTL'" Enter
         tmux send-keys -t "$session" "export REPO_ROOT='$REPO_ROOT'" Enter
+        # Honour ENRICHER_CLAUDE_MODEL (per-role) > CLAUDE_MODEL (global)
+        local enricher_model="${ENRICHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+        tmux send-keys -t "$session" "export CLAUDE_MODEL='$enricher_model'" Enter
 
         # Write prompt to file (avoids tmux multiline issues)
         local prompt_file="$LOGS_DIR/$session-prompt.md"
@@ -425,6 +428,8 @@ case "${1:-}" in
         tmux send-keys -t "$session" "export ENRICHER_ID='$enricher_id'" Enter
         tmux send-keys -t "$session" "export CLAIM_TTL='$CLAIM_TTL'" Enter
         tmux send-keys -t "$session" "export REPO_ROOT='$REPO_ROOT'" Enter
+        enricher_model="${ENRICHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+        tmux send-keys -t "$session" "export CLAUDE_MODEL='$enricher_model'" Enter
         prompt_file="$LOGS_DIR/$session-prompt.md"
         cat > "$prompt_file" << PROMPT_EOF
 # Proof Enrichment Agent $enricher_id

--- a/scripts/herald/launch-agent.sh
+++ b/scripts/herald/launch-agent.sh
@@ -346,10 +346,11 @@ launch_agent() {
     print_info "State: $STATE_FILE"
 
     # Launch in tmux — no worktree needed (read-only agent).
-    # Pin standard-context Opus 4.7: herald's prompt + state file can trigger 1M
-    # auto-selection, which fails on accounts without the 1M-context entitlement.
+    # Defaults to the wrapper's CLAUDE_MODEL (currently Opus 4.8, 1M native).
+    # Override per-role with HERALD_CLAUDE_MODEL=<id> to A/B a different model
+    # (e.g. claude-fable-5) without affecting the rest of the pool.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
-    local herald_model="${HERALD_CLAUDE_MODEL:-claude-opus-4-7}"
+    local herald_model="${HERALD_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
     tmux new-session -d -s "$SESSION_NAME" -c "$REPO_ROOT" \
         "ENHANCER_ID=herald REPO_ROOT=$REPO_ROOT CLAUDE_MODEL=$herald_model $wrapper_script --daemon --prompt 'You are the herald agent. Read $prompt_file for your instructions, then start the scan loop.' --log '$LOG_FILE'"
 

--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1551,6 +1551,11 @@ _do_respawn_agent() {
             sleep 0.2
             tmux send-keys -t "$session" "export REPO_ROOT='$repo_root'" Enter
             sleep 0.2
+            # Honour ENRICHER_CLAUDE_MODEL (per-role) > CLAUDE_MODEL (global),
+            # mirroring initial-start in parallel-enrich.sh
+            local enricher_model="${ENRICHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+            tmux send-keys -t "$session" "export CLAUDE_MODEL='$enricher_model'" Enter
+            sleep 0.2
             local prompt="You are $enricher_id. Read $repo_root/$prompt_file for your instructions, then start the enrichment workflow."
             local wrapper_script="$repo_root/scripts/agents/claude-wrapper.sh"
             tmux send-keys -t "$session" "$wrapper_script --prompt '$prompt' --log '$repo_root/$log_file' --max-retries 5" Enter
@@ -1603,6 +1608,11 @@ _do_respawn_agent() {
             tmux send-keys -t "$session" "export REPO_ROOT='$repo_root'" Enter
             sleep 0.2
             tmux send-keys -t "$session" "export CLAUDE_TIMEOUT=14400" Enter
+            sleep 0.2
+            # Honour RESEARCHER_CLAUDE_MODEL (per-role) > CLAUDE_MODEL (global),
+            # mirroring initial-start in parallel-research.sh
+            local researcher_model="${RESEARCHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+            tmux send-keys -t "$session" "export CLAUDE_MODEL='$researcher_model'" Enter
             sleep 0.2
             local prompt="You are researcher-$agent_num. Read $repo_root/$prompt_file for your instructions, then start the research workflow."
             local wrapper_script="$repo_root/scripts/agents/claude-wrapper.sh"

--- a/scripts/mechanic/launch-agent.sh
+++ b/scripts/mechanic/launch-agent.sh
@@ -225,10 +225,12 @@ launch_agent() {
     print_info "Interval: $INTERVAL minutes"
     print_info "Worktree: $WORKTREE_PATH"
 
-    # Launch in tmux with resilient wrapper in DAEMON mode
+    # Launch in tmux with resilient wrapper in DAEMON mode.
+    # Per-role override: MECHANIC_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    local mechanic_model="${MECHANIC_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "ENHANCER_ID=mechanic REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the lean mechanic agent. Read $prompt_file for your instructions, then start the repair loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=mechanic REPO_ROOT=$WORKTREE_PATH CLAUDE_MODEL=$mechanic_model $wrapper_script --daemon --prompt 'You are the lean mechanic agent. Read $prompt_file for your instructions, then start the repair loop.' --log '$LOG_FILE'"
 
     print_success "Launched mechanic agent"
     echo ""

--- a/scripts/peer-reviewer/launch-agent.sh
+++ b/scripts/peer-reviewer/launch-agent.sh
@@ -179,15 +179,18 @@ launch_agent() {
     local prompt_file
     prompt_file=$(create_prompt_file)
 
+    # Per-role override: PEER_REVIEWER_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default.
+    local peer_reviewer_model="${PEER_REVIEWER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+
     print_info "Launching peer reviewer agent (${AGENT_ID})..."
     print_info "Interval: $INTERVAL minutes"
     print_info "Worktree: $WORKTREE_PATH"
-    print_info "Model: opus (deep review)"
+    print_info "Model: $peer_reviewer_model"
 
     # Launch in tmux with wrapper
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "REVIEWER_ID=${AGENT_ID} REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the peer reviewer agent. Read $prompt_file for your instructions, then start the review loop.' --log '$LOG_FILE'"
+        "REVIEWER_ID=${AGENT_ID} REPO_ROOT=$WORKTREE_PATH CLAUDE_MODEL=$peer_reviewer_model $wrapper_script --daemon --prompt 'You are the peer reviewer agent. Read $prompt_file for your instructions, then start the review loop.' --log '$LOG_FILE'"
 
     print_success "Launched peer reviewer agent (${AGENT_ID})"
     echo ""

--- a/scripts/research/launch-seeker.sh
+++ b/scripts/research/launch-seeker.sh
@@ -288,10 +288,12 @@ launch_agent() {
     fi
 
     # Launch in tmux with resilient wrapper in DAEMON mode
-    # Run in worktree to isolate from main repo
+    # Run in worktree to isolate from main repo.
+    # Per-role override: SEEKER_CLAUDE_MODEL > CLAUDE_MODEL > wrapper default.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    local seeker_model="${SEEKER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
     tmux new-session -d -s "$SESSION_NAME" -c "$WORKTREE_PATH" \
-        "ENHANCER_ID=seeker REPO_ROOT=$WORKTREE_PATH $wrapper_script --daemon --prompt 'You are the seeker agent. Read $prompt_file for your instructions, then start the selection loop.' --log '$LOG_FILE'"
+        "ENHANCER_ID=seeker REPO_ROOT=$WORKTREE_PATH CLAUDE_MODEL=$seeker_model $wrapper_script --daemon --prompt 'You are the seeker agent. Read $prompt_file for your instructions, then start the selection loop.' --log '$LOG_FILE'"
 
     print_success "Launched seeker agent"
     echo ""

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -229,10 +229,14 @@ launch_agent() {
     # Kill existing session if any
     tmux kill-session -t "$session_name" 2>/dev/null || true
 
-    # Launch in tmux with resilient wrapper for error handling
+    # Launch in tmux with resilient wrapper for error handling.
+    # Per-role model override: set RESEARCHER_CLAUDE_MODEL to A/B a different
+    # model (e.g. claude-fable-5) without affecting other agent roles. Falls
+    # through to the global CLAUDE_MODEL default in claude-wrapper.sh.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
+    local researcher_model="${RESEARCHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
     tmux new-session -d -s "$session_name" -c "$worktree_path" \
-        "ENHANCER_ID=researcher-$agent_num REPO_ROOT=$REPO_ROOT CLAUDE_TIMEOUT=14400 $wrapper_script --daemon --prompt 'You are researcher-$agent_num. Read $prompt_file for your instructions, then start the research workflow.' --log '$log_file'"
+        "ENHANCER_ID=researcher-$agent_num REPO_ROOT=$REPO_ROOT CLAUDE_TIMEOUT=14400 CLAUDE_MODEL=$researcher_model $wrapper_script --daemon --prompt 'You are researcher-$agent_num. Read $prompt_file for your instructions, then start the research workflow.' --log '$log_file'"
 
     print_success "Launched $session_name (worktree: $worktree_path)"
 }


### PR DESCRIPTION
## Summary

- Bumps the global default model in `claude-wrapper.sh` from `claude-opus-4-7` to `claude-opus-4-8` (same \$/MTok, native 1M context, makes the 1M-entitlement workaround comment obsolete).
- Adds per-role `<ROLE>_CLAUDE_MODEL` env knobs for researcher, enricher, seeker, peer-reviewer, mechanic, deployer, auditor (herald already had one — refreshed to use the same chain). Resolution order: `<ROLE>_CLAUDE_MODEL` → `CLAUDE_MODEL` → wrapper default.
- Lets us A/B newer models (e.g. `claude-fable-5`) on a single role without disturbing the rest of the pool. Aristotle and Tester are unchanged — neither launches via `claude-wrapper.sh`.

## Why

Opus 4.7 is now in the docs' legacy table; Opus 4.8 supersedes it at the same price. Fable 5 (released 2026-06-09) is the new top-tier model at 2× the cost, worth piloting on researcher (the slot most bottlenecked by capability) before any wider rollout.

## How to use

```bash
# Drop-in: everyone moves to Opus 4.8
./scripts/lean/launch.sh start --researcher 3

# Pilot Fable 5 on researcher only
RESEARCHER_CLAUDE_MODEL=claude-fable-5 ./scripts/lean/launch.sh start --researcher 1

# Run cheap-tier mechanic without affecting other roles
MECHANIC_CLAUDE_MODEL=claude-sonnet-4-6 ./scripts/mechanic/launch-agent.sh
```

The respawn paths in `scripts/lean/launch.sh` also honour these vars, so reloads after crashes pick up the same model.

## Test plan

- [x] `bash -n` clean on all 10 edited files
- [ ] Manual smoke: `./scripts/lean/launch.sh start --researcher 1` lands a session with `CLAUDE_MODEL=claude-opus-4-8` exported
- [ ] Manual smoke: `RESEARCHER_CLAUDE_MODEL=claude-fable-5 ./scripts/research/parallel-research.sh 1` lands a session with `CLAUDE_MODEL=claude-fable-5`
- [ ] Verify wrapper does not log "Extra usage is required for 1M context" with the new Opus 4.8 default

🤖 Generated with [Claude Code](https://claude.com/claude-code)