### PR TITLE
research(elementary-quadratic-reciprocity-oq-01-oq-02): AUDIT — sync meta.json to Lean source

### DIFF
--- a/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
+++ b/src/data/proofs/elementary-quadratic-reciprocity-oq-01-oq-02/meta.json
@@ -21,7 +21,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 2,
-    "lineCount": 578,
+    "lineCount": 580,
     "theoremCount": 27,
     "defCount": 6,
     "assumptions": "Two axioms predicated on the file's local `structure EisensteinPrime`: (1) cubicResidueSymbol — definition of the cubic residue symbol (ρ/π)₃ for Eisenstein primes. (2) cubic_reciprocity — (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via Jacobi sums. Mathlib v4.26.0 already ships the bearers needed to discharge these axioms (Mathlib.NumberTheory.NumberField.Cyclotomic.Three for ℤ[ω] as 𝓞 K, Mathlib.NumberTheory.NumberField.Cyclotomic.PID.three_pid for IsPrincipalIdealRing (𝓞 K), and Mathlib.NumberTheory.JacobiSum.Basic for the full jacobiSum/gaussSum API following Ireland–Rosen §8.3). Discharging the axioms is therefore an engineering refactor (rebase the local EisensteinPrime onto Mathlib's 𝓞 K and port Ireland–Rosen Theorem 1 of Chapter 9, ~250 LOC) rather than a wait-on-upstream-Mathlib task. See research/problems/elementary-quadratic-reciprocity-oq-01-oq-02/s5-observe-eisenstein-bearer.md for the bearer catalog and refactor plan. All 27 theorems proved; 0 sorries remain. Key: cubicChar_kernel_card and quarticChar_kernel_card (|ker χ| = (p-1)/3 and (p-1)/4 via IsCyclic.card_pow_eq_one_le), cubicEuler_hard and quarticEuler_hard (both Euler criterion hard directions via discrete log).",
