### PR TITLE
research(algebraic-numbers-countable-oq-02-oq-04): AUDIT — resync stale leanFile metrics to source

### DIFF
--- a/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
+++ b/src/data/proofs/algebraic-numbers-countable-oq-02-oq-04/meta.json
@@ -22,7 +22,7 @@
     "badge": "verified",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 998,
+    "lineCount": 1079,
     "assumptions": "",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-11",
@@ -89,7 +89,7 @@
         "module": "Mathlib.SetTheory.Cardinal.Continuum"
       }
     ],
-    "theoremCount": 43,
+    "theoremCount": 42,
     "definitionCount": 3,
     "relatedProblems": [
       {
@@ -315,9 +315,9 @@
       "Classical"
     ],
     "namespace": "AlgebraicNumbersCountableOQ02OQ04",
-    "lineCount": 998,
+    "lineCount": 1079,
     "axiomCount": 0,
-    "theoremCount": 43,
+    "theoremCount": 42,
     "definitionCount": 3,
     "sorries": 0,
     "path": "Proofs/AlgebraicNumbersCountableOQ02OQ04.lean"


### PR DESCRIPTION
## Summary
Source↔meta audit of the `algebraic-numbers-countable-oq-02-oq-04` gallery entry (status `verified`).

The hand-curated `leanFile` block went stale after S11 #22942 grew the source from ~998 to **1079** lines:
- `lineCount`: 998 → **1079** (`wc -l` of current `origin/main` source; matches the hand-curated `leanFile` schema's wc convention)
- `theoremCount`: 43 → **42** (canonical `^(theorem|lemma) ` count)

Corrected both occurrences (lines 25/318 and 92/320).

## Verification (build-free; Docker down)
- `lineCount`: 1079 ✓ (`wc -l`)
- `theoremCount`: 42 ✓ (`grep -cE '^(theorem|lemma) '`)
- `axiomCount`: 0 — accurate ✓
- `sorries`: 0 — accurate ✓ (the 4 `\bsorry\b` hits are all prose in proof-history comments at L88/91/137/330)
- `definitionCount`: 3 — accurate ✓
- **`verified` status sound**: 0 axioms, 0 real sorries, **no `structure`/`class` declarations** → no structure-encoded assumptions (per Axiom Integrity Policy)

No Lean build required — pure metadata correction against source counts.

## Test plan
- [x] JSON validates
- [x] Counts re-derived from `proofs/Proofs/AlgebraicNumbersCountableOQ02OQ04.lean` @ origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)