### PR TITLE
research(feuerbachs-theorem-oq-02): AUDIT — correct theoremCount 17→13 to match Lean source

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -39,7 +39,7 @@
       "Proof of the 3D Euler line relation: centroid divides circumcenter-Monge point segment in ratio 3:1",
       "Proof that the six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid (the midedge-sphere result; also shown not to be Feuerbach-tangent at T₀)"
     ],
-    "theoremCount": 17,
+    "theoremCount": 13,
     "definitionCount": 50,
     "additionalFiles": [
       "Proofs/FeuerbachsTheoremOQ02Aristotle.lean"
@@ -168,7 +168,7 @@
     "namespace": "FeuerbachsTheoremOQ02",
     "lineCount": 769,
     "axiomCount": 1,
-    "theoremCount": 17,
+    "theoremCount": 13,
     "substantiveTheoremCount": 8,
     "duplicateTheorems": 0,
     "definitionCount": 50,


### PR DESCRIPTION
## Summary
Source↔meta audit of the `feuerbachs-theorem-oq-02` gallery entry (claimed via the `feuerbachs-theorem-oq-02-murakami` open-formalization stub).

The hand-curated `leanFile` block claimed **theoremCount: 17**, but the actual source `Proofs/FeuerbachsTheoremOQ02.lean` has **13** col-0 `theorem`/`lemma` declarations (canonical `^(theorem|lemma) ` count). The 2026-05-02 refutation removed 6 sorry-stated tangency theorems (`feuerbach_3d_insphere`, `feuerbach_3d_exsphere_{A,B,C,D}`, bundled `feuerbach_3d_theorem`) — documented in the `assumptions` field — but the published count was never resynced. Corrected both occurrences (lines 42 and 171).

## Verification (build-free; Docker down)
- `theoremCount`: 17 → **13** ✓ (`grep -cE '^(theorem|lemma) '`)
- `axiomCount`: 1 — accurate ✓
- `sorries`: 0 — accurate ✓ (the single `\bsorry\b` hit is prose in a docstring at L494)
- `definitionCount`: 50 — accurate ✓ (47 `def` + 1 `abbrev` + 2 `structure`)
- `substantiveTheoremCount`: 8 — left unchanged (curated subset, ≤13, consistent)

No Lean build required — pure metadata correction against source counts.

## Test plan
- [x] JSON validates (`python3 -c json.load`)
- [x] Counts re-derived from `proofs/Proofs/FeuerbachsTheoremOQ02.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)