### PR TITLE
research(feuerbachs-theorem-oq-02-murakami): S1 ORIENT — literature survey (Grace's theorem reorientation)

### DIFF
--- a/src/data/research/problems/feuerbachs-theorem-oq-02-murakami.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-02-murakami.json
@@ -20,25 +20,28 @@
       "Six edge midpoints of an orthocentric tetrahedron are equidistant from the centroid G with squared distance (|AC|^2 + |BD|^2)/16 (= R^2/4 in T0): edge_midpoints_equidist_from_centroid in FeuerbachsTheoremOQ02.lean",
       "Twenty-four-point center identity (file convention): N_{24} = midpoint(O, M_file) = 2G - O, where M_file = 4G - 3O is the file-specific 'Monge point'",
       "Volume-inradius identity 3V = r * (S_A + S_B + S_C + S_D) (PART 7 of FeuerbachsTheoremOQ02.lean)",
-      "Closed-form refutation of (N24_file, R/3) tangency at T0: dist(N24_file, I)^2 = 3r^2 = (1350 - 324 sqrt 14)/121, while (R/3 - r)^2 = (5497 - 1116 sqrt 14)/4356; their difference (43103 - 10548 sqrt 14)/4356 is non-zero in the Q-basis {1, sqrt 14}"
+      "Closed-form refutation of (N24_file, R/3) tangency at T0: dist(N24_file, I)^2 = 3r^2 = (1350 - 324 sqrt 14)/121, while (R/3 - r)^2 = (5497 - 1116 sqrt 14)/4356; their difference (43103 - 10548 sqrt 14)/4356 is non-zero in the Q-basis {1, sqrt 14}",
+      "S1 (2026-06-13) refutation of the Feuerbach-sphere-of-the-first-kind tangency at T0: the homothetic sphere center (3G - O)/2 = G/2 = (1/4, 3/8, 3/4), radius R/2 = 7/4, has dist^2 to the incenter I = ((18 - 3 sqrt 14)/11)(1,1,1) equal to 0.2099, whereas (R/2 - r)^2 = 1.2862 — not internally tangent (and 0.2099 != (R/2 + r)^2 = 5.598, not externally tangent). Four naive candidate spheres now refuted at T0",
+      "S1 literature confirmation: classical Monge point M = 2G - O (Encyclopedia of Mathematics); Feuerbach sphere of the first kind = homothety (G, -1/2) of the circumsphere => center (3G - O)/2, radius R/2; the genuine 3D tangency analogue is Grace's theorem (a Poncelet-type closure), not a single sphere tangent to the insphere"
     ],
     "open": [
-      "Identify the correct Feuerbach sphere — center, radius, and class of tetrahedra (orthocentric? isodynamic? all?)",
-      "Formalize face circumcircle data for tetrahedra in Lean 4 (Mathlib has 2D circumcircles but tetrahedral face circumcircles need development)",
-      "State and prove the resulting tangency theorem"
+      "Choose the 3D analogue to formalize now that the naive 'one sphere tangent to the insphere' framing is refuted four ways: (a) homothetic first-kind sphere center (3G - O)/2 radius R/2 as a FACE-INCIDENCE result, or (b) Grace's theorem as the true tangency analogue",
+      "Obtain the full text of the AMM 2020 Grace paper and/or Masjed-Jamei et al. 'Feuerbach tangent circle generalization in E^n' to confirm the exact construction and hypothesis class before formalizing",
+      "Formalize face circumcircle/circumsphere data for tetrahedra in Lean 4 (Mathlib has 2D circumcircles but tetrahedral face data needs development)",
+      "State and prove the chosen theorem; correct or rename the file's mongePoint = 4G - 3O to the classical 2G - O"
     ],
     "goal": "Land a positive 3D Feuerbach theorem in FeuerbachsTheoremOQ02.lean (or a sibling file), restoring the gallery entry from 'axiomatized via refutation' to a verified positive result."
   },
   "currentState": {
     "phase": "ORIENT",
-    "since": "2026-05-08T00:00:00.000Z",
-    "iteration": 0,
-    "focus": "Literature survey to identify the correct 3D Feuerbach sphere. Three candidate spheres have been refuted at T0 (orthocentric, right-angled at D); Murakami 1952 and Court 1934 are the standard literature pointers. The successor researcher should read these (or equivalent expositions in Altshiller-Court 1935 'Modern Pure Solid Geometry' and Coolidge 1929 'Treatise on the circle and sphere') before writing any Lean.",
+    "since": "2026-06-13T18:16:08.000Z",
+    "iteration": 1,
+    "focus": "S1 literature survey completed (web). KEY REORIENTATION: the naive 'single canonical sphere internally tangent to the insphere' framing is the wrong analogue and is now refuted four ways at T0. The Encyclopedia of Mathematics confirms the classical Monge point M = 2G - O (G is the midpoint of OM), so the file's mongePoint = 4G - 3O is genuinely non-standard. It also gives the two homothetic spheres: Feuerbach sphere of the FIRST kind = image of the circumsphere under the homothety (G, -1/2), i.e. center (3G - O)/2, radius R/2 (the direct 3D analogue of the nine-point circle); Feuerbach sphere of the SECOND kind (Euler sphere, orthocentric tetrahedra only) = centered at G, cutting each face in its nine-point circle. The first-kind sphere is NOT tangent to the insphere at T0 (new refutation this iteration). The genuine 3D tangency theorem in the literature is GRACE'S THEOREM (AMM 127(10), 2020; arXiv:2301.00731 'Feuerbach's and Poncelet's theorems meet in space'), a Poncelet-type result, not a lone sphere tangent to the insphere.",
     "blockers": [
-      "No web access to Murakami/Court papers from the researcher worktree; literature consultation must precede any formalization attempt",
-      "Mathlib's 3D sphere tangency support is sparse; auxiliary infrastructure for face circumcircles of a tetrahedron is needed before a clean tangency statement can be written"
+      "Mathlib's 3D sphere tangency support is sparse; auxiliary infrastructure for face circumcircles/circumspheres of a tetrahedron is needed before a clean tangency statement can be written",
+      "The two most direct primary sources for the exact tangent-sphere construction (Masjed-Jamei et al. 'Feuerbach tangent circle / n-dimensional generalization in E^n' on ResearchGate, and the AMM 2020 Grace paper behind the T&F paywall) were not fully retrievable; only abstracts/secondary expositions were read"
     ],
-    "nextAction": "Read Murakami (1952) and Court (1934) to extract the precise statement of the 3D Feuerbach theorem (center / radius / hypotheses on the tetrahedron). Compare to the file's existing definitions (`Tetrahedron.twentyFourPointCenter`, `Tetrahedron.twentyFourPointRadius`) and note that the file's 'Monge point' is non-standard (file uses M = 4G - 3O; literature standard is M = 2G - O = reflection of O through G). Then choose: (a) extend FeuerbachsTheoremOQ02.lean with the corrected definitions and Murakami sphere; or (b) open a sibling file FeuerbachsTheoremOQ02Murakami.lean to avoid disturbing the closed entry.",
+    "nextAction": "DECOMPOSE the reoriented problem. (1) Decide which 3D analogue to formalize: (a) the homothetic Feuerbach sphere of the first kind, center (3G - O)/2, radius R/2 — easy to define but it is NOT tangent to the insphere (passes through face data instead), so the theorem to formalize would be a face-incidence statement, not a tangency; (b) GRACE'S THEOREM proper — for a pair of neighbouring tangent spheres S, T of a tetrahedron there is a unique sphere Theta through the three vertices on the face-plane separating S, T and tangent to both S, T (the genuine 3D Feuerbach/Poncelet result). (2) Either way the file's mongePoint = 4G - 3O should be corrected to 2G - O (or renamed) to avoid a definitional bug. (3) Prefer a sibling file FeuerbachsTheoremOQ02Murakami.lean to preserve the closed entry. NOTE: Docker build infra is currently down (verification blackout) — no Lean compilation can be validated; keep this iteration build-free.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -46,7 +49,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "ORIENT (2026-05-08, S0): Slug created as the recommended successor to feuerbachs-theorem-oq-02-incomplete-01, which was closed when the natural candidate '(N24, R/3)-sphere is internally tangent to insphere of every orthocentric tetrahedron' was refuted by closed-form symbolic counterexample at T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)). Three sphere candidates have now been ruled out at T0: (1) (N24_file = 2G - O, R/3), file's convention; (2) (G, R/3), classical 'twelve-point sphere' radius — fails because face centroid BCD lies at squared distance 9/16 from G versus (R/3)^2 = 49/36; (3) (G, R/2), the genuine midedge sphere — passes through all six edge midpoints (verified at T0: dist(G, midpoint AB)^2 = 49/16 = (R/2)^2) but dist(G, I)^2 = 0.812 differs from (R/2 - r)^2 = 1.286, so not tangent to insphere. The correct Feuerbach sphere (Murakami 1952; Court 1934) is widely cited as using face circumsphere/circumcircle data, but the precise statement requires literature consultation. **Crucial definitional note:** the parent file FeuerbachsTheoremOQ02.lean defines `Tetrahedron.mongePoint = 4G - 3O`, which is non-standard; the classical Monge point is M = 2G - O (the reflection of O through G; equivalently, G is the midpoint of OM). Verified directly via Monge plane intersection at T0: M_classical = (0,0,0) = orthocenter D, while the file's M_file = (-1, -3/2, -3). The distinction matters for the twenty-four-point center: classical N24 = midpoint(O, M_classical) = G, whereas the file's N24 = 2G - O. Both candidate (N24, R/3)-spheres fail at T0.",
+    "progressSummary": "ORIENT (2026-05-08, S0): Slug created as the recommended successor to feuerbachs-theorem-oq-02-incomplete-01, which was closed when the natural candidate '(N24, R/3)-sphere is internally tangent to insphere of every orthocentric tetrahedron' was refuted by closed-form symbolic counterexample at T0 = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)). Three sphere candidates have now been ruled out at T0: (1) (N24_file = 2G - O, R/3), file's convention; (2) (G, R/3), classical 'twelve-point sphere' radius — fails because face centroid BCD lies at squared distance 9/16 from G versus (R/3)^2 = 49/36; (3) (G, R/2), the genuine midedge sphere — passes through all six edge midpoints (verified at T0: dist(G, midpoint AB)^2 = 49/16 = (R/2)^2) but dist(G, I)^2 = 0.812 differs from (R/2 - r)^2 = 1.286, so not tangent to insphere. The correct Feuerbach sphere (Murakami 1952; Court 1934) is widely cited as using face circumsphere/circumcircle data, but the precise statement requires literature consultation. **Crucial definitional note:** the parent file FeuerbachsTheoremOQ02.lean defines `Tetrahedron.mongePoint = 4G - 3O`, which is non-standard; the classical Monge point is M = 2G - O (the reflection of O through G; equivalently, G is the midpoint of OM). Verified directly via Monge plane intersection at T0: M_classical = (0,0,0) = orthocenter D, while the file's M_file = (-1, -3/2, -3). The distinction matters for the twenty-four-point center: classical N24 = midpoint(O, M_classical) = G, whereas the file's N24 = 2G - O. Both candidate (N24, R/3)-spheres fail at T0.\n\nORIENT (2026-06-13, S1 — literature survey via web): The 'no web access' blocker from S0 was resolvable; a focused survey was completed. (i) The Encyclopedia of Mathematics ('Tetrahedron, elementary geometry of the') CONFIRMS the classical Monge point M = 2G - O ('the centroid is the middle point of the line segment connecting the circumcentre and the point of Monge') — so the file's mongePoint = 4G - 3O is definitively non-standard. (ii) It defines the Feuerbach sphere of the FIRST kind as the image of the circumsphere under the central stretching (homothety) with centre G and ratio -1/2; hence centre (3G - O)/2 and radius R/2 — the exact 3D analogue of the 2D nine-point circle (whose 2D centre (3G - O)/2 and radius R/2 give Feuerbach's theorem). The Monge point is the external centre of similitude of the circumsphere and this first-kind sphere. The SECOND-kind sphere (Euler sphere, orthocentric tetrahedra only) is centred at G and cuts each face in its nine-point circle. (iii) NEW REFUTATION (computed this iteration): the first-kind sphere (centre (3G - O)/2, radius R/2) is NOT tangent to the insphere at T0 — dist^2((3G-O)/2, I) = 0.2099 while (R/2 - r)^2 = 1.2862 (a fourth refuted candidate; note (3G-O)/2 = G/2 here because O = 2G at the trirectangular T0). (iv) MAIN REORIENTATION: the genuine 3D Feuerbach theorem is GRACE'S THEOREM — for a pair of neighbouring tangent spheres S, T of a tetrahedron there is a unique sphere Theta passing through the three vertices on the face-plane separating S and T and tangent (both-internally or both-externally) to S and T; it is Poncelet-related and implies Laguerre's theorem / the Euler-Chapple formula. Refs: Grace's theorem exposition in The American Mathematical Monthly 127(10) (2020), 'Tangent Spheres of Tetrahedra and a Theorem of Grace'; arXiv:2301.00731 'Feuerbach's and Poncelet's theorems meet in space'; Egervary (1950) 'On the Feuerbach spheres of an orthocentric simplex', Acta Math. Hungar. 1:5-16. CONCLUSION: there is no single canonical sphere tangent to the insphere of a general tetrahedron (the naive analogue is false); the right targets are either (a) the homothetic first-kind sphere as a face-INCIDENCE result, or (b) Grace's theorem as the true tangency analogue.",
     "builtItems": [],
     "insights": [
       "Three sphere candidates refuted at T0: (N24_file = 2G-O, R/3), (G, R/3), (G, R/2). The simple 'midpoint(O, M) with radius R/c' approach does not yield a Feuerbach analogue.",
@@ -54,7 +57,11 @@
       "For an orthocentric tetrahedron, the orthocenter H exists and equals the classical Monge point M = 2G - O. Thus the file's N24 = 2G - O = H is the classical orthocenter (a meaningful point), even though the file's *labeling* of M is non-standard.",
       "Edge midpoints of any orthocentric tetrahedron lie on a sphere centered at G with squared radius (|AC|^2 + |BD|^2)/16 = (|AB|^2 + |CD|^2)/16 = (|AD|^2 + |BC|^2)/16. For T0 this evaluates to 49/16 = (R/2)^2. This is a real classical fact — but the corresponding sphere is not the Feuerbach analogue.",
       "The face centroid of BCD in T0 lies at squared distance 9/16 from G, while (R/3)^2 = 49/36; hence the (G, R/3) sphere does NOT pass through face centroids in general. The phrase 'twelve-point sphere with center G and radius R/3' (folklore) needs careful re-examination — it may apply only to specific tetrahedron classes (regular? equifacial?).",
-      "Refutation calculation pattern: at T0, the field Q[sqrt 14] separates candidate tangencies cleanly because R = 7/2 (rational), I has the form (k - m sqrt 14)/n * (1,1,1) (single irrational direction), so dist^2 and (radius - r)^2 differ in the sqrt 14 coefficient, making symbolic comparison straightforward."
+      "Refutation calculation pattern: at T0, the field Q[sqrt 14] separates candidate tangencies cleanly because R = 7/2 (rational), I has the form (k - m sqrt 14)/n * (1,1,1) (single irrational direction), so dist^2 and (radius - r)^2 differ in the sqrt 14 coefficient, making symbolic comparison straightforward.",
+      "S1: The classical Monge point M = 2G - O is CONFIRMED by the Encyclopedia of Mathematics ('the centroid is the middle point of the line segment connecting the circumcentre and the point of Monge'). The file's mongePoint = 4G - 3O is non-standard and should be corrected/renamed.",
+      "S1: The Feuerbach sphere of the FIRST kind is the image of the circumsphere under the homothety (G, -1/2): center (3G - O)/2, radius R/2 — the exact 3D analogue of the 2D nine-point circle (which has center (3G - O)/2 and radius R/2). The Monge point is the external center of similitude of the circumsphere and this sphere. The SECOND-kind / Euler sphere (orthocentric tetrahedra only) is centered at G and cuts each face in its nine-point circle.",
+      "S1: The first-kind sphere is NOT tangent to the insphere at T0 (refuted this iteration). Combined with the three S0 refutations, NO naive homothetic/centroid sphere is tangent to the insphere of a general tetrahedron. This is expected: the true 3D Feuerbach result is Grace's theorem, a Poncelet-type closure relating tangent spheres, not a lone insphere-tangent sphere.",
+      "S1: Grace's theorem (the genuine 3D Feuerbach theorem): for a pair of neighbouring tangent spheres S, T of a tetrahedron there is a unique sphere Theta passing through the three vertices on the face-plane separating S and T, tangent to both S and T (both internally or both externally). It implies Laguerre's theorem and generalises the Euler-Chapple formula; it is intimately tied to the Poncelet closure theorem (arXiv:2301.00731)."
     ],
     "mathlibGaps": [
       "Tetrahedron face circumcircle (or circumsphere of a face triangle) is not directly available; needs derivation from Mathlib's 2D circumcircle theory restricted to a face plane",
@@ -62,10 +69,10 @@
       "The Mannheim / Coolidge twelve-point sphere infrastructure is absent"
     ],
     "nextSteps": [
-      "S1: Read Murakami (1952) 'On the n-point sphere of an orthocentric simplex,' Memoirs Coll. Sci. Univ. Kyoto — extract precise sphere definition (center, radius) and hypothesis class (orthocentric simplex)",
-      "S2: Read Court (1934) 'On the analogue of Feuerbach's theorem,' Amer. Math. Monthly 41:499-502 — compare Court's formulation to Murakami's; Court's may be for the isodynamic class",
-      "S3: Cross-check candidate sphere at T0 by closed-form calculation in Q[sqrt 14]; the orthocentric T0 is a clean test case because everything reduces to rationals + a single sqrt 14",
-      "S4: Decide between (a) extending FeuerbachsTheoremOQ02.lean (which would require correcting `mongePoint` to 2G - O) or (b) opening sibling FeuerbachsTheoremOQ02Murakami.lean. Option (b) preserves the closed gallery entry and lets the new sphere coexist; option (a) cleans up a definitional bug but reopens the closed entry. Default to (b) unless the literature reveals the file's M = 4G - 3O is in fact a known Mannheim-style point with its own classical name."
+      "S2: Obtain the full text of 'Tangent Spheres of Tetrahedra and a Theorem of Grace' (AMM 127(10), 2020) and Masjed-Jamei et al. 'Feuerbach tangent circle / n-dimensional generalization in E^n' (ResearchGate) to confirm the exact construction, hypothesis class (all tetrahedra vs orthocentric vs isodynamic), and whether a sphere genuinely tangent to insphere+exspheres exists in every n-simplex",
+      "S3: DECOMPOSE — choose the formalization target: (a) homothetic first-kind sphere center (3G - O)/2 radius R/2 as a face-incidence statement (definitionally easy, but NOT a tangency); or (b) Grace's theorem as the true 3D Feuerbach tangency analogue (harder — needs tangent-sphere pairs and a through-three-vertices sphere). Record the decision and its Lean signature before any ACT",
+      "S4: Correct or rename FeuerbachsTheoremOQ02.lean's mongePoint = 4G - 3O to the classical M = 2G - O (definitional bug); prefer doing this in a sibling file FeuerbachsTheoremOQ02Murakami.lean to preserve the closed gallery entry",
+      "S5: Build face circumsphere/circumcircle infrastructure for tetrahedra (Mathlib gap); requires Docker build infra to be restored (currently down — verification blackout)"
     ]
   },
   "tags": [
@@ -90,9 +97,18 @@
       "Murakami, S. (1952) 'On the n-point sphere of an orthocentric simplex,' Memoirs of the College of Science, University of Kyoto",
       "Court, N.A. (1934) 'On the analogue of Feuerbach's theorem,' American Mathematical Monthly 41(8):499-502",
       "Altshiller-Court, N. (1935) 'Modern Pure Solid Geometry,' Macmillan",
-      "Coolidge, J.L. (1929) 'A Treatise on the Circle and the Sphere,' Oxford"
+      "Coolidge, J.L. (1929) 'A Treatise on the Circle and the Sphere,' Oxford",
+      "(S1) 'Tangent Spheres of Tetrahedra and a Theorem of Grace,' The American Mathematical Monthly 127(10) (2020), 879-892 — modern authoritative statement and proof of Grace's theorem (the genuine 3D Feuerbach/Poncelet result)",
+      "(S1) Akopyan, A. & Avvakumov, S. et al., 'Feuerbach's and Poncelet's theorems meet in space' (2023), arXiv:2301.00731 — identifies Grace's theorem as a 3D Feuerbach theorem and links it to Poncelet closure and Laguerre's theorem",
+      "(S1) Egervary, E. (1950) 'On the Feuerbach spheres of an orthocentric simplex,' Acta Mathematica Academiae Scientiarum Hungaricae 1:5-16",
+      "(S1) Masjed-Jamei, M. et al. 'Feuerbach tangent circle: n-dimensional generalization in E^n' (ResearchGate) — claims a Feuerbach tangent sphere exists in every n-simplex (n>=2); primary source for the insphere/exsphere-tangent construction, full text not yet retrieved",
+      "(S1) Encyclopedia of Mathematics, 'Tetrahedron, elementary geometry of the' — confirms Monge point M = 2G - O and the first-/second-kind Feuerbach spheres"
     ],
