### PR TITLE
research(erdos-668): sync research-pool leanFiles to source (A3→6, +52 lines, +4 theorems)

### DIFF
--- a/src/data/research/problems/erdos-668.json
+++ b/src/data/research/problems/erdos-668.json
@@ -66,16 +66,16 @@
     "mathlib": []
   },
   "started": "2026-01-13T18:22:04.305Z",
-  "lastUpdate": "2026-04-28T00:00:00Z",
+  "lastUpdate": "2026-06-10T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos668Problem.lean",
       "filename": "Erdos668Problem.lean",
-      "lineCount": 283,
-      "theoremCount": 10,
-      "axiomCount": 3,
+      "lineCount": 335,
+      "theoremCount": 14,
+      "axiomCount": 6,
       "defCount": 12,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary
The research-pool JSON (`src/data/research/problems/erdos-668.json`) `leanFiles` block was frozen at iteration-1 state while the Lean source grew. This is a build-free state-sync (no Lean rebuild required; Docker is down).

| metric | JSON (was) | source (origin/main) |
|--------|-----------|----------------------|
| lineCount | 283 | **335** |
| theoremCount | 10 | **14** |
| axiomCount | 3 | **6** |
| defCount | 12 | 12 |
| sorryCount | 0 | 0 |

## Verification
- Recomputed all 5 metrics from `proofs/Proofs/Erdos668Problem.lean` on `origin/main` using the exact `enrich-research.ts` conventions (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all, `lineCount = content.split('\n').length`).
- Comment-stripped check: **real sorry = 0, real axiom = 6** (no docstring false-positives).
- The gallery `meta.json` `leanFile` already reflects `axiomCount: 6` — this PR syncs the **independently-lagging** research-pool JSON to match.
- `lastUpdate` bumped 2026-04-28 → 2026-06-10 (source's last-touched commit on `main`).

## Scope
Tightly scoped to `leanFiles` + `lastUpdate`. The prose/narrative (iteration-1 "3 axioms remain" reasoning) is left untouched — reconstructing the 3→6 axiom history is build-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)