### PR TITLE
research(erdos-1210): correct statement from source, re-axiomatize with O(1)

### DIFF
--- a/proofs/Proofs/Erdos1210Problem.lean
+++ b/proofs/Proofs/Erdos1210Problem.lean
@@ -1,34 +1,43 @@
 /-
-# Erdős Problem #1210: Pairwise Coprime Subset Sum Inequality
+# Erdős Problem #1210: Pairwise Coprime Weighted Harmonic Sum
 
-Source: https://erdosproblems.com/1210
+Source: https://erdosproblems.com/1210 (T. F. Bloom, accessed 2026-06-13)
 
-## Problem Statement
+## Problem Statement (corrected)
 
 Let A ⊆ [1,n) be a set of integers such that gcd(a,b) = 1 for all distinct
 a,b ∈ A (pairwise coprime). Is it true that
 
-  ∑_{a ∈ A} 1/(n - a) ≤ ∑_{p prime, p < n} 1/(n - p)?
+  ∑_{a ∈ A} 1/(n - a) ≤ ∑_{p prime, p < n} 1/p + O(1)?
 
-In other words: among all pairwise coprime subsets of {1,...,n-1}, does the
-set of primes below n maximize the weighted harmonic sum ∑ 1/(n-a)?
+The right-hand side is the Mertens sum ∑_{p<n} 1/p = log log n + O(1); the "+O(1)"
+is an additive constant **uniform in n and A**. Formally the conjecture asserts:
+
+  ∃ C, ∀ n, ∀ pairwise-coprime A ⊆ [1,n),  ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + C.
 
 ## Status: OPEN
 
-This is an open conjecture of Erdős. The inequality asserts that primes are
-"optimal" for this particular density measure among pairwise coprime sets.
+Per the source, this is open and "cannot be resolved with a finite computation."
 
-## Key Observations
+## Transcription note (why this file was revised)
 
-1. Primes < n are pairwise coprime, so they form a valid candidate set A.
-2. The sum ∑_{p<n} 1/(n-p) is a finite positive quantity for n ≥ 3.
-3. Any pairwise coprime set A has at most one even element.
-4. The inequality is tight when A = {primes < n}.
+An earlier formalization transcribed the right-hand side as ∑_{p<n} 1/(n-p)
+**and dropped the +O(1) term**, yielding the *exact* inequality
+∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/(n-p). That literal statement is FALSE: at n = 5,
+A = {4} gives LHS = 1 while ∑_{p<5} 1/(5-p) = 5/6. The refutation is preserved
+below (see `naive_statement_fails_at_five`) precisely to document that the
+O(1) term is essential — with it, the n=5 discrepancy of 1/6 is absorbed by the
+constant and there is no contradiction (`corrected_statement_consistent_at_five`).
+
+In [Er80] Erdős notes he "did not state [this] quite correctly" in [Er77c]. The
+reformulation he gives there concerns primes in an interval: if
+n < q₁ < ⋯ < q_k ≤ m are the primes in (n,m], then
+∑ 1/(qᵢ - n) < ∑_{p < m-n} 1/p + O(1). See also problems #460 and #950.
 
 ## References
 
-- Erdős (1980), Er80
-- Erdős (1977), Er77c
+- Erdős (1977), [Er77c, p.64]
+- Erdős (1980), [Er80, p.112]
 -/
 
 import Mathlib.Data.Nat.Prime.Basic
@@ -57,6 +66,11 @@ def PairwiseCoprime (A : Finset ℕ) : Prop :=
 /-- A finset A is valid for Erdős 1210: all elements in [1, n). -/
 def ValidSubset (n : ℕ) (A : Finset ℕ) : Prop :=
   ∀ a ∈ A, 1 ≤ a ∧ a < n
+
+/-- The corrected right-hand side: the sum of prime reciprocals ∑_{p<n} 1/p
+    (the Mertens sum ~ log log n). NOTE: this is 1/p, **not** 1/(n-p). -/
+noncomputable def primeReciprocalSum (n : ℕ) : ℝ :=
+  ∑ p ∈ primesBelow n, (1 : ℝ) / (p : ℝ)
 
 /-
 ## Basic Properties of Primes
