### PR TITLE
research(birthday-problem-oq-01-oq-01-oq-03): S1 SURVEY — non-uniform generalization resolved on paper

### DIFF
--- a/src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json
@@ -1,0 +1,251 @@
+{
+  "slug": "birthday-problem-oq-01-oq-01-oq-03",
+  "title": "Does the formalization generalize to non-uniform birthday distributions (unequal day probabilities)?",
+  "phase": "ORIENT",
+  "status": "active",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Generalize collision count X(f) = #{(i,j): i<j, f(i)=f(j)} from the counting measure on f: Fin n -> Fin d to the i.i.d. product measure P_p[f] = prod_i p_{f(i)} for a probability vector p=(p_1,...,p_d). Establish E_p[X] = C(n,2)*sum_k p_k^2 and Pr_p(X=0) = n!*e_n(p), and the optimization theorem that the uniform distribution minimizes collision probability.",
+    "plain": "Extend the collision-count analysis of the birthday problem from equally-likely days to days with unequal probabilities p_k (the setting for hash-collision analysis). Does each formula generalize, and which distribution is best/worst for collisions?",
+    "whyMatters": [
+      "Non-uniform day probabilities are the realistic model for hash-collision analysis in cryptography",
+      "sum_k p_k^2 is exactly the collision probability / index of coincidence used in cryptanalysis",
+      "Shows the uniform parent result is the extremal (collision-minimizing) case of a whole family"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "E_p[X] = C(n,2) * sum_k p_k^2 (expected collision pairs; reduces to C(n,2)/d when uniform)",
+      "sum_k p_k^2 >= 1/d with equality iff p uniform (Cauchy-Schwarz) -> uniform minimizes expected collisions",
+      "Pr_p(X=0) = n! * e_n(p_1,...,p_d) (elementary symmetric polynomial; reduces to descFactorial(d,n)/d^n when uniform)",
+      "n! * e_n(p) is Schur-concave (Schur-Ostrowski via the e_n deletion identity) -> uniform maximizes Pr(all distinct), i.e. minimizes collision probability"
+    ],
+    "open": [
+      "Lean formalization (ACT) of the above, blocked by the 2026-06-13 verification blackout (Docker build down, Aristotle 404)",
+      "Variance Var_p(X) closed form (involves S_3 = sum p_k^3 from index-sharing pairs)"
+    ],
+    "goal": "Confirm the parent collision-count formalization generalizes to non-uniform p and identify the uniform-is-optimal extremal property."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13",
+    "iteration": 2,
+    "focus": "Resolved on paper during first survey; remaining work is the Docker-gated Lean ACT.",
+    "blockers": [
+      "Docker build infrastructure down (cannot run docker-build.sh) and Aristotle backend returns 404 (2026-06-13 verification blackout) -> no Lean committed",
+      "Full optimization theorem (Schur-concavity of e_n) has no Mathlib majorization / Schur-Ostrowski API"
+    ],
+    "nextAction": "When Docker/Aristotle return: create proofs/Proofs/BirthdayProblemOQ01OQ01OQ03.lean proving E_p[X]=C(n,2)*sum p_k^2 and sum p_k^2 >= 1/d (equality iff uniform); defer the e_n/Schur-concavity layer.",
+    "attemptCounts": {
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Open question fully resolved on paper. The collision-count formalization generalizes cleanly to non-uniform day probabilities p via the i.i.d. product measure. Expected collisions E_p[X]=C(n,2)*sum p_k^2 (the cryptographic coincidence index), no-collision probability Pr_p(X=0)=n!*e_n(p), and in both the uniform distribution is the collision-minimizing extremum. Lean ACT deferred (Docker/Aristotle down).",
+    "builtItems": [],
+    "insights": [
+      "E_p[X] = C(n,2)*sum_k p_k^2 by linearity of expectation; Pr[f(i)=f(j)] = sum_k p_k^2 per pair.",
+      "sum_k p_k^2 is the collision probability / Renyi-2 / index of coincidence; >= 1/d by Cauchy-Schwarz with equality iff uniform, so uniform minimizes expected collisions.",
+      "Pr_p(X=0) = n!*e_n(p), the degree-n elementary symmetric polynomial of p; uniform gives n!*C(d,n)/d^n = descFactorial(d,n)/d^n, recovering the parent.",
+      "n!*e_n is Schur-concave (Schur-Ostrowski: (p_i-p_j)(d_i e_n - d_j e_n) = -(p_i-p_j)^2 * e_{n-2}(rest) <= 0), so uniform maximizes Pr(all distinct) -> minimizes collision probability. Classical: Bloom 1973, Munford 1977, Klotz 1979, Nunnikhoven 1992.",
+      "Degenerate p (all mass on one day) gives Pr(X=0)=0 for n>=2: maximal collisions, confirming concentration is worst."
+    ],
+    "mathlibGaps": [
+      "No majorization / Schur-Ostrowski / Schur-convexity API in Mathlib, needed for the full uniform-optimality theorem on e_n.",
+      "Weighted (product-measure) version of the birthday/embedding counting lemmas not present; parent's Fintype.card lemmas must be re-cast as Finset.sum of products."
+    ],
+    "nextSteps": [
+      "ACT (post-blackout): port parent indicator decomposition to product measure, prove E_p[X]=C(n,2)*sum p_k^2.",
+      "ACT: prove sum p_k^2 >= 1/d (equality iff uniform) via Finset Cauchy-Schwarz (sq_sum_le_card_mul_sum_sq).",
+      "Follow-up file: Pr_p(X=0)=n!*e_n(p) via Finset.esymm; optimization layer pending majorization scaffolding."
+    ]
+  },
+  "tags": [
+    "probability",
+    "birthday-problem",
+    "combinatorics",
+    "random-variable",
+    "expected-value",
+    "descFactorial",
+    "indicator",
+    "non-uniform",
+    "collision-probability",
+    "index-of-coincidence",
+    "schur-convexity",
+    "cryptography",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "birthday-problem",
+    "birthday-problem-oq-01",
+    "birthday-problem-oq-01-oq-01",
+    "birthday-problem-oq-02",
+    "birthday-problem-oq-02-oq-01",
+    "birthday-problem-oq-03",
+    "birthday-problem-oq-03-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-01",
+    "birthday-problem-oq-03-oq-01-oq-02",
+    "birthday-problem-oq-03-oq-03"
+  ],
+  "references": {
+    "papers": [
+      "R. F. Bloom (1973), A birthday problem, Amer. Math. Monthly",
+      "M. Klotz (1979) / D. Munford (1977) — non-uniform birthday / coincidence probability minimized at uniform",
+      "T. S. Nunnikhoven (1992), A birthday problem solution for nonuniform birth frequencies, Amer. Statistician"
+    ],
+    "urls": [],
+    "mathlib": []
+  },
+  "started": "2026-06-10T18:04:48.639Z",
+  "lastUpdate": "2026-06-13",
+  "significance": 6,
+  "tractability": 7,
+  "leanFiles": [
+    {
+      "path": "Proofs/BirthdayProblem.lean",
+      "filename": "BirthdayProblem.lean",
+      "lineCount": 403,
+      "theoremCount": 24,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblem.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemAsymptotics.lean",
+      "filename": "BirthdayProblemAsymptotics.lean",
+      "lineCount": 85,
+      "theoremCount": 5,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemAsymptotics.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ01.lean",
+      "filename": "BirthdayProblemOQ01.lean",
+      "lineCount": 514,
+      "theoremCount": 53,
+      "axiomCount": 0,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ01OQ01.lean",
+      "filename": "BirthdayProblemOQ01OQ01.lean",
+      "lineCount": 281,
+      "theoremCount": 14,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ01OQ01Aristotle.lean",
+      "filename": "BirthdayProblemOQ01OQ01Aristotle.lean",
+      "lineCount": 35,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ01OQ02.lean",
+      "lineCount": 264,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ02.lean",
+      "filename": "BirthdayProblemOQ02.lean",
+      "lineCount": 301,
+      "theoremCount": 18,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ02OQ01.lean",
+      "filename": "BirthdayProblemOQ02OQ01.lean",
+      "lineCount": 230,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ02OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03.lean",
+      "filename": "BirthdayProblemOQ03.lean",
+      "lineCount": 369,
+      "theoremCount": 19,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01.lean",
+      "filename": "BirthdayProblemOQ03OQ01.lean",
+      "lineCount": 246,
+      "theoremCount": 15,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ01.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ01.lean",
+      "lineCount": 318,
+      "theoremCount": 41,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ01OQ02.lean",
+      "filename": "BirthdayProblemOQ03OQ01OQ02.lean",
+      "lineCount": 2264,
+      "theoremCount": 54,
+      "axiomCount": 1,
+      "defCount": 7,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ01OQ02.lean"
+    },
+    {
+      "path": "Proofs/BirthdayProblemOQ03OQ03.lean",
+      "filename": "BirthdayProblemOQ03OQ03.lean",
+      "lineCount": 242,
+      "theoremCount": 20,
+      "axiomCount": 0,
+      "defCount": 2,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BirthdayProblemOQ03OQ03.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

OBSERVE→ORIENT survey of the open question from `birthday-problem-oq-01-oq-01`:
**does the collision-count formalization generalize to non-uniform birthday
distributions (unequal day probabilities), the setting for hash-collision
analysis in cryptography?**

**Answer: yes, fully — resolved on paper.** Every uniform formula has a
non-uniform analogue indexed by the probability vector `p = (p₁,…,p_d)`, and
the uniform parent is the *extremal* (collision-minimizing) case:

- **Expected collisions:** `E_p[X] = C(n,2)·Σₖ pₖ²` — and `Σₖ pₖ²` is exactly
  the cryptographic **collision probability / index of coincidence**.
  `Σₖ pₖ² ≥ 1/d` with equality iff uniform (Cauchy–Schwarz) ⇒ uniform
  minimizes expected collisions. Recovers parent `C(n,2)/d`.
- **No-collision probability:** `Pr_p(X=0) = n!·eₙ(p)` (elementary symmetric
  polynomial); recovers parent `descFactorial(d,n)/dⁿ` at uniform.
- **Optimization theorem:** `n!·eₙ` is Schur-concave (Schur–Ostrowski via the
  `eₙ` deletion identity) ⇒ uniform maximizes `Pr(all distinct)`, i.e.
  minimizes collision probability. Classical (Bloom 1973, Munford 1977,
  Klotz 1979, Nunnikhoven 1992).

No Lean committed: Docker build infra is down and the Aristotle backend returns
404 (2026-06-13 verification blackout). knowledge.md includes a Mathlib
tractability map and a recommended first ACT (the `E_p[X]` formula + the
`Σpₖ² ≥ 1/d` bound are easy/in-Mathlib; the Schur-concavity layer needs
majorization scaffolding Mathlib lacks).

## Changes
- `research/problems/.../knowledge.md` — full paper resolution + tractability map + dead ends
- `research/problems/.../state.md` — phase OBSERVE→ORIENT, blockers, next action
- `src/data/research/problems/birthday-problem-oq-01-oq-01-oq-03.json` — seeded knowledge/insights/results fields (was absent on main)

## Test plan
- [x] JSON validates (`python3 -m json.tool`)
- [ ] Lean ACT deferred to post-blackout (Docker + Aristotle required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)