### PR TITLE
research(angle-trisection-oq-02-oq-01-oq-01-oq-01): remove false axiom — file now axiom-free

### DIFF
--- a/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean
+++ b/proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean
@@ -112,7 +112,7 @@ theorem galois_2group_implies_degree_is_pow2_sep {F : Type*} [Field F]
   exact AngleTrisectionOQ01.dvd_pow_two_is_pow_two _ n hpos hdvd
 
 /-!
-## Part IV: The Inseparable Obstruction
+## Part IV: The Inseparable Obstruction (axiom-free)
 
 When separability fails, the divisibility natDegree(p) ∣ |Gal(p)| can fail.
 
@@ -126,38 +126,79 @@ This shows separability is NOT just a proof artifact — it is necessary for the
 The CharZero hypothesis in the original theorem was doing real mathematical work
 (ensuring all irreducibles are separable). Our generalization identifies separability
 as the exact hypothesis needed.
+
+**Integrity history**: an earlier revision encoded the obstruction via an axiom
+`insep_gal_trivial` asserting "inseparable irreducible ⇒ |Gal| = 1". That axiom is
+**mathematically false** (refuted in the OQ-01 descendant by `X⁴ + X² + a` over `F₂(a)`,
+which has |Gal| = 2). It has now been **deleted** and replaced by the honest,
+axiom-free `gal_card_one_of_purelyInseparable_splitting` (purely-inseparable *splitting
+field* hypothesis) and its consequence
+`natDeg_notDvd_gal_of_purelyInseparable_splitting`. The classical `X^p - t` example
+satisfies the purely-inseparable-splitting-field hypothesis, so the obstruction it
+illustrates is fully covered by the axiom-free theorem.
 -/
 
-/-- **WARNING — this axiom is MATHEMATICALLY FALSE as stated.**
+/-- In characteristic `p`, `(a - b) ^ (p ^ n) = a ^ (p ^ n) - b ^ (p ^ n)` — the iterated
+    Frobenius `x ↦ x ^ (p ^ n)` is a ring hom, so it commutes with subtraction. Ported from
+    the OQ-01 descendant (which imports this file and so cannot be imported here). -/
+lemma sub_pow_char_pow_eq {K : Type*} [CommRing K] {p : ℕ} [CharP K p] [hp : Fact p.Prime]
+    (a b : K) (n : ℕ) : (a - b) ^ p ^ n = a ^ p ^ n - b ^ p ^ n := by
+  simpa [iterateFrobenius_def] using map_sub (iterateFrobenius K p n) a b
 
-    The intended claim — "in char p, every inseparable irreducible f has |Gal(f)| = 1" —
-    fails whenever f = g(X^p) for g a separable irreducible of degree ≥ 2. In that case
-    f is inseparable irreducible but Gal(f) ≅ Gal(g) can be nontrivial.
+/-- A purely inseparable F-algebra automorphism of a field `K` is the identity.
 
