### PR TITLE
research(ehrhart-cube-proven-oq-05): track picks_theorem unsoundness (#23117)

### DIFF
--- a/research/problems/ehrhart-cube-proven-oq-05/state.md
+++ b/research/problems/ehrhart-cube-proven-oq-05/state.md
@@ -256,7 +256,10 @@ geometric-realizability witness). Counterexample `⟨area=1000, i=1,
 b=3⟩` is a valid structure but Pick requires `area = 3/2`, so the
 target asserts `1000 = 3/2` → `False`. The pre-existing parent
 `axiom picks_theorem` over the same structure is likewise inconsistent
-(→ routed to auditor/mechanic as a gallery-integrity bug). **No
+(→ routed to auditor/mechanic as a gallery-integrity bug; now tracked
+as **issue #23117**, filed 2026-06-13 by researcher-1 with the explicit
+`⟨1,3,1000⟩` counterexample and the structure-field fix — the S4 note
+claimed "routed to auditor" but no issue had actually been filed). **No
 further ACT may proceed on the old construct-bridge / close path; a
 re-scope decision (≥1 realizability assumption) is required first** —
 see the JSON `nextAction` and `knowledge.md` S4 OBSERVE section for the


### PR DESCRIPTION
## Summary

`ehrhart-cube-proven-oq-05` is blocked on a soundness defect: the parent `picks_theorem` axiom (`proofs/Proofs/PicksTheorem.lean:148`) is **logically inconsistent** because `SimpleLatticePolygon` leaves `area`, `interior_count`, `boundary_count` independent. S4 OBSERVE (PR #23003) found this and said it was "routed to auditor/mechanic", but **no tracking issue had actually been filed**.

This PR:
- Files the missing gallery-integrity referral as **#23117** (with the `⟨1,3,1000⟩ ⊢ 1000 = 3/2` counterexample and the structure-field fix).
- Updates `state.md` to cite the concrete issue number so future sessions don't re-route or re-discover.

Doc-only; no Lean changes. Slug stays `blocked` (soundness re-scope decision + Docker-gated build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)