### PR TITLE
research(konigsberg-oq-03): S7 ACT — one-edge no-Euler-path theorems

### DIFF
--- a/proofs/Proofs/KonigsbergOQ03.lean
+++ b/proofs/Proofs/KonigsbergOQ03.lean
@@ -253,4 +253,68 @@ theorem not_hasInfiniteEulerPath_of_no_edges {V : Type*} {G : InfiniteGraph V}
   rintro ⟨w, _⟩
   exact h _ _ (w.step_adj 0)
 
+/-! ### One-edge sanity theorems
+
+The next-smallest case after the no-edge graph: an `InfiniteGraph` with a
+single undirected edge `{a, b}` (`a ≠ b`). Unlike the no-edge case its walk
+type is *nonempty* (the alternating walk `a, b, a, b, …` is a valid
+`InfiniteWalk`), so emptiness no longer closes the goal. Yet there is still no
+Euler path: any walk must re-traverse the single edge at consecutive steps,
+violating edge-injectivity. This is a strictly stronger non-degeneracy witness
+for the predicates than the no-edge theorems above. -/
+
+/-- The `InfiniteGraph` on `V` with exactly one undirected edge `{a, b}`
+(`a ≠ b`) and no other adjacencies. -/
+def oneEdgeGraph {V : Type*} (a b : V) (hab : a ≠ b) : InfiniteGraph V where
+  adj u v := (u = a ∧ v = b) ∨ (u = b ∧ v = a)
+  symm := by
+    rintro u v (⟨rfl, rfl⟩ | ⟨rfl, rfl⟩)
+    · exact Or.inr ⟨rfl, rfl⟩
+    · exact Or.inl ⟨rfl, rfl⟩
+  loopless := by
+    rintro v (⟨rfl, h⟩ | ⟨rfl, h⟩)
+    · exact hab h
+    · exact hab h.symm
+
+/-- Two consecutive steps on the one-edge graph return to the start vertex:
+if `x → y` and `y → z` are both the edge `{a, b}` then `x = z`. The
+degenerate cross-cases (`y = a` and `y = b` simultaneously) are ruled out by
+`a ≠ b`. -/
+theorem oneEdge_double_step {V : Type*} {a b : V} (hab : a ≠ b) {x y z : V}
+    (h1 : (x = a ∧ y = b) ∨ (x = b ∧ y = a))
+    (h2 : (y = a ∧ z = b) ∨ (y = b ∧ z = a)) : x = z := by
+  rcases h1 with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ <;> rcases h2 with ⟨h, rfl⟩ | ⟨h, rfl⟩
+  · exact h.symm
+  · rfl
+  · rfl
+  · exact h.symm
+
+/-- A one-edge `InfiniteGraph` has no one-way Euler path: steps 0 and 1 both
+traverse the single edge `{a, b}`, so they form the same undirected edge,
+contradicting edge-injectivity (`0 ≠ 1`). -/
+theorem not_hasOneWayEulerPath_of_one_edge {V : Type*} (a b : V) (hab : a ≠ b) :
+    ¬ HasOneWayEulerPath (oneEdgeGraph a b hab) := by
+  rintro ⟨w, hw⟩
+  have h0 := w.step_adj 0
+  have h1 := w.step_adj 1
+  simp only [zero_add] at h0
+  have hxz : w.vertex 0 = w.vertex (1 + 1) := oneEdge_double_step hab h0 h1
+  have hsame : w.sameEdge 0 1 := by
+    right
+    exact ⟨hxz, by rw [zero_add]⟩
+  exact absurd (hw.2 0 1 hsame) (by norm_num)
+
+/-- A one-edge `InfiniteGraph` has no bi-infinite Euler path: steps 0 and 1
+both traverse the single edge `{a, b}`, contradicting the bi-infinite
+edge-injectivity condition at `0 ≠ 1`. -/
+theorem not_hasInfiniteEulerPath_of_one_edge {V : Type*} (a b : V) (hab : a ≠ b) :
+    ¬ HasInfiniteEulerPath (oneEdgeGraph a b hab) := by
+  rintro ⟨w, hw⟩
+  have h0 := w.step_adj 0
+  have h1 := w.step_adj 1
+  simp only [zero_add] at h0
+  have hxz : w.vertex 0 = w.vertex (1 + 1) := oneEdge_double_step hab h0 h1
+  refine hw.2 0 1 (by norm_num) ?_
+  exact Or.inr ⟨hxz, by rw [zero_add]⟩
+
 end KonigsbergOQ03

--- a/research/problems/konigsberg-oq-03-wip-01/state.md
+++ b/research/problems/konigsberg-oq-03-wip-01/state.md
@@ -2,10 +2,34 @@
 
 ## Current State
 
-**Phase**: STATE-SYNC (S6 — S4+S5 Docker-GREEN retroactive verification at T+6d/T+5d; build-uncertainty banner removed)
+**Phase**: S7 ACT (one-edge non-existence sanity theorems; Docker-GREEN)
 **Path**: full
