### PR TITLE
Fix: make picks_theorem consistent via pick_relation field

### DIFF
--- a/proofs/Proofs/PicksTheorem.lean
+++ b/proofs/Proofs/PicksTheorem.lean
@@ -110,6 +110,14 @@ structure SimpleLatticePolygon where
   area_pos : 0 < area
   /-- Boundary has at least 3 points (polygon is non-degenerate) -/
   boundary_ge_three : 3 ≤ boundary_count
+  /-- Pick's relation: the area is determined by the lattice-point counts.
+      Without this field the three numeric components are independent, so one
+      could build a "polygon" whose area is unrelated to its point counts --
+      which makes the bare formula `A = i + b/2 - 1` an inconsistent assertion.
+      Carrying it here is the geometric-realizability constraint that every
+      genuine simple lattice polygon satisfies, and it lets `picks_theorem`
+      be a proved theorem rather than an (unsound) axiom. -/
+  pick_relation : area = (interior_count : ℚ) + (boundary_count : ℚ) / 2 - 1
 
 /-- Notation for interior point count -/
 notation "i(" P ")" => SimpleLatticePolygon.interior_count P
@@ -144,9 +152,14 @@ def picks_formula (interior boundary : ℕ) : ℚ :=
 For a simple polygon with vertices at lattice points:
   Area = (interior points) + (boundary points)/2 - 1
 
-This relates discrete counting to continuous area measurement. -/
-axiom picks_theorem (P : SimpleLatticePolygon) :
-    A(P) = picks_formula i(P) b(P)
+This relates discrete counting to continuous area measurement.
+
+Now a proved theorem (not an axiom): it follows directly from the
+`pick_relation` realizability field carried by `SimpleLatticePolygon`. -/
+theorem picks_theorem (P : SimpleLatticePolygon) :
+    A(P) = picks_formula i(P) b(P) := by
+  unfold picks_formula
+  exact P.pick_relation
 
 /-- Alternative statement: Area formula -/
 theorem picks_theorem_explicit (P : SimpleLatticePolygon) :
@@ -192,6 +205,7 @@ def unit_right_triangle : SimpleLatticePolygon where
   area := 1/2
   area_pos := by norm_num
   boundary_ge_three := by norm_num
+  pick_relation := by norm_num
 
 /-- Pick's formula gives correct area for unit right triangle -/
 theorem picks_unit_triangle :
@@ -235,6 +249,9 @@ def rectangle (m n : ℕ) (hm : 0 < m) (hn : 0 < n) : SimpleLatticePolygon where
     have hm' : 1 ≤ m := hm
     have hn' : 1 ≤ n := hn
     omega
+  pick_relation := by
+    simp only [Nat.cast_mul, Nat.cast_add, Nat.cast_sub hm, Nat.cast_sub hn, Nat.cast_one]
+    ring
 
 /-- Pick's formula verification for rectangles -/
 theorem picks_rectangle (m n : ℕ) (hm : 0 < m) (hn : 0 < n) :
@@ -286,6 +303,7 @@ def large_right_triangle : SimpleLatticePolygon where
   area := 8
   area_pos := by norm_num
   boundary_ge_three := by norm_num
+  pick_relation := by norm_num
 
 theorem picks_large_right_triangle :
     picks_formula 3 12 = 8 := by

--- a/proofs/Proofs/PicksTheoremOQ01OQ02.lean
+++ b/proofs/Proofs/PicksTheoremOQ01OQ02.lean
@@ -134,11 +134,16 @@ structure SimpleLatticePolygon where
   area           : ℚ
   area_pos       : 0 < area
   boundary_ge_three : 3 ≤ boundary_count
+  /-- Pick's relation: the area is determined by the lattice-point counts.
+      This realizability constraint links the three otherwise-independent
+      fields, so the structure can only represent genuine lattice polygons
+      and `picks_theorem` is a proved theorem rather than an unsound axiom. -/
+  pick_relation : area = (interior_count : ℚ) + (boundary_count : ℚ) / 2 - 1
 
-/-- Pick's theorem (axiom, matching PicksTheorem.lean):
-    Area = interior_count + boundary_count/2 - 1. -/
-axiom picks_theorem (P : SimpleLatticePolygon) :
-    P.area = P.interior_count + P.boundary_count / 2 - 1
+/-- Pick's theorem (now proved from the `pick_relation` field, matching
+    PicksTheorem.lean): Area = interior_count + boundary_count/2 - 1. -/
+theorem picks_theorem (P : SimpleLatticePolygon) :
+    P.area = P.interior_count + P.boundary_count / 2 - 1 := P.pick_relation
 
 /-- The integer dilation tP of P (opaque: implementation not needed for the theorem). -/
 opaque scaledPolygon (P : SimpleLatticePolygon) (t : ℕ) : SimpleLatticePolygon
@@ -219,6 +224,11 @@ noncomputable def rectanglePolygon (m n : ℕ) (hm : 1 ≤ m) (hn : 1 ≤ n) :
   area           := (m : ℚ) * n
   area_pos       := by positivity
   boundary_ge_three := by omega
+  pick_relation := by
+    have hcm : ((m - 1 : ℕ) : ℚ) = m - 1 := by exact_mod_cast Nat.cast_sub hm
+    have hcn : ((n - 1 : ℕ) : ℚ) = n - 1 := by exact_mod_cast Nat.cast_sub hn
+    push_cast [hcm, hcn]
+    ring
 
 /-- Pick's theorem is satisfied for rectangles: mn = (m-1)(n-1) + (m+n) - 1 = mn - 1 + 1 = mn. -/
 theorem rectangle_picks_check (m n : ℕ) (hm : 1 ≤ m) (hn : 1 ≤ n) :


### PR DESCRIPTION
## Fix

`SimpleLatticePolygon` is given a `pick_relation` realizability field so that `picks_theorem` becomes a proved theorem instead of a logically inconsistent axiom.

## Evidence

**Before**: `interior_count`, `boundary_count`, and `area` were independent fields with no link, so `axiom picks_theorem : area = i + b/2 - 1` could be instantiated on a structure with `area = 1000, i = 1, b = 3`, deriving `1000 = 3/2` (i.e. `False`). Any theorem importing the axiom was potentially vacuous.

**After**: a new field
```lean
pick_relation : area = (interior_count : ℚ) + (boundary_count : ℚ) / 2 - 1
```
ties area to the lattice-point counts. `picks_theorem` is now `theorem ... := P.pick_relation` (no axiom). The inconsistent witness `⟨1, 3, 1000, …⟩` no longer typechecks because it cannot supply `pick_relation`. All in-file constructors (`unit_right_triangle`, `rectangle`, `large_right_triangle`, `rectanglePolygon`) already satisfy the relation and supply the field with short `norm_num` / `ring` proofs.

Applied to **both** independent copies of the structure named in the issue:
- `proofs/Proofs/PicksTheorem.lean` (canonical, line 148)
- `proofs/Proofs/PicksTheoremOQ01OQ02.lean` (local duplicate)

`PicksTheoremOQ01.lean` references the axiom only in prose (no code dependency); `EhrhartCubeProvenOQ05.lean` only consumes the structure (never constructs one), so neither needs changes.

## Verification status

**Draft** — Docker build infrastructure is currently down (verification blackout), so this could not be confirmed with `docker-build.sh`. The change is mechanical and the constructor proofs mirror the existing `picks_rectangle` / `rectangle_picks_check` lemmas, but it should be built before un-drafting/merging. Left as draft so the deployer does not auto-merge unverified Lean.

Closes #23117

---
Automated fix by lean-mechanic agent.