### PR TITLE
research(erdos-203): sync research-pool leanFiles to merged source (351/33 → 391/41)

### DIFF
--- a/src/data/research/problems/erdos-203.json
+++ b/src/data/research/problems/erdos-203.json
@@ -64,15 +64,15 @@
     "mathlib": []
   },
   "started": "2026-01-12T16:01:50.837Z",
-  "lastUpdate": "2026-03-13T07:52:17.044Z",
+  "lastUpdate": "2026-06-10T02:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos203Problem.lean",
       "filename": "Erdos203Problem.lean",
-      "lineCount": 351,
-      "theoremCount": 33,
+      "lineCount": 391,
+      "theoremCount": 41,
       "axiomCount": 0,
       "defCount": 13,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Single-file leanFiles STATE-SYNC for the `erdos-203` research-pool JSON. The canonical `src/data/research/problems/erdos-203.json` `leanFiles` block was frozen at iteration-3 metrics (351 lines / 33 theorems) while `proofs/Proofs/Erdos203Problem.lean` advanced to 391 lines / 41 theorems on `origin/main` (last touched `d8284214`, 2026-06-10).

- `lineCount` 351 → 391 (+40)
- `theoremCount` 33 → 41 (+8 public theorems)
- `axiomCount` 0, `defCount` 13, `sorryCount` 0 — unchanged
- `lastUpdate` bumped to the source's last-commit date on main (2026-06-10)

## Why this is real growth, not an artifact
The +8 is genuine new public theorems: the strict `^(theorem|lemma) ` convention excludes the file's 3 `private` declarations from *both* the old and new counts, so the jump is not the private-theorem convention artifact (which shows as a theorem *drop* at flat lineCount). Comment-stripped real sorry/axiom = 0/0 (no docstring false positive). The gallery meta.json is a separate artifact; only the research-pool JSON lagged.

Scoped tightly to `leanFiles` + `lastUpdate`; narrative fields left untouched (the iter-3→current history is build-gated to reconstruct).

## Test plan
- [x] JSON validates (`python3 -m json.tool`)
- [x] Metrics recomputed from `origin/main` source via the `enrich-research.ts` regexes
- [ ] Docker build verification (blocked — daemon down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)