### PR TITLE
research(legendre-oq02): iter6 S5-ACT-B' — eventually-suffices Legendre criterion

### DIFF
--- a/proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean
+++ b/proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean
@@ -106,77 +106,117 @@ lemma nth_prime_ge (k : ℕ) : k + 2 ≤ Nat.nth Nat.Prime k := by
 
 /-! ## Main theorem -/
 
-/-- **Sqrt prime-gap upper bound implies Legendre's Conjecture.**
+/-- **Eventually-suffices form of the sqrt prime-gap criterion.**
 
-If consecutive prime gaps are bounded by `2 · √p_k + 1` for every `k`, then
-for every `n ≥ 1` there is a prime in `(n², (n+1)²)`. The proof uses the
-largest prime ≤ `n²` (existence via `Nat.findGreatest`) and the strict
-inequality `p_k < n²` from compositeness of `n²` for `n ≥ 2`. -/
-theorem prime_gap_sqrt_bound_implies_legendre (h : PrimeGapSqrtBound) :
+If the sqrt prime-gap bound `p_{k+1} - p_k ≤ 2·√p_k + 1` holds for every prime
+`p_k ≥ M`, and Legendre's conjecture is verified directly for every `n` with
+`n² < 2M`, then Legendre's Conjecture holds in full.
+
+The threshold `2M` is exactly what Bertrand's postulate supplies: when
+`n² ≥ 2M`, Bertrand gives a prime in `(n²/2, n²]`, so the largest prime `p_k`
+not exceeding `n²` satisfies `p_k > n²/2 ≥ M`, and the gap hypothesis is
+applicable at that `k`. The remainder of the argument is the iter-5
+`findGreatest` construction. Taking `M = 0` recovers the unconditional
+`prime_gap_sqrt_bound_implies_legendre` below. -/
+theorem prime_gap_sqrt_bound_above_implies_legendre (M : ℕ)
+    (h_gap_above : ∀ k, M ≤ Nat.nth Nat.Prime k →
+      Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
+        ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1)
+    (h_legendre_below : ∀ n, 1 ≤ n → n^2 < 2 * M → LegendreAt n) :
     LegendreConjecture := by
   intro n hn
   rcases lt_or_ge n 2 with hn1 | hn2
   · -- n = 1 case: prime 2 witnesses LegendreAt 1
     interval_cases n
     exact ⟨2, Nat.prime_two, by norm_num, by norm_num⟩
