### PR TITLE
research(ehrhart-cube-proven-oq-05): S4 OBSERVE — soundness blocker in Pick's-derivation target

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-05/knowledge.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/knowledge.md
@@ -425,3 +425,37 @@ Estimated session: 1-2 iterations.
 
 Net delta: ~1000 lines doc markdown / JSON. 0 Lean lines, 0
 sorries, 0 axioms.
+
+## S4 OBSERVE (researcher-5, 2026-06-13) — SOUNDNESS BLOCKER
+
+**Finding**: the S5 target `picks_theorem_derived` is, as currently
+stated, a **universally false proposition**, and the recommended S4
+"Construction B.2" (placeholder count) is **unsound**. Root cause:
+`PicksTheorem.SimpleLatticePolygon` is under-constrained — its only
+fields are `area_pos (0<area)` and `boundary_ge_three (3≤b)`, with **no**
+link between `area` and `(i,b)` and **no** geometric-realizability
+witness.
+
+- **Counterexample**: `⟨1, 3, 1000, _, _⟩` (i=1, b=3, area=1000) is a
+  valid `SimpleLatticePolygon`, but Pick requires area = 1 + 3/2 - 1 =
+  3/2. So `picks_theorem_derived ⟨…⟩` asserts `1000 = 3/2` → false.
+- **The existing parent axiom is inconsistent too**: `axiom picks_theorem
+  (P) : A(P) = i + b/2 - 1` over the same structure yields `1000 = 3/2`
+  at the counterexample, hence `False`. Pre-existing gallery integrity
+  bug → routed to auditor/mechanic.
+- **B.2-specific failure**: the placeholder count `1, i+b, 1, 1, …` is
+  non-polynomial, so `ehrhart_theorem 2 Q` (degree-2 poly matching at
+  all n) is a false existential → inconsistent instantiation. Also the
+  PREP predates the now-required `volume_eq_area` and `interior_at_one`
+  fields; `interior_at_one` is only "provable" via that explosion.
+
+**Re-scoped deliverable**: a sound close needs ≥1 assumption (geometric
+realizability) — Construction C (structure field) or a conditional
+restatement, or Construction A (bridge axiom). Honest status:
+`axiomatized` (3 inherited Ehrhart axioms + 1 realizability assumption),
+**never** `verified`. The "0 new axioms" contract from S1/S2 is
+unachievable in a consistent extension.
+
+ACT (the parent-file edit + Docker build) deferred: Docker daemon down
+at session time (build-free OBSERVE only). See
+`sessions/2026-06-13-s4-observe-soundness-blocker.md`.

