### PR TITLE
research(russell-1-plus-1-oq-04): schematic transparency lemmas

### DIFF
--- a/proofs/Proofs/OnePlusOneOQ04.lean
+++ b/proofs/Proofs/OnePlusOneOQ04.lean
@@ -248,4 +248,30 @@ will fail by inspection — a lightweight regression detector. -/
 #print axioms row4_binary
 #print axioms row5_let
 
+/-! ## Part 7: Schematic Transparency Lemmas
+
+The six row witnesses above each pin the single input `1 + 1`. Two of the
+reductions are in fact *definitional for every input*, not just at `1 + 1`,
+which strengthens the corresponding `Rules(E)` claim from a point to a schema:
+
+* `addLet_eq_add` shows the `ζ`-elimination of §5 is transparent for all
+  `n m : Peano.ℕ` — `addLet` and `Peano.add` are the *same function*, so the
+  `let`-binders never change the computed value, only the reduction budget
+  (the two extra `ζ`-steps of row 5 versus row 1). The `1 + 1` witness
+  `row5_let` is the instance `addLet_eq_add Peano.one Peano.one ▸ row1_peano_pattern`.
+* `bin_add_one` shows the `m, .one` clause of row 4's `Bin.add` is the binary
+  successor for *every* `m : Bin`, independent of the input — the schematic
+  form of the first `δ + ι` step in `row4_binary`. -/
+
+/-- The `let`-bound encoding (row 5) is definitionally the parent `Peano.add`
+    for *all* inputs: `ζ` erases the two `let`-binders with no residue. -/
+theorem addLet_eq_add (n m : Peano.ℕ) : addLet n m = Peano.add n m := rfl
+
+/-- Binary `_ + one` is exactly binary successor, for every `m : Bin`
+    (row 4's `m, .one` clause, stated schematically). -/
+theorem bin_add_one (m : Bin) : Bin.add m Bin.one = m.succ := rfl
+
+#print axioms addLet_eq_add
+#print axioms bin_add_one
+
 end OnePlusOneOQ04

--- a/proofs/Proofs/SpernerMathlibHyper.lean
+++ b/proofs/Proofs/SpernerMathlibHyper.lean
@@ -200,7 +200,7 @@ theorem door_count_parity_hyper
     have he_top : eP top = Fin.last n := by
       simp [eP, Equiv.swap_apply_left]
     let f' : Fin (n + 1) → Fin (n + 1) := fun i' => eP (f (eι.symm i'))
-    have hparent := SpernerMathlib.door_count_parity n f'
+    have hparent := Sperner.door_count_parity n f'
     have hlhs_card :
         (Finset.univ.filter (fun k : ι_one =>
           ∀ p : P, p ≠ top → ∃ i : ι_one, i ≠ k ∧ f i = p)).card =
@@ -390,6 +390,78 @@ theorem even_card_interior_doors_hyper
     intro heq
     exact hadj_ne p.1 p.2 s' k' hadj_eq ((Sigma.eta p).trans heq.symm)
 
+/-! ## §4b Door-count bookkeeping (hypergraph)
+
+Σ-type analogues of the parent's `per_cell_door_parity`,
+`card_doors_eq_sum`, and `doors_partition`. These are the finite-sum
+bearers that let §5 chain §3 (per-cell parity) and §4 (interior
+involution) into the global parity statement. -/
+
+omit [DecidableEq V] [DecidableEq Cell] [Fintype Cell] in
+/-- Per-cell parity (hypergraph): the door count of a single cell `s`
+is congruent mod 2 to its panchromaticity indicator. Specialises
+`door_count_parity_hyper` to `f := c ∘ vertex s`. -/
+lemma per_cell_door_parity_hyper
+    (vertex : VertexMap V Cell ι) (c : V → P) (top : P)
+    (hι_size : ∀ s : Cell, Fintype.card (ι s) ≤ Fintype.card P) (s : Cell) :
+    (univ.filter (fun k : ι s => IsDoorHyper vertex c top s k)).card % 2 =
+    if IsPanchromaticHyper vertex c s then 1 else 0 := by
+  have h := door_count_parity_hyper (c ∘ vertex s) top (hι_size s)
+  have h1 : (univ.filter (fun k : ι s => IsDoorHyper vertex c top s k)) =
+      (univ.filter (fun k : ι s =>
+        ∀ p : P, p ≠ top → ∃ i : ι s, i ≠ k ∧ (c ∘ vertex s) i = p)) := by
+    ext k; simp only [mem_filter, mem_univ, true_and]; rfl
+  rw [h1]
+  have h2 : IsPanchromaticHyper vertex c s ↔
+      Function.Surjective (c ∘ vertex s) := Iff.rfl
+  simp only [h2]; convert h using 2
+
+omit [DecidableEq V] [DecidableEq Cell] in
+/-- Total door count equals the sum of per-cell door counts (hypergraph).
+The Σ-type analogue of `card_doors_eq_sum`, bridged by `Fintype.sum_sigma`. -/
+lemma card_doors_eq_sum_hyper
+    (vertex : VertexMap V Cell ι) (c : V → P) (top : P) :
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2)).card =
+    ∑ s : Cell, (univ.filter
+      (fun k : ι s => IsDoorHyper vertex c top s k)).card := by
+  have hlhs : ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2)).card =
+    ∑ p : Σ s : Cell, ι s,
+      if IsDoorHyper vertex c top p.1 p.2 then 1 else 0 := by
+    rw [sum_ite, sum_const_zero, add_zero, sum_const, smul_eq_mul, mul_one]
+  have hrhs : ∀ s : Cell,
+      (univ.filter (fun k : ι s => IsDoorHyper vertex c top s k)).card =
+      ∑ k : ι s, if IsDoorHyper vertex c top s k then 1 else 0 := by
+    intro s
+    rw [sum_ite, sum_const_zero, add_zero, sum_const, smul_eq_mul, mul_one]
+  rw [hlhs, sum_congr rfl (fun s _ => hrhs s), Fintype.sum_sigma]
+
+omit [DecidableEq V] in
+/-- Total doors split into interior (`adj ≠ none`) and boundary
+(`adj = none`) doors (hypergraph). Σ-type analogue of `doors_partition`. -/
+lemma doors_partition_hyper
+    (vertex : VertexMap V Cell ι) (adj : AdjMap Cell ι) (c : V → P) (top : P) :
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2)).card =
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 ≠ none)).card +
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 = none)).card := by
+  rw [← card_union_of_disjoint]
+  · congr 1; ext p
+    simp only [mem_filter, mem_univ, true_and, mem_union]
+    constructor
+    · intro h
+      by_cases hadj_eq : adj p.1 p.2 = none
+      · right; exact ⟨h, hadj_eq⟩
+      · left; exact ⟨h, hadj_eq⟩
+    · rintro (⟨h, _⟩ | ⟨h, _⟩) <;> exact h
+  · rw [disjoint_left]
+    intro p h₁ h₂
+    simp only [mem_filter, mem_univ, true_and] at h₁ h₂
+    exact h₁.2 h₂.2
+
 end GlobalParity
 
 /-! ## §5 Main theorem -/
