### PR TITLE
research(status-sync): mark 3 already-solved OQs completed

### DIFF
--- a/src/data/research/problems/divisibility-by-3-oq-03-oq-02.json
+++ b/src/data/research/problems/divisibility-by-3-oq-03-oq-02.json
@@ -71,7 +71,7 @@
     "divisibility-by-3-oq-04",
     "divisibility-by-3-oq-04-oq-02"
   ],
-  "status": "available",
+  "status": "completed",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [

--- a/src/data/research/problems/euler-totient-oq-02-oq-01.json
+++ b/src/data/research/problems/euler-totient-oq-02-oq-01.json
@@ -69,7 +69,7 @@
     "euler-totient-oq-03",
     "euler-totient-oq-04"
   ],
-  "status": "available",
+  "status": "completed",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [

--- a/src/data/research/problems/kummer-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/kummer-theorem-oq-01-oq-01.json
@@ -48,7 +48,7 @@
     "kummer-theorem-oq-02",
     "kummer-theorem-oq-03"
   ],
-  "status": "available",
+  "status": "completed",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [


### PR DESCRIPTION
## Summary

Three research-pool problems carry the `available` status but already have **complete, build-wired Lean proofs** whose main theorem genuinely resolves the stated open question. Leaving them `available` causes researchers to repeatedly re-claim solved work. This flips their research status `available → completed`.

| Slug | Lean file (wired in `Proofs.lean`) | Closes OQ via |
|------|-----------------------------------|---------------|
| `euler-totient-oq-02-oq-01` | `EulerTotientOQ02OQ01.lean` (10 thm) | `Nat.totient_eq_prod_factorization` / `totient_from_multiplicativity` |
| `divisibility-by-3-oq-03-oq-02` | `DivisibilityBy3OQ03OQ02.lean` (19 thm) | `Nat.modEq_digits_sum`, `Nat.dvd_iff_dvd_digits_sum` |
| `kummer-theorem-oq-01-oq-01` | `KummerTheoremOQ01OQ01.lean` (7 thm) | `Nat.factorization_choose'` (full carry-count multinomial Kummer) |

Each file: 0 sorry / 0 axiom (comment-stripped), present on `origin/main`, imported in `Proofs.lean`.

## Verification notes

- Main theorems read and confirmed to close the OQ (not weakened restatements / supporting lemmas only).
- **Gallery `meta.json` status left unchanged** (still `null`) — Docker daemon is down, so a fresh `lake build` cannot confirm; promote to `verified` only after a build.
- Excluded as genuinely-still-open / partial: `erdos-327-oq-01-oq-04` (only proves unboundedness, not the `~C·N·log N` asymptotic), `partition-theorem-oq-01-oq-01` (only `native_decide` through n=8), `picks-theorem-oq-01-oq-01` (blocked — needs Jordan-curve infra), `feuerbachs-theorem-oq-01-oq-03` / `lebesgue-measure-oq-03-oq-01` / `cramers-rule-oq-03-oq-03` (not fully verified this pass).

Same pattern as subset-count-oq-02-oq-01 (#23062).

🤖 Generated with [Claude Code](https://claude.com/claude-code)