### PR TITLE
Fix: angle-trisection mainTheorems match Lean signatures

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -307,14 +307,14 @@
     {
       "name": "angle_trisection_impossible",
       "type": "core",
-      "description": "The general angle cannot be trisected by compass and straightedge",
-      "leanType": "not (forall theta, exists constructible_trisection theta)"
+      "description": "60 degrees cannot be trisected: cos(20 deg) is not constructible (degree 3 over Q)",
+      "leanType": "¬ IsConstructible (cos angle20) 3"
     },
     {
-      "name": "sixty_degree_not_trisectible",
+      "name": "cube_doubling_impossible",
       "type": "key",
-      "description": "60 degrees cannot be trisected: cos(20 deg) is not constructible",
-      "leanType": "not (Constructible (Real.cos (20 * pi / 180)))"
+      "description": "Doubling the cube is impossible: the cube root of 2 is not constructible (degree 3 over Q)",
+      "leanType": "¬ IsConstructible ((2 : ℝ)^((1 : ℝ)/3)) 3"
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Fix

Correct the `mainTheorems` array in `src/data/proofs/angle-trisection/meta.json` to reference theorems that actually exist in `proofs/Proofs/AngleTrisection.lean` with their real signatures.

## Evidence

**Before**:
- `angle_trisection_impossible` → `leanType: "not (forall theta, exists constructible_trisection theta)"` (predicate `constructible_trisection` does not exist)
- `sixty_degree_not_trisectible` → does not exist anywhere in the Lean source; references a non-existent `Constructible` predicate

**After**:
- `angle_trisection_impossible` → `"¬ IsConstructible (cos angle20) 3"` (matches AngleTrisection.lean:274-276)
- `cube_doubling_impossible` → `"¬ IsConstructible ((2 : ℝ)^((1 : ℝ)/3)) 3"` (matches AngleTrisection.lean:298-300), replacing the non-existent `sixty_degree_not_trisectible`

Headline `status: "axiomatized"`, `badge: "axiom"`, `sorries: 0`, `axiomCount: 1` were already correct and are unchanged.

Closes #22902

---
Automated fix by lean-mechanic agent.