### PR TITLE
research(erdos-1072): sync research-pool leanFiles to merged source (170/7 → 242/15)

### DIFF
--- a/src/data/research/problems/erdos-1072.json
+++ b/src/data/research/problems/erdos-1072.json
@@ -70,15 +70,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T14:38:41.572Z",
-  "lastUpdate": "2026-03-13T07:52:17.056Z",
+  "lastUpdate": "2026-06-10T00:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1072Problem.lean",
       "filename": "Erdos1072Problem.lean",
-      "lineCount": 170,
-      "theoremCount": 7,
+      "lineCount": 242,
+      "theoremCount": 15,
       "axiomCount": 3,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The research-pool JSON (`src/data/research/problems/erdos-1072.json`) `leanFiles` block was frozen at `lineCount 170 / theoremCount 7` (lastUpdate 2026-03-13) while merged work (PRs #18767, #18872) grew `Erdos1072Problem.lean` to **242 lines / 15 theorems** on origin/main.

The **gallery** meta.json `leanFile` block was already synced (241/15) — only the **research-pool** JSON lagged independently, consistent with the two artifacts drifting separately.

## Verification (build-free, against origin/main)

Recomputed via `enrich-research.ts` conventions:
- `lineCount` = `content.split('\n').length` = **242**
- `theoremCount` (`^(theorem|lemma) `) = **15** — **0 private** theorems/lemmas, so the 7→15 jump is genuine new theorems, not a strict-vs-private counting artifact
- `axiomCount` **3** / `defCount` **2** / `sorryCount` **0** — unchanged
- Comment-stripped real `sorry`=0 / `axiom`=3 → no docstring false positives

`lastUpdate` bumped to the source's last-commit date on origin/main (2026-06-10, `d8284214`). Scoped strictly to the mechanical `leanFiles` block; narrative fields left untouched (the iteration history is build-gated to reconstruct).

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics recomputed against `git show origin/main:proofs/Proofs/Erdos1072Problem.lean`
- [x] No source build required (data-only sync; Docker unavailable)