### PR TITLE
research(roth-theorem-k3-oq-01-incomplete-01): S6 ACT REPAIR — fresh-build green (Docker 7744 jobs)

### DIFF
--- a/proofs/Proofs/RothTheoremQuantitative.lean
+++ b/proofs/Proofs/RothTheoremQuantitative.lean
@@ -26,21 +26,45 @@ open Finset
 def APFree {N : ℕ} (A : Finset (ZMod N)) : Prop :=
   ∀ a d : ZMod N, d ≠ 0 → a ∈ A → a + d ∈ A → a + 2 * d ∉ A
 
+/-- A single global (noncomputable, classical) decidability instance for `APFree`.
+
+    Every `Finset.filter (fun A => APFree A)` site in this file — the
+    `rothNumber` definition and the theorems that unfold it — elaborates
+    against this one instance, so the filtered sets are syntactically equal
+    and unify. Without it, instance synthesis fails on Mathlib v4.26.0
+    (`APFree` is a plain `def`, invisible to typeclass resolution), and
+    per-theorem `classical` patches produce filter terms that do NOT unify
+    with the one inside `rothNumber`. -/
+noncomputable instance {N : ℕ} : DecidablePred (@APFree N) :=
+  fun _ => Classical.dec _
+
 /-- The Roth number r₃(N): the maximum cardinality of an AP-free subset
     of ZMod N. This is the central quantity in Roth's theorem.
 
     r₃(N) = max { |A| : A ⊆ ZMod N, A is AP-free }
 
-    Note: When N = 0, ZMod 0 = ℤ and Finset.univ is not finite, so
-    this definition is only meaningful for N ≥ 1 (where ZMod N is finite). -/
+    When N = 0, ZMod 0 = ℤ is infinite, so `Finset.univ` does not exist
+    (`Fintype (ZMod N)` requires `NeZero N`); we assign the junk value 0.
+    All substantive theorems assume `NeZero N` and work through the
+    equation lemma `rothNumber_def`. -/
 noncomputable def rothNumber (N : ℕ) : ℕ :=
-  Finset.sup (Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A))
-    Finset.card
+  if h : N = 0 then 0
+  else
+    haveI : NeZero N := ⟨h⟩
+    Finset.sup (Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A))
+      Finset.card
+
+/-- Equation lemma for `rothNumber` in the meaningful case `N ≠ 0`. -/
+theorem rothNumber_def {N : ℕ} [NeZero N] :
+    rothNumber N =
+      Finset.sup (Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A))
+        Finset.card :=
+  dif_neg (NeZero.ne N)
 
 /-- The empty set is AP-free. -/
 theorem apFree_empty {N : ℕ} : APFree (∅ : Finset (ZMod N)) := by
   intro a d _ ha
-  exact absurd ha (Finset.not_mem_empty a)
+  exact absurd ha (Finset.notMem_empty a)
 
 /-- A singleton set is AP-free. -/
 theorem apFree_singleton {N : ℕ} (x : ZMod N) : APFree ({x} : Finset (ZMod N)) := by
@@ -56,17 +80,17 @@ theorem apFree_subset {N : ℕ} {A B : Finset (ZMod N)} (h : B ⊆ A) (hA : APFr
     APFree B :=
   fun a d hd ha had hadd => hA a d hd (h ha) (h had) (h hadd)
 
-/-- For N ≥ 2, ZMod N contains the 3-AP {0, 1, 2}, so is not AP-free. -/
-theorem not_apFree_univ {N : ℕ} (hN : 1 < N) :
+/-- For N ≥ 2, ZMod N contains the 3-AP {0, 1, 2}, so is not AP-free.
+    (`NeZero N` is needed for `Finset.univ` to exist in the statement.) -/
+theorem not_apFree_univ {N : ℕ} [NeZero N] (hN : 1 < N) :
     ¬APFree (Finset.univ : Finset (ZMod N)) := by
-  haveI : NeZero N := ⟨by omega⟩
   haveI : Fact (1 < N) := ⟨hN⟩
   intro h
   exact h 0 1 one_ne_zero (Finset.mem_univ _) (Finset.mem_univ _) (Finset.mem_univ _)
 
 /-- r₃(N) ≤ N: no AP-free subset of ZMod N can exceed N elements. -/
 theorem rothNumber_le (N : ℕ) [NeZero N] : rothNumber N ≤ N := by
-  unfold rothNumber
+  rw [rothNumber_def]
   apply Finset.sup_le
   intro A hA
   rw [Finset.mem_filter] at hA
@@ -76,13 +100,14 @@ theorem rothNumber_le (N : ℕ) [NeZero N] : rothNumber N ≤ N := by
 /-- r₃(N) < N for N ≥ 2: the full ZMod N is never AP-free. -/
 theorem rothNumber_lt {N : ℕ} (hN : 1 < N) : rothNumber N < N := by
   haveI : NeZero N := ⟨by omega⟩
-  unfold rothNumber
-  rw [Finset.sup_lt_iff (show (0 : ℕ) < N by omega)]
+  rw [rothNumber_def, Finset.sup_lt_iff (show (0 : ℕ) < N by omega)]
   intro A hA
   rw [Finset.mem_filter] at hA
   by_contra hge; push_neg at hge
-  have hcard : A.card = Fintype.card (ZMod N) :=
-    le_antisymm (Finset.card_le_univ A) (ZMod.card N ▸ hge)
+  have hcard : A.card = Fintype.card (ZMod N) := by
+    have h1 : A.card ≤ Fintype.card (ZMod N) := Finset.card_le_univ A
+    have h2 : Fintype.card (ZMod N) = N := ZMod.card N
+    omega
   exact absurd (Finset.eq_univ_of_card A hcard ▸ hA.2) (not_apFree_univ hN)
 
 /-- r₃(N) ≤ N - 1 for N ≥ 2 (corollary of the strict bound). -/
@@ -91,19 +116,22 @@ theorem rothNumber_le_sub_one {N : ℕ} (hN : 1 < N) : rothNumber N ≤ N - 1 :=
 
 /-- r₃(N) ≥ 1 when N ≥ 1: any singleton is AP-free. -/
 theorem rothNumber_pos (N : ℕ) [NeZero N] : 1 ≤ rothNumber N := by
-  unfold rothNumber
+  rw [rothNumber_def]
   have hset : ({0} : Finset (ZMod N)) ∈
       Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A) := by
     rw [Finset.mem_filter]
     exact ⟨Finset.mem_powerset.mpr (Finset.subset_univ _), apFree_singleton 0⟩
   calc 1 = ({0} : Finset (ZMod N)).card := by simp
-    _ ≤ Finset.sup (Finset.univ.powerset.filter (fun A => APFree A)) Finset.card :=
+    _ ≤ Finset.sup (Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A))
+          Finset.card :=
         Finset.le_sup hset
 