-    **Explicit counterexample** (see `AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`):
-    over F = F₂(a), the polynomial f = X⁴ + X² + a is irreducible and inseparable
-    (f' = 0 in char 2), yet |Gal(f)| = 2 via the Artin-Schreier automorphism
-    α^{1/2} ↦ α^{1/2} + 1.
+    Each `x ∈ K` satisfies `x ^ p ^ n = algebraMap F K c` for some `c : F` and `n`
+    (purely-inseparable lift); `σ` fixes that element, so `(σ x - x) ^ p ^ n = 0` by the
+    char-`p` freshman's dream, and `K` being a field forces `σ x = x`.
 
-    **Correct theorem** (proved without axioms in the OQ-01 descendant file):
-    `gal_card_one_of_purelyInseparable_splitting` — if `f.SplittingField` is purely
-    inseparable over F, then |Gal(f)| = 1. The honest hypothesis is purely-inseparable
-    splitting field, NOT mere inseparability of f.
+    Ported from the OQ-01 descendant (`AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`), which
+    cannot be imported here (it imports this file). -/
+theorem algEquiv_eq_refl_of_isPurelyInseparable {F K : Type*} [Field F] [Field K]
+    [Algebra F K] {p : ℕ} [CharP K p] [hp : Fact p.Prime]
+    [IsPurelyInseparable F K] (σ : K ≃ₐ[F] K) :
+    σ = (AlgEquiv.refl : K ≃ₐ[F] K) := by
+  ext x
+  show σ x = x
+  haveI hF_p : CharP F p := (Algebra.charP_iff F K p).mpr inferInstance
+  obtain ⟨n, c, hc⟩ : ∃ n : ℕ, ∃ c : F, algebraMap F K c = x ^ p ^ n := by
+    obtain ⟨n, hn⟩ := IsPurelyInseparable.pow_mem F p x
+    obtain ⟨c, hc⟩ := hn
+    exact ⟨n, c, hc⟩
+  have hfixed : σ (x ^ p ^ n) = x ^ p ^ n := by
+    rw [← hc]; exact σ.commutes c
+  have hpow : σ x ^ p ^ n = x ^ p ^ n := by rw [← map_pow σ x, hfixed]
+  have hzero : (σ x - x) ^ p ^ n = 0 := by
+    rw [sub_pow_char_pow_eq (σ x) x n, hpow, sub_self]
+  have hne : p ^ n ≠ 0 := pow_ne_zero _ (Nat.Prime.pos hp.out).ne'
+  exact sub_eq_zero.mp (pow_eq_zero_iff hne |>.mp hzero)
 
-    This axiom is **retained only as a placeholder** so the downstream consequence
-    `natDeg_notDvd_gal_of_insep` still type-checks. Its statement does not reflect
-    a true mathematical fact; the descendant file `insep_gal_trivial_refuted` formally
-    exhibits the refutation. -/
-axiom insep_gal_trivial {F : Type*} [Field F] {p : ℕ} [CharP F p] [hp : Fact p.Prime]
-    {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable) :
-    Nat.card f.Gal = 1
+/-- **Correct replacement for the (now-deleted) false axiom `insep_gal_trivial`.**
 
-/-- Consequence: for an inseparable irreducible of degree > 1, natDegree ∤ |Gal|. -/
-theorem natDeg_notDvd_gal_of_insep {F : Type*} [Field F] {p : ℕ} [CharP F p]
-    [hp : Fact p.Prime] {f : F[X]} (hf_irr : Irreducible f) (hf_insep : ¬f.Separable)
-    (hf_deg : 1 < f.natDegree) :
+    If `f.SplittingField` is purely inseparable over `F`, then `|Gal(f)| = 1`. The honest
+    hypothesis is a *purely-inseparable splitting field*, NOT mere inseparability of `f`:
+    the naive "inseparable irreducible ⇒ |Gal| = 1" claim is false (e.g. `X⁴ + X² + a`
+    over `F₂(a)` is irreducible and inseparable yet has `|Gal| = 2` via the Artin–Schreier
+    automorphism `α^{1/2} ↦ α^{1/2} + 1`; see `insep_gal_trivial_refuted` in the OQ-01
+    descendant). Proved here without axioms by porting the descendant's argument. -/
+theorem gal_card_one_of_purelyInseparable_splitting {F : Type*} [Field F]
+    {p : ℕ} [CharP F p] [hp : Fact p.Prime]
+    (f : F[X]) [hK : IsPurelyInseparable F f.SplittingField] :
+    Nat.card f.Gal = 1 := by
+  haveI : CharP f.SplittingField p :=
+    (Algebra.charP_iff F f.SplittingField p).mp inferInstance
+  rw [Nat.card_eq_one_iff_unique]
+  refine ⟨⟨fun σ τ => (algEquiv_eq_refl_of_isPurelyInseparable σ).trans
+                      (algEquiv_eq_refl_of_isPurelyInseparable τ).symm⟩,
+          ⟨(AlgEquiv.refl : f.SplittingField ≃ₐ[F] f.SplittingField)⟩⟩
+
+/-- Honest consequence (replacing the false-axiom-backed `natDeg_notDvd_gal_of_insep`):
+    for `f` of degree > 1 with purely-inseparable splitting field, `natDegree ∤ |Gal|`
+    since `|Gal| = 1`. -/
+theorem natDeg_notDvd_gal_of_purelyInseparable_splitting {F : Type*} [Field F] {p : ℕ}
+    [CharP F p] [hp : Fact p.Prime] (f : F[X])
+    [IsPurelyInseparable F f.SplittingField] (hf_deg : 1 < f.natDegree) :
     ¬(f.natDegree ∣ Nat.card f.Gal) := by
-  rw [insep_gal_trivial hf_irr hf_insep]
+  rw [gal_card_one_of_purelyInseparable_splitting f]
   intro h
   have : f.natDegree ≤ 1 := Nat.le_of_dvd Nat.one_pos h
   omega
@@ -171,27 +212,26 @@ theorem natDeg_notDvd_gal_of_insep {F : Type*} [Field F] {p : ℕ} [CharP F p]
 | `natDegree_dvd_card_gal_charZero` | Irreducible, CharZero | natDegree ∣ |Gal| |
 | `galois_2group_implies_degree_pow2_sep` | Irred, Sep, 2-group Gal | natDegree ∣ 2^n |
 | `galois_2group_implies_degree_is_pow2_sep` | Irred, Sep, 2-group Gal | natDegree = 2^k |
-| `natDeg_notDvd_gal_of_insep` | Irred, Insep, degree > 1 | natDegree ∤ |Gal| |
+| `sub_pow_char_pow_eq` | char `p` | `(a-b)^(p^n) = a^(p^n) - b^(p^n)` |
+| `algEquiv_eq_refl_of_isPurelyInseparable` | purely insep `F ≤ K` | every `σ : K ≃ₐ[F] K` is `refl` |
+| `gal_card_one_of_purelyInseparable_splitting` | purely insep splitting field | |Gal| = 1 |
+| `natDeg_notDvd_gal_of_purelyInseparable_splitting` | purely insep splitting, degree > 1 | natDegree ∤ |Gal| |
 
-Theorems proved: 5 (0 sorries)
-Axioms: 1 (`insep_gal_trivial` — **mathematically FALSE as stated**; see warning on the
-        axiom declaration. Retained as a placeholder pending S2 ACT migration to the
-        purely-inseparable-splitting-field hypothesis proved in the OQ-01 descendant.)
+Theorems/lemmas proved: 8 (0 sorries)
+Axioms: 0
 
-## Integrity Note (S2 STATE-SYNC 2026-06-09)
+## Integrity Note (S3 ACT 2026-06-12 — false axiom removed)
 
-The axiom `insep_gal_trivial` was originally introduced as "documented but unformalized."
-The OQ-01 descendant file (`AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`) subsequently proved
-the axiom is **false** (X⁴+X²+a over F₂(a) has |Gal|=2, not 1) and supplied the correct
-replacement `gal_card_one_of_purelyInseparable_splitting` (0 axioms, 0 sorries). The
-correct hypothesis is purely-inseparable splitting field, not mere inseparability.
+The axiom `insep_gal_trivial` ("inseparable irreducible ⇒ |Gal| = 1") was
+**mathematically false** (the OQ-01 descendant `AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`
+refuted it: `X⁴+X²+a` over `F₂(a)` has |Gal|=2). It had been retained as a placeholder.
 
-The downstream theorem `natDeg_notDvd_gal_of_insep` in this file inherits the falsity of
-its hypothesis chain. A future ACT iteration should either (a) replace this axiom with
-the correct theorem and weaken `natDeg_notDvd_gal_of_insep` accordingly, or (b) lift the
-correct theorem and downstream consequence into this file from the descendant.
-
-This iteration is doc-only — no Lean bodies change; axiomCount and theoremCount unchanged.
+This iteration **deletes the false axiom** and its false-axiom-backed consequence
+`natDeg_notDvd_gal_of_insep`, porting the descendant's axiom-free
+`algEquiv_eq_refl_of_isPurelyInseparable` and `gal_card_one_of_purelyInseparable_splitting`
+into this file (the descendant cannot be imported — it imports this file) and restating
+the obstruction honestly as `natDeg_notDvd_gal_of_purelyInseparable_splitting`. The file
+is now **axiom-free** (axiomCount 1 → 0, 0 sorries).
 -/
 
 end AngleTrisectionOQ02OQ01OQ01OQ01

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/sessions/2026-06-12-s3-act-remove-false-axiom.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/sessions/2026-06-12-s3-act-remove-false-axiom.md
@@ -1,0 +1,79 @@
+# S3 ACT — remove the false axiom `insep_gal_trivial` (axiom-free)
+
+**Date**: 2026-06-12
+**Researcher**: researcher-2
+**Mode**: ACT (Lean bodies change; Docker build-verified)
+**Phase**: S3 ACT
+**Branch**: `research/erdos-735-oq-04-s6a-tetrahedron-<ts>` (this session bundled two slugs;
+see also the erdos-735-oq-04 S6a scaffold commit)
+
+## Problem
+
+`proofs/Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean` carried **1 axiom**,
+`insep_gal_trivial` ("char p, inseparable irreducible ⇒ |Gal| = 1"), which is
+**mathematically FALSE**: the OQ-01 descendant
+(`AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`) refutes it with `f = X⁴ + X² + a`
+over `F₂(a)` — irreducible, inseparable, yet `|Gal(f)| = 2` via the
+Artin–Schreier automorphism `α^{1/2} ↦ α^{1/2} + 1`. The axiom had been retained
+as a placeholder so the consequence `natDeg_notDvd_gal_of_insep` type-checked.
+The S2 STATE-SYNC (2026-06-09) flagged this and named the removal as the next ACT.
+
+## What this iteration did
+
+Deleted the false axiom and its false-axiom-backed consequence, and replaced them
+with the honest, axiom-free obstruction — **ported** from the descendant (which
+imports this file and so cannot be imported back without a cycle):
+
+| Declaration | Role |
+|---|---|
+| `sub_pow_char_pow_eq` | char-`p` Frobenius identity `(a-b)^(p^n)=a^(p^n)-b^(p^n)` |
+| `algEquiv_eq_refl_of_isPurelyInseparable` | every `σ : K ≃ₐ[F] K` over a purely inseparable `K` is `refl` |
+| `gal_card_one_of_purelyInseparable_splitting` | purely-inseparable splitting field ⇒ `|Gal| = 1` |
+| `natDeg_notDvd_gal_of_purelyInseparable_splitting` | honest non-divisibility for degree > 1 |
+
+The correct hypothesis is **purely-inseparable splitting field**, not mere
+inseparability of `f` — exactly the distinction the descendant's counterexample
+forces.
+
+## Verification
+
+- `./proofs/scripts/docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ01OQ01` →
+  clean, **7745 jobs**, 0 warnings.
+- `./proofs/scripts/docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01`
+  (the importing descendant) → clean, **7746 jobs**; only pre-existing
+  `unusedSimpArgs` linter warnings (not introduced here). No regression.
+- Confirmed no other file references the deleted symbols in code
+  (`grep` for `insep_gal_trivial` / `natDeg_notDvd_gal_of_insep` → only this file's
+  code + docstring mentions in the descendant).
+
+## Gallery / docs
+
+- `meta.json`: `status: axiomatized → verified`, `badge: axiom → verified`,
+  `axiomCount: 1 → 0`, `theoremCount: 5 → 8`, `lineCount: 197 → 237`;
+  `assumptions`, `proofStrategy`, the Part-IV and summary-table annotations,
+  the open-questions list, and the child cross-reference all corrected to the
+  axiom-free reality.
+- `state.md`: phase → S3 ACT, iteration 3 → 4, new section.
+
+## Counts
+
+- Lean: +3 theorems, +1 lemma; −1 axiom; −1 false theorem; 0 sorries.
+- File: `axiomCount 1 → 0`, `theoremCount 5 → 8`, `lineCount 197 → 237`.
+
+## Why this matters
+
+Removing a **known-false axiom** is a direct integrity win: the slug moves from
+`axiomatized` (with a false assumption) to `verified` (fully machine-checked, no
+assumptions). The mathematical content (separability is the exact hypothesis for
+`natDegree ∣ |Gal|`; the inseparable obstruction needs a purely-inseparable
+*splitting field*) is now faithfully formalized without any axiom.
+
+## Follow-up
+
+- The descendant `…OQ01` still re-proves `sub_pow_char_pow_eq`,
+  `algEquiv_eq_refl_of_isPurelyInseparable`, and
+  `gal_card_one_of_purelyInseparable_splitting` locally; it could be simplified to
+  reuse this file's now-exported versions (separate slug's concern).
+- The descendant still contains `axiom counterexample_gal_card` (the |Gal|=2
+  Artin–Schreier fact) — that is the descendant slug's open obligation, untouched
+  here.

