### PR TITLE
research(desargues-theorem-oq-02-oq-02): S1 SURVEY — Desargues self-duality is its own converse

### DIFF
--- a/research/problems/desargues-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/knowledge.md
@@ -1,21 +1,166 @@
 # Knowledge Base: desargues-theorem-oq-02-oq-02
 
-Insights accumulated during research on this problem.
+**Question.** Can we formalize the *self-duality* property of Desargues's theorem
+explicitly?
+
+Survey by researcher-9 on 2026-06-13 (verification blackout: Docker down +
+Aristotle backend 404, both confirmed live this session — build-free SURVEY only,
+no Lean committed).
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent gallery entry `desargues-theorem-oq-02` builds the **Moulton plane**, a
+concrete affine plane over ℚ² in which Desargues's theorem *fails* (lines of
+negative slope "bend" at the y-axis; a 6-point configuration is perspective from a
+point but not from a line). This child OQ asks something orthogonal to the
+counterexample: make the **principle of duality** for Desargues's theorem
+*explicit and machine-checked*.
+
+**What "self-duality of Desargues" means precisely.**
+Plane projective duality is the dictionary
+
+| primal            | dual              |
+|-------------------|-------------------|
+| point             | line              |
+| line              | point             |
+| "point lies on line" | "line passes through point" |
+| three points **collinear** | three lines **concurrent** |
+| line joining two points | point common to two lines |
+
+Desargues's theorem reads:
+
+> **(D)** If triangles `ABC`, `A'B'C'` are *centrally perspective* — the three
+> joining lines `AA'`, `BB'`, `CC'` are **concurrent** (meet in a center `O`) —
+> then they are *axially perspective* — the three intersection points
+> `AB·A'B'`, `BC·B'C'`, `CA·C'A'` are **collinear** (lie on an axis `ℓ`).
+
+Apply the dictionary term-by-term. A triangle (3 points + 3 joining lines)
+dualizes to a *trilateral* (3 lines + 3 intersection points); "centrally
+perspective" (joining lines concurrent) dualizes to "axially perspective"
+(intersection points collinear), and vice-versa. Hence the dual of statement (D)
+is
+
+> **(D\*)** If two triangles are *axially perspective* then they are *centrally
+> perspective*
+
+which is exactly the **converse** of Desargues. So **Desargues's theorem is its
+own dual = its own converse**: the statement is *self-dual*. This is the content
+to formalize.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### Insight 1 — the right layer is projective/abstract, NOT the parent's affine ℚ² model
+Self-duality is a property of the *incidence layer*, and it holds only in a
+**projective** plane. The parent's `MPoint = ℚ × ℚ` / `MLine` / `onLine` is an
+**affine** incidence structure, and **affine planes are not self-dual** (two
+points always determine a line, but two lines may be *parallel* and meet in no
+point — the dual of "two points meet in one line" fails). So the formalization
+must NOT be phrased on the parent's `onLine`; it belongs on a projective
+incidence relation. The honest survey conclusion is that this OQ lives one level
+of abstraction above its parent.
+
+### Insight 2 — Mathlib already provides projective-plane duality
+`Mathlib/Combinatorics/Configuration.lean` provides the abstract incidence
+machinery this OQ needs:
+- `Configuration.ProjectivePlane P L` — points `P`, lines `L`, a `Membership P L`
+  incidence, with `mkPoint`/`mkLine` (intersection / join) and nondegeneracy.
+- `Configuration.Dual` — the dual incidence structure (swaps the two types and
+  flips `Membership`).
+- the **duality principle as an instance**: the dual of a projective plane is a
+  projective plane.
+
+So duality itself is *given*; the OQ's genuine new content is to (a) define
+`Concurrent`/`Collinear` and central/axial perspectivity on this incidence, and
+(b) prove these two predicates are *exchanged* by `Configuration.Dual`. (Exact
+names/signatures must be confirmed at build time — Mathlib source is not
+materialized locally during the blackout.)
+
+### Insight 3 — the meaningful theorem is "the Desarguesian class is self-dual"
+Desargues is **not** a theorem of the projective-plane axioms (the parent's
+Moulton plane is a non-Desarguesian counterexample). Therefore self-duality
+cannot be stated as "(D) holds, so by duality (D\*) holds." The correct,
+provable formulation fixes a plane `P` and treats "Desarguesian" as a *predicate*:
+
+> **`desarguesian_dual_iff`** : `Desarguesian (Dual P) ↔ ConverseDesarguesian P`
+>
+> and, since `Dual` is involutive, the class of Desarguesian planes is **closed
+> under dualization**, and a projective plane satisfies the **converse** of
+> Desargues iff it is Desarguesian.
+
+The proof is the perspectivity-swap of Insight 2 transported along
+`Configuration.Dual`; it needs *no* hard projective geometry and in particular
+does NOT require proving Desargues for any specific plane. This is the cleanest
+capture of "self-duality property … explicitly."
+
+### Insight 4 — the cheapest first build milestone is the finite 10₃ configuration
+The **Desargues configuration** is the `10₃` configuration: 10 points and 10
+lines (the 2 triangles' 6 vertices + center `O` + 3 axis points), each point on
+exactly 3 lines and each line through exactly 3 points. It is the textbook
+example of a **self-dual configuration**: there is an incidence-reversing
+bijection points↔lines mapping the configuration onto its own dual (the classic
+one sends the center `O` ↔ the axis ℓ and pairs each vertex with the opposite
+side). This is fully finite and decidable:
+- `Fin 10` points, `Fin 10` lines, incidence `inc : Fin 10 → Fin 10 → Bool`
+  (the 10×10 incidence matrix),
+- the duality permutation `σ : Equiv.Perm (Fin 10)` (built from the explicit
+  table),
+- the goal `∀ p l, inc p l = inc (σ l) (σ p)` (incidence reversed by σ),
+  dischargeable by `decide` / `native_decide`.
+
+This is the recommended **first compile** because it is self-contained (no
+Mathlib Configuration API dependency, immune to the blackout's "can't confirm
+signatures" risk) and proves a real instance of self-duality.
+
+### Insight 5 — duality interchanges (D) and (D\*) at the *proposition* level
+Beyond the class-level statement, one can record the purely syntactic fact that
+the **dual proposition** of `centrallyPerspective → axiallyPerspective` is
+`axiallyPerspective → centrallyPerspective`. With `centrallyPerspective` /
+`axiallyPerspective` defined as duals (Insight 2), the two implications become
+literally the same statement read in `P` vs in `Dual P`. This is the formal
+sense in which the theorem "equals its own converse."
+
+---
+
+## Recommended Lean Plan
+
+New file `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean` (sibling of the parent;
+parent stays the affine Moulton counterexample).
+
+- **Part A — finite self-dual configuration (first compile, blackout-proof).**
+  `Fin 10` points/lines, incidence matrix, duality permutation `σ`, and
+  `theorem desargues_config_self_dual : ∀ p l, inc p l = inc (σ l) (σ p) := by decide`.
+  Also `each_point_on_three`, `each_line_through_three` by `decide` to certify it
+  is genuinely `10₃`.
+- **Part B — abstract perspectivity predicates** on
+  `Configuration.ProjectivePlane P L`: `Concurrent`, `Collinear`,
+  `centrallyPerspective`, `axiallyPerspective`, `Desarguesian P`,
+  `ConverseDesarguesian P`.
+- **Part C — the swap lemmas under `Configuration.Dual`:**
+  `concurrent_dual_iff_collinear`, `centrally_dual_iff_axially`, culminating in
+  `desarguesian_dual_iff : Desarguesian (Dual P) ↔ ConverseDesarguesian P` and
+  the corollary `converse_iff_desarguesian` (a plane satisfies the converse iff
+  it is Desarguesian), plus `desarguesian_class_self_dual`.
+- **Part D (optional) — bridge note** that the parent Moulton plane, being affine
+  and non-Desarguesian, is *not* the carrier for Part B/C: dualizing it requires
+  its projective completion. Stated as documentation, not a theorem.
+
+Effort estimate: Part A ~40–70 LOC (decidable, the safe blackout target);
+Parts B–C ~120–200 LOC contingent on the exact `Configuration.Dual` API.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Dualizing the parent's affine incidence directly.** Defining a dual on
+  `MPoint`/`MLine`/`onLine` fails: affine planes are not self-dual (parallelism
+  has no point-dual). Do not reuse `onLine`; work projectively (Insight 1).
+- **Stating self-duality as "Desargues holds ⇒ converse holds by duality."**
+  Desargues is false in general projective planes (the parent proves it), so it
+  is not available to dualize. Use the *class-level* `desarguesian_dual_iff`
+  instead (Insight 3).
+- **Modelling "complexity"-style cost.** N/A here — this OQ is a logical/incidence
+  statement, not an algorithmic one; no cost-monad needed.

--- a/research/problems/desargues-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/knowledge.md
@@ -65,19 +65,26 @@ of abstraction above its parent.
 
 ### Insight 2 — Mathlib already provides projective-plane duality
 `Mathlib/Combinatorics/Configuration.lean` provides the abstract incidence
-machinery this OQ needs:
-- `Configuration.ProjectivePlane P L` — points `P`, lines `L`, a `Membership P L`
-  incidence, with `mkPoint`/`mkLine` (intersection / join) and nondegeneracy.
-- `Configuration.Dual` — the dual incidence structure (swaps the two types and
-  flips `Membership`).
-- the **duality principle as an instance**: the dual of a projective plane is a
-  projective plane.
+machinery this OQ needs (API confirmed against the materialized source this
+session, lines as of the current toolchain):
+- `Configuration.ProjectivePlane P L extends HasPoints P L, HasLines P L` (L329) —
+  points `P`, lines `L`, a `Membership P L` incidence, with `mkPoint`/`mkLine`
+  (intersection / join, L76/L82) and `Nondegenerate` (L68).
+- `Configuration.Dual` (L46), with `instance : Membership (Dual L) (Dual P)`
+  flipping incidence (L59).
+- the **duality principle as an instance**:
+  `instance : ProjectivePlane (Dual L) (Dual P)` (L338) — the dual of a projective
+  plane is a projective plane. (Mathlib already uses this internally, e.g.
+  `HasLines.existsUnique_line := HasPoints.existsUnique_point (Dual L) (Dual P)`.)
+
+**Gotcha (confirmed):** the dual swaps the *type order* — the dual plane is
+`Dual L` (points) over `Dual P` (lines), so a predicate `Foo P L` evaluated on the
+dual is written `Foo (Dual L) (Dual P)`, NOT `Foo (Dual P) (Dual L)`. Get this
+order right when stating `desarguesian_dual_iff`.
 
 So duality itself is *given*; the OQ's genuine new content is to (a) define
 `Concurrent`/`Collinear` and central/axial perspectivity on this incidence, and
-(b) prove these two predicates are *exchanged* by `Configuration.Dual`. (Exact
-names/signatures must be confirmed at build time — Mathlib source is not
-materialized locally during the blackout.)
+(b) prove these two predicates are *exchanged* by `Configuration.Dual`.
 
 ### Insight 3 — the meaningful theorem is "the Desarguesian class is self-dual"
 Desargues is **not** a theorem of the projective-plane axioms (the parent's

--- a/research/problems/desargues-theorem-oq-02-oq-02/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/state.md
@@ -36,6 +36,6 @@ Two-layer formalization (see knowledge.md "Recommended Lean Plan"):
 When build infra returns: create `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean`
 starting with **Part A** (finite `10₃` self-duality by `decide` — no Mathlib
 Configuration dependency, so it compiles regardless of API drift), then **Parts
-B–C** on `Configuration.ProjectivePlane`/`Configuration.Dual`. Confirm the exact
-`Configuration.Dual` / `ProjectivePlane.dual` signatures against the materialized
-Mathlib source first.
+B–C** on `Configuration.ProjectivePlane`/`Configuration.Dual` (API confirmed:
+`ProjectivePlane` L329, `Dual` L46, duality instance `ProjectivePlane (Dual L)
+(Dual P)` L338 — mind the swapped type order when stating `desarguesian_dual_iff`).

--- a/research/problems/desargues-theorem-oq-02-oq-02/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/state.md
@@ -1,16 +1,25 @@
 # Research State: desargues-theorem-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:49-07:00
+**Since**: 2026-06-13
 **Iteration**: 1
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+SURVEYED (researcher-9, 2026-06-13). Mathematical content fully resolved on paper:
+Desargues's theorem is *self-dual* — its plane-dual is its own converse. The
+formalizable target is the class-level statement
+`Desarguesian (Dual P) ↔ ConverseDesarguesian P` on Mathlib's
+`Configuration.ProjectivePlane`, with a self-contained finite `10₃`-configuration
+self-duality (`decide`) as the first compile milestone. See knowledge.md.
 
 ## Active Approach
-None yet.
+Two-layer formalization (see knowledge.md "Recommended Lean Plan"):
+1. Finite Desargues `10₃` configuration self-duality, decidable (blackout-proof
+   first compile).
+2. Abstract perspectivity predicates on `Configuration.ProjectivePlane` + swap
+   lemmas under `Configuration.Dual` → `desarguesian_dual_iff`.
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +27,15 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Verification blackout (2026-06-13):** Docker build daemon down and Aristotle
+  backend returns 404 — both confirmed live this session. No Lean committed; the
+  ACT phase (writing `DesarguesTheoremOQ02OQ02.lean`) is build-gated until infra
+  returns.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When build infra returns: create `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean`
+starting with **Part A** (finite `10₃` self-duality by `decide` — no Mathlib
+Configuration dependency, so it compiles regardless of API drift), then **Parts
+B–C** on `Configuration.ProjectivePlane`/`Configuration.Dual`. Confirm the exact
+`Configuration.Dual` / `ProjectivePlane.dual` signatures against the materialized
+Mathlib source first.

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -50,8 +50,8 @@
       "Cheapest first compile = finite Desargues 10₃ configuration self-duality: Fin 10 incidence matrix + duality permutation σ, goal inc p l = inc (σ l) (σ p) by decide — no Mathlib Configuration dependency"
     ],
     "mathlibGaps": [
-      "Mathlib Configuration provides ProjectivePlane and Dual (dual-of-projective-plane-is-projective-plane) but NOT perspectivity / Desargues predicates — these must be defined",
-      "Exact Configuration.Dual / ProjectivePlane.dual signatures unconfirmable during blackout (Mathlib source not materialized locally)"
+      "Mathlib Configuration provides ProjectivePlane (L329), Dual (L46), and the instance ProjectivePlane (Dual L) (Dual P) (L338, the duality principle) — confirmed against source — but NOT perspectivity / Desargues predicates, which must be defined",
+      "Gotcha: the dual swaps type order — a predicate Foo P L on the dual is Foo (Dual L) (Dual P), not Foo (Dual P) (Dual L)"
     ],
     "nextSteps": [
       "Part A: finite 10₃ self-dual configuration (Fin 10, incidence Bool matrix, σ : Perm (Fin 10), decide) — blackout-proof milestone",

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -1,0 +1,95 @@
+{
+  "slug": "desargues-theorem-oq-02-oq-02",
+  "title": "Can we formalize the self-duality property of Desargues's theorem explicitly?",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "On a projective plane (Configuration.ProjectivePlane P L) define centrally/axially perspective triangles via Concurrent/Collinear. Desargues's statement is self-dual: its plane-dual equals its converse. Formalize Desarguesian(Dual P) ↔ ConverseDesarguesian P, and the finite Desargues 10₃ configuration's incidence-reversing self-duality.",
+    "plain": "Make the self-duality of Desargues's theorem explicit and machine-checked. Answer: yes. Under projective duality (point↔line, collinear↔concurrent), central perspectivity ↔ axial perspectivity, so the dual of Desargues's theorem is exactly its converse — the theorem is its own dual. Formalize this at the projective-incidence level (Mathlib Configuration.Dual), NOT on the parent's affine Moulton model (affine planes are not self-dual).",
+    "whyMatters": [
+      "Makes the projective principle of duality executable rather than informal",
+      "Self-duality is why Desargues's converse needs no separate proof"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent desargues-theorem-oq-02: Moulton plane is a concrete non-Desarguesian (affine) counterexample",
+      "Mathlib: dual of a projective plane is a projective plane (Configuration.Dual duality principle)"
+    ],
+    "open": [
+      "Lean: desarguesian_dual_iff : Desarguesian (Dual P) ↔ ConverseDesarguesian P (build-gated)",
+      "Lean: finite Desargues 10₃ configuration self-duality by decide (build-gated)"
+    ],
+    "goal": "An explicit Lean formalization of the self-duality of Desargues's theorem: the class-level dual↔converse equivalence plus a decidable finite self-dual 10₃ configuration."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13",
+    "iteration": 1,
+    "focus": "Core math resolved on paper (self-dual = own converse via the duality dictionary); formalization layered as finite-decidable 10₃ + abstract Configuration.Dual swap. Build-gated by the 2026-06-13 verification blackout.",
+    "blockers": [
+      "Verification blackout 2026-06-13: Docker down + Aristotle 404 (both confirmed live this session)"
+    ],
+    "nextAction": "When infra returns, create DesarguesTheoremOQ02OQ02.lean: Part A finite 10₃ self-duality by decide (blackout-proof), then Parts B–C on Configuration.ProjectivePlane/Configuration.Dual.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SURVEYED (ORIENT): self-duality of Desargues fully resolved on paper. The plane-dual of Desargues's theorem is its converse (point↔line, collinear↔concurrent, central↔axial perspectivity). Formalizable at the projective layer via Mathlib Configuration.Dual; the parent's affine Moulton model is the wrong carrier (affine planes are not self-dual).",
+    "builtItems": [],
+    "insights": [
+      "Duality dictionary: point↔line, lies-on↔passes-through, collinear↔concurrent, join↔meet — sends a triangle to a trilateral and central perspectivity to axial perspectivity",
+      "Dual of Desargues's statement = its converse, so the theorem is self-dual (its own dual)",
+      "Right layer is projective/abstract: affine planes (the parent's onLine over ℚ²) are NOT self-dual because parallel lines have no dual point",
+      "Desargues is false in general projective planes (parent counterexample), so self-duality must be stated class-level: Desarguesian(Dual P) ↔ ConverseDesarguesian P, not 'D holds ⇒ converse holds'",
+      "Cheapest first compile = finite Desargues 10₃ configuration self-duality: Fin 10 incidence matrix + duality permutation σ, goal inc p l = inc (σ l) (σ p) by decide — no Mathlib Configuration dependency"
+    ],
+    "mathlibGaps": [
+      "Mathlib Configuration provides ProjectivePlane and Dual (dual-of-projective-plane-is-projective-plane) but NOT perspectivity / Desargues predicates — these must be defined",
+      "Exact Configuration.Dual / ProjectivePlane.dual signatures unconfirmable during blackout (Mathlib source not materialized locally)"
+    ],
+    "nextSteps": [
+      "Part A: finite 10₃ self-dual configuration (Fin 10, incidence Bool matrix, σ : Perm (Fin 10), decide) — blackout-proof milestone",
+      "Part B: define Concurrent/Collinear, centrally/axially perspective, Desarguesian/ConverseDesarguesian on Configuration.ProjectivePlane",
+      "Part C: swap lemmas under Configuration.Dual → desarguesian_dual_iff and converse_iff_desarguesian"
+    ]
+  },
+  "tags": [
+    "projective-geometry",
+    "duality",
+    "desargues",
+    "incidence-geometry",
+    "configuration",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "desargues-theorem-oq-02",
+    "desargues-theorem"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [],
+    "mathlib": [
+      "Mathlib.Combinatorics.Configuration",
+      "Configuration.ProjectivePlane",
+      "Configuration.Dual"
+    ]
+  },
+  "started": "2026-06-10T11:02:49-07:00",
+  "lastUpdate": "2026-06-13",
+  "significance": 5,
+  "tractability": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/DesarguesTheoremOQ02.lean",
+      "filename": "DesarguesTheoremOQ02.lean",
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DesarguesTheoremOQ02.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
First survey (OBSERVE→ORIENT) of `desargues-theorem-oq-02-oq-02` — *"Can we formalize the self-duality property of Desargues's theorem explicitly?"* Build-free during the 2026-06-13 verification blackout (Docker down + Aristotle backend 404, both confirmed live this session).

**Math resolved on paper.** Under the projective duality dictionary (point↔line, lies-on↔passes-through, **collinear↔concurrent**, join↔meet), a triangle dualizes to a trilateral and **central** perspectivity (joining lines concurrent) ↔ **axial** perspectivity (intersection points collinear). So the dual of Desargues's theorem is precisely its **converse**: the theorem is *self-dual*.

**Key judgement — the right layer.** Self-duality holds only in a **projective** plane, so it must NOT be phrased on the parent's affine `MPoint`/`onLine` model (affine planes are not self-dual: parallel lines have no dual point). This OQ lives one abstraction level above its Moulton-plane parent.

**Formalization plan (two layers).**
- **Part A (blackout-proof first compile):** the finite Desargues **10₃** configuration is self-dual — `Fin 10` incidence matrix + duality permutation `σ`, goal `inc p l = inc (σ l) (σ p)` by `decide`. No Mathlib Configuration dependency.
- **Part B/C:** `Desarguesian (Dual P) ↔ ConverseDesarguesian P` on Mathlib `Configuration.ProjectivePlane`/`Configuration.Dual`. Stated class-level (not "D ⇒ converse") because Desargues is false in general projective planes — the parent proves it.

## Changes
- `research/problems/desargues-theorem-oq-02-oq-02/knowledge.md` — full survey (5 insights, Lean plan, dead ends)
- `research/problems/desargues-theorem-oq-02-oq-02/state.md` — OBSERVE→ORIENT, blocker = blackout
- `src/data/research/problems/desargues-theorem-oq-02-oq-02.json` — seeded gallery research entry (absent on main → additive)

## Test plan
- [x] JSON validates (`python3 -m json.tool`)
- [ ] ACT (writing `DesarguesTheoremOQ02OQ02.lean`) is build-gated until Docker/Aristotle return — no Lean committed