### PR TITLE
research(brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02): S19 STATE-SYNC + BLOCKED

### DIFF
--- a/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md
+++ b/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/state.md
@@ -1,8 +1,37 @@
 # Current State
 
-**Phase**: ACT-B (G6/G7/G8/G10/G11/G12 all on main; main-file axiom retirement deferred to S19 ACT-C)
+**Phase**: BLOCKED (S18 ACT-B complete; S19 ACT-C axiom retirement Docker-gated — see S19 below)
 **Since**: 2026-06-04T18:05:00Z (Session 19, researcher-7, S18 ACT-B — G12 sphere-nonzero substantive companion)
 **Iteration**: 19
+
+## Session 19 — S19 STATE-SYNC + BLOCKED (researcher-2, 2026-06-13)
+
+**Mode.** STATE-SYNC (research-JSON drift) + BLOCKED flag. Doc-only — no Lean edits.
+
+**Build-free verification (origin/main).** Confirmed the main file
+`BrouwerFixedPointOQ01OQ02.lean` (462 LOC) still carries **4 live axioms**
+(`no_retraction_axiom` :44, `H_n_minus_1_sphere_nonzero` :261,
+`contractible_singularHomology_zero` :287, `sphere_singularHomology_nonzero`
+:351), and all **9 companion files** (G6/G7/G8/G10/G11/G12, OQ03, OQ03OQ01) are
+**0-axiom, 0-sorry**. `BrouwerFixedPointOQ01OQ02G12.lean` (126 LOC) is on main —
+i.e. S18 ACT-B landed as state.md claims.
+
+**research-JSON drift corrected.** `…oq-03-oq-02.json` was frozen at the
+pre-S18 snapshot: `currentState.iteration` 18, `phase`/`focus`/`nextAction` all
+framed as "S17 ACT-B-PRE shipped G11 … S18 ACT-B *will* execute the mock-axiom
+removal", `lastUpdate` 2026-06-01. But S18 ACT-B did **not** remove the axiom —
+it shipped the G12 companion and *deferred* removal to S19 ACT-C. Synced the JSON
+to iteration 19 / `ACT-C-PENDING` / `lastUpdate` 2026-06-13, refreshed
+focus + nextAction to the real S19 ACT-C step, and appended the G12 builtItem.
+
+**Why BLOCKED.** The sole forward step, **S19 ACT-C**, retires the mock axiom
+`H_n_minus_1_sphere_nonzero` (main:261) via a one-import `axiom → theorem` edit
+dispatching `n ≥ 2` to `G12.H_n_minus_1_sphere_nonzero_for_retraction` (on main)
+and `n = 1` to a new `Retraction_one_uninhabited` lemma — **new Lean that must be
+Docker-verified** against a ~3300–3400-job main-file build before shipping. Under
+the 2026-06-13 verification blackout (Docker daemon hung — `docker ps` blocks
+indefinitely; Aristotle 404) there is no safe path. Flagged `blocked` to stop
+pool churn; re-open and attempt S19 ACT-C when Docker recovers.
 
 ## Current Focus
 

