### PR TITLE
research(sperner-oq05): S8 ACT — discharge Scarf-walk soundness (corrected hypothesis)

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstance.lean
+++ b/proofs/Proofs/SpernerSimplicialInstance.lean
@@ -970,6 +970,23 @@ def intervalTriangulation (m : ℕ) (hm : 0 < m) :
   adj_vertex := fun s k s' k' hadj => iadj_vertex' hadj
   adj_ne := fun s k s' k' hadj => iadj_ne' hadj
 
+/-- Computational rightward adjacency of the interval triangulation:
+from cell `i`, the face opposite vertex `0` leads to cell `i+1`
+(entered through its vertex-`1` face), provided `i+1 < m`.
+
+This is a public accessor exposing the rightward branch of the
+otherwise-`private` `iadj`. It is the missing infrastructure that
+lets a downstream file (e.g. the constructive Scarf walk in
+`SpernerSimplicialInstanceOQ05Scarf1d`) reduce one step of the walk
+without access to the private adjacency definition. -/
+lemma intervalTriangulation_adj_zero {m : ℕ} (hm : 0 < m) (i : Fin m)
+    (h : i.val + 1 < m) :
+    (intervalTriangulation m hm).adj i ⟨0, by omega⟩
+      = some (⟨i.val + 1, h⟩, ⟨1, by omega⟩) := by
+  show iadj m i ⟨0, by omega⟩ = _
+  unfold iadj
+  rw [dif_pos rfl, dif_pos h]
+
 end Interval
 
 /-! ## Trivial 2-Simplex Triangulation

--- a/proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean
@@ -26,12 +26,14 @@ parent; this file adds:
   `T.adj` of the parent triangulation.
 * `scarfWalkAux` / `scarfWalk` — the walk itself, bounded by `m`
   fuel.
-* `scarfWalk_isPanchromatic` — soundness (the walk returns a
-  panchromatic cell); proof currently a `sorry` (S6+ discharge
-  plan in `research/problems/sperner-simplicial-instance-oq-05/
-  sessions/2026-05-30-s6-act-c2-1d.md`).
+* `scarfWalk_isPanchromatic` — soundness (the rightward walk
+  returns a panchromatic cell), proved from the start-relative
+  reachability hypothesis `c start ≠ c m`. See the soundness note
+  below for why the unconditional / endpoint-only statements are
+  false for a general start.
 * `exists_panchromatic_constructive` — the constructive Sperner
-  1-d witness extracted from the walk + soundness.
+  1-d witness extracted from the walk + soundness, under the
+  endpoint-parity hypothesis `c 0 ≠ c m`.
 
 The companion smoke test verifies the walk on the `m = 3`,
 "0, 0, 1" colouring at kernel level via `decide`.
@@ -94,26 +96,38 @@ def scarfWalk (hm : 0 < m) (start : Fin m) (k : Fin 2)
     (_h_start : ¬ IsPanchromatic1d c start) : Fin m :=
   scarfWalkAux c hm start k m
 
-/-- **Soundness** of the 1-d Scarf walk: the returned cell is
-panchromatic.
+/-! ## Soundness
 
-(Discharge plan in S6 session memo §4: monotone-walk invariant +
-no-revisit corollary + fuel-exhaustion impossibility.) -/
-theorem scarfWalk_isPanchromatic (hm : 0 < m) (start : Fin m) (k : Fin 2)
-    (h_start : ¬ IsPanchromatic1d c start) :
-    IsPanchromatic1d c (scarfWalk c hm start k h_start) := by
-  sorry
+The soundness theorem `scarfWalk_isPanchromatic` and the
+constructive existence corollary `exists_panchromatic_constructive`
+are proved further down (after the structural reduction lemmas they
+depend on).
 
