### PR TITLE
Enrich konigsberg-oq-01-oq-02: split 808-line Hierholzer section into 7 navigable sections

### DIFF
--- a/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
+++ b/src/data/proofs/konigsberg-oq-01-oq-02/meta.json
@@ -112,12 +112,59 @@
       "mathContext": "Eulerian circuit $\\Rightarrow$ $\\sum_v \\text{outDeg}(v) = \\sum_v \\text{inDeg}(v)$ (as integers). Eulerian circuit $\\Rightarrow$ $\\text{inDeg}(v) = \\text{outDeg}(v)$ for all $v$."
     },
     {
-      "id": "hierholzer-infrastructure",
-      "title": "Hierholzer Infrastructure: Greedy Trail and Circuit Existence",
+      "id": "hierholzer-roadmap",
+      "title": "Degree-Balance Corollary and Hierholzer Roadmap",
       "startLine": 390,
+      "endLine": 412,
+      "summary": "States eulerian_balanced_implies_degree_balance (a direct corollary of the proved necessity theorem) and opens Part VII with the six-step roadmap for the Hierholzer sufficiency infrastructure: open-walk counting, the greedy maximal trail, closure of that trail in a balanced graph, circuit existence, balance-preservation under circuit removal, and the path-necessity direction. The roadmap also flags the one ingredient left axiomatized — splicing component circuits together — which is why directed_eulerian_iff (balanced → Eulerian) remains an axiom."
+    },
+    {
+      "id": "hierholzer-step1-open-walk-counting",
+      "title": "Hierholzer Step 1: Open-Walk Counting Lemmas",
+      "startLine": 413,
+      "endLine": 561,
+      "summary": "Proves the endpoint-asymmetry facts for an open walk v₀,…,vₙ with v₀ ≠ vₙ: open_walk_last_target_excess (target-count of the last vertex = source-count + 1) and the symmetric open_walk_first_source_excess for the first vertex, plus open_walk_interior_balanced showing every other vertex has equal source- and target-counts. Each is established by an explicit Finset.card_bij — the shift i ↦ i+1 (or i ↦ i−1) bijects source positions with target positions, leaving exactly one unmatched endpoint position.",
+      "mathContext": "For a walk of length $n$ ending at $w$ with $v_0 \\neq w$: $\\#\\{i < n : v_{i+1} = w\\} = \\#\\{i < n : v_i = w\\} + 1$. The bijection $i \\mapsto i+1$ matches each source occurrence of $w$ with a target occurrence, and position $n-1$ supplies the surplus target occurrence."
+    },
+    {
+      "id": "hierholzer-step2-greedy-trail",
+      "title": "Hierholzer Step 2: Greedy Maximal Trail",
+      "startLine": 562,
+      "endLine": 917,
+      "summary": "Constructs maxTrail E v, the greedy trail that repeatedly follows an unused outgoing edge until none remains, and proves its structural lemmas: it is non-empty and starts at v (maxTrail_nonempty', maxTrail_head'), its used-edge set is a subset of E that shrinks by one per step (maxTrailRem_subset, maxTrail_used_eq), its final vertex has no remaining outgoing edge (maxTrailRem_last_no_out, maxTrail_last_exhausted), every step is an edge of E (maxTrail_steps_in_E), and all steps are distinct (maxTrail_steps_distinct). Termination follows because |E| strictly decreases each step.",
+      "mathContext": "$\\mathrm{maxTrail}\\,E\\,v$ is well-founded on $|E|$: each step consumes one edge, so the recursion halts at a vertex with no unused outgoing edge. Distinctness of steps makes the trail a genuine trail (no repeated edge), the prerequisite for the closure argument."
+    },
+    {
+      "id": "hierholzer-step3-trail-closed",
+      "title": "Hierholzer Step 3: Maximal Trail Is Closed in a Balanced Graph",
+      "startLine": 918,
+      "endLine": 1043,
+      "summary": "Proves maxTrail_closed: in a balanced digraph the greedy trail from v returns to v, i.e. it is a closed circuit. The argument is by contradiction — if the trail ended at some w ≠ v, the Step 1 open-walk counting would force target-count(w) = source-count(w) + 1 along the trail, but the trail exhausts w's outgoing edges at its terminus while balance (inDeg w = outDeg w) leaves an unused outgoing edge, contradicting maximality.",
+      "mathContext": "Balance $\\mathrm{inDeg}(w) = \\mathrm{outDeg}(w)$ together with the open-walk excess $\\#\\text{target} = \\#\\text{source} + 1$ at a terminus $w \\neq v$ leaves an outgoing edge at $w$ unused, contradicting that maxTrail stops only when no outgoing edge remains. Hence the trail closes."
+    },
+    {
+      "id": "hierholzer-step4-circuit-existence",
+      "title": "Hierholzer Step 4: Circuit Existence",
+      "startLine": 1044,
+      "endLine": 1080,
+      "summary": "Packages the closed greedy trail as a DirectedCircuit structure and proves circuit_exists: every non-empty balanced digraph contains a directed circuit. This is the existence half of Hierholzer's decomposition — the object whose iterated removal will eventually consume all edges.",
+      "mathContext": "$G$ balanced and $G.\\mathrm{edges} \\neq \\emptyset$ $\\Rightarrow$ $\\exists$ a directed circuit in $G$: instantiate the circuit with $\\mathrm{maxTrail}\\,G.\\mathrm{edges}\\,v$ at any $v$ with an outgoing edge, closed by Step 3."
+    },
+    {
+      "id": "hierholzer-step5-removal-preserves-balance",
+      "title": "Hierholzer Step 5: Removing a Circuit Preserves Balance",
+      "startLine": 1081,
+      "endLine": 1109,
+      "summary": "Defines walkEdges and DiGraph.removeEdgeSet, then states remove_circuit_balanced: deleting a circuit's edge set from a balanced digraph leaves a balanced digraph. This is the inductive step that lets Hierholzer peel off circuits until no edges remain. It carries the file's single sorry (line 1105), blocked on a Finset.sdiff distributivity lemma rather than any mathematical gap — each vertex loses equally many incoming and outgoing edges because a circuit visits it equally often as source and target.",
+      "mathContext": "A circuit traverses each vertex the same number of times as source and as target, so removing its edges subtracts the same amount from $\\mathrm{inDeg}$ and $\\mathrm{outDeg}$ at every vertex, preserving $\\mathrm{inDeg} = \\mathrm{outDeg}$."
+    },
+    {
+      "id": "hierholzer-step6-path-necessity",
+      "title": "Hierholzer Step 6: Necessity Direction for Eulerian Paths",
+      "startLine": 1110,
       "endLine": 1198,
-      "summary": "Develops the mathematical infrastructure for Hierholzer's directed Eulerian algorithm in 6 steps. (1) Open-walk counting (lines 419-504): for an open walk u→w (u≠w), target-count(w) = source-count(w)+1, plus the symmetric source-excess lemma. (2) maxTrail (lines 513-728): a greedy trail following outgoing edges, terminating since |E| decreases by 1 per step. (3) maxTrail_closed (lines 933-1041): in a balanced digraph, the greedy trail is always a closed circuit — proved via a 5-step balance contradiction (STEPs A-E). (4) circuit_exists + DirectedCircuit (lines 1052-1078): every non-empty balanced digraph contains a directed circuit. (5) remove_circuit_balanced (lines 1100-1107, sorry): removing a circuit preserves balance — the only sorry in the file, blocked on Finset.sdiff distributivity API. (6) euler_path_implies_degree_balance (lines 1125-1198, FULLY PROVED): Eulerian path implies asymmetric degree conditions at start/end. Five of the six steps are proved; only step 5 carries a sorry.",
-      "mathContext": "Key theorem: $G$ balanced + $G.edges \\neq \\emptyset$ $\\Rightarrow$ $\\exists$ directed circuit in $G$. Proof: run greedy trail from any vertex $v$ with an outgoing edge; by balance, the trail closes (proof by contradiction using open-walk counting). Removing the circuit preserves balance (each vertex appears equally often as trail source and target). The path-necessity step is the open-walk analogue: an Eulerian path $s \\to t$ creates a +1 source asymmetry at $s$ and a +1 target asymmetry at $t$, while interior vertices remain balanced."
+      "summary": "Proves euler_path_implies_degree_balance (fully, no sorry): an Eulerian path from s to t (s ≠ t) forces outDeg(s) = inDeg(s) + 1, inDeg(t) = outDeg(t) + 1, and balance at every interior vertex. This is the open-walk analogue of the circuit necessity result, obtained by applying the Step 1 endpoint-excess and interior-balance lemmas to the path's vertex sequence.",
+      "mathContext": "An Eulerian path $s \\to t$ is an open walk covering every edge once, so the endpoint asymmetries of Step 1 transfer directly: $+1$ out-excess at $s$, $+1$ in-excess at $t$, balance elsewhere."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `konigsberg-oq-01-oq-02` entry ("Eulerian Paths in Directed Graphs") had its largest region — Lean lines **390–1198** (over half of the 1202-line file) — collapsed into a single `sections` entry titled "Hierholzer Infrastructure", with a long six-step description crammed into one summary. In the gallery that renders as one un-navigable block.

This PR splits it into **seven accurately-bounded sections** along the file's own `STEP` markers, each with a focused `summary` and `mathContext`:

| Lines | Section |
|-------|---------|
| 390–412 | Degree-Balance Corollary and Hierholzer Roadmap |
| 413–561 | Step 1: Open-Walk Counting Lemmas |
| 562–917 | Step 2: Greedy Maximal Trail |
| 918–1043 | Step 3: Maximal Trail Is Closed in a Balanced Graph |
| 1044–1080 | Step 4: Circuit Existence |
| 1081–1109 | Step 5: Removing a Circuit Preserves Balance |
| 1110–1198 | Step 6: Necessity Direction for Eulerian Paths |

Boundaries match the `STEP 1`–`STEP 6` comment markers and declaration locations in `proofs/Proofs/KonigsbergOQ01OQ02.lean`. No content was removed — the per-step detail is preserved and now correctly attributed to the lines it describes.

Only `meta.json` changed; annotations, axiom fields (`axiomCount: 2`, `sorries: 1`, `status: axiomatized`), and all other content are untouched and remain accurate to the Lean source.

## Test plan

- [x] `meta.json` validates as JSON; new sections use the same `ProofSection` keys as the six pre-existing sections
- [x] All `startLine`/`endLine` fall within the 1202-line file and align with the Lean `STEP` markers / declaration positions
- [ ] Full `pnpm build` typecheck could not run in this environment (`node_modules`/`tsc` absent in both worktree and main); the build's data-enrichment stage completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)