### PR TITLE
research(minpoly-charpoly-oq-02): S14 — flag BLOCKED on verification blackout + Bridge A reverse recipe

### DIFF
--- a/research/problems/minpoly-charpoly-oq-02/state.md
+++ b/research/problems/minpoly-charpoly-oq-02/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: S8 ACT readiness — **REVERSE DIRECTION ONLY** (forward shipped via #22909)
-**Since**: 2026-06-13 (S13 content correction)
-**Iteration**: 16
+**Phase**: BLOCKED (infra) — **REVERSE DIRECTION ONLY** (forward shipped via #22909)
+**Since**: 2026-06-13 (S14 flagged blocked on verification blackout)
+**Iteration**: 17
 
 > **S13 CONTENT CORRECTION (researcher-1, 2026-06-13).** The S11/S12 records
 > below are stale, NOT dormant. They claim "no PRs touched MinpolyCharpolyOQ02.lean
@@ -20,6 +20,75 @@
 > forward direction. This corrects a missed-merge content error, distinct from the
 > prior S6/S8/S10/S11/S12 infra re-measurement churn. Docker down 2026-06-13
 > (verification blackout) so no build attempted this session.
+
+---
+
+## S14 BLOCKED (researcher-1, 2026-06-13) — verification blackout, all routes down
+
+Flagging this slug **`blocked`** (infra, not math). The state is fully
+synced (S13, today) and the **only** remaining work is the reverse-direction
+`sorry` at `MinpolyCharpolyOQ02.lean:221`, which is **build-dependent and
+unverifiable today**:
+
+| Route | Status (2026-06-13) | Check |
+|-------|---------------------|-------|
+| Docker local build | **HUNG** | `docker info` times out (rc=124) |
+| Aristotle proof search | **404** | `mcp-smoke-test.sh` → `404 Not Found` on `…/api/v1/project` |
+
+Both verification routes are down (cf. fleet-wide blackout). CI does **not**
+build Lean, so a blind reverse-direction edit could silently break the
+currently-green file (forward direction + 5 sanity lemmas all build). Per the
+"flag BLOCKED over PREP churn" rule (16 iters, 1 ACT, 5 prior STATE-SYNCs),
+this session does **not** add a doc-only PREP memo #6 — it flags blocked and
+records the fully-specified unblock recipe below.
+
+### Unblock path (when Docker recovers — paste at line 221)
+
+The three bridges B-fwd / C / D are **already in-tree**. The sole missing
+piece is **Bridge A reverse** (eigenspace decomposition → conjugating matrix),
+which no prior PREP wrote out concretely. Recipe:
+
+```lean
+-- hsq : Squarefree (minpoly K M),  goal : M.IsDiagonalizable
+set f := Matrix.toLin' M with hf
+-- Bridge D: minpoly K f = minpoly K M  (verify exact name at pin)
+have hmp : minpoly K f = minpoly K M := by simp [hf, Matrix.minpoly_toLin']
+-- Bridge C (in-tree): f is semisimple
+have hss : f.IsSemisimple :=
+  (Module.End.isSemisimple_iff_squarefree_minpoly).mpr (hmp ▸ hsq)
+-- Bridge B fwd (in-tree): eigenspaces span ⊤
+have htop : ⨆ μ : K, f.eigenspace μ = ⊤ :=
+  Module.End.iSup_eigenspace_eq_top_of_isSemisimple hss
+-- Bridge A reverse (NEW — the only real gap):
+--   1. eigenspaces are independent: Module.End.eigenspaces_independent f
+--      (or iSupIndep_…; verify name at v4.26.0).
+--   2. independent + htop ⇒ DirectSum.IsInternal (fun μ => f.eigenspace μ)
+--      via DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top.mpr.
+--   3. collected eigenbasis: hInternal.collectedBasis (fun μ => (f.eigenspace μ).basis …),
+--      indexed by Σ μ, Fin (finrank K (f.eigenspace μ)); reindex to n via
+--      Fintype.card equality (Σ-card = finrank = card n over alg-closed).
+--   4. P := (b.reindex e).toMatrix (Pi.basisFun K n)  (columns = eigenvectors);
+--      IsUnit P from basis.toMatrix invertibility.
+--   5. IsDiag (P⁻¹ * M * P): in the eigenbasis toLin' M acts diagonally
+--      (M • bᵢ = μᵢ • bᵢ), so LinearMap.toMatrix b b f is diagonal and the
+--      conjugation P⁻¹ M P equals that diagonal matrix.
+```
+
+Bearers to re-pin-verify when unblocked: `Matrix.minpoly_toLin'`,
+`Module.End.eigenspaces_independent`,
+`DirectSum.isInternal_submodule_iff_iSupIndep_and_iSup_eq_top`,
+`DirectSum.IsInternal.collectedBasis`, `Basis.toMatrix`,
+`LinearMap.toMatrix_toLin'`. Estimated ~50 LOC. Expected final state:
+**~330 LOC, 0 sorries, 0 axioms** → promote to `verified`.
+
+### Files touched this S14 (2)
+
+- `research/problems/minpoly-charpoly-oq-02/state.md` — this block + header.
+- `src/data/research/problems/minpoly-charpoly-oq-02.json` — `status` →
+  `blocked`, `currentState.{phase, since, iteration, blockers, nextAction}`,
+  `lastUpdate`.
+
+No Lean file touched (sorry count unchanged at 1; axiom count unchanged at 0).
 
 ---
 

--- a/src/data/research/problems/minpoly-charpoly-oq-02.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "minpoly-charpoly-oq-02",
   "title": "Diagonalizable Matrices via Squarefree Minimal Polynomial",
   "phase": "ACT",
-  "status": "in-progress",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -31,12 +31,14 @@
     "goal": "Statement and proof of `diagonalizable_iff_squarefree_minpoly`: over an algebraically closed field of characteristic zero (and, in OQ-02-OQ-03, over any field with the explicit `splits` hypothesis), `M.IsDiagonalizable ↔ Squarefree (minpoly K M)`."
   },
   "currentState": {
-    "phase": "S8-ACT-READY",
+    "phase": "BLOCKED",
     "since": "2026-06-13T00:00:00Z",
-    "iteration": 16,
+    "iteration": 17,
     "focus": "S13 STATE-SYNC (researcher-1, 2026-06-13): CONTENT CORRECTION — prior records (leanFiles + S12 focus) were stale, NOT dormant. They claimed MinpolyCharpolyOQ02.lean = 169 LOC, 1 sorry at line 122, '25 days dormant, no PRs since S7'. Reality on origin/main: PR #22923 (helpers) and PR #22909 (forward direction) merged AFTER S12, growing the file to 279 LOC. The FORWARD direction (diagonalizable ⇒ squarefree minpoly) is now FULLY PROVED and unconditional over any field (Matrix.IsDiagonalizable.squarefree_minpoly); matConj similarity-transport automorphism built. The SOLE remaining sorry is the REVERSE direction at line 221 inside diagonalizable_iff_squarefree_minpoly ([IsAlgClosed K][CharZero K]): squarefree minpoly ⇒ diagonalizable, via Bridge C (Module.End.isSemisimple_iff_squarefree_minpoly) + Bridge B (iSup_eigenspace_eq_top_of_isSemisimple) transported through Matrix.toLin'. This corrects a factual missed-merge, distinct from the prior 5:1 doc-only infra re-measurement churn (S6/S8/S10/S11/S12). Build NOT attempted: Docker down 2026-06-13 (verification blackout).",
-    "blockers": [],
-    "nextAction": "S8 ACT (reverse direction only — forward is already shipped via #22909). Discharge the single sorry at MinpolyCharpolyOQ02.lean:221 inside diagonalizable_iff_squarefree_minpoly. Strategy (per file docstring + S7c): transport the squarefree-minpoly ⇒ semisimple ⇒ eigenspaces-span result back through Matrix.toLin' over an alg-closed char-0 field — Bridge C (Module.End.isSemisimple_iff_squarefree_minpoly) + Bridge B (Module.End.iSup_eigenspace_eq_top_of_isSemisimple). The prior 'Bridge A forward ~20 LOC' line item is DONE — do not re-prove it. Pre-flight: df -h ≥30 Gi free; docker info responsive (DOWN as of 2026-06-13 — wait for recovery); lake-manifest Mathlib rev still 2df2f0150c2. docker-build.sh Proofs.MinpolyCharpolyOQ02 to verify.",
+    "blockers": [
+      "Verification blackout (2026-06-13, all routes): Docker daemon HUNG (docker info rc=124) and Aristotle backend 404 (mcp-smoke-test.sh). The sole remaining sorry (reverse direction, MinpolyCharpolyOQ02.lean:221) is build-dependent; CI does not build Lean, so a blind edit could silently break the currently-green file. Mathematically unblocked — bridges pinned."
+    ],
+    "nextAction": "UNBLOCK when Docker recovers, then S15 ACT (reverse direction only). Bridges B-fwd/C/D are in-tree; the sole gap is Bridge A reverse (eigenspace decomposition -> conjugating matrix), recipe written out in state.md S14: set f:=toLin' M; minpoly K f = minpoly K M (Matrix.minpoly_toLin'); f.IsSemisimple (Bridge C); iSup eigenspace = top (Bridge B fwd); then DirectSum.IsInternal of eigenspaces -> collectedBasis -> reindex to n -> P:=Basis.toMatrix -> IsDiag(P-inv M P). Est ~50 LOC -> ~330 LOC, 0 sorries, promote to verified.",
     "attemptCounts": {
       "total": 15,
       "currentApproach": 14,
@@ -114,7 +116,7 @@
     ]
   },
   "started": "2026-05-12T20:35:00Z",
-  "lastUpdate": "2026-06-10T00:00:00.000Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Flags `minpoly-charpoly-oq-02` **`blocked`** (infra, not math) and records the fully-specified unblock recipe for the sole remaining `sorry`.

- **Both verification routes are down (2026-06-13):** Docker daemon HUNG (`docker info` rc=124) and Aristotle backend 404 (`mcp-smoke-test.sh`). The reverse-direction `sorry` at `MinpolyCharpolyOQ02.lean:221` is build-dependent; CI does not build Lean, so a blind edit could silently break the currently-green file (forward direction + 5 sanity lemmas all build).
- **Per the flag-BLOCKED-over-PREP-churn rule** (16 iters, 1 ACT, 5 prior STATE-SYNCs), this does *not* add doc memo #6 — it flags blocked and writes out the **Bridge A reverse** recipe (eigenspace decomposition → conjugating matrix), the only real gap (bridges B-fwd / C / D are already in-tree).
- **State is already synced** (S13, today): drift audit confirms leanFiles accurate (279 LOC, theoremCount 9, defCount 2, real sorryCount 1, axiom 0).

## Changes
- `state.md` — S14 BLOCKED block + header; unblock recipe + bearer list.
- `minpoly-charpoly-oq-02.json` — `status` → `blocked`; `currentState.{phase, iteration, blockers, nextAction}`; `lastUpdate`.

No Lean file touched (sorry count 1, axiom count 0 unchanged).

## Test plan
- [ ] When Docker recovers: paste Bridge A reverse per state.md S14, `docker-build.sh Proofs.MinpolyCharpolyOQ02`, expect ~330 LOC / 0 sorries → promote to `verified`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)