### PR TITLE
research(erdos-1150): sync leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-1150.json
+++ b/src/data/research/problems/erdos-1150.json
@@ -82,17 +82,17 @@
     "mathlib": []
   },
   "started": "2026-01-15T16:24:55.487Z",
-  "lastUpdate": "2026-03-29T20:30:00Z",
+  "lastUpdate": "2026-06-10T09:47:38Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1150Problem.lean",
       "filename": "Erdos1150Problem.lean",
-      "lineCount": 342,
-      "theoremCount": 9,
+      "lineCount": 391,
+      "theoremCount": 13,
       "axiomCount": 3,
-      "defCount": 4,
+      "defCount": 7,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1150Problem.lean"


### PR DESCRIPTION
## Summary
The canonical research JSON for **erdos-1150** had a stale `leanFiles` block: `Proofs/Erdos1150Problem.lean` grew from 342→391 lines (adding 4 theorems and 3 defs) but the metadata was never regenerated. This syncs the block to the current `origin/main` source.

| metric | was | now |
|--------|-----|-----|
| lineCount | 342 | 391 |
| theoremCount | 9 | 13 |
| defCount | 4 | 7 |
| axiomCount | 3 | 3 (unchanged) |
| sorryCount | 0 | 0 (unchanged) |

All five metrics recomputed using the exact `enrich-research.ts` conventions (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all occurrences, `lineCount = split('\n').length`). `lastUpdate` bumped to the source file's last-touched date on `origin/main`.

This is a build-free metadata sync — **no Lean source changed**. Surfaced via a global meta↔source drift scan over all 1971 problem JSONs.

## Test plan
- [x] JSON validates (`python3 -m json.tool`)
- [x] Metrics verified against `git show origin/main:proofs/Proofs/Erdos1150Problem.lean`
- [x] axiomCount/sorryCount confirmed unchanged (no claim change)