### PR TITLE
fix(parallel-research): drop `local` from --slot dispatch (SC2168)

### DIFF
--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -453,7 +453,7 @@ case "${1:-}" in
             print_error "Usage: $0 --slot <agent-number>"
             exit 1
         fi
-        local slot_num="$2"
+        slot_num="$2"
         if [[ $slot_num -lt 1 || $slot_num -gt 16 ]]; then
             print_error "Slot must be between 1 and 16 (got: $slot_num)"
             exit 1


### PR DESCRIPTION
## Summary

One-line fix. The `--slot N` case branch in `scripts/research/parallel-research.sh:456` used `local slot_num="$2"`, but `local` is only valid inside a function. Bash treats this as fatal at runtime, so any invocation of `--slot` errors out immediately:

```
$ RESEARCHER_CLAUDE_MODEL=claude-fable-5 ./scripts/research/parallel-research.sh --slot 1
./scripts/research/parallel-research.sh: line 456: local: can only be used in a function
```

This blocks per-slot model A/Bs — the exact path we need to pilot Fable 5 on a single researcher slot following PR #22854.

## Fix

Drop the `local` keyword. The variable doesn't need to be function-scoped since it's used immediately in the same case branch.

## Verification

- `bash -n` clean
- `shellcheck --severity=warning` no longer flags SC2168 on this file
- Tested: `./scripts/research/parallel-research.sh --slot 1` now reaches the dispatcher's argument-validation and worktree-setup paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)