--- a/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/angle-trisection-oq-02-oq-01-oq-01-oq-01/state.md
@@ -1,8 +1,39 @@
 # Current State
 
-**Phase**: STATE-SYNC (S2 STATE-SYNC shipped 2026-06-09 by researcher-5)
-**Since**: 2026-04-26 (NEW stub) → 2026-06-05 (S1 OBSERVE) → 2026-06-09 (S2 STATE-SYNC)
-**Iteration**: 3
+**Phase**: S3 ACT — false axiom removed; file now axiom-free (researcher-2, 2026-06-12), Docker build-verified
+**Since**: 2026-04-26 (NEW stub) → 2026-06-05 (S1 OBSERVE) → 2026-06-09 (S2 STATE-SYNC) → 2026-06-12 (S3 ACT axiom removal)
+**Iteration**: 4
+
+## S3 ACT (2026-06-12, researcher-2) — delete the false axiom `insep_gal_trivial`
+
+**Mode**: ACT (Lean bodies change; Docker build-verified).
+
+**Outcome**: The file `AngleTrisectionOQ02OQ01OQ01OQ01.lean` is now **axiom-free**
+(`axiomCount: 1 → 0`, 0 sorries). The mathematically-false axiom `insep_gal_trivial`
+("inseparable irreducible ⇒ |Gal| = 1") and its false-axiom-backed consequence
+`natDeg_notDvd_gal_of_insep` were **deleted** and replaced by the honest, axiom-free
+obstruction:
+
+- `sub_pow_char_pow_eq` — char-`p` Frobenius identity `(a-b)^(p^n) = a^(p^n) - b^(p^n)`.
+- `algEquiv_eq_refl_of_isPurelyInseparable` — every F-automorphism of a purely
+  inseparable extension is the identity.
+- `gal_card_one_of_purelyInseparable_splitting` — purely-inseparable splitting field
+  ⇒ |Gal| = 1 (the correct replacement; the descendant's counterexample `X⁴+X²+a`
+  over `F₂(a)` shows mere inseparability of `f` does NOT suffice).
+- `natDeg_notDvd_gal_of_purelyInseparable_splitting` — the honest non-divisibility.
+
+These three theorems + the helper lemma were **ported** from the OQ-01 descendant
+`AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean`, which cannot be imported here (it imports
+this file → cyclic). The descendant was rebuilt to confirm no regression.
+
+**Build**: `docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ01OQ01` clean (7745 jobs);
+descendant `…OQ01` also clean (7746 jobs, pre-existing unusedSimpArgs warnings only).
+
+**Gallery**: `meta.json` updated — `status: axiomatized → verified`, `badge: axiom →
+verified`, `axiomCount: 1 → 0`, `theoremCount: 5 → 8`, `lineCount: 197 → 237`,
+`assumptions` rewritten, stale annotations corrected.
+
+**Lean delta**: +3 theorems +1 lemma; −1 axiom; −1 (false) theorem; 0 sorries.
 
 ## S2 STATE-SYNC (2026-06-09, researcher-5) — integrity correction for `insep_gal_trivial`
 

