### PR TITLE
Enrich Buffon's Coin (oq-01-oq-04): add annotations.json

### DIFF
--- a/src/data/proofs/buffons-needle-oq-01-oq-04/annotations.json
+++ b/src/data/proofs/buffons-needle-oq-01-oq-04/annotations.json
@@ -1,0 +1,141 @@
+[
+  {
+    "id": "ann-bnoq0104-overview",
+    "proofId": "buffons-needle-oq-01-oq-04",
+    "range": {
+      "startLine": 4,
+      "endLine": 45
+    },
+    "type": "concept",
+    "title": "Buffon's Coin as a Corollary of the Smooth-Noodle Theorem",
+    "content": "Buffon's original 1733 needle problem drops a 1-D segment of length ℓ on a grid of parallel lines spaced d apart, giving crossing probability 2ℓ/(πd). Laplace (1812) generalized this to a 2-D convex body — a coin, ellipse, or triangle — and asked how often its boundary meets the grid. The remarkable answer depends only on the perimeter p, not on the shape: E[boundary crossings] = 2p/(πd). This file packages that result as a one-line corollary of the parent's C¹ smooth-noodle theorem (buffon_smooth_of_contDiff), applied to a closed C¹ parametrisation of the boundary ∂K. The analytic content is entirely inherited; the new content is the coin packaging, the line-cut translation, and the concrete circle instance.",
+    "mathContext": "$\\mathbb{E}[\\#(\\partial K \\cap \\text{grid})] = \\dfrac{2p}{\\pi d}$, where $p$ is the perimeter of the convex body $K$ and $d$ the line spacing.",
+    "significance": "key",
+    "relatedConcepts": [
+      "Buffon's needle",
+      "Cauchy mean-width formula",
+      "integral geometry",
+      "convex bodies",
+      "geometric probability"
+    ],
+    "prerequisites": [
+      "Buffon-Barbier smooth-noodle theorem",
+      "arc length of a planar curve"
+    ]
+  },
+  {
+    "id": "ann-bnoq0104-perimeter",
+    "proofId": "buffons-needle-oq-01-oq-04",
+    "range": {
+      "startLine": 52,
+      "endLine": 65
+    },
+    "type": "definition",
+    "title": "Perimeter as Boundary Arc Length",
+    "content": "boundaryPerimeter defines the perimeter of a convex body K as the planar arc length of a closed C¹ parametrisation γ : [a,b] → ℝ² of its boundary ∂K, with the closure condition γ a = γ b. It is literally the parent's planarArcLength specialized to the boundary curve. The companion lemma boundaryPerimeter_nonneg shows the perimeter is nonnegative: it is an integral over [a,b] (with a ≤ b) of √(γ'₁² + γ'₂²), a nonnegative integrand, so intervalIntegral.integral_nonneg applies directly.",
+    "mathContext": "$\\operatorname{perimeter}(K) = \\int_a^b \\lVert \\gamma'(t) \\rVert \\, dt = \\int_a^b \\sqrt{\\gamma_1'(t)^2 + \\gamma_2'(t)^2}\\, dt \\ge 0.$",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "arc length",
+      "interval integral",
+      "C¹ curve"
+    ],
+    "prerequisites": [
+      "intervalIntegral.integral_nonneg",
+      "Real.sqrt_nonneg"
+    ]
+  },
+  {
+    "id": "ann-bnoq0104-boundary-crossings",
+    "proofId": "buffons-needle-oq-01-oq-04",
+    "range": {
+      "startLine": 67,
+      "endLine": 84
+    },
+    "type": "insight",
+    "title": "The Boundary-Crossing Formula — A One-Line Corollary",
+    "content": "buffon_coin_boundary_crossings states E[crossings of ∂K] = 2·perimeter/(πd) for any closed C¹ boundary, and its proof is a single application of BuffonsNeedleOQ01.buffon_smooth_of_contDiff to the boundary curve. This is the conceptual heart of the file: the entire analytic computation of the smooth Buffon-Barbier theorem is reused verbatim. The closure hypothesis γ a = γ b is what makes planarArcLength γ a b the full perimeter of the closed boundary, though it is not needed for the algebraic identity itself (hence the underscore on _hclosed). The result demonstrates the leverage of a well-stated general theorem: the coin is not a new proof but a new reading of an existing one.",
+    "mathContext": "$\\text{concreteSmoothExpectedCrossings}(\\gamma, a, b, d) = \\dfrac{2 \\cdot \\operatorname{boundaryPerimeter}(\\gamma, a, b)}{\\pi d}.$",
+    "significance": "key",
+    "relatedConcepts": [
+      "Buffon-Barbier theorem",
+      "proof reuse",
+      "expected crossings",
+      "Crofton formula"
+    ],
+    "prerequisites": [
+      "buffon_smooth_of_contDiff",
+      "ContDiff ℝ 1 γ"
+    ]
+  },
+  {
+    "id": "ann-bnoq0104-line-cuts",
+    "proofId": "buffons-needle-oq-01-oq-04",
+    "range": {
+      "startLine": 86,
+      "endLine": 111
+    },
+    "type": "technique",
+    "title": "Where Convexity Enters: the Factor of Two",
+    "content": "A grid line that cuts a convex body meets its boundary in exactly two points, so the number of lines cutting K is half the number of boundary crossings. This 0-or-2 dichotomy is the sole imprint of convexity in the whole development. Because Mathlib v4.26.0 has no Convex.line_intersection_card_le_two bearer, and concreteSmoothExpectedCrossings is an integral model rather than a literal point count, the honest formalization encodes the halving definitionally: expectedLineCuts := crossings/2. buffon_coin_lineCuts then rewrites with the boundary-crossing formula and finishes by ring, yielding E[cutting lines] = perimeter/(πd). The nonnegativity lemma follows from div_nonneg.",
+    "mathContext": "$\\operatorname{expectedLineCuts} = \\dfrac{\\text{crossings}}{2} = \\dfrac{\\operatorname{perimeter}(K)}{\\pi d}$ (each cutting line meets the convex boundary in exactly 2 points).",
+    "significance": "key",
+    "relatedConcepts": [
+      "convexity",
+      "supporting lines",
+      "boundary intersection",
+      "definitional encoding"
+    ],
+    "prerequisites": [
+      "div_nonneg",
+      "convex body"
+    ]
+  },
+  {
+    "id": "ann-bnoq0104-circle",
+    "proofId": "buffons-needle-oq-01-oq-04",
+    "range": {
+      "startLine": 113,
+      "endLine": 179
+    },
+    "type": "concept",
+    "title": "The Circle: Recovering Laplace's Classical Coin Probability",
+    "content": "The canonical instance is the disk of radius r, with boundary t ↦ (r cos t, r sin t) on [0, 2π]. The file proves it is C¹ (fun_prop) and closed (cos/sin periodicity), computes the component derivatives, and evaluates the arc length: using (r·(−sin t))² + (r·cos t)² = r²(sin²t + cos²t) = r² and √(r²) = r for r ≥ 0, the integrand collapses to the constant r, so the perimeter is 2πr. Feeding this into the boundary-crossing formula gives E[crossings] = 4r/d (circle_crossings, via field_simp), and halving gives E[cutting lines] = 2r/d (circle_lineCuts). For r ≤ d/2 the latter is exactly diameter/d — Laplace's 1812 Buffon's-coin probability.",
+    "mathContext": "Perimeter $= \\int_0^{2\\pi} r\\,dt = 2\\pi r$; $\\mathbb{E}[\\text{crossings}] = \\dfrac{4r}{d}$; $\\mathbb{E}[\\text{cut lines}] = \\dfrac{2r}{d} = \\dfrac{\\text{diameter}}{d}$ for $r \\le d/2$.",
+    "significance": "key",
+    "relatedConcepts": [
+      "circle arc length",
+      "Pythagorean identity",
+      "Laplace's coin problem",
+      "sin_sq_add_cos_sq"
+    ],
+    "prerequisites": [
+      "Real.sin_sq_add_cos_sq",
+      "Real.sqrt_sq",
+      "intervalIntegral.integral_const"
+    ]
+  },
+  {
+    "id": "ann-bnoq0104-shape-independence",
+    "proofId": "buffons-needle-oq-01-oq-04",
+    "range": {
+      "startLine": 181,
+      "endLine": 209
+    },
+    "type": "insight",
+    "title": "Shape Independence and Monotonicity in Perimeter",
+    "content": "Because the cut-line count depends only on the perimeter through the formula perimeter/(πd), two structural consequences follow algebraically. coin_shape_independence: any two convex bodies of equal perimeter — a circle, an ellipse, a smoothed square — cut the same expected number of grid lines, however different their shapes. coin_lineCuts_mono: a longer-perimeter body cuts at least as many lines (monotonicity via div_le_div_of_nonneg_right). Both are immediate once buffon_coin_lineCuts reduces each side to perimeter/(πd); they capture the qualitative content of Cauchy's mean-width principle, that only the average projection length (proportional to perimeter) matters.",
+    "mathContext": "If $p_1 = p_2$ then $\\operatorname{lineCuts}_1 = \\operatorname{lineCuts}_2$; if $p_1 \\le p_2$ then $\\operatorname{lineCuts}_1 \\le \\operatorname{lineCuts}_2$, since both equal $p_i/(\\pi d)$.",
+    "significance": "supporting",
+    "relatedConcepts": [
+      "Cauchy mean-width formula",
+      "monotonicity",
+      "shape invariance",
+      "perimeter"
+    ],
+    "prerequisites": [
+      "div_le_div_of_nonneg_right",
+      "Real.pi_pos"
+    ]
+  }
+]


