### PR TITLE
research(general-quartic-oq-02): sync leanFiles to S8 source state

### DIFF
--- a/src/data/research/problems/general-quartic-oq-02.json
+++ b/src/data/research/problems/general-quartic-oq-02.json
@@ -114,18 +114,18 @@
     ]
   },
   "started": "2026-05-12T04:48:16.448Z",
-  "lastUpdate": "2026-05-12T12:35Z",
+  "lastUpdate": "2026-06-13T02:30Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/GeneralQuartic.lean",
       "filename": "GeneralQuartic.lean",
-      "lineCount": 428,
-      "theoremCount": 12,
-      "axiomCount": 6,
+      "lineCount": 759,
+      "theoremCount": 21,
+      "axiomCount": 3,
       "defCount": 5,
-      "sorryCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GeneralQuartic.lean"
     }


### PR DESCRIPTION
## Summary

The `general-quartic-oq-02` research JSON's narrative fields (`currentState`, `knowledge.progressSummary`, `knowledge.builtItems`) already document the **S8 axiom-elimination** work (2026-06-13, researcher-2): `axiomCount 6 → 3`, `sorryCount 1 → 0`, Docker build verified (3058 jobs). But the `leanFiles` metadata block was never regenerated and stayed frozen at a pre-S6 state, so the gallery displays stale counts.

This syncs the `GeneralQuartic.lean` metrics to the **already-merged** `origin/main` source, computed with the exact `enrich-research.ts` conventions:

| field | old | new |
|-------|-----|-----|
| lineCount | 428 | 759 |
| theoremCount | 12 | 21 |
| axiomCount | 6 | 3 |
| sorryCount | 1 | 0 |
| defCount | 5 | 5 (unchanged) |

Also bumps the stale `lastUpdate` (`2026-05-12` → `2026-06-13T02:30Z`) to match `currentState.since`.

## Why build-free

Pure metadata sync to source that is already committed on `main`. No Lean rebuild required; verified the counts directly against the `origin/main` blob using `^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all, and `split('\n')` lineCount.

## Test plan

- [x] JSON parses
- [x] Counts match `git show origin/main:proofs/Proofs/GeneralQuartic.lean` through the canonical regexes (21 theorem/lemma, 3 axiom, 5 def, 0 sorry, 759 split-lines)
- [x] Single-file leanFiles set matches the `enrich-research.ts` prefix-matcher output