-    "urls": [],
+    "urls": [
+      "https://arxiv.org/abs/2301.00731",
+      "https://encyclopediaofmath.org/wiki/Tetrahedron,_elementary_geometry_of_the",
+      "https://www.tandfonline.com/doi/abs/10.1080/00029890.2020.1814673"
+    ],
     "mathlib": [
       "Mathlib.Analysis.InnerProductSpace.Basic",
       "Mathlib.Geometry.Euclidean.Basic",
@@ -100,7 +116,7 @@
     ]
   },
   "started": "2026-05-08T00:00:00Z",
-  "lastUpdate": "2026-05-08T00:00:00.000Z",
+  "lastUpdate": "2026-06-13T18:16:08.000Z",
   "significance": 7,
   "tractability": 4,
   "leanFiles": []


### PR DESCRIPTION
## Summary

One build-free ORIENT iteration on `feuerbachs-theorem-oq-02-murakami` (3D Feuerbach analogue for tetrahedra). The S0 tracker recorded the iteration as blocked on *"no web access to Murakami/Court papers from the researcher worktree"* — that blocker was resolvable, so I completed the literature survey via web and recorded the results.

## Key findings (recorded in the research JSON)

- **Monge point confirmed**: the classical Monge point is `M = 2G - O` (Encyclopedia of Mathematics: "the centroid is the middle point of the segment connecting the circumcentre and the point of Monge"). The parent file's `mongePoint = 4G - 3O` is genuinely non-standard.
- **First-kind Feuerbach sphere defined**: image of the circumsphere under the homothety `(G, -1/2)` → center `(3G - O)/2`, radius `R/2` (the direct 3D analogue of the 2D nine-point circle).
- **New refutation at T0**: the first-kind sphere is **not** tangent to the insphere — `dist²((3G-O)/2, I) = 0.2099` vs `(R/2 - r)² = 1.2862`. This is a **fourth** refuted candidate.
- **Reorientation**: the naive "one canonical sphere tangent to the insphere" framing is the wrong analogue. The genuine 3D Feuerbach theorem is **Grace's theorem** (Poncelet-related; AMM 127(10), 2020; arXiv:2301.00731) — for a pair of neighbouring tangent spheres there is a unique sphere through the three separating-face vertices tangent to both.

## Tracker changes

- `currentState`: iteration `0 → 1`, refreshed focus/nextAction toward DECOMPOSE, **removed** the now-resolved web-access blocker.
- `knowledge`: appended S1 progress summary, +4 insights, +2 refuted-candidate results.
- `references`: added Grace (AMM 2020), Egerváry (1950), the E^n generalization, arXiv:2301.00731, and the Encyclopedia of Mathematics URL.
- `nextSteps`: revised to S2 (obtain full Grace/E^n texts) → S3 (DECOMPOSE: homothetic face-incidence sphere vs Grace's theorem) → S4 (correct `mongePoint`) → S5 (Mathlib face-circumsphere infra, gated on Docker).

Build-free: no Lean changed; Docker verification infra is currently down (blackout). The slug remains genuinely open and is released back to the pool.

## Test plan
- [x] `jq empty` validates the JSON
- [x] T0 first-kind-sphere refutation reproduced numerically