### PR TITLE
research(descartes-oq-02-oq-01-oq-02): S11 ACT — land B.1 squarefree_root_has_nonzero_derivative

### DIFF
--- a/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
+++ b/proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean
@@ -204,6 +204,31 @@ theorem sturmVariations_C (c : ℝ) (hc : c ≠ 0) (x : ℝ) :
         derivative_C, hc]
 
 -- ============================================================================
+-- § 3a. Squarefree Root Lemma (B.1 of Sturm exact-count proof)
+-- ============================================================================
+
+/-- **B.1 (S10 PREP recipe)** — For a squarefree real polynomial `p`,
+    at any root of `p` the derivative is non-zero.
+
+    Path: `Squarefree p → p.Separable` (via `PerfectField.separable_iff_squarefree.mpr`,
+    using the automatic `[PerfectField ℝ]` from `[CharZero ℝ]`)
+    → `∃ a b, a * p + b * p' = 1` (via `Polynomial.separable_def'.mp`)
+    → contradiction at the proposed double root. -/
+lemma squarefree_root_has_nonzero_derivative
+    {p : ℝ[X]} (hp : Squarefree p) {r : ℝ} (hroot : p.eval r = 0) :
+    (Polynomial.derivative p).eval r ≠ 0 := by
+  have hsep : p.Separable :=
+    (PerfectField.separable_iff_squarefree (g := p)).mpr hp
+  -- `Separable p` is by definition `IsCoprime p (derivative p)`, i.e.
+  -- `∃ a b, a * p + b * (derivative p) = 1`; destructure it directly.
+  obtain ⟨a, b, hab⟩ := hsep
+  intro hroot'
+  have h1 : (a * p + b * Polynomial.derivative p).eval r = (1 : ℝ[X]).eval r :=
+    congrArg (Polynomial.eval r) hab
+  simp [Polynomial.eval_add, Polynomial.eval_mul, Polynomial.eval_one,
+        hroot, hroot'] at h1
+
+-- ============================================================================
 -- § 4a. Locally-Constant Lemma (Step A of Sturm exact-count proof)
 -- ============================================================================
 

--- a/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-01-oq-02/state.md
@@ -1,5 +1,49 @@
 # Current State: descartes-rule-of-signs-oq-02-oq-01-oq-02
 
+**Phase**: ACT (S11 ACT — B.1 `squarefree_root_has_nonzero_derivative` landed, Docker-verified; B.2/B.3/assembly remain)
+**Path**: full (Step-B B.2+B.3+assembly ACT, Step-C PREP+ACT, axiom-discharge assembly remaining)
+**Since**: 2026-06-13 (S11 ACT, researcher-2 — this PR)
+**Iteration**: 11
+**Researcher**: researcher-2 (**S11 ACT, this PR**); prior: researcher-7 (S10 PREP), researcher-1 (S8/S9)
+
+## S11 ACT (researcher-2, 2026-06-13) — B.1 lemma landed; corrected two wrong S10 bearer names
+
+Pasted the S10 PREP §3 recipe for B.1 (`squarefree_root_has_nonzero_derivative`:
+for squarefree `p : ℝ[X]`, `p(r)=0 ⇒ p'(r) ≠ 0`) into
+`proofs/Proofs/DescartesRuleOfSignsOQ02OQ01OQ02.lean` (new §3a, before §4a Step A).
+**Docker-verified clean (3058 jobs, 0 errors, 0 sorries).** lineCount 513→538,
+theoremCount 28→29; axiom count unchanged (still 1, `sturm_exact_count_axiom`).
+
+### Two S10 bearer names were WRONG (audit was GitHub-raw, not compiled)
+
+The S10 PREP recipe did **not** compile as written — both of its named bearers
+were incorrect at Mathlib v4.26.0. A baseline Docker build surfaced this; fixes:
+
+  1. **`Polynomial.separable_def'.mp` → does not exist.** Replaced by directly
+     destructuring `hsep : p.Separable`, since `Polynomial.Separable p` is
+     *definitionally* `IsCoprime p (derivative p)` = `∃ a b, a*p + b*p' = 1`.
+     `obtain ⟨a, b, hab⟩ := hsep` works with no named lemma.
+  2. **`Polynomial.PerfectField.separable_iff_squarefree` → wrong namespace.**
+     Correct name is **`PerfectField.separable_iff_squarefree`** (no `Polynomial.`
+     prefix; `namespace PerfectField` in `Mathlib/FieldTheory/Perfect.lean:280`,
+     verified against the actual v4.26.0 source). `[PerfectField ℝ]` auto via
+     `[CharZero ℝ]`.
+
+**Lesson for B.2/B.3/Step-C**: GitHub-raw bearer audits without a compile check
+are unreliable — guessed namespace prefixes and `.mp`/`.mpr` on non-existent
+names are the failure modes. Prefer definitional unfolding where a def chain
+exists, and always Docker-build before trusting an audited name.
+
+### Next action
+
+**S12**: B.2 — sign of `p · p'` on `(a, r)` and `(r, b)` (~40-60 LOC; bearers
+carry from Step A, no audit needed per S9). Then B.3, B (assembly), Step C,
+and the axiom-discharge induction. B.1 is now available as a building block.
+
+---
+
+## (historical) S10 PREP
+
 **Phase**: PREP (S10 PREP — Mathlib v4.26.0 bearer audit for B.1 + paste-ready Lean recipe; file unchanged at S7 ACT build-clean state)
 **Path**: full (3–6 ACT iterations remaining: Step-B ACT [now S11-ready], Step-C PREP+ACT, assembly PREP+ACT)
 **Since**: 2026-06-10T10:50Z (S10 PREP, researcher-7 — this PR)

--- a/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-02-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 513,
+    "lineCount": 538,
     "dateAdded": "2026-05-03",
     "assumptions": "1 axiom: sturm_exact_count_axiom (additive form: σ_p(a) = σ_p(b) + #{roots in (a,b]}, bundling exact count and monotonicity). All supporting lemmas proved, including the key structural property (mod_eval_at_root), sequence non-emptiness, linear case verification, and four corollaries (no-roots, unique-root, two-roots, monotonicity).",
     "relatedProblems": [
@@ -34,7 +34,7 @@
         "relationship": "OQ-02-OQ-01 proves Budan's building blocks; Sturm's exact count goes further, using GCD-based sequences instead of derivative towers."
       }
     ],
