### PR TITLE
research(tractatus-ontology-oq-06): S4 ACT — refinement lattice via image profiles

### DIFF
--- a/proofs/Proofs/TractatusOntologySpectrum.lean
+++ b/proofs/Proofs/TractatusOntologySpectrum.lean
@@ -304,4 +304,156 @@ theorem freeModel_not_refines_weatherModel :
     (hf bad .clouds).mpr hc
   cases habs
 
+/-! ## S4 — Refinement lattice via image profiles
+
+The refinement preorder `Refines` collapses to subset-inclusion on the
+set of Boolean profiles each model realises (`ImageProfiles`). Under that
+reduction the lattice operations on `(WorldModel S, Refines)` are exactly
+the Set-theoretic operations on `Set (S → Prop)`:
+
+- **join** = profile union (`JoinModel`, always defined; arbitrary
+  suprema via `iJoinModel`);
+- **meet** = profile intersection (`MeetModel`, defined exactly when the
+  intersection is non-empty — there is no bottom element);
+- **top** = `freeModel S` (`imageProfiles_freeModel`).
+
+See `research/problems/tractatus-ontology-oq-06/sessions/2026-05-13-s4-prep-refines-lattice-via-image-profiles.md`.
+-/
+
+/-- The **image profile set** of a world model: the Boolean assignments
+    `S → Prop` actually realised by some world of `M`. -/
+def ImageProfiles (M : WorldModel S) : Set (S → Prop) :=
+  { w | ∃ v : M.W, ∀ s, w s ↔ M.holds v s }
+
+/-- The image profile set is non-empty: the profile of any world of `M`
+    (which exists by `M.nonempty`) inhabits it. -/
+theorem imageProfiles_nonempty (M : WorldModel S) :
+    (ImageProfiles M).Nonempty := by
+  obtain ⟨v⟩ := M.nonempty
+  exact ⟨fun s => M.holds v s, ⟨v, fun _ => Iff.rfl⟩⟩
+
+/-- **R-Lattice-1.** `Refines` is exactly subset-inclusion on image
+    profiles.  This is the load-bearing reduction: a structural question
+    on `WorldModel S` becomes a Set-theoretic question on `Set (S → Prop)`. -/
+theorem refines_iff_subset_imageProfiles (M M' : WorldModel S) :
+    Refines M M' ↔ ImageProfiles M ⊆ ImageProfiles M' := by
+  constructor
+  · rintro ⟨f, hf⟩ w ⟨v, hv⟩
+    refine ⟨f v, fun s => ?_⟩
+    rw [hv s]; exact hf v s
+  · intro hsub
+    classical
+    refine ⟨fun v => Classical.choose (hsub ⟨v, fun _ => Iff.rfl⟩), fun v s => ?_⟩
+    exact Classical.choose_spec (hsub ⟨v, fun _ => Iff.rfl⟩) s
+
+/-- Mutual refinement is exactly equality of image profile sets. -/
+theorem refinesEquiv_iff_image_eq (M M' : WorldModel S) :
+    Refines M M' ∧ Refines M' M ↔ ImageProfiles M = ImageProfiles M' := by
+  rw [refines_iff_subset_imageProfiles, refines_iff_subset_imageProfiles,
+      Set.Subset.antisymm_iff]
+
+/-- **Top element.**  `freeModel S` realises every Boolean profile, so its
+    image profile set is the entire ambient `Set (S → Prop)`.  This is the
+    image-profile reformulation of `refines_freeModel`. -/
+theorem imageProfiles_freeModel : ImageProfiles (freeModel S) = Set.univ := by
+  ext w
+  exact ⟨fun _ => trivial, fun _ => ⟨w, fun _ => Iff.rfl⟩⟩
+
+/-- The **disjoint-sum join** of two world models: its worlds are the
+    disjoint union of the two world-types, with `holds` inherited
+    componentwise. -/
+def JoinModel (M₁ M₂ : WorldModel S) : WorldModel S where
+  W        := M₁.W ⊕ M₂.W
+  holds    := fun w s => Sum.elim (fun v₁ => M₁.holds v₁ s)
+                                  (fun v₂ => M₂.holds v₂ s) w
+  nonempty := M₁.nonempty.map Sum.inl
+
+/-- The join realises exactly the union of the two profile sets. -/
+theorem imageProfiles_join (M₁ M₂ : WorldModel S) :
+    ImageProfiles (JoinModel M₁ M₂)
+      = ImageProfiles M₁ ∪ ImageProfiles M₂ := by
+  ext w
+  constructor
+  · rintro ⟨v, hv⟩
+    cases v with
+    | inl v₁ => exact Or.inl ⟨v₁, hv⟩
+    | inr v₂ => exact Or.inr ⟨v₂, hv⟩
+  · rintro (⟨v, hv⟩ | ⟨v, hv⟩)
+    · exact ⟨Sum.inl v, hv⟩
+    · exact ⟨Sum.inr v, hv⟩
+
+/-- **LUB property.**  `JoinModel M₁ M₂` is the least upper bound of `M₁`
+    and `M₂` in the refinement preorder. -/
+theorem refines_join_iff (M₁ M₂ M : WorldModel S) :
+    Refines (JoinModel M₁ M₂) M ↔ Refines M₁ M ∧ Refines M₂ M := by
+  rw [refines_iff_subset_imageProfiles, imageProfiles_join,
+      refines_iff_subset_imageProfiles, refines_iff_subset_imageProfiles,
+      Set.union_subset_iff]
+
+/-- The **Boolean-profile pullback (meet)** of two world models, defined
+    exactly when the intersection of their image profile sets is
+    non-empty.  Its worlds are the shared profiles themselves. -/
+def MeetModel (M₁ M₂ : WorldModel S)
+    (h : (ImageProfiles M₁ ∩ ImageProfiles M₂).Nonempty) : WorldModel S where
+  W        := { wp : (S → Prop) // wp ∈ ImageProfiles M₁ ∩ ImageProfiles M₂ }
+  holds    := fun wp s => wp.val s
+  nonempty := ⟨⟨h.some, h.some_mem⟩⟩
+
+/-- The meet realises exactly the intersection of the two profile sets. -/
+theorem imageProfiles_meet (M₁ M₂ : WorldModel S)
+    (h : (ImageProfiles M₁ ∩ ImageProfiles M₂).Nonempty) :
+    ImageProfiles (MeetModel M₁ M₂ h)
+      = ImageProfiles M₁ ∩ ImageProfiles M₂ := by
+  ext w
+  constructor
+  · rintro ⟨⟨wp, hwp⟩, hh⟩
+    have heq : w = wp := funext (fun s => propext (hh s))
+    rw [heq]; exact hwp
+  · intro hw
+    exact ⟨⟨w, hw⟩, fun _ => Iff.rfl⟩
+
+/-- **GLB property.**  `MeetModel M₁ M₂ h` is the greatest lower bound of
+    `M₁` and `M₂` in the refinement preorder, on the (non-empty
+    intersection) domain where it is defined. -/
+theorem refines_meet_iff (M M₁ M₂ : WorldModel S)
+    (h : (ImageProfiles M₁ ∩ ImageProfiles M₂).Nonempty) :
+    Refines M (MeetModel M₁ M₂ h)
+      ↔ Refines M M₁ ∧ Refines M M₂ := by
+  rw [refines_iff_subset_imageProfiles, imageProfiles_meet,
+      refines_iff_subset_imageProfiles, refines_iff_subset_imageProfiles,
+      Set.subset_inter_iff]
+
+/-- The **arbitrary join** of a non-empty indexed family of world models
+    (`Σ`-type construction), witnessing that the refinement preorder is a
+    complete join-semilattice (modulo refinement-equivalence). -/
+def iJoinModel {I : Type} [Nonempty I] (M : I → WorldModel S) :
+    WorldModel S where
+  W        := Σ i : I, (M i).W
+  holds    := fun w s => (M w.1).holds w.2 s
+  nonempty := by
+    obtain ⟨i⟩ := ‹Nonempty I›
+    obtain ⟨v⟩ := (M i).nonempty
+    exact ⟨⟨i, v⟩⟩
+
+/-- The arbitrary join realises exactly the union of the families'
+    profile sets. -/
+theorem imageProfiles_iJoin {I : Type} [Nonempty I] (M : I → WorldModel S) :
+    ImageProfiles (iJoinModel M) = ⋃ i, ImageProfiles (M i) := by
+  ext w
+  simp only [Set.mem_iUnion]
+  constructor
+  · rintro ⟨⟨i, v⟩, hv⟩
+    exact ⟨i, v, hv⟩
+  · rintro ⟨i, v, hv⟩
+    exact ⟨⟨i, v⟩, hv⟩
+
+/-- **Arbitrary LUB property.**  `iJoinModel M` is the least upper bound of
+    the family `M` in the refinement preorder. -/
+theorem refines_iJoin_iff {I : Type} [Nonempty I]
+    (M : I → WorldModel S) (N : WorldModel S) :
+    Refines (iJoinModel M) N ↔ ∀ i, Refines (M i) N := by
+  rw [refines_iff_subset_imageProfiles, imageProfiles_iJoin,
+      Set.iUnion_subset_iff]
+  simp_rw [refines_iff_subset_imageProfiles]
+
 end Tractatus

--- a/research/problems/tractatus-ontology-oq-06/sessions/2026-06-11-s4-act-refines-lattice.md
+++ b/research/problems/tractatus-ontology-oq-06/sessions/2026-06-11-s4-act-refines-lattice.md
@@ -1,0 +1,104 @@
+# S4 ACT — Refinement lattice via image profiles
+
+**Date**: 2026-06-11
+**Researcher**: researcher-2
+**Mode**: ACT (Lean implementation)
+**Source PREP**: S4 PREP #18470
+(`sessions/2026-05-13-s4-prep-refines-lattice-via-image-profiles.md`)
+**Build**: `./proofs/scripts/docker-build.sh Proofs.TractatusOntologySpectrum`
+→ **3059 jobs clean** (9.7s incremental on the Spectrum file).
+
+## TL;DR
+
+Implemented the entire S4 PREP skeleton plus the arbitrary-suprema bonus.
+`(WorldModel S, Refines)` modulo refinement-equivalence is shown to be a
+**bounded-above, non-empty-meet-partial, complete join-semilattice**: the
+refinement preorder collapses to subset-inclusion on Boolean image
+profiles, so the lattice operations are exactly the Set operations on
+`Set (S → Prop)`. Top is `freeModel S`; there is no bottom.
+
+This was the **last remaining ACT candidate** for the slug. All five S1
+OBSERVE open questions are now realised in Lean.
+
+## Deliverable inventory
+
+Appended to `proofs/Proofs/TractatusOntologySpectrum.lean` (new S4
+section), 0 sorries, 0 axioms:
+
+| Declaration | Kind | Content |
+|---|---|---|
+| `ImageProfiles` | def | profiles `S → Prop` realised by some world of `M` |
+| `imageProfiles_nonempty` | thm | non-empty (from `M.nonempty`) |
+| `refines_iff_subset_imageProfiles` | thm | **R-Lattice-1**: `Refines ↔ ⊆` on profiles |
+| `refinesEquiv_iff_image_eq` | thm | mutual refinement ↔ equal profile sets |
+| `imageProfiles_freeModel` | thm | top: `= Set.univ` |
+| `JoinModel` | def | `⊕`-join |
+| `imageProfiles_join` | thm | `Im (Join) = Im M₁ ∪ Im M₂` |
+| `refines_join_iff` | thm | binary LUB property |
+| `MeetModel` | def | Boolean-profile pullback (partial) |
+| `imageProfiles_meet` | thm | `Im (Meet) = Im M₁ ∩ Im M₂` |
+| `refines_meet_iff` | thm | binary GLB property |
+| `iJoinModel` | def | `Σ`-join of an indexed family |
+| `imageProfiles_iJoin` | thm | `Im (iJoin) = ⋃ i, Im (M i)` |
+| `refines_iJoin_iff` | thm | arbitrary LUB property |
+
+3 defs + 11 theorems = 14 declarations.
+
+## Deviation from PREP skeleton
+
+The PREP's proof sketch for the **backward** direction of
+`refines_iff_subset_imageProfiles` ended with `.symm`:
+
+```lean
+exact (Classical.choose_spec (hsub ⟨v, fun _ => Iff.rfl⟩) s).symm
+```
+
+This is **the wrong orientation**. The membership predicate of
+`ImageProfiles` is `∀ s, w s ↔ M.holds v s` (profile on the *left*), so for
+the witness `w = fun s => M.holds v s`, `Classical.choose_spec ... s` has
+type `M.holds v s ↔ M'.holds (choose) s` — already exactly the `Refines`
+goal. The `.symm` flips it to a type mismatch (caught on the first Docker
+build). Fix: drop the `.symm`. All other PREP proofs went through verbatim.
+
+## Structural summary
+
+- **Top**: `freeModel S` (`imageProfiles_freeModel`).
+- **Joins**: always defined; binary (`JoinModel`) and arbitrary
+  non-empty-indexed (`iJoinModel`).
+- **Meets**: partial — `MeetModel` is defined exactly when
+  `Im M₁ ∩ Im M₂` is non-empty.
+- **Bottom**: does **not** exist (`Im M` is forced non-empty by
+  `M.nonempty`; the intersection of all non-empty subsets is empty).
+
+## Correction recorded in state.md
+
+The earlier "pointwise intersection of `holds`-relations" candidate meet
+(`ConjModel`, worlds in `M₁.W × M₂.W`) is **neither ≤ nor ≥** the true GLB
+in general (PREP counter-examples at |S| = 1 and |S| = 2). The correct
+construction is the Boolean-profile pullback `MeetModel`. state.md updated.
+
+## Mathlib API used
+
+`Set.subset_inter_iff`, `Set.union_subset_iff`, `Set.Subset.antisymm_iff`,
+`Set.iUnion_subset_iff`, `Set.mem_iUnion`, `Set.Nonempty.some`/`.some_mem`,
+`Sum.elim`, `Classical.choose`/`.choose_spec`, `funext`/`propext`. All at
+the pinned `mathlib4` v4.26.0; no new imports beyond what
+`TractatusOntologySpectrum.lean` already transitively has via
+`import Proofs.TractatusOntology` (`import Mathlib.Tactic`).
+
+## Race awareness
+
+- Open PRs for this slug at push time: **none** (`gh pr list --search
+  tractatus --state open` → empty).
+- Conflict surface: strictly additive single-file append to
+  `TractatusOntologySpectrum.lean` (already on origin/main) + state.md +
+  this memo. No edits to `TractatusOntology.lean`, `TractatusOntologyHorn.lean`,
+  `TractatusOntologyEquiv.lean`, or any `.json`.
+- Branch off `origin/main` (`84a9a65db11` family).
+
+## Status after ACT
+
+`verified` for all 14 declarations (0 sorries, 0 axioms). The slug's
+T0/T1a/T1b spectrum tiers and the refinement lattice are now fully
+realised in Lean. T2 (Kripke) and T3 (quotient) remain out of scope per
+S1 OBSERVE. No remaining ACT candidates.

--- a/research/problems/tractatus-ontology-oq-06/state.md
+++ b/research/problems/tractatus-ontology-oq-06/state.md
@@ -1,6 +1,54 @@
 # State — tractatus-ontology-oq-06
 
-## Phase: S11 ACT (this PR) — `EquivModel` / T1b via symmetric Horn closure
+## Phase: S4 ACT (this PR) — Refinement lattice via image profiles
+
+**File**: appended to `proofs/Proofs/TractatusOntologySpectrum.lean`
+(307 → ~450 LOC; +14 declarations: 3 defs + 11 theorems, 0 sorries,
+0 axioms, **Docker-verified 3059 jobs clean**). Implements S4 PREP
+#18470 in full, plus the arbitrary-suprema bonus from §"Arbitrary joins":
+
+- `ImageProfiles M` — the set of Boolean profiles `S → Prop` realised by
+  some world of `M`; `imageProfiles_nonempty` (non-empty by `M.nonempty`).
+- `refines_iff_subset_imageProfiles` — **R-Lattice-1**: `Refines` is
+  exactly subset-inclusion on image profiles. The load-bearing reduction
+  of a `WorldModel` question to a `Set (S → Prop)` question.
+- `refinesEquiv_iff_image_eq` — mutual refinement ↔ equal profile sets.
+- `imageProfiles_freeModel` — **top element**: `ImageProfiles (freeModel S)
+  = Set.univ`.
+- `JoinModel` (`⊕`) + `imageProfiles_join` + `refines_join_iff` — binary
+  **join (LUB)** = profile union; always defined.
+- `MeetModel` (Boolean-profile pullback) + `imageProfiles_meet` +
+  `refines_meet_iff` — binary **meet (GLB)** = profile intersection,
+  defined exactly when the intersection is non-empty.
+- `iJoinModel` (`Σ`) + `imageProfiles_iJoin` + `refines_iJoin_iff` —
+  **arbitrary join (LUB)** of a non-empty indexed family, witnessing a
+  complete join-semilattice modulo refinement-equivalence.
+
+**Structural result.** `(WorldModel S, Refines)` modulo refinement
+equivalence is a **bounded-above, non-empty-meet-partial, complete
+join-semilattice**: top = `freeModel S`, arbitrary joins, partial binary
+meets, and **no bottom** (image profiles are forced non-empty).
+
+**Correction to earlier state.md note.** The previous "Not yet addressed"
+remark proposed *pointwise intersection of `holds`-relations* (worlds in
+`M₁.W × M₂.W`) as the candidate meet. S4 PREP #18470 showed that
+candidate (`ConjModel`) is **neither ≤ nor ≥ the true GLB** in general —
+its image is `{α ∧ β | α ∈ Im M₁, β ∈ Im M₂}`, generically distinct from
+`Im M₁ ∩ Im M₂`. The correct meet is the **Boolean-profile pullback**
+`MeetModel`, now realised in Lean.
+
+**Closes the last remaining ACT candidate.** With S4 landed, all five S1
+OBSERVE open questions and all PREP-deferred candidates (S3 Horn, S4
+lattice, S5 uniqueness, S6 EquivModel, S7 spectrum-invariance) are
+realised in Lean. The slug's T0/T1a/T1b/T2/T3 spectrum architecture is
+complete on the proven tiers (T2/T3 out of scope per S1 OBSERVE).
+
+See `sessions/2026-06-11-s4-act-refines-lattice.md` for the deliverable
+inventory and build verification.
+
+---
+
+## Phase: S11 ACT — `EquivModel` / T1b via symmetric Horn closure
 
 **New file**: `proofs/Proofs/TractatusOntologyEquiv.lean` (138 LOC, 3 defs +
 3 theorem-or-Equiv constructions, 0 sorries, 0 axioms, **Docker-verified

--- a/src/data/research/problems/tractatus-ontology-oq-06.json
+++ b/src/data/research/problems/tractatus-ontology-oq-06.json
@@ -23,9 +23,10 @@
       "Generic EquivModel S (cs : List (S × S)) constructor + structural iso EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap) + T1b-refines-T1a + biconditional-tier independence failure (TractatusOntologyEquiv.lean, S11 ACT this PR — Docker 3061 jobs clean)."
     ],
     "open": [
-      "Refinement preorder forms a (semi)lattice — meet/join existence on WorldModel S (S4 ACT target, PREP doc #18470)."
+      "None remaining — all S1 OBSERVE open questions and PREP-deferred candidates are realised in Lean as of S4 ACT (this PR)."
     ],
     "verified": [
+      "Refinement lattice on (WorldModel S, Refines) via image profiles (S4 ACT, this PR, PREP #18470): Refines collapses to subset-inclusion on Boolean image profiles (refines_iff_subset_imageProfiles); freeModel S is the top (imageProfiles_freeModel = Set.univ); binary join = profile union (JoinModel/refines_join_iff, always defined); binary meet = profile intersection (MeetModel/refines_meet_iff, partial — defined when the intersection is non-empty); arbitrary join of a non-empty indexed family (iJoinModel/refines_iJoin_iff). Structure: bounded-above, non-empty-meet-partial, complete join-semilattice with NO bottom. Docker-verified 3059 jobs clean. Corrects the obsolete pointwise-intersection meet candidate (ConjModel is neither <= nor >= the GLB).",
       "Refines : WorldModel S → WorldModel S → Prop is reflexive, transitive (TractatusOntologySpectrum.lean refines_refl, refines_trans).",
       "freeModel S is the maximum element of the refinement preorder (refines_freeModel).",
       "Evaluation is invariant along refinements (refines_preserves_eval).",
@@ -37,14 +38,14 @@
     "goal": "Four-tier classification (free / Horn-constrained / equivalence-constrained / Kripke or quotient), with theorem-survival table and a refinement preorder making freeModel the maximum element."
   },
   "currentState": {
-    "phase": "S11 ACT — EquivModel / T1b via symmetric Horn closure (this PR; Docker 3061 jobs clean)",
-    "since": "2026-05-31T20:50:00Z",
-    "iteration": 11,
-    "focus": "S11 ACT (this PR, researcher-1) — TractatusOntologyEquiv.lean (138 LOC, 3 defs + 3 def/theorems, 0 sorries, 0 axioms). Implements S6 PREP #18518 §8 sequence: EquivModel S cs subtype, EquivModel.toWorldModel packaging, equivModel_iso_hornModel_symm (the structural iso EquivModel S cs ≃ HornModel S (cs ++ cs.map Prod.swap) witnessing T1b ⊆ T1a-symm), refines_equivModel_hornModel (T1b refines into T1a), and equivModel_independence_fails (HasIndependentProfiles failure at the spectrum level). Closes the last T1-tier deferral from S1 OBSERVE. Architecture decision: S6 PREP §6 Option C (keep both HornModel and EquivModel named, document subsumption). Build status: Docker-verified end-to-end via ./proofs/scripts/docker-build.sh Proofs.TractatusOntologyEquiv (3061 jobs OK, the new file builds in 10s on top of TractatusOntologyHorn and TractatusOntologySpectrum). Imports: only Proofs.TractatusOntologyHorn + Proofs.TractatusOntologySpectrum; no new Mathlib imports. ONE remaining ACT candidate: S4 Refines lattice via image-profiles (PREP #18470).",
+    "phase": "S4 ACT — Refinement lattice via image profiles (this PR; Docker 3059 jobs clean)",
+    "since": "2026-06-11T00:00:00Z",
+    "iteration": 12,
+    "focus": "S4 ACT (this PR, researcher-2) — appended the refinement-lattice section to TractatusOntologySpectrum.lean (+14 declarations: 3 defs + 11 theorems, 0 sorries, 0 axioms, Docker-verified 3059 jobs clean). Implements S4 PREP #18470 in full plus the arbitrary-suprema bonus. ImageProfiles M (Boolean profiles realised by some world) + imageProfiles_nonempty; refines_iff_subset_imageProfiles (R-Lattice-1: Refines collapses to subset-inclusion on profiles — the load-bearing reduction); refinesEquiv_iff_image_eq; imageProfiles_freeModel (top = Set.univ); JoinModel/imageProfiles_join/refines_join_iff (binary LUB = profile union, always defined); MeetModel/imageProfiles_meet/refines_meet_iff (binary GLB = profile intersection, partial — defined when the intersection is non-empty); iJoinModel/imageProfiles_iJoin/refines_iJoin_iff (arbitrary join of a non-empty indexed family). Structural result: (WorldModel S, Refines) mod refinement-equivalence is a bounded-above, non-empty-meet-partial, complete join-semilattice — top freeModel S, arbitrary joins, partial binary meets, NO bottom (image profiles forced non-empty). Corrected the obsolete 'pointwise intersection of holds-relations' meet candidate (ConjModel is neither <= nor >= the GLB; the correct meet is the Boolean-profile pullback). One deviation from PREP: the backward direction of refines_iff_subset_imageProfiles needed Classical.choose_spec WITHOUT the PREP's spurious .symm. Build: ./proofs/scripts/docker-build.sh Proofs.TractatusOntologySpectrum, 3059 jobs OK. No new imports. CLOSES the last remaining ACT candidate — all five S1 OBSERVE open questions realised in Lean.",
     "blockers": [],
-    "nextAction": "S4 ACT (PREP #18470) — Refines lattice via image-profiles on (WorldModel S, Refines): meet/join existence and characterisation via subset-inclusion on Boolean-profile sets. ~40-80 LOC, higher complexity than T1-tier ACTs because of the Boolean-profile pullback infrastructure. After S4 lands, all five S1 OBSERVE open questions and four PREP-deferred candidates are realised in Lean; the slug closes on the T0/T1a/T1b/T2/T3 spectrum architecture.",
+    "nextAction": "No remaining ACT candidates. The slug's T0/T1a/T1b spectrum tiers, refinement preorder, freeModel uniqueness/maximum, spectrum-invariance, and the refinement lattice are all realised in Lean. T2 (Kripke) and T3 (quotient) remain out of scope per S1 OBSERVE. Optional future bonuses only: S6-bonus IsTight/Equiv freeModel_unique upgrade (~12 LOC), S5-bonus hornModel_independent_iff_vacuous (~3 LOC), S11-bonus equivModel_card cardinality (~25 LOC + Fintype scope), and a Mathlib SemilatticeSup/BoundedOrder typeclass bridge on the RefinesEquiv quotient (deferred Quotient plumbing).",
     "attemptCounts": {
-      "total": 11,
+      "total": 12,
       "currentApproach": 1,
       "approachesTried": 4
     }
@@ -111,7 +112,7 @@
     ]
   },
   "started": "2026-05-12T14:35:20.294Z",
-  "lastUpdate": "2026-05-31T20:50:00Z",
+  "lastUpdate": "2026-06-11T00:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -129,10 +130,10 @@
     {
       "path": "Proofs/TractatusOntologySpectrum.lean",
       "filename": "TractatusOntologySpectrum.lean",
-      "lineCount": 307,
-      "theoremCount": 19,
+      "lineCount": 459,
+      "theoremCount": 29,
       "axiomCount": 0,
-      "defCount": 4,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TractatusOntologySpectrum.lean"


### PR DESCRIPTION
## Summary

S4 ACT for `tractatus-ontology-oq-06`, implementing **S4 PREP #18470** (Refines lattice via image profiles) plus the arbitrary-suprema bonus. Appends a refinement-lattice section to `proofs/Proofs/TractatusOntologySpectrum.lean` (+14 declarations: 3 defs + 11 theorems, **0 sorries, 0 axioms**).

The refinement preorder `Refines` collapses to subset-inclusion on Boolean **image profiles** (`refines_iff_subset_imageProfiles` — *R-Lattice-1*), so the lattice operations on `(WorldModel S, Refines)` are exactly the Set operations on `Set (S → Prop)`:

- **top** = `freeModel S` (`imageProfiles_freeModel = Set.univ`)
- **binary join** = profile union (`JoinModel` / `refines_join_iff`, total)
- **binary meet** = profile intersection (`MeetModel` / `refines_meet_iff`, **partial** — defined when the intersection is non-empty)
- **arbitrary join** of a non-empty indexed family (`iJoinModel` / `refines_iJoin_iff`)

**Structural result:** modulo refinement-equivalence, `(WorldModel S, Refines)` is a **bounded-above, non-empty-meet-partial, complete join-semilattice** with **no bottom** (image profiles are forced non-empty by `M.nonempty`).

**Correction:** the obsolete "pointwise intersection of `holds`-relations" meet candidate (`ConjModel`) is neither ≤ nor ≥ the true GLB; the correct meet is the Boolean-profile pullback `MeetModel`. state.md updated.

**One deviation from the PREP skeleton:** the backward direction of `refines_iff_subset_imageProfiles` uses `Classical.choose_spec` *without* the PREP's spurious `.symm` (orientation already matches the `Refines` goal).

Closes the **last remaining ACT candidate** — all five S1 OBSERVE open questions are now realised in Lean. T2 (Kripke) / T3 (quotient) remain out of scope per S1 OBSERVE.

## Build verification

`./proofs/scripts/docker-build.sh Proofs.TractatusOntologySpectrum` → **3059 jobs clean** (9.7s incremental).

## Test plan

- [x] Docker build green (3059 jobs, 0 errors, 0 sorries, 0 axioms)
- [x] Strictly additive single Lean-file append; no edits to `TractatusOntology.lean`, `TractatusOntologyHorn.lean`, or `TractatusOntologyEquiv.lean`
- [x] No open PRs for this slug at push time (no conflict surface)
- [x] state.md, problem JSON (leanFiles counts + currentState), and session memo updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)