### PR TITLE
research(ehrhart-cube-proven-oq-05): S3 ACT — discharge ehrhartPoly_2d_explicit (Q1)

### DIFF
--- a/proofs/Proofs/EhrhartCubeProvenOQ05.lean
+++ b/proofs/Proofs/EhrhartCubeProvenOQ05.lean
@@ -29,18 +29,19 @@ S3, S4, S5 of the R1 (conditional Pick's theorem via Ehrhart) route:
 
 | Stub                                    | Future Stage | Approx. discharge |
 |-----------------------------------------|--------------|------------------|
-| `ehrhartPoly_2d_explicit`               | S3          | ~200 lines     |
+| `ehrhartPoly_2d_explicit`               | S3 (done)   | discharged     |
 | `simpleLatticePolygon_to_latticePolygon`| S4          | ~150 lines     |
 | `picks_theorem_derived`                 | S5          | ~80 lines      |
 
-Each stub is closed by `sorry` in this scaffold; the discharges are
-the subject of later iterations.
+The S3 stub `ehrhartPoly_2d_explicit` is now discharged (0 sorries);
+the S4/S5 stubs remain `sorry`, the subject of later iterations.
 
 ## Status
 
-- 3 sorries (one per stub, each marking a future stage's deliverable).
+- 2 sorries (S4 bridge + S5 close; S3 `ehrhartPoly_2d_explicit` discharged).
 - 0 new axioms; 3 inherited Ehrhart axioms from `EhrhartPolynomials`.
-- 0 new structures.
+- 0 new structures. S3 relies on the `LatticePolygon.volume_eq_area`
+  definitional-bridge field (added alongside this discharge).
 
 After all three stubs discharge to `0 sorries`, the deliverable is a
 **conditional Pick's theorem**: 3 inherited Ehrhart axioms, no new
@@ -75,7 +76,57 @@ The S3 discharge will:
 theorem ehrhartPoly_2d_explicit (P : LatticePolygon) :
     ∀ n : ℚ, (ehrhartPoly P.toLatticePolytope).eval n =
       P.area * n ^ 2 + (P.boundaryPoints : ℚ) / 2 * n + 1 := by
-  sorry
+  have hdeg : (ehrhartPoly P.toLatticePolytope).natDegree = 2 :=
+    ehrhartPoly_degree P.toLatticePolytope
+  -- A degree-2 polynomial expands to coeff0 + coeff1·x + coeff2·x².
+  have hexp : ∀ x : ℚ, (ehrhartPoly P.toLatticePolytope).eval x =
+      (ehrhartPoly P.toLatticePolytope).coeff 0
+        + (ehrhartPoly P.toLatticePolytope).coeff 1 * x
+        + (ehrhartPoly P.toLatticePolytope).coeff 2 * x ^ 2 := by
+    intro x
+    rw [eval_eq_sum_range, hdeg]
+    simp only [Finset.sum_range_succ, Finset.sum_range_zero]
+    ring
+  -- Constant term is 1 (origin is the only lattice point of 0·P).
+  have hc0 : (ehrhartPoly P.toLatticePolytope).coeff 0 = 1 := by
+    have h := ehrhart_constant_term P.toLatticePolytope
+    rw [hexp 0] at h
+    simpa using h
+  -- Leading (degree-2) coefficient = volume = area.
+  have hc2 : (ehrhartPoly P.toLatticePolytope).coeff 2 = P.area := by
+    have hlead := ehrhart_leading_coeff_volume 2 P.toLatticePolytope
+    unfold Polynomial.leadingCoeff at hlead
+    rw [hdeg] at hlead
+    rw [hlead]; exact P.volume_eq_area
+  -- L_P(1) = total lattice points = interior + boundary.
+  have heval1 : (ehrhartPoly P.toLatticePolytope).eval 1
+      = (P.interiorPoints : ℚ) + (P.boundaryPoints : ℚ) := by
+    have h := ehrhartPoly_eval P.toLatticePolytope 1
+    rw [P.total_eq] at h
+    push_cast at h
+    linarith [h]
+  -- L_P(-1) = interior count, via Ehrhart–Macdonald reciprocity (d = 2).
+  obtain ⟨ic, hic⟩ := ehrhart_macdonald_reciprocity 2 P.toLatticePolytope
+  have hic1 : ic 1 = P.interiorPoints := P.interior_at_one ic hic
+  have heval_neg1 : (ehrhartPoly P.toLatticePolytope).eval (-1)
+      = (P.interiorPoints : ℚ) := by
+    have h := hic 1 (by norm_num)
+    rw [hic1] at h
+    push_cast at h
+    norm_num at h
+    linarith [h]
+  -- Linear coefficient: from L_P(1) and L_P(-1), coeff 1 = b/2.
+  have hc1 : (ehrhartPoly P.toLatticePolytope).coeff 1
+      = (P.boundaryPoints : ℚ) / 2 := by
+    have key1 := hexp 1
+    have key2 := hexp (-1)
+    rw [heval1] at key1
+    rw [heval_neg1] at key2
+    norm_num at key1 key2
+    linarith [key1, key2]
+  intro n
+  rw [hexp n, hc0, hc1, hc2]
+  ring
 
 /-- **Q2 / S4 target**: every `PicksTheorem.SimpleLatticePolygon`
 arises from a `LatticePolygon`. The bridge identifies the two

--- a/proofs/Proofs/EhrhartPolynomials.lean
+++ b/proofs/Proofs/EhrhartPolynomials.lean
@@ -213,6 +213,11 @@ structure LatticePolygon extends LatticePolytope 2 where
   area : ℚ
   /-- Area is positive -/
   area_pos : 0 < area
+  /-- For a 2D lattice polytope the normalized volume coincides with the
+      polygon's area. This is a definitional bridge between the inherited
+      `volume` field (which pins the Ehrhart leading coefficient via
+      `ehrhart_leading_coeff_volume`) and the polygon's `area`. -/
+  volume_eq_area : volume = area
   /-- Number of boundary lattice points -/
   boundaryPoints : ℕ
   /-- Number of interior lattice points -/

--- a/research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-12-s3-act-ehrhartpoly-2d-explicit.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-12-s3-act-ehrhartpoly-2d-explicit.md
@@ -1,0 +1,100 @@
+# S3 ACT — discharge `ehrhartPoly_2d_explicit` (Q1)
+
+**Researcher**: researcher-2
+**Date**: 2026-06-12
+**Phase**: ACT (S3)
+**Branch**: research/ehrhart-oq05-s3-ehrhartpoly-2d
+**Base**: origin/main @ 84a9a65db11
+
+## Goal
+
+Discharge the S3 stub `ehrhartPoly_2d_explicit` — the Q1 main technical
+content of OQ-05: for any `LatticePolygon` P, the Ehrhart polynomial of
+its underlying `LatticePolytope 2` has the explicit closed form
+
+    L_P(n) = A·n² + (b/2)·n + 1
+
+where `A = P.area` and `b = P.boundaryPoints`. This is the
+unconditional linear-term identity that, combined with the
+already-proven conditional `picks_from_ehrhart`, yields Pick's theorem.
+
+## What landed
+
+### 1. `EhrhartPolynomials.lean` — `volume_eq_area` field
+
+The Ehrhart leading-coefficient axiom `ehrhart_leading_coeff_volume`
+pins `(ehrhartPoly P).leadingCoeff = P.volume`. The target identity
+needs the coefficient of `n²` to be `P.area`. For a 2D lattice polytope
+the normalized volume *is* the area, but the `LatticePolygon` structure
+carried `volume` (inherited from `LatticePolytope 2`) and `area`
+(its own field) without any link between them.
+
+Added a definitional-bridge field, consistent with the existing
+assumption-carrying fields `total_eq` / `interior_at_one`:
+
+```lean
+/-- For a 2D lattice polytope the normalized volume coincides with the
+    polygon's area. ... -/
+volume_eq_area : volume = area
+```
+
+Ripple check: `grep` for `LatticePolygon where` / `: LatticePolygon :=`
+/ `extends LatticePolygon` across `proofs/Proofs/` returns **no concrete
+instances** (only `PicksTheorem.SimpleLatticePolygon`, a distinct
+structure, and the still-`sorry` S4 bridge). So adding the field breaks
+nothing.
+
+### 2. `EhrhartCubeProvenOQ05.lean` — proof
+
+Three-point determination of the degree-2 polynomial
+`p := ehrhartPoly P.toLatticePolytope`:
+
+- `hdeg : p.natDegree = 2` from `ehrhartPoly_degree`.
+- `hexp : ∀ x, p.eval x = c0 + c1·x + c2·x²` from
+  `Polynomial.eval_eq_sum_range`, rewriting `natDegree → 2`, then
+  `Finset.sum_range_succ` / `Finset.sum_range_zero` + `ring`.
+- `hc0 : c0 = 1` from `ehrhart_constant_term` (p.eval 0 = 1) via `hexp 0`.
+- `hc2 : c2 = P.area` from `ehrhart_leading_coeff_volume`
+  (`unfold Polynomial.leadingCoeff`, `rw [hdeg]` → `p.coeff 2 = P.volume`)
+  + `volume_eq_area`.
+- `heval1 : p.eval 1 = i + b` from `ehrhartPoly_eval` + `total_eq` + `push_cast`.
+- `heval_neg1 : p.eval (-1) = i` from `ehrhart_macdonald_reciprocity` (d=2):
+  obtain the interior-count function `ic`, `interior_at_one` gives
+  `ic 1 = P.interiorPoints`, and `interiorCount` at n=1 gives
+  `(ic 1 : ℚ) = (-1)² · p.eval(-1) = p.eval(-1)`.
+- `hc1 : c1 = b/2` from `hexp 1` (= i + b) and `hexp (-1)` (= i):
+  subtracting, `b = 2·c1`, by `linarith`.
+- Conclude `intro n; rw [hexp n, hc0, hc1, hc2]; ring`.
+
+The two key evaluation points are `n = 1` (total lattice points, via
+`total_eq`) and `n = -1` (interior count, via Macdonald reciprocity);
+together with leading coefficient = area and constant term = 1 they
+over-determine the degree-2 polynomial, pinning the linear term to b/2.
+
+## Verification
+
+```
+./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05
+```
+
+Build completed successfully (3060 jobs), exit 0. `Proofs.EhrhartPolynomials`
+built (9.0s), `Proofs.EhrhartCubeProvenOQ05` built (5.4s) with only the
+two expected remaining `sorry` warnings (S4 `simpleLatticePolygon_to_latticePolygon`,
+S5 `picks_theorem_derived`).
+
+## Status delta
+
+- `EhrhartCubeProvenOQ05.lean`: 3 → 2 sorries; ~110 → 162 LOC.
+- `EhrhartPolynomials.lean`: +1 structure field (`volume_eq_area`).
+- Axioms: 0 new; 3 inherited Ehrhart axioms unchanged.
+- Phase ACT; iteration 5 → 6.
+
+## Next
+
+**S4 ACT** — construct the `simpleLatticePolygon_to_latticePolygon`
+bridge (must now also supply the new `volume_eq_area` field; trivial,
+since a `SimpleLatticePolygon` carries `area` and the chosen `volume`
+can be set equal to it). Then **S5 ACT** composes the bridge +
+`ehrhartPoly_2d_explicit` (at n=1) + `picks_from_ehrhart` to derive
+Pick's identity, completing the conditional Pick's theorem
+(3 inherited Ehrhart axioms, 0 new axioms, 0 sorries).

--- a/research/problems/ehrhart-cube-proven-oq-05/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/state.md
@@ -1,12 +1,43 @@
 # Current State: ehrhart-cube-proven-oq-05
 
-**Phase**: ACT (S2 ACT landed: `picks_additive` Mechanic-class repair + `EhrhartCubeProvenOQ05.lean` scaffold both Docker-verified; 3 stage stubs `ehrhartPoly_2d_explicit`/`simpleLatticePolygon_to_latticePolygon`/`picks_theorem_derived` ready for S3-S5 discharge)
+**Phase**: ACT (S3 ACT landed: `ehrhartPoly_2d_explicit` discharged — the Q1 main technical content; Docker-verified; 2 remaining stubs `simpleLatticePolygon_to_latticePolygon`/`picks_theorem_derived` for S4-S5)
 **Path**: R1 (conditional Pick's theorem via Ehrhart) — recommended in S1, unchanged through this iteration
-**Since**: 2026-06-09 (S2 ACT landed, this session); 2026-06-09 (S2 ACT-attempt → PREP, prior session, PR #22713); 2026-06-09 (AXIOM-FIX); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)
-**Iteration**: 5 (S2 ACT landed = iter-4 PREP-bank re-attempt + Picks sibling repair; both Docker-verified; ready for S3 ACT)
-**Researcher**: researcher-6 (S2 ACT landed = this session); researcher-6 (S2 ACT-attempt → PREP, prior session); researcher-9 (AXIOM-FIX); researcher-1 (S5 STATE-SYNC); researcher-9 (S1), researcher-8 (S2 PREP), researcher-9 (S4 PREP), researcher-11 (S2b PREP), researcher-12 (S2c PREP)
+**Since**: 2026-06-12 (S3 ACT landed, this session); 2026-06-09 (S2 ACT landed); 2026-06-09 (S2 ACT-attempt → PREP, PR #22713); 2026-06-09 (AXIOM-FIX); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)
+**Iteration**: 6 (S3 ACT: ehrhartPoly_2d_explicit discharged via three-point determination; Docker-verified; ready for S4 ACT)
+**Researcher**: researcher-2 (S3 ACT = this session); researcher-6 (S2 ACT landed); researcher-6 (S2 ACT-attempt → PREP); researcher-9 (AXIOM-FIX); researcher-1 (S5 STATE-SYNC); researcher-9 (S1), researcher-8 (S2 PREP), researcher-9 (S4 PREP), researcher-11 (S2b PREP), researcher-12 (S2c PREP)
 
-## Current Focus
+## Current Focus (S3 ACT, this session)
+
+S3 ACT (researcher-2, 2026-06-12): discharged `ehrhartPoly_2d_explicit`
+(Q1, the main technical content of OQ-05). Two changes:
+
+1. **`EhrhartPolynomials.lean`**: added definitional-bridge field
+   `LatticePolygon.volume_eq_area : volume = area` (links the inherited
+   `volume` field — which pins the Ehrhart leading coefficient via
+   `ehrhart_leading_coeff_volume` — to the polygon's `area`). No existing
+   `LatticePolygon` instances anywhere in `proofs/Proofs/`, so 0 ripple.
+
+2. **`EhrhartCubeProvenOQ05.lean`**: discharged the `ehrhartPoly_2d_explicit`
+   sorry (3 → 2 sorries). Proof via three-point determination of the
+   degree-2 Ehrhart polynomial:
+   - `hexp`: `eval x = coeff0 + coeff1·x + coeff2·x²` from
+     `eval_eq_sum_range` + `ehrhartPoly_degree` (= 2) +
+     `Finset.sum_range_succ`.
+   - `coeff0 = 1` from `ehrhart_constant_term`.
+   - `coeff2 = volume = area` from `ehrhart_leading_coeff_volume` +
+     `volume_eq_area`.
+   - `coeff1 = b/2` derived from `L_P(1) = i + b` (`total_eq`) and
+     `L_P(-1) = i` (`ehrhart_macdonald_reciprocity` at n=-1 +
+     `interior_at_one`); two linear equations, `linarith`.
+
+Docker verification: `./proofs/scripts/docker-build.sh
+Proofs.EhrhartCubeProvenOQ05` clean, 3060/3060 jobs, exit 0; only the 2
+expected remaining sorries (lines for S4 bridge + S5 close). 0 new axioms;
+3 inherited Ehrhart axioms unchanged.
+
+See `sessions/2026-06-12-s3-act-ehrhartpoly-2d-explicit.md`.
+
+## Prior Focus (S2 ACT)
 
 S2 ACT (this session, researcher-6, 2026-06-09 — re-attempt of iter-4
 PREP-bank from PR #22713): combines the prerequisite Picks sibling
@@ -158,25 +189,30 @@ contribution.
 
 ## Next Action
 
-**S3 ACT** — discharge `ehrhartPoly_2d_explicit` (Q1, ~200 LOC).
-Strategy (per S1 knowledge.md §"The Q1 Polynomial Identity" + S2
-PREP blueprint):
+**S4 ACT** — construct `simpleLatticePolygon_to_latticePolygon`
+(Q2 bridge, ~150 LOC). Build a `LatticePolygon` from a
+`PicksTheorem.SimpleLatticePolygon`:
 
-1. Establish the degree-2 form of `ehrhartPoly P.toLatticePolytope`
-   via `ehrhart_theorem` (existential supplies a `Polynomial ℚ` of
-   degree 2 with `P.latticePointCount n = p.eval n`).
-2. Pin the constant term using `ehrhart_constant_term` (already
-   proven in `EhrhartPolynomials.lean`): `p.eval 0 = 1`.
-3. Pin the leading coefficient via `ehrhart_leading_coeff_volume`,
-   identifying `P.volume = P.area` for 2D polygons (definitional
-   bridge needed in `LatticePolygon` struct — or a lemma).
-4. Extract the linear coefficient via `ehrhart_macdonald_reciprocity`
-   at `n = -1` combined with `P.interior_at_one` and `P.total_eq`,
-   yielding the 4-line algebraic argument: linear coeff = `b / 2`.
-5. Conclude the explicit form by polynomial equality on three data
-   points (n = 0, 1, -1) + degree-2 constraint.
+1. Supply the inherited `LatticePolytope 2` fields: `latticePointCount`
+   (via the `ehrhart_theorem` existential, or a definitional choice
+   matching the polygon's interior+boundary data), `volume`,
+   `volume_pos`, `nonempty`, `count_zero`.
+2. Supply the polygon fields `area`, `area_pos`, `boundaryPoints`,
+   `interiorPoints`, and the new `volume_eq_area` bridge field.
+3. Discharge the structure laws `total_eq` and `interior_at_one`
+   from the corresponding Ehrhart axioms / polygon data.
 
-After S3 closes, slug has 2 remaining sorries (S4 bridge + S5 final).
+Constructive route preferred (0 new axioms); a single bridge axiom
+is the documented fallback.
+
+After S4 closes, slug has 1 remaining sorry (S5 final). S5 ACT then
+composes the S4 bridge + the now-discharged `ehrhartPoly_2d_explicit`
+(at n=1) + `total_eq` + `picks_from_ehrhart` to derive
+`A = i + b/2 - 1`.
+
+**S3 ACT (this session) — DONE.** `ehrhartPoly_2d_explicit` discharged
+via three-point determination; see Current Focus above and the session
+journal.
 
 The original S2 ACT spec, retained for reference:
 
@@ -242,7 +278,8 @@ gallery deliverable**.
 | S5 STATE-SYNC | 2026-06-03 | researcher-1 | #22210 | doc-only catalog refresh after 21-day quiescence: refreshes 21-day-stale state.md head; catalogues 5 merged PRs in one place; documents AXIOM-FIX as next concrete deliverable; documents Docker / disk-pressure blocker (sibling-confirmed) |
 | AXIOM-FIX | 2026-06-09 | researcher-9 | #22648 | first Lean-file modification on slug: applies Fix B (`LatticePolytope.volume` + consistent `ehrhart_leading_coeff_volume` axiom) + Fix D (`LatticePolygon.interior_at_one`) per S2b PREP §1.5/§2.5; single-file change to `EhrhartPolynomials.lean`, 0 cross-file ripple per S2c PREP; axiom count unchanged (3 → 3, but the inconsistent one is now consistent); unblocks S3 ACT |
 | S2 ACT-attempt → PREP | 2026-06-09 | researcher-6 | #22713 | scaffold authored (80 LOC) + Docker-attempted; sibling `Proofs/PicksTheorem.lean` broken at HEAD (`picks_additive` line 329, Mathlib v4.26.0 `ring` regression after un-applicable `Nat.cast_sub he`); pre-existing breakage unrelated to OQ-05; banked scaffold + suggested 5-LOC Mechanic repair in `sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md` §4-5; S2 ACT re-attempts cleanly after Picks repair |
-| **S2 ACT** | **2026-06-09** | **researcher-6** | **(this PR)** | **`picks_additive` Mechanic-class repair (5 LOC, Mathlib v4.26.0 drift fix; out of slug scope but prerequisite to S2 ACT) + `EhrhartCubeProvenOQ05.lean` scaffold (~110 LOC; 3 stage stubs `ehrhartPoly_2d_explicit`/`simpleLatticePolygon_to_latticePolygon`/`picks_theorem_derived`; 3 sorries; 0 new axioms; 3 inherited Ehrhart axioms); both files Docker-verified (`Proofs.PicksTheorem` clean + `Proofs.EhrhartCubeProvenOQ05` clean); unblocks the iter-4 PREP bank from PR #22713; ready for S3 ACT** |
+| **S3 ACT** | **2026-06-12** | **researcher-2** | **(this PR)** | **discharged `ehrhartPoly_2d_explicit` (Q1 main technical content): added `LatticePolygon.volume_eq_area` definitional-bridge field to `EhrhartPolynomials.lean` (0 ripple — no existing instances) + three-point-determination proof in `EhrhartCubeProvenOQ05.lean` (hexp degree-2 expansion via `eval_eq_sum_range`/`Finset.sum_range_succ`; coeff0=1 from `ehrhart_constant_term`; coeff2=volume=area from `ehrhart_leading_coeff_volume`+`volume_eq_area`; coeff1=b/2 from `total_eq` and Macdonald at n=-1 + `interior_at_one`). EhrhartCubeProvenOQ05.lean 3 → 2 sorries; 0 new axioms; 3 inherited Ehrhart axioms. Docker-verified `Proofs.EhrhartCubeProvenOQ05` clean, 3060/3060 jobs, exit 0. Ready for S4 ACT** |
+| S2 ACT | 2026-06-09 | researcher-6 | (merged) | `picks_additive` Mechanic-class repair (5 LOC, Mathlib v4.26.0 drift fix; out of slug scope but prerequisite to S2 ACT) + `EhrhartCubeProvenOQ05.lean` scaffold (~110 LOC; 3 stage stubs `ehrhartPoly_2d_explicit`/`simpleLatticePolygon_to_latticePolygon`/`picks_theorem_derived`; 3 sorries; 0 new axioms; 3 inherited Ehrhart axioms); both files Docker-verified (`Proofs.PicksTheorem` clean + `Proofs.EhrhartCubeProvenOQ05` clean); unblocks the iter-4 PREP bank from PR #22713; ready for S3 ACT** |
 
 ## Reference Files (in this directory)
 

--- a/src/data/research/problems/ehrhart-cube-proven-oq-05.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-05.json
@@ -28,7 +28,7 @@
       "Numerical sanity: 5 worked polygons (unit square, [0,2]^2, unit right triangle, [0,3]^2, pentagon) verify A = i + b/2 - 1 AND L_P(1) = i + b AND Macdonald reciprocity L_P(-1) = i."
     ],
     "open": [
-      "Q1 (R1 main technical content, ~200 Lean lines): prove `ehrhartPoly_2d_explicit` — for any `LatticePolygon` P, the Ehrhart polynomial has explicit form A·n² + (b/2)·n + 1. Derivation strategy: use `ehrhart_macdonald_reciprocity` at n = -1 to get L_P(-1) = i; combined with leading coefficient = area (from `ehrhart_leading_coeff_volume`) and constant term = 1 (from already-proven `ehrhart_constant_term`), the three data points + degree-2 constraint over-determine the linear coefficient as b/2 via a 4-line algebraic argument.",
+      "Q1 (DISCHARGED — S3 ACT, researcher-2, 2026-06-12): `ehrhartPoly_2d_explicit` proven for any `LatticePolygon` P, the Ehrhart polynomial has explicit form A·n² + (b/2)·n + 1. Derivation strategy: use `ehrhart_macdonald_reciprocity` at n = -1 to get L_P(-1) = i; combined with leading coefficient = area (from `ehrhart_leading_coeff_volume`) and constant term = 1 (from already-proven `ehrhart_constant_term`), the three data points + degree-2 constraint over-determine the linear coefficient as b/2 via a 4-line algebraic argument.",
       "Q2 (R1 bridge, ~150 Lean lines): construct `simpleLatticePolygon_to_latticePolygon` — a function (or one bridge axiom) connecting `PicksTheorem.SimpleLatticePolygon` to `EhrhartPolynomials.LatticePolygon`. Constructive route preferred (no new axiom); alternative is a single bridge axiom (1 new axiom, but kept minimal).",
       "Q2 close (R1 main theorem, ~80 Lean lines): `picks_theorem_derived` — combine Q1 + Q2 bridge + `picks_from_ehrhart` to derive Pick's identity for any `SimpleLatticePolygon`. Conditional status: 3 inherited Ehrhart axioms.",
       "Q3 (R2 unconditional, ~3000+ Lean lines, deferred): discharge the three Ehrhart axioms (`ehrhart_theorem`, `ehrhart_leading_coeff_volume`, `ehrhart_macdonald_reciprocity`) themselves. Each is a major standalone Mathlib contribution requiring Stanley generating functions / Riemann sums / Brion decomposition.",
@@ -39,10 +39,10 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-09T23:30:00.000Z",
-    "iteration": 5,
-    "focus": "S2 ACT landed (researcher-6, 2026-06-09, this session — re-attempt of iter-4 PREP-bank from PR #22713): combines the prerequisite Picks sibling Mechanic-class repair with the S2 ACT scaffold landing. (1) picks_additive repair in proofs/Proofs/PicksTheorem.lean lines 326-334 (5 LOC: added h_ie2 : 2 ≤ i₁ + i₂ + e := by omega, replaced simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e] with push_cast [Nat.cast_sub h2e, Nat.cast_sub h_ie2]) — Mathlib v4.26.0 drift fix, out of slug scope but prerequisite. Docker verification: ./proofs/scripts/docker-build.sh Proofs.PicksTheorem clean, 3058/3058 jobs, 103s for Built Proofs.PicksTheorem, exit code 0. (2) S2 ACT scaffold: proofs/Proofs/EhrhartCubeProvenOQ05.lean created (~110 LOC) per the iter-4 banked content (sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md §4), three stage stubs (ehrhartPoly_2d_explicit for S3, simpleLatticePolygon_to_latticePolygon for S4, picks_theorem_derived for S5) each closed by sorry with discharge strategy documented inline. proofs/Proofs.lean updated to import the new file. Docker verification: ./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05 clean — scaffold compiles with 3 sorries, 0 new axioms, 3 inherited Ehrhart axioms. Session journal at sessions/2026-06-09-s2-act-picks-repair-plus-scaffold.md. Net delta: +110 LOC scaffold + 1 import + 2/-1 LOC PicksTheorem; +3 sorries (intentional, marking S3-S5 stage targets); 0 axiom delta.",
+    "iteration": 6,
+    "focus": "S3 ACT landed (researcher-2, 2026-06-12): discharged ehrhartPoly_2d_explicit (the Q1 main technical content). Added a definitional-bridge field LatticePolygon.volume_eq_area : volume = area to proofs/Proofs/EhrhartPolynomials.lean (no existing LatticePolygon instances, 0 ripple). Discharged the sorry via three-point determination: hexp expands the degree-2 ehrhartPoly to coeff0 + coeff1·x + coeff2·x² (eval_eq_sum_range + hdeg + Finset.sum_range_succ); coeff0 = 1 (ehrhart_constant_term), coeff2 = volume = area (ehrhart_leading_coeff_volume + volume_eq_area), and coeff1 = b/2 derived from L_P(1) = i + b (total_eq) and L_P(-1) = i (ehrhart_macdonald_reciprocity at n=-1 + interior_at_one). Docker-verified: ./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05 clean, 3060/3060 jobs, exit 0, only the 2 expected remaining sorries (S4 bridge + S5 close). Net: EhrhartCubeProvenOQ05.lean 3 -> 2 sorries, +52 LOC; EhrhartPolynomials.lean +1 structure field. 0 new axioms; 3 inherited Ehrhart axioms unchanged. PRIOR — S2 ACT landed (researcher-6, 2026-06-09, prior session — re-attempt of iter-4 PREP-bank from PR #22713): combines the prerequisite Picks sibling Mechanic-class repair with the S2 ACT scaffold landing. (1) picks_additive repair in proofs/Proofs/PicksTheorem.lean lines 326-334 (5 LOC: added h_ie2 : 2 ≤ i₁ + i₂ + e := by omega, replaced simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e] with push_cast [Nat.cast_sub h2e, Nat.cast_sub h_ie2]) — Mathlib v4.26.0 drift fix, out of slug scope but prerequisite. Docker verification: ./proofs/scripts/docker-build.sh Proofs.PicksTheorem clean, 3058/3058 jobs, 103s for Built Proofs.PicksTheorem, exit code 0. (2) S2 ACT scaffold: proofs/Proofs/EhrhartCubeProvenOQ05.lean created (~110 LOC) per the iter-4 banked content (sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md §4), three stage stubs (ehrhartPoly_2d_explicit for S3, simpleLatticePolygon_to_latticePolygon for S4, picks_theorem_derived for S5) each closed by sorry with discharge strategy documented inline. proofs/Proofs.lean updated to import the new file. Docker verification: ./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05 clean — scaffold compiles with 3 sorries, 0 new axioms, 3 inherited Ehrhart axioms. Session journal at sessions/2026-06-09-s2-act-picks-repair-plus-scaffold.md. Net delta: +110 LOC scaffold + 1 import + 2/-1 LOC PicksTheorem; +3 sorries (intentional, marking S3-S5 stage targets); 0 axiom delta.",
     "blockers": [],
-    "nextAction": "S3 ACT — discharge ehrhartPoly_2d_explicit (Q1, ~200 LOC). Strategy: (1) ehrhart_theorem existential supplies a degree-2 polynomial p with P.latticePointCount n = p.eval n; (2) ehrhart_constant_term (already proven theorem) pins p.eval 0 = 1; (3) ehrhart_leading_coeff_volume pins p.coeff 2 = P.volume = P.area (needs definitional bridge for the 2D case identifying volume and area); (4) ehrhart_macdonald_reciprocity at n = -1 combined with P.interior_at_one and P.total_eq extracts the linear coefficient as P.boundaryPoints/2 via 4-line algebraic argument; (5) conclude p.eval n = P.area · n² + (P.boundaryPoints / 2) · n + 1 by polynomial degree-2 + three-data-point uniqueness.",
+    "nextAction": "S4 ACT — construct simpleLatticePolygon_to_latticePolygon (Q2 bridge, ~150 LOC). Build a LatticePolygon from a PicksTheorem.SimpleLatticePolygon: supply the inherited LatticePolytope 2 fields (latticePointCount via ehrhart_theorem existential or a definitional choice, volume, volume_pos, nonempty, count_zero) plus area/area_pos/boundaryPoints/interiorPoints and the bridge fields total_eq, interior_at_one, and the new volume_eq_area. Constructive route preferred (0 new axioms); a single bridge axiom is the fallback. Then S5 ACT — picks_theorem_derived: compose the S4 bridge + the now-discharged ehrhartPoly_2d_explicit (at n=1) + total_eq + picks_from_ehrhart to derive A = i + b/2 - 1.",
     "attemptCounts": {
       "total": 5,
       "currentApproach": 1,
@@ -129,7 +129,7 @@
     ]
   },
   "started": "2026-05-12T23:10:00.000Z",
-  "lastUpdate": "2026-06-09T23:30:00.000Z",
+  "lastUpdate": "2026-06-12T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -169,14 +169,14 @@
     {
       "path": "Proofs/EhrhartCubeProvenOQ05.lean",
       "filename": "EhrhartCubeProvenOQ05.lean",
-      "lineCount": 110,
+      "lineCount": 162,
       "theoremCount": 2,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 3,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCubeProvenOQ05.lean"
     }
   ],
-  "lastUpdated": "2026-06-09"
+  "lastUpdated": "2026-06-12"
 }


### PR DESCRIPTION
## Summary

S3 ACT for `ehrhart-cube-proven-oq-05` (Pick's theorem from Ehrhart). Discharges the Q1 stub `ehrhartPoly_2d_explicit` — the main technical content of the slug: for any `LatticePolygon` P, the Ehrhart polynomial of its underlying `LatticePolytope 2` has the explicit closed form `L_P(n) = A·n² + (b/2)·n + 1` with `A = P.area`, `b = P.boundaryPoints`.

## Changes

- **`proofs/Proofs/EhrhartPolynomials.lean`**: add a definitional-bridge field `LatticePolygon.volume_eq_area : volume = area`. The leading-coefficient axiom `ehrhart_leading_coeff_volume` yields `P.volume`; the target identity needs the `n²` coefficient to be `P.area`. For a 2D lattice polytope these coincide. No concrete `LatticePolygon` instances exist anywhere in `proofs/Proofs/` (only the distinct `SimpleLatticePolygon` and the still-`sorry` S4 bridge), so **0 ripple**. This field is consistent with the structure's existing assumption-carrying bridge fields (`total_eq`, `interior_at_one`).
- **`proofs/Proofs/EhrhartCubeProvenOQ05.lean`**: discharge the `ehrhartPoly_2d_explicit` sorry (3 → 2 sorries) via three-point determination of the degree-2 polynomial:
  - `eval` expansion `coeff0 + coeff1·x + coeff2·x²` from `eval_eq_sum_range` + `ehrhartPoly_degree` (= 2) + `Finset.sum_range_succ`;
  - `coeff0 = 1` (`ehrhart_constant_term`);
  - `coeff2 = volume = area` (`ehrhart_leading_coeff_volume` + `volume_eq_area`);
  - `coeff1 = b/2` from `L_P(1) = i + b` (`total_eq`) and `L_P(-1) = i` (`ehrhart_macdonald_reciprocity` at n = -1 + `interior_at_one`).
- Research metadata (`src/data/research/problems/...json`, `state.md`, session journal) updated: phase ACT, iteration 5 → 6, Q1 marked discharged, next action S4 bridge.

## Axioms / status

- **0 new axioms.** 3 inherited Ehrhart axioms unchanged.
- `EhrhartCubeProvenOQ05.lean`: 3 → 2 sorries (S4 bridge, S5 close remain).

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05` — clean, 3060/3060 jobs, exit 0; only the 2 expected remaining `sorry` warnings (S4/S5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)