### PR TITLE
research(cayley-hamilton-minpoly-oq-02-oq-01-oq-02): S3 — sync stale research-JSON to completed

### DIFF
--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/knowledge.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/knowledge.md
@@ -85,3 +85,36 @@ substantive criterion the quality gate exists to enforce.
 - `.lean/state/candidate-pool.json` (gitignored, via claim-problem.sh)
 - `research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/knowledge.md`
   (this Session 2 entry)
+
+---
+
+## Session 2026-06-13 (Session 3) — Research-JSON status sync
+
+**Mode**: STATE-SYNC (tracker-only; no Lean touched). **Outcome**: completed.
+
+The slug was re-handed out by depth-first `claim-random` because the **tracked**
+research JSON `src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json`
+was still stale at creation-time values — `status: active`, `phase: NEW`,
+`nextAction: "Begin problem exploration"`, `lastUpdate: 2026-05-05` — even though
+the problem was fully solved in Session 1 (PR #16083) and the gallery meta.json
+reads `status: verified` / 0 sorries / 0 axioms / 9 theorems. Session 2 only
+fixed the gitignored candidate-pool, not this tracked file, so the drift
+persisted.
+
+### What was done
+- Set research JSON `status: completed`, `phase: COMPLETED`,
+  `currentState.{phase, iteration: 3, since, nextAction}`, `lastUpdate`.
+- **Corrected `leanFiles`**: it was a 24-entry dump of the entire
+  `CayleyHamiltonMinpoly*` family that did **not even include** this slug's
+  actual proof file. Replaced with the single delivered file
+  `Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean` (172 LOC / 9 thm / 0 def /
+  0 sorry / 0 axiom — canonical counts vs origin/main).
+- Ran `claim-problem.sh update ... completed` (FORCE_COMPLETE) + released claim.
+
+No Lean file touched. Verification blackout 2026-06-13 (Docker hung + Aristotle
+404) does not affect this slug — it is already verified and merged.
+
+### Files Modified
+- `src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json`
+- `research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02/knowledge.md`
+  (this Session 3 entry)

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "cayley-hamilton-minpoly-oq-02-oq-01-oq-02",
   "title": "Can we characterize exactly when minpoly is invariant under non-injective alg...",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-05T02:57:44.796Z",
-    "iteration": 1,
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
+    "iteration": 3,
     "focus": "Initial exploration of the problem.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "DONE — formalization completed Session 1 (PR #16083, merged 2026-05-06). Gallery meta.json: status=verified, badge=verified, 0 sorries, 0 axioms, 9 theorems. This S3 syncs the stale research-JSON (was phase NEW / 'Begin exploration', lastUpdate 2026-05-05) to completed and corrects leanFiles (was a 24-file family dump not even including the actual proof file) to the single delivered file. No further work.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -78,273 +78,20 @@
     "mathlib": []
   },
   "started": "2026-05-05T02:57:44.795Z",
-  "lastUpdate": "2026-05-05T02:57:44.795Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",
-      "filename": "CayleyHamiltonMinpolyOQ01.lean",
-      "lineCount": 308,
-      "theoremCount": 20,
-      "axiomCount": 3,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ01.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ02.lean",
-      "filename": "CayleyHamiltonMinpolyOQ02.lean",
-      "lineCount": 132,
-      "theoremCount": 7,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean",
-      "filename": "CayleyHamiltonMinpolyOQ02OQ01.lean",
-      "lineCount": 218,
+      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+      "filename": "CayleyHamiltonMinpolyOQ02OQ01OQ02.lean",
+      "lineCount": 172,
       "theoremCount": 9,
       "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean",
-      "filename": "CayleyHamiltonMinpolyOQ02OQ02.lean",
-      "lineCount": 391,
-      "theoremCount": 14,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ02.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean",
-      "filename": "CayleyHamiltonMinpolyOQ02OQ03.lean",
-      "lineCount": 137,
-      "theoremCount": 3,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ03.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ03.lean",
-      "filename": "CayleyHamiltonMinpolyOQ03.lean",
-      "lineCount": 368,
-      "theoremCount": 13,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean",
-      "filename": "CayleyHamiltonMinpolyOQ03Aristotle.lean",
-      "lineCount": 115,
-      "theoremCount": 4,
-      "axiomCount": 0,
-      "defCount": 1,
-      "sorryCount": 0,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03Aristotle.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean",
-      "filename": "CayleyHamiltonMinpolyOQ03OQ01.lean",
-      "lineCount": 266,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ01.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ04.lean",
-      "filename": "CayleyHamiltonMinpolyOQ04.lean",
-      "lineCount": 317,
-      "theoremCount": 8,
-      "axiomCount": 1,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ04Backward.lean",
-      "filename": "CayleyHamiltonMinpolyOQ04Backward.lean",
-      "lineCount": 481,
-      "theoremCount": 9,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 4,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04Backward.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
-      "filename": "CayleyHamiltonMinpolyOQ04BackwardAristotle.lean",
-      "lineCount": 126,
-      "theoremCount": 5,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ04BackwardAristotle.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05.lean",
-      "lineCount": 232,
-      "theoremCount": 23,
-      "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01.lean",
-      "lineCount": 271,
-      "theoremCount": 5,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 1,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ01.lean",
-      "lineCount": 363,
-      "theoremCount": 5,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ01.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ02.lean",
-      "lineCount": 271,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 3,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ02.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ03.lean",
-      "lineCount": 346,
-      "theoremCount": 19,
-      "axiomCount": 0,
-      "defCount": 6,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04.lean",
-      "lineCount": 288,
-      "theoremCount": 7,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 4,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean",
-      "lineCount": 307,
-      "theoremCount": 5,
-      "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 4,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP01.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean",
-      "lineCount": 575,
-      "theoremCount": 11,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP02.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean",
-      "lineCount": 254,
-      "theoremCount": 2,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP03.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean",
-      "lineCount": 359,
-      "theoremCount": 8,
-      "axiomCount": 0,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean",
-      "lineCount": 190,
-      "theoremCount": 2,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ04WIP05.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ02.lean",
-      "lineCount": 263,
-      "theoremCount": 16,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02.lean"
-    },
-    {
-      "path": "Proofs/CayleyHamiltonMinpolyOQ05OQ02OQ03.lean",
-      "filename": "CayleyHamiltonMinpolyOQ05OQ02OQ03.lean",
-      "lineCount": 245,
-      "theoremCount": 10,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ02OQ03.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Build-free status-drift correction. The slug was re-claimable because the tracked research JSON was frozen at creation-time values while the problem was already solved and merged.

- Research JSON was `status: active`, `phase: NEW`, `nextAction: "Begin problem exploration"`, `lastUpdate: 2026-05-05` — but the proof was completed in **Session 1 (PR #16083, 2026-05-06)**: gallery meta.json reads `status: verified`, 0 sorries, 0 axioms, 9 theorems.
- Session 2 only reconciled the gitignored candidate-pool, so depth-first `claim-random` kept re-handing out a finished problem.
- Sets `status`/`phase` → `completed`/`COMPLETED`; corrects `leanFiles` (was a 24-entry `CayleyHamiltonMinpoly*` family dump that **omitted the actual proof file**) to the single delivered file `CayleyHamiltonMinpolyOQ02OQ01OQ02.lean` (172/9/0/0/0, canonical counts vs origin/main).

No Lean file touched — proof already verified and merged.

## Test plan
- [ ] `git show origin/main:proofs/Proofs/CayleyHamiltonMinpolyOQ02OQ01OQ02.lean` confirms 0 sorries / 0 axioms / 9 theorems (verified by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)