### PR TITLE
research(minpoly-charpoly-oq-02): prove forward direction of diagonalizable ⇔ squarefree minpoly

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ02.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ02.lean
@@ -1,6 +1,7 @@
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Basic
 import Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly
 import Mathlib.LinearAlgebra.Matrix.IsDiag
+import Mathlib.LinearAlgebra.Matrix.NonsingularInverse
 import Mathlib.LinearAlgebra.Semisimple
 import Mathlib.LinearAlgebra.Eigenspace.Semisimple
 import Mathlib.LinearAlgebra.Eigenspace.Triangularizable
@@ -107,10 +108,107 @@ endomorphism. -/
 def _root_.Matrix.IsDiagonalizable (M : Matrix n n K) : Prop :=
   ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P)
 
-/-- **S1 OBSERVE main theorem (statement only).** Over an algebraically
-closed field of characteristic zero, a matrix is diagonalizable iff its
-minimal polynomial is squarefree. The four sub-OQs (OQ-02-OQ-01 ..
-OQ-02-OQ-04) are designed to discharge the `sorry`.
+-- ============================================================
+-- Forward direction (PROVED, unconditional over any field)
+-- ============================================================
+
+/-- Conjugation `x ↦ Q * x * P` by a two-sided-inverse pair `(P, Q)` as an
+algebra automorphism of the matrix algebra. Used to transport the minimal
+polynomial across a similarity transform. -/
+def matConj (P Q : Matrix n n K) (hPQ : P * Q = 1) (hQP : Q * P = 1) :
+    Matrix n n K ≃ₐ[K] Matrix n n K where
+  toFun x := Q * x * P
+  invFun x := P * x * Q
+  left_inv x := by
+    show P * (Q * x * P) * Q = x
+    calc P * (Q * x * P) * Q
+        = (P * Q) * x * (P * Q) := by simp only [mul_assoc]
+      _ = x := by rw [hPQ]; simp
+  right_inv x := by
+    show Q * (P * x * Q) * P = x
+    calc Q * (P * x * Q) * P
+        = (Q * P) * x * (Q * P) := by simp only [mul_assoc]
+      _ = x := by rw [hQP]; simp
+  map_mul' x y := by
+    show Q * (x * y) * P = Q * x * P * (Q * y * P)
+    calc Q * (x * y) * P
+        = Q * x * (P * Q) * y * P := by rw [hPQ]; simp only [mul_assoc, mul_one]
+      _ = Q * x * P * (Q * y * P) := by simp only [mul_assoc]
+  map_add' x y := by
+    show Q * (x + y) * P = Q * x * P + Q * y * P
+    rw [mul_add, add_mul]
+  commutes' r := by
+    show Q * (algebraMap K (Matrix n n K) r) * P = algebraMap K (Matrix n n K) r
+    rw [mul_assoc, Algebra.commutes, ← mul_assoc, hQP, one_mul]
+
+/-- A diagonal matrix has squarefree minimal polynomial. The minimal
+polynomial divides `∏_{c ∈ image of the diagonal} (X - c)`, a product of
+distinct linear factors, which is separable hence squarefree. Holds over any
+field. -/
+theorem squarefree_minpoly_of_isDiag {D : Matrix n n K} (hD : D.IsDiag) :
+    Squarefree (minpoly K D) := by
+  classical
+  set v : n → K := Matrix.diag D with hv
+  have hDdiag : D = diagonal v := (hD.diagonal_diag).symm
+  set S : Finset K := Finset.image v Finset.univ with hS
+  set p : K[X] := ∏ c ∈ S, (X - C c) with hp
+  have key : (aeval (diagonal v)) p = diagonal (fun i => (aeval (v i)) p) := by
+    have h1 : (diagonal v : Matrix n n K) = diagonalAlgHom K v := by
+      simp [diagonalAlgHom_apply]
+    rw [h1, aeval_algHom_apply, diagonalAlgHom_apply]
+    congr 1
+    funext i
+    exact aeval_pi_apply₂ v p i
+  have hentry : ∀ i, (aeval (v i)) p = 0 := by
+    intro i
+    have hvi : v i ∈ S := Finset.mem_image_of_mem v (Finset.mem_univ i)
+    have : (aeval (v i)) p = ∏ c ∈ S, (v i - c) := by
+      rw [hp, map_prod]
+      refine Finset.prod_congr rfl ?_
+      intro c _
+      simp [map_sub, aeval_X, aeval_C]
+    rw [this]
+    exact Finset.prod_eq_zero hvi (by simp)
+  have hann : (aeval D) p = 0 := by
+    rw [hDdiag, key]
+    ext i j
+    by_cases h : i = j
+    · subst h
+      simp only [Matrix.diagonal_apply_eq, Matrix.zero_apply, hentry]
+    · simp only [Matrix.diagonal_apply_ne _ h, Matrix.zero_apply]
+  have hdvd : minpoly K D ∣ p := minpoly.dvd K D hann
+  have hsep : p.Separable := by
+    rw [hp]
+    exact (separable_prod_X_sub_C_iff' (f := fun c : K => c) (s := S)).mpr
+      (fun x _ y _ h => h)
+  exact hsep.squarefree.squarefree_of_dvd hdvd
+
+/-- **Forward direction of the headline biconditional (PROVED).** A
+diagonalizable matrix has squarefree minimal polynomial. This holds over any
+field — no algebraic-closure or characteristic-zero hypotheses are needed
+(those are only required for the converse). -/
+theorem _root_.Matrix.IsDiagonalizable.squarefree_minpoly {M : Matrix n n K}
+    (h : M.IsDiagonalizable) : Squarefree (minpoly K M) := by
+  obtain ⟨P, hP, hdiag⟩ := h
+  have hdet : IsUnit P.det := (Matrix.isUnit_iff_isUnit_det P).mp hP
+  have hPQ : P * P⁻¹ = 1 := Matrix.mul_nonsing_inv P hdet
+  have hQP : P⁻¹ * P = 1 := Matrix.nonsing_inv_mul P hdet
+  have hmeq : minpoly K (P⁻¹ * M * P) = minpoly K M :=
+    minpoly.algEquiv_eq (matConj P P⁻¹ hPQ hQP) M
+  rw [← hmeq]
+  exact squarefree_minpoly_of_isDiag hdiag
+
+/-- **S1 OBSERVE → S7 ACT main theorem.** Over an algebraically closed field
+of characteristic zero, a matrix is diagonalizable iff its minimal polynomial
+is squarefree.
+
+The **forward** direction (`→`) is now fully proved and unconditional
+(`Matrix.IsDiagonalizable.squarefree_minpoly`, any field). The **reverse**
+direction (`←`, squarefree minpoly ⇒ diagonalizable) remains the single
+`sorry`: over an algebraically closed field it follows from Bridge C
+(`Module.End.isSemisimple_iff_squarefree_minpoly`) plus Bridge B
+(`Module.End.iSup_eigenspace_eq_top_of_isSemisimple`) transported back through
+`Matrix.toLin'`, and is the target of sub-OQ-02-OQ-02.
 
 Note: the field hypotheses can be weakened to "perfect field + minpoly
 splits", but the alg-closed-char-0 case is the headline textbook statement
@@ -119,6 +217,7 @@ form is the target of OQ-02-OQ-03. -/
 theorem diagonalizable_iff_squarefree_minpoly
     [IsAlgClosed K] [CharZero K] (M : Matrix n n K) :
     M.IsDiagonalizable ↔ Squarefree (minpoly K M) := by
+  refine ⟨fun h => h.squarefree_minpoly, ?_⟩
   sorry
 
 /-- **Sanity lemma (unconditional).** A diagonal matrix is diagonalizable —


### PR DESCRIPTION
Forward direction of M.IsDiagonalizable ↔ Squarefree (minpoly K M) now proved over any field (squarefree_minpoly_of_isDiag + matConj similarity-invariance). Lone remaining sorry guards only the reverse direction (sub-OQ-02-OQ-02). Docker-verified: 3083 jobs, 1 expected sorry at line 217. meta.json updated (lineCount 169→268, 0 axioms, 1 sorry, status formalized).