### PR TITLE
research(buffons-needle-oq-01-oq-04): Buffon's coin via C¹ boundary (0 axioms, 0 sorries)

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -348,6 +348,7 @@ import Proofs.BuffonsNeedleOQ01OQ01OQ01
 import Proofs.BuffonsNeedleOQ01OQ01OQ04
 import Proofs.BuffonsNeedleOQ01OQ01OQ04OQ01
 import Proofs.BuffonsNeedleOQ01OQ02
+import Proofs.BuffonsNeedleOQ01OQ04
 import Proofs.BuffonsNeedleOQ02
 import Proofs.BuffonsNeedleOQ02OQ01
 import Proofs.BuffonsNeedleOQ02OQ02

--- a/proofs/Proofs/BuffonsNeedleOQ01OQ04.lean
+++ b/proofs/Proofs/BuffonsNeedleOQ01OQ04.lean
@@ -1,0 +1,209 @@
+import Mathlib
+import Proofs.BuffonsNeedleOQ01
+
+/-
+# Buffon's Coin: the Cauchy mean-width specialization (OQ-01-OQ-04)
+
+**Status**: Fully verified (0 axioms, 0 sorries)
+
+This file resolves the fourth open question of `buffons-needle-oq-01`: the
+connection between the smooth Buffon-Barbier theorem and **Buffon's coin**
+(Laplace 1812). Instead of a 1-D needle, a 2-D convex body `K` with a
+C¹-smooth boundary is dropped onto a parallel line grid of spacing `d`. The
+expected number of times its boundary `∂K` crosses the grid depends only on
+the perimeter `p`, not on the shape:
+
+  E[boundary crossings] = 2 · p / (π · d).
+
+This is exactly `buffon_smooth_of_contDiff` (the parent's main theorem)
+applied to a closed C¹ parametrisation of `∂K`, so the analytic content is
+entirely reused. The contribution here is the **coin packaging**:
+
+1. `buffon_coin_boundary_crossings` — the boundary-crossing formula for a
+   closed C¹ curve, a one-line corollary of the bearer.
+2. `expectedLineCuts` / `buffon_coin_lineCuts` — the number of grid *lines*
+   that cut `K`. For a convex body each cutting line meets `∂K` in exactly
+   two points, so the line count is half the boundary-crossing count, giving
+   E[lines cutting K] = p / (π · d). This factor-of-two is the *only* place
+   convexity enters; it is encoded definitionally (`expectedLineCuts := … / 2`)
+   rather than derived from a convex-geometry API — Mathlib v4.26.0 has no
+   `Convex.line_intersection_card_le_two` bearer, and the integral model of
+   `concreteSmoothExpectedCrossings` is not a literal point count, so the
+   honest statement of the 0/2 dichotomy is the halving definition.
+3. The **circle (coin)** instance: `circle r` of radius `r` has perimeter
+   `2πr`, hence E[crossings] = `4r/d` and E[lines cutting] = `2r/d`. The
+   latter, for `r ≤ d/2`, is the classical Buffon's-coin crossing probability
+   `diameter / d`.
+4. Shape independence and sign structural lemmas.
+
+## Connection to prior work
+
+- `BuffonsNeedle.lean` (Wiedijk #99): straight needle, P = 2ℓ/(πd).
+- `BuffonsNeedleOQ01.lean`: `buffon_smooth_of_contDiff` — the C¹ bearer used here.
+- `BuffonsNeedleOQ01OQ02.lean`: hyperplane-arrangement sibling (n-D constants).
+- **This file**: Buffon's coin (convex-body specialization), 0 axioms, 0 sorries.
+-/
+
+namespace BuffonsNeedleOQ01OQ04
+
+open Real MeasureTheory
+open BuffonsNeedleOQ01OQ01 (concreteSmoothExpectedCrossings planarArcLength)
+
+/-! ## Part I: Perimeter of a C¹ convex boundary -/
+
+/-- The perimeter of a convex body `K` whose boundary `∂K` is parametrised by a
+    closed C¹ curve `γ : [a, b] → ℝ²` (with `γ a = γ b`) is the arc length of
+    that boundary curve. -/
+noncomputable def boundaryPerimeter (γ : ℝ → ℝ × ℝ) (a b : ℝ) : ℝ :=
+  planarArcLength γ a b
+
+/-- The perimeter is nonnegative on `[a, b]` with `a ≤ b` (an arc-length integral
+    of a nonnegative integrand). -/
+theorem boundaryPerimeter_nonneg (γ : ℝ → ℝ × ℝ) (a b : ℝ) (hab : a ≤ b) :
+    0 ≤ boundaryPerimeter γ a b := by
+  unfold boundaryPerimeter planarArcLength
+  exact intervalIntegral.integral_nonneg hab (fun t _ => Real.sqrt_nonneg _)
+
+/-! ## Part II: Buffon's coin — boundary crossings -/
+
+/-- **Buffon's coin (boundary form)**: for a convex body `K` whose boundary is a
+    closed C¹ curve `γ` on `[a, b]`, the expected number of crossings of `∂K`
+    with a parallel line grid of spacing `d` is `2 · perimeter(K) / (π · d)`.
+
+    This is `buffon_smooth_of_contDiff` applied to the boundary curve; the
+    closure hypothesis `γ a = γ b` is what makes `planarArcLength γ a b` the
+    full perimeter of the closed boundary (it is not needed for the formula
+    itself). -/
+theorem buffon_coin_boundary_crossings
+    (γ : ℝ → ℝ × ℝ) (a b d : ℝ)
+    (hd : 0 < d) (hab : a ≤ b)
+    (hC1 : ContDiff ℝ 1 γ)
+    (_hclosed : γ a = γ b) :
+    concreteSmoothExpectedCrossings γ a b d
+      = 2 * boundaryPerimeter γ a b / (π * d) :=
+  BuffonsNeedleOQ01.buffon_smooth_of_contDiff γ a b d hd hab hC1
+
+/-! ## Part III: Buffon's coin — lines that cut `K` -/
+
+/-- Expected number of grid lines that **cut** the convex body `K` (meet its
+    interior). For a convex body, each cutting line crosses the boundary `∂K` in
+    exactly two points, so the number of lines cutting `K` is half the number of
+    boundary crossings. This factor-of-two is the sole imprint of convexity. -/
+noncomputable def expectedLineCuts (γ : ℝ → ℝ × ℝ) (a b d : ℝ) : ℝ :=
+  concreteSmoothExpectedCrossings γ a b d / 2
+
+/-- **Buffon's coin (line-cut form)**: the expected number of grid lines cutting
+    a convex body `K` with closed C¹ boundary equals `perimeter(K) / (π · d)`. -/
+theorem buffon_coin_lineCuts
+    (γ : ℝ → ℝ × ℝ) (a b d : ℝ)
+    (hd : 0 < d) (hab : a ≤ b) (hC1 : ContDiff ℝ 1 γ) (hclosed : γ a = γ b) :
+    expectedLineCuts γ a b d = boundaryPerimeter γ a b / (π * d) := by
+  unfold expectedLineCuts
+  rw [buffon_coin_boundary_crossings γ a b d hd hab hC1 hclosed]
+  ring
+
+/-- The expected number of cutting lines is nonnegative. -/
+theorem expectedLineCuts_nonneg
+    (γ : ℝ → ℝ × ℝ) (a b d : ℝ)
+    (hd : 0 < d) (hab : a ≤ b) (hC1 : ContDiff ℝ 1 γ) (hclosed : γ a = γ b) :
+    0 ≤ expectedLineCuts γ a b d := by
+  rw [buffon_coin_lineCuts γ a b d hd hab hC1 hclosed]
+  exact div_nonneg (boundaryPerimeter_nonneg γ a b hab) (mul_pos Real.pi_pos hd).le
+
+/-! ## Part IV: The circle (the coin)
+
+The canonical convex body: a disk of radius `r`, boundary `t ↦ (r cos t, r sin t)`.
+-/
+
+/-- The boundary circle of radius `r`, parametrised on `[0, 2π]`. -/
+noncomputable def circle (r : ℝ) : ℝ → ℝ × ℝ :=
+  fun t => (r * Real.cos t, r * Real.sin t)
+
+/-- The circle parametrisation is C¹. -/
+theorem circle_contDiff (r : ℝ) : ContDiff ℝ 1 (circle r) := by
+  unfold circle
+  fun_prop
+
+/-- The circle is a closed curve: `γ 0 = γ (2π)`. -/
+theorem circle_closed (r : ℝ) : circle r 0 = circle r (2 * π) := by
+  unfold circle
+  rw [Real.cos_zero, Real.sin_zero, Real.cos_two_pi, Real.sin_two_pi]
+
+/-- x-component derivative of the circle: `d/dt (r cos t) = r · (-sin t)`. -/
+theorem circle_deriv_fst (r : ℝ) (t : ℝ) :
+    deriv (Prod.fst ∘ circle r) t = r * (-Real.sin t) :=
+  ((Real.hasDerivAt_cos t).const_mul r).deriv
+
+/-- y-component derivative of the circle: `d/dt (r sin t) = r · cos t`. -/
+theorem circle_deriv_snd (r : ℝ) (t : ℝ) :
+    deriv (Prod.snd ∘ circle r) t = r * Real.cos t :=
+  ((Real.hasDerivAt_sin t).const_mul r).deriv
+
+/-- **Circle perimeter**: the boundary of a disk of radius `r ≥ 0` has perimeter
+    `2πr`. -/
+theorem circle_perimeter (r : ℝ) (hr : 0 ≤ r) :
+    boundaryPerimeter (circle r) 0 (2 * π) = 2 * π * r := by
+  unfold boundaryPerimeter planarArcLength
+  have hint :
+      (fun t => Real.sqrt ((deriv (Prod.fst ∘ circle r) t) ^ 2
+        + (deriv (Prod.snd ∘ circle r) t) ^ 2)) = fun _ => r := by
+    ext t
+    rw [circle_deriv_fst, circle_deriv_snd]
+    have hsc : (r * (-Real.sin t)) ^ 2 + (r * Real.cos t) ^ 2 = r ^ 2 := by
+      have h : (r * (-Real.sin t)) ^ 2 + (r * Real.cos t) ^ 2
+          = r ^ 2 * (Real.sin t ^ 2 + Real.cos t ^ 2) := by ring
+      rw [h, Real.sin_sq_add_cos_sq, mul_one]
+    rw [hsc, Real.sqrt_sq hr]
+  rw [hint, intervalIntegral.integral_const, smul_eq_mul]
+  ring
+
+/-- **Circle boundary crossings**: a coin of radius `r ≥ 0` has expected boundary
+    crossings `4r/d`. -/
+theorem circle_crossings (r d : ℝ) (hr : 0 ≤ r) (hd : 0 < d) :
+    concreteSmoothExpectedCrossings (circle r) 0 (2 * π) d = 4 * r / d := by
+  rw [buffon_coin_boundary_crossings (circle r) 0 (2 * π) d hd
+        (by positivity) (circle_contDiff r) (circle_closed r),
+      circle_perimeter r hr]
+  have hπ : π ≠ 0 := Real.pi_ne_zero
+  have hd' : d ≠ 0 := hd.ne'
+  field_simp
+  ring
+
+/-- **Buffon's coin (classical)**: the expected number of grid lines cutting a
+    coin of radius `r ≥ 0` is `2r/d`. For `r ≤ d/2` (diameter `≤ d`) this is the
+    crossing probability `diameter / d` — Laplace's 1812 result. -/
+theorem circle_lineCuts (r d : ℝ) (hr : 0 ≤ r) (hd : 0 < d) :
+    expectedLineCuts (circle r) 0 (2 * π) d = 2 * r / d := by
+  unfold expectedLineCuts
+  rw [circle_crossings r d hr hd]
+  ring
+
+/-! ## Part V: Shape independence -/
+
+/-- **Shape independence**: two convex bodies with equal perimeter have the same
+    expected number of cutting lines, regardless of shape. -/
+theorem coin_shape_independence
+    (γ₁ γ₂ : ℝ → ℝ × ℝ) (a₁ b₁ a₂ b₂ d : ℝ)
+    (hd : 0 < d) (h₁ : a₁ ≤ b₁) (h₂ : a₂ ≤ b₂)
+    (hC1₁ : ContDiff ℝ 1 γ₁) (hC1₂ : ContDiff ℝ 1 γ₂)
+    (hcl₁ : γ₁ a₁ = γ₁ b₁) (hcl₂ : γ₂ a₂ = γ₂ b₂)
+    (hP : boundaryPerimeter γ₁ a₁ b₁ = boundaryPerimeter γ₂ a₂ b₂) :
+    expectedLineCuts γ₁ a₁ b₁ d = expectedLineCuts γ₂ a₂ b₂ d := by
+  rw [buffon_coin_lineCuts γ₁ a₁ b₁ d hd h₁ hC1₁ hcl₁,
+      buffon_coin_lineCuts γ₂ a₂ b₂ d hd h₂ hC1₂ hcl₂, hP]
+
+/-- **Monotonicity**: a longer-perimeter convex body has at least as many expected
+    cutting lines (same spacing). -/
+theorem coin_lineCuts_mono
+    (γ₁ γ₂ : ℝ → ℝ × ℝ) (a₁ b₁ a₂ b₂ d : ℝ)
+    (hd : 0 < d) (h₁ : a₁ ≤ b₁) (h₂ : a₂ ≤ b₂)
+    (hC1₁ : ContDiff ℝ 1 γ₁) (hC1₂ : ContDiff ℝ 1 γ₂)
+    (hcl₁ : γ₁ a₁ = γ₁ b₁) (hcl₂ : γ₂ a₂ = γ₂ b₂)
+    (hP : boundaryPerimeter γ₁ a₁ b₁ ≤ boundaryPerimeter γ₂ a₂ b₂) :
+    expectedLineCuts γ₁ a₁ b₁ d ≤ expectedLineCuts γ₂ a₂ b₂ d := by
+  rw [buffon_coin_lineCuts γ₁ a₁ b₁ d hd h₁ hC1₁ hcl₁,
+      buffon_coin_lineCuts γ₂ a₂ b₂ d hd h₂ hC1₂ hcl₂]
+  apply div_le_div_of_nonneg_right _ (mul_pos Real.pi_pos hd).le
+  exact hP
+
+end BuffonsNeedleOQ01OQ04

--- a/research/problems/buffons-needle-oq-01-oq-04/state.md
+++ b/research/problems/buffons-needle-oq-01-oq-04/state.md
@@ -1,11 +1,51 @@
 # Research State: buffons-needle-oq-01-oq-04
 
 ## Current State
-**Phase**: ORIENT (S1 OBSERVE complete; ready for S2 ACT)
+**Phase**: ACT COMPLETE (S2 ACT delivered; Approach A verified, Docker-built)
 **Path**: full
 **Since**: 2026-04-05T19:30:47-07:00
+**Iteration**: 3
+**Last Updated**: 2026-06-11 (S2 ACT, researcher-2)
+
+## S2 ACT Summary (2026-06-11, researcher-2)
+
+**Mode**: ACT — created and Docker-verified `proofs/Proofs/BuffonsNeedleOQ01OQ04.lean`
+(Approach A: Buffon's coin via C¹ boundary parametrisation), plus the gallery
+directory `src/data/proofs/buffons-needle-oq-01-oq-04/meta.json`.
+
+### Deliverable
+
+* **`BuffonsNeedleOQ01OQ04.lean`** (209 LOC, 13 theorems, 3 defs, **0 axioms, 0 sorries**).
+  Docker-verified clean: `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ01OQ04`
+  → `Built Proofs.BuffonsNeedleOQ01OQ04` (7745/7745 jobs).
+* Registered in `proofs/Proofs.lean` (import after `BuffonsNeedleOQ01OQ02`).
+* Gallery `meta.json` (status `verified`, badge `mathlib`).
+
+### Key theorems
+
+1. `buffon_coin_boundary_crossings`: closed C¹ boundary →
+   `concreteSmoothExpectedCrossings = 2 · boundaryPerimeter / (π·d)`.
+   A one-line corollary of `BuffonsNeedleOQ01.buffon_smooth_of_contDiff`.
+2. `expectedLineCuts` / `buffon_coin_lineCuts`: `= boundaryPerimeter / (π·d)`.
+   The convex 0-or-2 boundary-intersection dichotomy is encoded as the
+   factor-of-two halving (honest: no Mathlib convex bearer exists; the
+   crossings model is an integral, not a literal point count).
+3. **Circle (coin)**: `circle_perimeter` = `2πr`; `circle_crossings` = `4r/d`;
+   `circle_lineCuts` = `2r/d` (= diameter/d, Laplace's classical probability).
+4. `coin_shape_independence`, `coin_lineCuts_mono`, nonneg lemmas.
+
+### Honest-status block
+
+Zero new analytic mathematics: the heavy lifting is inherited from the parent's
+0-axiom-0-sorry bearer. The contribution is the coin packaging + the concrete
+circle verification (genuine new arc-length computation via sin²+cos²=1). The
+factor-of-two convexity step is modeled definitionally and documented as such
+in both the Lean docstring and `meta.json` assumptions — not overclaimed.
+
+## Prior State
+**Phase (pre-2026-06-11)**: ORIENT (S1 OBSERVE complete; ready for S2 ACT)
 **Iteration**: 2
-**Last Updated**: 2026-05-31T23:50:00Z (S1 OBSERVE, researcher-1)
+**S1 OBSERVE**: 2026-05-31T23:50:00Z (researcher-1)
 
 ## S1 OBSERVE Summary (2026-05-31, researcher-1)
 

--- a/src/data/proofs/buffons-needle-oq-01-oq-04/meta.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-04/meta.json
@@ -1,0 +1,217 @@
+{
+  "id": "buffons-needle-oq-01-oq-04",
+  "title": "Buffon's Coin: the Cauchy Mean-Width Specialization",
+  "slug": "buffons-needle-oq-01-oq-04",
+  "description": "Resolves the fourth open question of buffons-needle-oq-01 by packaging Buffon's coin (Laplace 1812) as a corollary of the C¹ smooth-noodle theorem. For a convex body K with closed C¹ boundary dropped on a parallel line grid of spacing d, the expected boundary crossings equal 2·perimeter/(πd) and the expected number of cutting lines equals perimeter/(πd). Verified on the circle: a coin of radius r has E[crossings]=4r/d and E[line-cuts]=2r/d (the classical diameter/d probability).",
+  "meta": {
+    "author": "Laplace (1812), Cauchy (1850); formalized here",
+    "sourceUrl": "https://en.wikipedia.org/wiki/Buffon%27s_needle_problem#Buffon's_coin_problem",
+    "date": "1812",
+    "status": "verified",
+    "proofRepoPath": "Proofs/BuffonsNeedleOQ01OQ04.lean",
+    "tags": [
+      "probability",
+      "geometric-probability",
+      "integral-geometry",
+      "cauchy-crofton",
+      "buffon-coin",
+      "convex-bodies",
+      "mean-width",
+      "research",
+      "open-question"
+    ],
+    "badge": "mathlib",
+    "sorries": 0,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "defCount": 3,
+    "lineCount": 209,
+    "mathlibDependencies": [
+      {
+        "theorem": "Real.hasDerivAt_cos",
+        "description": "d/dx cos x = -sin x",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv"
+      },
+      {
+        "theorem": "Real.hasDerivAt_sin",
+        "description": "d/dx sin x = cos x",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Deriv"
+      },
+      {
+        "theorem": "Real.sin_sq_add_cos_sq",
+        "description": "sin²x + cos²x = 1",
+        "module": "Mathlib.Analysis.SpecialFunctions.Trigonometric.Basic"
+      },
+      {
+        "theorem": "Real.sqrt_sq",
+        "description": "√(a²) = a for a ≥ 0",
+        "module": "Mathlib.Analysis.SpecialFunctions.Sqrt"
+      },
+      {
+        "theorem": "intervalIntegral.integral_const",
+        "description": "∫ over [a,b] of a constant equals (b-a)·c",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+      },
+      {
+        "theorem": "intervalIntegral.integral_nonneg",
+        "description": "Nonnegative integrand gives nonnegative integral",
+        "module": "Mathlib.MeasureTheory.Integral.IntervalIntegral"
+      }
+    ],
+    "originalContributions": [
+      "buffon_coin_boundary_crossings: E[∂K crossings] = 2·perimeter/(πd) for any closed C¹ boundary, as a one-line corollary of buffon_smooth_of_contDiff",
+      "expectedLineCuts / buffon_coin_lineCuts: E[lines cutting K] = perimeter/(πd), with the convex 0-or-2 dichotomy modeled by the factor-of-two halving",
+      "circle_perimeter: the disk of radius r has boundary perimeter 2πr (arc-length of (r cos t, r sin t))",
+      "circle_crossings: a coin of radius r has E[boundary crossings] = 4r/d",
+      "circle_lineCuts: a coin of radius r has E[lines cutting] = 2r/d — the classical Buffon's-coin probability diameter/d for r ≤ d/2",
+      "coin_shape_independence: convex bodies of equal perimeter share the same expected cut-line count regardless of shape",
+      "coin_lineCuts_mono: monotonicity of expected cut-lines in perimeter",
+      "boundaryPerimeter_nonneg, expectedLineCuts_nonneg: sign structure"
+    ],
+    "dateAdded": "2026-06-11",
+    "assumptions": "Fully verified: 0 axioms, 0 sorries. The C¹ smoothness hypothesis (ContDiff ℝ 1 γ) and the closed-curve hypothesis (γ a = γ b) are explicit. The convex 'each cutting line meets ∂K in exactly 0 or 2 points' fact is encoded definitionally as the factor-of-two halving in expectedLineCuts rather than derived from a convex-geometry API (Mathlib v4.26.0 has no such bearer, and concreteSmoothExpectedCrossings is an integral model rather than a literal point count). The analytic content is entirely inherited from the parent's 0-axiom-0-sorry bearer buffon_smooth_of_contDiff.",
+    "prerequisites": [
+      "Buffon-Barbier smooth-noodle theorem for C¹ curves (buffons-needle-oq-01)",
+      "Arc length of a planar C¹ curve",
+      "Cauchy's mean-width formula for convex bodies",
+      "Buffon's needle problem in 2D"
+    ],
+    "mathlib_version": "4.26.0",
+    "definitionCount": 3
+  },
+  "overview": {
+    "historicalContext": "Buffon's original 1733 needle problem asks for the probability that a needle of length ℓ dropped on a floor of parallel lines spaced d apart crosses a line: P = 2ℓ/(πd) for ℓ ≤ d. Laplace (1812) generalized this to **Buffon's coin**: drop a 2-D convex object — a coin, ellipse, or triangle — instead of a 1-D needle, and ask how often its boundary meets the line grid. The answer depends only on the perimeter, not the shape: E[boundary crossings] = 2p/(πd). This is a special case of **Cauchy's mean-width formula** (1850), which states that the average projection length of a convex body onto a random line equals p/π.",
+    "problemStatement": "**Buffon's Coin**: Let K ⊂ ℝ² be a convex body whose boundary ∂K is a closed C¹ curve of perimeter p. Drop K uniformly at random onto an infinite family of parallel lines spaced d apart. Then\n$$\\mathbb{E}[\\#\\{\\text{crossings of } \\partial K\\text{ with the grid}\\}] = \\frac{2p}{\\pi d},$$\nand the expected number of grid lines that cut K (meet its interior) is p/(πd), since each cutting line meets ∂K in exactly two points.\n\nFor a coin (disk) of radius r ≤ d/2, the expected number of lines cut is 2r/d = diameter/d, recovering Laplace's classical probability.",
+    "text": "Packages Buffon's coin as a corollary of the C¹ smooth-noodle theorem. The expected boundary-crossing count equals 2·perimeter/(πd); the expected cut-line count equals perimeter/(πd). Verified concretely on the circle, where a radius-r coin gives 4r/d crossings and 2r/d cut lines.",
+    "proofStrategy": "1. **Define the perimeter** of a closed C¹ boundary as its planar arc length (boundaryPerimeter).\n\n2. **Apply the bearer**: buffon_coin_boundary_crossings is buffon_smooth_of_contDiff (the parent's main theorem) applied to the closed boundary curve — the entire analytic computation is reused.\n\n3. **Translate to cut lines**: each line cutting a convex body meets its boundary in exactly two points, so expectedLineCuts := crossings/2, giving perimeter/(πd).\n\n4. **Verify on the circle**: compute the arc length of (r cos t, r sin t) on [0,2π] via sin²+cos²=1, obtaining perimeter 2πr, hence 4r/d crossings and 2r/d cut lines.\n\n5. **Structural lemmas**: shape independence, monotonicity, and nonnegativity follow algebraically from the formula.",
+    "keyInsights": [
+      "Buffon's coin is structurally a one-line corollary of the smooth-noodle theorem applied to the boundary curve — the perimeter, not the shape, is all that matters",
+      "Convexity enters in exactly one place: the factor of two relating boundary crossings to cutting lines (each line meets a convex boundary in 0 or 2 points)",
+      "The circle of radius r gives the cleanest instance: 4r/d crossings, 2r/d cut lines — and 2r/d = diameter/d is exactly Laplace's classical Buffon's-coin probability",
+      "Shape independence is immediate: two convex bodies of equal perimeter cut the same expected number of lines, however different their shapes",
+      "This is the most tractable of the parent's four open questions; the other three (random-line measures, ℝⁿ hyperplane arrangements, Lipschitz boundaries) require Mathlib infrastructure that does not yet exist"
+    ],
+    "prerequisites": [
+      "Buffon-Barbier smooth-noodle theorem for C¹ curves (buffons-needle-oq-01)",
+      "Arc length of a planar C¹ curve",
+      "Cauchy's mean-width formula for convex bodies",
+      "Buffon's needle problem in 2D"
+    ]
+  },
+  "sections": [
+    {
+      "id": "perimeter",
+      "title": "Perimeter of a C¹ Convex Boundary",
+      "startLine": 52,
+      "endLine": 66,
+      "summary": "Defines boundaryPerimeter as the arc length of a closed C¹ boundary curve and proves it is nonnegative.",
+      "mathContext": "perimeter(K) = ∫ₐᵇ ‖γ'(t)‖ dt for a closed C¹ parametrisation γ of ∂K."
+    },
+    {
+      "id": "boundary-crossings",
+      "title": "Buffon's Coin — Boundary Crossings",
+      "startLine": 67,
+      "endLine": 85,
+      "summary": "The boundary-crossing formula E[crossings] = 2·perimeter/(πd), a corollary of buffon_smooth_of_contDiff.",
+      "mathContext": "Applies the parent's C¹ smooth-noodle bearer to the closed boundary curve."
+    },
+    {
+      "id": "line-cuts",
+      "title": "Buffon's Coin — Lines that Cut K",
+      "startLine": 86,
+      "endLine": 112,
+      "summary": "Expected cut-line count = perimeter/(πd) via the convex 0-or-2 dichotomy (factor of two).",
+      "mathContext": "Each line cutting a convex body meets ∂K in exactly two points, so cut lines = crossings/2."
+    },
+    {
+      "id": "circle",
+      "title": "The Circle (the Coin)",
+      "startLine": 113,
+      "endLine": 179,
+      "summary": "The disk of radius r: C¹, closed, perimeter 2πr; E[crossings] = 4r/d, E[cut-lines] = 2r/d.",
+      "mathContext": "Arc length of (r cos t, r sin t) on [0,2π] is 2πr via sin²+cos²=1; 2r/d = diameter/d is Laplace's probability."
+    },
+    {
+      "id": "shape-independence",
+      "title": "Shape Independence and Monotonicity",
+      "startLine": 181,
+      "endLine": 209,
+      "summary": "Convex bodies of equal perimeter cut the same expected number of lines; monotonicity in perimeter.",
+      "mathContext": "The cut-line count depends only on perimeter, not on shape."
+    }
+  ],
+  "conclusion": {
+    "summary": "Buffon's coin — the 2-D convex-body generalization of Buffon's needle — is formalized as a corollary of the parent's C¹ smooth-noodle theorem. The expected boundary-crossing count is 2·perimeter/(πd) and the expected number of cut lines is perimeter/(πd), verified concretely on the circle where a radius-r coin gives 4r/d crossings and 2r/d cut lines (the classical diameter/d probability). 0 axioms, 0 sorries.",
+    "implications": "1. **Shape independence**: any two convex bodies of equal perimeter cut the same expected number of grid lines — a circle, square (smoothed), or ellipse all behave identically.\n\n2. **Reuse of the smooth-noodle bearer**: the entire analytic content is inherited from buffon_smooth_of_contDiff; the coin result is a packaging step, showing the value of a well-stated general theorem.\n\n3. **Mean-width direction**: this closes the most tractable of the parent's four open questions and points toward the full Cauchy mean-width theory for general convex bodies.",
+    "openQuestions": [
+      "Derive the convex 0-or-2 boundary-intersection dichotomy from a Mathlib convex-geometry API rather than modeling it definitionally",
+      "Extend to rectifiable (Lipschitz) boundaries via C¹ approximation, covering polygons and the unit square",
+      "Formalize the full Cauchy mean-width formula for general convex bodies, defining Convex.perimeter and Convex.meanWidth",
+      "The full Cauchy-Crofton formula for arbitrary measures on lines in ℝ²"
+    ]
+  },
+  "leanFile": {
+    "imports": [
+      "Mathlib",
+      "Proofs.BuffonsNeedleOQ01"
+    ],
+    "opens": [
+      "Real",
+      "MeasureTheory"
+    ],
+    "namespace": "BuffonsNeedleOQ01OQ04",
+    "lineCount": 209,
+    "axiomCount": 0,
+    "theoremCount": 13,
+    "definitionCount": 3,
+    "path": "Proofs/BuffonsNeedleOQ01OQ04.lean",
+    "sorries": 0
+  },
+  "crossReferences": [
+    {
+      "targetId": "buffons-needle-oq-01",
+      "relationship": "extends",
+      "description": "Applies the parent's main theorem buffon_smooth_of_contDiff (E[crossings] = 2·arcLength/(πd) for C¹ curves) to the closed boundary curve of a convex body, yielding Buffon's coin"
+    },
+    {
+      "targetId": "buffons-needle",
+      "relationship": "extends",
+      "description": "Generalizes the 1-D needle (P = 2ℓ/(πd)) to a 2-D convex body; the needle is the degenerate boundary case"
+    },
+    {
+      "targetId": "buffons-needle-oq-01-oq-02",
+      "relationship": "sibling",
+      "description": "Sibling open question of the same parent, exploring n-dimensional hyperplane arrangements via the Gamma-function dimensional constant"
+    }
+  ],
+  "references": [
+    {
+      "authors": [
+        "Laplace, Pierre-Simon"
+      ],
+      "title": "Théorie analytique des probabilités",
+      "year": "1812",
+      "venue": "Courcier, Paris",
+      "note": "Extended Buffon's needle to the coin problem and to grids of perpendicular lines"
+    },
+    {
+      "authors": [
+        "Cauchy, Augustin-Louis"
+      ],
+      "title": "Note sur divers théorèmes relatifs à la rectification des courbes",
+      "year": "1850",
+      "venue": "Comptes Rendus de l'Académie des Sciences 31, 344-346",
+      "note": "Established the mean-width formula: the average projection length of a convex body equals p/π"
+    },
+    {
+      "authors": [
+        "Santaló, Lluís"
+      ],
+      "title": "Integral Geometry and Geometric Probability",
+      "year": "1976",
+      "venue": "Cambridge University Press",
+      "note": "Definitive reference for integral geometry, including Buffon's coin and the Cauchy-Crofton formulas"
+    }
+  ],
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Resolves the **fourth open question** of `buffons-needle-oq-01`: the connection to **Buffon's coin** (Laplace 1812). A new file `proofs/Proofs/BuffonsNeedleOQ01OQ04.lean` (209 LOC, 13 theorems, 3 defs, **0 axioms, 0 sorries**) packages Buffon's coin as a corollary of the parent's C¹ smooth-noodle bearer `buffon_smooth_of_contDiff`.

For a convex body `K` with closed C¹ boundary of perimeter `p`, dropped on a parallel line grid of spacing `d`:
- `buffon_coin_boundary_crossings`: `E[∂K crossings] = 2·p/(πd)`
- `buffon_coin_lineCuts`: `E[lines cutting K] = p/(πd)`

**Circle (coin) instance** — genuine new arc-length computation:
- `circle_perimeter` = `2πr` (via `sin²+cos²=1`)
- `circle_crossings` = `4r/d`
- `circle_lineCuts` = `2r/d` — for `r ≤ d/2` this is the classical Buffon's-coin probability `diameter/d`

Plus `coin_shape_independence`, `coin_lineCuts_mono`, and nonnegativity lemmas.

## Honest status

The analytic content is entirely inherited from the parent's 0-axiom-0-sorry bearer; this PR is the coin packaging + the concrete circle verification. The convex "each cutting line meets `∂K` in exactly 0 or 2 points" dichotomy is encoded **definitionally** as the factor-of-two halving in `expectedLineCuts`, not derived from a convex-geometry API — Mathlib v4.26.0 has no such bearer, and `concreteSmoothExpectedCrossings` is an integral model rather than a literal point count. This is documented in both the Lean docstring and `meta.json` assumptions; nothing is overclaimed.

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.BuffonsNeedleOQ01OQ04` → `Built Proofs.BuffonsNeedleOQ01OQ04` (7745/7745 jobs), 0 sorries, 0 axioms
- [x] Registered in `proofs/Proofs.lean`
- [x] Gallery `meta.json` added (status `verified`, badge `mathlib`), valid JSON, section line refs verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)