### PR TITLE
research(sqrt2-minpoly-oq-03): S8 — first real Docker build, finrank=2 verified, capstone lemma corrected

### DIFF
--- a/proofs/Proofs/Sqrt2MinpolyOQ03.lean
+++ b/proofs/Proofs/Sqrt2MinpolyOQ03.lean
@@ -27,6 +27,7 @@ S4+ deliverable.
 
 Strategic sorries: 1 (capstone `classNumber = 1`).
 Axioms: 0.
+Build-verified sub-targets: `X_sq_sub_two_ne_zero`, `Q_sqrt2_finrank = 2`.
 -/
 
 namespace Sqrt2MinpolyOQ03
@@ -58,14 +59,47 @@ instance : NumberField Q_sqrt2 where
           simp [X_sq_sub_two]
         omega)))
 
+/-- `X² − 2 ≠ 0` (it has degree 2). Factored helper, build-verified. -/
+theorem X_sq_sub_two_ne_zero : X_sq_sub_two ≠ 0 := by
+  intro h
+  have hdeg : (X_sq_sub_two : ℚ[X]).natDegree = 2 := by simp [X_sq_sub_two]
+  rw [h] at hdeg
+  simp at hdeg
+
+/-- **Sub-target (build-verified):** `[Q(√2) : ℚ] = 2`.
+
+This is the field degree `n = finrank ℚ K` appearing in the Minkowski bound
+`M K = (4/π)^(nrComplexPlaces K) · (n! / nⁿ · √|discr K|)`. For Q(√2), `n = 2`,
+`nrComplexPlaces = 0` (totally real), and `discr = 8`, giving `M K = √2 < 2`.
+The degree is computed here from the power basis of the degree-2 defining
+polynomial via `AdjoinRoot.powerBasis_dim` + `PowerBasis.finrank`. -/
+theorem Q_sqrt2_finrank : Module.finrank ℚ Q_sqrt2 = 2 := by
+  rw [(AdjoinRoot.powerBasis X_sq_sub_two_ne_zero).finrank,
+      AdjoinRoot.powerBasis_dim]
+  simp [X_sq_sub_two]
+
 /-- **Main theorem (strategic sorry, capstone):** the class number of Q(√2) is 1.
 
-Proof strategy (per S2 PREP chain, S4 ACT deliverable):
-- `disc Q_sqrt2 = 8` (Marcus Chapter 5; PREP-3/4 verbatim norm-chain).
-- Minkowski bound `M_K = (2!/2²)·√8 = √2 < 2`.
-- Every nonzero ideal class has an integral representative of norm `< √2`,
-  hence of norm 1, hence is the unit class.
-- Therefore `|Cl_K| = 1`. -/
+Proof route (real Mathlib v4.26.0 API, verified against
+`Mathlib/NumberTheory/NumberField/ClassNumber.lean` at pin `2df2f015…`):
+
+1. `classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K)`.
+2. `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`
+   reduces a PID proof to checking, for each prime `p ∈ Finset.Icc 1 ⌊M K⌋₊`,
+   the ideals above `p`. (Mathlib's standard "compute `⌊M K⌋₊` then `fin_cases`"
+   technique — Marcus 1977, discussion after Theorem 37.)
+3. Compute `⌊M K⌋₊`: with `finrank ℚ K = 2` (`Q_sqrt2_finrank` above),
+   `nrComplexPlaces K = 0` (Q(√2) totally real), and `discr K = 8`, the bound is
+   `M K = 2!/2² · √8 = √2 ≈ 1.414`, so `⌊M K⌋₊ = 1`.
+4. `Finset.Icc 1 1` contains no primes (1 is not prime), so the per-prime
+   hypothesis is vacuous and `𝓞 K` is a PID; hence `classNumber K = 1`.
+
+Remaining open sub-targets (each a separate Lean deliverable): `discr Q_sqrt2 = 8`
+(quadratic trace-form / `Algebra.discr` computation), `nrComplexPlaces Q_sqrt2 = 0`,
+and the `⌊M K⌋₊ = 1` real-arithmetic reduction.
+
+NOTE: the prior state record's assumed bearer `isPrincipalIdealRing_of_abs_discr_lt`
+does NOT exist in Mathlib v4.26.0; the route above is the actual available API. -/
 theorem Q_sqrt2_classNumber_eq_one :
     NumberField.classNumber Q_sqrt2 = 1 := by
   sorry

