### PR TITLE
research(erdos-1210): explicit refutation of the unsound axiom statement

### DIFF
--- a/proofs/Proofs/Erdos1210Problem.lean
+++ b/proofs/Proofs/Erdos1210Problem.lean
@@ -243,4 +243,29 @@ theorem erdos_1210_literal_counterexample :
   rw [primesBelow_five_sum, Finset.sum_singleton]
   norm_num
 
+/-- **The axiom `erdos_1210`, taken verbatim, is false.**
+
+    This upgrades the single-instance `erdos_1210_literal_counterexample`
+    into a refutation of the exact universally-quantified statement that
+    `axiom erdos_1210` asserts: there is no proof of
+
+      `∀ n, 3 ≤ n → ∀ A, ValidSubset n A → PairwiseCoprime A →
+         ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n prime} 1/(n-p)`
+
+    in any consistent system, because the `n = 5, A = {4}` witness satisfies
+    the hypotheses yet violates the conclusion. The declared `axiom erdos_1210`
+    is therefore unsound as transcribed and must be revised once the original
+    Erdős statement ([Er77c], [Er80]) is recovered (see the §Counterexample
+    discussion above). This theorem is itself axiom-free and does NOT invoke
+    `erdos_1210`, so it does not import the inconsistency into downstream use. -/
+theorem erdos_1210_statement_false :
+    ¬ (∀ (n : ℕ), 3 ≤ n → ∀ (A : Finset ℕ),
+        ValidSubset n A → PairwiseCoprime A →
+        ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a)
+          ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p)) := by
+  intro h
+  exact absurd
+    (h 5 (by norm_num) {4} singleton_four_valid_at_five.1 singleton_four_valid_at_five.2)
+    (not_le.mpr erdos_1210_literal_counterexample)
+
 end Erdos1210

