### PR TITLE
research(divisibility-by-3-oq-01-oq-02): add truncation rules for 41 and 43

### DIFF
--- a/proofs/Proofs/DivisibilityTruncationGeneral.lean
+++ b/proofs/Proofs/DivisibilityTruncationGeneral.lean
@@ -181,6 +181,16 @@ theorem thirtyseven_dvd_trunc (n : ℕ) :
     (37 : ℤ) ∣ n ↔ (37 : ℤ) ∣ (↑(n / 10) - 11 * ↑(n % 10)) :=
   truncation_neg 37 11 n (by decide) ⟨3, by norm_num⟩
 
+/-- d=41, negative osculator c=4: 10·4+1 = 41 = 1·41 -/
+theorem fortyone_dvd_trunc (n : ℕ) :
+    (41 : ℤ) ∣ n ↔ (41 : ℤ) ∣ (↑(n / 10) - 4 * ↑(n % 10)) :=
+  truncation_neg 41 4 n (by decide) ⟨1, by norm_num⟩
+
+/-- d=43, positive osculator c=13: 10·13-1 = 129 = 3·43 -/
+theorem fortythree_dvd_trunc (n : ℕ) :
+    (43 : ℤ) ∣ n ↔ (43 : ℤ) ∣ (↑(n / 10) + 13 * ↑(n % 10)) :=
+  truncation_pos 43 13 n (by decide) ⟨3, by norm_num⟩
+
 /-
 ## Osculator Table
 -/
@@ -193,6 +203,7 @@ example : (3 : ℤ) ∣ 10 * 1 - 1 := ⟨3, by norm_num⟩    -- 9 = 3 × 3
 example : (9 : ℤ) ∣ 10 * 1 - 1 := ⟨1, by norm_num⟩    -- 9 = 1 × 9
 example : (23 : ℤ) ∣ 10 * 7 - 1 := ⟨3, by norm_num⟩   -- 69 = 3 × 23
 example : (29 : ℤ) ∣ 10 * 3 - 1 := ⟨1, by norm_num⟩   -- 29 = 1 × 29
+example : (43 : ℤ) ∣ 10 * 13 - 1 := ⟨3, by norm_num⟩  -- 129 = 3 × 43
 
 -- Negative osculators (10c + 1 ≡ 0 mod d):
 example : (7 : ℤ) ∣ 10 * 2 + 1 := ⟨3, by norm_num⟩    -- 21 = 3 × 7
@@ -200,6 +211,7 @@ example : (11 : ℤ) ∣ 10 * 1 + 1 := ⟨1, by norm_num⟩   -- 11 = 1 × 11
 example : (17 : ℤ) ∣ 10 * 5 + 1 := ⟨3, by norm_num⟩   -- 51 = 3 × 17
 example : (31 : ℤ) ∣ 10 * 3 + 1 := ⟨1, by norm_num⟩   -- 31 = 1 × 31
 example : (37 : ℤ) ∣ 10 * 11 + 1 := ⟨3, by norm_num⟩  -- 111 = 3 × 37
+example : (41 : ℤ) ∣ 10 * 4 + 1 := ⟨1, by norm_num⟩   -- 41 = 1 × 41
 
 /-
 ## Examples and Sanity Checks
@@ -251,5 +263,22 @@ theorem truncation_method_summary :
     (∀ n : ℕ, (19 : ℤ) ∣ n ↔ (19 : ℤ) ∣ (↑(n / 10) + 2 * ↑(n % 10))) :=
   ⟨seven_dvd_trunc, eleven_dvd_trunc, thirteen_dvd_trunc,
    seventeen_dvd_trunc, nineteen_dvd_trunc⟩
