### PR TITLE
research(minkowski-theorem-oq-04): S31 AUDIT — realign gallery sections[] to source

### DIFF
--- a/src/data/proofs/minkowski-theorem-oq-04/meta.json
+++ b/src/data/proofs/minkowski-theorem-oq-04/meta.json
@@ -2,7 +2,7 @@
   "id": "minkowski-theorem-oq-04",
   "title": "Blichfeldt's Theorem: k+1 Congruent Points When vol(S) > k",
   "slug": "minkowski-theorem-oq-04",
-  "description": "Blichfeldt's theorem (1914): any measurable set S \u2286 \u211d\u207f with Lebesgue measure > k contains k+1 distinct points whose pairwise differences lie in \u2124\u207f. Generalizes Minkowski's lattice point theorem (no convexity or symmetry needed) and recovers Minkowski as a corollary via the half-scaling T = S/2.",
+  "description": "Blichfeldt's theorem (1914): any measurable set S ⊆ ℝⁿ with Lebesgue measure > k contains k+1 distinct points whose pairwise differences lie in ℤⁿ. Generalizes Minkowski's lattice point theorem (no convexity or symmetry needed) and recovers Minkowski as a corollary via the half-scaling T = S/2.",
   "meta": {
     "id": "minkowski-theorem-oq-04",
     "title": "Blichfeldt's Theorem: k+1 Congruent Points When vol(S) > k",
@@ -25,46 +25,46 @@
     "lineCount": 1126,
     "theoremCount": 17,
     "definitionCount": 0,
-    "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Docker build verified clean (3075 jobs, PR #19113, 2026-05-14); status promoted from `axiomatized` to `verified` and badge from `axiom` to `original`. History: (1) `blichfeldt_proj_measurable` (translation continuity \u2192 preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k\u22651 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route \u2014 Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core \u222b\u207b x in F, \u03a3' g, 1_s((g:\u211d\u207f)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) \u2192 L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)\u00b7s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2\u207f is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`.",
+    "assumptions": "All four originally-stated axioms have been eliminated in the source file (`MinkowskiTheoremOQ04.lean`). The `axiomCount` fields are synced to 0 (PR #17402, 2026-05-08). Docker build verified clean (3075 jobs, PR #19113, 2026-05-14); status promoted from `axiomatized` to `verified` and badge from `axiom` to `original`. History: (1) `blichfeldt_proj_measurable` (translation continuity → preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity vs vol(F) = 1) were promoted to proved theorems in earlier sessions; (2) `blichfeldt_volume_partition` was eliminated by rewriting `blichfeldt_basic` as a direct call to `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib's pigeonhole on a fundamental domain); (3) `blichfeldt_general` (the k≥1 covering-count averaging form) was promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route — Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core ∫⁻ x in F, Σ' g, 1_s((g:ℝⁿ)+x) dx = vol(s) from `IsAddFundamentalDomain.lintegral_eq_tsum''` + Tonelli); Move B: pointwise c(z) ≤ k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` to extract `Fin (k+1) → L` from the encard bound; Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s ≤ k`, contradicting `k < volume s`. The two former sorries in `minkowski_from_blichfeldt` are closed: T = (1/2)·s is shown measurable by rewriting as the preimage of s under the doubling map, and the volume identity vol(T) = vol(s)/2ⁿ is proved via `Measure.addHaar_smul` plus ENNReal arithmetic on `(2⁻¹)ⁿ · 2ⁿ = 1`.",
     "dateAdded": "2026-05-07",
     "mathlibDependencies": [
       {
         "theorem": "MeasureTheory.IsAddFundamentalDomain.lintegral_eq_tsum",
-        "description": "Fundamental domain integral identity: \u222b f = \u03a3' g, \u222b_F f(z + g) \u2014 the engine behind the volume partition axiom",
+        "description": "Fundamental domain integral identity: ∫ f = Σ' g, ∫_F f(z + g) — the engine behind the volume partition axiom",
         "module": "Mathlib.MeasureTheory.Group.FundamentalDomain"
       },
       {
         "theorem": "MeasureTheory.measure_iUnion",
-        "description": "Sigma-additivity of measure on pairwise-disjoint measurable sets \u2014 backs the disjoint-bound axiom",
+        "description": "Sigma-additivity of measure on pairwise-disjoint measurable sets — backs the disjoint-bound axiom",
         "module": "Mathlib.MeasureTheory.MeasureSpace"
       },
       {
         "theorem": "MinkowskiProved.stdLattice",
-        "description": "The standard integer lattice \u2124\u207f \u2286 \u211d\u207f from the parent Minkowski formalization",
+        "description": "The standard integer lattice ℤⁿ ⊆ ℝⁿ from the parent Minkowski formalization",
         "module": "Proofs.MinkowskiFundamentalTheorem"
       },
       {
         "theorem": "MinkowskiProved.stdFundDomain",
-        "description": "The fundamental domain F = [0,1)\u207f for \u2124\u207f in \u211d\u207f",
+        "description": "The fundamental domain F = [0,1)ⁿ for ℤⁿ in ℝⁿ",
         "module": "Proofs.MinkowskiFundamentalTheorem"
       }
     ],
     "originalContributions": [
-      "blichfeldt_proj_measurable: theorem (was axiom). Translation `(\u00b7 + v)` is measurable, so the preimage of s is measurable; intersect with the measurable fundamental domain.",
+      "blichfeldt_proj_measurable: theorem (was axiom). Translation `(· + v)` is measurable, so the preimage of s is measurable; intersect with the measurable fundamental domain.",
       "blichfeldt_disj_bound: theorem (was axiom). `Pairwise.measure_iUnion` (sigma-additivity) on disjoint measurable subsets, bounded above by `stdLattice_covolume = 1`.",
       "blichfeldt_basic: axiom-free proof of the k=1 case via direct application of `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` (Mathlib pigeonhole on a fundamental domain). The earlier proof manually built the partition-pigeonhole from a `blichfeldt_volume_partition` axiom; that axiom is now eliminated.",
-      "Bridge from `g +\u1d65 x = y` (AddSubgroup action on the parent group) to `(g : \u211d\u207f) + x = y` (additive group equation) via `AddSubgroup.vadd_def` + `vadd_eq_add`; this gives `y - x = (g : \u211d\u207f) \u2208 \u2124\u207f` directly.",
+      "Bridge from `g +ᵥ x = y` (AddSubgroup action on the parent group) to `(g : ℝⁿ) + x = y` (additive group equation) via `AddSubgroup.vadd_def` + `vadd_eq_add`; this gives `y - x = (g : ℝⁿ) ∈ ℤⁿ` directly.",
       "blichfeldt_general: promoted from axiom to fully-proved theorem (S13/S14, PRs #17298 + #17329, 2026-05-08) via the Path A contrapose route. Move A reuses `volume_eq_setLIntegral_indicator_tsum` (S9 analytic core). Move B contraposes `¬ ∃ Fin (k+1) injection` to a pointwise `c(z) ≤ k` bound, with the `∑' v, 1_s((v:ℝⁿ)+z)` rewritten as `T(z).encard` via `tsum_subtype` + `ENNReal.tsum_set_one` (S10 simplification, PR #17028), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` extract `Fin (k+1) → L` from the encard bound (S11+S12 v4.26.0 API verification). Move C integrates the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s ≤ k`, contradicting `k < volume s`. ENNReal-scope fix in S14 (PR #17329) for the integral inequality block. ~130 lines including docstring; build verification of the post-S14 source pending the `proofs/.lake` Docker infra-repair.",
       "blichfeldt_basic_from_general: derives k=1 from the now-proved general-k theorem with the Fin (k+1) injectivity argument.",
-      "volume_eq_setLIntegral_indicator_tsum: covering-count integral identity \u222b_F (\u03a3' g : \u2124\u207f, 1_s((g : \u211d\u207f) + x)) dx = vol(s). Fully proved (~63 lines) from `IsAddFundamentalDomain.lintegral_eq_tsum''` (additive form via `to_additive`) combined with Tonelli (`lintegral_tsum`); the `g +\u1d65 x` \u2194 `(g : \u211d\u207f) + x` conversion uses `AddSubgroup.vadd_def + vadd_eq_add`. This is the analytic core of the covering-count argument and reduces the remaining `blichfeldt_general` work to a self-contained combinatorial extraction step (S9, 2026-05-08).",
-      "minkowski_from_blichfeldt: structural reduction Minkowski \u2192 Blichfeldt via T = (1/2)\u00b7s; central symmetry + convexity give the lattice point in s. The two former sorries (measurability of T, volume identity vol(T) = vol(s)/2\u207f) are now closed via preimage rewriting + `Measure.addHaar_smul` + ENNReal arithmetic.",
+      "volume_eq_setLIntegral_indicator_tsum: covering-count integral identity ∫_F (Σ' g : ℤⁿ, 1_s((g : ℝⁿ) + x)) dx = vol(s). Fully proved (~63 lines) from `IsAddFundamentalDomain.lintegral_eq_tsum''` (additive form via `to_additive`) combined with Tonelli (`lintegral_tsum`); the `g +ᵥ x` ↔ `(g : ℝⁿ) + x` conversion uses `AddSubgroup.vadd_def + vadd_eq_add`. This is the analytic core of the covering-count argument and reduces the remaining `blichfeldt_general` work to a self-contained combinatorial extraction step (S9, 2026-05-08).",
+      "minkowski_from_blichfeldt: structural reduction Minkowski → Blichfeldt via T = (1/2)·s; central symmetry + convexity give the lattice point in s. The two former sorries (measurability of T, volume identity vol(T) = vol(s)/2ⁿ) are now closed via preimage rewriting + `Measure.addHaar_smul` + ENNReal arithmetic.",
       "Mathlib 4.26.0 API drift fixes: `Pairwise (Disjoint on f)` lambda rewrite; ENNReal Nat-coerce via `exact_mod_cast`; `Submodule.mem_toAddSubgroup` removal compensation; `open Pointwise` for the `Set.SMul` instance needed by `Measure.addHaar_smul`."
     ],
     "mathlib_version": "4.26.0",
     "prerequisites": [
-      "Lebesgue measure on \u211d\u207f and the fundamental-domain integral formula",
+      "Lebesgue measure on ℝⁿ and the fundamental-domain integral formula",
       "Sigma-additivity and monotonicity of measure",
-      "Integer lattices \u2124\u207f as additive subgroups of \u211d\u207f",
+      "Integer lattices ℤⁿ as additive subgroups of ℝⁿ",
       "Minkowski's convex body theorem (recovered as a corollary)"
     ],
     "relatedProofs": [
@@ -74,22 +74,22 @@
     ]
   },
   "overview": {
-    "historicalContext": "Hans Blichfeldt published this strengthening of Minkowski's geometry of numbers in 1914 (Trans. AMS), removing the convexity and symmetry hypotheses entirely. The proof \u2014 the fundamental-domain pigeonhole \u2014 is so geometric that it makes Minkowski's theorem a one-line corollary: apply Blichfeldt to T = (1/2)\u00b7S, then use central symmetry + convexity to extract a lattice point of S. Blichfeldt's theorem is now a standard pillar of geometry of numbers (Cassels 1959, ch. III; Gruber\u2013Lekkerkerker 1987, ch. 6).",
-    "problemStatement": "**Blichfeldt's Theorem**: If S \u2286 \u211d\u207f is Lebesgue measurable with vol(S) > k for some k \u2208 \u2115, then S contains k+1 distinct points x\u2080, \u2026, x\u2096 such that all pairwise differences x\u1d62 \u2212 x\u2c7c lie in \u2124\u207f.\n\nNo convexity or symmetry is required. The k=1 case (two \u2124\u207f-congruent points whenever vol(S) > 1) is the original Blichfeldt statement.",
-    "text": "Proves the k=1 case of Blichfeldt's theorem fully (289 lines, 0 sorries on the path) from one remaining measure-theoretic axiom \u2014 the fundamental-domain partition formula \u2014 that captures a standard Mathlib fact. Two former measure-theory axioms (measurability of projections, disjoint-subset bound) are now proved theorems. The general k+1 case is taken as an axiom, and Minkowski's theorem is recovered as a corollary via the half-scaling T = (1/2)\u00b7s with **0 sorries** (the measurability of T and the volume identity vol(T) = vol(s)/2\u207f are proved via preimage rewriting and `Measure.addHaar_smul`).",
-    "proofStrategy": "**Fundamental domain pigeonhole** (k=1 case, fully proved):\n\n1. **Setup**: \u2124\u207f tiles \u211d\u207f with fundamental domain F = [0,1)\u207f. For each v \u2208 \u2124\u207f, define the projection S\u1d65 = {z \u2208 F | z+v \u2208 S}.\n2. **Suppose no two \u2124\u207f-congruent points in S** (proof by contradiction). Then for v \u2260 w in \u2124\u207f, S\u1d65 and Sw are *disjoint*: any z in both would give two points z+v, z+w \u2208 S with difference v \u2212 w \u2208 \u2124\u207f.\n3. **Volume identity (Axiom)**: vol(S) = \u03a3'\u1d65 vol(S\u1d65). This is the fundamental-domain partition formula from `IsAddFundamentalDomain.lintegral_eq_tsum` applied to the indicator 1_S.\n4. **Disjoint bound (proved theorem)**: pairwise-disjoint measurable subsets of F have total volume \u2264 vol(F) = 1, via `measure_iUnion` + `measure_mono`.\n5. **Contradiction**: \u03a3'\u1d65 vol(S\u1d65) \u2264 1 but equals vol(S) > 1.\n\n**Recovering Minkowski** (Part 4):\n1. T = (1/2)\u00b7S has vol(T) = vol(S)/2\u207f > 1.\n2. Blichfeldt gives a \u2260 b \u2208 T with a \u2212 b \u2208 \u2124\u207f.\n3. Write a = x\u2080/2, b = y\u2080/2 with x\u2080, y\u2080 \u2208 S. Central symmetry: \u2212y\u2080 \u2208 S.\n4. Convexity: (x\u2080 + (\u2212y\u2080))/2 = a \u2212 b \u2208 S, and a \u2212 b \u2260 0.",
+    "historicalContext": "Hans Blichfeldt published this strengthening of Minkowski's geometry of numbers in 1914 (Trans. AMS), removing the convexity and symmetry hypotheses entirely. The proof — the fundamental-domain pigeonhole — is so geometric that it makes Minkowski's theorem a one-line corollary: apply Blichfeldt to T = (1/2)·S, then use central symmetry + convexity to extract a lattice point of S. Blichfeldt's theorem is now a standard pillar of geometry of numbers (Cassels 1959, ch. III; Gruber–Lekkerkerker 1987, ch. 6).",
+    "problemStatement": "**Blichfeldt's Theorem**: If S ⊆ ℝⁿ is Lebesgue measurable with vol(S) > k for some k ∈ ℕ, then S contains k+1 distinct points x₀, …, xₖ such that all pairwise differences xᵢ − xⱼ lie in ℤⁿ.\n\nNo convexity or symmetry is required. The k=1 case (two ℤⁿ-congruent points whenever vol(S) > 1) is the original Blichfeldt statement.",
+    "text": "Proves the k=1 case of Blichfeldt's theorem fully (289 lines, 0 sorries on the path) from one remaining measure-theoretic axiom — the fundamental-domain partition formula — that captures a standard Mathlib fact. Two former measure-theory axioms (measurability of projections, disjoint-subset bound) are now proved theorems. The general k+1 case is taken as an axiom, and Minkowski's theorem is recovered as a corollary via the half-scaling T = (1/2)·s with **0 sorries** (the measurability of T and the volume identity vol(T) = vol(s)/2ⁿ are proved via preimage rewriting and `Measure.addHaar_smul`).",
+    "proofStrategy": "**Fundamental domain pigeonhole** (k=1 case, fully proved):\n\n1. **Setup**: ℤⁿ tiles ℝⁿ with fundamental domain F = [0,1)ⁿ. For each v ∈ ℤⁿ, define the projection Sᵥ = {z ∈ F | z+v ∈ S}.\n2. **Suppose no two ℤⁿ-congruent points in S** (proof by contradiction). Then for v ≠ w in ℤⁿ, Sᵥ and Sw are *disjoint*: any z in both would give two points z+v, z+w ∈ S with difference v − w ∈ ℤⁿ.\n3. **Volume identity (Axiom)**: vol(S) = Σ'ᵥ vol(Sᵥ). This is the fundamental-domain partition formula from `IsAddFundamentalDomain.lintegral_eq_tsum` applied to the indicator 1_S.\n4. **Disjoint bound (proved theorem)**: pairwise-disjoint measurable subsets of F have total volume ≤ vol(F) = 1, via `measure_iUnion` + `measure_mono`.\n5. **Contradiction**: Σ'ᵥ vol(Sᵥ) ≤ 1 but equals vol(S) > 1.\n\n**Recovering Minkowski** (Part 4):\n1. T = (1/2)·S has vol(T) = vol(S)/2ⁿ > 1.\n2. Blichfeldt gives a ≠ b ∈ T with a − b ∈ ℤⁿ.\n3. Write a = x₀/2, b = y₀/2 with x₀, y₀ ∈ S. Central symmetry: −y₀ ∈ S.\n4. Convexity: (x₀ + (−y₀))/2 = a − b ∈ S, and a − b ≠ 0.",
     "keyInsights": [
       "Removing convexity and symmetry: Blichfeldt's pigeonhole works on the *measure* of S alone, no geometric structure of S beyond measurability is used. The fundamental domain provides the pigeonholes.",
-      "The half-scaling trick T = (1/2)\u00b7S is the bridge to Minkowski: vol(S) > 2\u207f becomes vol(T) > 1, and the central symmetry + convexity of S give the lattice point in S itself rather than in (S \u2212 S)/2.",
-      "The k=1 to general-k gap: the general case uses a covering-count averaging argument (\u222b_F #{v | z+v \u2208 S} dz = vol(S)) but the existence of z with high covering count is more subtle than the disjoint-set pigeonhole in the k=1 case. We axiomatize this step here.",
-      "Why exactly three measure axioms? Each captures one ingredient of the pigeonhole: partition (Axiom 1) reads vol(S) as a sum over translates; measurability (Axiom 2) makes that sum well-defined; covolume bound (Axiom 3) says the sum cannot exceed vol(F)=1. Removing any one collapses the proof \u2014 and each axiom is a one-line Mathlib invocation, so the formalization is genuinely close to fully verified.",
+      "The half-scaling trick T = (1/2)·S is the bridge to Minkowski: vol(S) > 2ⁿ becomes vol(T) > 1, and the central symmetry + convexity of S give the lattice point in S itself rather than in (S − S)/2.",
+      "The k=1 to general-k gap: the general case uses a covering-count averaging argument (∫_F #{v | z+v ∈ S} dz = vol(S)) but the existence of z with high covering count is more subtle than the disjoint-set pigeonhole in the k=1 case. We axiomatize this step here.",
+      "Why exactly three measure axioms? Each captures one ingredient of the pigeonhole: partition (Axiom 1) reads vol(S) as a sum over translates; measurability (Axiom 2) makes that sum well-defined; covolume bound (Axiom 3) says the sum cannot exceed vol(F)=1. Removing any one collapses the proof — and each axiom is a one-line Mathlib invocation, so the formalization is genuinely close to fully verified.",
       "Lean 4 + Mathlib 4.26.0 friction points: `Pairwise (Disjoint on f)` infix needs a lambda rewrite; ENNReal Nat-coercion at literal-1 sites needs `exact_mod_cast`; `Submodule.mem_toAddSubgroup` was removed and SetLike defEq must be used directly."
     ],
     "prerequisites": [
-      "Lebesgue measure and Lebesgue integration on \u211d\u207f",
+      "Lebesgue measure and Lebesgue integration on ℝⁿ",
       "Fundamental domain integral identity (Mathlib `IsAddFundamentalDomain.lintegral_eq_tsum`)",
       "Pairwise-disjoint measurable sets and sigma-additivity",
-      "Integer lattice \u2124\u207f \u2286 \u211d\u207f as an additive subgroup",
+      "Integer lattice ℤⁿ ⊆ ℝⁿ as an additive subgroup",
       "Minkowski's convex body theorem (used as a downstream consequence, not a prerequisite)"
     ]
   },