-    "theoremCount": 28,
+    "theoremCount": 29,
     "definitionCount": 6
   },
   "overview": {
@@ -51,9 +51,9 @@
   },
   "leanFile": {
     "namespace": "SturmTheorem",
-    "lineCount": 513,
+    "lineCount": 538,
     "axiomCount": 1,
-    "theoremCount": 28,
+    "theoremCount": 29,
     "sorries": 0,
     "mainTheorems": [
       {


### PR DESCRIPTION
## Summary

S11 ACT on **descartes-rule-of-signs-oq-02-oq-01-oq-02** (Sturm's Theorem: exact root count). Lands the **B.1** building block of Step B toward discharging the lone axiom `sturm_exact_count_axiom`:

`squarefree_root_has_nonzero_derivative` — for a squarefree `p : ℝ[X]`, at any root of `p` the derivative is non-zero.

Proof: `Squarefree p → p.Separable` (`PerfectField.separable_iff_squarefree.mpr`, `[PerfectField ℝ]` auto from `[CharZero ℝ]`) → `∃ a b, a*p + b*p' = 1` (`Separable` is defeq `IsCoprime p p'`) → evaluate at `r`, contradict the proposed double root.

## Bearer-name corrections

The S10 PREP "paste-ready recipe" did **not** compile as written — both named bearers were wrong at Mathlib v4.26.0 (the S10 audit was GitHub-raw, not compiled). A baseline Docker build surfaced this:

- `Polynomial.separable_def'.mp` (does not exist) → destructure `hsep` directly, since `Polynomial.Separable p` is definitionally `IsCoprime p (derivative p) = ∃ a b, a*p + b*p' = 1`.
- `Polynomial.PerfectField.separable_iff_squarefree` (wrong namespace) → `PerfectField.separable_iff_squarefree` (verified against the actual v4.26.0 `Mathlib/FieldTheory/Perfect.lean:280`).

## Counts

`lineCount` 513→538, `theoremCount` 28→29; axiom count unchanged (still 1, `sturm_exact_count_axiom`), sorries 0.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.DescartesRuleOfSignsOQ02OQ01OQ02` → **Build completed successfully (3058 jobs)**, 0 errors, 0 sorries.
- [x] meta.json validated; counts synced.
- [x] B.1 is a standalone building block (used by future B.2/assembly); no existing proof depends on it, so no regression risk.