### PR TITLE
research(qt-multichoose-oq): S7 ACT — gallery entry for (q,t)-multichoose deformation

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/annotations.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/annotations.json
@@ -1,0 +1,98 @@
+[
+  {
+    "id": "ann-qt-definitions",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 148, "endLine": 165 },
+    "type": "definition",
+    "title": "qtBinom and qtMultichoose: The Macdonald (q,t)-Binomial",
+    "content": "qtBinom q t N k is defined as the 0-indexed product ∏ i ∈ range k, (1 - q^(N-i) t^i)/(1 - q^(i+1) t^i), the rewrite of Macdonald's 1-indexed (q,t)-binomial ∏_{i=1}^k (1 - q^{N+1-i} t^{i-1})/(1 - q^i t^{i-1}). At t=1 this collapses to the Gaussian binomial qBinom q N k. The (q,t)-multichoose uses the same n+k-1 index shift as the parent: qtMultichoose q t n k := qtBinom q t (n+k-1) k. Both are noncomputable and live over a Field R because the rational product needs division — the Path A choice from the PREP cascade (cheaper than redefining piecewise or lifting to RatFunc).",
+    "mathContext": "$$\\mathrm{qtBinom}(q,t,N,k) := \\prod_{i=0}^{k-1} \\frac{1 - q^{N-i} t^i}{1 - q^{i+1} t^i}, \\qquad \\mathrm{qtMultichoose}(q,t,n,k) := \\mathrm{qtBinom}(q,t,n+k-1,k)$$",
+    "significance": "key",
+    "relatedConcepts": ["Macdonald polynomials", "Gaussian binomial coefficients", "q-Pochhammer symbol", "(q,t)-deformation"],
+    "prerequisites": ["Gaussian binomial definition", "Finset.range products", "Field structure for rational expressions"]
+  },
+  {
+    "id": "ann-qt-k-recurrence",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 206, "endLine": 223 },
+    "type": "technique",
+    "title": "The Unconditional k-Direction Multiplicative Recurrence",
+    "content": "qtBinom_succ is a direct consequence of Finset.prod_range_succ: extracting the top factor of the range-(k+1) product gives qtBinom q t N (k+1) = qtBinom q t N k · ((1 - q^(N-k) t^k)/(1 - q^(k+1) t^k)) with no hypothesis whatsoever. This is the foundational identity of the file. Its denominator depends only on k (not on N), which is exactly why the k-direction recurrence telescopes cleanly while a Pascal-style two-direction recurrence does not — the latter would have an (n,k)-dependent denominator shape.",
+    "mathContext": "$$\\mathrm{qtBinom}(q,t,N,k+1) = \\mathrm{qtBinom}(q,t,N,k) \\cdot \\frac{1 - q^{N-k} t^k}{1 - q^{k+1} t^k}$$",
+    "significance": "key",
+    "relatedConcepts": ["Finset.prod_range_succ", "telescoping products", "recurrence relations"],
+    "prerequisites": ["product over Finset.range", "rational function manipulation"]
+  },
+  {
+    "id": "ann-qt-mult-qpascal",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 229, "endLine": 247 },
+    "type": "insight",
+    "title": "CommRing Multiplicative q-Pascal: The Bridge Lemma",
+    "content": "The private helper qBinom_mult_recur states qBinom q n (k+1) · (1 - q^(k+1)) = qBinom q n k · (1 - q^(n-k)), unconditionally over any CommRing. It is obtained by subtracting the two standard q-Pascal identities (qBinom_pascal and qBinom_pascal'), both of which expand qBinom q (n+1) (k+1); the differing q-weights q^(k+1) and q^(n-k) cancel via linear_combination. Out-of-range n < k is handled by zeroing both qBinom factors. This is the exact algebraic bridge that connects the rational Macdonald recurrence to the polynomial Gaussian recurrence at t=1.",
+    "mathContext": "$$\\binom{n}{k+1}_q (1 - q^{k+1}) = \\binom{n}{k}_q (1 - q^{n-k})$$",
+    "significance": "key",
+    "relatedConcepts": ["q-Pascal identity", "linear_combination tactic", "qBinom_pascal", "multiplicative recurrence"],
+    "prerequisites": ["both q-Pascal forms", "linear_combination over CommRing"]
+  },
+  {
+    "id": "ann-qt-t-eq-one",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 249, "endLine": 294 },
+    "type": "insight",
+    "title": "Recovery of qMultichoose at t = 1 (Conditional)",
+    "content": "qtBinom_at_t_eq_one proves qtBinom q 1 N k = qBinom q N k by induction on k. The base case is the empty product (= 1); the inductive step combines the Macdonald-side qtBinom_succ with the Gaussian-side qBinom_mult_recur, bridged by the field identity a·(b/c) = d ↔ a·b = d·c. The Path A hypothesis q^(j+1) ≠ 1 for j < k keeps the denominator 1 - q^(k+1) nonzero. The corollary qtMultichoose_at_t_eq_one specializes via the shared n+k-1 index shift. The hypothesis is necessary, not cosmetic: the parent's qMultichoose is hypothesis-free (no division), so this theorem precisely asserts that the rational Macdonald form agrees with the polynomial Gaussian form on the open dense set of non-roots-of-unity.",
+    "mathContext": "$$\\mathrm{qtMultichoose}(q,1,n,k) = \\mathrm{qMultichoose}(q,n,k) \\quad \\text{whenever } q^{j+1} \\neq 1 \\text{ for } j < k$$",
+    "significance": "key",
+    "relatedConcepts": ["induction on k", "t=1 specialization", "roots of unity", "open dense set"],
+    "prerequisites": ["qBinom_mult_recur", "div_eq_iff field manipulation", "the parent qMultichoose definition"]
+  },
+  {
+    "id": "ann-qt-sublattice",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 300, "endLine": 325 },
+    "type": "technique",
+    "title": "The (2,2) Interior Point: Where t Cancels",
+    "content": "qtMultichoose_two_two shows qtMultichoose q t 2 2 = (1 - q^3)/(1 - q), independent of t, under the guard 1 - q^2 t ≠ 0. Mechanism: in qtBinom q t 3 2, the i=1 factor has numerator 1 - q^(3-1) t = 1 - q^2 t and denominator 1 - q^(1+1) t = 1 - q^2 t (because 3-1 = 2 = 1+1), so it cancels to 1 via div_self; the i=0 factor is the t-free (1 - q^3)/(1 - q). This (2,2) point is the unique genuinely interior member of the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} on which qtMultichoose is t-independent as a rational function in ℚ(q,t).",
+    "mathContext": "$$\\mathrm{qtMultichoose}(q,t,2,2) = \\frac{1 - q^3}{1 - q} = 1 + q + q^2, \\quad \\text{independent of } t$$",
+    "significance": "key",
+    "relatedConcepts": ["polynomial sub-lattice", "div_self cancellation", "rational function in two variables"],
+    "prerequisites": ["qtBinom_succ", "qtBinom_one_right", "field cancellation"]
+  },
+  {
+    "id": "ann-qt-field-trap",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 327, "endLine": 362 },
+    "type": "insight",
+    "title": "The Field R 0/0 Trap at q = t = 1",
+    "content": "qtBinom_at_one_one_eq_zero proves qtBinom 1 1 N (k+1) = 0. Under Lean's Field convention (0:R)/0 = 0, the i=0 factor (1 - 1^N·1^0)/(1 - 1^1·1^0) is exactly 0/0 = 0, and a single zero factor zeros the whole product (extracted via Finset.prod_range_succ', closed by simp). This is the NEGATIVE statement: the naive q=t=1 substitution does not recover Nat.multichoose — it collapses to 0. It formalizes why the Path A hypothesis q^(j+1) ≠ 1 is mandatory and motivates a future RatFunc.eval lift (Path C) to obtain the positive recovery as a genuine removable-singularity limit rather than a field artifact.",
+    "mathContext": "$$\\mathrm{qtBinom}(1,1,N,k+1) = 0 \\neq \\mathrm{multichoose}(n,k) \\quad \\text{(Field } R \\text{ artifact, not the classical limit)}$$",
+    "significance": "key",
+    "relatedConcepts": ["0/0 = 0 field convention", "removable singularity", "RatFunc.eval", "Finset.prod_range_succ'"],
+    "prerequisites": ["Lean field division convention", "product zeroing from a single zero factor"]
+  },
+  {
+    "id": "ann-qt-ratio-form",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 368, "endLine": 396 },
+    "type": "technique",
+    "title": "The Ratio-Form Recurrence for Telescoping",
+    "content": "qtBinom_succ_div divides qtBinom_succ by qtBinom q t N k (when nonzero) to expose the clean consecutive ratio (1 - q^(N-k) t^k)/(1 - q^(k+1) t^k). This ratio form is the natural foundation for telescoping or chain proofs where the residual qtBinom q t N k factor of the multiplicative form would otherwise need to be carried; the multiplicative form is preferred for substitution proofs (as in the t=1 specialization).",
+    "mathContext": "$$\\frac{\\mathrm{qtBinom}(q,t,N,k+1)}{\\mathrm{qtBinom}(q,t,N,k)} = \\frac{1 - q^{N-k} t^k}{1 - q^{k+1} t^k}$$",
+    "significance": "supporting",
+    "relatedConcepts": ["mul_div_cancel_left", "telescoping", "ratio recurrence"],
+    "prerequisites": ["qtBinom_succ", "nonvanishing hypothesis"]
+  },
+  {
+    "id": "ann-qt-bridges",
+    "proofId": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+    "range": { "startLine": 402, "endLine": 518 },
+    "type": "context",
+    "title": "Bridges to the Parent's Named Objects",
+    "content": "Three sections of bridge lemmas connect each polynomial-sub-lattice point to the parent gallery entry's named objects. Section VIII (S5 ACT) bridges to qNumber via qNumber_geometric: qtMultichoose_one_right_eq_qNumber and qtMultichoose_two_two_eq_qNumber. Section IX (S5b ACT) bridges the k ≤ 1 slice directly to qBinom/qMultichoose. Section X (S5c ACT) bridges the (2,2) interior point to qMultichoose via the parent's qMultichoose_two_left. Together they make the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} fully transparent: every point is equated to a parent-side object, so gallery readers can identify the (q,t)-multichoose with the established q-multichoose wherever it is t-independent.",
+    "mathContext": "$$\\mathrm{qtMultichoose}(q,t,n,1) = \\mathrm{qMultichoose}(q,n,1), \\qquad \\mathrm{qtMultichoose}(q,t,2,2) = \\mathrm{qMultichoose}(q,2,2)$$",
+    "significance": "supporting",
+    "relatedConcepts": ["qNumber_geometric", "qMultichoose_two_left", "qBinom_one_right", "bridge lemmas"],
+    "prerequisites": ["parent q-multichoose entry", "qNumber as q-integer"]
+  }
+]