--- a/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/angle-trisection-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -7,7 +7,7 @@
     "author": "Lean Genius Research",
     "sourceUrl": "",
     "date": "2026",
-    "status": "axiomatized",
+    "status": "verified",
     "proofRepoPath": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean",
     "tags": [
       "algebra",
@@ -16,7 +16,7 @@
       "separability",
       "characteristic-p"
     ],
-    "badge": "axiom",
+    "badge": "verified",
     "sorries": 0,
     "dateAdded": "2026-05-04",
     "mathlibDependencies": [
@@ -41,20 +41,20 @@
       "Identifies separability as the exact necessary condition \u2014 not CharZero",
       "galois_2group_implies_degree_pow2_sep: 2-group Galois criterion for separable polynomials over any field",
       "galois_2group_implies_degree_is_pow2_sep: degree = 2^k for separable polynomials over any field",
-      "Axiomatized inseparable counterexample: insep_gal_trivial and natDeg_notDvd_gal_of_insep"
+      "Axiom-free inseparable obstruction: gal_card_one_of_purelyInseparable_splitting and natDeg_notDvd_gal_of_purelyInseparable_splitting (replacing the deleted false axiom insep_gal_trivial)"
     ],
-    "axiomCount": 1,
-    "assumptions": "One axiom: insep_gal_trivial — **the axiom as stated is MATHEMATICALLY FALSE**. The OQ-01 descendant file (AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean) proves the counterexample f = X⁴ + X² + a over F₂(a): irreducible, inseparable, yet |Gal(f)| = 2 (not 1) via the Artin-Schreier automorphism α^{1/2} ↦ α^{1/2} + 1. The correct theorem requires `IsPurelyInseparable F f.SplittingField` (not mere inseparability of f); see `gal_card_one_of_purelyInseparable_splitting` in the descendant (proved without axioms or sorries). The axiom is retained in this file only so the downstream consequence `natDeg_notDvd_gal_of_insep` type-checks; a future ACT iteration will replace it. The four other theorems (`natDegree_dvd_card_gal_of_sep`, `natDegree_dvd_card_gal_charZero`, `galois_2group_implies_degree_pow2_sep`, `galois_2group_implies_degree_is_pow2_sep`) are axiom-free and unaffected.",
-    "lineCount": 197,
-    "theoremCount": 5,
+    "axiomCount": 0,
+    "assumptions": "None — the file is axiom-free (0 axioms, 0 sorries). A prior revision contained the axiom `insep_gal_trivial` (\"inseparable irreducible ⇒ |Gal| = 1\"), which is MATHEMATICALLY FALSE (refuted in the OQ-01 descendant AngleTrisectionOQ02OQ01OQ01OQ01OQ01.lean by f = X⁴ + X² + a over F₂(a): irreducible, inseparable, yet |Gal(f)| = 2 via the Artin-Schreier automorphism α^{1/2} ↦ α^{1/2} + 1). That axiom and its false-axiom-backed consequence `natDeg_notDvd_gal_of_insep` have been DELETED. The obstruction is now stated honestly and proved without axioms: `gal_card_one_of_purelyInseparable_splitting` (hypothesis: purely-inseparable splitting field, the correct condition) and `natDeg_notDvd_gal_of_purelyInseparable_splitting`, ported from the descendant (which imports this file and so cannot be imported back).",
+    "lineCount": 237,
+    "theoremCount": 8,
     "definitionCount": 0
   },
   "leanFile": {
     "path": "Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean",
-    "axiomCount": 1,
-    "theoremCount": 5,
+    "axiomCount": 0,
+    "theoremCount": 8,
     "definitionCount": 0,
-    "lineCount": 197,
+    "lineCount": 237,
     "sorries": 0
   },
   "overview": {
@@ -69,7 +69,7 @@
       "**Constructibility connection**: The 2-group Galois criterion (Part III) is the algebraic core of the classical Wantzel 1837 impossibility theorems for compass-and-straightedge constructions: a real number $\\alpha$ is constructible iff its Galois closure has degree $2^k$. By extending the criterion to any characteristic for separable polynomials, this entry makes the constructibility framework available over the rationals' completions ($\\mathbb{Q}_p$), function fields ($\\mathbb{F}_q(t)$), and other classical objects of arithmetic geometry — settings where 'constructibility' has analogues in moduli problems and ruler-compass constructions over local rings.",
       "**Tower law is characteristic-free**: The proof of `natDegree_dvd_card_gal_of_sep` uses *only* the multiplicativity of the field-extension degree $[E:F] = [E:K][K:F]$ and the identity $[F(\\alpha):F] = \\deg(\\text{minpoly}(F, \\alpha))$. Both are valid in any characteristic without separability. The *only* place separability enters is the rewrite $|\\text{Gal}(p)| = [E:F]$ (where $E$ is the splitting field) — this requires `Gal.card_of_separable` because in the inseparable case $|\\text{Gal}(p)|$ can be strictly less than $[E:F]$. Cleanly isolating this single use of separability is what makes the generalization possible."
     ],
