### PR TITLE
research(erdos-szekeres-oq-02): S1 SURVEY — complexity of finding the monotone subsequence

### DIFF
--- a/research/problems/erdos-szekeres-oq-02/knowledge.md
+++ b/research/problems/erdos-szekeres-oq-02/knowledge.md
@@ -1,21 +1,218 @@
 # Knowledge Base: erdos-szekeres-oq-02
 
-Insights accumulated during research on this problem.
+Survey of the open question *"What is the complexity of finding the actual
+monotonic subsequence?"* arising from the gallery proof `erdos-szekeres`.
+
+Phase: OBSERVE → ORIENT (first survey, researcher-9 2026-06-13). No Lean was
+built — all Lean verification routes were down this session (Docker daemon down,
+Aristotle backend 404). Deliverable is a build-free survey: the math resolved on
+paper plus a tractable Lean formalization plan with the real-math-vs-engineering
+boundary made explicit.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent file `proofs/Proofs/ErdosSzekeres.lean` proves Erdős–Szekeres in
+**existence form** (`erdos_szekeres_existence`, currently axiomatized — that
+axiom is the target of sibling **oq-01**). The existence proof is the Seidenberg
+pigeonhole over the pair map `i ↦ (maxIncLen f i, maxDecLen f i)`, where
+
+- `maxIncLen f i := Nat.findGreatest (HasIncreasingEndingAt f i) (i.val + 1)`
+- `maxDecLen f i := Nat.findGreatest (HasDecreasingEndingAt f i) (i.val + 1)`
+
+are **`noncomputable`** (Classical `Nat.findGreatest` over a `Prop` existential).
+So the parent says *a* monotone subsequence of the guaranteed length exists, but
+gives no algorithm and no data — there is no way to run it and obtain the actual
+indices.
+
+**oq-02 is the algorithmic / complexity sibling of oq-01.** Where oq-01 asks to
+*prove existence* (eliminate the pigeonhole axiom), oq-02 asks: *how expensive is
+it to actually produce the witnessing subsequence, and can that be formalized?*
+
+---
+
+## Resolution on paper (the classical answer)
+
+Finding the actual longest increasing subsequence (LIS) — and hence an
+Erdős–Szekeres witness — is a textbook algorithmic problem with a settled
+complexity:
+
+1. **Elementary DP — Θ(n²) comparisons.** Define, for each position `i`,
+   `L_inc(i) = 1 + max { L_inc(j) : j < i, f j < f i }` (and `0`→`1` when the set
+   is empty), the computable analog of the parent's noncomputable `maxIncLen`.
+   Dually `L_dec(i)` with `f j > f i`. Evaluating the table is Θ(n²): each `i`
+   scans all `j < i`, giving `Σ_{i<n} i = n(n−1)/2` order comparisons.
+
+2. **Witness reconstruction — O(n).** Store a predecessor pointer
+   `pred(i) = argmax_{j<i, f j<f i} L_inc(j)` while filling the table; backtrack
+   from the position attaining the global max length. O(n) time, O(n) space.
+   This is the "find the *actual* subsequence" step.
+
+3. **The Erdős–Szekeres witness — same Θ(n²).** The pigeonhole guarantees some
+   `i` has `L_inc(i) ≥ r` **or** `L_dec(i) ≥ s` (whenever `n ≥ (r−1)(s−1)+1`).
+   Scanning the two tables for such an `i` is O(n); reconstructing that one
+   subsequence is O(n). So the whole ES witness costs Θ(n²) by the elementary
+   method — no harder than the LIS itself.
+
+4. **Optimal — Θ(n log n) via patience sorting.** Maintaining the sorted array of
+   pile-top values and binary-searching each new element computes the LIS length
+   in Θ(n log n) comparisons (Mallows 1963; Schensted's RSK correspondence is the
+   structural backbone). Back-pointers between consecutive piles reconstruct the
+   actual subsequence in O(n). **Fredman (1975)** proved a matching
+   **Ω(n log n)** lower bound in the comparison-decision-tree model, so
+   Θ(n log n) is optimal for comparison-based algorithms.
+
+**Bottom line (answer to the OQ):** finding the actual monotonic subsequence
+costs **Θ(n²) comparisons by the elementary DP and Θ(n log n) by patience
+sorting, which is optimal in the comparison model**; witness reconstruction adds
+only O(n) on top of either length computation.
+
+---
+
+## The real-math-vs-engineering boundary (the survey's main judgement)
+
+Mathlib has **no cost / complexity model** — no Big-O over a cost monad, no
+RAM-machine or comparison-decision-tree machinery, no Master theorem. Confirmed
+by grep of the materialized Mathlib source (via a sibling worktree's
+`.lake/packages/mathlib`): **no** `longestIncreasing*`, `patienceSort*`,
+`increasingSubseq*`, or Erdős–Szekeres definitions exist in the importable
+library. (The only ES proof is `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean`,
+which is an Archive target and **not** re-exported to downstream projects — same
+gap oq-01 documents.) `Nat.findGreatest` is present
+(`Mathlib/Data/Nat/Find.lean:164`).
+
+Consequently the OQ splits cleanly:
+
+### Formalizable real math (build-free recipe)
+
+(a) **Computable length DP.** Define `incDP : Fin n → ℕ` by strong recursion on
+the index, using `LinearOrder`'s `decidableLT` for the `f j < f i` test:
+```
+def incDP (f : Sequence α n) : Fin n → ℕ :=
+  -- well-founded on i.val; for each i, fold over the Finset {j : j < i ∧ f j < f i}
+  fun i => 1 + (Finset.univ.filter (fun j : Fin n => j < i ∧ f j < f i)).sup
+                 (fun j => incDP f j)        -- sup of ∅ is 0, so value is ≥ 1
+```
+(termination by `j < i ⇒ j.val < i.val`; `Finset.sup` with `⊥ = 0`).
+
+(b) **Correctness — the genuine mathematical content.**
+`incDP f i = maxIncLen f i`, connecting the computable recurrence to the parent's
+noncomputable `Nat.findGreatest` spec. This is the heart of the problem:
+- `≤` direction reuses oq-01's **extension lemma** `maxIncLen_lt_of_lt` (if
+  `i < j` and `f i < f j` then `maxIncLen f i < maxIncLen f j`).
+- `≥` direction is the **optimal-substructure** lemma: any longest increasing
+  subsequence ending at `i` has, as its second-to-last vertex `j`, a position
+  with `j < i`, `f j < f i`, and `maxIncLen f j = maxIncLen f i − 1` (strip the
+  last element ⇒ a witness ending at `j`; combine with (a)'s extension to show it
+  is *longest* at `j`).
+
+(c) **Constructive witness — "the actual subsequence".** A function
+`incWitness : (i : Fin n) → IncreasingSubseq f (incDP f i)` that builds the
+explicit index map by backtracking predecessor pointers, turning the existential
+`HasIncreasingEndingAt` into concrete data (a Σ-type / structure). This is the
+literal content of "finding the actual subsequence", and as a by-product it
+**constructivizes** the parent's existence axiom in the algorithmic case (an
+independent route to what oq-01 does by pigeonhole — see "Relation to oq-01").
+
+(d) **Comparison count as a proved closed form (the Garner move).** Since there
+is no cost monad, formalize complexity as a hand-rolled `Nat`-valued counter
+```
+def incDPcost (n : ℕ) : ℕ := Finset.univ.sum (fun i : Fin n => i.val)   -- = n(n-1)/2
+theorem incDPcost_closed (n : ℕ) : incDPcost n = n * (n - 1) / 2
+```
+proving the Θ(n²) bound as an exact equation, **not** a Big-O over a cost monad.
+This mirrors the judgement that made the Garner OQ
+(`chinese-remainder-non-coprime-oq-01-oq-02`, PR #23098) tractable: runtime
+bounds with no Mathlib cost model become explicit `Nat` operation-counters with
+proved closed forms.
+
+### Out of Lean scope (document, do not attempt)
+
+- **Θ(n log n) patience-sorting upper bound.** Needs a verified balanced-BST or
+  Fenwick/order-statistics structure for the per-element binary search — a
+  research-grade Lean project in its own right.
+- **Ω(n log n) comparison lower bound (Fredman).** Needs a comparison-decision-tree
+  / adversary formalization that Mathlib lacks entirely. This is the same class of
+  gap that caps the binary-gcd Brent-constant OQ and that the missing Master
+  theorem imposes on the bezout-HGCD OQ.
+
+So "complexity O(n log n)" is **not** the formalizable deliverable. The
+formalizable deliverable is *correct algorithm + constructive witness + exact
+Θ(n²) comparison count* for the elementary DP.
+
+---
+
+## Tractable Lean target (milestones)
+
+1. **First buildable milestone** (blackout-independent once Docker returns):
+   computable `incDP` with its termination + `DecidablePred`, and the exact
+   comparison count `incDPcost n = n(n−1)/2`. Pure `Fin`/`Finset`/`Nat` algebra,
+   no dependence on oq-01.
+2. **Correctness** `incDP f i = maxIncLen f i` — depends on oq-01's extension
+   lemma `maxIncLen_lt_of_lt` plus the optimal-substructure lemma. Best sequenced
+   *after* oq-01's ACT-2 lands the extension lemma (avoid duplicating it).
+3. **Constructive witness** `incWitness` producing `IncreasingSubseq f (incDP f i)`
+   — the "actual subsequence", and an alternative constructive elimination of the
+   parent existence axiom.
+
+Estimated ~150–250 LOC across the three milestones; milestone 1 is ~40–60 LOC and
+self-contained.
+
+---
+
+## Relation to oq-01
+
+| | oq-01 | oq-02 (this) |
+|---|---|---|
+| Question | prove existence (kill the pigeonhole axiom) | complexity of *finding* the witness |
+| Method | Seidenberg pigeonhole over `(maxIncLen, maxDecLen)` | computable DP + backtracking |
+| Lean core | non-constructive existence via `Finset` pigeonhole | computable `incDP` + correctness + witness |
+| Shared lemma | builds `maxIncLen_lt_of_lt` (ACT-2) | **consumes** `maxIncLen_lt_of_lt` for correctness |
+| Axiom impact | eliminates `erdos_szekeres_existence_axiom` (pigeonhole) | constructive `incWitness` is an *alternative* elimination |
+
+**Coordination note:** the extension lemma `maxIncLen_lt_of_lt` is produced by
+oq-01 and consumed by oq-02's correctness proof. Sequence oq-02 milestone 2 after
+oq-01 ACT-2 to reuse it rather than re-prove it.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+- The parent's `maxIncLen`/`maxDecLen` being `noncomputable` is exactly *why*
+  oq-02 is non-trivial: a "find the subsequence" OQ over a spec defined by
+  `Nat.findGreatest` is precisely the gap between a non-constructive existence
+  spec and an executable algorithm proven to meet it.
+- The right framing keeps the witness as **data** (`IncreasingSubseq` / a Σ-type),
+  not just a re-proof of the `Prop`. "Finding" means producing the indices.
+- The Θ(n²) DP, not patience sorting, is the formalization target: it computes the
+  same answer, its cost has a clean closed form, and it needs no data structure
+  Mathlib lacks. Patience sorting is the *optimal* algorithm but its log factor is
+  out of reach without a verified BST — record it as the literature answer only.
+- Pattern match to prior surveys: this is the **Garner / binary-gcd cost-model
+  judgement** (no Big-O monad ⇒ exact `Nat` counter) combined with the
+  **noncomputable-spec-to-computable-algorithm correctness** task. Neither half is
+  a cost-monad trap once the comparison count is reframed as a closed form.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **Big-O / asymptotic complexity as the Lean statement.** Mathlib has no cost
+  monad or decision-tree model; an "O(n log n)" or "Θ(n²)" *as asymptotics* has no
+  home. RULED OUT — use exact `Nat` operation-counters with proved closed forms
+  instead.
+- **Importing Mathlib's patience-sorting / ES algorithm.** None exists; the only
+  ES material is the non-importable `Archive/Wiedijk100Theorems` proof (and it is
+  an existence proof, not an algorithm). RULED OUT.
+- **Formalizing the Ω(n log n) lower bound.** Requires comparison-decision-tree
+  machinery absent from Mathlib; research-grade on its own. OUT OF SCOPE.
+
+---
+
+## Out of Scope
+
+- The Θ(n log n) optimality (upper and lower bound) — record as the literature
+  answer; not formalizable without a comparison-cost model.
+- `erdos_szekeres_tight_axiom` (the tightness construction) — a separate OQ, as
+  oq-01 also notes.

--- a/research/problems/erdos-szekeres-oq-02/state.md
+++ b/research/problems/erdos-szekeres-oq-02/state.md
@@ -1,25 +1,40 @@
 # Research State: erdos-szekeres-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:48-07:00
-**Iteration**: 1
+**Since**: 2026-06-13T00:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+First survey complete (researcher-9 2026-06-13, build-free during the
+Docker/Aristotle verification blackout). The OQ "complexity of finding the actual
+monotonic subsequence" is resolved on paper and decomposed into a formalizable
+core plus a cost-model-gated remainder. See knowledge.md.
 
 ## Active Approach
-None yet.
+Computable DP `incDP : Fin n → ℕ` (strong recursion, `decidableLT`) shown equal to
+the parent's noncomputable `maxIncLen`, plus a constructive witness extractor and
+an exact Θ(n²) comparison-count closed form `n(n−1)/2`. The Θ(n log n)
+patience-sorting optimum (and Fredman's matching Ω(n log n) lower bound) is the
+literature answer but is out of Lean scope — Mathlib has no comparison-cost model.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (survey only; no Lean built)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- All Lean build/verification routes down this session (Docker daemon down;
+  Aristotle backend 404). ACT (writing `incDP` etc.) deferred until a build route
+  returns.
+- Correctness milestone (`incDP = maxIncLen`) depends on oq-01's extension lemma
+  `maxIncLen_lt_of_lt`; sequence it after oq-01 ACT-2 lands that lemma to avoid
+  duplicating it.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+ORIENT → ACT when a build route is available. First buildable milestone is
+self-contained and oq-01-independent: the computable `incDP` (termination +
+`DecidablePred`) and the exact comparison count `incDPcost n = n(n−1)/2`
+(~40–60 LOC). Then milestone 2 (correctness, after oq-01 ACT-2) and milestone 3
+(constructive `incWitness` producing `IncreasingSubseq f (incDP f i)`).

--- a/src/data/research/problems/erdos-szekeres-oq-02.json
+++ b/src/data/research/problems/erdos-szekeres-oq-02.json
@@ -1,0 +1,118 @@
+{
+  "slug": "erdos-szekeres-oq-02",
+  "title": "Complexity of finding the actual Erdos-Szekeres monotonic subsequence",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "\\text{Given } f : \\mathrm{Fin}\\ n \\to \\alpha \\text{ over a } \\mathrm{LinearOrder}, \\text{ compute the actual longest monotone subsequence (equivalently an Erdos-Szekeres witness) and determine the comparison complexity of doing so.}",
+    "plain": "The parent Erdos-Szekeres proof guarantees a monotone subsequence exists but defines its length noncomputably (Nat.findGreatest). This question asks how expensive it is to actually produce the witnessing subsequence, and whether the algorithm and its cost can be formalized in Lean.",
+    "whyMatters": [
+      "The parent maxIncLen/maxDecLen are noncomputable, so the gallery proof yields no algorithm and no data — there is no way to run it and get the actual indices.",
+      "A computable DP proven equal to maxIncLen, plus a backtracking witness extractor, constructivizes the parent existence statement in the algorithmic case (an alternative to oq-01's pigeonhole elimination).",
+      "It pins down the real-math-vs-engineering boundary for complexity OQs: Mathlib has no cost model, so the formalizable content is an exact Nat comparison count, not Big-O."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Elementary DP L_inc(i) = 1 + max{L_inc(j) : j<i, f j<f i} computes the longest increasing subsequence length in Theta(n^2) comparisons.",
+      "Witness reconstruction by predecessor backtracking is O(n) on top of the DP table.",
+      "Patience sorting computes the LIS length in Theta(n log n) comparisons (Mallows 1963; Schensted/RSK), and Fredman (1975) proved a matching Omega(n log n) comparison lower bound, so Theta(n log n) is optimal."
+    ],
+    "open": [
+      "No computable analog of the parent's noncomputable maxIncLen/maxDecLen exists yet in the gallery file.",
+      "No constructive witness extractor producing an explicit IncreasingSubseq/DecreasingSubseq has been formalized.",
+      "Complexity bounds have no home in Mathlib (no cost monad / no comparison-decision-tree model); they must be reframed as exact Nat operation-counters."
+    ],
+    "goal": "Formalize a computable incDP : Fin n -> Nat proven equal to maxIncLen, a constructive witness extractor, and an exact Theta(n^2) comparison-count closed form n(n-1)/2; document the Theta(n log n) optimum as the cost-model-gated remainder."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13T00:00:00-07:00",
+    "iteration": 2,
+    "focus": "First survey complete (researcher-9 2026-06-13, build-free during the Docker/Aristotle verification blackout). The OQ is resolved on paper and decomposed into a formalizable core (computable DP + correctness + constructive witness + exact comparison count) plus a cost-model-gated remainder (Theta(n log n) optimality).",
+    "blockers": [
+      "All Lean build/verification routes down this session (Docker daemon down; Aristotle backend 404). ACT deferred until a build route returns.",
+      "Correctness milestone (incDP = maxIncLen) depends on oq-01's extension lemma maxIncLen_lt_of_lt; sequence after oq-01 ACT-2 to reuse it."
+    ],
+    "nextAction": "ACT milestone 1 (oq-01-independent, ~40-60 LOC): computable incDP via strong recursion with DecidablePred from LinearOrder's decidableLT, and the exact comparison count incDPcost n = n(n-1)/2. Then milestone 2 (correctness incDP = maxIncLen, after oq-01 ACT-2) and milestone 3 (constructive incWitness : (i : Fin n) -> IncreasingSubseq f (incDP f i)).",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "ORIENT (researcher-9 2026-06-13 S1, build-free survey). Resolved the OQ on paper: finding the actual monotone subsequence costs Theta(n^2) by the elementary DP and Theta(n log n) by patience sorting (optimal, Fredman lower bound); witness reconstruction adds O(n). Identified the formalizable core vs the cost-model-gated remainder. No Lean built (Docker down + Aristotle 404).",
+    "builtItems": [],
+    "insights": [
+      "The parent maxIncLen/maxDecLen are noncomputable (Nat.findGreatest over a Prop existential), so oq-02 is precisely the gap between a non-constructive existence spec and an executable algorithm proven to meet it.",
+      "Mathlib has NO cost/complexity model and NO LIS/patience-sorting/Erdos-Szekeres machinery in the importable library (grep of materialized Mathlib source: no longestIncreasing*/patienceSort*/increasingSubseq*; only Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean, not re-exported). Nat.findGreatest is in Mathlib/Data/Nat/Find.lean.",
+      "The formalizable core splits into: (a) computable incDP : Fin n -> Nat via strong recursion with decidableLT; (b) correctness incDP = maxIncLen (the genuine math: <= via oq-01's maxIncLen_lt_of_lt, >= via an optimal-substructure lemma); (c) constructive witness incWitness producing IncreasingSubseq f (incDP f i); (d) exact comparison count incDPcost n = n(n-1)/2.",
+      "Complexity must be formalized as an exact Nat operation-counter with a proved closed form, NOT a Big-O over a cost monad — the same judgement that made the Garner OQ (chinese-remainder-non-coprime-oq-01-oq-02, PR #23098) tractable.",
+      "The Theta(n log n) patience-sorting upper bound (needs a verified balanced-BST/Fenwick) and Fredman's Omega(n log n) lower bound (needs a comparison-decision-tree model) are out of Lean scope — same class of gap as the binary-gcd Brent-constant and bezout-HGCD Master-theorem OQs.",
+      "Relation to oq-01: oq-01 BUILDS the extension lemma maxIncLen_lt_of_lt (ACT-2); oq-02 CONSUMES it for the correctness proof. Sequence oq-02 milestone 2 after oq-01 ACT-2. The constructive incWitness is an alternative (constructive) elimination of the parent existence axiom.",
+      "First buildable milestone is self-contained and oq-01-independent: incDP + termination + DecidablePred + the closed-form comparison count. Pure Fin/Finset/Nat algebra, ~40-60 LOC."
+    ],
+    "mathlibGaps": [
+      "No cost/complexity model (no Big-O cost monad, no RAM/comparison-decision-tree machinery, no Master theorem) — so asymptotic complexity statements have no Lean home; use exact Nat operation-counters instead.",
+      "No longest-increasing-subsequence / patience-sorting / Erdos-Szekeres algorithm in the importable library; the only ES material is the non-importable Archive Wiedijk #73 existence proof.",
+      "Nat.findGreatest (Mathlib/Data/Nat/Find.lean), Finset.sup/filter, and well-founded recursion on Fin.val are sufficient for the computable DP; no new foundational definitions needed for milestone 1."
+    ],
+    "nextSteps": [
+      "ACT milestone 1 (oq-01-independent): computable incDP : Fin n -> Nat (strong recursion on i.val, Finset.sup over {j<i, f j<f i}, DecidablePred via decidableLT) + exact comparison count incDPcost n = n(n-1)/2. ~40-60 LOC.",
+      "ACT milestone 2 (after oq-01 ACT-2): correctness incDP f i = maxIncLen f i. <= via oq-01's maxIncLen_lt_of_lt; >= via the optimal-substructure lemma (strip the last element of a longest subseq ending at i).",
+      "ACT milestone 3: constructive witness incWitness : (i : Fin n) -> IncreasingSubseq f (incDP f i) by backtracking predecessor pointers — the literal 'find the actual subsequence', and an alternative constructive elimination of the parent existence axiom.",
+      "Document only (out of scope): Theta(n log n) patience-sorting optimum and Fredman's Omega(n log n) lower bound — not formalizable without a comparison-cost model."
+    ],
+    "markdown": "See research/problems/erdos-szekeres-oq-02/knowledge.md for the full survey (resolution on paper, the real-math-vs-engineering boundary, the build-free Lean recipe, milestones, and the relation to oq-01)."
+  },
+  "tags": [
+    "combinatorics",
+    "order-theory",
+    "algorithms",
+    "complexity",
+    "sequences",
+    "pigeonhole"
+  ],
+  "relatedProofs": [
+    "erdos-szekeres",
+    "ramseys-theorem",
+    "pigeonhole-principle"
+  ],
+  "references": {
+    "papers": [
+      "Fredman, M. L. (1975). On computing the length of longest increasing subsequences. Discrete Math. 11: 29-35. Proves the Omega(n log n) comparison lower bound.",
+      "Schensted, C. (1961). Longest increasing and decreasing subsequences. Canad. J. Math. 13: 179-191. The RSK correspondence underlying patience sorting.",
+      "Aldous, D. and Diaconis, P. (1999). Longest increasing subsequences: from patience sorting to the Baik-Deift-Johansson theorem. Bull. AMS 36: 413-432. Survey including the patience-sorting algorithm and reconstruction."
+    ],
+    "urls": [
+      "https://leanprover-community.github.io/mathlib4_docs/Archive/Wiedijk100Theorems/AscendingDescendingSequences.html — Mathlib's Archive ES existence proof (Wiedijk #73); not importable from downstream projects and not algorithmic."
+    ],
+    "mathlib": [
+      "Nat.findGreatest",
+      "Finset.sup",
+      "Finset.filter",
+      "Finset.sum",
+      "WellFoundedRecursion"
+    ]
+  },
+  "started": "2026-06-10T11:02:48-07:00",
+  "lastUpdate": "2026-06-13T00:00:00-07:00",
+  "significance": 5,
+  "tractability": 5,
+  "leanFiles": [
+    {
+      "path": "Proofs/ErdosSzekeres.lean",
+      "filename": "ErdosSzekeres.lean",
+      "lineCount": 344,
+      "theoremCount": 8,
+      "axiomCount": 2,
+      "defCount": 8,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/ErdosSzekeres.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

First survey (OBSERVE→ORIENT) of `erdos-szekeres-oq-02` — *"What is the complexity of finding the actual monotonic subsequence?"* Build-free; no Lean compiled (Docker daemon down + Aristotle backend 404 confirmed live this session).

**Answer (on paper):** finding the actual monotone (Erdős–Szekeres) subsequence costs **Θ(n²)** by the elementary DP and **Θ(n log n)** by patience sorting — optimal in the comparison model (Fredman 1975, Ω(n log n) lower bound). Witness reconstruction adds only O(n).

**Key judgement (the survey's value):** the parent's `maxIncLen`/`maxDecLen` are `noncomputable` (`Nat.findGreatest` over a `Prop`), and Mathlib has no cost model and no LIS/patience-sorting machinery (verified against materialized Mathlib source). So the OQ splits into:
- **Formalizable real math:** a computable `incDP : Fin n → ℕ` proven equal to `maxIncLen`, a constructive witness extractor `incWitness` producing an explicit `IncreasingSubseq`, and an exact `Nat` comparison-count closed form `n(n−1)/2` — **not** a Big-O over a cost monad (the Garner #23098 precedent).
- **Cost-model-gated remainder (out of scope):** the Θ(n log n) patience-sorting optimum and Fredman's Ω(n log n) lower bound — both need machinery Mathlib lacks.

**Coordination:** oq-02's correctness proof *consumes* oq-01's extension lemma `maxIncLen_lt_of_lt`; milestone 1 (computable `incDP` + comparison count, ~40–60 LOC) is oq-01-independent and the first buildable target.

## Changes
- `research/problems/erdos-szekeres-oq-02/knowledge.md` — full survey
- `research/problems/erdos-szekeres-oq-02/state.md` — OBSERVE → ORIENT
- `src/data/research/problems/erdos-szekeres-oq-02.json` — seeded (absent on main; additive)

## Test plan
- [x] JSON validates (`json.load`)
- [x] No Lean modified — no build required
- [ ] ACT milestone 1 once a build route returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)