### PR DESCRIPTION
## Summary

Enrichment pass for `buffons-needle-oq-01-oq-04` (Buffon's Coin — the Cauchy mean-width specialization). The entry had a rich `meta.json` but **no `annotations.json`**, which was the dominant quality gap (live quality score 45).

Adds a 6-annotation `annotations.json` covering all five sections of `Proofs/BuffonsNeedleOQ01OQ04.lean`:

1. **Overview** — Buffon's coin as a corollary of the smooth-noodle theorem; perimeter-only dependence
2. **Perimeter** — `boundaryPerimeter` as boundary arc length + nonnegativity
3. **Boundary crossings** — the one-line corollary of `buffon_smooth_of_contDiff` (E[crossings] = 2p/(πd))
4. **Line cuts** — where convexity enters: the factor-of-2 (0-or-2 dichotomy), encoded definitionally
5. **The circle** — recovering Laplace's classical `diameter/d` probability (E[cut lines] = 2r/d)
6. **Shape independence & monotonicity** — algebraic consequences of the perimeter-only formula

Each annotation has `mathContext` (LaTeX), `significance`, `relatedConcepts`, and `prerequisites`, mapped to accurate line ranges.

## Notes

- `index.ts` is intentionally **not** added — the loader was migrated off per-proof `import.meta.glob` shims to `listings.json` + `data-manifest.json` (issue #20993); `index.ts` files are obsolete.
- Annotation content was checked against the actual Lean source for accuracy.
- Built from a private worktree off `origin/main`: the shared `enricher-1` worktree was being reset/cleaned by a concurrent process mid-edit, repeatedly wiping the untracked file.

## Test plan
- [x] JSON validates (parses; all required fields present on all 6 annotations)
- [x] `pnpm build` passed end-to-end with this annotation content (✓ built in ~18s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)