### PR TITLE
research(minpoly-charpoly-oq-03): S14-align OQ-03-OQ-01 bridge statement

### DIFF
--- a/proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean
+++ b/proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean
@@ -189,14 +189,25 @@ The chain is packaged as the parent's `InvariantFactorChain` structure
 
 /-- **OQ-03-OQ-02 target (statement, sorry-guarded here)**:
     `xModule M` admits an invariant-factor chain whose product equals
-    `M.charpoly`. This is a restatement of the parent's
-    `rational_canonical_form_exists` consuming the F[X]-module
-    constructed in this file. The two are mutually-derivable; the
-    benefit of stating both is to fix the bridging surface between
-    this sub-OQ and the parent. -/
+    `M.charpoly` **and** whose last factor equals `minpoly F M`. This is
+    a restatement of the parent's `rational_canonical_form_exists`
+    consuming the F[X]-module constructed in this file. The two are
+    mutually-derivable; the benefit of stating both is to fix the
+    bridging surface between this sub-OQ and the parent.
+
+    *Faithfulness note (S14-alignment).* The `lastFactor = minpoly`
+    conjunct is **not** optional padding: without it the existential is
+    vacuously satisfiable by a degenerate chain (`factors = [M.charpoly]`
+    for nonempty `n`, or the empty chain for the `0 × 0` case), which
+    would make the bridge strictly weaker than the parent's S14
+    strong-form `rational_canonical_form_exists`. Adding `c.lastFactor =
+    minpoly F M` forces the genuine invariant-factor decomposition
+    (`minpoly = charpoly` holds only for non-derogatory `M`), restoring
+    the claimed mutual-derivability with the parent. The proof remains
+    deferred to the OQ-03-OQ-02 regrouping algorithm. -/
 theorem xModule_has_invariantFactorChain (M : Matrix n n F) :
     ∃ c : MinpolyCharpolyOQ03.InvariantFactorChain F,
-      c.prodFactors = M.charpoly := by
+      c.prodFactors = M.charpoly ∧ c.lastFactor = minpoly F M := by
   sorry
 
 end MinpolyCharpolyOQ03OQ01


### PR DESCRIPTION
## Summary

Strengthens `xModule_has_invariantFactorChain` in
`proofs/Proofs/MinpolyCharpolyOQ03OQ01.lean` to require **both**
`c.prodFactors = M.charpoly` **and** `c.lastFactor = minpoly F M`,
matching the parent's S14 strong-form `rational_canonical_form_exists`
in `MinpolyCharpolyOQ03.lean`.

## Why (faithfulness fix)

The prior `prodFactors = charpoly`-only statement was **vacuously
satisfiable** by a degenerate invariant-factor chain:
- `factors = [M.charpoly]` for nonempty `n` (single monic factor of
  positive degree `= Fintype.card n`, trivial divisibility chain), or
- the empty chain for the `0 × 0` case (`prodFactors = 1 = charpoly`).

So the bridge was strictly weaker than the parent it claimed to be
"mutually-derivable" with. The added `c.lastFactor = minpoly F M`
conjunct forces the genuine invariant-factor decomposition
(`minpoly = charpoly` only for non-derogatory `M`), restoring the
intended bridging surface to the parent. Proof remains deferred
(`sorry`) to the OQ-03-OQ-02 regrouping algorithm.

## Status

- **UNVERIFIED / build-pending** per this slug's S2–S5 convention
  (`proofs/.lake` self-symlink trap precludes a local Docker build here).
- Statement-only change guarded by `sorry`; `minpoly F M` elaborates
  under the same `[Field F] [Fintype n] [DecidableEq n]` instances the
  parent uses for the identical term.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.MinpolyCharpolyOQ03OQ01`
      (deferred — self-symlink trap; build-pending per slug convention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)