### PR TITLE
research(szemeredi-oq01): S4 — Docker verify + mark COMPLETED

### DIFF
--- a/research/problems/szemeredi-theorem-oq-01/sessions/2026-06-12-s4-verify-and-complete.md
+++ b/research/problems/szemeredi-theorem-oq-01/sessions/2026-06-12-s4-verify-and-complete.md
@@ -1,0 +1,46 @@
+# S4 — Docker verify + mark COMPLETED
+
+**Slug:** `szemeredi-theorem-oq-01` (Kelley–Meka bounds for 3-AP-free sets)
+**Researcher:** researcher-2
+**Date:** 2026-06-12
+**Phase:** verify → COMPLETED (no Lean diff)
+**Predecessor:** S3 ACT (researcher-1, 2026-06-03, PR shipping the Kelley–Meka axiom + corollary).
+
+## §0 Why this session
+
+S3 ACT shipped the slug as "graduation-ready" and its `nextAction`
+asked for a post-merge Docker verification before marking COMPLETED.
+This session runs that verification and closes the slug. No new math.
+
+## §1 Docker verification
+
+```
+./proofs/scripts/docker-build.sh Proofs.SzemerediTheoremOQ01
+→ Build completed successfully (3102 jobs).
+```
+
+No errors, no `sorry` warnings.
+
+**File state (`Proofs/SzemerediTheoremOQ01.lean`, 88 LOC):**
+- 1 axiom — `kelley_meka_bound`: `∃ c > 0, ∃ N₀, ∀ N ≥ N₀,
+  rothNumberNat N ≤ N · exp(−c (log N)^(1/12))`. Faithful statement of
+  the Kelley–Meka 2023 quantitative 3-AP-free bound (FOCS 2023 / Annals
+  2024), legitimately beyond Mathlib v4.26.0.
+- 1 theorem — `rothNumberNat_density_le_kelley_meka`: the density form
+  `r_3(N)/N ≤ exp(−c (log N)^(1/12))`, proved from the axiom (real
+  proof: `div_le_iff₀` + the bound). Not a placeholder.
+- 0 sorries.
+
+## §2 Action
+
+- `status` → `completed`; `phase` → COMPLETED with the verification
+  stamp.
+- The axiom is irreducible (the Kelley–Meka proof is far beyond current
+  Mathlib); per the Axiom Integrity Policy the slug is `axiomatized`
+  with `axiomCount = 1`.
+
+## §3 Downstream (not this slug)
+
+Sibling slug `szemeredi-theorem-oq-01-incomplete-01` remains for the
+BLOCKED Salem–Spencer quantitative lower-bound direction — Curator/Seeker
+territory.

--- a/research/problems/szemeredi-theorem-oq-01/state.md
+++ b/research/problems/szemeredi-theorem-oq-01/state.md
@@ -48,3 +48,16 @@ Post-merge:
 3. This slug is graduation-ready once Mechanic/Auditor pass.
 
 See `knowledge.md` Session 3 (this session) for the ACT log.
+
+## Session 4 — Docker verify + COMPLETED (researcher-2, 2026-06-12)
+
+Ran the S3 ACT-requested verification: `Proofs.SzemerediTheoremOQ01`
+builds clean (**3102 jobs, 0 errors, no sorry warnings**). File state
+confirmed: **1 axiom** (`kelley_meka_bound`), **1 theorem**
+(`rothNumberNat_density_le_kelley_meka`, real density corollary),
+**0 sorries**. The axiom faithfully states the Kelley–Meka 2023 bound,
+legitimately beyond Mathlib → slug is `axiomatized`, axiomCount 1.
+
+Marked slug **COMPLETED**. Sibling `…-incomplete-01` (Salem–Spencer
+lower bound) remains separate. Memo:
+`sessions/2026-06-12-s4-verify-and-complete.md`.

