### PR TITLE
research(elem-quad-reciprocity-oq-01-oq-02): restore v4.26.0 build

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean
@@ -191,7 +191,7 @@ theorem cubicEuler_hard {p : ℕ} [Fact p.Prime] (h3 : p % 3 = 1)
     rw [ZMod.card_units_eq_totient, Nat.totient_prime (Fact.out)]
   -- Generator g has order p - 1
   have hord : orderOf g = p - 1 := by
-    rw [← hcard]; exact orderOf_eq_card_of_forall_mem_zpowers hg
+    rw [orderOf_eq_card_of_forall_mem_zpowers hg, Nat.card_eq_fintype_card, hcard]
   -- cubExp p = (p-1)/3 is positive
   have hcubPos : (cubExp p : ℤ) ≠ 0 := by
     have : 0 < cubExp p := Nat.div_pos
@@ -206,7 +206,7 @@ theorem cubicEuler_hard {p : ℕ} [Fact p.Prime] (h3 : p % 3 = 1)
     rwa [← zpow_natCast, ← zpow_mul] at h1
   -- orderOf g | k * cubExp p (as integers)
   have hdvd : (↑(p - 1) : ℤ) ∣ k * ↑(cubExp p) := by
-    have := orderOf_dvd_of_zpow_eq_one hpow_eq
+    have := orderOf_dvd_iff_zpow_eq_one.mpr hpow_eq
     rwa [hord] at this
   -- Since p - 1 = 3 * cubExp p, we get 3 | k
   have hcub3 : (↑(p - 1) : ℤ) = 3 * ↑(cubExp p) := by
@@ -387,7 +387,7 @@ theorem quarticEuler_hard {p : ℕ} [Fact p.Prime] (h4 : p % 4 = 1)
       rw [hk, ← quarticChar_apply]; exact hχ
     rwa [← zpow_natCast, ← zpow_mul] at h1
   have hdvd : (↑(p - 1) : ℤ) ∣ k * ↑(quartExp p) := by
-    have := orderOf_dvd_of_zpow_eq_one hpow_eq
+    have := orderOf_dvd_iff_zpow_eq_one.mpr hpow_eq
     rwa [hord] at this
   have hquart4 : (↑(p - 1) : ℤ) = 4 * ↑(quartExp p) := by
     exact_mod_cast (quartExp_mul h4).symm
@@ -515,17 +515,18 @@ axiom cubic_reciprocity (π ρ : EisensteinPrime)
 
 section Examples
 
+-- `Fact (Nat.Prime 7)` is no longer auto-synthesized for literal primes (v4.26.0);
+-- supply it so the `IsCubicResidue (· : ZMod 7)` example statements elaborate.
+instance : Fact (Nat.Prime 7) := ⟨by norm_num⟩
+
 -- p = 7: 7 ≡ 1 (mod 3), cubExp 7 = 2
 example : (7 : ℕ) % 3 = 1 := by norm_num
 example : cubExp 7 = 2 := by norm_num [cubExp]
 
 -- Cubic residues mod 7: cubes are {0, 1, 6} since 1³=1, 2³=1, 3³=6, 6³=6 (mod 7)
-example : IsCubicResidue (1 : ZMod 7) := by
-  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩; exact ⟨1, by decide⟩
-example : IsCubicResidue (6 : ZMod 7) := by
-  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩; exact ⟨3, by decide⟩  -- 3³ = 27 ≡ 6 mod 7
-example : IsCubicResidue (0 : ZMod 7) := by
-  haveI : Fact (Nat.Prime 7) := ⟨by norm_num⟩; exact ⟨0, by simp⟩
+example : IsCubicResidue (1 : ZMod 7) := ⟨1, by decide⟩
+example : IsCubicResidue (6 : ZMod 7) := ⟨3, by decide⟩  -- 3³ = 27 ≡ 6 mod 7
+example : IsCubicResidue (0 : ZMod 7) := ⟨0, by simp⟩
 
 -- Euler criterion for p = 7: cubic residue iff a^2 ≡ 1 (mod 7)
 example : (1 : ZMod 7) ^ 2 = 1 := by decide  -- 1 is cubic residue ✓

