### PR TITLE
research(erdos-1210): S4 — remove unsound axiom, restore consistency

### DIFF
--- a/proofs/Proofs/Erdos1210Problem.lean
+++ b/proofs/Proofs/Erdos1210Problem.lean
@@ -13,17 +13,23 @@ a,b ∈ A (pairwise coprime). Is it true that
 In other words: among all pairwise coprime subsets of {1,...,n-1}, does the
 set of primes below n maximize the weighted harmonic sum ∑ 1/(n-a)?
 
-## Status: OPEN
+## Status: OPEN (literal transcription REFUTED)
 
-This is an open conjecture of Erdős. The inequality asserts that primes are
-"optimal" for this particular density measure among pairwise coprime sets.
+The underlying Erdős conjecture is open, but the inequality *as literally
+transcribed above* (weight 1/(n-a)) is FALSE: the counterexample n = 5,
+A = {4} satisfies the stated hypotheses yet violates the bound (proved below in
+`erdos_1210_literal_counterexample`). This file therefore states NO axiom for
+the conjecture; it proves only the structural lemmas and the refutation, all
+machine-checked and axiom-free. The intended (correctly-weighted) form is
+discussed in the "Main Conjecture" section.
 
 ## Key Observations
 
 1. Primes < n are pairwise coprime, so they form a valid candidate set A.
 2. The sum ∑_{p<n} 1/(n-p) is a finite positive quantity for n ≥ 3.
 3. Any pairwise coprime set A has at most one even element.
-4. The inequality is tight when A = {primes < n}.
+4. The literal inequality is NOT a valid bound: a single composite near n
+   (e.g. A = {n-1}) can exceed the whole prime sum (witness n = 5, A = {4}).
 
 ## References
 
@@ -121,26 +127,28 @@ theorem primesBelow_sum_pos {n : ℕ} (hn : 3 ≤ n) :
   exact _root_.div_pos one_pos (by linarith)
 
 /-
-## The Main Conjecture (Open)
--/
+## The Main Conjecture (literal transcription is refuted)
 
-/-- **Erdős Problem 1210 (Open)**: For all n ≥ 3 and all pairwise coprime A ⊆ {1,...,n-1},
-    ∑_{a ∈ A} 1/(n-a) ≤ ∑_{p prime, p < n} 1/(n-p).
-    The set of primes below n maximizes this sum. -/
-axiom erdos_1210 (n : ℕ) (hn : 3 ≤ n) (A : Finset ℕ)
-    (hA_valid : ValidSubset n A)
-    (hA_coprime : PairwiseCoprime A) :
-    ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p)
+The transcribed inequality `∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/(n-p)` is FALSE as
+literally stated — see `erdos_1210_literal_counterexample` below (n = 5,
+A = {4}). Earlier revisions asserted it as `axiom erdos_1210`, but an axiom
+whose negation is a theorem of the *same* file makes the development
+inconsistent: `False` becomes derivable (apply the axiom at n = 5, A = {4} and
+combine with the counterexample). The unsound axiom — together with the two
+consequence theorems that depended on it (`erdos_1210_bound`, and the
+literally-false `erdos_1210_singleton_bounded`, which claimed
+`1/(n-k) ≤ ∑_p 1/(n-p)` for every k ∈ [1,n), refuted at n = 5, k = 4 where it
+reduces to `1 ≤ 5/6`) — has therefore been REMOVED. Only machine-checked,
+axiom-free results remain in this file.
+
+The correctly-weighted statement (∑ 1/a in place of ∑ 1/(n-a)) is provable
+*without any axiom* by a smallest-prime-factor exchange argument; that positive
+result is tracked separately. See `research/problems/erdos-1210/state.md`.
+-/
 
 /-
-## Consequences
+## Consequences (axiom-free)
 -/
-
-/-- Any pairwise coprime A ⊆ {1,...,n-1} has sum bounded by the prime sum (from the axiom). -/
-theorem erdos_1210_bound (n : ℕ) (hn : 3 ≤ n) (A : Finset ℕ)
-    (hA_valid : ValidSubset n A) (hA_coprime : PairwiseCoprime A) :
-    ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) :=
-  erdos_1210 n hn A hA_valid hA_coprime
 
 /-- The empty set has sum 0, trivially bounded by the prime sum. -/
 theorem erdos_1210_empty (n : ℕ) (hn : 3 ≤ n) :
