### PR TITLE
research(erdos-1006-oq-01-oq-02): fix phantom sorryCount (grep counted "no sorry" comment)

### DIFF
--- a/research/problems/erdos-1006-oq-01-oq-02/state.md
+++ b/research/problems/erdos-1006-oq-01-oq-02/state.md
@@ -1,5 +1,18 @@
 # Research State: erdos-1006-oq-01-oq-02
 
+> **S4 tracker fix (researcher-1, 2026-06-13) — phantom sorryCount.** The JSON
+> `leanFiles` listed `sorryCount: 1` for `Erdos1006OQ01.lean`, `Erdos1006OQ02.lean`,
+> and `Erdos1006OQ03.lean`, but each file's only `sorry` occurrence is the
+> **docstring line `### Proved (no sorry):`** — a grep `\bsorry\b` false positive.
+> Real proof-position count is **0** in all three (verified against origin/main).
+> Corrected to `0`. **Anti-false-positive note for future `enrich` runs:** do NOT
+> "restore" these to 1 from a raw `\bsorry\b` grep — the word appears only inside
+> "(no sorry)" comments (angle-trisection precedent; see
+> reference-leanfiles-count-convention). All other counts (lineCount, theoremCount,
+> defCount, axiomCount) already matched origin/main. The slug's forward ACT
+> (`recognizeChainCover` skeleton → paste-ready Lean → build) remains build-dependent
+> and blocked by the 2026-06-13 verification blackout (Docker hung + Aristotle 404).
+
 ## Current State
 **Phase**: STATE-SYNC (S3 STATE-SYNC — INFRA gates recovered RED→GREEN over T+23d; S2 picker-matrix top row now operationally valid, but S2 skeleton is not paste-ready (has `sorry` + `...` placeholders), so S4 PREP is the next required step)
 **Path**: full

--- a/src/data/research/problems/erdos-1006-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-1006-oq-01-oq-02.json
@@ -45,7 +45,7 @@
       "theoremCount": 6,
       "axiomCount": 3,
       "defCount": 12,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ01.lean"
     },
@@ -67,7 +67,7 @@
       "theoremCount": 17,
       "axiomCount": 1,
       "defCount": 8,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ02.lean"
     },
@@ -78,7 +78,7 @@
       "theoremCount": 7,
       "axiomCount": 0,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1006OQ03.lean"
     },
@@ -141,14 +141,16 @@
     "np",
     "open-question"
   ],
-  "lastUpdate": "2026-06-09T23:58:00.000Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "currentState": {
     "phase": "STATE-SYNC",
     "since": "2026-06-09T23:58:00Z",
     "iteration": 4,
     "focus": "S3 STATE-SYNC (researcher-1, 2026-06-09T23:58Z): doc-only INFRA recovery + picker-matrix amendment. Over T+23d since S2 OBSERVE (2026-05-17), all three INFRA gates have recovered from RED to GREEN: G7 host disk 3.3 Gi -> 99 GiB free; G8 docker info Server section empty -> populated (Server Version 29.5.3); G9 proofs/.lake self-cycle -> real directory. Per the S2 picker matrix, the top row (full S3 ACT chains sub-case) should now fire — BUT the S2 skeleton (sessions/2026-05-17-s2-observe-chains-subcase-skeleton.md §4) is NOT paste-ready despite the framing: recognizeChainCover body contains `...` placeholder and chain_cover_recognition_decidable body is a single `sorry` (S2 OBSERVE memo §4 explicitly confirms this). S3 STATE-SYNC amends the picker matrix to require BOTH INFRA GREEN AND skeleton paste-readiness (0 sorry, 0 `...`) as joint preconditions for ACT. Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 (v4.26.0) unchanged at T+24d SHA-stable. File 256 LOC, 9 thm, 2 axiom, 4 def, 0 sorries — byte-identical to S1/S2. Full record in sessions/2026-06-09-s3-statesync-infra-green-recovery.md.",
     "nextAction": "S4 PREP (recommended for next picker): refine the S2 skeleton from sketch to paste-ready Lean. Concrete sub-steps: (1) pick recognizeChainCover concrete formulation — candidate: connected + Finset.card G.edgeFinset = card V - 1 + (forall v, G.degree v <= 2); (2) verify Mathlib.Combinatorics.SimpleGraph.Path signatures (SimpleGraph.IsPath, SimpleGraph.Connected, SimpleGraph.degree) at pin SHA via gh api walks; (3) write the bridge: for LinearOrder V, cover graph = path on sorted vertex list, using existing coverOrientation + posetRank_strictMono machinery; (4) produce paste-ready Lean with 0 sorry and 0 `...`. Estimated S4 PREP: ~3-4 hours + ~50-100 LOC skeleton + verified Mathlib bearer table. S5 ACT would then discharge the paste-ready skeleton under Docker (now GREEN).",
-    "blockers": ["S2 skeleton has `sorry` + `...` placeholders (not paste-ready as advertised) — S4 PREP must refine before any ACT cycle"],
+    "blockers": [
+      "S2 skeleton has `sorry` + `...` placeholders (not paste-ready as advertised) — S4 PREP must refine before any ACT cycle"
+    ],
     "attemptCounts": {
       "total": 4,
       "currentApproach": 2,


### PR DESCRIPTION
## Summary

Build-free honesty fix. The research JSON `leanFiles` reported `sorryCount: 1` for `Erdos1006OQ01.lean`, `Erdos1006OQ02.lean`, and `Erdos1006OQ03.lean`.

- The only `sorry` occurrence in each file is the **docstring line `### Proved (no sorry):`** — a `\bsorry\b` grep false positive. Real proof-position count is **0** in all three (verified vs origin/main).
- Corrected to `0` with an anti-false-positive note in state.md so future `enrich` runs don't re-inflate (angle-trisection precedent).
- All other counts (lineCount / theoremCount / defCount / axiomCount) already matched origin/main.

The same false positive likely affects the sibling slugs `erdos-1006-oq-01` / `-oq-02` / `-oq-03` (their leanFiles copies) — candidate for a future sweep. No Lean file touched.

## Test plan
- [ ] `git show origin/main:proofs/Proofs/Erdos1006OQ0{1,2,3}.lean | grep -n sorry` → only the `(no sorry)` comment (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)