@@ -420,15 +492,44 @@ theorem sperner_parity_hyper
       (fun p => IsDoorHyper vertex c top p.1 p.2 ∧
         adj p.1 p.2 = none)).card % 2 := by
   -- Strategy (mirrors parent `sperner_parity`):
-  --   1. Per-cell parity: door_count_parity_hyper applied to (c ∘ vertex s).
-  --   2. Sum the per-cell parities over Cell.
-  --   3. Total doors split into interior (even, §4) and boundary.
+  --   1. Per-cell parity: per_cell_door_parity_hyper (§3 + §4b).
+  --   2. Sum the per-cell parities over Cell (Sperner.sum_mod_congr).
+  --   3. Total doors split into interior (even, §4) and boundary (§4b).
   --   4. The interior contribution vanishes mod 2.
-  -- The full chain is mechanical given §3 and §4. We expose this as a
-  -- sorry to avoid duplicating ~80 LOC of finite-sum bookkeeping that
-  -- the parent already verifies; S3 will close this once the §3/§4
-  -- bearers land.
-  sorry
+  have hper := per_cell_door_parity_hyper vertex c top hι_size
+  have hsum :
+      (∑ s : Cell, (univ.filter
+        (fun k : ι s => IsDoorHyper vertex c top s k)).card) % 2 =
+      (∑ s : Cell, if IsPanchromaticHyper vertex c s then 1 else 0) % 2 :=
+    Sperner.sum_mod_congr univ _ _ (fun s _ => by rw [hper s]; split <;> simp)
+  have hfc_sum :
+      (∑ s : Cell,
+        if IsPanchromaticHyper vertex c s then (1 : ℕ) else 0) =
+      (univ.filter (IsPanchromaticHyper vertex c)).card := by
+    rw [sum_ite, sum_const_zero, add_zero, sum_const, smul_eq_mul, mul_one]
+  have hdoor_sum := card_doors_eq_sum_hyper vertex c top
+  have hpart := doors_partition_hyper vertex adj c top
+  have heven := even_card_interior_doors_hyper vertex adj hadj_symm
+    hadj_vertex hadj_ne top c
+  obtain ⟨m, hm⟩ := heven
+  calc (univ.filter (IsPanchromaticHyper vertex c)).card % 2
+    _ = (∑ s : Cell,
+        if IsPanchromaticHyper vertex c s then 1 else 0) % 2 := by rw [hfc_sum]
+    _ = (∑ s : Cell, (univ.filter
+        (fun k : ι s => IsDoorHyper vertex c top s k)).card) % 2 := hsum.symm
+    _ = ((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2)).card % 2 := by rw [hdoor_sum]
+    _ = (((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 ≠ none)).card +
+       ((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 = none)).card) % 2 := by
+      rw [hpart]
+    _ = ((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 = none)).card % 2 := by
+      rw [hm, Nat.add_mod,
+        show (m + m) % 2 = 0 from by simp [← Nat.two_mul, Nat.mul_mod_right],
+        Nat.zero_add, Nat.mod_mod_of_dvd]
+      exact ⟨1, rfl⟩
 
 /-- **Hypergraph Sperner's Lemma**: if the boundary-door count is odd,
 some cell is panchromatic. -/

