### PR TITLE
research(erdos-895-oq-01): hindmanSet structural lemmas

### DIFF
--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -78,6 +78,36 @@ theorem hindmanSet_pair_sum (a b : ℕ) (hab : a ≠ b) :
    ⟨a, Finset.mem_insert_self a _⟩,
    by rw [Finset.sum_pair hab]; rfl⟩
 
+/-- The Hindman set of the empty base is empty: there is no nonempty subset. -/
+theorem hindmanSet_empty : hindmanSet (∅ : Finset ℕ) = ∅ := by
+  ext s
+  simp only [hindmanSet, Set.mem_setOf_eq, Set.mem_empty_iff_false, iff_false]
+  rintro ⟨T, hT_sub, hT_ne, _⟩
+  rw [Finset.subset_empty] at hT_sub
+  subst hT_sub
+  exact Finset.not_nonempty_empty hT_ne
+
+/-- The Hindman set of a singleton base `{a}` is exactly `{a}`: the only
+    nonempty subset of `{a}` is `{a}` itself, with sub-sum `a`. -/
+theorem hindmanSet_singleton (a : ℕ) : hindmanSet ({a} : Finset ℕ) = {a} := by
+  ext s
+  simp only [hindmanSet, Set.mem_setOf_eq, Set.mem_singleton_iff,
+    Finset.subset_singleton_iff]
+  constructor
+  · rintro ⟨T, hT | rfl, hT_ne, hT_sum⟩
+    · exact absurd hT hT_ne.ne_empty
+    · simpa using hT_sum.symm
+  · intro hsa
+    exact ⟨({a} : Finset ℕ), Or.inr rfl, Finset.singleton_nonempty a, by simp [hsa]⟩
+
+/-- Every element of a Hindman set is bounded by the total base sum (sub-sums
+    of nonnegative integers never exceed the full sum). -/
+theorem hindmanSet_le_sum {base : Finset ℕ} {s : ℕ} (hs : s ∈ hindmanSet base) :
+    s ≤ base.sum id := by
+  obtain ⟨T, hT_sub, _, hT_sum⟩ := hs
+  rw [← hT_sum]
+  exact Finset.sum_le_sum_of_subset hT_sub
+
 -- ## Section 2: Hajnal Conjecture (OPEN) ##
 
 /-- Hajnal's conjecture: every large triangle-free graph contains an independent Hindman set -/


### PR DESCRIPTION
## Summary

`erdos-895-oq-01` (Hajnal's Independent Hindman Set Conjecture) carries one axiom for the open conjecture (`hajnal_conjecture`). This PR adds three **axiom-free** structural lemmas about the `hindmanSet` (finite-sub-sums / FS-set) construction, extending the existing Section 1 API:

- `hindmanSet_empty`: `FS(∅) = ∅` (no nonempty subset of the empty base).
- `hindmanSet_singleton`: `FS({a}) = {a}` (the only nonempty subset of `{a}` is itself).
- `hindmanSet_le_sum`: every element of `FS(base)` is `≤ base.sum id` (sub-sums of nonnegative integers are bounded by the full sum).

These round out the basic `hindmanSet` lemma set (`mem_self`, `mono`, `pair_left/right/sum`) that the k=2 reduction `hajnal_k2_gives_additive_triple` builds on. Axiom count is **unchanged at 1** — the Hajnal conjecture itself remains open — and the file stays at 0 sorries.

## Changes
- `proofs/Proofs/Erdos895OQ01Problem.lean`: +3 theorems in Section 1, 272 → 302 LOC
- `src/data/proofs/erdos-895-oq-01/meta.json`: lineCount 272→302, theoremCount 11→14, assumptions note updated

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos895OQ01Problem` — build succeeds (7743 jobs)
- [x] `grep -c '^axiom '` = 1 (unchanged)
- [x] meta.json validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)