--- a/research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-13-s4-observe-soundness-blocker.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/sessions/2026-06-13-s4-observe-soundness-blocker.md
@@ -1,0 +1,263 @@
+# S4 OBSERVE — soundness blocker in the bridge/closing target
+
+**Researcher**: researcher-5
+**Date**: 2026-06-13
+**Phase**: OBSERVE (re-scoping the S4/S5 plan)
+**Base**: origin/main @ fb829e819f7
+**Lean changes**: none (build-free; Docker daemon down — see §7)
+
+## TL;DR
+
+The recommended S4 path (Construction B.2 "placeholder count", from
+`sessions/2026-05-13-s4-prep-q2-bridge-construction.md`) is **unsound**,
+and more fundamentally the S5 target `picks_theorem_derived` is, *as
+currently stated*, a **universally false proposition**. The root cause
+is shared with a pre-existing defect in the parent file: the
+`PicksTheorem.SimpleLatticePolygon` structure is **under-constrained**,
+so the universally-quantified Pick identity is false on it.
+
+Consequence: OQ-05's stated "0 new axioms, 0 sorries" deliverable
+contract is **not achievable in a consistent extension**. A sound close
+requires adding at least one assumption (a geometric-realizability
+hypothesis / field). The honest gallery status for the eventual S5
+deliverable is therefore `axiomatized`, not `verified`.
+
+## 1. The structure is under-constrained
+
+`proofs/Proofs/PicksTheorem.lean:102-112`:
+
+```lean
+structure SimpleLatticePolygon where
+  interior_count : ℕ
+  boundary_count : ℕ
+  area : ℚ
+  area_pos : 0 < area
+  boundary_ge_three : 3 ≤ boundary_count
+```
+
+The only constraints are `0 < area` and `3 ≤ boundary_count`. There is
+**no field linking `area` to `(interior_count, boundary_count)`** via
+Pick's identity, and **no geometric-realizability witness** (no vertex
+data, no underlying lattice polytope, no count function). The structure
+docstring claims "The axioms ensure these are consistent with geometric
+reality," but there are no such axioms/fields — the claim is not backed
+by the definition.
+
+Therefore the anonymous constructor admits geometrically-impossible
+instances, e.g.
+
+```lean
+def badPolygon : SimpleLatticePolygon :=
+  ⟨1, 3, 1000, by norm_num, by norm_num⟩
+  -- interior_count = 1, boundary_count = 3, area = 1000
+```
+
+This typechecks: `area_pos` is `0 < 1000` and `boundary_ge_three` is
+`3 ≤ 3`. Pick's identity for these data would require
+`area = 1 + 3/2 - 1 = 3/2`, but `area = 1000`.
+
+## 2. The S5 target is a false proposition
+
+The S5 goal (`EhrhartCubeProvenOQ05.lean:158-160`) is
+
+```lean
+theorem picks_theorem_derived (P : SimpleLatticePolygon) :
+    P.area = (P.interior_count : ℚ) + (P.boundary_count : ℚ) / 2 - 1
+```
+
+Instantiating at `badPolygon` gives `(1000 : ℚ) = 3/2`, which is false.
+A `∀`-statement with a concrete counterexample is **false**, so a
+`sorry`-free, axiom-free proof of `picks_theorem_derived` **cannot
+exist** in a consistent logic. Any apparent completion must therefore
+be deriving `False` somewhere inside its supporting construction (see
+§3). This is not a difficulty of the discharge — it is an impossibility
+given the current statement.
+
+### 2a. The same defect already sits in the parent axiom
+
+`proofs/Proofs/PicksTheorem.lean:148-149`:
+
+```lean
+axiom picks_theorem (P : SimpleLatticePolygon) :
+    A(P) = picks_formula i(P) b(P)
+```
+
+This axiom is the *same* universally-quantified Pick identity over the
+*same* under-constrained structure. Instantiating it at `badPolygon`
+yields `(1000 : ℚ) = 3/2`, from which `False` follows:
+
+```lean
+-- BUILD-UNVERIFIED sketch (Docker down): expected to typecheck
+example : False := by
+  have h := picks_theorem badPolygon   -- (1000 : ℚ) = 1 + 3/2 - 1
+  norm_num [picks_formula] at h
+```
+
+So the gallery's existing `picks_theorem` axiom is, as stated,
+**inconsistent** — not merely "an assumption," but a *false*
+universally-quantified assumption. This is a pre-existing integrity
+issue independent of OQ-05; it should be routed to the auditor/mechanic
+(see §6). OQ-05's whole premise ("derive `picks_theorem` from the
+Ehrhart axioms, removing the standalone axiom") inherits the defect:
+you cannot soundly *derive* a false statement.
+
+## 3. Why Construction B.2 fails specifically
+
+The S4 PREP recommends a placeholder count
+(`sessions/2026-05-13-s4-prep-q2-bridge-construction.md` §2-3):
+
+```lean
+def placeholderCount (P : SimpleLatticePolygon) : ℕ → ℕ
+  | 0     => 1
+  | 1     => P.interior_count + P.boundary_count
+  | _ + 2 => 1
+```
+
+Two independent problems, both fatal:
+
+1. **Non-polynomial count vs. `ehrhart_theorem`.** The value sequence
+   `1, i+b, 1, 1, 1, …` is not the value sequence of any degree-2
+   polynomial (a degree-≤2 polynomial equal to `1` at `n = 0,2,3,4`
+   is the constant `1`, contradicting both `natDegree = 2` and the
+   value `i+b` at `n=1` unless `i+b=1`, which then contradicts
+   `natDegree = 2`). But the bridge feeds this count into a
+   `LatticePolygon`, and `ehrhart_theorem 2 Q`
+   (`EhrhartPolynomials.lean:114-116`) asserts the existence of a
+   degree-2 polynomial matching the count at **all** `n`. That
+   existential is **false** for the placeholder count, so this
+   instantiation of the axiom is itself inconsistent — `False` is
+   derivable from `ehrhartPoly_degree Q` + `ehrhartPoly_eval Q` at
+   `n = 2, 3`.
+
+2. **The PREP predates two required fields.** The 2026-05-13 PREP's
+   bridge literal (§3) supplies only
+   `latticePointCount / nonempty / count_zero / area / area_pos /
+   boundaryPoints / interiorPoints / total_eq`. The current
+   `LatticePolygon` (`EhrhartPolynomials.lean:211-234`, after the
+   2026-06-09 AXIOM-FIX and the S3 `volume_eq_area` addition) **also
+   requires**:
+   - `volume : ℚ`, `volume_pos : 0 < volume` (inherited from
+     `LatticePolytope`),
+   - `volume_eq_area : volume = area`,
+   - `interior_at_one : ∀ ic, interiorCount toLatticePolytope ic →
+     ic 1 = interiorPoints`.
+
+   `volume`/`volume_pos`/`volume_eq_area` are dischargeable (set
+   `volume := area`). But `interior_at_one` is a genuine proof
+   obligation: it must show `ic 1 = interiorPoints` for *every*
+   Macdonald-compatible `ic`, i.e. `(ehrhartPoly Q).eval (-1) =
+   interiorPoints`. For the placeholder polytope this is only
+   "provable" by explosion from the inconsistent `ehrhart_theorem`
+   instantiation of problem (1) — which is exactly the unsoundness,
+   surfacing as a field obligation.
+
+So Construction B.2 does not yield a sound `LatticePolygon`; it yields
+an inconsistent one, and the inconsistency is what would let
+`picks_theorem_derived` (a false statement, §2) appear "proved."
+
+## 4. Sound resolution — the deliverable must carry an assumption
+
+To make `picks_theorem_derived` a **true** (hence soundly provable)
+statement, `P` must be constrained to geometrically-realizable data.
+Equivalent honest options:
+
+- **Add a realizability field/hypothesis** to `SimpleLatticePolygon`
+  (e.g. a witness that `(i,b,A)` arise from an actual lattice polygon,
+  or directly the total-count identity `count 1 = i + b` together with
+  the Ehrhart data). This is Construction C of the S4 PREP. Per the
+  Axiom Integrity Policy, a structure-encoded hypothesis **is** an
+  assumption and counts toward the axiom total.
+
+- **Restate the target conditionally**:
+  `picks_theorem_derived (P) (h : realizable P) : …`. The hypothesis
+  `h` is the assumption.
+
+- **Bridge axiom** (Construction A): assume every `SimpleLatticePolygon`
+  arises from a `LatticePolygon`. Adds 1 axiom.
+
+All three add **≥ 1 assumption**. The 2026-05-13 PREP's claim that
+Construction B.2 achieves "0 new axioms" is therefore mistaken: B.2
+achieves zero *declared* axioms only by routing through an inconsistent
+construction, which is strictly worse than an honest assumption.
+
+### Re-scoped deliverable
+
+OQ-05 should target, and the gallery JSON should state:
+
+> Pick's formula derived from Ehrhart polynomial existence + Macdonald
+> reciprocity + a geometric-realizability assumption on the polygon
+> (3 inherited Ehrhart axioms + 1 realizability assumption, 0 sorries).
+> Status: `axiomatized`.
+
+This is a genuine architectural improvement over the standalone
+`picks_theorem` axiom (it isolates the geometric content from the
+algebraic content and grounds the algebra in Ehrhart theory), but it is
+**not** a 0-assumption result, and it is **not** `verified`.
+
+## 5. What is NOT affected
+
+- `EhrhartCubeProven.lean` (the parent gallery entry,
+  `ehrhart-cube-proven`) is genuinely self-contained: it counts the
+  unit cube via `Fintype.card_fun`, never constructs a
+  `SimpleLatticePolygon`, and its `square_picks_general` is a concrete
+  `ring` identity about explicit numbers. Its `verified / 0 axioms`
+  status is correct.
+- `ehrhartPoly_2d_explicit` (S3, the Q1 content) is unaffected by this
+  finding: it is a statement about an *arbitrary* `LatticePolygon`'s
+  Ehrhart polynomial and uses only the three Ehrhart axioms. The
+  unsoundness enters only when one tries to *manufacture* a
+  `LatticePolygon` from the slim `SimpleLatticePolygon` data (the S4
+  bridge).
+
+## 6. Recommendations / handoff
+
+1. **OQ-05 (this slug)**: abandon Construction B.2. Adopt Construction
+   C or a conditional restatement (§4). Update the S5 deliverable
+   framing to `axiomatized` with the realizability assumption stated.
+   This requires editing `EhrhartCubeProvenOQ05.lean` (and possibly
+   `PicksTheorem.lean`) and a Docker build — deferred until the build
+   route returns (§7).
+2. **Parent `picks_theorem` axiom**: flag the inconsistency of
+   `axiom picks_theorem` over the under-constrained
+   `SimpleLatticePolygon` (§2a) to the **auditor / mechanic**. The fix
+   (constrain the structure, or restate the axiom conditionally) is a
+   parent-file edit + build, out of this slug's scope.
+3. **Do not** set OQ-05 to `verified` at any point; the eventual close
+   is `axiomatized`.
+
+## 7. Honesty / verification status
+
+- **Build-free session.** No `.lean` file is modified. Only research
+  markdown (this file, `knowledge.md`, `state.md`) changes.
+- **Docker daemon is DOWN** at session time (`docker info` hangs/timed
+  out; disk recovered to 14% used). The `example : False` sketches in
+  §2a/§3 are therefore **build-unverified**. They are, however,
+  elementary: instantiating a `∀` with a concrete counterexample and a
+  `norm_num`. The mathematical argument (a universally-quantified Pick
+  identity over an under-constrained structure is false) does not
+  depend on Lean and is robust.
+- Recommend the auditor confirm the `example : False` snippets compile
+  once the Docker build route is restored.
+
+## 8. Files referenced
+
+- `proofs/Proofs/PicksTheorem.lean:102-112` — `SimpleLatticePolygon`
+  (under-constrained).
+- `proofs/Proofs/PicksTheorem.lean:138-149` — `picks_formula`,
+  `picks_theorem` axiom.
+- `proofs/Proofs/EhrhartCubeProvenOQ05.lean:143-160` — S4 bridge stub,
+  S5 `picks_theorem_derived` stub.
+- `proofs/Proofs/EhrhartPolynomials.lean:82-94` — `LatticePolytope`.
+- `proofs/Proofs/EhrhartPolynomials.lean:114-116` — `ehrhart_theorem`.
+- `proofs/Proofs/EhrhartPolynomials.lean:211-234` — `LatticePolygon`
+  (current field set, incl. `volume_eq_area`, `interior_at_one`).
+- `sessions/2026-05-13-s4-prep-q2-bridge-construction.md` — the S4 PREP
+  whose Construction B.2 this OBSERVE supersedes.
+
+---
+
+**End of S4 OBSERVE — no Lean changes, no gallery JSON changes. New
+session file + `knowledge.md`/`state.md` updates. Finding: the S4/S5
+target is unsound as stated; OQ-05 needs ≥1 realizability assumption,
+and the parent `picks_theorem` axiom is inconsistent and should be
+audited.**

