### PR TITLE
research(crt-non-coprime-oq-01-oq-02): S2 SURVEY — full Garner algorithm

### DIFF
--- a/research/problems/chinese-remainder-non-coprime-oq-01-oq-02/knowledge.md
+++ b/research/problems/chinese-remainder-non-coprime-oq-01-oq-02/knowledge.md
@@ -2,20 +2,208 @@
 
 Insights accumulated during research on this problem.
 
+**Phase**: ORIENT · **Status**: surveyed (paper resolution complete; Lean build gated by infra blackout 2026-06-13)
+
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Open question (verbatim):** *Formalize the full Garner algorithm (not just the
+mixed-radix decomposition) with runtime complexity bounds.*
+
+The parent entry `chinese-remainder-non-coprime-oq-01`
+(`ChineseRemainderNonCoprimeOQ01.lean`, Part IV) formalizes only the **k = 2**
+mixed-radix fact:
+
+```lean
+theorem garner_mixed_radix (m n : ℕ) (x : ℕ) (hm : 0 < m) (hx : x < m * n) :
+    ∃ c₁ c₂ : ℕ, x = c₁ + c₂ * m ∧ c₁ < m ∧ c₂ < n
+```
+
+plus uniqueness (`garner_mixed_radix_unique`) and the bound
+`garner_coefficients_bounded`. That is the *representation existence* for two
+moduli — it does **not** give the constructive reconstruction procedure for
+`k` coprime moduli, nor the operation count. The sibling
+`ChineseRemainderNonCoprimeList.lean` supplies a general-`R` list CRT
+(`System`, `Compatible`, `ed_crt_list_iff`, `ed_crt_list_unique`) but it is
+existence/uniqueness only — **no constructive coefficient algorithm**. So the OQ
+is genuinely open in this gallery.
+
+This survey resolves the mathematics completely on paper and pins down the exact
+Lean formalization path. (Build-free: Docker daemon down + Aristotle backend 404
+confirmed live this session — see the project verification-blackout note.)
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### 1. The full k-modulus Garner algorithm (Garner 1959; Knuth TAOCP vol 2, §4.3.2 Alg. 4.3.2C)
+
+**Setup.** Pairwise-coprime moduli `m₁,…,m_k`, residues `r_i ∈ [0,m_i)`. Goal:
+the unique `x ∈ [0, M)`, `M = ∏ m_i`, with `x ≡ r_i (mod m_i)` for all `i`.
+
+**Mixed-radix (Garner) representation.** Write
+
+```
+x = v₁ + v₂·m₁ + v₃·m₁m₂ + ⋯ + v_k·(m₁m₂⋯m_{k-1}),   0 ≤ v_i < m_i.
+```
+
+Every `x ∈ [0,M)` has a unique such form (k-fold generalization of the parent's
+`garner_mixed_radix`, which is exactly the `k = 2` case `x = c₁ + c₂·m₁`,
+`M = m₁m₂`). Existence+uniqueness is a clean induction on `k` using the parent
+lemma as the splitting step (`x = (x mod m₁) + m₁·⌊x/m₁⌋`, recurse on
+`⌊x/m₁⌋ < m₂⋯m_k`).
+
+**Why mixed-radix is the efficient target.** Each `v_i < m_i` (single-precision /
+word-sized). All arithmetic that produces the `v_i` stays bounded by the
+individual moduli; only the *final* assembly of `x` touches big integers.
+
+### 2. Triangular system → forward substitution
+
+Reduce the representation mod `m_i`. For `j ≥ i+1`, the term
+`v_j·(m₁⋯m_{j-1})` is divisible by `m_i` (since `i ≤ j-1`), so it vanishes:
+
+```
+r_i ≡ v₁ + v₂m₁ + ⋯ + v_i·(m₁⋯m_{i-1})   (mod m_i).
+```
+
+This lower-triangular system is solved top-down:
+
+```
+v₁ = r₁ mod m₁
+v_i = ( r_i − (v₁ + v₂m₁ + ⋯ + v_{i-1}·m₁⋯m_{i-2}) ) · (m₁⋯m_{i-1})⁻¹  mod m_i   (i ≥ 2)
+```
+
+The inverse `(m₁⋯m_{i-1})⁻¹ mod m_i` exists because every `m_j` (`j < i`) is
+coprime to `m_i`.
+
+### 3. Garner's Horner form (the actual algorithm — avoids big partial sums)
+
+Precompute the pairwise inverse constants (moduli-only, residue-independent):
+
+```
+C_{ij} = (m_i)⁻¹ mod m_j   for i < j.
+```
+
+Then compute, using only mod-`m_i` arithmetic:
+
+```
+v₁ = r₁ mod m₁
+v₂ = (r₂ − v₁)·C_{12}                              mod m₂
+v₃ = ((r₃ − v₁)·C_{13} − v₂)·C_{23}                mod m₃
+⋮
+v_i = (⋯((r_i − v₁)·C_{1i} − v₂)·C_{2i} − ⋯ − v_{i-1})·C_{i-1,i}  mod m_i
+```
+
+**Telescoping proof that the Horner form equals the substitution formula** (the
+key correctness lemma). For `i = 3`, with `C_{13}=m₁⁻¹`, `C_{23}=m₂⁻¹ (mod m₃)`:
+
+```
+((r₃−v₁)C_{13} − v₂)C_{23}
+  = (r₃−v₁)·C_{13}C_{23} − v₂·C_{23}
+  = (r₃−v₁)·(m₁m₂)⁻¹ − v₂·m₂⁻¹
+  = m₂⁻¹·[ (r₃−v₁)·m₁⁻¹ − v₂ ]
+  = (m₁m₂)⁻¹·(r₃ − v₁ − v₂m₁)     (mod m₃)   ✓  = v₃.
+```
+
+The general telescoping is an induction: peeling the outermost `·C_{i-1,i}`
+multiplies the accumulated `(m₁⋯m_{i-2})⁻¹` by `m_{i-1}⁻¹` and subtracts the
+matching `v_{i-1}` term, reproducing `(r_i − S_{i-1})·(m₁⋯m_{i-1})⁻¹` where
+`S_{i-1}=v₁+v₂m₁+⋯+v_{i-1}m₁⋯m_{i-2}`.
+
+### 4. Reconstruction of x (only big-integer step)
+
+By Horner on the radices:
+
+```
+x = v₁ + m₁(v₂ + m₂(v₃ + ⋯ + m_{k-1}·v_k)) ,   x ∈ [0, M).
+```
+
+This is `O(k)` big-integer mul-adds; skip it entirely if the mixed-radix form is
+the desired output (e.g. staying in a residue number system).
+
+### 5. Runtime complexity bound (the second half of the OQ)
+
+Let one **single-precision modular operation** = an `add/sub/mul mod m_i` on
+word-sized operands.
+
+| Phase | Cost | Notes |
+|-------|------|-------|
+| Inverse precompute `C_{ij}` | `O(k²)` ext-gcd inversions, `O(log max mᵢ)` each | moduli-only ⇒ amortized free across many conversions (RNS) |
+| Forward (compute `v_i`) | `Σ_{i=1}^{k}(i−1) = k(k−1)/2 = O(k²)` single-precision mod ops | each `v_i` costs `i−1` mults + `i−1` subs, all `< m_i` |
+| Reconstruct `x` | `O(k)` big-integer mul-adds | optional |
+
+**The win vs. direct (Lagrange) CRT** `x = Σ r_i·M_i·(M_i⁻¹ mod m_i) mod M`,
+`M_i = M/m_i`: that needs `O(k)` operations on `O(k·log m)`-**bit** numbers (true
+multi-precision). Garner replaces every inner operation with single-precision
+arithmetic — the classical Garner-1959 point that residue number systems support
+multi-precision arithmetic via single-precision operations (already quoted in the
+parent file's header).
+
+The closed form `k(k−1)/2` is **pure `Nat` arithmetic** — provable by
+`induction`/`Finset.sum_range_id`/`omega`, *no* Mathlib gap.
+
+---
+
+## Lean Formalization Path
+
+**Tractable core (extends the parent directly; build-gated only by the blackout):**
+
+1. `def garnerCoeffs (ms rs : List ℕ) : List ℕ` — forward substitution producing
+   `[v₁,…,v_k]`. Modular inverse via the parent's idiom (`Int.gcdA`/`gcdB`,
+   already used in `noncoprime_crt_efficiency_summary`) or `ZMod.inv`/
+   `Nat.ModEq` over `ZMod m_i`.
+2. `def garnerReconstruct (ms vs : List ℕ) : ℕ` — `List.foldr` Horner assembly.
+3. **Main theorem** (the deliverable):
+   `Pairwise Nat.Coprime ms → garnerReconstruct ms (garnerCoeffs ms rs) ≡ rs[i] [MOD ms[i]]`
+   for each `i`, **and** `garnerReconstruct … < ms.prod`. Induction on the list;
+   base case is the parent `garner_mixed_radix`.
+4. **Uniqueness**: lift `garner_mixed_radix_unique` to the list (each `v_i` is
+   determined mod `m_i`).
+5. Reuse `ChineseRemainderNonCoprimeList.System`/`moduli` for the statement shape
+   and `ed_crt_list_unique` for the uniqueness wiring.
+
+**Complexity bound (the harder half):** Mathlib has **no operation-cost model**.
+The honest, build-free formalizable route is an *instrumented* counter:
+`def garnerCoeffsOps (ms : List ℕ) : ℕ` returning the number of modular ops the
+recursion performs, with `garnerCoeffsOps ms = ms.length*(ms.length−1)/2` proved
+by induction (pure `Nat`). This makes "runtime complexity bound" a *theorem about
+an explicit step-count function*, the only rigorous reading available without a
+cost monad. State `O(k²)` as the closed form of that counter.
+
+### Mathlib inventory
+
+- Present: `Nat.Coprime`, `Nat.chineseRemainder`, `ZMod.chineseRemainder`,
+  `ZMod.inv`, `Nat.ModEq`, `Int.gcdA/gcdB`, `List.foldr/foldl`,
+  `Finset.sum_range_id` (for `k(k−1)/2`), `List.Pairwise`.
+- **Gap**: no complexity / cost-model API. ⇒ operation counts must be a
+  hand-rolled `Nat`-valued counter (no external dependency, fully tractable).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Reading "runtime complexity bounds" as a Big-O over a real cost monad.**
+  Mathlib lacks a machine/cost model; chasing one turns a 1–3 day algorithm
+  formalization into an open-ended infrastructure project. The tractable reading
+  is an explicit counter function with a proved closed form `k(k−1)/2`.
+- **Trying to get the full algorithm "for free" from `ChineseRemainderNonCoprimeList`.**
+  That file is existence/uniqueness over a general Euclidean domain — it never
+  constructs the coefficients, so it cannot supply the Garner recursion. It is
+  useful only for the *statement shape* (`System`/`moduli`) and uniqueness glue.
+
+---
+
+## Status / Next
+
+- **Math: fully resolved on paper** (algorithm, telescoping correctness,
+  `O(k²)` = `k(k−1)/2` count, formalization plan). Tractability 6 confirmed for
+  the algorithm+correctness core; the complexity *bound* is the genuinely harder
+  add-on (build-gated, plus the cost-model judgement call above).
+- **Blocked on build**: Docker down + Aristotle 404 (blackout 2026-06-13). The
+  `garnerCoeffs`/`garnerReconstruct` defs and the main correctness theorem need a
+  Docker build to verify; no Lean committed this session.
+- **Next action when infra returns**: implement steps 1–3 above in a new
+  `ChineseRemainderNonCoprimeOQ01OQ02.lean`, base the correctness induction on
+  `garner_mixed_radix`, then add the `garnerCoeffsOps` counter + closed-form
+  lemma for the complexity half.

