### PR TITLE
audit(buffons-needle-oq-02): re-audit clean — meta matches Lean source

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -1373,9 +1373,9 @@
       "result": "clean"
     },
     "buffons-needle-oq-02": {
-      "auditCount": 5,
+      "auditCount": 6,
       "issues": [],
-      "lastAudited": "2026-05-03T16:43:29Z",
+      "lastAudited": "2026-06-13T10:42:31Z",
       "result": "clean"
     },
     "buffons-needle-oq-02-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: buffons-needle-oq-02 (3D Buffon's Noodle)
**Result**: CLEAN — no integrity issues

## Verification

All `meta.json` claims verified against `proofs/Proofs/BuffonsNeedleOQ02.lean`:

| Field | meta.json | Lean source |
|-------|-----------|-------------|
| sorries | 0 | 0 |
| axiomCount | 0 | 0 (no axioms, no structure-encoded assumptions) |
| theoremCount | 16 | 16 |
| definitionCount | 1 | 1 |
| lineCount | 262 | 262 |
| True stubs | — | 0 |

Badge `mathlib` is appropriately conservative — the file proves its integral via Mathlib infrastructure (FTC, derivative lemmas) rather than delegating its core result to a single deep theorem. The one nuance — `buffon3d` is a *definition* of L/(2d) rather than a measure-theoretically derived expectation — is honestly disclosed in `originalContributions`. No overclaiming.

Only change: tracker bump (auditCount 5→6, lastAudited timestamp).

---
Discovered during gallery integrity audit. No `loom:review-requested` — deployer merges math PRs directly.