### PR TITLE
research(burnside-counting-oq-01): S4 ACT — discharge binary_necklaces_4 (file axiom-free)

### DIFF
--- a/proofs/Proofs/BurnsideCounting.lean
+++ b/proofs/Proofs/BurnsideCounting.lean
@@ -380,10 +380,20 @@ def coloringQuotientFintype (n k : ℕ) [NeZero n] :
 /-- **Binary Necklaces of Length 4**:
     There are exactly 6 distinct binary necklaces of length 4.
 
-    This follows from Burnside's lemma with the fixed-point sum of 24
-    divided by |Z_4| = 4. -/
-axiom binary_necklaces_4 :
-  @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6
+    Mathematically this is Burnside's lemma: `(16 + 2 + 4 + 2) / 4 = 6`.
+    Formally it is discharged directly: `coloringQuotientFintype 4 2` is a
+    *computable* `Fintype (Quotient (coloringSetoid 4 2))` — built from
+    `Quotient.fintype` over the finite carrier `Coloring 4 2 = Fin 4 → Fin 2`
+    and the decidable orbit relation `coloringSetoid_decidableRel`. So
+    `Fintype.card` of the orbit quotient is obtained by enumerating the 16
+    colorings, mapping each to its rotation orbit, and counting the 6
+    distinct classes. `native_decide` evaluates that chain at native speed.
+
+    Discharged in S4 (this PR): the last of the 5 original axioms in this
+    file; `BurnsideCounting.lean` is now axiom-free. -/
+theorem binary_necklaces_4 :
+    @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6 := by
+  native_decide
 
 #check burnside_lemma
 #check cyclicAddActionOnColorings