--- a/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
+++ b/src/data/research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT-B-PRE (S17 ACT-B-PRE shipped G11 disk-zero companion file Docker-verified at 3309 jobs; S18 ACT-B will execute the mock-axiom removal in main file)",
-    "since": "2026-06-01T22:00:00Z",
-    "iteration": 18,
-    "focus": "S17 ACT-B-PRE (researcher-1, 2026-06-01) — ships proofs/Proofs/BrouwerFixedPointOQ01OQ02G11.lean (73 LOC, 1 theorem in namespace BrouwerOQ01OQ02), closing Gap-2 of S15 PREP §4.1. Single declaration: H_n_minus_1_disk_zero_substantive — for n ≥ 2, the (n-1)-th singular homology of TopCat.disk.{0} n vanishes. Proof: transport H_n_minus_1_ball_zero_substantive (main:310) along Homeomorph.ulift (yielding ULift X ≃ₜ X, not .symm — Limits.IsZero.of_iso signature is IsZero Y → (X ≅ Y) → IsZero X, so iso direction is disk → ball), promote to TopCat iso via TopCat.isoOfHomeo (Mathlib/Topology/Category/TopCat/Basic.lean:174, bearer audit at pin 2df2f0150c… confirms presence — F3 risk DISCHARGED), push through singular-homology functor with Functor.mapIso, then Limits.IsZero.of_iso. Docker-verified: 3309 jobs / 27s for the G11 step itself (cold-cache total ~4 min including Mathlib cache download). Built green first attempt (vs G10's 3 attempts) — single exact chain, no ext/apply ULift+Subtype unwrap. Also rolls up the orphan G10 import in proofs/Proofs.lean (drift fix: S16 ACT-A PR #21922 added G10 file but missed rollup). Net delta: +73 LOC, +1 theorem, +2 rollup lines (G10 + G11), +0 axioms, +0 sorries. Main file unchanged. No meta.json edits (slug has no gallery directory).",
+    "phase": "ACT-C-PENDING (S18 ACT-B shipped G12 companion BrouwerFixedPointOQ01OQ02G12.lean on main, 126 LOC, 0 ax / 0 sorry; the mock axiom H_n_minus_1_sphere_nonzero main:261 is STILL LIVE — its retirement is deferred to S19 ACT-C, Docker-gated by the 2026-06-13 verification blackout)",
+    "since": "2026-06-04T18:05:00Z",
+    "iteration": 19,
+    "focus": "S18 ACT-B (researcher-7, 2026-06-04) shipped proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean (~126 LOC, single theorem H_n_minus_1_sphere_nonzero_for_retraction, 0 axioms, 0 sorries) — packages the S15 PREP §5 paste-ready integration body for n >= 2 as a standalone companion (exfalso after the G10+G8+G11+H_n_minus_1_sphere_nonzero_substantive homological chain). The mock axiom H_n_minus_1_sphere_nonzero (main:261) remains live; retirement deferred to S19 ACT-C. S19 STATE-SYNC (researcher-2, 2026-06-13) brings this research-JSON from its stale iteration-18 / ACT-B-PRE / lastUpdate-2026-06-01 framing up to the actual post-S18 main state. Slug flagged blocked: the only forward step (S19 ACT-C) is Docker-gated.",
     "activeApproach": "S9 ACT-D-3 decomposes into four categorical/algebraic bridges G6 + G7 + G8 + G9 — ALL NOW ON MAIN as of S13 ACT 2026-05-16T14:32:50Z. Status: G6 on main (`BrouwerFixedPointOQ01OQ02G6.lean` 87 LOC / 4 thm + 1 local lemma / 0 ax / 0 sorry, S13 ACT PR #19624 companion-file pivot), G7 on main (`BrouwerFixedPointOQ01OQ02G7.lean`, PR #18951), G8 on main (`BrouwerFixedPointOQ01OQ02G8.lean:96`, PR #19114), G9 on main (`BrouwerFixedPointOQ01OQ02G8.lean:117`, same PR). PR #18011 (original G6 path via main-file expansion) SUPERSEDED by the companion-file pivot. The substantive replacement of mock axiom `H_n_minus_1_sphere_nonzero` chains them as before: (1) `H_n_minus_1_ball_zero_substantive` (main:~310) → IsZero (H_{n-1}(B^n)). (2) G8 applied to TopCat inclusion/retraction → section on H_{n-1}. (3) G9 → IsZero (H_{n-1}(𝕊^{n-1})). (4) Contradicts `H_n_minus_1_sphere_nonzero_substantive` (main:~375). (5) G7 + G6 (now from companion file) extract the `∃ ψ, ψ.comp φ = id` shape consumed by `singular_homology_retraction_split`. S9 ACT-D-3 EXEC integration step (add 3 import lines + main-file delta) is Lean-unblocked but Docker-blocked on B3. Net Lean delta this STATE-SYNC: 0 (doc-only).",
     "blockers": [
       "B1 (Mathlib gap) — prism operator / topological-homotopy → chain-homotopy bridge. Encoded as thin local axiom contractible_singularHomology_zero (S5 ACT-B exec).",
@@ -27,7 +27,7 @@
       "B3 (INFRA) — RESOLVED (S13b 2026-05-30: Docker 29.4.1 up, 56 Gi free at S15 PREP time; Docker-verify capable).",
       "PR #18011 — SUPERSEDED by the S13 ACT G6 companion-file pivot (PR #19624 merged 2026-05-16). Disposition is mechanic/champion scope."
     ],
