### PR TITLE
research(derangements-convergence-oq-01-oq-02): S1 SURVEY — k-cycle Poisson(1/k) limit

### DIFF
--- a/src/data/research/problems/derangements-convergence-oq-01-oq-02.json
+++ b/src/data/research/problems/derangements-convergence-oq-01-oq-02.json
@@ -1,0 +1,69 @@
+{
+  "slug": "derangements-convergence-oq-01-oq-02",
+  "status": "surveyed",
+  "phase": "ORIENT",
+  "problemStatement": {
+    "formal": "Let C_k^{(n)} be the number of k-cycles of a uniformly random permutation of Fin n. Then for fixed k ≥ 1 and m ≥ 0, P(C_k^{(n)} = m) → e^{-1/k} · (1/k)^m / m! = Poisson(1/k) pmf at m, as n → ∞.",
+    "plain": "Generalize the parent result (number of fixed points = 1-cycles → Poisson(1)) to k-cycles: the number of k-cycles in a random permutation converges in distribution to Poisson(1/k). This is the classical Goncharov (1944) theorem.",
+    "whyMatters": [
+      "Generalizes the parent entry's fixed-point (k=1) Poisson(1) limit to all cycle lengths in one uniform statement",
+      "Exposes the exact finite-n pmf P(C_k=m) = (1/(k^m m!))·g_k(n-km)/(n-km)!, the direct analog of the parent's P(X_n=k) = (1/k!)·D(n-k)/(n-k)!",
+      "Identifies the precise missing Mathlib infrastructure (k-cycle-avoiding permutation count generalizing numDerangements)"
+    ]
+  },
+  "knowledge": {
+    "progressSummary": "SURVEYED (paper-resolved, formalization build-gated): Derived the exact finite-n pmf and the Poisson(1/k) limit on paper. The whole result reduces to one missing ingredient — g_k(j)/j! → e^{-1/k}, where g_k(j) = #permutations of [j] with no k-cycle (k=1 is Mathlib's numDerangements). Mathlib has no general-k analog; building it generalizes the Combinatorics.Derangements development (~300-600 lines). No Lean committed (Docker blackout 2026-06-13 prevents verification).",
+    "builtItems": [],
+    "insights": [
+      "EXACT pmf: for n ≥ km, P(C_k^{(n)} = m) = (1/(k^m · m!)) · g_k(n-km)/(n-km)!, where g_k(j) = #{permutations of [j] with no k-cycle}. This is the verbatim analog of the parent's probKFixed_eq: P(X_n=k) = (1/k!)·D(n-k)/(n-k)!, recovered at k=1 since g_1 = numDerangements.",
+      "Cycle-type count: #{permutations of a km-set whose cycle type is exactly m cycles of length k} = (km)!/(k^m · m!) (Cauchy's cycle-type formula N!/∏ j^{a_j} a_j! with a_k=m, N=km). Multiplying by C(n,km) and the g_k(n-km) ways to fill the rest, then dividing by n!, telescopes C(n,km)·(km)! = n!/(n-km)! to give the pmf above.",
+      "Avoidance count partial sum: g_k(j)/j! = Σ_{i=0}^{⌊j/k⌋} (-1)^i/(k^i · i!). Via the EGF exp(Σ_{j≠k} x^j/j) = exp(-x^k/k)/(1-x); coefficient extraction gives the partial sum. At k=1 this is exactly numDerangements_sum: D(j)/j! = Σ_{i=0}^j (-1)^i/i!.",
+      "Limit: g_k(j)/j! → Σ_{i=0}^∞ (-1)^i/(k^i · i!) = e^{-1/k} as j→∞. Hence P(C_k=m) → e^{-1/k}/(k^m m!) = e^{-1/k}(1/k)^m/m! = Poisson(1/k) pmf. At k=1 this is the parent's numDerangements_tendsto_inv_e (→ e^{-1}).",
+      "Rate bound (alternating series est, terms (-1)^i/(k^i i!) decreasing for k≥1): |g_k(j)/j! - e^{-1/k}| ≤ 1/(k^{⌊j/k⌋+1}·(⌊j/k⌋+1)!), generalizing the parent's |D(n)/n! - e^{-1}| ≤ 1/(n+1)!.",
+      "The entire generalization is structurally identical to DerangementsConvergenceOQ01.lean with the single substitution numDerangements ↦ g_k and the constant e^{-1} ↦ e^{-1/k}; only g_k and its sum/limit lemmas are new."
+    ],
+    "mathlibGaps": [
+      "No general 'number of permutations of Fin j with no k-cycle' (g_k) in Mathlib. Mathlib.Combinatorics.Derangements covers only k=1 (numDerangements, numDerangements_sum, numDerangements_tendsto_inv_e). Building g_k + its partial-sum identity + its e^{-1/k} limit generalizes that development; estimated 300-600 lines.",
+      "No clean lemma for the count of permutations of a given cycle type (Cauchy's formula N!/∏ j^{a_j} a_j!). Equiv.Perm.cycleType exists in Mathlib.GroupTheory.Perm.Cycle.Type but the cardinality-by-cycle-type count needs checking / may need building.",
+      "No method-of-moments / Poisson-limit-via-factorial-moments lemma, which would enable the alternative route E[(C_k)_{(r)}] = 1/k^r (exact for n ≥ kr) ⇒ Poisson(1/k)."
+    ],
+    "nextSteps": [
+      "When Docker/build is restored: create proofs/Proofs/DerangementsConvergenceOQ01OQ02.lean mirroring DerangementsConvergenceOQ01.lean. Define probKCycles (n k m) := (#perms of Fin n with exactly m k-cycles)/n!.",
+      "Build g_k: define numAvoidingKCycle (k j : ℕ), prove g_k(j)/j! = Σ_{i=0}^{⌊j/k⌋} (-1)^i/(k^i i!) (generalize numDerangements_sum), and g_k(j)/j! → e^{-1/k} (generalize numDerangements_tendsto_inv_e).",
+      "State+prove probKCycles_eq: P(C_k=m) = (1/(k^m m!))·g_k(n-km)/(n-km)! for km ≤ n (analog of probKFixed_eq), then kCycle_tendsto: P(C_k^{(n)}=m) → e^{-1/k}(1/k)^m/m!.",
+      "Verify whether the cycle-type count (km)!/(k^m m!) can be sourced from Mathlib's Perm.Cycle.Type or must be built; this is the gating sub-lemma for probKCycles_eq.",
+      "Sanity checks before claiming: k=1,m fixed must recover probKFixed/Poisson(1); k arbitrary, m=0 gives P(no k-cycle) = g_k(n)/n! → e^{-1/k}."
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/DerangementsConvergence.lean",
+      "filename": "DerangementsConvergence.lean",
+      "lineCount": 282,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergence.lean"
+    },
+    {
+      "path": "Proofs/DerangementsConvergenceOQ01.lean",
+      "filename": "DerangementsConvergenceOQ01.lean",
+      "lineCount": 152,
+      "theoremCount": 7,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DerangementsConvergenceOQ01.lean"
+    }
+  ],
+  "relatedProofs": [
+    "derangements",
+    "derangements-convergence",
+    "derangements-convergence-oq-01",
+    "derangements-convergence-oq-01-oq-01",
+    "derangements-convergence-oq-03"
+  ]
+}


