### PR TITLE
research(picks-oq-01-oq-01-oq-01): translation invariance of the Pick bridge (S4-prep)

### DIFF
--- a/proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
+++ b/proofs/Proofs/PicksTheoremOQ01OQ01OQ01.lean
@@ -921,7 +921,7 @@ lemma vEnd_mem_latticeSegmentPoints (v w : ℤ × ℤ) :
     rw [hxe, hye]
     show (v.1 + dx, v.2 + dy) = w
     rw [hdx_def, hdy_def]
-    ext <;> simp <;> ring
+    ext <;> simp
 
 end LatticeTriangle
 
@@ -980,7 +980,7 @@ theorem no_strict_edge_interior_of_edgeGCD_eq_one
     · rw [hxv]; exact hv_mem
     · rw [Finset.mem_singleton] at hxw; rw [hxw]; exact hw_mem
   have hpair_card : ({T.vEdgeStart i, T.vEdgeEnd i} : Finset (ℤ × ℤ)).card = 2 := by
-    rw [Finset.card_insert_of_not_mem (by simp [hvw]), Finset.card_singleton]
+    rw [Finset.card_insert_of_notMem (by simp [hvw]), Finset.card_singleton]
   have hSeq : LatticeTriangle.latticeSegmentPoints
                 (T.vEdgeStart i) (T.vEdgeEnd i) =
               ({T.vEdgeStart i, T.vEdgeEnd i} : Finset (ℤ × ℤ)) := by
@@ -1011,13 +1011,12 @@ theorem exists_strict_edge_interior_iff_edgeGCD_ge_two
   -- edgeGCD i < 2 means edgeGCD i ∈ {0, 1}.
   by_contra hlt
   push_neg at hlt
-  interval_cases (T.edgeGCD i)
+  rcases (by omega : T.edgeGCD i = 0 ∨ T.edgeGCD i = 1) with hg0 | hg1
   · -- edgeGCD i = 0.  Then both v and w are equal (since Int.gcd Δx Δy = 0
     -- forces Δx = Δy = 0), and the segment is just {v}, so card = 1.  But
     -- `OnStrictEdgeInterior` requires p in the segment with p ≠ v, impossible.
     -- Alternatively: g = 0 ⟹ segment has card 1, and (p ∈ segment, p ≠ v) is
     -- self-contradictory.
-    have hg0 : T.edgeGCD i = 0 := by assumption
     have hcard : (LatticeTriangle.latticeSegmentPoints
                     (T.vEdgeStart i) (T.vEdgeEnd i)).card = 1 := by
       have := card_latticeSegmentPoints (T.vEdgeStart i) (T.vEdgeEnd i)
@@ -1036,13 +1035,215 @@ theorem exists_strict_edge_interior_iff_edgeGCD_ge_two
       · rw [hxp]; exact hmem
       · rw [Finset.mem_singleton] at hxv; rw [hxv]; exact hv_mem
     have hcard2 : ({p, T.vEdgeStart i} : Finset (ℤ × ℤ)).card = 2 := by
-      rw [Finset.card_insert_of_not_mem (by simp [hne_v]), Finset.card_singleton]
+      rw [Finset.card_insert_of_notMem (by simp [hne_v]), Finset.card_singleton]
     have : 2 ≤ 1 := by
       have := Finset.card_le_card hsub
       rw [hcard2, hcard] at this
       exact this
     omega
   · -- edgeGCD i = 1.  Direct application of S3b-act-3.
