### PR TITLE
Fix: erdos-28 axiomCount 3 -> 2 to match Lean source

### DIFF
--- a/src/data/proofs/erdos-28/meta.json
+++ b/src/data/proofs/erdos-28/meta.json
@@ -18,7 +18,7 @@
     "sourceUrl": "https://erdosproblems.com/28",
     "erdosUrl": "https://erdosproblems.com/28",
     "proofRepoPath": "Proofs/Erdos28AdditiveBases.lean",
-    "axiomCount": 3,
+    "axiomCount": 2,
     "assumptions": "2 axioms: grekos_lower_bound (Grekos et al. 2003: r_A(n) ≥ 6 infinitely often), borwein_lower_bound (Borwein et al.: r_A(n) ≥ 8 infinitely often). sidon_not_basis PROVED as theorem (PR #6840). sidon_density_bound PROVED via bridge lemma importing Erdos340.sidon_upper_bound_weak. 14 theorems proved including isAsymptoticBasis_iff, sidon_repFunc_bounded, erdos_turan_holds_for_nat, basis_element_count_sq, sidon_density_bound.",
     "badge": "axiom",
     "prerequisites": [


### PR DESCRIPTION
## Fix

Correct `meta.axiomCount` for erdos-28 from `3` to `2`.

## Evidence

**Before**: `meta.axiomCount: 3`
**After**: `meta.axiomCount: 2`

The Lean source `proofs/Proofs/Erdos28AdditiveBases.lean` declares exactly 2 axioms (`grekos_lower_bound` L229, `borwein_lower_bound` L233). No structure/class declarations → no structure-encoded assumptions. The corrected value now matches `leanFile.axiomCount: 2` and the `assumptions` text in the same file. Status `axiomatized` / badge `axiom` were already correct.

Closes #22904

---
Automated fix by lean-mechanic agent.