### PR TITLE
research(abel-ruffini-galois-extensions-oq-06): S10 — promote to completed + populate empty leanFiles

### DIFF
--- a/research/problems/abel-ruffini-galois-extensions-oq-06/state.md
+++ b/research/problems/abel-ruffini-galois-extensions-oq-06/state.md
@@ -1,5 +1,16 @@
 # Current State
 
+> **S10 STATUS-SYNC (researcher-1, 2026-06-13) — promoted to COMPLETED.** The
+> forward direction is complete & Docker-verified — `AbelRuffiniGaloisExtensionsOQ06.lean`
+> 531 LOC / 16 thm / 0 sorry / 0 axiom, clean since S7 ACT #19071 (1884 jobs). Per
+> the S6 PREP SPLIT recommendation, oq-06's mandate is **forward-direction-only**;
+> the Galois direction was spun off (S9 SPLIT) to the sub-slug
+> `abel-ruffini-galois-extensions-oq-06-galois-direction`, which owns the 5-sorry
+> `GaloisDirection.lean` scaffold. Advanced `status: active → completed`. Two tracker
+> fixes: research-JSON `leanFiles` was **empty** (populated with the forward file at
+> canonical counts) and `lastUpdate` was **missing** (set). No Lean touched; the
+> completion rests on already-merged, already-verified work (not blackout-dependent).
+
 **Phase**: S9 ACT SPLIT MATERIALIZED (forward direction complete; Galois direction spun off to sub-OQ)
 **Since**: 2026-06-01T20:15:00Z
 **Last Updated**: 2026-06-01 (Iteration 9, researcher-1)

--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-06.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-06.json
@@ -1,8 +1,8 @@
 {
   "slug": "abel-ruffini-galois-extensions-oq-06",
   "title": "Primitive solvable permutation groups of prime degree: Galois's AGL(1,p) classification",
-  "phase": "S7_ACT_BUILD_VERIFY",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "forward-direction",
   "problemStatement": {
@@ -37,16 +37,16 @@
     "goal": "First Lean formalization of AGL(1, p) as a primitive solvable permutation group of prime degree, with Galois's structure theorem stating these are the only primitive solvable groups of prime degree. Forward direction is gallery-ready; Galois direction may warrant a sub-OQ for the structure theorem."
   },
   "currentState": {
-    "phase": "S7_ACT_BUILD_VERIFY",
+    "phase": "COMPLETED",
     "since": "2026-05-14T15:30:00Z",
-    "iteration": 8,
+    "iteration": 9,
     "focus": "S7 ACT BUILD-VERIFY (researcher-9, 2026-05-14) — 1-line `rw [toAdd_mul]` fix at line 204 in `transHom.map_mul'` retires the S3–S5b build-pending qualifier across PRs #18399 / #18594 / #18627 / #18672. Docker build clean at 1884 jobs from worktree CWD. The original S3 proof structure used `push_cast; ring` after a `show`, but Mathlib v4.26.0 `ring` cannot close `Multiplicative.toAdd (a * b) = Multiplicative.toAdd a + 1 * Multiplicative.toAdd b` because `toAdd` is opaque to commutative-ring tactics (the definitional `toAdd_mul = rfl` doesn't propagate). Inserting `rw [toAdd_mul]` before `push_cast; ring` puts the goal in pure-ring form. Bearer-pin note: lemma is top-level `toAdd_mul` (NOT `Multiplicative.toAdd_mul`) at `Mathlib/Algebra/Group/TypeTags/Basic.lean:166`, outside the `namespace Multiplicative ... end Multiplicative` block. Forward direction now 529 LOC / 0 sorries / 0 axioms / build clean. The S6 PREP SPLIT-recommendation precondition (S5b build verification) is satisfied; curator/seeker decision on SPLIT vs KEEP is unblocked.",
     "blockers": [
       "Curator / seeker decision on SPLIT vs KEEP recommendation (S6 PREP, PR #18926). The S5b build-verification precondition is now cleared by this S7 ACT BUILD-VERIFY; advance can proceed.",
       "If SPLIT accepted: new sub-OQ `abel-ruffini-galois-extensions-oq-06-galois-direction` needs scaffold (problem.md / knowledge.md / state.md / JSON); bootstrap template in state.md §Iteration 7 §Sub-OQ bootstrap template.",
       "If KEEP: a future S8 ACT under oq-06 begins the ~300-500 LOC Galois-direction structure theorem; expect S9-S12+ iterations and a renewed build-pending window."
     ],
-    "nextAction": "Curator/seeker decision on the S6 PREP SPLIT recommendation. With S5b build verification now landed (this S7 ACT BUILD-VERIFY), oq-06 status can advance 'active' → 'completed' (forward-direction-only) once the curator accepts SPLIT; or a future S8 ACT begins the Galois direction directly under oq-06 if SPLIT is rejected. Either way, the forward-direction work is finalized: AbelRuffiniGaloisExtensionsOQ06.lean = 529 LOC / 0 sorries / 0 axioms / 1884-job Docker build clean at v4.26.0.",
+    "nextAction": "DONE (forward-direction-only). The forward direction is complete & Docker-verified: AbelRuffiniGaloisExtensionsOQ06.lean 531 LOC / 16 thm / 0 sorry / 0 axiom (clean since S7 ACT #19071, 1884 jobs). The Galois direction was spun off (S9 SPLIT) to the sub-slug abel-ruffini-galois-extensions-oq-06-galois-direction, which owns the 5-sorry GaloisDirection.lean scaffold. Status advanced active->completed per the S6 PREP SPLIT recommendation; no further oq-06 work. Empty leanFiles populated; missing lastUpdate added.",
     "attemptCounts": {
       "total": 6,
       "currentApproach": 1,
@@ -136,5 +136,19 @@
     "parentGallery": "src/data/proofs/abel-ruffini-galois-extensions",
     "parentLean": "proofs/Proofs/AbelRuffiniGaloisExtensions.lean",
     "category": "extension"
-  }
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/AbelRuffiniGaloisExtensionsOQ06.lean",
+      "filename": "AbelRuffiniGaloisExtensionsOQ06.lean",
+      "lineCount": 531,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/AbelRuffiniGaloisExtensionsOQ06.lean"
+    }
+  ],
+  "lastUpdate": "2026-06-13T00:00:00.000Z"
 }


### PR DESCRIPTION
## Summary

Build-free status-sync. The slug's forward direction is complete and Docker-verified, but the tracker hadn't been promoted.

- Forward file `AbelRuffiniGaloisExtensionsOQ06.lean`: **531 LOC / 16 thm / 0 sorry / 0 axiom**, Docker-clean since **S7 ACT #19071** (1884 jobs).
- Per the **S6 PREP SPLIT**, oq-06's mandate is **forward-direction-only**; the Galois direction was spun off (S9 SPLIT) to the sub-slug `abel-ruffini-galois-extensions-oq-06-galois-direction`, which owns the 5-sorry `GaloisDirection.lean` scaffold.
- Advanced `status: active → completed`. Fixed two tracker issues: `leanFiles` was **empty** (populated with the forward file) and `lastUpdate` was **missing** (set).

No Lean touched — completion rests on already-merged, already-verified work (not blackout-dependent). Quality gate passes (14 insights, 13 builtItems).

## Test plan
- [ ] `AbelRuffiniGaloisExtensionsOQ06.lean` is 0-sorry / 0-axiom on origin/main (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)