### PR TITLE
research(fodor-pressing-down): STATE-SYNC meta + trackers to refactored source

### DIFF
--- a/src/data/proofs/fodor-pressing-down/meta.json
+++ b/src/data/proofs/fodor-pressing-down/meta.json
@@ -19,9 +19,9 @@
     ],
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 727,
-    "theoremCount": 22,
-    "definitionCount": 4
+    "lineCount": 654,
+    "theoremCount": 14,
+    "definitionCount": 1
   },
   "overview": {
     "historicalContext": "Fodor's Pressing-Down Lemma was proved by G\u00e9za Fodor in 1956, and is sometimes also called the Fodor-Neumer theorem. It is one of the most useful tools in combinatorial and descriptive set theory. The lemma asserts that any regressive function (f(\u03b1) < \u03b1) on a stationary subset of a regular uncountable cardinal \u03ba must be constant on some stationary subset \u2014 the function cannot 'press down' uniformly. The key technique is the **diagonal intersection**: if f\u207b\u00b9(\u03b2) is non-stationary for every \u03b2, we can find clubs C_\u03b2 avoiding each fiber, and their diagonal intersection \u0394_{\u03b2<\u03ba}(C_\u03b2) is still a club (since diagonal intersections of clubs are clubs), contradicting the stationarity of the domain.",
@@ -223,18 +223,19 @@
   ],
   "leanFile": {
     "path": "Proofs/FodorPressingDown.lean",
-    "lineCount": 727,
+    "lineCount": 654,
     "axiomCount": 0,
     "sorries": 0,
-    "theoremCount": 22,
-    "definitionCount": 4,
+    "theoremCount": 14,
+    "definitionCount": 1,
     "imports": [
       "import Mathlib.SetTheory.Cardinal.Ordinal",
       "import Mathlib.SetTheory.Cardinal.Cofinality",
       "import Mathlib.SetTheory.Cardinal.Regular",
       "import Mathlib.SetTheory.Ordinal.Arithmetic",
       "import Mathlib.SetTheory.Ordinal.Topology",
-      "import Mathlib.Tactic"
+      "import Mathlib.Tactic",
+      "import Proofs.Club.Basic"
     ],
     "opens": [
       "Cardinal",

--- a/src/data/research/problems/fodor-pressing-down-oq-01.json
+++ b/src/data/research/problems/fodor-pressing-down-oq-01.json
@@ -123,10 +123,10 @@
     {
       "path": "Proofs/Club/Basic.lean",
       "filename": "Basic.lean",
-      "lineCount": 183,
-      "theoremCount": 11,
+      "lineCount": 231,
+      "theoremCount": 18,
       "axiomCount": 0,
-      "defCount": 5,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Club/Basic.lean"

--- a/src/data/research/problems/fodor-pressing-down-oq-04.json
+++ b/src/data/research/problems/fodor-pressing-down-oq-04.json
@@ -122,9 +122,9 @@
       "path": "Proofs/FodorPressingDown.lean",
       "filename": "FodorPressingDown.lean",
       "lineCount": 654,
-      "theoremCount": 20,
+      "theoremCount": 14,
       "axiomCount": 0,
-      "defCount": 4,
+      "defCount": 1,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FodorPressingDown.lean"


### PR DESCRIPTION
## Summary

Build-free state-sync (Docker down) for the `fodor-pressing-down` gallery entry and its two research trackers. The Club/stationary/diagonal-intersection infrastructure was refactored out of `Proofs/FodorPressingDown.lean` into `Proofs/Club/Basic.lean`, but the gallery `meta.json` and the `oq-01`/`oq-04` research JSONs still carried pre-refactor declaration counts. All numbers below were recomputed against verified `origin/main` source using the `enrich-research.ts` convention (`^(theorem|lemma) `, `^(def|noncomputable def|opaque def) `, `^axiom `, `\bsorry\b`, `split('\n').length`).

## Changes

| File | Field | Was | Now |
|------|-------|-----|-----|
| `meta.json` (`meta` + `leanFile`) | lineCount | 727 | 654 |
| | theoremCount | 22 | 14 |
| | definitionCount | 4 | 1 |
| | imports | — | + `import Proofs.Club.Basic` |
| `oq-01.json` (Club/Basic.lean) | lineCount | 183 | 231 |
| | theoremCount | 11 | 18 |
| | defCount | 5 | 4 |
| `oq-04.json` (FodorPressingDown.lean) | theoremCount | 20 | 14 |
| | defCount | 4 | 1 |

`sorries`/`axiomCount` were already 0 and remain 0 (re-confirmed). No Lean source changes.

## Verification
- [x] Counts derived from `git show origin/main:` source (not the drifting shared worktree)
- [x] All three JSON files parse (`json.load`)
- [ ] Docker build — DOWN; metadata-only change, no build required