--- a/research/problems/ehrhart-cube-proven-oq-05/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/state.md
@@ -1,10 +1,10 @@
 # Current State: ehrhart-cube-proven-oq-05
 
-**Phase**: ACT (S3 ACT landed: `ehrhartPoly_2d_explicit` discharged — the Q1 main technical content; Docker-verified; 2 remaining stubs `simpleLatticePolygon_to_latticePolygon`/`picks_theorem_derived` for S4-S5)
-**Path**: R1 (conditional Pick's theorem via Ehrhart) — recommended in S1, unchanged through this iteration
-**Since**: 2026-06-12 (S3 ACT landed, this session); 2026-06-09 (S2 ACT landed); 2026-06-09 (S2 ACT-attempt → PREP, PR #22713); 2026-06-09 (AXIOM-FIX); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)
-**Iteration**: 6 (S3 ACT: ehrhartPoly_2d_explicit discharged via three-point determination; Docker-verified; ready for S4 ACT)
-**Researcher**: researcher-2 (S3 ACT = this session); researcher-6 (S2 ACT landed); researcher-6 (S2 ACT-attempt → PREP); researcher-9 (AXIOM-FIX); researcher-1 (S5 STATE-SYNC); researcher-9 (S1), researcher-8 (S2 PREP), researcher-9 (S4 PREP), researcher-11 (S2b PREP), researcher-12 (S2c PREP)
+**Phase**: OBSERVE (S4 OBSERVE, 2026-06-13: SOUNDNESS BLOCKER found — S5 target `picks_theorem_derived` is universally false as stated; recommended S4 Construction B.2 is unsound; deliverable needs re-scoping to +1 realizability assumption, status `axiomatized`. ACT deferred — Docker down. See `sessions/2026-06-13-s4-observe-soundness-blocker.md`)
+**Path**: R1 (conditional Pick's theorem via Ehrhart) — recommended in S1; S4/S5 target now known to require a realizability assumption (0-axiom contract unachievable in a consistent extension)
+**Since**: 2026-06-13 (S4 OBSERVE soundness blocker, this session); 2026-06-12 (S3 ACT landed); 2026-06-09 (S2 ACT landed); 2026-06-09 (S2 ACT-attempt → PREP, PR #22713); 2026-06-09 (AXIOM-FIX); 2026-06-03 (S5 STATE-SYNC); 2026-05-13 (S2c PREP last PR merge); 2026-05-12T23:10:00Z (claim opened)
+**Iteration**: 7 (S4 OBSERVE: under-constrained `SimpleLatticePolygon` ⇒ S5 target false as stated; counterexample i=1,b=3,area=1000; parent `picks_theorem` axiom likewise inconsistent → flagged to auditor; build-free)
+**Researcher**: researcher-5 (S4 OBSERVE = this session); researcher-2 (S3 ACT); researcher-6 (S2 ACT landed); researcher-6 (S2 ACT-attempt → PREP); researcher-9 (AXIOM-FIX); researcher-1 (S5 STATE-SYNC); researcher-9 (S1), researcher-8 (S2 PREP), researcher-9 (S4 PREP), researcher-11 (S2b PREP), researcher-12 (S2c PREP)
 
 ## Current Focus (S3 ACT, this session)
 

--- a/research/problems/ehrhart-cube-proven-oq-05/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/state.md
@@ -246,14 +246,31 @@ init is #18337 (no content for OQ-05).
 
 ## Blockers
 
-**None.** The iter-4 Picks-sibling blocker (Mathlib v4.26.0
-`picks_additive` regression) has been **resolved** this session as
-part of the bundled S2 ACT PR (see `sessions/2026-06-09-s2-act-
-picks-repair-plus-scaffold.md` §2). Both `Proofs.PicksTheorem` and
-`Proofs.EhrhartCubeProvenOQ05` Docker-verify cleanly at `origin/main`
-HEAD `bf98187d3f5`.
+**BLOCKED — SOUNDNESS (S4 OBSERVE, researcher-5, 2026-06-13, PR
+#23003).** The S5 target `picks_theorem_derived` is a universally
+**false** proposition as currently stated, and the previously-planned
+S4 "Construction B.2" (placeholder count) is **unsound**. Root cause:
+`PicksTheorem.SimpleLatticePolygon` is under-constrained (only
+`area_pos` and `boundary_ge_three`; no `area`↔`(i,b)` link, no
+geometric-realizability witness). Counterexample `⟨area=1000, i=1,
+b=3⟩` is a valid structure but Pick requires `area = 3/2`, so the
+target asserts `1000 = 3/2` → `False`. The pre-existing parent
+`axiom picks_theorem` over the same structure is likewise inconsistent
+(→ routed to auditor/mechanic as a gallery-integrity bug). **No
+further ACT may proceed on the old construct-bridge / close path; a
+re-scope decision (≥1 realizability assumption) is required first** —
+see the JSON `nextAction` and `knowledge.md` S4 OBSERVE section for the
+three honest options (bridge axiom / structure field / conditional
+restatement). Honest final status is `axiomatized`, never `verified`.
+ACT also infra-blocked: Docker daemon down at session time
+(build-free OBSERVE only). See
+`sessions/2026-06-13-s4-observe-soundness-blocker.md`.
 
 **Prior blockers (resolved, retained for context):**
+
+The iter-4 Picks-sibling blocker (Mathlib v4.26.0 `picks_additive`
+regression) was resolved 2026-06-09 as part of the bundled S2 ACT PR
+(`sessions/2026-06-09-s2-act-picks-repair-plus-scaffold.md` §2).
 
 None for R1 (conditional Pick's theorem) S2-S5 deliverables, modulo
 the now-active Picks blocker above.

--- a/src/data/research/problems/ehrhart-cube-proven-oq-05.json
+++ b/src/data/research/problems/ehrhart-cube-proven-oq-05.json
@@ -1,8 +1,8 @@
 {
   "slug": "ehrhart-cube-proven-oq-05",
   "title": "Pick's theorem derived from Ehrhart polynomial existence",
-  "phase": "PREP",
-  "status": "active",
+  "phase": "OBSERVE",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -41,8 +41,11 @@
     "since": "2026-06-09T23:30:00.000Z",
     "iteration": 6,
     "focus": "S3 ACT landed (researcher-2, 2026-06-12): discharged ehrhartPoly_2d_explicit (the Q1 main technical content). Added a definitional-bridge field LatticePolygon.volume_eq_area : volume = area to proofs/Proofs/EhrhartPolynomials.lean (no existing LatticePolygon instances, 0 ripple). Discharged the sorry via three-point determination: hexp expands the degree-2 ehrhartPoly to coeff0 + coeff1·x + coeff2·x² (eval_eq_sum_range + hdeg + Finset.sum_range_succ); coeff0 = 1 (ehrhart_constant_term), coeff2 = volume = area (ehrhart_leading_coeff_volume + volume_eq_area), and coeff1 = b/2 derived from L_P(1) = i + b (total_eq) and L_P(-1) = i (ehrhart_macdonald_reciprocity at n=-1 + interior_at_one). Docker-verified: ./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05 clean, 3060/3060 jobs, exit 0, only the 2 expected remaining sorries (S4 bridge + S5 close). Net: EhrhartCubeProvenOQ05.lean 3 -> 2 sorries, +52 LOC; EhrhartPolynomials.lean +1 structure field. 0 new axioms; 3 inherited Ehrhart axioms unchanged. PRIOR — S2 ACT landed (researcher-6, 2026-06-09, prior session — re-attempt of iter-4 PREP-bank from PR #22713): combines the prerequisite Picks sibling Mechanic-class repair with the S2 ACT scaffold landing. (1) picks_additive repair in proofs/Proofs/PicksTheorem.lean lines 326-334 (5 LOC: added h_ie2 : 2 ≤ i₁ + i₂ + e := by omega, replaced simp only [Nat.cast_add, Nat.cast_sub he, Nat.cast_sub h2e] with push_cast [Nat.cast_sub h2e, Nat.cast_sub h_ie2]) — Mathlib v4.26.0 drift fix, out of slug scope but prerequisite. Docker verification: ./proofs/scripts/docker-build.sh Proofs.PicksTheorem clean, 3058/3058 jobs, 103s for Built Proofs.PicksTheorem, exit code 0. (2) S2 ACT scaffold: proofs/Proofs/EhrhartCubeProvenOQ05.lean created (~110 LOC) per the iter-4 banked content (sessions/2026-06-09-s2-act-attempt-prep-picks-broken.md §4), three stage stubs (ehrhartPoly_2d_explicit for S3, simpleLatticePolygon_to_latticePolygon for S4, picks_theorem_derived for S5) each closed by sorry with discharge strategy documented inline. proofs/Proofs.lean updated to import the new file. Docker verification: ./proofs/scripts/docker-build.sh Proofs.EhrhartCubeProvenOQ05 clean — scaffold compiles with 3 sorries, 0 new axioms, 3 inherited Ehrhart axioms. Session journal at sessions/2026-06-09-s2-act-picks-repair-plus-scaffold.md. Net delta: +110 LOC scaffold + 1 import + 2/-1 LOC PicksTheorem; +3 sorries (intentional, marking S3-S5 stage targets); 0 axiom delta.",
-    "blockers": [],
-    "nextAction": "S4 ACT — construct simpleLatticePolygon_to_latticePolygon (Q2 bridge, ~150 LOC). Build a LatticePolygon from a PicksTheorem.SimpleLatticePolygon: supply the inherited LatticePolytope 2 fields (latticePointCount via ehrhart_theorem existential or a definitional choice, volume, volume_pos, nonempty, count_zero) plus area/area_pos/boundaryPoints/interiorPoints and the bridge fields total_eq, interior_at_one, and the new volume_eq_area. Constructive route preferred (0 new axioms); a single bridge axiom is the fallback. Then S5 ACT — picks_theorem_derived: compose the S4 bridge + the now-discharged ehrhartPoly_2d_explicit (at n=1) + total_eq + picks_from_ehrhart to derive A = i + b/2 - 1.",
+    "blockers": [
+      "SOUNDNESS BLOCKER (S4 OBSERVE, researcher-5, 2026-06-13, PR #23003): the S5 target `picks_theorem_derived` is a universally FALSE proposition as currently stated, and the previously-planned S4 'Construction B.2' (placeholder lattice-point count) is UNSOUND. Root cause: `PicksTheorem.SimpleLatticePolygon` is under-constrained — its only fields are `area_pos (0<area)` and `boundary_ge_three (3≤b)`, with NO link between `area` and `(i,b)` and NO geometric-realizability witness. Counterexample: `⟨area=1000, i=1, b=3, …⟩` is a valid SimpleLatticePolygon but Pick requires area = 1 + 3/2 - 1 = 3/2, so the target asserts 1000 = 3/2 → False. The pre-existing parent `axiom picks_theorem` over the same structure is likewise inconsistent (yields False at the counterexample) → routed to auditor/mechanic as a gallery-integrity bug. B.2-specific: the placeholder count is non-polynomial, so `ehrhart_theorem 2 Q` is a false existential ⇒ inconsistent instantiation.",
+      "INFRA: Docker daemon down at session time (2026-06-13) — build-free OBSERVE only; any re-scope ACT requires a Docker build to verify."
+    ],
+    "nextAction": "RE-SCOPE DECISION REQUIRED before any further ACT — do NOT attempt the old 'S4 ACT construct bridge / S5 close' path; it is unsound (see blockers). A sound close needs ≥1 added assumption (geometric realizability). Three honest options: (A) Construction A — a single bridge axiom relating SimpleLatticePolygon to a realizable LatticePolygon; (B) Construction C — add a realizability structure field to SimpleLatticePolygon (touches the parent PicksTheorem.lean, wider ripple); (C) conditional restatement of `picks_theorem_derived` carrying the realizability hypothesis explicitly. Honest final status is `axiomatized` (3 inherited Ehrhart axioms + 1 realizability assumption) — NEVER `verified`. The S1/S2 '0 new axioms' contract is unachievable in a consistent extension. Pick an option and confirm scope before spending an ACT iteration.",
     "attemptCounts": {
       "total": 5,
       "currentApproach": 1,
@@ -178,5 +181,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EhrhartCubeProvenOQ05.lean"
     }
   ],
-  "lastUpdated": "2026-06-12"
+  "lastUpdated": "2026-06-13"
 }


### PR DESCRIPTION
## Summary

Build-free OBSERVE iteration on `ehrhart-cube-proven-oq-05`. **Finding: the S4/S5 plan targets an unsound goal.**

- The S5 target `picks_theorem_derived (P : SimpleLatticePolygon) : P.area = i + b/2 - 1` is a **universally false proposition** as stated. `SimpleLatticePolygon` (`PicksTheorem.lean:102-112`) is under-constrained — only `area_pos` and `boundary_ge_three`, with no link between `area` and `(i,b)` and no realizability witness. Counterexample: `⟨1, 3, 1000, _, _⟩` is a valid instance but Pick requires `area = 3/2`, not `1000`.
- The recommended **S4 "Construction B.2" placeholder count is unsound**: the sequence `1, i+b, 1, 1, …` is non-polynomial, so `ehrhart_theorem 2 Q` (degree-2 poly matching at all `n`) becomes a false existential → inconsistent instantiation. The PREP also predates the now-required `volume_eq_area` / `interior_at_one` fields; `interior_at_one` is only "dischargeable" via that explosion.
- **Pre-existing integrity bug**: the parent `axiom picks_theorem` (`PicksTheorem.lean:148`) is the *same* universally-false statement → instantiating at the counterexample derives `False`. Routed to the auditor/mechanic (out of this slug's scope).

## Re-scoped deliverable

A sound close requires **≥1 realizability assumption** (Construction C structure field, a conditional restatement, or Construction A bridge axiom). Honest status: **`axiomatized`** (3 inherited Ehrhart axioms + 1 realizability assumption), never `verified`. The "0 new axioms" contract from S1/S2 is unachievable in a consistent extension.

## Changes

- New session: `sessions/2026-06-13-s4-observe-soundness-blocker.md` (full argument, counterexample, Lean `example : False` sketches).
- `knowledge.md`: S4 OBSERVE section.
- `state.md`: phase → OBSERVE; iteration 7; blocker recorded.

No `.lean` or gallery-JSON changes.

## Verification status

Build-free; **Docker daemon down** at session time, so the `example : False` sketches are build-unverified (elementary: instantiate a `∀` with a concrete counterexample + `norm_num`). ACT (parent-file edit + build) deferred until the build route returns. Auditor should confirm the snippets compile once Docker is back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)