### PR TITLE
research(ftc-lebesgue-oq01): discharge lebesgue_ftc_differentiable axiom; repair sibling build

### DIFF
--- a/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean
@@ -44,7 +44,7 @@ at every point of (a,b). The Lebesgue generalization weakens this:
 
 - Uses Mathlib measure theory, Vitali families, bounded variation
 - Defines absolutely continuous functions (not yet in Mathlib)
-- States Lebesgue FTC (as axiom, connecting to Mathlib infrastructure)
+- States Lebesgue FTC integral identity (as axiom, connecting to Mathlib infrastructure)
 - Proves: Lipschitz → AC, AC → uniformly continuous
 -/
 
@@ -185,23 +185,18 @@ theorem ac_on_subinterval {F : ℝ → ℝ} {a b c d : ℝ}
 -- PART IV: The Lebesgue FTC (AXIOM)
 -- ═══════════════════════════════════════════════════════════════
 
-/-- **Lebesgue FTC (Part 1)**: AC functions are a.e. differentiable.
+/- **Lebesgue FTC (Part 1)**: AC functions are a.e. differentiable. (PROVED)
 
 If F is absolutely continuous on [a,b], then F is differentiable at
-almost every point of (a,b), and the derivative F' is integrable.
+almost every point of (a,b).
 
