### PR TITLE
research(hilbert-11-oq-02): S26 — fix stale leanFiles + trim family dump + flag BLOCKED

### DIFF
--- a/research/problems/hilbert-11-oq-02/state.md
+++ b/research/problems/hilbert-11-oq-02/state.md
@@ -1,5 +1,19 @@
 # Current State
 
+> **S26 STATE-SYNC + BLOCKED (researcher-1, 2026-06-13).** leanFiles fixes:
+> (a) the slug's own file `Hilbert11OQ02.lean` had stale counts — lineCount
+> 1975→**2093** (file grew), theoremCount 88→**64** (canonical `^(theorem|lemma) `
+> top-level; the 88 was the old broader convention incl. indented/`@[simp]`/`private`
+> — gauss-wilson precedent, NOT lost theorems). axiomCount stays **2** (real: lines
+> 157/183; lines 528/683 are prose, not declarations — known false-positive). 0 sorries.
+> (b) Trimmed leanFiles from a 6-file family dump to just `Hilbert11OQ02.lean` — the
+> parent (`Hilbert11_QuadraticForms`) and sibling (`Hilbert11OQ01*`) files belong to
+> other slugs and their 14+ sorries misrepresented this 0-sorry slug. Status set
+> `blocked`: the S26 forward options are both unavailable — (1) the unconditional
+> Case-B theorem needs Hasse-Weil for genus-1 curves over F_p (multi-thousand-line
+> Mathlib gap, math-blocked); (3) the ~-40 LOC Hensel dedup refactor is build-dependent
+> under the 2026-06-13 verification blackout (Docker hung + Aristotle 404). No Lean touched.
+
 **Phase**: ACT (S25 added Section 28 Conditional Case-B Closure — `selmer_padic_solubility_from_caseB` + `_recovered`; remaining ℚ_[p]-solubility assumption now isolated to the single Case-B class `p ≡ 1 mod 3`; axiom count unchanged at 2 but assumption structure transparent)
 **Since**: 2026-06-03T15:00:00Z (S25 ACT — Section 28 conditional Case-B closure)
 **Last Updated**: 2026-06-03 (Iteration 25, researcher-1 — S25 Section 28)

--- a/src/data/research/problems/hilbert-11-oq-02.json
+++ b/src/data/research/problems/hilbert-11-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "hilbert-11-oq-02",
   "title": "When exactly does the Hasse principle fail for higher-degree forms",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -40,13 +40,20 @@
     "goal": "Three layers of partial answers: (1) For each degree n and number of variables k, give a sharp bound below which Hasse can fail and above which it must hold (cubic forms: Davenport bound). (2) Identify a uniform obstruction theory (Brauer-Manin / étale-Brauer-Manin) and prove it is the ONLY obstruction for natural classes. (3) Make this effective/algorithmic for explicit families (cubic surfaces, del Pezzo, K3)."
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "BLOCKED",
     "since": "2026-06-03T15:00:00Z",
     "iteration": 25,
     "focus": "Section 28 conditional Case-B closure: selmer_padic_solubility_from_caseB makes the residual ℚ_[p]-solubility axiom assumption transparent by decomposing it into Case-A (Section 27) + special primes {2,3,5} (Sections 17/19) + Case-B (the only remaining hypothesis). Tautological recovery via selmer_padic_solubility_recovered closes the type-check loop and verifies decomposition exhaustiveness.",
     "blockers": [
       "Hasse-Weil for genus-1 curves over F_p (Mathlib gap)",
-      "host disk capacity (S25 docker build skipped at 1.1 Gi avail vs ~10 Gi needed for fresh Mathlib clone via proofs/.lake self-symlink)"
+      "host disk capacity (S25 docker build skipped at 1.1 Gi avail vs ~10 Gi needed for fresh Mathlib clone via proofs/.lake self-symlink)",
+      {
+        "id": "BLACKOUT",
+        "kind": "verification-blackout+deep-gap",
+        "severity": "high",
+        "since": "2026-06-13",
+        "description": "Hilbert11OQ02.lean is 0-sorry / 2-axiom (deep Selmer axioms: selmer_no_rational_solution @157, selmer_padic_solubility @183). The S26 forward options are both unavailable: (1) full unconditional Case-B universal theorem needs Hasse-Weil for genus-1 curves over F_p — a multi-thousand-line Mathlib gap (math-blocked regardless of infra); (3) the ~-40 LOC Hensel*.Gint dedup refactor is build-dependent and unbuildable under the 2026-06-13 verification blackout (Docker hung + Aristotle 404). Flagged blocked to stop depth-first re-claim churn on this RICH (score 64) slug."
+      }
     ],
     "nextAction": "S26: prefer (1) full unconditional Case-B universal theorem (requires Hasse-Weil for genus-1 curves over F_p — multi-session, multi-thousand-line Mathlib gap), or (3) cleanup refactor of duplicated Hensel*.Gint definitions (~-40 LOC, no semantic change, deferred from iter 17). Option (2) in-place axiom replacement requires ~1700-line file reorganization and is deferred.",
     "attemptCounts": {
@@ -169,70 +176,15 @@
     ]
   },
   "started": "2026-05-06T21:20:28.056Z",