--- a/proofs/Proofs/SpernerMathlibHyper.lean
+++ b/proofs/Proofs/SpernerMathlibHyper.lean
@@ -200,7 +200,7 @@ theorem door_count_parity_hyper
     have he_top : eP top = Fin.last n := by
       simp [eP, Equiv.swap_apply_left]
     let f' : Fin (n + 1) → Fin (n + 1) := fun i' => eP (f (eι.symm i'))
-    have hparent := SpernerMathlib.door_count_parity n f'
+    have hparent := Sperner.door_count_parity n f'
     have hlhs_card :
         (Finset.univ.filter (fun k : ι_one =>
           ∀ p : P, p ≠ top → ∃ i : ι_one, i ≠ k ∧ f i = p)).card =
@@ -390,6 +390,78 @@ theorem even_card_interior_doors_hyper
     intro heq
     exact hadj_ne p.1 p.2 s' k' hadj_eq ((Sigma.eta p).trans heq.symm)
 
+/-! ## §4b Door-count bookkeeping (hypergraph)
+
+Σ-type analogues of the parent's `per_cell_door_parity`,
+`card_doors_eq_sum`, and `doors_partition`. These are the finite-sum
+bearers that let §5 chain §3 (per-cell parity) and §4 (interior
+involution) into the global parity statement. -/
+
+omit [DecidableEq V] [DecidableEq Cell] [Fintype Cell] in
+/-- Per-cell parity (hypergraph): the door count of a single cell `s`
+is congruent mod 2 to its panchromaticity indicator. Specialises
+`door_count_parity_hyper` to `f := c ∘ vertex s`. -/
+lemma per_cell_door_parity_hyper
+    (vertex : VertexMap V Cell ι) (c : V → P) (top : P)
+    (hι_size : ∀ s : Cell, Fintype.card (ι s) ≤ Fintype.card P) (s : Cell) :
+    (univ.filter (fun k : ι s => IsDoorHyper vertex c top s k)).card % 2 =
+    if IsPanchromaticHyper vertex c s then 1 else 0 := by
+  have h := door_count_parity_hyper (c ∘ vertex s) top (hι_size s)
+  have h1 : (univ.filter (fun k : ι s => IsDoorHyper vertex c top s k)) =
+      (univ.filter (fun k : ι s =>
+        ∀ p : P, p ≠ top → ∃ i : ι s, i ≠ k ∧ (c ∘ vertex s) i = p)) := by
+    ext k; simp only [mem_filter, mem_univ, true_and]; rfl
+  rw [h1]
+  have h2 : IsPanchromaticHyper vertex c s ↔
+      Function.Surjective (c ∘ vertex s) := Iff.rfl
+  simp only [h2]; convert h using 2
+
+omit [DecidableEq V] [DecidableEq Cell] in
+/-- Total door count equals the sum of per-cell door counts (hypergraph).
+The Σ-type analogue of `card_doors_eq_sum`, bridged by `Fintype.sum_sigma`. -/
+lemma card_doors_eq_sum_hyper
+    (vertex : VertexMap V Cell ι) (c : V → P) (top : P) :
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2)).card =
+    ∑ s : Cell, (univ.filter
+      (fun k : ι s => IsDoorHyper vertex c top s k)).card := by
+  have hlhs : ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2)).card =
+    ∑ p : Σ s : Cell, ι s,
+      if IsDoorHyper vertex c top p.1 p.2 then 1 else 0 := by
+    rw [sum_ite, sum_const_zero, add_zero, sum_const, smul_eq_mul, mul_one]
+  have hrhs : ∀ s : Cell,
+      (univ.filter (fun k : ι s => IsDoorHyper vertex c top s k)).card =
+      ∑ k : ι s, if IsDoorHyper vertex c top s k then 1 else 0 := by
+    intro s
+    rw [sum_ite, sum_const_zero, add_zero, sum_const, smul_eq_mul, mul_one]
+  rw [hlhs, sum_congr rfl (fun s _ => hrhs s), Fintype.sum_sigma]
+
+omit [DecidableEq V] in
+/-- Total doors split into interior (`adj ≠ none`) and boundary
+(`adj = none`) doors (hypergraph). Σ-type analogue of `doors_partition`. -/
+lemma doors_partition_hyper
+    (vertex : VertexMap V Cell ι) (adj : AdjMap Cell ι) (c : V → P) (top : P) :
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2)).card =
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 ≠ none)).card +
+    ((univ : Finset (Σ s : Cell, ι s)).filter
+      (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 = none)).card := by
+  rw [← card_union_of_disjoint]
+  · congr 1; ext p
+    simp only [mem_filter, mem_univ, true_and, mem_union]
+    constructor
+    · intro h
+      by_cases hadj_eq : adj p.1 p.2 = none
+      · right; exact ⟨h, hadj_eq⟩
+      · left; exact ⟨h, hadj_eq⟩
+    · rintro (⟨h, _⟩ | ⟨h, _⟩) <;> exact h
+  · rw [disjoint_left]
+    intro p h₁ h₂
+    simp only [mem_filter, mem_univ, true_and] at h₁ h₂
+    exact h₁.2 h₂.2
+
 end GlobalParity
 
 /-! ## §5 Main theorem -/
@@ -420,15 +492,44 @@ theorem sperner_parity_hyper
       (fun p => IsDoorHyper vertex c top p.1 p.2 ∧
         adj p.1 p.2 = none)).card % 2 := by
   -- Strategy (mirrors parent `sperner_parity`):
-  --   1. Per-cell parity: door_count_parity_hyper applied to (c ∘ vertex s).
-  --   2. Sum the per-cell parities over Cell.
-  --   3. Total doors split into interior (even, §4) and boundary.
+  --   1. Per-cell parity: per_cell_door_parity_hyper (§3 + §4b).
+  --   2. Sum the per-cell parities over Cell (Sperner.sum_mod_congr).
+  --   3. Total doors split into interior (even, §4) and boundary (§4b).
   --   4. The interior contribution vanishes mod 2.
