### PR TITLE
research(triangle-inequality-oq-04-oq-01): STATE-SYNC back-fill S3c + flag BLOCKED

### DIFF
--- a/research/problems/triangle-inequality-oq-04-oq-01/state.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/state.md
@@ -1,11 +1,45 @@
 # Research State: triangle-inequality-oq-04-oq-01
 
 ## Current State
-**Phase**: ACT (S3b ACT — both reparametrisation adapters discharged; build-verified)
+**Phase**: ACT (S3c ACT — `chartArcLength_pathTrans` concatenation additivity discharged; build-verified)
 **Path**: A (chart-local Euclidean length)
 **Since**: 2026-05-14 (researcher-3, S2a)
-**Iteration**: 6 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT, S3b ACT)
-**Last Updated**: 2026-06-05 (researcher-1, S3b ACT — shipped `chartArcLength_comp_mul_left` + `chartArcLength_comp_mul_left_shift` via `deriv.scomp` + `norm_smul` + `smul_integral_comp_mul_right` / `smul_integral_comp_mul_sub` chain; +86 LOC (120 → 206); 0 new sorries / 0 new axioms; build-verified 2590 Docker jobs clean (3 new transitive imports: Deriv.Mul + Deriv.Add + Deriv.Comp, +39 jobs). Discharges S3 PREP §8 sub-iter S3b (MEDIUM risk). S3c chartArcLength_pathTrans next.)
+**Iteration**: 7 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT, S3b ACT, S3c ACT)
+**Last Updated**: 2026-06-12 (researcher-2, S3c ACT — shipped `chartArcLength_pathTrans` (concatenation additivity of `chartArcLength` along `Path.trans`) plus `Ioo`-interior helpers `eqOn_trans_first`/`eqOn_trans_second`; +96 LOC (206 → 302); 0 sorries / 0 axioms; build-verified 2590 Docker jobs clean. Discharges S3 PREP §8 sub-iter S3c. S3d `chartIntrinsicDist_triangle` main calc next.)
+
+> **STATE-SYNC note (researcher-1, 2026-06-13)**: this header + the S3c ACT
+> section below were back-filled. The S3c PR (researcher-2, 2026-06-12)
+> shipped the source (`TriangleInequalityOQ04OQ01.lean` now 302 LOC,
+> 0 sorries / 0 axioms, with `chartArcLength_pathTrans` @ line 250 and the
+> two `eqOn_trans_*` helpers @ lines 212/227 on `origin/main`) and updated the
+> JSON registry (iteration 7, S3c focus) but left this narrative at the S3b
+> header. No build performed (verification blackout, Docker down); this edit
+> only reconciles the tracker with the already-merged source.
+
+## S3c ACT 2026-06-12 (researcher-2)
+
+Discharges S3 PREP §8 sub-iter **S3c** (`chartArcLength_pathTrans`, LOW-MEDIUM
+risk):
+
+```lean
+theorem chartArcLength_pathTrans {p q r : E} (f : Path p q) (g : Path q r)
+    -- (differentiability + interval-integrability hypotheses) :
+    chartArcLength (f.trans g).extend 0 1
+      = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1
+```
+
+Concatenation additivity of `chartArcLength` along `Path.trans`. Proof: split
+at `1/2` via `chartArcLength_trans`; on each half the concatenated speed agrees
+a.e. with the reparametrised single-path speed — equal on the open interior via
+two new helpers `eqOn_trans_first`/`eqOn_trans_second` (`Ioo`-versions of the
+parent's `eqOn_first`/`eqOn_second`, sidestepping the `t = 1/2` case), lifted to
+a `deriv` identity via `Filter.eventuallyEq_of_mem` + `EventuallyEq.deriv_eq`,
+the lone boundary point Lebesgue-null (`MeasureTheory.ae_iff` +
+`measure_mono_null` + `Real.volume_singleton`) — reducing each half to S3b's
+adapters `chartArcLength_comp_mul_left`/`_shift`. +96 LOC (206 → 302);
+0 sorries / 0 axioms; `omit [NormedSpace ℝ E]` on the two topology-only `eqOn`
+helpers clears `unusedSectionVars`. Build-verified: 2590 Docker jobs clean.
+**Next ACT (S3d)**: `chartIntrinsicDist_triangle` main calc (~10–20 LOC).
 
 ## S3b ACT 2026-06-05 (researcher-1)
 
@@ -262,4 +296,5 @@ Gi avail. Docker R8 INFRASTRUCTURE blocker stayed resolved through S3b.
 | S3   | 2026-05-16 | researcher-10  | #19561      | PREP — `chartIntrinsicDist_triangle` design (Option A: Path-mirror + reparam) + paste-ready skeleton (~120 LOC, 2 sorries on reparam adapters) + risk inventory (R1–R8) + ACT-readiness gate (6/8 GREEN, 1/8 AMBER, 1/8 RED Docker); doc-only |
 | S3a  | 2026-05-30 | researcher-1   | #21188      | ACT — `chartIntrinsicDist` def + `chartIntrinsicDist_nonneg` discharged via nested `Real.iInf_nonneg`; +36 LOC (84 → 120); 0 new sorries / 0 new axioms; build-verified post-Docker-recovery (T+14d); discharges first of four S3 PREP §8 sub-iters |
 | S3bPREP | 2026-05-30 | researcher-1 | #21305      | PREP — refined paste-ready recipe via `smul_integral_comp_mul_left` collapsing the S3 PREP 4-step chain to 3 bearers; 1 NEW catalogued bearer (`smul_integral_comp_mul_left` at IntervalIntegral/Basic.lean:866); doc-only |
-| S3b  | 2026-06-05 | researcher-1   | (this PR)   | ACT — both reparam adapters discharged: `chartArcLength_comp_mul_left` + `chartArcLength_comp_mul_left_shift` via `deriv.scomp` + `norm_smul` + `smul_integral_comp_mul_right` / `smul_integral_comp_mul_sub` chain; +86 LOC (120 → 206); 0 new sorries / 0 new axioms; build-verified 2590 Docker jobs (+39 from 3 new Deriv.* imports); S3c (chartArcLength_pathTrans) next |
+| S3b  | 2026-06-05 | researcher-1   | #22474      | ACT — both reparam adapters discharged: `chartArcLength_comp_mul_left` + `chartArcLength_comp_mul_left_shift` via `deriv.scomp` + `norm_smul` + `smul_integral_comp_mul_right` / `smul_integral_comp_mul_sub` chain; +86 LOC (120 → 206); 0 new sorries / 0 new axioms; build-verified 2590 Docker jobs (+39 from 3 new Deriv.* imports); S3c (chartArcLength_pathTrans) next |
+| S3c  | 2026-06-12 | researcher-2   | #22933      | ACT — `chartArcLength_pathTrans` (concatenation additivity along `Path.trans`) + `Ioo`-interior helpers `eqOn_trans_first`/`eqOn_trans_second`; split at 1/2 via `chartArcLength_trans`, a.e. speed agreement on each half reducing to S3b adapters, boundary point Lebesgue-null; +96 LOC (206 → 302); 0 sorries / 0 axioms; build-verified 2590 Docker jobs; S3d (`chartIntrinsicDist_triangle` main calc) next |

--- a/research/problems/triangle-inequality-oq-04-oq-01/state.md
+++ b/research/problems/triangle-inequality-oq-04-oq-01/state.md
@@ -1,7 +1,7 @@
 # Research State: triangle-inequality-oq-04-oq-01
 
 ## Current State
-**Phase**: ACT (S3c ACT — `chartArcLength_pathTrans` concatenation additivity discharged; build-verified)
+**Phase**: BLOCKED (verification blackout) — S2–S3c framework complete on `origin/main` (302 LOC, 0 sorries, 0 axioms); the sole remaining ACT (S3d `chartIntrinsicDist_triangle`) is Docker-gated and both verification routes are down (`docker info` exit 124, Aristotle 404). Last shipped: S3c ACT — `chartArcLength_pathTrans` concatenation additivity (build-verified). Re-open when Docker recovers.
 **Path**: A (chart-local Euclidean length)
 **Since**: 2026-05-14 (researcher-3, S2a)
 **Iteration**: 7 (S1 OBSERVE, S2a ACT, S2b ACT, S3 PREP, S3a ACT, S3b ACT, S3c ACT)

--- a/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
+++ b/src/data/research/problems/triangle-inequality-oq-04-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "triangle-inequality-oq-04-oq-01",
   "title": "Triangle Inequality for Geodesic Distances on Riemannian Manifolds",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,13 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-12",
+    "phase": "BLOCKED",
+    "since": "2026-06-13",
     "iteration": 7,
     "focus": "S3c ACT (researcher-2, 2026-06-12): shipped `chartArcLength_pathTrans` — concatenation additivity of `chartArcLength` along `Path.trans`. For f : Path p q, g : Path q r with f.extend/g.extend differentiable on [0,1] and the concatenated speed interval-integrable on [0,1/2] and [1/2,1]: chartArcLength (f.trans g).extend 0 1 = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1. Proof: split at 1/2 via `chartArcLength_trans`, then on each half the concatenated speed agrees a.e. with the reparametrised single-path speed — equal on the open interior via two new helpers `eqOn_trans_first`/`eqOn_trans_second` (Ioo-versions of the parent's eqOn_first/second, sidestepping the t=1/2 case), lifted to a deriv identity via `Filter.eventuallyEq_of_mem` + `EventuallyEq.deriv_eq`, the lone boundary point Lebesgue-null (`MeasureTheory.ae_iff` + `measure_mono_null` + `Real.volume_singleton`) — reducing each half to S3b's adapters `chartArcLength_comp_mul_left`/`_shift`. +96 LOC (206 -> 302). Build-verified: 2590 Docker jobs clean, 0 errors/0 warnings/0 sorries/0 axioms (`omit [NormedSpace ℝ E]` on the two topology-only eqOn helpers clears unusedSectionVars). Bearer gotchas this iter: `not_imp` ambiguous -> `push_neg`; `measure_mono_null` has no `s₂` named arg -> pin null set via a `have`. PREVIOUS — S3b ACT (researcher-1, 2026-06-05): shipped both reparametrisation adapters — `chartArcLength_comp_mul_left` (γ ∘ (· * 2) on [0, 1/2]) and `chartArcLength_comp_mul_left_shift` (γ ∘ (· * 2 - 1) on [1/2, 1]) — via the 3-lemma chain `deriv.scomp` (Mathlib/Analysis/Calculus/Deriv/Comp.lean:146) + `norm_smul` + `Real.norm_ofNat` (Mathlib/Analysis/Normed/Group/Basic.lean:1097) + `smul_integral_comp_mul_right` (Basic.lean:856) / `smul_integral_comp_mul_sub` (Basic.lean:940). +86 LOC in `proofs/Proofs/TriangleInequalityOQ04OQ01.lean` (120 → 206). Three new transitive imports: `Mathlib.Analysis.Calculus.Deriv.Mul` (for `hasDerivAt_mul_const`), `Mathlib.Analysis.Calculus.Deriv.Add` (for `HasDerivAt.sub_const`), `Mathlib.Analysis.Calculus.Deriv.Comp` (for `deriv.scomp`). Build-verified at v4.26.0 + Mathlib pin `2df2f0150c…`: 2590 Docker jobs clean (up from 2551; +39 jobs from new imports). Discharges both reparam adapters (S3 PREP §8 sub-iter S3b, MEDIUM risk per R1+R5+R6). Sorries: 0 (unchanged). Axioms: 0 (unchanged). S3b PREP recipe (researcher-1, 2026-05-30, PR #21305) successfully applied (Option α: `smul_integral_comp_mul_sub` for the right-half affine shift).",
     "activeApproach": "Path A: chart-local Euclidean length via intervalIntegral of ‖deriv γ t‖ on ℝ → E, with chart map applied externally.",
     "blockers": [
+      "Verification blackout (2026-06-13): docker info exits 124 (daemon down) and Aristotle MCP backend returns 404. The only remaining ACT (S3d chartIntrinsicDist_triangle) adds new Lean code that cannot be build-verified. S2-S3c framework is complete on origin/main (302 LOC, 0 sorries, 0 axioms). Flagged blocked rather than churning a PREP memo; re-open when Docker recovers.",
       "**Upstream Mathlib blocker** (full Riemannian formalization): the natural"
     ],
     "nextAction": "S3d ACT (next, MEDIUM risk, ~20-40 LOC): with `chartArcLength_pathTrans` (S3c) now available, prove `chartIntrinsicDist_triangle` — the chart-local triangle inequality chartIntrinsicDist p r ≤ chartIntrinsicDist p q + chartIntrinsicDist q r — by mirroring parent `intrinsicDist_triangle`'s 2-step iInf-exchange. For any f : Path p q, g : Path q r in the (integrability-restricted) index set, `chartArcLength (f.trans g).extend 0 1 = chartArcLength f.extend 0 1 + chartArcLength g.extend 0 1` (S3c) bounds chartIntrinsicDist p r ≤ that sum; then exchange the two infima. CAVEAT: chartIntrinsicDist's iInf carries the IntervalIntegrable side-condition, so to invoke S3c you must discharge `hint_left`/`hint_right` (concatenated speed integrable on [0,1/2],[1/2,1]) from f,g's own integrability — derive via the eqOn_trans helpers + IntervalIntegrable congruence (ae). Real.iInf_add/Real.add_iInf may be needed; if absent, ad-hoc via chartArcLength_nonneg bound (R2, S3 PREP §6). Also will likely need DifferentiableAt hypotheses threaded into the index set or as side conditions. Build-verify via `./proofs/scripts/docker-build.sh Proofs.TriangleInequalityOQ04OQ01`.",


### PR DESCRIPTION
## Summary

Two build-free changes to research trackers for `triangle-inequality-oq-04-oq-01`:

### 1. STATE-SYNC — back-fill S3c into `state.md`
The S3c PR (#22933, researcher-2, 2026-06-12) shipped the Lean source and updated the JSON registry but left `state.md` at the **S3b** header. On `origin/main` the source is current: `TriangleInequalityOQ04OQ01.lean` is **302 LOC, 0 sorries, 0 axioms**, with `chartArcLength_pathTrans` @ line 250 and `eqOn_trans_first`/`eqOn_trans_second` @ 212/227, matching the JSON (iteration 7, S3c focus) — but `state.md` still read S3b / iteration 6 / 206 LOC and "Next ACT (S3c)".

- Header → S3c ACT, iteration 6→7, last-updated 2026-06-12.
- Added an **S3c ACT** section; fixed stale `(this PR)` S3b row → #22474; appended S3c row (#22933) to the history table.

### 2. Flag BLOCKED (verification blackout)
After the sync, the only remaining ACT is **S3d** (`chartIntrinsicDist_triangle` main calc), which adds new Lean code requiring Docker verification. Both routes are down: `docker info` exits 124 (daemon down); Aristotle MCP returns 404. The S2–S3c framework is complete on `origin/main`, so the slug is flagged blocked rather than churning a PREP memo.

- JSON: phase ACT→BLOCKED, status active→blocked, prepended a verification-blackout blocker.
- `state.md` header reflects BLOCKED.

## Test plan

- [x] JSON validated (`python3 -m json.tool`)
- [x] Source↔JSON↔state consistency confirmed against `origin/main`
- [ ] No Lean build (verification blackout; source unchanged by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)