--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
@@ -1,0 +1,229 @@
+{
+  "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+  "title": "(q,t)-Multichoose: A Macdonald-Type Deformation of the Gaussian Binomial",
+  "slug": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02",
+  "description": "Formalizes the Macdonald-style (q,t)-deformation of the q-multichoose coefficient. Defines qtBinom q t N k as the Macdonald (q,t)-binomial rational product and qtMultichoose q t n k := qtBinom q t (n+k-1) k. Proves: (1) boundary cases; (2) an unconditional k-direction multiplicative recurrence; (3) recovery of the parent's qMultichoose at t=1 (under a Path A non-degeneracy hypothesis); (4) the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} where qtMultichoose is t-independent, with explicit bridges to the parent's qNumber/qBinom/qMultichoose; (5) the Field-R 0/0 trap that the naive q=t=1 substitution collapses to zero. The interpolating (q,t)-Pascal recurrence and the positive q=t=1 recovery of Nat.multichoose remain open.",
+  "parent": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
+  "openQuestion": "Does the Macdonald-style (q,t)-deformation qtMultichoose(q,t,n,k) := qtBinom(q,t,n+k-1,k) recover qMultichoose at t=1, recover Nat.multichoose at q=t=1, and satisfy an interpolating (q,t)-Pascal recurrence?",
+  "meta": {
+    "author": "Lean Genius",
+    "date": "2026-06-13",
+    "status": "axiomatized",
+    "proofRepoPath": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean",
+    "tags": [
+      "combinatorics",
+      "q-analogs",
+      "qt-analogs",
+      "macdonald-polynomials",
+      "hall-littlewood",
+      "gaussian-binomial",
+      "multiset",
+      "representation-theory",
+      "mathlib-gap",
+      "research"
+    ],
+    "badge": "axiom",
+    "sorries": 0,
+    "dateAdded": "2026-06-13",
+    "axiomCount": 0,
+    "assumptions": "No axiom declarations and no sorries: every theorem in the file is machine-checked. The entry is classified `axiomatized` because the open question is only partially resolved and the headline results are conditional. Specifically: (1) the t=1 specialization qtMultichoose q 1 n k = qMultichoose q n k holds under the Path A non-degeneracy hypothesis `q^(j+1) ≠ 1 for all j < k` (q not a low-order root of unity), which keeps the Macdonald rational denominators nonzero; (2) the polynomial-sub-lattice bridges carry the analogous `1 - q ≠ 0` / `1 - q^2 t ≠ 0` guards; (3) the positive q=t=1 recovery of Nat.multichoose is NOT formalized — only the negative `Field R` 0/0-trap form (= 0) is proved, since Lean's field convention sets 0/0 = 0; a positive recovery requires a RatFunc.eval lift (Path C, future work); (4) the interpolating (q,t)-Pascal recurrence remains open (prior PREP analysis falsified the naive candidate at small cases).",
+    "lineCount": 518,
+    "theoremCount": 18,
+    "definitionCount": 2,
+    "mathlib_version": "4.26.0",
+    "mathlibDependencies": [
+      {
+        "theorem": "qBinom_pascal",
+        "description": "q-Pascal: qBinom q (n+1) (k+1) = qBinom q n k + q^(k+1) * qBinom q n (k+1)",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qBinom_pascal'",
+        "description": "Second q-Pascal form (used with qBinom_pascal to derive the multiplicative q-Pascal)",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qBinom_eq_zero_of_lt",
+        "description": "qBinom q n k = 0 when n < k (out-of-range zeroing)",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qBinom_one_right",
+        "description": "qBinom q n 1 = qNumber q n",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qNumber_geometric",
+        "description": "(q - 1) * qNumber q n = q^n - 1 (geometric-series form of the q-integer)",
+        "module": "Proofs.CombinationsFormulaOQ03"
+      },
+      {
+        "theorem": "qMultichoose_one_right",
+        "description": "qMultichoose q n 1 = qNumber q n",
+        "module": "Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03"
+      },
+      {
+        "theorem": "qMultichoose_two_left",
+        "description": "qMultichoose q 2 k = qNumber q (k+1)",
+        "module": "Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03"
+      },
+      {
+        "theorem": "Finset.prod_range_succ",
+        "description": "Extracts the top factor of a product over range (k+1); foundation of the k-direction recurrence",
+        "module": "Mathlib.Algebra.BigOperators.Basic"
+      }
+    ],
+    "originalContributions": [
+      "Definition qtBinom q t N k := ∏ i ∈ range k, (1 - q^(N-i) t^i) / (1 - q^(i+1) t^i): the Macdonald (q,t)-binomial as a Lean rational product over a Field R",
+      "Definition qtMultichoose q t n k := qtBinom q t (n+k-1) k: the (q,t)-deformation of the parent's q-multichoose",
+      "Unconditional k-direction multiplicative recurrence qtBinom_succ (and its ratio-form corollary qtBinom_succ_div)",
+      "t=1 specialization qtMultichoose q 1 n k = qMultichoose q n k under Path A non-degeneracy, via a new CommRing-level multiplicative q-Pascal helper qBinom_mult_recur derived by subtracting the two q-Pascal identities",
+      "Characterization and formalization of the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} on which qtMultichoose is t-independent, with explicit bridges to qNumber, qBinom, and qMultichoose",
+      "Formalization of the Field-R 0/0 trap: qtBinom 1 1 N (k+1) = 0, pinning down why the Path A hypothesis is mandatory and motivating a RatFunc migration for the positive q=t=1 recovery",
+      "First Lean gallery entry to engage with Macdonald (q,t)-binomial theory (Mathlib v4.26.0 has no Macdonald polynomials, Hall-Littlewood functions, or DAHA infrastructure)"
+    ],
+    "prerequisites": [
+      "q-Multichoose / Gaussian binomial parent entry (Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03.lean)",
+      "Gaussian binomial coefficients and q-Pascal (Proofs/CombinationsFormulaOQ03.lean)"
+    ],
+    "additionalFiles": []
+  },
+  "overview": {
+    "historicalContext": "Macdonald introduced the two-parameter (q,t)-symmetric functions in the 1980s (collected in his 1995 monograph 'Symmetric Functions and Hall Polynomials', 2nd ed.), unifying Schur functions (q=t), Hall-Littlewood functions (q=0), and Jack polynomials (q=t^α, t→1) under a single family. The associated (q,t)-binomial coefficient (Macdonald §VI.6) is the natural two-parameter deformation of the Gaussian binomial. These objects sit at the center of modern algebraic combinatorics: Cherednik's double affine Hecke algebras (DAHA), Haiman's proof of the n! conjecture via the geometry of Hilbert schemes of points (2001), and the diagonal-harmonics / shuffle-conjecture circle of ideas. The present entry asks the elementary but previously unformalized question of how the Macdonald (q,t)-binomial behaves when specialized along the multichoose index shift n+k-1 — that is, whether it gives a well-behaved (q,t)-multichoose coefficient.",
+    "problemStatement": "The parent entry establishes qMultichoose(q,n,k) = [n+k-1 choose k]_q as the canonical q-analog of multichoose(n,k), satisfying a q-Pascal recurrence and recovering multichoose at q=1. This sub-question asks whether the Macdonald (q,t)-binomial qtBinom(q,t,N,k) = ∏_{i=1}^k (1 - q^{N+1-i} t^{i-1})/(1 - q^i t^{i-1}), evaluated at N = n+k-1, yields a (q,t)-multichoose that (i) recovers qMultichoose at t=1, (ii) recovers multichoose at q=t=1, (iii) satisfies an interpolating (q,t)-Pascal recurrence specializing to the parent's q-Pascal at t=1, and (iv) connects to Macdonald polynomial principal specializations.",
+    "proofStrategy": "Work over a Field R so the Macdonald rational product is well-typed (Path A, the cheapest of the three rescues for the rational denominators). Define qtBinom via a 0-indexed Finset.range product and qtMultichoose via the n+k-1 index shift. Establish boundary cases by empty/single-factor product evaluation. Prove the unconditional k-direction multiplicative recurrence qtBinom_succ directly from Finset.prod_range_succ. For the t=1 specialization, induct on k: the inductive step bridges the Macdonald side (qtBinom_succ) to the Gaussian side via a new CommRing-level multiplicative q-Pascal qBinom_mult_recur (obtained by subtracting the two standard q-Pascal identities), using the Path A hypothesis to keep denominators nonzero. Characterize the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)} where t cancels, and bridge each point to the parent's named objects. Finally formalize the Field-R 0/0 trap to document why the naive q=t=1 substitution fails.",
+    "keyInsights": [
+      "The k=0 and k=1 columns of qtBinom are t-independent for trivial reasons (empty product; single factor with t^0 = 1). The only genuinely interior point where t cancels is (n,k)=(2,2): in qtBinom q t 3 2 the i=1 factor has numerator 1 - q^2 t and denominator 1 - q^2 t (since 3-1 = 2 = 1+1), so it cancels to 1, leaving (1 - q^3)/(1 - q) = qNumber q 3, independent of t.",
+      "The bridge from the rational Macdonald form to the polynomial Gaussian form at t=1 is a CommRing-level multiplicative q-Pascal: qBinom q n (k+1) · (1 - q^(k+1)) = qBinom q n k · (1 - q^(n-k)). This is unconditional (out-of-range n < k zeros both sides) and is obtained by subtracting the two q-Pascal identities, whose q-weights q^(k+1) and q^(n-k) cancel via linear_combination.",
+      "Lean's field convention (0:R)/0 = 0 turns the naive q=t=1 substitution into a trap: qtBinom 1 1 N (k+1) = 0 because the i=0 factor is exactly 0/0. This is why the Path A non-degeneracy hypothesis q^(j+1) ≠ 1 is mandatory for the t=1 specialization, and why the positive q=t=1 recovery of Nat.multichoose needs a RatFunc.eval lift rather than a direct substitution.",
+      "The Macdonald §VI.6 (q,t)-Pascal recurrence has a rational t-coefficient (1 - t^(k+1))/(1 - q^(n-k) t^k) whose t-factor vanishes at t=1, so it does NOT specialize to the parent's q-Pascal. Finding an interpolating (q,t)-Pascal that does specialize correctly is the deepest remaining task and is left open.",
+      "The k-direction recurrence is preferred over a Pascal-style two-direction recurrence because its denominator (1 - q^(k+1) t^k) depends only on k, not on N — giving a uniform telescoping shape, whereas Pascal-style coefficients have an (n,k)-dependent denominator shape."
+    ]
+  },
+  "sections": [
+    {
+      "id": "preamble",
+      "title": "Module Docstring and Imports",
+      "startLine": 1,
+      "endLine": 142,
+      "summary": "Extensive docstring tracing the S1–S6 PREP cascade and the S2–S5c ACT iterations, stating what the file does and does NOT contain (no positive q=t=1 recovery, no Pascal-style recurrence, no Macdonald-polynomial axiom). Imports Mathlib and the parent q-multichoose entry. Works over a Field R (Path A) so the Macdonald rational product is well-typed.",
+      "mathContext": "Open question: does the Macdonald (q,t)-binomial, evaluated at N = n+k-1, give a well-behaved (q,t)-multichoose?"
+    },
+    {
+      "id": "definitions",
+      "title": "I. Definitions of qtBinom and qtMultichoose",
+      "startLine": 144,
+      "endLine": 165,
+      "summary": "Defines qtBinom q t N k := ∏ i ∈ range k, (1 - q^(N-i) t^i)/(1 - q^(i+1) t^i), the 0-indexed form of the Macdonald (q,t)-binomial, and qtMultichoose q t n k := qtBinom q t (n+k-1) k. Both noncomputable over a Field R.",
+      "mathContext": "$$\\mathrm{qtBinom}(q,t,N,k) := \\prod_{i=0}^{k-1} \\frac{1 - q^{N-i} t^i}{1 - q^{i+1} t^i}, \\quad \\mathrm{qtMultichoose}(q,t,n,k) := \\mathrm{qtBinom}(q,t,n+k-1,k)$$"
+    },
+    {
+      "id": "boundary-k0",
+      "title": "II. Boundary Cases (k = 0)",
+      "startLine": 167,
+      "endLine": 180,
+      "summary": "Empty-product boundaries: qtBinom q t N 0 = 1 and qtMultichoose q t n 0 = 1, both by simp. Tagged @[simp].",
+      "mathContext": "$$\\mathrm{qtBinom}(q,t,N,0) = 1, \\quad \\mathrm{qtMultichoose}(q,t,n,0) = 1$$"
+    },
+    {
+      "id": "boundary-k1",
+      "title": "III. Boundary Cases (k = 1)",
+      "startLine": 182,
+      "endLine": 200,
+      "summary": "Single-factor evaluations qtBinom q t N 1 = (1 - q^N)/(1 - q) and qtMultichoose q t n 1 = (1 - q^n)/(1 - q), both independent of t because the product runs over the single term i=0 where t^0 = 1.",
+      "mathContext": "$$\\mathrm{qtBinom}(q,t,N,1) = \\frac{1 - q^N}{1 - q}, \\quad \\text{independent of } t$$"
+    },
+    {
+      "id": "k-recurrence",
+      "title": "IV. k-Direction Multiplicative Recurrence",
+      "startLine": 202,
+      "endLine": 223,
+      "summary": "The foundational unconditional recurrence qtBinom_succ: qtBinom q t N (k+1) = qtBinom q t N k · ((1 - q^(N-k) t^k)/(1 - q^(k+1) t^k)), a direct application of Finset.prod_range_succ. No hypothesis on q, t, N, k.",
+      "mathContext": "$$\\mathrm{qtBinom}(q,t,N,k+1) = \\mathrm{qtBinom}(q,t,N,k) \\cdot \\frac{1 - q^{N-k} t^k}{1 - q^{k+1} t^k}$$"
+    },
+    {
+      "id": "t-eq-one",
+      "title": "V. Specialization at t = 1 (S3 ACT)",
+      "startLine": 225,
+      "endLine": 294,
+      "summary": "The private helper qBinom_mult_recur (CommRing multiplicative q-Pascal, derived by subtracting the two q-Pascal identities) bridges the Macdonald side to the Gaussian side. The headline qtBinom_at_t_eq_one (induction on k) and its corollary qtMultichoose_at_t_eq_one establish qtBinom q 1 N k = qBinom q N k and qtMultichoose q 1 n k = qMultichoose q n k, under the Path A non-degeneracy hypothesis q^(j+1) ≠ 1 for j < k.",
+      "mathContext": "$$\\mathrm{qtMultichoose}(q,1,n,k) = \\mathrm{qMultichoose}(q,n,k) \\quad \\text{for } q^{j+1} \\neq 1,\\ j < k$$"
+    },
+    {
+      "id": "sublattice-trap",
+      "title": "VI. Polynomial Sub-lattice and the Field 0/0 Trap (S4 ACT)",
+      "startLine": 296,
+      "endLine": 362,
+      "summary": "qtMultichoose_two_two: the unique interior point (2,2) cancels its t-dependence to (1 - q^3)/(1 - q) under the guard 1 - q^2 t ≠ 0. qtBinom_at_one_one_eq_zero and its qtMultichoose corollary formalize the Field-R 0/0 trap: the naive q=t=1 substitution collapses to 0, not Nat.multichoose, because the i=0 factor is 0/0 = 0.",
+      "mathContext": "$$\\mathrm{qtMultichoose}(q,t,2,2) = \\frac{1 - q^3}{1 - q}; \\qquad \\mathrm{qtBinom}(1,1,N,k+1) = 0 \\text{ (Field } R \\text{ trap)}$$"
+    },
+    {
+      "id": "ratio-form",
+      "title": "VII. k-Direction Telescoping Ratio Identity (S6 ACT)",
+      "startLine": 364,
+      "endLine": 396,
+      "summary": "qtBinom_succ_div: when qtBinom q t N k ≠ 0, the consecutive ratio is the clean rational function (1 - q^(N-k) t^k)/(1 - q^(k+1) t^k). The ratio form is the natural foundation for telescoping/chain arguments, complementing the multiplicative qtBinom_succ.",
+      "mathContext": "$$\\frac{\\mathrm{qtBinom}(q,t,N,k+1)}{\\mathrm{qtBinom}(q,t,N,k)} = \\frac{1 - q^{N-k} t^k}{1 - q^{k+1} t^k}$$"
+    },
+    {
+      "id": "bridges-qnumber",
+      "title": "VIII. Polynomial-Form Bridges to the Parent's qNumber (S5 ACT)",
+      "startLine": 398,
+      "endLine": 457,
+      "summary": "Three bridges expressing the polynomial-sub-lattice points as the parent's polynomial qNumber: qtBinom_one_right_eq_qNumber, qtMultichoose_one_right_eq_qNumber (at k=1, under 1 - q ≠ 0), and qtMultichoose_two_two_eq_qNumber (at (2,2), under both guards), all via qNumber_geometric.",
+      "mathContext": "$$\\mathrm{qtMultichoose}(q,t,n,1) = \\mathrm{qNumber}(q,n), \\quad \\mathrm{qtMultichoose}(q,t,2,2) = \\mathrm{qNumber}(q,3)$$"
+    },
+    {
+      "id": "bridges-qbinom",
+      "title": "IX. Direct Bridges to the Parent's qBinom / qMultichoose (S5b ACT)",
+      "startLine": 459,
+      "endLine": 492,
+      "summary": "Four direct bridges from the k ≤ 1 slice to the parent's named objects: qtBinom_zero_right_eq_qBinom and qtMultichoose_zero_right_eq_qMultichoose (unconditional, both = 1), and qtBinom_one_right_eq_qBinom and qtMultichoose_one_right_eq_qMultichoose (under 1 - q ≠ 0), composing the qNumber bridges with the parent's qBinom_one_right / qMultichoose_one_right.",
+      "mathContext": "$$\\mathrm{qtMultichoose}(q,t,n,1) = \\mathrm{qMultichoose}(q,n,1) \\quad (1 - q \\neq 0)$$"
+    },
+    {
+      "id": "bridge-interior",
+      "title": "X. (2,2) Interior Bridge to qMultichoose (S5c ACT)",
+      "startLine": 494,
+      "endLine": 518,
+      "summary": "qtMultichoose_two_two_eq_qMultichoose: the unique interior polynomial-sub-lattice point equals the parent's qMultichoose q 2 2 under both Path A guards, composing qtMultichoose_two_two_eq_qNumber with the parent's qMultichoose_two_left. This closes the bridge chain: every point of {k ≤ 1} ∪ {(2,2)} is now equated directly to a parent-side named object.",
+      "mathContext": "$$\\mathrm{qtMultichoose}(q,t,2,2) = \\mathrm{qMultichoose}(q,2,2) \\quad (1 - q^2 t \\neq 0,\\ 1 - q \\neq 0)$$"
+    }
+  ],
+  "conclusion": {
+    "summary": "The Macdonald (q,t)-binomial, evaluated at the multichoose index shift N = n+k-1, yields a (q,t)-multichoose coefficient that is well-typed over a Field R and recovers the parent's qMultichoose at t=1 on the open dense set where q is not a low-order root of unity (Path A). The (q,t)-multichoose is t-independent precisely on the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)}, and every point there is bridged to the parent's qNumber/qBinom/qMultichoose. The file is sorry-free and axiom-free (18 machine-checked theorems), but the open question is only partially resolved.",
+    "implications": "This is the gallery's first contact with Macdonald (q,t)-binomial theory, an area entirely absent from Mathlib v4.26.0 (no Macdonald polynomials, Hall-Littlewood functions, or DAHA). The k-direction multiplicative recurrence and its ratio form give clean Lean handles on the Macdonald binomial that future work can reuse. The explicit formalization of the Field-R 0/0 trap is a reusable cautionary pattern for any rational-function specialization under Lean's 0/0 = 0 convention.",
+    "openQuestions": [
+      "Positive q=t=1 recovery: prove qtMultichoose 1 1 n k = Nat.multichoose n k by lifting to RatFunc ℚ and evaluating (Path C), avoiding the Field-R 0/0 trap. Estimated ~80–120 LOC and likely multi-session.",
+      "Interpolating (q,t)-Pascal recurrence: find an explicit a(n,k) such that qtMultichoose q t (n+1) (k+1) = qtMultichoose q t (n+1) k + q^(k+1) t^(a(n,k)) · qtMultichoose q t n (k+1) and that specializes to the parent's q-Pascal at t=1. Prior PREP analysis falsified the naive candidate at small cases; this is the deepest remaining task.",
+      "Macdonald polynomial connection: identify (and optionally axiomatize) the Macdonald polynomial principal-specialization identity that the (q,t)-multichoose realizes (Macdonald §VI.6, Exercise 1)."
+    ]
+  },
+  "crossReferences": [
+    {
+      "id": "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03",
+      "title": "q-Multichoose: The Gaussian Binomial as q-Analog of Multiset Coefficients",
+      "relationship": "parent — this entry answers (partially) the (q,t)-deformation open question posed in the parent's conclusion; it recovers the parent's qMultichoose at t=1 and bridges its polynomial sub-lattice to the parent's named objects"
+    },
+    {
+      "id": "combinations-formula-oq-03",
+      "title": "q-Analog Binomial Coefficients (Gaussian Binomial Coefficients)",
+      "relationship": "dependency — provides qBinom, qBinom_pascal, qBinom_pascal', qBinom_eq_zero_of_lt, qBinom_one_right, and qNumber_geometric, used to derive the t=1 specialization and the polynomial-form bridges"
+    }
+  ],
+  "leanFile": {
+    "path": "Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean",
+    "namespace": "QtMultichooseCoefficients",
+    "imports": [
+      "Mathlib",
+      "Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03"
+    ],
+    "axiomCount": 0,
+    "lineCount": 518,
+    "theoremCount": 18,
+    "definitionCount": 2,
+    "sorries": 0,
+    "additionalFiles": []
+  },
+  "sorries": 0
+}