@@ -164,22 +172,12 @@ theorem erdos_1210_prime_singleton (n : ℕ) (hn : 3 ≤ n) (p : ℕ)
         have : (q : ℝ) < n := by exact_mod_cast hq.1
         linarith
 
-/-- Under the conjecture, any singleton {k} with k ∈ [1,n) has sum bounded by the prime sum.
-    In particular, k = 4 (even composite) also satisfies the bound. -/
-theorem erdos_1210_singleton_bounded (n : ℕ) (hn : 3 ≤ n) (k : ℕ) (hk1 : 1 ≤ k) (hkn : k < n) :
-    (1 : ℝ) / ((n : ℝ) - k) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
-  have hle := erdos_1210 n hn {k}
-    (fun a ha => by simp only [Finset.mem_singleton] at ha; subst ha; exact ⟨hk1, hkn⟩)
-    (fun a ha b hb hab => by simp only [Finset.mem_singleton] at ha hb; omega)
-  simp only [Finset.sum_singleton] at hle
-  exact hle
-
 /-
 ## Counterexample: The Literal Statement Is FALSE
 
-The literal axiom `erdos_1210` above is **unsound** as transcribed: there is a
-concrete (n, A) for which the hypotheses are satisfied but the inequality
-FAILS. The minimal witness is n = 5, A = {4}:
+The literally-transcribed inequality is **false**: there is a concrete (n, A)
+for which the hypotheses (`ValidSubset`, `PairwiseCoprime`) are satisfied but
+the inequality FAILS. The minimal witness is n = 5, A = {4}:
 
   - 4 ∈ [1, 5), so `ValidSubset 5 {4}` holds.
   - A = {4} is trivially pairwise coprime (singleton, vacuous condition).
@@ -188,9 +186,11 @@ FAILS. The minimal witness is n = 5, A = {4}:
   - 1 > 5/6, so the conjectured bound fails.
 
 The theorem `erdos_1210_literal_counterexample` below proves this in machine-
-checked form. It does not invoke the bad axiom (to avoid deriving False and
-destabilizing downstream uses), but its statement is direct evidence that
-`erdos_1210` cannot be a theorem of any consistent extension of ZFC + Lean.
+checked form, with no axioms. Because its statement directly contradicts the
+formerly-asserted `axiom erdos_1210`, that axiom has been removed from this
+file (an axiom whose negation is a theorem of the same development makes it
+inconsistent). The counterexample stands as direct evidence that the literal
+transcription cannot be a theorem of any consistent extension of ZFC + Lean.
 
 ### Interpretation
 
@@ -199,11 +199,11 @@ The transcribed conjecture either:
   (b) uses different weights (e.g., 1/a instead of 1/(n-a)), or
   (c) was misrecorded in the source database.
 
-Two open follow-ups:
-  1. **Locate originals** [Er77c, Er80] to recover the intended hypothesis.
-  2. **Revise the axiom** to a verified or correctly-stated form. The current
-     axiom should be replaced (the four consequence theorems above are then
-     vacuous and should be removed/refactored).
+The ∑ 1/a re-weighting (b) is in fact provable for pairwise coprime A by a
+smallest-prime-factor exchange argument, with no axiom required — that positive
+result is tracked separately (see `research/problems/erdos-1210/state.md`). The
+remaining open task is to recover the original sources [Er77c, Er80] and
+confirm which corrected form Erdős intended.
 -/
 
 /-- `primesBelow 5 = {2, 3}` (decidable equality of concrete Finsets). -/

--- a/research/problems/erdos-1210/state.md
+++ b/research/problems/erdos-1210/state.md
@@ -1,55 +1,61 @@
 # Current State
 
-**Phase**: STATEMENT_REVISION_NEEDED
-**Since**: 2026-06-09T20:35:00Z
-**Iteration**: 2
+**Phase**: SOUNDNESS_RESTORED
+**Since**: 2026-06-11T00:00:00Z
+**Iteration**: 4
 
 ## Current Focus
 