-/-- **Constructive Sperner 1-d**: from a boundary door at
-`(boundary_door.1, boundary_door.2)` (i.e. an `adj = none` site)
-with a non-panchromatic source cell, the Scarf walk produces a
-panchromatic cell of `intervalTriangulation m hm`. -/
-theorem exists_panchromatic_constructive (hm : 0 < m)
-    (boundary_door : Fin m × Fin 2)
-    (h_door : ¬ IsPanchromatic1d c boundary_door.1) :
-    ∃ i : Fin m, IsPanchromatic1d c i :=
-  ⟨scarfWalk c hm boundary_door.1 boundary_door.2 h_door,
-   scarfWalk_isPanchromatic c hm _ _ _⟩
+**S8 correction (this session, researcher-2).** Two earlier sessions
+established that the *unconditional* soundness statement (over an
+arbitrary entry face `k`) is false:
+
+* S7 (researcher-1, 2026-06-01) found the **constant-colouring**
+  counterexample (`m = 3`, `c ≡ 0`): no cell is panchromatic, so the
+  walk can only terminate on a non-panchromatic cell.
+* S8 PREP (researcher-1, 2026-06-04) proposed repairing this with the
+  endpoint-parity hypothesis `c 0 ≠ c m`.
+
+That proposal is **still insufficient for a general start/direction**:
+take `m = 5`, `c = (1, 0, 0, 0, 0, 0)`, `start = 2`, entry face `1`
+(rightward). Then `c 0 = 1 ≠ 0 = c 5`, so the parity hypothesis holds,
+yet the only colour switch is the edge `[0,1]` — which lies *behind*
+the rightward walk. The walk runs `2 → 3 → 4` and stops at the
+non-panchromatic right boundary cell `4`. Soundness fails.
+
+The walk is monotone in the cell index with direction fixed by the
+entry face, so the correct hypothesis is **start-relative**: a
+rightward walk (entry face `1`) from cell `start` lands on a
+panchromatic cell iff a colour switch lies in `{start, …, m}`, for
+which `c start ≠ c m` is sufficient. That is the hypothesis used
+below. The boundary-door existence corollary then instantiates it at
+`start = 0`, where `c 0 ≠ c m` is exactly the classical 1-d Sperner
+endpoint condition. -/
 
 /-! ## S7 ACT — Structural Reduction Lemmas
 
@@ -148,6 +162,120 @@ theorem scarfWalkAux_of_panchromatic_start (hm : 0 < m) (start : Fin m)
     scarfWalkAux c hm start k (n + 1) = start := by
   unfold scarfWalkAux
   simp [h]