@@ -98,112 +112,75 @@ theorem pairwiseCoprime_at_most_one_even {A : Finset ℕ} (hA : PairwiseCoprime 
   exact absurd this (by norm_num)
 
 /-
-## The Sum Inequality
+## The Corrected Right-Hand Side
 -/
 
-/-- The prime sum is nonneg: each term 1/(n-p) ≥ 0 for p < n. -/
-theorem primesBelow_sum_nonneg (n : ℕ) :
-    0 ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
+/-- Each prime reciprocal 1/p is nonneg, so the prime-reciprocal sum is nonneg. -/
+theorem primeReciprocalSum_nonneg (n : ℕ) : 0 ≤ primeReciprocalSum n := by
+  unfold primeReciprocalSum
   apply Finset.sum_nonneg
-  intro p hp
-  simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
-  apply div_nonneg zero_le_one
-  have : (p : ℝ) < n := by exact_mod_cast hp.1
-  linarith
+  intro p _
+  positivity
 
-/-- The prime sum is positive for n ≥ 3 (since 1/(n-2) > 0). -/
-theorem primesBelow_sum_pos {n : ℕ} (hn : 3 ≤ n) :
-    0 < ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
+/-- The prime-reciprocal sum is positive for n ≥ 3 (it contains the term 1/2). -/
+theorem primeReciprocalSum_pos {n : ℕ} (hn : 3 ≤ n) : 0 < primeReciprocalSum n := by
+  unfold primeReciprocalSum
   refine Finset.sum_pos ?_ (primesBelow_nonempty hn)
   intro p hp
   simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hp
-  have hpn : (p : ℝ) < n := by exact_mod_cast hp.1
-  exact _root_.div_pos one_pos (by linarith)
+  exact div_pos one_pos (by exact_mod_cast hp.2.pos)
 
 /-
 ## The Main Conjecture (Open)
+
+The conjecture is an asymptotic inequality with an additive O(1) constant that
+is uniform over both n and the pairwise-coprime set A. We axiomatize it with an
+explicit existential constant C — the honest formalization of "+O(1)".
 -/
 
-/-- **Erdős Problem 1210 (Open)**: For all n ≥ 3 and all pairwise coprime A ⊆ {1,...,n-1},
-    ∑_{a ∈ A} 1/(n-a) ≤ ∑_{p prime, p < n} 1/(n-p).
-    The set of primes below n maximizes this sum. -/
-axiom erdos_1210 (n : ℕ) (hn : 3 ≤ n) (A : Finset ℕ)
-    (hA_valid : ValidSubset n A)
-    (hA_coprime : PairwiseCoprime A) :
-    ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p)
+/-- **Erdős Problem 1210 (Open)**. There is an absolute constant C such that for
+    every n ≥ 3 and every pairwise coprime A ⊆ {1,…,n-1},
+
+      ∑_{a ∈ A} 1/(n-a) ≤ ∑_{p prime, p < n} 1/p + C.
+
+    Equivalently, the weighted harmonic sum over any pairwise coprime set is
+    bounded by the Mertens sum (~ log log n) up to an additive constant. -/
+axiom erdos_1210 :
+    ∃ C : ℝ, ∀ (n : ℕ), 3 ≤ n → ∀ (A : Finset ℕ),
+      ValidSubset n A → PairwiseCoprime A →
+      ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ primeReciprocalSum n + C
 
 /-
 ## Consequences
 -/
 
-/-- Any pairwise coprime A ⊆ {1,...,n-1} has sum bounded by the prime sum (from the axiom). -/
-theorem erdos_1210_bound (n : ℕ) (hn : 3 ≤ n) (A : Finset ℕ)
-    (hA_valid : ValidSubset n A) (hA_coprime : PairwiseCoprime A) :
-    ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) :=
-  erdos_1210 n hn A hA_valid hA_coprime
+/-- Re-statement of the conjecture: a single uniform constant works for all n, A. -/
+theorem erdos_1210_uniform_bound :
+    ∃ C : ℝ, ∀ (n : ℕ), 3 ≤ n → ∀ (A : Finset ℕ),
+      ValidSubset n A → PairwiseCoprime A →
+      ∑ a ∈ A, (1 : ℝ) / ((n : ℝ) - a) ≤ primeReciprocalSum n + C :=
+  erdos_1210
 
-/-- The empty set has sum 0, trivially bounded by the prime sum. -/
+/-- The empty set has sum 0, trivially bounded by the (nonneg) prime-reciprocal
+    sum — this holds unconditionally, with no need for the O(1) constant. -/
 theorem erdos_1210_empty (n : ℕ) (hn : 3 ≤ n) :
-    (0 : ℝ) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) :=
-  le_of_lt (primesBelow_sum_pos hn)
-
-/-- The prime sum dominates any singleton prime: {p} has sum 1/(n-p) ≤ total prime sum. -/
-theorem erdos_1210_prime_singleton (n : ℕ) (hn : 3 ≤ n) (p : ℕ)
-    (hp : p.Prime) (hpn : p < n) :
-    (1 : ℝ) / ((n : ℝ) - p) ≤ ∑ q ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - q) := by
-  have hp_mem : p ∈ primesBelow n := by
-    simp only [primesBelow, Finset.mem_filter, Finset.mem_range]
-    exact ⟨hpn, hp⟩
-  calc (1 : ℝ) / ((n : ℝ) - p)
-      = ∑ q ∈ ({p} : Finset ℕ), (1 : ℝ) / ((n : ℝ) - q) := by simp
-    _ ≤ ∑ q ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - q) := by
-        apply Finset.sum_le_sum_of_subset_of_nonneg (by simp [hp_mem])
-        intro q hq _
-        simp only [primesBelow, Finset.mem_filter, Finset.mem_range] at hq
-        apply div_nonneg zero_le_one
-        have : (q : ℝ) < n := by exact_mod_cast hq.1
-        linarith
-
-/-- Under the conjecture, any singleton {k} with k ∈ [1,n) has sum bounded by the prime sum.
-    In particular, k = 4 (even composite) also satisfies the bound. -/
-theorem erdos_1210_singleton_bounded (n : ℕ) (hn : 3 ≤ n) (k : ℕ) (hk1 : 1 ≤ k) (hkn : k < n) :
-    (1 : ℝ) / ((n : ℝ) - k) ≤ ∑ p ∈ primesBelow n, (1 : ℝ) / ((n : ℝ) - p) := by
-  have hle := erdos_1210 n hn {k}
-    (fun a ha => by simp only [Finset.mem_singleton] at ha; subst ha; exact ⟨hk1, hkn⟩)
-    (fun a ha b hb hab => by simp only [Finset.mem_singleton] at ha hb; omega)
-  simp only [Finset.sum_singleton] at hle
-  exact hle
+    (0 : ℝ) ≤ primeReciprocalSum n :=
+  le_of_lt (primeReciprocalSum_pos hn)
 
 /-
