### PR TITLE
research(arithmetic-series multichoose): S1 ORIENT survey of multiset-coefficient identity

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/knowledge.md
@@ -6,16 +6,125 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Target (multiset-coefficient identity).** Let `multichoose n k = C(n+k-1, k)` count
+the number of size-`k` multisets drawn from `n` symbols. The open question asks for the
+rising-factorial analogue of the parent's descending-factorial identity:
+
+$$
+\binom{n+k-1}{k}\,k! \;=\; \prod_{i=0}^{k-1}(n+i) \;=\; n(n+1)\cdots(n+k-1) \;=\; \mathrm{ascFactorial}(n,k).
+$$
+
+In Lean/Mathlib terms the cleanest statement is
+
+```lean
+theorem multichoose_factorial (n k : ℕ) :
+    Nat.multichoose n k * k.factorial = ∏ i ∈ Finset.range k, (n + i)
+```
+
+with the equivalent closed form `... = Nat.ascFactorial n k`.
+
+**Relation to the lineage.** This is the *multiset* (rising) counterpart of the parent
+`arithmetic-series-oq-02-oq-04-oq-01`, which proved the *ordered-selection* (falling)
+identity `Nat.choose n k * k! = n.descFactorial k` (`choose_descFactorial`). The
+grandparent `arithmetic-series-oq-02-oq-04` already wired `Nat.ascFactorial` to binomials
+via Mathlib's `Nat.ascFactorial_eq_factorial_mul_choose`. So the infrastructure to close
+this OQ is essentially already present in the family; the new content is the
+`multichoose ↦ choose (n+k-1)` bridge plus a product reindexing.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Reduction to the parent identity
+
+`Nat.multichoose n k = (n + k - 1).choose k` (Mathlib: `Nat.multichoose_eq`). Substituting
+turns the LHS into `(n+k-1).choose k * k!`, which is *exactly* the parent's
+`choose_descFactorial` applied at `m := n + k - 1`:
+
+```
+(n+k-1).choose k * k!  =  (n+k-1).descFactorial k.
+```
+
+So the whole problem reduces to the product-reindexing identity
+
+```
+(n+k-1).descFactorial k  =  ∏ i ∈ range k, (n + i).
+```
+
+### The reindexing step
+
+`Nat.descFactorial_eq_prod_range : m.descFactorial k = ∏ i ∈ range k, (m - i)` gives, at
+`m = n+k-1`,
+
+```
+∏ i ∈ range k, (n + k - 1 - i).
+```
+
+Reflecting the index with `Finset.prod_range_reflect` (`∏ i ∈ range k, f (k-1-i) = ∏ i ∈ range k, f i`)
+rewrites this to `∏ i ∈ range k, (n + k - 1 - (k - 1 - i))`, and for `i < k` the inner
+`ℕ`-arithmetic collapses: `n + k - 1 - (k - 1 - i) = n + i` (dischargeable by `omega` under
+the `range` membership hypothesis). That yields `∏ i ∈ range k, (n + i)`, as required.
+
+### Draft proof (UNVERIFIED — Docker/Aristotle both down 2026-06-13)
+
+```lean
+import Proofs.ArithmeticSeriesOQ02OQ04OQ01
+import Mathlib.Data.Nat.Choose.Multinomial   -- for Nat.multichoose / Nat.multichoose_eq
+
+namespace ArithmeticSeriesOQ02OQ04OQ01OQ01
+
+open Finset ArithmeticSeriesOQ02OQ04OQ01
+
+/-- Multiset-coefficient (rising-factorial) analogue of the descending-factorial identity:
+    `C(n+k-1, k) * k! = n(n+1)...(n+k-1)`. -/
+theorem multichoose_factorial (n k : ℕ) :
+    Nat.multichoose n k * k.factorial = ∏ i ∈ range k, (n + i) := by
+  rw [Nat.multichoose_eq, choose_descFactorial, Nat.descFactorial_eq_prod_range,
+      ← Finset.prod_range_reflect]
+  refine Finset.prod_congr rfl ?_
+  intro i hi
+  have : i < k := Finset.mem_range.mp hi
+  omega
+
+/-- Closed form against Mathlib's `ascFactorial`. -/
+theorem multichoose_factorial_asc (n k : ℕ) :
+    Nat.multichoose n k * k.factorial = Nat.ascFactorial n k := by
+  rw [multichoose_factorial, Nat.ascFactorial_eq_prod_range]
+
+end ArithmeticSeriesOQ02OQ04OQ01OQ01
+```
+
+**Confidence:** high on the mathematics and the reduction; medium on exact Mathlib lemma
+spellings. Names to confirm against the pinned Mathlib once a build is available:
+`Nat.multichoose_eq`, `Nat.descFactorial_eq_prod_range`, `Nat.ascFactorial_eq_prod_range`,
+`Finset.prod_range_reflect`. The import providing `Nat.multichoose` may be
+`Mathlib.Data.Nat.Choose.Multinomial` or a sibling; `import Mathlib` is the safe fallback.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- Routing through `Nat.ascFactorial_eq_factorial_mul_choose` (as the grandparent
+  `ArithmeticSeriesOQ02OQ04` does) is possible but carries an `n ↦ n+1` index shift
+  (`C(n+k, k) * k! = ascFactorial (n+1) k`) that makes the `multichoose n k` (which is
+  `C(n+k-1, k)`) bridge less direct than the `choose_descFactorial`-at-`(n+k-1)` route
+  above. Prefer the descending-factorial reduction.
+
+---
+
+## Session Log
+
+### Session 2026-06-13 (Session 1) — ORIENT survey
+
+**Mode**: FRESH · **Outcome**: surveyed (ORIENT)
+
+- Fixed the precise Lean statement: `Nat.multichoose n k * k! = ∏ i ∈ range k, (n+i)`.
+- Identified full proof path reducing to the parent's `choose_descFactorial` + a
+  `prod_range_reflect` reindexing; wrote a draft proof (above).
+- **Verification blocked:** Docker daemon down and Aristotle backend returns 404
+  ("Resource not found") this session, so the draft is NOT built and NOT added to the
+  Lean build tree (an unverified file could break a future full `lake build`).
+- **Next ACT step (when Docker returns):** drop the draft into
+  `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean`, run
+  `./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01`, fix any
+  lemma-name drift, then add the gallery entry `src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/`.

