### PR TITLE
research(picks-theorem-oq-01-oq-01): ORIENT — flag blocked (infrastructure-gated)

### DIFF
--- a/research/problems/picks-theorem-oq-01-oq-01/knowledge.md
+++ b/research/problems/picks-theorem-oq-01-oq-01/knowledge.md
@@ -1,0 +1,64 @@
+# picks-theorem-oq-01-oq-01
+
+**Question:** Can polygon triangulation into primitive lattice triangles be
+formalized in Lean/Mathlib? The ear-clipping algorithm requires a simple-polygon
+data structure, the Jordan curve theorem for polygons, and a proof that every
+simple polygon has an ear. None of these are currently in Mathlib.
+
+**Source proof:** `Proofs/PicksTheorem.lean` (Pick's Theorem via Triangulation),
+which carries one `axiom` standing in for the existence of a triangulation into
+primitive lattice triangles. This OQ asks whether that axiom can be discharged.
+
+---
+
+## Session 2026-06-13 (S1) — ORIENT / feasibility survey
+
+**Mode:** FRESH
+**Outcome:** blocked (documented infrastructure assessment)
+
+### What I did
+- Reviewed the OQ statement and the `picks-theorem` proof family
+  (`PicksTheorem.lean` + 8 companion files, all 0-sorry; `PicksTheorem.lean`
+  has `axiomCount=1` — the triangulation-existence stand-in this OQ targets).
+- Decomposed the missing infrastructure required to *prove* (not axiomatize)
+  that every simple lattice polygon admits a triangulation into primitive
+  lattice triangles.
+- Assessed buildability against the project's BUILD/BLOCKED size thresholds.
+
+### Infrastructure assessment
+
+| Prerequisite | In Mathlib? | Rough size to build locally |
+|---|---|---|
+| Simple-polygon data structure (vertex cycle, non-self-intersecting predicate) | No | ~200–400 lines |
+| Jordan curve theorem for polygons (interior/exterior, polygon bounds a region) | No | many hundreds of lines; full JCT is a famous formalization gap, and even the polygonal special case needs winding-number / planar-topology machinery |
+| Two-ears theorem (every simple polygon with ≥4 vertices has an ear) | No | nontrivial combinatorial-geometric proof, hundreds of lines, depends on the polygon structure + interior notion above |
+| Induction assembling a full triangulation and tracking primitivity / area | No | hundreds of lines on top of the above |
+
+These prerequisites are deeply interdependent (the ear theorem and the
+triangulation induction both consume the polygon structure and the
+interior/Jordan notion), so they cannot be built in isolation as small,
+self-contained pieces.
+
+**Total estimate: well over 1000 lines of foundational, interlocking work.**
+This exceeds the project's >1000-line "truly blocked" threshold, and there is no
+known elementary shortcut that bypasses the Jordan-curve / ear machinery — the
+ear-clipping correctness argument is precisely what makes the OQ hard.
+
+**Decision: BLOCKED** (infrastructure, not Docker). Independent of the current
+build-verification outage: even with Docker available, this is a foundational
+Mathlib-contribution-scale effort, not a single-session proof.
+
+### Why not just keep the axiom
+The axiom in `PicksTheorem.lean` is a legitimate, clearly-stated assumption and
+the proof family is honestly classified around it. Discharging it is the *open
+question*; the answer today is "yes in principle, but only via 1000+ lines of
+currently-missing planar-topology infrastructure."
+
+### Next steps (for whoever revisits)
+- Track upstream Mathlib for any planar Jordan-curve / simple-polygon additions;
+  this OQ unblocks the moment a usable polygon-interior + two-ears API lands.
+- If pursued locally, build in dependency order: polygon structure → interior
+  predicate (polygonal JCT) → two-ears → triangulation induction. Consider
+  upstreaming the polygon structure + two-ears theorem as a standalone Mathlib
+  contribution rather than a one-off proof helper.
+- Do NOT re-claim as a quick win: tractability is genuinely "challenging".

--- a/src/data/research/problems/picks-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/picks-theorem-oq-01-oq-01.json
@@ -25,7 +25,7 @@
     "picks-theorem-oq-03-ext",
     "picks-theorem-oq-03-product"
   ],
-  "status": "available",
+  "status": "blocked",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [
@@ -128,5 +128,24 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/PicksTheoremOQ03Product.lean"
     }
-  ]
+  ],
+  "phase": "ORIENT",
+  "knowledge": {
+    "insights": [
+      "PicksTheorem.lean axiomatizes existence of a primitive-lattice triangulation (axiomCount=1); this OQ asks whether that axiom can be discharged by formalizing the triangulation.",
+      "Discharging it requires three interdependent pieces absent from Mathlib: a simple-polygon data structure, the Jordan curve theorem for polygons (interior/exterior), and the two-ears theorem.",
+      "No elementary shortcut bypasses the Jordan-curve/ear machinery: ear-clipping correctness IS the hard core."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks a simple-polygon (non-self-intersecting vertex cycle) data structure (~200-400 lines).",
+      "Mathlib lacks the Jordan curve theorem for polygons / polygon interior predicate (hundreds of lines; full JCT is a known formalization gap).",
+      "Mathlib lacks the two-ears theorem (every simple polygon with >=4 vertices has an ear)."
+    ],
+    "nextSteps": [
+      "Track upstream Mathlib for planar Jordan-curve / simple-polygon additions; this OQ unblocks when a polygon-interior + two-ears API lands.",
+      "If built locally, build in dependency order: polygon structure -> interior predicate -> two-ears -> triangulation induction; consider upstreaming polygon structure + two-ears as a Mathlib contribution.",
+      "Do NOT re-claim as a quick win; tractability is genuinely challenging (>1000 lines foundational)."
+    ],
+    "progressSummary": "BLOCKED: discharging the triangulation-existence axiom needs >1000 lines of interdependent planar-topology infrastructure (simple-polygon structure + polygonal Jordan curve theorem + two-ears theorem) absent from Mathlib. Infrastructure-blocked, independent of the Docker outage."
+  }
 }


### PR DESCRIPTION
## Summary
ORIENT feasibility survey of `picks-theorem-oq-01-oq-01`: *can polygon
triangulation into primitive lattice triangles be formalized, discharging the
triangulation-existence axiom in `PicksTheorem.lean`?*

**Verdict: BLOCKED on infrastructure** (independent of the current Docker
build-verification outage).

Discharging the axiom requires three interdependent pieces, none in Mathlib:
- a simple-polygon (non-self-intersecting vertex cycle) data structure (~200–400 lines),
- the Jordan curve theorem for polygons / polygon-interior predicate (hundreds of lines; full JCT is a known formalization gap),
- the two-ears theorem (every simple polygon with ≥4 vertices has an ear).

Combined, well over 1000 lines of interlocking planar-topology work — past the
project's "truly blocked" threshold, with no elementary shortcut (ear-clipping
correctness *is* the hard core). The existing axiom remains a legitimate, clearly
labeled assumption; this OQ is the open question of removing it.

## Changes
- Add `research/problems/picks-theorem-oq-01-oq-01/knowledge.md` (ORIENT survey + infrastructure assessment + dependency-ordered next steps).
- `src/data/research/problems/picks-theorem-oq-01-oq-01.json`: `status` available→blocked, `phase`=ORIENT, populate `knowledge` (insights/mathlibGaps/nextSteps/progressSummary).

No Lean changes; no build required. Prevents future re-claiming as a quick win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)