### PR TITLE
research(erdos-1151-oq-04): S38 — sync stale leanFiles + flag BLOCKED under blackout

### DIFF
--- a/research/problems/erdos-1151-oq-04/state.md
+++ b/research/problems/erdos-1151-oq-04/state.md
@@ -1,5 +1,21 @@
 # Research State: erdos-1151-oq-04
 
+> **S38 STATE-SYNC + BLOCKED (researcher-1, 2026-06-13).** Two tracker drifts
+> fixed after S37 BUILD-VERIFY (#22947, 2026-06-12) grew the file: research-JSON
+> `leanFiles` lineCounts were stale (`Erdos1151OQ04` 2692→**2714**, `…Aristotle`
+> 140→**141**, `…Problem` 185→**216**) and theoremCounts were off-convention
+> (`Erdos1151OQ04` **66→32**, `…Problem` **5→7**). Synced to canonical generator
+> values (`lineCount = wc -l + 1`; `theoremCount = ^(theorem|lemma) ` top-level
+> only). NB the 66→32 is generator-parity, **not** lost theorems: the file has 32
+> top-level + 34 indented/`@[simp]`/`private` theorem-like decls (66 total); the
+> leanFiles convention counts only top-level (gauss-wilson precedent, see
+> reference-leanfiles-count-convention). Status set `blocked`: the S38 ACT
+> (discharge Sorry 2 `divergence_from_lebesgue_growth` via ContinuousLinearMap +
+> Tietze lift, ~80–120 LOC) is build-dependent and unbuildable under the
+> 2026-06-13 verification blackout (Docker hung + Aristotle 404); flagged to stop
+> depth-first re-claim churn on this RICH (score 76) slug until Docker recovers.
+> S37 left the file BUILD-VERIFY clean (3084 jobs, 1 sorry). No Lean touched.
+
 ## Current State
 **Phase**: ACT (S36 CLUSTER-A-CLOSE — researcher folds chebyshevInterp_sub proof into a single `simp only` matching sibling chebyshevInterp_neg pattern; Cluster A (1 error) eliminated, Cluster B (21 errors at lines 952–1247) deferred to subsequent mechanic-handoff sub-cluster PRs)
 **Path**: full

--- a/src/data/research/problems/erdos-1151-oq-04.json
+++ b/src/data/research/problems/erdos-1151-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-1151-oq-04",
   "title": "Prove erdos_1941_divergence via Lebesgue Function Growth at Chebyshev Nodes",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -27,7 +27,7 @@
     "goal": "Prove erdos_1941_divergence to eliminate the axiom from the gallery"
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-06-09T18:55:00Z",
     "iteration": 36,
     "focus": "Session 36 (researcher-3, 2026-06-09, build pending — Cluster A surgically closed; Cluster B still 21 errors): Fold chebyshevInterp_sub proof body L175–180 from 3-line `simp only / simp_rw / exact Finset.sum_sub_distrib` form (S31 PR #17612, typeclass-stuck on SubtractionCommMonoid ?m.15) into single-line `simp only [chebyshevInterp, lagrangeInterp, sub_mul, Finset.sum_sub_distrib]`. Brings structural parity with sibling chebyshevInterp_neg at L168 (already single-`simp only`). Sibling-precedent for the exact 1-line shape confirmed at v4.26.0 Mathlib pin: HurwitzTheorem.lean:607 (`simp only [innerProd, Pi.sub_apply, sub_mul, Finset.sum_sub_distrib]` — structurally identical), ProbMethodSecondMomentOQ01.lean:48, HurwitzTheorem.lean:409. Three independent build-clean siblings use this exact `simp only [..., Finset.sum_sub_distrib]` shape. Net change: −2 LOC (2692 → 2690), 0 theorem/def/axiom/sorry delta, 0 sibling-slug touches. Build PENDING (deferred): single Cluster A site closed by construction; Cluster B (21 errors at lines 952–1247) remains out of scope per S35 §6 picker matrix row (b); a fresh Docker build here would still fail with 21 Cluster B errors, so the verifiable improvement is \"22 → 21 errors\" best confirmed in the eventual S38 BUILD-VERIFY after all sub-cluster PRs merge. Sibling-precedent envelope for tactic-glue surgical fixes matches S35 (8 inline fixes shipped by researcher-8). 0 role-overlap with future mechanic Cluster B work (cleanly partitioned: this PR = Cluster A; mechanic batch = Cluster B sub-clusters). nextAction re-anchors to S37 MECHANIC-HANDOFF Cluster B sub-cluster sweeps.\\n\\n---\\n\\nSession 35 (researcher-8, 2026-06-09, BUILD-VERIFY-PARTIAL): Picker matrix S34 §6 row (a) fires — G7 host disk 3.2 → 101 GiB (+97.8 GiB recovery / GREEN); G8 Docker daemon 8s-timeout → 29.5.3 sub-second (GREEN); 23-day INFRA recovery window. G9 .lake self-symlink persists but confirmed non-blocking for Docker builds (overlay volume shadows host self-loop; corroborated by PR #22624 'Docker 3113 jobs clean' today). Build attempt 1: `LEAN_BUILD_TIMEOUT=45m ./proofs/scripts/docker-build.sh Proofs.Erdos1151OQ04` → cache fetch 7727 files + 21 cache-exe jobs + Mathlib elaboration begins → fails with 29 errors at lines 180–2255. Outcome: file not build-verified since pre-S22; 22 of 29 errors latent in S22+ helper infrastructure (masked first by 'build pending' qualifier S22–S31, then by Docker daemon outage S32–S34). Mathlib pin 2df2f0150c byte-stable ≈4.7 mo so accumulated latent drift, not new. S35 ships 8 surgical fixes inline (trailing tactic-glue drift; −3 net LOC, 2695 → 2692): (1) L1758/1882/1895/1897 drop `; ring` after `field_simp`; (2) L1841 drop standalone `ring`; (3) L2055/2073 convert orphan `/-- ... -/` docstring to `/- ... -/` plain comment; (4) L2133–2134 drop redundant `push_cast; ring` (S20 `congr 2` now closes goal alone); (5) L2166 `le_div_iff hd_pos` → `le_div_iff₀ hd_pos` (Mathlib rename; sibling-precedent S15 div_lt_div_iff→div_lt_div_iff₀); (6) L~2255 drop trailing `ring` after `field_simp`. Build attempt 2 after the 8 fixes: 22 errors remain (29 → 22, −7 root + −2 cascade from L2073 parser), all at lines 180–1247. Cluster A (line 180, 1 error): S31 chebyshevInterp_sub `exact Finset.sum_sub_distrib` typeclass instance stuck on SubtractionCommMonoid ?m.15. Cluster B (lines 952–1247, 21 errors): pre-S22 helper region with linarith / unsolved-goals / Application-type-mismatch / omega / mod_cast / positivity / rewrite-pattern-not-found / unknown-tactic mix; 3–5 root-cause sites with cascade likely. S35 nextAction: S36 mechanic-handoff for Cluster A as simplest standalone repair; then sub-cluster sweeps of Cluster B by error-type; then S37 BUILD-VERIFY re-run; expected clean at ∼3060/3060 jobs post-repair.\n\n---\n\nSession 34 (researcher-11, 2026-05-17, doc-only STATE-SYNC): Absorbs 2 intervening PRs in the ~9.5 h post-S33 window — PR #19967 (S34a registry mirror, T-7 min) flipped `research/registry.json` `phase: OBSERVE → ACT` + `lastUpdate` catchup but did NOT bump canonical `currentState.iteration` / `nextAction` / `focus` / `blockers` / `progressSummary` / `nextSteps[]`; PR #19775 (researcher-mechanic, T-6.5 h) batch-synced `leanFiles[i]` for `Erdos1151OQ04.lean` across 6 siblings from stale 1283/29/4 to canonical 2695/66/1 (axiomCount/defCount unchanged). S34 canonically reconciles: iter 33 → 34, since/lastUpdate refresh, focus prepend, nextAction re-anchor as **S35 BUILD-VERIFY** (was \"S33 BUILD-VERIFY\"; the BUILD-VERIFY pass is the deferred next step), blockers [] → 3-entry G7/G8/G9 RED, attemptCounts.total 3 → 4, progressSummary prepend with S34 absorption, nextSteps[0] refresh (\"5.2 Gi avail\" → \"3.2 Gi avail (5 GiB soft floor breached ≥9.5 h)\"). 3 RED INFRA persist: **G7 disk 3.2 GiB avail** (S33 was 5.2 Gi, **−2.0 Gi over ~9 h 45 min**, oscillated to 2.8 Gi during birthday-problem S25 ACT-1 #19997 cycle T-15 min, 2.9 Gi during ballot-problem S80 STATE-SYNC #19994 T-15 min); **G8 Docker daemon `docker info` 8 s timeout / empty ServerVersion** (≥10 h cumulative hung); **G9 `proofs/.lake → proofs/.lake` self-symlink** on main repo (worktree's `proofs/.lake` resolves to the main's self-loop transitively). `Erdos1151Problem.lean` sibling-list entry has separate +30-LOC off-by-one drift (actual `wc -l` 215 vs JSON `lineCount: 185`) deferred to a future mechanic batch per the mechanic's own single-root-cause-fix scope boundary. Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67` (v4.26.0) byte-stable since pre-S32 era; bearer SHA-stable carry-forward chain S22 → S23 → S29 → S32 → S33 → S34 with **no re-walk needed**. 0 Lean / 0 meta.json / 0 lake-manifest / 0 problem.md / 0 knowledge.md body / 0 sibling-slug edits. 0 axiom / 0 sorry change (1 sorry preserved at `divergence_from_lebesgue_growth`).\n\n---\n\nSession 32 (researcher-10, 2026-05-15, build pending — Docker daemon I/O blocked): ACT executing PREP-2 §6 nine-step recipe — cherry-pick of long-stranded commit 2099b97d59a (chebyshev_lebesgue_saturated, 108-LOC private lemma, authored 2026-05-09, never opened as a PR). The lemma is the UBP operator-norm saturation lower bound for the Chebyshev interpolation functional: ∃ f : ℝ → ℝ with |f t| ≤ 1 and chebyshevInterp n f x = chebyshevLebesgue n x. Construction: sign-pattern weights w k = ±1 at each Chebyshev node, f t := ∑ k, w k * indicator(t = chebyshevNode n k); injectivity collapses single-node sum, sign saturates each |lagrangeBasis _ k x|. Applies the PREP-2 §4.1 micro-refactor (Finset.sum_eq_single → sum_eq_single_of_mem with Finset.mem_univ membership pre-supplied) at both call sites, dropping 1 trivially-impossible bullet per site (−2 LOC vs raw cherry-pick). Net change: +106 LOC, +1 theorem (66 total, was 65), sorryCount unchanged at 1 (still divergence_from_lebesgue_growth), axiomCount 0, defCount 5. File: 2589 → 2695 LOC. Build status: PENDING (Docker daemon unresponsive due to 100% host disk pressure; container never reached build phase after 10min); HIGH confidence on bearers + §4.1 substitution via PREP-2 bearer pin audit at lake SHA 2df2f0150c + sibling-precedent confirmation against Erdos671Problem.lean:128-131. See session-33-act-ubp-saturation-cherry-pick.md §5 for honest disclosure + S33 BUILD-VERIFY plan.",
@@ -47,6 +47,13 @@
         "since": "≥30 d cumulative",
         "evidence": "`ls -l /Users/rwalters/GitHub/lean-genius/proofs/.lake` shows `proofs/.lake -> /Users/rwalters/GitHub/lean-genius/proofs/.lake` (self-loop). Worktree's `.loom/worktrees/researcher-8/proofs/.lake` resolves through main's self-loop. Confirmed at 2026-06-09T18:30Z.",
         "discharge": "Replace self-loop with valid target: `rm /Users/rwalters/GitHub/lean-genius/proofs/.lake && ln -sf /Users/rwalters/GitHub/lean-genius/proofs/.lake-real proofs/.lake` (or equivalent host-level fix). NON-BLOCKING for Docker builds in practice — docker-build.sh overlays persistent Mathlib cache volume at `/workspace/proofs/.lake/build`; container's writable `.lake` shadows the host self-loop; PR #22624 corroborates clean Docker build today through identical host G9 state. Track for future host-level mechanic batch but does NOT gate research progress."
+      },
+      {
+        "id": "B2",
+        "kind": "verification-blackout",
+        "severity": "high",
+        "since": "2026-06-13",
+        "description": "Docker daemon hung + Aristotle backend 404 — no verification route. The S38 ACT (discharge Sorry 2 divergence_from_lebesgue_growth via ContinuousLinearMap + Tietze lift, ~80-120 LOC) is build-dependent and cannot be verified; CI does not build Lean. Flagged blocked to stop depth-first re-claim churn on this RICH (score 76) slug until Docker recovers. S37 left the file BUILD-VERIFY clean (3084 jobs, 1 sorry)."
       }
     ],
     "nextAction": "(Researcher) S38 ACT: file is BUILD-VERIFY clean (S37, 3084 jobs, 1 sorry). Resume the ACT roadmap to discharge Sorry 2 (`divergence_from_lebesgue_growth`): ContinuousLinearMap packaging Λₙ_x via LinearMap.mkContinuous + Tietze lift to C(Icc -1 1, ℝ) (~80–120 LOC) → operator-norm identity ‖Λₙ_x‖ = chebyshevLebesgue n x (~30–50 LOC) → Banach–Steinhaus contrapositive → Sorry 2 discharge (~20–40 LOC). Total to 0 sorries: ~130–210 LOC across ~3 ACT PRs. Each ACT PR must be BUILD-VERIFY'd via ./proofs/scripts/docker-build.sh Proofs.Erdos1151OQ04.\\n",
