### PR TITLE
research(divisibility-by-three-oq-01-oq-01): SURVEY — automated divisibility-rule tactic

### DIFF
--- a/research/problems/divisibility-by-three-oq-01-oq-01/knowledge.md
+++ b/research/problems/divisibility-by-three-oq-01-oq-01/knowledge.md
@@ -2,20 +2,157 @@
 
 Insights accumulated during research on this problem.
 
+**OQ**: "Extend to an automated *tactic* that generates and verifies divisibility
+rules for arbitrary input divisors `d` coprime to a given base `b`."
+
+Source: gallery entry `divisibility-by-three-oq-01` (general last-k-digits / digital
+root theory). Significance 6, tractability 6.
+
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+A "divisibility rule for `d` in base `b`" (with `gcd(b,d)=1`) is one of two classical
+forms, both of which reduce an arbitrary `n` to a much smaller test quantity:
+
+1. **Osculator / truncation rule.** Writing `n = b·q + r` with `q = n / b`,
+   `r = n % b`, pick an osculator `c` with `b·c ≡ 1 (mod d)`. Then
+   `d ∣ n ↔ d ∣ (q + c·r)`. The "subtract" variant uses `c'` with `b·c' ≡ -1`,
+   i.e. `d ∣ n ↔ d ∣ (q − c'·r)`; this is the same theorem with osculator `−c'`.
+   Examples (base 10): d=7 → c=−2, d=11 → c=−1, d=13 → c=4, d=17 → c=−5, d=19 → c=2.
+
+2. **Digit-block (digit-sum) rule.** Let `k = ord_d(b)` be the multiplicative order
+   of `b` mod `d` (smallest `k>0` with `b^k ≡ 1 (mod d)`). Then
+   `d ∣ n ↔ d ∣ (digits (b^k) n).sum` — group the base-`b` digits into blocks of
+   length `k` and sum the blocks. The familiar digit-sum rule for 3 and 9 is the
+   `b=10, d∈{3,9}, k=1` case (since `10 ≡ 1`); casting-out-elevens is `d=11, k=2`.
+
+The OQ asks to turn this classical recipe into a Lean **tactic** that, given `b` and
+`d`, *generates* the appropriate rule (computes `c` or `k`) and *verifies* it
+(produces a checked proof term).
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### The underlying mathematics is ALREADY formalized in the gallery
+
+This is the central finding of the survey. The OQ is mostly already done at the
+theorem level; what is missing is (A) one mechanical generalization and (B) the
+metaprogramming layer.
+
+**Osculator family — proven, base 10 only**
+(`proofs/Proofs/DivisibilityTruncationGeneralOQ01.lean`):
+
+```lean
+theorem unified_osculator (d : ℕ) (c : ℤ) (n : ℕ)
+    (hcop : IsCoprime (d : ℤ) 10) (hc : (d : ℤ) ∣ 10 * c - 1) :
+    (d : ℤ) ∣ n ↔ (d : ℤ) ∣ (↑(n / 10) + c * ↑(n % 10))
+```
+
+plus `neg_osculator_from_unified` (negative osculator as the `−c` special case) and
+the per-prime instances `seven_unified`, `eleven_unified`, `thirteen_unified`,
+`seventeen_unified`, `nineteen_unified`. The proof is the single algebraic identity
+`10·(n/10 + c·(n%10)) = n + (10c − 1)·(n%10)`, transferred through coprimality.
+
+**Digit-block family — proven, ARBITRARY base b**
+(`proofs/Proofs/DivisibilityRulesOQ01OQ01OQ01.lean`, Part V):
+
+```lean
+theorem digit_block_rule_base_b (b d : ℕ) (hd : 1 < d) (hcop : Nat.Coprime d b)
+    (k : ℕ) (hk : orderOf (b : ZMod d) ∣ k) (n : ℕ) :
+    d ∣ n ↔ d ∣ (Nat.digits (b ^ k) n).sum
+```
+
+plus `period_iff_orderOf_dvd_base_b`, `orderOf_base_b_is_minimal_period`,
+`orderOf_pos_of_coprime` (Euler's theorem gives finite positive order). So the
+digit-block half of the OQ is *fully general in the base already*.
+
+Note: the existing `src/data` `leanFiles`/`relatedProofs` for this slug point only at
+the `DivisibilityByThreeOQ01*` parent. The load-bearing prior art is actually in
+`DivisibilityTruncationGeneral*.lean` and `DivisibilityRulesOQ01OQ01OQ01.lean`.
+
+### Gap A — base-`b` osculator (mechanical port, ~15 lines)
+
+The osculator theorem is the only rule family still hard-coded to base 10. The
+general statement is a verbatim port:
+
+```lean
+theorem unified_osculator_base_b (b d : ℕ) (c : ℤ) (n : ℕ)
+    (hcop : IsCoprime (d : ℤ) (b : ℤ)) (hc : (d : ℤ) ∣ (b : ℤ) * c - 1) :
+    (d : ℤ) ∣ n ↔ (d : ℤ) ∣ (↑(n / b) + c * ↑(n % b))
+```
+
+Proof is identical to `unified_osculator` with the key identity
+`b·(n/b + c·(n%b)) = n + (b·c − 1)·(n%b)`, obtained from `Nat.div_add_mod n b` cast to
+ℤ (the base-10 file's `div_mod_cast` helper, generalized). Needs `0 < b` only so that
+`n/b`, `n%b` behave; for `b ≥ 2` (the only interesting case) it is automatic.
+
+### Gap B — the tactic itself (the actual OQ ask)
+
+No tactic/metaprogram exists; every instance above is hand-instantiated with `c` (or
+`k`) supplied by the author and the side conditions closed by `decide`/`native_decide`.
+A tactic `divisibility_rule b d` (an `elab`/macro) closes the OQ by automating:
+
+1. Check `Nat.Coprime d b` (decidable) → discharge by `decide`; fail with a clear
+   message otherwise.
+2. **Choose the rule and compute its parameter, externally (in meta code):**
+   - If `b % d = 1` (order 1): pure digit-sum rule.
+   - Osculator route: compute `c = b⁻¹ mod d` via extended Euclid (`Nat.gcdA b d`),
+     then pick the signed representative of smaller magnitude (`c` vs `c − d`) to get
+     the prettier "+" or "−" rule. Emit `unified_osculator_base_b b d c n …`.
+   - Digit-block route: search the least `k > 0` with `b^k % d = 1` (the period). Emit
+     `digit_block_rule_base_b b d _ _ k _ n`.
+3. Discharge the numeric side goals — `(d:ℤ) ∣ b*c − 1`, `b^k % d = 1`,
+   `Nat.Coprime d b`, `1 < d` — by `decide` / `native_decide` / `norm_num`.
+
+In Lean the produced proof term **is** the verification, so "generate" and "verify"
+are one step: the tactic builds the term; the kernel checks it.
+
+### KEY subtlety — `orderOf` is noncomputable
+
+`orderOf (b : ZMod d)` cannot be evaluated by `decide`/`native_decide` (explicit file
+comment at `DivisibilityRulesOQ01OQ01OQ01.lean:146`). Consequently the tactic must NOT
+try to compute the order symbolically. Instead it:
+  (i)  searches in meta code for the least `k>0` with `b^k % d = 1` (plain `Nat`
+       arithmetic, fast), then
+  (ii) supplies that `k` explicitly and discharges the hypothesis
+       `orderOf (b : ZMod d) ∣ k` *indirectly* via
+       `(period_iff_orderOf_dvd_base_b b d (by norm_num) k).mp (by native_decide)`,
+       where the `native_decide` proves the computable fact `b^k % d = 1`.
+
+This "search for the witness period externally, then verify it computationally and
+convert to the order statement" pattern is exactly what the manual examples at
+`DivisibilityRulesOQ01OQ01OQ01.lean:150–165` already do by hand; the tactic just
+automates the witness search and term assembly. This is the one genuinely non-obvious
+piece of the design.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Evaluating `orderOf` directly inside the rule / making the period computable.**
+  Blocked by the noncomputability of `orderOf` (Mathlib). The witness-and-verify route
+  above (least-`k` search + `native_decide` on `b^k % d = 1` + `period_iff_orderOf_dvd_base_b`)
+  is the correct workaround and is already used manually in the gallery.
+
+- **Treating "automated tactic" as new mathematics.** It is not: both rule theorems
+  exist (digit-block already base-general; osculator a one-port-away from base-general).
+  The OQ's remaining content is engineering — a base-`b` port plus an elaboration-layer
+  decision/term-construction tactic — not a new theorem. (Same shape as the
+  "no Big-O cost model in Mathlib" judgement recorded for the Garner / binary-GCD OQs:
+  identify which half of the question is genuine new math and which is tooling.)
+
+---
+
+## Status
+
+SURVEY complete (OBSERVE → ORIENT). Resolution is fully specified on paper:
+- Gap A: `unified_osculator_base_b` — mechanical port of the existing base-10 theorem.
+- Gap B: `divisibility_rule` tactic — extended-Euclid osculator + least-period search,
+  side goals via `native_decide`, period hypothesis via `period_iff_orderOf_dvd_base_b`.
+
+ACT (writing + building the Lean) is **build-gated**: needs a Docker `lake build` to
+confirm the new theorem and the `elab`/macro compile. Deferred during the 2026-06-13
+verification blackout (Docker daemon down — `docker info` exit 124; Aristotle backend
+404 — both confirmed live this session). No Lean committed.

--- a/research/problems/divisibility-by-three-oq-01-oq-01/state.md
+++ b/research/problems/divisibility-by-three-oq-01-oq-01/state.md
@@ -1,25 +1,52 @@
 # Research State: divisibility-by-three-oq-01-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:49-07:00
-**Iteration**: 1
+**Since**: 2026-06-13
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+SURVEY complete. The OQ ("automated tactic generating + verifying divisibility rules
+for arbitrary d coprime to base b") is mostly already solved at the theorem level in
+the gallery. Two concrete remaining pieces identified; both are build-gated.
 
 ## Active Approach
-None yet.
+Resolve the OQ via existing gallery machinery + two additions:
+- **Gap A**: `unified_osculator_base_b` — port the proven base-10 `unified_osculator`
+  (`DivisibilityTruncationGeneralOQ01.lean`) to arbitrary base `b`. Mechanical (~15 lines);
+  same identity `b·(n/b + c·(n%b)) = n + (b·c−1)·(n%b)`.
+- **Gap B**: a `divisibility_rule b d` tactic (elab/macro) that computes the osculator
+  `c = b⁻¹ mod d` (extended Euclid) or the period `k` (least k>0 with b^k%d=1), emits
+  `unified_osculator_base_b` / `digit_block_rule_base_b`, and discharges side goals by
+  `native_decide`.
+
+Prior art already present:
+- `DivisibilityRulesOQ01OQ01OQ01.lean` — `digit_block_rule_base_b`,
+  `period_iff_orderOf_dvd_base_b`, `orderOf_base_b_is_minimal_period` (digit-block rule
+  ALREADY general in base b).
+- `DivisibilityTruncationGeneralOQ01.lean` — `unified_osculator`,
+  `neg_osculator_from_unified` (osculator rule, base 10).
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (survey only; no proof attempts)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Build-gated (verification blackout, 2026-06-13).** Both Gap A and Gap B need a
+  Docker `lake build` to confirm they compile (the tactic especially). Docker daemon
+  down (`docker info` exit 124) and Aristotle backend 404 — both confirmed live this
+  session. No Lean committed.
+
+## Key insight
+`orderOf (b : ZMod d)` is noncomputable, so the tactic cannot evaluate the period
+directly. It must search for the least `k>0` with `b^k % d = 1` externally and discharge
+`orderOf (b:ZMod d) ∣ k` via `period_iff_orderOf_dvd_base_b … (by native_decide)`. This
+witness-and-verify pattern is already used by hand in the gallery
+(`DivisibilityRulesOQ01OQ01OQ01.lean:150–165`).
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker recovers: implement Gap A (`unified_osculator_base_b`) first as the clean
+build milestone, then Gap B (the `divisibility_rule` tactic). See knowledge.md for the
+full design.

--- a/src/data/research/problems/divisibility-by-three-oq-01-oq-01.json
+++ b/src/data/research/problems/divisibility-by-three-oq-01-oq-01.json
@@ -1,0 +1,111 @@
+{
+  "slug": "divisibility-by-three-oq-01-oq-01",
+  "title": "Automated tactic for divisibility rules over arbitrary base b",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "For d coprime to base b, automate generation+verification of either the osculator rule (d ∣ n ↔ d ∣ (n/b + c·(n%b)) with b·c ≡ 1 mod d) or the digit-block rule (d ∣ n ↔ d ∣ (digits (b^k) n).sum with k = ord_d(b)).",
+    "plain": "Build a Lean tactic that, given a divisor d and a base b with gcd(b,d)=1, automatically produces and proves the appropriate divisibility rule (truncation/osculator rule, or block-digit-sum rule), generalizing the hand-written per-prime rules in the gallery.",
+    "whyMatters": [
+      "Unifies the gallery's ~5 hand-coded per-prime truncation proofs and per-modulus digit-sum proofs into one parametric, automatically-instantiated procedure.",
+      "Exercises Lean metaprogramming (elab/macro) on top of already-verified number-theory lemmas."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Base-10 osculator rule (parametric in osculator c): unified_osculator, neg_osculator_from_unified in DivisibilityTruncationGeneralOQ01.lean.",
+      "Arbitrary-base digit-block rule: digit_block_rule_base_b, period_iff_orderOf_dvd_base_b, orderOf_base_b_is_minimal_period in DivisibilityRulesOQ01OQ01OQ01.lean (already general in base b).",
+      "Per-prime instances (7,11,13,17,19) and per-modulus digit-sum rules in DivisibilityByThreeOQ01.lean."
+    ],
+    "open": [
+      "Gap A: base-b osculator theorem unified_osculator_base_b (mechanical port of the base-10 version; ~15 lines).",
+      "Gap B: the divisibility_rule b d tactic (elab/macro) that computes c via extended Euclid or the period k via least-k search, emits the rule, and discharges side goals by native_decide."
+    ],
+    "goal": "Close the OQ with (A) a base-b osculator theorem and (B) a tactic that auto-instantiates either rule family for any (b,d) with gcd(b,d)=1."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13",
+    "iteration": 2,
+    "focus": "Survey complete; resolution fully specified on paper. Both remaining pieces are build-gated by the 2026-06-13 verification blackout.",
+    "blockers": [
+      "Build-gated: Gap A and the tactic need a Docker lake build to confirm compilation. Docker daemon down (docker info exit 124); Aristotle backend 404 — both confirmed live 2026-06-13."
+    ],
+    "nextAction": "When Docker recovers: implement unified_osculator_base_b (clean first build milestone), then the divisibility_rule tactic. See research/problems/.../knowledge.md for the design.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "The OQ is mostly already solved at the theorem level. The digit-block rule is ALREADY general in base b (digit_block_rule_base_b); the osculator rule is proven for base 10 (unified_osculator). Remaining: (A) a mechanical base-b port of the osculator theorem, and (B) the actual tactic that auto-computes the osculator c (extended Euclid) or the period k (least-k search) and assembles a checked proof term. The substantive mathematics exists; the OQ's remaining content is metaprogramming + one port, not a new theorem.",
+    "builtItems": [],
+    "insights": [
+      "Both classical rule families are formalized in the gallery: osculator (base 10, parametric in c) and digit-block (already arbitrary base b, via multiplicative order).",
+      "KEY: orderOf (b : ZMod d) is noncomputable, so the tactic cannot evaluate the period. It must search externally for the least k>0 with b^k % d = 1, then discharge orderOf (b:ZMod d) ∣ k via period_iff_orderOf_dvd_base_b … (by native_decide). This witness-and-verify pattern is already used by hand in DivisibilityRulesOQ01OQ01OQ01.lean:150-165.",
+      "In Lean the produced proof term IS the verification, so the tactic's 'generate' and 'verify' steps coincide.",
+      "The existing leanFiles/relatedProofs for this slug point only at the DivisibilityByThreeOQ01 parent; the load-bearing prior art is in DivisibilityTruncationGeneral*.lean and DivisibilityRulesOQ01OQ01OQ01.lean."
+    ],
+    "mathlibGaps": [
+      "orderOf is noncomputable in Mathlib — forces the witness-period + native_decide route rather than direct evaluation."
+    ],
+    "nextSteps": [
+      "Gap A: prove unified_osculator_base_b (b d c n) (IsCoprime d b) (d ∣ b*c-1): d ∣ n ↔ d ∣ (n/b + c*(n%b)), identity b·(n/b + c·(n%b)) = n + (b·c−1)·(n%b).",
+      "Gap B: implement divisibility_rule b d as an elab/macro: coprimality check, extended-Euclid osculator or least-period search, emit unified_osculator_base_b / digit_block_rule_base_b, discharge side goals by native_decide/decide/norm_num."
+    ]
+  },
+  "tags": [
+    "number-theory",
+    "divisibility",
+    "digit-sum",
+    "modular-arithmetic",
+    "three",
+    "metaprogramming",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "divisibility-by-3-oq-01",
+    "divisibility-by-three-oq-01",
+    "divisibility-by-three-oq-01-oq-02",
+    "divisibility-rules-oq-01-oq-01-oq-01",
+    "divisibility-truncation-general-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Nat.modEq_digits_sum",
+      "orderOf",
+      "ZMod.unitOfCoprime",
+      "ZMod.pow_totient",
+      "Nat.gcdA"
+    ]
+  },
+  "started": "2026-06-10T18:04:48.641Z",
+  "lastUpdate": "2026-06-13",
+  "significance": 6,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/DivisibilityTruncationGeneralOQ01.lean",
+      "filename": "DivisibilityTruncationGeneralOQ01.lean",
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityTruncationGeneralOQ01.lean"
+    },
+    {
+      "path": "Proofs/DivisibilityRulesOQ01OQ01OQ01.lean",
+      "filename": "DivisibilityRulesOQ01OQ01OQ01.lean",
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityRulesOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/DivisibilityByThreeOQ01.lean",
+      "filename": "DivisibilityByThreeOQ01.lean",
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityByThreeOQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

SURVEY (OBSERVE→ORIENT) of `divisibility-by-three-oq-01-oq-01`: *"Extend to an automated tactic that generates and verifies divisibility rules for arbitrary divisors d coprime to a given base b."*

**Central finding:** the underlying mathematics is largely already formalized in the gallery, so the OQ's remaining content is metaprogramming + one mechanical port, not a new theorem.

- **Already proven:** the digit-block rule is *already general in base b* (`digit_block_rule_base_b`, `period_iff_orderOf_dvd_base_b`, `orderOf_base_b_is_minimal_period` in `DivisibilityRulesOQ01OQ01OQ01.lean`), and the osculator rule is parametric for base 10 (`unified_osculator`, `neg_osculator_from_unified` in `DivisibilityTruncationGeneralOQ01.lean`).
- **Gap A:** `unified_osculator_base_b` — a verbatim base-b port of the base-10 osculator theorem (~15 lines; identity `b·(n/b + c·(n%b)) = n + (b·c−1)·(n%b)`).
- **Gap B:** the `divisibility_rule b d` tactic — compute the osculator `c = b⁻¹ mod d` (extended Euclid) or the period `k` (least k>0 with `b^k % d = 1`), emit the rule, discharge side goals by `native_decide`.

**KEY subtlety:** `orderOf (b : ZMod d)` is noncomputable, so the tactic cannot evaluate the period directly — it must search for the witness period externally and discharge `orderOf (b:ZMod d) ∣ k` via `period_iff_orderOf_dvd_base_b … (by native_decide)`. This witness-and-verify pattern is already used by hand at `DivisibilityRulesOQ01OQ01OQ01.lean:150-165`.

## Deliverables
- `research/problems/divisibility-by-three-oq-01-oq-01/{knowledge,state}.md` — full survey + design
- `src/data/research/problems/divisibility-by-three-oq-01-oq-01.json` — seeded knowledge fields (was absent on main; additive)

## Status
Build-gated by the 2026-06-13 verification blackout (Docker daemon down — `docker info` exit 124; Aristotle backend 404, both confirmed live this session). No Lean committed. ACT deferred until Docker recovers.

## Test plan
- [ ] Doc/JSON only — no build. When Docker is back: implement Gap A as the clean first build milestone, then Gap B.