-## Counterexample: The Literal Statement Is FALSE
+## Why the O(1) Term Is Essential (machine-checked)
 
-The literal axiom `erdos_1210` above is **unsound** as transcribed: there is a
-concrete (n, A) for which the hypotheses are satisfied but the inequality
-FAILS. The minimal witness is n = 5, A = {4}:
+The naive "exact" inequality (constant C = 0, with the further mis-transcription
+of the right-hand side as ∑ 1/(n-p)) is FALSE. The minimal witness is n = 5,
+A = {4}:
 
-  - 4 ∈ [1, 5), so `ValidSubset 5 {4}` holds.
-  - A = {4} is trivially pairwise coprime (singleton, vacuous condition).
+  - 4 ∈ [1, 5), so `ValidSubset 5 {4}` holds; {4} is trivially pairwise coprime.
   - ∑_{a ∈ {4}} 1/(5 - a) = 1/(5-4) = 1.
-  - primesBelow 5 = {2, 3}, so ∑_{p < 5 prime} 1/(5 - p) = 1/3 + 1/2 = 5/6.
-  - 1 > 5/6, so the conjectured bound fails.
+  - ∑_{p prime, p < 5} 1/p = 1/2 + 1/3 = 5/6   (and ∑ 1/(5-p) = 1/3 + 1/2 = 5/6 too).
+  - 1 > 5/6, so the C = 0 statement fails by exactly 1/6.
 
-The theorem `erdos_1210_literal_counterexample` below proves this in machine-
-checked form. It does not invoke the bad axiom (to avoid deriving False and
-destabilizing downstream uses), but its statement is direct evidence that
-`erdos_1210` cannot be a theorem of any consistent extension of ZFC + Lean.
-
-### Interpretation
-
-The transcribed conjecture either:
-  (a) requires unstated constraints on A (e.g., A ⊆ (n/2, n) or a > √n), or
-  (b) uses different weights (e.g., 1/a instead of 1/(n-a)), or
-  (c) was misrecorded in the source database.
-
-Two open follow-ups:
-  1. **Locate originals** [Er77c, Er80] to recover the intended hypothesis.
-  2. **Revise the axiom** to a verified or correctly-stated form. The current
-     axiom should be replaced (the four consequence theorems above are then
-     vacuous and should be removed/refactored).
+With the O(1) term any C ≥ 1/6 absorbs this gap, so the corrected conjecture is
+not contradicted. The theorems below record both facts.
 -/
 
 /-- `primesBelow 5 = {2, 3}` (decidable equality of concrete Finsets). -/
@@ -211,13 +188,12 @@ theorem primesBelow_five : primesBelow 5 = ({2, 3} : Finset ℕ) := by
   unfold primesBelow
   decide
 
-/-- The weighted sum over primes below 5 equals 5/6. -/
-theorem primesBelow_five_sum :
-    ∑ p ∈ primesBelow 5, (1 : ℝ) / ((5 : ℝ) - p) = 5 / 6 := by
+/-- The corrected right-hand side at n = 5 equals 5/6 (= 1/2 + 1/3). -/
+theorem primeReciprocalSum_five : primeReciprocalSum 5 = 5 / 6 := by
+  unfold primeReciprocalSum
   rw [primesBelow_five]
-  have h23 : (2 : ℕ) ∉ ({3} : Finset ℕ) := by decide
   rw [show ({2, 3} : Finset ℕ) = insert 2 {3} from rfl,
-      Finset.sum_insert h23, Finset.sum_singleton]
+      Finset.sum_insert (by decide), Finset.sum_singleton]
   norm_num
 
 /-- `{4}` satisfies the hypotheses of `erdos_1210` at n = 5. -/
@@ -232,15 +208,23 @@ theorem singleton_four_valid_at_five :
     simp only [Finset.mem_singleton] at ha hb
     omega
 
-/-- **Counterexample to `erdos_1210` (as literally stated)**.
-
-    At n = 5, A = {4}, the A-sum (= 1) STRICTLY EXCEEDS the prime-sum (= 5/6).
-    All hypotheses of `erdos_1210` are satisfied (see
-    `singleton_four_valid_at_five`), but the conclusion fails. -/
-theorem erdos_1210_literal_counterexample :
-    (∑ p ∈ primesBelow 5, (1 : ℝ) / ((5 : ℝ) - p)) <
-      ∑ a ∈ ({4} : Finset ℕ), (1 : ℝ) / ((5 : ℝ) - a) := by
-  rw [primesBelow_five_sum, Finset.sum_singleton]
+/-- **The naive (C = 0) statement fails at n = 5, A = {4}**: the A-sum (= 1)
+    strictly exceeds the prime-reciprocal sum (= 5/6). This is why an additive
+    O(1) constant is required in the conjecture. -/
+theorem naive_statement_fails_at_five :
+    primeReciprocalSum 5 < ∑ a ∈ ({4} : Finset ℕ), (1 : ℝ) / ((5 : ℝ) - a) := by
+  rw [primeReciprocalSum_five, Finset.sum_singleton]
+  push_cast
   norm_num