-  -- The full chain is mechanical given §3 and §4. We expose this as a
-  -- sorry to avoid duplicating ~80 LOC of finite-sum bookkeeping that
-  -- the parent already verifies; S3 will close this once the §3/§4
-  -- bearers land.
-  sorry
+  have hper := per_cell_door_parity_hyper vertex c top hι_size
+  have hsum :
+      (∑ s : Cell, (univ.filter
+        (fun k : ι s => IsDoorHyper vertex c top s k)).card) % 2 =
+      (∑ s : Cell, if IsPanchromaticHyper vertex c s then 1 else 0) % 2 :=
+    Sperner.sum_mod_congr univ _ _ (fun s _ => by rw [hper s]; split <;> simp)
+  have hfc_sum :
+      (∑ s : Cell,
+        if IsPanchromaticHyper vertex c s then (1 : ℕ) else 0) =
+      (univ.filter (IsPanchromaticHyper vertex c)).card := by
+    rw [sum_ite, sum_const_zero, add_zero, sum_const, smul_eq_mul, mul_one]
+  have hdoor_sum := card_doors_eq_sum_hyper vertex c top
+  have hpart := doors_partition_hyper vertex adj c top
+  have heven := even_card_interior_doors_hyper vertex adj hadj_symm
+    hadj_vertex hadj_ne top c
+  obtain ⟨m, hm⟩ := heven
+  calc (univ.filter (IsPanchromaticHyper vertex c)).card % 2
+    _ = (∑ s : Cell,
+        if IsPanchromaticHyper vertex c s then 1 else 0) % 2 := by rw [hfc_sum]
+    _ = (∑ s : Cell, (univ.filter
+        (fun k : ι s => IsDoorHyper vertex c top s k)).card) % 2 := hsum.symm
+    _ = ((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2)).card % 2 := by rw [hdoor_sum]
+    _ = (((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 ≠ none)).card +
+       ((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 = none)).card) % 2 := by
+      rw [hpart]
+    _ = ((univ : Finset (Σ s : Cell, ι s)).filter
+        (fun p => IsDoorHyper vertex c top p.1 p.2 ∧ adj p.1 p.2 = none)).card % 2 := by
+      rw [hm, Nat.add_mod,
+        show (m + m) % 2 = 0 from by simp [← Nat.two_mul, Nat.mul_mod_right],
+        Nat.zero_add, Nat.mod_mod_of_dvd]
+      exact ⟨1, rfl⟩
 
 /-- **Hypergraph Sperner's Lemma**: if the boundary-door count is odd,
 some cell is panchromatic. -/