-/-- Any AP-free subset A of ZMod N satisfies |A| ≤ r₃(N). -/
-theorem card_le_rothNumber {N : ℕ} (A : Finset (ZMod N)) (hA : APFree A) :
+/-- Any AP-free subset A of ZMod N satisfies |A| ≤ r₃(N).
+    (`NeZero N` is required: for N = 0 the junk value `rothNumber 0 = 0`
+    is exceeded by any AP-free singleton in ZMod 0 = ℤ.) -/
+theorem card_le_rothNumber {N : ℕ} [NeZero N] (A : Finset (ZMod N)) (hA : APFree A) :
     A.card ≤ rothNumber N := by
-  unfold rothNumber
+  rw [rothNumber_def]
   apply Finset.le_sup
   rw [Finset.mem_filter]
   exact ⟨Finset.mem_powerset.mpr (Finset.subset_univ _), hA⟩
@@ -111,12 +139,13 @@ theorem card_le_rothNumber {N : ℕ} (A : Finset (ZMod N)) (hA : APFree A) :
 /-- The Roth number is achieved: there exists an AP-free set of maximum size. -/
 theorem rothNumber_achieved {N : ℕ} [NeZero N] :
     ∃ A : Finset (ZMod N), APFree A ∧ A.card = rothNumber N := by
-  set S := Finset.univ.powerset.filter (fun A : Finset (ZMod N) => APFree A)
-  have hne : S.Nonempty :=
+  have hne : (Finset.univ.powerset.filter
+      (fun A : Finset (ZMod N) => APFree A)).Nonempty :=
     ⟨∅, Finset.mem_filter.mpr ⟨Finset.mem_powerset.mpr (Finset.empty_subset _), apFree_empty⟩⟩
-  obtain ⟨A, hAS, hmax⟩ := Finset.exists_max_image S Finset.card hne
-  exact ⟨A, (Finset.mem_filter.mp hAS).2,
-    le_antisymm (Finset.le_sup hAS) (Finset.sup_le fun B hB => hmax B hB)⟩
+  obtain ⟨A, hAS, hmax⟩ := Finset.exists_max_image _ Finset.card hne
+  refine ⟨A, (Finset.mem_filter.mp hAS).2, ?_⟩
+  rw [rothNumber_def]
+  exact le_antisymm (Finset.le_sup hAS) (Finset.sup_le fun B hB => hmax B hB)
 
 /-- r₃(2) = 1: in ZMod 2, every 2-element set contains the AP {0, 1, 0}. -/
 theorem rothNumber_two : rothNumber 2 = 1 := by
@@ -129,9 +158,12 @@ theorem rothNumber_three : rothNumber 3 = 2 := by
   have hlt : rothNumber 3 < 3 := rothNumber_lt (by omega)
   suffices 2 ≤ rothNumber 3 by omega
   apply card_le_rothNumber ({0, 1} : Finset (ZMod 3))
-  intro a d hd ha had hadd
-  simp only [Finset.mem_insert, Finset.mem_singleton] at ha had hadd
-  fin_cases a <;> fin_cases d <;> simp_all
+  -- Unfold `APFree` by defeq so `decide` can use the computable
+  -- `Fintype (ZMod 3)` instances (the global `APFree` instance is
+  -- classical and does not evaluate).
+  show ∀ a d : ZMod 3, d ≠ 0 → a ∈ ({0, 1} : Finset (ZMod 3)) →
+    a + d ∈ ({0, 1} : Finset (ZMod 3)) → a + 2 * d ∉ ({0, 1} : Finset (ZMod 3))
+  decide
 
 -- ═══════════════════════════════════════════════════════════════════
 -- PART I.B: QUALITATIVE ROTH ASYMPTOTIC
@@ -171,7 +203,7 @@ theorem rothNumber_div_tendsto_zero :
   have hN_pos : (0 : ℝ) < N := by exact_mod_cast hN1_le
   -- `|rothNumber N / N - 0| = rothNumber N / N` (both numerator and denominator nonneg).
   rw [Real.dist_eq, sub_zero, abs_div, abs_of_nonneg (Nat.cast_nonneg _),
-      abs_of_pos hN_pos, div_lt_iff hN_pos]
+      abs_of_pos hN_pos, div_lt_iff₀ hN_pos]
   -- Suffices to show `rothNumber N < δ * N`, since `δ ≤ ε` and `N ≥ 0`.
   suffices h : (rothNumber N : ℝ) < δ * N by
     calc (rothNumber N : ℝ) < δ * N := h
@@ -188,35 +220,23 @@ theorem rothNumber_div_tendsto_zero :
 -- PART II: ITERATION BOUND FROM DENSITY INCREMENT
 -- ═══════════════════════════════════════════════════════════════════
 
-/-- The density increment gives an explicit iteration bound:
-    if density starts at δ, then after k increments of δ²/100 each,
-    the density reaches δ + kδ²/100. For this to stay ≤ 1, we need
-    k ≤ ⌊100/δ²⌋. -/
-theorem max_iterations_bound (delta : ℝ) (hdelta : 0 < delta) :
-    ∀ k : ℕ, delta + k * delta ^ 2 / 100 > 1 → k > ⌊100 / delta ^ 2⌋₊ := by
-  intro k hk
-  by_contra h
-  push_neg at h
-  have hd2 : delta ^ 2 > 0 := by positivity
-  have hk_le : (k : ℝ) ≤ ⌊100 / delta ^ 2⌋₊ := Nat.cast_le.mpr h
-  have hfloor : (⌊100 / delta ^ 2⌋₊ : ℝ) ≤ 100 / delta ^ 2 := Nat.floor_le (by positivity)
-  have hk_bound : (k : ℝ) ≤ 100 / delta ^ 2 := le_trans hk_le hfloor
-  have hkd : k * delta ^ 2 / 100 ≤ 1 := by
-    rw [div_le_one (by norm_num : (100 : ℝ) > 0)]
-    calc (k : ℝ) * delta ^ 2
-        ≤ (100 / delta ^ 2) * delta ^ 2 :=
-          mul_le_mul_of_nonneg_right hk_bound (le_of_lt hd2)
-      _ = 100 := by field_simp
-  linarith
+-- NOTE: max_iterations_bound (δ + kδ²/100 > 1 → k > ⌊100/δ²⌋₊) was REMOVED.
+-- The statement is FALSE for δ > 1: with δ = 2, k = 0 the hypothesis holds
+-- (2 > 1) but the conclusion demands 0 > ⌊25⌋₊ = 25. Only the weaker bound
+-- k > 100(1-δ)/δ² follows from the hypothesis; no extra side condition
+-- (including δ ≤ 1) recovers the stated bound. See S3 session memo
+-- (research/problems/roth-theorem-k3-oq-01-incomplete-01, 2026-06-01).
 
-/-- Contrapositive form: if density δ satisfies δ + kδ²/100 ≤ 1, then
-    we can perform at least k density increments. -/
+/-- If density δ > 0 satisfies δ + kδ²/100 ≤ 1 (i.e., k increments of
+    δ²/100 starting from δ have not yet pushed the density past 1),
+    then k ≤ 100/δ². -/
 theorem iterations_before_contradiction (delta : ℝ) (hdelta : 0 < delta) (k : ℕ)
     (hk : delta + k * delta ^ 2 / 100 ≤ 1) :
     (k : ℝ) ≤ 100 / delta ^ 2 := by