+
+/-- **The corrected (O(1)) statement is consistent at n = 5, A = {4}**: for any
+    constant C ≥ 1/6, the A-sum is bounded by the prime-reciprocal sum plus C.
+    The n = 5 case therefore imposes only the lower bound C ≥ 1/6 — no
+    contradiction with the conjecture. -/
+theorem corrected_statement_consistent_at_five (C : ℝ) (hC : 1 / 6 ≤ C) :
+    ∑ a ∈ ({4} : Finset ℕ), (1 : ℝ) / ((5 : ℝ) - a) ≤ primeReciprocalSum 5 + C := by
+  rw [primeReciprocalSum_five, Finset.sum_singleton]
+  push_cast
+  linarith
 
 end Erdos1210

--- a/research/problems/erdos-1210/knowledge.md
+++ b/research/problems/erdos-1210/knowledge.md
@@ -3,8 +3,16 @@
 ## Problem Statement
 
 Let $A \subseteq [1,n)$ be a set of integers such that $(a,b)=1$ for all distinct $a,b \in A$ (pairwise coprime). Is it true that
-$$\sum_{a \in A} \frac{1}{n-a} \leq \sum_{\substack{p < n \\ p \text{ prime}}} \frac{1}{n-p}$$
-i.e., does the set of primes below $n$ maximize this weighted harmonic sum over all pairwise coprime subsets?
+$$\sum_{a \in A} \frac{1}{n-a} \leq \sum_{\substack{p < n \\ p \text{ prime}}} \frac{1}{p} + O(1)?$$
+i.e., is the proximity-weighted harmonic sum over any pairwise coprime set bounded by the Mertens sum $\sum_{p<n} 1/p \sim \log\log n$ up to an absolute additive constant?
+
+> **Correction note (S3, verified against the source 2026-06-13).** The RHS is
+> $\sum_{p<n} 1/p$ (prime reciprocals), **not** $\sum_{p<n} 1/(n-p)$, and there is
+> an essential $+O(1)$ term. Earlier sessions transcribed both incorrectly,
+> which is why S2 found a (spurious) "counterexample". In [Er80] Erdős notes he
+> "did not state [this] quite correctly" in [Er77c]; the [Er80] reformulation
+> concerns primes $q_i$ in an interval $(n,m]$:
+> $\sum 1/(q_i - n) < \sum_{p<m-n} 1/p + O(1)$.
 
 ## Status
 
@@ -115,6 +123,42 @@ i.e., does the set of primes below $n$ maximize this weighted harmonic sum over 
 - Possibly downgrade gallery `status` from `axiomatized` →
   `formalized-pending-statement-revision`.
 
+### Session 2026-06-13 (Session 3) — researcher-2
+
+**Mode**: ITERATION (resolving S2's source-access blocker)
+**Outcome**: STATEMENT CORRECTED — re-axiomatized with the true Erdős statement; Docker-verified.
+
+#### What Was Done
+- Recovered the verbatim problem statement from erdosproblems.com/1210 using
+  `curl` (WebFetch returned HTTP 403). The true statement is
+  $\sum_{a\in A} 1/(n-a) \le \sum_{p<n} 1/p + O(1)$ — RHS uses prime reciprocals
+  $1/p$ (NOT $1/(n-p)$) and carries an essential additive $O(1)$ term.
+- Diagnosed S2's "unsoundness" as a double transcription error (wrong RHS +
+  dropped $O(1)$), not a flaw in the conjecture. The n=5, A={4} discrepancy of
+  1/6 is absorbed by the constant.
+- Rewrote `proofs/Proofs/Erdos1210Problem.lean`:
+  - Added `primeReciprocalSum n := ∑_{p<n} 1/p` (corrected RHS).
+  - Replaced the unsound exact axiom with the honest existential-constant form:
+    `∃ C, ∀ n≥3, ∀ pairwise-coprime A ⊆ [1,n), ∑ 1/(n-a) ≤ primeReciprocalSum n + C`.
+  - Kept all verified structural lemmas; added `primeReciprocalSum_nonneg/pos`.
+  - Reframed the n=5 facts as `naive_statement_fails_at_five` (C=0 is false) and
+    `corrected_statement_consistent_at_five` (any C ≥ 1/6 works) — a
+    machine-checked proof that the $O(1)$ term is essential.
+- Docker build succeeded (3058 jobs). Updated gallery `meta.json` to the
+  corrected statement; final tally: 14 theorems, 4 defs, 1 axiom, 230 lines.
+
+#### Key Findings
+- The conjecture is a Mertens-type ($\log\log n$) upper bound, uniform over all
+  pairwise coprime sets, for the proximity-weighted sum — not an "primes are
+  extremal" exact equality as previously framed.
+- Erdős's [Er80] interval reformulation (primes in $(n,m]$) is the form he
+  considered correctly stated; relates to #460, #950.
+
+#### Next Steps (S4)
+- Attempt an unconditional partial bound $\sum_{a\in A} 1/(n-a) \le f(n)$ for
+  pairwise coprime A (e.g. via the ≤1-even-element structure + a sieve/Mertens
+  estimate), which would be genuine progress toward the open problem.
+
 ---
 
-*Generated from erdosproblems.com on 2026-04-16*
+*Generated from erdosproblems.com on 2026-04-16; statement corrected from source 2026-06-13.*

--- a/research/problems/erdos-1210/state.md
+++ b/research/problems/erdos-1210/state.md
@@ -1,55 +1,63 @@
 # Current State
 
-**Phase**: STATEMENT_REVISION_NEEDED
-**Since**: 2026-06-09T20:35:00Z
-**Iteration**: 2
+**Phase**: AXIOMATIZED (statement corrected)
+**Since**: 2026-06-13T08:00:00Z
+**Iteration**: 3
 
 ## Current Focus
 
