### PR TITLE
research(spherical-law-of-cosines-oq-05): S5 — haversine bijection [0,π] ≃ [0,1]

### DIFF
--- a/proofs/Proofs/SphericalLawOfCosinesOQ05.lean
+++ b/proofs/Proofs/SphericalLawOfCosinesOQ05.lean
@@ -571,7 +571,73 @@ theorem haversine_eq_zero_iff_of_mem_Icc {θ : ℝ}
   rw [haversine_zero] at h
   exact h
 
-/- ## Part X: Summary
+/- ## Part X: The haversine bijection `[0, π] ≃ [0, 1]` (S5)
+
+S4 established that `haversine` is *strictly monotone* (hence injective) on the
+principal range `[0, π]`. This part completes the picture by proving it is also
+*surjective* onto `[0, 1]`, so the forward map and the inverse
+`2 · arcsin(√·)` (S3) are mutually inverse bijections between `[0, π]` and
+`[0, 1]`.
+
+Surjectivity is *constructive* and needs no intermediate-value argument: for any
+target `y ∈ [0, 1]`, the explicit preimage `2 · arcsin(√y)` lies in `[0, π]` and
+maps to `y`, because `sin(arcsin(√y)) = √y` and `(√y)² = y`. This is the exact
+range statement underlying the navigation recovery — every admissible haversine
+value `y ∈ [0, 1]` is realised by a unique great-circle distance `c ∈ [0, π]`. -/
+
+/-- **Right inverse / realisability**: every `y ∈ [0, 1]` is the haversine of its
+explicit preimage `2 · arcsin(√y)`. Purely algebraic: `sin(arcsin √y) = √y`
+(since `0 ≤ √y ≤ 1`) and `(√y)² = y` (since `0 ≤ y`). -/
+theorem haversine_two_arcsin_sqrt {y : ℝ} (h0 : 0 ≤ y) (h1 : y ≤ 1) :
+    haversine (2 * Real.arcsin (Real.sqrt y)) = y := by
+  have hsqrt_le : Real.sqrt y ≤ 1 := by
+    rw [show (1 : ℝ) = Real.sqrt 1 from Real.sqrt_one.symm]
+    exact Real.sqrt_le_sqrt h1
+  have hhalf : (2 * Real.arcsin (Real.sqrt y)) / 2 = Real.arcsin (Real.sqrt y) := by
+    ring
+  unfold haversine
+  rw [hhalf, Real.sin_arcsin (by linarith [Real.sqrt_nonneg y]) hsqrt_le,
+      Real.sq_sqrt h0]
+
+/-- The explicit preimage `2 · arcsin(√y)` always lies in the principal range
+`[0, π]` (its half lies in `[0, π/2]` since `arcsin ≥ 0` on nonnegative inputs and
+`arcsin ≤ π/2` always). -/
+theorem two_arcsin_sqrt_mem_Icc (y : ℝ) :
+    2 * Real.arcsin (Real.sqrt y) ∈ Set.Icc (0 : ℝ) π := by
+  refine ⟨?_, ?_⟩
+  · have h := Real.arcsin_nonneg.mpr (Real.sqrt_nonneg y)
+    linarith
+  · have h := Real.arcsin_le_pi_div_two (Real.sqrt y)
+    linarith
+
+/-- **`haversine` maps `[0, π]` into `[0, 1]`** (the codomain statement). -/
+theorem haversine_mapsTo :
+    Set.MapsTo haversine (Set.Icc (0 : ℝ) π) (Set.Icc (0 : ℝ) 1) :=
+  fun θ _ => ⟨haversine_nonneg θ, haversine_le_one θ⟩
+
+/-- **`haversine` is surjective from `[0, π]` onto `[0, 1]`.** Constructive: the
+preimage of `y` is `2 · arcsin(√y)`. -/
+theorem haversine_surjOn :
+    Set.SurjOn haversine (Set.Icc (0 : ℝ) π) (Set.Icc (0 : ℝ) 1) := by
+  intro y hy
+  obtain ⟨h0, h1⟩ := hy
+  exact ⟨2 * Real.arcsin (Real.sqrt y), two_arcsin_sqrt_mem_Icc y,
+    haversine_two_arcsin_sqrt h0 h1⟩
+
+/-- **The haversine bijection.** `haversine` is a bijection from the principal
+arc-length range `[0, π]` onto the haversine range `[0, 1]`. Combined with the
+inverse `eq_two_arcsin_sqrt_haversine` (S3), this makes great-circle distance
+recovery a genuine two-sided inverse, not merely a one-sided formula. -/
+theorem haversine_bijOn :
+    Set.BijOn haversine (Set.Icc (0 : ℝ) π) (Set.Icc (0 : ℝ) 1) :=
+  ⟨haversine_mapsTo, haversine_injOn_Icc_zero_pi, haversine_surjOn⟩
+
+/-- **Image characterisation**: `haversine '' [0, π] = [0, 1]`. -/
+theorem haversine_image_Icc :
+    haversine '' (Set.Icc (0 : ℝ) π) = Set.Icc (0 : ℝ) 1 :=
+  haversine_bijOn.image_eq
+
+/- ## Part XI: Summary
 
 | Result                                | Status   |
 |---------------------------------------|----------|
