### PR TITLE
research(bezout-hgcd-oq): S2 ORIENT survey — HGCD matrix invariant vs Master-theorem-gated asymptotic

### DIFF
--- a/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02/knowledge.md
+++ b/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02/knowledge.md
@@ -1,21 +1,124 @@
 # Knowledge Base: bezout-identity-oq-01-oq-01-oq-01-oq-02
 
-Insights accumulated during research on this problem.
+HGCD (half-GCD / Schönhage) complexity extension of the binary-GCD bit-complexity
+gallery proof. Survey iteration during the 2026-06-13 verification blackout
+(Docker down, Aristotle backend 404 — both confirmed live this session), so this
+is a build-free OBSERVE→ORIENT survey: no Lean committed.
 
 ---
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+The parent `bezout-identity-oq-01-oq-01-oq-01` (Binary GCD O(log² n) bit complexity)
+established the family's working pattern in `BezoutIdentityOQ01OQ01OQ01.lean`:
+
+- `binaryGcdSteps : ℕ → ℕ → ℕ` — an **explicit, computable** step counter mirroring
+  the algorithm's recursion (`termination_by a + b`).
+- `binaryGcdSteps_le_log` — the **proved** O(log n) step bound (Part 1, 0 sorries).
+- `stepBitOps`, `totalBitOps`, `binaryGcd_log_sq_bound` — per-step and total bit-op
+  bounds; the closing Θ/Big-O statement is **bounded/axiomatized** (Part 2).
+
+The OQ asks: does this extend to the HGCD algorithm of Schönhage, giving
+`O(M(n) log n)` where `M(n)` is the integer-multiplication cost, via the recurrence
+`T(n) = 2 T(n/2) + M(n)`? The Seeker statement itself names three sub-tasks:
+(a) HGCD's invariant that 2×2 integer matrices encode partial Euclidean steps,
+(b) the Master theorem in Lean (**currently absent from Mathlib**),
+(c) parametrization over the multiplication primitive `M`.
+
+### The key judgement (the survey's value)
+
+The ask conflates a **tractable, build-free core** with a **cost-model-gated remainder**.
+This is the same shape as the reframes used on `chinese-remainder-...-oq-01-oq-02`
+(Garner: no Big-O cost monad → exact `Nat` op-counter with closed form) and
+`erdos-szekeres-oq-02` (noncomputable spec → computable equality + exact comparison
+count). Decompose:
+
+- **Part (a) — the matrix invariant — is genuine, constructive, blackout-buildable
+  linear algebra.** It is NOT gated on the Master theorem or on any cost model.
+  This is the correct first compile and the real deliverable of the OQ.
+- **Parts (b)+(c) — the Θ(M(n) log n) asymptotic via the Master theorem, parametric
+  over `M` — are the cost-model-gated trap**, the same class as the parent's
+  axiomatized Part 2, as `binary-gcd-...-oq-04-oq-03` (Brent average-case constant),
+  and as `erdos-szekeres-oq-02`'s Θ(n log n) lower bound. Out of scope until Mathlib
+  grows a Master/Akra–Bazzi theorem. Worse: `T(n)=2T(n/2)+Θ(n)` is the **critical
+  case** of the Master theorem (the Θ(n log n) case), the hardest to formalize.
+
+So the survey carves the precise tractable sub-claim out of the intractable
+asymptotic, rather than reporting "blocked: needs Master theorem."
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### I1 — The HGCD matrix invariant is the integer continuant/convergent recurrence
+
+A single Euclidean step `(r_{i-1}, r_i) ↦ (r_i, r_{i-1} - q_i r_i)` is left
+multiplication of the column `(r_{i-1}, r_i)ᵀ` by the **quotient matrix**
+`Q(q_i) = !![0, 1; 1, -q_i]` over `ℤ`. Hence for the remainder sequence
+`r_0 = a, r_1 = b, r_{i+1} = r_{i-1} - q_i r_i`:
+
+    (r_i, r_{i+1})ᵀ = Q(q_i) · Q(q_{i-1}) · … · Q(q_1) · (a, b)ᵀ.
+
+Write `R_k = Q(q_k) ⋯ Q(q_1)`. The invariant has two provable halves:
+- **`mulVec` correctness:** `R_k.mulVec ![a, b] = ![r_k, r_{k+1}]` (induction on k).
+- **Determinant:** `det (Q q) = -1`, so `det R_k = (-1)^k` (by `Matrix.det_mul` +
+  `Matrix.det_fin_two`). The entries of `R_k` are (up to sign) the Bézout cofactors
+  `s_k, t_k` — i.e. the **continuants** `K(q_1,…,q_k)`, exactly what the extended
+  Euclidean algorithm computes. This det = ±1 is what makes `R_k` unimodular, which
+  is what lets HGCD splice a partial matrix into a recursive call.
+
+### I2 — Mathlib already proves the field-level analogue (but the ℤ route is cleaner)
+
+`Mathlib/Algebra/ContinuedFractions/Determinant.lean` proves
+`determinant : Aₙ·B_{n-1} − A_{n-1}·Bₙ = (−1)ⁿ` for the continuant numerators/
+denominators `A, B` of a `GenContFract` over a field `K`
+(`ContinuantsRecurrence.lean` gives `nums_recurrence`/`dens_recurrence`). This *is*
+the convergent-matrix determinant relation. **However**, that machinery lives over a
+`DivisionRing`/field with `GenContFract` and `Pair K`; bridging it to integer
+Euclidean quotients is bookkeeping (a/b's continued fraction = its Euclidean
+quotient sequence, but the types differ). The practical first compile works
+**directly with `Matrix (Fin 2) (Fin 2) ℤ`** products of `Q(q_i)` and proves
+`det = (-1)^k` by induction with `Matrix.det_fin_two`/`Matrix.det_mul` — no detour
+through `GenContFract`. Note the field result as the conceptual precedent, formalize
+over ℤ.
+
+### I3 — The exact-`Nat`-counter milestone mirrors the parent verbatim
+
+By analogy to `binaryGcdSteps`/`stepBitOps`, define a **computable** HGCD that
+returns `(R : Matrix (Fin 2) (Fin 2) ℤ, opCount : ℕ)` where `opCount` counts 2×2
+matrix multiplications. The recurrence is then a concrete `Nat` (in)equality
+`hgcdOps n ≤ 2 * hgcdOps (n/2) + c * stepBitOps n` — NOT a Big-O statement. This is
+the maximal claim provable without a cost-model. The jump from this `Nat` recurrence
+to the closed form `Θ(M(n) log n)` is precisely the Master-theorem step that Mathlib
+cannot yet take.
+
+---
+
+## Suggested milestones (ACT plan, build-gated until Docker/Aristotle return)
+
+- **MS1 (genuine math, blackout-buildable):** `Q : ℤ → Matrix (Fin 2) (Fin 2) ℤ`,
+  the remainder-sequence product `R_k`, and the two invariant lemmas
+  (`mulVec` correctness + `det R_k = (-1)^k`). ~40–80 LOC, pure `Matrix`/induction,
+  zero Master-theorem dependency. **This is the clean first compile.**
+- **MS2 (exact `Nat` counter):** computable HGCD returning `(R, opCount)`, plus the
+  `Nat` recurrence inequality `hgcdOps n ≤ 2 hgcdOps (n/2) + c·stepBitOps n`. Reuse
+  the parent's `stepBitOps`/`Nat.size`/`Nat.log` lemmas.
+- **MS3 (the trap, document only):** `O(M(n) log n)` via the Master theorem
+  (critical case `2T(n/2)+Θ(n)`), parametric over `M`. Blocked on Mathlib lacking
+  Master/Akra–Bazzi. Mirror the parent's choice to **bound/axiomatize** the closing
+  asymptotic rather than overclaim.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **DE1 — "needs the Master theorem" is NOT a reason to skip the whole OQ.** The
+  Master theorem blocks ONLY MS3 (the asymptotic). MS1/MS2 are independent of it.
+  A prior pass had this slug filed "research-level, skip"; that was too coarse.
+- **DE2 — Do not route MS1 through Mathlib's `GenContFract` continuants.** The field
+  typing (`Pair K`, `DivisionRing`) makes the integer Euclidean bridge more work than
+  proving `det = (-1)^k` directly over `Matrix (Fin 2) (Fin 2) ℤ`. Cite the field
+  result (I2) as precedent only.
+- **DE3 — No Big-O cost monad for `M(n)`.** As with Garner and binary-gcd-Brent,
+  Mathlib has no cost model; the parametric multiplication cost `M` and the Θ bound
+  cannot be stated as asymptotics — only as explicit `Nat` op-counts (MS2).