-Discovered the transcribed axiom `erdos_1210` is **unsound** as literally
-stated. Adding machine-checked counterexample and flagging the formalization
-for statement-revision.
+S3 RESOLVED the S2 blocker. Recovered the correct Erdős statement directly from
+erdosproblems.com/1210 (via curl; WebFetch was 403-blocked). The earlier
+"unsoundness" was a transcription error, not a flaw in Erdős's conjecture.
 
-## Active Approach
+## What the source actually says
 
-S2 COUNTEREXAMPLE — Construct a concrete witness (n = 5, A = {4}) where the
-hypotheses of `erdos_1210` hold but the conclusion fails. Verify in Lean.
+> Let A ⊆ [1,n) be a set of integers such that (a,b)=1 for all distinct
+> a,b ∈ A. Is it true that ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + O(1)?
 
-## Findings (S2)
+Two corrections vs. the original Lean transcription:
+1. **RHS is ∑_{p<n} 1/p** (prime reciprocals, the Mertens sum ~ log log n),
+   NOT ∑_{p<n} 1/(n-p).
+2. **There is a +O(1) additive term** — the inequality is asymptotic up to an
+   absolute constant, not exact.
 
-The transcribed statement
-`∑_{a ∈ A} 1/(n-a) ≤ ∑_{p < n, p prime} 1/(n-p)`
-admits the following counterexample at n = 5:
+The S2 counterexample (n=5, A={4}: LHS=1 > 5/6) does NOT refute the real
+conjecture; the 1/6 gap is absorbed by the O(1) constant.
 
-- A = {4} trivially satisfies `ValidSubset 5 A` (1 ≤ 4 < 5) and
-  `PairwiseCoprime A` (singleton).
-- LHS = 1/(5-4) = 1.
-- RHS = 1/(5-2) + 1/(5-3) = 1/3 + 1/2 = 5/6 ≈ 0.833.
-- 1 > 5/6, so the conjectured inequality FAILS.
+Erdős's own note ([Er80]): he "did not state [this] quite correctly" in
+[Er77c]. The [Er80] reformulation concerns primes in an interval: if
+n < q₁ < ⋯ < q_k ≤ m are the primes in (n,m], then
+∑ 1/(qᵢ-n) < ∑_{p<m-n} 1/p + O(1). See also #460, #950.
 
-Hence the existing `axiom erdos_1210` and its four consequence theorems are
-unsound and should be refactored once the intended Erdős statement is
-recovered from [Er77c] / [Er80].
+## Action taken (S3)
+
+Rewrote `proofs/Proofs/Erdos1210Problem.lean` (Docker-verified, 3058 jobs):
+- New def `primeReciprocalSum n = ∑_{p<n} 1/p` (corrected RHS).
+- Replaced the unsound exact axiom with the honest O(1) form:
+  `axiom erdos_1210 : ∃ C, ∀ n ≥ 3, ∀ pairwise-coprime A ⊆ [1,n),
+   ∑ 1/(n-a) ≤ primeReciprocalSum n + C`.
+- Kept all verified structural lemmas (primes_coprime, primesBelow_*,
+  pairwiseCoprime_at_most_one_even, primeReciprocalSum_nonneg/pos).
+- Reframed the n=5 case: `naive_statement_fails_at_five` (the C=0 version is
+  false) + `corrected_statement_consistent_at_five` (any C ≥ 1/6 works), proving
+  the O(1) term is essential.
+- Updated gallery `meta.json` to the corrected statement and counts
+  (14 theorems, 4 defs, 1 axiom, 230 lines).
 
 ## Blockers
 
-- Source-text access: cannot directly fetch the original Erdős papers
-  ([Er77c] Erdős 1977c, [Er80] Erdős 1980) to recover the unstated hypothesis
-  (e.g., a > n/2, a > √n, or a different weight like 1/a).
-- Without the corrected statement, the axiom cannot be replaced — only flagged.
+None remaining for the statement. The conjecture itself is open and "cannot be
+resolved with a finite computation" (per the source).
 
 ## Next Action
 
-S3 — A future iteration should:
-  1. Locate the Erdős source for problem 1210 (likely contains the missing
-     hypothesis).
-  2. Replace the unsound axiom with the corrected statement (or with a verified
-     theorem if the corrected version is provable).
-  3. Refactor or remove the four consequence theorems that depend on the
-     current axiom.
+S4 — explore a partial bound: can one prove ∑_{a∈A} 1/(n-a) ≤ C·log log n
+(or any explicit unconditional upper bound) for pairwise coprime A, e.g. via
+the "at most one even element" structure plus a sieve/Mertens estimate? That
+would be a genuine partial result toward the open conjecture.
 
 ## Attempt Counts
 
-- Total attempts: 2
-- Current approach attempts: 1 (S2 counterexample)
-- Approaches tried: 2 (S1 formalization → axiomatization; S2 falsification)
+- Total attempts: 3
+- Approaches tried: 3 (S1 formalization/axiomatization; S2 falsification of the
+  mis-transcribed statement; S3 source recovery + corrected re-axiomatization)

--- a/src/data/proofs/erdos-1210/meta.json
+++ b/src/data/proofs/erdos-1210/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "erdos-1210",
-  "title": "Pairwise Coprime Subset Sum Inequality",
+  "title": "Pairwise Coprime Weighted Harmonic Sum",
   "slug": "erdos-1210",
