### PR TITLE
research(cs-lp-duality-synthesis): S1 SURVEY — proposed axiom-elimination recipe is unsound

### DIFF
--- a/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
+++ b/src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json
@@ -2,10 +2,10 @@
   "slug": "cauchy-schwarz-integral-lp-duality-synthesis",
   "title": "Synthesis: Eliminate riesz_lp_surjective axiom — Full Lp Duality",
   "type": "synthesis",
-  "status": "available",
+  "status": "surveyed",
   "tier": "A",
   "significance": 8,
-  "tractability": 9,
+  "tractability": 6,
   "tags": [
     "synthesis",
     "functional-analysis",
@@ -18,9 +18,21 @@
     "cauchy-schwarz-integral-oq-01-oq-01-oq-02-oq-01"
   ],
   "description": "The recent completion of riesz_lp_surjective_from_rn (0 sorries, 0 axioms) in CauchySchwarzIntegralOQ01OQ01OQ02OQ01.lean proves exactly the statement that was axiomatized as riesz_lp_surjective in the parent CauchySchwarzIntegralOQ01OQ01OQ02.lean. Replacing the axiom with the theorem upgrades the Riesz Lp representation theorem from axiomatized (1 axiom) to verified (0 axioms), completing the full Lp duality chain: Young → Hölder (eLpNorm form) → isometric embedding Lq ↪ (Lp)* + surjectivity via Radon-Nikodým → Full (Lp)* ≅ Lq.",
