### PR TITLE
research(infinitude-primes-4k1-oq-03): S7 fix Mathlib API drift breaking parent file

### DIFF
--- a/proofs/Proofs/InfinitudePrimes4k1.lean
+++ b/proofs/Proofs/InfinitudePrimes4k1.lean
@@ -65,7 +65,9 @@ lemma prime_dvd_sq_add_one_mod_four {p k : ℕ} (hp : Nat.Prime p) (hp2 : p ≠ 
     exact h.symm
   -- Apply the key lemma from Mathlib
   haveI : Fact (Nat.Prime p) := ⟨hp⟩
-  have hne3 := Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one hp (dvd_refl p) hsq
+  have hpmem : p ∈ Nat.primeFactors p :=
+    Nat.mem_primeFactors.mpr ⟨hp, dvd_refl p, hp.pos.ne'⟩
+  have hne3 := Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one hpmem hsq
   -- p % 4 ∈ {0, 1, 2, 3}, p is odd prime, so p % 4 ∈ {1, 3}
   have hodd : Odd p := hp.odd_of_ne_two hp2
   have hmod : p % 4 = 1 ∨ p % 4 = 3 := by
@@ -83,8 +85,10 @@ lemma exists_odd_prime_factor {n : ℕ} (hn : n > 1) (hodd : Odd n) :
   use p, hp_prime, hp_div
   intro hp2
   rw [hp2] at hp_div
-  have : Even n := even_iff_two_dvd.mpr hp_div
-  exact (Nat.odd_iff_not_even.mp hodd) this
+  have heven : Even n := even_iff_two_dvd.mpr hp_div
+  obtain ⟨k, hk⟩ := hodd
+  obtain ⟨m, hm⟩ := heven
+  omega
 
 /-! ## The Main Theorem -/
 
@@ -129,7 +133,7 @@ theorem infinitely_many_primes_1_mod_4 :
       exact dvd_mul_of_dvd_left hp_dvd_2fact _
     -- But p ∣ N = (2 * (n+1)!)² + 1
     -- So p ∣ N - (2 * (n+1)!)² = 1
-    have hp_dvd_diff : p ∣ N - (2 * (n + 1).factorial) ^ 2 := Nat.dvd_sub' hp_div hp_dvd_sq
+    have hp_dvd_diff : p ∣ N - (2 * (n + 1).factorial) ^ 2 := Nat.dvd_sub hp_div hp_dvd_sq
     -- N - (2*(n+1)!)² = (2*(n+1)!)² + 1 - (2*(n+1)!)² = 1
     have hN_sub : N - (2 * (n + 1).factorial) ^ 2 = 1 := by simp only [N]; omega
     rw [hN_sub] at hp_dvd_diff

--- a/research/problems/infinitude-primes-4k1-oq-03/knowledge.md
+++ b/research/problems/infinitude-primes-4k1-oq-03/knowledge.md
@@ -596,3 +596,53 @@ docstring as a 5-step plan (~100-150 lines):
 
 All required Mathlib API is verified present at the v4.26.0 pin. S7 can
 attack the proof body directly; the structure is no longer ambiguous.
+
+## S7 (researcher-2, 2026-06-13) — BUILD REPAIR: parent file Mathlib API drift
+
+### Critical finding: the OQ-03 chain did not compile
+
+A Docker verification build (`docker-build.sh Proofs.InfinitudePrimes4k1OQ03`)
+revealed that the **parent** file `Proofs/InfinitudePrimes4k1.lean` — described
+in S1 knowledge as "178 lines, 5 theorems, 0 sorries, 0 axioms, already
+verified" — **no longer compiles** against the current Mathlib pin (v4.26.0,
+`2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`). Because OQ-03's file imports the
+parent, the entire OQ-03 chain was uncompilable. All six prior iterations
+(S1–S6) merged "build pending" and none caught this; the parent had silently
+bit-rotted under Mathlib API drift.
+
+Three hard errors in `InfinitudePrimes4k1.lean`:
+
+1. **L68** `Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one` — signature
+   changed to take `p ∈ Nat.primeFactors n` (not `(hp : Prime p) (h : p ∣ n)`).
+   Fix: pass `Nat.mem_primeFactors.mpr ⟨hp, dvd_refl p, hp.pos.ne'⟩`.
+2. **L87** `Nat.odd_iff_not_even` — removed constant. Fix: destructure
+   `Odd n`/`Even n` and close with `omega` (immune to future name churn).
+3. **L132** `Nat.dvd_sub'` — removed constant (renamed). Fix: `Nat.dvd_sub`.
+
+(Also a non-fatal deprecation warning at L55 `ZMod.natCast_zmod_eq_zero_iff_dvd`
+→ `ZMod.natCast_eq_zero_iff`, left untouched to keep the diff minimal.)
+
+### Build status: NOT verified this session (infra blocker)
+
+The repaired build could not be confirmed green: the Docker host disk reached
+100% capacity, crashing Docker Desktop mid-cache-unpack (`tar.rs:201` I/O
+panic, containerd `meta.db` write failure, exit 125). This is an environment
+failure, not a Lean error. The three fixes target the exact compiler errors
+emitted by the first (pre-crash) build run, which had progressed far enough to
+type-check the parent file and report these three errors specifically. Fixes 1
+and 2 are high-confidence; fix 3 relies on the standard `Nat.dvd_sub'`→
+`Nat.dvd_sub` rename (the `'` form is reported as a *removed* constant, which is
+the signature of that rename).
+
+The parent file is already red on `main`, so committing these fixes is strictly
+non-regressive. An auditor/deployer should re-run the Docker build once host
+disk is reclaimed to confirm green before treating the chain as verified.
+
+### S7 deliverable summary
+
+* **1 file changed**: `proofs/Proofs/InfinitudePrimes4k1.lean` (3 fixes).
+* **0 new Lean files**, **0 new theorems**, **0 axiom changes**, **0 sorry
+  changes** (the two OQ-03 target sorries `mertens_log_density_4k1` and
+  `primes_4k1_natural_density` are untouched).
+* **Build: NOT verified** (Docker host disk exhaustion — infra). Fixes address
+  concretely-observed errors; re-verification required post-infra-recovery.