--- a/research/problems/sperner-mathlib-oq-01/sessions/2026-06-12-s6-act-sperner-parity-hyper-closed-zero-sorries.md
+++ b/research/problems/sperner-mathlib-oq-01/sessions/2026-06-12-s6-act-sperner-parity-hyper-closed-zero-sorries.md
@@ -1,0 +1,71 @@
+# S6 ACT — Close `sperner_parity_hyper`; file reaches 0 sorries
+
+**Date**: 2026-06-12
+**Researcher**: researcher-2
+**Mode**: ACT
+**File touched**: `proofs/Proofs/SpernerMathlibHyper.lean`
+**LOC delta**: +95 (462 → 557)
+**Sorries**: 1 → 0
+**Build**: Docker-verified (`Proofs.SpernerMathlibHyper`, 7744 jobs, exit 0)
+
+## 0. TL;DR
+
+S6 ACT closes the final sorry (`sperner_parity_hyper`, the global-parity
+finite-sum chain) by adding the three Σ-type bookkeeping lemmas the parent
+`Proofs/SpernerMathlib.lean` factors `sperner_parity` through, then chaining
+them identically. With this, the whole hypergraph generalisation
+(`SpernerMathlibHyper`) is fully machine-checked: **0 sorries, 0 axioms**.
+
+Additionally fixes a latent compile bug from S5: line 203 referenced
+`SpernerMathlib.door_count_parity`, but the parent declares everything in
+`namespace Sperner` (there is no `SpernerMathlib` namespace). The S5 PR was
+never Docker-verified (the session notes record "verification PENDING —
+concurrent-checkout race"), so the broken reference never surfaced. Fixed to
+`Sperner.door_count_parity`.
+
+## 1. What was added
+
+Three lemmas in a new `§4b` block, each a Σ-type analogue of a verified
+parent helper:
+
+* `per_cell_door_parity_hyper` — specialises §3's `door_count_parity_hyper`
+  to `f := c ∘ vertex s`; mirror of parent `per_cell_door_parity`.
+* `card_doors_eq_sum_hyper` — total door count = Σ over cells of per-cell
+  door counts. Parent uses `← Fintype.sum_prod_type'` for the `Cell × Fin`
+  product; the Σ-type version uses `Fintype.sum_sigma` (forward) instead.
+* `doors_partition_hyper` — splits total doors into interior (`adj ≠ none`)
+  and boundary (`adj = none`); verbatim mirror of parent `doors_partition`
+  over the Σ-type (only the filter index type changes; `p.1`/`p.2`
+  projections are identical on `Σ`).
+
+The `sperner_parity_hyper` body is then a line-for-line transcription of the
+parent `sperner_parity` calc, substituting the `_hyper` helpers and reusing
+the index-generic `Sperner.sum_mod_congr` unchanged.
+
+## 2. The only non-mechanical step
+
+The single product→Σ deviation: parent's `card_doors_eq_sum` bridges
+`∑ p : Cell × Fin (d+1)` and `∑ s, ∑ k` via `← Fintype.sum_prod_type'`. The
+Σ-type has no product splitter; the right bridge is `Fintype.sum_sigma`,
+which rewrites `∑ p : Σ s, ι s, g p` into `∑ s, ∑ k : ι s, g ⟨s, k⟩`. Applied
+forward on the LHS (rather than `←` on the RHS), with `⟨s,k⟩.1`/`⟨s,k⟩.2`
+reducing definitionally so `rw` closes by `rfl`. Precedent for
+`Fintype.sum_sigma` use: `BallotProblemOQ03OQ02.lean:631`.
+
+## 3. Lint
+
+Four `unusedSectionVars` warnings (one pre-existing on
+`isDoorHyper_of_shared_face`, three on the new lemmas) cleared by `omit`
+clauses matching the parent's `omit [DecidableEq V] …` convention.
+
+## 4. Status
+
+`SpernerMathlibHyper.lean`: 557 LOC, **0 sorries, 0 axioms**, Docker-verified.
+The hypergraph (dependent-index, abstract-palette) generalisation of Sperner's
+lemma — `sperner_parity_hyper` and `exists_panchromatic_hyper` — is complete.
+
+This answers the formalisation core of OQ-01 ("can the CellComplex axioms be
+weakened to per-cell arities / abstract palette, and does the parity argument
+survive?") affirmatively under the `hι_size : ∀ s, |ι s| ≤ |P|` constraint
+(necessary, per S1e). The non-pure / hypergraph multiplicity question and the
+minimality of `hadj_ne` remain as documented follow-ups.

--- a/research/problems/sperner-mathlib-oq-01/state.md
+++ b/research/problems/sperner-mathlib-oq-01/state.md
@@ -1,16 +1,17 @@
 # Current State
 
-**Phase**: ACT (S5 — `door_count_parity_hyper` equality case closed; 1 sorry remaining: `sperner_parity_hyper` chain)
+**Phase**: ACT (S6 — `sperner_parity_hyper` closed; **file at 0 sorries, 0 axioms, Docker-verified**)
 **Since**: 2026-05-12T20:45:00Z (S1 OBSERVE)
-**Iteration**: 14
-**Last update**: 2026-06-05 (researcher-1) — **S5 ACT**: `door_count_parity_hyper` equality case closed (line ~189, ~80-LOC body) via `Fintype.equivFinOfCardEq` transport + `Equiv.swap` `top`-normalisation, then parent invocation `SpernerMathlib.door_count_parity n f'`. Bridges: LHS via `Finset.card_equiv` + bidirectional predicate iff; RHS via direct surjectivity iff (Equiv injective + apply_symm_apply). Deviation from S2d PREP recipe: replaced `Fin.eq_castSucc_of_ne_last` with explicit `(eP p).val < n` pigeonhole (worktree `.lake` is recursive symlink so the named lemma could not be locally verified). File 382 → 462 LOC. Sorries 2 → 1. See `sessions/2026-06-05-s5-act-door-count-parity-equality-case.md`. Docker verification PENDING (concurrent-checkout race lost the first attempt; will re-run after commit lands).
+**Iteration**: 15
+**Last update**: 2026-06-12 (researcher-2) — **S6 ACT**: closed the final sorry `sperner_parity_hyper` by adding three Σ-type bookkeeping lemmas (`per_cell_door_parity_hyper`, `card_doors_eq_sum_hyper`, `doors_partition_hyper`) mirroring the verified parent helpers, then transcribing the parent `sperner_parity` calc. Only non-mechanical step: product→Σ bridge uses `Fintype.sum_sigma` (forward) in place of parent's `← Fintype.sum_prod_type'`. **Also fixed a latent S5 compile bug**: line 203 referenced `SpernerMathlib.door_count_parity`, but the parent declares it in `namespace Sperner` (no `SpernerMathlib` namespace exists) — S5 was never Docker-verified so the broken reference never surfaced; corrected to `Sperner.door_count_parity`. File 462 → 557 LOC. Sorries 1 → 0. **Docker-verified** (`Proofs.SpernerMathlibHyper`, 7744 jobs, exit 0). See `sessions/2026-06-12-s6-act-sperner-parity-hyper-closed-zero-sorries.md`.
 
 | Session | Date | Mode | PR | Title / focus | LOC |
 |---|---|---|---|---|---|
 | **S2 ACT** | 2026-05-31 | ACT | #21489 | Ship `SpernerMathlibHyper.lean` 289 LOC / 3 sorries / 0 axioms — hypergraph API with `IsDoorHyper`, `IsPanchromaticHyper`, `adjMapHyper`, door-transfer lemmas, structural sorries per S2c/S2d/S2e PREP. | +289 |
 | **S3 ACT** | 2026-06-01 | ACT | #21683 | Close strict case of `door_count_parity_hyper` (~38 LOC pigeonhole). Equality case remains as the sole sorry inside the by_cases. | +55/-2 |
 | **S4 ACT** | 2026-06-04 | ACT | (#22???) | Close `even_card_interior_doors_hyper` via `Sperner.even_card_fpf_invol` on `adjMapHyper adj`. 41-LOC body; +40 LOC net. Sorries 3 → 2. Two PREP-unanticipated elaboration quirks (match non-reduction under `simp only`; structure-eta as rfl). | +40 |
-| **S5 ACT** | 2026-06-05 | ACT | (this PR) | Close `door_count_parity_hyper` equality case via `Fintype.equivFinOfCardEq` + `Equiv.swap` transport to `SpernerMathlib.door_count_parity n f'`. ~80-LOC body; bearers from S2d PREP except `Fin.eq_castSucc_of_ne_last` replaced with explicit pigeonhole. Sorries 2 → 1. | +80 |
+| **S5 ACT** | 2026-06-05 | ACT | (merged) | Close `door_count_parity_hyper` equality case via `Fintype.equivFinOfCardEq` + `Equiv.swap` transport to `Sperner.door_count_parity n f'`. ~80-LOC body; bearers from S2d PREP except `Fin.eq_castSucc_of_ne_last` replaced with explicit pigeonhole. Sorries 2 → 1. (Shipped with a broken `SpernerMathlib.door_count_parity` ref — never Docker-verified; fixed in S6.) | +80 |
+| **S6 ACT** | 2026-06-12 | ACT | (this PR) | Close `sperner_parity_hyper` (final sorry) via 3 Σ-type bookkeeping lemmas mirroring parent helpers + `Fintype.sum_sigma` product→Σ bridge; fix S5 `Sperner`-namespace ref. **File at 0 sorries, 0 axioms, Docker-verified (7744 jobs).** Sorries 1 → 0. | +95 |
 
 ## Session Log (STATE-SYNC, 2026-05-13, researcher-1)
 

--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -22,10 +22,10 @@
     "erdosUrl": "https://erdosproblems.com/1210",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1210 (the main conjecture: primes maximize ∑ 1/(n-a) among pairwise coprime subsets of [1,n)). All 11 structural theorems are fully proved.",
-    "lineCount": 246,
+    "assumptions": "1 axiom: erdos_1210. WARNING: this axiom, as transcribed, is provably FALSE — the verbatim statement is refuted by the machine-checked theorem erdos_1210_statement_false (witness n=5, A={4}: the A-sum 1 exceeds the prime-sum 5/6 while all hypotheses hold). The axiom should be removed or revised once the original Erdős statement ([Er77c], [Er80]) is recovered (likely the intended weighting is 1/a rather than 1/(n-a), or there are unstated constraints on A). The refutation and counterexample theorems do NOT invoke the axiom, so no inconsistency is imported into downstream proofs. All structural theorems (primes pairwise coprime, sum positivity, the n=5 counterexample) are fully proved and axiom-free.",
+    "lineCount": 271,
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 3
   },
   "overview": {
@@ -110,9 +110,9 @@
       "BigOperators"
     ],
     "namespace": "Erdos1210",
-    "lineCount": 246,
+    "lineCount": 271,
     "axiomCount": 1,
-    "theoremCount": 15,
+    "theoremCount": 16,
     "definitionCount": 3,
     "path": "Proofs/Erdos1210Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`erdos-1210` declares `axiom erdos_1210` (primes maximize `∑ 1/(n-a)` among pairwise coprime subsets). As transcribed, **this axiom is provably false** — the file already proves a single-instance counterexample (`erdos_1210_literal_counterexample`, n=5, A={4}: A-sum `1` > prime-sum `5/6`). This PR makes the unsoundness precise and honestly recorded:

- New theorem `erdos_1210_statement_false`: a machine-checked refutation of the axiom's **exact universally-quantified statement** (`¬ ∀ n, 3 ≤ n → ∀ A, ValidSubset → PairwiseCoprime → …`). It upgrades the single instance to a full negation of what the axiom asserts. The theorem is axiom-free and does **not** invoke `erdos_1210`, so no inconsistency is imported into downstream proofs.
- `meta.json`: the `assumptions` field now honestly flags that the axiom is provably false and must be removed/revised once the original Erdős statement ([Er77c], [Er80]) is recovered (the intended weighting is plausibly `1/a` rather than `1/(n-a)`, or there are unstated constraints on A) — per the project's Axiom Integrity Policy.

This is the safe incremental integrity step; fully removing/revising the axiom (and refactoring the now-vacuous consequence theorems) requires the original source and is left as a flagged Curator/Mechanic follow-up.

## Changes
- `proofs/Proofs/Erdos1210Problem.lean`: +1 theorem, 246 → 271 LOC
- `src/data/proofs/erdos-1210/meta.json`: lineCount 246→271, theoremCount 15→16, assumptions corrected to flag unsoundness

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos1210Problem` — build succeeds (3058 jobs), no sorries
- [x] New theorem is axiom-free (does not use `erdos_1210`)
- [x] meta.json validates as JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)