### PR TITLE
research(amgm-oq-04-oq-02): repair Mathlib-drift build breakage (Legendre relation file)

### DIFF
--- a/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
+++ b/proofs/Proofs/AmgmInequalityOQ04OQ02.lean
@@ -66,6 +66,7 @@ namespace AmgmInequalityOQ04OQ02
 
 open MeasureTheory intervalIntegral Real
 open AmgmInequalityOQ04OQ01 (ellipticK)
+open scoped Topology
 
 -- ============================================================================
 -- § 1. The Complete Elliptic Integral E(k) of the Second Kind
@@ -594,7 +595,7 @@ lemma dIntegrandE_abs_le_bound
     abs_of_pos hκ_sqrt_pos
   rw [abs_div, h_num, h_denom]
   -- Goal: |κ| · sin²θ / √(1 − κ² sin²θ) ≤ M · sin²θ / √(1 − M² sin²θ).
-  apply div_le_div
+  apply div_le_div₀
   · exact mul_nonneg hM_nn hsin2_nn
   · exact mul_le_mul_of_nonneg_right habs_κ hsin2_nn
   · exact hM_sqrt_pos
@@ -846,7 +847,7 @@ lemma dIntegrandK_abs_le_bound
   -- Goal:
   --   |κ| · sin²θ / [(1 − κ²sin²θ)·√(1 − κ²sin²θ)]
   --     ≤ M · sin²θ / [(1 − M²sin²θ)·√(1 − M²sin²θ)].
-  apply div_le_div
+  apply div_le_div₀
   · -- 0 ≤ numerator on RHS
     exact mul_nonneg hM_nn hsin2_nn
   · -- numerator inequality: |κ|·sin²θ ≤ M·sin²θ
@@ -930,8 +931,18 @@ lemma integral_sin_sq_div_sqrt_denom (hk_pos : 0 < k) (hk_lt : k < 1) :
       Real.mul_self_sqrt
         (le_of_lt (AmgmInequalityOQ04OQ01.denom_pos hk_sq θ))
     unfold AmgmInequalityOQ04OQ01.ellipticIntegrand ellipticIntegrandE