-  "lastUpdate": "2026-05-16T14:05:00Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
-      "path": "Proofs/Hilbert11_QuadraticForms.lean",
-      "filename": "Hilbert11_QuadraticForms.lean",
-      "lineCount": 499,
-      "theoremCount": 9,
-      "axiomCount": 3,
-      "defCount": 17,
-      "sorryCount": 14,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11_QuadraticForms.lean"
-    },
-    {
-      "path": "Proofs/Hilbert11OQ01.lean",
-      "filename": "Hilbert11OQ01.lean",
-      "lineCount": 275,
-      "theoremCount": 6,
-      "axiomCount": 1,
-      "defCount": 2,
-      "sorryCount": 2,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01.lean"
-    },
-    {
-      "path": "Proofs/Hilbert11OQ01Aristotle.lean",
-      "filename": "Hilbert11OQ01Aristotle.lean",
-      "lineCount": 65,
-      "theoremCount": 2,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 0,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01Aristotle.lean"
-    },
-    {
-      "path": "Proofs/Hilbert11OQ01OQ01.lean",
-      "filename": "Hilbert11OQ01OQ01.lean",
-      "lineCount": 130,
-      "theoremCount": 4,
-      "axiomCount": 1,
-      "defCount": 0,
-      "sorryCount": 2,
-      "isAristotle": false,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01OQ01.lean"
-    },
-    {
-      "path": "Proofs/Hilbert11OQ01OQ01Aristotle.lean",
-      "filename": "Hilbert11OQ01OQ01Aristotle.lean",
-      "lineCount": 105,
-      "theoremCount": 3,
-      "axiomCount": 0,
-      "defCount": 0,
-      "sorryCount": 3,
-      "isAristotle": true,
-      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Hilbert11OQ01OQ01Aristotle.lean"
-    },
-    {
       "path": "Proofs/Hilbert11OQ02.lean",
       "filename": "Hilbert11OQ02.lean",
-      "lineCount": 1975,
-      "theoremCount": 88,
+      "lineCount": 2093,
+      "theoremCount": 64,
       "axiomCount": 2,
       "defCount": 9,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Build-free tracker fix + blackout block.

- **`Hilbert11OQ02.lean` counts stale**: lineCount 1975→**2093** (file grew), theoremCount 88→**64** (canonical `^(theorem|lemma) ` top-level; the 88 was the old broader convention incl. indented/`@[simp]`/`private` — gauss-wilson precedent, not lost theorems). axiomCount stays **2** (real declarations at lines 157/183; lines 528/683 are prose — known false-positive, per leanfiles-count-convention). 0 sorries.
- **Trimmed `leanFiles`** from a 6-file family dump to just `Hilbert11OQ02.lean`. The parent (`Hilbert11_QuadraticForms`) and sibling (`Hilbert11OQ01*`) files belong to other slugs; their 14+ sorries misrepresented this 0-sorry slug.
- **`status: blocked`**: the S26 forward options are both unavailable — (1) unconditional Case-B needs Hasse-Weil for genus-1 curves over F_p (multi-thousand-line Mathlib gap); (3) the ~-40 LOC Hensel dedup refactor is build-dependent under the 2026-06-13 verification blackout (Docker hung + Aristotle 404).

No Lean file touched.

## Test plan
- [ ] `Hilbert11OQ02.lean` counts match origin/main (verified: 64 thm top-level, 2 real axioms, 0 sorries, 2093 LC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)