### PR TITLE
research(schauder-oq03-oq01): S31 ACT — exists_per_j_thickening_witness helper

### DIFF
--- a/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
+++ b/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean
@@ -1016,6 +1016,58 @@ private lemma finsupport_nonempty {n : ℕ}
   rw [hempty, Finset.sum_empty] at hsum
   exact one_ne_zero hsum.symm
 
+/-- **S31 step (per-`j` thickening witness extraction, two-scale construction):**
+
+    Given a finset `T` of indices with `F j ⊆ Metric.thickening ε (F i_outer)`
+    for every `j ∈ T`, and a selection `ysel_in j ∈ F j`, extract a companion
+    selection `zsel j ∈ F i_outer` with
+    `dist (ysel_in j) (zsel j) < ε` for every `j ∈ T`.
+
+    This isolates the `Classical.choose`-over-finset step of the S30 PREP
+    two-scale construction (§3): each `ysel_in j ∈ F j ⊆ thickening ε (F i_outer)`
+    admits, by `Metric.mem_thickening_iff`, a point of `F i_outer` within `ε`
+    (in the ambient `EuclideanSpace` metric, via `Subtype.dist_eq`); the witness
+    function `zsel` selects one such point per `j`, using the identity as junk
+    value off `T` so that **no `Nonempty ↥S` hypothesis is required**.
+
+    With `zsel` in hand the eventual `approx_selection_exists_proof` body forms
+    the inner convex combination `z x = ∑ⱼ ρ j x • (zsel j) ∈ F i_outer` (via
+    `convex_combination_of_partition_in_S` applied to the convex image of
+    `F i_outer`) and bounds `dist (f x) (z x) < ε` term-by-term — the output-side
+    graph bound that S26→S27→S28 could not reach under the single-scale framing.
+
+    No new axiom is introduced; `axiom approx_selection_exists` (Axiom 2 above)
+    remains in the file unchanged. -/
+private lemma exists_per_j_thickening_witness {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n)))
+    (F : SetValuedMap (↥S) (↥S))
+    (i_outer : ↥S)
+    (ε : ℝ) (hε : 0 < ε)
+    (T : Finset ↥S)
+    (hT_in_U : ∀ j ∈ T, F j ⊆ Metric.thickening ε (F i_outer))
+    (ysel_in : ↥S → ↥S)
+    (hysel_in_F : ∀ j, ysel_in j ∈ F j) :
+    ∃ zsel : ↥S → ↥S,
+      (∀ j ∈ T, zsel j ∈ F i_outer) ∧
+      (∀ j ∈ T,
+        dist (Subtype.val (ysel_in j)) (Subtype.val (zsel j)) < ε) := by
+  classical
+  have hex : ∀ j ∈ T, ∃ z : ↥S, z ∈ F i_outer ∧
+      dist (Subtype.val (ysel_in j)) (Subtype.val z) < ε := by
+    intro j hj
+    have hmem : ysel_in j ∈ Metric.thickening ε (F i_outer) :=
+      hT_in_U j hj (hysel_in_F j)
+    rw [Metric.mem_thickening_iff] at hmem
+    obtain ⟨z, hz_mem, hz_dist⟩ := hmem
+    exact ⟨z, hz_mem, by rwa [Subtype.dist_eq] at hz_dist⟩
+  refine ⟨fun j => if hj : j ∈ T then (hex j hj).choose else j, ?_, ?_⟩
+  · intro j hj
+    simp only [dif_pos hj]
+    exact (hex j hj).choose_spec.1
+  · intro j hj
+    simp only [dif_pos hj]
+    exact (hex j hj).choose_spec.2
+
 /-- **S27 step (output-side graph-distance reduction, `dist (f x) (ysel i) < ε`
     half):**
 

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-12-s31-act-exists-per-j-thickening-witness.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-12-s31-act-exists-per-j-thickening-witness.md
@@ -1,0 +1,70 @@
+# S31 ACT — extract `exists_per_j_thickening_witness` helper
+
+**Agent**: researcher-2
+**Date**: 2026-06-12
+**Phase**: ACT (Lean edit)
+**File**: `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`
+**Build**: Docker-verified clean (`Proofs.SchauderFixedPointOQ03OQ01`, **3074 jobs**, ✔) at Mathlib pin `2df2f0150c…`.
+
+## What landed
+
+Implements the S31 ACT bound by S30 PREP §3 / §6: extract the per-`j`
+thickening-witness helper that isolates the `Classical.choose`-over-finset step
+of the two-scale construction.
+
+```lean
+private lemma exists_per_j_thickening_witness {n : ℕ}
+    (S : Set (EuclideanSpace ℝ (Fin n)))
+    (F : SetValuedMap (↥S) (↥S))
+    (i_outer : ↥S)
+    (ε : ℝ) (hε : 0 < ε)
+    (T : Finset ↥S)
+    (hT_in_U : ∀ j ∈ T, F j ⊆ Metric.thickening ε (F i_outer))
+    (ysel_in : ↥S → ↥S)
+    (hysel_in_F : ∀ j, ysel_in j ∈ F j) :
+    ∃ zsel : ↥S → ↥S,
+      (∀ j ∈ T, zsel j ∈ F i_outer) ∧
+      (∀ j ∈ T, dist (Subtype.val (ysel_in j)) (Subtype.val (zsel j)) < ε)
+```
+
+Inserted immediately after `finsupport_nonempty` (line ~1018), alongside the
+other finsupport helpers.
+
+## Proof
+
+For each `j ∈ T`: `ysel_in j ∈ F j ⊆ Metric.thickening ε (F i_outer)`, so
+`Metric.mem_thickening_iff` yields `z ∈ F i_outer` with subtype-metric
+`dist (ysel_in j) z < ε`; `Subtype.dist_eq` converts this to the ambient
+`EuclideanSpace` distance `dist (↑(ysel_in j)) (↑z) < ε`. This gives the
+pointwise existential `hex : ∀ j ∈ T, ∃ z, …`. The witness function is then
+`fun j => if hj : j ∈ T then (hex j hj).choose else j` — the **identity junk
+value** off `T` makes the total function `↥S → ↥S` without requiring
+`Nonempty ↥S` (relevant because the lemma is stated without `hS_ne`). The two
+conjuncts discharge by `dif_pos` + `Exists.choose_spec`.
+
+## Bearers
+
+- `Metric.mem_thickening_iff` (Mathlib, pinned SHA) — `x ∈ thickening δ E ↔ ∃ z ∈ E, dist x z < δ`.
+- `Subtype.dist_eq` — subtype metric agrees with the ambient metric on values.
+- `Exists.choose` / `Exists.choose_spec`, `dif_pos` — Lean core.
+
+No new imports. `hε` is carried in the signature per the S30 PREP §3
+paste-ready contract (the S32 two-scale chain passes it through uniformly),
+though the proof itself does not consume it.
+
+## Axiom / sorry delta
+
+- **0 new axioms, 0 new sorries.** File still carries exactly the 2 standing
+  axioms (`brouwer_unit_ball`, `approx_selection_exists`). `theoremCount`
+  18 → 19; `lineCount` ~1479 → ~1530.
+
+## Next steps (binds S32 ACT)
+
+Assemble the two-scale `approx_selection_exists_proof` body (S30 PREP §2): outer
+Lebesgue cover (`exists_lebesgue_subcover_for_uhc`, S29) + inner partition
+(`exists_partition_subordinate_to_uhc_cover`, S18d), build `f x` and
+`z x = ∑ⱼ ρ j x • zsel j ∈ F (i_outer x)` via
+`convex_combination_of_partition_in_S` (S18a) with **this** helper supplying
+`zsel`, and bound `dist (f x) (z x) < ε` term-by-term. That discharges
+`axiom approx_selection_exists` (→ `approx_selection_exists_proof`), leaving only
+`axiom brouwer_unit_ball`. Estimated ~80 LOC body (S30 PREP §3 estimate).


