### PR TITLE
research(lagrange-theorem-oq-02-oq-01): STATUS-SYNC — completed to match COMPLETED phase

### DIFF
--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "lagrange-theorem-oq-02-oq-01",
   "title": "Formalize Burnside's counting lemma directly from orbit-stabilizer: |X/G| = (...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -69,7 +69,7 @@
     "mathlib": []
   },
   "started": "2026-05-04T17:47:35.846Z",
-  "lastUpdate": "2026-06-10T17:00:00.000Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
Status/phase mismatch fix. The research record for `lagrange-theorem-oq-02-oq-01` had `phase: COMPLETED` but `status: active` (last touched 2026-06-10) — the stale pattern that keeps a finished slug claimable in the depth-first pool and produces recurring no-op claims.

## Why this is a real completion (not an empty stub)
- Gallery entry: `status: verified`, `badge: mathlib`
- Slug source `Proofs/LagrangeTheoremOQ02OQ01.lean`: **6 theorems, 0 axioms, 0 sorries, 226 lines** (verified against origin/main)
- `leanFiles` record matches source exactly

Flipped `status` active→completed and bumped `lastUpdate`. Mirrors merged #23019/#23021. No Lean source changed; build-free.

## Test plan
- [x] JSON validates
- [x] Slug source confirmed complete @ origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)