### PR TITLE
research(euler-totient-oq-04-oq-01): record existing Möbius-inversion proof

### DIFF
--- a/research/problems/euler-totient-oq-04-oq-01/knowledge.md
+++ b/research/problems/euler-totient-oq-04-oq-01/knowledge.md
@@ -1,0 +1,81 @@
+# euler-totient-oq-04-oq-01 — Möbius inversion: Σ_{d|n} μ(d) = [n=1]
+
+**Parent**: euler-totient-oq-04 (Divisor Sum Identity via GCD Partition)
+**Tier**: B · significance 6 · tractability 6
+
+## Summary
+
+Target identity:
+
+    Σ_{d | n} μ(d) = if n = 1 then 1 else 0
+
+A **complete constructive Lean proof already exists** at
+`proofs/Proofs/EulerTotientOQ04OQ01.lean` and is wired into `proofs/Proofs.lean`.
+It has 6 theorems, 0 real `sorry`s (one `\bsorry\b` grep hit is the prose
+"Zero `sorry`s" in the docstring), and 0 `axiom`s.
+
+The proof uses the **squarefree-divisor / powerset bijection**, deliberately
+*not* Mathlib's multiplicative-induction route
+(`ArithmeticFunction.moebius_mul_coe_zeta`, which goes via
+`recOnPosPrimePosCoprime`). This mirrors the GCD-class-partition aesthetic of
+the parent file `EulerTotientOQ04.lean`.
+
+### Proof skeleton (already implemented)
+1. `sum_moebius_divisors_eq_filter_squarefree` — μ vanishes on non-squarefree
+   divisors (`moebius_eq_zero_of_not_squarefree`), so the divisor sum collapses
+   to squarefree divisors.
+2. `moebius_prod_squarefree` — for a finite set of distinct primes,
+   `μ(∏ s) = (-1)^|s|` via `isMultiplicative_moebius.map_prod_of_prime` and
+   `moebius_apply_prime`.
+3. `sum_filter_squarefree_moebius_eq_powerset` — squarefree divisors biject with
+   `(n.primeFactors).powerset` via `Nat.sum_divisors_filter_squarefree`, giving
+   `Σ_{S ⊆ primeFactors n} (-1)^|S|`.
+4. `sum_moebius_eq_indicator` — finish with
+   `Finset.sum_powerset_neg_one_pow_card` = `[primeFactors n = ∅]` = `[n = 1]`
+   (for `n ≠ 0`; the `n = 0` case is `simp`).
+5. `sum_moebius_eq_one_iff_one` — corollary `Σ_{d|n} μ(d) = 1 ↔ n = 1`.
+
+## Current blocker (not mathematical)
+
+**Verification blackout 2026-06-13**: the Docker build daemon is down and the
+Aristotle backend returns `Resource not found` (404). CI does not build Lean.
+So the file **cannot be compiled/verified this session**. The proof is written
+but its `verified` status is unconfirmed — Mathlib lemma names it depends on
+(`Nat.sum_divisors_filter_squarefree`, `Finset.sum_powerset_neg_one_pow_card`,
+`isMultiplicative_moebius.map_prod_of_prime`, `Nat.factors_eq`,
+`Finset.prod_val`, `Nat.primeFactors_eq_empty`) may have drifted.
+
+## State discrepancy this session corrected
+
+- `.lean/state/candidate-pool.json` still lists this problem as `available`,
+  i.e. fresh/unclaimed — but a full proof already exists. The pool file is not
+  git-tracked (runtime state, clobbered by concurrent agents), so it cannot be
+  durably fixed via PR; this research entry is the durable record instead.
+- No gallery entry `src/data/proofs/euler-totient-oq-04-oq-01/` exists yet.
+
+## Next steps (in order)
+
+1. When Docker is back:
+   `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ04OQ01` to confirm it
+   compiles with 0 sorries / 0 axioms.
+2. If green: create `src/data/proofs/euler-totient-oq-04-oq-01/`
+   (`meta.json` + `annotations.json`); status `verified`, badge `original`
+   (0 axioms, distinct-from-Mathlib approach).
+3. Flip the candidate-pool entry to `completed`.
+
+## Session log
+
+### 2026-06-13 (Session 1) — REVISIT/audit, ORIENT→ACT
+
+**Mode**: FRESH (selected from available pool by tractability under blackout)
+**Outcome**: documented — discovered the proof is already written
+
+- Verification blackout confirmed: Docker down, Aristotle 404 (tested via
+  `mcp__aristotle__prove`, got `Resource not found`).
+- Found `proofs/Proofs/EulerTotientOQ04OQ01.lean` already contains a complete
+  constructive proof of the target identity (0 real sorry, 0 axiom), wired into
+  `proofs/Proofs.lean`, but with no dedicated research entry and the pool still
+  marking the problem `available`.
+- Created this research entry + `src/data/research/problems/euler-totient-oq-04-oq-01.json`
+  to record the true state and the remaining build/integration steps. No Lean
+  was modified; nothing could be verified.