@@ -607,10 +673,16 @@ theorem haversine_eq_zero_iff_of_mem_Icc {θ : ℝ}
 | `sideA_eq_of_haversine_sideA_eq`      | PROVED (S4) |
 | `sideB_eq_of_haversine_sideB_eq`      | PROVED (S4) |
 | `haversine_eq_zero_iff_of_mem_Icc`    | PROVED (S4) |
+| `haversine_two_arcsin_sqrt`           | PROVED (S5) |
+| `two_arcsin_sqrt_mem_Icc`             | PROVED (S5) |
+| `haversine_mapsTo`                    | PROVED (S5) |
+| `haversine_surjOn`                    | PROVED (S5) |
+| `haversine_bijOn`                     | PROVED (S5) |
+| `haversine_image_Icc`                 | PROVED (S5) |
 
 Axioms: 0
 Sorries: 0
-Proved theorems: 31
+Proved theorems: 37
 Definitions: 1
 -/
 

--- a/research/problems/spherical-law-of-cosines-oq-05/state.md
+++ b/research/problems/spherical-law-of-cosines-oq-05/state.md
@@ -1,9 +1,42 @@
 # Current State
 
+**Phase**: ACT (S5 complete; file Docker-verified, 0 sorries, 0 axioms, 37 theorems)
+**Since**: 2026-06-11 (S5)
+**Iteration**: 5
+**Last Updated**: 2026-06-11 (researcher-2)
+
+## S5 Summary (2026-06-11, researcher-2)
+
+Added **Part X: the haversine bijection `[0, π] ≃ [0, 1]`**. S4 had proved
+*injectivity* (via strict monotonicity); S5 adds *surjectivity* and bundles
+both into a `Set.BijOn`. Six new theorems (31 → 37):
+
+1. `haversine_two_arcsin_sqrt` — right inverse: for `y ∈ [0,1]`,
+   `haversine (2·arcsin(√y)) = y`. Algebraic: `sin(arcsin √y) = √y`
+   (`Real.sin_arcsin`, valid since `0 ≤ √y ≤ 1`) then `(√y)² = y`
+   (`Real.sq_sqrt`). No IVT needed — surjectivity is constructive.
+2. `two_arcsin_sqrt_mem_Icc` — the explicit preimage `2·arcsin(√y)` lands in
+   `[0,π]` (`Real.arcsin_nonneg`, `Real.arcsin_le_pi_div_two`).
+3. `haversine_mapsTo` — codomain statement `[0,π] → [0,1]`.
+4. `haversine_surjOn` — `Set.SurjOn haversine (Icc 0 π) (Icc 0 1)`.
+5. `haversine_bijOn` — `Set.BijOn …`, combining mapsTo + S4 injOn + surjOn.
+6. `haversine_image_Icc` — `haversine '' Icc 0 π = Icc 0 1`.
+
+**Build**: DOCKER-VERIFIED (researcher-2, 2026-06-11), 3059/3059 jobs,
+`Built Proofs.SphericalLawOfCosinesOQ05`. 689 lines, 37 theorems, 1 def,
+0 sorries, 0 axioms.
+
+**Honest status**: incremental extension of an already-verified file. All six
+theorems reuse standard Mathlib trig/sqrt API and the existing S3/S4 lemmas;
+no new axioms or assumptions. This closes the S8 "bijective inverse" candidate
+from the prior S5+ shortlist (the order-iso `Equiv`/`OrderIso` bundling is left
+as a further refinement, but the mathematical bijection is now fully established).
+
+## Prior State (pre-S5)
+
 **Phase**: ACT (S4 complete; file Docker-verified, 0 sorries, 0 axioms, 31 theorems)
 **Since**: 2026-06-10 (S4)
 **Iteration**: 4
-**Last Updated**: 2026-06-10 (researcher-1)
 
 ## Current Focus
 

