### PR TITLE
research(minpoly-charpoly-oq-01): discharge weak form of jordan_normal_form_exists (sorry-free)

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ01.lean
@@ -90,9 +90,10 @@ The S1 OBSERVE iteration provided:
 * **`jordanBlock_diag_eq`** / **`jordanBlock_super_diag_eq`** —
   unconditional sanity lemmas for the diagonal entries (all `λ`) and
   super-diagonal entries (all `1`) of `jordanBlock K λ d`.
-* **`jordan_normal_form_exists`** — the **main JNF existence theorem
-  statement**, guarded by a single `sorry` that the four sub-OQs above
-  are intended to discharge.
+* **`jordan_normal_form_exists`** — the **weak (dimension-matching)
+  form** of the JNF existence theorem. As of S10 this is fully
+  discharged (constructive, sorry-free): see the theorem docstring. The
+  stronger *similarity* form remains the target of the four sub-OQs.
 
 The S2 iteration (this PR) adds the *third* case of the entry-wise
 classification, completing the case-by-case coverage of every
@@ -116,9 +117,12 @@ iteration (this PR) adds the `toFinset.card`-side refinement:
   characterises the "diagonalisable, simple spectrum" boundary of the
   JNF shape data.
 
-These lemmas do **not** discharge any of OQ-01-OQ-01..04. The single
-sorry on `jordan_normal_form_exists` is the entire JNF assembly. The
-contribution of S1+S2 is the resolution of the OQ at the strategy
+These lemmas do **not** discharge any of OQ-01-OQ-01..04. The entire
+JNF *similarity* assembly remains open (the load-bearing content of the
+four sub-OQs); only the weak dimension-matching form of
+`jordan_normal_form_exists` is proved (S10), so the file is now
+sorry-free. The contribution of S1+S2 is the resolution of the OQ at the
+strategy
 level (affirmative + 4-step roadmap + 1 identified Mathlib gap), the
 Lean-side surface for follow-on iterations, and a complete entry-wise
 API for the `jordanBlock` definition. Together the three entry-wise
@@ -145,7 +149,11 @@ upcoming OQ-01-OQ-01 charpoly identity will consume.
   `eigenvalueMultiset_card_eq_totalDim`; S4-E:
   `eigenvalueMultiset_toFinset_card_le_totalDim` +
   `_eq_totalDim_iff`)
-* [ ] Discharge `jordan_normal_form_exists` (sorry-guarded — deferred to sub-OQs)
+* [x] Discharge the **weak (dimension-matching) form** of
+  `jordan_normal_form_exists` (S10 — constructive, sorry-free; file now
+  fully machine-checked, 0 sorries, 0 axioms)
+* [ ] Full **similarity** form of the JNF theorem (similarity transform
+  `P`) — deferred to sub-OQs OQ-01-OQ-02..04
 
 ## Mathlib Dependencies
 
@@ -390,22 +398,41 @@ Chevalley + a local nilpotent-canonical-form construction (OQ-01-OQ-02).
 -/
 
 /--
-**The Jordan normal form theorem (statement, S1)**: every square matrix
-over an algebraically closed field is similar to a block-diagonal matrix
-of Jordan blocks. The full similarity assembly is deferred to
-OQ-01-OQ-02..04 (see module docstring).
+**JNF shape-dimension consistency (S10, weak form of the JNF theorem)**:
+for every square matrix over an algebraically closed field there exists a
+`JordanBlockShape` whose total dimension equals the matrix size.
+
+This is the *dimension-matching* necessary condition for a Jordan normal
+form: it asserts only that a shape of the correct total dimension exists,
+**not** that `M` is similar to the corresponding block-diagonal matrix.
+That stronger similarity claim — the genuine content of the JNF theorem —
+is the load-bearing target deferred to OQ-01-OQ-02..04 (see the module
+docstring and the sub-OQ table).
+
+Because the statement quantifies existentially over the shape *without*
+referencing `M`'s spectral data, it is discharged constructively: when
+`Fintype.card n = 0` the empty shape works; otherwise a single block of
+size `Fintype.card n` (eigenvalue `0`, chosen arbitrarily — the statement
+constrains only the dimension) witnesses it. No gen-eigenspace or
+Jordan-Chevalley machinery is required for *this* weak form; those enter
+only for the deferred similarity assembly.
 -/
 theorem jordan_normal_form_exists
     {K : Type*} [Field K] [IsAlgClosed K]
     {n : Type*} [DecidableEq n] [Fintype n]
     (M : Matrix n n K) :
     ∃ S : JordanBlockShape K, S.totalDim = Fintype.card n := by
-  -- The full statement (existence of a similarity transform) is the
-  -- target of OQ-01-OQ-04. The weak-form S1 statement above asserts
-  -- only existence of a shape with the correct total dimension, which
-  -- already requires the gen-eigenspace decomposition (#1, #2). This
-  -- is sorry-guarded in S1; sub-OQs OQ-01-OQ-01..04 discharge it.
-  sorry
+  rcases Nat.eq_zero_or_pos (Fintype.card n) with h | h
+  · -- Empty matrix: the empty shape has total dimension `0`.
+    exact ⟨⟨[], by intro _ hp; nomatch hp⟩, by
+      simp [JordanBlockShape.totalDim, h]⟩
+  · -- Nonempty: one block of size `Fintype.card n` with eigenvalue `0`.
+    refine ⟨⟨[(0, Fintype.card n)], ?_⟩, ?_⟩
+    · intro p hp
+      simp only [List.mem_singleton] at hp
+      subst hp
+      exact h
+    · simp [JordanBlockShape.totalDim]
 
 /-- Sanity check: `JordanBlockShape.totalDim` of the empty shape is `0`.
 


### PR DESCRIPTION
## Summary

`MinpolyCharpolyOQ01.lean` (open question *minpoly-charpoly-oq-01*: "Can the Jordan normal form theorem be formalized in Lean 4 using this infrastructure?") carried a single `sorry` on `jordan_normal_form_exists`. This PR discharges it, making the file **0 sorries / 0 axioms**.

The key observation: the *stated* theorem is much weaker than its old docstring implied. It asserts only

```lean
∃ S : JordanBlockShape K, S.totalDim = Fintype.card n
```

— the existence of a Jordan-block *shape* whose total dimension matches the matrix size. This is a necessary dimension-matching consistency condition; it does **not** reference `M`'s spectral data and therefore needs none of the gen-eigenspace / Jordan–Chevalley machinery the prior comment claimed. It is proved constructively:

- `Fintype.card n = 0` → the empty shape (`totalDim = 0`);
- otherwise → a single block of size `Fintype.card n` (eigenvalue `0`, chosen arbitrarily since only the dimension is constrained).

## Honesty / scope

The genuine content of the JNF theorem — that `M` is *similar* to the block-diagonal matrix — remains open and is still the load-bearing target of sub-OQs OQ-01-OQ-02..04. Docstrings (module header, theorem doc, status checklist) are corrected to scope the claim to the **weak dimension-matching form** and to avoid overclaiming the full similarity result.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ01` → **Build succeeded** (3081 jobs).
- Only warning: unused parameter `M` (intentional — kept to align the signature with the eventual full theorem).
- No `axiom` declarations, no structure-encoded assumptions, no proof-term `sorry`.

## Test plan

- [x] Docker build passes
- [x] `grep` confirms 0 `axiom` / 0 proof `sorry`
- [x] Diff isolated to a single file

🤖 Generated with [Claude Code](https://claude.com/claude-code)