-  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)? Erdős conjectured the primes maximize this weighted harmonic sum among all pairwise coprime subsets.",
+  "description": "Let A ⊆ {1,...,n-1} be pairwise coprime. Erdős asks whether ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/p + O(1), i.e. the weighted harmonic sum over any pairwise coprime set is bounded by the Mertens sum (~ log log n) up to an additive constant.",
   "meta": {
     "author": "Erdős",
     "sourceUrl": "https://erdosproblems.com/1210",
@@ -22,27 +22,27 @@
     "erdosUrl": "https://erdosproblems.com/1210",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "assumptions": "1 axiom: erdos_1210 (the main conjecture: primes maximize ∑ 1/(n-a) among pairwise coprime subsets of [1,n)). All 11 structural theorems are fully proved.",
-    "lineCount": 246,
+    "assumptions": "1 axiom: erdos_1210 (the main open conjecture, stated with an explicit existential O(1) constant C: ∃C, ∀ pairwise-coprime A ⊆ [1,n), ∑ 1/(n-a) ≤ ∑_{p<n} 1/p + C). All 13 supporting theorems are fully proved, including a machine-checked demonstration that the O(1) term is essential.",
+    "lineCount": 230,
     "mathlib_version": "4.26.0",
-    "theoremCount": 15,
-    "definitionCount": 3
+    "theoremCount": 14,
+    "definitionCount": 4
   },
   "overview": {
-    "historicalContext": "Erdős conjectured (references Er77c, Er80) that among all pairwise coprime subsets A of {1,...,n-1}, the set of primes below n maximizes the sum ∑_{a∈A} 1/(n-a). This is an extremal problem in additive-multiplicative number theory: it asks whether the primes are 'optimal' for a specific density measure among all multiplicatively independent sets.\n\nThe intuition is that pairwise coprime sets are sparse — any two elements share no common prime factor — and the primes, being the atoms of multiplication, are the canonical extremal example. The weighting 1/(n-a) gives more importance to elements close to n; the conjecture says primes up to n are 'spread out' in a way that maximizes this proximity measure.\n\nThe problem remains open as of 2026. Connections to Mertens' theorem (∑_{p≤n} 1/p ~ log log n) and rough number estimates suggest analytic tools may be needed for a full proof.",
-    "problemStatement": "Let A ⊆ {1,...,n-1} be pairwise coprime (gcd(a,b)=1 for distinct a,b∈A). Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/(n-p)?",
-    "text": "Among all pairwise coprime subsets of {1,...,n-1}, the primes below n maximize ∑_{a∈A} 1/(n-a). Open conjecture of Erdős.",
-    "proofStrategy": "Define primesBelow, PairwiseCoprime, ValidSubset. Prove structural properties: primes are pairwise coprime, the prime sum is positive, pairwise coprime sets have at most one even element. State the main conjecture as an axiom. Derive consequences including bounds for singletons.",
+    "historicalContext": "Erdős (references [Er77c, p.64], [Er80, p.112]) asks whether the weighted harmonic sum ∑_{a∈A} 1/(n-a) over a pairwise coprime set A ⊆ {1,...,n-1} is bounded above by the prime-reciprocal (Mertens) sum ∑_{p<n} 1/p up to an additive O(1) constant. By Mertens' theorem ∑_{p≤n} 1/p ~ log log n, so the conjecture asserts a log-log-n upper bound, uniform over all pairwise coprime sets, for this proximity-weighted sum.\n\nErdős himself flagged a subtlety: in [Er80] he notes he 'did not state [this] quite correctly' in [Er77c]. The reformulation he gives there concerns primes in an interval — if n < q₁ < ⋯ < q_k ≤ m are the primes in (n,m] then ∑ 1/(qᵢ-n) < ∑_{p<m-n} 1/p + O(1). See also problems #460 and #950.\n\nThe additive O(1) term is genuinely necessary: even at n = 5 the singleton A = {4} achieves ∑ 1/(n-a) = 1 while ∑_{p<5} 1/p = 5/6, so the bound fails by 1/6 without a constant. The problem remains open as of 2026 and, per the source, 'cannot be resolved with a finite computation.'",
+    "problemStatement": "Let A ⊆ {1,...,n-1} be pairwise coprime (gcd(a,b)=1 for distinct a,b∈A). Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p prime, p<n} 1/p + O(1)?",
+    "text": "The proximity-weighted harmonic sum ∑_{a∈A} 1/(n-a) over any pairwise coprime A ⊆ {1,...,n-1} is bounded by the Mertens sum ∑_{p<n} 1/p plus an absolute constant. Open conjecture of Erdős.",
+    "proofStrategy": "Define primesBelow, PairwiseCoprime, ValidSubset, and the corrected right-hand side primeReciprocalSum n = ∑_{p<n} 1/p. Prove structural properties: distinct primes are coprime, the prime-reciprocal sum is positive for n≥3, pairwise coprime sets have at most one even element. State the open conjecture as an axiom with an explicit existential O(1) constant. Machine-check that the additive constant is essential by exhibiting the n=5, A={4} discrepancy and showing any C ≥ 1/6 restores consistency.",
     "keyInsights": [
-      "Distinct primes are coprime: p∣q with p,q prime implies p=q (by primality of q), so any two distinct primes are coprime",
-      "Any pairwise coprime set has at most one even element (since two even numbers share factor 2)",
-      "The prime sum is strictly positive for n≥3 since 2<n contributes the term 1/(n-2)>0",
-      "The conjecture is tight when A = {primes < n}, since the prime set achieves equality by construction",
-      "Singletons {k} for any k∈[1,n) satisfy the inequality (via the axiom), giving a uniform bound"
+      "The correct right-hand side is the prime-reciprocal (Mertens) sum ∑_{p<n} 1/p (~ log log n), NOT ∑ 1/(n-p); the proximity weighting 1/(n-a) appears only on the left",
+      "The '+O(1)' additive constant is mathematically essential: at n=5, A={4} gives LHS=1 > 5/6=∑_{p<5}1/p, so the exact (constant-free) inequality is false by 1/6",
+      "Distinct primes are coprime: p∣q with p,q prime implies p=q, so any two distinct primes are coprime",
+      "Any pairwise coprime set has at most one even element (two even numbers share the factor 2)",
+      "The honest formalization of 'A ≤ B + O(1)' is an existential constant: ∃C, ∀n, ∀A, LHS ≤ RHS + C, uniform in both n and A"
     ],
     "prerequisites": [
-      "Number theory (primes, coprimality, divisibility)",
-      "Real analysis (harmonic sums, inequalities)"
+      "Number theory (primes, coprimality, divisibility, Mertens' theorem)",
+      "Real analysis (harmonic sums, asymptotic inequalities)"
     ]
   },
   "sections": [
@@ -50,50 +50,58 @@
       "id": "preamble",
       "title": "Problem Statement and Module Header",
       "startLine": 1,
-      "endLine": 49,
-      "summary": "Module docstring states Erdős Problem #1210: does the prime set maximize ∑ 1/(n-a) among all pairwise coprime A ⊆ [1,n)? Lists key observations: primes are pairwise coprime, the prime sum is positive for n≥3, coprime sets have ≤1 even element, and the bound is tight at A = {primes}. References Er77c and Er80.",
-      "mathContext": "$\\sum_{a \\in A} \\frac{1}{n-a} \\le \\sum_{p < n,\\, p \\text{ prime}} \\frac{1}{n-p}$ for all pairwise coprime $A \\subseteq [1,n)$."
+      "endLine": 53,
+      "summary": "Module docstring states the corrected Erdős Problem #1210: ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + O(1) for pairwise coprime A ⊆ [1,n). Documents the earlier mis-transcription (wrong RHS ∑1/(n-p) with the O(1) dropped), Erdős's own [Er80] correction, and the interval reformulation. References [Er77c, p.64] and [Er80, p.112].",
+      "mathContext": "$\\sum_{a \\in A} \\frac{1}{n-a} \\le \\sum_{p < n,\\, p \\text{ prime}} \\frac{1}{p} + O(1)$ for all pairwise coprime $A \\subseteq [1,n)$."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 50,
-      "endLine": 64,
-      "summary": "Defines primesBelow, PairwiseCoprime, ValidSubset.",
-      "mathContext": "$\\text{primesBelow}(n) = \\{p < n : p \\text{ prime}\\}$. $\\text{PairwiseCoprime}(A)$: $\\gcd(a,b)=1$ for distinct $a,b\\in A$."
+      "startLine": 54,
+      "endLine": 73,
+      "summary": "Defines primesBelow, PairwiseCoprime, ValidSubset, and primeReciprocalSum (the corrected right-hand side ∑_{p<n} 1/p).",
+      "mathContext": "$\\text{primesBelow}(n) = \\{p < n : p \\text{ prime}\\}$; $\\text{primeReciprocalSum}(n) = \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{p}$."
     },
     {
       "id": "prime-properties",
       "title": "Properties of Primes and Coprimality",
-      "startLine": 66,
-      "endLine": 102,
-      "summary": "Proves primes are pairwise coprime, primesBelow is valid and nonempty for n≥3, and pairwise coprime sets have ≤1 even element.",
-      "mathContext": "Distinct primes are coprime. $|\\text{primesBelow}(n)| \\geq 1$ for $n \\geq 3$ (since $2 \\in \\text{primesBelow}(n)$). $|\\{a \\in A : 2 \\mid a\\}| \\leq 1$ for pairwise coprime $A$."
+      "startLine": 74,
+      "endLine": 116,
+      "summary": "Proves distinct primes are coprime, primesBelow is valid and nonempty for n≥3, and pairwise coprime sets have ≤1 even element.",
+      "mathContext": "Distinct primes are coprime. $|\\text{primesBelow}(n)| \\geq 1$ for $n \\geq 3$. $|\\{a \\in A : 2 \\mid a\\}| \\leq 1$ for pairwise coprime $A$."
     },
     {
-      "id": "sum-bounds",
-      "title": "Sum Bounds",
-      "startLine": 104,
-      "endLine": 130,
-      "summary": "Proves the prime sum is nonneg and strictly positive.",
-      "mathContext": "$0 < \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for $n \\geq 3$."
+      "id": "rhs-bounds",
+      "title": "The Corrected Right-Hand Side",
+      "startLine": 117,
+      "endLine": 132,
+      "summary": "Proves the prime-reciprocal sum ∑_{p<n} 1/p is nonneg and strictly positive for n≥3.",
+      "mathContext": "$0 < \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{p}$ for $n \\geq 3$."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture and Consequences",
-      "startLine": 131,
-      "endLine": 178,
-      "summary": "States erdos_1210 axiom and derives consequences for empty set, prime singletons, and arbitrary singletons.",
-      "mathContext": "$\\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p \\in \\text{primesBelow}(n)} \\frac{1}{n-p}$ for all pairwise coprime $A \\subseteq [1,n)$."
+      "startLine": 133,
+      "endLine": 170,
+      "summary": "States the erdos_1210 axiom with an explicit existential O(1) constant, re-exposes it as a uniform bound, and records the unconditional empty-set bound.",
+      "mathContext": "$\\exists C,\\ \\forall n \\geq 3,\\ \\forall \\text{ pairwise coprime } A,\\ \\sum_{a\\in A} \\frac{1}{n-a} \\leq \\sum_{p<n} \\frac{1}{p} + C$."
+    },
+    {
+      "id": "o1-essential",
+      "title": "Why the O(1) Term Is Essential",
+      "startLine": 171,
+      "endLine": 230,
+      "summary": "Machine-checked: primesBelow 5 = {2,3}, primeReciprocalSum 5 = 5/6, {4} is valid at n=5, the constant-free statement fails there (1 > 5/6), and any C ≥ 1/6 restores consistency with the conjecture.",
+      "mathContext": "At $n=5$, $A=\\{4\\}$: $\\sum 1/(5-a) = 1 > 5/6 = \\sum_{p<5} 1/p$, so the $C=0$ statement fails; any $C \\geq 1/6$ suffices."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 1210 on the optimality of primes for the weighted harmonic sum ∑ 1/(n-a) over pairwise coprime sets. 11 structural theorems proved, 1 axiom (the open conjecture), 0 sorries.",
-    "implications": "Resolution would advance our understanding of extremal properties of pairwise coprime sets and connect to Mertens' theorem and related prime counting results.",
+    "summary": "The formalization captures the corrected Erdős Problem 1210: the proximity-weighted harmonic sum ∑ 1/(n-a) over any pairwise coprime set is bounded by the Mertens sum ∑_{p<n} 1/p up to an absolute additive constant. 13 supporting theorems proved (including a machine-checked proof that the O(1) term is essential), 1 axiom (the open conjecture), 0 sorries.",
+    "implications": "Resolution would give a uniform log-log-n bound on weighted harmonic sums over pairwise coprime sets, connecting extremal set theory to Mertens' theorem and prime-gap estimates.",
     "openQuestions": [
-      "Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/(n-p) for all pairwise coprime A?",
-      "What is the growth rate of ∑_{p<n} 1/(n-p) as n → ∞?",
-      "Do other 'optimal' pairwise coprime sets exist for related sums?"
+      "Is ∑_{a∈A} 1/(n-a) ≤ ∑_{p<n} 1/p + O(1) for all pairwise coprime A ⊆ [1,n)?",
+      "What is the optimal value of the additive constant C?",
+      "Does Erdős's interval reformulation (∑ 1/(qᵢ-n) for primes qᵢ ∈ (n,m]) admit a proof via sieve or Mertens-type estimates?"
     ]
   },
   "leanFile": {
@@ -101,7 +109,7 @@
       "Mathlib.Data.Nat.Prime.Basic",
       "Mathlib.Data.Nat.GCD.Basic",
       "Mathlib.Data.Finset.Basic",
-      "Mathlib.Algebra.BigOperators.Group.Finset",
+      "Mathlib.Algebra.BigOperators.Group.Finset.Basic",
       "Mathlib.Data.Real.Basic",
       "Mathlib.Tactic"
     ],