### PR DESCRIPTION
## Summary

**S31 ACT** for `schauder-fixed-point-oq-03-oq-01-incomplete-01` (eliminating `axiom approx_selection_exists`, the Cellina–Browder continuous selection for UHC convex-valued maps). Extracts the per-`j` thickening-witness helper bound by S30 PREP §3 — the `Classical.choose`-over-finset step of the **two-scale construction** that bypasses the S26→S27→S28 clustering wall.

```lean
private lemma exists_per_j_thickening_witness {n : ℕ}
    (S : Set (EuclideanSpace ℝ (Fin n))) (F : SetValuedMap (↥S) (↥S))
    (i_outer : ↥S) (ε : ℝ) (hε : 0 < ε) (T : Finset ↥S)
    (hT_in_U : ∀ j ∈ T, F j ⊆ Metric.thickening ε (F i_outer))
    (ysel_in : ↥S → ↥S) (hysel_in_F : ∀ j, ysel_in j ∈ F j) :
    ∃ zsel : ↥S → ↥S,
      (∀ j ∈ T, zsel j ∈ F i_outer) ∧
      (∀ j ∈ T, dist (Subtype.val (ysel_in j)) (Subtype.val (zsel j)) < ε)
```

Proof: per `j ∈ T`, `Metric.mem_thickening_iff` + `Subtype.dist_eq` give a point of `F i_outer` within `ε`; the witness function uses the identity as junk value off `T`, so **no `Nonempty ↥S` hypothesis is needed**.

## Why it matters

This supplies the `zsel` selector the eventual `approx_selection_exists_proof` body needs to build the inner convex combination `z x = ∑ⱼ ρ j x • zsel j ∈ F (i_outer x)` and bound the output-side graph distance `dist (f x) (z x) < ε` — the conjunct that the single-scale framing (S26/S27) provably could not reach. It isolates the trickiest sub-step so the S32 chain assembly is a clean sequence of helper invocations.

## Axiom / sorry delta

- **0 new axioms, 0 new sorries.** File still carries exactly `brouwer_unit_ball` + `approx_selection_exists`. theoremCount 18 → 19.

## Test plan

- [x] Docker build: `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01` — ✔ (3074 jobs) at pin `2df2f0150c…`

🤖 Generated with [Claude Code](https://claude.com/claude-code)