### PR TITLE
audit(binomial-theorem): re-audit clean — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -970,9 +970,9 @@
       "result": "clean"
     },
     "binomial-theorem": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T16:43:29Z",
+      "lastAudited": "2026-06-12T15:35:25Z",
       "result": "clean"
     },
     "binomial-theorem-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: binomial-theorem (Wiedijk #44)
**Result**: CLEAN — all claims match Lean source at HEAD fa1c4d27aa8.

## Checks
- `status: verified` / `badge: mathlib` — correct Tier B classification. Core result derives from Mathlib's `add_pow`, explicitly disclosed in the description and `mathlibDependencies`. No delegation opacity or import masking.
- `theoremCount: 9` matches actual (`grep -cE '^theorem '` = 9)
- `sorries: 0` matches actual
- `axiomCount: 0` matches actual; 0 structure-encoded assumptions
- No `True` stubs

Tracker bump only (no meta.json changes needed).

---
Discovered during gallery integrity audit.