### PR TITLE
research(descartes-oq-02-oq-02): ORIENT survey — Sturm via PolyChain framework

### DIFF
--- a/research/problems/descartes-rule-of-signs-oq-02-oq-02/knowledge.md
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-02/knowledge.md
@@ -1,21 +1,141 @@
 # Knowledge Base: descartes-rule-of-signs-oq-02-oq-02
 
-Insights accumulated during research on this problem.
+**Question:** Can Sturm's theorem be formalized using the `PolyChain` framework
+introduced in the parent entry `descartes-rule-of-signs-oq-02` (Budan's theorem)?
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent entry OQ-02 (`proofs/Proofs/DescartesRuleOfSignsOQ02.lean`) defines a small
+abstraction for sign-variation root counting:
+
+```lean
+structure PolyChain (m : ℕ) where
+  polys : Fin (m + 1) → ℝ[X]
+
+noncomputable def chainVariation {m : ℕ} (sc : PolyChain m) (x : ℝ) : ℕ :=
+  signChangesInList ((List.finRange (m + 1)).map (fun k => (sc.polys k).eval x))
+
+noncomputable def budanChain (p : ℝ[X]) : PolyChain p.natDegree where
+  polys k := iterDeriv p k          -- [p, p', p'', …, p⁽ⁿ⁾]
+```
+
+`PolyChain` is purely a **container + counting wrapper**: a finite tuple of polynomials
+plus a function `chainVariation` that counts sign changes of their evaluations at a point.
+Budan's chain instantiates it with iterated derivatives; the Budan–Fourier theorem then
+bounds `#roots(a,b]` by `chainVariation(a) − chainVariation(b)` (an **upper bound** with even
+defect).
+
+The OQ asks whether the **Sturm chain** — the signed remainder (pseudo-remainder) sequence
+`p₀ = p`, `p₁ = p'`, `pₖ₊₁ = −rem(pₖ₋₁, pₖ)` — can be hosted by the same `PolyChain` structure,
+and whether Sturm's theorem (an **exact** count of *distinct* real roots in `(a,b]`) can be
+proved through it.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+1. **The `PolyChain` structure is general enough to host a Sturm chain — trivially.**
+   `PolyChain m` imposes no constraint beyond "a tuple of polynomials," so defining
+   `sturmChain : ℝ[X] → PolyChain m` by the signed-remainder recursion is a small, purely
+   definitional exercise (≈50–80 LOC). Mathlib gives `ℝ[X]` a `EuclideanDomain` instance, so
+   `%` / `Polynomial.modByMonic` supply the remainder operation the recursion needs. The chain
+   *length* is data-dependent (it terminates at the gcd), which is the only mild bookkeeping
+   wrinkle versus Budan's fixed length `natDegree + 1`.
+
+2. **But the framework provides essentially ZERO leverage toward Sturm's theorem itself.**
+   `PolyChain`/`chainVariation` is a counting shell. Budan and Sturm are *different theorems
+   with different proofs*: Budan is an inequality proved (in the literature) by a Rolle /
+   derivative-sign argument; Sturm is an *equality* (exact distinct-root count) proved via the
+   non-vanishing and sign-alternation properties of the *remainder* sequence at common roots.
+   Sharing the container buys the definitions of the chain and its variation count — nothing of
+   the analytic content. The framework answers "can it be *expressed* here?" (yes) but not
+   "does it help *prove* it?" (no).
+
+3. **The parent's own main results are axiomatized, not verified.** OQ-02 carries 3 axioms
+   (`budan_upper_bound`, `budan_parity`, `budanCount_large`). So "formalize Sturm using the
+   PolyChain framework" would, at the framework's current maturity, most naturally reproduce the
+   *same* pattern: define `sturmChain` + `sturmVariation`, then **state** Sturm's theorem as an
+   axiom. That is a legitimate axiomatized formalization (matching the parent's status) but does
+   NOT constitute a verified proof of Sturm.
+
+4. **Sturm is genuinely harder than Budan in one key respect: exactness.** Descartes/Budan give
+   an upper bound (with even defect); Sturm gives the *exact* number of distinct roots. Exactness
+   is the crux and is precisely what requires the full signed-remainder theory — there is no
+   "free" path from the derivative-based Budan machinery to it.
+
+---
+
+## Mathlib Gaps
+
+- **Mathlib4 does NOT have Sturm's theorem.** Confirmed by literature survey (2026): the
+  Sturm / Sturm–Tarski theorem has been formalized in Isabelle/HOL (Wenda Li), Coq, and PVS,
+  but not in Mathlib4. There is no signed-remainder-sequence API and no
+  "sign-variation = exact root count" theorem.
+- Mathlib **does** have the prerequisites for the *chain construction*: `ℝ[X]` is a
+  `EuclideanDomain` (`%`, `EuclideanDomain.mod`, `Polynomial.modByMonic`), `Polynomial.roots`,
+  squarefree / gcd machinery (`Polynomial.gcd`, `EuclideanDomain.gcd`), and `Polynomial.derivative`.
+- The missing analytic core — that variation of the Sturm chain changes by exactly one only when
+  crossing a root of `p`, and is invariant at roots of interior chain members — is the
+  >1000-LOC foundational development, with no elementary shortcut.
+
+---
+
+## Tractability Reassessment
+
+Seeker assigned tractability 6/10. This survey splits that into two very different layers:
+
+| Layer | Effort | Verdict |
+|-------|--------|---------|
+| Define `sturmChain : PolyChain` + `sturmVariation` via Mathlib `%` | ~50–80 LOC | TRACTABLE |
+| State Sturm's theorem (as an axiom, parent-style) | ~10 LOC | TRACTABLE |
+| **Prove** Sturm's theorem (exact distinct-root count) | >1000 LOC, new theory, no Mathlib support | **BLOCKED-scale** |
+
+Net: the **definitional/axiomatized** deliverable is a clean, parent-consistent extension and
+is buildable; the **fully verified** theorem is a major foundational effort beyond the
+>1000-line "truly blocked" threshold. Effective tractability for a *verified* result is ~2/10.
+
+---
+
+## Recommended Next Steps
+
+1. **Scoped deliverable (when Docker verification is available):** create
+   `proofs/Proofs/DescartesRuleOfSignsOQ02OQ02.lean` that
+   (a) defines `sturmChain p : PolyChain (sturmLength p)` via the signed-remainder recursion
+   using `ℝ[X]`'s `EuclideanDomain` `%`, reusing the parent `PolyChain`/`chainVariation`;
+   (b) states Sturm's theorem as `axiom sturm_root_count` mirroring `budan_upper_bound`; and
+   (c) verifies the chain definition compiles. This *answers the OQ's first clause affirmatively
+   with a concrete artifact* (the framework hosts the Sturm chain) while honestly leaving the
+   theorem axiomatized — exactly the parent entry's posture.
+2. **Do NOT attempt the full verified Sturm proof** in this pipeline: no Mathlib support, >1000 LOC,
+   and the right home is a Mathlib contribution, not a gallery one-off.
+3. Cross-reference the sibling axiom-elimination effort `descartes-rule-of-signs-oq-02-oq-01`
+   (proving `budan_upper_bound`) — if the Budan bound is ever fully discharged, the
+   sign-variation infrastructure built there may partially seed the Sturm sign-tracking lemmas.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- "PolyChain gives Sturm for free" — NO. It supplies only the chain container and the variation
+  count, not the exact-count theorem. Budan and Sturm share the wrapper, not the proof.
+- "Reuse Budan's Rolle-based argument for Sturm" — NO. Budan bounds via derivatives; Sturm's
+  exactness comes from remainder-sequence sign behavior, a structurally different argument.
+
+---
+
+## Session Log
+
+### 2026-06-13 (Session 1, researcher-5) — OBSERVE → ORIENT
+
+**Mode**: FRESH (first claim of this Seeker-scaffolded slug; prior knowledge.md was boilerplate).
+**Outcome**: surveyed.
+
+Read parent OQ-02 (`DescartesRuleOfSignsOQ02.lean`, 698 LOC) and sibling OQ-02-OQ-01.
+Identified the `PolyChain` structure (L675–697) and confirmed it is a generic container.
+Literature survey confirmed Sturm's theorem is absent from Mathlib4 (present only in
+Isabelle/Coq/PVS). Concluded: framework *hosts* a Sturm chain trivially, but proving Sturm's
+exact-count theorem is a >1000-LOC, no-Mathlib-support effort. Recommended an axiomatized
+definitional deliverable mirroring the parent's posture; deferred Lean writing because Docker
+build verification is unavailable this session (verification blackout). Advanced phase to ORIENT.

--- a/research/problems/descartes-rule-of-signs-oq-02-oq-02/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-02/state.md
@@ -1,25 +1,35 @@
 # Research State: descartes-rule-of-signs-oq-02-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:49-07:00
-**Iteration**: 1
+**Since**: 2026-06-13
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+Feasibility surveyed. The `PolyChain` framework trivially hosts a Sturm chain (definitional,
+~50–80 LOC via Mathlib's `EuclideanDomain` `%` on `ℝ[X]`), but proving Sturm's exact-root-count
+theorem through it is a >1000-LOC foundational effort with no Mathlib support.
 
 ## Active Approach
-None yet.
+Axiomatized definitional deliverable mirroring the parent OQ-02 (which itself axiomatizes
+`budan_upper_bound`, `budan_parity`, `budanCount_large`): define `sturmChain : PolyChain` +
+`sturmVariation`, state Sturm's theorem as an axiom. Deferred until Docker build verification
+is available (verification blackout 2026-06-13).
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (survey only — no Lean written)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Full verified Sturm proof**: BLOCKED-scale (>1000 LOC, Sturm's theorem absent from Mathlib4;
+  present only in Isabelle/Coq/PVS). Not appropriate for the gallery pipeline.
+- **Build verification**: Docker daemon down (verification blackout 2026-06-13) — even the small
+  definitional artifact cannot be build-verified this session.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker verification returns: create `proofs/Proofs/DescartesRuleOfSignsOQ02OQ02.lean`
+defining `sturmChain p : PolyChain (sturmLength p)` via the signed-remainder recursion and
+stating `axiom sturm_root_count`; confirm the chain definition compiles. See knowledge.md
+"Recommended Next Steps".

--- a/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-02.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-02-oq-02.json
@@ -1,0 +1,89 @@
+{
+  "slug": "descartes-rule-of-signs-oq-02-oq-02",
+  "title": "Can Sturm's theorem be formalized using the `PolyChain` framework",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "significance": 5,
+  "tractability": 6,
+  "problemStatement": {
+    "formal": "Define the Sturm chain (signed remainder sequence p₀=p, p₁=p', pₖ₊₁ = −rem(pₖ₋₁,pₖ)) as a PolyChain, and prove #distinct-roots(p, (a,b]) = chainVariation(sturmChain p, a) − chainVariation(sturmChain p, b).",
+    "plain": "The parent entry OQ-02 (Budan's theorem) introduced a `PolyChain` abstraction: a tuple of polynomials with a sign-variation count. This question asks whether Sturm's theorem — an exact count of distinct real roots in an interval via the signed-remainder sequence — can be formalized through that same framework.",
+    "whyMatters": [
+      "Extends the verified gallery entry's PolyChain abstraction in a concrete direction",
+      "Sturm's theorem is a cornerstone of real root isolation; it is notably absent from Mathlib4"
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent OQ-02 defines `PolyChain`/`chainVariation` and the Budan chain (iterated derivatives)",
+      "ℝ[X] is a EuclideanDomain in Mathlib, supplying the remainder operation for the Sturm chain"
+    ],
+    "open": [
+      "A full verified proof of Sturm's theorem (exact distinct-root count) — absent from Mathlib4"
+    ],
+    "goal": "Host the Sturm chain in PolyChain and either prove or (parent-consistently) axiomatize Sturm's theorem."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13",
+    "iteration": 2,
+    "focus": "Feasibility survey complete. PolyChain trivially hosts a Sturm chain (~50–80 LOC definitional, via Mathlib EuclideanDomain `%` on ℝ[X]), but the framework gives no leverage toward Sturm's exact-count theorem, which is a >1000-LOC effort with no Mathlib support.",
+    "blockers": [
+      "Full verified Sturm proof is BLOCKED-scale (>1000 LOC; Sturm's theorem absent from Mathlib4, present only in Isabelle/Coq/PVS).",
+      "Docker build verification unavailable (verification blackout 2026-06-13) — no Lean written this session."
+    ],
+    "nextAction": "When Docker returns: create DescartesRuleOfSignsOQ02OQ02.lean defining `sturmChain p : PolyChain` via the signed-remainder recursion + `axiom sturm_root_count` (mirroring parent's axiomatized posture); confirm chain definition compiles.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "SURVEYED: PolyChain (a generic tuple-of-polynomials + sign-variation count) structurally hosts a Sturm chain via Mathlib's EuclideanDomain `%`, but provides no leverage toward Sturm's exactness theorem. Parent OQ-02 itself axiomatizes its bounds (3 axioms). Recommended deliverable: a parent-consistent axiomatized formalization (define sturmChain + state Sturm as an axiom), deferred until Docker verification returns. Full verified Sturm proof is >1000 LOC with no Mathlib support and is BLOCKED-scale.",
+    "builtItems": [],
+    "insights": [
+      "PolyChain (`structure PolyChain (m) where polys : Fin (m+1) → ℝ[X]`) is a generic container; defining a Sturm chain through it is purely definitional (~50–80 LOC).",
+      "The framework hosts the Sturm chain but gives ZERO leverage toward the theorem: Budan is a derivative-based upper bound, Sturm is a remainder-based EXACT count — different proofs sharing only the counting wrapper.",
+      "Parent OQ-02 axiomatizes its own main results (budan_upper_bound, budan_parity, budanCount_large), so 'use the framework' naturally reproduces an axiomatized, not verified, Sturm.",
+      "Exactness is Sturm's crux and is exactly what needs the full signed-remainder theory; no shortcut from the Budan derivative machinery."
+    ],
+    "mathlibGaps": [
+      "Mathlib4 has NO Sturm/Sturm–Tarski theorem (confirmed 2026 survey; only Isabelle/Coq/PVS have it). No signed-remainder-sequence API, no sign-variation = exact-root-count theorem.",
+      "Mathlib DOES supply chain-construction prerequisites: ℝ[X] EuclideanDomain (`%`, modByMonic), Polynomial.roots, gcd/squarefree, derivative."
+    ],
+    "nextSteps": [
+      "When Docker verification is available: define `sturmChain p : PolyChain (sturmLength p)` via signed-remainder recursion (Mathlib `%`), reuse parent PolyChain/chainVariation, state `axiom sturm_root_count` mirroring budan_upper_bound, confirm it compiles.",
+      "Do NOT attempt the full verified Sturm proof in this pipeline (>1000 LOC, no Mathlib support; belongs in a Mathlib contribution).",
+      "Cross-reference sibling descartes-rule-of-signs-oq-02-oq-01 (proving budan_upper_bound); its sign-variation infrastructure may partially seed Sturm sign-tracking lemmas if completed."
+    ]
+  },
+  "tags": [
+    "algebra",
+    "polynomials",
+    "roots",
+    "real-analysis",
+    "sign-variations",
+    "root-isolation",
+    "sturm",
+    "research",
+    "seeker-selected"
+  ],
+  "relatedProofs": [
+    "descartes-rule-of-signs",
+    "descartes-rule-of-signs-oq-02",
+    "descartes-rule-of-signs-oq-02-oq-01"
+  ],
+  "references": {
+    "papers": [],
+    "urls": [
+      "https://en.wikipedia.org/wiki/Sturm%27s_theorem"
+    ],
+    "mathlib": []
+  },
+  "started": "2026-06-10T11:02:49Z",
+  "lastUpdate": "2026-06-13",
+  "leanFiles": []
+}


### PR DESCRIPTION
## Summary

First research survey of the Seeker-scaffolded open question **descartes-rule-of-signs-oq-02-oq-02**: *"Can Sturm's theorem be formalized using the `PolyChain` framework?"* (introduced in the parent Budan's-theorem entry OQ-02). Doc-only; phase advanced OBSERVE → ORIENT, status → `surveyed`.

## Findings

- **The `PolyChain` abstraction trivially hosts a Sturm chain.** `PolyChain m = { polys : Fin (m+1) → ℝ[X] }` is a generic container; defining the signed-remainder Sturm sequence through it is ~50–80 LOC, using Mathlib's `EuclideanDomain` `%` on `ℝ[X]`.
- **…but it provides ZERO leverage toward Sturm's theorem.** Budan is a derivative-based *upper bound*; Sturm is a remainder-based *exact* distinct-root count. They share only the counting wrapper, not the proof.
- **Sturm's theorem is absent from Mathlib4** (confirmed 2026 survey — only Isabelle/HOL, Coq, PVS have it). A full verified proof is >1000 LOC with no Mathlib support → BLOCKED-scale; belongs in a Mathlib contribution, not a gallery one-off.
- **Recommended parent-consistent deliverable** (deferred until Docker build verification returns — verification blackout 2026-06-13): define `sturmChain : PolyChain` + state `axiom sturm_root_count`, mirroring the parent's own axiomatized posture (OQ-02 carries 3 axioms).

## Changes (doc-only, no Lean written)

- `research/problems/descartes-rule-of-signs-oq-02-oq-02/{knowledge.md,state.md}` — survey + phase ORIENT
- `src/data/research/problems/descartes-rule-of-signs-oq-02-oq-02.json` — new gallery research entry (was missing)

## Test plan

- [x] `jq empty` validates the new JSON
- [ ] N/A — no Lean changes; nothing to build