+
+/-- **Extended Coverage (osculators beyond 19)**: bundles the truncation rules for
+    the next primes coprime to 10 — 23, 29, 31, 37, 41, 43 — each obtained as a direct
+    instance of the parametric `truncation_pos` / `truncation_neg` theorems.
+
+    This answers the follow-up question "extend truncation coverage beyond 19
+    (23, 29, 31, 37, 41, 43)": every listed prime is covered, with no new machinery
+    required — only its osculator constant. -/
+theorem extended_truncation_coverage :
+    (∀ n : ℕ, (23 : ℤ) ∣ n ↔ (23 : ℤ) ∣ (↑(n / 10) + 7 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (29 : ℤ) ∣ n ↔ (29 : ℤ) ∣ (↑(n / 10) + 3 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (31 : ℤ) ∣ n ↔ (31 : ℤ) ∣ (↑(n / 10) - 3 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (37 : ℤ) ∣ n ↔ (37 : ℤ) ∣ (↑(n / 10) - 11 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (41 : ℤ) ∣ n ↔ (41 : ℤ) ∣ (↑(n / 10) - 4 * ↑(n % 10))) ∧
+    (∀ n : ℕ, (43 : ℤ) ∣ n ↔ (43 : ℤ) ∣ (↑(n / 10) + 13 * ↑(n % 10))) :=
+  ⟨twentythree_dvd_trunc, twentynine_dvd_trunc, thirtyone_dvd_trunc,
+   thirtyseven_dvd_trunc, fortyone_dvd_trunc, fortythree_dvd_trunc⟩
 
 end DivisibilityTruncationGeneral

--- a/research/problems/divisibility-by-3-oq-01-oq-02/knowledge.md
+++ b/research/problems/divisibility-by-3-oq-01-oq-02/knowledge.md
@@ -1,21 +1,72 @@
 # Knowledge Base: divisibility-by-3-oq-01-oq-02
 
-Insights accumulated during research on this problem.
+Extend truncation coverage beyond 19 (23, 29, 31, 37, 41, 43).
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent entry `divisibility-truncation-general` (file
+`proofs/Proofs/DivisibilityTruncationGeneral.lean`) proves two **parametric**
+osculator theorems that subsume every base-10 truncation divisibility test:
+
+- `truncation_pos d c n` : for `d` coprime to 10 with positive osculator `c`
+  (`d ∣ 10c − 1`), `d ∣ n ↔ d ∣ (n/10 + c·(n%10))`.
+- `truncation_neg d c n` : for `d` coprime to 10 with negative osculator `c`
+  (`d ∣ 10c + 1`), `d ∣ n ↔ d ∣ (n/10 − c·(n%10))`.
+
+The osculator `c` is just `10⁻¹ mod d` (positive case) or `d − 10⁻¹` (negative
+case); it always exists because `gcd(d, 10) = 1`. So "extending coverage" to a new
+prime is purely a matter of supplying its osculator constant — **no new machinery**.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
-
----
+- The OQ list is 23, 29, 31, 37, 41, 43. Of these, **23, 29, 31, 37 were already
+  present** in `DivisibilityTruncationGeneral.lean` (`twentythree_dvd_trunc`, …,
+  `thirtyseven_dvd_trunc`). Only **41 and 43 were genuinely missing.**
+- Osculators computed and added:
+  - **41**: negative osculator `c = 4`, since `10·4 + 1 = 41 = 41·1`
+    → `41 ∣ n ↔ 41 ∣ (n/10 − 4·(n%10))`  (`fortyone_dvd_trunc`).
+  - **43**: positive osculator `c = 13`, since `10·13 − 1 = 129 = 43·3`
+    → `43 ∣ n ↔ 43 ∣ (n/10 + 13·(n%10))`  (`fortythree_dvd_trunc`).
+- Added a bundling theorem `extended_truncation_coverage` collecting all six
+  primes (23–43) as the explicit answer to this OQ.
+- Coprimality discharged by `by decide` and the osculator witness by `⟨k, by norm_num⟩`,
+  exactly mirroring the four existing 23/29/31/37 instances — so the new code is
+  structurally identical to already-merged, building code.
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- None. This OQ is fully tractable: it is an instantiation of an existing general
+  theorem, not new mathematics.
+
+---
+
+## Session Log
+
+### Session 2026-06-13 (S1) — ORIENT → ACT
+
+**Mode**: FRESH
+**Outcome**: progress (proof code written; build-unverified — Docker daemon down)
+
+**What I did**
+- Surveyed the parent truncation framework; found 23/29/31/37 already covered.
+- Computed osculators for the two missing primes (41 neg c=4, 43 pos c=13) and
+  added `fortyone_dvd_trunc`, `fortythree_dvd_trunc`, two osculator-table examples,
+  and an `extended_truncation_coverage` bundling theorem.
+
+**Files modified**
+- `proofs/Proofs/DivisibilityTruncationGeneral.lean`
+
+**Build status**
+- NOT verified locally: Docker daemon is down (verification blackout 2026-06-13).
+  The additions are textually identical in structure to the adjacent merged
+  23/29/31/37 instances, so confidence is high, but the deployer's Docker build
+  must confirm before this OQ is marked `completed`.
+
+**Next steps**
+- After Docker is restored: `./proofs/scripts/docker-build.sh Proofs.DivisibilityTruncationGeneral`.
+  If green, flip candidate status available → completed and (optionally) generate a
+  follow-up OQ on whether `c` can be produced uniformly via a decidable osculator function.

--- a/research/problems/divisibility-by-3-oq-01-oq-02/state.md
+++ b/research/problems/divisibility-by-3-oq-01-oq-02/state.md
@@ -1,25 +1,30 @@
 # Research State: divisibility-by-3-oq-01-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-06-10T11:02:49-07:00
-**Iteration**: 1
+**Since**: 2026-06-13T00:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Extending the parametric truncation framework to the two missing primes (41, 43).
+Proof code written; awaiting Docker build verification.
 
 ## Active Approach
-None yet.
+Instantiate the existing `truncation_pos` / `truncation_neg` parametric theorems at
+the missing primes with their osculator constants (41: neg c=4; 43: pos c=13).
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 1
+- Current approach attempts: 1
+- Approaches tried: 1
 
 ## Blockers
-None.
+- Build verification blocked: Docker daemon down (2026-06-13 verification blackout).
+  Code is structurally identical to merged 23/29/31/37 instances; deployer build
+  must confirm before marking completed.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+After Docker is restored, run
+`./proofs/scripts/docker-build.sh Proofs.DivisibilityTruncationGeneral`.
+If green, flip candidate available → completed.


### PR DESCRIPTION
## Summary

Closes the follow-up open question **divisibility-by-3-oq-01-oq-02**: *"Extend truncation coverage beyond 19 (23, 29, 31, 37, 41, 43)."*

The parent file `DivisibilityTruncationGeneral.lean` already proves two parametric osculator theorems (`truncation_pos` / `truncation_neg`) that subsume every base-10 truncation divisibility test. Of the six primes in the OQ list, **23, 29, 31, 37 were already instantiated**; only **41 and 43 were missing**. This PR adds them.

- `fortyone_dvd_trunc` — 41, negative osculator `c = 4` (`10·4 + 1 = 41`): `41 ∣ n ↔ 41 ∣ (n/10 − 4·(n%10))`
- `fortythree_dvd_trunc` — 43, positive osculator `c = 13` (`10·13 − 1 = 129 = 3·43`): `43 ∣ n ↔ 43 ∣ (n/10 + 13·(n%10))`
- `extended_truncation_coverage` — bundling theorem collecting 23–43 as the explicit OQ answer
- Osculator-table `example`s for 41 and 43

Each new theorem is a direct instance of the existing parametric theorems, structurally identical to the merged 23/29/31/37 cases — no new machinery.

## ⚠️ Build status

**Unverified locally — Docker daemon is down (2026-06-13 verification blackout).** The additions mirror adjacent already-merged instances, so confidence is high, but the deployer's Docker build should confirm before the OQ is marked `completed` in the candidate pool.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.DivisibilityTruncationGeneral` is green
- [ ] If green, flip `divisibility-by-3-oq-01-oq-02` status available → completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)