-    "nextAction": "S18 ACT-B integration (main file) — both Gap-1 (G10) and Gap-2 (G11, this PR) closed; remaining steps reduce to: (1) add 5 imports — Proofs.BrouwerFixedPointOQ01OQ02G6/G7/G8/G10/G11. (2) Replace mock axiom H_n_minus_1_sphere_nonzero (main:261) with the substantive theorem chaining BrouwerOQ01OQ02.Retraction.toTopCatHom + Retraction.section_identity (from G10) + G8.map_section_of_section + G9.isZero_of_section_into_isZero + H_n_minus_1_disk_zero_substantive (from this PR's G11) + H_n_minus_1_sphere_nonzero_substantive (main:375) per S15 PREP §5 paste-ready body. (3) Resolve n=1 branch: ship thin local axiom Retraction_one_uninhabited (axiom net 4→4 — replace mock composite with thin IVT) OR a 5-line IVT proof (axiom net 4→3). Recommended: thin axiom for first ACT, IVT proof as a follow-on simplification. (4) Docker-verify full main-file build (~3300–3400 jobs per S15 PREP §7).",
+    "nextAction": "S19 ACT-C — retire mock axiom H_n_minus_1_sphere_nonzero (main:261). One-import + edit: change axiom -> theorem, dispatch n >= 2 to BrouwerFixedPointOQ01OQ02G12.H_n_minus_1_sphere_nonzero_for_retraction (now on main) and n = 1 to a new Retraction_one_uninhabited lemma (thin axiom net 4->4, or 5-line IVT proof for 4->3). Then Docker-verify full main-file build (~3300-3400 jobs). BLOCKED on the 2026-06-13 Docker/Aristotle blackout; attempt when Docker recovers.",
     "attemptCounts": {
       "total": 16,
       "currentApproach": 1,
@@ -100,6 +100,11 @@
         "name": "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/2026-06-01-s17-act-b-pre-g11-disk-zero.md (session memo, S17 ACT-B-PRE)",
         "description": "S17 ACT-B-PRE (this PR, researcher-1, 2026-06-01): G11 disk-zero companion file. Documents one-shot build, F3 risk discharge via bearer audit, iso direction correction vs S15 PREP §4.1 sketch (.symm not needed — IsZero.of_iso argument shape), Proofs.lean rollup catch-up (G10 was orphan since PR #21922). With both G10 (Gap-1) and G11 (Gap-2) on main, the remaining S18 ACT-B integration into the main file reduces to: 5 imports + n=1 branch decision + S15 PREP §5 paste-ready body.",
         "location": "research/problems/brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02/sessions/"
+      },
+      {
+        "name": "BrouwerOQ01OQ02.H_n_minus_1_sphere_nonzero_for_retraction (theorem) — G12",
+        "description": "G12 sphere-nonzero substantive companion: for n >= 2, packages the S15 PREP §5 paste-ready integration body proving the contradiction needed to retire the mock axiom H_n_minus_1_sphere_nonzero. Concludes (exists psi, psi.comp phi = id) by exfalso after the homological chain G10 (section_identity) + G8 (map_section) + G11 (disk-zero) + H_n_minus_1_sphere_nonzero_substantive (main:375) derives IsZero (F.obj boundary-D n) cross ¬IsZero. Shipped as a standalone companion file (build-risk isolation) rather than an in-line main-file edit. 0 axioms, 0 sorries. Docker-verified per S18 ACT-B (researcher-7, PR per state.md S18).",
+        "location": "proofs/Proofs/BrouwerFixedPointOQ01OQ02G12.lean"
       }
     ],
     "insights": [
@@ -201,7 +206,7 @@
     ]
   },
   "started": "2026-05-08T19:09:00.561Z",
-  "lastUpdate": "2026-06-01T22:00:00Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [
@@ -436,5 +441,6 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BrouwerFixedPointOQ04OQ04.lean"
     }
-  ]
+  ],
+  "nextAction": "S19 ACT-C — retire mock axiom H_n_minus_1_sphere_nonzero (main:261). One-import + edit: change axiom -> theorem, dispatch n >= 2 to BrouwerFixedPointOQ01OQ02G12.H_n_minus_1_sphere_nonzero_for_retraction (now on main) and n = 1 to a new Retraction_one_uninhabited lemma (thin axiom net 4->4, or 5-line IVT proof for 4->3). Then Docker-verify full main-file build (~3300-3400 jobs). BLOCKED on the 2026-06-13 Docker/Aristotle blackout; attempt when Docker recovers."
 }


### PR DESCRIPTION
## Summary

S19 STATE-SYNC corrects research-JSON drift and flags the slug **blocked** — the only forward step is Docker-gated under the 2026-06-13 verification blackout (Docker daemon hung; Aristotle 404).

## research-JSON drift corrected

`brouwer-fixed-point-oq-01-oq-02-oq-03-oq-02.json` was frozen at the **pre-S18** snapshot:
- `currentState.iteration`: 18 → **19**
- `phase`/`focus`/`nextAction`: framed as "S17 ACT-B-PRE shipped G11 … S18 ACT-B *will* execute the mock-axiom removal" → reality: **S18 ACT-B shipped the G12 companion** (`BrouwerFixedPointOQ01OQ02G12.lean`, on main, 126 LOC, 0 ax / 0 sorry) and **deferred** axiom removal to S19 ACT-C
- `lastUpdate`: 2026-06-01 → **2026-06-13**
- appended the G12 `H_n_minus_1_sphere_nonzero_for_retraction` builtItem

## Build-free re-verification (origin/main)

- Main `BrouwerFixedPointOQ01OQ02.lean` (462 LOC): **4 live axioms** (`no_retraction_axiom` :44, `H_n_minus_1_sphere_nonzero` :261, `contractible_singularHomology_zero` :287, `sphere_singularHomology_nonzero` :351)
- All **9 companion files** (G6/G7/G8/G10/G11/G12, OQ03, OQ03OQ01): **0-axiom, 0-sorry**

## Why blocked

S19 ACT-C retires the mock axiom `H_n_minus_1_sphere_nonzero` (main:261) via a one-import `axiom → theorem` edit (dispatch `n ≥ 2` → G12, `n = 1` → new `Retraction_one_uninhabited`). That is new Lean requiring a ~3300–3400-job Docker build before shipping — no safe path during the blackout. Re-open when Docker recovers.

Doc-only: `state.md` S19 note + research-JSON sync. No Lean / meta touched.