### PR TITLE
research(euler-polyhedral-oq-02-oq-01-wip-01): S4 flag BLOCKED (verification blackout)

### DIFF
--- a/research/problems/euler-polyhedral-formula-oq-02-oq-01-wip-01/state.md
+++ b/research/problems/euler-polyhedral-formula-oq-02-oq-01-wip-01/state.md
@@ -1,11 +1,42 @@
 # Research State: euler-polyhedral-formula-oq-02-oq-01-wip-01
 
 ## Current State
-**Phase**: ACT
+**Phase**: BLOCKED (verification blackout)
 **Path**: full
-**Since**: 2026-06-10 (S3 ACT — researcher-1)
-**Iteration**: 3
-**Last Updated**: 2026-06-10 (S3 ACT: Reduction D landed, Docker-verified, parent axiomCount 10 → 9)
+**Since**: 2026-06-13 (S4 BLOCKED — researcher-1)
+**Iteration**: 4
+**Last Updated**: 2026-06-13 (S4: flagged BLOCKED — only Docker-gated work remains; meta.json verified in-sync)
+
+## S4 BLOCKED (2026-06-13, researcher-1)
+
+**Mode**: triage during the Docker verification blackout. No code change.
+
+The sole remaining work on this slug is **S4 ACT (Reduction B)** — adding a
+`GeodesicPolygon.toBoundary` coercion to discharge the `gauss_bonnet_polygon`
+structure-encoded assumption (axiomCount 9 → 8). That change is a ~10 LOC code
+edit whose only acceptance gate is a successful
+`./proofs/scripts/docker-build.sh Proofs.EulerPolyhedralOQ02OQ01`. The Docker
+daemon is unresponsive (`docker info`/`docker ps` time out), so the build cannot
+run and the reduction cannot be verified. Per project policy, build-dependent
+ACT must not be blind-shipped.
+
+**Build-free diligence performed this session (all clean):**
+- `src/data/proofs/euler-polyhedral-formula-oq-02-oq-01/meta.json` is fully in
+  sync with `proofs/Proofs/EulerPolyhedralOQ02OQ01.lean` on origin/main:
+  lineCount 810 == 810, theoremCount 61 == 61 (col-0 `theorem|lemma`),
+  definitionCount 15 == 15 (col-0 `def|structure|abbrev|instance`), sorries
+  0 == 0, top-level `axiom` decls 0.
+- axiomCount 9 confirmed against the 9 structure-encoded assumptions present in
+  source: `gauss_bonnet`, `chi_genus`, `chern_gauss_bonnet`,
+  `gauss_bonnet_boundary`, `gauss_bonnet_polygon`, `curvature_is_K_area`,
+  `gauss_bonnet_triangle`, `poincare_hopf`, `morse_relation`. The S3-discharged
+  `nonvanishing_index` is correctly a derived theorem (via `Finset.sum_empty`),
+  not a field.
+
+**Re-open when**: Docker is restored. Resume directly at S4 ACT (Reduction B);
+the concrete sketch is in
+`sessions/2026-06-09-s2-orient-assumption-inventory.md` §Reduction B and in the
+"Active Approach" section below.
 
 ## S3 ACT Summary (2026-06-10, researcher-1)
 

--- a/research/registry.json
+++ b/research/registry.json
@@ -12454,11 +12454,11 @@
     },
     {
       "slug": "euler-polyhedral-formula-oq-02-oq-01-wip-01",
-      "phase": "OBSERVE",
-      "path": "fast",
+      "phase": "BLOCKED",
+      "path": "full",
       "started": "2026-04-04T09:42:47.007Z",
-      "status": "active",
-      "lastUpdate": "2026-04-04T09:42:47.023Z"
+      "status": "blocked",
+      "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
       "slug": "inverse-galois-oq-06-oq-01",


### PR DESCRIPTION
## Summary

Triage action during the Docker verification blackout. No Lean code change.

`euler-polyhedral-formula-oq-02-oq-01-wip-01` is flagged **BLOCKED**. Its only
remaining work is **S4 ACT (Reduction B)** — a ~10 LOC `GeodesicPolygon.toBoundary`
coercion that discharges the `gauss_bonnet_polygon` structure-encoded assumption
(parent axiomCount 9 → 8). The sole acceptance gate is
`./proofs/scripts/docker-build.sh Proofs.EulerPolyhedralOQ02OQ01`, and the Docker
daemon is unresponsive (`docker info`/`docker ps` time out). Build-dependent ACT
must not be blind-shipped, so the slug is parked rather than re-claimed into churn.

## Build-free diligence (all clean)

- Parent `meta.json` is fully in sync with `Proofs/EulerPolyhedralOQ02OQ01.lean`
  on origin/main: lineCount 810, theoremCount 61, definitionCount 15, sorries 0,
  0 top-level `axiom` declarations.
- `axiomCount: 9` matches the 9 structure-encoded assumptions present in source
  (`gauss_bonnet`, `chi_genus`, `chern_gauss_bonnet`, `gauss_bonnet_boundary`,
  `gauss_bonnet_polygon`, `curvature_is_K_area`, `gauss_bonnet_triangle`,
  `poincare_hopf`, `morse_relation`). The S3-discharged `nonvanishing_index` is
  correctly a derived theorem (`Finset.sum_empty`), not a field.

## Changes

- `research/problems/.../state.md`: BLOCKED banner + re-open instructions.
- `research/registry.json`: corrects the stale entry (`OBSERVE/fast/active` →
  `BLOCKED/full/blocked`). The deployer sync only re-infers phase for `NEW`
  entries, so this stale phase would never self-heal.

**Re-open when** Docker is restored; resume directly at S4 ACT (Reduction B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)