--- a/research/problems/burnside-counting-oq-01/sessions/2026-06-11-s4-act-binary-necklaces-native-decide.md
+++ b/research/problems/burnside-counting-oq-01/sessions/2026-06-11-s4-act-binary-necklaces-native-decide.md
@@ -1,0 +1,88 @@
+# S4 ACT — `binary_necklaces_4` discharged; file is axiom-free
+
+**Date**: 2026-06-11
+**Researcher**: researcher-2
+**Mode**: ACT (Lean implementation)
+**Branch**: `research/burnside-oq-01-s4-necklaces-act`
+**Build**: `./proofs/scripts/docker-build.sh Proofs.BurnsideCounting`
+→ **3058 / 3058 jobs clean**.
+
+## TL;DR
+
+Discharged `binary_necklaces_4`, the **last of the 5 original axioms** in
+`Proofs/BurnsideCounting.lean`. The file is now **axiom-free** (0 axioms,
+0 sorries, 9 theorems, 404 LOC). The proof is a single `native_decide`.
+
+## The key realisation
+
+The S3 state.md recommended a ~30-50 LOC route: `burnside_lemma`
+(MulAction form) + `fixed_point_sum_binary_4 = 24` + `|ZMod 4| = 4`, with
+a bridge `AddAction.orbitRel.Quotient (ZMod 4) (Coloring 4 2) ↔
+MulAction.orbitRel.Quotient (Multiplicative (ZMod 4)) (Coloring 4 2)` (or
+`to_additive` on `burnside_lemma`).
+
+That is the correct *mathematical* derivation, but it is unnecessary for
+the *formal* goal. The goal is a single finite cardinality equality:
+
+```lean
+@Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6
+```
+
+S2 (researcher-1) had already shipped `coloringQuotientFintype` as a
+**computable** `Fintype (Quotient (coloringSetoid n k))`, built from
+`Quotient.fintype` over the finite carrier `Coloring 4 2 = Fin 4 → Fin 2`
+and the decidable orbit relation `coloringSetoid_decidableRel`
+(`decidable_of_iff (∃ x : ZMod n, x +ᵥ b = a) AddAction.mem_orbit_iff.symm`,
+itself decidable because `ZMod n` is a `Fintype` and `Coloring` has
+`DecidableEq`).
+
+A computable `Fintype` makes `Fintype.card` of the quotient itself
+decidable. `native_decide` enumerates the 16 colorings, maps each to its
+rotation orbit, dedups via the decidable orbit equality, counts the 6
+distinct classes, and decides `6 = 6`. Done.
+
+```lean
+theorem binary_necklaces_4 :
+    @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6 := by
+  native_decide
+```
+
+`burnside_lemma` (the MulAction Mathlib statement at line 48) stays in the
+file as a referenced result; it is not on the proof path for the necklace
+count.
+
+## Soundness note
+
+`native_decide` is already the accepted idiom in this file (S3 used it for
+`fixed_point_sum_binary_4`). The computed answer `6` is the classic count
+of binary necklaces of length 4 — the verification is genuine (the
+decision procedure returned `6` and `6 = 6` decided `true`), not vacuous.
+All instances on the path (`Quotient.fintype`, `coloringSetoid_decidableRel`,
+`rotateColoring`, `DecidableEq (Fin 4 → Fin 2)`) are computable; no
+`Classical.choice` / noncomputable defs are reachable.
+
+## Axiom history of `BurnsideCounting.lean`
+
+| Iter | Axiom discharged | Method |
+|---|---|---|
+| S1 (#21148) | `rotatedIndex_add` | full Nat-modular proof (8-leaf case split) |
+| S2 (2026-06-09) | `coloringSetoid`, `coloringQuotientFintype` | `AddAction.orbitRel` + `Quotient.fintype` + decidable rel |
+| S3 (2026-06-10) | `fixed_point_sum_binary_4` | `native_decide` |
+| **S4 (this PR)** | **`binary_necklaces_4`** | **`native_decide` on the computable quotient card** |
+
+All 5 original axioms gone. File axiom-free.
+
+## Race awareness
+
+- Open PRs for this slug at push time: checked via `gh pr list`.
+- Conflict surface: strictly additive single-file change (axiom → theorem)
+  + state.md + JSON + this memo. No other Lean file touched.
+- Branched off `origin/main`.
+
+## Status
+
+`verified` — `BurnsideCounting.lean` is axiom-free, 0 sorries,
+Docker 3058 jobs clean. The slug's OQ target (`rotatedIndex_add`) was
+already closed in S1; this iteration completes the broader file-level
+axiom elimination. No remaining axioms or sorries; only the 3 cosmetic
+pre-existing simpArgs linter warnings remain (untouched).

--- a/research/problems/burnside-counting-oq-01/state.md
+++ b/research/problems/burnside-counting-oq-01/state.md
@@ -1,25 +1,53 @@
 # Research State: burnside-counting-oq-01
 
-**Phase**: **S3 ACT** — `fixed_point_sum_binary_4` discharged (axiom → theorem via `native_decide`)
-**Owner**: researcher-1 (S1 ACT 2026-05-30; S1b STATE-SYNC 2026-06-03; S2 ACT 2026-06-09); **researcher-9 (S3 ACT 2026-06-10)**
-**Iteration**: 3 (S3 is a fresh iteration after S2)
-**Last Updated**: 2026-06-10Z
-**Branch**: `research/burnside-counting-oq-01-s3-act-fixed-point-sum`
+**Phase**: **S4 ACT** — `binary_necklaces_4` discharged (axiom → theorem via `native_decide`); **file is now AXIOM-FREE**
+**Owner**: researcher-1 (S1 ACT 2026-05-30; S1b STATE-SYNC 2026-06-03; S2 ACT 2026-06-09); researcher-9 (S3 ACT 2026-06-10); **researcher-2 (S4 ACT 2026-06-11)**
+**Iteration**: 4 (S4 is a fresh iteration after S3)
+**Last Updated**: 2026-06-11Z
+**Branch**: `research/burnside-oq-01-s4-necklaces-act`
 
-## Lean file inventory (post S3, Docker-verified)
+## Lean file inventory (post S4, Docker-verified)
 
 ```
 File:        proofs/Proofs/BurnsideCounting.lean
-Lines:       394 (was 387 at S2; +7 LOC for docstring on the new theorem)
-Theorems:    8 (was 7; fixed_point_sum_binary_4 promoted from axiom to theorem)
-Definitions: 9 (unchanged from S2)
+Lines:       404 (was 394 at S3; +10 LOC for docstring on the new theorem)
+Theorems:    9 (was 8; binary_necklaces_4 promoted from axiom to theorem)
+Definitions: 9 (unchanged from S3)
 Sorries:     0
-Axioms:      1 (was 2 at S2; only binary_necklaces_4 remains)
+Axioms:      0 (was 1 at S3; binary_necklaces_4 discharged — FILE IS AXIOM-FREE)
 Build:       ✔ Docker 3058/3058 jobs clean
              (3 pre-existing simpArgs linter warnings at 77/299/301; untouched)
 ```
 
-## What's Done (S3, this iteration)
+## What's Done (S4, this iteration)
+
+- **Discharged `binary_necklaces_4` axiom** — the LAST of the 5 original
+  axioms — to a one-line `native_decide` theorem. **`BurnsideCounting.lean`
+  is now axiom-free.**
+- **Route taken (simpler than the S3-planned Burnside bridge).** S2 already
+  made `coloringQuotientFintype 4 2` a *computable* `Fintype (Quotient
+  (coloringSetoid 4 2))` (via `Quotient.fintype` over the finite carrier
+  `Coloring 4 2 = Fin 4 → Fin 2` + the decidable orbit relation
+  `coloringSetoid_decidableRel`). Therefore `@Fintype.card (Quotient …)
+  (coloringQuotientFintype 4 2)` is itself decidable: `native_decide`
+  enumerates the 16 colorings, maps each to its rotation orbit, dedups via
+  the decidable orbit equality, and counts the 6 distinct classes — then
+  decides `6 = 6`. No `burnside_lemma` invocation, no
+  `AddAction.orbitRel.Quotient ↔ MulAction.orbitRel.Quotient` bridge, no
+  `to_additive` are needed.
+- **Why the planned ~30-50 LOC Burnside route was unnecessary.** The S3
+  state.md recommended applying `burnside_lemma` (MulAction form) + the
+  `fixed_point_sum_binary_4 = 24` theorem + `|ZMod 4| = 4`. That is the
+  right *mathematical* derivation, but for the *formal* goal — a single
+  finite cardinality equality — the computable Fintype instance shipped in
+  S2 makes the whole thing directly decidable. The MulAction
+  `burnside_lemma` (line 48) stays in the file as a referenced Mathlib
+  statement; it is simply not on the proof path for the necklace count.
+- **+10 LOC** (docstring); proof body is one tactic. Build verified
+  `./proofs/scripts/docker-build.sh Proofs.BurnsideCounting` →
+  3058 / 3058 jobs clean (same 3 pre-existing simpArgs warnings).
+
+## What's Done (S3)
 
 - **Discharged `fixed_point_sum_binary_4` axiom** to a `native_decide`
   theorem. The pre-existing `DecidablePred (@IsFixedByRotation 4 2 _ r)`

--- a/src/data/proofs/burnside-counting/meta.json
+++ b/src/data/proofs/burnside-counting/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "William Burnside (1897), Cauchy (1845), Frobenius (1887), formalized via Mathlib",
     "date": "1897",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/BurnsideCounting.lean",
     "tags": [
       "combinatorics",
@@ -17,13 +17,13 @@
       "group-actions",
       "polya-enumeration"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-04-02",
-    "axiomCount": 2,
-    "assumptions": "2 axioms: fixed_point_sum_binary_4 (computed fixed-point sum = 24) and binary_necklaces_4 (6 distinct binary 4-necklaces). The earlier rotatedIndex_add axiom (modular-arithmetic composition law, discharged in S1 / PR #21148) and the coloringSetoid + coloringQuotientFintype axioms (orbit-equivalence relation and quotient Fintype, discharged in S2 ACT via AddAction.orbitRel + Quotient.fintype with a decidable-orbit-relation instance) are now fully proved.",
-    "lineCount": 387,
-    "theoremCount": 7,
+    "axiomCount": 0,
+    "assumptions": "Axiom-free: 0 `axiom` declarations, 0 sorries, no assumption-carrying structures. All 5 original axioms are discharged across S1–S4 of burnside-counting-oq-01: rotatedIndex_add (S1 / PR #21148, full Nat-modular proof); coloringSetoid + coloringQuotientFintype (S2, AddAction.orbitRel + Quotient.fintype with a decidable-orbit-relation instance); fixed_point_sum_binary_4 (S3, native_decide); binary_necklaces_4 (S4, native_decide on the computable orbit-quotient cardinality). NOTE: the two finite counts (fixed_point_sum_binary_4, binary_necklaces_4) close by `native_decide`, which trusts the Lean compiler (Lean.ofReduceBool) rather than performing kernel reduction; everything else is kernel-checked. burnside_lemma is a re-export of Mathlib's MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group (a theorem, not an assumption).",
+    "lineCount": 404,
+    "theoremCount": 9,
     "definitionCount": 9,
     "originalContributions": [
       "burnside_lemma: Burnside orbit-counting theorem from Mathlib (MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group)",
@@ -36,7 +36,9 @@
       "IsFixedByRotation: decidable predicate for fixed colorings",
       "coloringSetoid: orbit-equivalence relation on colorings, derived from AddAction.orbitRel (ZMod n) (Coloring n k) (previously axiomatized; discharged in S2 ACT)",
       "coloringSetoid_decidableRel: DecidableRel instance for the orbit relation, via Fintype.decidableExistsFintype on ZMod n and decidable equality of Fin n → Fin k colorings",
-      "coloringQuotientFintype: Fintype instance for the quotient by rotation, via Quotient.fintype + the decidable-orbit-relation instance (previously axiomatized; discharged in S2 ACT)"
+      "coloringQuotientFintype: Fintype instance for the quotient by rotation, via Quotient.fintype + the decidable-orbit-relation instance (previously axiomatized; discharged in S2 ACT)",
+      "fixed_point_sum_binary_4: |Fix(0)|+|Fix(1)|+|Fix(2)|+|Fix(3)| = 16+2+4+2 = 24, closed by native_decide on the decidable IsFixedByRotation subtype cardinalities (previously axiomatized; discharged in S3 ACT)",
+      "binary_necklaces_4: |Coloring 4 2 / rotation| = 6, closed by native_decide on the computable coloringQuotientFintype orbit-quotient cardinality (previously axiomatized; discharged in S4 ACT — the last of the 5 original axioms, making the file axiom-free)"
     ]
   },
   "overview": {
@@ -60,20 +62,19 @@
     ]
   },
   "conclusion": {
-    "summary": "Burnside's lemma is formalized from Mathlib and applied to the classic necklace counting problem. The key mathematical content — the orbit-counting formula — is proved. The application to binary 4-necklaces is axiomatized pending formal proof of modular arithmetic details.",
-    "implications": "This formalization demonstrates the two-layer structure of applying abstract Mathlib theorems to concrete problems: (1) the abstract `burnside_lemma` wraps `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` with zero proof effort; (2) the concrete application requires defining the specific action (cyclic rotation), verifying it satisfies the `AddAction` axioms, and computing fixed-point cardinalities for each group element. The fully verified lemmas (`rotatedIndex_zero`, `rotatedIndex_add`, `binary_4_colorings_count`, `constant_coloring_count`, `period2_count`) show that both the modular-arithmetic infrastructure and the fixed-point counting are elementarily decidable — the remaining 4 axioms are a bridge-building problem between Mathlib's multiplicative and additive group-action APIs. Once that bridge is built (via a `MulAction` instance from the `AddAction` + `AddCommGroup (ZMod n)`, e.g. through `Multiplicative (ZMod n)`), all remaining axioms collapse to `native_decide` or Mathlib lemmas. Burnside's lemma underlies Pólya enumeration (used in chemical isomer counting, OEIS necklace sequences), and this formalization provides the scaffolding for a full Pólya cycle index theorem in Lean 4.",
+    "summary": "Burnside's lemma is formalized from Mathlib and applied to the classic necklace counting problem. The file is now axiom-free: the orbit-counting formula, the cyclic action, the fixed-point counts, and the headline binary 4-necklace count (= 6) are all proved (0 axiom declarations, 0 sorries). The two finite counts are closed by native_decide (compiler-trusted).",
+    "implications": "This formalization demonstrates the two-layer structure of applying abstract Mathlib theorems to concrete problems: (1) the abstract `burnside_lemma` wraps `MulAction.sum_card_fixedBy_eq_card_orbits_mul_card_group` with zero proof effort; (2) the concrete application defines the specific action (cyclic rotation), verifies it satisfies the `AddAction` axioms, and computes fixed-point cardinalities. The instructive lesson from the axiom-elimination programme (burnside-counting-oq-01, S1–S4): the headline count `binary_necklaces_4 = 6` did NOT require bridging Mathlib's multiplicative `burnside_lemma` to the additive `ZMod n` action. Instead, once the orbit-equivalence relation was made a decidable `AddAction.orbitRel` and the quotient given a computable `Quotient.fintype` (S2), the cardinality of the orbit quotient became directly decidable — so both `fixed_point_sum_binary_4` and `binary_necklaces_4` collapse to a single `native_decide`. The abstract Burnside identity remains in the file as a referenced Mathlib result, but the concrete count is obtained computationally. Burnside's lemma underlies Pólya enumeration (chemical isomer counting, OEIS necklace sequences), and this axiom-free formalization provides clean scaffolding for a full Pólya cycle index theorem in Lean 4.",
     "openQuestions": [
-      "Prove fixed_point_sum_binary_4 via native_decide (S3 candidate)",
-      "Discharge binary_necklaces_4 from burnside_lemma + fixed_point_sum_binary_4 + |ZMod 4| = 4 (S4 candidate)",
       "Generalize to Polya enumeration: weighted counting by color frequency",
-      "Extend to dihedral group D_n (necklaces with flip symmetry)"
+      "Extend to dihedral group D_n (necklaces with flip symmetry)",
+      "Derive binary_necklaces_4 via the abstract burnside_lemma (AddAction↔MulAction bridge) as an alternative kernel-checked proof not relying on native_decide"
     ]
   },
   "leanFile": {
     "namespace": "BurnsideCounting",
-    "lineCount": 387,
-    "axiomCount": 2,
-    "theoremCount": 7,
+    "lineCount": 404,
+    "axiomCount": 0,
+    "theoremCount": 9,
     "definitionCount": 9,
     "path": "Proofs/BurnsideCounting.lean",
     "sorries": 0
@@ -123,17 +124,17 @@
     },
     {
       "name": "fixed_point_sum_binary_4",
-      "type": "axiom",
+      "type": "supporting",
       "statement": "$|\\mathrm{Fix}(0)| + |\\mathrm{Fix}(1)| + |\\mathrm{Fix}(2)| + |\\mathrm{Fix}(3)| = 24$",
-      "significance": "**The Burnside numerator.** Records the explicit fixed-point counts for the four elements of $\\mathbb{Z}/4\\mathbb{Z}$ acting on binary 4-colorings: $16 + 2 + 4 + 2 = 24$. Could be discharged by `native_decide` once `IsFixedByRotation` is wired into a fully-decidable framework, but the axiom currently sidesteps the `AddAction` / `MulAction` API mismatch.",
-      "description": "Stated as a sum of `Fintype.card { c : Coloring 4 2 // IsFixedByRotation r c }` for $r = 0, 1, 2, 3$. The arithmetic $16 + 2 + 4 + 2 = 24$ is decidable; the wrapping `Fintype.card` is decidable provided `IsFixedByRotation` is. The 24 directly produces the necklace count $24/4 = 6$ via Burnside."
+      "significance": "**The Burnside numerator (now proved).** Records the explicit fixed-point counts for the four elements of $\\mathbb{Z}/4\\mathbb{Z}$ acting on binary 4-colorings: $16 + 2 + 4 + 2 = 24$. Discharged in S3 ACT (burnside-counting-oq-01) by `native_decide`: `IsFixedByRotation r` is a decidable predicate (instance in the file), so each `Fintype.card { c : Coloring 4 2 // IsFixedByRotation r c }` and their sum are computable.",
+      "description": "Stated as a sum of `Fintype.card { c : Coloring 4 2 // IsFixedByRotation r c }` for $r = 0, 1, 2, 3$. Proof body: `native_decide` (compiler-trusted via Lean.ofReduceBool). The 24 directly produces the necklace count $24/4 = 6$ via Burnside. Previously stated as an axiom."
     },
     {
       "name": "binary_necklaces_4",
-      "type": "axiom",
+      "type": "core",
       "statement": "$|(\\mathrm{Coloring}\\ 4\\ 2)/\\sim| = 6$",
-      "significance": "**The headline application.** The number of distinct binary necklaces of length 4 is exactly 6: $\\{0000\\}, \\{1111\\}, \\{0001, 0010, 0100, 1000\\}, \\{0011, 0110, 1100, 1001\\}, \\{0101, 1010\\}, \\{0111, 1011, 1101, 1110\\}$. Matches OEIS A000029 (necklaces under rotation) at $n=4$.",
-      "description": "Stated against the axiomatized `coloringSetoid` and `coloringQuotientFintype` instance. Once `MulAction.orbitRel` is bridged to the `AddAction` of `ZMod 4`, `binary_necklaces_4` follows from `burnside_lemma` applied to `fixed_point_sum_binary_4` divided by $|\\mathbb{Z}/4\\mathbb{Z}| = 4$."
+      "significance": "**The headline application (now proved).** The number of distinct binary necklaces of length 4 is exactly 6: $\\{0000\\}, \\{1111\\}, \\{0001, 0010, 0100, 1000\\}, \\{0011, 0110, 1100, 1001\\}, \\{0101, 1010\\}, \\{0111, 1011, 1101, 1110\\}$. Matches OEIS A000029 (necklaces under rotation) at $n=4$. Discharged in S4 ACT (burnside-counting-oq-01) — the last of the 5 original axioms, making the file axiom-free.",
+      "description": "Stated against `coloringSetoid` (= `AddAction.orbitRel (ZMod 4) (Coloring 4 2)`) and the computable `coloringQuotientFintype` instance (both derived, not axiomatized, since S2). Because that Fintype is computable, `@Fintype.card (Quotient (coloringSetoid 4 2)) (coloringQuotientFintype 4 2)` is itself decidable, and the proof body is one `native_decide`: enumerate the 16 colorings, map to rotation orbits, dedup via the decidable orbit equality, count the 6 distinct classes. No `burnside_lemma` invocation or AddAction↔MulAction bridge is needed for the formal goal. Previously stated as an axiom."
     }
   ],
   "references": [
@@ -252,10 +253,10 @@
     },
     {
       "id": "sec-burnside-axioms",
-      "title": "Part IV: Summary, Decidable Predicates, and 4 Final Axioms",
-      "startLine": 194,
-      "endLine": 255,
-      "summary": "Documents the 6 necklace classes and fixed-point computation in comments. Defines IsFixedByRotation (decidable) and ColoringEquiv. Axioms: fixed_point_sum_binary_4 (sum=24), coloringSetoid, coloringQuotientFintype, binary_necklaces_4 (= 6). Ends with #check statements confirming all definitions type-check."
+      "title": "Part IV: Summary, Decidable Predicates, and the (now-proved) Necklace Count",
+      "startLine": 306,
+      "endLine": 404,
+      "summary": "Documents the 6 necklace classes and fixed-point computation in comments. Defines IsFixedByRotation (decidable) and ColoringEquiv. Proves fixed_point_sum_binary_4 (sum=24, native_decide), derives coloringSetoid (= AddAction.orbitRel) + coloringSetoid_decidableRel + coloringQuotientFintype (Quotient.fintype), and proves binary_necklaces_4 (= 6, native_decide on the computable orbit-quotient cardinality). All four were axioms in earlier revisions; the file is now axiom-free. Ends with #check statements confirming the definitions type-check."
     }
   ],
   "sorries": 0

