### PR TITLE
audit(qt-multichoose): meta↔source metric sync

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
@@ -27,8 +27,8 @@
     "dateAdded": "2026-06-13",
     "axiomCount": 0,
     "assumptions": "No axiom declarations and no sorries: every theorem in the file is machine-checked. The entry is classified `axiomatized` because the open question is only partially resolved and the headline results are conditional. Specifically: (1) the t=1 specialization qtMultichoose q 1 n k = qMultichoose q n k holds under the Path A non-degeneracy hypothesis `q^(j+1) ≠ 1 for all j < k` (q not a low-order root of unity), which keeps the Macdonald rational denominators nonzero; (2) the polynomial-sub-lattice bridges carry the analogous `1 - q ≠ 0` / `1 - q^2 t ≠ 0` guards; (3) the positive q=t=1 recovery of Nat.multichoose is NOT formalized — only the negative `Field R` 0/0-trap form (= 0) is proved, since Lean's field convention sets 0/0 = 0; a positive recovery requires a RatFunc.eval lift (Path C, future work); (4) the interpolating (q,t)-Pascal recurrence remains open (prior PREP analysis falsified the naive candidate at small cases).",
-    "lineCount": 518,
-    "theoremCount": 18,
+    "lineCount": 563,
+    "theoremCount": 22,
     "definitionCount": 2,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -191,7 +191,7 @@
     }
   ],
   "conclusion": {
-    "summary": "The Macdonald (q,t)-binomial, evaluated at the multichoose index shift N = n+k-1, yields a (q,t)-multichoose coefficient that is well-typed over a Field R and recovers the parent's qMultichoose at t=1 on the open dense set where q is not a low-order root of unity (Path A). The (q,t)-multichoose is t-independent precisely on the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)}, and every point there is bridged to the parent's qNumber/qBinom/qMultichoose. The file is sorry-free and axiom-free (18 machine-checked theorems), but the open question is only partially resolved.",
+    "summary": "The Macdonald (q,t)-binomial, evaluated at the multichoose index shift N = n+k-1, yields a (q,t)-multichoose coefficient that is well-typed over a Field R and recovers the parent's qMultichoose at t=1 on the open dense set where q is not a low-order root of unity (Path A). The (q,t)-multichoose is t-independent precisely on the polynomial sub-lattice {k ≤ 1} ∪ {(2,2)}, and every point there is bridged to the parent's qNumber/qBinom/qMultichoose. The file is sorry-free and axiom-free (22 machine-checked theorems), but the open question is only partially resolved.",
     "implications": "This is the gallery's first contact with Macdonald (q,t)-binomial theory, an area entirely absent from Mathlib v4.26.0 (no Macdonald polynomials, Hall-Littlewood functions, or DAHA). The k-direction multiplicative recurrence and its ratio form give clean Lean handles on the Macdonald binomial that future work can reuse. The explicit formalization of the Field-R 0/0 trap is a reusable cautionary pattern for any rational-function specialization under Lean's 0/0 = 0 convention.",
     "openQuestions": [
       "Positive q=t=1 recovery: prove qtMultichoose 1 1 n k = Nat.multichoose n k by lifting to RatFunc ℚ and evaluating (Path C), avoiding the Field-R 0/0 trap. Estimated ~80–120 LOC and likely multi-session.",
@@ -219,8 +219,8 @@
       "Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03"
     ],
     "axiomCount": 0,
-    "lineCount": 518,
-    "theoremCount": 18,
+    "lineCount": 563,
+    "theoremCount": 22,
     "definitionCount": 2,
     "sorries": 0,
     "additionalFiles": []

--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15308,6 +15308,12 @@
       "lastAudited": "2026-06-10T16:48:43Z",
       "result": "clean",
       "issues": []
+    },
+    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-13T15:09:16Z",
+      "result": "issues-fixed",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02

**Result:** issues-fixed (metadata staleness; no overclaim)

### What was wrong
The Lean source grew to **563 lines / 22 theorems** (two sharpness theorems
`qtMultichoose_at_one_one_zero` and `qtMultichoose_at_one_one_ne_classical` were
added past line 518), but `meta.json` still reported **518 lines / 18 theorems**.

### Fix
- `meta.meta.lineCount` 518 → 563, `theoremCount` 18 → 22
- `meta.leanFile.lineCount` 518 → 563, `theoremCount` 18 → 22
- `conclusion.summary`: "18 machine-checked theorems" → "22"

### Integrity-critical fields verified correct (unchanged)
- `sorries: 0` — matches source (0 sorries)
- `axiomCount: 0` — matches source (0 `axiom` decls, **no structure-encoded assumptions**)
- No `True` stubs
- `status: "axiomatized"` / `badge: "axiom"` — appropriately conservative: the
  file is sorry/axiom-free but headline results are conditional on Path A
  non-degeneracy hypotheses and the open question is only partially resolved.
  Correct per the project's "when in doubt, axiomatized" policy.

`sections[].endLine` left as-is: the two new theorems are a distinct topic
(sharpness of the 0/0 trap); documenting them as a new section is enrichment
scope, not an audit metric fix.

Build-free change (JSON metadata only).

---
Discovered during gallery integrity audit.