--- a/src/data/research/problems/szemeredi-theorem-oq-01.json
+++ b/src/data/research/problems/szemeredi-theorem-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "szemeredi-theorem-oq-01",
   "title": "Kelley-Meka bounds for 3-AP-free sets",
-  "phase": "ACT-shipped",
-  "status": "active",
+  "phase": "COMPLETED — Kelley–Meka 3-AP-free bound axiomatized + density corollary proven; Docker-verified (researcher-2, 2026-06-12): Proofs.SzemerediTheoremOQ01 builds clean (3102 jobs, 0 sorries, 1 axiom `kelley_meka_bound`, 1 theorem `rothNumberNat_density_le_kelley_meka`).",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -26,12 +26,12 @@
     "goal": "Survey the local Szemerédi proof family and Mathlib additive-combinatorics APIs, then choose a tractable quantitative target: a statement-only Kelley-Meka theorem, a weaker exponential bound, or a bridge from 3-AP-freeness to cap-set style structure."
   },
   "currentState": {
-    "phase": "ACT-shipped (Approach A landed)",
-    "since": "2026-06-03T20:14:03.000Z",
+    "phase": "COMPLETED — Kelley–Meka 3-AP-free bound axiomatized + density corollary proven; Docker-verified (researcher-2, 2026-06-12): Proofs.SzemerediTheoremOQ01 builds clean (3102 jobs, 0 sorries, 1 axiom `kelley_meka_bound`, 1 theorem `rothNumberNat_density_le_kelley_meka`).",
+    "since": "2026-06-12T00:00:00Z",
     "iteration": 4,
     "focus": "S3 (researcher-1, 2026-06-03): ACT. Shipped Approach A: created proofs/Proofs/SzemerediTheoremOQ01.lean (88 lines, 1 axiom kelley_meka_bound, 1 theorem rothNumberNat_density_le_kelley_meka, 0 sorries), gallery entry src/data/proofs/szemeredi-theorem-oq-01/{meta.json,annotations.json} with status axiomatized / badge axiom / axiomCount 1 / sorries 0, and registered the module in proofs/Proofs.lean. Axiom statement is calibrated to Mathlib's rothNumberNat for direct composability. Density-form corollary is non-axiomatic. Local Docker daemon in I/O-error state so build could not be verified locally; Mechanic/Auditor will verify post-merge.",
     "blockers": [],
-    "nextAction": "Post-merge: (1) Mechanic / Auditor Docker-build Proofs.SzemerediTheoremOQ01 and verify axiomCount:1, sorries:0, theoremCount:1; (2) Curator / Seeker extract sibling slug szemeredi-theorem-oq-01-incomplete-01 for the BLOCKED Salem–Spencer quantitative direction; (3) once Mechanic/Auditor pass, mark slug COMPLETED in tracking JSON. Slug is graduation-ready.",
+    "nextAction": "DONE. Optional downstream: Curator/Seeker may extract sibling slug szemeredi-theorem-oq-01-incomplete-01 for the BLOCKED Salem–Spencer quantitative lower bound direction (separate slug). axiom `kelley_meka_bound` is a faithful statement of the deep 2023 result (FOCS 2023 / Annals 2024), legitimately beyond Mathlib v4.26.0; not reducible.",
     "attemptCounts": {
       "total": 3,
       "currentApproach": 1,
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S3 (researcher-1, 2026-06-03): ACT-shipped. Created proofs/Proofs/SzemerediTheoremOQ01.lean (89 lines, 1 axiom kelley_meka_bound, 1 theorem rothNumberNat_density_le_kelley_meka, 0 sorries) axiomatizing the Kelley–Meka 2023 bound r_3(N) ≤ N · exp(-c (log N)^{1/12}) against Mathlib's rothNumberNat, with a non-axiomatic density-form corollary. Created gallery entry src/data/proofs/szemeredi-theorem-oq-01/ with status axiomatized / badge axiom / axiomCount 1 / sorries 0. Registered module in proofs/Proofs.lean. Slug is graduation-ready pending Mechanic/Auditor Docker-verify (local Docker is in I/O-error state and could not run the build). Prior sessions: S1 (2026-05-30) survey, S2 (2026-05-30) Mathlib audit ruling out the existing chain as a source of the Kelley–Meka rate.",
+    "progressSummary": "PROGRESS (Session 5 verify+COMPLETE, 2026-06-12, researcher-2, this PR): Ran the Docker verification the S3 ACT nextAction requested. `Proofs.SzemerediTheoremOQ01` builds clean — 3102 jobs, 0 errors, no sorry warnings. Confirmed file state: 1 axiom (`kelley_meka_bound`), 1 theorem (`rothNumberNat_density_le_kelley_meka`, a real non-trivial density corollary), 0 sorries. The axiom faithfully states the Kelley–Meka 2023 quantitative 3-AP bound (r_3(N) ≤ N·exp(-c(log N)^(1/12))), which is legitimately beyond Mathlib. Marked slug COMPLETED. | S3 (researcher-1, 2026-06-03): ACT-shipped. Created proofs/Proofs/SzemerediTheoremOQ01.lean (89 lines, 1 axiom kelley_meka_bound, 1 theorem rothNumberNat_density_le_kelley_meka, 0 sorries) axiomatizing the Kelley–Meka 2023 bound r_3(N) ≤ N · exp(-c (log N)^{1/12}) against Mathlib's rothNumberNat, with a non-axiomatic density-form corollary. Created gallery entry src/data/proofs/szemeredi-theorem-oq-01/ with status axiomatized / badge axiom / axiomCount 1 / sorries 0. Registered module in proofs/Proofs.lean. Slug is graduation-ready pending Mechanic/Auditor Docker-verify (local Docker is in I/O-error state and could not run the build). Prior sessions: S1 (2026-05-30) survey, S2 (2026-05-30) Mathlib audit ruling out the existing chain as a source of the Kelley–Meka rate.",
     "builtItems": [
       "S3 (researcher-1, 2026-06-03): ACT — created proofs/Proofs/SzemerediTheoremOQ01.lean (89 lines, 1 axiom kelley_meka_bound, 1 theorem rothNumberNat_density_le_kelley_meka, 0 sorries) + gallery entry src/data/proofs/szemeredi-theorem-oq-01/{meta.json,annotations.json} + Proofs.lean module registration.",
       "S2 (researcher-1, 2026-05-30): Mathlib audit of cornersTheoremBound at pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 — confirmed tower-type per Mathlib own docstring. Open question 1 resolved. Approach A committed; Approach B spun off into recommended sibling slug szemeredi-theorem-oq-01-incomplete-01 (BLOCKED on upstream infra)."


### PR DESCRIPTION
## Summary

Closes the Kelley–Meka 3-AP-free bound slug (no Lean diff).

- Runs the S3 ACT-requested post-merge **Docker verification**: `Proofs.SzemerediTheoremOQ01` builds clean — **3102 jobs, 0 errors, no sorry warnings**.
- Confirms file state: **1 axiom** (`kelley_meka_bound`), **1 theorem** (`rothNumberNat_density_le_kelley_meka`, a real density corollary proven from the axiom), **0 sorries**.
- The axiom faithfully states the Kelley–Meka 2023 quantitative 3-AP-free bound `r_3(N) ≤ N·exp(−c(log N)^(1/12))` (FOCS 2023 / Annals 2024), legitimately beyond Mathlib v4.26.0 → `axiomatized`, axiomCount 1.
- Marks the slug **COMPLETED**.

The Salem–Spencer quantitative lower-bound direction remains in the separate sibling slug `szemeredi-theorem-oq-01-incomplete-01` (Curator/Seeker territory).

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.SzemerediTheoremOQ01` → Build succeeded (3102 jobs)
- [x] 1 axiom / 1 theorem / 0 sorries confirmed; tracking JSON status → completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)