-  have hd2 : delta ^ 2 > 0 := by positivity
-  rw [div_le_iff (by norm_num : (100 : ℝ) > 0)] at hk
-  linarith [mul_comm (k : ℝ) (delta ^ 2)]
+  have hd2 : (0 : ℝ) < delta ^ 2 := by positivity
+  rw [le_div_iff₀ hd2]
+  -- From the hypothesis, k·δ²/100 ≤ 1 - δ ≤ 1, hence k·δ² ≤ 100.
+  linarith
 
 -- NOTE: density_upper_bound_from_iteration (δ² ≤ 100/N) was REMOVED.
 -- The claim r₃(N) ≤ 10√N is FALSE for large N:

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/sessions/2026-06-12-s6-act-repair.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/sessions/2026-06-12-s6-act-repair.md
@@ -1,0 +1,94 @@
+# S6 ACT REPAIR — full fresh-build repair of `RothTheoremQuantitative.lean`
+
+**Researcher**: researcher-1
+**Date**: 2026-06-12
+**Phase**: ACT (iteration 6)
+**Outcome**: SUCCESS — file restored to fresh-Docker-build green
+(7744/7744 jobs, only the 4 expected landmark-sorry warnings)
+
+## TL;DR
+
+S6 implements the repair S5 scoped — and, in doing so, found the
+**true root cause that S3–S5 all missed**: the `noncomputable def
+rothNumber` itself never compiled on fresh Mathlib v4.26.0.
+`Finset.univ : Finset (ZMod N)` requires `Fintype (ZMod N)`, whose
+only instance demands `NeZero N`; with `N : ℕ` free, synthesis fails
+and Lean error-recovers by elaborating `rothNumber` to `sorry`.
+Every baffling downstream symptom S5 recorded — `sorry.sup card` in
+unification mismatches, `sorry N` in unsolved goals, the
+"DecidablePred APFree" errors that came and went — was a casualty of
+the def being `sorry`, not an independent failure.
+
+## Root-cause inventory (final, supersedes S3/S5 lists)
+
+| # | Site | Cause | Fix |
+|---|------|-------|-----|
+| 0 | `rothNumber` def | `Fintype (ZMod N)` unsynthesizable for free `N` (needs `NeZero N`); def elaborates to `sorry`, poisoning every theorem that mentions it | Total `dite`-definition: junk value 0 at N = 0, `haveI : NeZero N := ⟨h⟩` in the else-branch; new equation lemma `rothNumber_def` (`:= dif_neg (NeZero.ne N)`) for the `NeZero` case |
+| 1 | `rothNumber` def + every `Finset.filter` site | `DecidablePred APFree` unsynthesizable (`APFree` is a plain `def`, invisible to TC resolution) | Single global `noncomputable instance : DecidablePred (@APFree N) := fun _ => Classical.dec _` right after `APFree` — every filter site elaborates against the same instance term, so filter expressions unify syntactically (S5 proved per-theorem `classical` yields non-unifying terms) |
+| 2 | `not_apFree_univ` | Statement mentions `Finset.univ`, so `Fintype` is needed at *statement* elaboration — the proof-body `haveI : NeZero N` can't help | `[NeZero N]` added to the signature |
+| 3 | `card_le_rothNumber` | No `NeZero N`; under the total def the statement is *false* for N = 0 (an AP-free singleton in ZMod 0 = ℤ has card 1 > 0 = junk value) | `[NeZero N]` added |
+| 4 | `rothNumber_div_tendsto_zero` | `div_lt_iff` renamed in v4.26.0 | `div_lt_iff₀` (S4 fix #1) |
+| 5 | `max_iterations_bound` | Mathematically false for δ > 1 (S3's finding; counterexample δ = 2, k = 0) | Removed, NOTE comment preserves the finding. `iterations_before_contradiction` (the true weak direction) RETAINED with repaired `le_div_iff₀` + `linarith` proof replacing the never-matching `rw [div_le_iff] at hk` |
+| 6 | `rothNumber_three` | `fin_cases <;> simp_all` leaves 3 residual ZMod 3 subcases on v4.26.0 (S5's finding; not a heartbeat issue) | Defeq `show` unfolding `APFree` to its ∀-statement, then `decide`. Unfold-first is mandatory: the global instance (#1) is classical and `decide` cannot evaluate it; the unfolded statement picks computable `Fintype (ZMod 3)` instances |
+| 7 | `unfold rothNumber` sites (`rothNumber_le`, `rothNumber_lt`, `rothNumber_pos`, `card_le_rothNumber`, `rothNumber_achieved`) | `unfold` exposes the `dite` after fix #0 | `rw [rothNumber_def]` everywhere; `rothNumber_achieved` rewritten without `set` (the filter expressions are now syntactically equal by #1, so S4's annotation workaround is moot) |
+| 8 | `apFree_empty` | `Finset.not_mem_empty` deprecated | `Finset.notMem_empty` |
+
+## Why S3/S5 misdiagnosed
+
+Lean's error recovery turns a failed `def` into a `sorry`
+declaration and keeps checking the file. The reported errors then
+point at *theorems*, with the def's failure visible only as one
+`failed to synthesize Fintype (ZMod N)` line that is easy to
+mis-attribute to the neighboring theorem. S5's "cache fluke"
+(attempt 1 building `rothNumber_achieved` clean) is also explained:
+a stale pre-v4.26.0 `.olean` supplied a *compiled* `rothNumber`,
+hiding root cause #0 and #1 entirely.
+
+## Verification
+
+- Cleared `/cache/ir/Proofs/RothTheoremQuantitative.*` and
+  `/cache/lib/lean/Proofs/RothTheoremQuantitative.*` from the shared
+  `lean-mathlib-cache` volume before building (S5's lesson).
+- Round 1 (instance + S4-style fixes only): exposed root causes
+  #0, #2, #7 cleanly for the first time — `Fintype (ZMod N)` at the
+  def, statement-level failure in `not_apFree_univ`, and
+  `sorry`-poisoned unification in `rothNumber_pos` /
+  `rothNumber_achieved`.
+- Round 2 (full design above): one residual error — a `▸`-motive
+  failure in `rothNumber_lt` (`ZMod.card N ▸ hge` produced motive
+  `Fintype.card (ZMod (Fintype.card (ZMod N))) ≤ #A`), previously
+  masked by the sorried def. Replaced with an explicit
+  `have h1/h2 + omega` step.
+- Round 3: **green** — `Build completed successfully (7744 jobs)`,
+  warnings only for the four landmark sorries (lines 259, 273, 283,
+  295). The module's compile time is ~13 s; no heartbeat options
+  anywhere in the file.
+
+## File deltas
+
+- `rothNumber` is now total (junk 0 at N = 0) with `rothNumber_def`
+  as its working equation lemma — +1 theorem.
+- `max_iterations_bound` removed (math-false), −1 theorem.
+- Sorries: 4 → 4 (the landmark bounds — Roth 1953, Behrend 1946,
+  Bloom–Sisask 2020, Kelley–Meka 2023 — untouched).
+- Axioms: 0 → 0.
+
+## Follow-ups unlocked
+
+S7 small-N enumeration (r₃(4) ∈ [2,3], drafted in state.md) can
+resume on the green base. Two patterns future sessions MUST follow:
+
+1. `decide` on `APFree` goals: unfold to the ∀-statement first
+   (`show ∀ a d : ZMod n, ...`); bare `decide` hits the classical
+   instance and fails.
+2. Unfolding `rothNumber`: use `rw [rothNumber_def]` (requires
+   `NeZero N` in scope), never `unfold rothNumber`.
+
+## PR #22075 disposition
+
+Closed as superseded by this PR (S5's recommendation): its fixes
+#1/#2 survive verbatim, #3 was re-designed, #4 became moot, and the
+decisive repairs (#0 Fintype-totalization and #1 global instance)
+were absent from it.
+
+🤖 Generated by researcher-1

--- a/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
+++ b/research/problems/roth-theorem-k3-oq-01-incomplete-01/state.md
@@ -3,180 +3,152 @@
 ## Current State
 **Phase**: ACT
 **Path**: full
-**Since**: 2026-06-09T00:00:00Z (S5 ACT VERIFY-DISCOVERY this PR)
-**Iteration**: 5
+**Since**: 2026-06-12T00:00:00Z (S6 ACT REPAIR this PR)
+**Iteration**: 6
 
 ## Current Focus
 
-**S5 ACT VERIFY-DISCOVERY (researcher-4, 2026-06-09)** — Attempted
-to Docker-verify the S4 four-fix surgical repair on a remediated
-host disk (105 GiB free vs S4's 158 Mi). The verification failed
-on multiple grounds and S5 ships this as a discovery memo (doc-only
-PR, no Lean file changes) so S6+ does not repeat the trip-up.
+**S6 ACT REPAIR (researcher-1, 2026-06-12)** — Implemented the full
+fresh-build repair AND found the true root cause S3–S5 all missed:
+**the `noncomputable def rothNumber` itself never compiled on fresh
+Mathlib v4.26.0**. `Finset.univ : Finset (ZMod N)` needs
+`Fintype (ZMod N)`, whose only instance requires `NeZero N`; with
+`N` free, synthesis fails and Lean error-recovers by elaborating
+`rothNumber` to `sorry` — every baffling downstream symptom S5
+recorded (`sorry.sup card` mismatches, wandering `DecidablePred`
+errors, the "cache fluke") was a casualty of the sorried def.
 
-### Key finding — S4 diagnosis was incomplete
+The repair (9 root causes, full table in
+`sessions/2026-06-12-s6-act-repair.md`):
 
-The four S4 fixes are individually correct but **collectively
-insufficient** to restore the file to a fresh-Docker-build-green
-state on Mathlib v4.26.0:
+1. **`rothNumber` totalized**: `dite (N = 0)` with junk value 0,
+   `haveI : NeZero N := ⟨h⟩` in the else-branch; new equation lemma
+   `rothNumber_def := dif_neg (NeZero.ne N)` for the `NeZero` case.
+   All former `unfold rothNumber` sites now `rw [rothNumber_def]`.
+2. **Global noncomputable instance**
+   `DecidablePred (@APFree N) := fun _ => Classical.dec _` right
+   after the `APFree` def — every `Finset.filter` site elaborates
+   against the same instance term, so filter expressions unify
+   syntactically (S5 proved per-theorem `classical` yields
+   non-unifying terms).
+3. `[NeZero N]` added to `not_apFree_univ` (statement-level
+   `Finset.univ`) and `card_le_rothNumber` (false for N = 0 under
+   the junk value).
+4. `div_lt_iff` → `div_lt_iff₀` (S4 fix #1, kept).
+5. Removed math-false `max_iterations_bound`; **retained**
+   `iterations_before_contradiction` (the true weak direction) with
+   a repaired `le_div_iff₀` + `linarith` proof.
+6. `rothNumber_three`: defeq `show` (unfolding `APFree` to its
+   ∀-statement) + `decide`; unfold-first is mandatory because the
+   global instance is classical and `decide` cannot evaluate it.
+7. `rothNumber_achieved` rewritten without `set` (filter terms now
+   unify by #2; S4's annotation workaround moot).
+8. `Finset.not_mem_empty` → `Finset.notMem_empty` (deprecation).
 
-- **Fix #1** (`div_lt_iff` → `div_lt_iff₀`) — necessary and correct.
-- **Fix #2** (remove math-false `max_iterations_bound`) — necessary
-  and correct. The math finding (`max_iterations_bound` is False
-  for `δ > 1`, counterexample `δ=2, k=0`) is real and valuable.
-- **Fix #3** (`set_option maxHeartbeats 400000 in` before
-  `rothNumber_three`) — **diagnosis wrong**. The actual fresh-build
-  failure of `fin_cases ... simp_all` is **unclosed subgoals**, not
-  a heartbeat panic. `simp_all` returns successfully with three
-  residual subcases of ZMod 3 arithmetic that it no longer reduces
-  (a `Decidable` discharger moved in v4.26.0). Bumping
-  `maxHeartbeats` does nothing.
-- **Fix #4** (`set S : Finset (Finset (ZMod N))` type annotation +
-  `hS_def ▸` rewrite chain in `rothNumber_achieved`) — **necessary
-  but insufficient**. The actual failure is
-  `failed to synthesize DecidablePred APFree` at three sites inside
-  `rothNumber_achieved` (and same failure in `rothNumber_pos` and
-  `card_le_rothNumber`). The type annotation fixes the membership
-  goal but not the underlying instance-synthesis failure.
+Verified per S5's cache-fluke protocol: cleared
+`/cache/{ir,lib/lean}/Proofs/RothTheoremQuantitative.*` from the
+shared `lean-mathlib-cache` volume before the Docker build.
 
-See `sessions/2026-06-09-s5-act-verify.md` for the full
-verification log (≥10 Docker build attempts, escalating tactic
-replacements, cache clearing, classical-tactic experiment).
-
-### Tentative diagnostic — `DecidablePred APFree`
-
-The `noncomputable def rothNumber` uses
-`Finset.univ.powerset.filter (fun A => APFree A)`, which requires
-`DecidablePred APFree`. On the older Mathlib snapshot this was
-implicitly synthesizable; on v4.26.0 the synthesis fails and the
-classical fallback isn't applied automatically.
-
-S5's experimental fix attempt was to add `classical` to each
-affected theorem (`rothNumber_pos`, `card_le_rothNumber`,
-`rothNumber_achieved`). This shifted the error but didn't
-eliminate it — the `classical`-introduced local `Decidable`
-instance differs from the global `Classical.dec` used by the
-`noncomputable def`, so the `Finset.filter` expressions no longer
-unify (`{A ∈ univ.powerset | APFree A}.sup card ≤ sorry.sup card`).
-
-The correct fix likely requires one of:
-- A file-scoped `noncomputable instance : DecidablePred (@APFree N)`;
-- Explicit `Classical.decPred` annotations at every `Finset.filter`
-  site;
-- Relocating `rothNumber_three` (the `decide`-cascade trigger) to a
-  separate file.
-
-All three are deeper than the surgical-repair scope S4 envisaged.
+See `sessions/2026-06-12-s6-act-repair.md` for the full design
+rationale and build log.
 
 ## Diff this PR ships
 
 ```
-proofs/Proofs/RothTheoremQuantitative.lean — UNCHANGED
-research/problems/.../sessions/2026-06-02-s4-act-repair.md — IMPORTED from S4 (never merged)
-research/problems/.../sessions/2026-06-09-s5-act-verify.md — NEW (this S5 report)
+proofs/Proofs/RothTheoremQuantitative.lean — REPAIRED (see above)
+research/problems/.../sessions/2026-06-12-s6-act-repair.md — NEW
 research/problems/.../state.md — UPDATED (this file)
 src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json — UPDATED
 ```
 
-Zero Lean changes. Counts unchanged: 286 LOC, 9 theorems,
-4 sorries, 0 axioms, 1 def.
+Counts after repair: 4 sorries (unchanged — the four landmark
+bounds), 0 axioms, 1 def, 1 noncomputable instance, 19 theorems
+(+`rothNumber_def`, −`max_iterations_bound`; count = `grep -c
+"^theorem "`, the previous "9" used a different/stale metric),
+306 LOC.
 
 ## Status of S4 PR #22075
 
-S4 PR #22075 (DRAFT) is **not promotable as-is**. The four edits
-are necessary contributors but not sufficient. S5 leaves the PR
-open for the team to decide whether to:
-- Close as superseded (S6 starts fresh);
-- Rebase + extend with the additional `DecidablePred APFree` /
-  `simp_all`-residue fixes;
-- Cherry-pick fixes #1, #2 only (they're independent and useful
-  even without the full repair).
+Closed as superseded by this S6 PR (per S5's recommendation). Two
+of its four fixes survive verbatim, one partially, one re-designed;
+the decisive global-instance edit was absent from it.
+
+## Prior Focus (S5 ACT VERIFY-DISCOVERY, 2026-06-09)
+
+S5 (researcher-4) Docker-verified the S4 four-fix repair and found
+it collectively insufficient: fix #3's heartbeat diagnosis was wrong
+(real failure: `simp_all` leaves three residual ZMod 3 subcases) and
+fix #4 masked but did not resolve `DecidablePred APFree` synthesis
+failures in `rothNumber_pos`, `card_le_rothNumber`,
+`rothNumber_achieved`. Also discovered the `classical`-tactic
+instance-mismatch trap and the shared-cache stale-olean fluke.
+See `sessions/2026-06-09-s5-act-verify.md`.
 
 ## Prior Focus (S4 ACT REPAIR DRAFT, 2026-06-02, PR #22075)
 
-S4 (researcher-1, 2026-06-02) drafted four surgical fixes for the
-issues S3 (2026-06-01) discovered. PR opened DRAFT because host
-disk was at 99 % (158 Mi free) and the Docker build could not
-run. S5's host has 105 GiB free, so verification finally
-proceeded — and discovered that the S4 fix design was
-incomplete. See `sessions/2026-06-02-s4-act-repair.md`.
+Four surgical fixes drafted; PR opened DRAFT because host disk was
+at 99% and Docker could not run. See
+`sessions/2026-06-02-s4-act-repair.md`.
 
 ## Prior Focus (S3 ACT REPAIR-DISCOVERY, 2026-06-01, PR #22001)
 
-S3 began as a small-N enumeration ACT but pivoted to a
-fresh-build audit when Docker surfaced 6 distinct compile
-failures in the file *as it sits on `main`*. Identified four
-root causes (which S4 attempted to address surgically; S5
-proves at least two of the four diagnoses were incomplete).
+Fresh-build audit: 6 distinct compile failures in the file as it
+sat on `main` (masked since the Mathlib v4.26.0 bump by Lake's
+incremental cache). Math finding: `max_iterations_bound` is false
+for `δ > 1`. Small-N enumeration plan drafted and deferred.
 
-## Prior Focus (S2 contribution merged 2026-05-31, PR #21520)
+## Prior Focus (S2 ACT, merged 2026-05-31, PR #21520)
 
-S2 shipped `rothNumber_div_tendsto_zero` to the file (lines
-156–207 of that revision). Proof reduces to
-`Szemeredi.Roth.roth_density_bound` via the corners-theorem
-chain. CI passed via Lake's incremental cache; rebuilding the
-file from a clean state on Mathlib v4.26.0 surfaced the issues
-S3 → S4 → S5 are still working through.
+Shipped `rothNumber_div_tendsto_zero` (qualitative `r₃(N)/N → 0`
+via `Szemeredi.Roth.roth_density_bound` and Mathlib's corners
+chain). CI passed via incremental cache, which masked the
+fresh-build regressions S3 later found.
 
 ## Prior Focus (S1 OBSERVE, 2026-04-03)
 
-Initial problem understanding from problem.md. The Lean file
-`RothTheoremQuantitative.lean` has 4 landmark sorries remaining
-(Roth 1953, Behrend 1946, Bloom–Sisask 2020, Kelley–Meka 2023),
-each requiring ≥ 1000 LOC of formalization.
+Initial problem understanding. The four landmark sorries (Roth
+1953, Behrend 1946, Bloom–Sisask 2020, Kelley–Meka 2023) each need
+≥ 1000 LOC; none is single-session tractable.
 
 ## Active Approach
 
-S6 ACT OBSERVE/REPAIR-DESIGN — design the actual repair given
-S5's findings. Not a simple surgical edit; needs investigation
-into `Finset.filter` over noncomputably-decidable predicates and
-how to keep `DecidablePred APFree` synthesizable across the
-file.
+S6 repairs the base file to fresh-Docker-build green. Once merged,
+S7 resumes the S3 small-N enumeration plan (≤ 30 LOC):
+
+```lean
+theorem apFree_zero_one_zmod_four : APFree ({0, 1} : Finset (ZMod 4)) := by
+  show ∀ a d : ZMod 4, d ≠ 0 → a ∈ ({0,1} : Finset (ZMod 4)) →
+    a + d ∈ ({0,1} : Finset (ZMod 4)) → a + 2 * d ∉ ({0,1} : Finset (ZMod 4))
+  decide
+
+theorem two_le_rothNumber_four : 2 ≤ rothNumber 4 :=
+  card_le_rothNumber ({0, 1} : Finset (ZMod 4)) apFree_zero_one_zmod_four
+
+theorem rothNumber_four_le_three : rothNumber 4 ≤ 3 := by
+  have h := rothNumber_le_sub_one (N := 4) (by omega)
+  omega
+```
+
+**S7 note**: small-N `decide` proofs MUST use the defeq-unfold-first
+pattern above (the global `APFree` instance is classical; bare
+`decide` on `APFree _` goals cannot evaluate it).
 
 ## Attempt Count
-- Total attempts: 5 (S1 OBSERVE, S2 ACT qualitative, S3 ACT
-  REPAIR-DISCOVERY, S4 ACT REPAIR DRAFT, S5 ACT
-  VERIFY-DISCOVERY this PR)
+- Total attempts: 6 (S1 OBSERVE, S2 ACT qualitative, S3 ACT
+  REPAIR-DISCOVERY, S4 ACT REPAIR DRAFT, S5 ACT VERIFY-DISCOVERY,
+  S6 ACT REPAIR this PR)
 - Current approach attempts: 1
-- Approaches tried: 4 (OBSERVE, qualitative ACT,
-  REPAIR-DISCOVERY, REPAIR DRAFT → VERIFY-DISCOVERY)
+- Approaches tried: 5
 
 ## Blockers
 
-`RothTheoremQuantitative.lean` fails fresh Docker build on
-Mathlib v4.26.0. Root causes (S5-revised diagnosis):
-
-1. `div_lt_iff` API rename (drop-in fix, S4 had this right).
-2. Math-false `max_iterations_bound` (S4 had this right;
-   remove and document).
-3. `rothNumber_three`: `simp_all` leaves three residual ZMod 3
-   arithmetic subcases on v4.26.0. Needs tactic redesign,
-   not heartbeat bump.
-4. `DecidablePred APFree` synthesis failure across the
-   noncomputable filter chain in `rothNumber`,
-   `rothNumber_pos`, `card_le_rothNumber`,
-   `rothNumber_achieved`. Needs instance-handling redesign,
-   not just `set` type annotations.
+None for the repair (this PR). The four landmark sorries
+(`roth_quantitative_upper_bound`, `behrend_lower_bound`,
+`bloom_sisask_bound`, `kelley_meka_upper_bound`) remain multi-PR
+research efforts.
 
 ## Next Action
 
-**S6 ACT REPAIR-DESIGN** — investigate `Finset.filter` over
-`DecidablePred` for noncomputable-by-default predicates. Three
-candidate approaches sketched in
-`sessions/2026-06-09-s5-act-verify.md` (file-scoped instance,
-explicit Classical.decPred, separate-file isolation).
-
-Once S6 lands a green-on-fresh-build file, the original S3
-small-N enumeration plan can resume:
-
-```lean
-theorem apFree_zero_one_zmod_four : APFree ({0, 1} : Finset (ZMod 4)) := by ...
-theorem two_le_rothNumber_four : 2 ≤ rothNumber 4 := ...
-theorem rothNumber_four_le_three : rothNumber 4 ≤ 3 := ...
-```
-
-≤ 30 LOC total.
-
-The four landmark sorries (`roth_quantitative_upper_bound`,
-`behrend_lower_bound`, `bloom_sisask_bound`,
-`kelley_meka_upper_bound`) remain multi-PR research efforts.
+**S7 ACT SMALL-N** — re-add the r₃(4) ∈ [2, 3] pin (three theorems
+above) on the repaired base; optionally sharpen to r₃(4) = 2 by
+enumerating 3-element subsets of ZMod 4.

--- a/src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json
+++ b/src/data/research/problems/roth-theorem-k3-oq-01-incomplete-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "roth-theorem-k3-oq-01-incomplete-01",
   "title": "Roth's Theorem: Main k=3 Formalization",
-  "phase": "ORIENT",
+  "phase": "ACT",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -27,29 +27,29 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-06-09T00:00:00.000Z",
-    "iteration": 5,
-    "focus": "S5 ACT VERIFY-DISCOVERY (researcher-4, 2026-06-09): Attempted to Docker-verify the S4 four-fix surgical repair on a remediated host (105 GiB free vs S4's 158 Mi). The verification FAILED: S4's diagnosis was incomplete. Fix #1 (div_lt_iff → div_lt_iff₀ rename) is necessary and correct. Fix #2 (remove math-false max_iterations_bound) is necessary and correct. Fix #3 (maxHeartbeats 400000 for rothNumber_three) is based on a WRONG hypothesis — the actual fresh-build failure is simp_all returning successfully with 3 unresolved subgoals of ZMod 3 arithmetic (1 + 2 * 2 = 0 etc.) that a Mathlib v4.26.0 lemma move no longer reduces, NOT a heartbeat panic. Fix #4 (set S type annotation in rothNumber_achieved) is necessary but INSUFFICIENT: the actual failure is `failed to synthesize DecidablePred APFree` at 3 sites in rothNumber_achieved AND in rothNumber_pos + card_le_rothNumber. S5 tried 10+ tactic replacements (revert decide, refine decide, simp_all decide config, all_goals discharge variants, sorry stub, removed theorem entirely, added `classical` tactic to affected theorems) — every approach surfaced DecidablePred APFree synthesis errors. Adding `classical` shifted the error to a unification mismatch between the local classical Decidable instance and the global Classical.dec used by noncomputable def rothNumber. The correct fix needs file-scoped noncomputable instance for DecidablePred APFree OR explicit Classical.decPred at every Finset.filter site OR relocating the decide-cascade trigger to a separate file. S5 ships this as a doc-only PR (no Lean changes) — the verification revealed the repair is materially larger than S4 envisaged.",
-    "blockers": [
-      "RothTheoremQuantitative.lean fails fresh Docker build on Mathlib v4.26.0 with 4 root causes (S5-revised diagnosis): (1) div_lt_iff rename (drop-in fix), (2) math-false max_iterations_bound (remove + document), (3) rothNumber_three simp_all leaves 3 ZMod 3 arithmetic subcases (needs tactic redesign), (4) DecidablePred APFree synthesis failure across noncomputable filter chain in rothNumber, rothNumber_pos, card_le_rothNumber, rothNumber_achieved (needs instance-handling redesign, not just set type annotations)."
-    ],
-    "nextAction": "S6 ACT REPAIR-DESIGN: investigate Finset.filter over DecidablePred for noncomputable-by-default predicates. Three candidate approaches sketched in S5 session report — (a) file-scoped noncomputable instance for DecidablePred APFree; (b) explicit Classical.decPred at every Finset.filter site; (c) relocate rothNumber_three (the decide-cascade trigger) to a separate RothTheoremK3Small.lean. After S6 lands a green-on-fresh-build file, the originally-planned r₃(4) ∈ [2, 3] enumeration can resume. The four landmark sorries (roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound) remain multi-PR research efforts. S4 PR #22075 may stay open or be closed superseded — fixes #1 and #2 from S4 are still cherry-pickable independently.",
+    "since": "2026-06-12T00:00:00.000Z",
+    "iteration": 6,
+    "focus": "S6 ACT REPAIR (researcher-1, 2026-06-12): Implemented the full fresh-build repair AND found the true root cause S3–S5 all missed: the noncomputable def rothNumber itself never compiled on fresh Mathlib v4.26.0. Finset.univ : Finset (ZMod N) needs Fintype (ZMod N), whose only instance requires NeZero N; with N free, synthesis fails and Lean error-recovers by elaborating rothNumber to sorry — every baffling downstream symptom S5 recorded (sorry.sup card mismatches, wandering DecidablePred errors, the cache fluke) was a casualty of the sorried def. Repair: (1) rothNumber totalized via dite (N = 0) with junk value 0 and haveI NeZero in the else-branch, plus equation lemma rothNumber_def := dif_neg (NeZero.ne N) replacing every unfold rothNumber site; (2) global noncomputable instance DecidablePred (@APFree N) := fun _ => Classical.dec _ so every Finset.filter site elaborates against the same instance term and filter expressions unify syntactically (S5 proved per-theorem classical yields non-unifying terms); (3) [NeZero N] added to not_apFree_univ (statement-level Finset.univ) and card_le_rothNumber (false for N = 0 under the junk value); (4) div_lt_iff → div_lt_iff₀; (5) removed math-false max_iterations_bound, RETAINED iterations_before_contradiction (true weak direction) with repaired le_div_iff₀ + linarith proof; (6) rothNumber_three as defeq show (unfolding APFree to its ∀-statement) + decide — unfold-first mandatory since the global instance is classical and decide cannot evaluate it; (7) rothNumber_achieved rewritten without set (filter terms now unify); (8) notMem_empty deprecation fix. Cache-fluke protocol observed: cleared /cache/{ir,lib/lean}/Proofs/RothTheoremQuantitative.* before Docker verification.",
+    "blockers": [],
+    "nextAction": "S7 ACT SMALL-N: on the repaired base, re-add the r₃(4) ∈ [2, 3] pin (apFree_zero_one_zmod_four via the defeq-unfold + decide pattern, two_le_rothNumber_four, rothNumber_four_le_three — ≤ 30 LOC, drafted in state.md); optionally sharpen to r₃(4) = 2. The four landmark sorries (roth_quantitative_upper_bound, behrend_lower_bound, bloom_sisask_bound, kelley_meka_upper_bound) remain multi-PR research efforts. NOTE for all future sessions: bare `decide` on APFree goals will NOT work — unfold to the ∀-statement first (the global APFree instance is classical).",
     "attemptCounts": {
-      "total": 5,
+      "total": 6,
       "currentApproach": 1,
-      "approachesTried": 4
+      "approachesTried": 5
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (DISCOVERY): S5 ACT VERIFY-DISCOVERY shipped as doc-only PR. Attempted to Docker-verify the S4 four-fix surgical repair on remediated host (105 GiB free vs S4's 158 Mi); FAILED. S4's diagnosis was incomplete: fix #3 (maxHeartbeats) was based on wrong hypothesis (simp_all leaves unclosed subgoals on Mathlib v4.26.0, not heartbeat panic); fix #4 (rothNumber_achieved type annotation) is necessary but insufficient (DecidablePred APFree synthesis fails at 3 sites in rothNumber_achieved + same failure in rothNumber_pos + card_le_rothNumber). The actual repair is materially larger — needs file-scoped DecidablePred APFree instance, explicit Classical.decPred, or relocating the decide-cascade trigger. Cumulative state: sorry count 4 (unchanged), axiom count 0, theorem count 9 (unchanged — S5 ships zero Lean changes), LOC 286 (unchanged). S4 PR #22075 remains open as DRAFT — team decision whether to close superseded or rebase+extend. The two math findings from S4 (max_iterations_bound False for δ > 1, div_lt_iff renamed in v4.26.0) are bankable knowledge independent of the broader repair.",
+    "progressSummary": "PROGRESS (REPAIR): S6 ACT REPAIR restored RothTheoremQuantitative.lean to fresh-Docker-build green on Mathlib v4.26.0 and identified the true root cause S3–S5 missed: the noncomputable def rothNumber itself never compiled fresh — Finset.univ requires Fintype (ZMod N) which requires NeZero N, so with N free the def elaborated to sorry and poisoned every downstream theorem (explains S5's sorry.sup card mismatches, wandering DecidablePred errors, and the cache fluke, where a stale pre-bump .olean supplied a compiled rothNumber). Repair: rothNumber totalized via dite (junk 0 at N = 0) + equation lemma rothNumber_def; global noncomputable DecidablePred APFree instance (Classical.dec) for filter-term unification; [NeZero N] on not_apFree_univ and card_le_rothNumber; div_lt_iff₀ rename; math-false max_iterations_bound removed (iterations_before_contradiction retained with fixed proof); rothNumber_three via defeq-unfold + decide. Cumulative state: sorry count 4 (the landmark bounds, unchanged), axiom count 0, 18 theorems (grep ^theorem), ~300 LOC. S4 PR #22075 closed as superseded.",
     "builtItems": [
       "Added Szemeredi.Roth.Quantitative.rothNumber_div_tendsto_zero in proofs/Proofs/RothTheoremQuantitative.lean (qualitative r_3(N)/N → 0)",
       "Added private apFree_to_parent helper bridging Szemeredi.Roth.Quantitative.APFree to Szemeredi.Roth.APFree (identical bodies, reducible)",
       "Added import Proofs.RothTheorem to RothTheoremQuantitative.lean",
-      "S4 ACT REPAIR: Renamed div_lt_iff → div_lt_iff₀ at line 174 of proofs/Proofs/RothTheoremQuantitative.lean (Mathlib v4.26.0 API drift)",
-      "S4 ACT REPAIR: Removed max_iterations_bound (math-false for δ > 1, no callers) and iterations_before_contradiction (downstream of removed div_le_iff); replaced with explanatory comment block documenting the math finding and correct contrapositive bound k > 100(1-δ)/δ² for future density-increment work",
-      "S4 ACT REPAIR: Added set_option maxHeartbeats 400000 in before rothNumber_three (fin_cases × 9 ZMod 3 subcases was on edge of default budget on fresh build)",
-      "S4 ACT REPAIR: Type-annotated set S : Finset (Finset (ZMod N)) in rothNumber_achieved and rewrote post-obtain chain via hS_def ▸ to resolve filter predicate without metavariable leak"
+      "S6 ACT REPAIR: totalized rothNumber via dite (N = 0 → junk 0, else haveI NeZero) and added equation lemma rothNumber_def := dif_neg (NeZero.ne N); replaced every unfold rothNumber with rw [rothNumber_def]",
+      "S6 ACT REPAIR: added global noncomputable instance DecidablePred (@APFree N) := fun _ => Classical.dec _ so all Finset.filter sites elaborate against one instance term and unify syntactically",
+      "S6 ACT REPAIR: added [NeZero N] to not_apFree_univ (statement-level Finset.univ) and card_le_rothNumber (statement false at N = 0 under junk value)",
+      "S6 ACT REPAIR: renamed div_lt_iff → div_lt_iff₀ (Mathlib v4.26.0 API drift); removed math-false max_iterations_bound with explanatory NOTE; retained iterations_before_contradiction with repaired le_div_iff₀ + linarith proof",
+      "S6 ACT REPAIR: rothNumber_three proved via defeq show (unfolding APFree to its ∀-statement) + decide, replacing the v4.26.0-broken fin_cases <;> simp_all cascade",
+      "S6 ACT REPAIR: rothNumber_achieved rewritten without set (filter terms unify via the global instance); Finset.notMem_empty deprecation fix"
     ],
     "insights": [
       "The target statement is a density version of Roth's theorem over cyclic groups.",
@@ -60,7 +60,10 @@
       "The two APFree definitions (Szemeredi.Roth vs Szemeredi.Roth.Quantitative) have identical bodies and convert via a one-line lambda.",
       "RothTheoremQuantitativeAristotle.lean already provides the Behrend-side analytic glue (behrend_lower_eventually_large, behrend_exponent_vs_poly) — only the sphere construction itself remains for the Behrend lower bound.",
       "max_iterations_bound (δ + kδ²/100 > 1 → k > ⌊100/δ²⌋₊) is FALSE for δ > 1: counterexample δ=2, k=0 satisfies the hypothesis but k=0 < 25 = ⌊100/4⌋₊. The correct contrapositive of δ + kδ²/100 > 1 is k > 100(1-δ)/δ², strictly weaker than 100/δ² for all δ > 0. Any future density-increment scaffolding must use this weaker bound under hδ : δ ≤ 1.",
-      "Lake incremental cache can mask Mathlib API drift across version bumps: PR #21520 merged with green CI on Mathlib v4.26.0 because the cached build skipped re-verification of unrelated lines. A fresh Docker build is required to catch this class of regression. Pattern: include a periodic fresh-build audit in research workflow."
+      "Lake incremental cache can mask Mathlib API drift across version bumps: PR #21520 merged with green CI on Mathlib v4.26.0 because the cached build skipped re-verification of unrelated lines. A fresh Docker build is required to catch this class of regression. Pattern: include a periodic fresh-build audit in research workflow.",
+      "Lean error recovery turns a failed def into a sorry declaration and keeps checking: the def's own one-line synthesis error (Fintype (ZMod N)) is easy to mis-attribute to neighboring theorems while the downstream errors (sorry.sup card, sorry N) look like independent unification/instance failures. When triaging multi-error Lean files, fix the FIRST error (topologically, by declaration order) before trusting any later diagnostic.",
+      "Finset.univ : Finset (ZMod N) requires Fintype (ZMod N) whose only instance needs NeZero N — definitions quantified over all N : ℕ must either take [NeZero N] or branch on N = 0 (dite + junk value + NeZero-conditional equation lemma is the pattern that keeps downstream statements like Tendsto over all N elaborable).",
+      "decide cannot evaluate classical Decidable instances: after installing a global noncomputable DecidablePred APFree, decide on an APFree goal must first defeq-unfold (show ∀ a d : ZMod n, ...) so synthesis picks the computable Fintype instances instead."
     ],
     "mathlibGaps": [
       "No public bridge rothNumber N ≤ rothNumberNat N in either gallery file or Mathlib; would unlock transfer of Mathlibs unconditional Behrend.roth_lower_bound and rothNumberNat_isLittleO_id to the gallerys ZMod-based rothNumber."
@@ -71,7 +74,7 @@
       "Defer the four landmark sorries until per-bound formalization projects are funded — each is multi-thousand-line work."
     ],
     "markdown": "# Knowledge Base: roth-theorem-k3-oq-01-incomplete-01\n\n## Problem Understanding\n\nThis task targets the main k=3 formalization of Roth's theorem. The statement in the local notes is: for every density `delta > 0`, sufficiently large cyclic groups have the property that every subset of size at least `delta N` contains a three-term arithmetic progression.\n\n## Known Local Context\n\nThe parent gallery proof `roth-theorem-k3-oq-01` provides the foundation. The notes say the Lean file has 5 remaining sorries and that Mathlib's corners theorem chain, especially `Finset.addCornerFree`, is the key building block.\n\n## Current Focus\n\nThe current phase is OBSERVE. The next local action is to read `problem.md` thoroughly, then move to ORIENT by inspecting literature and the related parent proof.\n",
-    "lastUpdated": "2026-06-09T00:00:00.000Z"
+    "lastUpdated": "2026-06-12T00:00:00.000Z"
   },
   "tags": [
     "combinatorics",
@@ -95,8 +98,8 @@
     {
       "path": "Proofs/RothTheoremQuantitative.lean",
       "filename": "RothTheoremQuantitative.lean",
-      "lineCount": 286,
-      "theoremCount": 9,
+      "lineCount": 306,
+      "theoremCount": 19,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 4,
@@ -104,6 +107,6 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/RothTheoremQuantitative.lean"
     }
   ],
-  "lastUpdate": "2026-06-09T00:00:00.000Z",
-  "lastUpdated": "2026-06-09T00:00:00.000Z"
+  "lastUpdate": "2026-06-12T00:00:00.000Z",
+  "lastUpdated": "2026-06-12T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

- **Restores `proofs/Proofs/RothTheoremQuantitative.lean` to fresh-Docker-build green on Mathlib v4.26.0** (broken since the v4.26.0 bump, masked by Lake's incremental cache — tracked through S3 → S4 → S5).
- **Identifies the true root cause S3–S5 all missed**: the `noncomputable def rothNumber` itself never compiled fresh. `Finset.univ : Finset (ZMod N)` requires `Fintype (ZMod N)`, whose only instance needs `NeZero N`; with `N` free, synthesis fails and Lean error-recovers the def to `sorry`, poisoning every downstream theorem (this explains all of S5's `sorry.sup card` mismatches, wandering `DecidablePred` errors, and the "cache fluke").
- Repair design (full table in `sessions/2026-06-12-s6-act-repair.md`):
  - `rothNumber` totalized via `dite (N = 0)` (junk value 0) + new equation lemma `rothNumber_def := dif_neg (NeZero.ne N)`; all `unfold rothNumber` sites → `rw [rothNumber_def]`
  - global `noncomputable instance : DecidablePred (@APFree N) := fun _ => Classical.dec _` so every `Finset.filter` site elaborates against one instance term and unifies syntactically
  - `[NeZero N]` added to `not_apFree_univ` (statement-level `Finset.univ`) and `card_le_rothNumber` (false at N = 0 under the junk value)
  - `div_lt_iff` → `div_lt_iff₀`; math-false `max_iterations_bound` removed (NOTE comment preserves the S3 finding); `iterations_before_contradiction` retained with repaired `le_div_iff₀` + `linarith` proof
  - `rothNumber_three` via defeq `show` (unfolds `APFree` to its ∀-statement) + `decide`
  - `rothNumber_achieved` rewritten without `set`; `▸`-motive fix in `rothNumber_lt`; `notMem_empty` deprecation fix
- Counts: 4 sorries (the landmark bounds — unchanged), 0 axioms, 0 structure-encoded assumptions, 19 theorems, 306 LOC.

## Verification

- Cleared `/cache/{ir,lib/lean}/Proofs/RothTheoremQuantitative.*` from the shared `lean-mathlib-cache` volume first (S5's stale-olean lesson)
- `./proofs/scripts/docker-build.sh Proofs.RothTheoremQuantitative` → **Build completed successfully (7744 jobs)**, warnings only for the four expected landmark sorries

## Supersedes

Closes the S4 draft PR #22075 (its fixes #1/#2 survive verbatim here; #3 re-designed per S5's findings; #4 moot; the decisive Fintype-totalization and global-instance repairs were absent from it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)