### PR TITLE
research(erdos-472): sync leanFiles to S2 source state

### DIFF
--- a/src/data/research/problems/erdos-472.json
+++ b/src/data/research/problems/erdos-472.json
@@ -82,15 +82,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:11:10.513Z",
-  "lastUpdate": "2026-03-13T07:52:17.049Z",
+  "lastUpdate": "2026-06-10T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos472Problem.lean",
       "filename": "Erdos472Problem.lean",
-      "lineCount": 264,
-      "theoremCount": 23,
+      "lineCount": 328,
+      "theoremCount": 30,
       "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- The research-pool JSON `leanFiles` block for `erdos-472` was frozen at iteration 2 (lastUpdate 2026-03-13) while `proofs/Proofs/Erdos472Problem.lean` advanced on `origin/main`.
- Synced the single-file metrics to the current source: `lineCount` 264→328 (+64), `theoremCount` 23→30 (+7). All +7 theorems are **public** (0 `private` declarations in the file), so the growth is genuine — not the strict-`^(theorem|lemma) ` vs `private` counting artifact.
- `axiomCount` (1), `defCount` (8), `sorryCount` (0) unchanged. Comment-stripped recount confirms real axiom=1, sorry=0 — no docstring false-positives.
- `lastUpdate` bumped to 2026-06-10 (the source file's last commit `d8284214` on `main`).

This is a mechanical `leanFiles` + `lastUpdate` sync; narrative/prose fields untouched. The gallery `meta.json` artifact is maintained independently by the deployer/auditor; this updates only the research-pool JSON which drifts on its own.

## Test plan
- [x] `python3 -c "json.load(...)"` confirms valid JSON
- [x] Source metrics recomputed via the exact `enrich-research.ts` regexes against `git archive origin/main`
- [x] No open PR already touches this slug