### PR TITLE
audit(buffons-needle-oq-02): re-audit — fix theoremCount 16→14

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1376,7 +1376,7 @@
       "auditCount": 6,
       "issues": [],
       "lastAudited": "2026-06-12T08:42:23Z",
-      "result": "clean"
+      "result": "issues-fixed"
     },
     "buffons-needle-oq-02-oq-01": {
       "auditCount": 6,

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1373,9 +1373,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T16:43:29Z",
+      "lastAudited": "2026-06-12T08:42:23Z",
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-01": {

--- a/src/data/proofs/buffons-needle-oq-02/meta.json
+++ b/src/data/proofs/buffons-needle-oq-02/meta.json
@@ -65,7 +65,7 @@
     "lineCount": 262,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 1
   },
   "overview": {
@@ -225,7 +225,7 @@
     "namespace": "BuffonsNeedleOQ02",
     "lineCount": 262,
     "axiomCount": 0,
-    "theoremCount": 16,
+    "theoremCount": 14,
     "definitionCount": 1,
     "path": "Proofs/BuffonsNeedleOQ02.lean",
     "sorries": 0


### PR DESCRIPTION
## Re-audit: buffons-needle-oq-02

6th audit of this proof (last audited 2026-05-03). Verified meta.json claims against `proofs/Proofs/BuffonsNeedleOQ02.lean`.

### Integrity checks
| Check | meta.json | Lean source | Result |
|-------|-----------|-------------|--------|
| sorries | 0 | 0 | ✅ |
| axiomCount | 0 | 0 (no `axiom`, no structure-encoded assumptions) | ✅ |
| True stubs | — | none | ✅ |
| badge | `mathlib` | core integral via Mathlib FTC; contributions correctly scoped | ✅ appropriate |
| lineCount | 262 | 262 | ✅ |
| **theoremCount** | **16** | **14** theorem/lemma decls (0 examples) | ❌ → fixed to 14 |

### Fix
- `meta.json`: corrected `theoremCount` 16 → 14 in both the `meta` and `leanFile` blocks (LOW severity — count overstatement, no credibility impact on status/badge/sorries).
- `audit-tracker.json`: recorded re-audit (auditCount 5→6), result `issues-fixed`.

All substantive claims (status `verified`, badge `mathlib`, 0 sorries, 0 axioms) accurately match the Lean source.

---
Gallery integrity audit.