@@ -110,10 +118,10 @@
       "BigOperators"
     ],
     "namespace": "Erdos1210",
-    "lineCount": 246,
+    "lineCount": 230,
     "axiomCount": 1,
-    "theoremCount": 15,
-    "definitionCount": 3,
+    "theoremCount": 14,
+    "definitionCount": 4,
     "path": "Proofs/Erdos1210Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Erdős Problem **#1210** was formalized with an **unsound axiom** flagged in a prior session (S2 found a counterexample at n=5, A={4}). This PR resolves that blocker by recovering the **verbatim statement from the source** (erdosproblems.com/1210, via `curl` — `WebFetch` is 403-blocked) and re-axiomatizing it correctly.

The earlier transcription had **two errors**:
1. RHS should be the prime-reciprocal (Mertens) sum `∑_{p<n} 1/p`, **not** `∑_{p<n} 1/(n-p)`.
2. It dropped the essential **`+O(1)`** additive term.

So the axiom was never unsound — it was mis-stated. The S2 "counterexample" is a 1/6 discrepancy that the `O(1)` constant absorbs. (Erdős himself noted in [Er80] that he "did not state [this] quite correctly" in [Er77c].)

## Changes

- **`primeReciprocalSum n := ∑_{p<n} 1/p`** — the corrected RHS.
- Axiom restated honestly with an explicit existential constant:
  `∃ C, ∀ n≥3, ∀ pairwise-coprime A ⊆ [1,n), ∑ 1/(n-a) ≤ primeReciprocalSum n + C`.
- Kept all verified structural lemmas; added `primeReciprocalSum_nonneg` / `_pos`.
- **`naive_statement_fails_at_five`** + **`corrected_statement_consistent_at_five`**: a machine-checked proof that the `O(1)` term is essential (C=0 is false; any C≥1/6 works).
- Updated gallery `meta.json`, `knowledge.md`, `state.md` to the corrected statement.

Final tally: 14 theorems, 4 defs, **1 axiom** (the open conjecture), 0 sorries.

## Test plan

- [x] `./proofs/scripts/docker-build.sh Proofs.Erdos1210Problem` — succeeds (3058 jobs).
- [x] `meta.json` validates as JSON; `axiomCount` = 1 reflects the single open-conjecture axiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)