### PR TITLE
research(shannon-channel-coding-oq-02-oq-01-oq-01): S22 — flag BLOCKED (verification blackout)

### DIFF
--- a/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md
@@ -1,8 +1,8 @@
 # Current State
 
-**Phase**: STATE-SYNC (Docker-down) — S21 corrected stale slug `meta.json` to record that the problem's primary goal is COMPLETE: the `fano_inequality` axiom in `ShannonChannelCoding.lean` is discharged (now a `theorem` @ line 199 `:= FanoFromConditionalEntropy.fano_inequality_proved`, parent axiomCount 4 → 3). S20's cascade-repair confirmed in HEAD `fa1c4d27aa8`. Docker daemon DOWN (8s timeout) → no build/ACT possible; disk recovered (15%, 67 Gi free). The S18a-2/capacity paste (S17 PREP §6.2) remains the next ACT but is gated on Docker AND targets the **parent** file (where `DMChannel`/`channelMI` live), not OQ02OQ01. Next: S22 ACT = capacity bundle paste once Docker is up (re-pin insertion point in parent file first).
+**Phase**: BLOCKED (verification blackout) — S22 flags the slug `blocked`. Primary goal is COMPLETE on `origin/main`: `fano_inequality` is a `theorem` @ `ShannonChannelCoding.lean:200` (discharged via `FanoFromConditionalEntropy.fano_inequality_proved`); parent `axiomCount 3` (channel_coding_achievability, channel_coding_converse, bsc_capacity_eq), `sorries 0`, `status axiomatized` — all accurate, no meta fix needed. The only remaining work is the **Docker-gated** capacity bundle (S18a-2/S18b/S18c: uniform-input-achieves-capacity for weakly symmetric channels). Both verification routes are down this session: `docker info` exit 124 (daemon down); Aristotle MCP backend returns `Resource not found` (404). No build-free progress remains (stale `lineCount`/`theoremCount` in meta are deployer-owned auto-sync, not a semantic fix). Re-open when Docker recovers.
 **Since**: 2026-06-13T00:00:00Z
-**Iteration**: 21 (S21 STATE-SYNC — Docker-down; meta-accuracy fix, Fano discharge recorded)
+**Iteration**: 22 (S22 BLOCKED — Docker exit124 + Aristotle 404; primary goal already complete on main)
 **Last Updated**: 2026-06-13Z
 
 ## Iteration 21 (researcher-1, 2026-06-13) — S21 STATE-SYNC (Docker-down, meta-accuracy)

--- a/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
+++ b/src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "shannon-channel-coding-oq-02-oq-01-oq-01",
   "title": "Fix ShannonEntropy",
-  "phase": "STATE-SYNC",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "STATE-SYNC",
+    "phase": "BLOCKED",
     "since": "2026-06-13T00:00:00.000Z",
-    "iteration": 21,
-    "focus": "S21 STATE-SYNC (Docker-down): corrected stale slug meta.json to record the problem's primary goal is COMPLETE \u2014 the fano_inequality axiom in ShannonChannelCoding.lean is discharged (theorem @ line 199 := FanoFromConditionalEntropy.fano_inequality_proved; parent axiomCount 4 -> 3). Docker daemon down (8s timeout) so no build/ACT; disk recovered (15%, 67Gi free). Next ACT = S17 PREP \u00a76.2 capacity bundle paste into the PARENT file (DMChannel/channelMI live there), gated on Docker.",
+    "iteration": 22,
+    "focus": "S22 BLOCKED (verification blackout): primary goal COMPLETE on main (fano_inequality is a theorem @ ShannonChannelCoding.lean:200, discharged via FanoFromConditionalEntropy.fano_inequality_proved; parent axiomCount 3, sorries 0, status axiomatized -- all accurate). Only remaining work is the Docker-gated capacity bundle (S18a-2/S18b/S18c: uniform-input-achieves-capacity for weakly symmetric channels). Both verification routes down this session: docker info exit 124 (daemon down); Aristotle MCP backend returns 'Resource not found' (404). No build-free progress remains -- semantic meta is correct; stale lineCount/theoremCount are deployer-owned auto-sync. Re-open when Docker recovers.",
     "blockers": [],
     "nextAction": "S21 ACT (next): paste S18a-2 lemma `output_marginal_uniform_of_uniform_input_and_column_sum_const` from S17 PREP \u00a76.2 (~25-35 LOC) into ShannonChannelCoding.lean immediately after the `def DMChannel.IsWeaklySymmetric` block (lines 487-491). Bearers stable v4.26.0. Then S21b: row_entropy_invariant_under_input.",
     "attemptCounts": {


### PR DESCRIPTION
## Summary

Flags `shannon-channel-coding-oq-02-oq-01-oq-01` as **blocked**. The slug's stated goal — discharge the `fano_inequality` axiom — is **already complete on `origin/main`**, and the only remaining work is Docker-gated, with both verification routes down this session.

- **Primary goal complete**: `fano_inequality` is a `theorem` @ `ShannonChannelCoding.lean:200` (discharged via `FanoFromConditionalEntropy.fano_inequality_proved`). Parent file has `axiomCount 3` (channel_coding_achievability, channel_coding_converse, bsc_capacity_eq), `sorries 0`, `status axiomatized` — gallery meta is accurate, no fix needed.
- **Remaining work is Docker-gated**: the capacity bundle (S18a-2/S18b/S18c: uniform-input-achieves-capacity for weakly symmetric channels) requires a Lean build to verify.
- **Both verification routes down**: `docker info` exits 124 (daemon down); Aristotle MCP backend returns `Resource not found` (404).
- No build-free progress remains (stale `lineCount`/`theoremCount` in meta are deployer-owned auto-sync, not a semantic fix), so the slug is flagged `blocked` instead of churning another PREP memo. Re-open when Docker recovers.

## Changes
- `src/data/research/problems/shannon-channel-coding-oq-02-oq-01-oq-01.json`: `status` active→blocked, `phase` STATE-SYNC→BLOCKED, iteration 21→22, focus note.
- `research/problems/shannon-channel-coding-oq-02-oq-01-oq-01/state.md`: Current State header → BLOCKED.

## Test plan
- [x] JSON validates
- [x] No Lean files touched (build-free; both verification routes confirmed down)
- [x] Source claims cross-checked against `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)