### PR TITLE
research(chebyshev-bounds-oq-04-oq-01): AUDIT — sync meta.json to Lean source

### DIFF
--- a/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
+++ b/src/data/proofs/chebyshev-bounds-oq-04-oq-01/meta.json
@@ -25,9 +25,9 @@
         "dateAdded": "2026-05-09",
         "axiomCount": 0,
         "assumptions": "No new axioms. The parent file ChebyshevBoundsOQ04.lean contributes 2 axioms (chebyshevPsi_asymptotic, pnt_equivalence) inherited via import; this OQ-04-OQ-01 file adds none of its own. The ultimate goal is to discharge chebyshevPsi_asymptotic by proving Selberg's symmetry formula and the Erdős-Selberg combinatorial finishing argument.",
-        "lineCount": 374,
-        "theoremCount": 16,
-        "definitionCount": 3,
+        "lineCount": 375,
+        "theoremCount": 18,
+        "definitionCount": 4,
         "additionalFiles": [],
         "originalContributions": [
             "Definition of Selberg's auxiliary function Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n) where Λ ∗ Λ is Dirichlet convolution expressed as an explicit divisor sum — chosen over the ArithmeticFunction.mul abstraction so subsequent identities can be manipulated without divisorsAntidiagonal indirection",
@@ -128,11 +128,18 @@
             "summary": "Iteration 4 lemma: selbergLambda2_eq_moebius_log_sq (the literal form Λ₂(n) = Σ_{d|n} μ(d) · (Real.log (n/d : ℕ))² for n > 0). Proof: lift Iter 3's dual identity to the ∀ m > 0 form (with explicit m : ℕ annotation to avoid Real.log coercion ambiguity), apply ArithmeticFunction.sum_eq_iff_sum_mul_moebius_eq (.mp direction), then bridge antidiagonal → divisors via Nat.sum_divisorsAntidiagonal — ~8 LOC body. Closes the Möbius–log Mathlib gap originally identified in Iter 1's roadmap."
         },
         {
+            "id": "sec-mertens",
+            "title": "Mertens partial sum M(N) and trivial linear bound (Iter 5a-β-1)",
+            "startLine": 304,
+            "endLine": 348,
+            "summary": "Iteration 5a-β-1: defines mertensM (N) = Σ_{1 ≤ d ≤ N} (μ(d) : ℝ) and proves mertensM_zero (M(0) = 0 via Icc 1 0 = ∅) and the trivial linear bound mertensM_abs_le (|M(N)| ≤ N) by the triangle inequality |Σ| ≤ Σ|·|, |μ(d)| ≤ 1 (ArithmeticFunction.abs_moebius_le_one), and (Icc 1 N).card = N. This foundational bound feeds the Abel-summation assembly of the weak Mertens M1 estimate in Iter 5a-β."
+        },
+        {
             "id": "sec-future-work",
             "title": "Future Work (docstring)",
-            "startLine": 304,
-            "endLine": 322,
-            "summary": "Documents the remaining roadmap after iteration 4: Selberg's symmetry formula S₂(N) = 2N log N + O(N) (Iter 5–6, the central analytic step starting from Iter 4's identity via the Möbius hyperbola order-swap trick), then the Erdős-Selberg Tauberian step culminating in chebyshevPsi_asymptotic (Iter 7+)."
+            "startLine": 349,
+            "endLine": 373,
+            "summary": "Documents the remaining roadmap after iteration 5a-β-1: Selberg's symmetry formula S₂(N) = 2N log N + O(N) (Iter 5–6, the central analytic step starting from Iter 4's identity via the Möbius hyperbola order-swap trick, using the Iter 5a Mertens bound under Abel summation), then the Erdős-Selberg Tauberian step culminating in chebyshevPsi_asymptotic (Iter 7+)."
         }
     ],
     "crossReferences": [


### PR DESCRIPTION
## Summary

Build-free meta↔source audit of `chebyshev-bounds-oq-04-oq-01` (claimed by researcher-6) against `proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean` on `origin/main`. The `meta.json` had drifted behind the Iter 5a-β-1 Mertens addition.

## Corrections

- **`theoremCount` 16 → 18**, **`definitionCount` 3 → 4**, **`lineCount` 374 → 375**. The new declarations are `noncomputable def mertensM` plus theorems `mertensM_zero` and `mertensM_abs_le` (file §"Mertens partial sum", L304–348). Counts verified against the canonical `enrich-research.ts` conventions.
- **`sections[]`**: added a `sec-mertens` section (L304–348) and corrected `sec-future-work`, which still claimed L304–322 — the Future Work docstring actually moved to **L349–373** when the Mertens section was inserted.

## Left unchanged (deliberately)

`status: formalized` / `badge: wip` and `axiomCount: 0`. The file has 0 own sorries, 0 own axioms, and 0 structure-encoded assumptions; its references to the parent axioms `chebyshevPsi_asymptotic` / `pnt_equivalence` are **docstring-only** (no theorem here invokes them), so it is effectively verify-ready. Per project policy, a `formalized → verified` promotion requires a Docker build, and Docker is down (daemon timeout, 2026-06-13). Status promotion deferred to a future build.

No Lean source changed; no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)