### PR TITLE
research(cevas-oq-02-oq-01-oq-02-oq-01): SURVEY — projective Ceva unification via Cayley-Klein

### DIFF
--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/knowledge.md
@@ -1,21 +1,193 @@
 # Knowledge Base: cevas-theorem-oq-02-oq-01-oq-02-oq-01
 
-Insights accumulated during research on this problem.
+**OQ**: Formalize the projective unification — prove all three cases (spherical,
+Euclidean, hyperbolic) from a *single* projective Ceva theorem via the Klein model.
+
+Parent: `cevas-theorem-oq-02-oq-01-oq-02` (Hyperbolic Ceva via Weight Parameters,
+`proofs/Proofs/CevasTheoremOQ02OQ01OQ02.lean`).
+
+Phase: OBSERVE → ORIENT. Build-free SURVEY (Docker down + Aristotle 404,
+2026-06-13 verification blackout). No Lean committed.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent file already proves the three classical Ceva theorems share **one
+algebraic concurrency criterion**:
+
+> cevians `AD, BE, CF` concur  ⟺  `αD·αE·αF = βD·βE·βF`  ⟺
+> `(βD/αD)(βE/αE)(βF/αF) = 1`        (`universal_weight_balance`, parent L254)
+
+and that each geometry's metric side-ratio collapses to the **same** weight ratio:
+
+| Geometry   | bilinear form `m = ⟨B,C⟩`     | ratio fn | side ratio `t(BD)/t(DC)`                       |
+|------------|-------------------------------|----------|-----------------------------------------------|
+| Spherical  | `+x₁y₁+x₂y₂+x₃y₃`, `m=cos d∈(−1,1)` | `sin`    | `β√(1−m²)/n ÷ α√(1−m²)/n = β/α`                |
+| Euclidean  | degenerate, `m = 1`           | identity | `β/α` (barycentric, directly)                 |
+| Hyperbolic | `+x₁y₁+x₂y₂−x₃y₃`, `m=cosh d>1`     | `sinh`   | `β√(m²−1)/n ÷ α√(m²−1)/n = β/α`                |
+
+with `n² = α² + 2αβm + β²` in **all three** cases.
+
+**What the parent does NOT do** — and what this OQ asks for: the parent proves the
+three side-ratio identities *separately* (one structure `HyperbolicCevianConfig`
+for the hyperbolic case, parallel reasoning for the spherical sibling
+`cevas-theorem-oq-02-oq-01`) and then observes the criterion matches. It never
+exhibits **one geometric object** from which all three descend. The OQ wants the
+genuine unification: a single projective Ceva theorem in the **Cayley–Klein /
+Beltrami–Klein model** whose three specializations *are* the three geometries.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### 1. The right ambient object is the Cayley–Klein plane
+
+All three constant-curvature geometries are **Cayley–Klein geometries**: the
+projective plane `ℝP²` equipped with an *absolute conic* `Q` (the "absolute"),
+with metric defined by cross-ratio against `Q`. Choosing `Q` selects the geometry:
+
+- `Q : x²+y²+z² = 0` (empty over ℝ, the imaginary conic) → **elliptic/spherical**.
+- `Q` = the line at infinity doubled (degenerate `z²=0`) → **Euclidean**.
+- `Q : x²+y²−z² = 0` (the real Klein-disk boundary circle) → **hyperbolic**.
+
+Encode all three by a single **curvature sign** `κ ∈ {+1, 0, −1}` (ell./eucl./hyp.)
+and the symmetric bilinear form `diag(1,1,−κ)` (so the third-coordinate sign is
+`−κ`: `κ=−1` gives Minkowski `diag(1,1,1)`-rotation, `κ=+1` gives the elliptic
+`diag(1,1,−1)`; the relevant scalar output is `m = ⟨B,C⟩_κ`, see below).
+
+The Cayley–Klein distance between unit points `B,C` is governed by the
+curvature-`κ` trig function `cos_κ` via `m = ⟨B,C⟩_κ = cos_κ(d(B,C))`:
+
+```
+κ = +1 (spherical):  cos_κ = cos,   m = cos d ∈ (−1,1),   1 − m² > 0
+κ =  0 (Euclidean):  limit,         m = 1,                1 − m² = 0
+κ = −1 (hyperbolic): cos_κ = cosh,  m = cosh d > 1,       1 − m² < 0
+```
+
+### 2. A "Cevian point" is a *projective* point, weight-parametrised
+
+In every Cayley–Klein model a cevian point `D` on geodesic `BC` is the
+**projective** point `D ∝ α·B + β·C` (homogeneous coordinates in the `{B,C}`
+basis). This is *geometry-independent* — pure projective incidence. The metric
+only enters when we measure `d(B,D)`, `d(D,C)`.
+
+Normalising `D` to the model surface uses the **single** norm
+`n = √(α² + 2αβm + β²)`, valid for every `κ` (it is just `⟨αB+βC, αB+βC⟩_κ`
+expanded, the cross term `2αβ⟨B,C⟩_κ = 2αβm`). This is *the same `n_sq`* the
+parent already defines.
+
+### 3. The universal side-ratio (the crux, one identity for all κ)
+
+The curvature-`κ` "sine" satisfies `sin_κ²(d) = 1 − m²` up to the sign that `√|·|`
+absorbs. The side ratio is
+
+```
+t_κ(BD)/t_κ(DC) = ( β·√|1 − m²| / n ) / ( α·√|1 − m²| / n ) = β/α        (★)
+```
+
+**The geometry-specific factor `√|1 − m²|/n` is common to numerator and
+denominator and cancels — for every κ, including the Euclidean limit** where
+`√|1−m²|→0` but the *ratio* survives (barycentric: `BD/DC = β/α`). This (★) is the
+single fact the parent proves three times; the OQ asks to prove it **once**,
+abstractly, with `g := √|1−m²|/n` a free nonzero common factor.
+
+### 4. The single projective Ceva theorem
+
+> **Projective Ceva (Cayley–Klein form).** Fix any κ and absolute form `⟨·,·⟩_κ`.
+> For triangle `ABC` with cevian points `D∝α_D B+β_D C`, `E∝α_E C+β_E A`,
+> `F∝α_F A+β_F B`, the cevians `AD, BE, CF` are concurrent **iff**
+> `α_D α_E α_F = β_D β_E β_F`. The metric side-ratio `t_κ` along each side equals
+> the weight ratio `β/α` by (★), independent of κ.
+
+The concurrency half is a **projective incidence statement** — the affine Ceva
+theorem read in homogeneous `{B,C}/{C,A}/{A,B}` coordinates, where the cevian
+weights *are* the barycentric coordinates of `D`. It is invariant under the
+projective group preserving `Q` (= the isometry group of the geometry). Proving it
+once projectively gives all three metric Ceva theorems as corollaries by plugging
+in `κ = +1, 0, −1`. This is the precise sense in which "all three cases follow
+from a single projective Ceva theorem via the Klein model".
+
+### 5. Why the Klein (Beltrami–Klein) model specifically
+
+In the Beltrami–Klein disk, hyperbolic geodesics are **Euclidean chords**, so a
+hyperbolic cevian and its Euclidean shadow are the *same projective line*.
+Concurrency of three chords is a projective property visible in the model picture
+itself — the Klein model is exactly the one in which "hyperbolic Ceva = projective
+Ceva of chords" is literal, with no transcendental detour. The spherical case is
+the antipodal-quotient (elliptic) Cayley–Klein with the imaginary absolute; the
+Euclidean case is the degenerate `κ→0` contraction. One model, three absolutes.
+
+---
+
+## Lean Formalisation Plan
+
+Mathlib has **no** Cayley–Klein / projective-metric API (no `CayleyKlein`, no
+projective absolute-conic metric). So this is a *definitional* build, not
+API-wiring. Reuse the parent's algebra verbatim.
+
+**Step A — generalise the config.** Replace `HyperbolicCevianConfig` (which
+hard-codes `1 < m`) with a κ-carrying version whose single positivity hypothesis
+is `n² > 0`:
+
+```lean
+structure CKCevianConfig where
+  κ : ℝ                       -- curvature sentinel (+1 / 0 / −1)
+  m : ℝ                       -- ⟨B,C⟩_κ
+  α β : ℝ
+  hα : 0 < α
+  hβ : 0 < β
+  hn : 0 < α^2 + 2*α*β*m + β^2 -- n² > 0  (replaces the per-geometry m-bound)
+```
+
+`n_sq`, `n_sq_pos` carry over (the parent's `n_sq_pos` only used `α,β>0, m>1`;
+with the explicit `hn` field it is immediate — and `hn` is provable from each
+geometry's `m`-bound, so no strength is lost).
+
+**Step B — the one abstract ratio lemma.** Factor (★) as geometry-free algebra:
+
+```lean
+theorem ck_ratio_cancel (g α β : ℝ) (hg : g ≠ 0) (hα : α ≠ 0) :
+    (β * g) / (α * g) = β / α := by field_simp
+```
+
+i.e. `hyp_sinh_ratio` with the `√(m²−1)/n` factor abstracted to `g`. This single
+identity replaces the three per-geometry derivations.
+
+**Step C — three instantiations (corollaries).** Define
+`gSph m n = Real.sqrt (1 - m^2) / n`, `gHyp m n = Real.sqrt (m^2 - 1) / n`,
+`gEuc = 1` and feed each to `ck_ratio_cancel`, recovering `sin`-ratio,
+`sinh`-ratio, identity-ratio = `β/α`. The Euclidean case is the `m=1` barycentric
+limit (`gEuc` constant), so (★) holds without a `√` at all.
+
+**Step D — concurrency.** Reuse the parent's `universal_weight_balance`
+*unchanged* (already κ-free) to close
+`∏(β/α)=1 ⟺ α_Dα_Eα_F = β_Dβ_Eβ_F`. Top theorem
+`projective_ceva_unification` bundles Steps B–D and exhibits the three classical
+Ceva theorems as `example`s by instantiating `κ`.
+
+**Estimated size**: ~100–160 LOC, mostly the structure + three `Real.sqrt`
+factor definitions; the hard mathematical content (the cancellation, the
+criterion) is already proved in the parent and reused. Tractability 8/10 is fair
+*for the algebra*; the only genuine modelling decision is how literally to encode
+the absolute conic (recommended: keep `κ` a sentinel `ℝ` and the bilinear form
+implicit via `m`, rather than building full `ℝP²` projective geometry — the OQ is
+about the *unification of the ratio/criterion*, which lives entirely in the
+`(m, α, β, n)` algebra).
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Building genuine `ℝP²` + absolute-conic projective geometry in Mathlib.**
+  Unnecessary: the concurrency criterion and side-ratio are already fully captured
+  by the scalar `(m, α, β)` data. Encoding the full projective plane would
+  re-derive incidence (`Projectivization`) with no payoff for this OQ. Keep the
+  unification at the algebraic/`m`-parameter layer.
+- **Forcing one `m`-bound for all geometries.** Spherical needs `m∈(−1,1)`,
+  hyperbolic `m>1`; there is no common interval. Resolution: drop the `m`-bound and
+  carry `n² > 0` as the single hypothesis (Step A `hn`) — exactly the condition
+  both bounds were there to guarantee, and what every downstream proof uses.
+- **Treating Euclidean as a separate `√`-bearing case.** It is the `√|1−m²|→0`
+  degeneration; writing `sin_0` as a nonzero `√` factor fails. Encode Euclidean
+  with `gEuc = 1` (barycentric ratio `β/α`, no radical).

--- a/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/state.md
+++ b/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01/state.md
@@ -1,25 +1,47 @@
 # Research State: cevas-theorem-oq-02-oq-01-oq-02-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:48-07:00
-**Iteration**: 1
+**Since**: 2026-06-13 (researcher-9 survey)
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Paper survey complete. The projective unification resolves cleanly via the
+**Cayley–Klein model**: all three Ceva theorems (spherical/Euclidean/hyperbolic)
+descend from one projective concurrency criterion, with the metric side-ratio
+collapsing to the weight ratio `β/α` through a single curvature-independent
+cancellation (★). See knowledge.md.
 
 ## Active Approach
-None yet.
+Cayley–Klein unification: encode curvature by a sentinel `κ ∈ {+1,0,−1}`, carry the
+parent's `n² = α²+2αβm+β²` and the abstract common factor `g = √|1−m²|/n`. Prove
+the cancellation `(βg)/(αg)=β/α` ONCE; instantiate κ to recover sin/sinh/identity
+ratios. Close concurrency by reusing the parent's already-κ-free
+`universal_weight_balance`.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (survey only; no Lean built)
 - Current approach attempts: 0
-- Approaches tried: 0
+- Approaches tried: 1 (Cayley–Klein algebraic unification — viable)
 
 ## Blockers
-None.
+- **Verification blackout (2026-06-13)**: Docker daemon down (`docker info` exit
+  124) and Aristotle backend 404. No Lean build possible, so the ~100–160 LOC
+  formalisation (knowledge.md "Lean Formalisation Plan") is build-gated. Survey is
+  build-free and complete.
 
-## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+## Next Action (when Docker recovers)
+1. Add `CKCevianConfig` (κ-carrying, single `hn : n²>0` hypothesis) to a new
+   `CevasTheoremOQ02OQ01OQ02OQ01.lean`, importing/mirroring the parent's algebra.
+2. Prove `ck_ratio_cancel` (one `field_simp`).
+3. Instantiate `gSph / gHyp / gEuc` → three corollary side-ratio lemmas.
+4. Reuse `universal_weight_balance` for concurrency; bundle into
+   `projective_ceva_unification` with three `example`s (κ = +1/0/−1).
+5. Build via `./proofs/scripts/docker-build.sh Proofs.CevasTheoremOQ02OQ01OQ02OQ01`,
+   then add gallery `src/data/proofs/...` entry.
+
+## Dead Ends (see knowledge.md)
+- Full `ℝP²` projective-geometry encoding (unnecessary; algebra suffices).
+- A single common `m`-interval across geometries (none exists; use `n²>0`).
+- Euclidean as a `√`-bearing case (it is the `√|1−m²|→0` limit; use `gEuc=1`).

--- a/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json
@@ -1,0 +1,65 @@
+{
+  "id": "cevas-theorem-oq-02-oq-01-oq-02-oq-01",
+  "name": "Projective Unification of Ceva's Theorem via the Klein Model",
+  "status": "surveyed",
+  "phase": "ORIENT",
+  "problemStatement": {
+    "formal": "Exhibit a single projective (Cayley-Klein) Ceva theorem from which the spherical (sin), Euclidean (identity), and hyperbolic (sinh) cevian side-ratio identities and the common concurrency criterion alphaD*alphaE*alphaF = betaD*betaE*betaF all follow as specializations of a curvature sign kappa in {+1,0,-1}.",
+    "plain": "The parent proof proves the three classical Ceva theorems (spherical, Euclidean, hyperbolic) share one algebraic concurrency criterion, but derives each metric side-ratio separately. This OQ asks for the genuine geometric unification: one projective Ceva theorem in the Beltrami-Klein / Cayley-Klein model whose three specializations ARE the three geometries. The survey resolves it on paper: all three are Cayley-Klein geometries selected by an absolute conic (curvature sign kappa); a cevian point is the projective point alpha*B + beta*C; and the metric side-ratio collapses to beta/alpha via one curvature-independent cancellation of the common factor sqrt|1-m^2|/n.",
+    "whyMatters": [
+      "Replaces three parallel per-geometry side-ratio derivations with a single projective statement, exposing the projective-incidence core of Ceva concurrency.",
+      "Demonstrates the Cayley-Klein model as the right ambient object unifying constant-curvature geometries in the gallery.",
+      "The unification reuses the parent's existing kappa-free universal_weight_balance, so concurrency needs no new proof."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent CevasTheoremOQ02OQ01OQ02.lean proves the hyperbolic sinh-ratio = beta/alpha and the concurrency criterion, plus the geometry-independent universal_weight_balance.",
+      "The norm n^2 = alpha^2 + 2*alpha*beta*m + beta^2 is identical in all three geometries (it is <alpha*B+beta*C, alpha*B+beta*C>_kappa)."
+    ],
+    "open": [
+      "No single Lean object yet derives all three cases; the parent proves them separately. The unified projective theorem (CKCevianConfig + ck_ratio_cancel + three kappa instantiations) is build-gated by the 2026-06-13 verification blackout (Docker down, Aristotle 404)."
+    ],
+    "goal": "Formalize one CKCevianConfig (curvature sentinel kappa, single hypothesis n^2 > 0) and a single cancellation lemma ck_ratio_cancel : (beta*g)/(alpha*g) = beta/alpha, then recover spherical/Euclidean/hyperbolic side-ratios as corollaries (g = sqrt(1-m^2)/n, 1, sqrt(m^2-1)/n) and close concurrency by reusing universal_weight_balance."
+  },
+  "tags": [
+    "geometry",
+    "cevas-theorem",
+    "projective-geometry",
+    "cayley-klein",
+    "non-euclidean-geometry",
+    "hyperbolic-geometry",
+    "triangle-geometry",
+    "survey"
+  ],
+  "knowledge": {
+    "insights": [
+      "All three constant-curvature geometries are Cayley-Klein geometries: projective plane RP^2 with an absolute conic Q selected by curvature sign kappa in {+1 (spherical/elliptic), 0 (Euclidean), -1 (hyperbolic)}.",
+      "A cevian point is the projective point D ~ alpha*B + beta*C; concurrency of cevians is a projective-incidence fact, invariant under the isometry group (= projective stabilizer of Q), hence geometry-independent.",
+      "The metric side-ratio t_kappa(BD)/t_kappa(DC) = (beta*g)/(alpha*g) = beta/alpha with common factor g = sqrt|1-m^2|/n cancelling for every kappa; this is the single identity replacing the parent's three derivations.",
+      "Euclidean is the degenerate kappa->0 limit where sqrt|1-m^2| -> 0 but the ratio survives (barycentric beta/alpha); encode it with g = 1, not a vanishing radical.",
+      "No common m-interval exists across geometries (spherical m in (-1,1), hyperbolic m>1); the right single hypothesis is n^2 > 0, which is exactly what both per-geometry m-bounds guaranteed.",
+      "Mathlib has no Cayley-Klein / projective-metric API, so the formalization is definitional (CKCevianConfig + three sqrt factors), not API-wiring; the hard algebra is already in the parent and reused.",
+      "The Beltrami-Klein model is the natural one: hyperbolic geodesics are Euclidean chords, so 'hyperbolic Ceva = projective Ceva of chords' is literal with no transcendental detour."
+    ],
+    "builtItems": [],
+    "deadEnds": [
+      "Building genuine RP^2 + absolute-conic projective geometry in Mathlib: unnecessary, the scalar (m, alpha, beta) data captures the criterion and side-ratio.",
+      "Forcing one m-bound for all geometries: none exists; carry n^2 > 0 instead.",
+      "Treating Euclidean as a separate sqrt-bearing case: it is the sqrt|1-m^2| -> 0 limit; use g = 1."
+    ]
+  },
+  "leanFiles": [
+    {
+      "path": "Proofs/CevasTheoremOQ02OQ01OQ02.lean",
+      "filename": "CevasTheoremOQ02OQ01OQ02.lean",
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/CevasTheoremOQ02OQ01OQ02.lean"
+    }
+  ],
+  "relatedProofs": [
+    "cevas-theorem",
+    "cevas-theorem-oq-02-oq-01",
+    "cevas-theorem-oq-02-oq-01-oq-02"
+  ]
+}


### PR DESCRIPTION
## Summary

Build-free **SURVEY** (OBSERVE→ORIENT) of the open question *"Formalize the projective unification: prove all three cases from a single projective Ceva theorem via the Klein model"* (parent `cevas-theorem-oq-02-oq-01-oq-02`, Hyperbolic Ceva via Weight Parameters).

The parent proves the three classical Ceva theorems (spherical/sin, Euclidean/identity, hyperbolic/sinh) share one algebraic concurrency criterion, but derives each metric side-ratio **separately**. This survey resolves the genuine geometric unification on paper:

- All three are **Cayley–Klein geometries**, selected by an absolute conic ↔ curvature sentinel `κ ∈ {+1,0,−1}`.
- A cevian point is the **projective** point `α·B + β·C`; concurrency is a projective-incidence fact, so the criterion `αD·αE·αF = βD·βE·βF` is geometry-independent (reuses the parent's already-`κ`-free `universal_weight_balance`).
- The metric side-ratio collapses to `β/α` through **one** curvature-independent cancellation of the common factor `√|1−m²|/n`, replacing three per-geometry derivations.
- Includes a concrete ~100–160 LOC Lean plan: `CKCevianConfig` (single hypothesis `n²>0`), one `ck_ratio_cancel` lemma, three `κ` instantiations as corollaries.

## Why build-free
2026-06-13 verification blackout — Docker daemon down (`docker info` exit 124) and Aristotle backend 404. The Lean formalization is build-gated; no Lean committed.

## Files
- `research/problems/.../knowledge.md` — full survey (Cayley–Klein unification, the cancellation (★), Lean plan, dead ends)
- `research/problems/.../state.md` — phase OBSERVE→ORIENT, blocker + next actions
- `src/data/research/problems/cevas-theorem-oq-02-oq-01-oq-02-oq-01.json` — seeded (absent on `main` → additive)

## Test plan
- [x] `jq empty` validates the seeded JSON
- [ ] Build-gated Lean formalization deferred until Docker recovers (no `lake build` run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)