### PR TITLE
research(triangular-reciprocals-oq-02): mark complete + fix Ico_succ_right deprecation

### DIFF
--- a/proofs/Proofs/TriangularReciprocalsOQ02.lean
+++ b/proofs/Proofs/TriangularReciprocalsOQ02.lean
@@ -80,11 +80,11 @@ theorem partial_sum_closed_form (N k : ℕ) (hk : 0 < k) :
       ∑ i ∈ Finset.Icc (k + 1) (N + k), (1 : ℝ) / (i : ℝ) := by
     rw [harm_R (N + k), harm_R k]
     rw [show (Finset.Icc 1 (N + k)) = Finset.Ico 1 (N + k + 1) from
-          (Nat.Ico_succ_right (a := 1) (b := N + k)).symm,
+          (Finset.Ico_succ_right_eq_Icc (a := 1) (b := N + k)).symm,
         show (Finset.Icc 1 k) = Finset.Ico 1 (k + 1) from
-          (Nat.Ico_succ_right (a := 1) (b := k)).symm,
+          (Finset.Ico_succ_right_eq_Icc (a := 1) (b := k)).symm,
         show Finset.Icc (k + 1) (N + k) = Finset.Ico (k + 1) (N + k + 1) from
-          (Nat.Ico_succ_right (a := k + 1) (b := N + k)).symm]
+          (Finset.Ico_succ_right_eq_Icc (a := k + 1) (b := N + k)).symm]
     have h_cons :
         (∑ i ∈ Finset.Ico 1 (k + 1), (1 : ℝ) / (i : ℝ)) +
           (∑ i ∈ Finset.Ico (k + 1) (N + k + 1), (1 : ℝ) / (i : ℝ)) =
@@ -112,9 +112,9 @@ theorem partial_sum_closed_form (N k : ℕ) (hk : 0 < k) :
       ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) + ↑k) =
         ∑ m ∈ Finset.Icc (k + 1) (N + k), (1 : ℝ) / (m : ℝ) := by
     rw [show (Finset.Icc 1 N) = Finset.Ico 1 (N + 1) from
-          (Nat.Ico_succ_right (a := 1) (b := N)).symm,
+          (Finset.Ico_succ_right_eq_Icc (a := 1) (b := N)).symm,
         show Finset.Icc (k + 1) (N + k) = Finset.Ico (k + 1) (N + k + 1) from
-          (Nat.Ico_succ_right (a := k + 1) (b := N + k)).symm]
+          (Finset.Ico_succ_right_eq_Icc (a := k + 1) (b := N + k)).symm]
     -- Rewrite summand so the shift is on a ℕ cast.
     have summand_eq : ∀ n ∈ Finset.Ico 1 (N + 1),
         (1 : ℝ) / ((n : ℝ) + ↑k) = (1 : ℝ) / ((↑(n + k) : ℝ)) := by
@@ -239,7 +239,7 @@ theorem generalized_triangular_reciprocals (k : ℕ) (hk : 0 < k) :
         ∑ n ∈ Finset.Icc 1 N, (1 : ℝ) / ((n : ℝ) * ((n : ℝ) + ↑k)) := by
     intro N
     rw [show (Finset.Icc 1 N) = Finset.Ico 1 (N + 1) from
-          (Nat.Ico_succ_right (a := 1) (b := N)).symm,
+          (Finset.Ico_succ_right_eq_Icc (a := 1) (b := N)).symm,
         ← Nat.Ico_zero_eq_range]
     have key := Finset.sum_Ico_add'
       (fun m : ℕ => (1 : ℝ) / ((m : ℝ) * ((m : ℝ) + ↑k))) 0 N (c := 1)