--- a/src/data/research/problems/burnside-counting-oq-01.json
+++ b/src/data/research/problems/burnside-counting-oq-01.json
@@ -21,22 +21,21 @@
       "Local metadata records `Proofs/BurnsideCounting.lean` as having 0 sorries but 5 axioms."
     ],
     "open": [
-      "`rotatedIndex_add` itself is still an axiom in `Proofs/BurnsideCounting.lean`.",
-      "Four other parent-file axioms remain outside this OQ: `fixed_point_sum_binary_4`, `coloringSetoid`, `coloringQuotientFintype`, and `binary_necklaces_4`."
+      "None — all 5 original axioms of `Proofs/BurnsideCounting.lean` are discharged. `rotatedIndex_add` (S1), `coloringSetoid` + `coloringQuotientFintype` (S2), `fixed_point_sum_binary_4` (S3), and `binary_necklaces_4` (S4, this PR) are all theorems/defs now; the file is axiom-free."
     ],
     "goal": "Prove the `rotatedIndex_add` composition theorem for the existing `ZMod n`/`Fin n` definition without adding new axioms or sorries."
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-10T00:00:00Z",
-    "iteration": 3,
-    "focus": "S3 ACT (researcher-9, 2026-06-10): discharged fixed_point_sum_binary_4 via native_decide. axiom → theorem. Docker 3058/3058 jobs clean. Coloring 4 2 = Fin 4 → Fin 2 is finite, IsFixedByRotation is decidable (existing instance at line 329), so the 4 subtype cardinalities and their sum to 24 evaluate at compile time. lineCount 387 → 394 (+7 LOC for docstring + theorem header). Only binary_necklaces_4 axiom remains in BurnsideCounting.lean.",
+    "since": "2026-06-11T00:00:00Z",
+    "iteration": 4,
+    "focus": "S4 ACT (researcher-2, 2026-06-11): discharged binary_necklaces_4 — the LAST of the 5 original axioms. BurnsideCounting.lean is now AXIOM-FREE (0 axioms, 0 sorries, 9 theorems, 404 LOC, Docker 3058/3058 jobs clean). Proof is a single native_decide: coloringQuotientFintype 4 2 is a computable Fintype (Quotient (coloringSetoid 4 2)) — built from Quotient.fintype over the finite carrier Coloring 4 2 = Fin 4 → Fin 2 and the decidable orbit relation coloringSetoid_decidableRel — so Fintype.card of the rotation-orbit quotient is obtained by enumerating the 16 colorings, mapping to orbits, and counting the 6 distinct classes. This is dramatically simpler than the S3-planned ~30-50 LOC Burnside-lemma/AddAction-MulAction-bridge route: because S2 already made the quotient Fintype computable, the cardinality is directly decidable. axiom → theorem, +10 LOC (docstring). The MulAction burnside_lemma (line 48) remains in the file as a referenced Mathlib statement but is not needed for the necklace count.",
     "blockers": [],
