### PR TITLE
research(cayley-hamilton-cyclic-vector): prove no_cyclic_vector over ZMod 4

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean
@@ -14,9 +14,8 @@ we show:
   3. `minpoly_natDegree_eq_two` — `(minpoly (ZMod 4) M).natDegree = 2`
      (paste-ready with sorry — see proof outline; depends on bearer pins to
      be sharpened in S3 ACT-2).
-  4. `no_cyclic_vector` — `¬ ∃ v, IsCyclicVector M v` (paste-ready with
-     sorry — see proof outline; depends on small tactic adjustments to be
-     verified in S3 ACT-2).
+  4. `no_cyclic_vector` — `¬ ∃ v, IsCyclicVector M v` (proved, sorry-free;
+     the polynomial `q = 2 * X` is a degree-1 annihilator with `2 • M = 0`).
 
 Companion to `CayleyHamiltonCyclicVectorCommRingOQ01.lean`, which proves the
 backward direction `(∃ v, IsCyclicVector M v) → IsNonderogatory M` over any
@@ -116,6 +115,22 @@ the nonzero polynomial `q = 2 * X` satisfies `q.natDegree = 1 < 2`,
 Reuses `IsCyclicVector` from `GeneralCyclicVectorRing` (S2 ACT). -/
 theorem no_cyclic_vector :
     ¬ ∃ v : Fin 2 → ZMod 4, IsCyclicVector M v := by
-  sorry
+  rintro ⟨v, hcyc⟩
+  -- The nonzero polynomial `q = 2 * X` annihilates `M` (as `aeval M (2*X) = 2•M = 0`)
+  -- and has `natDegree 1 < 2`, so cyclicity forces `2 * X = 0` — contradiction.
+  have haeval0 : aeval M (2 * X : (ZMod 4)[X]) = 0 := by
+    simp only [map_mul, aeval_X, map_ofNat]
+    ext i j; fin_cases i <;> fin_cases j <;> decide
+  have hdeg : (2 * X : (ZMod 4)[X]).natDegree < 2 := by
+    haveI : Nontrivial (ZMod 4) := nontrivial_zmod_four
+    have h : (2 * X : (ZMod 4)[X]).natDegree
+        ≤ (2 : (ZMod 4)[X]).natDegree + (X : (ZMod 4)[X]).natDegree := natDegree_mul_le
+    simp only [natDegree_ofNat, natDegree_X] at h
+    omega
+  have hq : (2 * X : (ZMod 4)[X]) = 0 :=
+    hcyc (2 * X) hdeg (by rw [haeval0]; simp)
+  have hc := congrArg (Polynomial.eval (1 : ZMod 4)) hq
+  simp only [eval_mul, eval_ofNat, eval_X, mul_one, eval_zero] at hc
+  exact absurd hc (by decide)
 
 end CayleyHamiltonCyclicVectorZMod4Counterexample


### PR DESCRIPTION
## Summary

Discharges the `no_cyclic_vector` `sorry` in `proofs/Proofs/CayleyHamiltonCyclicVectorZMod4Counterexample.lean` — a paste-ready placeholder deferred since S3 ACT-1 (2026-06-10).

The theorem proves that `M = !![0, 2; 0, 0] : Matrix (Fin 2) (Fin 2) (ZMod 4)` has **no cyclic vector**, settling the forward direction of the cyclic-vector ↔ nonderogatory biconditional **negatively over the non-domain `ZMod 4`**.

**Proof:** For any `v`, the polynomial `q = 2 * X` is a degree-1 annihilator: `aeval M (2*X) = 2 • M = 0` over `ZMod 4` (via the existing `two_smul_M_eq_zero`), and `natDegree (2*X) ≤ 1 < 2`. By the `IsCyclicVector` predicate this forces `2 * X = 0`; evaluating at `1` gives `(2 : ZMod 4) = 0`, a contradiction.

**Sorries in this file: 2 → 1.** Remaining: `minpoly_natDegree_eq_two` (the degree-form minpoly bound, still paste-ready per S3 PREP-3 §4.1).

## Verification

- Docker build: `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonCyclicVectorZMod4Counterexample` — **succeeded, 7744 jobs**, exit 0.
- Only remaining `sorry` warning is `minpoly_natDegree_eq_two` (line 98).
- No new axioms.

## Test plan

- [x] `docker-build.sh Proofs.CayleyHamiltonCyclicVectorZMod4Counterexample` passes with only the single expected `minpoly_natDegree_eq_two` sorry warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)