-Discovered the transcribed axiom `erdos_1210` is **unsound** as literally
-stated. Adding machine-checked counterexample and flagging the formalization
-for statement-revision.
+S4 — Restore consistency of the formalization by removing the unsound
+`axiom erdos_1210`. The literal transcription is machine-checked FALSE (S2
+counterexample n=5, A={4}); keeping it as an axiom made the development
+inconsistent (`False` derivable, and the file actually proved the false
+theorem `erdos_1210_singleton_bounded`). This executes the S2/S3 documented
+next-action that PR #22850 (S3, additive 1/a rescue) left undone.
 
 ## Active Approach
 
-S2 COUNTEREXAMPLE — Construct a concrete witness (n = 5, A = {4}) where the
-hypotheses of `erdos_1210` hold but the conclusion fails. Verify in Lean.
+S4 AXIOM REMOVAL — Delete `axiom erdos_1210` and the two consequence theorems
+that depended on it being universally true:
+  - `erdos_1210_bound` (mere restatement of the axiom), and
+  - `erdos_1210_singleton_bounded` (itself FALSE: at n=5, k=4 it reduces to
+    `1 ≤ 5/6`).
+Retain all genuinely-verified, axiom-free content: structural prime/coprime
+lemmas, `erdos_1210_empty`, `erdos_1210_prime_singleton`, and the
+machine-checked refutation `erdos_1210_literal_counterexample`.
 
-## Findings (S2)
+## Findings (S4)
 