-    "proofStrategy": "1. **Rewrite |Gal(p)| via Gal.card_of_separable**: Apply `Gal.card_of_separable p_sep` to convert |Gal(p)| to Module.finrank F (SplittingField p). This is the only step that uses any characteristic information \u2014 it requires p.Separable, not CharZero.\n2. **Pick a root \u03b1**: Obtain \u03b1 : SplittingField p as a root of p (which is nonconstant by irreducibility). Then SplittingField p = F(\u03b1) as intermediate fields.\n3. **Apply the tower law**: [SplittingField p : F] = [SplittingField p : F(\u03b1)] \u00b7 [F(\u03b1) : F]. The factor [F(\u03b1) : F] equals natDegree(minpoly F \u03b1) = natDegree(p) (since p is the minimal polynomial of \u03b1 over F by irreducibility).\n4. **Conclude divisibility**: natDegree(p) | [SplittingField p : F] = |Gal(p)|.\n5. **CharZero corollary**: Over CharZero, `Irreducible.separable` supplies p.Separable for free.\n6. **Counterexample**: Axiomatize that inseparable irreducibles have trivial Galois groups (|Gal| = 1), then natDegree(p) > 1 gives natDegree \u2224 |Gal|."
+    "proofStrategy": "1. **Rewrite |Gal(p)| via Gal.card_of_separable**: Apply `Gal.card_of_separable p_sep` to convert |Gal(p)| to Module.finrank F (SplittingField p). This is the only step that uses any characteristic information \u2014 it requires p.Separable, not CharZero.\n2. **Pick a root \u03b1**: Obtain \u03b1 : SplittingField p as a root of p (which is nonconstant by irreducibility). Then SplittingField p = F(\u03b1) as intermediate fields.\n3. **Apply the tower law**: [SplittingField p : F] = [SplittingField p : F(\u03b1)] \u00b7 [F(\u03b1) : F]. The factor [F(\u03b1) : F] equals natDegree(minpoly F \u03b1) = natDegree(p) (since p is the minimal polynomial of \u03b1 over F by irreducibility).\n4. **Conclude divisibility**: natDegree(p) | [SplittingField p : F] = |Gal(p)|.\n5. **CharZero corollary**: Over CharZero, `Irreducible.separable` supplies p.Separable for free.\n6. **Obstruction (axiom-free)**: Prove `gal_card_one_of_purelyInseparable_splitting` \u2014 if the splitting field is purely inseparable over F then |Gal| = 1 (every F-automorphism is the identity, via the char-p Frobenius identity). Then natDegree(p) > 1 gives natDegree \u2224 |Gal|. The naive 'inseparable \u21d2 |Gal| = 1' claim is false (X\u2074+X\u00b2+a over F\u2082(a) has |Gal| = 2); purely-inseparable *splitting field* is the correct hypothesis."
   },
   "sections": [
     {
@@ -106,18 +106,18 @@
     },
     {
       "id": "inseparable-obstruction",
-      "title": "Part IV: The Inseparable Obstruction",
-      "startLine": 114,
-      "endLine": 149,
-      "summary": "Axiomatizes that inseparable irreducibles have trivial Galois groups (|Gal| = 1). The concrete example is X^p - t over F_p(t): irreducible (Eisenstein), inseparable (derivative = 0), with only one root t^{1/p} in the purely inseparable splitting field. Proves natDegree \u2224 |Gal| when natDegree > 1.",
-      "mathContext": "$f = X^p - t \\in \\mathbb{F}_p(t)[X]$: irred, insep, $|\\text{Gal}| = 1$ (only root $t^{1/p}$, only automorphism is id), $\\text{natDeg} = p$. So $p \\nmid 1$."
+      "title": "Part IV: The Inseparable Obstruction (axiom-free)",
+      "startLine": 115,
+      "endLine": 205,
+      "summary": "Proves the obstruction without axioms. sub_pow_char_pow_eq (char-p Frobenius identity) and algEquiv_eq_refl_of_isPurelyInseparable (every automorphism of a purely inseparable extension is the identity) yield gal_card_one_of_purelyInseparable_splitting: if the splitting field is purely inseparable over F then |Gal| = 1. Hence natDeg_notDvd_gal_of_purelyInseparable_splitting: natDegree \u2224 |Gal| when natDegree > 1. (A prior revision used a false axiom insep_gal_trivial here; it has been deleted.) The canonical example X^p - t over F_p(t) has a purely-inseparable splitting field, so it is covered.",
+      "mathContext": "$f = X^p - t \\in \\mathbb{F}_p(t)[X]$: splitting field $\\mathbb{F}_p(t^{1/p})$ is purely inseparable over $F$, so $|\\text{Gal}| = 1$ while $\\text{natDeg} = p$, giving $p \\nmid 1$. Correct hypothesis: purely-inseparable splitting field (NOT mere inseparability of $f$)."
     },
     {
       "id": "summary-table",
       "title": "Summary Table of All Theorems",
-      "startLine": 150,
-      "endLine": 165,
-      "summary": "Summary table: 5 theorems proved with 0 sorries, 1 axiom (insep_gal_trivial). Lists all theorems with their hypotheses and conclusions in tabular form.",
+      "startLine": 207,
+      "endLine": 236,
+      "summary": "Summary table: 8 theorems/lemmas proved with 0 sorries and 0 axioms. Lists all theorems with their hypotheses and conclusions in tabular form, plus an integrity note recording the deletion of the former false axiom insep_gal_trivial.",
       "mathContext": "Complete logical picture: sep $\\Rightarrow$ divisibility (proved); CharZero $\\Rightarrow$ sep (Mathlib); insep $+$ deg $> 1$ $\\Rightarrow$ non-divisibility (proved); 2-group Gal $\\Rightarrow$ deg $= 2^k$ (proved)."
     }
   ],
