### PR TITLE
research(schauder-fixed-point-oq-03-oq-01): S32 AUDIT — sync meta.json to Lean source

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -38,8 +38,8 @@
     "originalContributions": [
       "IsGraphApproxSelection: Definition of ε-graph-approximate continuous selections (Cellina–Browder form)",
       "brouwer_unit_ball: Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (AXIOMATIZED, S11.A strict-weakening 2026-05-09; replaces the previous brouwer_fpt axiom — strictly weaker mathematical commitment, identical axiom count)",
-      "exists_continuous_proj_convex: Continuous nearest-point retraction onto compact convex sets in EuclideanSpace (LEMMA, sorry-stubbed; S11.B work item)",
-      "brouwer_fpt: Brouwer's FPT for general compact convex S, derived from brouwer_unit_ball + exists_continuous_proj_convex via the nearest-point retraction reduction (THEOREM, body landed S13/2026-05-09 — no sorry in body; transitively depends on the sorry-stubbed exists_continuous_proj_convex helper)",
+      "exists_continuous_proj_convex: Continuous nearest-point retraction onto compact convex sets in EuclideanSpace (LEMMA, landed S14 — sorry-free)",
+      "brouwer_fpt: Brouwer's FPT for general compact convex S, derived from brouwer_unit_ball + exists_continuous_proj_convex via the nearest-point retraction reduction (THEOREM, body landed S13/2026-05-09 — no sorry in body; the exists_continuous_proj_convex helper it depends on landed S14 and is itself sorry-free, so the theorem is end-to-end sorry-free modulo the two axioms)",
       "approx_selection_exists: UHC + convex → continuous ε-graph-approximate selections (AXIOMATIZED, Cellina–Browder form; pointwise form is provably false under USC alone — see S6 analysis)",
       "uhc_local_thickening: S17 Cellina–Browder Step-1 scaffold (UHC at any open V = ε-thickening yields a local U where F maps into the thickening; proved from the UHC definition)",
       "convex_combination_of_partition_in_S: S18a Step-4 helper (Convex.sum_mem + PartitionOfUnity API: weighted sums by a partition of unity stay in the convex target)",
@@ -54,16 +54,16 @@
     ],
     "dateAdded": "2026-04-12",
     "axiomCount": 2,
-    "lineCount": 1479,
+    "lineCount": 1531,
     "prerequisites": [
       "Brouwer's fixed point theorem",
       "Compact metric spaces",
       "Convex sets in Euclidean space",
       "Upper hemicontinuity"
     ],
-    "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; S11.A.body landed S13/2026-05-09, so the theorem's body is sorry-free, but it transitively depends on the sorry-stubbed `exists_continuous_proj_convex` helper pending S11.B — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
+    "assumptions": "Two axioms: (1) `brouwer_unit_ball` — Brouwer's FPT on the closed unit ball in EuclideanSpace ℝ (Fin n) (S11.A strict-weakening 2026-05-09: the previous axiom asserted FPT for any nonempty compact convex S; the unit-ball-only form is strictly weaker — identical axiom count, smaller mathematical commitment); (2) `approx_selection_exists` — existence of continuous ε-graph-approximate selections (Cellina–Browder form) for UHC maps with convex values. The general-compact-convex Brouwer form is recovered in-house as `theorem brouwer_fpt` via the nearest-point retraction reduction (S8/S11.A; S11.A.body landed S13/2026-05-09, so the theorem's body is sorry-free; the `exists_continuous_proj_convex` helper it depends on landed in S14 and is itself sorry-free, so `brouwer_fpt` is end-to-end machine-checked modulo the two axioms — see s11-strict-weakening-spec.md). Sequential compactness, previously a third axiom, is now derived from Mathlib. The combination argument and the limit lemma are fully proved. S6 analysis showed that the strictly stronger pointwise form `∀ x, ∃ y ∈ F x, dist (f x) y < ε` is FALSE under USC + convex values alone, so the selection axiom must be stated in the graph form; `kakutani_from_brouwer` threads a triangle-inequality `ε ↦ 2·(ε/2) = ε` step to recover the diagonal-distance witness expected by `approx_fixedpoint_implies_fixedpoint`.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 14,
+    "theoremCount": 7,
     "definitionCount": 4
   },
   "overview": {
@@ -212,9 +212,9 @@
       "Metric"
     ],
     "namespace": "KakutaniFromBrouwer",
-    "lineCount": 1479,
+    "lineCount": 1531,
     "axiomCount": 2,
-    "theoremCount": 14,
+    "theoremCount": 7,
     "definitionCount": 4,
     "path": "Proofs/SchauderFixedPointOQ03OQ01.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Build-free metadata audit of `schauder-fixed-point-oq-03-oq-01` (Kakutani from Brouwer). `SchauderFixedPointOQ03OQ01.lean` had drifted from its `meta.json`. Synced the canonical numeric fields and corrected stale prose. No Lean source changes.

## Verified against source (`proofs/Proofs/SchauderFixedPointOQ03OQ01.lean`)

Using the canonical `enrich-research.ts` counting convention (`^(theorem|lemma) `, `^axiom `, `wc -l`), cross-checked against sibling meta (`oq-01`, `oq-03`):

| field | was | now | source |
|-------|-----|-----|--------|
| lineCount | 1479 | **1531** | `wc -l` |
| theoremCount | 14 | **7** | 7 public `theorem`/`lemma`; 12 `private lemma` scaffolds excluded by convention |
| axiomCount | 2 | 2 ✓ | `brouwer_unit_ball`, `approx_selection_exists` |
| definitionCount | 4 | 4 ✓ | unchanged |
| sorries | 0 | 0 ✓ | confirmed 0 real sorries (3 matches are all in comments) |

## Prose correction

`exists_continuous_proj_convex` was described as "sorry-stubbed; S11.B work item". It landed in S14 and is **sorry-free** (verified: no `sorry` in its body lines 218–369, in `brouwer_fpt` 371–516, or in any of the 12 private scaffolds 563–1226). Updated the `assumptions` field and two `originalContributions` entries accordingly. Status remains `axiomatized` (the 2 axioms are unchanged).

## Out of scope

The `sections[]` line ranges are also stale (e.g. `kakutani-proof` lists 290–352; the theorem is now at line 1393). Correcting those accurately requires restructuring the section narrative around the 12 new private scaffold lemmas and is better verified with a gallery build (Docker currently down). Left for a follow-up.

## Test plan
- [x] `python3 -m json.tool` validates meta.json
- [x] All numeric fields re-derived from source via the canonical convention
- [ ] Gallery render (`pnpm build`) — deferred (Docker/build infra down)