### PR TITLE
research(binomial-clt-oq-03): AUDIT — reclassify formalized/wip → axiomatized/axiom

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -6,7 +6,7 @@
   "meta": {
     "author": "Formalized in Lean 4 with Mathlib",
     "date": "2026-05-08",
-    "status": "formalized",
+    "status": "axiomatized",
     "tags": [
       "probability",
       "central-limit-theorem",
@@ -16,7 +16,7 @@
       "convergence-in-distribution"
     ],
     "proofRepoPath": "Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean",
-    "badge": "wip",
+    "badge": "axiom",
     "sorries": 0,
     "dateAdded": "2026-05-08",
     "axiomCount": 1,


### PR DESCRIPTION
## Summary

Build-free meta-correctness audit of `binomial-theorem-oq-02-oq-01-oq-01-oq-03` (Multinomial Marginal Central Limit Theorem) during the Docker verification blackout.

The entry is a **complete axiomatized formalization**: 0 sorries, 1 deliberate axiom (`binomial_clt_pointwise` = the classical de Moivre-Laplace theorem, 1733/1812). It was mislabeled `status: "formalized"` / `badge: "wip"`.

Per the **CLAUDE.md Axiom Integrity Policy**:
- `formalized` ⇒ *"Has sorries remaining"* — **false here** (0 sorries).
- `axiomatized` / `axiom` ⇒ *"Has axiom declarations OR structure-encoded assumptions"* — **true here** (1 axiom declaration).

This matches the convention of the cross-referenced sibling `central-limit-theorem` (0 sorries, 12 axioms → `axiomatized`/`axiom`), which this entry "specializes."

## Change
- `meta.status`: `formalized` → `axiomatized`
- `meta.badge`: `wip` → `axiom`

No Lean source change.

## Source audit (CLEAN)
All meta.json counts match `proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ03.lean`:
- `axiomCount` = 1 ✓ (`binomial_clt_pointwise`, line 379)
- `theoremCount` = 16 ✓
- `definitionCount` = 3 ✓
- `sorries` = 0 ✓ (the two `sorry` grep hits are in the header prose comment, lines 62/85)
- `lineCount` = 712 ✓

## Note on remaining work
Discharging the de Moivre-Laplace axiom via a Portmanteau bridge (Sessions 6–8 scaffolding) requires writing and building new Lean — Docker-gated under the current verification blackout. `axiomatized` is the correct stable classification regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)