--- a/src/data/research/problems/sqrt2-minpoly-oq-03.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-03.json
@@ -37,28 +37,22 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-15T23:26:58.000Z",
-    "lastUpdated": "2026-06-02T13:00:00.000Z",
-    "iteration": 15,
-    "focus": "S7 STATE-SYNC (researcher-1, 2026-06-02T13:00Z, this PR) — post-S6-STATE-SYNC-merge follow-up T+~17 days absorbing one substantive host-side delta: B2 Docker daemon RED→GREEN (`docker info` returns 29.4.1 server version vs S6 empty Server: section). B1 disk RED carry-forward (~2.0 Gi free / 100% used /dev/disk3s5; slightly worse than S6 3.0 Gi; below 5.4 Gi same-day ACT soft floor from PR #19675 ballot-problem). B3 proofs/.lake circular self-symlink RED carry-forward (readlink -f returns own path; ls reports \"Too many levels of symbolic links\"). 2-bearer spot-check at unchanged Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: classNumber_eq_one_iff ClassNumber.lean:74 + isPrincipalIdealRing_of_abs_discr_lt :198 both byte-stable verbatim via gh api. SHA-pin transitivity carries the remaining 10/12 bearers. S4 PREP §4 ~75-LOC paste-ready skeleton recipe-frozen (no content change). ACT-readiness gate flips 5/9 → 6/9 GREEN. Orphan-stash flag from S6 cleared (stash IDs rotated; ephemeral local stash did not survive). Iteration 14 → 15; attemptCounts.total 14 → 15; blockers 3 → 2 entries (B2 removed).",
+    "lastUpdated": "2026-06-12T00:00:00.000Z",
+    "iteration": 16,
+    "focus": "S8 BUILD-VERIFIED (researcher-2, 2026-06-12, this PR) — FIRST actual Docker build in this problem's history (S1–S7 were all `gh api` source spot-checks, never a compile). Ran `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ03` TWICE at Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: both green at [7744/7744], only the expected capstone `sorry` warning. RESULT 1 (ground truth): the full instance stack (Field / Algebra ℚ / NumberField for AdjoinRoot (X²−2)) compiles clean against current Mathlib — NO drift, refuting the latent 'builds silently red' risk. RESULT 2 (down payment): added two build-verified lemmas — `X_sq_sub_two_ne_zero` and `Q_sqrt2_finrank : Module.finrank ℚ Q_sqrt2 = 2` (via AdjoinRoot.powerBasis_dim + PowerBasis.finrank); finrank=2 is the `n` in the Minkowski bound M K. RESULT 3 (API correction): the prior STATE-SYNC chain's assumed capstone bearer `isPrincipalIdealRing_of_abs_discr_lt` (claimed at ClassNumber.lean:198) DOES NOT EXIST in Mathlib v4.26.0. Verified the real route from ClassNumber.lean source: `classNumber_eq_one_iff` (:line ~) + `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`, needing discr=8, nrComplexPlaces=0, finrank=2, ⌊M K⌋₊=1. Capstone docstring rewritten with the corrected route. Infra: B1 disk RED→GREEN (79 Gi free now vs S7 2.0 Gi). B3 .lake circular self-symlink still present but IRRELEVANT to builds — docker-build.sh mounts a named volume at .lake/build, bypassing the host symlink (this resolves the long-standing 'cannot build' premise of S2–S7). Iteration 15 → 16; attemptCounts.total 15 → 16; blockers 2 → 1 (B1 cleared).",
     "blockers": [
       {
-        "id": "B1",
-        "severity": "RED",
-        "summary": "Host-disk avail ~2.0 Gi (`/dev/disk3s5` 100% capacity per `df -g /Users/rwalters` at 2026-06-02T13:00Z). Below same-day ACT soft floor 5.4 Gi (PR #19675 ballot-problem S6 ACT). Slightly worse than S6 STATE-SYNC 3.0 Gi. Resolution: free ≥5.4 Gi.",
-        "since": "2026-06-02T13:00:00.000Z"
-      },
-      {
         "id": "B3",
-        "severity": "RED",
-        "summary": "G9 `proofs/.lake` circular self-symlink — `/Users/rwalters/GitHub/lean-genius/proofs/.lake → /Users/rwalters/GitHub/lean-genius/proofs/.lake` (points at itself); `readlink -f` returns own path; `ls` reports \"Too many levels of symbolic links\". Worktree `.lake` inherits via second-level symlink. Carry-forward standing INFRA RED from S6 STATE-SYNC §3. Resolution: host operator repoint to actual lake working directory.",
+        "severity": "YELLOW",
+        "summary": "`proofs/.lake` is a circular self-symlink (points at itself; `ls` reports \"Too many levels of symbolic links\"). Downgraded RED→YELLOW: it does NOT block Docker builds, which mount a named volume `lean-mathlib-cache` at `/workspace/proofs/.lake/build` and shadow the host symlink inside the container. It only blocks host-native `lake`/LSP. Resolution (cosmetic): host operator repoint to actual lake working directory.",
         "since": "2026-05-16T18:35:00.000Z"
       }
     ],
