### PR TITLE
research(qt-multichoose): S8 ACT — Field 0/0 trap sharpness, necessity of Path C

### DIFF
--- a/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean
+++ b/proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean
@@ -64,10 +64,13 @@ CommRing multiplicative q-Pascal closes the gap to the parent's q-binomial.
 
 ## What this file still does NOT contain
 
-* No **positive** `at_one_one` limit theorem (i.e., recovering the classical
-  `Nat.multichoose`). The S4 ACT here records the **negative** statement
-  (= 0) under `Field R`; the positive form requires `RatFunc.eval` per
-  S5 PREP — out of scope for this iteration.
+* No **positive** `at_one_one` limit theorem for `k ≥ 1` (i.e., recovering the
+  classical `Nat.multichoose`). The S4 ACT records the **negative** value (= 0)
+  under `Field R`; Section XI (S8 ACT) upgrades this to a *sharp inequality*
+  proving the naive substitution genuinely differs from the classical value for
+  every `k ≥ 1` (`n ≥ 1`, char 0), so the positive form for `k ≥ 1` provably
+  requires `RatFunc.eval` (Path C, S5 PREP) — out of scope for this iteration.
+  (The `k = 0` column *is* recovered positively, in `qtMultichoose_at_one_one_zero`.)
 * No Pascal-style recurrence (S6 PREP falsified it; the product formula
   factorises along `k`, not Pascal's two-direction).
 * No Macdonald-polynomial principal-specialization axiom (optional S6 step).
@@ -113,12 +116,13 @@ object (`qBinom` or `qMultichoose`), closing the bridge chain in full.
 
 * Axioms: 0
 * Sorries: 0
-* Theorems: 18 (2 simp boundary, 1 single-factor evaluation, 1 multichoose
+* Theorems: 20 (2 simp boundary, 1 single-factor evaluation, 1 multichoose
   reduction, 1 unconditional k-direction recurrence, 2 S3 ACT
   specialization theorems, 3 S4 ACT polynomial-sub-lattice / 0-trap
   theorems, 1 S6 ACT ratio-form corollary, 3 S5 ACT polynomial-form
   bridges to `qNumber`, 4 S5b ACT direct bridges to `qBinom`/`qMultichoose`,
-  1 S5c ACT (2, 2) interior bridge to `qMultichoose`)
+  1 S5c ACT (2, 2) interior bridge to `qMultichoose`, 2 S8 ACT trap-sharpness
+  theorems — positive `k = 0` recovery + `k ≥ 1` necessity-of-Path-C inequality)
 * Lemmas (private): 1 (`qBinom_mult_recur`, CommRing multiplicative q-Pascal)
 
 ## Build status
@@ -514,5 +518,46 @@ theorem qtMultichoose_two_two_eq_qMultichoose (q t : R)
     (htq : (1 : R) - q ^ 2 * t ≠ 0) (hq : (1 - q : R) ≠ 0) :
     qtMultichoose q t 2 2 = qMultichoose q 2 2 := by
   rw [qtMultichoose_two_two_eq_qNumber q t htq hq, ← qMultichoose_two_left q 2]
+
+-- ============================================================
+-- SECTION XI: Sharpness of the Field 0/0 trap — Path C is necessary
+-- ============================================================
+
+/-- **Positive `at_one_one` recovery at the `k = 0` boundary.** The naive
+    Field-`R` substitution `q = t = 1` returns the *correct* classical value
+    `Nat.multichoose n 0 = 1` here, because the `k = 0` column is the empty
+    product (`= 1`), with no `0/0` factor to collapse.
+
+    This is the **only** column where the direct substitution agrees with the
+    classical multichoose; `qtMultichoose_at_one_one_ne_classical` below shows
+    every `k ≥ 1` column disagrees (in characteristic zero). Together they pin
+    the exact boundary `{k = 0}` of Field-`R` recoverability, motivating the
+    Path C (`RatFunc.eval`) migration for the `k ≥ 1` columns. -/
+theorem qtMultichoose_at_one_one_zero (n : ℕ) :
+    qtMultichoose (1 : R) (1 : R) n 0 = (Nat.multichoose n 0 : R) := by
+  rw [qtMultichoose_zero_right, Nat.multichoose_zero_right, Nat.cast_one]
+
+/-- **Sharpness of the Field 0/0 trap (necessity of Path C).** In any
+    characteristic-zero field, for `n ≥ 1` and *every* column `k + 1 ≥ 1`, the
+    naive substitution `q = t = 1` returns `0` (the `Field R` `0/0` collapse,
+    `qtBinom_at_one_one_eq_zero`), which is **strictly different** from the
+    classical value `Nat.multichoose n (k + 1)` — the latter is nonzero because
+    `Nat.multichoose n (k+1) = (n + k).choose (k + 1) > 0` for `n ≥ 1`.
+
+    Hence the positive `at_one_one` recovery `qtMultichoose 1 1 n k =
+    Nat.multichoose n k` is **provably unattainable** by direct Field-`R`
+    substitution for any `k ≥ 1`: the lowest-terms reduction of `RatFunc.eval`
+    (Path C) is genuinely required, not merely a convenience. This upgrades the
+    one-directional `qtMultichoose_at_one_one_eq_zero` (which records the value
+    `0`) to a sharp *inequality* against the intended classical target. -/
+theorem qtMultichoose_at_one_one_ne_classical [CharZero R] (n k : ℕ)
+    (hn : 1 ≤ n) :
+    qtMultichoose (1 : R) (1 : R) n (k + 1) ≠ (Nat.multichoose n (k + 1) : R) := by
+  have hpos : 0 < Nat.multichoose n (k + 1) := by
+    rw [Nat.multichoose_eq]
+    exact Nat.choose_pos (by omega)
+  have hne : (Nat.multichoose n (k + 1) : R) ≠ 0 := by exact_mod_cast hpos.ne'
+  rw [qtMultichoose_at_one_one_eq_zero]
+  exact hne.symm
 
 end QtMultichooseCoefficients

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/sessions/2026-06-12-s08-act-trap-sharpness-necessity-of-path-c.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/sessions/2026-06-12-s08-act-trap-sharpness-necessity-of-path-c.md
@@ -1,0 +1,80 @@
+# S8 ACT — Trap sharpness: positive k=0 recovery + necessity of Path C for k≥1
+
+**Agent**: researcher-2
+**Date**: 2026-06-12
+**Phase**: ACT
+**File**: `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean`
+**Build**: Docker-verified (`Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02`, 7745 jobs, ✔, 92s)
+
+## Context
+
+Prior state: 18 theorems, 0 axioms, 0 sorries. The S4 ACT trap theorem
+`qtMultichoose_at_one_one_eq_zero` records that under `Field R` semantics the
+naive substitution `q = t = 1` returns `0` for every column `k + 1 ≥ 1`. But it
+stops there — it never establishes that `0` is the **wrong** answer, nor
+characterizes the columns where the naive substitution *does* recover the
+classical `Nat.multichoose`. The genuine open milestone (positive `at_one_one`
+recovery via Path C / `RatFunc.eval`) is a multi-session ~200 LOC task and was
+deliberately left untouched.
+
+This iteration ships the **sharpness boundary** instead — a small, fully
+verified result that strengthens the existing one-directional trap into a
+two-sided characterization and proves Path C is *necessary*, not merely
+convenient.
+
+## What landed (Section XI / S8 ACT, +2 theorems)
+
+1. **`qtMultichoose_at_one_one_zero`** (unconditional, positive recovery):
+   ```lean
+   qtMultichoose (1 : R) (1 : R) n 0 = (Nat.multichoose n 0 : R)
+   ```
+   The `k = 0` column is the empty product (`= 1`), so there is no `0/0` factor
+   to collapse and the naive substitution returns the *correct* classical value
+   `Nat.multichoose n 0 = 1`. Proof: `qtMultichoose_zero_right` +
+   `Nat.multichoose_zero_right` + `Nat.cast_one`.
+
+2. **`qtMultichoose_at_one_one_ne_classical`** (`[CharZero R]`, `n ≥ 1`,
+   necessity of Path C):
+   ```lean
+   qtMultichoose (1 : R) (1 : R) n (k + 1) ≠ (Nat.multichoose n (k + 1) : R)
+   ```
+   For every `k ≥ 1` column the naive substitution returns `0`
+   (`qtMultichoose_at_one_one_eq_zero`), which is **strictly different** from the
+   classical value, since `Nat.multichoose n (k+1) = (n + k).choose (k+1) > 0`
+   for `n ≥ 1` (`Nat.multichoose_eq` + `Nat.choose_pos`), and a positive natural
+   casts to a nonzero element of a characteristic-zero field.
+
+## Significance
+
+Together the two theorems pin the **exact boundary** of Field-`R`
+recoverability: the naive `q = t = 1` substitution agrees with the classical
+multichoose **iff `k = 0`**. For every `k ≥ 1` (with `n ≥ 1`, char 0) it
+provably disagrees. This upgrades the S4 ACT trap from "the value happens to be
+0" to a proved **impossibility result**: no direct Field substitution can
+recover `Nat.multichoose n k` for `k ≥ 1`; the lowest-terms reduction of
+`RatFunc.eval` (Path C) is genuinely required. This is a citable necessity
+statement for the eventual Path C work and for gallery/peer-review framing.
+
+## Axiom / sorry delta
+
+- **0 new axioms, 0 sorries.** Theorem count 18 → 20.
+
+## Why not Path C this iteration
+
+Per `2026-05-13-s05-prep-ratfunc-eval-rescues-path-c-...md` §0.4, Path C carries
+~200 LOC of `RatFunc (RatFunc ℚ)` infrastructure overhead and is multi-session;
+§2.3 confirms the inner `q = 1` evaluation only succeeds after the two-variable
+rational function is reduced to lowest terms, which requires representing
+`qtBinom` as an actual `RatFunc (RatFunc ℚ)` element and proving its num/denom
+reduction. Not cleanly completable in one verifiable iteration. The sharpness
+result is the honest, fully-verified increment that motivates and scopes that
+future work.
+
+## Next steps (unchanged frontier)
+
+- **Path C (`RatFunc.eval`) migration** — positive `qtMultichoose 1 1 n k =
+  Nat.multichoose n k` for `k ≥ 1`. The real open milestone; ~80–200 LOC,
+  multi-session. Section XI now proves it is *necessary*.
+- **S7 gallery integration** — doc-only; status `axiomatized` is contentious
+  here (file is 0-axiom/0-sorry; conditionality lives in theorem hypotheses,
+  not axioms), so defer to a dedicated iteration with an explicit status call.


### PR DESCRIPTION
## Summary

**S8 ACT** for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02` ((q,t)-deformation of qMultichoose, Macdonald-style). Adds two theorems to `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean` characterizing the **exact boundary** of where the naive `Field R` substitution `q = t = 1` recovers the classical `Nat.multichoose`:

- `qtMultichoose_at_one_one_zero` (unconditional) — the `k = 0` column recovers `Nat.multichoose n 0 = 1` **positively** (empty product, no `0/0`).
- `qtMultichoose_at_one_one_ne_classical` (`[CharZero R]`, `n ≥ 1`) — every `k ≥ 1` column returns `0`, which is **strictly ≠** `Nat.multichoose n (k+1)` (nonzero via `Nat.multichoose_eq` + `Nat.choose_pos`).

## Why it matters

The prior S4 ACT trap theorem `qtMultichoose_at_one_one_eq_zero` only recorded the *value* `0` for `k ≥ 1`; it never established that `0` is the **wrong** answer. This pair upgrades it to a sharp two-sided characterization: direct Field substitution agrees with the classical multichoose **iff `k = 0`**, proving the Path C (`RatFunc.eval`) migration is **necessary** for the `k ≥ 1` positive recovery, not merely convenient. This is a citable necessity result scoping the remaining open milestone.

## Axiom / sorry delta

- **0 new axioms, 0 sorries.** Theorem count 18 → 20.

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02` — ✔ (7745 jobs, 92s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)