@@ -164,15 +171,15 @@
     "mathlib": []
   },
   "started": "2026-04-21T19:30:00.000Z",
-  "lastUpdate": "2026-06-09T18:55:00Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1151OQ04.lean",
       "filename": "Erdos1151OQ04.lean",
-      "lineCount": 2692,
-      "theoremCount": 66,
+      "lineCount": 2714,
+      "theoremCount": 32,
       "axiomCount": 0,
       "defCount": 5,
       "sorryCount": 1,
@@ -182,7 +189,7 @@
     {
       "path": "Proofs/Erdos1151OQ04Aristotle.lean",
       "filename": "Erdos1151OQ04Aristotle.lean",
-      "lineCount": 140,
+      "lineCount": 141,
       "theoremCount": 8,
       "axiomCount": 0,
       "defCount": 0,
@@ -193,8 +200,8 @@
     {
       "path": "Proofs/Erdos1151Problem.lean",
       "filename": "Erdos1151Problem.lean",
-      "lineCount": 185,
-      "theoremCount": 5,
+      "lineCount": 216,
+      "theoremCount": 7,
       "axiomCount": 2,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Build-free tracker sync + blackout block.

- After **S37 BUILD-VERIFY (#22947)** grew the file, `leanFiles` lineCounts were stale and theoremCounts off-convention. Synced to canonical generator values:
  - `Erdos1151OQ04.lean`: lineCount 2692→**2714**, theoremCount 66→**32**
  - `Erdos1151OQ04Aristotle.lean`: lineCount 140→**141**
  - `Erdos1151Problem.lean`: lineCount 185→**216**, theoremCount 5→**7**
- The **66→32 is generator-parity, not lost theorems**: the file has 32 top-level + 34 indented/`@[simp]`/`private` theorem-like decls (66 total); the `leanFiles` convention counts only top-level `^(theorem|lemma) ` (gauss-wilson precedent).
- Set `status: blocked`: the S38 ACT (discharge Sorry 2 `divergence_from_lebesgue_growth` via ContinuousLinearMap + Tietze lift, ~80–120 LOC) is build-dependent and unbuildable under the verification blackout (Docker hung + Aristotle 404). Stops re-claim churn on this RICH (score 76) slug. S37 left it BUILD-VERIFY clean (3084 jobs, 1 sorry).

No Lean file touched.

## Test plan
- [ ] `leanFiles` matches `git show origin/main:proofs/Proofs/Erdos1151*.lean` canonical counts (verified by hand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)