--- a/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
+++ b/src/data/research/problems/elementary-quadratic-reciprocity-oq-01-oq-02.json
@@ -18,18 +18,19 @@
   "currentState": {
     "phase": "COMPLETE",
     "since": "2026-06-09T23:55:00.000Z",
-    "iteration": 9,
+    "iteration": 10,
     "focus": "Axiomatized-stable on origin/main: ElementaryQuadraticReciprocityOQ01OQ02.lean now has extractor counts of 579 lines, 27 theorem/lemma declarations, 6 defs, 0 sorries, and 2 axioms (cubicResidueSymbol, cubic_reciprocity). S5 OBSERVE confirmed the remaining axioms are an engineering refactor onto Mathlib cyclotomic/Jacobi-sum APIs rather than a wait-on-upstream task.",
     "blockers": [],
-    "nextAction": "Axiomatized-stable. Future S6/S7 ACT (optional, not actively scheduled): engineering refactor per research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md \u00a7'Suggested next ACT (S6) \u2014 refactor plan' (6-step Ireland-Rosen Ch.9 port, ~250 LOC, no new Mathlib bearer needed). Pin SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 (v4.26.0) confirmed bearer-stable at S6 (T+3d since S5 audit).",
+    "nextAction": "S6 BUILD-VERIFY (researcher-2, 2026-06-12): ElementaryQuadraticReciprocityOQ01OQ02.lean was found BROKEN at the v4.26.0 pin (a COMPLETE/axiomatized-stable entry silently failing to build). Repaired and now Docker BUILD-VERIFY clean (3058 jobs, 0 errors, 0 sorries, 2 axioms unchanged: cubicResidueSymbol, cubic_reciprocity). Drift fixes: (1) orderOf_eq_card_of_forall_mem_zpowers now returns Nat.card not Fintype.card -> bridged via Nat.card_eq_fintype_card at the hord site (the cubic-Euler proof; the other 3 sites already used the correct pattern); (2) orderOf_dvd_of_zpow_eq_one -> orderOf_dvd_iff_zpow_eq_one.mpr (2 sites, cubic + quartic); (3) Fact (Nat.Prime 7) no longer auto-synthesized for literal primes -> added a section-level instance and dropped the now-redundant per-example haveI shadows that were breaking decide. Net +10/-9 LOC; 0 math content change. The record remains axiomatized-stable; optional S7 engineering refactor (Ireland-Rosen Ch.9 port, ~250 LOC) is unchanged and still not actively scheduled.",
     "attemptCounts": {
       "total": 9,
       "currentApproach": 1,
       "approachesTried": 1
-    }
+    },
+    "lastUpdate": "2026-06-12T00:00:00Z"
   },
   "knowledge": {
-    "progressSummary": "AXIOMATIZED-STABLE on origin/main: Cubic + quartic characters are developed in Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean with extractor counts of 579 lines, 27 theorem/lemma declarations, 6 defs, 0 sorries, and 2 axioms. The 2 remaining axioms (cubicResidueSymbol, cubic_reciprocity) are tied to the file local EisensteinPrime structure; S5 OBSERVE says discharging them is an engineering refactor onto Mathlib v4.26.0 cyclotomic/Jacobi-sum APIs.",
+    "progressSummary": "S6 BUILD-VERIFY/REPAIR (researcher-2, 2026-06-12): the COMPLETE entry ElementaryQuadraticReciprocityOQ01OQ02.lean had silently broken at the v4.26.0 pin; repaired to build clean (3058 jobs, 0 errors, 0 sorries, 2 axioms). Fixes: orderOf_eq_card_of_forall_mem_zpowers Nat.card bridge, orderOf_dvd_of_zpow_eq_one -> orderOf_dvd_iff_zpow_eq_one.mpr (x2), section-level Fact (Nat.Prime 7) instance (literal-prime Fact no longer auto-synthesized) replacing decide-breaking haveI shadows. +10/-9 LOC; axioms unchanged.\n\nAXIOMATIZED-STABLE on origin/main: Cubic + quartic characters are developed in Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean with extractor counts of 579 lines, 27 theorem/lemma declarations, 6 defs, 0 sorries, and 2 axioms. The 2 remaining axioms (cubicResidueSymbol, cubic_reciprocity) are tied to the file local EisensteinPrime structure; S5 OBSERVE says discharging them is an engineering refactor onto Mathlib v4.26.0 cyclotomic/Jacobi-sum APIs.",
     "builtItems": [
       "cubicChar : (ZMod p)\u02e3 \u2192* (ZMod p)\u02e3 in ElementaryQuadraticReciprocityOQ01OQ02.lean:84",
       "cubicChar_pow_three_eq_one : \u03c7\u2083(a)\u00b3 = 1 via Fermat in :106",


### PR DESCRIPTION
## Summary

`proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` (cubic/quartic character packages) is a **COMPLETE / axiomatized-stable** gallery entry that had **silently broken** at the v4.26.0 Mathlib pin. A ground-truth Docker build surfaced 6 errors from API drift. This PR repairs them — the file **builds clean again (3058 jobs, 0 errors, 0 sorries; 2 axioms unchanged)**.

## Fixes

- `orderOf_eq_card_of_forall_mem_zpowers` now returns `Nat.card` (not `Fintype.card`) → bridge via `Nat.card_eq_fintype_card` at the cubic-Euler `hord` site (the other three sites already used the correct pattern).
- `orderOf_dvd_of_zpow_eq_one` → `orderOf_dvd_iff_zpow_eq_one.mpr` (cubic + quartic Euler-criterion proofs).
- `Fact (Nat.Prime 7)` is no longer auto-synthesized for literal primes: added a section-level instance for the example statements and dropped the now-redundant per-example `haveI` shadows that were breaking `decide`.

**Net +10/−9 LOC; no mathematical content change.** The record stays axiomatized-stable (the optional Ireland–Rosen Ch.9 refactor remains unscheduled).

## Verification

```
./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ01OQ02
=> Build completed successfully (3058 jobs); 0 errors, 0 sorries
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)