### PR TITLE
fix(aristotle): mcp-smoke-test JSON encoding works on bash 3.2 (macOS)

### DIFF
--- a/scripts/aristotle/mcp-smoke-test.sh
+++ b/scripts/aristotle/mcp-smoke-test.sh
@@ -101,13 +101,24 @@ MCP_CMD=(uvx --from "git+https://github.com/septract/lean-aristotle-mcp@${PINNED
 # project id in the response, or after 30 seconds total (10s for the
 # project id alone, but uvx may need extra time to fetch the package on
 # first run).
+# JSON-encode the snippet portably. We previously used ${SNIPPET@Q}, but the
+# @Q parameter transform requires bash 4.4+, while macOS ships bash 3.2 — there
+# it expands to "bad substitution", corrupting the request stream and faking a
+# handshake failure. Escape backslashes then double quotes by hand instead.
+json_escape() {
+    local s=$1
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    printf '"%s"' "$s"
+}
 SNIPPET='example : 1 + 1 = 2 := by sorry'
+SNIPPET_JSON=$(json_escape "$SNIPPET")
 
 REQUESTS=$(cat <<JSON
 {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"mcp-smoke-test","version":"0.1.0"}}}
 {"jsonrpc":"2.0","method":"notifications/initialized","params":{}}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
-{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"prove","arguments":{"code":${SNIPPET@Q},"wait":false}}}
+{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"prove","arguments":{"code":${SNIPPET_JSON},"wait":false}}}
 JSON
 )
 


### PR DESCRIPTION
## Summary
The Aristotle MCP smoke test was unusable on macOS. It built the `prove()`
JSON-RPC request with `${SNIPPET@Q}` — a bash 4.4+ parameter transform —
but macOS ships bash 3.2, where `@Q` expands to `bad substitution`. That
corrupted the request stream, so the server reported a spurious
`handshake failed` / `Internal Server Error` and masked the real backend
status.

## Fix
Replace `${SNIPPET@Q}` with a portable `json_escape` helper using
`${var//pat/rep}` substitution (available since bash 3.0). No behavior
change on bash 4.4+; correct behavior restored on bash 3.2.

## Verification
- `bash -n` passes; confirmed running shell is `GNU bash 3.2.57`.
- Before: `bad substitution` → `No response to initialize request — handshake failed`.
- After: handshake completes, `tools/list`/`tools/call` succeed, and the
  test reaches the real Harmonic API — which currently returns
  `HTTP 404 on /api/v1/project`. So the smoke test now correctly
  distinguishes a *script* failure from a *backend* outage.

## Note on backend status
This PR does not fix the backend: Aristotle's `/api/v1/project` endpoint
is returning 404 (service appears down). The value here is that the smoke
test now reports that truthfully instead of failing at the bash layer.

🤖 Generated by researcher-2