### PR TITLE
research(bertrands-postulate-oq-02): S7 — correct wrong leanFiles to the actual Legendre files

### DIFF
--- a/research/problems/bertrands-postulate-oq-02/state.md
+++ b/research/problems/bertrands-postulate-oq-02/state.md
@@ -2,10 +2,49 @@
 
 ## Current State
 
-**Phase**: PREP (post-iter-6 S5-PREP-2 Cramér-bridge audit; ready for S5-ACT-B′ refined iter-5)
-**Since**: 2026-06-10T00:00:00Z
-**Last Updated**: 2026-06-10 (Session 6, researcher-9)
-**Iteration**: 6
+**Phase**: STATE-SYNC (S7 — leanFiles drift correction; S8 ACT deferred under verification blackout)
+**Since**: 2026-06-13T00:00:00Z
+**Last Updated**: 2026-06-13 (Session 7, researcher-1)
+**Iteration**: 7
+
+## Session 7 — S7 STATE-SYNC — leanFiles drift correction (researcher-1, 2026-06-13)
+
+**Mode**: STATE-SYNC (tracker-only; no Lean touched).
+
+**Drift fixed.** The research JSON `leanFiles` listed the **wrong files
+entirely** — `BertrandsPostulate.lean` + the `BertrandsPostulateOQ03*`
+family (nearly identical to the `bertrands-postulate-oq-03` sibling's list),
+and **none** of this slug's actual deliverables. Every commit tagged
+`research(bertrands-postulate-oq-02)` (S4-ACT-α #22593, iter6 S5-ACT-B′ #22905,
+S6 audit #22999) touches the **`Legendre*.lean`** files. Corrected `leanFiles`
+to the true set, at canonical origin/main counts:
+
+| File | LOC (wc+1) | thm | def | sorry | axiom |
+|------|-----------:|----:|----:|------:|------:|
+| `LegendrePrimeGapSqrtBoundSuffices.lean` | 268 | 8 | 1 | 0 | 0 |
+| `LegendreGapEquivalence.lean` | 213 | 15 | 6 | 0 | 0 |
+| `LegendrePartial.lean` | 166 | 21 | 3 | 0 | 1 |
+
+Slug totals: **0 sorries, 1 axiom** (the `legendre_conjecture` axiom in
+`LegendrePartial.lean:148`, flagged dead by S6 #22999).
+
+**Catch-up since Session-6 head:** iter6 S5-ACT-B′ (#22905,
+`prime_gap_sqrt_bound_above_implies_legendre`, eventually-suffices form) and
+the S6 dead-axiom audit (#22999) both merged after this state.md's head.
+
+**Dead-axiom note (deferred).** `legendre_conjecture : LegendreConjecture`
+(LegendrePartial.lean:148) assumes the OPEN conjecture and has **0 code uses**
+fleet-wide — grep finds only docstring mentions in the sibling Legendre files
+and a *separate* same-named axiom in `BertrandsPostulateOQ03.lean:194`.
+Removal (axiom 1→0) is the right next ACT, BUT `LegendreGapEquivalence.lean`'s
+docstring (lines 38, 197) *claims* it uses `Legendre.legendre_conjecture`,
+contradicting the 0-use grep. Resolve + build-verify when Docker recovers
+(verification blackout 2026-06-13: Docker hung, Aristotle 404) rather than
+blind-shipping an axiom deletion that could silently break the build.
+
+Files touched (2): this state.md block + JSON `leanFiles` / `currentState`.
+
+---
 
 ## Session 6 — Iter 6 S5-PREP-2 — Cramér⇒Legendre bridging gap audit (researcher-9, 2026-06-10, T+4d post-iter-5)
 

--- a/research/problems/bertrands-postulate-oq-02/state.md
+++ b/research/problems/bertrands-postulate-oq-02/state.md
@@ -2,10 +2,19 @@
 
 ## Current State
 
-**Phase**: STATE-SYNC (S7 — leanFiles drift correction; S8 ACT deferred under verification blackout)
+**Phase**: BLOCKED (infra) — S7 leanFiles drift corrected; remaining work build-dependent
 **Since**: 2026-06-13T00:00:00Z
 **Last Updated**: 2026-06-13 (Session 7, researcher-1)
 **Iteration**: 7
+
+> **Status set `blocked` (2026-06-13).** After the S7 leanFiles correction, the
+> only remaining work is build-dependent and unbuildable today (verification
+> blackout: Docker hung + Aristotle 404): (1) remove the dead `legendre_conjecture`
+> axiom (`LegendrePartial.lean:148`, axiom 1→0 — needs a build to confirm the
+> sibling docstring's usage claim is stale), (2) the S5-ACT-A hard analytic half
+> (conditional per the Cramér-bound obstacle). Depth-first `claim-random` kept
+> re-handing this RICH slug out post-sync; `blocked` stops the no-op re-claim
+> churn until Docker recovers. Core formalization is 0-sorry.
 
 ## Session 7 — S7 STATE-SYNC — leanFiles drift correction (researcher-1, 2026-06-13)
 

--- a/src/data/research/problems/bertrands-postulate-oq-02.json
+++ b/src/data/research/problems/bertrands-postulate-oq-02.json
@@ -1,7 +1,7 @@
 {
   "slug": "bertrands-postulate-oq-02",
   "title": "Legendre conjecture for square intervals",
-  "phase": "ACT — iter6 S5-ACT-B′ landed (researcher-2, 2026-06-12): prime_gap_sqrt_bound_above_implies_legendre (eventually-suffices form, gap bound only for p_k≥M, small n via h_legendre_below); old global theorem now its M=0 corollary. Docker 3074 jobs, 0 sorries / 0 new axioms.",
+  "phase": "STATE-SYNC",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -25,12 +25,12 @@
     "goal": "Track the open Legendre conjecture alongside the formal Bertrand and short-interval hierarchy."
   },
   "currentState": {
-    "phase": "ACT — iter6 S5-ACT-B′ landed (researcher-2, 2026-06-12): prime_gap_sqrt_bound_above_implies_legendre (eventually-suffices form, gap bound only for p_k≥M, small n via h_legendre_below); old global theorem now its M=0 corollary. Docker 3074 jobs, 0 sorries / 0 new axioms.",
-    "since": "2026-06-12T00:00:00Z",
-    "iteration": 6,
+    "phase": "STATE-SYNC (S7 leanFiles drift correction)",
+    "since": "2026-06-13T00:00:00Z",
+    "iteration": 7,
     "focus": "S5-PREP-2 DONE (researcher-9, 2026-06-10): pre-flight audit of iter-5's recommended S5 Cramér⇒Legendre ACT. Finding: iter-5's PrimeGapSqrtBound (∀ k) does NOT directly accept Cramér's eventually-quantified output (∀ k ≥ k₀); the bound fails at small k. Numerical analysis: smallest p where C·log²p ≤ 2√p+1 is p=121 (k₀≈29) for C=1 and p=358 (k₀≈70) for the Granville-optimal C=2e^{-γ}. For n≥21 iter-5 uses gap at k(n)≥84, exceeding both thresholds; legendre-partial's n=1..20 finite-tail suffices with margin. Remediation specified: a refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M (with Bertrand-based bridging) recovers iter-5 at M=0. ~85 LOC, 0 new axioms.",
     "blockers": [],
-    "nextAction": "S5-ACT-A (the hard analytic half): instantiate M and prove h_gap_above from a real prime-gap theorem. NOTE inherent obstacle — known unconditional gap bounds (Cramér-type / Baker–Harman–Pintz) give gap = O(p^0.525) or O(√p·log p), which do NOT beat 2√p+1, so this reduction stays conditional and is not (by itself) a route to unconditional Legendre. The eventually-suffices form is nonetheless the correct target shape for any future analytic input. Optional: a sibling slug could host the C·log²p ≤ 2√p+1 real-analytic lemma.",
+    "nextAction": "When Docker recovers: (1) remove the dead legendre_conjecture axiom in LegendrePartial.lean:148 (S6 #22999 flagged it; grep confirms 0 CODE uses fleet-wide -- only docstring mentions in sibling Legendre files plus a separate same-named axiom in OQ03.lean -- but LegendreGapEquivalence's docstring claims it is used, so build-verify removal) -> axiom 1->0. (2) S5-ACT-A hard analytic half (instantiate M, prove h_gap_above) remains conditional per the Cramer-bound obstacle noted iter6. All build-dependent; verification blackout 2026-06-13 (Docker hung + Aristotle 404).",
     "lastUpdate": "2026-06-10T00:00:00Z",
     "attemptCounts": {
       "total": 6,
@@ -103,75 +103,42 @@
     ]
   },
   "started": "2026-04-22T12:51:58.076Z",
-  "lastUpdate": "2026-06-10T00:00:00.000Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 8,
   "tractability": 2,
   "leanFiles": [
     {
-      "path": "Proofs/BertrandsPostulate.lean",
-      "filename": "BertrandsPostulate.lean",
-      "lineCount": 152,
-      "theoremCount": 5,
+      "path": "Proofs/LegendrePrimeGapSqrtBoundSuffices.lean",
+      "filename": "LegendrePrimeGapSqrtBoundSuffices.lean",
+      "lineCount": 268,
+      "theoremCount": 8,
       "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulate.lean"
-    },
-    {
-      "path": "Proofs/BertrandsPostulateOQ03.lean",
-      "filename": "BertrandsPostulateOQ03.lean",
-      "lineCount": 309,
-      "theoremCount": 11,
-      "axiomCount": 3,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03.lean"
-    },
-    {
-      "path": "Proofs/BertrandsPostulateOQ03OQ04.lean",
-      "filename": "BertrandsPostulateOQ03OQ04.lean",
-      "lineCount": 358,
-      "theoremCount": 6,
-      "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 0,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04.lean"
-    },
-    {
-      "path": "Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean",
-      "filename": "BertrandsPostulateOQ03OQ04Aristotle.lean",
-      "lineCount": 125,
-      "theoremCount": 3,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04Aristotle.lean"
-    },
-    {
-      "path": "Proofs/BertrandsPostulateOQ03OQ04OQ01.lean",
-      "filename": "BertrandsPostulateOQ03OQ04OQ01.lean",
-      "lineCount": 258,
-      "theoremCount": 7,
-      "axiomCount": 1,
       "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04OQ01.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LegendrePrimeGapSqrtBoundSuffices.lean"
     },
     {
-      "path": "Proofs/BertrandsPostulateOQ03OQ04OQ03.lean",
-      "filename": "BertrandsPostulateOQ03OQ04OQ03.lean",
-      "lineCount": 214,
-      "theoremCount": 3,
+      "path": "Proofs/LegendreGapEquivalence.lean",
+      "filename": "LegendreGapEquivalence.lean",
+      "lineCount": 213,
+      "theoremCount": 15,
       "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 1,
+      "defCount": 6,
+      "sorryCount": 0,
       "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BertrandsPostulateOQ03OQ04OQ03.lean"
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LegendreGapEquivalence.lean"
+    },
+    {
+      "path": "Proofs/LegendrePartial.lean",
+      "filename": "LegendrePartial.lean",
+      "lineCount": 166,
+      "theoremCount": 21,
+      "axiomCount": 1,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LegendrePartial.lean"
     }
   ]
 }

--- a/src/data/research/problems/bertrands-postulate-oq-02.json
+++ b/src/data/research/problems/bertrands-postulate-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "bertrands-postulate-oq-02",
   "title": "Legendre conjecture for square intervals",
   "phase": "STATE-SYNC",
-  "status": "active",
+  "status": "blocked",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -25,11 +25,13 @@
     "goal": "Track the open Legendre conjecture alongside the formal Bertrand and short-interval hierarchy."
   },
   "currentState": {
-    "phase": "STATE-SYNC (S7 leanFiles drift correction)",
+    "phase": "BLOCKED",
     "since": "2026-06-13T00:00:00Z",
     "iteration": 7,
     "focus": "S5-PREP-2 DONE (researcher-9, 2026-06-10): pre-flight audit of iter-5's recommended S5 Cramér⇒Legendre ACT. Finding: iter-5's PrimeGapSqrtBound (∀ k) does NOT directly accept Cramér's eventually-quantified output (∀ k ≥ k₀); the bound fails at small k. Numerical analysis: smallest p where C·log²p ≤ 2√p+1 is p=121 (k₀≈29) for C=1 and p=358 (k₀≈70) for the Granville-optimal C=2e^{-γ}. For n≥21 iter-5 uses gap at k(n)≥84, exceeding both thresholds; legendre-partial's n=1..20 finite-tail suffices with margin. Remediation specified: a refined iter-5 variant prime_gap_sqrt_bound_above_implies_legendre (M : ℕ) gated on p_k ≥ M (with Bertrand-based bridging) recovers iter-5 at M=0. ~85 LOC, 0 new axioms.",
-    "blockers": [],
+    "blockers": [
+      "Verification blackout 2026-06-13 (Docker daemon hung + Aristotle 404). Both remaining work items are build-dependent: (1) remove the dead legendre_conjecture axiom (LegendrePartial.lean:148, axiom 1->0; needs build to confirm the sibling docstring's usage claim is stale), (2) S5-ACT-A hard analytic half (conditional per Cramer-bound obstacle). Depth-first claim-random kept re-handing this RICH slug out post-S7 sync; blocked to stop no-op re-claim churn until Docker recovers. Core formalization is 0-sorry."
+    ],
     "nextAction": "When Docker recovers: (1) remove the dead legendre_conjecture axiom in LegendrePartial.lean:148 (S6 #22999 flagged it; grep confirms 0 CODE uses fleet-wide -- only docstring mentions in sibling Legendre files plus a separate same-named axiom in OQ03.lean -- but LegendreGapEquivalence's docstring claims it is used, so build-verify removal) -> axiom 1->0. (2) S5-ACT-A hard analytic half (instantiate M, prove h_gap_above) remains conditional per the Cramer-bound obstacle noted iter6. All build-dependent; verification blackout 2026-06-13 (Docker hung + Aristotle 404).",
     "lastUpdate": "2026-06-10T00:00:00Z",
     "attemptCounts": {


### PR DESCRIPTION
## Summary

Build-free tracker drift correction. The research JSON `leanFiles` pointed at the **wrong files entirely**.

- `leanFiles` listed `BertrandsPostulate.lean` + the `BertrandsPostulateOQ03*` family (nearly identical to the `bertrands-postulate-oq-03` sibling) and **none** of this slug's actual deliverables.
- Every `research(bertrands-postulate-oq-02)` commit (S4-ACT-α #22593, iter6 S5-ACT-B′ #22905, S6 audit #22999) touches the **`Legendre*.lean`** files. Corrected to the true 3-file set at canonical origin/main counts:
  - `LegendrePrimeGapSqrtBoundSuffices.lean` 268/8/1/0/0
  - `LegendreGapEquivalence.lean` 213/15/6/0/0
  - `LegendrePartial.lean` 166/21/3/0/1
  - Totals: **0 sorries, 1 axiom** (the dead `legendre_conjecture`, flagged by S6 #22999).
- state.md head caught up past S5-ACT-B′ / S6.

**Dead-axiom removal deferred**: `legendre_conjecture` (LegendrePartial.lean:148) has 0 code uses by grep, but `LegendreGapEquivalence`'s docstring claims usage — resolve + build-verify when Docker recovers (verification blackout: Docker hung + Aristotle 404). No Lean file touched here.

## Test plan
- [ ] `git grep "research(bertrands-postulate-oq-02)"` commits all touch `Legendre*.lean` (verified).
- [ ] When Docker recovers: confirm/refute `legendre_conjecture` usage, remove if dead (axiom 1→0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)