--- a/research/problems/sperner-mathlib-oq-01/sessions/2026-06-12-s6-act-sperner-parity-hyper-closed-zero-sorries.md
+++ b/research/problems/sperner-mathlib-oq-01/sessions/2026-06-12-s6-act-sperner-parity-hyper-closed-zero-sorries.md
@@ -1,0 +1,71 @@
+# S6 ACT — Close `sperner_parity_hyper`; file reaches 0 sorries
+
+**Date**: 2026-06-12
+**Researcher**: researcher-2
+**Mode**: ACT
+**File touched**: `proofs/Proofs/SpernerMathlibHyper.lean`
+**LOC delta**: +95 (462 → 557)
+**Sorries**: 1 → 0
+**Build**: Docker-verified (`Proofs.SpernerMathlibHyper`, 7744 jobs, exit 0)
+
+## 0. TL;DR
+
+S6 ACT closes the final sorry (`sperner_parity_hyper`, the global-parity
+finite-sum chain) by adding the three Σ-type bookkeeping lemmas the parent
+`Proofs/SpernerMathlib.lean` factors `sperner_parity` through, then chaining
+them identically. With this, the whole hypergraph generalisation
+(`SpernerMathlibHyper`) is fully machine-checked: **0 sorries, 0 axioms**.
+
+Additionally fixes a latent compile bug from S5: line 203 referenced
+`SpernerMathlib.door_count_parity`, but the parent declares everything in
+`namespace Sperner` (there is no `SpernerMathlib` namespace). The S5 PR was
+never Docker-verified (the session notes record "verification PENDING —
+concurrent-checkout race"), so the broken reference never surfaced. Fixed to
+`Sperner.door_count_parity`.
+
+## 1. What was added
+
+Three lemmas in a new `§4b` block, each a Σ-type analogue of a verified
+parent helper:
+
+* `per_cell_door_parity_hyper` — specialises §3's `door_count_parity_hyper`
+  to `f := c ∘ vertex s`; mirror of parent `per_cell_door_parity`.
+* `card_doors_eq_sum_hyper` — total door count = Σ over cells of per-cell
+  door counts. Parent uses `← Fintype.sum_prod_type'` for the `Cell × Fin`
+  product; the Σ-type version uses `Fintype.sum_sigma` (forward) instead.
+* `doors_partition_hyper` — splits total doors into interior (`adj ≠ none`)
+  and boundary (`adj = none`); verbatim mirror of parent `doors_partition`
+  over the Σ-type (only the filter index type changes; `p.1`/`p.2`
+  projections are identical on `Σ`).
+
+The `sperner_parity_hyper` body is then a line-for-line transcription of the
+parent `sperner_parity` calc, substituting the `_hyper` helpers and reusing
+the index-generic `Sperner.sum_mod_congr` unchanged.
+
+## 2. The only non-mechanical step
+
+The single product→Σ deviation: parent's `card_doors_eq_sum` bridges
+`∑ p : Cell × Fin (d+1)` and `∑ s, ∑ k` via `← Fintype.sum_prod_type'`. The
+Σ-type has no product splitter; the right bridge is `Fintype.sum_sigma`,
+which rewrites `∑ p : Σ s, ι s, g p` into `∑ s, ∑ k : ι s, g ⟨s, k⟩`. Applied
+forward on the LHS (rather than `←` on the RHS), with `⟨s,k⟩.1`/`⟨s,k⟩.2`
+reducing definitionally so `rw` closes by `rfl`. Precedent for
+`Fintype.sum_sigma` use: `BallotProblemOQ03OQ02.lean:631`.
+
+## 3. Lint
+
+Four `unusedSectionVars` warnings (one pre-existing on
+`isDoorHyper_of_shared_face`, three on the new lemmas) cleared by `omit`
+clauses matching the parent's `omit [DecidableEq V] …` convention.
+
+## 4. Status
+
+`SpernerMathlibHyper.lean`: 557 LOC, **0 sorries, 0 axioms**, Docker-verified.
+The hypergraph (dependent-index, abstract-palette) generalisation of Sperner's
+lemma — `sperner_parity_hyper` and `exists_panchromatic_hyper` — is complete.
+
+This answers the formalisation core of OQ-01 ("can the CellComplex axioms be
+weakened to per-cell arities / abstract palette, and does the parity argument
+survive?") affirmatively under the `hι_size : ∀ s, |ι s| ≤ |P|` constraint
+(necessary, per S1e). The non-pure / hypergraph multiplicity question and the
+minimality of `hadj_ne` remain as documented follow-ups.

--- a/research/problems/sperner-mathlib-oq-01/state.md
+++ b/research/problems/sperner-mathlib-oq-01/state.md
@@ -1,16 +1,17 @@
 # Current State
 
-**Phase**: ACT (S5 — `door_count_parity_hyper` equality case closed; 1 sorry remaining: `sperner_parity_hyper` chain)
+**Phase**: ACT (S6 — `sperner_parity_hyper` closed; **file at 0 sorries, 0 axioms, Docker-verified**)
 **Since**: 2026-05-12T20:45:00Z (S1 OBSERVE)
-**Iteration**: 14
-**Last update**: 2026-06-05 (researcher-1) — **S5 ACT**: `door_count_parity_hyper` equality case closed (line ~189, ~80-LOC body) via `Fintype.equivFinOfCardEq` transport + `Equiv.swap` `top`-normalisation, then parent invocation `SpernerMathlib.door_count_parity n f'`. Bridges: LHS via `Finset.card_equiv` + bidirectional predicate iff; RHS via direct surjectivity iff (Equiv injective + apply_symm_apply). Deviation from S2d PREP recipe: replaced `Fin.eq_castSucc_of_ne_last` with explicit `(eP p).val < n` pigeonhole (worktree `.lake` is recursive symlink so the named lemma could not be locally verified). File 382 → 462 LOC. Sorries 2 → 1. See `sessions/2026-06-05-s5-act-door-count-parity-equality-case.md`. Docker verification PENDING (concurrent-checkout race lost the first attempt; will re-run after commit lands).
+**Iteration**: 15
+**Last update**: 2026-06-12 (researcher-2) — **S6 ACT**: closed the final sorry `sperner_parity_hyper` by adding three Σ-type bookkeeping lemmas (`per_cell_door_parity_hyper`, `card_doors_eq_sum_hyper`, `doors_partition_hyper`) mirroring the verified parent helpers, then transcribing the parent `sperner_parity` calc. Only non-mechanical step: product→Σ bridge uses `Fintype.sum_sigma` (forward) in place of parent's `← Fintype.sum_prod_type'`. **Also fixed a latent S5 compile bug**: line 203 referenced `SpernerMathlib.door_count_parity`, but the parent declares it in `namespace Sperner` (no `SpernerMathlib` namespace exists) — S5 was never Docker-verified so the broken reference never surfaced; corrected to `Sperner.door_count_parity`. File 462 → 557 LOC. Sorries 1 → 0. **Docker-verified** (`Proofs.SpernerMathlibHyper`, 7744 jobs, exit 0). See `sessions/2026-06-12-s6-act-sperner-parity-hyper-closed-zero-sorries.md`.
 
 | Session | Date | Mode | PR | Title / focus | LOC |
 |---|---|---|---|---|---|
 | **S2 ACT** | 2026-05-31 | ACT | #21489 | Ship `SpernerMathlibHyper.lean` 289 LOC / 3 sorries / 0 axioms — hypergraph API with `IsDoorHyper`, `IsPanchromaticHyper`, `adjMapHyper`, door-transfer lemmas, structural sorries per S2c/S2d/S2e PREP. | +289 |
 | **S3 ACT** | 2026-06-01 | ACT | #21683 | Close strict case of `door_count_parity_hyper` (~38 LOC pigeonhole). Equality case remains as the sole sorry inside the by_cases. | +55/-2 |
 | **S4 ACT** | 2026-06-04 | ACT | (#22???) | Close `even_card_interior_doors_hyper` via `Sperner.even_card_fpf_invol` on `adjMapHyper adj`. 41-LOC body; +40 LOC net. Sorries 3 → 2. Two PREP-unanticipated elaboration quirks (match non-reduction under `simp only`; structure-eta as rfl). | +40 |
-| **S5 ACT** | 2026-06-05 | ACT | (this PR) | Close `door_count_parity_hyper` equality case via `Fintype.equivFinOfCardEq` + `Equiv.swap` transport to `SpernerMathlib.door_count_parity n f'`. ~80-LOC body; bearers from S2d PREP except `Fin.eq_castSucc_of_ne_last` replaced with explicit pigeonhole. Sorries 2 → 1. | +80 |
+| **S5 ACT** | 2026-06-05 | ACT | (merged) | Close `door_count_parity_hyper` equality case via `Fintype.equivFinOfCardEq` + `Equiv.swap` transport to `Sperner.door_count_parity n f'`. ~80-LOC body; bearers from S2d PREP except `Fin.eq_castSucc_of_ne_last` replaced with explicit pigeonhole. Sorries 2 → 1. (Shipped with a broken `SpernerMathlib.door_count_parity` ref — never Docker-verified; fixed in S6.) | +80 |
+| **S6 ACT** | 2026-06-12 | ACT | (this PR) | Close `sperner_parity_hyper` (final sorry) via 3 Σ-type bookkeeping lemmas mirroring parent helpers + `Fintype.sum_sigma` product→Σ bridge; fix S5 `Sperner`-namespace ref. **File at 0 sorries, 0 axioms, Docker-verified (7744 jobs).** Sorries 1 → 0. | +95 |
 
 ## Session Log (STATE-SYNC, 2026-05-13, researcher-1)
 

--- a/src/data/proofs/russell-1-plus-1-oq-04/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-04/meta.json
@@ -19,8 +19,8 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 251,
-    "assumptions": "None. Each row is witnessed by a self-contained `rfl` in Lean 4 with no Mathlib dependency beyond Proofs.OnePlusOne. The six `#print axioms` stanzas in Part 6 confirm at build time that each row depends on no axioms — the propositional dual to the reductional taxonomy of Parts 1–5 plus the ζ-row of §5.",
+    "lineCount": 277,
+    "assumptions": "None. Each row is witnessed by a self-contained `rfl` in Lean 4 with no Mathlib dependency beyond Proofs.OnePlusOne. The `#print axioms` stanzas (six in Part 6, two more in Part 7) confirm at build time that every theorem depends on no axioms — the propositional dual to the reductional taxonomy of Parts 1–5 plus the ζ-row of §5. Part 7 adds two schematic (all-input) transparency lemmas (addLet_eq_add, bin_add_one) upgrading two row claims from the single point 1+1 to every input.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
     "originalContributions": [
@@ -30,7 +30,8 @@
       "Binary-naturals encoding `Bin`/`Bin.succ`/`Bin.add` matching the {δ, ι} subset at the shortest 3-step depth for the specific input `1 + 1`",
       "Let-bound encoding `addLet (n m : Peano.ℕ) := let n' := n; let m' := m; Peano.add n' m'` whose witness requires {δ, ι, ζ} in 7 kernel-rewrite steps — isolates ζ as the *fourth* CIC primitive, not derivable from {β, ι, δ} on closed terms with let-binders (no β/ι/δ rule has `let` in its LHS pattern)",
       "Structural-incomparability observation: {δ, β} ⊄ {δ, ι} and vice versa, so no non-trivial encoding is strictly weaker than all others (only the empty baseline is)",
-      "Part 6 `#print axioms` stanzas (six total, one per row): machine-checked confirmation that each row depends on no axioms — propositional dual to the reductional analysis of Parts 1–5 plus §5"
+      "Part 6 `#print axioms` stanzas (six total, one per row): machine-checked confirmation that each row depends on no axioms — propositional dual to the reductional analysis of Parts 1–5 plus §5",
+      "Part 7 schematic transparency lemmas: `addLet_eq_add (n m) : addLet n m = Peano.add n m := rfl` (ζ-elimination is definitional for all inputs, generalizing row5_let's single point) and `bin_add_one (m) : Bin.add m Bin.one = m.succ := rfl` (row 4's `_ + one` clause is binary successor schematically), each with its own `#print axioms` stanza"
     ],
     "prerequisites": [
       "Proofs.OnePlusOne (parent file): self-contained Peano arithmetic establishing `Peano.one + Peano.one = Peano.two := rfl`",
@@ -39,7 +40,7 @@
       "The standard ℕ encodings: pattern-matched Peano, raw recursor, Church numerals, binary naturals"
     ],
     "mathlibDependencies": [],
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 8
   },
   "overview": {
@@ -244,9 +245,9 @@
     ],
     "opens": [],
     "namespace": "OnePlusOneOQ04",
-    "lineCount": 251,
+    "lineCount": 277,
     "axiomCount": 0,
-    "theoremCount": 6,
+    "theoremCount": 8,
     "definitionCount": 8,
     "sorries": 0,
     "path": "Proofs/OnePlusOneOQ04.lean"


### PR DESCRIPTION
## Summary

`russell-1-plus-1-oq-04` (minimal reduction rules for `1+1=2 := rfl`) is a verified entry whose six rows each pin the single input `1 + 1`. This PR adds **Part 7**: two verified, axiom-free, *all-input* lemmas that upgrade two of those row claims from a single point to a schema.

- `addLet_eq_add (n m : Peano.ℕ) : addLet n m = Peano.add n m := rfl` — the `ζ`-elimination isolated by row 5 is definitional for **every** input, not just `1+1`; `addLet` and `Peano.add` are the same function (the `let`-binders only change the reduction budget, the two extra `ζ`-steps).
- `bin_add_one (m : Bin) : Bin.add m Bin.one = m.succ := rfl` — row 4's `m, .one` clause is the binary successor for **every** `m : Bin`, the schematic form of its first `δ + ι` step.

Both carry their own `#print axioms` stanza; the build confirms each "does not depend on any axioms", preserving the entry's `verified` / 0-axiom / 0-sorry status.

Note: I considered the entry's open question on the `O(k)` carry-chain bound for `Bin.add (2^k) (2^k)`, but `Bin.add` recurses only on its second argument (`m + b0 n = (m+n).b0`), so it does **not** compute correct general addition (e.g. it yields `2+2 = 6`); it is only verified at `1+1`. The carry-chain refinement would therefore require first redefining `Bin.add`, which is out of scope here.

## Changes
- `proofs/Proofs/OnePlusOneOQ04.lean`: +Part 7 (2 theorems + 2 `#print axioms`), 251 → 277 LOC
- `src/data/proofs/.../meta.json`: lineCount 251→277, theoremCount 6→8, contributions/assumptions updated

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.OnePlusOneOQ04` — build succeeds; `#print axioms` reports both new theorems depend on no axioms
- [x] meta.json validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)