### PR TITLE
research(hilbert-10-oq-01-oq-02): AUDIT — sections realignment + definitionCount sync

### DIFF
--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -138,7 +138,7 @@
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
     "theoremCount": 90,
-    "definitionCount": 15
+    "definitionCount": 9
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -166,63 +166,77 @@
       "id": "preamble",
       "title": "Σ₁ vs Π₂: Problem Statement and References",
       "startLine": 1,
-      "endLine": 60,
+      "endLine": 90,
       "summary": "Module documentation positioning this file as the Σ₁/Π₂ refinement of OQ-01. States the open Σ₁ question, contrasts with Koenigsmann's settled Π₂, lists the references (Koenigsmann 2016, Mazur 1992, Poonen 2009, Eisenträger-Park, Daans 2021)."
     },
     {
       "id": "subsets",
       "title": "Subsets of ℚ as Predicates",
-      "startLine": 61,
-      "endLine": 75,
+      "startLine": 91,
+      "endLine": 100,
       "summary": "Defines the abbreviation `RatSubset := Rat → Prop` and the specific subset `IntSubset := fun q => ∃ z : Int, q = z` representing ℤ ⊂ ℚ."
     },
     {
       "id": "sigma1",
       "title": "Σ₁ (Diophantine) Definability",
-      "startLine": 76,
-      "endLine": 110,
+      "startLine": 101,
+      "endLine": 127,
       "summary": "Defines `IsDiophantineDefinition` (existence of a parametric family of polynomials whose rational solutions characterize the subset) and `IntegersAreDiophantineOverQ` as the open Σ₁ question for ℤ ⊂ ℚ. Proves `integers_diophantine_iff` showing definitional equivalence with `IntegersDiophantineOverQ` from OQ-01 (no axioms used)."
     },
     {
       "id": "pi2",
       "title": "Π₂ (Universal-Existential) Definability and Koenigsmann's Witness",
-      "startLine": 111,
-      "endLine": 130,
+      "startLine": 128,
+      "endLine": 151,
       "summary": "Defines `IsUniversalExistentialDefinition` (parametric polynomial with both a universal block and an existential block over ℚ) and axiomatizes Koenigsmann's Annals 2016 theorem as `koenigsmann_2016_universal`: ℤ is Π₂-definable in ℚ."
     },
     {
       "id": "containment",
       "title": "Σ₁ ⊆ Π₂",
-      "startLine": 131,
-      "endLine": 160,
+      "startLine": 152,
+      "endLine": 182,
       "summary": "Proves `diophantine_implies_universal_existential`: every Σ₁-definable subset is Π₂-definable, by ignoring the universal block. As corollary `integers_diophantine_strengthens_koenigsmann`: a positive answer to the open Σ₁ question would strengthen Koenigsmann's result."
     },
     {
       "id": "consequences",
       "title": "Consequences: H10/ℚ Undecidability and Mazur's Conjecture",
-      "startLine": 161,
-      "endLine": 186,
+      "startLine": 183,
+      "endLine": 211,
       "summary": "Re-exports the OQ-01 conditionals against the Σ₁ predicate: `integers_diophantine_sigma1_implies_h10_q_undecidable` (Σ₁ → ¬decidable) and `mazur_implies_not_sigma1_definable` (Mazur → ¬Σ₁). Both are logical consequences of the OQ-01 axioms via `integers_diophantine_iff`, NOT new axioms."
     },
     {
       "id": "duality",
       "title": "Π₁ Definability and the Σ₁/Π₁ Duality",
-      "startLine": 187,
-      "endLine": 266,
+      "startLine": 212,
+      "endLine": 291,
       "summary": "Defines `IsCoDiophantineDefinition` (Π₁ — purely universal definability) and the helper `NotIntSubset = ℚ \\ ℤ`. Proves `diophantine_iff_codiophantine_complement` (general Σ₁/Π₁ duality, formalizing the narrative claim 'Σ₁ ⟺ ¬(Π₁ for the complement)'), specializes to ℤ as `integers_diophantine_iff_complement_codiophantine`, and re-exports the H10/ℚ-undecidability and Mazur consequences against the new Π₁(ℚ\\ℤ) predicate. All theorems axiom-free; the duality direction Π₁(¬S) → Σ₁(S) uses one classical excluded-middle step (`Classical.byContradiction`)."
     },
     {
       "id": "sigma2",
       "title": "Σ₂ Definability and the Σ₂/Π₂ Duality",
-      "startLine": 267,
-      "endLine": 384,
+      "startLine": 292,
+      "endLine": 467,
       "summary": "Defines `IsExistentialUniversalDefinition` (Σ₂ — ∃∀ definability of subsets of ℚ). Proves the precise dual of Σ₁ ⊆ Π₂: `codiophantine_implies_existentialUniversal` (Π₁ ⊆ Σ₂, axiom-free). Proves the higher-level analog of the Σ₁/Π₁ duality: `existentialUniversal_iff_universalExistential_complement` (S is Σ₂ iff its complement is Π₂; axiom-free up to two classical steps). Adds the Π₂-class congruence helper `universalExistentialDefinition_iff_of_pred_iff` and uses Σ₂/Π₂ duality + Koenigsmann to derive `koenigsmann_implies_complement_existentialUniversal` (ℚ \\ ℤ is Σ₂-definable in ℚ — corollary, no new axiom)."
+    },
+    {
+      "id": "sigma1-pi1-closure",
+      "title": "Σ₁/Π₁ Definability: Singletons, Finite Sets, and the Boolean Closure Grid (iters 5–17)",
+      "startLine": 468,
+      "endLine": 1840,
+      "summary": "Symmetric duality forms Σ₁ vs Π₁(¬·) (VIII.5), trivial-set definability across all four classes (VIII.6), {0}/{a} singletons and their complements (VIII.7, VIII.9), and ¬¬-shadow / double-negation invariance (VIII.8). Then the full finite Boolean closure grid for Σ₁ and Π₁ over ℚ at three arities — BINARY (VIII.10, VIII.12, VIII.13), finite-LIST (VIII.10 finite-list, VIII.14–VIII.17), and FINSET (VIII.19, VIII.20): Σ₁ is closed under ∪ and ∩, Π₁ under ∩ and ∪, witnessed by product P₁·P₂ and sum-of-squares polynomials. Neither class is closed under complement (which would collapse Σ₁ = Π₁, i.e. settle the open question). All theorems axiom-free; the finite ⋃_{n∈[-N,N]∩ℤ}{n} truncations are Σ₁-definable while a uniform witness for the countable ⋃_{n:ℤ}{n} is the open content."
+    },
+    {
+      "id": "sigma2-pi2-closure",
+      "title": "Σ₂/Π₂ Boolean Closure and the Level-2 Open Question (iters 20–27)",
+      "startLine": 1841,
+      "endLine": 2865,
+      "summary": "Lifts the closure programme to level 2: Σ₂ closed under binary/list/Finset intersection and Π₂ under union (VIII.21–VIII.26, VIII.29–VIII.32), the level-2 open question and its missing diagonal at level 2 (VIII.27, VIII.28), and the combined / contrapositive forms (VIII.33) relating H10/ℚ-decidability, Mazur's conjecture, and the Σ₁ ⊊ Π₂ non-collapse witnessed at ℤ ⊂ ℚ (e.g. h10_decidable_implies_not_sigma1_integers, mazur_implies_pi2_strict_above_sigma1_at_integers). All results are axiom-free corollaries of the level-1 closure work together with the Koenigsmann axiom; no new polynomial witnesses are introduced."
     },
     {
       "id": "landscape",
       "title": "The Sharpened Landscape",
-      "startLine": 385,
-      "endLine": 462,
+      "startLine": 2866,
+      "endLine": 3174,
       "summary": "Status table summarizing Σ₁ (open), Π₁(ℚ\\ℤ) (open, formally equivalent to Σ₁ via `integers_diophantine_iff_complement_codiophantine`), Σ₂(ℚ\\ℤ) (PROVED unconditionally as a corollary of Koenigsmann via `koenigsmann_implies_complement_existentialUniversal`), and Π₂ (proved by Koenigsmann). Lists this file's 1 net new axiom and 13 theorems, with #check commands for the main definitions and theorems including the new Σ₂ predicate, the Σ₂/Π₂ duality, and the Σ₂(ℚ\\ℤ) corollary."
     }
   ],