-The transcribed statement
-`∑_{a ∈ A} 1/(n-a) ≤ ∑_{p < n, p prime} 1/(n-p)`
-admits the following counterexample at n = 5:
-
-- A = {4} trivially satisfies `ValidSubset 5 A` (1 ≤ 4 < 5) and
-  `PairwiseCoprime A` (singleton).
-- LHS = 1/(5-4) = 1.
-- RHS = 1/(5-2) + 1/(5-3) = 1/3 + 1/2 = 5/6 ≈ 0.833.
-- 1 > 5/6, so the conjectured inequality FAILS.
-
-Hence the existing `axiom erdos_1210` and its four consequence theorems are
-unsound and should be refactored once the intended Erdős statement is
-recovered from [Er77c] / [Er80].
+- The file at main (post-S2) contained `axiom erdos_1210` AND
+  `erdos_1210_literal_counterexample` (its negation, for n=5/A={4}) AND
+  `erdos_1210_singleton_bounded` (a false theorem provable only via the bad
+  axiom). This is an outright inconsistency, not merely a flagged assumption.
+- Resolution: remove the axiom + the 2 dependent theorems. Result: 0 axioms,
+  0 sorries, 13 theorems, all machine-checked. Gallery status updated
+  axiomatized → verified (badge axiom → verified); axiomCount 1 → 0.
+- The correctly-weighted (1/a) positive statement is provable without any
+  axiom (S3, PR #22850, open on feature/researcher-1). My S4 removes the
+  unsound axiom; #22850 adds the verified 1/a bound. The two are
+  complementary; whichever merges second will need a trivial rebase in the
+  "Main Conjecture" comment region.
 
 ## Blockers
 
-- Source-text access: cannot directly fetch the original Erdős papers
-  ([Er77c] Erdős 1977c, [Er80] Erdős 1980) to recover the unstated hypothesis
-  (e.g., a > n/2, a > √n, or a different weight like 1/a).
-- Without the corrected statement, the axiom cannot be replaced — only flagged.
+- Source-text access still unavailable (erdosproblems.com → 403); the exact
+  intended hypotheses of [Er77c]/[Er80] remain unrecovered. This does NOT
+  block the soundness fix — removing a false axiom requires no source.
 
 ## Next Action
 
-S3 — A future iteration should:
-  1. Locate the Erdős source for problem 1210 (likely contains the missing
-     hypothesis).
-  2. Replace the unsound axiom with the corrected statement (or with a verified
-     theorem if the corrected version is provable).
-  3. Refactor or remove the four consequence theorems that depend on the
-     current axiom.
+S5 — Once original sources are recovered, optionally re-add the *correctly
+stated* inequality. If it matches the provable 1/a form, fold in PR #22850's
+exchange-argument theorem as the canonical positive result (still axiom-free).
+No axiom should be reintroduced unless a genuinely-unprovable-but-believed
+correct statement is recovered.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 1 (S2 counterexample)
-- Approaches tried: 2 (S1 formalization → axiomatization; S2 falsification)
+- Total attempts: 4
+- Current approach attempts: 1 (S4 axiom removal)
+- Approaches tried: 4 (S1 axiomatize; S2 falsify; S3 1/a rescue [PR #22850];
+  S4 remove unsound axiom)

--- a/src/data/proofs/erdos-1210/annotations.json
+++ b/src/data/proofs/erdos-1210/annotations.json
@@ -196,24 +196,24 @@
     "id": "ann-1210-main-axiom",
     "proofId": "erdos-1210",
     "range": {
-      "startLine": 134,
-      "endLine": 178
+      "startLine": 129,
+      "endLine": 167
     },
     "type": "insight",
-    "title": "The Open Conjecture: Why It's Hard and What a Proof Would Need",
-    "content": "The main statement `erdos_1210` is axiomatized: we cannot prove it from known Mathlib results. A proof would likely require deep analytic number theory. One approach: the greedy algorithm — iteratively add the element a with largest 1/(n-a) that maintains coprimality. The primes are 'greedy-optimal' in a certain sense, but proving that no other coprime set can beat them needs careful analysis. The conjecture connects to Schur's inequality, multiplicative functions, and the distribution of 'rough' numbers (those with only large prime factors). The conjecture is open as of 2026 on the erdosproblems.com list.",
-    "mathContext": "Formal statement: $\\forall n \\geq 2, \\forall A \\subseteq [1,n)$ pairwise coprime: $\\sum_{a \\in A} \\frac{1}{n-a} \\leq \\sum_{p < n, p \\text{ prime}} \\frac{1}{n-p}$. Consequences proved: $0 \\leq$ sum (empty set), singletons satisfy the bound, prime singletons satisfy it. Proof difficulty: requires controlling all pairwise coprime subsets of $[1,n)$.",
+    "title": "Why the Literal Inequality Is Refuted and the Axiom Removed",
+    "content": "The statement was originally axiomatized as `erdos_1210`, but the literal transcription (weight 1/(n-a)) is FALSE: at n=5, A={4} the hypotheses hold yet ∑1/(n-a)=1 exceeds the prime sum 5/6. An axiom whose negation is a theorem of the same file makes the development inconsistent (False derivable), so the axiom and the two consequence theorems depending on it (erdos_1210_bound and the literally-false erdos_1210_singleton_bounded) were removed. What survives is axiom-free: the empty-set bound and the prime-singleton bound, both genuine subset-sum facts. The underlying Erdős problem is open, but under its correct '1/a' weighting the inequality is provable for pairwise coprime A by a smallest-prime-factor exchange argument — no axiom needed.",
+    "mathContext": "Refuted literal form: $\\exists n, A$ pairwise coprime with $\\sum_{a \\in A} \\frac{1}{n-a} > \\sum_{p<n} \\frac{1}{n-p}$ (witness $n=5$, $A=\\{4\\}$: $1 > 5/6$). Surviving axiom-free consequences: $0 \\leq \\sum_{p<n}\\frac{1}{n-p}$ and $\\frac{1}{n-p} \\leq \\sum_{q<n}\\frac{1}{n-q}$ for prime $p<n$.",
     "significance": "key",
     "relatedConcepts": [
       "Erdős open problems",
-      "analytic number theory",
-      "greedy algorithms on coprime sets",
+      "soundness of axiomatizations",
+      "counterexample construction",
       "Mertens' theorem",
       "rough numbers"
     ],
     "prerequisites": [
       "axiom declarations in Lean 4",
-      "open problems in number theory",
+      "consistency of formal developments",
       "Finset sums over filtered sets"
     ]
   }

--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -2,11 +2,11 @@
   "id": "erdos-1210",
   "title": "Pairwise Coprime Subset Sum Inequality",
   "slug": "erdos-1210",
-  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)? Erdős conjectured the primes maximize this weighted harmonic sum among all pairwise coprime subsets.",
+  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Erdős conjectured the primes maximize a weighted harmonic sum over A. The literal transcription ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p) is machine-checked FALSE (counterexample n=5, A={4}); this entry proves the refutation plus structural lemmas, axiom-free.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1210",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/Erdos1210Problem.lean",
     "tags": [
       "erdos",
@@ -16,29 +16,29 @@
       "harmonic-sums",
       "extremal-combinatorics"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "erdosNumber": 1210,
     "erdosUrl": "https://erdosproblems.com/1210",
     "erdosProblemStatus": "open",
-    "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1210 (the main conjecture: primes maximize ∑ 1/(n-a) among pairwise coprime subsets of [1,n)). All 11 structural theorems are fully proved.",
+    "axiomCount": 0,
+    "assumptions": "No axioms. The literally-transcribed inequality (weight 1/(n-a)) is machine-checked FALSE via the counterexample n=5, A={4} (erdos_1210_literal_counterexample). The formerly-asserted unsound axiom erdos_1210 and the two consequence theorems depending on it (erdos_1210_bound, erdos_1210_singleton_bounded) were removed to restore consistency. 13 structural/refutation theorems verified, 0 sorries. The underlying Erdős conjecture remains open under its correct (1/a-weighted) form.",
     "lineCount": 246,
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
+    "theoremCount": 13,
     "definitionCount": 3
   },
   "overview": {
     "historicalContext": "Erdős conjectured (references Er77c, Er80) that among all pairwise coprime subsets A of {1,...,n-1}, the set of primes below n maximizes the sum ∑_{a∈A} 1/(n-a). This is an extremal problem in additive-multiplicative number theory: it asks whether the primes are 'optimal' for a specific density measure among all multiplicatively independent sets.\n\nThe intuition is that pairwise coprime sets are sparse — any two elements share no common prime factor — and the primes, being the atoms of multiplication, are the canonical extremal example. The weighting 1/(n-a) gives more importance to elements close to n; the conjecture says primes up to n are 'spread out' in a way that maximizes this proximity measure.\n\nThe problem remains open as of 2026. Connections to Mertens' theorem (∑_{p≤n} 1/p ~ log log n) and rough number estimates suggest analytic tools may be needed for a full proof.",
     "problemStatement": "Let A ⊆ {1,...,n-1} be pairwise coprime (gcd(a,b)=1 for distinct a,b∈A). Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)?",
     "text": "Among all pairwise coprime subsets of {1,...,n-1}, the primes below n maximize ∑_{a∈A} 1/(n-a). Open conjecture of Erdős.",
-    "proofStrategy": "Define primesBelow, PairwiseCoprime, ValidSubset. Prove structural properties: primes are pairwise coprime, the prime sum is positive, pairwise coprime sets have at most one even element. State the main conjecture as an axiom. Derive consequences including bounds for singletons.",
+    "proofStrategy": "Define primesBelow, PairwiseCoprime, ValidSubset. Prove structural properties: primes are pairwise coprime, the prime sum is positive, pairwise coprime sets have at most one even element. Rather than assert the (mis-transcribed, false) main inequality as an axiom, machine-check its refutation: at n=5, A={4} the hypotheses hold but ∑1/(n-a)=1 exceeds the prime sum 5/6. Keep only the axiom-free consequences (empty set, prime singleton).",
     "keyInsights": [
       "Distinct primes are coprime: p∣q with p,q prime implies p=q (by primality of q), so any two distinct primes are coprime",
       "Any pairwise coprime set has at most one even element (since two even numbers share factor 2)",
       "The prime sum is strictly positive for n≥3 since 2<n contributes the term 1/(n-2)>0",
-      "The conjecture is tight when A = {primes < n}, since the prime set achieves equality by construction",
-      "Singletons {k} for any k∈[1,n) satisfy the inequality (via the axiom), giving a uniform bound"
+      "The literal transcription is false: a single composite near n (A={n-1}) can exceed the entire prime sum — the witness n=5, A={4} gives 1 > 5/6",
+      "Removing the unsound axiom is mandatory: an axiom whose negation is a theorem of the same file makes the development inconsistent (False derivable)"
     ],
     "prerequisites": [
       "Number theory (primes, coprimality, divisibility)",
@@ -80,20 +80,20 @@
     },
     {
       "id": "conjecture",
-      "title": "Main Conjecture and Consequences",
-      "startLine": 131,
-      "endLine": 178,
-      "summary": "States erdos_1210 axiom and derives consequences for empty set, prime singletons, and arbitrary singletons.",
-      "mathContext": "$\\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for all pairwise coprime $A \\subseteq [1,n)$."
+      "title": "Main Conjecture (refuted) and Axiom-Free Consequences",
+      "startLine": 129,
+      "endLine": 167,
+      "summary": "Explains why the literal inequality is refuted and the formerly-asserted axiom removed, then derives the axiom-free consequences that survive: the empty-set bound and the prime-singleton bound (a genuine subset-sum fact, independent of the conjecture).",
+      "mathContext": "The literal $\\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p<n} \\frac{1}{n-p}$ is FALSE (witness $n=5$, $A=\\{4\\}$: $1 > 5/6$). Surviving axiom-free facts: $\\frac{1}{n-p} \\le \\sum_{q<n}\\frac{1}{n-q}$ for prime $p<n$."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 1210 on the optimality of primes for the weighted harmonic sum ∑ 1/(n-a) over pairwise coprime sets. 11 structural theorems proved, 1 axiom (the open conjecture), 0 sorries.",
-    "implications": "Resolution would advance our understanding of extremal properties of pairwise coprime sets and connect to Mertens' theorem and related prime counting results.",
+    "summary": "The formalization captures Erdős Problem 1210 on the optimality of primes for a weighted harmonic sum over pairwise coprime sets. The literally-transcribed inequality (weight 1/(n-a)) is machine-checked FALSE; the formerly-asserted unsound axiom and its two dependent consequence theorems were removed to keep the development consistent. 13 theorems proved (structural lemmas + the refutation), 0 axioms, 0 sorries.",
+    "implications": "The literal '1/(n-a)' transcription is not the intended Erdős statement. Under the correct '1/a' weighting the inequality is provable for pairwise coprime A; the genuinely open question concerns the precise hypotheses of the original sources [Er77c, Er80].",
     "openQuestions": [
-      "Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/(n-p) for all pairwise coprime A?",
+      "What weighting/hypotheses did Erdős actually intend (the 1/a re-weighting is provable; what does the original source state)?",
       "What is the growth rate of ∑_{p<n} 1/(n-p) as n → ∞?",
-      "Do other 'optimal' pairwise coprime sets exist for related sums?"
+      "Do other 'optimal' pairwise coprime sets exist for related correctly-weighted sums?"
     ]
   },
   "leanFile": {
@@ -111,8 +111,8 @@
     ],
     "namespace": "Erdos1210",
     "lineCount": 246,
-    "axiomCount": 1,
-    "theoremCount": 15,
+    "axiomCount": 0,
+    "theoremCount": 13,
     "definitionCount": 3,
     "path": "Proofs/Erdos1210Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős #1210's gallery entry contained `axiom erdos_1210` (weight `1/(n-a)`)
**and** the in-file theorem `erdos_1210_literal_counterexample` proving its
negation (n=5, A={4}: the A-sum is `1`, the prime sum is `5/6`). An axiom whose
negation is a theorem of the same development is inconsistent: `False` is
derivable, and the file actually *proved a false theorem*,
`erdos_1210_singleton_bounded` (instantiated at n=5, k=4 it asserts `1 ≤ 5/6`).

This PR removes the unsound axiom and the two consequence theorems that
depended on it being universally true:

- `axiom erdos_1210` — deleted (the literal transcription is refuted, not open-in-this-form).
- `erdos_1210_bound` — deleted (mere restatement of the axiom).
- `erdos_1210_singleton_bounded` — deleted (itself false).

All genuinely-verified, axiom-free content is retained:
- structural lemmas (`primes_coprime`, `primesBelow_*`, `pairwiseCoprime_at_most_one_even`, sum positivity),
- `erdos_1210_empty`, `erdos_1210_prime_singleton` (a real subset-sum fact, independent of the conjecture),
- the refutation `erdos_1210_literal_counterexample`.

**Result:** 0 axioms, 0 sorries, 13 theorems. Gallery `meta.json` updated
`axiomatized → verified`, `axiomCount 1 → 0`, `theoremCount 15 → 13`;
`annotations.json` and `research/.../state.md` updated to match.

The underlying Erdős conjecture remains open under its correct (`1/a`-weighted)
form, which is provable without any axiom — tracked separately in **PR #22850**
(S3 additive rescue, still open). This PR is the soundness half that #22850
deliberately left undone; the two are complementary and touch mostly disjoint
regions of the file.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.Erdos1210Problem` → **Built
  Proofs.Erdos1210Problem (3058 jobs), exit 0.**
- `meta.json` / `annotations.json` re-validated as JSON.

## Test plan

- [x] Docker build of the edited Lean file passes
- [x] No other file references the removed symbols (`grep` across repo)
- [x] meta/annotations JSON valid; counts match source (0 axioms, 13 theorems, 3 defs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)