@@ -97,67 +97,67 @@
     {
       "id": "axioms",
       "title": "Measure-Theoretic Infrastructure (helpers, no axioms)",
-      "startLine": 54,
-      "endLine": 103,
-      "summary": "Two helper theorems for the partition-based pigeonhole approach: `blichfeldt_proj_measurable` (continuous-translation preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity + monotonicity against vol(F) = 1). The current `blichfeldt_basic` proof no longer uses them \u2014 it calls Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` directly \u2014 and the now-proved `blichfeldt_general` (S13/S14 Path A contrapose) is built from `volume_eq_setLIntegral_indicator_tsum` + Tonelli rather than from these helpers; they are kept as reusable building blocks for downstream specializations.",
-      "mathContext": "These are the standard Mathlib facts that underpin Blichfeldt's argument: continuous-translation preimage measurability and sigma-additivity for pairwise-disjoint measurable sets. The original Blichfeldt 1914 proof composes them with the partition formula vol(S) = \u03a3' vol(S\u1d65); Mathlib's `exists_ne_zero_vadd_eq` packages this composition."
+      "startLine": 68,
+      "endLine": 118,
+      "summary": "Two helper theorems for the partition-based pigeonhole approach: `blichfeldt_proj_measurable` (continuous-translation preimage measurability) and `blichfeldt_disj_bound` (sigma-additivity + monotonicity against vol(F) = 1). The current `blichfeldt_basic` proof no longer uses them — it calls Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` directly — and the now-proved `blichfeldt_general` (S13/S14 Path A contrapose) is built from `volume_eq_setLIntegral_indicator_tsum` + Tonelli rather than from these helpers; they are kept as reusable building blocks for downstream specializations.",
+      "mathContext": "These are the standard Mathlib facts that underpin Blichfeldt's argument: continuous-translation preimage measurability and sigma-additivity for pairwise-disjoint measurable sets. The original Blichfeldt 1914 proof composes them with the partition formula vol(S) = Σ' vol(Sᵥ); Mathlib's `exists_ne_zero_vadd_eq` packages this composition."
     },
     {
       "id": "k1-blichfeldt",
       "title": "Blichfeldt's Basic Theorem (k = 1)",
-      "startLine": 105,
-      "endLine": 149,
-      "summary": "Axiom-free proof of the k=1 case. Reduces to Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` applied to the standard \u2124\u207f-fundamental-domain (covolume 1): a measurable set of volume > 1 admits two points x, y with `g +\u1d65 x = y` for some `g \u2260 0`, hence `y \u2212 x = (g : \u211d\u207f) \u2208 \u2124\u207f`.",
-      "mathContext": "Mathlib's pigeonhole encapsulates the original Blichfeldt 1914 argument: the lattice translates of the fundamental domain cover \u211d\u207f, and a set of volume > vol(F) = 1 cannot avoid all but one translate. The Lean bridge from `g +\u1d65 x = y` (action of an AddSubgroup on the parent group) to `(g : \u211d\u207f) + x = y` uses `AddSubgroup.vadd_def` + `vadd_eq_add`."
+      "startLine": 119,
+      "endLine": 166,
+      "summary": "Axiom-free proof of the k=1 case. Reduces to Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` applied to the standard ℤⁿ-fundamental-domain (covolume 1): a measurable set of volume > 1 admits two points x, y with `g +ᵥ x = y` for some `g ≠ 0`, hence `y − x = (g : ℝⁿ) ∈ ℤⁿ`.",
+      "mathContext": "Mathlib's pigeonhole encapsulates the original Blichfeldt 1914 argument: the lattice translates of the fundamental domain cover ℝⁿ, and a set of volume > vol(F) = 1 cannot avoid all but one translate. The Lean bridge from `g +ᵥ x = y` (action of an AddSubgroup on the parent group) to `(g : ℝⁿ) + x = y` uses `AddSubgroup.vadd_def` + `vadd_eq_add`."
     },
     {
       "id": "general-case",
       "title": "The General k+1 Version (Path A Contrapose Proof + Covering-Count Integral Identity)",
-      "startLine": 154,
-      "endLine": 248,
-      "summary": "Proves the general-k Blichfeldt theorem: vol(S) > k yields k+1 distinct \u2124\u207f-congruent points. Uses the covering-count function c(z) = #{v | z+v \u2208 S} which integrates to vol(S) > k over F. The Path A contrapose proof (S13, PR #17298; ENNReal-scope fix S14, PR #17329) decomposes as: Move A \u2014 reuse the proved `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core); Move B \u2014 pointwise `c(z) \u2264 k` from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` rewriting tsum-of-indicators as `T(z).encard`; Move C \u2014 integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`. The k=1 corollary `blichfeldt_basic_from_general` is derived as a sanity check. Build verification of the post-S14 source is pending the `proofs/.lake` Docker infra-repair.",
-      "mathContext": "The general case is a Lebesgue averaging argument: \u222b_F c dz = vol(S) > k = k \u00b7 vol(F), so c attains a value \u2265 k+1 on a positive-measure set. The integral identity \u222b_F c = vol(s) is the proved theorem `volume_eq_setLIntegral_indicator_tsum` (S9); the contrapositive extraction step (from a pointwise tsum > k, build k+1 distinct lattice translates via `tsum_subtype` + `ENNReal.tsum_set_one` + `Fintype.equivFinOfCardEq`) is the Path A proof completed in S13\u2013S14."
-    },
-    {
-      "id": "minkowski-corollary",
-      "title": "Minkowski as a Corollary",
-      "startLine": 254,
-      "endLine": 343,
-      "summary": "Proves Minkowski's theorem from `blichfeldt_basic` via the half-scaling T = (1/2)\u00b7s. **0 sorries** (was 2). Measurability of T proved by rewriting as preimage of s under the doubling map; volume identity vol(T) = vol(s)/2\u207f proved via `Measure.addHaar_smul` + ENNReal arithmetic on `(2\u207b\u00b9)\u207f \u00b7 2\u207f = 1`. The structural reduction \u2014 central symmetry + convexity giving (a \u2212 b) \u2208 s \u2014 was already proved cleanly.",
-      "mathContext": "Central symmetry gives \u2212y\u2080 \u2208 S; convexity then gives the midpoint (x\u2080 + (\u2212y\u2080))/2 = a \u2212 b \u2208 S. The lattice membership a \u2212 b \u2208 \u2124\u207f is the Blichfeldt output. Nonzero-ness comes from a \u2260 b."
+      "startLine": 167,
+      "endLine": 579,
+      "summary": "Proves the general-k Blichfeldt theorem: vol(S) > k yields k+1 distinct ℤⁿ-congruent points. Uses the covering-count function c(z) = #{v | z+v ∈ S} which integrates to vol(S) > k over F. The Path A contrapose proof (S13, PR #17298; ENNReal-scope fix S14, PR #17329) decomposes as: Move A — reuse the proved `volume_eq_setLIntegral_indicator_tsum` (S9, PR #16995, the analytic core); Move B — pointwise `c(z) ≤ k` from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` rewriting tsum-of-indicators as `T(z).encard`; Move C — integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s ≤ k`, contradicting `k < volume s`. The k=1 corollary `blichfeldt_basic_from_general` is derived as a sanity check. Build verification of the post-S14 source is pending the `proofs/.lake` Docker infra-repair.",
+      "mathContext": "The general case is a Lebesgue averaging argument: ∫_F c dz = vol(S) > k = k · vol(F), so c attains a value ≥ k+1 on a positive-measure set. The integral identity ∫_F c = vol(s) is the proved theorem `volume_eq_setLIntegral_indicator_tsum` (S9); the contrapositive extraction step (from a pointwise tsum > k, build k+1 distinct lattice translates via `tsum_subtype` + `ENNReal.tsum_set_one` + `Fintype.equivFinOfCardEq`) is the Path A proof completed in S13–S14."
     },
     {
       "id": "concrete-points",
       "title": "Concrete-Named Corollaries (k = 2, 3)",
-      "startLine": 387,
-      "endLine": 450,
-      "summary": "`blichfeldt_three_points` (k=2: vol(S) > 2 \u21d2 three \u2124\u207f-congruent points) and `blichfeldt_four_points` (k=3: vol(S) > 3 \u21d2 four points) \u2014 concrete-named specializations of the general theorem. Each rebrands the `Fin (k+1) \u2192 \u211d\u207f` output as a tuple `(x, y, z[, w])` with explicit injectivity and pairwise-difference clauses.",
+      "startLine": 580,
+      "endLine": 682,
+      "summary": "`blichfeldt_three_points` (k=2: vol(S) > 2 ⇒ three ℤⁿ-congruent points) and `blichfeldt_four_points` (k=3: vol(S) > 3 ⇒ four points) — concrete-named specializations of the general theorem. Each rebrands the `Fin (k+1) → ℝⁿ` output as a tuple `(x, y, z[, w])` with explicit injectivity and pairwise-difference clauses.",
       "mathContext": "Specializations of `blichfeldt_general` at $k = 2, 3$: produce $3$ or $4$ distinct points whose pairwise differences all lie in $\\mathbb{Z}^n$. Concrete-named to ease downstream use."
     },
     {
       "id": "pairwise-finset",
       "title": "Pairwise-Nonzero and Finset Forms of Blichfeldt",
-      "startLine": 451,
-      "endLine": 535,
-      "summary": "`blichfeldt_general_pairwise`: strengthens the conclusion by guaranteeing pairwise differences are *nonzero* lattice elements (matches the classical statement). `blichfeldt_general_finset`: rephrases the output as a `Finset` of cardinality k+1 with all elements in S and all pairwise differences in \u2124\u207f \u2014 the form most convenient for combinatorial applications.",
+      "startLine": 683,
+      "endLine": 738,
+      "summary": "`blichfeldt_general_pairwise`: strengthens the conclusion by guaranteeing pairwise differences are *nonzero* lattice elements (matches the classical statement). `blichfeldt_general_finset`: rephrases the output as a `Finset` of cardinality k+1 with all elements in S and all pairwise differences in ℤⁿ — the form most convenient for combinatorial applications.",
       "mathContext": "The injective $\\mathrm{Fin}(k+1)\\to S$ output is reshaped two ways: (i) emit a `Finset` of size $k+1$ via `Finset.image` + `Finset.card_image_of_injective`; (ii) extract nonzero pairwise differences via $i \\ne j \\Rightarrow \\mathrm{pts}\\ i \\ne \\mathrm{pts}\\ j \\Rightarrow \\mathrm{pts}\\ i - \\mathrm{pts}\\ j \\ne 0$."
+    },
+    {
+      "id": "minkowski-corollary",
+      "title": "Minkowski as a Corollary",
+      "startLine": 739,
+      "endLine": 856,
+      "summary": "Proves Minkowski's theorem from `blichfeldt_basic` via the half-scaling T = (1/2)·s. **0 sorries** (was 2). Measurability of T proved by rewriting as preimage of s under the doubling map; volume identity vol(T) = vol(s)/2ⁿ proved via `Measure.addHaar_smul` + ENNReal arithmetic on `(2⁻¹)ⁿ · 2ⁿ = 1`. The structural reduction — central symmetry + convexity giving (a − b) ∈ s — was already proved cleanly.",
+      "mathContext": "Central symmetry gives −y₀ ∈ S; convexity then gives the midpoint (x₀ + (−y₀))/2 = a − b ∈ S. The lattice membership a − b ∈ ℤⁿ is the Blichfeldt output. Nonzero-ness comes from a ≠ b."
     },
     {
       "id": "minkowski-general",
       "title": "Generalized Minkowski (k+1-Point Forms)",
-      "startLine": 536,
-      "endLine": 920,
-      "summary": "Five Minkowski generalizations derived from Blichfeldt-general. `minkowski_general_k`: vol(S) > k\u00b72\u207f \u21d2 k+1 lattice points in S (with convexity + symmetry). `minkowski_general_k_pairwise`: same with explicitly-nonzero pairwise differences. `minkowski_general_k_finset`: Finset-output form. `minkowski_four_points`: concrete k=3 specialization. The closing `#check` lines verify all four theorem types.",
+      "startLine": 857,
+      "endLine": 1108,
+      "summary": "Five Minkowski generalizations derived from Blichfeldt-general. `minkowski_general_k`: vol(S) > k·2ⁿ ⇒ k+1 lattice points in S (with convexity + symmetry). `minkowski_general_k_pairwise`: same with explicitly-nonzero pairwise differences. `minkowski_general_k_finset`: Finset-output form. `minkowski_four_points`: concrete k=3 specialization. The closing `#check` lines verify all four theorem types.",
       "mathContext": "The half-scaling lifts from Blichfeldt: $\\mathrm{vol}(S) > k \\cdot 2^n \\Rightarrow \\mathrm{vol}(T) > k$ for $T = \\tfrac{1}{2}S$. Apply `blichfeldt_general` to get $k+1$ pairwise $\\mathbb{Z}^n$-congruent points in $T$; convexity + central symmetry of $S$ converts each pairwise difference into a lattice point of $S$."
     }
   ],
   "conclusion": {
-    "summary": "Provides a Lean 4 formalization of Blichfeldt's 1914 strengthening of Minkowski's lattice point theorem. The source file is now textually 0-axiom: all four originally-stated axioms have been eliminated across S1\u2013S14, with `blichfeldt_general` promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route. The k=1 case `blichfeldt_basic` calls Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` directly. The general-k case decomposes as Move A (reuse `volume_eq_setLIntegral_indicator_tsum`, the analytic core) + Move B (pointwise c(z) \u2264 k via `tsum_subtype`/`ENNReal.tsum_set_one`) + Move C (integrate to contradict). Minkowski's classical theorem is recovered as a corollary via the half-scaling T = (1/2)\u00b7s with 0 sorries. Builds against Lean 4.26.0 / Mathlib 4.26.0; full Docker CI build verification of the post-S14 source is pending the `proofs/.lake` infra-repair, after which the entry graduates from `axiomatized` to `verified` / badge `original`.",
-    "implications": "Blichfeldt's theorem is the geometry-of-numbers tool of choice when convexity or central symmetry is unavailable. Applications include: pigeonhole arguments in number theory (e.g., bounds on simultaneous Diophantine approximations of irrationals); transference theorems between primal and dual lattices; and modern algorithmic results like LLL-based shortest-vector enumeration. With all four originally-axiomatized steps now proved in the source file, the formalization is one CI-green build away from full verified status \u2014 a downstream candidate for upstream Mathlib contribution as `MeasureTheory.IsAddFundamentalDomain.exists_kplus1_vadd_mem`, the natural k+1 generalization of Mathlib's existing `IsAddFundamentalDomain.exists_ne_zero_vadd_eq`.",
+    "summary": "Provides a Lean 4 formalization of Blichfeldt's 1914 strengthening of Minkowski's lattice point theorem. The source file is now textually 0-axiom: all four originally-stated axioms have been eliminated across S1–S14, with `blichfeldt_general` promoted from axiom to fully-proved theorem in S13 (PR #17298) and S14 (PR #17329) via the Path A contrapose route. The k=1 case `blichfeldt_basic` calls Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` directly. The general-k case decomposes as Move A (reuse `volume_eq_setLIntegral_indicator_tsum`, the analytic core) + Move B (pointwise c(z) ≤ k via `tsum_subtype`/`ENNReal.tsum_set_one`) + Move C (integrate to contradict). Minkowski's classical theorem is recovered as a corollary via the half-scaling T = (1/2)·s with 0 sorries. Builds against Lean 4.26.0 / Mathlib 4.26.0; full Docker CI build verification of the post-S14 source is pending the `proofs/.lake` infra-repair, after which the entry graduates from `axiomatized` to `verified` / badge `original`.",
+    "implications": "Blichfeldt's theorem is the geometry-of-numbers tool of choice when convexity or central symmetry is unavailable. Applications include: pigeonhole arguments in number theory (e.g., bounds on simultaneous Diophantine approximations of irrationals); transference theorems between primal and dual lattices; and modern algorithmic results like LLL-based shortest-vector enumeration. With all four originally-axiomatized steps now proved in the source file, the formalization is one CI-green build away from full verified status — a downstream candidate for upstream Mathlib contribution as `MeasureTheory.IsAddFundamentalDomain.exists_kplus1_vadd_mem`, the natural k+1 generalization of Mathlib's existing `IsAddFundamentalDomain.exists_ne_zero_vadd_eq`.",
     "openQuestions": [
-      "Can `blichfeldt_general` be sharpened to give a coset structure on the k+1 points (i.e. all (k+1)\u00b7k/2 pairwise differences lie in a single (k+1)-element subset of \u2124\u207f rather than just pairwise in \u2124\u207f separately)? The current conclusion only guarantees pairwise differences in \u2124\u207f.",
-      "Can the statement extend from the standard integer lattice \u2124\u207f to an arbitrary full-rank \u2124-lattice \u039b \u2286 \u211d\u207f with covolume V, replacing the threshold vol(S) > k with vol(S) > k\u00b7V? The S9 covering-count infrastructure should generalize via `IsAddFundamentalDomain.lintegral_eq_tsum''` for arbitrary \u039b, but the specific `stdLattice_covolume = 1` step would need replacement by a generic `\u039b.covolume = V` invocation.",
-      "What is the sharp boundary: does vol(S) = k (the closed-half threshold, attained by k disjoint translates of [0,1)\u207f) suffice for k+1 \u2124\u207f-congruent points, or does the strict inequality vol(S) > k matter? (Standard answer: the strict inequality is sharp; counterexamples like S = [0,1)\u207f \u2294 \u2026 \u2294 [k\u22121,k)\u207f-shifts achieve equality with no congruent points.)"
+      "Can `blichfeldt_general` be sharpened to give a coset structure on the k+1 points (i.e. all (k+1)·k/2 pairwise differences lie in a single (k+1)-element subset of ℤⁿ rather than just pairwise in ℤⁿ separately)? The current conclusion only guarantees pairwise differences in ℤⁿ.",
+      "Can the statement extend from the standard integer lattice ℤⁿ to an arbitrary full-rank ℤ-lattice Λ ⊆ ℝⁿ with covolume V, replacing the threshold vol(S) > k with vol(S) > k·V? The S9 covering-count infrastructure should generalize via `IsAddFundamentalDomain.lintegral_eq_tsum''` for arbitrary Λ, but the specific `stdLattice_covolume = 1` step would need replacement by a generic `Λ.covolume = V` invocation.",
+      "What is the sharp boundary: does vol(S) = k (the closed-half threshold, attained by k disjoint translates of [0,1)ⁿ) suffice for k+1 ℤⁿ-congruent points, or does the strict inequality vol(S) > k matter? (Standard answer: the strict inequality is sharp; counterexamples like S = [0,1)ⁿ ⊔ … ⊔ [k−1,k)ⁿ-shifts achieve equality with no congruent points.)"
     ]
   },
   "crossReferences": [
@@ -169,17 +169,17 @@
     {
       "targetId": "minkowski-fundamental-theorem",
       "relationship": "depends-on",
-      "description": "Imports `Proofs.MinkowskiFundamentalTheorem` for the `MinkowskiProved.stdLattice` and `MinkowskiProved.stdFundDomain` infrastructure (the standard \u2124\u207f lattice and the fundamental domain F = [0,1)\u207f). The half-scaling reduction `minkowski_from_blichfeldt` re-derives Minkowski's classical statement from Blichfeldt + \u2124\u207f."
+      "description": "Imports `Proofs.MinkowskiFundamentalTheorem` for the `MinkowskiProved.stdLattice` and `MinkowskiProved.stdFundDomain` infrastructure (the standard ℤⁿ lattice and the fundamental domain F = [0,1)ⁿ). The half-scaling reduction `minkowski_from_blichfeldt` re-derives Minkowski's classical statement from Blichfeldt + ℤⁿ."
     },
     {
       "targetId": "minkowski-theorem-oq-02",
       "relationship": "related",
-      "description": "Sibling Minkowski OQ \u2014 Dirichlet's approximation theorem from Minkowski. Uses the same `MinkowskiProved` infrastructure (stdLattice, stdFundDomain) from `Proofs.MinkowskiFundamentalTheorem`."
+      "description": "Sibling Minkowski OQ — Dirichlet's approximation theorem from Minkowski. Uses the same `MinkowskiProved` infrastructure (stdLattice, stdFundDomain) from `Proofs.MinkowskiFundamentalTheorem`."
     },
     {
       "targetId": "minkowski-theorem-oq-02-oq-01",
       "relationship": "related",
-      "description": "Sibling Minkowski OQ \u2014 axiom-free Dirichlet via Minkowski. Demonstrates the alternate formalization style (verified, 0 axioms via measurability/convexity/volume lemmas) that Blichfeldt's `axiomatized` status could eventually graduate to."
+      "description": "Sibling Minkowski OQ — axiom-free Dirichlet via Minkowski. Demonstrates the alternate formalization style (verified, 0 axioms via measurability/convexity/volume lemmas) that Blichfeldt's `axiomatized` status could eventually graduate to."
     }
   ],
   "leanFile": {
@@ -201,26 +201,26 @@
       {
         "name": "blichfeldt_basic",
         "type": "proved",
-        "description": "Blichfeldt's theorem k=1: vol(S) > 1 yields two distinct \u2124\u207f-congruent points in S (0 sorries, axiom-free; uses Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` directly)",
-        "leanType": "{n : \u2115} [NeZero n] (s : Set (Fin n \u2192 \u211d)) (h_meas : MeasurableSet s) (h_vol : (1 : ENNReal) < volume s) \u2192 \u2203 x y, x \u2208 s \u2227 y \u2208 s \u2227 x \u2260 y \u2227 x \u2212 y \u2208 stdLattice n"
+        "description": "Blichfeldt's theorem k=1: vol(S) > 1 yields two distinct ℤⁿ-congruent points in S (0 sorries, axiom-free; uses Mathlib's `IsAddFundamentalDomain.exists_ne_zero_vadd_eq` directly)",
+        "leanType": "{n : ℕ} [NeZero n] (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_vol : (1 : ENNReal) < volume s) → ∃ x y, x ∈ s ∧ y ∈ s ∧ x ≠ y ∧ x − y ∈ stdLattice n"
       },
       {
         "name": "volume_eq_setLIntegral_indicator_tsum",
         "type": "proved",
-        "description": "Covering-count integral identity (S9 infrastructure for `blichfeldt_general`): \u222b\u207b x in F, (\u03a3' g : \u2124\u207f, 1_s((g : \u211d\u207f) + x)) \u2202volume = vol(s). Fully proved from `IsAddFundamentalDomain.lintegral_eq_tsum''` (additive form via `to_additive`) and Tonelli (`lintegral_tsum`).",
-        "leanType": "{n : \u2115} [NeZero n] {s : Set (Fin n \u2192 \u211d)} (h_meas : MeasurableSet s) \u2192 \u222b\u207b x in stdFundDomain n, (\u2211' g : (stdLattice n).toAddSubgroup, s.indicator (fun _ => 1) ((g : Fin n \u2192 \u211d) + x)) \u2202volume = volume s"
+        "description": "Covering-count integral identity (S9 infrastructure for `blichfeldt_general`): ∫⁻ x in F, (Σ' g : ℤⁿ, 1_s((g : ℝⁿ) + x)) ∂volume = vol(s). Fully proved from `IsAddFundamentalDomain.lintegral_eq_tsum''` (additive form via `to_additive`) and Tonelli (`lintegral_tsum`).",
+        "leanType": "{n : ℕ} [NeZero n] {s : Set (Fin n → ℝ)} (h_meas : MeasurableSet s) → ∫⁻ x in stdFundDomain n, (∑' g : (stdLattice n).toAddSubgroup, s.indicator (fun _ => 1) ((g : Fin n → ℝ) + x)) ∂volume = volume s"
       },
       {
         "name": "blichfeldt_general",
         "type": "proved",
-        "description": "Blichfeldt's theorem general k: vol(S) > k yields k+1 \u2124\u207f-congruent points. Promoted from axiom to fully-proved theorem via the Path A contrapose route (S13 PR #17298 + S14 PR #17329, 2026-05-08; build verification pending the `proofs/.lake` Docker infra-repair). Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9 analytic core). Move B: pointwise c(z) \u2264 k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` extract `Fin (k+1) \u2192 L` from the encard bound. Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume` to derive `volume s \u2264 k`, contradicting `k < volume s`.",
-        "leanType": "{n : \u2115} [NeZero n] (k : \u2115) (s : Set (Fin n \u2192 \u211d)) (h_meas : MeasurableSet s) (h_vol : (k : ENNReal) < volume s) \u2192 \u2203 pts : Fin (k+1) \u2192 Fin n \u2192 \u211d, Function.Injective pts \u2227 (\u2200 i, pts i \u2208 s) \u2227 \u2200 i j, pts i \u2212 pts j \u2208 stdLattice n"
+        "description": "Blichfeldt's theorem general k: vol(S) > k yields k+1 ℤⁿ-congruent points. Promoted from axiom to fully-proved theorem via the Path A contrapose route (S13 PR #17298 + S14 PR #17329, 2026-05-08; build verification pending the `proofs/.lake` Docker infra-repair). Move A: reuse `volume_eq_setLIntegral_indicator_tsum` (S9 analytic core). Move B: pointwise c(z) ≤ k from contraposed hypothesis via `tsum_subtype` + `ENNReal.tsum_set_one` (rewriting tsum-of-indicators as `T(z).encard`), then `Set.toFinset_card` + `Fintype.equivFinOfCardEq` extract `Fin (k+1) → L` from the encard bound. Move C: integrate the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume` to derive `volume s ≤ k`, contradicting `k < volume s`.",
+        "leanType": "{n : ℕ} [NeZero n] (k : ℕ) (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_vol : (k : ENNReal) < volume s) → ∃ pts : Fin (k+1) → Fin n → ℝ, Function.Injective pts ∧ (∀ i, pts i ∈ s) ∧ ∀ i j, pts i − pts j ∈ stdLattice n"
       },
       {
         "name": "minkowski_from_blichfeldt",
         "type": "proved",
-        "description": "Recovers Minkowski's theorem via T = (1/2)\u00b7s (0 sorries \u2014 measurability of T via preimage rewriting + `measurable_const_smul`; volume identity vol(T) = vol(s)/2\u207f via `Measure.addHaar_smul` + ENNReal arithmetic)",
-        "leanType": "{n : \u2115} [NeZero n] (s : Set (Fin n \u2192 \u211d)) (h_meas : MeasurableSet s) (h_symm : \u2200 x \u2208 s, \u2212x \u2208 s) (h_conv : Convex \u211d s) (h_vol : (2 : ENNReal)^n < volume s) \u2192 \u2203 p : (stdLattice n).toAddSubgroup, p \u2260 0 \u2227 (p : Fin n \u2192 \u211d) \u2208 s"
+        "description": "Recovers Minkowski's theorem via T = (1/2)·s (0 sorries — measurability of T via preimage rewriting + `measurable_const_smul`; volume identity vol(T) = vol(s)/2ⁿ via `Measure.addHaar_smul` + ENNReal arithmetic)",
+        "leanType": "{n : ℕ} [NeZero n] (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_symm : ∀ x ∈ s, −x ∈ s) (h_conv : Convex ℝ s) (h_vol : (2 : ENNReal)^n < volume s) → ∃ p : (stdLattice n).toAddSubgroup, p ≠ 0 ∧ (p : Fin n → ℝ) ∈ s"
       }
     ],
     "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ04.lean"