### PR DESCRIPTION
## Summary
First survey (OBSERVE→ORIENT) of `derangements-convergence-oq-01-oq-02`, the k-cycle generalization of the parent fixed-point entry. Resolved on paper (classical Goncharov 1944 theorem):

- **Exact finite-n pmf** (n ≥ km): `P(C_k^{(n)} = m) = (1/(k^m·m!))·g_k(n−km)/(n−km)!`, where `g_k(j) = #permutations of [j] with no k-cycle`. At k=1, `g_1 = numDerangements` and this is the parent's `probKFixed_eq`.
- **Limit**: `g_k(j)/j! = Σ_{i≤⌊j/k⌋} (−1)^i/(k^i·i!) → e^{−1/k}`, so `P(C_k=m) → e^{−1/k}(1/k)^m/m! = Poisson(1/k)` pmf. At k=1 this is `numDerangements_tendsto_inv_e`.
- **Mathlib gap**: no general-k `g_k` (only the k=1 specialization in `Mathlib.Combinatorics.Derangements.*`). Building it generalizes that development (~300–600 lines).

## Why build-free
Docker daemon down + Aristotle backend 404 on 2026-06-13 → Lean cannot be verified. No unbuilt Lean committed (avoids unverified-blind ship). Deliverable is the knowledge survey + research JSON only.

## Files
- `research/problems/derangements-convergence-oq-01-oq-02/knowledge.md` — full paper resolution + infra assessment
- `research/problems/.../state.md` — phase ORIENT, blockers, next action
- `src/data/research/problems/derangements-convergence-oq-01-oq-02.json` — seeded knowledge fields (insights/gaps/nextSteps), status `surveyed`

## Test plan
- [x] JSON validates (`jq -e .`)
- [x] No Lean changes → no build required
- [ ] Formalize when verification infra restored (see `nextSteps`)