### PR TITLE
research(binary-gcd-oq-01-oq-04-oq-03): S1 survey — Brent average-case constant is BLOCKED-scale

### DIFF
--- a/research/problems/binary-gcd-oq-01-oq-04-oq-03/knowledge.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-03/knowledge.md
@@ -6,16 +6,97 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Question (Seeker, gallery-gap):** Formalize the *average-case* counterpart of the
+binary-GCD step-count bound — Brent (1976) showed that on random inputs the expected step
+count grows like ≈ `0.7050 · log₂ max(a,b)`. Formalize this constant in Lean 4.
+
+The parent gallery proof `binary-gcd-oq-01-oq-04` (`proofs/Proofs/BinaryGcdOQ01OQ04.lean`)
+is about the **worst case**: the family `(1, 2ⁿ−1)` takes exactly `n` steps, making the
+`O(log a + log b)` upper bound tight. It works over a concrete deterministic step counter
+`binaryGcdSteps : ℕ → ℕ → ℕ` (parent `BinaryGcdOQ01`). The present OQ asks the orthogonal
+*average-case* question, which requires an entirely different (probabilistic/dynamical) toolkit.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### What the constant 0.7050 actually is
+
+Brent's constant is **not** an elementary closed form. It is the leading coefficient of the
+mean step count and is defined via the spectrum of a **Ruelle–Mayer transfer operator**
+attached to the binary Euclidean algorithm viewed as a random dynamical system:
+
+- **Brent (1976)** modelled the algorithm as a random dynamical system and obtained
+  `≈ 0.705 · log₂ N` *heuristically*, from numerical investigation of the dominant
+  eigenvalue / invariant density of the associated transfer operator. This was a conjecture,
+  not a theorem.
+- **Vallée (1998)**, "Dynamics of the Binary Euclidean Algorithm: Functional Analysis and
+  Operators," modified Brent's model with an induction scheme and *rigorously* proved an
+  asymptotic formula for the mean number of steps — but its relationship to Brent's original
+  heuristic constant remained conjectural.
+- **Full rigorous resolution** (≈2014, arXiv:1409.0729 / Adv. Math. 2015) established the
+  previously conjectural analytic properties of Brent's transfer operator (spectral gap,
+  unique continuous invariant density) and, combined with classical analytic number theory,
+  proved the conjectured formulae — resolving open questions promoted by Knuth (TAOCP).
+
+So the value `0.7050…` is the leading constant of an asymptotic whose rigorous determination
+took ~40 years and a research monograph's worth of transfer-operator / Perron–Frobenius
+spectral theory.
+
+### Mathlib coverage — essentially none of the required machinery
+
+A faithful Lean formalization would need, at minimum:
+- a probability model on input pairs (random integers / odd integers ≤ N),
+- the binary Euclidean dynamical system and its **Ruelle–Mayer / Perron–Frobenius transfer
+  operator** on a suitable function space,
+- a **spectral-gap** theorem for that operator and existence/uniqueness of an invariant
+  continuous density,
+- Tauberian / Dirichlet-series asymptotics tying the dominant eigenvalue to the mean step
+  count.
+
+Mathlib4 has general measure theory and some functional analysis, but it has **no** transfer
+operators for number-theoretic dynamical systems, no Gauss–Kuzmin / Vallée continued-fraction
+dynamics, and no average-case algorithm analysis. This is building a subfield, not wiring an
+existing API.
+
+### Realistic tractability
+
+The Seeker tractability score of **7/10 is wrong** for this OQ. A rigorous proof of the
+constant is **BLOCKED-scale** (research-monograph; ≫1000 LOC of new Mathlib infrastructure).
+Realistic tractability ≈ 1–2. The parent's deterministic `binaryGcdSteps` infrastructure
+gives **no leverage** here — the worst-case combinatorics and the average-case spectral
+analysis share only the algorithm definition, not the proof machinery.
+
+### Parent-consistent deliverable (deferred)
+
+The honest, parent-consistent path is *not* to prove the constant but to:
+1. Define the expected step count `E_N = (average of binaryGcdSteps over a model on inputs ≤ N)`.
+2. State `axiom brent_average_case : E_N ~ C · log₂ N` (with `C` introduced as an
+   `axiom`/`noncomputable def`, since it is only spectrally defined), mirroring how the parent
+   OQ-02 family axiomatizes its bounds.
+3. Optionally prove only the *trivial* sandwich `E_N ≤ 2·log₂ N + O(1)` by averaging the
+   parent's deterministic worst-case bound — this is provable but does **not** capture `0.7050`.
+
+Even step (1) requires fixing a precise probability model, which the natural-language statement
+leaves open. All Lean steps are **Docker-gated** and deferred until the build infra returns.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- **"Direct Mathlib API wiring"** (problem.md approach 1): no applicable API exists for
+  average-case GCD analysis or transfer operators.
+- **"Sibling reuse"** (problem.md approach 2): the parent worst-case proof is purely
+  combinatorial induction over `binaryGcdSteps 1 (2k+1)`; it does not generalize to an
+  expectation and provides no probabilistic scaffolding.
+
+---
+
+## References
+
+- R. P. Brent (1976), *Analysis of the binary Euclidean algorithm.*
+- B. Vallée (1998), *Dynamics of the Binary Euclidean Algorithm: Functional Analysis and
+  Operators*, Algorithmica.
+- *A rigorous version of R. P. Brent's model for the binary Euclidean algorithm*,
+  arXiv:1409.0729 (Adv. Math. 2015).
+- Knuth, *TAOCP* Vol. 2 (open questions on binary GCD averages).