--- a/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02/state.md
+++ b/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02/state.md
@@ -1,25 +1,39 @@
 # Research State: bezout-identity-oq-01-oq-01-oq-01-oq-02
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: ORIENT
 **Path**: full
-**Since**: 2026-06-10T11:02:48-07:00
-**Iteration**: 1
+**Since**: 2026-06-13T00:00:00-07:00
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+OBSERVE→ORIENT survey complete (build-free, 2026-06-13 verification blackout).
+Decomposed the HGCD complexity OQ into a tractable matrix-invariant core (MS1/MS2)
+versus a cost-model-gated asymptotic remainder (MS3). See knowledge.md.
 
 ## Active Approach
-None yet.
+Schönhage HGCD via 2×2 integer quotient matrices `Q(q) = !![0,1; 1,-q]` over ℤ.
+The remainder-sequence product `R_k = Q(q_k)⋯Q(q_1)` satisfies
+`R_k.mulVec ![a,b] = ![r_k, r_{k+1}]` with `det R_k = (-1)^k` — the integer
+continuant/convergent recurrence. This is the OQ's part (a), and the clean first
+compile, independent of the Master theorem.
 
 ## Attempt Count
-- Total attempts: 0
+- Total attempts: 0 (no Lean committed — blackout)
 - Current approach attempts: 0
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Docker daemon DOWN** (`docker info` exit 124) → no `docker-build.sh` verification.
+- **Aristotle backend 404** (`prove` smoke-test returned `Resource not found.`).
+- **MS3 only:** Master/Akra–Bazzi theorem absent from Mathlib → the closing
+  `O(M(n) log n)` asymptotic (critical case `2T(n/2)+Θ(n)`) is out of scope.
+  MS1/MS2 are NOT blocked by this.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+When Docker returns: implement **MS1** in a new `BezoutIdentityOQ01OQ01OQ01OQ02.lean`
+— define `Q`, the product `R_k`, and prove the two invariant lemmas
+(`mulVec` correctness + `det R_k = (-1)^k`) using `Matrix.det_fin_two`/`Matrix.det_mul`.
+~40–80 LOC, zero Master-theorem dependency. Then **MS2** (computable HGCD + `Nat`
+op-count recurrence). Document **MS3** as the axiomatized/bounded asymptotic, mirroring
+the parent's Part 2. Do NOT route through Mathlib `GenContFract` (DE2).