+
+/-- Non-panchromatic unfolding: at positive fuel and a
+non-panchromatic current cell, `scarfWalkAux` reduces to a `step`
+followed by the recursive call on the remaining fuel. -/
+theorem scarfWalkAux_step (hm : 0 < m) (s : Fin m) (k : Fin 2) (n : ℕ)
+    (h : ¬ IsPanchromatic1d c s) :
+    scarfWalkAux c hm s k (n + 1)
+      = match step c hm s k h with
+        | Sum.inl w => w
+        | Sum.inr (next, k') => scarfWalkAux c hm next k' n := by
+  conv_lhs => unfold scarfWalkAux
+  rw [dif_neg h]
+
+/-- One **rightward** step (entry face `1`) of the Scarf walk. From a
+non-panchromatic cell `s` with `s + 1 < m`, the walk moves to cell
+`s + 1` (again entered through face `1`): it returns `s + 1` if that
+cell is panchromatic, otherwise it recurses there. -/
+theorem scarfWalkAux_right_succ (hm : 0 < m) (s : Fin m) (n : ℕ)
+    (hps : ¬ IsPanchromatic1d c s) (hlt : s.val + 1 < m) :
+    scarfWalkAux c hm s 1 (n + 1)
+      = if IsPanchromatic1d c (⟨s.val + 1, hlt⟩ : Fin m)
+        then (⟨s.val + 1, hlt⟩ : Fin m)
+        else scarfWalkAux c hm (⟨s.val + 1, hlt⟩ : Fin m) 1 n := by
+  rw [scarfWalkAux_step c hm s 1 n hps]
+  have hst : step c hm s 1 hps
+      = if IsPanchromatic1d c (⟨s.val + 1, hlt⟩ : Fin m)
+        then Sum.inl (⟨s.val + 1, hlt⟩ : Fin m)
+        else Sum.inr ((⟨s.val + 1, hlt⟩ : Fin m), (⟨1, by omega⟩ : Fin 2)) := by
+    show (match (intervalTriangulation m hm).adj s ⟨0, by omega⟩ with
+          | none => Sum.inl s
+          | some (i', k'') =>
+              if IsPanchromatic1d c i' then Sum.inl i' else Sum.inr (i', k''))
+        = _
+    rw [intervalTriangulation_adj_zero hm s hlt]
+  rw [hst]
+  by_cases hp1 : IsPanchromatic1d c (⟨s.val + 1, hlt⟩ : Fin m)
+  · rw [if_pos hp1, if_pos hp1]
+  · rw [if_neg hp1, if_neg hp1]; rfl
+
+/-- Soundness, by induction on the fuel: a rightward walk (entry
+face `1`) from any cell `s` whose left-vertex colour differs from the
+right-endpoint colour `c m` lands on a panchromatic cell, provided
+the fuel `n` is at least the remaining distance `m - s`. -/
+theorem scarfWalkAux_right_isPanchromatic (hm : 0 < m) :
+    ∀ (n : ℕ) (s : Fin m), m - s.val ≤ n → c s.val ≠ c m →
+      IsPanchromatic1d c (scarfWalkAux c hm s 1 n) := by
+  intro n
+  induction n with
+  | zero =>
+      intro s hle _
+      exact absurd hle (by have := s.isLt; omega)
+  | succ n ih =>
+      intro s hle hreach
+      by_cases hps : IsPanchromatic1d c s
+      · rw [scarfWalkAux_of_panchromatic_start c hm s 1 n hps]; exact hps
+      · have hcs : c s.val = c (s.val + 1) := by
+          unfold IsPanchromatic1d at hps; exact not_not.mp hps
+        have hlt : s.val + 1 < m := by
+          rcases Nat.lt_or_ge (s.val + 1) m with h | h
+          · exact h
+          · have heq : s.val + 1 = m := by have := s.isLt; omega
+            exact absurd (hcs.trans (congrArg c heq)) hreach
+        rw [scarfWalkAux_right_succ c hm s n hps hlt]
+        by_cases hp1 : IsPanchromatic1d c (⟨s.val + 1, hlt⟩ : Fin m)
+        · rw [if_pos hp1]; exact hp1
+        · rw [if_neg hp1]
+          refine ih ⟨s.val + 1, hlt⟩ ?_ ?_
+          · show m - (s.val + 1) ≤ n; omega
+          · show c (s.val + 1) ≠ c m; rw [← hcs]; exact hreach
+
+/-- **Soundness** of the rightward 1-d Scarf walk (entry face `1`):
+the returned cell is panchromatic, given the start-relative
+reachability hypothesis `c start ≠ c m` (a colour switch lies weakly
+to the right of `start`). See the module note above for why the
+unconditional and endpoint-only (`c 0 ≠ c m`) statements are false
+for a general start. -/
+theorem scarfWalk_isPanchromatic (hm : 0 < m) (start : Fin m)
+    (h_reach : c start.val ≠ c m)
+    (h_start : ¬ IsPanchromatic1d c start) :
+    IsPanchromatic1d c (scarfWalk c hm start 1 h_start) := by
+  rw [scarfWalk_eq_scarfWalkAux]
+  exact scarfWalkAux_right_isPanchromatic c hm m start
+    (by have := start.isLt; omega) h_reach
+
+/-- **Discrete intermediate-value theorem** (classical 1-d Sperner):
+if the two endpoint colours of `{0, …, m}` differ, some cell of
+`intervalTriangulation m hm` is panchromatic. Pure colour-combinatorics,
+independent of the walk. -/
+theorem discrete_ivt_panchromatic_cell (_hm : 0 < m) (h_parity : c 0 ≠ c m) :
+    ∃ i : Fin m, IsPanchromatic1d c i := by
+  by_contra hcon
+  push_neg at hcon
+  have key : ∀ j, j ≤ m → c 0 = c j := by
+    intro j
+    induction j with
+    | zero => intro _; rfl
+    | succ j ihj =>
+        intro hj
+        have hjm : j < m := by omega
+        have hpan := hcon ⟨j, hjm⟩
+        simp only [IsPanchromatic1d, not_not] at hpan
+        rw [ihj (by omega)]; exact hpan
+  exact h_parity (key m le_rfl)
+
+/-- **Constructive Sperner 1-d**: under the endpoint-parity
+hypothesis `c 0 ≠ c m`, the rightward Scarf walk started at the left
+boundary cell `0` produces a panchromatic cell of
+`intervalTriangulation m hm`. -/
+theorem exists_panchromatic_constructive (hm : 0 < m) (h_parity : c 0 ≠ c m) :
+    ∃ i : Fin m, IsPanchromatic1d c i := by
+  by_cases h0 : IsPanchromatic1d c (⟨0, hm⟩ : Fin m)
+  · exact ⟨_, h0⟩
+  · exact ⟨scarfWalk c hm ⟨0, hm⟩ 1 h0,
+      scarfWalk_isPanchromatic c hm ⟨0, hm⟩ (by simpa using h_parity) h0⟩
 
 /-- **Smoke test (m = 3 / colouring 0,0,1,1)**: starting at the
 left boundary door `(0, 1)` of `intervalTriangulation 3` with the

--- a/research/problems/sperner-simplicial-instance-oq-05/sessions/2026-06-12-s8-act-soundness-discharge.md
+++ b/research/problems/sperner-simplicial-instance-oq-05/sessions/2026-06-12-s8-act-soundness-discharge.md
@@ -1,0 +1,129 @@
+# S8 ACT — `scarfWalk_isPanchromatic` discharged (corrected, start-relative hypothesis)
+
+**Slug**: `sperner-simplicial-instance-oq-05`
+**Researcher**: researcher-2
+**Date**: 2026-06-12
+**Session**: 17 (S8 ACT)
+**Type**: Lean diff (Docker-verified) + parent infrastructure lemma
+**Predecessor**: Session 16 (S8 PREP, researcher-1, 2026-06-04) designed the
+`c 0 ≠ c m` endpoint-parity amendment.
+**Result**: the C2-1d Scarf-walk soundness `sorry` is **eliminated** (1 → 0).
+`SpernerSimplicialInstanceOQ05Scarf1d.lean` is now sorry-free and axiom-free.
+
+## 1. Headline
+
+The pre-existing soundness `sorry` in
+`proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean`
+(`scarfWalk_isPanchromatic`) is closed. The discharge required
+**correcting** the S8 PREP design *and* adding the missing parent-file
+infrastructure that blocked every prior attempt.
+
+Docker build `Proofs.SpernerSimplicialInstanceOQ05Scarf1d` succeeds
+(1098/1098 jobs); leaf file is **0 sorries / 0 axioms**, parent file
+remains **0 sorries / 0 axioms**.
+
+## 2. Correction to the S8 PREP amendment (important)
+
+S8 PREP proposed amending the soundness theorem with the endpoint-parity
+hypothesis `c 0 ≠ c m`, claiming it sufficient for a general
+`(start, k)`. **It is not.** A second counterexample:
+
+> `m = 5`, `c = (1, 0, 0, 0, 0, 0)`, `start = 2`, entry face `1`
+> (rightward). Then `c 0 = 1 ≠ 0 = c 5` — the parity hypothesis holds —
+> but the only colour switch is the edge `[0,1]`, which lies *behind*
+> the rightward walk. The walk runs `2 → 3 → 4` and terminates on the
+> non-panchromatic right boundary cell `4`. Soundness fails.
+
+Root cause: the 1-d Scarf walk is **monotone in the cell index**, with
+direction fixed by the entry face (`k = 1` ⇒ rightward `i → i+1`;
+`k = 0` ⇒ leftward `i → i-1`). The endpoint-parity hypothesis only
+guarantees a switch *somewhere* in `{0,…,m}`; it does not guarantee the
+switch is in the walk's forward cone. The correct hypothesis is
+**start-relative**.
+
+## 3. What was proved
+
+All in `SpernerSimplicialInstanceOQ05Scarf1d.lean` unless noted.
+
+- **`Triangulation.intervalTriangulation_adj_zero`** (NEW, *parent file*
+  `SpernerSimplicialInstance.lean`): public computational accessor for
+  the rightward branch of the otherwise-`private` `iadj` —
+  `(intervalTriangulation m hm).adj i ⟨0,_⟩ = some (⟨i+1,_⟩, ⟨1,_⟩)`
+  when `i+1 < m`. **This is the infrastructure gap that stalled S5–S8**:
+  from the leaf file the walk step could not be reduced because `iadj`
+  (and `ivtx`) are private, so a downstream proof could not compute
+  which cell the walk lands on. One 4-line lemma unblocks the whole
+  discharge.
+- **`scarfWalkAux_step`**: non-panchromatic unfolding of `scarfWalkAux`
+  at positive fuel (`conv_lhs => unfold; rw [dif_neg]`).
+- **`scarfWalkAux_right_succ`**: one rightward step — from a
+  non-panchromatic `s` with `s+1 < m`, the walk moves to `s+1`
+  (re-entered through face `1`).
+- **`scarfWalkAux_right_isPanchromatic`**: soundness by induction on the
+  fuel. Key invariant transfer: in the non-panchromatic branch
+  `c s = c (s+1)`, so `c s ≠ c m` both (a) forces `s+1 < m` (no early
+  boundary stop) and (b) transfers to `c (s+1) ≠ c m` for the recursive
+  call. The zero-fuel base case is vacuous because `m - s ≤ 0` with
+  `s < m` is impossible.
+- **`scarfWalk_isPanchromatic`** (REWRITTEN, soundness): rightward walk
+  (entry face `1`) with the corrected hypothesis `c start ≠ c m`.
+  0 sorries.
+- **`discrete_ivt_panchromatic_cell`** (NEW): classical 1-d Sperner /
+  discrete IVT — `c 0 ≠ c m → ∃ i : Fin m, IsPanchromatic1d c i`. Pure
+  colour-combinatorics by induction (`c 0 = c j` for all `j ≤ m` if no
+  cell switches, contradicting parity). Independent of the walk;
+  reusable.
+- **`exists_panchromatic_constructive`** (REWRITTEN): under
+  `c 0 ≠ c m`, runs the rightward walk from the **left boundary cell
+  `0`**, where `c 0 ≠ c m` is exactly the start-relative hypothesis.
+  This is where the classical endpoint-parity condition correctly
+  lives. 0 sorries.
+
+The S7 structural lemmas (`scarfWalk_eq_scarfWalkAux`,
+`scarfWalkAux_zero_fuel`, `scarfWalkAux_of_panchromatic_start`) and the
+concrete `decide` smoke-test `example` are unchanged and still build.
+
+## 4. Signature changes (no external fallout)
+
+`scarfWalk_isPanchromatic` and `exists_panchromatic_constructive` both
+changed signatures (dropped the general entry face `k`; soundness now
+takes `c start ≠ c m`, existence takes `c 0 ≠ c m`). Grep confirms
+neither is imported or referenced outside this leaf file, so the change
+is contained. The `scarfWalk` / `scarfWalkAux` / `step` *definitions*
+are untouched, so the kernel `decide` smoke-test is unaffected.
+
+## 5. Verification
+
+- Docker: `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialInstanceOQ05Scarf1d`
+  → "Build succeeded" (1098/1098). Parent rebuilt clean with the new lemma.
+- `grep "^axiom "` → 0 in both files. No real `sorry` tactic remains
+  (the two textual "sorry" hits are stale-docstring mentions, since
+  edited).
+
+## 6. Follow-ups / handoff
+
+- **Mechanic**: `src/data/research/problems/sperner-simplicial-instance-oq-05.json`
+  `leanFiles[].sorryCount` for `SpernerSimplicialInstanceOQ05Scarf1d.lean`
+  should now be **0** (was stale at 3; actual was 1 before this session,
+  0 after). jq:
+  ```jq
+  .leanFiles |= map(if .filename == "SpernerSimplicialInstanceOQ05Scarf1d.lean"
+                     then .sorryCount = 0 else . end)
+  ```
+- **Gallery (S9+)**: the C2-1d module is now a fully-verified
+  constructive Scarf algorithm; it could be promoted from
+  `additionalFiles[]` to a first-class annotated gallery entry, and the
+  `whyMatters` bullet about replacing `scarf_approx_fixed_point` in
+  `BrouwerFixedPointOQ04OQ04.lean:244` is one analytic-bridge step closer.
+- **Leftward symmetry (optional)**: a mirror `scarfWalkAux_left_*` with
+  hypothesis `c 0 ≠ c (start+1)` and a parent `intervalTriangulation_adj_one`
+  lemma would complete the directional pair, but is not needed for the
+  existence corollary.
+
+## 7. Host context
+
+- Worktree: `.loom/worktrees/researcher-2`, branch off `main`.
+- Mathlib pin v4.26.0 (unchanged).
+- Files touched: `proofs/Proofs/SpernerSimplicialInstance.lean` (+1 lemma),
+  `proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean` (soundness
+  discharge), this session memo, `state.md`.

--- a/research/problems/sperner-simplicial-instance-oq-05/state.md
+++ b/research/problems/sperner-simplicial-instance-oq-05/state.md
@@ -564,3 +564,29 @@ territory (one-time sweep, not per-slug).
 - **Misplaced knowledge / problem**: `research/sperner-simplicial-instance-oq-05/{knowledge,problem}.md` — until mechanic merges into canonical dir.
 - **Lean source**: `proofs/Proofs/SpernerSimplicialInstanceOQ05.lean` (168 LOC, 5 declarations, 0/0). `proofs/Proofs/SpernerSimplicialInstance.lean` (995 LOC parent, 28 thms). `proofs/Proofs/SpernerMathlib4.lean` (732 LOC abstract framework; OQ-stated bottleneck `findOppositeIdx` at L367).
 - **Memory pattern**: `feedback_researcher_state_sync_active_thread_prep_backlog.md` — STATE-SYNC variant for active threads with multi-PR backlog where state.md lags merged PREP/ACT work.
+
+## Session 17 — S8 ACT soundness discharge (researcher-2, 2026-06-12)
+
+**Result: C2-1d Scarf-walk soundness `sorry` eliminated (1 → 0).**
+`SpernerSimplicialInstanceOQ05Scarf1d.lean` is now 0 sorries / 0 axioms;
+Docker build `Proofs.SpernerSimplicialInstanceOQ05Scarf1d` succeeds (1098/1098).
+
+- **Correction to S8 PREP**: the proposed endpoint-only hypothesis
+  `c 0 ≠ c m` is *insufficient* for a general start. Counterexample:
+  `m = 5`, `c = (1,0,0,0,0,0)`, `start = 2`, entry face `1` — parity
+  holds (`c 0 = 1 ≠ 0 = c 5`) but the lone switch (edge `[0,1]`) is
+  behind the monotone rightward walk, which stops at non-pancho cell `4`.
+  The walk is monotone with direction fixed by the entry face, so the
+  correct soundness hypothesis is start-relative `c start ≠ c m`.
+- **Infrastructure unblock**: added public lemma
+  `Triangulation.intervalTriangulation_adj_zero` in the parent file —
+  exposes the rightward branch of the otherwise-`private` `iadj`, which
+  is what prevented S5–S8 from reducing the walk step from the leaf file.
+- **New lemmas** (leaf): `scarfWalkAux_step`, `scarfWalkAux_right_succ`,
+  `scarfWalkAux_right_isPanchromatic` (fuel induction),
+  `discrete_ivt_panchromatic_cell` (pure discrete IVT). Soundness and
+  the existence corollary rewritten with corrected hypotheses; no
+  external callers (grep-confirmed).
+- Session memo: `sessions/2026-06-12-s8-act-soundness-discharge.md`.
+- Next: S9 gallery promotion of the now-verified constructive module;
+  optional leftward symmetry.


### PR DESCRIPTION
## Summary

Discharges the long-standing **C2-1d Scarf-walk soundness `sorry`** in `proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean` (`scarfWalk_isPanchromatic`). The leaf file is now **0 sorries / 0 axioms**; Docker build `Proofs.SpernerSimplicialInstanceOQ05Scarf1d` succeeds (1098/1098). Parent stays 0/0.

This required both an **infrastructure unblock** and a **correction** to the prior design.

### Infrastructure unblock
Adds one public lemma to the parent file, `Triangulation.intervalTriangulation_adj_zero`, exposing the rightward branch of the otherwise-`private` `iadj`. Sessions S5–S8 stalled precisely because the leaf file could not reduce the walk step without access to the private adjacency definition (so it couldn't compute which cell the walk lands on). Four lines unblock the whole discharge.

### Correction to S8 PREP
The S8 PREP memo proposed amending soundness with the endpoint-parity hypothesis `c 0 ≠ c m` and claimed it sufficient for a general `(start, k)`. **It is not.** Counterexample:

> `m = 5`, `c = (1, 0, 0, 0, 0, 0)`, `start = 2`, entry face `1` (rightward). Then `c 0 = 1 ≠ 0 = c 5` (parity holds), but the only colour switch is the edge `[0,1]` — *behind* the rightward walk. The walk runs `2 → 3 → 4` and stops at the non-panchromatic boundary cell `4`.

The 1-d Scarf walk is **monotone in the cell index**, direction fixed by the entry face, so the correct soundness hypothesis is **start-relative**: `c start ≠ c m`. The existence corollary `exists_panchromatic_constructive` then instantiates it at `start = 0`, where `c 0 ≠ c m` is exactly the classical 1-d Sperner endpoint condition (its correct home).

### New / changed declarations
- `intervalTriangulation_adj_zero` (parent, NEW public lemma)
- `scarfWalkAux_step`, `scarfWalkAux_right_succ`, `scarfWalkAux_right_isPanchromatic` (fuel induction)
- `discrete_ivt_panchromatic_cell` (pure discrete IVT, reusable)
- `scarfWalk_isPanchromatic` (rewritten, start-relative hyp, 0 sorries)
- `exists_panchromatic_constructive` (rewritten, `c 0 ≠ c m`, 0 sorries)

Walk/step definitions and the kernel `decide` smoke-test are unchanged. Grep confirms no external callers of the changed signatures.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.SpernerSimplicialInstanceOQ05Scarf1d` → Build succeeded (1098/1098)
- [x] `grep "^axiom "` → 0 in both files; no real `sorry` tactic remains
- [ ] Follow-up (mechanic): `leanFiles[].sorryCount = 0` for Scarf1d if/when tracked
- [ ] Follow-up (S9): promote the now-verified constructive module to a first-class gallery entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)