-    "nextAction": "S4 candidate: discharge binary_necklaces_4. Now that fixed_point_sum_binary_4 is a real theorem, the route is burnside_lemma (MulAction form) + fixed_point_sum_binary_4 + |ZMod 4| = 4 → 24/4 = 6. Bridge needed: AddAction.orbitRel.Quotient (ZMod 4) (Coloring 4 2) ↔ MulAction.orbitRel.Quotient (Multiplicative (ZMod 4)) (Coloring 4 2). Estimated ~30-50 LOC. Once S4 lands, BurnsideCounting.lean is axiom-free (0 of 5 original axioms remaining).",
+    "nextAction": "DONE — BurnsideCounting.lean is axiom-free (all 5 original axioms discharged across S1–S4). No remaining axioms or sorries. Optional cleanup only: the 3 pre-existing simpArgs linter warnings at lines 77/299/301 (cosmetic, untouched since pre-S2). The slug's OQ target (rotatedIndex_add) was discharged in S1; the broader file axiom-elimination is now complete.",
     "attemptCounts": {
-      "total": 3,
+      "total": 4,
       "currentApproach": 1,
-      "approachesTried": 3
+      "approachesTried": 4
     }
   },
   "knowledge": {
@@ -94,9 +93,9 @@
     {
       "path": "Proofs/BurnsideCounting.lean",
       "filename": "BurnsideCounting.lean",
-      "lineCount": 394,
-      "theoremCount": 8,
-      "axiomCount": 1,
+      "lineCount": 404,
+      "theoremCount": 9,
+      "axiomCount": 0,
       "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,
@@ -136,5 +135,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BurnsideCountingOQ03OQ03.lean"
     }
   ],
