### PR TITLE
research(gauss-wilson-non-cyclic-oq-02): S1 survey — Sylow-2 structure resolved on paper

### DIFF
--- a/research/problems/gauss-wilson-non-cyclic-oq-02/knowledge.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-02/knowledge.md
@@ -1,21 +1,120 @@
 # Knowledge Base: gauss-wilson-non-cyclic-oq-02
 
-Insights accumulated during research on this problem.
+**Question.** Does the 2-torsion bound extend to characterize when the Sylow
+2-subgroup of `(ZMod n)ˣ` is *elementary abelian* versus *cyclic*?
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent entry `gauss-wilson-non-cyclic` proves the qualitative fact that for
+`n ≥ 3`, `¬IsCyclic (ZMod n)ˣ → ∃ x, x² = 1 ∧ x ≠ ±1` (the 2-torsion subgroup
+has order `≥ 3`, i.e. 2-rank `≥ 2`). Sibling `OQ-03` upgrades this to the exact
+**count** of square roots of unity,
+`#{x : x² = 1} = 2 ^ (ω_odd(n) + ε₂(n))`, which is exactly `2 ^ rank₂(S₂)`.
+
+OQ-02 asks a **different** invariant: not the rank/order of the Sylow
+2-subgroup `S₂ := Syl₂((ZMod n)ˣ)`, but its full isomorphism type — specifically
+the two boundary cases *cyclic* (rank `≤ 1`) and *elementary abelian*
+(exponent `≤ 2`). The count formula of OQ-03 determines the rank but **not** the
+exponent, so OQ-02 is not subsumed by OQ-03.
+
+## Resolution (on paper — complete)
+
+By CRT, writing `n = 2^a · ∏ pᵢ^{eᵢ}` with the `pᵢ` distinct odd primes:
+
+```
+  (ZMod n)ˣ  ≅  (ZMod 2^a)ˣ × ∏ᵢ (ZMod pᵢ^{eᵢ})ˣ
+```
+
+Each odd factor `(ZMod pᵢ^{eᵢ})ˣ` is **cyclic** of order `pᵢ^{eᵢ-1}(pᵢ-1)`; its
+Sylow 2-subgroup is cyclic of order `2^{v₂(pᵢ-1)}` (the `pᵢ^{eᵢ-1}` part is odd),
+and `v₂(pᵢ-1) ≥ 1` always (odd prime ⇒ `pᵢ-1` even). The 2-part:
+`(ZMod 2^a)ˣ` is trivial (`a≤1`), `≅ C₂` (`a=2`), or `≅ C₂ × C_{2^{a-2}}`
+(`a≥3`). Hence the Sylow 2-subgroup of the whole group is
+
+```
+  S₂(n)  ≅  D(a)  ×  ∏_{odd p | n} C_{2^{v₂(p-1)}},
+  where D(a) = 1 (a≤1),  C₂ (a=2),  C₂ × C_{2^{a-2}} (a≥3).
+```
+
+This is a finite abelian 2-group, a product of cyclic 2-groups. From it both
+boundary characterizations drop out:
+
+- **`S₂(n)` cyclic** ⟺ at most one nontrivial cyclic factor ⟺ `rank₂ ≤ 1`
+  ⟺ `ω_odd(n) + ε₂(n) ≤ 1` ⟺ `n ∈ {1, 2, 4, p^k, 2p^k}` (p odd prime).
+  Equivalently: **`S₂(n)` is cyclic ⟺ `(ZMod n)ˣ` is itself cyclic.** (The
+  reason is that `rank₂ ≤ 1` already forces `n` into the cyclic-classification
+  forms, so the odd parts cannot collide either.) This recovers
+  `ZMod.isCyclic_units_iff`.
+
+- **`S₂(n)` elementary abelian** ⟺ every cyclic factor has order `2`
+  ⟺ `v₂(p-1) = 1` for every odd `p | n` **and** `a ≤ 3`
+  ⟺ **every odd prime divisor of `n` is `≡ 3 (mod 4)` and `v₂(n) ≤ 3`.**
+  (`a = 3` gives `(ZMod 8)ˣ ≅ C₂ × C₂`, still exponent 2; `a ≥ 4` introduces a
+  `C_{2^{a-2}}` with `a-2 ≥ 2`, breaking exponent 2.)
+
+So the answer to OQ-02 is **yes**: the 2-torsion analysis extends to a complete
+characterization, and "elementary abelian vs cyclic" are the two extreme shapes
+of the general structure formula above. The two coincide (`S₂ ∈ {1, C₂}`)
+exactly when `rank₂ ≤ 1` and exponent `≤ 2`.
+
+### Numerical cross-checks (consistent with OQ-03 count = 2^rank)
+
+| n   | factor form        | S₂                | rank | #sqrts | cyclic? | elem.ab.? |
+|-----|--------------------|-------------------|------|--------|---------|-----------|
+| 8   | 2³                 | C₂×C₂             | 2    | 4      | no      | yes       |
+| 16  | 2⁴                 | C₂×C₄             | 2    | 4      | no      | no        |
+| 12  | 4·3                | C₂×C₂             | 2    | 4      | no      | yes       |
+| 15  | 3·5                | C₂×C₄ (5≡1 mod4)  | 2    | 4      | no      | no        |
+| 21  | 3·7                | C₂×C₂             | 2    | 4      | no      | yes       |
+| 7   | 7                  | C₂                | 1    | 2      | yes     | yes       |
+
+All `#sqrts = 2^rank` match OQ-03's formula; the `elem.ab.?` column is the new
+exponent information OQ-02 adds (note 8 vs 16 and 21 vs 15 differ in exponent at
+equal rank).
+
+## Mathlib API inventory (for ACT)
+
+- `ZMod.isCyclic_units_iff` — exact cyclic classification (already used by the
+  parent file); directly closes the **cyclic** half.
+- `ZMod.chineseRemainder` — CRT ring iso (already used by the parent file).
+- Units of odd prime powers cyclic: lemmas in
+  `Mathlib.RingTheory.ZMod.UnitsCyclic` (parent imports this).
+- **Gap to confirm during ACT:** an explicit Mathlib iso for `(ZMod (2^a))ˣ ≅
+  C₂ × C_{2^{a-2}}` (`a ≥ 3`). If absent, this is the one piece to build
+  (~80–150 lines; the `5`-generates-the-`2^{a-2}`-part is the classical lemma).
+  Without it the *elementary-abelian* direction can still be obtained via the
+  `x² = 1` square-root count combined with an exponent computation, but the
+  clean structural statement wants the iso.
+
+## Next Steps
+
+1. State two Lean theorems in a new `GaussWilsonNonCyclicOQ02.lean`:
+   `s2_cyclic_iff` (Sylow-2 cyclic ↔ `IsCyclic (ZMod n)ˣ`) and
+   `s2_elementaryAbelian_iff` ((∀ x in S₂, x²=1) ↔ every odd prime `p ∣ n` has
+   `p % 4 = 3` and `n.factorization 2 ≤ 3`).
+2. Reuse the CRT decomposition machinery already present in the parent file.
+3. Build/locate the `(ZMod 2^a)ˣ` structure lemma (the only likely Mathlib gap).
+
+**Status:** SURVEYED / ORIENT. Core mathematics resolved on paper; formalization
+is build-gated (Docker + Aristotle both down 2026-06-13). No Lean written this
+session — verification infra unavailable.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
-
----
+- OQ-02 (exponent / iso-type of `S₂`) is genuinely independent of OQ-03
+  (rank / square-root count): equal rank can carry different exponent
+  (`n=8` vs `n=16`).
+- `S₂` cyclic ⟺ `(ZMod n)ˣ` cyclic — the Sylow-2 shape alone already detects
+  the global cyclic classification, because rank `≤ 1` forces `n ∈ {1,2,4,p^k,2p^k}`.
+- The elementary-abelian condition is the conjunction of a per-odd-prime
+  congruence (`p ≡ 3 mod 4`) and a 2-adic cap (`v₂(n) ≤ 3`).
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Trying to read the cyclic/elementary-abelian distinction off OQ-03's count
+  formula alone — impossible, since the count is `2^rank` and is blind to the
+  exponent (compare `n=8`: C₂×C₂ vs `n=16`: C₂×C₄, both rank 2, count 4).