-  "concreteFirstStep": "1. Open proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean. 2. Add import: import Proofs.CauchySchwarzIntegralOQ01OQ01OQ02OQ01. 3. Replace 'axiom riesz_lp_surjective' with 'theorem riesz_lp_surjective := riesz_lp_surjective_from_rn'. 4. Build: ./proofs/scripts/docker-build.sh Proofs.CauchySchwarzIntegralOQ01OQ01OQ02. 5. Update src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02/meta.json: axiomCount 1→0, status axiomatized→verified, badge axiom→original.",
+  "concreteFirstStep": "SUPERSEDED — see surveyFindings. The original recipe ('theorem riesz_lp_surjective := riesz_lp_surjective_from_rn') does NOT typecheck: the axiom is stated for an arbitrary measure μ, whereas riesz_lp_surjective_from_rn requires [IsFiniteMeasure μ] [SigmaFinite μ]. Closing the GENERAL-measure axiom requires the σ-finite-support reduction described in surveyFindings; a build is required and Docker is currently down (2026-06-13).",
+  "surveyDate": "2026-06-13",
+  "surveyedBy": "researcher-5",
+  "surveyFindings": [
+    "SIGNATURE GAP (blocking the proposed first step): base file CauchySchwarzIntegralOQ01OQ01OQ02.lean line 36 declares `variable {μ : Measure α}` with NO finiteness instance, so `axiom riesz_lp_surjective` (line 117) is stated for an ARBITRARY measure. But `riesz_lp_surjective_from_rn` (OQ01 file line 1008-1010) requires `[IsFiniteMeasure μ] [SigmaFinite μ] [Fact (1 ≤ p)]`. Therefore `theorem riesz_lp_surjective := riesz_lp_surjective_from_rn` fails to elaborate (missing instances). The proven theorem covers only the FINITE-measure case, not the general axiom.",
+    "OVERCLAIM HAZARD: the naive fix of adding [IsFiniteMeasure μ] [SigmaFinite μ] to the axiom's statement to force the substitution through would silently NARROW the published 'Full Lp Duality' theorem from arbitrary measures to finite measures while keeping the 'Full' title — a soundness/overclaim issue. Do not do this.",
+    "PARTIAL PROGRESS ALREADY PRESENT: the sigma-finite case is independently proven axiom-free as `riesz_lp_surjective_sigma_finite` in CauchySchwarzIntegralOQ01OQ01OQ02OQ01OQ01.lean (delegating to RieszSigmaFiniteComplete in the *Incomplete01.lean file). This drops [IsFiniteMeasure] but still requires [SigmaFinite μ].",
+    "MINOR: the axiom uses the legacy spelling `Memℒp` while the proven theorems use `MemLp`; statements must be aligned during any substitution.",
+    "GALLERY META IS ACCURATE: src/data/proofs/cauchy-schwarz-integral-oq-01-oq-01-oq-02 correctly reports axiomCount=1/status=axiomatized; the children oq-01-oq-01-oq-02-oq-01[/-oq-01][/-incomplete-01] report 0 sorries / 0 axioms and static inspection confirms zero tactic-level sorries (all `sorry` tokens are in docstrings) and zero `axiom` declarations. The base axiom is NOT consumed by any downstream proof. No meta↔source mismatch found."
+  ],
+  "remainingWork": "To eliminate the GENERAL (arbitrary-measure) axiom for 1 < p < ∞: implement the σ-finite-support reduction (Folland, Real Analysis, Thm 6.16). For any φ ∈ (Lp(μ))*, the σ-finiteness hypothesis is removable because every f ∈ Lp(μ) is supported on a σ-finite set; one builds the representing g on the σ-finite hull and shows it represents φ on all of Lp(μ). Then `riesz_lp_surjective` follows from `riesz_lp_surjective_sigma_finite`. Alternatively, if the gallery is content with the σ-finite statement, restate the published theorem with an explicit [SigmaFinite μ] hypothesis (honest narrowing) rather than claiming the unqualified 'Full' duality.",
   "sharedLemmas": [
-    "riesz_lp_surjective (axiom in OQ01OQ01OQ02, proved as riesz_lp_surjective_from_rn in OQ01OQ01OQ02OQ01)"
+    "riesz_lp_surjective (axiom in OQ01OQ01OQ02, arbitrary measure)",
+    "riesz_lp_surjective_from_rn (proved in OQ01OQ01OQ02OQ01, requires [IsFiniteMeasure μ] [SigmaFinite μ])",
+    "riesz_lp_surjective_sigma_finite (proved in OQ01OQ01OQ02OQ01OQ01, requires [SigmaFinite μ])"
   ],
   "proposedBy": "lean-synthesis agent (2026-04-23)",
   "relatedProofs": [


### PR DESCRIPTION
## Summary

Surveyed the open synthesis problem **cauchy-schwarz-integral-lp-duality-synthesis** ("Eliminate riesz_lp_surjective axiom — Full Lp Duality") and found the proposed one-line recipe is **incorrect as stated**.

### The signature gap (blocking)
- `proofs/Proofs/CauchySchwarzIntegralOQ01OQ01OQ02.lean:36` declares `variable {μ : Measure α}` with **no** finiteness instance, so `axiom riesz_lp_surjective` (line 117) is stated for an **arbitrary** measure.
- `riesz_lp_surjective_from_rn` (`...OQ02OQ01.lean:1008-1010`) requires `[IsFiniteMeasure μ] [SigmaFinite μ] [Fact (1 ≤ p)]`.
- Therefore the proposal's `concreteFirstStep` — `theorem riesz_lp_surjective := riesz_lp_surjective_from_rn` — **cannot elaborate** (missing instances). The proven theorem only discharges the **finite-measure** case.

### Overclaim hazard
Forcing the substitution through by adding `[IsFiniteMeasure μ] [SigmaFinite μ]` to the axiom's statement would silently narrow the published "**Full** Lp Duality" theorem to finite measures while keeping the title. Flagged so no future session does this.

### What's actually true / remaining work
- The **sigma-finite** case is already proven axiom-free as `riesz_lp_surjective_sigma_finite` (`...OQ02OQ01OQ01.lean`, delegating to `RieszSigmaFiniteComplete`).
- Closing the **general** axiom for `1 < p < ∞` needs the σ-finite-support reduction (Folland, *Real Analysis*, Thm 6.16): every `f ∈ Lp(μ)` is supported on a σ-finite set, so the σ-finiteness hypothesis is removable. This is genuine work and is **build-gated** (Docker down 2026-06-13).
- Gallery meta for the whole chain is **accurate** — verified the `sorry=10/11/1` reported by a naive grep are all docstring prose; real tactic-sorry count is 0, axiom count is 0, and the base axiom is unused downstream.

### Change
Updated `src/data/research/problems/cauchy-schwarz-integral-lp-duality-synthesis.json`: status `available`→`surveyed`, recorded the signature gap, the overclaim hazard, partial progress, the reduction strategy, and the meta-accuracy confirmation.

## Test plan
- [x] `jq empty` validates the JSON
- [x] No Lean source touched (build-free; Docker down)
- [ ] When Docker returns: implement the σ-finite-support reduction, then promote the base entry axiomCount 1→0