### PR TITLE
research(laws-of-large-numbers-oq-01-oq-01): COMPLETION-SYNC status→completed

### DIFF
--- a/research/problems/laws-of-large-numbers-oq-01-oq-01/state.md
+++ b/research/problems/laws-of-large-numbers-oq-01-oq-01/state.md
@@ -6,11 +6,16 @@
 
 ## Current Focus
 
-Initial exploration of the problem.
+RESOLVED. The converse direction of Kolmogorov's SLLN (`slln_necessity` — a.s.
+convergence of the sample mean forces `E[|X₀|] < ∞`) is proved in Mathlib.
 
 ## Active Approach
 
-None yet.
+Borel-Cantelli (BC2 under pairwise independence) + layer-cake equivalence
+`E[|X|]=∞ ↔ Σₙ P(|X|>n)=∞` + Cesàro `Xₙ/n → 0`, combined by contradiction.
+Gallery entry `laws-of-large-numbers-oq-01-oq-01` is verified/original, 0 axioms /
+0 sorries across `LawsOfLargeNumbersOQ01OQ01.lean` and its
+`LawsOfLargeNumbersOQ01Aristotle.lean` companion (`slln_necessity_statement`).
 
 ## Blockers
 
@@ -18,7 +23,7 @@ None.
 
 ## Next Action
 
-Begin problem exploration.
+None — open question answered; gallery proof machine-checked. No further work.
 
 ## Attempt Counts
 

--- a/src/data/research/problems/laws-of-large-numbers-oq-01-oq-01.json
+++ b/src/data/research/problems/laws-of-large-numbers-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "laws-of-large-numbers-oq-01-oq-01",
   "title": "Can the converse (slln_necessity) be proved in Mathlib",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -19,9 +19,9 @@
     "phase": "COMPLETED",
     "since": "2026-05-05T02:57:44.816Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "RESOLVED: the converse direction of Kolmogorov's SLLN (slln_necessity — SLLN a.s. convergence forces E[|X₀|] < ∞) is proved in Mathlib via Borel-Cantelli (BC2 under pairwise independence) + layer-cake + Cesàro. Gallery entry verified/original, 0 axioms / 0 sorries across LawsOfLargeNumbersOQ01OQ01.lean and its LawsOfLargeNumbersOQ01Aristotle.lean companion (slln_necessity_statement).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — open question answered; gallery proof machine-checked. No further work.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
## Summary
Build-free completion-sync during the Docker blackout. The research tracker for
`laws-of-large-numbers-oq-01-oq-01` had **`phase: COMPLETED` but `status: "active"`**,
with the seeker-stub `focus`/`nextAction` ("Initial exploration" / "Begin problem
exploration") in both the JSON and `state.md`. The stale `status: active` kept the
slug in the claim-random pool, re-handing an already-solved problem.

The open question — *can the converse of Kolmogorov's SLLN
(`slln_necessity`: a.s. sample-mean convergence ⇒ `E[|X₀|] < ∞`) be proved in
Mathlib?* — is genuinely **answered**. The gallery entry is `verified`/`original`,
**0 axioms / 0 sorries** across `LawsOfLargeNumbersOQ01OQ01.lean` and its
`LawsOfLargeNumbersOQ01Aristotle.lean` companion (`slln_necessity_statement`), via
Borel-Cantelli (BC2 under pairwise independence) + layer-cake + Cesàro.

## Changes
- JSON `status` → `completed`; refreshed the stub `currentState.focus`/`nextAction`
  to record the resolution.
- `state.md` focus/approach/next-action synced to match.
- `leanFiles` array left untouched (deployer-owned).

## Verification (build-free)
- Source metrics on `origin/main` match the gallery meta exactly (74 LOC, 1
  theorem, 0 axioms, 0 sorries).
- **Verified-badge import-chain audit**: the companion's two `sorry` occurrences
  (L71, L407) are docstring/comment mentions, not proof-position — confirmed 0
  real sorries and 0 axioms/structures across the chain, so the `verified`/`original`
  badge is sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)