--- a/research/problems/gauss-wilson-non-cyclic-oq-02/state.md
+++ b/research/problems/gauss-wilson-non-cyclic-oq-02/state.md
@@ -1,25 +1,32 @@
 # Research State: gauss-wilson-non-cyclic-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:48-07:00
+**Since**: 2026-06-13
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Core mathematics resolved on paper (see knowledge.md): the Sylow 2-subgroup
+structure of `(ZMod n)ˣ` and both boundary characterizations (cyclic;
+elementary abelian). Next is formalization, currently build-gated.
 
 ## Active Approach
-None yet.
+CRT decomposition `(ZMod n)ˣ ≅ (ZMod 2^a)ˣ × ∏ (ZMod pᵢ^{eᵢ})ˣ`, then read off
+`S₂ ≅ D(a) × ∏ C_{2^{v₂(pᵢ-1)}}`. Reuse parent file's CRT machinery and
+`ZMod.isCyclic_units_iff`.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (no Lean written — verification infra down)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- Docker build daemon down and Aristotle backend returning 404 (2026-06-13
+  verification blackout) — no route to compile/verify Lean this session.
+- Likely Mathlib gap: explicit `(ZMod 2^a)ˣ ≅ C₂ × C_{2^{a-2}}` iso (to confirm).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When build infra returns: create `GaussWilsonNonCyclicOQ02.lean` stating
+`s2_cyclic_iff` and `s2_elementaryAbelian_iff`, reusing the parent CRT lemmas;
+locate or build the `(ZMod 2^a)ˣ` structure lemma.

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-02.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-02.json
@@ -1,0 +1,137 @@
+{
+  "slug": "gauss-wilson-non-cyclic-oq-02",
+  "title": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of ...",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Characterize n for which the Sylow 2-subgroup S2 of (ZMod n)ˣ is (a) cyclic, (b) elementary abelian. S2 ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}} where D(a)=1,C2,C2×C_{2^{a-2}} for v2(n)=a≤1,=2,≥3.",
+    "plain": "Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of (ZMod n)ˣ is elementary abelian versus cyclic? Answer: yes — S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}; S2 elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) and v2(n) ≤ 3.",
+    "whyMatters": [
+      "Research value"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent: not IsCyclic (ZMod n)ˣ → exists non-trivial sqrt of 1 (2-rank ≥ 2)",
+      "OQ-03: #{x:x²=1} = 2^(omega_odd(n)+eps2(n)) = 2^rank2(S2)"
+    ],
+    "open": [
+      "Lean formalization of s2_cyclic_iff and s2_elementaryAbelian_iff (build-gated)"
+    ],
+    "goal": "Two Lean theorems characterizing when S2((ZMod n)ˣ) is cyclic resp. elementary abelian."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13",
+    "iteration": 1,
+    "focus": "Core mathematics resolved on paper; formalization build-gated (verification blackout 2026-06-13).",
+    "blockers": [],
+    "nextAction": "Create GaussWilsonNonCyclicOQ02.lean stating s2_cyclic_iff and s2_elementaryAbelian_iff once build infra returns.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SURVEYED (ORIENT): core math fully resolved on paper; both boundary characterizations proven by hand and cross-checked vs OQ-03. Formalization build-gated.",
+    "builtItems": [],
+    "insights": [
+      "S2((ZMod n)ˣ) ≅ D(a) × prod_{odd p|n} C_{2^{v2(p-1)}}, D(a)=1/C2/C2×C_{2^{a-2}} for a=v2(n) ≤1/=2/≥3",
+      "S2 cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n in {1,2,4,p^k,2p^k}: rank2≤1 forces n into the cyclic-classification forms",
+      "S2 elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) AND v2(n) ≤ 3",
+      "OQ-02 (exponent/iso-type) is independent of OQ-03 (rank/count): n=8 (C2×C2) vs n=16 (C2×C4) share rank 2 but differ in exponent"
+    ],
+    "mathlibGaps": [
+      "Explicit (ZMod 2^a)ˣ ≅ C2 × C_{2^{a-2}} (a≥3) iso — confirm presence in Mathlib.RingTheory.ZMod.UnitsCyclic; if absent, ~80-150 LOC to build"
+    ],
+    "nextSteps": [
+      "State s2_cyclic_iff : IsCyclic(Syl2 (ZMod n)ˣ) ↔ IsCyclic (ZMod n)ˣ using ZMod.isCyclic_units_iff",
+      "State s2_elementaryAbelian_iff via per-odd-prime p%4=3 and n.factorization 2 ≤ 3",
+      "Reuse parent CRT machinery (ZMod.chineseRemainder); build/locate (ZMod 2^a)ˣ structure lemma"
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "group-theory",
+    "cyclic-groups",
+    "zmod",
+    "wilson-gauss",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "gauss-wilson-non-cyclic"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "ZMod.isCyclic_units_iff",
+      "ZMod.chineseRemainder",
+      "Mathlib.RingTheory.ZMod.UnitsCyclic"
+    ]
+  },
+  "started": "2026-06-10T18:04:48.642Z",
+  "lastUpdate": "2026-06-13",
+  "significance": 6,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/GaussWilsonNonCyclic.lean",
+      "filename": "GaussWilsonNonCyclic.lean",
+      "lineCount": 324,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclic.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01.lean",
+      "filename": "GaussWilsonNonCyclicOQ01.lean",
+      "lineCount": 258,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01A.lean",
+      "filename": "GaussWilsonNonCyclicOQ01A.lean",
+      "lineCount": 67,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01A.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ01B.lean",
+      "filename": "GaussWilsonNonCyclicOQ01B.lean",
+      "lineCount": 245,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ01B.lean"
+    },
+    {
+      "path": "Proofs/GaussWilsonNonCyclicOQ03.lean",
+      "filename": "GaussWilsonNonCyclicOQ03.lean",
+      "lineCount": 585,
+      "theoremCount": 11,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 3,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GaussWilsonNonCyclicOQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

First research iteration (OBSERVE→ORIENT) on `gauss-wilson-non-cyclic-oq-02`:
*"Does the 2-torsion bound extend to characterize when the Sylow 2-subgroup of
`(ZMod n)ˣ` is elementary abelian versus cyclic?"*

The core mathematics is **resolved on paper** (no Lean compiled — the Docker
build daemon and Aristotle backend are both down today, 2026-06-13). Via the CRT
decomposition already used by the parent proof:

```
S₂(n) ≅ D(a) × ∏_{odd p|n} C_{2^{v₂(p-1)}},   D(a)=1 / C₂ / C₂×C_{2^{a-2}}  for v₂(n)=a ≤1 / =2 / ≥3
```

- **S₂ cyclic ⟺ (ZMod n)ˣ cyclic ⟺ n ∈ {1,2,4,pᵏ,2pᵏ}** (recovers `ZMod.isCyclic_units_iff`).
- **S₂ elementary abelian ⟺ every odd prime divisor ≡ 3 (mod 4) and v₂(n) ≤ 3.**
- This is **independent of OQ-03** (which gives the count = `2^rank`): equal rank
  can carry a different exponent (`n=8`: C₂×C₂ vs `n=16`: C₂×C₄). The exponent is
  the new information OQ-02 supplies.

Cross-checked numerically against OQ-03's established count formula (table in
`knowledge.md`). Identifies the one likely Mathlib gap: an explicit
`(ZMod 2^a)ˣ ≅ C₂ × C_{2^{a-2}}` iso.

## Files

- `research/problems/gauss-wilson-non-cyclic-oq-02/knowledge.md` — full survey + structure + cross-checks
- `research/problems/gauss-wilson-non-cyclic-oq-02/state.md` — phase OBSERVE→ORIENT
- `src/data/research/problems/gauss-wilson-non-cyclic-oq-02.json` — knowledge fields seeded (insights/gaps/nextSteps)

## Test plan

- [x] Mathematics cross-checked by hand against OQ-03 count formula (n = 7,8,12,15,16,21)
- [ ] Lean formalization deferred — verification infra (Docker + Aristotle) down 2026-06-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)