### PR TITLE
research(erdos-1210): S4 survey — achievable-bounds landscape + canonical JSON state correction

### DIFF
--- a/research/problems/erdos-1210/knowledge.md
+++ b/research/problems/erdos-1210/knowledge.md
@@ -159,6 +159,50 @@ i.e., is the proximity-weighted harmonic sum over any pairwise coprime set bound
   pairwise coprime A (e.g. via the ≤1-even-element structure + a sieve/Mertens
   estimate), which would be genuine progress toward the open problem.
 
+### Session 2026-06-13 (Session 4) — researcher-1
+
+**Mode**: ITERATION (SURVEY only — Docker unreliable [`docker ps` hangs], Aristotle backend 404; no verification route, so no Lean changes shipped this session).
+**Outcome**: Tractability-boundary survey for the S4 partial-bound goal, plus a canonical-JSON state correction (the research JSON `progressSummary`/`nextSteps` still described the Session-1 mis-transcribed `1/(n-p)` form; brought into line with S3's corrected statement).
+
+#### The achievable-bounds landscape (what S4 should and should not target)
+
+The conjecture's target is a **`log log n`** (Mertens-order) bound, uniform in
+`n` and `A`. Two very different difficulty regimes:
+
+1. **Trivial `log n` baseline (no coprimality needed, elementary, provable).**
+   For *any* `A ⊆ [1,n)` with distinct elements, the values `{n − a : a ∈ A}`
+   are distinct integers in `[1, n−1]`, so
+   `∑_{a∈A} 1/(n−a) = ∑_{m ∈ {n−a : a∈A}} 1/m ≤ ∑_{m=1}^{n−1} 1/m = H_{n−1} ~ log n`.
+   This uses none of the pairwise-coprimality hypothesis. In Lean it is a
+   "sum over an injective image ≤ sum over the full range" argument
+   (`Finset.sum_le_sum_of_subset_of_nonneg` after mapping `a ↦ n − a`, with
+   injectivity of `a ↦ n − a` on `A ⊆ [1,n)`). **This is the right next ACT
+   deliverable** — a genuine *unconditional* `theorem` bounding the LHS by the
+   harmonic number, instantiating the conjecture's `C`-free shape with `f(n) =
+   H_{n−1}`. It is honest partial progress (a verified upper bound), but it is
+   **NOT** the conjecture: `log n ≫ log log n`.
+
+2. **The conjecture's `log log n` is the hard part — and it is the
+   coprimality that must close the `log n → log log n` gap.** Getting from the
+   trivial harmonic bound down to Mertens order is exactly where the
+   pairwise-coprime structure (≤ 1 element divisible by each prime `p`) does the
+   work, via a sieve/Mertens comparison. **Blocked by a Mathlib gap**: base
+   Mathlib `v4.26.0` does **not** contain Mertens' second theorem
+   (`∑_{p<n} 1/p = log log n + O(1)`) — see this repo's own assessment in
+   `research/problems/bertrands-postulate-oq-01/state.md` ("Mertens' theorems …
+   not present in base Mathlib v4.26.0"). So even *stating* the RHS asymptotic,
+   let alone proving the comparison, requires analytic number theory that would
+   be a substantial upstream contribution. The full conjecture should be treated
+   as **long-horizon / BLOCKED-on-infra**, not a near-term ACT.
+
+#### Recommendation
+- **S5 ACT (when build infra is reliable)**: ship the trivial `H_{n−1}`
+  unconditional bound from regime (1). Small, fully elementary, no new axioms,
+  Mathlib-reachable. Do **not** attempt the `log log n` conjecture directly.
+- Do not blind-ship the regime-(1) proof while Docker is down — the
+  injective-image reindex is exactly the kind of step that fails silently
+  without a compiler.
+
 ---
 
 *Generated from erdosproblems.com on 2026-04-16; statement corrected from source 2026-06-13.*

--- a/src/data/research/problems/erdos-1210.json
+++ b/src/data/research/problems/erdos-1210.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS (Session 1, 2026-05-03): Formalized Erdős Problem 1210. Defined primesBelow, PairwiseCoprime, ValidSubset. Proved primes are pairwise coprime, primesBelow nonempty for n≥3, at-most-one-even lemma, prime sum positivity. Stated main conjecture as axiom. Derived consequences including singleton bounds. 11 theorems, 1 axiom, 0 sorries.",
+    "progressSummary": "AXIOMATIZED (open conjecture), statement corrected. S1 (2026-05-03): formalized with primesBelow/PairwiseCoprime/ValidSubset + structural lemmas (≤1 even element); main conjecture as axiom. S2 (2026-06-09): found the S1 axiom was UNSOUND — double transcription error (RHS written as ∑1/(n-p) instead of ∑1/p, and the essential +O(1) dropped); witness n=5,A={4}. S3 (2026-06-13, researcher-2): recovered verbatim statement from erdosproblems.com/1210, re-axiomatized in the honest existential-constant Mertens form (∃C, ∀n≥3, ∀ pairwise-coprime A⊆[1,n), ∑1/(n-a) ≤ ∑_{p<n}1/p + C), added primeReciprocalSum + machine-checked `naive_statement_fails_at_five`/`corrected_statement_consistent_at_five` proving the O(1) term is essential; Docker-verified. File now: 14 theorems, 4 defs, 1 axiom (the open conjecture), 0 sorries. S4 (2026-06-13, researcher-1, SURVEY): mapped the achievable-bounds landscape — a trivial unconditional log n (harmonic H_{n-1}) bound is elementary/Mathlib-reachable and is the right next ACT deliverable; the conjecture target log log n is the hard part (coprimality closing the log n→log log n gap) and is BLOCKED on Mertens 2nd theorem being absent from base Mathlib v4.26.0. No Lean changes S4 (Docker unreliable, Aristotle 404).",
     "builtItems": [
       "primesBelow: Finset.range(n).filter Nat.Prime (Erdos1210Problem.lean:50)",
       "PairwiseCoprime: pairwise gcd=1 predicate (line:54)",
@@ -57,8 +57,9 @@
       "No direct Mathlib theorem about optimality of primes for harmonic-type sums over coprime sets"
     ],
     "nextSteps": [
-      "Docker build verification",
-      "Extension: prove asymptotic bound ∑_{p<n} 1/(n-p) ~ log log n using prime counting"
+      "S5 ACT (when build infra reliable): ship the trivial UNCONDITIONAL bound ∑_{a∈A} 1/(n-a) ≤ H_{n-1} (~log n) via the injective image a↦n-a ⊆ [1,n-1] + Finset.sum_le_sum_of_subset_of_nonneg. Elementary, no new axioms, no coprimality needed. Honest partial progress (verified upper bound), though weaker than the log log n conjecture.",
+      "BLOCKED/long-horizon: the conjecture target ∑1/(n-a) ≤ ∑_{p<n}1/p + O(1) (log log n) requires Mertens 2nd theorem (∑_{p<n}1/p = log log n + O(1)), which is ABSENT from base Mathlib v4.26.0 (cf. research/problems/bertrands-postulate-oq-01/state.md). Closing the log n→log log n gap is where pairwise-coprimality (≤1 element per prime) must be used via a sieve/Mertens comparison. Treat as upstream-Mathlib-dependent, not a near-term ACT.",
+      "Do NOT blind-ship Lean while Docker is down — the injective-image reindex step fails silently without a compiler."
     ],
     "markdown": "# Erdős #1210 - Knowledge Base\n\n## Problem Statement\n\nLet $A \\subseteq [1,n)$ be pairwise coprime (gcd(a,b)=1 for distinct a,b∈A). Is it true that\n$$\\sum_{a \\in A} \frac{1}{n-a} \\leq \\sum_{\\substack{p < n \\ p \text{ prime}}} \frac{1}{n-p}$$\n\n**Status**: OPEN (Erdős, Er80, Er77c)\n\n## Sessions\n\n### Session 2026-05-03 (Session 1) — researcher-10 + researcher-11\n\nFormalized the problem. Defined primesBelow, PairwiseCoprime, ValidSubset. Proved:\n- primes_coprime: distinct primes are coprime\n- primesBelow_pairwiseCoprime: primesBelow is pairwise coprime\n- pairwiseCoprime_at_most_one_even: ≤1 even element in any pairwise coprime set\n- primesBelow_sum_pos: prime sum strictly positive for n≥3\n- 4 consequence theorems\n\nStated main conjecture as axiom (erdos_1210). 11 theorems, 1 axiom, 0 sorries.\nGallery entry created: index.ts + annotations.json (researcher-11).\nPR #15117 open.\n"
   },


### PR DESCRIPTION
## Summary

Build-free survey/triage session on `erdos-1210` (pairwise-coprime weighted harmonic sum, OPEN Erdős problem). **No Lean files changed** — Docker is unreliable (`docker ps` hangs/timeouts) and the Aristotle backend 404s, so there is no verification route this session.

The Lean file itself is in good shape after S3 (researcher-2, earlier today): the previously-unsound axiom was corrected to the honest existential-constant Mertens form and Docker-verified. This session contributes triage, not Lean.

### 1. Achievable-bounds landscape (de-risks the S4 partial-bound goal)
- **Trivial `log n` baseline (provable, elementary, the right next ACT target).** For distinct `a ∈ A ⊆ [1,n)`, the values `{n−a}` are distinct integers in `[1,n−1]`, so `∑_{a∈A} 1/(n−a) ≤ ∑_{m=1}^{n−1} 1/m = H_{n−1} ~ log n` — uses no coprimality. A genuine *unconditional* verified upper bound, Mathlib-reachable via `Finset.sum_le_sum_of_subset_of_nonneg` after mapping `a ↦ n−a`. Honest partial progress, though weaker than the conjecture.
- **The conjecture's `log log n` is the hard part, and is BLOCKED on a Mathlib gap.** Closing `log n → log log n` is exactly where pairwise-coprimality (≤ 1 element per prime) must be used via a sieve/Mertens comparison. But **Mertens' 2nd theorem (`∑_{p<n} 1/p = log log n + O(1)`) is absent from base Mathlib v4.26.0** (per this repo's own assessment in `research/problems/bertrands-postulate-oq-01/state.md`). So even stating the RHS asymptotic is upstream-Mathlib work; treat the full conjecture as long-horizon, not a near-term ACT.

### 2. Canonical JSON state correction
`src/data/research/problems/erdos-1210.json` still carried the **Session-1** `progressSummary`/`nextSteps`, describing the mis-transcribed `∑ 1/(n−p)` form — predating both the S2 refutation and the S3 statement-correction (which updated `knowledge.md` but not the JSON). Synced to the corrected Mertens-form open conjecture.

## Files modified
- `research/problems/erdos-1210/knowledge.md` (new Session-4 survey section)
- `src/data/research/problems/erdos-1210.json` (progressSummary + nextSteps)

## Status
**Outcome**: surveyed (build-free triage). 0 axioms, 0 theorems, 0 sorries changed.
**Next steps**: S5 ACT (when build infra is reliable) — ship the trivial `H_{n−1}` unconditional bound. Do not blind-ship while Docker is down; do not attempt the Mertens-blocked `log log n` conjecture directly.

🤖 Generated by researcher-1