-  · -- n ≥ 2 case: use the largest prime ≤ n²
-    set P : ℕ → Prop := fun k => Nat.nth Nat.Prime k ≤ n^2 with hP_def
-    set k := Nat.findGreatest P (n^2) with hk_def
-    -- P 0 holds: nth Prime 0 = 2 ≤ n² (since n ≥ 2 implies n² ≥ 4)
-    have hP0 : P 0 := by
-      show Nat.nth Nat.Prime 0 ≤ n^2
-      rw [first_prime]
-      nlinarith [sq_nonneg n]
-    -- The predicate holds at the maximizer.
-    have hP_k : P k := Nat.findGreatest_spec (Nat.zero_le _) hP0
-    -- The maximizer is ≤ the search bound.
-    have hk_le : k ≤ n^2 := Nat.findGreatest_le _
-    -- nth Prime k is itself prime.
-    have hk_prime : Nat.Prime (Nat.nth Nat.Prime k) := nth_prime_is_prime k
-    -- n² is composite for n ≥ 2.
-    have hn2_not_prime : ¬ Nat.Prime (n^2) := not_prime_sq_of_ge_two hn2
-    -- So the inequality `nth Prime k ≤ n²` is strict.
-    have hk_lt : Nat.nth Nat.Prime k < n^2 := by
-      rcases lt_or_eq_of_le hP_k with h | h
-      · exact h
-      · exfalso
-        rw [← h] at hn2_not_prime
-        exact hn2_not_prime hk_prime
-    -- k + 1 ≤ n² (since nth Prime k ≥ k + 2 and nth Prime k < n²).
-    have hk_succ_le : k + 1 ≤ n^2 := by
-      have hge := nth_prime_ge k
-      omega
-    -- The predicate fails at k + 1, since k = findGreatest.
-    have hPk1_not : ¬ P (k + 1) := by
-      have hlt : Nat.findGreatest P (n^2) < k + 1 := by
-        rw [← hk_def]; omega
-      exact Nat.findGreatest_is_greatest hlt hk_succ_le
-    -- Therefore nth Prime (k+1) > n².
-    have hkp1_gt : n^2 < Nat.nth Nat.Prime (k + 1) := by
-      change ¬ (Nat.nth Nat.Prime (k + 1) ≤ n^2) at hPk1_not
-      omega
-    -- Apply the gap-bound hypothesis at k.
-    have hgap : Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
-              ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1 := h k
-    -- Strict monotonicity converts the Nat-subtraction into addition.
-    have hkp1_strict : Nat.nth Nat.Prime k < Nat.nth Nat.Prime (k + 1) :=
-      Nat.nth_strictMono Nat.infinite_setOf_prime (Nat.lt_succ_self k)
-    -- Bound the sqrt term by `n - 1`.
-    have hsqrt_mono : Nat.sqrt (Nat.nth Nat.Prime k) ≤ Nat.sqrt (n^2 - 1) := by
-      apply Nat.sqrt_le_sqrt; omega
-    have hsqrt_n_sub : Nat.sqrt (n^2 - 1) ≤ n - 1 := by
-      have h_lt_n : Nat.sqrt (n^2 - 1) < n := by
-        rw [Nat.sqrt_lt']
-        have hpos : (0 : ℕ) < n^2 := by positivity
+  · -- n ≥ 2 case
+    rcases lt_or_ge (n^2) (2 * M) with hsmall | hlarge
+    · -- n² < 2M: Legendre is verified below the threshold by hypothesis
+      exact h_legendre_below n hn hsmall
+    · -- n² ≥ 2M: use the largest prime ≤ n²
+      set P : ℕ → Prop := fun k => Nat.nth Nat.Prime k ≤ n^2 with hP_def
+      set k := Nat.findGreatest P (n^2) with hk_def
+      -- P 0 holds: nth Prime 0 = 2 ≤ n² (since n ≥ 2 implies n² ≥ 4)
+      have hP0 : P 0 := by
+        show Nat.nth Nat.Prime 0 ≤ n^2
+        rw [first_prime]
+        nlinarith [sq_nonneg n]
+      have hP_k : P k := Nat.findGreatest_spec (Nat.zero_le _) hP0
+      have hk_le : k ≤ n^2 := Nat.findGreatest_le _
+      have hk_prime : Nat.Prime (Nat.nth Nat.Prime k) := nth_prime_is_prime k
+      have hn2_not_prime : ¬ Nat.Prime (n^2) := not_prime_sq_of_ge_two hn2
+      have hk_lt : Nat.nth Nat.Prime k < n^2 := by
+        rcases lt_or_eq_of_le hP_k with h | h
+        · exact h
+        · exfalso
+          rw [← h] at hn2_not_prime
+          exact hn2_not_prime hk_prime
+      have hk_succ_le : k + 1 ≤ n^2 := by
+        have hge := nth_prime_ge k
         omega
-      omega
-    have hsqrt_bound : Nat.sqrt (Nat.nth Nat.Prime k) ≤ n - 1 := by omega
-    -- Combine: nth Prime (k+1) < (n+1)² = n² + 2n + 1.
-    have hkp1_lt : Nat.nth Nat.Prime (k + 1) < (n + 1)^2 := by
-      have hpow : (n + 1)^2 = n^2 + 2 * n + 1 := by ring
-      rw [hpow]
-      omega
-    exact ⟨Nat.nth Nat.Prime (k + 1), nth_prime_is_prime (k + 1), hkp1_gt, hkp1_lt⟩
+      have hPk1_not : ¬ P (k + 1) := by
+        have hlt : Nat.findGreatest P (n^2) < k + 1 := by
+          rw [← hk_def]; omega
+        exact Nat.findGreatest_is_greatest hlt hk_succ_le
+      have hkp1_gt : n^2 < Nat.nth Nat.Prime (k + 1) := by
+        change ¬ (Nat.nth Nat.Prime (k + 1) ≤ n^2) at hPk1_not
+        omega
+      -- NEW (this iteration): the largest prime ≤ n² is itself ≥ M.
+      -- Bertrand gives a prime q ∈ (n²/2, n²]; since p_k is the largest prime
+      -- ≤ n², we have q ≤ p_k, and q > n²/2 ≥ M, hence M ≤ p_k.
+      have hM_le_pk : M ≤ Nat.nth Nat.Prime k := by
+        have h4 : (4 : ℕ) ≤ n^2 := by
+          calc (4 : ℕ) = 2^2 := by norm_num
+            _ ≤ n^2 := Nat.pow_le_pow_left hn2 2
+        have hmpos : n^2 / 2 ≠ 0 := by omega
+        obtain ⟨q, hq_prime, hq_gt, hq_le⟩ := Nat.bertrand (n^2 / 2) hmpos
+        have hq_le_n2 : q ≤ n^2 := by omega
+        have hM_le_q : M ≤ q := by omega
+        set j := Nat.count Nat.Prime q with hj_def
+        have hnj : Nat.nth Nat.Prime j = q := Nat.nth_count hq_prime
+        have hj_le_n2 : j ≤ n^2 := by
+          have hge := nth_prime_ge j
+          rw [hnj] at hge; omega
+        have hPj : P j := by
+          show Nat.nth Nat.Prime j ≤ n^2
+          rw [hnj]; exact hq_le_n2
+        have hj_le_k : j ≤ k := Nat.le_findGreatest hj_le_n2 hPj
+        have hq_le_pk : q ≤ Nat.nth Nat.Prime k := by
+          have hmono := Nat.nth_monotone Nat.infinite_setOf_prime hj_le_k
+          rw [hnj] at hmono; exact hmono
+        omega
+      -- Apply the (eventual) gap-bound hypothesis at k.
+      have hgap : Nat.nth Nat.Prime (k + 1) - Nat.nth Nat.Prime k
+                ≤ 2 * Nat.sqrt (Nat.nth Nat.Prime k) + 1 := h_gap_above k hM_le_pk
+      have hkp1_strict : Nat.nth Nat.Prime k < Nat.nth Nat.Prime (k + 1) :=
+        Nat.nth_strictMono Nat.infinite_setOf_prime (Nat.lt_succ_self k)
+      have hsqrt_mono : Nat.sqrt (Nat.nth Nat.Prime k) ≤ Nat.sqrt (n^2 - 1) := by
+        apply Nat.sqrt_le_sqrt; omega
+      have hsqrt_n_sub : Nat.sqrt (n^2 - 1) ≤ n - 1 := by
+        have h_lt_n : Nat.sqrt (n^2 - 1) < n := by
+          rw [Nat.sqrt_lt']
+          have hpos : (0 : ℕ) < n^2 := by positivity
+          omega
+        omega
+      have hsqrt_bound : Nat.sqrt (Nat.nth Nat.Prime k) ≤ n - 1 := by omega
+      have hkp1_lt : Nat.nth Nat.Prime (k + 1) < (n + 1)^2 := by
+        have hpow : (n + 1)^2 = n^2 + 2 * n + 1 := by ring
+        rw [hpow]
+        omega
+      exact ⟨Nat.nth Nat.Prime (k + 1), nth_prime_is_prime (k + 1), hkp1_gt, hkp1_lt⟩
+
+/-- **Sqrt prime-gap upper bound implies Legendre's Conjecture.**
+
+If consecutive prime gaps are bounded by `2 · √p_k + 1` for every `k`, then
+for every `n ≥ 1` there is a prime in `(n², (n+1)²)`. This is the `M = 0`
+specialisation of `prime_gap_sqrt_bound_above_implies_legendre`: with no
+threshold, the gap hypothesis holds for every prime and the
+`n² < 0` "below" branch is vacuous. -/
+theorem prime_gap_sqrt_bound_implies_legendre (h : PrimeGapSqrtBound) :
+    LegendreConjecture :=
+  prime_gap_sqrt_bound_above_implies_legendre 0
+    (fun k _ => h k)
+    (fun _ _ hlt => absurd hlt (by omega))
 
 /-! ## Corollary: the gap bound suffices in all equivalent forms
 

--- a/research/problems/bertrands-postulate-oq-02/sessions/2026-06-12-iter6-s5-act-b-prime-above-suffices.md
+++ b/research/problems/bertrands-postulate-oq-02/sessions/2026-06-12-iter6-s5-act-b-prime-above-suffices.md
@@ -1,0 +1,71 @@
+# iter6 S5-ACT-B′ — `prime_gap_sqrt_bound_above_implies_legendre` landed
+
+**Slug:** `bertrands-postulate-oq-02` (Legendre's conjecture for square intervals)
+**Researcher:** researcher-2
+**Date:** 2026-06-12
+**Phase:** ACT (Lean diff, Docker-verified)
+**Predecessor:** iter5 S4 ACT (alpha sqrt-bound-suffices, the global-hypothesis
+`prime_gap_sqrt_bound_implies_legendre`); iter6 S5 PREP (Cramér bridge gap).
+**File:** `proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean`
+
+## Result
+
+Implements the iter-5 PREP refinement (the `S5-ACT-B′` next-action): a strictly
+stronger **eventually-suffices** conditional reduction for Legendre's
+conjecture, and re-derives the previous theorem as its `M = 0` corollary.
+
+```lean
+theorem prime_gap_sqrt_bound_above_implies_legendre (M : ℕ)
+    (h_gap_above : ∀ k, M ≤ nth Prime k → p_{k+1} - p_k ≤ 2·√p_k + 1)
+    (h_legendre_below : ∀ n, 1 ≤ n → n² < 2·M → LegendreAt n) :
+    LegendreConjecture
+```
+
+Docker: `./proofs/scripts/docker-build.sh Proofs.LegendrePrimeGapSqrtBoundSuffices`
+→ **Build succeeded (3074 jobs)**, first try. 0 sorries, 0 new axioms.
+
+## Why it is stronger
+
+The previous `prime_gap_sqrt_bound_implies_legendre` required the sqrt gap
+bound for **every** `k`. The new form only needs it for primes `p_k ≥ M`
+(an *eventual* / asymptotic hypothesis — the realistic shape of any
+analytic gap input, e.g. a Cramér-type bound that holds past some
+threshold), with the finitely-many small `n` (those with `n² < 2M`)
+discharged separately by `h_legendre_below` (e.g. `native_decide`, as the
+`legendre_k` facts in `LegendrePartial.lean` already do).
+
+## Proof structure
+
+`intro n hn`, then:
+
+1. `n = 1`: prime `2 ∈ (1,4)` directly (unchanged).
+2. `n ≥ 2`, `n² < 2M`: `exact h_legendre_below n hn _`.
+3. `n ≥ 2`, `n² ≥ 2M`: the iter-5 `Nat.findGreatest` construction for the
+   largest prime `p_k ≤ n²`, **plus** the new step establishing `M ≤ p_k`:
+   - `Nat.bertrand (n²/2)` gives a prime `q` with `n²/2 < q ≤ 2·(n²/2) ≤ n²`;
+   - `q`'s prime index `j = Nat.count Nat.Prime q` satisfies `P j` and
+     `j ≤ n²`, so `Nat.le_findGreatest` gives `j ≤ k`, hence (by
+     `Nat.nth_monotone`) `q ≤ p_k`;
+   - `n² ≥ 2M ⇒ n²/2 ≥ M`, so `M ≤ q ≤ p_k`.
+
+   With `M ≤ p_k`, apply `h_gap_above k`; the rest (sqrt bound `≤ n−1`,
+   `p_{k+1} < (n+1)²`) is verbatim the iter-5 argument.
+
+`prime_gap_sqrt_bound_implies_legendre` is now the one-liner
+`prime_gap_sqrt_bound_above_implies_legendre 0 (fun k _ => h k) (fun _ _ hlt => absurd hlt (by omega))`,
+so the three downstream equivalence corollaries (gap / distance / half-open
+forms) are unchanged and still build.
+
+## Axiom status
+
+0 new axioms. The ambient `Legendre.legendre_conjecture` axiom in
+`LegendrePartial.lean` is untouched; this file remains a pure conditional
+reduction (`hypothesis → LegendreConjecture`).
+
+## Next
+
+S5-ACT-A (the genuinely hard analytic half): supply an actual `M` and a proof
+of `h_gap_above` from a real prime-gap theorem (Cramér / known unconditional
+bounds give `gap = O(√p · log p)`, which does **not** beat `2√p+1` — so this
+reduction is currently a conditional statement, not a path to an unconditional
+Legendre proof; that obstacle is unchanged and inherent to the OQ).

--- a/research/problems/bertrands-postulate-oq-02/state.md
+++ b/research/problems/bertrands-postulate-oq-02/state.md
@@ -430,3 +430,16 @@ Size: +100-150 LOC. Could be done before or after S4; independent.
 - Tao, T. "Structure and randomness in the prime numbers" (2007).
   Notes that Legendre's Conjecture is strictly stronger than what RH
   implies for prime gaps.
+
+## iter6 S5-ACT-B′ — eventually-suffices theorem (researcher-2, 2026-06-12)
+
+Landed `prime_gap_sqrt_bound_above_implies_legendre (M)` in
+`LegendrePrimeGapSqrtBoundSuffices.lean`: the sqrt prime-gap bound need only
+hold for primes `p_k ≥ M`, with `n² < 2M` cases handled by a separate
+`h_legendre_below` hypothesis. New ingredient vs iter-5: `Nat.bertrand` +
+`Nat.nth_count`/`Nat.le_findGreatest`/`Nat.nth_monotone` to show the largest
+prime `≤ n²` is `≥ M` when `n² ≥ 2M`. The old global theorem
+`prime_gap_sqrt_bound_implies_legendre` is now its `M = 0` corollary;
+downstream equivalence corollaries unchanged. **Docker: 3074 jobs, first try;
+0 sorries, 0 new axioms.** Memo:
+`sessions/2026-06-12-iter6-s5-act-b-prime-above-suffices.md`.

--- a/src/data/research/problems/bertrands-postulate-oq-02.json
+++ b/src/data/research/problems/bertrands-postulate-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "bertrands-postulate-oq-02",
   "title": "Legendre conjecture for square intervals",
-  "phase": "ACT",
+  "phase": "ACT — iter6 S5-ACT-B′ landed (researcher-2, 2026-06-12): prime_gap_sqrt_bound_above_implies_legendre (eventually-suffices form, gap bound only for p_k≥M, small n via h_legendre_below); old global theorem now its M=0 corollary. Docker 3074 jobs, 0 sorries / 0 new axioms.",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -25,12 +25,12 @@
     "goal": "Track the open Legendre conjecture alongside the formal Bertrand and short-interval hierarchy."
   },
   "currentState": {
-    "phase": "PREP",
-    "since": "2026-06-10T00:00:00Z",
+    "phase": "ACT — iter6 S5-ACT-B′ landed (researcher-2, 2026-06-12): prime_gap_sqrt_bound_above_implies_legendre (eventually-suffices form, gap bound only for p_k≥M, small n via h_legendre_below); old global theorem now its M=0 corollary. Docker 3074 jobs, 0 sorries / 0 new axioms.",
+    "since": "2026-06-12T00:00:00Z",
     "iteration": 6,
     "focus": "S5-PREP-2 DONE (researcher-9, 2026-06-10): pre-flight audit of iter-5's recommended S5 Cramér⇒Legendre ACT. Finding: iter-5's PrimeGapSqrtBound (∀ k) does NOT directly accept Cramér's eventually-quantified output (∀ k ≥ k₀); the bound fails at small k. Numerical analysis: smallest p where C·log²p ≤ 2√p+1 is p=121 (k₀≈29) for C=1 and p=358 (k₀≈70) for the Granville-optimal C=2e^{-γ}. For n≥21 iter-5 uses gap at k(n)≥84, exceeding both thresholds; legendre-partial's n=1..20 finite-tail suffices with margin. Remediation specified: a refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M (with Bertrand-based bridging) recovers iter-5 at M=0. ~85 LOC, 0 new axioms.",
     "blockers": [],
-    "nextAction": "S5-ACT-B′ — implement the refined iter-5 variant inside LegendrePrimeGapSqrtBoundSuffices.lean. Add prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) with hypotheses (h_gap_above : ∀ k, M ≤ p_k → gap ≤ 2√p_k+1) and (h_legendre_below : ∀ n, 1 ≤ n → n² < 2*M → LegendreAt n). Proof: case n² < 2*M direct from h_legendre_below; case n² ≥ 2*M applies Nat.bertrand at n²/2 to obtain p_k > n²/2 ≥ M, then replays iter-5's findGreatest construction. Derive prime_gap_sqrt_bound_implies_legendre as the corollary at M = 0. Estimated +85 LOC, 0 new axioms. Unblocks S5-ACT-A (real-analytic C·log²p ≤ 2√p+1) and S5-ACT-C (Cramér composition).",
+    "nextAction": "S5-ACT-A (the hard analytic half): instantiate M and prove h_gap_above from a real prime-gap theorem. NOTE inherent obstacle — known unconditional gap bounds (Cramér-type / Baker–Harman–Pintz) give gap = O(p^0.525) or O(√p·log p), which do NOT beat 2√p+1, so this reduction stays conditional and is not (by itself) a route to unconditional Legendre. The eventually-suffices form is nonetheless the correct target shape for any future analytic input. Optional: a sibling slug could host the C·log²p ≤ 2√p+1 real-analytic lemma.",
     "lastUpdate": "2026-06-10T00:00:00Z",
     "attemptCounts": {
       "total": 6,
@@ -39,7 +39,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "Iter 6 PREP (2026-06-10): S5-PREP-2 DONE — pre-flight audit identified a structural quantifier mismatch between iter-5's PrimeGapSqrtBound (∀ k) and Cramér's eventually-quantified gap bound (∀ k ≥ k₀). Numerical thresholds pinned (p₀=121 for C=1, p₀=358 for Granville-optimal); legendre-partial's n=1..20 finite-tail covers the post-threshold regime with margin. Specified refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M, with Bertrand-based proof outline (~85 LOC, 0 new axioms); iter-5 is recovered at M=0. Iter 5 ACT (2026-06-06): S4-ACT-α DONE — LegendrePrimeGapSqrtBoundSuffices.lean (227 LOC, 0 axioms, 0 sorries, Docker build verified) formalizes the salvageable one-way implication PrimeGapSqrtBound → LegendreConjecture, plus three free corollaries via iter-2 equivalences. Iter 4 PREP-1 (2026-06-05): audited the iter-3 S4 plan; found the proposed iff is NOT a true equivalence. Iter 2 (2026-05-30): LegendreGapEquivalence.lean proves four equivalent reformulations.",
+    "progressSummary": "PROGRESS (iter6 S5-ACT-B′, 2026-06-12, researcher-2, this PR, Docker-verified): Added `prime_gap_sqrt_bound_above_implies_legendre (M)` to LegendrePrimeGapSqrtBoundSuffices.lean — a strictly stronger eventually-suffices conditional reduction: the sqrt prime-gap bound is only needed for primes p_k ≥ M, with the finitely-many n where n² < 2M discharged by a separate h_legendre_below hypothesis. New proof ingredient vs iter-5: Nat.bertrand at n²/2 + Nat.nth_count / Nat.le_findGreatest / Nat.nth_monotone to show the largest prime ≤ n² is ≥ M when n² ≥ 2M. The previous global theorem prime_gap_sqrt_bound_implies_legendre is now its M=0 corollary (one-liner); the three downstream equivalence corollaries are unchanged. Build: 3074 jobs, first try; 0 sorries, 0 new axioms. | Iter 6 PREP (2026-06-10): S5-PREP-2 DONE — pre-flight audit identified a structural quantifier mismatch between iter-5's PrimeGapSqrtBound (∀ k) and Cramér's eventually-quantified gap bound (∀ k ≥ k₀). Numerical thresholds pinned (p₀=121 for C=1, p₀=358 for Granville-optimal); legendre-partial's n=1..20 finite-tail covers the post-threshold regime with margin. Specified refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M, with Bertrand-based proof outline (~85 LOC, 0 new axioms); iter-5 is recovered at M=0. Iter 5 ACT (2026-06-06): S4-ACT-α DONE — LegendrePrimeGapSqrtBoundSuffices.lean (227 LOC, 0 axioms, 0 sorries, Docker build verified) formalizes the salvageable one-way implication PrimeGapSqrtBound → LegendreConjecture, plus three free corollaries via iter-2 equivalences. Iter 4 PREP-1 (2026-06-05): audited the iter-3 S4 plan; found the proposed iff is NOT a true equivalence. Iter 2 (2026-05-30): LegendreGapEquivalence.lean proves four equivalent reformulations.",
     "builtItems": [
       "legendre_conjecture axiom in BertrandsPostulateOQ03.lean",
       "prime-gap hierarchy rows shared with the Bertrand short-interval development",


### PR DESCRIPTION
## Summary

Strengthens the sqrt prime-gap criterion for Legendre's conjecture in `LegendrePrimeGapSqrtBoundSuffices.lean`.

New theorem (Docker-verified, 0 sorries, 0 new axioms):

```lean
theorem prime_gap_sqrt_bound_above_implies_legendre (M : ℕ)
    (h_gap_above : ∀ k, M ≤ nth Prime k → p_{k+1} - p_k ≤ 2·√p_k + 1)
    (h_legendre_below : ∀ n, 1 ≤ n → n² < 2·M → LegendreAt n) :
    LegendreConjecture
```

- **Why stronger:** the previous `prime_gap_sqrt_bound_implies_legendre` required the gap bound for *every* `k`. This form only needs it for primes `p_k ≥ M` (an *eventual*/asymptotic hypothesis — the realistic shape of any analytic gap input), with the finitely-many small `n` (those with `n² < 2M`) discharged separately.
- **New proof ingredient:** `Nat.bertrand` at `n²/2` gives a prime `q ∈ (n²/2, n²]`; via `Nat.nth_count` / `Nat.le_findGreatest` / `Nat.nth_monotone`, the largest prime `p_k ≤ n²` satisfies `q ≤ p_k`, and `n² ≥ 2M ⇒ n²/2 ≥ M`, so `M ≤ p_k` and the gap hypothesis applies. The rest is the iter-5 `findGreatest` argument verbatim.
- **Refactor:** `prime_gap_sqrt_bound_implies_legendre` is now the `M = 0` corollary (one-liner); the three downstream equivalence corollaries (gap / distance / half-open) are unchanged.

The reduction remains *conditional*: known unconditional gap bounds do not beat `2√p+1`, so this is not by itself a route to unconditional Legendre — but the eventually-suffices shape is the correct target for any future analytic input.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.LegendrePrimeGapSqrtBoundSuffices` → Build succeeded (3074 jobs, first try)
- [x] 0 sorries, 0 new axioms; downstream corollaries still build

🤖 Generated with [Claude Code](https://claude.com/claude-code)