### PR TITLE
research(lebesgue-measure-oq-03-oq-01): status-sync to completed

### DIFF
--- a/src/data/research/problems/lebesgue-measure-oq-03-oq-01.json
+++ b/src/data/research/problems/lebesgue-measure-oq-03-oq-01.json
@@ -26,7 +26,7 @@
     "lebesgue-measure-oq-03-oq-01",
     "lebesgue-measure-oq-06"
   ],
-  "status": "available",
+  "status": "completed",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [


### PR DESCRIPTION
## Summary
- The OQ `lebesgue-measure-oq-03-oq-01` asks: *"Can the impossibility theorem be fully formalized in Lean using Mathlib's MeasureTheory infrastructure?"*
- It already **is**, on `main`, in `proofs/Proofs/LebesgueMeasureOQ03OQ01.lean` — `no_invariant_locally_finite_ball`, `no_invariant_locally_finite_any_center`, `no_invariant_parametric` formalize the impossibility (no nonzero translation-invariant locally-finite Borel measure on an infinite-dim Hilbert space). 283 lines, **0 sorry, 0 axiom**.
- The slug's own `leanFiles[]` already lists that file, yet `status` was still `available`. This flips it `available` → `completed` to match reality (same one-line state-sync pattern as #23080).

## Verification
- Build-free state-sync only (no Lean changes). Docker/Aristotle blackout persists, so no new compilation was run; the 0-sorry/0-axiom proof predates this PR on `origin/main` (since #22746).

🤖 Generated with [Claude Code](https://claude.com/claude-code)