### PR TITLE
research(erdos-szekeres-oq-01): S3 STATE-SYNC — state.md ACT iter-3

### DIFF
--- a/research/problems/erdos-szekeres-oq-01/state.md
+++ b/research/problems/erdos-szekeres-oq-01/state.md
@@ -1,25 +1,41 @@
 # Research State: erdos-szekeres-oq-01
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ACT
 **Path**: full
-**Since**: 2026-04-05T19:30:46-07:00
-**Iteration**: 1
+**Since**: 2026-06-10T02:55:00-07:00
+**Iteration**: 3
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+ACT-1 complete (S2, #22772): `maxIncLen`/`maxDecLen` defined via `Nat.findGreatest`
+(Classical, noncomputable) plus singleton witnesses `hasIncreasingEndingAt_one` /
+`hasDecreasingEndingAt_one` and lower bounds `one_le_maxIncLen` / `one_le_maxDecLen`
+via `Nat.le_findGreatest` (commit f6642a8eeeb). Refactored
+`HasIncreasingEndingAt`/`HasDecreasingEndingAt` positional disjunction to use
+`j.val = len - 1` (fixes `Fin (len - 1 + 1)` vs `Fin len` type mismatch).
+Docker 3058 jobs clean. File 281 → 344 LOC. Axiom count unchanged at 2.
 
 ## Active Approach
-None yet.
+Assign each index `i` the pair `(a_i, b_i)` where `a_i = maxIncLen f i` is the
+longest increasing-subsequence length ending at `i` and `b_i = maxDecLen f i` is
+the longest decreasing one. If no increasing run of length `r` and no decreasing
+run of length `s` exist, all pairs lie in the grid `(r-1) × (s-1)`; the pigeonhole
+on an injective position→pair map yields the Erdős–Szekeres bound. The remaining
+formal burden is the injectivity of that map.
 
 ## Attempt Count
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 2
+- Approaches tried: 1
 
 ## Blockers
-None.
+None. (Next step is build-gated on Docker availability for verification.)
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+ACT-2: Prove the key extension lemma `maxIncLen_lt_of_lt` — for `i < j : Fin n`
+with `f i < f j`, `maxIncLen f i < maxIncLen f j`. Strategy: extract witness
+`k : Fin L → Fin n` from `HasIncreasingEndingAt f i L`; define `k'` on `Fin (L+1)`
+appending `j` after `k`'s end-position `i` (using the refactored predicate
+requirement `j.val = L` for the last index); verify `StrictMono` positions and
+values, then `Nat.le_findGreatest` gives `maxIncLen f j ≥ L+1`. Symmetric for
+`maxDecLen` under `f j < f i`. Target +60–100 LOC.


### PR DESCRIPTION
## Summary
Pure build-free STATE-SYNC during the Docker blackout. `state.md` for
`erdos-szekeres-oq-01` was frozen at the seeker-stub default (**Phase OBSERVE /
iteration 1 / "Initial problem understanding"**) while the canonical research
JSON (`src/data/research/problems/erdos-szekeres-oq-01.json`) had already advanced
to **iteration 3 / ACT**.

The S2 ACT-1 commit (#22772, `f6642a8eeeb`, Docker 3058 jobs clean) added
`maxIncLen`/`maxDecLen` + singleton/lower-bound lemmas and updated the JSON +
`knowledge.md`, but never touched `state.md` — the prose-twin trailed by two
iterations, so a reader of `state.md` alone would think the problem hadn't started.

## Changes
- `state.md` → Phase **ACT**, iteration **3**, ACT-1-complete focus, Seidenberg
  pair-tracking active approach, attempt counts (2/2/1), and the ACT-2 next action
  (`maxIncLen_lt_of_lt` extension lemma).
- No source or metric changes. `leanFiles` left for deployer regen.

## Verification
- Source `proofs/Proofs/ErdosSzekeres.lean` on `origin/main`: 344 LOC, 2 axioms,
  0 sorries — matches the JSON's recorded state.
- Docker remains **down**; the ACT-2 step is build-gated and intentionally left
  as the documented next action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)