### PR TITLE
research(schauder-oq03): S31 STATE-SYNC — Docker verify + sorryCount drift fix

### DIFF
--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-12-s31-statesync-docker-verify.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/sessions/2026-06-12-s31-statesync-docker-verify.md
@@ -1,0 +1,70 @@
+# S31 STATE-SYNC — Docker verification of merged S29 state + sorryCount drift fix
+
+**Slug:** `schauder-fixed-point-oq-03-oq-01-incomplete-01`
+**Researcher:** researcher-2
+**Date:** 2026-06-12
+**Phase:** STATE-SYNC (no Lean diff; JSON + state.md only)
+**Predecessors:** S30 PREP (researcher-1, 2026-06-06, two-scale construction design);
+S29 ACT (researcher-1, 2026-06-02, PR #22117, `exists_lebesgue_subcover_for_uhc`).
+
+## §0 Why this session
+
+S30 PREP and the JSON `nextAction` both flagged an **outstanding Docker
+verification**: the merged S29 ACT state was never confirmed to build
+("currently build-pending due to sibling container contention …
+Auditor or next-cycle picker can run Docker verify after sibling
+drains"). This session runs that verification and syncs the tracked
+metadata to ground truth. No mathematical progress on the open axiom
+is claimed.
+
+## §1 Docker verification (authoritative)
+
+```
+./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01
+→ Build completed successfully (3074 jobs).
+```
+
+No errors, no `declaration uses 'sorry'` warnings. The file's terminal
+`#print` of the main signatures (`approx_fixedpoint_implies_fixedpoint`,
+`kakutani_from_brouwer`, `approx_selection_exists`,
+`brouwer_unit_ball`) elaborates cleanly.
+
+**Ground-truth state of `Proofs/SchauderFixedPointOQ03OQ01.lean`:**
+
+- **0 functional sorries** (sorry-free since S15 / PR #17654; the three
+  textual `sorry` hits at lines 217/342/1442 are docstrings asserting
+  "sorry-free").
+- **2 axioms**: `brouwer_unit_ball` (line 196) and
+  `approx_selection_exists` (line 563).
+
+## §2 Metadata drift corrected
+
+`src/data/research/problems/…json` `leanFiles[].sorryCount` was **3**,
+which does not match the file (0) nor the axiom count (2) — stale drift.
+Set to **0**; `axiomCount` confirmed **2**. Phase / `nextAction` /
+`blockers` refreshed to point at S31 ACT.
+
+## §3 Where the math stands (unchanged, recorded for the next picker)
+
+- The clustering route to the third `IsGraphApproxSelection` conjunct
+  is **provably dead from UHC alone** (S28 PREP §3.3): UHC controls
+  `F z` as a *set*, not the pointwise `ysel` values.
+- S30 PREP's **two-scale construction** bypasses clustering: outer cover
+  at scale ε → S29 Lebesgue helper for a uniform δ → inner cover at
+  scale δ with subordinate partition of unity `ρ'` → average the
+  existential thickening witnesses `z_j ∈ F(i_outer(x))` by convexity.
+  This is the S31 ACT target and eliminates `axiom approx_selection_exists`.
+- **Effort estimate**: the existing S18a–S18e helpers all run at a
+  single scale; the two-scale chain interleaves them, so S31 ACT is a
+  structural refactor warranting a dedicated multi-PR ACT cycle, not a
+  one-shot.
+- `axiom brouwer_unit_ball` has no Mathlib replacement at the pinned
+  v4.26.0 (no general finite-dimensional Brouwer fixed-point theorem),
+  so it is expected to remain.
+
+## §4 Deliverables
+
+- Docker verify (this memo).
+- `leanFiles[].sorryCount` 3 → 0; phase/nextAction/blockers refresh.
+- This session memo + state.md entry.
+- No `.lean` edit.

--- a/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
+++ b/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/state.md
@@ -958,3 +958,19 @@ brouwer_unit_ball` (Axiom 1) and is otherwise sorry-free.
 - `s18d-subordinate-partition-of-unity.md` — S18d (researcher-12, merged #17993) subordinate partition of unity packaging note
 - `s18e-continuous-selection-with-witnesses.md` — **S18e (this iteration)** continuous selection from subordinate partition of unity packaging note
 
+
+## Session 31 — STATE-SYNC + Docker verify (researcher-2, 2026-06-12)
+
+Ran the Docker verification S30 PREP/S29 ACT flagged as outstanding
+("build-pending due to sibling container contention"):
+`Proofs.SchauderFixedPointOQ03OQ01` builds clean — **3074 jobs, 0 errors,
+no sorry warnings**. Authoritative state: **0 functional sorries, 2 axioms**
+(`brouwer_unit_ball`, `approx_selection_exists`).
+
+Corrected stale `leanFiles[].sorryCount` 3 → 0 in the research JSON
+(file sorry-free since S15/PR #17654). No Lean diff.
+
+Math unchanged: clustering route dead (S28 §3.3); next is S31 ACT —
+implement S30 PREP's two-scale construction to eliminate
+`approx_selection_exists` (a multi-helper structural refactor).
+Session memo: `sessions/2026-06-12-s31-statesync-docker-verify.md`.

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "schauder-fixed-point-oq-03-oq-01-incomplete-01",
   "title": "Kakutani from Brouwer via Approximate Selections (2 sorries)",
-  "phase": "ACT",
+  "phase": "S31 ACT pending — S30 PREP (two-scale construction bypassing the dead clustering obstacle) shipped; Lean implementation deferred to S31 ACT. STATE-SYNC (researcher-2, 2026-06-12): merged S29 state Docker-verified (3074 jobs, 0 sorries, 2 axioms); stale leanFiles sorryCount 3→0 corrected.",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -28,12 +28,14 @@
     "goal": "Fill 2 sorries using Mathlib's partition of unity machinery"
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-28",
+    "phase": "S31 ACT pending — S30 PREP (two-scale construction bypassing the dead clustering obstacle) shipped; Lean implementation deferred to S31 ACT. STATE-SYNC (researcher-2, 2026-06-12): merged S29 state Docker-verified (3074 jobs, 0 sorries, 2 axioms); stale leanFiles sorryCount 3→0 corrected.",
+    "since": "2026-06-12T00:00:00Z",
     "iteration": 31,
     "focus": "S29 ACT (researcher-1, 2026-06-02): land paste-ready Lebesgue helper from S28 PREP §5 verbatim. +60 LOC at SchauderFixedPointOQ03OQ01.lean:716 between exists_finite_subcover_for_uhc (S18c) and the S18d scaffold docstring. New private lemma exists_lebesgue_subcover_for_uhc augments S18c's open cover with a uniform Lebesgue radius δ>0 via lebesgue_number_lemma_of_metric (Mathlib/Topology/MetricSpace/Pseudo/Lemmas.lean at pinned SHA 2df2f0150c). Proof: 4 logical steps — materialise CompactSpace ↥S via isCompact_iff_compactSpace.mp; obtain S18c's open cover; derive Set.univ ⊆ ⋃ i, U i (S18d one-liner); apply lebesgue_number_lemma_of_metric isCompact_univ hU_open hU_cover_univ. Build pending: same sibling lake-build container 9db9a3f1bb19 ~4h+; disk 24Gi GREEN; SHA stable 21+ days; no new imports (all bearers in transitively imported modules). Risk-acceptance 8/8 GREEN per S28 PREP §7 picker matrix — recent BUILD-VERIFY 4 days ago (PR #20891 3074 jobs clean) is the qualitative difference vs the older 25-day-old lagrange S16 region BUILD-VERIFY. theoremCount 17→18 under canonical regex; lineCount 1419→1479; axiomCount unchanged at 2; sorries unchanged at 0 functional.",
-    "blockers": [],
-    "nextAction": "S30 (next ACT): re-pose the output-side clustering problem against the Lebesgue helper's δ-uniform-refinement output. The genuine obstacle (per S28 PREP §3) is that UHC controls F z as a set not the chosen ysel j values; S30 candidate paths are (a) thread convex_combination (S18a) through the δ-refined cover to bound dist (ysel j) (ysel i) via center-distance + thickening-radius decomposition, or (b) pivot to anchored selector via S22's exists_nearest_in_image_F + global reference whose distance to each F i is bounded. PREREQUISITE: S29 ACT Docker verify (currently build-pending due to sibling container contention). Auditor or next-cycle picker can run Docker verify after sibling drains.",
+    "blockers": [
+      "S31 ACT two-scale construction is a multi-helper structural refactor (S30 PREP); not yet implemented in Lean. Both file axioms (brouwer_unit_ball, approx_selection_exists) are deep; brouwer_unit_ball has no Mathlib replacement at v4.26.0."
+    ],
+    "nextAction": "S31 ACT: implement the S30 PREP two-scale construction (outer cover at scale ε + S29 Lebesgue helper for uniform δ + inner cover at scale δ with subordinate partition of unity ρ', then average existential thickening witnesses z_j ∈ F(i_outer(x)) by convexity) to discharge the third graph-bound conjunct of IsGraphApproxSelection without the (provably dead) clustering bound. This eliminates `axiom approx_selection_exists`. Large interleaved refactor of the one-scale S18a–S18e helpers; budget a dedicated multi-PR ACT cycle. STATE NOW Docker-verified (3074 jobs, 0 sorries, 2 axioms) on main.",
     "attemptCounts": {
       "total": 31,
       "currentApproach": 5,
@@ -41,7 +43,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S27 ACT (researcher-1, 2026-05-28): added private lemma finsupport_combination_within_output_ball reducing the output-side graph-bound conjunct dist(f x, ysel i) < ε to selected-value CLUSTERING — if all ysel j (j ∈ ρ.finsupport x) lie within r of ysel i, the partition-weighted sum f x = ∑ ρ j x • ysel j does too (closedBall(ysel i, r) is convex and contains every ysel j; convex_combination_of_partition_in_S + convex_closedBall). This yields a SIMPLER S27/S28 endgame than the prior thickening+nearest-point plan: with witness y := ysel i ∈ F i, the conjunct needs only the clustering dist(ysel j, ysel i) < ε, with NO exists_nearest_in_image_F call. The clustering (needs the uniform/Lebesgue refinement of the S18c cover) is now the sole remaining obstacle for eliminating axiom approx_selection_exists. Build-verified clean 3074 jobs (Built in 7.2s) at pinned SHA 2df2f0150c. 0 functional sorries, 2 axioms unchanged. lineCount 1369→1419, theoremCount 16→17. [Prior S26 ACT: input-ball clause propagation + finsupport_center_within_input_ball (dist x x' < ε half) + finsupport_nonempty.]",
+    "progressSummary": "PROGRESS (Session 31 STATE-SYNC + Docker verify, 2026-06-12, researcher-2, this PR): Ran the Docker verification the S30 PREP/S29 ACT flagged as outstanding (build was 'pending due to sibling container contention'). `Proofs.SchauderFixedPointOQ03OQ01` builds clean — 3074 jobs, no errors, no sorry warnings. Authoritative state: 0 functional sorries, 2 axioms (`brouwer_unit_ball`, `approx_selection_exists`). Corrected stale `leanFiles[].sorryCount` 3→0 (the file has been sorry-free since S15 PR #17654; the value was drift). No Lean diff. Next math step remains S31 ACT: implement the S30 PREP two-scale construction to eliminate `approx_selection_exists`; the clustering route is dead (S28 §3.3). | S27 ACT (researcher-1, 2026-05-28): added private lemma finsupport_combination_within_output_ball reducing the output-side graph-bound conjunct dist(f x, ysel i) < ε to selected-value CLUSTERING — if all ysel j (j ∈ ρ.finsupport x) lie within r of ysel i, the partition-weighted sum f x = ∑ ρ j x • ysel j does too (closedBall(ysel i, r) is convex and contains every ysel j; convex_combination_of_partition_in_S + convex_closedBall). This yields a SIMPLER S27/S28 endgame than the prior thickening+nearest-point plan: with witness y := ysel i ∈ F i, the conjunct needs only the clustering dist(ysel j, ysel i) < ε, with NO exists_nearest_in_image_F call. The clustering (needs the uniform/Lebesgue refinement of the S18c cover) is now the sole remaining obstacle for eliminating axiom approx_selection_exists. Build-verified clean 3074 jobs (Built in 7.2s) at pinned SHA 2df2f0150c. 0 functional sorries, 2 axioms unchanged. lineCount 1369→1419, theoremCount 16→17. [Prior S26 ACT: input-ball clause propagation + finsupport_center_within_input_ball (dist x x' < ε half) + finsupport_nonempty.]",
     "builtItems": [
       "S10 (researcher-12, 2026-05-08): research/problems/schauder-fixed-point-oq-03-oq-01-incomplete-01/s10-mathlib-v426-lookup3-resolved.md — GitHub-API resolution of LOOKUP-3 against the pinned mathlib4 rev. Definitive evidence that Mathlib4 lacks Brouwer FPT in any form. Three options analyzed (strict-weakening vs in-house Brouwer vs status quo); recommends Option A.",
       "S10 (researcher-12, 2026-05-08): proofs/Proofs/SchauderFixedPointOQ03OQ01.lean lines 76–87 — corrected docstring of axiom brouwer_fpt. Previous claim \"This is proved in Mathlib for the unit ball via degree theory\" replaced with a status note recording the S10 finding and pointing to the s10-... markdown file. No code change.",
@@ -151,7 +153,7 @@
       "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 4,
-      "sorryCount": 3,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SchauderFixedPointOQ03OQ01.lean"
     }


### PR DESCRIPTION
## Summary

State-sync (no Lean diff) for the Kakutani-from-Brouwer problem.

- Runs the **Docker verification** S30 PREP and S29 ACT flagged as outstanding (the merged S29 state was "build-pending due to sibling container contention"). `Proofs.SchauderFixedPointOQ03OQ01` builds clean — **3074 jobs, 0 errors, no sorry warnings**.
- Records authoritative state: **0 functional sorries, 2 axioms** (`brouwer_unit_ball`, `approx_selection_exists`).
- Corrects stale `leanFiles[].sorryCount` **3 → 0** in the research JSON (the file has been sorry-free since S15 / PR #17654; the three textual `sorry` hits are docstrings asserting "sorry-free").

No mathematical progress on the open axiom is claimed. The next math step remains **S31 ACT**: implement the S30 PREP two-scale construction to eliminate `approx_selection_exists` (the clustering route is provably dead per S28 §3.3). `brouwer_unit_ball` has no Mathlib replacement at v4.26.0.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.SchauderFixedPointOQ03OQ01` → Build succeeded (3074 jobs)
- [x] JSON validates; `sorryCount` now matches the file (0) and `axiomCount` = 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)