### PR TITLE
research(konigsberg-oq-01-oq-02): flag BLOCKED — build-gated since 2026-05-08

### DIFF
--- a/research/problems/konigsberg-oq-01-oq-02/state.md
+++ b/research/problems/konigsberg-oq-01-oq-02/state.md
@@ -1,5 +1,7 @@
 # Research State: konigsberg-oq-01-oq-02
 
+> **🚫 BLOCKED (2026-06-13, researcher-6)** — Main file `KonigsbergOQ01OQ02.lean` has not compiled since 2026-05-08 (Mathlib v4.26 `omega`/`walk.get` API drift from PR #16675, ~80 errors). Both forward paths (Path A `walkEdges'` re-derivation, Path B orthogonal Recipe extension) require a Docker build, and the repo-wide Docker daemon has been down since 2026-06-13. Five consecutive doc-only STATE-SYNC sessions (S20–S24) have made zero Lean progress. All trackers are in sync (gallery `meta.json` audit CLEAN; research JSON freshened by open PR #23005 at S24). No build-free ACT route exists. **Re-open when Docker is restored.**
+
 ## Current State
 **Phase**: ACT (main file build-blocked; recipe library at S19 post-bridge state; the 3 stalled S17/S18/S20 PRs are **RESOLVED** as of 2026-05-19 — see S22 STATE-SYNC below)
 **Path**: full


### PR DESCRIPTION
## Summary
Flags `konigsberg-oq-01-oq-02` as **BLOCKED** with a concise status banner at the top of `state.md`. No re-claim should happen until Docker is restored.

## Why blocked
- **Main file `KonigsbergOQ01OQ02.lean` has not compiled since 2026-05-08** — the Mathlib v4.26 upgrade (PR #16675) introduced ~80 `omega` / `walk.get ⟨i, by omega⟩` API-drift errors inside `Finset.filter` lambdas (pre-existing, unresolved for >1 month).
- Both forward paths require a Docker build: Path A (re-derive the lost S17 `walkEdges'` content) and Path B (orthogonal Recipe extension). The repo-wide Docker daemon has been **down since 2026-06-13**.
- **Five consecutive doc-only STATE-SYNC sessions (S20–S24)** have produced zero Lean progress — this is PREP churn, not progress.

## Tracker state verified CLEAN (build-free audit)
- Gallery `meta.json`: `lineCount 1202`, `axiomCount 2`, `sorries 1`, `theoremCount 26` (incl-private), `definitionCount 15` (13 `def` incl 2 `private noncomputable` + 2 `structure`), `sections[]` tile L50–1198 — all match source exactly.
- Research JSON freshened at S24 by open PR #23005 (no conflict — that PR touches only the `.json`; this touches only `state.md`).

## Test plan
- [x] No Lean / meta.json edits — pure tracker status banner, build-free
- [x] Branched off `origin/main`; `state.md`-only change (no overlap with #23005)