--- a/research/problems/infinitude-primes-4k1-oq-03/state.md
+++ b/research/problems/infinitude-primes-4k1-oq-03/state.md
@@ -1,10 +1,24 @@
 # Current State
 
-**Phase**: ACT (path-B + path-C scaffolding, S6 logarithmic-density statement scaffold)
-**Since**: 2026-05-12 (S6)
-**Iteration**: 6
+**Phase**: ACT (build repair — parent file Mathlib API drift)
+**Since**: 2026-06-13 (S7)
+**Iteration**: 7
 
 ## Current Focus
+
+S7 (researcher-2, 2026-06-13): **BUILD REPAIR.** A Docker verification build
+revealed the parent file `Proofs/InfinitudePrimes4k1.lean` (claimed verified,
+0 sorries) no longer compiles under the current Mathlib pin — three API-drift
+errors that silently broke the entire OQ-03 chain across all six prior
+build-pending iterations. Fixed all three (`mod_four_ne_three_of_dvd_isSquare_neg_one`
+new `primeFactors` signature; removed `Nat.odd_iff_not_even` → omega; renamed
+`Nat.dvd_sub'` → `Nat.dvd_sub`). **Build NOT verified this session**: the Docker
+host disk hit 100% and crashed Docker Desktop mid-build (infra failure, not a
+Lean error). Fixes target the exact pre-crash compiler errors; re-verification
+needed once host disk is reclaimed. The two OQ-03 target sorries are untouched.
+See knowledge.md S7 for full detail.
+
+## Previous Focus (Session 6)
 
 S6 (researcher-4, 2026-05-12): **Statement-only SCAFFOLD** for the
 logarithmic-density target. Added one new theorem to


### PR DESCRIPTION
## Summary

A Docker verification build of `Proofs.InfinitudePrimes4k1OQ03` revealed that the **parent** file `proofs/Proofs/InfinitudePrimes4k1.lean` — described in prior knowledge as "verified, 0 sorries, 0 axioms" — **no longer compiles** under the current Mathlib pin (v4.26.0). Because the OQ-03 file imports the parent, the entire OQ-03 chain was uncompilable. All six prior iterations (S1–S6) merged "build pending" and none caught this; the parent had silently bit-rotted under Mathlib API drift.

Three API-drift fixes in `InfinitudePrimes4k1.lean`:

1. `Nat.Prime.mod_four_ne_three_of_dvd_isSquare_neg_one` — signature changed to take `p ∈ Nat.primeFactors n`; now passes `Nat.mem_primeFactors.mpr ⟨hp, dvd_refl p, hp.pos.ne'⟩`.
2. `Nat.odd_iff_not_even` (removed constant) — replaced with destructure of `Odd`/`Even` + `omega` (immune to future name churn).
3. `Nat.dvd_sub'` (removed/renamed) → `Nat.dvd_sub`.

The two OQ-03 target sorries (`mertens_log_density_4k1`, `primes_4k1_natural_density`) are untouched.

## ⚠️ Build NOT verified this session (infra blocker)

The repaired build could not be confirmed green: the Docker host disk reached 100% capacity and crashed Docker Desktop mid-cache-unpack (`tar.rs` I/O panic, exit 125) — an environment failure, not a Lean error. The fixes target the **exact** compiler errors emitted by the first (pre-crash) build run, which had type-checked the parent far enough to report these three errors specifically. Fixes 1 and 2 are high-confidence; fix 3 is the standard `dvd_sub'`→`dvd_sub` rename.

The parent is already red on `main`, so this change is strictly **non-regressive**.

## Test plan

- [ ] Re-run `./proofs/scripts/docker-build.sh Proofs.InfinitudePrimes4k1OQ03` once host disk is reclaimed and confirm a green build before treating the OQ-03 chain as verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)