--- a/research/problems/chinese-remainder-non-coprime-oq-01-oq-02/state.md
+++ b/research/problems/chinese-remainder-non-coprime-oq-01-oq-02/state.md
@@ -1,25 +1,45 @@
 # Research State: chinese-remainder-non-coprime-oq-01-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:48-07:00
-**Iteration**: 1
+**Since**: 2026-06-13
+**Iteration**: 2
+**Status**: surveyed
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Paper resolution of the full k-modulus Garner algorithm complete. The algorithm,
+its Horner (telescoping) form, the correctness argument, and the `O(k²)` =
+`k(k−1)/2` single-precision operation count are all worked out in `knowledge.md`,
+together with the exact Lean formalization path reusing the parent's
+`garner_mixed_radix` as the `k = 2` base case.
 
 ## Active Approach
-None yet.
+Generalize `ChineseRemainderNonCoprimeOQ01.garner_mixed_radix` (k = 2) to k
+coprime moduli via list recursions `garnerCoeffs`/`garnerReconstruct`; prove
+correctness by induction on the modulus list with the parent lemma as the
+splitting step; formalize the runtime bound as a closed form of an explicit
+operation-counter `garnerCoeffsOps ms = k(k−1)/2`.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (survey only — no Lean committed)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Verification blackout (2026-06-13)**: Docker daemon down (`docker info`
+  timeout) + Aristotle backend returns 404 on a trivial `prove` (confirmed live
+  this session). The `garnerCoeffs`/`garnerReconstruct` defs and the main
+  correctness theorem require a Docker `lake` build to verify, so no Lean was
+  committed.
+- **Mathlib gap**: no operation-cost / complexity model. The "runtime complexity
+  bounds" half must be formalized as a hand-rolled `Nat` step-counter with a
+  proved closed form (no external dependency; tractable once builds work).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker/Aristotle infra recovers: create
+`proofs/Proofs/ChineseRemainderNonCoprimeOQ01OQ02.lean`, implement
+`garnerCoeffs` / `garnerReconstruct`, prove the per-modulus congruence +
+`< ms.prod` bound by list induction off `garner_mixed_radix`, then add the
+`garnerCoeffsOps` counter and its `k(k−1)/2` closed-form lemma. Build via
+`./proofs/scripts/docker-build.sh Proofs.ChineseRemainderNonCoprimeOQ01OQ02`.

