### PR TITLE
fix(brouwer-oq04-oq01): repair Mathlib-drift breakage in Nash-via-Kakutani file

### DIFF
--- a/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean
+++ b/proofs/Proofs/BrouwerFixedPointOQ04OQ01.lean
@@ -129,10 +129,20 @@ theorem bestResponse_convex {N : ℕ} (G : FiniteGame N) (i : Fin N)
       a * G.utility i (Function.update σ i x) +
       b * G.utility i (Function.update σ i y) := hlin i σ x y a b
   simp only [expectedUtility] at *
-  rw [hlin_eq]
+  have hcomb : (a • x + b • y : Fin (G.strategies i) → ℝ)
+      = fun k => a * x k + b * y k := by
+    funext k; simp [Pi.add_apply, Pi.smul_apply, smul_eq_mul]
+  rw [hcomb, hlin_eq]
   have h1 := hx_best τ' hτ'
   have h2 := hy_best τ' hτ'
-  nlinarith [hab]
+  -- a·EU(x) + b·EU(y) ≥ a·EU(τ') + b·EU(τ') = (a+b)·EU(τ') = EU(τ')
+  have key := add_le_add (mul_le_mul_of_nonneg_left h1 ha)
+    (mul_le_mul_of_nonneg_left h2 hb)
+  have hcollapse : a * G.utility i (Function.update σ i τ') +
+      b * G.utility i (Function.update σ i τ') =
+      G.utility i (Function.update σ i τ') := by
+    rw [← add_mul, hab, one_mul]
+  linarith [key, hcollapse]
 
 /-- The best response set is closed.
 
@@ -156,7 +166,7 @@ theorem bestResponse_closed {N : ℕ} (G : FiniteGame N) (i : Fin N)
   have heq : bestResponse G i σ =
       MixedStrategy (G.strategies i) ∩ {τ | M ≤ eu τ} := by
     ext τ
-    simp only [bestResponse, Set.mem_sep_iff, Set.mem_inter_iff,
+    simp only [bestResponse, Set.mem_inter_iff,
                Set.mem_setOf_eq, expectedUtility, eu, M]
     constructor
     · intro ⟨hτ_mixed, hτ_best⟩
@@ -201,7 +211,9 @@ theorem fixed_point_is_nash {N : ℕ} (G : FiniteGame N)
   · intro j
     exact bestResponse_subset G j σ (hfp j)
   · intro i τ hτ
-    exact (hfp i).2 τ hτ
+    have h := (hfp i).2 τ hτ
+    simp only [expectedUtility] at h
+    rwa [Function.update_eq_self] at h
 
 /-- **Kakutani on Product Simplices** (axiom).
 
@@ -231,7 +243,7 @@ axiom kakutani_product_simplex {N : ℕ} (G : FiniteGame N)
     Proof: The joint best response correspondence on Πᵢ Δᵢ satisfies all
     Kakutani hypotheses (by bestResponse_nonempty, _convex, _closed, _uhc),
     so Kakutani gives a fixed point which is a Nash equilibrium. -/
-theorem nash_existence {N : ℕ} (hN : 0 < N) (G : FiniteGame N)
+theorem nash_existence {N : ℕ} (_hN : 0 < N) (G : FiniteGame N)
     (hcont : ∀ i : Fin N, ∀ σ : ∀ j, Fin (G.strategies j) → ℝ,
       Continuous (fun τ : Fin (G.strategies i) → ℝ =>
         G.utility i (Function.update σ i τ))) :
@@ -246,12 +258,14 @@ theorem nash_existence {N : ℕ} (hN : 0 < N) (G : FiniteGame N)
 theorem matching_pennies_uniform_is_mixed :
     (![1/2, 1/2] : Fin 2 → ℝ) ∈ MixedStrategy 2 := by
   constructor
-  · intro j; fin_cases j <;> simp [Matrix.cons_val_zero, Matrix.cons_val_one]
-  · simp [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one]
+  · intro j; fin_cases j <;> norm_num [Matrix.cons_val_zero, Matrix.cons_val_one]
+  · norm_num [Fin.sum_univ_two, Matrix.cons_val_zero, Matrix.cons_val_one]
 
 /-- **Prisoner's Dilemma**: The unique Nash equilibrium is mutual defection.
-    We exhibit the dominant strategy equilibrium directly. -/
-def prisonersDilemmaGame : FiniteGame 2 where
+    We exhibit the dominant strategy equilibrium directly.
+    Marked `@[reducible]` so `strategies i` unfolds to `2` during instance
+    synthesis (lets numerals `0`/`1 : Fin (strategies i)` elaborate). -/
+@[reducible] def prisonersDilemmaGame : FiniteGame 2 where
   strategies := fun _ => 2  -- 2 strategies each: Cooperate (0) or Defect (1)
   strategies_pos := fun _ => by norm_num
   utility := fun i σ =>
@@ -260,33 +274,28 @@ def prisonersDilemmaGame : FiniteGame 2 where
     -- Payoff matrix: (C,C)→3, (C,D)→0, (D,C)→5, (D,D)→1
     3 * c * c' + 0 * c * (1 - c') + 5 * (1 - c) * c' + 1 * (1 - c) * (1 - c')
 
-/-- In the Prisoner's Dilemma, both-defect is a Nash equilibrium. -/
+/-- In the Prisoner's Dilemma, both-defect is a Nash equilibrium.
+    The "always defect" profile assigns probability 1 to strategy 1. -/
 theorem prisoners_dilemma_nash :
-    let σ : ∀ j : Fin 2, Fin 2 → ℝ := fun _ k => if k = 1 then 1 else 0  -- always defect
-    IsNashEquilibrium prisonersDilemmaGame σ := by
-  constructor
-  · intro j; constructor
-    · intro k; fin_cases k <;> simp
-    · simp [Fin.sum_univ_two]
-  · intro i τ hτ
-    simp only [prisonersDilemmaGame, Function.update]
-    split_ifs with hi
-    · -- Player 0 unilaterally deviates
-      have hτ_prob : τ 0 + τ 1 = 1 := by
-        have := hτ.2; simp [Fin.sum_univ_two] at this; linarith
-      have hτ_nn : 0 ≤ τ 0 ∧ 0 ≤ τ 1 := ⟨hτ.1 0, hτ.1 1⟩
-      -- EU(defect | opponent defects) = 1 ≥ EU(τ | opponent defects)
-      -- = 3*τ0*0 + 0*τ0*1 + 5*τ1*0 + 1*τ1*1 = τ1 ≤ τ0 + τ1 = 1
-      ring_nf
-      nlinarith [hτ_prob, hτ_nn.1, hτ_nn.2]
-    · -- Player 1 unilaterally deviates
-      have hi1 : i = 1 := by fin_cases i <;> simp_all [Fin.ext_iff]
-      subst hi1
-      have hτ_prob : τ 0 + τ 1 = 1 := by
-        have := hτ.2; simp [Fin.sum_univ_two] at this; linarith
-      have hτ_nn : 0 ≤ τ 0 ∧ 0 ≤ τ 1 := ⟨hτ.1 0, hτ.1 1⟩
-      ring_nf
-      nlinarith [hτ_prob, hτ_nn.1, hτ_nn.2]
+    IsNashEquilibrium prisonersDilemmaGame (fun _ k => if k = 1 then 1 else 0) := by
+  refine ⟨fun j => ⟨fun k => ?_, ?_⟩, ?_⟩
+  · -- each component is nonnegative
+    show (0:ℝ) ≤ if k = 1 then 1 else 0
+    split_ifs <;> norm_num
+  · -- each player's strategy sums to 1
+    show ∑ k : Fin 2, (if k = 1 then (1:ℝ) else 0) = 1
+    rw [Fin.sum_univ_two]; norm_num
+  · -- no player gains by unilateral deviation from "always defect"
+    intro i τ hτ
+    have h0 : (0:ℝ) ≤ τ 0 := hτ.1 0
+    have h1 : (0:ℝ) ≤ τ 1 := hτ.1 1
+    have hsum : τ 0 + τ 1 = 1 := by
+      have hs : ∑ k : Fin 2, τ k = 1 := hτ.2
+      rwa [Fin.sum_univ_two] at hs
+    fin_cases i <;>
+      · simp only [prisonersDilemmaGame, Function.update]
+        norm_num
+        nlinarith [h0, h1, hsum]
 
 end NashEquilibrium
 

--- a/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-04-oq-01.json
@@ -24,18 +24,20 @@
     "goal": "Turn the recorded user-requested target into a precise Lean formalization of Kakutani fixed point theorem derived from Brouwer using Mathlib topology."
   },
   "currentState": {
-    "phase": "OBSERVE",
+    "phase": "ACT",
     "since": "2026-04-02T21:57:15-07:00",
-    "iteration": 1,
-    "focus": "OBSERVE-stage context gathering for the Kakutani-from-Brouwer target; no active approach or proof attempts are recorded.",
+    "lastUpdated": "2026-06-12T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "S2 ACT — DRIFT REPAIR (researcher-2, 2026-06-12, this PR). Correcting a badly stale record: the prior 'OBSERVE iteration 1, formal statement not specified' was wrong — Proofs/BrouwerFixedPointOQ04OQ01.lean is a complete 297-line Nash-equilibrium-via-Kakutani development (8 theorems, 2 axioms, 0 sorries as recorded). First actual Docker build revealed the file was SILENTLY RED from Mathlib v4.26.0 drift (pin 2df2f015): 11 errors across bestResponse_convex (132: Convex now presents the segment as `a • x + b • y` not `fun k => a*x k + b*y k`), fixed_point_is_nash (204: needed `Function.update_eq_self` to collapse `update σ i (σ i) = σ`), matching_pennies (250: simp left `2⁻¹+2⁻¹=1`), and prisoners_dilemma_nash (271/275-289: `prisonersDilemmaGame.strategies i` no longer reduces to 2, breaking `OfNat (Fin (strategies i))` numerals and `Fin.sum_univ_two` rewrites). Repaired ALL to green at [2366/2366], 0 new axioms, 0 sorries: added a smul→pointwise conversion + explicit convexity inequality; `Function.update_eq_self`; `norm_num` finishers; made `prisonersDilemmaGame` `@[reducible]` and inlined the strategy profile so numerals elaborate. The two pre-existing axioms (bestResponse_uhc = Berge's theorem; kakutani_product_simplex) are unchanged — they remain stated assumptions.",
     "blockers": [
-      "The research notes do not yet specify the formal theorem statement, hypotheses, references, or candidate Mathlib modules."
+      "The slug's nominal target ('prove Kakutani from Brouwer') is NOT yet discharged: Kakutani is the axiom `kakutani_finite_dim` in Proofs/BrouwerFixedPointOQ04OQ03.lean:69, on which this file's `kakutani_product_simplex` axiom rests. Proving it from Brouwer is a large (multi-hundred-line) formalization (simplicial approximation / partition-of-unity), out of scope for a single iteration.",
+      "`bestResponse_uhc` (Berge's maximum theorem) is axiomatized; discharging it is a separate substantial deliverable."
     ],
-    "nextAction": "Move to ORIENT by choosing a precise Kakutani statement and identifying the Brouwer/topology prerequisites available in Mathlib and local related proofs.",
+    "nextAction": "File is green again at the current Mathlib pin. Next substantive ACT steps (each its own iteration): (1) discharge `kakutani_finite_dim` (Kakutani⇐Brouwer) — the slug's true target; (2) discharge `bestResponse_uhc` (Berge). Until then, keep the family build-verified: re-run `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ04OQ01` after any Mathlib bump, since this family drifts silently red.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -45,6 +47,8 @@
       "State file records OBSERVE phase, full path, iteration 1, no active approach, and zero attempts."
     ],
     "insights": [
+      "S2 ACT (researcher-2, 2026-06-12): BrouwerFixedPointOQ04OQ01.lean was silently drift-broken (11 errors) under Mathlib v4.26.0 despite being recorded as 0-sorry/compiling — confirming the gallery-wide 'builds silently red' risk. Key drift signatures for this family: (a) `Convex`'s segment is now `a • x + b • y` (pointwise Pi smul), so proofs that `rw` a `fun k => a*x k + b*y k` lemma must first convert via `funext k; simp [Pi.add_apply, Pi.smul_apply, smul_eq_mul]`; (b) numerals `0`/`1 : Fin (G.strategies i)` fail `OfNat` synthesis when `G` is a plain `def` whose `strategies` projection no longer reduces — mark such game defs `@[reducible]` and inline strategy profiles so the literals elaborate; (c) `Function.update σ i (σ i)` must be collapsed with `Function.update_eq_self`.",
+      "The whole Brouwer→Kakutani→Nash chain here is axiomatized at the Kakutani level: `kakutani_finite_dim` (OQ04OQ03:69) and `fan_glicksberg` (OQ04OQ03:85) are axioms, and this file's `kakutani_product_simplex` + `bestResponse_uhc` (Berge) are axioms. So Nash existence is proved *conditional on* Kakutani; the slug's nominal 'prove Kakutani from Brouwer' is exactly the undischarged `kakutani_finite_dim`.",
       "The intended route is explicitly from Brouwer via Mathlib topology.",
       "The formal theorem statement is absent from the allowed research notes, so the target must be specified before proof work starts.",
       "No active approach, completed attempts, dead ends, or literature references are recorded for this child problem."


### PR DESCRIPTION
## Summary

`Proofs/BrouwerFixedPointOQ04OQ01.lean` (Nash equilibrium existence via Kakutani) was **silently red** under Mathlib v4.26.0 (pin `2df2f015`) — recorded as 0-sorry/compiling, but an actual Docker build surfaced **11 errors** from API drift. This PR repairs all of them to green at `[2366/2366]`, **0 new axioms, 0 sorries**.

### Drift fixes
- **`bestResponse_convex`**: `Convex`'s segment now elaborates as `a • x + b • y` (pointwise `Pi` smul) rather than `fun k => a*x k + b*y k`. Added a `funext` conversion before the `rw`, and replaced the failing `nlinarith` with an explicit convex-combination bound (`a·EU(x)+b·EU(y) ≥ (a+b)·EU(τ') = EU(τ')`).
- **`fixed_point_is_nash`**: collapse `Function.update σ i (σ i) = σ` via `Function.update_eq_self`.
- **`matching_pennies_uniform_is_mixed`**: `norm_num` finisher (simp left `2⁻¹ + 2⁻¹ = 1`).
- **`prisoners_dilemma_nash`**: `prisonersDilemmaGame.strategies i` no longer reduces to `2`, so `OfNat (Fin (strategies i))` numerals and `Fin.sum_univ_two` rewrites failed. Marked the game `@[reducible]`, inlined the strategy profile (dropped the `let`), and pinned `Fin 2` via `show`.

### Unchanged
The two pre-existing axioms — `bestResponse_uhc` (Berge's maximum theorem) and `kakutani_product_simplex` — are untouched and remain stated assumptions. The slug's nominal target ("prove Kakutani from Brouwer") is the still-axiomatized `kakutani_finite_dim` (in `BrouwerFixedPointOQ04OQ03.lean`); discharging it is a separate large deliverable.

Also corrects the stale problem record (was "OBSERVE, formal statement not specified" for what is actually a complete 297-line development).

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.BrouwerFixedPointOQ04OQ01` → `Build completed successfully (2366 jobs)`, no errors, no sorry warnings
- [x] Axiom count unchanged (2: `bestResponse_uhc`, `kakutani_product_simplex`); no new axioms introduced
- [x] Problem JSON validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)