### PR TITLE
research(sturm-oq-02-oq-01-oq-02): axiom-free exact-count for linear polynomials

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
@@ -464,6 +464,52 @@ theorem sturm_linear_right (x : ℝ) (hx : x > c) :
 end LinearExample
 
 -- ============================================================================
+-- § 8a. Sturm's Exact Count, Verified for Linear Polynomials (axiom-free)
+-- ============================================================================
+
+/-- The roots of `X - C c` in the half-open interval `(a, b]`: exactly one
+    (namely `c`) when `a < c ≤ b`, and none otherwise. -/
+theorem rootsInInterval_X_sub_C (c a b : ℝ) :
+    rootsInInterval (X - C c) a b = if a < c ∧ c ≤ b then 1 else 0 := by
+  have hne : (X - C c : ℝ[X]) ≠ 0 := X_sub_C_ne_zero c
+  rw [rootsInInterval, if_neg hne, Polynomial.roots_X_sub_C, Multiset.filter_singleton]
+  by_cases h : a < c ∧ c ≤ b
+  · simp [h]
+  · simp [h]
+
+/-- **Sturm's exact count, verified for linear polynomials** (no axiom).
+
+    For `p = X - c`, the additive Sturm identity
+    `σ_p(a) = σ_p(b) + #{roots in (a,b]}` holds whenever `a < b`, `a ≠ c` and
+    `b ≠ c`. This is a fully machine-checked instance of `sturm_exact_count_axiom`,
+    confirming the axiom in the degree-1 base case via the explicit Sturm
+    sequence `[X - c, 1]`. -/
+theorem sturm_exact_count_linear (c a b : ℝ) (hab : a < b)
+    (ha : a ≠ c) (hb : b ≠ c) :
+    sturmVariations (X - C c) a =
+      sturmVariations (X - C c) b + rootsInInterval (X - C c) a b := by
+  rw [rootsInInterval_X_sub_C]
+  rcases lt_trichotomy c a with hca | hca | hca
+  · -- c < a < b: both endpoints exceed c, both counts 0, no root in (a,b]
+    have hva : sturmVariations (X - C c) a = 0 := sturm_linear_right c a hca
+    have hvb : sturmVariations (X - C c) b = 0 := sturm_linear_right c b (hca.trans hab)
+    have hnr : ¬ (a < c ∧ c ≤ b) := by rintro ⟨h, _⟩; linarith
+    rw [hva, hvb, if_neg hnr]
+  · exact absurd hca.symm ha
+  · -- a < c
+    have hva : sturmVariations (X - C c) a = 1 := sturm_linear_left c a hca
+    rcases lt_trichotomy c b with hcb | hcb | hcb
+    · -- a < c < b: count drops 1 → 0, exactly one root c ∈ (a,b]
+      have hvb : sturmVariations (X - C c) b = 0 := sturm_linear_right c b hcb
+      have hr : a < c ∧ c ≤ b := ⟨hca, hcb.le⟩
+      rw [hva, hvb, if_pos hr]
+    · exact absurd hcb.symm hb
+    · -- a < b < c: both endpoints below c, both counts 1, no root in (a,b]
+      have hvb : sturmVariations (X - C c) b = 1 := sturm_linear_left c b hcb
+      have hnr : ¬ (a < c ∧ c ≤ b) := by rintro ⟨_, h⟩; linarith
+      rw [hva, hvb, if_neg hnr]
+
+-- ============================================================================
 -- § 9. Squarefree Polynomials and the GCD Connection
 -- ============================================================================
 


### PR DESCRIPTION
## Summary

Sturm's exact-count theorem (`descartes-rule-of-signs-oq-02-oq-01-oq-02`) is stated as a single axiom `sturm_exact_count_axiom`. This PR makes incremental progress toward discharging that axiom by **machine-checking its statement, axiom-free, in the degree-1 base case**.

- New theorem `sturm_exact_count_linear`: for `p = X - c`, proves the additive Sturm identity `σ_p(a) = σ_p(b) + #{roots in (a,b]}` whenever `a < b`, `a ≠ c`, `b ≠ c`, using the explicit Sturm sequence `[X - c, 1]` (existing `sturm_linear_left`/`sturm_linear_right`) and a full trichotomy on `c` vs `(a,b]`.
- New supporting lemma `rootsInInterval_X_sub_C`: `rootsInInterval (X - C c) a b = 1` iff `a < c ≤ b`, else `0` (via `roots_X_sub_C` + `Multiset.filter_singleton`).

Both additions are axiom-free, so the file's axiom count is unchanged at **1** (`sturm_exact_count_axiom`). This is a verified instance confirming the axiom is correct in the base case — a step toward a future full proof.

## Changes
- `proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean`: +2 theorems (new §8a section)
- `src/data/proofs/.../meta.json`: lineCount 513→559, theoremCount 28→30, mainTheorems + assumptions updated

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.DescartesRuleOfSignsOQ02OQ01OQ02` — build succeeds (3058 jobs)
- [x] `grep -c '^axiom '` = 1 (unchanged)
- [x] meta.json validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)