--- a/src/data/research/problems/euler-totient-oq-04-oq-01.json
+++ b/src/data/research/problems/euler-totient-oq-04-oq-01.json
@@ -1,0 +1,104 @@
+{
+  "slug": "euler-totient-oq-04-oq-01",
+  "title": "Mobius inversion: prove Σ_{d|n} μ(d) = [n=1]",
+  "phase": "ACT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\sum_{d \\mid n} \\mu(d) = \\begin{cases} 1 & n = 1 \\\\ 0 & n > 1 \\end{cases}",
+    "plain": "PROOF WRITTEN (unverified): the classical Mobius-function divisor-sum identity, the n=1 indicator. A complete constructive Lean proof already exists at Proofs/EulerTotientOQ04OQ01.lean, via the squarefree-divisor / powerset bijection rather than the multiplicative-induction route used by Mathlib's moebius_mul_coe_zeta.",
+    "whyMatters": [
+      "Foundational identity underlying Mobius inversion and the inclusion-exclusion structure of arithmetic functions.",
+      "Squarefree/powerset-bijection proof is a genuinely distinct approach from Mathlib's recOnPosPrimePosCoprime induction, mirroring the parent file's GCD-class partition aesthetic."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "sum_moebius_divisors_eq_filter_squarefree: divisor sum of μ collapses to squarefree divisors (μ vanishes on non-squarefree).",
+      "moebius_prod_squarefree: μ(∏ of a finite set of distinct primes) = (-1)^card.",
+      "sum_filter_squarefree_moebius_eq_powerset: squarefree-divisor sum equals Σ_{S ⊆ primeFactors n} (-1)^|S| via Nat.sum_divisors_filter_squarefree.",
+      "sum_moebius_eq_indicator: main identity Σ_{d|n} μ(d) = if n = 1 then 1 else 0.",
+      "sum_moebius_eq_one_iff_one: corollary Σ_{d|n} μ(d) = 1 ↔ n = 1."
+    ],
+    "open": [],
+    "goal": "Confirm Proofs/EulerTotientOQ04OQ01.lean compiles under current Mathlib, then integrate into the gallery and close the candidate-pool entry."
+  },
+  "currentState": {
+    "phase": "ACT",
+    "since": "2026-06-13T16:17:37.000Z",
+    "iteration": 1,
+    "focus": "A complete proof is already written and wired into proofs/Proofs.lean; remaining work is verification + integration, not mathematics.",
+    "blockers": [
+      "VERIFICATION BLACKOUT 2026-06-13: Docker daemon down and Aristotle backend returns 'Resource not found' (404), so the file cannot be built/verified this session. CI does not build Lean."
+    ],
+    "nextAction": "When Docker is back, run ./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ04OQ01 to confirm 0 sorries / 0 axioms; if green, create src/data/proofs/euler-totient-oq-04-oq-01/{meta.json,annotations.json} and mark the pool entry completed.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "PROOF WRITTEN, UNVERIFIED — complete constructive proof exists at Proofs/EulerTotientOQ04OQ01.lean (6 theorems, 0 real sorries, 0 axioms); pending a Docker build to confirm compilation before gallery promotion. Pool still mislabels this as 'available'.",
+    "builtItems": [
+      "Proofs/EulerTotientOQ04OQ01.lean: sum_moebius_eq_indicator (main), plus sum_moebius_divisors_eq_filter_squarefree, moebius_prod_squarefree, normalizedFactors_toFinset_eq, sum_filter_squarefree_moebius_eq_powerset, sum_moebius_eq_one_iff_one."
+    ],
+    "insights": [
+      "μ vanishes on non-squarefree divisors (moebius_eq_zero_of_not_squarefree), so the divisor sum reduces to squarefree divisors only.",
+      "Squarefree divisors of n biject with the powerset of n.primeFactors via S ↦ ∏ S (Nat.sum_divisors_filter_squarefree), and μ(∏ S) = (-1)^|S| by multiplicativity on distinct primes.",
+      "The result then follows from the alternating powerset-cardinality sum Finset.sum_powerset_neg_one_pow_card = [primeFactors n = ∅] = [n = 1] (for n ≠ 0).",
+      "This is a multiplicativity-free route, distinct from Mathlib's ArithmeticFunction.moebius_mul_coe_zeta which uses recOnPosPrimePosCoprime induction."
+    ],
+    "mathlibGaps": [],
+    "nextSteps": [
+      "Docker build Proofs.EulerTotientOQ04OQ01 once the daemon is back to confirm the file compiles under current Mathlib (lemma names like Nat.sum_divisors_filter_squarefree, Finset.sum_powerset_neg_one_pow_card, isMultiplicative_moebius.map_prod_of_prime, Nat.factors_eq, Finset.prod_val may have drifted).",
+      "If green: create the gallery entry src/data/proofs/euler-totient-oq-04-oq-01/ (meta.json + annotations.json) and set status verified (0 axioms).",
+      "Flip the candidate-pool.json entry euler-totient-oq-04-oq-01 from 'available' to 'completed' so the fleet stops treating it as fresh work."
+    ]
+  },
+  "tags": [
+    "seeker-selected",
+    "number-theory",
+    "euler-totient",
+    "divisor-sum",
+    "gcd",
+    "category:specialization",
+    "source:euler-totient-oq-04"
+  ],
+  "relatedProofs": [
+    "euler-totient",
+    "euler-totient-oq-01",
+    "euler-totient-oq-02",
+    "euler-totient-oq-02-oq-01",
+    "euler-totient-oq-03",
+    "euler-totient-oq-04"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.NumberTheory.ArithmeticFunction.Moebius",
+      "Mathlib.Data.Nat.Squarefree",
+      "Mathlib.Data.Nat.Choose.Sum",
+      "Mathlib.RingTheory.UniqueFactorizationDomain.Nat"
+    ]
+  },
+  "started": "2026-06-13T16:17:37.000Z",
+  "lastUpdate": "2026-06-13T16:17:37.000Z",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/EulerTotientOQ04OQ01.lean",
+      "filename": "EulerTotientOQ04OQ01.lean",
+      "lineCount": 165,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/EulerTotientOQ04OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- A complete constructive Lean proof of the Möbius divisor-sum identity `Σ_{d|n} μ(d) = [n=1]` **already exists** at `proofs/Proofs/EulerTotientOQ04OQ01.lean` (squarefree-divisor / powerset bijection; distinct from Mathlib's `moebius_mul_coe_zeta` induction). It is wired into `proofs/Proofs.lean`, has 6 theorems, 0 real `sorry`s (the lone `\bsorry\b` grep hit is the docstring prose "Zero `sorry`s"), and 0 `axiom`s.
- The research system had **no entry** for this problem and `.lean/state/candidate-pool.json` still marked `euler-totient-oq-04-oq-01` as `available` (fresh/unclaimed). This PR adds the durable git-tracked record: `src/data/research/problems/euler-totient-oq-04-oq-01.json` + `research/problems/euler-totient-oq-04-oq-01/knowledge.md`.
- **No Lean was modified.** The proof's `verified` status is **not** confirmed: verification blackout 2026-06-13 (Docker daemon down + Aristotle backend 404), and CI does not build Lean. Status recorded as proof-written-pending-build, not verified.

## Next steps (documented in the entry)
1. When Docker returns: `./proofs/scripts/docker-build.sh Proofs.EulerTotientOQ04OQ01` to confirm it compiles under current Mathlib.
2. If green: create the gallery entry `src/data/proofs/euler-totient-oq-04-oq-01/` and mark `verified`.
3. Flip the candidate-pool entry to `completed` (pool is runtime state, not fixable via PR).

## Test plan
- [ ] `jq empty` passes on the new problem json (done locally).
- [ ] Docker build of `Proofs.EulerTotientOQ04OQ01` once infra is restored (blocked this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)