-    exact no_strict_edge_interior_of_edgeGCD_eq_one T i (by assumption) p hp
+    exact no_strict_edge_interior_of_edgeGCD_eq_one T i hg1 p hp
+
+-- ════════════════════════════════════════════════════════════════
+-- SECTION XII (S4-prep): Translation Invariance of the Pick Bridge
+-- ════════════════════════════════════════════════════════════════
+
+/-! ### Why translation invariance is the next step
+
+The future Pick induction (S4/S5) decomposes a triangle into `|det|`
+primitive sub-triangles and reasons about each.  Every step of that
+argument needs to *reposition* a sub-triangle to a canonical location
+(e.g. anchor a vertex at the origin) without changing any of the
+Pick data.  This section proves exactly that: translating all three
+vertices by a fixed lattice vector `t` leaves invariant
+
+  * the determinant `det` (hence `twiceArea`),
+  * every `edgeGCD` (hence `boundaryCount`),
+  * the rational `pickInterior` and the integer `pickInteriorNum`,
+  * the orientation predicate `StrictInterior` (up to the same shift),
+  * and — the substantive result — the geometric count
+    `realInteriorCount`, via an explicit `Finset` bijection.
+
+Unlike the S2 base-case agreements (which are `native_decide` facts
+about three concrete triangles), these lemmas hold for *every* lattice
+triangle and *every* translation vector.  The capstone
+`pick_agrees_translate_iff` records the payoff: Pick's agreement is a
+translation-invariant property, so it suffices to prove it at any single
+canonical position. -/
+
+namespace LatticeTriangle
+
+/-- Translate every vertex of `T` by a fixed lattice vector `t`. -/
+def translate (T : LatticeTriangle) (t : ℤ × ℤ) : LatticeTriangle :=
+  ⟨(T.v1.1 + t.1, T.v1.2 + t.2),
+   (T.v2.1 + t.1, T.v2.2 + t.2),
+   (T.v3.1 + t.1, T.v3.2 + t.2)⟩
+
+end LatticeTriangle
+
+/-! #### Algebraic invariances (det / area / boundary / Pick formula) -/
+
+/-- The determinant is translation-invariant: shifting all vertices by `t`
+    cancels in every coordinate difference. -/
+lemma det_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).det = T.det := by
+  simp only [LatticeTriangle.det, LatticeTriangle.translate]
+  ring
+
+/-- `twiceArea = |det|` is translation-invariant. -/
+lemma twiceArea_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).twiceArea = T.twiceArea := by
+  unfold LatticeTriangle.twiceArea
+  rw [det_translate]
+
+/-- Each signed edge vector is unchanged by translation (the shift `t`
+    cancels in the difference of consecutive vertices). -/
+lemma signedDelta_translate (T : LatticeTriangle) (t : ℤ × ℤ) (i : Fin 3) :
+    (T.translate t).signedDelta i = T.signedDelta i := by
+  fin_cases i <;>
+    simp only [LatticeTriangle.signedDelta, LatticeTriangle.translate,
+      Prod.mk.injEq] <;>
+    refine ⟨?_, ?_⟩ <;> ring
+
+/-- Each absolute edge delta is unchanged by translation. -/
+lemma edgeDelta_translate (T : LatticeTriangle) (t : ℤ × ℤ) (i : Fin 3) :
+    (T.translate t).edgeDelta i = T.edgeDelta i := by
+  rw [edgeDelta_eq_natAbs_signedDelta, edgeDelta_eq_natAbs_signedDelta,
+      signedDelta_translate]
+
+/-- Each edge GCD is translation-invariant. -/
+lemma edgeGCD_translate (T : LatticeTriangle) (t : ℤ × ℤ) (i : Fin 3) :
+    (T.translate t).edgeGCD i = T.edgeGCD i := by
+  unfold LatticeTriangle.edgeGCD
+  rw [edgeDelta_translate]
+
+/-- The boundary lattice-point count is translation-invariant. -/
+lemma boundaryCount_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).boundaryCount = T.boundaryCount := by
+  unfold LatticeTriangle.boundaryCount
+  rw [edgeGCD_translate, edgeGCD_translate, edgeGCD_translate]
+
+/-- Pick's rational interior formula is translation-invariant. -/
+lemma pickInterior_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).pickInterior = T.pickInterior := by
+  unfold LatticeTriangle.pickInterior
+  rw [twiceArea_translate, boundaryCount_translate]
+
+/-- The cleared-denominator integer form is translation-invariant. -/
+lemma pickInteriorNum_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).pickInteriorNum = T.pickInteriorNum := by
+  unfold LatticeTriangle.pickInteriorNum
+  rw [twiceArea_translate, boundaryCount_translate]
+
+/-! #### Geometric invariance (orientation predicate and interior count) -/
+
+/-- Translating the two reference vertices by `t` is the same as shifting
+    the test point by `-t`: `cross2 (a+t) (b+t) p = cross2 a b (p - t)`. -/
+lemma cross2_translate_pt (a b p t : ℤ × ℤ) :
+    cross2 (a.1 + t.1, a.2 + t.2) (b.1 + t.1, b.2 + t.2) p
+      = cross2 a b (p.1 - t.1, p.2 - t.2) := by
+  unfold cross2
+  ring
+
+/-- A point is strictly interior to the translated triangle iff its
+    back-shift `p - t` is strictly interior to the original.  Both
+    orientation disjuncts transport simultaneously. -/
+lemma strictInterior_translate (T : LatticeTriangle) (t p : ℤ × ℤ) :
+    (T.translate t).StrictInterior p ↔ T.StrictInterior (p.1 - t.1, p.2 - t.2) := by
+  simp only [LatticeTriangle.StrictInterior, LatticeTriangle.translate]
+  rw [cross2_translate_pt, cross2_translate_pt, cross2_translate_pt]
+
+/-! #### Bounding-box transport (each extreme coordinate shifts by `t`) -/
+
+lemma xmin_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).xmin = T.xmin + t.1 := by
+  simp only [LatticeTriangle.xmin, LatticeTriangle.translate]
+  omega
+
+lemma xmax_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).xmax = T.xmax + t.1 := by
+  simp only [LatticeTriangle.xmax, LatticeTriangle.translate]
+  omega
+
+lemma ymin_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).ymin = T.ymin + t.2 := by
+  simp only [LatticeTriangle.ymin, LatticeTriangle.translate]
+  omega
+
+lemma ymax_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).ymax = T.ymax + t.2 := by
+  simp only [LatticeTriangle.ymax, LatticeTriangle.translate]
+  omega
+
+/-- A point lies in the translated bounding box iff its back-shift lies in
+    the original bounding box. -/
+lemma mem_boundingBox_translate (T : LatticeTriangle) (t q : ℤ × ℤ) :
+    q ∈ (T.translate t).boundingBox ↔
+      (q.1 - t.1, q.2 - t.2) ∈ T.boundingBox := by
+  simp only [LatticeTriangle.boundingBox, Finset.mem_product, Finset.mem_Icc,
+    xmin_translate, xmax_translate, ymin_translate, ymax_translate]
+  omega
+
+/-! #### The substantive result: `realInteriorCount` is translation-invariant -/
+
+/-- The strictly-interior lattice points of the translated triangle are
+    exactly the image of those of the original under the shift map
+    `p ↦ p + t`.  This packages the orientation and bounding-box
+    transports into a single `Finset` identity. -/
+theorem realInterior_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).realInterior
+      = T.realInterior.image (fun p : ℤ × ℤ => (p.1 + t.1, p.2 + t.2)) := by
+  ext q
+  simp only [LatticeTriangle.realInterior, Finset.mem_filter, Finset.mem_image]
+  constructor
+  · rintro ⟨hbb, hsi⟩
+    exact ⟨(q.1 - t.1, q.2 - t.2),
+      ⟨(mem_boundingBox_translate T t q).mp hbb,
+       (strictInterior_translate T t q).mp hsi⟩,
+      by simp⟩
+  · rintro ⟨p, ⟨hbb, hsi⟩, rfl⟩
+    refine ⟨?_, ?_⟩
+    · rw [mem_boundingBox_translate]; simpa using hbb
+    · rw [strictInterior_translate]; simpa using hsi
+
+/-- **Translation invariance of the interior count.**  For every lattice
+    triangle `T` and every shift `t`, the strictly-interior lattice-point
+    count is unchanged.  The shift map is a bijection on lattice points,
+    so the filtered bounding boxes have equal cardinality.
+
+    This is the general repositioning lemma the Pick induction needs:
+    a primitive sub-triangle may be translated to any canonical anchor
+    without affecting its geometric interior count. -/
+theorem realInteriorCount_translate (T : LatticeTriangle) (t : ℤ × ℤ) :
+    (T.translate t).realInteriorCount = T.realInteriorCount := by
+  unfold LatticeTriangle.realInteriorCount
+  rw [realInterior_translate]
+  apply Finset.card_image_of_injective
+  intro a b hab
+  simp only [Prod.mk.injEq] at hab
+  exact Prod.ext (add_right_cancel hab.1) (add_right_cancel hab.2)
+
+/-- **Capstone — Pick's agreement is translation-invariant.**  The property
+    "the real interior count equals Pick's formula" holds for `T` iff it
+    holds for any translate `T.translate t`.  Consequently it suffices to
+    establish Pick's theorem at a single canonical position (e.g. a vertex
+    anchored at the origin), and the general case follows by translation.
+
+    Both sides of the equivalence reduce to the same statement once the
+    two invariances `realInteriorCount_translate` and
+    `pickInterior_translate` are applied. -/
+theorem pick_agrees_translate_iff (T : LatticeTriangle) (t : ℤ × ℤ) :
+    ((T.translate t).realInteriorCount : ℚ) = (T.translate t).pickInterior
+      ↔ ((T.realInteriorCount : ℚ) = T.pickInterior) := by
+  rw [realInteriorCount_translate, pickInterior_translate]
+
+/-- **Sanity check.**  The primitive base case `primitive_pick_agrees`
+    transports across translation: any translate of a primitive triangle
+    still satisfies Pick's agreement (its `twiceArea` is also `1`).  This
+    confirms the new invariance machinery is consistent with the S3a
+    primitive base case. -/
+example (T : LatticeTriangle) (t : ℤ × ℤ) (h : T.twiceArea = 1) :
+    ((T.translate t).realInteriorCount : ℚ) = (T.translate t).pickInterior :=
+  (pick_agrees_translate_iff T t).mpr (primitive_pick_agrees T h)
 
 end PicksTheoremOQ01OQ01OQ01