@@ -230,7 +230,7 @@
       "authors": "Blichfeldt, Hans Frederik",
       "title": "A new principle in the geometry of numbers, with some applications",
       "year": "1914",
-      "venue": "Transactions of the American Mathematical Society 15(3), pp. 227\u2013235",
+      "venue": "Transactions of the American Mathematical Society 15(3), pp. 227–235",
       "note": "Original publication of Blichfeldt's theorem (the k=1 measure-pigeonhole on a fundamental domain)"
     },
     {
@@ -253,30 +253,30 @@
       "name": "blichfeldt_basic",
       "type": "core",
       "statement": "$\\mathrm{vol}(S) > 1 \\Rightarrow \\exists\\, x \\ne y \\in S,\\; x - y \\in \\mathbb{Z}^n$",
-      "significance": "Blichfeldt's 1914 theorem, k=1 case: no convexity or symmetry, only Lebesgue measurability. The current proof is axiom-free, reducing directly to Mathlib's `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` on the standard fundamental domain F = [0,1)\u207f with covolume 1. The `g +\u1d65 x = y` AddSubgroup action is bridged to the additive equation `(g : \u211d\u207f) + x = y` via `AddSubgroup.vadd_def` + `vadd_eq_add`.",
-      "description": "Blichfeldt's theorem (k=1): vol(S) > 1 implies S contains two \u2124\u207f-congruent points.",
-      "leanType": "{n : \u2115} [NeZero n] (s : Set (Fin n \u2192 \u211d)) (h_meas : MeasurableSet s) (h_vol : (1 : ENNReal) < volume s) \u2192 \u2203 x y, x \u2208 s \u2227 y \u2208 s \u2227 x \u2260 y \u2227 x \u2212 y \u2208 stdLattice n"
+      "significance": "Blichfeldt's 1914 theorem, k=1 case: no convexity or symmetry, only Lebesgue measurability. The current proof is axiom-free, reducing directly to Mathlib's `MeasureTheory.IsAddFundamentalDomain.exists_ne_zero_vadd_eq` on the standard fundamental domain F = [0,1)ⁿ with covolume 1. The `g +ᵥ x = y` AddSubgroup action is bridged to the additive equation `(g : ℝⁿ) + x = y` via `AddSubgroup.vadd_def` + `vadd_eq_add`.",
+      "description": "Blichfeldt's theorem (k=1): vol(S) > 1 implies S contains two ℤⁿ-congruent points.",
+      "leanType": "{n : ℕ} [NeZero n] (s : Set (Fin n → ℝ)) (h_meas : MeasurableSet s) (h_vol : (1 : ENNReal) < volume s) → ∃ x y, x ∈ s ∧ y ∈ s ∧ x ≠ y ∧ x − y ∈ stdLattice n"
     },
     {
       "name": "volume_eq_setLIntegral_indicator_tsum",
       "type": "supporting",
       "statement": "$\\int^-_{F}\\!\\Bigl(\\sum'_{g \\in \\mathbb{Z}^n} \\mathbf{1}_S\\bigl((g : \\mathbb{R}^n) + x\\bigr)\\Bigr)\\,dx = \\mathrm{vol}(S)$",
       "significance": "Covering-count integral identity, the analytic engine of the general-k proof. Combines `IsAddFundamentalDomain.lintegral_eq_tsum''` (the additive form obtained via `to_additive` from the multiplicative `lintegral_eq_tsum`) with Tonelli's theorem (`lintegral_tsum`) to swap the integral and the unconditional sum. S9 milestone (PR #16995).",
-      "description": "Covering-count integral: \u222b_F \u03a3' v, 1_S((v:\u211d\u207f)+x) dx = vol(S). The analytic core of Path A."
+      "description": "Covering-count integral: ∫_F Σ' v, 1_S((v:ℝⁿ)+x) dx = vol(S). The analytic core of Path A."
     },
     {
       "name": "blichfeldt_general",
       "type": "core",
       "statement": "$\\mathrm{vol}(S) > k \\Rightarrow \\exists\\, \\mathrm{pts} : \\mathrm{Fin}(k{+}1) \\hookrightarrow S,\\;\\; \\forall i, j,\\; \\mathrm{pts}\\,i - \\mathrm{pts}\\,j \\in \\mathbb{Z}^n$",
-      "significance": "Path A contrapose proof (S13/S14, PRs #17298 + #17329). Move A reuses `volume_eq_setLIntegral_indicator_tsum` (S9 analytic core). Move B contraposes \u00ac\u2203 Fin(k+1)-injection \u21d2 pointwise c(z) \u2264 k via `tsum_subtype` + `ENNReal.tsum_set_one`. Move C integrates the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s \u2264 k`, contradicting `k < volume s`.",
+      "significance": "Path A contrapose proof (S13/S14, PRs #17298 + #17329). Move A reuses `volume_eq_setLIntegral_indicator_tsum` (S9 analytic core). Move B contraposes ¬∃ Fin(k+1)-injection ⇒ pointwise c(z) ≤ k via `tsum_subtype` + `ENNReal.tsum_set_one`. Move C integrates the pointwise bound via `setLIntegral_mono_ae` + `setLIntegral_const` + `stdLattice_covolume = 1` to derive `volume s ≤ k`, contradicting `k < volume s`.",
       "description": "Blichfeldt's general k+1-point theorem (Path A contrapose proof)."
     },
     {
       "name": "minkowski_from_blichfeldt",
       "type": "core",
       "statement": "$S$ measurable + centrally symmetric + convex + $\\mathrm{vol}(S) > 2^n \\Rightarrow \\exists\\, p \\in S \\cap \\mathbb{Z}^n,\\; p \\ne 0$",
-      "significance": "Recovers Minkowski's classical lattice point theorem via the half-scaling T = (1/2)\u00b7s. Two former sorries closed: measurability of T via preimage rewriting + `measurable_const_smul`; volume identity vol(T) = vol(s)/2\u207f via `Measure.addHaar_smul` and ENNReal arithmetic on $(2^{-1})^n \\cdot 2^n = 1$. Central symmetry gives $-y_0 \\in S$ and convexity gives the midpoint $(x_0 + (-y_0))/2 = a - b \\in S$.",
-      "description": "Minkowski recovered as a corollary via half-scaling T = (1/2)\u00b7s."
+      "significance": "Recovers Minkowski's classical lattice point theorem via the half-scaling T = (1/2)·s. Two former sorries closed: measurability of T via preimage rewriting + `measurable_const_smul`; volume identity vol(T) = vol(s)/2ⁿ via `Measure.addHaar_smul` and ENNReal arithmetic on $(2^{-1})^n \\cdot 2^n = 1$. Central symmetry gives $-y_0 \\in S$ and convexity gives the midpoint $(x_0 + (-y_0))/2 = a - b \\in S$.",
+      "description": "Minkowski recovered as a corollary via half-scaling T = (1/2)·s."
     },
     {
       "name": "blichfeldt_general_pairwise",


### PR DESCRIPTION
## Summary
Build-free gallery audit during the Docker blackout. The `minkowski-theorem-oq-04` gallery `meta.json` `sections[]` array had stale line ranges and one out-of-order section.

- The 7 sections ended at **L920** while the source `MinkowskiTheoremOQ04.lean` has grown to **1126 lines** (S27–S30 added `volume_eq_setLIntegral_indicator_tsum_lattice`, `blichfeldt_general_lattice`, and the Minkowski-lattice forms).
- "Minkowski as a Corollary" was listed at L254 but `minkowski_from_blichfeldt` actually lives at **L764** — out of source order.

Realigned + reordered all 7 sections to the real `PART` dividers so they tile **L68–1108 contiguously in source order**:

| section | range |
|---|---|
| axioms (Measure-Theoretic Infrastructure) | 68–118 |
| k1-blichfeldt (Basic Theorem k=1) | 119–166 |
| general-case (General k+1, Path A) | 167–579 |
| concrete-points (k=2,3 corollaries) | 580–682 |
| pairwise-finset | 683–738 |
| minkowski-corollary | 739–856 |
| minkowski-general | 857–1108 |

## Not changed (already correct)
Numeric metrics (lineCount 1126, theoremCount 17, defCount 0, axiomCount 0, sorries 0) and `mainTheorems[]` were already mechanic-synced at S30. Only `sections[]` lagged.

## Test plan
- [x] `jq empty meta.json` — valid JSON
- [x] Section ranges verified against `grep -nE '^-- PART' MinkowskiTheoremOQ04.lean` and theorem decl line numbers (origin/main)
- [x] No source/Lean changes — meta-only, no build required