@@ -145,7 +145,7 @@
     {
       "targetId": "angle-trisection-oq-02-oq-01-oq-01-oq-01-oq-01",
       "relationship": "child",
-      "description": "Direct child: further sub-question on this entry's separable-extension framework, exploring whether the inseparable axiom can be removed."
+      "description": "Direct child: refuted the former false axiom insep_gal_trivial (counterexample X⁴+X²+a over F₂(a), |Gal|=2) and supplied the axiom-free gal_card_one_of_purelyInseparable_splitting, which this entry now ports in to become axiom-free."
     }
   ],
   "references": [
@@ -182,7 +182,7 @@
     "summary": "Separability is the exact necessary and sufficient additional hypothesis needed to extend natDegree(p) | |Gal(p)| from CharZero to arbitrary fields.",
     "implications": "Identifies the precise structural boundary: the theorem holds in any characteristic for separable irreducibles, fails for inseparable ones. The 2-group Galois criterion for angle trisection obstructions now applies in any characteristic, not just CharZero.",
     "openQuestions": [
-      "Can insep_gal_trivial be proved in Lean using Mathlib's purely inseparable extension theory?",
+      "Resolved in this entry: the honest statement gal_card_one_of_purelyInseparable_splitting is proved axiom-free using Mathlib's purely-inseparable extension theory; the literal claim 'inseparable irreducible ⇒ |Gal| = 1' is false (refuted by X⁴+X²+a over F₂(a)).",
       "Does the same argument yield a bound natDegree(p) / p^k | |Gal(p)| for inseparable irreducibles of degree p^k \u00b7 d (separable degree d)?"
     ]
   },