--- a/src/data/proofs/spherical-law-of-cosines-oq-05/meta.json
+++ b/src/data/proofs/spherical-law-of-cosines-oq-05/meta.json
@@ -22,12 +22,12 @@
     "sourceUrl": "https://en.wikipedia.org/wiki/Haversine_formula",
     "dateAdded": "2026-05-12",
     "axiomCount": 0,
-    "lineCount": 616,
-    "assumptions": "None. All 31 theorems proved (0 sorries, 0 axioms). S2 (researcher-10, 2026-05-12) closed the S1 sorry on haversine_formula via the bridge lemma inner_projectPerp_eq_sin_sin_cos_angleC, which converts the parent's projection-inner-product form of the spherical law of cosines into the trigonometric sin(a)·sin(b)·cos(angleC) form. S3 (researcher-1, 2026-06-03) added the inverse haversine formula sideC = 2·arcsin(√(haversine sideC)) (general form for θ ∈ [0, π] plus SphericalTriangle specialisations for sideA, sideB, sideC) and the great-circle distance corollary sideC_eq_great_circle_haversine combining the forward and inverse formulas into the canonical navigation identity. S4 (researcher-1, 2026-06-10) added strict monotonicity haversine_strictMonoOn_Icc_zero_pi (via Real.strictAntiOn_cos), the InjOn corollary haversine_injOn_Icc_zero_pi, order/equality characterisations on [0,π], the generic-Vec3 corollary arcLength_eq_of_haversine_eq, and two-triangle uniqueness statements sideA/B/C_eq_of_haversine_sideA/B/C_eq formalising the well-definedness of great-circle distance recovery. Also fixed pre-existing S2 build issues (orphan docstring, split_ifs on let-wrapped if, le_div_iff → le_div_iff₀): file is now Docker-verified end-to-end for the first time.",
+    "lineCount": 689,
+    "assumptions": "None. All 37 theorems proved (0 sorries, 0 axioms). S2 (researcher-10, 2026-05-12) closed the S1 sorry on haversine_formula via the bridge lemma inner_projectPerp_eq_sin_sin_cos_angleC, which converts the parent's projection-inner-product form of the spherical law of cosines into the trigonometric sin(a)·sin(b)·cos(angleC) form. S3 (researcher-1, 2026-06-03) added the inverse haversine formula sideC = 2·arcsin(√(haversine sideC)) (general form for θ ∈ [0, π] plus SphericalTriangle specialisations for sideA, sideB, sideC) and the great-circle distance corollary sideC_eq_great_circle_haversine combining the forward and inverse formulas into the canonical navigation identity. S4 (researcher-1, 2026-06-10) added strict monotonicity haversine_strictMonoOn_Icc_zero_pi (via Real.strictAntiOn_cos), the InjOn corollary haversine_injOn_Icc_zero_pi, order/equality characterisations on [0,π], the generic-Vec3 corollary arcLength_eq_of_haversine_eq, and two-triangle uniqueness statements sideA/B/C_eq_of_haversine_sideA/B/C_eq formalising the well-definedness of great-circle distance recovery. S5 (researcher-2, 2026-06-11) added surjectivity of haversine onto [0,1] (constructive, via the explicit preimage 2·arcsin(√y)) and bundled it with the S4 injectivity into the bijection haversine_bijOn : Set.BijOn haversine (Set.Icc 0 π) (Set.Icc 0 1), plus the image characterisation haversine_image_Icc — making great-circle distance recovery a genuine two-sided inverse. Docker-verified end-to-end (3059/3059 jobs).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 31,
+    "theoremCount": 37,
     "definitionCount": 1,
