### PR TITLE
fix(erdos-28): correct meta.axiomCount 3->2 to match source

### DIFF
--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/28",
     "erdosUrl": "https://erdosproblems.com/28",
     "proofRepoPath": "Proofs/Erdos28AdditiveBases.lean",
-    "axiomCount": 3,
+    "axiomCount": 2,
     "assumptions": "2 axioms: grekos_lower_bound (Grekos et al. 2003: r_A(n) ≥ 6 infinitely often), borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 infinitely often). sidon_not_basis PROVED as theorem (PR #6840). sidon_density_bound PROVED via bridge lemma importing Erdos340.sidon_upper_bound_weak. 14 theorems proved including isAsymptoticBasis_iff, sidon_repFunc_bounded, erdos_turan_holds_for_nat, basis_element_count_sq, sidon_density_bound.",
     "badge": "axiom",
     "prerequisites": [


### PR DESCRIPTION
## Summary
- `src/data/proofs/erdos-28/meta.json` had `meta.axiomCount: 3`, but the Lean source (`proofs/Proofs/Erdos28AdditiveBases.lean`) declares exactly **2** axioms: `grekos_lower_bound` and `borwein_lower_bound`.
- This contradicted `leanFile.axiomCount` (2) and the `assumptions` text ("2 axioms: ..."). Corrected to 2.
- `sidon_density_bound` and `sidon_not_basis` are proved theorems, not axioms. The transitive `Erdos340.sidon_upper_bound_weak` dependency is disclosed in `assumptions` and counted in the Erdos340 entry, not double-counted here.
- Status `axiomatized` / badge `axiom` remain correct (no overclaim).

Metadata-only; no Lean changes.

Closes #22904

## Test plan
- [x] `grep -c '^axiom ' proofs/Proofs/Erdos28AdditiveBases.lean` = 2
- [x] `meta.axiomCount` now matches `leanFile.axiomCount` and `assumptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)