### PR TITLE
Enrich euler-identity-oq-01-oq-04: add Preliminaries section (quality 98→100)

### DIFF
--- a/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-04/meta.json
@@ -104,6 +104,19 @@
   },
   "sections": [
     {
+      "id": "sec-preliminaries",
+      "title": "Preliminaries: Module Overview and Imports",
+      "startLine": 1,
+      "endLine": 74,
+      "summary": "Module docstring framing the OQ-01-OQ-04 question (construct ℝ/2πℤ ≅ S¹ from Euler's t ↦ exp(i·t)) and its answer: package Mathlib's existing AddCircle.homeomorphCircle' bijection plus the AddCircle.toCircle_add homomorphism law into a named AddEquiv that Mathlib v4.26.0 leaves unexposed. Records the foundation (sibling file EulerIdentityOQ01OQ01OQ01.lean proves the analogous claims for the project's own circleMap), the verification status (0 axioms, 0 sorries, 1 private bridge lemma), and the three imports: Complex.Circle (for Circle and homeomorphCircle'), AddCircle.Defs (for the quotient), and Mathlib.Tactic. Opens the Real namespace so π denotes Real.pi, then opens namespace EulerIdentityOQ01OQ04.",
+      "concepts": [
+        "module docstring",
+        "open question OQ-01-OQ-04",
+        "Real namespace (π = Real.pi)",
+        "Mathlib imports"
+      ]
+    },
+    {
       "id": "sec-bridge",
       "title": "§0. Bridge: AddCircle.toCircle vs Real.Angle.toCircle at T = 2π",
       "startLine": 76,


### PR DESCRIPTION
## Summary
Adds a 5th `sections` entry, **"Preliminaries: Module Overview and Imports"**, covering lines 1–74 of `EulerIdentityOQ01OQ04.lean` — the module docstring, imports, and namespace setup that the existing four sections (§0–§3, lines 76–197) left uncovered.

This closes the **sole remaining quality gap in the entire gallery**: the `sections` component was 8/10 (4 sections × 2), and this entry was the only one scoring below 100. With a 5th genuine section, `sections` → 10/10 and entry quality goes **98 → 100**.

The new section is mathematically accurate: it summarizes the OQ-01-OQ-04 question, the answer (packaging Mathlib's `homeomorphCircle'` + `toCircle_add` into a named `≃+`), the sibling-file foundation, the 0-axiom/0-sorry status, and the three imports / `open Real` setup.

## Why a new branch (not feature/enricher-2)
`feature/enricher-2` backs open PR #22842; this is pushed to `feature/enricher-2-eioq04-prelim-sec` to avoid clobbering it. Complementary to the open annotation-depth PRs (#22842, #22846, #22856) — it closes the `sections` gap none of them touch.

## Build note
Full `pnpm build` (tsc/vite) could not run in this isolation worktree — `pnpm install` fails on the native `better-sqlite3` compile locally. The enrichment data-build pass parsed/validated `meta.json`, and `find-targets.ts` re-scored the entry to 100. Change is data-only JSON.

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] `find-targets.ts --json` reports quality 100, sections 10/10
- [ ] CI build on a main checkout (native deps available)