--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json
@@ -1,0 +1,110 @@
+{
+  "slug": "bezout-identity-oq-01-oq-01-oq-01-oq-02",
+  "title": "Does the bit-complexity analysis extend to the HGCD (half-GCD) algorithm of Schönhage?",
+  "phase": "ORIENT",
+  "status": "surveyed",
+  "tier": "B",
+  "path": "full",
+  "problemStatement": {
+    "formal": "Does the analysis extend to the HGCD (half-GCD) algorithm of Schönhage, giving O(M(n) log n) complexity where M(n) is the multiplication cost? HGCD's recurrence is T(n) = 2 T(n/2) + M(n), which by the Master theorem gives T(n) = O(M(n) log n). Formalizing this requires (a) HGCD's invariant that 2×2 integer matrices encode partial Euclidean steps, (b) the Master theorem in Lean (absent from Mathlib), and (c) parametrization over the multiplication primitive M.",
+    "plain": "Extend the verified binary-GCD bit-complexity result to Schönhage's half-GCD algorithm. The ask splits cleanly: the 2×2 integer-matrix encoding of Euclidean steps is genuine constructive linear algebra, while the O(M(n) log n) asymptotic needs a Master/Akra–Bazzi theorem that Mathlib does not yet have.",
+    "whyMatters": [
+      "Adds a generalization-style follow-up to the verified binary-GCD gallery entry.",
+      "Exercises the family's established exact-Nat-counter pattern (binaryGcdSteps / stepBitOps) on a fast-GCD algorithm."
+    ]
+  },
+  "knownResults": {
+    "proven": [
+      "Parent bezout-identity-oq-01-oq-01-oq-01: binaryGcdSteps step counter + O(log n) bound (binaryGcdSteps_le_log), per-step stepBitOps, and the bounded O(log^2 n) total.",
+      "Mathlib ContinuedFractions/Determinant.lean proves the field-level convergent determinant A_n B_{n-1} - A_{n-1} B_n = (-1)^n (the continuant analogue of the integer matrix invariant)."
+    ],
+    "open": [
+      "MS1: define quotient matrices Q(q) = [[0,1],[1,-q]] over ZZ, the remainder-sequence product R_k, and prove R_k.mulVec [a,b] = [r_k, r_{k+1}] with det R_k = (-1)^k (build-free core; the OQ's part (a)).",
+      "MS2: computable HGCD returning (R, opCount) with the explicit Nat recurrence hgcdOps n <= 2 hgcdOps (n/2) + c * stepBitOps n.",
+      "MS3 (cost-model-gated): O(M(n) log n) via the Master theorem, critical case 2T(n/2)+Theta(n); parametric over M. Blocked on Mathlib lacking Master/Akra-Bazzi."
+    ],
+    "goal": "Formalize MS1 (matrix invariant) as the first compile, then MS2 (exact Nat op-counter recurrence); bound/axiomatize MS3 mirroring the parent's Part 2 rather than overclaiming the asymptotic."
+  },
+  "currentState": {
+    "phase": "ORIENT",
+    "since": "2026-06-13T00:00:00-07:00",
+    "iteration": 2,
+    "focus": "OBSERVE->ORIENT survey complete; HGCD OQ decomposed into tractable matrix-invariant core (MS1/MS2) vs cost-model-gated asymptotic (MS3).",
+    "blockers": [
+      "Docker daemon down (docker info exit 124) - no build verification.",
+      "Aristotle backend 404 (prove smoke-test: Resource not found).",
+      "MS3 only: Master/Akra-Bazzi theorem absent from Mathlib."
+    ],
+    "nextAction": "When Docker returns, implement MS1 in a new BezoutIdentityOQ01OQ01OQ01OQ02.lean: Q, R_k, mulVec correctness, det R_k = (-1)^k via Matrix.det_fin_two/Matrix.det_mul (~40-80 LOC). Do not route through Mathlib GenContFract.",
+    "attemptCounts": {
+      "total": 0,
+      "currentApproach": 0,
+      "approachesTried": 0
+    }
+  },
+  "knowledge": {
+    "progressSummary": "Build-free OBSERVE->ORIENT survey (2026-06-13 blackout). Resolved on paper that the HGCD OQ separates into a tractable, Master-theorem-free matrix-invariant core (the quotient-matrix encoding of the Euclidean remainder sequence, det = (-1)^k) and a cost-model-gated asymptotic remainder. Carved the precise tractable sub-claim (MS1/MS2) and identified MS3 as the same trap class as binary-gcd-Brent and erdos-szekeres Theta(n log n).",
+    "builtItems": [],
+    "insights": [
+      "One Euclidean step (r_{i-1},r_i) -> (r_i, r_{i-1}-q_i r_i) is left-mult by Q(q_i)=[[0,1],[1,-q_i]] over ZZ; the product R_k = Q(q_k)...Q(q_1) has det (-1)^k and its entries are the Bezout cofactors / continuants K(q_1..q_k). This is the OQ's part (a) and is constructive, blackout-buildable linear algebra.",
+      "Mathlib ContinuedFractions/Determinant.lean gives the field-level analogue (GenContFract over a DivisionRing), but the integer Euclidean bridge is bookkeeping; formalize directly over Matrix (Fin 2) (Fin 2) ZZ with Matrix.det_fin_two/Matrix.det_mul instead.",
+      "Mirror the parent's exact-Nat-counter pattern: a computable HGCD returning (R, opCount) yields a concrete Nat recurrence, not a Big-O statement. The jump to Theta(M(n) log n) is exactly the Master-theorem step Mathlib cannot take.",
+      "'Needs the Master theorem' blocks ONLY the asymptotic MS3; MS1/MS2 are independent. Filing the whole OQ as research-level-skip was too coarse."
+    ],
+    "mathlibGaps": [
+      "No Master theorem / Akra-Bazzi (blocks MS3 asymptotic; critical case 2T(n/2)+Theta(n)).",
+      "No cost model / Big-O monad for the parametric multiplication primitive M (MS3 part (c))."
+    ],
+    "nextSteps": [
+      "MS1: Q, R_k, mulVec correctness, det R_k = (-1)^k (first compile, ~40-80 LOC).",
+      "MS2: computable HGCD + Nat op-count recurrence reusing parent stepBitOps/Nat.size/Nat.log.",
+      "MS3: bound/axiomatize the O(M(n) log n) asymptotic, documented as gated on Mathlib Master theorem."
+    ],
+    "markdown": "See research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02/knowledge.md for the full survey (MS1/MS2/MS3 decomposition, matrix-invariant insight I1-I3, dead ends DE1-DE3)."
+  },
+  "tags": ["gcd", "complexity", "matrix-invariant", "continuant", "blackout-survey", "cost-model-gated"],
+  "relatedProofs": [
+    "bezout-identity",
+    "bezout-identity-oq-01-oq-01-oq-01",
+    "binary-gcd-oq-01-oq-04-oq-03"
+  ],
+  "references": {
+    "papers": [
+      "Schönhage (1971), Schnelle Berechnung von Kettenbruchentwicklungen (HGCD).",
+      "Knuth, TAOCP Vol. 2, §4.5.2 (Euclid's algorithm and continuants).",
+      "Stehlé & Zimmermann (2004), A binary recursive GCD algorithm."
+    ],
+    "urls": [],
+    "mathlib": [
+      "Mathlib/Algebra/ContinuedFractions/Determinant.lean",
+      "Mathlib/Algebra/ContinuedFractions/ContinuantsRecurrence.lean",
+      "Mathlib/Data/Matrix/Basic.lean (det_fin_two, det_mul, mulVec)"
+    ]
+  },
+  "started": "2026-06-10T11:02:48-07:00",
+  "significance": 6,
+  "leanFiles": [
+    {
+      "path": "Proofs/BezoutIdentityOQ01OQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01OQ01.lean",
+      "lineCount": 286,
+      "theoremCount": 4,
+      "axiomCount": 0,
+      "defCount": 3,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01OQ01.lean"
+    },
+    {
+      "path": "Proofs/BezoutIdentityOQ01OQ01.lean",
+      "filename": "BezoutIdentityOQ01OQ01.lean",
+      "lineCount": 189,
+      "theoremCount": 6,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/BezoutIdentityOQ01OQ01.lean"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Build-free OBSERVE→ORIENT survey of `bezout-identity-oq-01-oq-01-oq-01-oq-02` (does the binary-GCD bit-complexity analysis extend to Schönhage's half-GCD?), conducted during the 2026-06-13 verification blackout (Docker `docker info` exit 124, Aristotle `prove` 404 — both confirmed live this session). **No Lean committed.**

The OQ was previously filed "research-level, skip (needs the Master theorem)." This survey shows that classification was too coarse: the ask splits into a tractable build-free core and a genuinely-gated asymptotic.

- **MS1 (build-free, the clean first compile):** the 2×2 integer quotient matrices `Q(q) = [[0,1],[1,-q]]` encode the Euclidean remainder sequence — `R_k.mulVec [a,b] = [r_k, r_{k+1}]` with `det R_k = (-1)^k`. Pure `Matrix`/induction (`Matrix.det_fin_two`/`Matrix.det_mul`), **zero Master-theorem dependency**. This is the OQ's part (a).
- **MS2 (exact `Nat` counter):** a computable HGCD returning `(R, opCount)` with the explicit `Nat` recurrence `hgcdOps n ≤ 2 hgcdOps (n/2) + c·stepBitOps n` — mirroring the parent's `binaryGcdSteps`/`stepBitOps` pattern, not a Big-O statement.
- **MS3 (cost-model-gated trap, document only):** `O(M(n) log n)` via the Master theorem (critical case `2T(n/2)+Θ(n)`, absent from Mathlib) + parametric multiplication cost `M`. Same class as `binary-gcd-...-oq-04-oq-03` (Brent constant) and `erdos-szekeres-oq-02`'s Θ(n log n).

Identified Mathlib `ContinuedFractions/Determinant.lean` as the field-level precedent for the matrix invariant, but recommends formalizing directly over `Matrix (Fin 2) (Fin 2) ℤ` rather than routing through `GenContFract` (the integer-Euclidean bridge is bookkeeping).

## Changes

- `research/problems/.../knowledge.md` — full survey (insights I1–I3, milestones MS1–MS3, dead ends DE1–DE3)
- `research/problems/.../state.md` — OBSERVE→ORIENT, blockers, next action
- `src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json` — seeded (absent on main → additive)

## Test plan

- [ ] Build-free survey — no Lean to verify (blackout). When Docker returns, MS1 is the first buildable target in a new `BezoutIdentityOQ01OQ01OQ01OQ02.lean`.
- [x] JSON validated (`python3 -m json.tool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)