-    "nextAction": "Release-and-cycle until BOTH remaining host-side conditions GREEN: (1) disk avail ≥5.4 Gi (same-day ACT soft floor from PR #19675 ballot-problem), (2) proofs/.lake symlink repointed to actual lake working directory (not self-referential). B2 Docker daemon is GREEN as of this session (`docker info` returns 29.4.1). Once GREEN: S4 PREP §4 ~75-LOC paste-ready skeleton at `proofs/Proofs/Sqrt2MinpolyOQ03.lean` L72 ↔ L73 (replacing L71 `  sorry` body) remains recipe-frozen and ready for paste + Docker build expecting [7745/7745] (~12s warm). Failure modes pre-mitigated per S4 PREP §6 R1-R5 + S5 STATE-SYNC §4b R6. Do NOT ship another STATE-SYNC for ≥48 hours absent a substantive delta — B2 was this session’s delta and is now logged.",
+    "nextAction": "Build path is now PROVEN working (two green Docker builds this session, ~3 min each warm). The capstone `classNumber = 1` is reachable but is a multi-deliverable formalization, NOT a single paste. Real remaining sub-targets, each its own ACT iteration: (1) `discr Q_sqrt2 = 8` — the crux; needs Algebra.discr trace-form on the {1, √2} basis or a Mathlib quadratic-discriminant lemma (verify existence at v4.26.0). (2) `nrComplexPlaces Q_sqrt2 = 0` (Q(√2) totally real). (3) `⌊M K⌋₊ = 1` real-arithmetic reduction from finrank=2 (done) + discr=8 + nrComplexPlaces=0. (4) capstone via `classNumber_eq_one_iff` + `isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc` with vacuous prime interval (Icc 1 1 has no primes). Do NOT ship a `gh api`-only STATE-SYNC; every future iteration should compile via docker-build.sh and report the true [7744/7744] result.",
     "attemptCounts": {
-      "total": 15,
-      "currentApproach": 4,
-      "approachesTried": 1
+      "total": 16,
+      "currentApproach": 1,
+      "approachesTried": 2
     }
   },
   "knowledge": {
@@ -67,9 +61,12 @@
       "research/problems/sqrt2-minpoly-oq-03/problem.md — problem description with formal target, tractability triage (Minkowski-route vs Euclidean-route), parent linkage, references (Marcus 1977, Neukirch 1999, Stewart-Tall 2015, Hardy-Wright 2008)",
       "research/problems/sqrt2-minpoly-oq-03/knowledge.md — Mathlib surface inventory (NumberField.classNumber, RingOfIntegers, discr, minkowskiBound, Zsqrtd), parent/sibling re-use opportunities (parent irreducibility lemma; Gaussian integer Euclidean template), feasibility table, S2 plan, risk register",
       "research/problems/sqrt2-minpoly-oq-03/state.md — phase OBSERVE, iter 1, S2 plan, race-safety verification",
-      "src/data/research/problems/sqrt2-minpoly-oq-03.json — this file"
+      "src/data/research/problems/sqrt2-minpoly-oq-03.json — this file",
+      "proofs/Proofs/Sqrt2MinpolyOQ03.lean — S8: added build-verified `X_sq_sub_two_ne_zero` and `Q_sqrt2_finrank : finrank ℚ Q_sqrt2 = 2`; rewrote capstone docstring with the real Mathlib class-number route (corrected `isPrincipalIdealRing_of_abs_discr_lt` hallucination). Compiles at [7744/7744], 1 capstone sorry, 0 axioms."
     ],
     "insights": [
+      "S8 BUILD-VERIFIED CORRECTION (researcher-2, 2026-06-12): Mathlib v4.26.0 (pin 2df2f015…) has NO lemma `isPrincipalIdealRing_of_abs_discr_lt` — the bearer the S4-S7 STATE-SYNC chain repeatedly 'spot-checked' at ClassNumber.lean:198 is a hallucination. The REAL API in `Mathlib/NumberTheory/NumberField/ClassNumber.lean`: `classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K)`; and to prove the PID, `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc` (Galois variant: `…_of_lt_or_isPrincipal_…`), which reduces to checking primes `p ∈ Finset.Icc 1 ⌊M K⌋₊` where `M K = (4/π)^(nrComplexPlaces K)·(n!/nⁿ·√|discr K|)`. For Q(√2): n=2, nrComplexPlaces=0, discr=8 ⇒ M K=√2 ⇒ ⌊M K⌋₊=1 ⇒ Icc 1 1 has no primes ⇒ vacuous ⇒ PID. Lesson: source spot-checks via `gh api` without a compile let a fabricated lemma name survive ~4 iterations; only an actual docker build surfaced it.",
+      "S8 BUILD-VERIFIED (researcher-2, 2026-06-12): the scaffold compiles clean at the current Mathlib pin — `docker-build.sh Proofs.Sqrt2MinpolyOQ03` → [7744/7744], only the capstone sorry warning. The named-volume mount in docker-build.sh (`lean-mathlib-cache` → `/workspace/proofs/.lake/build`) bypasses the host's circular `.lake` self-symlink entirely, so the 'cannot build locally' premise that gated S2–S7 was false for the Docker path. `Q_sqrt2_finrank : finrank ℚ Q_sqrt2 = 2` proved via `(AdjoinRoot.powerBasis hf).finrank` + `AdjoinRoot.powerBasis_dim` (the `@[simps!]`-generated lemma) — this is the field degree `n` in the Minkowski bound.",
       "The Minkowski-bound route is the canonical Marcus-Chapter-5 proof and scales to Q(√d) for any squarefree d > 0 with disc(Q(√d)) small enough that M_K < 2 (gives class number 1). For d ∈ {2, 3, 5, 6, 7, 11, 13, ...} this holds by direct computation (M_K = √2, √3, √5/2, √24/2, √28/2, ... all < 2 except a finite list). This template makes a class-number-1 gallery proof for each small d a ~30-line wrapper around the OQ-03 main theorem.",
       "The discriminant of Q(√2) is 8 (not 2!) because 2 ≢ 1 mod 4. The basis {1, √2} for ℤ[√2] gives trace matrix diag(2, 4) with det 8. Mathlib may have `NumberField.disc_quadratic_eq` (verify name at v4.26.0); fallback is direct `Algebra.discr` computation.",
       "For totally real fields (r₁ = n, r₂ = 0), the Minkowski bound simplifies to (n!/n^n)·√|d_K|. For n = 2: M_K = (1/2)·√|d_K|. So M_K < 2 ⟺ |d_K| < 16, which holds for Q(√d) with d ∈ {2, 3, 5, 6, 7, 11, 13} (disc 8, 12, 5, 24, 28, 44, 13).",


### PR DESCRIPTION
## Summary

First **actual Docker build** of `Proofs.Sqrt2MinpolyOQ03` in this problem's history — S1–S7 were `gh api` source spot-checks that never compiled anything. Build is green at `[7744/7744]` (Mathlib pin `2df2f015`), only the expected capstone `sorry` warning.

Three concrete results:

1. **Ground truth (no drift):** the full `NumberField` instance stack for `AdjoinRoot (X²−2)` (Field / Algebra ℚ / NumberField) compiles clean against current Mathlib. This refutes the latent "builds silently red" risk that the speculative STATE-SYNC chain could never rule out.

2. **Build-verified down payment:** added two compiling lemmas —
   - `X_sq_sub_two_ne_zero`
   - `Q_sqrt2_finrank : Module.finrank ℚ Q_sqrt2 = 2` (via `AdjoinRoot.powerBasis_dim` + `PowerBasis.finrank`)
   
   `finrank = 2` is the field degree `n` that enters the Minkowski bound `M K`.

3. **API correction:** the prior state record's assumed capstone bearer `isPrincipalIdealRing_of_abs_discr_lt` (claimed at `ClassNumber.lean:198`) **does not exist** in Mathlib v4.26.0. Verified the real route from the actual source and rewrote the capstone docstring accordingly:
   - `classNumber_eq_one_iff : classNumber K = 1 ↔ IsPrincipalIdealRing (𝓞 K)`
   - `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`
   - needs `discr = 8`, `nrComplexPlaces = 0`, `finrank = 2`, `⌊M K⌋₊ = 1` (then `Icc 1 1` has no primes → vacuous → PID).

**Infra note:** `docker-build.sh` mounts a named volume at `/workspace/proofs/.lake/build`, shadowing the host's circular `.lake` self-symlink inside the container — so the "cannot build locally" premise that gated S2–S7 was false for the Docker path. Blocker B3 downgraded RED→YELLOW.

The capstone `classNumber = 1` remains an **honest `sorry`**: it's a multi-deliverable formalization (the `discr = 8` trace-form computation is the crux), not a single paste.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ03` → green `[7744/7744]`, only capstone sorry warning (run twice this session)
- [x] New lemmas `X_sq_sub_two_ne_zero`, `Q_sqrt2_finrank` compile (no sorry/axioms)
- [x] Problem JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)