### PR TITLE
agents: per-slot researcher model pin (RESEARCHER_${slot}_CLAUDE_MODEL)

### DIFF
--- a/scripts/lean/launch.sh
+++ b/scripts/lean/launch.sh
@@ -1609,9 +1609,15 @@ _do_respawn_agent() {
             sleep 0.2
             tmux send-keys -t "$session" "export CLAUDE_TIMEOUT=14400" Enter
             sleep 0.2
-            # Honour RESEARCHER_CLAUDE_MODEL (per-role) > CLAUDE_MODEL (global),
-            # mirroring initial-start in parallel-research.sh
-            local researcher_model="${RESEARCHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+            # Model resolution chain (mirroring initial-start in parallel-research.sh):
+            #   1. RESEARCHER_${slot}_CLAUDE_MODEL  — per-slot pin survives respawn
+            #   2. RESEARCHER_CLAUDE_MODEL          — per-role override (whole pool)
+            #   3. CLAUDE_MODEL                      — global override
+            #   4. claude-opus-4-8                   — wrapper default
+            # The per-slot pin only works if the daemon's own shell env has it
+            # exported; otherwise the respawn falls through to the pool default.
+            local slot_model_var="RESEARCHER_${agent_num}_CLAUDE_MODEL"
+            local researcher_model="${!slot_model_var:-${RESEARCHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}}"
             tmux send-keys -t "$session" "export CLAUDE_MODEL='$researcher_model'" Enter
             sleep 0.2
             local prompt="You are researcher-$agent_num. Read $repo_root/$prompt_file for your instructions, then start the research workflow."

--- a/scripts/research/parallel-research.sh
+++ b/scripts/research/parallel-research.sh
@@ -230,11 +230,17 @@ launch_agent() {
     tmux kill-session -t "$session_name" 2>/dev/null || true
 
     # Launch in tmux with resilient wrapper for error handling.
-    # Per-role model override: set RESEARCHER_CLAUDE_MODEL to A/B a different
-    # model (e.g. claude-fable-5) without affecting other agent roles. Falls
-    # through to the global CLAUDE_MODEL default in claude-wrapper.sh.
+    # Model resolution chain (first set wins):
+    #   1. RESEARCHER_${slot}_CLAUDE_MODEL  — per-slot pin (e.g. RESEARCHER_1_CLAUDE_MODEL=claude-fable-5)
+    #   2. RESEARCHER_CLAUDE_MODEL          — per-role override (whole pool)
+    #   3. CLAUDE_MODEL                      — global override
+    #   4. claude-opus-4-8                   — wrapper default
+    # Per-slot lets one researcher A/B a different model while peers stay on
+    # the pool default. The daemon's respawn path in scripts/lean/launch.sh
+    # honours the same chain so respawns preserve the pin.
     local wrapper_script="$REPO_ROOT/scripts/agents/claude-wrapper.sh"
-    local researcher_model="${RESEARCHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}"
+    local slot_model_var="RESEARCHER_${agent_num}_CLAUDE_MODEL"
+    local researcher_model="${!slot_model_var:-${RESEARCHER_CLAUDE_MODEL:-${CLAUDE_MODEL:-claude-opus-4-8}}}"
     tmux new-session -d -s "$session_name" -c "$worktree_path" \
         "ENHANCER_ID=researcher-$agent_num REPO_ROOT=$REPO_ROOT CLAUDE_TIMEOUT=14400 CLAUDE_MODEL=$researcher_model $wrapper_script --daemon --prompt 'You are researcher-$agent_num. Read $prompt_file for your instructions, then start the research workflow.' --log '$log_file'"
 


### PR DESCRIPTION
## Summary

Extends PR #22854's per-role knob with a **per-slot** variant so a single researcher can A/B a different model while peers stay on the pool default — and, critically, so the pin survives daemon respawn.

## Resolution chain

| Priority | Variable | Use case |
|---|---|---|
| 1 | `RESEARCHER_${slot}_CLAUDE_MODEL` | Per-slot pin (e.g. `RESEARCHER_1_CLAUDE_MODEL=claude-fable-5`) |
| 2 | `RESEARCHER_CLAUDE_MODEL` | Per-role override (whole researcher pool) |
| 3 | `CLAUDE_MODEL` | Global override |
| 4 | `claude-opus-4-8` | Wrapper default |

Applied in two places:
- `scripts/research/parallel-research.sh` initial-start (`launch_agent`)
- `scripts/lean/launch.sh` `_do_respawn_agent` / researcher case

## Why

PR #22854 added `RESEARCHER_CLAUDE_MODEL` but the daemon's respawn reads it from the daemon's own shell, not the agent's. So a per-slot pin set in an ad-hoc env (e.g. `RESEARCHER_CLAUDE_MODEL=claude-fable-5 ./parallel-research.sh --slot 1`) gets lost the first time the daemon respawns that slot.

Today's Fable 5 vs Opus 4.8 A/B ended that way after ~6 hours when the daemon's researcher target scaled to 10 and researcher-1 respawned to Opus. With per-slot vars in the daemon's environment:

```bash
export RESEARCHER_1_CLAUDE_MODEL=claude-fable-5
./scripts/lean/launch.sh daemon --researcher 10
```

slot 1 stays on Fable across all respawns; slots 2–10 get the default.

## Implementation note

Uses bash indirect expansion (`${!var:-default}`), requires bash 4+. The lean engine already requires it.

## Test plan

- [x] `bash -n` clean on both files
- [x] `shellcheck --severity=warning` shows no new findings (3 pre-existing SC2034 warnings on launch.sh are unrelated and from before #22854)
- [x] Resolution chain verified by direct bash run:
  | env | slot 1 | slot 2 |
  |---|---|---|
  | `RESEARCHER_1_CLAUDE_MODEL=claude-fable-5` | claude-fable-5 ✅ | claude-opus-4-8 ✅ |
  | + `RESEARCHER_CLAUDE_MODEL=claude-sonnet-4-6` | claude-fable-5 ✅ (slot pin wins) | claude-sonnet-4-6 ✅ |
  | unset | claude-opus-4-8 | claude-opus-4-8 |
- [ ] Manual smoke: start daemon with `RESEARCHER_1_CLAUDE_MODEL=claude-fable-5` exported, kill researcher-1 tmux session, watch daemon respawn — should land on Fable

🤖 Generated with [Claude Code](https://claude.com/claude-code)