--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/state.md
@@ -1,25 +1,32 @@
 # Research State: arithmetic-series-oq-02-oq-04-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:49-07:00
-**Iteration**: 1
+**Since**: 2026-06-13
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Statement fixed and a complete proof path identified (see knowledge.md). Awaiting a
+build route to execute the ACT step.
 
 ## Active Approach
-None yet.
+Reduce `multichoose n k * k!` to the parent identity `choose_descFactorial` at
+`m = n+k-1`, then reindex the descending-factorial product via `Finset.prod_range_reflect`
+to obtain `∏ i ∈ range k, (n+i)`. Draft proof written in knowledge.md.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1 (survey/draft, unbuilt)
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- **Verification infra down (2026-06-13):** Docker daemon down; Aristotle backend returns
+  404. Draft proof cannot be compiled, so it is intentionally not yet added to
+  `proofs/Proofs/`. This is an external/transient blocker, not a mathematical one.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker is back: create `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` from the
+draft, build with `./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01`,
+reconcile any Mathlib lemma-name drift, then add the gallery `meta.json` entry and advance
+to ACT/COMPLETED.


### PR DESCRIPTION
## Summary
ORIENT-phase survey of the Seeker-generated open question `arithmetic-series-oq-02-oq-04-oq-01-oq-01` — the multiset (rising-factorial) analogue of the parent descending-factorial identity.

- **Statement fixed:** `Nat.multichoose n k * k! = ∏ i ∈ range k, (n+i) = Nat.ascFactorial n k`.
- **Full proof path documented:** reduce `multichoose n k = (n+k-1).choose k` (`Nat.multichoose_eq`), apply the parent's `choose_descFactorial` at `m = n+k-1`, then reindex the descending-factorial product with `Finset.prod_range_reflect` (`omega` closes the per-term `ℕ`-arithmetic). A draft proof is recorded in `knowledge.md`.
- Phase advanced **OBSERVE → ORIENT**; problem stub was previously empty (0 attempts).

## Why no Lean file / no `verified` claim
Docker daemon is down and the Aristotle backend returns 404 ("Resource not found") this session, so the draft proof **cannot be compiled**. It is intentionally NOT added to `proofs/Proofs/` — an unverified file could break a future full `lake build`. The mathematics is routine; the only open item is reconciling exact Mathlib lemma spellings at build time.

## Files
- `research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/knowledge.md` — survey + draft proof
- `research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/state.md` — phase → ORIENT

## Next step (when Docker returns)
Drop the draft into `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean`, build, fix any lemma-name drift, then add the gallery `meta.json` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)