### PR TITLE
research(ehrhart-oq05): S3-prereq — add LatticePolygon.volume_eq_area structural link

### DIFF
--- a/proofs/Proofs/EhrhartCubeProvenOQ05.lean
+++ b/proofs/Proofs/EhrhartCubeProvenOQ05.lean
@@ -66,7 +66,9 @@ and `b = P.boundaryPoints`.
 
 The S3 discharge will:
 1. Use `ehrhart_leading_coeff_volume` to pin the leading coefficient
-   to `P.area` (after identifying `P.volume = P.area` for 2D polygons).
+   to `P.volume`, then `P.volume_eq_area` to rewrite it as `P.area`
+   (the `LatticePolygon.volume_eq_area` field exists for exactly this
+   step — without it `leadingCoeff = P.volume` cannot reach `P.area`).
 2. Use `ehrhart_constant_term` (already proved) for the constant term `1`.
 3. Use `ehrhart_macdonald_reciprocity` at `n = -1` together with
    `P.interior_at_one` to extract the linear coefficient as `b/2`,

--- a/proofs/Proofs/EhrhartPolynomials.lean
+++ b/proofs/Proofs/EhrhartPolynomials.lean
@@ -213,6 +213,14 @@ structure LatticePolygon extends LatticePolytope 2 where
   area : ℚ
   /-- Area is positive -/
   area_pos : 0 < area
+  /-- For a 2D lattice polytope the normalized volume coincides with the
+      area, so the inherited `volume` field — which pins the Ehrhart
+      polynomial's leading coefficient via `ehrhart_leading_coeff_volume` —
+      equals `area`. This is a definitional identification of the polygon's
+      own data (in the same spirit as `total_eq`), not a new mathematical
+      assumption: it encodes only the 2D normalization `vol = area`, not
+      Pick's theorem itself. -/
+  volume_eq_area : volume = area
   /-- Number of boundary lattice points -/
   boundaryPoints : ℕ
   /-- Number of interior lattice points -/

--- a/research/problems/ehrhart-cube-proven-oq-05/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/state.md
@@ -1,5 +1,25 @@
 # Current State: ehrhart-cube-proven-oq-05
 
+**S3-PREREQ (researcher-2, 2026-06-11):** Added the missing
+`LatticePolygon.volume_eq_area : volume = area` structural field to
+`EhrhartPolynomials.lean`. Discovered while opening S3 ACT: the target
+`ehrhartPoly_2d_explicit` requires the n^2-coefficient = `P.area`, but
+`ehrhart_leading_coeff_volume` only pins `leadingCoeff = P.volume`, and
+`LatticePolygon` carried `volume` (inherited) and `area` as *independent*
+fields with no link — so the stub's documented strategy referenced a
+non-existent `P.volume = P.area` identification and the theorem was
+unprovable as stated. The new field is a definitional 2D-normalization
+link (same spirit as `total_eq`), 0 new axioms, no construction sites to
+update (the only LatticePolygon constructor is the still-`sorry` S4
+bridge). This unblocks S3: `ehrhartPoly_2d_explicit` is now provable via
+the 3-point determination — eval(0)=1 (constant term), leadingCoeff =
+volume = area (n^2 coeff, via the new field), and the
+eval(1)/eval(-1)+Macdonald pair giving 2·c1 = b hence c1 = b/2. That
+~150-LOC polynomial-equality discharge is the remaining S3 ACT work for a
+build-capable session (this researcher worktree's `.lake` self-symlink
+blocks local Docker verification). PR opened on branch
+`research/ehrhart-oq05-volume-area-link`.
+
 **Phase**: ACT (S2 ACT landed: `picks_additive` Mechanic-class repair + `EhrhartCubeProvenOQ05.lean` scaffold both Docker-verified; 3 stage stubs `ehrhartPoly_2d_explicit`/`simpleLatticePolygon_to_latticePolygon`/`picks_theorem_derived` ready for S3-S5 discharge)
 **Path**: R1 (conditional Pick's theorem via Ehrhart) — recommended in S1, unchanged through this iteration
 **Since**: 2026-06-09 (S2 ACT landed, this session); 2026-06-09 (S2 ACT-attempt → PREP, prior session, PR #22713); 2026-06-09 (AXIOM-FIX); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)


### PR DESCRIPTION
## Summary

OQ-05 (derive Pick's theorem from Ehrhart polynomial existence) — **S3 prerequisite unblock**.

While opening **S3 ACT** (discharge `ehrhartPoly_2d_explicit`), I found the theorem was **unprovable as stated**:

- Target: `(ehrhartPoly P.toLatticePolytope).eval n = P.area·n² + (b/2)·n + 1`, so the n²-coefficient must be `P.area`.
- But `ehrhart_leading_coeff_volume` only pins `(ehrhartPoly P).leadingCoeff = P.volume`.
- `LatticePolygon extends LatticePolytope 2` carried `volume` (inherited) and `area` as **independent** fields with **no linking invariant**, so `leadingCoeff = P.volume` could never reach `P.area`. The existing stub strategy ("after identifying `P.volume = P.area`") referenced a field that did not exist.

**Fix:** add `volume_eq_area : volume = area` to `LatticePolygon` — a definitional 2D-normalization link (normalized volume = area in dimension 2), in the same spirit as the existing `total_eq` / `interior_at_one` structural fields. It encodes only `vol = area`, **not** Pick's theorem, so it is not an assumption-carrying field.

- **No construction sites break**: the only `EhrhartPolynomials.LatticePolygon` constructor in the repo is the still-`sorry` S4 bridge. (The separately-named `PicksTheorem.SimpleLatticePolygon` is unrelated.)
- Updates the OQ-05 S3 strategy docstring to use the new field.

This unblocks S3 via 3-point determination: `eval(0)=1`, `leadingCoeff = volume = area` (n² coeff), and `eval(1)`/`eval(-1)`+Macdonald giving `2·c₁ = b` ⇒ `c₁ = b/2`.

- **0 new axioms**; 3 inherited Ehrhart axioms and 3 sorries unchanged.

## Test plan

- [ ] Docker build `Proofs.EhrhartCubeProvenOQ05` (CI; local docker blocked by the researcher worktree's `.lake` self-symlink trap).
- [x] Single structure-field addition, no existing construction sites — compiles by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)