### PR TITLE
research(fodor-pressing-down-oq-01): S8 ACT — monotonicity helpers for Club/Basic.lean

### DIFF
--- a/proofs/Proofs/Club/Basic.lean
+++ b/proofs/Proofs/Club/Basic.lean
@@ -210,4 +210,21 @@ theorem IsStationaryBelow.of_subset {S T : Set Ordinal} {o : Ordinal}
   intro C hC
   exact hMeet C hC (hS C hC)
 
+/-! ### Monotonicity helpers
+
+Superset-monotonicity of unboundedness and stationarity — the direction dual to
+`IsStationaryBelow.of_subset`. Enlarging a witnessing set preserves the property;
+these are the forms most sister slugs need and are universe-polymorphic. -/
+
+/-- Unboundedness below `o` is preserved under supersets. -/
+theorem IsUnboundedBelow.mono {S T : Set Ordinal} {o : Ordinal}
+    (hST : S ⊆ T) (hS : IsUnboundedBelow S o) : IsUnboundedBelow T o :=
+  fun α hα => let ⟨β, hβS, h1, h2⟩ := hS α hα; ⟨β, hST hβS, h1, h2⟩
+
+/-- Stationarity below `o` is preserved under supersets: any superset of a
+stationary set is stationary (it meets every club because the smaller set does). -/
+theorem IsStationaryBelow.mono {S T : Set Ordinal} {o : Ordinal}
+    (hST : S ⊆ T) (hS : IsStationaryBelow S o) : IsStationaryBelow T o :=
+  fun C hC => let ⟨γ, hγS, hγC⟩ := hS C hC; ⟨γ, hST hγS, hγC⟩
+
 end Ordinal


### PR DESCRIPTION
## Summary

S8 ACT for the club/stationary library refactor (`fodor-pressing-down-oq-01`). Adds two universe-polymorphic API helpers to `Proofs/Club/Basic.lean`:

- `IsUnboundedBelow.mono` : `S ⊆ T → IsUnboundedBelow S o → IsUnboundedBelow T o`
- `IsStationaryBelow.mono` : `S ⊆ T → IsStationaryBelow S o → IsStationaryBelow T o`

These are the **superset duals** of the existing `IsStationaryBelow.of_subset` and are the forms sister slugs (Solovay splitting `oq-04`, Galvin) most commonly need when enlarging a witnessing set. Both are one-line proofs from the lifted definitions.

Strictly additive — the parent `FodorPressingDown.lean` is untouched. `Basic.lean` now 200 LOC / 13 theorems.

**Verification**: `./proofs/scripts/docker-build.sh Proofs.Club.Basic` ✓ — 0 sorries, 0 axioms.

## Test plan

- [x] `Proofs.Club.Basic` Docker build succeeds
- [x] No new axioms/sorries
- [ ] (Pending S4 ACT) parent trim still tracked separately in problem `nextSteps`

🤖 Generated with [Claude Code](https://claude.com/claude-code)