### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): STATE-SYNC leanFiles to canonical source

### DIFF
--- a/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-04-oq-03.json
@@ -88,14 +88,14 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.846Z",
-  "lastUpdate": "2026-06-12T22:45:00.000Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/LawsOfLargeNumbers.lean",
       "filename": "LawsOfLargeNumbers.lean",
-      "lineCount": 396,
+      "lineCount": 397,
       "theoremCount": 11,
       "axiomCount": 1,
       "defCount": 3,
@@ -106,7 +106,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01.lean",
-      "lineCount": 403,
+      "lineCount": 404,
       "theoremCount": 13,
       "axiomCount": 1,
       "defCount": 0,
@@ -117,18 +117,18 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01Aristotle.lean",
       "filename": "LawsOfLargeNumbersOQ01Aristotle.lean",
-      "lineCount": 723,
+      "lineCount": 724,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 1,
-      "sorryCount": 0,
+      "sorryCount": 2,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ01Aristotle.lean"
     },
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ01.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ01.lean",
-      "lineCount": 74,
+      "lineCount": 75,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
@@ -139,7 +139,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ02.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ02.lean",
-      "lineCount": 344,
+      "lineCount": 345,
       "theoremCount": 10,
       "axiomCount": 3,
       "defCount": 1,
@@ -150,7 +150,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ01OQ03.lean",
       "filename": "LawsOfLargeNumbersOQ01OQ03.lean",
-      "lineCount": 98,
+      "lineCount": 99,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
@@ -161,7 +161,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ02.lean",
       "filename": "LawsOfLargeNumbersOQ02.lean",
-      "lineCount": 356,
+      "lineCount": 357,
       "theoremCount": 9,
       "axiomCount": 2,
       "defCount": 2,
@@ -172,7 +172,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ03.lean",
       "filename": "LawsOfLargeNumbersOQ03.lean",
-      "lineCount": 404,
+      "lineCount": 405,
       "theoremCount": 9,
       "axiomCount": 4,
       "defCount": 5,
@@ -183,18 +183,18 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ03Aristotle.lean",
       "filename": "LawsOfLargeNumbersOQ03Aristotle.lean",
-      "lineCount": 71,
+      "lineCount": 72,
       "theoremCount": 1,
       "axiomCount": 0,
       "defCount": 0,
-      "sorryCount": 0,
+      "sorryCount": 1,
       "isAristotle": true,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LawsOfLargeNumbersOQ03Aristotle.lean"
     },
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04.lean",
       "filename": "LawsOfLargeNumbersOQ04.lean",
-      "lineCount": 228,
+      "lineCount": 229,
       "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 3,
@@ -205,7 +205,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03.lean",
-      "lineCount": 180,
+      "lineCount": 181,
       "theoremCount": 3,
       "axiomCount": 1,
       "defCount": 0,
@@ -216,7 +216,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
-      "lineCount": 672,
+      "lineCount": 673,
       "theoremCount": 11,
       "axiomCount": 2,
       "defCount": 0,
@@ -227,7 +227,7 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean",
-      "lineCount": 150,
+      "lineCount": 151,
       "theoremCount": 5,
       "axiomCount": 0,
       "defCount": 0,
@@ -238,8 +238,8 @@
     {
       "path": "Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean",
       "filename": "LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean",
-      "lineCount": 239,
-      "theoremCount": 4,
+      "lineCount": 240,
+      "theoremCount": 3,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The `laws-of-large-numbers-oq-04-oq-03` research JSON's `leanFiles` block had drifted from the merged Lean source. Resynced all 14 entries to the canonical `enrich-research.ts` counting convention (`extractLeanMetadata`, `lineCount = content.split('\n').length`).

## Changes (doc-only)

- **14 lineCounts +1** — the block predated the `split('\n').length` convention (was using bare `wc -l`).
- **LawsOfLargeNumbersOQ01Aristotle.lean** `sorryCount` 0 → 2 — two `\bsorry\b` mentions in docstrings (canonical convention counts all word-boundary `sorry`, including prose).
- **LawsOfLargeNumbersOQ03Aristotle.lean** `sorryCount` 0 → 1 — one docstring `sorry` mention.
- **LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean** `theoremCount` 4 → 3 — a `lemma`/`theorem` declaration was removed upstream; only 3 top-level decls remain (`trueCDF_exists_le`, `trueCDF_exists_ge`, `leftLim_le_of_forall_lt`).
- `lastUpdate` bumped to 2026-06-13.

No real-sorry regressions: every file remains at `sorryCount` 0 for *real* (non-docstring) sorries; the 0→2 / 0→1 changes are docstring mentions only, per the `\bsorry\b`-all convention.

All values verified against `git show origin/main:proofs/<path>` through the exact `enrich-research.ts` regexes. No Lean edits; no build required.

## Test plan

- [x] Each leanFiles count recomputed from `origin/main` source via the canonical regexes
- [x] Targeted diff (18 lines: 17 count fields + lastUpdate); no collateral reformatting