### PR TITLE
Enrich Abel-Ruffini: sync orphaned cross-refs into annotation source

### DIFF
--- a/src/data/proofs/abel-ruffini/annotations.source.json
+++ b/src/data/proofs/abel-ruffini/annotations.source.json
@@ -562,7 +562,11 @@
       "measure-theoretic vs structural threshold",
       "inverse-galois-f20 (solvable degree-5 witness)",
       "keyInsight #22 (Hilbert irreducibility)",
-      "keyInsight #34 (Bhargava-Shankar-Tsimerman)"
+      "keyInsight #34 (Bhargava-Shankar-Tsimerman)",
+      "abel-ruffini-galois-extensions (sibling companion: complete $S_n$ classification for $n \\leq 4$ via Klein-four chain $\\{e\\} \\trianglelefteq V_4 \\trianglelefteq A_4 \\trianglelefteq S_4$)",
+      "abel-ruffini-oq-04-oq-02 (companion: instance build-out for $S_2, S_3, S_4$ via `solvable_of_ker_le_range` and Klein-four normality)",
+      "derived length $\\text{dl}(S_4) = 3$ vs $\\text{dl}(S_5) = \\infty$ (the quantitative form of the threshold)",
+      "$A_5 \\cong \\text{PSL}(2, 5) \\cong I$ icosahedral correspondence (Klein 1884)"
     ],
     "prerequisites": [
       "derived series",


### PR DESCRIPTION
## Enrichment pass for `abel-ruffini`

### What
The generated `annotations.json` for the `ann-part-vi-threshold` annotation carried **4 `relatedConcepts` that were absent from `annotations.source.json`** — the build-time source-of-truth that `pnpm annotations:build` regenerates the resolved file from (`scripts/annotations/build.ts:processAnchorBased`).

A prior enrichment pass edited the generated file directly rather than the source, so these curated cross-references would have been **silently dropped on the next deploy build**. This PR ports them into the source so they persist:

- `abel-ruffini-galois-extensions` (sibling: complete $S_n$ classification for $n \leq 4$)
- `abel-ruffini-oq-04-oq-02` (companion: $S_2,S_3,S_4$ instance build-out)
- derived length $\text{dl}(S_4)=3$ vs $\text{dl}(S_5)=\infty$ (quantitative threshold)
- $A_5 \cong \text{PSL}(2,5) \cong I$ icosahedral correspondence (Klein 1884)

### Verification
- `pnpm annotations:build` resolves `abel-ruffini` with no errors.
- After regeneration, `annotations.json` is **byte-identical** to before (it already contained these 4) — so this is a pure source-of-truth alignment with **no frontend change**, only data-loss prevention.
- Note: full `pnpm build` (tsc/vite) could not run in this worktree — `node_modules` is not installed. The relevant annotation-resolution step passed.

### Notes
- Branch `feature/enricher-1` already backs open PR #22846 (unrelated S¹ work), so this pass uses a dedicated branch to avoid clobbering it.
- Entry is otherwise at full maturity: quality 100, 7 passes, all peer-review action items resolved, 16 annotations with complete fields, full line coverage, 103 valid crossReferences, 49 valid relatedProblems, all 9 mainTheorems matching the Lean source.