--- a/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/picks-theorem-oq-01-oq-01-oq-01/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "picks-theorem-oq-01-oq-01-oq-01",
-  "title": "Pick's Theorem via Primitive Triangulation + GCD Boundary Count (S2 OBSERVE)",
+  "title": "Pick's Theorem via Primitive Triangulation + GCD Boundary Count (S4-prep: Translation Invariance)",
   "slug": "picks-theorem-oq-01-oq-01-oq-01",
-  "description": "S2 OBSERVE for the open question of whether Pick's theorem (Area = I + B/2 - 1) can be derived in Lean by combining (a) the primitive-triangulation result of PicksTheoremOQ01OQ01 (every lattice triangle decomposes into exactly |det| primitive sub-triangles) and (b) the GCD boundary-count formula of PicksTheoremOQ02 (the segment from (0,0) to (a,b) has gcd(a,b)+1 lattice points). S1 scaffolded the bridge data structures + algebraic identity + Pick-formula verification on three concrete triangles. S2 adds a decidable definition of the *real* strictly-interior lattice-point count (via cross-product orientation test on a bounding-box Finset) and verifies the base-case agreement realInteriorCount = pickInterior on the unit, 2-by-1, and 3-by-3 triangles — closing the base case of the future Pick induction.",
+  "description": "S2 OBSERVE for the open question of whether Pick's theorem (Area = I + B/2 - 1) can be derived in Lean by combining (a) the primitive-triangulation result of PicksTheoremOQ01OQ01 (every lattice triangle decomposes into exactly |det| primitive sub-triangles) and (b) the GCD boundary-count formula of PicksTheoremOQ02 (the segment from (0,0) to (a,b) has gcd(a,b)+1 lattice points). S1 scaffolded the bridge data structures + algebraic identity + Pick-formula verification on three concrete triangles. S2 adds a decidable definition of the *real* strictly-interior lattice-point count (via cross-product orientation test on a bounding-box Finset) and verifies the base-case agreement realInteriorCount = pickInterior on the unit, 2-by-1, and 3-by-3 triangles — closing the base case of the future Pick induction. S4-prep adds a full translation-invariance section: a `translate` operation on triangles together with lemmas proving every Pick quantity (det, twiceArea, edgeGCD, boundaryCount, pickInterior, pickInteriorNum) is unchanged by a lattice shift, that the StrictInterior orientation predicate transports under back-shift, and — the substantive result — that realInteriorCount is translation-invariant via an explicit Finset bijection (realInterior_translate / realInteriorCount_translate). The capstone pick_agrees_translate_iff shows Pick's agreement is itself translation-invariant, so it suffices to prove Pick's theorem at a single canonical anchor position. Unlike the S2 native_decide agreements (three concrete triangles), these hold for every lattice triangle and every shift.",
   "meta": {
     "author": "Lean Genius Research (researcher-4)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Pick%27s_theorem",
@@ -12,9 +12,9 @@
     "proofRepoPath": "Proofs/PicksTheoremOQ01OQ01OQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 45,
-    "definitionCount": 26,
-    "lineCount": 1048,
+    "theoremCount": 63,
+    "definitionCount": 27,
+    "lineCount": 1249,
     "tags": [
       "number-theory",
       "geometry",
@@ -25,6 +25,7 @@
       "determinant",
       "cross-product",
       "decidable-geometry",
+      "translation-invariance",
       "research-scaffold"
     ],
     "assumptions": [],


### PR DESCRIPTION
## Summary

Advances `picks-theorem-oq-01-oq-01-oq-01` with a new **Section XII (S4-prep): Translation Invariance of the Pick Bridge**. This is the repositioning machinery the eventual Pick induction needs: a primitive sub-triangle can be shifted to any canonical anchor (e.g. a vertex at the origin) without changing any Pick data.

A new `LatticeTriangle.translate T t` shifts all three vertices by a lattice vector `t`, and we prove the whole bridge is invariant:

- **Algebraic** — `det`, `twiceArea`, every `edgeGCD`, `boundaryCount`, `pickInterior`, `pickInteriorNum` are all unchanged (via `signedDelta` cancellation, so even the `Int.natAbs`-wrapped edge deltas transport).
- **Geometric** — `cross2_translate_pt` and `strictInterior_translate` show the orientation predicate transports under the back-shift `p ↦ p - t`; bounding-box extremes shift by `t` (`xmin/xmax/ymin/ymax_translate`, `mem_boundingBox_translate`).
- **Substantive** — `realInterior_translate` (the interior point set is the image under the shift bijection) and `realInteriorCount_translate` (the geometric interior count is invariant, proved via a `Finset` bijection / `card_image_of_injective`).
- **Capstone** — `pick_agrees_translate_iff`: Pick's agreement `realInteriorCount = pickInterior` is itself translation-invariant, so it suffices to prove Pick's theorem at a single canonical position.

Unlike the S2 `native_decide` agreements (three specific triangles), every lemma here holds for **every** lattice triangle and **every** shift.

This PR also repairs latent breakage in the pre-existing `exists_strict_edge_interior_iff_edgeGCD_ge_two` under the current Mathlib pin (the module was outside the build-safe subset): `interval_cases + assumption` no longer connects, replaced with an `omega`-derived case split; deprecated `card_insert_of_not_mem` → `card_insert_of_notMem`.

## Verification

- `./proofs/scripts/docker-build.sh Proofs.PicksTheoremOQ01OQ01OQ01` — **Build succeeded, 3058 jobs, 0 errors, 0 warnings.**
- 0 sorries, 0 axioms, 0 structure-encoded assumptions.
- meta.json updated: theoremCount 45→63, definitionCount 26→27, lineCount 1048→1249, new `translation-invariance` tag.

## Test plan

- [x] Docker build passes with no errors or warnings
- [x] No new sorries/axioms introduced
- [x] meta.json counts reconciled with the source

🤖 Generated with [Claude Code](https://claude.com/claude-code)