### PR TITLE
research(erdos-776): sync stale leanFiles to S7 source state

### DIFF
--- a/src/data/research/problems/erdos-776.json
+++ b/src/data/research/problems/erdos-776.json
@@ -117,17 +117,17 @@
     "mathlib": []
   },
   "started": "2026-01-15T08:39:26.858Z",
-  "lastUpdate": "2026-05-07T16:00:00.000Z",
+  "lastUpdate": "2026-06-10T02:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos776Problem.lean",
       "filename": "Erdos776Problem.lean",
-      "lineCount": 411,
-      "theoremCount": 14,
+      "lineCount": 559,
+      "theoremCount": 27,
       "axiomCount": 3,
-      "defCount": 6,
+      "defCount": 8,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos776Problem.lean"


### PR DESCRIPTION
## Summary

The research-pool JSON `src/data/research/problems/erdos-776.json` `leanFiles` block was frozen at **411/14/3/6/0** (line/theorem/axiom/def/sorry) while the merged source `proofs/Proofs/Erdos776Problem.lean` is at **559/27/3/8/0** — real mathematical progress that the leanFiles block never tracked:

- lineCount 411 → 559 (+148)
- theoremCount 14 → 27 (+13)
- defCount 6 → 8 (+2)
- axiomCount 3 (unchanged), sorryCount 0 (unchanged)

The gallery meta.json was already synced (PR #19465 brought `leanFile` to 558/27); only the lagging research-pool JSON remained. Also bumped `lastUpdate` 2026-05-07 → 2026-06-10 (the source's landing date on origin/main).

## Verification

- Recomputed all five metrics from `git show origin/main:proofs/Proofs/Erdos776Problem.lean` using the exact `enrich-research.ts` regexes (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all, `lineCount = split('\n').length`).
- Comment-stripped sorry/axiom counts confirm **0 real sorries, 3 real axioms** (no docstring false-positives).
- Build not run: Docker daemon down this session; this is a metadata-only sync requiring no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)