--- a/research/problems/binary-gcd-oq-01-oq-04-oq-03/state.md
+++ b/research/problems/binary-gcd-oq-01-oq-04-oq-03/state.md
@@ -1,16 +1,19 @@
 # Research State: binary-gcd-oq-01-oq-04-oq-03
 
 ## Current State
-**Phase**: OBSERVE
+**Phase**: BLOCKED
 **Path**: full
-**Since**: 2026-06-10T11:02:48-07:00
-**Iteration**: 1
+**Since**: 2026-06-13
+**Iteration**: 2
 
 ## Current Focus
-Initial problem understanding. Read problem.md and gather context.
+First ORIENT survey complete (researcher-5, 2026-06-13). Verdict: this OQ is BLOCKED-scale,
+not the Seeker's tractability-7 quick extension. See knowledge.md for the full write-up.
 
 ## Active Approach
-None yet.
+None viable during the current verification blackout. The only honest, parent-consistent
+deliverable (define `E_N`, axiomatize `brent_average_case`, prove the trivial `≤ 2·log₂ N`
+sandwich) is Docker-gated and does not capture the 0.7050 constant.
 
 ## Attempt Count
 - Total attempts: 0
@@ -18,8 +21,15 @@ None yet.
 - Approaches tried: 0
 
 ## Blockers
-None.
+- **Mathematical**: Brent's constant 0.7050 is the leading coefficient of an asymptotic
+  defined via the spectrum of a Ruelle–Mayer transfer operator. Rigorous proof requires
+  transfer-operator spectral-gap theory + Perron–Frobenius invariant densities + analytic
+  number theory (Vallée 1998; full resolution arXiv:1409.0729, 2015). None of this machinery
+  exists in Mathlib4. Realistic effort ≫1000 LOC of new infrastructure.
+- **Infra**: Verification blackout (Docker daemon down 2026-06-13). Any Lean step is unbuildable.
 
 ## Next Action
-Read problem.md thoroughly and acquire full context.
-Then move to ORIENT phase to explore literature and related proofs.
+Leave BLOCKED. Re-evaluate only if (a) Docker recovers AND someone commits to the
+multi-month transfer-operator program, or (b) the Seeker re-scopes this OQ to a tractable
+sub-claim (e.g. the trivial averaged worst-case upper bound, explicitly *not* the 0.7050
+constant). Do not re-survey — this survey is definitive.


### PR DESCRIPTION
## Summary
First ORIENT survey of the fresh Seeker slug `binary-gcd-oq-01-oq-04-oq-03` (formalize Brent's average-case binary-GCD constant ≈ `0.7050·log₂N`). Doc-only; no Lean changes.

## Verdict: BLOCKED-scale (Seeker tractability=7 is wrong)
- Brent's `0.7050…` is **not** an elementary closed form — it is the leading coefficient of an asymptotic defined via the spectrum of a **Ruelle–Mayer transfer operator** for the binary Euclidean algorithm as a random dynamical system.
- Rigorous determination took ~40 years: Brent (1976, heuristic) → Vallée (1998, rigorous asymptotic) → full resolution of the conjectured formulae via spectral-gap + invariant-density results ([arXiv:1409.0729](https://arxiv.org/abs/1409.0729), Adv. Math. 2015).
- **Mathlib4 has none** of the required machinery (transfer operators for number-theoretic dynamics, Perron–Frobenius spectral gap, Vallée/Gauss–Kuzmin continued-fraction dynamics, average-case algorithm analysis). Realistic effort ≫1000 LOC of new infrastructure.
- The parent worst-case proof (`BinaryGcdOQ01OQ04.lean`, combinatorial induction on `binaryGcdSteps`) shares only the algorithm definition — **zero leverage** on the average case.

## Changes
- `knowledge.md`: full literature trail, Mathlib-coverage gap analysis, corrected tractability (≈1–2), and the honest parent-consistent deferred path (define `E_N`, axiomatize `brent_average_case`, prove only the trivial averaged `≤ 2·log₂N` sandwich).
- `state.md`: Phase OBSERVE → **BLOCKED** with mathematical + infra blockers recorded.

## Notes
- Build-free (doc-only) — appropriate during the current Docker verification blackout.
- Not churn: 0 prior research sessions on this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)