-  "lastUpdate": "2026-06-10T02:50:00Z"
+  "lastUpdate": "2026-06-11T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

S4 ACT for `burnside-counting-oq-01`. Converts the **last of the 5 original axioms** in `proofs/Proofs/BurnsideCounting.lean` (`binary_necklaces_4`) from an `axiom` to a `theorem` proved by a single `native_decide`. **The file is now axiom-free** (0 axiom declarations, 0 sorries, 9 theorems, 404 LOC).

```lean
theorem binary_necklaces_4 :
    @Fintype.card (Quotient (@coloringSetoid 4 2 _)) (coloringQuotientFintype 4 2) = 6 := by
  native_decide
```

### Why `native_decide` suffices (simpler than the S3-planned Burnside bridge)

The S3 state.md recommended a ~30-50 LOC route: `burnside_lemma` (MulAction form) + `fixed_point_sum_binary_4 = 24` + `|ZMod 4| = 4`, bridging `AddAction.orbitRel.Quotient ↔ MulAction.orbitRel.Quotient`. That is the correct *mathematical* derivation, but the *formal* goal is a single finite cardinality equality. S2 already shipped `coloringQuotientFintype` as a **computable** `Fintype (Quotient (coloringSetoid 4 2))` (via `Quotient.fintype` over the finite carrier `Coloring 4 2 = Fin 4 → Fin 2` and the decidable orbit relation). A computable `Fintype` makes `Fintype.card` of the orbit quotient itself decidable — `native_decide` enumerates the 16 colorings, maps to rotation orbits, dedups, and counts the 6 distinct classes. No `burnside_lemma` invocation or AddAction↔MulAction bridge is needed.

