### PR TITLE
audit: sync theoremCount to Lean source (4 proofs)

### DIFF
--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -52,7 +52,7 @@
     ],
     "assumptions": "1 axiom: hajnal_conjecture (Hajnal's open conjecture, unsolved as of 2026). 0 sorries: all structural lemmas and the greedy independence bound are fully proved.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 6,
     "lineCount": 289
   },
@@ -255,7 +255,7 @@
     "imports": ["Mathlib"],
     "opens": ["Finset", "SimpleGraph"],
     "lineCount": 289,
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 6,
     "axiomCount": 1,
     "sorries": 0,

--- a/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
+++ b/src/data/proofs/fourier-series-oq-04-oq-01/meta.json
@@ -19,7 +19,7 @@
     "axiomCount": 1,
     "sorries": 0,
     "definitionCount": 5,
-    "theoremCount": 16
+    "theoremCount": 15
   },
   "meta": {
     "author": "Open in mathematics (Stein 1971 ICM; Tao 2002 survey). Formalized statement: Lean Genius contributors.",
@@ -41,7 +41,7 @@
     "dateAdded": "2026-05-12",
     "axiomCount": 1,
     "lineCount": 598,
-    "theoremCount": 16,
+    "theoremCount": 15,
     "definitionCount": 5,
     "assumptions": "1 axiom: `carleson_2d_sph` — the open 2D Carleson spherical-summation conjecture on T² (the a.e.-pointwise claim, genuinely open in mathematics). 0 sorries: the unconditional L²-norm convergence companion `sphPartialSum_L2_norm_converge` is now proved (S15) sorry-free via Mathlib's multivariate Fourier engine `UnitAddTorus.hasSum_mFourier_series_L2`. No other assumptions.",
     "mathlibDependencies": [

--- a/src/data/proofs/minpoly-charpoly-oq-02/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-02/meta.json
@@ -26,7 +26,7 @@
     "assumptions": "0 axioms; 1 sorry guarding the proof of `diagonalizable_iff_squarefree_minpoly`. The statement itself is unconditional (hypotheses [IsAlgClosed K] [CharZero K] are explicit, not assumed-as-axiom). The two pre-shipped endomorphism-level bridges (Module.End.iSup_eigenspace_eq_top_of_isSemisimple and Module.End.isSemisimple_iff_squarefree_minpoly) are fully proved with no sorry. The four sub-OQs OQ-02-OQ-01..OQ-02-OQ-04 (estimated ~450 lines total) are the planned discharge route, with the picker-estimated final synthesis at ~59 LOC (~12 + 8 + 33 + 1 + 5 for Bridges A fwd + A rev + B rev + D + compose). Pinned at Mathlib v4.26.0; 18 bearer lemmas verified at SHA 2df2f015… by S7c PREP #19257.",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-06-04",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 1,
     "originalContributions": [
       "Matrix.IsDiagonalizable predicate: ∃ P : Matrix n n K, IsUnit P ∧ IsDiag (P⁻¹ * M * P) — the matrix-level analogue of Module.End.IsSemisimple ∧ Polynomial.Splits for the associated endomorphism",
@@ -195,7 +195,7 @@
     "namespace": "Proofs.MinpolyCharpolyOQ02",
     "lineCount": 180,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 1,
     "path": "Proofs/MinpolyCharpolyOQ02.lean",
     "sorries": 1

--- a/src/data/proofs/sperner-simplicial-instance/meta.json
+++ b/src/data/proofs/sperner-simplicial-instance/meta.json
@@ -42,7 +42,7 @@
     ],
     "dateAdded": "2026-05-04",
     "lineCount": 1022,
-    "theoremCount": 29,
+    "theoremCount": 26,
     "definitionCount": 13,
     "mathlib_version": "4.26.0"
   },
@@ -98,7 +98,7 @@
     "namespace": "Triangulation",
     "lineCount": 1022,
     "axiomCount": 0,
-    "theoremCount": 29,
+    "theoremCount": 26,
     "definitionCount": 13,
     "path": "Proofs/SpernerSimplicialInstance.lean",
     "sorries": 0,


### PR DESCRIPTION
## Gallery Integrity Audit

Re-audited gallery proofs whose `.lean` source changed in recent merges (the highest-risk surface for overclaiming). The **credibility-critical axes — sorries, axioms, status, badge — were all clean** across every recently-changed proof. No True-stubs, no axiom-masking, no verified-with-sorries.

The only drift found was a stale `theoremCount` metric on 4 proofs (matches neither the column-0 nor the indented-inclusive convention → genuinely stale). Synced to the canonical `^(theorem|lemma) ` count produced by `scripts/research/enrich-research.ts` `extractLeanMetadata`:

| slug | meta | source |
|------|------|--------|
| erdos-895-oq-01 | 12 | 13 |
| fourier-series-oq-04-oq-01 | 16 | 15 |
| minpoly-charpoly-oq-02 | 7 | 9 |
| sperner-simplicial-instance | 29 | 26 |

Both the `meta` summary block and the `leanFile` block were synced in each file. No Lean build required (data-only).

---
Discovered during gallery integrity audit.