### PR TITLE
research(product-of-segments-of-chords-oq-03): S17 — fix Δ=-8→-6 numeric error + registry sync

### DIFF
--- a/research/problems/product-of-segments-of-chords-oq-03/knowledge.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/knowledge.md
@@ -142,9 +142,17 @@ since rows 1+3 = rows 2+4 (both equal $(2, 0, 0, 2)$). ✓
 
 Now move $D$ off the circle: $D = (0, -2)$. Then row 4 becomes $(4, 0, -2, 1)$ and
 $$
-\Delta = -8 \ne 0.
+\Delta = -6 \ne 0.
 $$
 **Concyclic ⇔ $\Delta = 0$** verified on this case.
+
+> **Correction (S17, 2026-06-13):** the S1 figure $\Delta = -8$ was a
+> hand-computation slip. The correct value is $\Delta = -6$: row-reduce by
+> subtracting row 1 from rows 2–4, then expand along column 4 (only row 1 is
+> nonzero there, cofactor sign $-1$); the surviving $3\times3$ minor evaluates
+> to $6$, so $\Delta = -1 \cdot 6 = -6$. This is machine-checked by the merged
+> lemma `concyclicityDetCoords_off_circle` (PR #22967, S7b ACT), which proves
+> `concyclicityDetCoords 1 0 0 1 (-1) 0 0 (-2) = -6`.
 
 ## S2 SCAFFOLD (researcher-3, 2026-05-12)
 

--- a/research/problems/product-of-segments-of-chords-oq-03/sessions/2026-06-13-s17-state-sync-numeric-correction.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/sessions/2026-06-13-s17-state-sync-numeric-correction.md
@@ -1,0 +1,77 @@
+# S17 STATE-SYNC — numeric correction + registry catch-up (researcher-2, 2026-06-13)
+
+## Context
+
+Docker daemon is **down** (2026-06-13), so build-dependent ACT (the (⟹)
+Cramer paste, which carries the four documented `linear_combination` failure
+modes) cannot be verified. This iteration is therefore deliberately
+**build-free**: a correctness fix plus a registry sync, no Lean edit.
+
+## What this iteration found
+
+The S11-era `state.md` / JSON registry was stale relative to `origin/main`.
+Two Lean PRs had merged without updating the registry:
+
+1. **S7b ACT (#22967)** — reinstated the two numeric sanity lemmas via
+   `Matrix.det_succ_row_zero` + `Matrix.det_fin_three`:
+   - `concyclicityDetCoords_unit_circle = 0`
+   - `concyclicityDetCoords_off_circle = -6`
+
+2. **easy-direction ACT (#22917)** — proved `concyclic_implies_concyclicityDet_zero`
+   **unconditionally** (concyclic ⟹ Δ = 0), via the explicit kernel vector
+   `(1, -2O₀, -2O₁, O₀²+O₁²-r²)` and `Matrix.exists_mulVec_eq_zero_iff`. This
+   discharges the **(⟸) half** of the headline iff; only the (⟹) Cramer
+   direction is genuinely open now.
+
+Plus S15 (`norm_sub_sq_coord`, `signed_inner_product_to_scalar(_coord)`) and
+S16 (`coord_of_smul_diff`) which the S11 ledger predates. The file is now
+**265 LOC, 1 sorry, 0 axioms** on `origin/main`.
+
+## Correctness fix (the substantive win)
+
+`knowledge.md` line 145 (S1 OBSERVE, 2026-05-12) claimed that moving the
+fourth point off the unit circle to `(0, -2)` gives `Δ = -8`. **This is
+wrong.** The correct value is `Δ = -6`.
+
+Hand verification (points `(1,0), (0,1), (-1,0), (0,-2)`; matrix rows
+`[x²+y², x, y, 1]`):
+
+```
+| 1  1  0  1 |     R2-R1, R3-R1, R4-R1     | 1  1  0  1 |
+| 1  0  1  1 |   ───────────────────────>  | 0 -1  1  0 |
+| 1 -1  0  1 |   (det unchanged)           | 0 -2  0  0 |
+| 4  0 -2  1 |                             | 3 -1 -2  0 |
+```
+
+Expand along column 4: only row 1 is nonzero there (entry 1, cofactor sign
+`(-1)^(1+4) = -1`). The surviving 3×3 minor
+
+```
+| 0 -1  1 |
+| 0 -2  0 |   = 3 · det| -1  1 | = 3·(0+2) = 6
+| 3 -1 -2 |            | -2  0 |
+```
+
+so `Δ = 1 · (-1) · 6 = -6`. This matches the **machine-checked** merged lemma
+`concyclicityDetCoords_off_circle` (#22967), which proves
+`concyclicityDetCoords 1 0 0 1 (-1) 0 0 (-2) = -6`. The file itself already
+carried a comment flagging -8 as a slip; the knowledge base had not been
+corrected.
+
+## Files touched (no Lean edit)
+
+- `research/problems/.../knowledge.md` — `Δ = -8` → `Δ = -6` with a derivation
+  + machine-check note.
+- `research/problems/.../state.md` — S17 STATE-SYNC header, updated Lean-status
+  snapshot (111 → 265 LOC; new decl table), fixed two historical `-8` mentions.
+- `src/data/research/problems/...json` — `currentState` (phase/since/iteration
+  17/focus/blockers/nextAction), `knowledge.progressSummary`, `lastUpdatedAt`.
+- this session log.
+
+## Next action (when Docker recovers)
+
+S18 ACT: (a) wire `concyclic_implies_concyclicityDet_zero` into the (⟸) branch
+of `concyclicityDet_eq_zero_iff_concyclic`; (b) replace the `(hNonCollinear :
+True)` placeholder with the algebraic 2×2 non-collinearity (S3 PREP Choice 1b);
+(c) discharge the (⟹) direction via `Matrix.cramer` (S3 ACT, ~80 LOC). All
+build-dependent — do not blind-ship during the outage.

--- a/research/problems/product-of-segments-of-chords-oq-03/state.md
+++ b/research/problems/product-of-segments-of-chords-oq-03/state.md
@@ -2,10 +2,41 @@
 
 ## Current State
 
-**Phase**: ACT (S16 ACT shipped `coord_of_smul_diff` 2026-06-01; S15 ACT shipped 3 scalar-bridge theorems 2026-05-31; S7 ACT remains the import-unblocker baseline 2026-05-15)
+**Phase**: ACT (S17 STATE-SYNC 2026-06-13 — registry catch-up after two
+untracked Lean merges; S7b ACT shipped the two numeric lemmas PR #22967;
+the **easy direction `concyclic_implies_concyclicityDet_zero` is now PROVEN
+standalone** PR #22917; S16 ACT shipped `coord_of_smul_diff` 2026-06-01)
 **Path**: full
-**Since**: 2026-06-01 (S16 ACT pulse — coordinate substitution lemma for S17 ACT discharge)
-**Iteration**: 16 (S1 OBSERVE + S2 SCAFFOLD + S3-S5 PREP + S6 STATE-SYNC + S7 ACT + S8-S10 PREP + S11 STATE-SYNC + S12-S14 PREP + S15 ACT + S16 ACT)
+**Since**: 2026-06-13 (S17 STATE-SYNC — Docker-down build-free iteration:
+fixed the Δ = −8 → −6 numerical error in knowledge.md and synced the ledger)
+**Iteration**: 17 (S1 OBSERVE + S2 SCAFFOLD + S3-S5 PREP + S6 STATE-SYNC +
+S7 ACT + S7b ACT + S8-S10 PREP + S11 STATE-SYNC + S12-S14 PREP + S15 ACT +
+S16 ACT + easy-direction ACT + S17 STATE-SYNC)
+
+### S17 STATE-SYNC (researcher-2, 2026-06-13, this PR)
+
+Build-free registry catch-up. Two Lean PRs merged since the S11-era state.md
+was written but neither updated `state.md` / JSON:
+
+- **S7b ACT (#22967)** — reinstated the two numeric sanity lemmas
+  (`concyclicityDetCoords_unit_circle = 0`, `concyclicityDetCoords_off_circle
+  = -6`) via `Matrix.det_succ_row_zero` + `Matrix.det_fin_three`. This
+  surfaced that the S1/S2 doc figure **Δ = -8 was wrong; the correct value is
+  -6** (now machine-checked).
+- **easy-direction ACT (#22917)** — proved
+  `concyclic_implies_concyclicityDet_zero` **unconditionally** (no
+  non-degeneracy hypothesis): concyclic ⟹ Δ = 0, via the explicit kernel
+  vector `(1, -2O₀, -2O₁, O₀²+O₁²-r²)` and `Matrix.exists_mulVec_eq_zero_iff`.
+  This discharges the **(⟸) half** of the headline iff sorry — only the
+  (⟹) Cramer direction remains.
+
+Plus S15 ACT (`signed_inner_product_to_scalar` + `_coord`, `norm_sub_sq_coord`)
+and S16 ACT (`coord_of_smul_diff`) which the S11 ledger predates.
+
+**Verification note:** Docker daemon is down (2026-06-13), so this iteration
+is deliberately build-free — doc/registry only, no Lean edit. The Δ = -6
+correction is independently hand-verified (row-reduce + col-4 cofactor) and
+already machine-checked by the merged #22967 lemma.
 
 ## Current Focus
 
@@ -99,18 +130,34 @@ S7 ACT delivered: 1-LOC import patch + removal of two broken
 Docker-builds clean (3058 jobs, single `sorry` warning at line 109
 on the headline iff theorem).
 
-## Lean status (post-S7 BUILD-VERIFY snapshot, unchanged at S11)
+## Lean status (S17 STATE-SYNC snapshot, 2026-06-13)
+
+`proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean` — **265 LOC, 1
+sorry, 0 axioms** (origin/main as of PR #22917; S7b #22967 + easy-direction
+#22917 + S15/S16 lemmas all merged since the S11 snapshot below). Decls now
+present beyond the S11 baseline:
+
+| Decl | Status |
+|------|--------|
+| `concyclicityDetCoords_unit_circle` (= 0) | Proven (S7b, #22967) |
+| `concyclicityDetCoords_off_circle` (= -6) | Proven (S7b, #22967) — corrects the S1 doc figure -8 |
+| `norm_sub_sq_coord` | Proven (S15) |
+| `signed_inner_product_to_scalar` / `_coord` | Proven (S15) |
+| `coord_of_smul_diff` | Proven (S16) |
+| `concyclic_implies_concyclicityDet_zero` | **Proven unconditionally (easy direction, #22917)** — the (⟸) half of the iff |
+| `concyclicityDet_eq_zero_iff_concyclic` | **1 sorry** at line 125 — only the (⟹) Cramer direction now genuinely open; the (⟸) branch can cite `concyclic_implies_concyclicityDet_zero` |
+
+### Historical: post-S7 BUILD-VERIFY snapshot (S11-era, superseded above)
 
 `proofs/Proofs/ProductOfSegmentsOfChordsOQ03.lean` — **111 LOC, 1
-sorry, 0 axioms** (Docker-verified after S7 patch; no Lean diff since
-S7 merged at 2026-05-15T22:59:25Z):
+sorry, 0 axioms** (Docker-verified after S7 patch):
 
 | Decl                                            | Status                         |
 |-------------------------------------------------|--------------------------------|
 | `Vec2` (abbrev)                                 | Sealed; `EuclideanSpace ℝ (Fin 2)` |
 | `concyclicityDetCoords` (def)                   | Sealed; `Matrix.det !![...]` 4×4 in raw coords |
 | `concyclicityDet` (def)                         | Sealed; `Vec2`-wrapped form    |
-| Numerical examples (unit-square Δ = 0, perturbed Δ = -8) | **Removed in S7 BUILD-VERIFY** — relied on non-existent `Matrix.det_fin_four`. Re-add via S7b ACT (row-dependence or `det_succ_row_zero` cascade; optional / cosmetic). |
+| Numerical examples (unit-square Δ = 0, perturbed Δ = -6) | **Re-added in S7b ACT (PR #22967)** via `det_succ_row_zero` + `det_fin_three`; the S1/S2 figure Δ = -8 was a hand-computation slip (correct value -6, machine-checked). |
 | `concyclicityDet_eq_zero_iff_concyclic`         | **1 sorry** at line 109 (the headline iff) — placeholder `(hNonCollinear : True)` to be replaced per S3 PREP §1.b (post-S8 §4 corrections) |
 
 Parent file `proofs/Proofs/ProductOfSegmentsOfChords.lean` — **541
@@ -399,7 +446,8 @@ S6 ACT grew by ~15-30 LOC (axiom signature swap + caller update).
 - ACT iterations: 1 (S7 — build unblocker; S3-S6 ACT still pending)
 - Approaches tried:
   - S1 OBSERVE (researcher-11, 2026-05-12): determinant-criterion ↔
-    power-of-a-point bridge; numerical Δ = 0 / Δ = -8 verification.
+    power-of-a-point bridge; numerical Δ = 0 / Δ = -6 verification
+    (S1 wrote -8 — a hand slip; corrected at S17).
   - S2 SCAFFOLD (researcher-3, 2026-05-12): `concyclicityDet` def +
     `Vec2` wrapper + 2 numerical examples (build pending — assumed
     `Matrix.det_fin_four` exists, which it doesn't).

--- a/src/data/research/problems/product-of-segments-of-chords-oq-03.json
+++ b/src/data/research/problems/product-of-segments-of-chords-oq-03.json
@@ -33,19 +33,19 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-31T21:50:00.000Z",
-    "iteration": 15,
-    "focus": "S15 ACT shipped 3 building-block theorems via Docker-verified PR. S16 ACT picker handoff prepared: final concyclicityDet_eq_zero_of_signed_chord_product theorem is now a thin wrapper around signed_inner_product_to_scalar_coord (~50 LOC, single substitution + cofactor + linear_combination step).",
-    "blockers": [],
-    "nextAction": "S16 ACT — paste concyclicityDet_eq_zero_of_signed_chord_product (~50 LOC) using S15 ACT lemmas. Substitution via hB0/hB1/hD0/hD1 in B 0 = P 0 + t·(A 0 - P 0) form (S14 §4.1 fix); cofactor via det_succ_row_zero + det_fin_three; linear_combination witness ((t-1)(s-1)(cross_AC)) * h_signed_coords where h_signed_coords is signed_inner_product_to_scalar_coord. Fallbacks per S14 §4.4 if linear_combination rejects. Pre-flight: re-verify manifest pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67. Expected build: ~120s via ./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChordsOQ03.",
+    "since": "2026-06-13T00:00:00.000Z",
+    "iteration": 17,
+    "focus": "S17 STATE-SYNC (researcher-2, 2026-06-13, build-free, Docker down): registry catch-up after two untracked Lean merges. S7b ACT (#22967) reinstated the numeric lemmas and surfaced that the S1 doc figure Δ=-8 was wrong (correct -6, machine-checked). Easy-direction ACT (#22917) proved concyclic_implies_concyclicityDet_zero unconditionally — the (⟸) half of the headline iff. File now 265 LOC, still 1 sorry (only the (⟹) Cramer direction genuinely open), 0 axioms.",
+    "blockers": ["Docker daemon down 2026-06-13 — build-dependent ACT (the (⟹) Cramer paste) cannot be verified; build-free doc/registry work only this iteration."],
+    "nextAction": "S18 ACT (when Docker recovers): (a) wire the proven concyclic_implies_concyclicityDet_zero into the (⟸) branch of concyclicityDet_eq_zero_iff_concyclic, leaving only the (⟹) sorry; (b) replace the (hNonCollinear : True) placeholder with the algebraic 2×2 non-collinearity (S3 PREP Choice 1b); (c) discharge (⟹) via Matrix.cramer on the implicit-circle system (S3 ACT, ~80 LOC). Build: ./proofs/scripts/docker-build.sh Proofs.ProductOfSegmentsOfChordsOQ03.",
     "attemptCounts": {
-      "total": 15,
-      "currentApproach": 15,
-      "approachesTried": 15
+      "total": 17,
+      "currentApproach": 17,
+      "approachesTried": 17
     }
   },
   "knowledge": {
-    "progressSummary": "S15 ACT (this PR, researcher-1, 2026-05-31): factored S14 §4.2 paste into 3 opaque lemmas — norm_sub_sq_coord (coord-form ‖·‖²), signed_inner_product_to_scalar (abstract scalar bridge), signed_inner_product_to_scalar_coord (coord scalar bridge). All Docker-verified (3058 jobs clean); +73 LOC, 0 new sorries, 0 new axioms. Two bearer corrections: real_inner_self_eq_norm_sq at :871 (not :384); EuclideanSpace.norm_sq_eq does not exist (use real_inner_self_eq_norm_sq + PiLp.inner_apply instead). One notation gotcha: ⟪x,y⟫_ℝ fails in binder position — use scoped ⟪x,y⟫. File now 184 LOC, 1 sorry (pre-existing placeholder on headline iff), 0 axioms. S16 ACT picker owes ~50 LOC: substitution machinery + det_succ_row_zero/det_fin_three cofactor + linear_combination witness from S12 §3.2.",
+    "progressSummary": "S17 STATE-SYNC (researcher-2, 2026-06-13, build-free): registry catch-up after S7b ACT (#22967) and easy-direction ACT (#22917) merged without updating state.md/JSON. File is now 265 LOC, 1 sorry, 0 axioms on origin/main. The (⟸) direction is PROVEN unconditionally as standalone theorem concyclic_implies_concyclicityDet_zero (kernel vector (1,-2O₀,-2O₁,O₀²+O₁²-r²) + Matrix.exists_mulVec_eq_zero_iff); only the (⟹) Cramer direction of the headline iff remains open. Also corrected a genuine math error: the S1 numerical-sanity figure Δ=-8 (off-circle point (0,-2)) is wrong — the correct value is Δ=-6, hand-verified (row-reduce + col-4 cofactor → minor 6, sign -1) and machine-checked by the merged concyclicityDetCoords_off_circle lemma. Docker daemon is down 2026-06-13 so no Lean edit this iteration. Earlier ACT lemmas in place: norm_sub_sq_coord, signed_inner_product_to_scalar(_coord) (S15), coord_of_smul_diff (S16). Bearer notes retained: real_inner_self_eq_norm_sq at :871; ⟪x,y⟫_ℝ fails in binder position (use scoped ⟪x,y⟫).",
     "builtItems": [
       "norm_sub_sq_coord (ProductOfSegmentsOfChordsOQ03.lean:117-120) — coord-form norm-squared for Vec2: ‖X-Y‖² = (X 0 - Y 0)² + (X 1 - Y 1)² (S15 ACT)",
       "signed_inner_product_to_scalar (ProductOfSegmentsOfChordsOQ03.lean:155-166) — abstract scalar bridge under chord-collinearity (S15 ACT)",
@@ -107,5 +107,5 @@
     "seeker-selected"
   ],
   "createdAt": "2026-05-12T15:12:46Z",
-  "lastUpdatedAt": "2026-05-31T21:50:00Z"
+  "lastUpdatedAt": "2026-06-13T00:00:00Z"
 }


### PR DESCRIPTION
## Summary

Build-free research iteration on `product-of-segments-of-chords-oq-03` (Docker daemon down 2026-06-13 — no Lean edit, doc/registry only).

- **Correctness fix.** `knowledge.md` (S1 OBSERVE) claimed the off-circle concyclicity determinant for point `(0,-2)` is `Δ = -8`. This is wrong — the correct value is **`Δ = -6`**. Verified two ways:
  - By hand: row-reduce (subtract row 1 from rows 2–4), expand along column 4 (only row 1 nonzero, cofactor sign `-1`); the surviving 3×3 minor evaluates to `6`, so `Δ = -1·6 = -6`.
  - Machine-checked by the already-merged lemma `concyclicityDetCoords_off_circle` (#22967), which proves `concyclicityDetCoords 1 0 0 1 (-1) 0 0 (-2) = -6`.
- **Registry catch-up.** `state.md` / JSON were stale (S11 era, 111 LOC). Two Lean PRs merged since without updating the registry:
  - **#22967** (S7b ACT) — reinstated the numeric sanity lemmas.
  - **#22917** (easy direction) — proved `concyclic_implies_concyclicityDet_zero` **unconditionally** (concyclic ⟹ Δ=0), discharging the **(⟸) half** of the headline iff.
  - File is now **265 LOC, 1 sorry, 0 axioms**; only the (⟹) Cramer direction remains open.

## Why build-free

Docker is down today, so the remaining open step — the (⟹) `Matrix.cramer` paste with its four documented `linear_combination` failure modes — cannot be verified and is **not** attempted here. This PR touches **0 Lean files**.

## Test plan

- [x] No `.lean` files changed (doc/JSON only).
- [x] JSON registry parses.
- [x] Δ=-6 hand-verified and cross-checked against merged machine-checked lemma #22967.

🤖 Generated with [Claude Code](https://claude.com/claude-code)