--- a/src/data/research/problems/chinese-remainder-non-coprime-oq-01-oq-02.json
+++ b/src/data/research/problems/chinese-remainder-non-coprime-oq-01-oq-02.json
@@ -1,0 +1,148 @@
+{
+  "slug": "chinese-remainder-non-coprime-oq-01-oq-02",
+  "title": "Formalize the full Garner algorithm (not just the mixed-radix decomposition) with runtime complexity bounds",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Given pairwise-coprime moduli m_1,...,m_k and residues r_i in [0,m_i), construct the unique x in [0, prod m_i) with x === r_i (mod m_i) via Garner's mixed-radix algorithm x = v_1 + v_2 m_1 + ... + v_k (m_1...m_{k-1}), and bound its cost at O(k^2) single-precision modular operations.",
+    "plain": "Generalize the parent's k=2 mixed-radix fact (garner_mixed_radix) to the full k-modulus Garner reconstruction algorithm with an explicit operation-count complexity bound.",
+    "whyMatters": [
+      "Garner (1959) is the standard efficient CRT reconstruction: it does multi-precision arithmetic using only single-precision modular operations, central to residue number systems and RSA/CRT cryptography.",
+      "The parent entry only proves the k=2 representation; the constructive k-modulus algorithm and its complexity are not yet in the gallery."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent garner_mixed_radix (k=2): every x < m*n factors uniquely as c_1 + c_2*m with c_1 < m, c_2 < n (ChineseRemainderNonCoprimeOQ01.lean Part IV).",
+      "Parent garner_mixed_radix_unique and garner_coefficients_bounded.",
+      "ChineseRemainderNonCoprimeList.lean: existence/uniqueness of list CRT over a Euclidean domain (System, Compatible, ed_crt_list_iff, ed_crt_list_unique) — but NO constructive coefficient algorithm."
+    ],
+    "open": [
+      "Constructive k-modulus Garner coefficient recursion garnerCoeffs and reconstruction garnerReconstruct.",
+      "Main correctness theorem: reconstruction === r_i (mod m_i) for all i and result < prod m_i, by list induction off garner_mixed_radix.",
+      "Runtime complexity bound as a closed form k(k-1)/2 of an explicit operation counter."
+    ],
+    "goal": "A new ChineseRemainderNonCoprimeOQ01OQ02.lean implementing garnerCoeffs/garnerReconstruct, the per-modulus correctness theorem, and a garnerCoeffsOps counter with proved k(k-1)/2 closed form."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13",
+    "iteration": 2,
+    "focus": "Paper resolution complete (algorithm + Horner telescoping correctness + O(k^2)=k(k-1)/2 count + Lean path). Build-gated by the 2026-06-13 verification blackout.",
+    "blockers": [
+      "Docker daemon down + Aristotle backend 404 (verification blackout 2026-06-13): the defs and correctness theorem need a Docker lake build to verify, so no Lean committed.",
+      "Mathlib has no cost/complexity model: the runtime bound must be a hand-rolled Nat operation-counter with a proved closed form."
+    ],
+    "nextAction": "When infra recovers: create ChineseRemainderNonCoprimeOQ01OQ02.lean, implement garnerCoeffs/garnerReconstruct, prove correctness by list induction off garner_mixed_radix, add the garnerCoeffsOps k(k-1)/2 lemma.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Full k-modulus Garner algorithm resolved on paper: mixed-radix representation x = v_1 + v_2 m_1 + ... + v_k(m_1...m_{k-1}) with 0<=v_i<m_i; coefficients via forward substitution v_i = (r_i - S_{i-1})(m_1...m_{i-1})^{-1} mod m_i, computed by Garner's Horner form using precomputed pairwise inverses C_{ij}=m_i^{-1} mod m_j. Correctness via a telescoping identity (verified explicitly for i=3). Cost = sum_{i=1}^k (i-1) = k(k-1)/2 = O(k^2) single-precision modular operations vs O(k) multi-precision ops for direct Lagrange CRT. Lean path reuses parent garner_mixed_radix as the k=2 base case.",
+    "builtItems": [],
+    "insights": [
+      "The parent's garner_mixed_radix IS exactly the k=2 base case (x = c_1 + c_2 m_1, M = m_1 m_2); the k-modulus version is a clean list induction on it.",
+      "For j >= i+1 the term v_j(m_1...m_{j-1}) is divisible by m_i, so reducing mod m_i gives a lower-triangular system solved by forward substitution.",
+      "Garner's Horner form ((r_i - v_1)C_{1i} - v_2)C_{2i} - ... avoids forming big partial sums; it equals the substitution formula by a telescoping identity since C_{1i}...C_{i-1,i} = (m_1...m_{i-1})^{-1} mod m_i.",
+      "Only the final reconstruction x = v_1 + m_1(v_2 + m_2(... )) touches big integers (O(k) ops); all coefficient arithmetic is single-precision.",
+      "The closed-form count k(k-1)/2 is pure Nat arithmetic (Finset.sum_range_id) with no Mathlib gap."
+    ],
+    "mathlibGaps": [
+      "No operation-cost / complexity model in Mathlib: the runtime bound must be formalized as an explicit Nat-valued step counter garnerCoeffsOps with a proved closed form, not a Big-O over a cost monad.",
+      "No prepackaged constructive k-modulus mixed-radix reconstruction; must build garnerCoeffs/garnerReconstruct from Int.gcdA/gcdB or ZMod.inv."
+    ],
+    "nextSteps": [
+      "Implement def garnerCoeffs (ms rs : List Nat) : List Nat (forward substitution, modular inverse via Int.gcdA/gcdB or ZMod.inv).",
+      "Implement def garnerReconstruct (ms vs : List Nat) : Nat (List.foldr Horner assembly).",
+      "Prove main theorem: Pairwise Nat.Coprime ms -> garnerReconstruct ms (garnerCoeffs ms rs) === rs[i] [MOD ms[i]] and < ms.prod, by list induction off garner_mixed_radix.",
+      "Lift garner_mixed_radix_unique to the list for uniqueness.",
+      "Add def garnerCoeffsOps and lemma garnerCoeffsOps ms = ms.length*(ms.length-1)/2 for the complexity half."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "modular-arithmetic",
+    "crt",
+    "computational",
+    "gcd",
+    "lcm",
+    "garner",
+    "cryptography",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "chinese-remainder-constructive-oq-04-oq-03",
+    "chinese-remainder-non-coprime",
+    "chinese-remainder-non-coprime-oq-01",
+    "chinese-remainder-non-coprime-oq-01-oq-01",
+    "chinese-remainder-non-coprime-oq-02",
+    "chinese-remainder-non-coprime-oq-03",
+    "chinese-remainder-non-coprime-oq-03-oq-02",
+    "chinese-remainder-non-coprime-oq-04"
+  ],
+  "references": {
+    "papers": [
+      "H. L. Garner, The residue number system, IRE Transactions on Electronic Computers, 1959.",
+      "D. E. Knuth, The Art of Computer Programming, Vol. 2 (Seminumerical Algorithms), Sec. 4.3.2, Algorithm 4.3.2C (Garner)."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/"
+    ],
+    "mathlib": [
+      "Nat.Coprime",
+      "Nat.chineseRemainder",
+      "ZMod.chineseRemainder",
+      "ZMod.inv",
+      "Nat.ModEq",
+      "Int.gcdA",
+      "Int.gcdB",
+      "Finset.sum_range_id",
+      "List.Pairwise",
+      "List.foldr"
+    ]
+  },
+  "started": "2026-06-10T18:04:48.640Z",
+  "lastUpdate": "2026-06-13",
+  "significance": 5,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/ChineseRemainderNonCoprime.lean",
+      "filename": "ChineseRemainderNonCoprime.lean",
+      "lineCount": 306,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprime.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeList.lean",
+      "filename": "ChineseRemainderNonCoprimeList.lean",
+      "lineCount": 217,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeList.lean"
+    },
+    {
+      "path": "Proofs/ChineseRemainderNonCoprimeOQ01.lean",
+      "filename": "ChineseRemainderNonCoprimeOQ01.lean",
+      "lineCount": 309,
+      "theoremCount": 16,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ChineseRemainderNonCoprimeOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Build-free **SURVEY** of `chinese-remainder-non-coprime-oq-01-oq-02` — *"Formalize the full Garner algorithm (not just the mixed-radix decomposition) with runtime complexity bounds."*

Resolves the mathematics completely on paper and pins the Lean formalization path:

- **Full k-modulus Garner algorithm** (Garner 1959 / Knuth TAOCP §4.3.2 Alg. 4.3.2C): mixed-radix representation `x = v₁ + v₂m₁ + ⋯ + v_k(m₁⋯m_{k-1})`, the forward-substitution coefficient formula, and Garner's Horner form using precomputed pairwise inverses `C_{ij}=mᵢ⁻¹ mod mⱼ`.
- **Correctness** via an explicit telescoping identity (verified for `i=3`; general induction sketched). The parent's `garner_mixed_radix` is exactly the `k=2` base case.
- **Complexity**: `Σ(i−1) = k(k−1)/2 = O(k²)` single-precision modular operations vs. `O(k)` true multi-precision ops for direct Lagrange CRT — the classical RNS win.
- **Lean path**: new `garnerCoeffs`/`garnerReconstruct` + correctness by list induction off `garner_mixed_radix`; complexity as a hand-rolled `Nat` operation-counter (Mathlib has no cost model). Confirmed `ChineseRemainderNonCoprimeList.lean` is existence/uniqueness only — the constructive algorithm is genuinely absent.

## Why no Lean

Verification blackout 2026-06-13: Docker daemon down (`docker info` timeout) + Aristotle backend 404 on a trivial `prove`, both confirmed live this session. The defs/correctness theorem need a Docker build to verify, so no Lean was committed.

## Changes
- `research/problems/.../knowledge.md` — full paper resolution + formalization path + dead ends.
- `research/problems/.../state.md` — OBSERVE → ORIENT, status surveyed, blockers recorded.
- `src/data/research/problems/....json` — seeded knowledge fields (file was absent on origin/main).

## Test plan
- [x] No Lean changed; no build required.
- [x] JSON validates (`jq`).
- [ ] When infra recovers: implement `ChineseRemainderNonCoprimeOQ01OQ02.lean` per the documented plan and build via docker-build.sh.