### PR TITLE
audit(qt-multichoose): sync meta.json counts + assumptions with Lean source

### DIFF
--- a/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02/meta.json
@@ -26,9 +26,9 @@
     "sorries": 0,
     "dateAdded": "2026-06-13",
     "axiomCount": 0,
-    "assumptions": "No axiom declarations and no sorries: every theorem in the file is machine-checked. The entry is classified `axiomatized` because the open question is only partially resolved and the headline results are conditional. Specifically: (1) the t=1 specialization qtMultichoose q 1 n k = qMultichoose q n k holds under the Path A non-degeneracy hypothesis `q^(j+1) ≠ 1 for all j < k` (q not a low-order root of unity), which keeps the Macdonald rational denominators nonzero; (2) the polynomial-sub-lattice bridges carry the analogous `1 - q ≠ 0` / `1 - q^2 t ≠ 0` guards; (3) the positive q=t=1 recovery of Nat.multichoose is NOT formalized — only the negative `Field R` 0/0-trap form (= 0) is proved, since Lean's field convention sets 0/0 = 0; a positive recovery requires a RatFunc.eval lift (Path C, future work); (4) the interpolating (q,t)-Pascal recurrence remains open (prior PREP analysis falsified the naive candidate at small cases).",
-    "lineCount": 518,
-    "theoremCount": 18,
+    "assumptions": "No axiom declarations and no sorries: every theorem in the file is machine-checked. The entry is classified `axiomatized` because the open question is only partially resolved and the headline results are conditional. Specifically: (1) the t=1 specialization qtMultichoose q 1 n k = qMultichoose q n k holds under the Path A non-degeneracy hypothesis `q^(j+1) ≠ 1 for all j < k` (q not a low-order root of unity), which keeps the Macdonald rational denominators nonzero; (2) the polynomial-sub-lattice bridges carry the analogous `1 - q ≠ 0` / `1 - q^2 t ≠ 0` guards; (3) the positive q=t=1 recovery of Nat.multichoose is formalized only at the k=0 boundary column (qtMultichoose_at_one_one_zero: = Nat.multichoose n 0 = 1, the empty product); for every k≥1 the Field-R 0/0 trap collapses the naive substitution to 0, and a sharpness inequality (qtMultichoose_at_one_one_ne_classical, char 0) proves this 0 strictly differs from the nonzero classical value, so positive recovery for k≥1 provably requires a RatFunc.eval lift (Path C, future work); (4) the interpolating (q,t)-Pascal recurrence remains open (prior PREP analysis falsified the naive candidate at small cases).",
+    "lineCount": 563,
+    "theoremCount": 21,
     "definitionCount": 2,
     "mathlib_version": "4.26.0",
     "mathlibDependencies": [
@@ -219,8 +219,8 @@
       "Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ03OQ02OQ03"
     ],
     "axiomCount": 0,
-    "lineCount": 518,
-    "theoremCount": 18,
+    "lineCount": 563,
+    "theoremCount": 21,
     "definitionCount": 2,
     "sorries": 0,
     "additionalFiles": []


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02` ((q,t)-Multichoose)

Doc-only meta.json sync. **No overclaiming found** — the file is genuinely sorry-free and axiom-free. The meta.json had drifted *behind* the Lean source (under-representing it).

### Mismatches corrected
| Field | meta.json (stale) | Lean source (actual) |
|-------|-------------------|----------------------|
| `lineCount` | 518 | 563 |
| `theoremCount` | 18 | 21 |
| `assumptions` (pt 3) | "positive q=t=1 recovery NOT formalized" | k=0 positive recovery now formalized (`qtMultichoose_at_one_one_zero`); k≥1 sharpness inequality added (`qtMultichoose_at_one_one_ne_classical`) |

A Section XI (S8 ACT) was added to the Lean file after the meta was last written, adding 2 theorems and the positive/sharpness pair.

### Verified against source (unchanged)
- 0 sorries ✓
- 0 axiom declarations ✓
- 0 True stubs ✓
- status `axiomatized` / badge `axiom`: conservative (open question only partially resolved) — appropriate

---
Discovered during gallery integrity audit. Build-free metadata correction.