### PR TITLE
research(prob-method-lovasz-local-oq-01): sync leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -119,8 +119,8 @@
     {
       "path": "Proofs/LovaszLocalLemma.lean",
       "filename": "LovaszLocalLemma.lean",
-      "lineCount": 364,
-      "theoremCount": 25,
+      "lineCount": 365,
+      "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,
@@ -130,11 +130,11 @@
     {
       "path": "Proofs/MoserTardos.lean",
       "filename": "MoserTardos.lean",
-      "lineCount": 517,
-      "theoremCount": 12,
+      "lineCount": 518,
+      "theoremCount": 11,
       "axiomCount": 0,
       "defCount": 7,
-      "sorryCount": 0,
+      "sorryCount": 2,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MoserTardos.lean"
     }

--- a/src/data/research/problems/prob-method-lovasz-local.json
+++ b/src/data/research/problems/prob-method-lovasz-local.json
@@ -80,8 +80,8 @@
     {
       "path": "Proofs/LovaszLocalLemma.lean",
       "filename": "LovaszLocalLemma.lean",
-      "lineCount": 364,
-      "theoremCount": 25,
+      "lineCount": 365,
+      "theoremCount": 24,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The `leanFiles` metric blocks for the Lovász Local Lemma research slugs were frozen while the underlying Lean sources evolved on `main`. This resyncs the cached counts to exactly what `enrich-research.ts` produces from current `origin/main`.

**`prob-method-lovasz-local-oq-01.json`**
- `LovaszLocalLemma.lean`: lineCount 364→365, theoremCount 25→24
- `MoserTardos.lean`: lineCount 517→518, theoremCount 12→11, sorryCount 0→2

**`prob-method-lovasz-local.json`** (shares `LovaszLocalLemma.lean`)
- `LovaszLocalLemma.lean`: lineCount 364→365, theoremCount 25→24

The two `MoserTardos.lean` `sorry` hits are docstring mentions (lines 7, 22), counted by the enrich `\bsorry\b`-all convention.

## Verification

All counts computed via `git grep` against `origin/main` using the exact `enrich-research.ts:144` regexes:
- `lineCount` = `content.split('\n').length`
- `theoremCount` = `^(theorem|lemma) `
- `defCount` = `^(def|noncomputable def|opaque def) `
- `axiomCount` = `^axiom `
- `sorryCount` = `\bsorry\b` (all occurrences)

Metadata-only — no Lean source changed, no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)