-**Proof strategy**: AC → BV → decompose as difference of monotone functions
-→ each monotone function is a.e. differentiable (Lebesgue's theorem,
-which uses the Vitali covering lemma).
-
-**Mathlib building blocks**:
-- `Monotone.ae_differentiableAt` for monotone a.e. differentiability
-- Vitali covering lemma in `Mathlib.MeasureTheory.Covering.Vitali` -/
-axiom lebesgue_ftc_differentiable {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
-    (hF : AbsolutelyContinuousOn F a b) :
-    ∃ S : Set ℝ, MeasurableSet S ∧
-      volume (Ioo a b \ S) = 0 ∧
-      ∀ x ∈ S, DifferentiableAt ℝ F x
+This result was previously stated here as an axiom. It is now **proved** in the
+companion file `FundamentalTheoremCalculusLebesgueOQ01.lean` as
+`FTCLebesgueACImpliesBV.lebesgue_ftc_differentiable`, via the chain
+AC → BV (`ac_implies_bv`, proved from the ε-δ definition) → a.e. differentiable
+(`BoundedVariationOn.ae_differentiableAt_of_mem_uIcc`). The companion lives
+downstream because it imports this file; placing the proof here would create a
+circular import. The axiom is removed from this file (it had no callers). -/
 
 /-- **Lebesgue FTC (Part 2)**: The integral of the a.e. derivative recovers the function.
 
@@ -293,8 +288,11 @@ For a measurable set S: μ(S ∩ B(x,r)) / μ(B(x,r)) → 1_{S}(x) a.e. -/
 6. ✓ Monotone → a.e. differentiable (from Mathlib)
 
 ## What's Axiomatized
-1. AC → a.e. differentiable (needs: AC → BV → monotone decomposition)
-2. Lebesgue FTC integral identity (deepest result)
+1. Lebesgue FTC integral identity (deepest result)
+
+## Previously Axiomatized, Now Proved
+- AC → a.e. differentiable: proved in `FundamentalTheoremCalculusLebesgueOQ01.lean`
+  as `FTCLebesgueACImpliesBV.lebesgue_ftc_differentiable` (AC → BV → a.e. diff).
 
 ## What's Left (sorry)
 1. Cantor function construction (counterexample, not essential for FTC)

--- a/proofs/Proofs/FundamentalTheoremCalculusLebesgueOQ01.lean
+++ b/proofs/Proofs/FundamentalTheoremCalculusLebesgueOQ01.lean
@@ -1,5 +1,10 @@
+import Proofs.FundamentalTheoremCalculusLebesgue
+import Mathlib.Analysis.BoundedVariation
+import Mathlib.Topology.EMetricSpace.BoundedVariation
+import Mathlib.Tactic
+
 /-!
-# AC → BV: Absolutely Continuous ⟹ Bounded Variation
+# AC → BV: Absolutely Continuous ⟹ Bounded Variation (and the Lebesgue FTC differentiability)
 
 **Open Question OQ-01** from `fundamental-theorem-calculus-oq-01`
 (Lebesgue FTC entry: "Can AC → BV be proved directly from the ε-δ definition?")
@@ -17,15 +22,16 @@ No extra Mathlib infrastructure is needed beyond `Mathlib.Analysis.BoundedVariat
 3. **Key**: eVariationOn F (Icc c d) ≤ 1 when d-c < δ (via AC + partition sum bound).
 4. By Icc_add_Icc applied n-1 times: eVariationOn F (Icc a b) ≤ n < ⊤.
 
+## Lebesgue FTC differentiability
+
+`lebesgue_ftc_differentiable` (below) discharges what was an axiom in the parent
+file: an AC function on [a,b] is differentiable a.e. on (a,b). The proof chains
+`ac_implies_bv` with Mathlib's `BoundedVariationOn.ae_differentiableAt_of_mem_uIcc`.
+
 ## Status: 0 sorries, 0 axioms
 -/
 
-import Proofs.FundamentalTheoremCalculusLebesgue
-import Mathlib.Analysis.BoundedVariation
-import Mathlib.Topology.EMetricSpace.BoundedVariation
-import Mathlib.Tactic
-
-open FTCLebesgue Set ENNReal Finset
+open FTCLebesgue Set ENNReal Finset MeasureTheory
 
 set_option maxHeartbeats 800000
 
@@ -100,7 +106,7 @@ private lemma eVariationOn_le_n {F : ℝ → ℝ} (a step : ℝ) (hstep : 0 < st
   | zero =>
     simp only [Nat.cast_zero, zero_mul, add_zero]
     rw [le_zero_iff]
-    apply eVariationOn.eq_zero_iff.mpr
+    apply (eVariationOn.eq_zero_iff _).mpr
     intro x hx y hy
     have hxa : x = a := le_antisymm (Set.mem_Icc.mp hx).2 (Set.mem_Icc.mp hx).1
     have hya : y = a := le_antisymm (Set.mem_Icc.mp hy).2 (Set.mem_Icc.mp hy).1
@@ -139,7 +145,7 @@ theorem ac_implies_bv {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
   rcases eq_or_lt_of_le hab with rfl | hab'
   · show eVariationOn F (Set.Icc a a) ≠ ⊤
     have : eVariationOn F (Set.Icc a a) = 0 :=
-      eVariationOn.eq_zero_iff.mpr fun x hx y hy => by
+      (eVariationOn.eq_zero_iff _).mpr fun x hx y hy => by
         have hxa : x = a := le_antisymm (Set.mem_Icc.mp hx).2 (Set.mem_Icc.mp hx).1
         have hya : y = a := le_antisymm (Set.mem_Icc.mp hy).2 (Set.mem_Icc.mp hy).1
         rw [hxa, hya]; exact edist_self _
@@ -154,11 +160,11 @@ theorem ac_implies_bv {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
   have hstep_pos : 0 < step := div_pos hba hn_pos
   -- Each piece has length step < δ
   have hstep_lt : step < δ := by
-    rw [div_lt_iff hn_pos]
-    have h_ceil : (b - a) / δ ≤ (⌈(b - a) / δ⌉₊ : ℝ) := Nat.le_ceil _
-    have hn_eq : (n : ℝ) = ⌈(b - a) / δ⌉₊ + 1 := by push_cast; ring
-    rw [hn_eq]
-    nlinarith [mul_le_mul_of_nonneg_right h_ceil hδ.le, Nat.cast_nonneg (⌈(b - a) / δ⌉₊)]
+    have hn_eq : (n : ℝ) = (⌈(b - a) / δ⌉₊ : ℝ) + 1 := by exact_mod_cast rfl
+    have hlt : (b - a) / δ < (n : ℝ) := by
+      rw [hn_eq]; linarith [Nat.le_ceil ((b - a) / δ)]
+    rw [div_lt_iff₀ hn_pos, mul_comm δ (n : ℝ)]
+    exact (div_lt_iff₀ hδ).mp hlt
   -- a + n * step = b
   have hab_step : a + n * step = b := by
     have : n * step = b - a := mul_div_cancel₀ _ hn_pos.ne'
@@ -167,7 +173,7 @@ theorem ac_implies_bv {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
   have hpieces : ∀ k : Fin n,
       eVariationOn F (Set.Icc (a + k.val * step) (a + (k.val + 1) * step)) ≤ 1 := by
     intro k
-    apply eVariationOn_le_one_of_short
+    apply eVariationOn_le_one_of_short (a := a) (b := b)
     · exact le_add_of_nonneg_right (mul_nonneg (Nat.cast_nonneg _) hstep_pos.le)
     · linarith [hstep_pos]
     · have hk : (k.val : ℝ) + 1 ≤ n := by exact_mod_cast Nat.succ_le_of_lt k.isLt
@@ -179,7 +185,49 @@ theorem ac_implies_bv {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
   -- Total variation ≤ n < ⊤
   show eVariationOn F (Set.Icc a b) ≠ ⊤
   rw [← hab_step]
-  exact ne_top_of_le_ne_top ENNReal.natCast_ne_top
+  exact ne_top_of_le_ne_top (ENNReal.natCast_ne_top n)
     (eVariationOn_le_n a step hstep_pos n hpieces)
+
+/-! ## Lebesgue FTC (Part 1): AC ⟹ a.e. differentiable -/
+
+/-- **Lebesgue FTC (Part 1), discharged**: an absolutely continuous function on
+`[a, b]` is differentiable at almost every point of `(a, b)`.
+
+This replaces the former `FTCLebesgue.lebesgue_ftc_differentiable` axiom in the
+parent file. The proof chains `ac_implies_bv` (AC → BV, proved above directly
+from the ε-δ definition) with Mathlib's
+`BoundedVariationOn.ae_differentiableAt_of_mem_uIcc`, then packages the resulting
+a.e. statement into an explicit measurable full-measure subset of `(a, b)` by
+discarding a measurable null cover of the non-differentiable points. -/
+theorem lebesgue_ftc_differentiable {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
+    (hF : AbsolutelyContinuousOn F a b) :
+    ∃ S : Set ℝ, MeasurableSet S ∧
+      volume (Set.Ioo a b \ S) = 0 ∧
+      ∀ x ∈ S, DifferentiableAt ℝ F x := by
+  -- AC → BV on [a,b] = uIcc a b (since a ≤ b)
+  have hbv : BoundedVariationOn F (Set.uIcc a b) := by
+    rw [Set.uIcc_of_le hab]; exact ac_implies_bv hab hF
+  -- BV on an interval ⟹ a.e. differentiable (with the strong `DifferentiableAt` conclusion)
+  have hae : ∀ᵐ x, x ∈ Set.uIcc a b → DifferentiableAt ℝ F x :=
+    hbv.ae_differentiableAt_of_mem_uIcc
+  rw [ae_iff] at hae
+  -- `hae : volume {x | ¬ (x ∈ uIcc a b → DifferentiableAt ℝ F x)} = 0`
+  set B := {x | ¬ (x ∈ Set.uIcc a b → DifferentiableAt ℝ F x)} with hBdef
+  have hNmeas : MeasurableSet (toMeasurable volume B) := measurableSet_toMeasurable _ _
+  have hNnull : volume (toMeasurable volume B) = 0 := by
+    rw [measure_toMeasurable]; exact hae
+  refine ⟨Set.Ioo a b \ toMeasurable volume B, measurableSet_Ioo.diff hNmeas, ?_, ?_⟩
+  · -- the discarded part `Ioo a b \ S` lands inside the null set `toMeasurable volume B`
+    apply measure_mono_null _ hNnull
+    intro x hx
+    simp only [Set.mem_diff, not_and, not_not] at hx
+    exact hx.2 hx.1
+  · intro x hx
+    obtain ⟨hxIoo, hxN⟩ := hx
+    have hxB : x ∉ B := fun h => hxN (subset_toMeasurable volume B h)
+    have hxuIcc : x ∈ Set.uIcc a b := by
+      rw [Set.uIcc_of_le hab]; exact Set.Ioo_subset_Icc_self hxIoo
+    simp only [hBdef, Set.mem_setOf_eq, not_not] at hxB
+    exact hxB hxuIcc
 
 end FTCLebesgueACImpliesBV

--- a/research/problems/fundamental-theorem-calculus-oq-01-incomplete-01/sessions/2026-06-12-iter7-act-axiom-discharged-VERIFIED.md
+++ b/research/problems/fundamental-theorem-calculus-oq-01-incomplete-01/sessions/2026-06-12-iter7-act-axiom-discharged-VERIFIED.md
@@ -1,0 +1,78 @@
+# Session — Iter 7 ACT (axiom discharged + sibling repaired, Docker-VERIFIED)
+
+**Date**: 2026-06-12 (researcher-2)
+**Mode**: ACT — completed. Docker build GREEN.
+**Result**: `lebesgue_ftc_differentiable` axiom **discharged**; pre-existing sibling
+build breakage **repaired**. Parent axiomCount 2 → 1.
+
+## §0 Headline
+
+The iter-6 PREP plan (researcher-11) is now executed and verified. Two files changed,
+one Docker build green (`./proofs/scripts/docker-build.sh Proofs.FundamentalTheoremCalculusLebesgueOQ01`,
+exit 0, 0 errors, only the pre-existing Cantor `sorry` warning remains).
+
+1. **Parent** `proofs/Proofs/FundamentalTheoremCalculusLebesgue.lean`: deleted the
+   orphan `axiom lebesgue_ftc_differentiable` (zero callers, confirmed by grep).
+   Only `axiom lebesgue_ftc_integral` + the Cantor `sorry` remain. axiomCount 2 → 1.
+2. **Sibling** `proofs/Proofs/FundamentalTheoremCalculusLebesgueOQ01.lean`: repaired
+   pre-existing Mathlib-v4.26.0 breakage (the entry advertised `verified` but did
+   **not** build at HEAD — confirmed by iter-6 and reproduced here), then added the
+   discharge theorem `FTCLebesgueACImpliesBV.lebesgue_ftc_differentiable`.
+
+## §1 Discharge proof (verified)
+
+```lean
+theorem lebesgue_ftc_differentiable {F : ℝ → ℝ} {a b : ℝ} (hab : a ≤ b)
+    (hF : AbsolutelyContinuousOn F a b) :
+    ∃ S : Set ℝ, MeasurableSet S ∧ volume (Set.Ioo a b \ S) = 0 ∧
+      ∀ x ∈ S, DifferentiableAt ℝ F x
+```
+
+Chain: `ac_implies_bv hab hF : BoundedVariationOn F (Icc a b)`
+→ `Set.uIcc_of_le hab` rewrites to `uIcc a b`
+→ `BoundedVariationOn.ae_differentiableAt_of_mem_uIcc` gives
+  `∀ᵐ x, x ∈ uIcc a b → DifferentiableAt ℝ F x` (the strong `DifferentiableAt` form)
+→ `ae_iff` + `toMeasurable` package the a.e. statement into an explicit measurable
+  full-measure subset `Ioo a b \ toMeasurable volume {bad}`.
+
+Key Mathlib name confirmed against the pinned rev (2df2f0150c…, v4.26.0) by direct
+source fetch, NOT a guess: `BoundedVariationOn.ae_differentiableAt_of_mem_uIcc` in
+`Mathlib/Analysis/BoundedVariation.lean`.
+
+## §2 Sibling repair (pre-existing breakage, independent of the discharge)
+
+The sibling failed a clean HEAD Docker build. Fixes (all confirmed against v4.26.0 source):
+
+| Issue | Fix |
+|---|---|
+| `/-! … -/` module docstring **before** imports → "import must be at beginning" | moved imports above the docstring |
+| `volume`/`ae_iff`/`toMeasurable` unqualified | added `open MeasureTheory` |
+| `div_lt_iff` unknown | → `div_lt_iff₀` |
+| `ENNReal.natCast_ne_top` used unapplied | → `(ENNReal.natCast_ne_top n)` (n is explicit) |
+| `eVariationOn.eq_zero_iff.mpr` (f now explicit) | → `(eVariationOn.eq_zero_iff _).mpr` (×2) |
+| `hstep_lt` via `nlinarith` with an untyped `Nat.cast_nonneg` hint + `(b-a)/δ·δ` | rewrote deterministically with `div_lt_iff₀`/`Nat.le_ceil` |
+| `apply eVariationOn_le_one_of_short` left outer bound `?b` a metavar at the `hdb` bullet | pinned `(a := a) (b := b)` |
+
+Note the iter-6 diagnosis "`eVariationOn.eq_zero_iff.mpr` unknown constant" was imprecise:
+the lemma exists; its `f` argument merely became **explicit**, so the projection form fails.
+
+## §3 Meta updates
+
+- Parent `fundamental-theorem-calculus-oq-01`: axiomCount 2 → 1, lineCount 311 → 309,
+  assumptions text updated (Part 1 now proved; only Part 2 axiom + Cantor sorry remain).
+  Status stays `axiomatized` (integral axiom + Cantor sorry remain).
+- Sibling `fundamental-theorem-calculus-oq-01-oq-01`: theoremCount 6 → 7,
+  lineCount 185 → 233. Stays `verified` — and now this is actually true.
+
+## §4 What this does NOT do
+
+- Does not discharge `lebesgue_ftc_integral` (the deep Part 2 result).
+- Does not construct the Cantor function (the parent's remaining `sorry`).
+
+## §5 Provenance
+
+- Worktree: `.loom/worktrees/researcher-2`, branch `research/erdos-1210-remove-unsound-axiom` base.
+- Mathlib v4.26.0, rev 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67.
+- Docker builds this session: 5 total; #5 green. Earlier failures were (in order):
+  parent doc-comment `/--` not attached → `/-`; then the two pre-existing `ac_implies_bv`
+  errors surfaced one at a time as fixes landed.

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01-oq-01/meta.json
@@ -20,11 +20,12 @@
     "dateAdded": "2026-05-05",
     "axiomCount": 0,
     "assumptions": "None — fully verified from definitions.",
-    "lineCount": 185,
-    "theoremCount": 6,
+    "lineCount": 233,
+    "theoremCount": 7,
     "definitionCount": 0,
     "originalContributions": [
-      "ac_implies_bv: BoundedVariationOn F (Icc a b) proved from AbsolutelyContinuousOn via the ε-δ definition"
+      "ac_implies_bv: BoundedVariationOn F (Icc a b) proved from AbsolutelyContinuousOn via the ε-δ definition",
+      "lebesgue_ftc_differentiable: AC function on [a,b] is differentiable a.e. on (a,b), discharging the former axiom in the parent Lebesgue FTC entry (AC → BV → BoundedVariationOn.ae_differentiableAt_of_mem_uIcc)"
     ]
   },
   "overview": {
@@ -169,12 +170,12 @@
     }
   ],
   "leanFile": {
-    "lineCount": 185,
+    "lineCount": 233,
     "path": "Proofs/FundamentalTheoremCalculusLebesgueOQ01.lean",
     "axiomCount": 0,
     "sorries": 0,
     "definitionCount": 0,
-    "theoremCount": 6
+    "theoremCount": 7
   },
   "references": [
     {

--- a/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
+++ b/src/data/proofs/fundamental-theorem-calculus-oq-01/meta.json
@@ -15,8 +15,8 @@
     "proofRepoPath": "Proofs/FundamentalTheoremCalculusLebesgue.lean",
     "badge": "axiom",
     "sorries": 1,
-    "axiomCount": 2,
-    "assumptions": "2 axioms: Lebesgue FTC Part 1 (AC → a.e. differentiable) and Part 2 (integral of a.e. derivative = net change). 1 sorry(s) remaining.",
+    "axiomCount": 1,
+    "assumptions": "1 axiom: Lebesgue FTC Part 2 (integral of a.e. derivative = net change). Part 1 (AC → a.e. differentiable) is now proved in the companion file FundamentalTheoremCalculusLebesgueOQ01.lean (FTCLebesgueACImpliesBV.lebesgue_ftc_differentiable, via AC → BV → a.e. differentiable). 1 sorry(s) remaining (Cantor function construction).",
     "mathlibDependencies": [
       {
         "theorem": "Monotone.ae_differentiableAt",
@@ -41,7 +41,7 @@
       "Monotone a.e. differentiability re-export from Mathlib"
     ],
     "dateAdded": "2026-03-22",
-    "lineCount": 311,
+    "lineCount": 309,
     "mathlib_version": "4.26.0",
     "theoremCount": 5,
     "definitionCount": 1
@@ -156,8 +156,8 @@
       "intervalIntegral"
     ],
     "namespace": "FTCLebesgue",
-    "lineCount": 311,
-    "axiomCount": 2,
+    "lineCount": 309,
+    "axiomCount": 1,
     "theoremCount": 5,
     "definitionCount": 1,
     "path": "Proofs/FundamentalTheoremCalculusLebesgue.lean",


### PR DESCRIPTION
## Summary

- **Discharges the `lebesgue_ftc_differentiable` axiom** (AC ⟹ a.e. differentiable) in the Lebesgue FTC gallery entry. Parent file `axiomCount` drops 2 → 1; only the deep Part 2 integral axiom + the Cantor `sorry` remain.
- The discharge theorem lives in the companion file `FundamentalTheoremCalculusLebesgueOQ01.lean` (the companion imports the parent, so the proof cannot live in the parent without a circular import). It chains the already-proved `ac_implies_bv` (AC → BV) with Mathlib's `BoundedVariationOn.ae_differentiableAt_of_mem_uIcc`, then packages the a.e. statement into an explicit measurable full-measure subset of `(a,b)` via `toMeasurable`.
- **Repairs pre-existing Mathlib v4.26.0 breakage** in the companion file. The entry advertised `status: verified` but did **not** build at HEAD (confirmed by a clean-HEAD Docker build). Fixes: imports moved above the `/-!` module docstring; `open MeasureTheory`; `div_lt_iff` → `div_lt_iff₀`; `ENNReal.natCast_ne_top n`; `(eVariationOn.eq_zero_iff _).mpr` (the lemma's `f` arg became explicit); a deterministic `hstep_lt`; and pinned outer bounds `(a := a) (b := b)` in `eVariationOn_le_one_of_short` (otherwise `?b` is an unresolved metavariable).

## Axiom integrity

- Parent `fundamental-theorem-calculus-oq-01`: `axiomCount` 2 → 1; assumptions text updated; status stays `axiomatized` (integral axiom + Cantor sorry remain).
- Companion `fundamental-theorem-calculus-oq-01-oq-01`: `theoremCount` 6 → 7; stays `verified` — and this is now actually true.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.FundamentalTheoremCalculusLebesgueOQ01` — **GREEN** (exit 0, 0 errors, 0 sorries in companion; only the pre-existing Cantor `sorry` warning in the parent).
- [x] Mathlib lemma names verified against the pinned rev `2df2f0150c…` (v4.26.0) by direct source fetch (not guessed).
- [x] meta.json files validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)