### PR DESCRIPTION
## Summary

Adds the **S7 gallery integration** for `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02` — the Macdonald-style (q,t)-deformation of the q-multichoose coefficient. The Lean file (`Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03OQ02.lean`, 18 theorems, 2 defs, **0 sorries, 0 axioms**, Docker-verified 7745/7745 in prior iterations) had no gallery entry; this PR creates `meta.json` + `annotations.json` so the work is visible in the gallery.

This is the **first gallery entry to engage with Macdonald (q,t)-binomial theory** (absent from Mathlib v4.26.0).

## What the entry documents
- `qtBinom`/`qtMultichoose` definitions (Macdonald rational product over `Field R`, Path A)
- Unconditional k-direction multiplicative recurrence + ratio form
- Recovery of the parent's `qMultichoose` at `t=1` (under Path A non-degeneracy `q^(j+1) ≠ 1`)
- The polynomial sub-lattice `{k ≤ 1} ∪ {(2,2)}` where `t` cancels, with bridges to the parent's `qNumber`/`qBinom`/`qMultichoose`
- The `Field R` 0/0 trap formalizing why the naive `q=t=1` substitution collapses to 0

## Status: `axiomatized` (honest)
No axiom declarations and no sorries — every theorem is machine-checked — but the open question is only **partially resolved**: the headline results are conditional (Path A hypotheses), the positive `q=t=1` recovery of `Nat.multichoose` is NOT formalized (only the negative 0/0-trap form), and the interpolating (q,t)-Pascal recurrence remains open. The `assumptions` field states all of this explicitly, per the project axiom-integrity policy ("open conjectures: always axiomatized").

## Test plan
- [x] `meta.json` and `annotations.json` are valid JSON
- [x] `pnpm annotations:validate` produces **no warnings for this entry** (all 8 annotations resolve to Lean constructs)
- [x] No Lean source changed (file unchanged from prior Docker-verified state)
- [x] Referenced parent lemmas (`qNumber_geometric`, `qMultichoose_two_left`, `qMultichoose_one_right`) confirmed present

🤖 Generated with [Claude Code](https://claude.com/claude-code)