-    "substantiveTheoremCount": 31
+    "substantiveTheoremCount": 37
   },
   "sections": [
     {
@@ -103,12 +103,20 @@
       "mathContext": "Strict monotonicity formalises the navigation pipeline's well-definedness: the forward `haversine_formula` (S2) plus the inverse `eq_two_arcsin_sqrt_haversine` (S3) compute a great-circle distance, and injectivity confirms this distance is uniquely recoverable from its haversine. Mathematically: $\\text{hav}(\\theta) = (1 - \\cos\\theta)/2$, and `cos` is strictly antitone on $[0, \\pi]$, so `haversine` is strictly monotone there. The corollary `arcLength_eq_of_haversine_eq` makes the injectivity directly applicable to arc-lengths between unit vectors, which always lie in $[0, \\pi]$ by `arcLength_nonneg`/`arcLength_le_pi` from the parent file."
     },
     {
+      "id": "haversine-bijection",
+      "title": "Part X: The haversine bijection [0,π] ≃ [0,1] (S5)",
+      "startLine": 574,
+      "endLine": 639,
+      "summary": "Completes the bijection picture started in S4. S4 proved injectivity (via strict monotonicity); this part proves surjectivity onto [0,1] and bundles both into `Set.BijOn haversine (Set.Icc 0 π) (Set.Icc 0 1)`. Surjectivity is constructive — the preimage of y is the explicit `2·arcsin(√y)` — so no intermediate-value argument is needed. Six new theorems: `haversine_two_arcsin_sqrt` (right inverse), `two_arcsin_sqrt_mem_Icc` (preimage lands in [0,π]), `haversine_mapsTo`, `haversine_surjOn`, `haversine_bijOn`, and the image characterisation `haversine_image_Icc`.",
+      "mathContext": "Surjectivity onto [0,1] is algebraic: for y ∈ [0,1], hav(2·arcsin(√y)) = sin(arcsin(√y))² = (√y)² = y, using `Real.sin_arcsin` (valid since 0 ≤ √y ≤ 1) and `Real.sq_sqrt` (valid since 0 ≤ y). Combined with the S4 injectivity, `haversine` is a bijection from the principal arc-length range [0,π] onto the haversine range [0,1]. Together with the inverse `eq_two_arcsin_sqrt_haversine` (S3), this makes the great-circle distance recovery a genuine two-sided inverse rather than a one-sided formula — every admissible haversine value is realised by exactly one distance."
+    },
+    {
       "id": "summary-final",
-      "title": "Part X: Summary (post-S4)",
-      "startLine": 581,
-      "endLine": 615,
-      "summary": "Tabular summary of the file's contents after S4: 31 proved theorems, 0 axioms, 0 sorries, 1 definition, 616 lines.",
-      "mathContext": "Status accounting: this file is `verified` with badge `original`. The S1 algebraic identity, S2 SphericalTriangle bridge, S3 inverse-formula/navigation corollary, and S4 strict-monotonicity/injectivity together form a complete formalisation of the haversine identity loop with full navigation-pipeline well-definedness guarantees."
+      "title": "Part XI: Summary (post-S5)",
+      "startLine": 640,
+      "endLine": 689,
+      "summary": "Tabular summary of the file's contents after S5: 37 proved theorems, 0 axioms, 0 sorries, 1 definition, 689 lines.",
+      "mathContext": "Status accounting: this file is `verified` with badge `original`. The S1 algebraic identity, S2 SphericalTriangle bridge, S3 inverse-formula/navigation corollary, S4 strict-monotonicity/injectivity, and S5 surjectivity/bijection together form a complete formalisation of the haversine identity loop with full navigation-pipeline well-definedness guarantees and an explicit bijection [0,π] ≃ [0,1]."
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary

Extends the fully-verified `SphericalLawOfCosinesOQ05.lean` (haversine formula) with **Part X: the haversine bijection `[0, π] ≃ [0, 1]`**.

S4 established that `haversine` is **injective** on the principal arc-length range `[0, π]` (via strict monotonicity). S5 completes the picture by proving it is also **surjective** onto `[0, 1]` and bundling both into `Set.BijOn`. Surjectivity is **constructive** — the preimage of any `y ∈ [0, 1]` is the explicit `2·arcsin(√y)` — so no intermediate-value argument is needed.

Six new theorems (31 → 37):
- `haversine_two_arcsin_sqrt`: `hav(2·arcsin(√y)) = y` for `y ∈ [0,1]` (right inverse)
- `two_arcsin_sqrt_mem_Icc`: the preimage lands in `[0,π]`
- `haversine_mapsTo`, `haversine_surjOn`, `haversine_bijOn`
- `haversine_image_Icc`: `hav '' [0,π] = [0,1]`

Combined with the S3 inverse `eq_two_arcsin_sqrt_haversine`, this makes great-circle distance recovery a genuine **two-sided inverse** — every admissible haversine value is realised by exactly one distance.

## Honest status

Incremental extension of an already-`verified` file. All six theorems reuse standard Mathlib trig/sqrt API (`Real.sin_arcsin`, `Real.sq_sqrt`, `Real.arcsin_nonneg`, `Real.arcsin_le_pi_div_two`) and the existing S3/S4 lemmas. 0 new axioms, 0 sorries. Closes the prior shortlist's "bijective inverse" (S8) candidate at the level of the mathematical bijection; the bundled `OrderIso`/`Equiv` packaging is left as a further refinement.

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.SphericalLawOfCosinesOQ05` → `Built Proofs.SphericalLawOfCosinesOQ05` (3059/3059 jobs), 689 lines, 37 theorems, 0 sorries, 0 axioms
- [x] Gallery `meta.json` updated (theoremCount 31→37, lineCount 616→689, new Part X section), valid JSON, section line refs verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)