@@ -51,23 +51,23 @@
     {
       "id": "cubic-character",
       "title": "Cubic Character Construction",
-      "startLine": 59,
-      "endLine": 145,
+      "startLine": 55,
+      "endLine": 148,
       "summary": "Defines IsCubicResidue and cubExp = (p-1)/3. Constructs cubicChar = powMonoidHom(cubExp) as a group homomorphism. Proves χ₃(a)³ = 1 via Fermat's little theorem for units. Proves closure properties: cubic residues are closed under 0, 1, cubing, multiplication, squaring, and inverse.",
       "mathContext": "χ₃ : (ZMod p)ˣ →* (ZMod p)ˣ, χ₃(a) = a^{(p-1)/3}, χ₃(a)³ = a^{p-1} = 1"
     },
     {
       "id": "euler-criterion",
       "title": "Cubic Euler Criterion",
-      "startLine": 156,
-      "endLine": 238,
+      "startLine": 149,
+      "endLine": 237,
       "summary": "Proves both directions: easy (a = x³ → χ₃(a) = 1 via Fermat) and hard (χ₃(a) = 1 → a is a cube via discrete log in cyclic group). The hard direction uses IsCyclic.exists_generator + Subgroup.mem_zpowers_iff + orderOf_dvd_of_zpow_eq_one to get 3 | k, then a = (g^(k/3))³. Together gives the full Euler criterion iff.",
       "mathContext": "∀ a : (ZMod p)ˣ, IsCubicResidue a ↔ χ₃(a) = 1 (fully proved, 0 axioms)"
     },
     {
       "id": "kernel-cardinality",
       "title": "Cubic Character Kernel Cardinality",
-      "startLine": 267,
+      "startLine": 238,
       "endLine": 302,
       "summary": "Proves cubicChar_kernel_card: |{a : (ZMod p)ˣ | χ₃(a) = 1}| = (p-1)/3. Uses IsCyclic.card_pow_eq_one_le for the upper bound and Finset.le_card_of_inj_on_range with the injection k ↦ (g^3)^k for the lower bound, where g is a generator with orderOf(g^3) = (p-1)/3.",
       "mathContext": "|ker χ₃| = |{a : (ZMod p)ˣ | a^{(p-1)/3} = 1}| = (p-1)/3. Proved: upper bound from IsCyclic.card_pow_eq_one_le; lower bound from injectivity of k ↦ (g³)^k via pow_injOn_Iio_orderOf."
@@ -75,24 +75,32 @@
     {
       "id": "quartic-character",
       "title": "Quartic Character Parallel",
-      "startLine": 307,
-      "endLine": 375,
-      "summary": "Mirrors the cubic construction for quartExp = (p-1)/4 when p ≡ 1 (mod 4). Defines quarticChar = powMonoidHom(quartExp), proves χ₄(a)⁴ = 1 via Fermat, and proves the easy Euler criterion direction via identical Units.mk0 technique.",
-      "mathContext": "χ₄ : (ZMod p)ˣ →* (ZMod p)ˣ, χ₄(a) = a^{(p-1)/4}, χ₄(a)⁴ = a^{p-1} = 1"
+      "startLine": 303,
+      "endLine": 450,
+      "summary": "Mirrors the cubic construction for quartExp = (p-1)/4 when p ≡ 1 (mod 4). PART 7 defines quarticChar = powMonoidHom(quartExp), proves χ₄(a)⁴ = 1 via Fermat, and the easy Euler criterion direction via the Units.mk0 technique. PART 7b completes the analogue: quarticEuler_hard (χ₄(a) = 1 → a is a quartic residue via discrete log) and quarticChar_kernel_card (|ker χ₄| = (p-1)/4), giving the full quartic Euler criterion iff isQuarticResidue_iff_quarticChar_one.",
+      "mathContext": "χ₄ : (ZMod p)ˣ →* (ZMod p)ˣ, χ₄(a) = a^{(p-1)/4}, χ₄(a)⁴ = a^{p-1} = 1; IsQuarticResidue a ↔ χ₄(a) = 1; |ker χ₄| = (p-1)/4"
     },
     {
       "id": "eisenstein-integers",
       "title": "Eisenstein Primes and Cubic Reciprocity",
-      "startLine": 360,
-      "endLine": 440,
-      "summary": "Defines the EisensteinPrime structure (norm, primary condition, not rational prime condition). Axiomatizes the cubic residue symbol (ρ/π)₃ and cubic reciprocity (ρ/π)₃ = (π/ρ)₃ for primary primes. Documents the Jacobi sum proof strategy in detail.",
+      "startLine": 451,
+      "endLine": 511,
+      "summary": "Defines the EisensteinPrime structure (norm, primary condition, not rational prime condition). Axiomatizes the cubic residue symbol (ρ/π)₃ (cubicResidueSymbol) and cubic reciprocity (ρ/π)₃ = (π/ρ)₃ for primary primes (cubic_reciprocity) — the file's two axioms. Documents the Jacobi sum proof strategy in detail.",
       "mathContext": "Cubic reciprocity: (ρ/π)₃ = (π/ρ)₃ for primary Eisenstein primes; proved via J(χ₃,χ₃) ∈ ℤ[ω]"
+    },
+    {
+      "id": "concrete-examples",
+      "title": "Concrete Examples",
+      "startLine": 512,
+      "endLine": 547,
+      "summary": "Worked examples for small primes (instance Fact (Nat.Prime 7) supplied for v4.26.0). For p = 7 (≡ 1 mod 3, cubExp = 2): cubic residues mod 7 are {0, 1, 6}, verified via the Euler criterion a² ≡ 1; non-residues 2, 3 fail it. For p = 13 (≡ 1 mod 3 and mod 4): cubExp 13 = 4 and quartExp 13 = 3. All examples elaborate by decide/norm_num.",
+      "mathContext": "p = 7: cubic residues {0,1,6}; a cubic residue ⟺ a² ≡ 1 (mod 7). p = 13: cubExp = 4, quartExp = 3"
     },
     {
       "id": "summary-packages",
       "title": "Character Package Summary",
-      "startLine": 444,
-      "endLine": 460,
+      "startLine": 548,
+      "endLine": 578,
       "summary": "Two summary theorems packaging the main results: cubic_character_package (for p ≡ 1 mod 3) states χ₃ is a hom with χ₃(a)³ = 1 and the Euler criterion iff. quartic_character_package (for p ≡ 1 mod 4) states the analogous quartic results.",
       "mathContext": "Packages for p ≡ 1 (mod 3): χ₃ hom property + χ₃³ = 1 + Euler criterion iff"
     }
@@ -167,7 +175,7 @@
       "ZMod"
     ],
     "namespace": "CubicCharacter",
-    "lineCount": 578,
+    "lineCount": 580,
     "axiomCount": 2,
     "theoremCount": 27,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary

Build-free meta↔source audit of `elementary-quadratic-reciprocity-oq-01-oq-02` (claimed by researcher-6). Verified `meta.json` against `proofs/Proofs/ElementaryQuadraticReciprocityOQ01OQ02.lean` on `origin/main` (580 lines) using the canonical counting conventions in `scripts/research/enrich-research.ts`.

## Corrections

- **`lineCount` 578 → 580** (both `meta.lineCount` and `leanFile.lineCount`). The enrichment script computes `content.split('\n').length`; the file has 579 newlines + trailing content → 580.
- **`sections[]` realigned to actual PART dividers.** The array had drifted as the file grew across S-stages:
  - `eisenstein-integers` claimed L360–440, but `structure EisensteinPrime` + the two axioms (`cubicResidueSymbol`, `cubic_reciprocity`) live at L451–511.
  - `summary-packages` claimed L444–460, but PART 10 (the package theorems) is at L548–578.
  - `quartic-character` ended at L375 (easy direction only); extended to L450 to cover PART 7b (`quarticEuler_hard` + `quarticChar_kernel_card`), previously unrecorded.
  - Added a `concrete-examples` section for PART 9 (L512–547).

## Verified unchanged (already correct)

`axiomCount` 2, `theoremCount` 27, `defCount` 6, `sorries` 0. Status `axiomatized` / badge `axiom` unchanged (two `EisensteinPrime`-predicated axioms remain).

No Lean source changed; no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)