-**Since**: 2026-06-09 (S6 STATE-SYNC, researcher-1)
-**Iteration**: 6
+**Since**: 2026-06-11 (S7 ACT, researcher-2)
+**Iteration**: 7
+
+## S7 ACT Summary (2026-06-11, researcher-2)
+
+**Mode**: ACT (Lean content). Implemented S7-menu items 1+2 (collapsed): the
+single-edge `InfiniteGraph` and its no-Euler-path theorems.
+
+Added to `Proofs/KonigsbergOQ03.lean` (+64 LOC → 320 total):
+- `oneEdgeGraph a b hab : InfiniteGraph V` — the one-edge graph `{a,b}`, `a≠b`.
+- `oneEdge_double_step` — helper: two consecutive one-edge steps return to start.
+- `not_hasOneWayEulerPath_of_one_edge`, `not_hasInfiniteEulerPath_of_one_edge`
+  — no one-way / bi-infinite Euler path. Contradiction is via edge-injectivity
+  (steps 0,1 re-traverse the single edge), NOT walk-type emptiness: the
+  alternating walk `a,b,a,b,…` IS a valid `InfiniteWalk`, so this is a strictly
+  stronger non-degeneracy witness than the existing no-edge theorems.
+
+**Build**: `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ03` →
+`✔ Built Proofs.KonigsbergOQ03 (18s)`, `Build completed successfully (7743 jobs)`.
+No warnings, no sorries. meta.json counts bumped: theoremCount 9→12,
+definitionCount 14→15, lineCount 256→320; stale S4 build-uncertainty note
+replaced with the S7 GREEN reading.
+
+**S8 menu** (carried from S6, items 1/2 now done): (3) sibling DRY refactor
+across parent + `KonigsbergOQ03OQ02` (~100 LOC); (4) EGW characterisation proof
+(multi-week, König's lemma). Badge stays `wip` until a characterisation lands.
 
 ## S6 STATE-SYNC Summary (2026-06-09, researcher-1)
 

--- a/src/data/proofs/konigsberg-oq-03/meta.json
+++ b/src/data/proofs/konigsberg-oq-03/meta.json
@@ -23,8 +23,8 @@
     "sorries": 0,
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 256,
-    "assumptions": "0 axioms, 0 sorries, **0 `:= True` placeholders**. The 2026-06-03 S4 ACT discharged the remaining 2 placeholders (`HasInfiniteEulerPath`, `HasOneWayEulerPath`) by porting the `InfiniteWalk` / `BiInfiniteWalk` / `IsEulerWalk` / `IsBiInfiniteEulerWalk` infrastructure from sibling `Proofs/KonigsbergOQ03OQ02.lean` (adapted to use this file's own `InfiniteGraph`). All three Eulerian predicates (`HasEulerTour` from 2026-06-01 S3 ACT for the r=2 hypergraph case, `HasInfiniteEulerPath` for the bi-infinite case, `HasOneWayEulerPath` for the one-way infinite case) are now bound to genuine mathematical content. The file remains badge=`wip` because, while the predicates are now honestly defined, no nontrivial theorems characterising when they hold (e.g. Erdős–Grünwald–Weiszfeld) have been proved yet. Structure fields (uniform, symm, loopless, step_adj) are definitional, not assumptions. Build NOT independently verified after the S4 ACT (Docker daemon broken on the contributor's host) — confidence grounded in line-for-line pattern equivalence with the verified sibling file.",
+    "lineCount": 320,
+    "assumptions": "0 axioms, 0 sorries, **0 `:= True` placeholders**. The 2026-06-03 S4 ACT discharged the remaining 2 placeholders (`HasInfiniteEulerPath`, `HasOneWayEulerPath`) by porting the `InfiniteWalk` / `BiInfiniteWalk` / `IsEulerWalk` / `IsBiInfiniteEulerWalk` infrastructure from sibling `Proofs/KonigsbergOQ03OQ02.lean` (adapted to use this file's own `InfiniteGraph`). All three Eulerian predicates (`HasEulerTour` from 2026-06-01 S3 ACT for the r=2 hypergraph case, `HasInfiniteEulerPath` for the bi-infinite case, `HasOneWayEulerPath` for the one-way infinite case) are now bound to genuine mathematical content. The file remains badge=`wip` because, while the predicates are now honestly defined, no nontrivial theorems characterising when they hold (e.g. Erdős–Grünwald–Weiszfeld) have been proved yet; the 2026-06-11 S7 ACT added one-edge non-existence sanity theorems (still not a characterisation). Structure fields (uniform, symm, loopless, step_adj) are definitional, not assumptions. Docker-verified GREEN at 2026-06-11 (`Built Proofs.KonigsbergOQ03`, 7743 jobs) — supersedes the earlier S4 build-uncertainty note (Docker daemon has since recovered).",
     "sourceUrl": "https://en.wikipedia.org/wiki/Eulerian_path#In_directed_graphs",
     "mathlibDependencies": [
       {
@@ -65,10 +65,11 @@
       "BiInfiniteWalk structure (S4 ACT, 2026-06-03): ℤ-indexed sequence of adjacent vertices, with CoversEdge predicate, needed for the bi-infinite version of the Erdős–Grünwald–Weiszfeld theorem",
       "IsBiInfiniteEulerWalk (S4 ACT, 2026-06-03): bi-infinite Euler walk = covers every edge + distinct integer step indices traverse distinct edges",
       "HasInfiniteEulerPath (S4 ACT, 2026-06-03): bi-infinite Euler path bound to ∃ w : BiInfiniteWalk G, IsBiInfiniteEulerWalk G w — replaces the prior := True placeholder",
-      "HasOneWayEulerPath (S4 ACT, 2026-06-03): one-way infinite Euler path bound to ∃ w : InfiniteWalk G, IsEulerWalk G w — replaces the prior := True placeholder"
+      "HasOneWayEulerPath (S4 ACT, 2026-06-03): one-way infinite Euler path bound to ∃ w : InfiniteWalk G, IsEulerWalk G w — replaces the prior := True placeholder",
+      "oneEdgeGraph + one-edge sanity theorems (S7 ACT, 2026-06-11, Docker-verified): the single-edge InfiniteGraph {a,b} (a≠b) and the theorems not_hasOneWayEulerPath_of_one_edge / not_hasInfiniteEulerPath_of_one_edge proving it admits no Euler path. Unlike the no-edge case its walk type is nonempty (the alternating walk a,b,a,b,… exists), so the contradiction comes from edge-injectivity (steps 0 and 1 re-traverse the same edge) rather than from emptiness — a strictly stronger non-degeneracy witness. Helper: oneEdge_double_step."
     ],
-    "theoremCount": 9,
-    "definitionCount": 14
+    "theoremCount": 12,
+    "definitionCount": 15
   },
   "overview": {
     "historicalContext": "Euler's 1736 solution to the Königsberg bridge problem established that a graph has an Eulerian circuit iff every vertex has even degree, and an Eulerian path iff exactly two vertices have odd degree. This is one of the founding results of graph theory. Generalizing Euler's theorem beyond simple finite graphs has occupied mathematicians for nearly three centuries. For *hypergraphs* (where edges can connect more than 2 vertices), the naive degree condition fails for $r \\geq 3$: Lonc and Naroski (2010) proved that determining whether an $r$-uniform hypergraph ($r \\geq 3$) has an Eulerian circuit is NP-complete. For *infinite graphs*, the situation is more subtle: Erdős, Grünwald, and Weiszfeld (1936) characterized Eulerian paths in countable graphs. Their result has two parts: for locally finite graphs (every vertex has finite degree), the condition is essentially the same as the finite case; for graphs with vertices of infinite degree, additional conditions on finite subgraphs are required.",
@@ -266,11 +267,11 @@
   ],
   "leanFile": {
     "axiomCount": 0,
-    "lineCount": 256,
+    "lineCount": 320,
     "path": "Proofs/KonigsbergOQ03.lean",
     "sorries": 0,
-    "definitionCount": 14,
-    "theoremCount": 9
+    "definitionCount": 15,
+    "theoremCount": 12
   },
   "sorries": 0
 }