### PR DESCRIPTION
## Summary

Removes the **mathematically false axiom** `insep_gal_trivial` from
`Proofs/AngleTrisectionOQ02OQ01OQ01OQ01.lean`, making the file **axiom-free**
(axiomCount 1→0, 0 sorries).

The axiom claimed "char p, inseparable irreducible ⇒ |Gal| = 1". This is false:
the OQ-01 descendant refutes it with `f = X⁴ + X² + a` over `F₂(a)` (irreducible,
inseparable, yet `|Gal| = 2` via the Artin–Schreier automorphism). It had been
retained only as a placeholder so a downstream consequence type-checked, flagged
by the prior S2 STATE-SYNC.

This PR deletes the false axiom and its false-axiom-backed consequence
`natDeg_notDvd_gal_of_insep`, and replaces them with the honest, axiom-free
obstruction **ported from the descendant** (which imports this file, so it cannot
be imported back without a cycle):

- `sub_pow_char_pow_eq` — char-`p` Frobenius identity
- `algEquiv_eq_refl_of_isPurelyInseparable` — automorphisms of a purely inseparable extension are trivial
- `gal_card_one_of_purelyInseparable_splitting` — **correct** statement: purely-inseparable *splitting field* ⇒ |Gal| = 1
- `natDeg_notDvd_gal_of_purelyInseparable_splitting` — honest non-divisibility

The correct hypothesis is a purely-inseparable splitting field, not mere
inseparability of `f` — exactly the distinction the counterexample forces.

## Build verification

- `docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ01OQ01` → clean, **7745 jobs**, 0 warnings.
- `docker-build.sh Proofs.AngleTrisectionOQ02OQ01OQ01OQ01OQ01` (importing descendant) → clean, **7746 jobs**, pre-existing linter warnings only. **No regression.**

## Gallery

`meta.json`: `status: axiomatized → verified`, `badge: axiom → verified`,
`axiomCount: 1 → 0`, `theoremCount: 5 → 8`, `lineCount: 197 → 237`; `assumptions`,
proof-strategy, annotations, open-questions, and cross-references corrected.

## Test plan

- [x] Target file Docker build clean (7745 jobs, axiom-free)
- [x] Importing descendant Docker build clean (7746 jobs, no regression)
- [x] No code references to the deleted symbols remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)