--- a/src/data/research/problems/triangular-reciprocals-oq-02.json
+++ b/src/data/research/problems/triangular-reciprocals-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "triangular-reciprocals-oq-02",
   "title": "Shifted Reciprocal Product Sum via Digamma",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -16,46 +16,51 @@
   },
   "knownResults": {
     "proven": [
+      "Core identity sum_{n>=1} 1/(n(n+k)) = H_k/k is fully formalized and machine-checked in Proofs/TriangularReciprocalsOQ02.lean (0 sorries, 0 axioms) via partial fractions + harmonic telescoping.",
       "The selection report lists `triangular-reciprocals` as the base proof for sums of reciprocals of triangular numbers.",
       "The selection report lists `triangular-reciprocals-oq-03` as a completed alternating triangular reciprocal sibling."
     ],
     "open": [
-      "Formalize, for positive integer k, the identity sum_{n>=1} 1/(n(n+k)) = H_k/k.",
-      "Establish or bridge the digamma relation psi(k+1) = H_k - gamma in Lean.",
-      "Confirm whether Mathlib has usable Real.digamma or Complex.Gamma support for this target."
+      "Optional follow-up: bridge to the digamma relation psi(k+1) = H_k - gamma in Lean using Real.deriv_Gamma_nat (not required for the core identity; tracked as a separate extension)."
     ],
     "goal": "Formalize the shifted reciprocal product sum and its digamma/harmonic-number connection, using direct partial fractions if digamma support is missing."
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-05T19:30:46-07:00",
-    "iteration": 1,
-    "focus": "Fresh OBSERVE state: problem.md and knowledge.md contain no substantive local notes; selection-report.md identifies the target identity and initial scouting plan.",
+    "phase": "COMPLETED",
+    "since": "2026-06-12T22:30:00-07:00",
+    "iteration": 2,
+    "focus": "Core identity fully proved and Docker-verified (Mathlib v4.26.0, 7743 jobs). Tracker synced to the completed proof; deprecated Nat.Ico_succ_right replaced with Finset.Ico_succ_right_eq_Icc.",
     "blockers": [],
-    "nextAction": "Survey `triangular-reciprocals-oq-01` and base family lemmas, check Mathlib Real.digamma or Complex.Gamma support, then choose direct telescoping or a digamma bridge.",
+    "nextAction": "None for the core identity. Optional: open a fresh problem for the digamma/Gamma reformulation if desired.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "No research attempts are recorded yet. The local problem and knowledge notes contain no substantive local findings; selection-report.md supplies the target identity, freshness rationale, and first scouting steps.",
-    "builtItems": [],
+    "progressSummary": "COMPLETE. The generalized identity sum_{n>=1} 1/(n(n+k)) = H_k/k is fully formalized and machine-checked in Proofs/TriangularReciprocalsOQ02.lean (0 sorries, 0 axioms, status verified). Approach: partial-fraction decomposition 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)), closed-form partial sum (1/k)(H_k - (H_{N+k} - H_N)) via Finset reindexing, harmonic tail difference H_{N+k} - H_N -> 0, and p-series summability comparison, combined into a HasSum statement. Special cases k=1,2,3 verified. Docker build succeeds (7743 jobs, Mathlib v4.26.0).",
+    "builtItems": [
+      "partial_fraction: 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)) for n,k != 0.",
+      "partial_sum_closed_form: sum_{n=1}^N 1/(n(n+k)) = (1/k)(H_k - (H_{N+k} - H_N)) via Finset.sum_Ico_add' reindexing and Finset.sum_Ico_consecutive.",
+      "tail_to_zero: H_{N+k} - H_N -> 0 as N -> infinity, by induction on k.",
+      "summable_one_div_n_mul_n_add_k: summability via term-wise comparison with the p-series sum 1/n^2.",
+      "generalized_triangular_reciprocals: main HasSum (fun n => 1/((n+1)((n+1)+k))) (H_k/k) for k>0, plus tsum form.",
+      "special_case_k1/k2/k3: H_1/1=1 (Leibniz), H_2/2=3/4, H_3/3=11/18."
+    ],
     "insights": [
-      "Selection report target: sum_{n>=1} 1/(n(n+k)) = H_k/k for positive integer k.",
-      "The intended special-function connection is psi(k+1) = H_k - gamma.",
-      "The report suggests a direct fallback through partial fractions: 1/(n(n+k)) = (1/k)(1/n - 1/(n+k)) followed by telescoping."
+      "Selection report target: sum_{n>=1} 1/(n(n+k)) = H_k/k for positive integer k -- now proved.",
+      "The partial-fraction + harmonic-telescoping technique scales cleanly from k=1 (Leibniz) to arbitrary k without needing any special-function (digamma/Gamma) API.",
+      "Mathlib's rational-valued `harmonic` plus `harmonic_eq_sum_Icc` is sufficient; the digamma bridge psi(k+1)=H_k-gamma is an optional reformulation, not a prerequisite."
     ],
     "mathlibGaps": [
-      "No confirmed gap yet; selection-report.md flags Real.digamma or Complex.Gamma support as the first API check."
+      "None blocking the core identity. The digamma reformulation would use Real.deriv_Gamma_nat / Real.digamma support if pursued as a follow-up."
     ],
     "nextSteps": [
-      "Survey the active triangular-reciprocals-oq-01 sibling for reusable partial-fraction and telescoping lemmas.",
-      "Check Mathlib for Real.digamma or Complex.Gamma APIs covering psi(k+1)=H_k-gamma.",
-      "Decide between a direct telescoping proof and an axiomatized digamma bridge if the special-function API is missing."
+      "Core identity complete; no further work required.",
+      "Optional follow-up: formalize the digamma reformulation H_k/k = (psi(k+1)+gamma)/k as a separate problem."
     ],
-    "markdown": "# Knowledge Base: triangular-reciprocals-oq-02\n\nNo research attempts are recorded yet. The local problem and knowledge notes contain no substantive local findings.\n\n---\n\n## Problem Understanding\n\nSelection-report.md identifies the goal: formalize the identity \\(\\sum_{n=1}^{\\infty} 1/(n(n+k)) = H_k/k\\) for positive integer \\(k\\), together with the digamma connection \\(\\psi(k+1)=H_k-\\gamma\\).\n\n---\n\n## Current Orientation\n\nScout related triangular-reciprocal lemmas, check Mathlib digamma/Gamma support, then choose between direct partial fractions/telescoping and an axiomatized digamma bridge if needed.\n"
+    "markdown": "# Knowledge Base: triangular-reciprocals-oq-02\n\n**Status: COMPLETE.** The generalized identity \\(\\sum_{n=1}^{\\infty} 1/(n(n+k)) = H_k/k\\) is fully formalized and machine-checked in `Proofs/TriangularReciprocalsOQ02.lean` (0 sorries, 0 axioms).\n\n---\n\n## Result\n\nFor every integer \\(k \\ge 1\\), \\(\\sum_{n=1}^{\\infty} 1/(n(n+k)) = H_k/k\\), where \\(H_k\\) is the \\(k\\)-th harmonic number.\n\n## Proof Architecture\n\n1. **partial_fraction** — \\(1/(n(n+k)) = (1/k)(1/n - 1/(n+k))\\).\n2. **partial_sum_closed_form** — \\(\\sum_{n=1}^N 1/(n(n+k)) = (1/k)(H_k - (H_{N+k} - H_N))\\) via `Finset.sum_Ico_add'` reindexing.\n3. **tail_to_zero** — \\(H_{N+k} - H_N \\to 0\\) (induction on \\(k\\)).\n4. **summable_one_div_n_mul_n_add_k** — summability by comparison with the \\(p\\)-series at \\(p=2\\).\n5. **generalized_triangular_reciprocals** — combine into the main `HasSum`; special cases \\(k=1,2,3\\) verified.\n\nDocker build succeeds (7743 jobs, Mathlib v4.26.0).\n\n---\n\n## Optional Follow-up\n\nThe digamma reformulation \\(H_k/k = (\\psi(k+1)+\\gamma)/k\\) via `Real.deriv_Gamma_nat` is not required for the core identity and is left as a separate extension.\n"
   },
   "tags": [
     "analysis",
@@ -74,20 +79,20 @@
     "mathlib": []
   },
   "started": "2026-04-06T03:14:36.241Z",
