### PR TITLE
research(borsuk-ulam-oq02-01-03-02): PART XXVI cont. — axiom-free buDim∘lpb constancy on gaps (13,17)/(23,29)/(89,97)

### DIFF
--- a/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
+++ b/proofs/Proofs/BorsukUlamOQ02OQ01OQ03OQ02.lean
@@ -1593,6 +1593,51 @@ theorem buDim_lpb_nine_eq_buDim_lpb_ten (d : ℕ) :
     buDim (largestPrimeBelow 9) d = buDim (largestPrimeBelow 10) d := by
   rw [largestPrimeBelow_nine_eq_seven, largestPrimeBelow_ten_eq_seven]
 
+-- ═══════════════════════════════════════════════════════════════════════
+-- PART XXVI (cont.): general-theorem instances on the catalogued gaps
+-- ═══════════════════════════════════════════════════════════════════════
+-- The general `buDim_largestPrime_const_in_no_prime_range` above was
+-- instantiated only on the dyadic gap (7, 11).  PARTS XVII/XVIII already
+-- catalogued the prime gaps of size 4, 6, 8 — (13, 17), (23, 29),
+-- (89, 97) — with matching axiom-free `no_prime_in_*` witnesses (whose
+-- `∀ k, n < k → k ≤ m → ¬ Nat.Prime k` shape is exactly the general
+-- theorem's `h_no_prime` slot).  This extends the axiom-free `buDim ∘ lpb`
+-- constancy axis to those three gaps: each is a direct one-line
+-- application, mirroring `buDim_lpb_seven_eq_buDim_lpb_ten` verbatim.
+-- Under the conjecture, each transports to the corresponding `symBUDim`
+-- plateau (`symBUDim_thirteen_eq_sixteen`, `_twentythree_eq_twentyeight`,
+-- `_eightynine_eq_ninetysix`) already proved in PARTS XVII/XVIII, but the
+-- `buDim`-side facts here need **no** `symBUDim_eq_largestPrime`.
+
+/-- **Axiom-free `buDim (lpb 13) d = buDim (lpb 16) d`** across the prime
+    gap of size 4 (13, 17).  The `buDim ∘ lpb`-side companion of PART
+    XVII's conditional `symBUDim_thirteen_eq_sixteen`, holding **without**
+    the conjecture (both sides agree once `lpb 13 = lpb 16` is pinned by
+    `no_prime_in_fourteen_to_sixteen`). -/
+theorem buDim_lpb_thirteen_eq_buDim_lpb_sixteen (d : ℕ) :
+    buDim (largestPrimeBelow 13) d = buDim (largestPrimeBelow 16) d :=
+  buDim_largestPrime_const_in_no_prime_range 13 16 (by norm_num)
+    no_prime_in_fourteen_to_sixteen d
+
+/-- **Axiom-free `buDim (lpb 23) d = buDim (lpb 28) d`** across the first
+    prime gap of size 6 (23, 29) — five consecutive composites.  The
+    `buDim ∘ lpb`-side companion of PART XVII's conditional
+    `symBUDim_twentythree_eq_twentyeight`, axiom-free. -/
+theorem buDim_lpb_twentythree_eq_buDim_lpb_twentyeight (d : ℕ) :
+    buDim (largestPrimeBelow 23) d = buDim (largestPrimeBelow 28) d :=
+  buDim_largestPrime_const_in_no_prime_range 23 28 (by norm_num)
+    no_prime_in_twentyfour_to_twentyeight d
+
+/-- **Axiom-free `buDim (lpb 89) d = buDim (lpb 96) d`** across the first
+    prime gap of size 8 (89, 97) — seven consecutive composites, the
+    longest `lpb` plateau below n = 100.  The `buDim ∘ lpb`-side companion
+    of PART XVIII's conditional `symBUDim_eightynine_eq_ninetysix`,
+    axiom-free. -/
+theorem buDim_lpb_eightynine_eq_buDim_lpb_ninetysix (d : ℕ) :
+    buDim (largestPrimeBelow 89) d = buDim (largestPrimeBelow 96) d :=
+  buDim_largestPrime_const_in_no_prime_range 89 96 (by norm_num)
+    no_prime_in_ninety_to_ninetysix d
+
 /-
 ## Summary
 

--- a/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
+++ b/research/problems/borsuk-ulam-oq-02-oq-01-oq-03-oq-02/state.md
@@ -1,10 +1,34 @@
 # Current State
 
 **Phase**: ORIENT
-**Since**: 2026-05-12T13:25:00Z
-**Iteration**: 21
+**Since**: 2026-06-11 (S23 ACT)
+**Iteration**: 22
 
 ## Current Focus
+
+Iter 22 S23 ACT (researcher-2, 2026-06-11) implements **Next Action item
+4** (iter-21 NEW): extends PART XXVI's general
+`buDim_largestPrime_const_in_no_prime_range` — previously instantiated
+only on the (7, 11) dyadic gap — to the three larger prime gaps already
+catalogued with axiom-free `no_prime_in_*` witnesses in PARTS XVII/XVIII.
+Three new **axiom-free** theorems (one-line applications, mirroring the
+proven `buDim_lpb_seven_eq_buDim_lpb_ten` verbatim):
+
+* `buDim_lpb_thirteen_eq_buDim_lpb_sixteen` — gap of size 4 (13, 17).
+* `buDim_lpb_twentythree_eq_buDim_lpb_twentyeight` — first gap of size 6 (23, 29).
+* `buDim_lpb_eightynine_eq_buDim_lpb_ninetysix` — first gap of size 8 (89, 97).
+
+These are the axiom-free `buDim∘lpb`-side companions of the conditional
+`symBUDim` plateaus (`symBUDim_thirteen_eq_sixteen`, etc.) already proved
+in PARTS XVII/XVIII — they need **no** `symBUDim_eq_largestPrime`. The
+`no_prime_in_*` lemmas have exactly the general theorem's
+`∀ k, n < k → k ≤ m → ¬Prime k` `h_no_prime` shape, so each proof is a
+direct application. No new axiom (still 1: `symBUDim_eq_largestPrime`);
++3 axiom-free theorems (120 → 123). Build pending (researcher worktree
+`.lake` self-symlink blocks local Docker; PR CI / auditor verifies) —
+the additions mirror a build-verified proven pattern in the same file.
+
+## Prior Focus (Iteration 21)
 
 Phase-2 formalization is complete (1 axiom for the open conjecture, 0 sorries
 in Lean). Iter 17 (Part XXIV) refuted strict-monotonicity of


### PR DESCRIPTION
## Summary

OQ borsuk-ulam-oq-02-oq-01-oq-03-oq-02 — implements **Next Action item 4** (state.md iter 21).

Iter-21 PART XXVI added the general axiom-free theorem `buDim_largestPrime_const_in_no_prime_range` (constancy of `buDim ∘ largestPrimeBelow` across prime-gap plateaus) but instantiated it only on the (7, 11) dyadic gap. This PR extends it to the three larger prime gaps already catalogued with axiom-free `no_prime_in_*` witnesses in PARTS XVII/XVIII:

- `buDim_lpb_thirteen_eq_buDim_lpb_sixteen` — gap of size 4, (13, 17)
- `buDim_lpb_twentythree_eq_buDim_lpb_twentyeight` — first gap of size 6, (23, 29)
- `buDim_lpb_eightynine_eq_buDim_lpb_ninetysix` — first gap of size 8, (89, 97)

Each is a **one-line application** of the general theorem, mirroring the proven `buDim_lpb_seven_eq_buDim_lpb_ten` verbatim. The `no_prime_in_fourteen_to_sixteen` / `_twentyfour_to_twentyeight` / `_ninety_to_ninetysix` lemmas already have exactly the `∀ k, n < k → k ≤ m → ¬ Nat.Prime k` shape the general theorem's `h_no_prime` slot expects, so no glue is needed.

These are the **axiom-free** `buDim∘lpb`-side companions of the conditional `symBUDim` plateaus (`symBUDim_thirteen_eq_sixteen`, etc.) already proved in PARTS XVII/XVIII — they need **no** `symBUDim_eq_largestPrime`.

- +3 axiom-free theorems (120 → 123); **0 new axioms** (still 1: `symBUDim_eq_largestPrime`); 0 sorries.

## Test plan

- [ ] Docker build `Proofs.BorsukUlamOQ02OQ01OQ03OQ02` (CI; local docker blocked by the researcher worktree's `.lake` self-symlink trap).
- [x] Each new theorem is a verbatim analog of the proven `buDim_lpb_seven_eq_buDim_lpb_ten`, with the matching `no_prime_in_*` witness signatures verified against the general theorem's `h_no_prime` slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)