@@ -274,7 +288,7 @@
     "lineCount": 3174,
     "axiomCount": 1,
     "theoremCount": 90,
-    "definitionCount": 15,
+    "definitionCount": 9,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Build-free meta↔source AUDIT of the `hilbert-10-oq-01-oq-02` gallery entry against `proofs/Proofs/Hilbert10OQ01OQ02.lean` (3174 LOC on origin/main). Docker remains down; no source change.

### Findings fixed
- **`sections[]` drift (major):** the array covered only L1–462 of the 3174-line file, with head line numbers shifted ~30 lines (e.g. `subsets` claimed L61–75 but Part I is L91–100). The whole iter-5..27 closure-property bulk (Parts VIII.5–VIII.33, L468–2865) and Part IX (now L2866–3174) were unrepresented/mislocated. Realigned the 9 existing sections to real PART dividers and added two thematic sections (Σ₁/Π₁ closure grid; Σ₂/Π₂ closure + level-2 OQ). Sections now tile **L1–3174 contiguously** across 11 sections.
- **`definitionCount` 15 → 9** in both `.meta` and `.leanFile`. File has 8 col-0 `def` + 1 `abbrev` = 9 public definitions; the 7 `private def`s are excluded under the same convention that sets `theoremCount=90` (90 public vs 96 incl. private). 15 matched neither 9 (public) nor 16 (incl. private) → stale.

### Verified already-correct (unchanged)
`lineCount=3174`, `theoremCount=90` (`^(theorem|lemma) `), `axiomCount=1` (`koenigsmann_2016_universal`, structure of the axiomatized badge), `sorries=0`, and all 18 `mainTheorems[]` names still exist in source.

## Test plan
- [x] `python3 -c json.load` validates the meta.json
- [x] sections verified to tile L1–3174 with no gaps/overlaps
- [ ] Docker build gated (infra down) — meta-only change, no Lean source touched