### PR TITLE
research(computable-reals oq-02-oq-04): S11 — neither half is open or closed

### DIFF
--- a/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
+++ b/proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean
@@ -995,4 +995,85 @@ theorem computable_reals_isFsigma_witness :
     · obtain ⟨c, hc⟩ := Set.mem_iUnion.mp hr
       exact hc.2
 
+/-! ## S11 — Open/closed status: neither half is open or closed
+
+S7-S10 computed every fine topological invariant of the computable/non-computable
+partition — closure (`= univ` for both halves), interior (`= ∅` for both halves),
+frontier (`= univ` for both halves), `IsGδ`/Fσ-witness, residual, and meagre.
+What the file never stated is the single headline consequence those invariants
+force: **neither half of the partition is open, and neither is closed.**
+
+This is immediate from the invariants already proven, with no new Mathlib API
+beyond `IsClosed.closure_eq` and `IsOpen.interior_eq`:
+
+* A closed set equals its closure; both halves have closure `univ`, so a closed
+  half would equal `univ` — contradicted by `exists_non_computable_real`
+  (a non-computable witness) and `zero_isComputable` (a computable witness)
+  respectively.
+* An open set equals its interior; both halves have empty interior, so an open
+  half would be `∅` — contradicted by `computable_reals_nonempty` and
+  `nonComputableReals_nonempty`.
+
+The four statements complete the topological-status profile: each half of the
+computable/non-computable split is a proper, dense, boundaryless subset of `ℝ`
+that is simultaneously not open and not closed — the canonical signature of a
+countable-dense set and its residual complement sharing the line.
+
+* `computable_reals_not_isClosed`, `computable_reals_not_isOpen`
+* `nonComputableReals_not_isClosed`, `nonComputableReals_not_isOpen`
+-/
+
+/-- **S11 — the computable reals are not closed.**
+
+    A closed set equals its closure (`IsClosed.closure_eq`), but
+    `closure_computable_reals_eq_univ` gives closure `= univ`; a closed
+    `{r | IsComputable r}` would therefore be all of `ℝ`, contradicting the
+    existence of a non-computable real (`exists_non_computable_real`). -/
+theorem computable_reals_not_isClosed :
+    ¬ IsClosed {r : ℝ | IsComputable r} := by
+  intro h
+  have h_eq : {r : ℝ | IsComputable r} = Set.univ := by
+    rw [← h.closure_eq, closure_computable_reals_eq_univ]
+  obtain ⟨r, hr⟩ := exists_non_computable_real
+  have hmem : r ∈ {r : ℝ | IsComputable r} := by rw [h_eq]; exact Set.mem_univ r
+  exact hr hmem
+
+/-- **S11 — the computable reals are not open.**
+
+    An open set equals its interior (`IsOpen.interior_eq`), but
+    `interior_computable_reals_eq_empty` gives interior `= ∅`; an open
+    `{r | IsComputable r}` would therefore be empty, contradicting
+    `computable_reals_nonempty` (`0` is computable). -/
+theorem computable_reals_not_isOpen :
+    ¬ IsOpen {r : ℝ | IsComputable r} := by
+  intro h
+  have h_eq : {r : ℝ | IsComputable r} = ∅ := by
+    rw [← h.interior_eq, interior_computable_reals_eq_empty]
+  exact absurd h_eq computable_reals_nonempty.ne_empty
+
+/-- **S11 — the non-computable reals are not closed.**
+
+    Symmetric to `computable_reals_not_isClosed`: a closed `nonComputableReals`
+    would equal its closure `univ` (`closure_nonComputableReals_eq_univ`), making
+    every real non-computable — contradicted by `zero_isComputable`. -/
+theorem nonComputableReals_not_isClosed :
+    ¬ IsClosed nonComputableReals := by
+  intro h
+  have h_eq : nonComputableReals = Set.univ := by
+    rw [← h.closure_eq, closure_nonComputableReals_eq_univ]
+  have hmem : (0 : ℝ) ∈ nonComputableReals := by rw [h_eq]; exact Set.mem_univ 0
+  exact hmem zero_isComputable
+
+/-- **S11 — the non-computable reals are not open.**
+
+    Symmetric to `computable_reals_not_isOpen`: an open `nonComputableReals`
+    would equal its interior `∅` (`interior_nonComputableReals_eq_empty`),
+    contradicting `nonComputableReals_nonempty`. -/
+theorem nonComputableReals_not_isOpen :
+    ¬ IsOpen nonComputableReals := by
+  intro h
+  have h_eq : nonComputableReals = ∅ := by
+    rw [← h.interior_eq, interior_nonComputableReals_eq_empty]
+  exact absurd h_eq nonComputableReals_nonempty.ne_empty
+
 end AlgebraicNumbersCountableOQ02OQ04


### PR DESCRIPTION
## Summary

Adds an **S11** section to `Proofs/AlgebraicNumbersCountableOQ02OQ04.lean` with four short theorems stating that **neither half of the computable/non-computable partition of ℝ is open, and neither is closed**:

- `computable_reals_not_isClosed`, `computable_reals_not_isOpen`
- `nonComputableReals_not_isClosed`, `nonComputableReals_not_isOpen`

These are the headline topological-status conclusions that the file's existing S7–S10 invariants already force but never stated: both halves have `closure = Set.univ` (S7/S8-prep) and `interior = ∅` (S8), so a closed half would equal `univ` (refuted by a non-computable / computable witness) and an open half would equal `∅` (refuted by nonemptiness). Each proof is a few lines from `IsClosed.closure_eq` / `IsOpen.interior_eq` plus existing lemmas.

This completes the topological-status profile: each half is a proper, dense, boundaryless subset of ℝ that is simultaneously not open and not closed — the canonical signature of a countable-dense set and its residual complement sharing the line.

## Scope / honesty

Modest corollary-level work, not a frontier result. The genuinely-open directions on this problem (the `IsComputable` arithmetic algebra — closure under +, ×, neg, inv — and explicit `e`/`π` witnesses) are **blocked**: Mathlib v4.26.0 provides only `Encodable ℚ`, with **no** `Computable`/`Primrec` instances for ℚ arithmetic, so `Computable (fun n => -(f n))` etc. cannot be discharged without first building that infrastructure (a substantial standalone effort).

## Verification

- `./proofs/scripts/docker-build.sh Proofs.AlgebraicNumbersCountableOQ02OQ04` → ✔ **3067/3067 jobs clean**
- 0 sorries, 0 axioms. +81 LOC, +4 theorems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)