-    field_simp
-    linear_combination hs_sq
+    -- Canonicalize all radicands to a single `sin²·k²` order so `ring`/
+    -- `linear_combination` see one sqrt atom (current Mathlib `ring_nf`
+    -- commutes `k²·sin²θ → sin²θ·k²`, splitting the atom otherwise).
+    simp only [show (1 : ℝ) - k ^ 2 * Real.sin θ ^ 2
+        = 1 - Real.sin θ ^ 2 * k ^ 2 from by ring]
+    have hs_sq' : Real.sqrt (1 - Real.sin θ ^ 2 * k ^ 2)
+        * Real.sqrt (1 - Real.sin θ ^ 2 * k ^ 2) = 1 - Real.sin θ ^ 2 * k ^ 2 := by
+      rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact hs_sq
+    have hs_ne' : Real.sqrt (1 - Real.sin θ ^ 2 * k ^ 2) ≠ 0 := by
+      rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact hs_ne
+    field_simp [hs_ne']
+    linear_combination hs_sq'
   rw [intervalIntegral.integral_congr h_pointwise]
   rw [intervalIntegral.integral_div]
   rw [intervalIntegral.integral_sub
@@ -1111,7 +1122,13 @@ lemma auxFnK_deriv_form_eq {k θ : ℝ} (hk : k ^ 2 < 1) :
     have h := Real.sin_sq_add_cos_sq θ
     linarith
   rw [hcos_sq]
-  field_simp [h_pos_ne, hs_ne]
+  simp only [show (1 : ℝ) - k ^ 2 * Real.sin θ ^ 2
+      = 1 - Real.sin θ ^ 2 * k ^ 2 from by ring]
+  have h_pos_ne' : (1 - Real.sin θ ^ 2 * k ^ 2) ≠ 0 := by
+    rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact h_pos_ne
+  have hs_ne' : Real.sqrt (1 - Real.sin θ ^ 2 * k ^ 2) ≠ 0 := by
+    rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact hs_ne
+  field_simp [h_pos_ne', hs_ne']
   ring
 
 /-- **Pointwise chain rule** for `auxFnK` in θ.
@@ -1204,7 +1221,17 @@ lemma auxFnK_hasDerivAt {k : ℝ} (hk : k ^ 2 < 1) (θ : ℝ) :
         = 1 - k ^ 2 * Real.sin θ ^ 2 := by
       rw [sq, Real.mul_self_sqrt h_pos.le]
     rw [hsq]
-    field_simp [h_pos_ne, hs_ne]
+    simp only [show (1 : ℝ) - k ^ 2 * Real.sin θ ^ 2
+        = 1 - Real.sin θ ^ 2 * k ^ 2 from by ring]
+    have h_pos_ne' : (1 - Real.sin θ ^ 2 * k ^ 2) ≠ 0 := by
+      rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact h_pos_ne
+    have hs_ne' : Real.sqrt (1 - Real.sin θ ^ 2 * k ^ 2) ≠ 0 := by
+      rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact hs_ne
+    have hsq' : Real.sqrt (1 - Real.sin θ ^ 2 * k ^ 2) ^ 2
+        = 1 - Real.sin θ ^ 2 * k ^ 2 := by
+      rw [mul_comm (Real.sin θ ^ 2) (k ^ 2)]; exact hsq
+    field_simp [h_pos_ne', hs_ne']
+    rw [hsq']
     ring
   -- Compose: target → intermediate → raw, in reverse so `exact h_div` closes.
   rw [show
@@ -1397,7 +1424,6 @@ theorem integral_dIntegrandK_eq (hk_pos : 0 < k) (hk_lt : k < 1) :
     have hsp_ne : Real.sqrt (1 - k ^ 2 * Real.sin θ ^ 2) ≠ 0 := hsp.ne'
     unfold dIntegrandK
     field_simp
-    ring
   rw [intervalIntegral.integral_congr h_pw] at h_ftc
   -- Split the integral and pull the constant `(1-k²)/k` outside.
   have h_cos_int : IntervalIntegrable

--- a/research/problems/amgm-inequality-oq-04-oq-02/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-02/state.md
@@ -1,8 +1,55 @@
 # Current State
 
-**Phase**: ACT (S14 ACT Site-1 applied — B1 dispatched in `dK_dk`; B2 fully resolved since S13; Site-2 `dE_dk` deferred to S15)
-**Since**: 2026-06-02T19:00:00Z
-**Iteration**: 14
+**Phase**: ACT (S15 BUILD-REPAIR — file now Docker-verified clean; G3 AMBER→GREEN. dE_dk assembly still due.)
+**Since**: 2026-06-13T00:00:00Z
+**Iteration**: 15
+
+## Iteration 15 (2026-06-13, researcher-2): S15 BUILD-REPAIR — Mathlib-drift fixes; file builds clean (Docker 7745)
+
+**Critical finding**: `AmgmInequalityOQ04OQ02.lean` did **not** compile at the
+current Mathlib pin (v4.26.0), despite being labeled `status: axiomatized,
+sorries: 0` in the gallery. The S14 patch (#22… era) left it "build pending"
+and it had in fact accumulated **7 distinct Mathlib-drift breakages** across 6
+sites. A baseline Docker build (this session) surfaced them; all are now fixed
+and the file is **Docker-verified clean (7745 jobs, 0 errors, 0 sorries)**.
+
+### Breakages fixed (Mathlib v4.26.0 drift)
+
+1. **`𝓝` unknown** (×2, `dK_dk`): the file opened `MeasureTheory
+   intervalIntegral Real` but not `Topology`. Added `open scoped Topology`.
+2. **`div_le_div` unknown** (×2, §9 bound lemmas): renamed to `div_le_div₀`
+   in current Mathlib (same 4-arg signature `(0≤c)(a≤c)(0<d)(d≤b) : a/b ≤ c/d`).
+3. **`field_simp; ring` / `linear_combination` failures** (3 sites: the
+   pointwise K/E identity §12, `auxFnK_deriv_form_eq`, `h_eq_intermediate`):
+   current `field_simp`/`ring_nf` commutes the radicand `k²·sin²θ → sin²θ·k²`,
+   splitting `√(1−k²sin²θ)` and `√(1−sin²θk²)` into two distinct atoms `ring`
+   cannot unify, and leaving inverses uncleared because the `≠ 0` hypotheses
+   kept the un-commuted order. **Fix pattern**: canonicalize the radicand to a
+   single `sin²·k²` order via `simp only [show 1−k²sin²θ = 1−sin²θk² from by
+   ring]`, supply commuted `≠ 0` / sqrt-square facts (`mul_comm` + the
+   original), then `field_simp [commuted facts]` clears denominators and
+   `rw [hsq']; ring` closes.
+4. **`field_simp; ring` no-goals** (1 site, §16 dIntegrandK rewrite): current
+   `field_simp` fully closes the goal, so the trailing `ring` errored with
+   "No goals". Removed the redundant `ring`.
+
+### Counts
+
+| | Before | After |
+|--|--|--|
+| Builds (Docker) | **NO (broken)** | **YES (7745 jobs)** |
+| LOC | 1575 | 1601 |
+| Axioms | 1 (`legendre_relation`) | 1 (unchanged) |
+| Theorems | 47 | 47 (unchanged) |
+| Sorries | 0 | 0 |
+
+**Axiom unchanged** — this is a build repair, not an axiom discharge. It
+restores the 47 theorems to genuinely machine-checked status (they were
+unverified while the file was broken). G3 (dK_dk Mathlib-API-clean) is now
+**GREEN/Docker-verified**. G4 (`dE_dk` assembly) remains the next milestone
+toward discharging `legendre_relation` via the Wronskian closure.
+
+---
 
 ## Iteration 14 (2026-06-02T19:00Z, researcher-1): S14 ACT Site-1 — minimal-diff B1 fix in `dK_dk` (§4.4 path; +16 LOC; build pending; Site-2 deferred)
 

--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -20,7 +20,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 1575,
+    "lineCount": 1601,
     "theoremCount": 47,
     "definitionCount": 10,
     "assumptions": "1 axiom: legendre_relation (the general Legendre relation E(k)·K(k') + E(k')·K(k) − K(k)·K(k') = π/2 for 0 < k < 1; classical 19th-century result; proof requires differentiation under the integral sign and the Wronskian of the Legendre ODE — to be replaced with a constructive proof in a future session). The file inherits 1 additional axiom from AmgmInequalityOQ04OQ01 (agm_ellipticK_connection), but that is not declared in this file.",
@@ -176,7 +176,7 @@
       "AmgmInequalityOQ04OQ01"
     ],
     "namespace": "AmgmInequalityOQ04OQ02",
-    "lineCount": 1575,
+    "lineCount": 1601,
     "axiomCount": 1,
     "theoremCount": 47,
     "definitionCount": 10,


### PR DESCRIPTION
## Summary

**`AmgmInequalityOQ04OQ02.lean` (Legendre's Relation for complete elliptic integrals — 47 theorems + 1 axiom) did not compile** at the current Mathlib pin (v4.26.0), despite being labeled `status: axiomatized, sorries: 0` in the gallery. It had been "build pending" since the S14 patch and accumulated **7 distinct Mathlib-drift breakages across 6 sites**. This PR fixes all of them; the file is now **Docker-verified clean (7745 jobs, 0 errors, 0 sorries)**.

This is a **build repair, not an axiom discharge** — but it restores 47 theorems to genuinely machine-checked status (they were unverified while the file was broken).

## Breakages fixed

1. **`𝓝` unknown** (×2, `dK_dk`) — the file opened `MeasureTheory intervalIntegral Real` but not `Topology`. Added `open scoped Topology`.
2. **`div_le_div` unknown** (×2, §9 bounds) — renamed to `div_le_div₀` in current Mathlib (same 4-arg signature).
3. **`field_simp; ring` / `linear_combination` failures** (3 sites) — current `field_simp`/`ring_nf` commutes the radicand `k²·sin²θ → sin²θ·k²`, splitting `√(1−k²sin²θ)` and `√(1−sin²θk²)` into non-unifiable atoms and leaving inverses uncleared (the `≠0` hyps kept the un-commuted order). Fixed by canonicalizing the radicand order (`simp only [show 1−k²sin²θ = 1−sin²θk² from by ring]`) + commuted `≠0`/sqrt-square facts, then `field_simp` + `rw` + `ring`.
4. **`field_simp; ring` no-goals** (1 site, §16) — `field_simp` now fully closes the goal; removed the redundant trailing `ring`.

Counts: `lineCount` 1575→1601, axioms 1 (unchanged, `legendre_relation`), theorems 47 (unchanged), sorries 0.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.AmgmInequalityOQ04OQ02` → **Build completed successfully (7745 jobs)**, 0 errors. (Baseline build before the fix failed with 7 errors — logged.)
- [x] meta.json validated as well-formed JSON; `lineCount` synced 1575→1601.
- [x] Axiom count unchanged; no new sorries.