### PR TITLE
audit(buffons-needle-oq-01-oq-04): tracker bump — clean

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -15308,6 +15308,12 @@
       "lastAudited": "2026-06-10T16:48:43Z",
       "result": "clean",
       "issues": []
+    },
+    "buffons-needle-oq-01-oq-04": {
+      "auditCount": 1,
+      "lastAudited": "2026-06-13T15:12:04Z",
+      "result": "clean",
+      "issues": []
     }
   },
   "version": 1,


### PR DESCRIPTION
## Gallery Integrity Audit — buffons-needle-oq-01-oq-04

**Result:** clean (no issues)

### Verified
- Metrics match source exactly: 209 lines, 13 theorems, 3 defs
- `sorries: 0` ✓ — source has 0 sorries
- `axiomCount: 0` ✓ — 0 `axiom` decls, **no structure-encoded assumptions**
- No `True` stubs
- `status: "verified"` / `badge: "mathlib"` — appropriate. The analytic content
  is inherited from the parent's 0-axiom/0-sorry `buffon_smooth_of_contDiff`
  bearer (parent confirmed sorry/axiom-free with no structures). The `mathlib`
  badge correctly signals the Mathlib/parent reliance — not a hidden import.
- The definitional factor-of-two convexity encoding (`expectedLineCuts := … / 2`)
  is transparently disclosed in both the `def` docstring and the `assumptions`
  field. No delegation opacity, no axiom masking, no overclaim.

Tracker bump only (build-free).

---
Discovered during gallery integrity audit.