### Axiom history (now complete)

| Iter | Axiom discharged | Method |
|---|---|---|
| S1 (#21148) | `rotatedIndex_add` | full Nat-modular proof |
| S2 | `coloringSetoid`, `coloringQuotientFintype` | `AddAction.orbitRel` + `Quotient.fintype` |
| S3 | `fixed_point_sum_binary_4` | `native_decide` |
| **S4 (this PR)** | **`binary_necklaces_4`** | **`native_decide` on the computable quotient card** |

### Honesty note

The two finite counts (`fixed_point_sum_binary_4`, `binary_necklaces_4`) close via `native_decide`, which trusts the Lean compiler (`Lean.ofReduceBool`) rather than kernel reduction. This is recorded in the gallery meta `assumptions` field. An alternative kernel-checked proof via the abstract `burnside_lemma` is noted as a follow-up open question.

### Gallery meta sync

`src/data/proofs/burnside-counting/meta.json` was stale (predated S3). Synced: `status` axiomatized→verified, `badge` axiom→verified, `axiomCount` 2→0, line/theorem counts, section summaries, and the two finite-count theorems retagged from `axiom` to `theorem`.

## Build verification

`./proofs/scripts/docker-build.sh Proofs.BurnsideCounting` → **3058 / 3058 jobs clean** (3 pre-existing cosmetic simpArgs linter warnings, untouched).

## Test plan

- [x] Docker build green (3058 jobs, 0 errors)
- [x] `grep -c "^axiom " BurnsideCounting.lean` = 0; sorries = 0
- [x] Single-file Lean change (axiom → theorem); no other Lean file touched
- [x] Gallery + research JSON validated; state.md + session memo updated
- [x] No open PRs for this slug at push time

🤖 Generated with [Claude Code](https://claude.com/claude-code)