### PR TITLE
research(erdos-895-oq-01): add triangleFree_indep_pair corollary (α(G) ≥ 2 for n ≥ 4)

### DIFF
--- a/proofs/Proofs/Erdos895OQ01Problem.lean
+++ b/proofs/Proofs/Erdos895OQ01Problem.lean
@@ -22,7 +22,9 @@
   2. Hajnal conjecture as an axiom (OPEN)
   3. The k=2 case: Hajnal base {a,b} with a+b < n → independent additive triple
   4. Independence number lower bound α(G) ≥ √n for triangle-free graphs
-     (Case 1 proved; Case 2 has one HARD sorry for greedy algorithm)
+     (both cases proved, sorry-free: Case 1 high-degree, Case 2 greedy)
+  5. Corollary: for n ≥ 4, α(G) ≥ 2, yielding an independent pair
+     (first step toward an independent Hindman base of card ≥ 2)
 -/
 import Mathlib
 
@@ -268,5 +270,20 @@ theorem triangleFree_independence_bound {n : ℕ} (G : GraphOnInterval n) [Decid
         have := Nat.sqrt_le' n; rwa [pow_two] at this
       -- √n * √n ≤ n ≤ S.card * √n  →  √n ≤ S.card
       exact Nat.le_of_mul_le_mul_right (hkk.trans hS) hk
+
+/-- Corollary of the α(G) ≥ √n bound: for n ≥ 4 (so √n ≥ 2), every
+    triangle-free graph on Fin n has an independent set of size ≥ 2.
+    This yields an independent *pair* {a, b} (a, b non-adjacent), the first
+    structural step toward an independent Hindman base of card ≥ 2 — though
+    a plain independent pair is not yet sub-sum (Hindman) independent, since
+    a + b may still be adjacent to a or b. -/
+theorem triangleFree_indep_pair {n : ℕ} (G : GraphOnInterval n) [DecidableRel G.Adj]
+    (hG : IsTriangleFree G) (hn : 4 ≤ n) :
+    ∃ S : Finset (Fin n), 2 ≤ S.card ∧
+      ∀ a b : Fin n, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b := by
+  obtain ⟨S, hS, hindep⟩ := triangleFree_independence_bound G hG
+  refine ⟨S, ?_, hindep⟩
+  have h2 : 2 ≤ Nat.sqrt n := Nat.le_sqrt.mpr (by omega)
+  omega
 
 end Erdos895OQ01Problem

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-895-oq-01",
   "title": "Hajnal's Independent Hindman Set Conjecture",
   "slug": "erdos-895-oq-01",
-  "description": "Hajnal's open generalization of Erdős #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set — a base B with all finite sub-sums forming a mutually non-adjacent set.",
+  "description": "Hajnal's open generalization of Erd\u0151s #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set \u2014 a base B with all finite sub-sums forming a mutually non-adjacent set.",
   "meta": {
-    "author": "Erdős-Hajnal (conjectured)",
+    "author": "Erd\u0151s-Hajnal (conjectured)",
     "sourceUrl": "https://erdosproblems.com/895",
     "date": "1995",
     "status": "axiomatized",
@@ -46,9 +46,9 @@
       "Monotonicity and structural lemmas for hindmanSet (sorry-free)",
       "Axiomatization of Hajnal's conjecture as an open problem",
       "Proof that Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple",
-      "Proved Case 1 of α(G) ≥ √n bound: high-degree vertex N(v) is independent",
-      "Full proof of α(G) ≥ √n via two-case greedy argument: Case 1 (high-degree vertex N(v)), Case 2 (greedy induction on candidate set cardinality)",
-      "triangleFree_indep_pair: for n ≥ 4, a triangle-free graph on Fin n has an independent set of card ≥ 2 (corollary of α(G) ≥ √n via √n ≥ 2 = Nat.sqrt 4); yields an independent pair as a first step toward an independent Hindman base of card ≥ 2 (sorry-free)"
+      "Proved Case 1 of \u03b1(G) \u2265 \u221an bound: high-degree vertex N(v) is independent",
+      "Full proof of \u03b1(G) \u2265 \u221an via two-case greedy argument: Case 1 (high-degree vertex N(v)), Case 2 (greedy induction on candidate set cardinality)",
+      "triangleFree_indep_pair: for n >= 4, a triangle-free graph on Fin n has an independent set of card >= 2 (corollary of the alpha(G) >= sqrt(n) bound via sqrt(n) >= 2 = Nat.sqrt 4); yields an independent pair as a first step toward an independent Hindman base of card >= 2 (sorry-free)"
     ],
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
     "mathlib_version": "4.26.0",
@@ -57,48 +57,48 @@
     "lineCount": 289
   },
   "overview": {
-    "historicalContext": "**Hajnal's Generalization of Erdős Problem #895**\n\nThe parent problem, Erdős #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by András Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** — a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting — a fundamentally different kind of constraint.",
-    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ — proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
-    "text": "Hajnal's open generalization of Erdős #895: does every large triangle-free graph contain an independent Hindman set?",
-    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base → independent additive triple\n5. Proves `triangleFree_independence_bound` (α ≥ √n) via two-case greedy argument (0 sorries)",
+    "historicalContext": "**Hajnal's Generalization of Erd\u0151s Problem #895**\n\nThe parent problem, Erd\u0151s #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by Andr\u00e1s Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** \u2014 a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting \u2014 a fundamentally different kind of constraint.",
+    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ \u2014 proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
+    "text": "Hajnal's open generalization of Erd\u0151s #895: does every large triangle-free graph contain an independent Hindman set?",
+    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base \u2192 independent additive triple\n5. Proves `triangleFree_independence_bound` (\u03b1 \u2265 \u221an) via two-case greedy argument (0 sorries)",
     "keyInsights": [
-      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erdős #895 — the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements: $|\\mathrm{FS}(B)|$ can be as large as $2^{|B|} - 1$, so the constraint count grows from 3 (at $k=2$) to 7 (at $k=3$) to 15 (at $k=4$).",
-      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erdős-Barber structure.",
-      "**Independence number bound:** Triangle-free graphs satisfy α(G) ≥ √n. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
-      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent — giving exactly the Erdős-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
-      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k≥3 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics.",
-      "**Sharpness of the √n bound:** The elementary $\\alpha(G) \\geq \\sqrt{n}$ proved here is essentially tight in form — Kim (1995) showed the Ramsey number $R(3,t)$ has order $t^2/\\log t$, so the true bound is $\\alpha(G) = \\Omega(\\sqrt{n \\log n})$. The Lean proof captures the elementary half; the logarithmic improvement is a deep probabilistic argument (Lovász Local Lemma + nibble) not yet formalized."
+      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erd\u0151s #895 \u2014 the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements: $|\\mathrm{FS}(B)|$ can be as large as $2^{|B|} - 1$, so the constraint count grows from 3 (at $k=2$) to 7 (at $k=3$) to 15 (at $k=4$).",
+      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erd\u0151s-Barber structure.",
+      "**Independence number bound:** Triangle-free graphs satisfy \u03b1(G) \u2265 \u221an. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
+      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent \u2014 giving exactly the Erd\u0151s-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
+      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k\u22653 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics.",
+      "**Sharpness of the \u221an bound:** The elementary $\\alpha(G) \\geq \\sqrt{n}$ proved here is essentially tight in form \u2014 Kim (1995) showed the Ramsey number $R(3,t)$ has order $t^2/\\log t$, so the true bound is $\\alpha(G) = \\Omega(\\sqrt{n \\log n})$. The Lean proof captures the elementary half; the logarithmic improvement is a deep probabilistic argument (Lov\u00e1sz Local Lemma + nibble) not yet formalized."
     ],
     "prerequisites": [
       "Graph theory: triangle-free graphs, independent sets, neighborhood sets",
       "Additive combinatorics: sumsets, Schur triples, Hindman sets",
       "Ramsey theory: R(3,3)=6, triangle-free graph structure",
-      "Parent result: Erdős #895 (Barber 2015)"
+      "Parent result: Erd\u0151s #895 (Barber 2015)"
     ],
     "mainTheorems": [
       {
         "name": "hajnal_conjecture",
-        "statement": "∃ N : ℕ, ∀ n ≥ N, ∀ G : GraphOnInterval n, IsTriangleFree G → ∃ base : Finset (Fin n), base.card ≥ 2 ∧ ∀ s t : Fin n, s.val ∈ hindmanSet (base.image (·.val)) → t.val ∈ hindmanSet (base.image (·.val)) → s ≠ t → ¬G.Adj s t",
-        "description": "Hajnal's open conjecture: every sufficiently large triangle-free graph on {1,…,n} contains an independent Hindman set. AXIOM (open as of 2026)."
+        "statement": "\u2203 N : \u2115, \u2200 n \u2265 N, \u2200 G : GraphOnInterval n, IsTriangleFree G \u2192 \u2203 base : Finset (Fin n), base.card \u2265 2 \u2227 \u2200 s t : Fin n, s.val \u2208 hindmanSet (base.image (\u00b7.val)) \u2192 t.val \u2208 hindmanSet (base.image (\u00b7.val)) \u2192 s \u2260 t \u2192 \u00acG.Adj s t",
+        "description": "Hajnal's open conjecture: every sufficiently large triangle-free graph on {1,\u2026,n} contains an independent Hindman set. AXIOM (open as of 2026)."
       },
       {
         "name": "hajnal_k2_gives_additive_triple",
-        "statement": "∀ {n} (G : GraphOnInterval n) (a b : Fin n), a ≠ b → a.val > 0 → b.val > 0 → a.val + b.val < n → (∀ s t, s.val ∈ hindmanSet … → t.val ∈ hindmanSet … → s ≠ t → ¬G.Adj s t) → HasIndependentAdditiveTriple G",
-        "description": "Hajnal at base size k=2 directly recovers Erdős-Barber: a Hajnal base {a,b} with in-range sum a+b<n yields the additive triple (a, b, a+b) being mutually non-adjacent. Sorry-free."
+        "statement": "\u2200 {n} (G : GraphOnInterval n) (a b : Fin n), a \u2260 b \u2192 a.val > 0 \u2192 b.val > 0 \u2192 a.val + b.val < n \u2192 (\u2200 s t, s.val \u2208 hindmanSet \u2026 \u2192 t.val \u2208 hindmanSet \u2026 \u2192 s \u2260 t \u2192 \u00acG.Adj s t) \u2192 HasIndependentAdditiveTriple G",
+        "description": "Hajnal at base size k=2 directly recovers Erd\u0151s-Barber: a Hajnal base {a,b} with in-range sum a+b<n yields the additive triple (a, b, a+b) being mutually non-adjacent. Sorry-free."
       },
       {
         "name": "triangleFree_independence_bound",
-        "statement": "∀ {n} (G : GraphOnInterval n) [DecidableRel G.Adj], IsTriangleFree G → ∃ S : Finset (Fin n), S.card ≥ Nat.sqrt n ∧ ∀ a b, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b",
-        "description": "Independence number bound α(G) ≥ √n for any triangle-free graph on n vertices, proved by a two-case argument (high-degree vertex N(v) or greedy on bounded-degree). Sorry-free, no axiom dependency."
+        "statement": "\u2200 {n} (G : GraphOnInterval n) [DecidableRel G.Adj], IsTriangleFree G \u2192 \u2203 S : Finset (Fin n), S.card \u2265 Nat.sqrt n \u2227 \u2200 a b, a \u2208 S \u2192 b \u2208 S \u2192 a \u2260 b \u2192 \u00acG.Adj a b",
+        "description": "Independence number bound \u03b1(G) \u2265 \u221an for any triangle-free graph on n vertices, proved by a two-case argument (high-degree vertex N(v) or greedy on bounded-degree). Sorry-free, no axiom dependency."
       },
       {
         "name": "triangleFree_nbhd_independent",
-        "statement": "∀ {n} (G : GraphOnInterval n), IsTriangleFree G → ∀ v u w : Fin n, G.Adj v u → G.Adj v w → ¬G.Adj u w",
-        "description": "Defining structural lemma: in a triangle-free graph, any two distinct neighbors of v are non-adjacent (would close the triangle vuw). Underlies Case 1 of the √n bound."
+        "statement": "\u2200 {n} (G : GraphOnInterval n), IsTriangleFree G \u2192 \u2200 v u w : Fin n, G.Adj v u \u2192 G.Adj v w \u2192 \u00acG.Adj u w",
+        "description": "Defining structural lemma: in a triangle-free graph, any two distinct neighbors of v are non-adjacent (would close the triangle vuw). Underlies Case 1 of the \u221an bound."
       },
       {
         "name": "hindmanSet_pair_sum",
-        "statement": "∀ a b : ℕ, a ≠ b → a + b ∈ hindmanSet ({a, b} : Finset ℕ)",
+        "statement": "\u2200 a b : \u2115, a \u2260 b \u2192 a + b \u2208 hindmanSet ({a, b} : Finset \u2115)",
         "description": "Witnesses that the pair-sum a+b is in FS({a,b}); together with `hindmanSet_pair_left/right` gives the three k=2 elements {a, b, a+b}."
       }
     ]
@@ -110,7 +110,7 @@
       "summary": "Graph-on-interval, triangle-free predicate, additive triple, and the hindmanSet (Hindman finite-sums set FS(B)).",
       "startLine": 33,
       "endLine": 49,
-      "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set ℕ`."
+      "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set \u2115`."
     },
     {
       "id": "hindman-structure",
@@ -123,7 +123,7 @@
     {
       "id": "hajnal-conjecture",
       "title": "Hajnal's Conjecture",
-      "summary": "Formal statement of Hajnal's generalization of Erdős #895 and its axiomatization as an open problem.",
+      "summary": "Formal statement of Hajnal's generalization of Erd\u0151s #895 and its axiomatization as an open problem.",
       "startLine": 79,
       "endLine": 91,
       "mathContext": "$\\exists N, \\forall n \\geq N, \\forall G$ triangle-free on `Fin n`, $\\exists B \\subseteq V$ with $|B| \\geq 2$ such that $\\mathrm{FS}(B.\\mathrm{image}\\,(\\cdot.\\mathrm{val}))$ is a graph-independent set. Asserted via `axiom hajnal_conjecture` (OPEN as of 2026)."
@@ -131,10 +131,10 @@
     {
       "id": "k2-reduction",
       "title": "The k=2 Reduction",
-      "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) — recovers Erdős-Barber.",
+      "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) \u2014 recovers Erd\u0151s-Barber.",
       "startLine": 93,
       "endLine": 129,
-      "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erdős-Barber on the $k=2$ slice."
+      "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erd\u0151s-Barber on the $k=2$ slice."
     },
     {
       "id": "triangle-free-neighborhoods",
@@ -147,137 +147,115 @@
     {
       "id": "greedy-bounded-degree",
       "title": "Greedy Independent Set on Bounded-Degree Subgraphs",
-      "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives α ≥ |C|/(Δ+1).",
+      "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives \u03b1 \u2265 |C|/(\u0394+1).",
       "startLine": 149,
       "endLine": 242,
       "mathContext": "Private lemma `greedy_indep_of_bounded_deg`: if $\\Delta(G[C]) \\leq \\Delta$, greedy step removes $\\leq \\Delta + 1$ vertices and recurses, yielding $|C| \\leq |S|(\\Delta+1)$. Wrapper `indep_from_bounded_deg` specializes to $C = V$."
     },
     {
       "id": "independence-bound",
-      "title": "Independence Number Bound α(G) ≥ √n",
-      "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size ≥ √n.",
+      "title": "Independence Number Bound \u03b1(G) \u2265 \u221an",
+      "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size \u2265 \u221an.",
       "startLine": 244,
       "endLine": 271,
       "mathContext": "`triangleFree_independence_bound`: split on $\\exists v$ with $\\deg(v) \\geq \\sqrt{n}$. Case 1 reuses `triangleFree_indep_high_deg`. Case 2: all $\\deg \\leq \\sqrt{n} - 1$, so greedy gives $n \\leq |S| \\cdot \\sqrt{n}$; combined with `Nat.sqrt_le'` ($\\lfloor\\sqrt{n}\\rfloor^2 \\leq n$) and `Nat.le_of_mul_le_mul_right` we conclude $|S| \\geq \\sqrt{n}$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization axiomatizes Hajnal's open generalization of Erdős #895 and proves all available structural components: hindmanSet properties (4 lemmas, sorry-free), the k=2 reduction (Hajnal base of size 2 implies Erdős-Barber structure), and the independence number bound α(G) ≥ √n for triangle-free graphs via a complete two-case greedy argument (0 sorries, 1 axiom for the conjecture itself).",
-    "implications": "The independence bound α(G) ≥ √n for triangle-free graphs is tight — Paley graphs and polarity graphs show the bound cannot be improved to ω(√n) in general. Hajnal's conjecture, if true, would give a structural reason for the additive richness of large independent sets in triangle-free graphs: not only do large independent sets exist (by the √n bound), they contain sets that are closed under addition (FS-sets). This would bridge graph Ramsey theory and additive Ramsey theory (Hindman's theorem). The greedy bound α ≥ n/(Δ+1) proved here is also useful beyond the √n application: for triangle-free graphs with bounded maximum degree Δ ≪ √n, it gives the tighter bound α ≥ n/Δ.",
+    "summary": "This formalization axiomatizes Hajnal's open generalization of Erd\u0151s #895 and proves all available structural components: hindmanSet properties (4 lemmas, sorry-free), the k=2 reduction (Hajnal base of size 2 implies Erd\u0151s-Barber structure), and the independence number bound \u03b1(G) \u2265 \u221an for triangle-free graphs via a complete two-case greedy argument (0 sorries, 1 axiom for the conjecture itself).",
+    "implications": "The independence bound \u03b1(G) \u2265 \u221an for triangle-free graphs is tight \u2014 Paley graphs and polarity graphs show the bound cannot be improved to \u03c9(\u221an) in general. Hajnal's conjecture, if true, would give a structural reason for the additive richness of large independent sets in triangle-free graphs: not only do large independent sets exist (by the \u221an bound), they contain sets that are closed under addition (FS-sets). This would bridge graph Ramsey theory and additive Ramsey theory (Hindman's theorem). The greedy bound \u03b1 \u2265 n/(\u0394+1) proved here is also useful beyond the \u221an application: for triangle-free graphs with bounded maximum degree \u0394 \u226a \u221an, it gives the tighter bound \u03b1 \u2265 n/\u0394.",
     "openQuestions": [
-      "Hajnal's conjecture for k=3: does every large triangle-free graph on {1,...,n} contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}? The 7 elements must all be in {1,...,n} and mutually non-adjacent — a substantially harder combinatorial constraint than the k=2 case.",
-      "Can the independence bound α(G) ≥ √n be proved using the Bonferroni/Lovász Local Lemma approach (probabilistic method) rather than the greedy algorithm? A probabilistic proof might give tighter constants or extend to hypergraphs.",
-      "The parent result (Erdős #895, Barber 2015) was proved by SAT verification. Can the Lean 4 formalization be extended to verify Barber's argument — that n ≥ 18 is sufficient for the k=2 case — without using the axiom?"
+      "Hajnal's conjecture for k=3: does every large triangle-free graph on {1,...,n} contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}? The 7 elements must all be in {1,...,n} and mutually non-adjacent \u2014 a substantially harder combinatorial constraint than the k=2 case.",
+      "Can the independence bound \u03b1(G) \u2265 \u221an be proved using the Bonferroni/Lov\u00e1sz Local Lemma approach (probabilistic method) rather than the greedy algorithm? A probabilistic proof might give tighter constants or extend to hypergraphs.",
+      "The parent result (Erd\u0151s #895, Barber 2015) was proved by SAT verification. Can the Lean 4 formalization be extended to verify Barber's argument \u2014 that n \u2265 18 is sufficient for the k=2 case \u2014 without using the axiom?"
     ]
   },
   "crossReferences": [
     {
       "id": "erdos-895",
-      "title": "Erdős Problem #895 — Independent Additive Triples",
-      "relationship": "Parent: proves the k=2 case of Hajnal's conjecture (Barber 2015: every triangle-free graph on {1,...,n} for n ≥ 18 contains independent a, b, a+b). This entry extends the question to larger Hindman bases."
+      "title": "Erd\u0151s Problem #895 \u2014 Independent Additive Triples",
+      "relationship": "Parent: proves the k=2 case of Hajnal's conjecture (Barber 2015: every triangle-free graph on {1,...,n} for n \u2265 18 contains independent a, b, a+b). This entry extends the question to larger Hindman bases."
     },
     {
       "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Thematic sibling: Ramsey theory studies structure in large combinatorial objects. Hajnal's conjecture is a hybrid of graph Ramsey theory (triangle-free = K₃-free) and additive Ramsey theory (Hindman sets)."
+      "relationship": "Thematic sibling: Ramsey theory studies structure in large combinatorial objects. Hajnal's conjecture is a hybrid of graph Ramsey theory (triangle-free = K\u2083-free) and additive Ramsey theory (Hindman sets)."
     },
     {
       "id": "ramsey-r4k",
       "title": "Ramsey R(4,k) Bounds",
-      "relationship": "Related combinatorial result in the Ramsey family. The independence bound α(G) ≥ √n proved here is related to Ramsey-multiplicity and diagonal Ramsey bounds."
+      "relationship": "Related combinatorial result in the Ramsey family. The independence bound \u03b1(G) \u2265 \u221an proved here is related to Ramsey-multiplicity and diagonal Ramsey bounds."
     }
   ],
   "references": [
     {
-      "authors": [
-        "Neil Hindman"
-      ],
+      "authors": ["Neil Hindman"],
       "title": "Finite sums from sequences within cells of a partition of N",
       "year": 1974,
       "venue": "Journal of Combinatorial Theory, Series A",
       "volume": "17",
-      "pages": "1–11",
+      "pages": "1\u201311",
       "doi": "10.1016/0097-3165(74)90023-5",
-      "note": "Original Hindman's theorem: for any finite coloring of ℕ, there is an infinite set whose finite sums are monochromatic. Hajnal's conjecture is the graph-Ramsey analogue in the finite setting."
+      "note": "Original Hindman's theorem: for any finite coloring of \u2115, there is an infinite set whose finite sums are monochromatic. Hajnal's conjecture is the graph-Ramsey analogue in the finite setting."
     },
     {
-      "authors": [
-        "Ben Barber"
-      ],
+      "authors": ["Ben Barber"],
       "title": "Independent sets in graphs with an excluded clique minor",
       "year": 2015,
       "venue": "preprint / arXiv",
       "arxiv": "1502.05015",
-      "note": "Resolves Erdős #895 (the k=2 base case of this conjecture) for n ≥ 18 via SAT-assisted case analysis."
+      "note": "Resolves Erd\u0151s #895 (the k=2 base case of this conjecture) for n \u2265 18 via SAT-assisted case analysis."
     },
     {
-      "authors": [
-        "András Hajnal"
-      ],
+      "authors": ["Andr\u00e1s Hajnal"],
       "title": "Open problems on combinatorics and graph theory",
       "year": "1995",
       "venue": "Combinatorica / talk notes",
-      "note": "Hajnal's original posing of the FS-independence conjecture, generalizing Erdős #895 from k=2 to arbitrary base size."
+      "note": "Hajnal's original posing of the FS-independence conjecture, generalizing Erd\u0151s #895 from k=2 to arbitrary base size."
     },
     {
-      "authors": [
-        "Paul Erdős",
-        "András Hajnal",
-        "Joel Spencer"
-      ],
+      "authors": ["Paul Erd\u0151s", "Andr\u00e1s Hajnal", "Joel Spencer"],
       "title": "Graphs without large complete subgraphs of given chromatic number",
       "year": 1985,
       "venue": "Combinatorica",
-      "note": "Foundational Erdős-Hajnal collaboration on triangle-free / clique-free graph structure underpinning the conjecture."
+      "note": "Foundational Erd\u0151s-Hajnal collaboration on triangle-free / clique-free graph structure underpinning the conjecture."
     },
     {
-      "authors": [
-        "Issai Schur"
-      ],
-      "title": "Über die Kongruenz $x^m + y^m \\equiv z^m \\pmod{p}$",
+      "authors": ["Issai Schur"],
+      "title": "\u00dcber die Kongruenz $x^m + y^m \\equiv z^m \\pmod{p}$",
       "year": 1916,
       "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung",
       "volume": "25",
-      "pages": "114–117",
-      "note": "Schur's theorem on monochromatic additive triples (a, b, a+b) — historical antecedent to Erdős-Barber and Hajnal's generalization."
+      "pages": "114\u2013117",
+      "note": "Schur's theorem on monochromatic additive triples (a, b, a+b) \u2014 historical antecedent to Erd\u0151s-Barber and Hajnal's generalization."
     },
     {
-      "authors": [
-        "Paul Erdős",
-        "George Szekeres"
-      ],
+      "authors": ["Paul Erd\u0151s", "George Szekeres"],
       "title": "A combinatorial problem in geometry",
       "year": 1935,
       "venue": "Compositio Mathematica",
       "volume": "2",
-      "pages": "463–470",
-      "note": "Origin of finite Ramsey theory, providing the framework in which the α(G) ≥ √n bound for triangle-free graphs (proved here) lives."
+      "pages": "463\u2013470",
+      "note": "Origin of finite Ramsey theory, providing the framework in which the \u03b1(G) \u2265 \u221an bound for triangle-free graphs (proved here) lives."
     },
     {
-      "authors": [
-        "Jeong Han Kim"
-      ],
+      "authors": ["Jeong Han Kim"],
       "title": "The Ramsey number R(3, t) has order of magnitude $t^2/\\log t$",
       "year": 1995,
       "venue": "Random Structures & Algorithms",
       "volume": "7",
-      "pages": "173–207",
+      "pages": "173\u2013207",
       "doi": "10.1002/rsa.3240070302",
-      "note": "Tight asymptotics for the independence number of triangle-free graphs — shows the elementary √n bound proved here is off by only a $\\sqrt{\\log n}$ factor."
+      "note": "Tight asymptotics for the independence number of triangle-free graphs \u2014 shows the elementary \u221an bound proved here is off by only a $\\sqrt{\\log n}$ factor."
     }
   ],
   "leanFile": {
     "path": "Proofs/Erdos895OQ01Problem.lean",
     "namespace": "Erdos895OQ01Problem",
-    "imports": [
-      "Mathlib"
-    ],
-    "opens": [
-      "Finset",
-      "SimpleGraph"
-    ],
-    "lineCount": 272,
-    "theoremCount": 11,
+    "imports": ["Mathlib"],
+    "opens": ["Finset", "SimpleGraph"],
+    "lineCount": 289,
+    "theoremCount": 12,
     "definitionCount": 6,
     "axiomCount": 1,
     "sorries": 0,

--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -2,9 +2,9 @@
   "id": "erdos-895-oq-01",
   "title": "Hajnal's Independent Hindman Set Conjecture",
   "slug": "erdos-895-oq-01",
-  "description": "Hajnal's open generalization of Erd\u0151s #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set \u2014 a base B with all finite sub-sums forming a mutually non-adjacent set.",
+  "description": "Hajnal's open generalization of Erdős #895: every large triangle-free graph on {1,...,n} contains an independent Hindman set — a base B with all finite sub-sums forming a mutually non-adjacent set.",
   "meta": {
-    "author": "Erd\u0151s-Hajnal (conjectured)",
+    "author": "Erdős-Hajnal (conjectured)",
     "sourceUrl": "https://erdosproblems.com/895",
     "date": "1995",
     "status": "axiomatized",
@@ -46,58 +46,59 @@
       "Monotonicity and structural lemmas for hindmanSet (sorry-free)",
       "Axiomatization of Hajnal's conjecture as an open problem",
       "Proof that Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple",
-      "Proved Case 1 of \u03b1(G) \u2265 \u221an bound: high-degree vertex N(v) is independent",
-      "Full proof of \u03b1(G) \u2265 \u221an via two-case greedy argument: Case 1 (high-degree vertex N(v)), Case 2 (greedy induction on candidate set cardinality)"
+      "Proved Case 1 of α(G) ≥ √n bound: high-degree vertex N(v) is independent",
+      "Full proof of α(G) ≥ √n via two-case greedy argument: Case 1 (high-degree vertex N(v)), Case 2 (greedy induction on candidate set cardinality)",
+      "triangleFree_indep_pair: for n ≥ 4, a triangle-free graph on Fin n has an independent set of card ≥ 2 (corollary of α(G) ≥ √n via √n ≥ 2 = Nat.sqrt 4); yields an independent pair as a first step toward an independent Hindman base of card ≥ 2 (sorry-free)"
     ],
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 11,
+    "theoremCount": 12,
     "definitionCount": 6,
-    "lineCount": 272
+    "lineCount": 289
   },
   "overview": {
-    "historicalContext": "**Hajnal's Generalization of Erd\u0151s Problem #895**\n\nThe parent problem, Erd\u0151s #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by Andr\u00e1s Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** \u2014 a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting \u2014 a fundamentally different kind of constraint.",
-    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ \u2014 proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
-    "text": "Hajnal's open generalization of Erd\u0151s #895: does every large triangle-free graph contain an independent Hindman set?",
-    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base \u2192 independent additive triple\n5. Proves `triangleFree_independence_bound` (\u03b1 \u2265 \u221an) via two-case greedy argument (0 sorries)",
+    "historicalContext": "**Hajnal's Generalization of Erdős Problem #895**\n\nThe parent problem, Erdős #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by András Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** — a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting — a fundamentally different kind of constraint.",
+    "problemStatement": "Let $G$ be a triangle-free graph with vertex set $\\{1, 2, \\ldots, n\\}$.\n\n**Conjecture (Hajnal):** For sufficiently large $n$, there exists a base $B \\subseteq \\{1,\\ldots,n\\}$ with $|B| \\geq 2$ such that the finite sums set FS$(B) = \\{\\sum_{i \\in T} a_i \\mid T \\subseteq B, T \\neq \\emptyset\\}$ forms an independent set in $G$.\n\n**Special case $k=2$:** FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$ — proved by Barber for $n \\geq 18$.\n\n**Status:** OPEN for base size $k \\geq 3$. No counterexample or proof is known.",
+    "text": "Hajnal's open generalization of Erdős #895: does every large triangle-free graph contain an independent Hindman set?",
+    "proofStrategy": "This file:\n1. Defines `hindmanSet base` as all finite nonempty sub-sums of `base`\n2. Proves structural properties of hindmanSet (monotonicity, pair lemmas)\n3. States `hajnalConjecture` and axiomatizes it (OPEN)\n4. Proves `hajnal_k2_gives_additive_triple`: k=2 Hajnal base → independent additive triple\n5. Proves `triangleFree_independence_bound` (α ≥ √n) via two-case greedy argument (0 sorries)",
     "keyInsights": [
-      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erd\u0151s #895 \u2014 the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements: $|\\mathrm{FS}(B)|$ can be as large as $2^{|B|} - 1$, so the constraint count grows from 3 (at $k=2$) to 7 (at $k=3$) to 15 (at $k=4$).",
-      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erd\u0151s-Barber structure.",
-      "**Independence number bound:** Triangle-free graphs satisfy \u03b1(G) \u2265 \u221an. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
-      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent \u2014 giving exactly the Erd\u0151s-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
-      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k\u22653 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics.",
-      "**Sharpness of the \u221an bound:** The elementary $\\alpha(G) \\geq \\sqrt{n}$ proved here is essentially tight in form \u2014 Kim (1995) showed the Ramsey number $R(3,t)$ has order $t^2/\\log t$, so the true bound is $\\alpha(G) = \\Omega(\\sqrt{n \\log n})$. The Lean proof captures the elementary half; the logarithmic improvement is a deep probabilistic argument (Lov\u00e1sz Local Lemma + nibble) not yet formalized."
+      "**Hierarchy of Hindman strength:** Hajnal's conjecture strictly generalizes Erdős #895 — the k=2 base case IS the Barber theorem. Each additional base element adds exponentially more sum-independence requirements: $|\\mathrm{FS}(B)|$ can be as large as $2^{|B|} - 1$, so the constraint count grows from 3 (at $k=2$) to 7 (at $k=3$) to 15 (at $k=4$).",
+      "**hindmanSet monotonicity:** Larger bases produce larger sum sets. This allows reducing from a full Hajnal base to a 2-element sub-base to recover the Erdős-Barber structure.",
+      "**Independence number bound:** Triangle-free graphs satisfy α(G) ≥ √n. Case 1 (high-degree vertex) is proved here via N(v) being independent; Case 2 (greedy algorithm) reduces to a bounded-degree independence number bound.",
+      "**k=2 reduction:** If the Hajnal base {a,b} has a+b < n (in-range sum), then a, b, a+b are all in FS({a,b}) and are mutually non-adjacent — giving exactly the Erdős-Barber structure. This is `hajnal_k2_gives_additive_triple`.",
+      "**Open territory:** The gap between k=2 (computationally verified by Barber's SAT proof) and k≥3 (unknown) mirrors the gap between Schur's theorem (1916) and Hindman's theorem (1974) in pure additive combinatorics.",
+      "**Sharpness of the √n bound:** The elementary $\\alpha(G) \\geq \\sqrt{n}$ proved here is essentially tight in form — Kim (1995) showed the Ramsey number $R(3,t)$ has order $t^2/\\log t$, so the true bound is $\\alpha(G) = \\Omega(\\sqrt{n \\log n})$. The Lean proof captures the elementary half; the logarithmic improvement is a deep probabilistic argument (Lovász Local Lemma + nibble) not yet formalized."
     ],
     "prerequisites": [
       "Graph theory: triangle-free graphs, independent sets, neighborhood sets",
       "Additive combinatorics: sumsets, Schur triples, Hindman sets",
       "Ramsey theory: R(3,3)=6, triangle-free graph structure",
-      "Parent result: Erd\u0151s #895 (Barber 2015)"
+      "Parent result: Erdős #895 (Barber 2015)"
     ],
     "mainTheorems": [
       {
         "name": "hajnal_conjecture",
-        "statement": "\u2203 N : \u2115, \u2200 n \u2265 N, \u2200 G : GraphOnInterval n, IsTriangleFree G \u2192 \u2203 base : Finset (Fin n), base.card \u2265 2 \u2227 \u2200 s t : Fin n, s.val \u2208 hindmanSet (base.image (\u00b7.val)) \u2192 t.val \u2208 hindmanSet (base.image (\u00b7.val)) \u2192 s \u2260 t \u2192 \u00acG.Adj s t",
-        "description": "Hajnal's open conjecture: every sufficiently large triangle-free graph on {1,\u2026,n} contains an independent Hindman set. AXIOM (open as of 2026)."
+        "statement": "∃ N : ℕ, ∀ n ≥ N, ∀ G : GraphOnInterval n, IsTriangleFree G → ∃ base : Finset (Fin n), base.card ≥ 2 ∧ ∀ s t : Fin n, s.val ∈ hindmanSet (base.image (·.val)) → t.val ∈ hindmanSet (base.image (·.val)) → s ≠ t → ¬G.Adj s t",
+        "description": "Hajnal's open conjecture: every sufficiently large triangle-free graph on {1,…,n} contains an independent Hindman set. AXIOM (open as of 2026)."
       },
       {
         "name": "hajnal_k2_gives_additive_triple",
-        "statement": "\u2200 {n} (G : GraphOnInterval n) (a b : Fin n), a \u2260 b \u2192 a.val > 0 \u2192 b.val > 0 \u2192 a.val + b.val < n \u2192 (\u2200 s t, s.val \u2208 hindmanSet \u2026 \u2192 t.val \u2208 hindmanSet \u2026 \u2192 s \u2260 t \u2192 \u00acG.Adj s t) \u2192 HasIndependentAdditiveTriple G",
-        "description": "Hajnal at base size k=2 directly recovers Erd\u0151s-Barber: a Hajnal base {a,b} with in-range sum a+b<n yields the additive triple (a, b, a+b) being mutually non-adjacent. Sorry-free."
+        "statement": "∀ {n} (G : GraphOnInterval n) (a b : Fin n), a ≠ b → a.val > 0 → b.val > 0 → a.val + b.val < n → (∀ s t, s.val ∈ hindmanSet … → t.val ∈ hindmanSet … → s ≠ t → ¬G.Adj s t) → HasIndependentAdditiveTriple G",
+        "description": "Hajnal at base size k=2 directly recovers Erdős-Barber: a Hajnal base {a,b} with in-range sum a+b<n yields the additive triple (a, b, a+b) being mutually non-adjacent. Sorry-free."
       },
       {
         "name": "triangleFree_independence_bound",
-        "statement": "\u2200 {n} (G : GraphOnInterval n) [DecidableRel G.Adj], IsTriangleFree G \u2192 \u2203 S : Finset (Fin n), S.card \u2265 Nat.sqrt n \u2227 \u2200 a b, a \u2208 S \u2192 b \u2208 S \u2192 a \u2260 b \u2192 \u00acG.Adj a b",
-        "description": "Independence number bound \u03b1(G) \u2265 \u221an for any triangle-free graph on n vertices, proved by a two-case argument (high-degree vertex N(v) or greedy on bounded-degree). Sorry-free, no axiom dependency."
+        "statement": "∀ {n} (G : GraphOnInterval n) [DecidableRel G.Adj], IsTriangleFree G → ∃ S : Finset (Fin n), S.card ≥ Nat.sqrt n ∧ ∀ a b, a ∈ S → b ∈ S → a ≠ b → ¬G.Adj a b",
+        "description": "Independence number bound α(G) ≥ √n for any triangle-free graph on n vertices, proved by a two-case argument (high-degree vertex N(v) or greedy on bounded-degree). Sorry-free, no axiom dependency."
       },
       {
         "name": "triangleFree_nbhd_independent",
-        "statement": "\u2200 {n} (G : GraphOnInterval n), IsTriangleFree G \u2192 \u2200 v u w : Fin n, G.Adj v u \u2192 G.Adj v w \u2192 \u00acG.Adj u w",
-        "description": "Defining structural lemma: in a triangle-free graph, any two distinct neighbors of v are non-adjacent (would close the triangle vuw). Underlies Case 1 of the \u221an bound."
+        "statement": "∀ {n} (G : GraphOnInterval n), IsTriangleFree G → ∀ v u w : Fin n, G.Adj v u → G.Adj v w → ¬G.Adj u w",
+        "description": "Defining structural lemma: in a triangle-free graph, any two distinct neighbors of v are non-adjacent (would close the triangle vuw). Underlies Case 1 of the √n bound."
       },
       {
         "name": "hindmanSet_pair_sum",
-        "statement": "\u2200 a b : \u2115, a \u2260 b \u2192 a + b \u2208 hindmanSet ({a, b} : Finset \u2115)",
+        "statement": "∀ a b : ℕ, a ≠ b → a + b ∈ hindmanSet ({a, b} : Finset ℕ)",
         "description": "Witnesses that the pair-sum a+b is in FS({a,b}); together with `hindmanSet_pair_left/right` gives the three k=2 elements {a, b, a+b}."
       }
     ]
@@ -109,7 +110,7 @@
       "summary": "Graph-on-interval, triangle-free predicate, additive triple, and the hindmanSet (Hindman finite-sums set FS(B)).",
       "startLine": 33,
       "endLine": 49,
-      "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set \u2115`."
+      "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set ℕ`."
     },
     {
       "id": "hindman-structure",
@@ -122,7 +123,7 @@
     {
       "id": "hajnal-conjecture",
       "title": "Hajnal's Conjecture",
-      "summary": "Formal statement of Hajnal's generalization of Erd\u0151s #895 and its axiomatization as an open problem.",
+      "summary": "Formal statement of Hajnal's generalization of Erdős #895 and its axiomatization as an open problem.",
       "startLine": 79,
       "endLine": 91,
       "mathContext": "$\\exists N, \\forall n \\geq N, \\forall G$ triangle-free on `Fin n`, $\\exists B \\subseteq V$ with $|B| \\geq 2$ such that $\\mathrm{FS}(B.\\mathrm{image}\\,(\\cdot.\\mathrm{val}))$ is a graph-independent set. Asserted via `axiom hajnal_conjecture` (OPEN as of 2026)."
@@ -130,10 +131,10 @@
     {
       "id": "k2-reduction",
       "title": "The k=2 Reduction",
-      "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) \u2014 recovers Erd\u0151s-Barber.",
+      "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) — recovers Erdős-Barber.",
       "startLine": 93,
       "endLine": 129,
-      "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erd\u0151s-Barber on the $k=2$ slice."
+      "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erdős-Barber on the $k=2$ slice."
     },
     {
       "id": "triangle-free-neighborhoods",
@@ -146,113 +147,135 @@
     {
       "id": "greedy-bounded-degree",
       "title": "Greedy Independent Set on Bounded-Degree Subgraphs",
-      "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives \u03b1 \u2265 |C|/(\u0394+1).",
+      "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives α ≥ |C|/(Δ+1).",
       "startLine": 149,
       "endLine": 242,
       "mathContext": "Private lemma `greedy_indep_of_bounded_deg`: if $\\Delta(G[C]) \\leq \\Delta$, greedy step removes $\\leq \\Delta + 1$ vertices and recurses, yielding $|C| \\leq |S|(\\Delta+1)$. Wrapper `indep_from_bounded_deg` specializes to $C = V$."
     },
     {
       "id": "independence-bound",
-      "title": "Independence Number Bound \u03b1(G) \u2265 \u221an",
-      "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size \u2265 \u221an.",
+      "title": "Independence Number Bound α(G) ≥ √n",
+      "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size ≥ √n.",
       "startLine": 244,
       "endLine": 271,
       "mathContext": "`triangleFree_independence_bound`: split on $\\exists v$ with $\\deg(v) \\geq \\sqrt{n}$. Case 1 reuses `triangleFree_indep_high_deg`. Case 2: all $\\deg \\leq \\sqrt{n} - 1$, so greedy gives $n \\leq |S| \\cdot \\sqrt{n}$; combined with `Nat.sqrt_le'` ($\\lfloor\\sqrt{n}\\rfloor^2 \\leq n$) and `Nat.le_of_mul_le_mul_right` we conclude $|S| \\geq \\sqrt{n}$."
     }
   ],
   "conclusion": {
-    "summary": "This formalization axiomatizes Hajnal's open generalization of Erd\u0151s #895 and proves all available structural components: hindmanSet properties (4 lemmas, sorry-free), the k=2 reduction (Hajnal base of size 2 implies Erd\u0151s-Barber structure), and the independence number bound \u03b1(G) \u2265 \u221an for triangle-free graphs via a complete two-case greedy argument (0 sorries, 1 axiom for the conjecture itself).",
-    "implications": "The independence bound \u03b1(G) \u2265 \u221an for triangle-free graphs is tight \u2014 Paley graphs and polarity graphs show the bound cannot be improved to \u03c9(\u221an) in general. Hajnal's conjecture, if true, would give a structural reason for the additive richness of large independent sets in triangle-free graphs: not only do large independent sets exist (by the \u221an bound), they contain sets that are closed under addition (FS-sets). This would bridge graph Ramsey theory and additive Ramsey theory (Hindman's theorem). The greedy bound \u03b1 \u2265 n/(\u0394+1) proved here is also useful beyond the \u221an application: for triangle-free graphs with bounded maximum degree \u0394 \u226a \u221an, it gives the tighter bound \u03b1 \u2265 n/\u0394.",
+    "summary": "This formalization axiomatizes Hajnal's open generalization of Erdős #895 and proves all available structural components: hindmanSet properties (4 lemmas, sorry-free), the k=2 reduction (Hajnal base of size 2 implies Erdős-Barber structure), and the independence number bound α(G) ≥ √n for triangle-free graphs via a complete two-case greedy argument (0 sorries, 1 axiom for the conjecture itself).",
+    "implications": "The independence bound α(G) ≥ √n for triangle-free graphs is tight — Paley graphs and polarity graphs show the bound cannot be improved to ω(√n) in general. Hajnal's conjecture, if true, would give a structural reason for the additive richness of large independent sets in triangle-free graphs: not only do large independent sets exist (by the √n bound), they contain sets that are closed under addition (FS-sets). This would bridge graph Ramsey theory and additive Ramsey theory (Hindman's theorem). The greedy bound α ≥ n/(Δ+1) proved here is also useful beyond the √n application: for triangle-free graphs with bounded maximum degree Δ ≪ √n, it gives the tighter bound α ≥ n/Δ.",
     "openQuestions": [
-      "Hajnal's conjecture for k=3: does every large triangle-free graph on {1,...,n} contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}? The 7 elements must all be in {1,...,n} and mutually non-adjacent \u2014 a substantially harder combinatorial constraint than the k=2 case.",
-      "Can the independence bound \u03b1(G) \u2265 \u221an be proved using the Bonferroni/Lov\u00e1sz Local Lemma approach (probabilistic method) rather than the greedy algorithm? A probabilistic proof might give tighter constants or extend to hypergraphs.",
-      "The parent result (Erd\u0151s #895, Barber 2015) was proved by SAT verification. Can the Lean 4 formalization be extended to verify Barber's argument \u2014 that n \u2265 18 is sufficient for the k=2 case \u2014 without using the axiom?"
+      "Hajnal's conjecture for k=3: does every large triangle-free graph on {1,...,n} contain an independent FS({a,b,c}) = {a,b,c,a+b,a+c,b+c,a+b+c}? The 7 elements must all be in {1,...,n} and mutually non-adjacent — a substantially harder combinatorial constraint than the k=2 case.",
+      "Can the independence bound α(G) ≥ √n be proved using the Bonferroni/Lovász Local Lemma approach (probabilistic method) rather than the greedy algorithm? A probabilistic proof might give tighter constants or extend to hypergraphs.",
+      "The parent result (Erdős #895, Barber 2015) was proved by SAT verification. Can the Lean 4 formalization be extended to verify Barber's argument — that n ≥ 18 is sufficient for the k=2 case — without using the axiom?"
     ]
   },
   "crossReferences": [
     {
       "id": "erdos-895",
-      "title": "Erd\u0151s Problem #895 \u2014 Independent Additive Triples",
-      "relationship": "Parent: proves the k=2 case of Hajnal's conjecture (Barber 2015: every triangle-free graph on {1,...,n} for n \u2265 18 contains independent a, b, a+b). This entry extends the question to larger Hindman bases."
+      "title": "Erdős Problem #895 — Independent Additive Triples",
+      "relationship": "Parent: proves the k=2 case of Hajnal's conjecture (Barber 2015: every triangle-free graph on {1,...,n} for n ≥ 18 contains independent a, b, a+b). This entry extends the question to larger Hindman bases."
     },
     {
       "id": "ramseys-theorem",
       "title": "Ramsey's Theorem",
-      "relationship": "Thematic sibling: Ramsey theory studies structure in large combinatorial objects. Hajnal's conjecture is a hybrid of graph Ramsey theory (triangle-free = K\u2083-free) and additive Ramsey theory (Hindman sets)."
+      "relationship": "Thematic sibling: Ramsey theory studies structure in large combinatorial objects. Hajnal's conjecture is a hybrid of graph Ramsey theory (triangle-free = K₃-free) and additive Ramsey theory (Hindman sets)."
     },
     {
       "id": "ramsey-r4k",
       "title": "Ramsey R(4,k) Bounds",
-      "relationship": "Related combinatorial result in the Ramsey family. The independence bound \u03b1(G) \u2265 \u221an proved here is related to Ramsey-multiplicity and diagonal Ramsey bounds."
+      "relationship": "Related combinatorial result in the Ramsey family. The independence bound α(G) ≥ √n proved here is related to Ramsey-multiplicity and diagonal Ramsey bounds."
     }
   ],
   "references": [
     {
-      "authors": ["Neil Hindman"],
+      "authors": [
+        "Neil Hindman"
+      ],
       "title": "Finite sums from sequences within cells of a partition of N",
       "year": 1974,
       "venue": "Journal of Combinatorial Theory, Series A",
       "volume": "17",
-      "pages": "1\u201311",
+      "pages": "1–11",
       "doi": "10.1016/0097-3165(74)90023-5",
-      "note": "Original Hindman's theorem: for any finite coloring of \u2115, there is an infinite set whose finite sums are monochromatic. Hajnal's conjecture is the graph-Ramsey analogue in the finite setting."
+      "note": "Original Hindman's theorem: for any finite coloring of ℕ, there is an infinite set whose finite sums are monochromatic. Hajnal's conjecture is the graph-Ramsey analogue in the finite setting."
     },
     {
-      "authors": ["Ben Barber"],
+      "authors": [
+        "Ben Barber"
+      ],
       "title": "Independent sets in graphs with an excluded clique minor",
       "year": 2015,
       "venue": "preprint / arXiv",
       "arxiv": "1502.05015",
-      "note": "Resolves Erd\u0151s #895 (the k=2 base case of this conjecture) for n \u2265 18 via SAT-assisted case analysis."
+      "note": "Resolves Erdős #895 (the k=2 base case of this conjecture) for n ≥ 18 via SAT-assisted case analysis."
     },
     {
-      "authors": ["Andr\u00e1s Hajnal"],
+      "authors": [
+        "András Hajnal"
+      ],
       "title": "Open problems on combinatorics and graph theory",
       "year": "1995",
       "venue": "Combinatorica / talk notes",
-      "note": "Hajnal's original posing of the FS-independence conjecture, generalizing Erd\u0151s #895 from k=2 to arbitrary base size."
+      "note": "Hajnal's original posing of the FS-independence conjecture, generalizing Erdős #895 from k=2 to arbitrary base size."
     },
     {
-      "authors": ["Paul Erd\u0151s", "Andr\u00e1s Hajnal", "Joel Spencer"],
+      "authors": [
+        "Paul Erdős",
+        "András Hajnal",
+        "Joel Spencer"
+      ],
       "title": "Graphs without large complete subgraphs of given chromatic number",
       "year": 1985,
       "venue": "Combinatorica",
-      "note": "Foundational Erd\u0151s-Hajnal collaboration on triangle-free / clique-free graph structure underpinning the conjecture."
+      "note": "Foundational Erdős-Hajnal collaboration on triangle-free / clique-free graph structure underpinning the conjecture."
     },
     {
-      "authors": ["Issai Schur"],
-      "title": "\u00dcber die Kongruenz $x^m + y^m \\equiv z^m \\pmod{p}$",
+      "authors": [
+        "Issai Schur"
+      ],
+      "title": "Über die Kongruenz $x^m + y^m \\equiv z^m \\pmod{p}$",
       "year": 1916,
       "venue": "Jahresbericht der Deutschen Mathematiker-Vereinigung",
       "volume": "25",
-      "pages": "114\u2013117",
-      "note": "Schur's theorem on monochromatic additive triples (a, b, a+b) \u2014 historical antecedent to Erd\u0151s-Barber and Hajnal's generalization."
+      "pages": "114–117",
+      "note": "Schur's theorem on monochromatic additive triples (a, b, a+b) — historical antecedent to Erdős-Barber and Hajnal's generalization."
     },
     {
-      "authors": ["Paul Erd\u0151s", "George Szekeres"],
+      "authors": [
+        "Paul Erdős",
+        "George Szekeres"
+      ],
       "title": "A combinatorial problem in geometry",
       "year": 1935,
       "venue": "Compositio Mathematica",
       "volume": "2",
-      "pages": "463\u2013470",
-      "note": "Origin of finite Ramsey theory, providing the framework in which the \u03b1(G) \u2265 \u221an bound for triangle-free graphs (proved here) lives."
+      "pages": "463–470",
+      "note": "Origin of finite Ramsey theory, providing the framework in which the α(G) ≥ √n bound for triangle-free graphs (proved here) lives."
     },
     {
-      "authors": ["Jeong Han Kim"],
+      "authors": [
+        "Jeong Han Kim"
+      ],
       "title": "The Ramsey number R(3, t) has order of magnitude $t^2/\\log t$",
       "year": 1995,
       "venue": "Random Structures & Algorithms",
       "volume": "7",
-      "pages": "173\u2013207",
+      "pages": "173–207",
       "doi": "10.1002/rsa.3240070302",
-      "note": "Tight asymptotics for the independence number of triangle-free graphs \u2014 shows the elementary \u221an bound proved here is off by only a $\\sqrt{\\log n}$ factor."
+      "note": "Tight asymptotics for the independence number of triangle-free graphs — shows the elementary √n bound proved here is off by only a $\\sqrt{\\log n}$ factor."
     }
   ],
   "leanFile": {
     "path": "Proofs/Erdos895OQ01Problem.lean",
     "namespace": "Erdos895OQ01Problem",
-    "imports": ["Mathlib"],
-    "opens": ["Finset", "SimpleGraph"],
+    "imports": [
+      "Mathlib"
+    ],
+    "opens": [
+      "Finset",
+      "SimpleGraph"
+    ],
     "lineCount": 272,
     "theoremCount": 11,
     "definitionCount": 6,

--- a/src/data/research/problems/erdos-895-oq-01.json
+++ b/src/data/research/problems/erdos-895-oq-01.json
@@ -19,9 +19,9 @@
     "phase": "ACT",
     "since": "2026-06-12",
     "iteration": 2,
-    "focus": "Added triangleFree_indep_pair (researcher-2, 2026-06-12): for n ≥ 4, a triangle-free graph on Fin n has an independent set of card ≥ 2, a sorry-free corollary of the α(G) ≥ √n bound (via Nat.le_sqrt: √n ≥ 2 ⟺ 4 ≤ n). Also fixed a stale header comment that falsely claimed Case 2 of the independence bound still had a HARD sorry — the file is fully sorry-free (only axiom: the open hajnal_conjecture). Docker build green (7743 jobs). File 272 → 289 LOC, theoremCount 11 → 12.",
+    "focus": "Added triangleFree_indep_pair (researcher-2, 2026-06-12): for n >= 4, a triangle-free graph on Fin n has an independent set of card >= 2, a sorry-free corollary of the alpha(G) >= sqrt(n) bound (via Nat.le_sqrt: sqrt(n) >= 2 iff 4 <= n). Also fixed a stale header comment that falsely claimed Case 2 of the independence bound still had a HARD sorry; the file is fully sorry-free (only axiom: the open hajnal_conjecture). Docker build green (7743 jobs). File 272 -> 289 LOC, theoremCount 11 -> 12.",
     "blockers": [],
-    "nextAction": "Strengthen toward Hindman: the independent pair {a,b} is not yet sub-sum independent (a+b may be adjacent). Next, formalize a lemma quantifying when an independent set in a triangle-free additive graph extends to a card-2 Hindman base (a,b,a+b all pairwise non-adjacent), connecting triangleFree_indep_pair to hajnal_k2_gives_additive_triple. The k≥3 Hajnal cases remain open (axiomatized).",
+    "nextAction": "Strengthen toward Hindman: the independent pair {a,b} is not yet sub-sum independent (a+b may be adjacent). Next, formalize when an independent set in a triangle-free additive graph extends to a card-2 Hindman base (a,b,a+b pairwise non-adjacent), connecting triangleFree_indep_pair to hajnal_k2_gives_additive_triple. The k>=3 Hajnal cases remain open (axiomatized).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,

--- a/src/data/research/problems/erdos-895-oq-01.json
+++ b/src/data/research/problems/erdos-895-oq-01.json
@@ -17,14 +17,14 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-04T17:47:35.844Z",
-    "iteration": 1,
-    "focus": "Supporting lemmas proved; Hajnal conjecture is open",
+    "since": "2026-06-12",
+    "iteration": 2,
+    "focus": "Added triangleFree_indep_pair (researcher-2, 2026-06-12): for n ≥ 4, a triangle-free graph on Fin n has an independent set of card ≥ 2, a sorry-free corollary of the α(G) ≥ √n bound (via Nat.le_sqrt: √n ≥ 2 ⟺ 4 ≤ n). Also fixed a stale header comment that falsely claimed Case 2 of the independence bound still had a HARD sorry — the file is fully sorry-free (only axiom: the open hajnal_conjecture). Docker build green (7743 jobs). File 272 → 289 LOC, theoremCount 11 → 12.",
     "blockers": [],
-    "nextAction": "Investigate triangleFree_independence_bound or Hajnal conjecture approaches",
+    "nextAction": "Strengthen toward Hindman: the independent pair {a,b} is not yet sub-sum independent (a+b may be adjacent). Next, formalize a lemma quantifying when an independent set in a triangle-free additive graph extends to a card-2 Hindman base (a,b,a+b all pairwise non-adjacent), connecting triangleFree_indep_pair to hajnal_k2_gives_additive_triple. The k≥3 Hajnal cases remain open (axiomatized).",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
+      "total": 1,
+      "currentApproach": 1,
       "approachesTried": 0
     }
   },
@@ -63,7 +63,7 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.844Z",
-  "lastUpdate": "2026-05-04T17:47:35.844Z",
+  "lastUpdate": "2026-06-12",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

One sorry-free addition to the Hajnal Independent-Hindman-Set formalization
(`Erdos895OQ01Problem.lean`), plus an honesty fix.

- **New theorem `triangleFree_indep_pair`**: for `n ≥ 4`, every triangle-free
  graph on `Fin n` has an independent set of card `≥ 2`. Proved as a
  corollary of the existing `triangleFree_independence_bound` (α(G) ≥ √n),
  using `Nat.le_sqrt` to get `√n ≥ 2 ⟺ 4 ≤ n`. This yields an independent
  *pair* — the first structural step toward an independent Hindman base of
  card ≥ 2 (the `|B| ≥ 2` requirement of `hajnalConjecture`). The docstring
  is explicit that a plain pair is **not** yet sub-sum (Hindman) independent,
  since `a + b` may still be adjacent to `a` or `b`.
- **Honesty fix**: the file header claimed "Case 2 has one HARD sorry for
  greedy algorithm". That sorry is gone — `greedy_indep_of_bounded_deg` and
  `triangleFree_independence_bound` are fully proved. Updated the comment to
  reflect the sorry-free state.

The file remains axiom-gated only on the genuinely-open `hajnal_conjecture`
(`axiomCount: 1`, `sorries: 0`), consistent with the `axiomatized` status.

## Verification

- Docker build green: `docker-build.sh Proofs.Erdos895OQ01Problem` →
  `✔ Built Proofs.Erdos895OQ01Problem`, 7743 jobs, **0 errors, 0 sorry
  warnings**.
- `meta.json` updated: `theoremCount` 11 → 12, `lineCount` 272 → 289, one
  `originalContributions` entry; research tracker `currentState` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)