### PR DESCRIPTION
## Summary

Implements the recommended S7-menu one-edge sanity case for
`Proofs/KonigsbergOQ03.lean` (Eulerian paths in infinite graphs). The file was
already complete (0 sorries, 0 axioms); this adds genuine new verified content.

- `oneEdgeGraph a b hab : InfiniteGraph V` — the single-edge infinite graph with
  exactly one undirected edge `{a, b}` (`a ≠ b`).
- `oneEdge_double_step` — helper: two consecutive steps on the one-edge graph
  return to the start vertex (the `a≠b` rules out the degenerate cross-cases).
- `not_hasOneWayEulerPath_of_one_edge` / `not_hasInfiniteEulerPath_of_one_edge`
  — the one-edge graph has neither a one-way nor a bi-infinite Euler path.

**Why it's a stronger witness than the existing no-edge theorems.** For the
no-edge graph the walk type is *empty*, so the goal closes trivially. The
one-edge walk type is **nonempty** — the alternating walk `a, b, a, b, …` is a
valid `InfiniteWalk` — so emptiness no longer helps. The contradiction instead
comes from **edge-injectivity**: steps 0 and 1 both traverse the single edge
`{a, b}`, forming the same undirected edge at distinct indices `0 ≠ 1`. This
confirms the Euler-path predicates are non-degenerate in a way the no-edge
theorems cannot.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.KonigsbergOQ03` →
  `✔ Built Proofs.KonigsbergOQ03 (18s)`, `Build completed successfully (7743 jobs)`.
  No warnings, no sorries.
- `meta.json` updated: theoremCount 9→12, definitionCount 14→15, lineCount
  256→320; the stale S4 "build NOT verified" note replaced with the S7 GREEN
  reading; `originalContributions` + research `state.md` (S7 ACT) updated.

## Test plan

- [x] Docker build of `Proofs.KonigsbergOQ03` passes (7743 jobs, 0 sorries)
- [x] meta.json valid JSON; counts match source

🤖 Generated with [Claude Code](https://claude.com/claude-code)