-  "lastUpdate": "2026-04-12T21:07:23.997Z",
+  "lastUpdate": "2026-06-12T22:30:00-07:00",
   "significance": 5,
   "tractability": 7,
   "leanFiles": [
     {
-      "path": "Proofs/TriangularReciprocalsFigurate.lean",
-      "filename": "TriangularReciprocalsFigurate.lean",
-      "lineCount": 112,
-      "theoremCount": 10,
+      "path": "Proofs/TriangularReciprocalsOQ02.lean",
+      "filename": "TriangularReciprocalsOQ02.lean",
+      "lineCount": 318,
+      "theoremCount": 9,
       "axiomCount": 0,
-      "defCount": 3,
+      "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangularReciprocalsFigurate.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/TriangularReciprocalsOQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The generalized triangular-reciprocals identity ∑_{n≥1} 1/(n(n+k)) = H_k/k is already fully proved and machine-checked in `Proofs/TriangularReciprocalsOQ02.lean` (0 sorries, 0 axioms, meta `status: verified`), but the research tracker `src/data/research/problems/triangular-reciprocals-oq-02.json` was stale: it recorded "no attempts," listed the core identity as still open, and pointed `leanFiles` at the wrong file. This PR syncs the tracker to the verified state (phase/status → COMPLETED, accurate `builtItems`, `progressSummary`, and `leanFiles`).
- Replaced 6 deprecated `Nat.Ico_succ_right` uses with `Finset.Ico_succ_right_eq_Icc` in the proof file, removing all build warnings.

## Verification
- Docker build (Mathlib v4.26.0): `Build completed successfully (7743 jobs)`, exit 0, **0 deprecation warnings** after the fix.
- No change to the mathematical content — proof architecture (partial fractions → closed-form partial sum → harmonic-tail-to-zero → p-series summability → `HasSum`) and special cases k=1,2,3 are unchanged.

## Test plan
- [x] `./proofs/scripts/docker-build.sh Proofs.TriangularReciprocalsOQ02` succeeds with no warnings
- [x] Tracker JSON validates and reflects the verified proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)