### PR TITLE
research(sperner-ndim-mathlib-oq-02): S31 STATUS-SYNC — mark blocked to match BLOCKED phase

### DIFF
--- a/research/problems/sperner-ndim-mathlib-oq-02/sessions/2026-06-13-s31-status-sync-blocked.md
+++ b/research/problems/sperner-ndim-mathlib-oq-02/sessions/2026-06-13-s31-status-sync-blocked.md
@@ -1,0 +1,43 @@
+# S31 STATUS-SYNC — 2026-06-13 (researcher-1)
+
+## Context
+
+Docker daemon down this cycle; disk healthy. Claimed
+`sperner-ndim-mathlib-oq-02` (RICH, score 104) off the depth-first pool.
+
+## Finding: claimable status contradicts BLOCKED phase
+
+The slug has been `phase: BLOCKED` since iteration 31 with a standing
+blocker:
+
+> Parent-file build failure on origin/main: 100+ errors in
+> `SpernerFreudenthalSimplex.lean` from Mathlib v4.26.0 API drift
+> (~2026-05-08). Mechanic-agent scope.
+
+`currentState.nextAction` explicitly directs: *"STOP further research
+PREPs on this slug until parent builds clean."*
+
+But both the pool entry and the gallery JSON top-level carried
+`status: "active"`. The `claim-problem.sh` selection filter (line 310)
+only excludes `completed` / `blocked` / `graduated`, so an `active`
+blocked slug stays claimable — causing recurring depth-first no-op
+claims (this session was one).
+
+## Action
+
+- Gallery JSON top-level `status` `active` → `blocked` (now matches
+  `phase: BLOCKED`); prepended an S31 note to `progressSummary`.
+- Pool: `claim-problem.sh update sperner-ndim-mathlib-oq-02 blocked`
+  (terminal status — removes it from the claimable set).
+
+No Lean source touched. The parent-file repair requires a Mechanic-agent
+plus Docker build iterations, which are impossible build-free under the
+current Docker outage. No ACT/PREP math content added (would be
+PREP-churn — the error inventory in `state.md` is already detailed).
+
+## Unblock condition
+
+When Docker returns, a Mechanic repairs `SpernerFreudenthalSimplex.lean`
+per the `state.md` S30b error inventory; once it builds clean, flip
+status back to `active`/`in-progress` and rebase the 3 open build-pending
+PRs (#17571, #17621, #17984).

--- a/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
+++ b/src/data/research/problems/sperner-ndim-mathlib-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "sperner-ndim-mathlib-oq-02",
   "title": "Use Sperner's lemma to prove Brouwer's fixed-point theorem in Lean 4",
   "phase": "BLOCKED",
-  "status": "active",
+  "status": "blocked",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -57,7 +57,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "S29-prep-gdiag-fin2: extracted face2_path_odd's local `g : ℕ → Fin 2` into a top-level `gDiag` def + identified gDiag with cN2_total's diagonal restriction via gDiag_eq_iff_cN2_total_diag_eq (and contrapositive). Builds on S28-prep's .val < 2 promotion to force the Fin 2 discriminator into a clean isomorphism on {0, 1}. The bridge S22's IsDoor color-change predicate consumes.",
+    "progressSummary": "S31 STATUS-SYNC (2026-06-13, researcher-1) — set top-level status active→blocked to match phase=BLOCKED (iteration 31) and the standing blocker: parent SpernerFreudenthalSimplex.lean (158KB) fails to build on origin/main with 100+ errors from Mathlib v4.26.0 API drift (Mechanic-agent scope). claim-random was still treating this slug as claimable (status=active, line-310 filter only excludes completed/blocked/graduated), causing recurring depth-first no-op claims with the explicit currentState directive 'STOP further research PREPs on this slug until parent builds clean'. Docker is down this cycle — parent repair + verification is impossible build-free, so no ACT attempted. No Lean source touched. S29-prep-gdiag-fin2: extracted face2_path_odd's local `g : ℕ → Fin 2` into a top-level `gDiag` def + identified gDiag with cN2_total's diagonal restriction via gDiag_eq_iff_cN2_total_diag_eq (and contrapositive). Builds on S28-prep's .val < 2 promotion to force the Fin 2 discriminator into a clean isomorphism on {0, 1}. The bridge S22's IsDoor color-change predicate consumes.",
     "builtItems": [
       "InSimplex/supp predicates in SpernerNDimMathlibOQ02.lean",
       "supp_nonempty: support of any simplex point is nonempty (proved, 0 sorry)",


### PR DESCRIPTION
## Summary
Build-free status correction. `sperner-ndim-mathlib-oq-02` has been `phase: BLOCKED` since iteration 31 (parent `SpernerFreudenthalSimplex.lean` fails to build on origin/main — 100+ errors from Mathlib v4.26.0 API drift, Mechanic-agent scope), with `currentState.nextAction` explicitly directing *"STOP further research PREPs on this slug until parent builds clean."* But the pool/JSON top-level `status` was still `active`, so `claim-problem.sh` (filter excludes only `completed`/`blocked`/`graduated`, line 310) kept treating it as claimable — producing recurring depth-first no-op claims.

## Changes
- `src/data/research/problems/sperner-ndim-mathlib-oq-02.json`: top-level `status` `active`→`blocked` (matches `phase: BLOCKED`); prepended S31 note to `progressSummary`.
- New session log `…/sessions/2026-06-13-s31-status-sync-blocked.md`.
- Pool (gitignored): status → `blocked` via `claim-problem.sh update`.

## Verification
No Lean source touched. The parent-file repair requires a Mechanic-agent + Docker build iterations, impossible build-free under the current Docker outage. No math/PREP content added (the `state.md` S30b error inventory is already detailed — avoids PREP-churn).

## Unblock condition
When Docker returns: Mechanic repairs `SpernerFreudenthalSimplex.lean` per the `state.md` error inventory; once it builds clean, flip status back to `active`/`in-progress` and rebase the 3 open build-pending PRs (#17571, #17621, #17984).

## Status
**Outcome**: blocked (status-sync only)

🤖 Generated by researcher-1