### PR TITLE
research(sqrt2-minpoly-oq-03): S8 STATE-SYNC — record build-verified ACT in state.md

### DIFF
--- a/research/problems/sqrt2-minpoly-oq-03/sessions/2026-06-13-s8-state-sync-record-build-verified.md
+++ b/research/problems/sqrt2-minpoly-oq-03/sessions/2026-06-13-s8-state-sync-record-build-verified.md
@@ -1,0 +1,45 @@
+# 2026-06-13 — S8 STATE-SYNC (researcher-4): record build-verified ACT in state.md
+
+## TL;DR
+
+`state.md` head was stale at **Iteration 15 / S7 STATE-SYNC** (2026-06-02) while the
+tracked JSON (`src/data/research/problems/sqrt2-minpoly-oq-03.json`) and the Lean source
+(`proofs/Proofs/Sqrt2MinpolyOQ03.lean`) on `origin/main` were already at **Iteration 16 /
+S8 BUILD-VERIFIED** (researcher-2, 2026-06-12). This session records S8 in `state.md` so the
+human-readable tracker matches reality. **Pure doc-sync: 0 Lean edits, 0 JSON edits.**
+
+## Drift detected
+
+| Tracker | Before this session | Reality on `origin/main` |
+|---|---|---|
+| `state.md` head | Iteration 15, Phase "ACT GATED by 2 RED blockers, paste-ready 75-LOC skeleton" | stale |
+| JSON `currentState` | Iteration 16, S8 BUILD-VERIFIED, B1 cleared, B3 YELLOW | current |
+| `Sqrt2MinpolyOQ03.lean` | `X_sq_sub_two_ne_zero` (L63) + `Q_sqrt2_finrank` (L76) present; bogus bearer removed | current |
+
+The S8 PR shipped the `.lean` lemmas + JSON `currentState` bump but never touched `state.md`,
+leaving the head describing a pre-S8 world ("2 RED blockers", "paste-ready skeleton") that S8
+had already superseded (B1 cleared, build proven working, remaining capstone is 4 sub-targets
+not a single paste, and the assumed bearer `isPrincipalIdealRing_of_abs_discr_lt` was found
+NOT to exist in Mathlib v4.26.0).
+
+## What I changed
+
+- `state.md` head: Phase / Last Updated / Iteration 15 → 16.
+- `state.md`: inserted an **Iteration 16 (S8 BUILD-VERIFIED)** block above the Iteration 15
+  block, recording S8's three results (clean instance-stack compile; 2 build-verified lemmas;
+  API-route correction), the infra downgrades (B1 GREEN, B3 YELLOW), the 4 remaining capstone
+  sub-targets, and today's Docker-down status.
+- This session note.
+
+## Why not flag blocked
+
+A genuine, build-verified ACT (S8) happened yesterday — this is **not** PREP churn deferring a
+build. The slug is healthily in-progress with concrete next sub-targets, so top-level
+`status` correctly stays `active`. The only remaining gate is Docker availability (down today,
+up on 2026-06-12, host disk healthy at 18%) — a transient infra condition, not a code defect.
+
+## Next action
+
+If Docker is up on the next claim: proceed with sub-target (1) `discr Q_sqrt2 = 8` via
+`Algebra.discr` trace-form on `{1, √2}`, compiling via `docker-build.sh`. If Docker is down:
+release-and-cycle — this entry already absorbs the S8 delta, so no further doc-sync is needed.

--- a/research/problems/sqrt2-minpoly-oq-03/state.md
+++ b/research/problems/sqrt2-minpoly-oq-03/state.md
@@ -1,9 +1,31 @@
 # Current State
 
-**Phase**: ACT (S3 SCAFFOLD + S4 PREP merged; capstone discharge skeleton paste-ready against `main` — but ACT structurally GATED by 2 host-side RED INFRA blockers as of S7 STATE-SYNC; B2 Docker cleared this session)
+**Phase**: ACT (S8 BUILD-VERIFIED — first real Docker compile in this problem's history; `X_sq_sub_two_ne_zero` + `Q_sqrt2_finrank = 2` build-verified; capstone `Q_sqrt2_classNumber_eq_one` still a strategic `sorry`. Remaining capstone is a multi-deliverable formalization, NOT a single paste — gated on Docker availability for each sub-target compile.)
 **Since**: 2026-05-15T23:26:58Z (S3 ACT SCAFFOLD merge anchor)
-**Last Updated**: 2026-06-02T13:00Z (Iteration 15, researcher-1)
-**Iteration**: 15
+**Last Updated**: 2026-06-13 (Iteration 16 STATE-SYNC, researcher-4 — recording S8 in state.md; JSON already at iter 16)
+**Iteration**: 16
+
+## Iteration 16 (researcher-2, 2026-06-12) — S8 BUILD-VERIFIED  ·  state.md recorded by researcher-4, 2026-06-13
+
+**Note**: S8 (researcher-2, 2026-06-12) updated `src/data/research/problems/sqrt2-minpoly-oq-03.json` (currentState → iteration 16) and `proofs/Proofs/Sqrt2MinpolyOQ03.lean` (2 new build-verified lemmas + capstone docstring rewrite), but did NOT update this `state.md` head, which remained at Iteration 15 / S7. This entry records S8 so the human-readable tracker matches the JSON + Lean source on `main`. Pure doc-sync; 0 Lean / 0 JSON edits in this STATE-SYNC.
+
+**S8 outcome (researcher-2, 2026-06-12)**: FIRST actual Docker build in this problem's history (S1–S7 were all `gh api` source spot-checks, never a compile). Ran `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ03` twice at Mathlib pin `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`: both green at `[7744/7744]`, only the expected capstone `sorry` warning.
+
+- **Result 1 (ground truth)**: the full instance stack (Field / Algebra ℚ / NumberField for `AdjoinRoot (X²−2)`) compiles clean against current Mathlib — NO drift; refutes the latent "builds silently red" risk that the S2–S7 `gh api`-only chain could never rule out.
+- **Result 2 (down payment)**: added two build-verified lemmas to `Sqrt2MinpolyOQ03.lean` — `X_sq_sub_two_ne_zero` (L63) and `Q_sqrt2_finrank : Module.finrank ℚ Q_sqrt2 = 2` (L76, via `AdjoinRoot.powerBasis_dim` + `PowerBasis.finrank`). `finrank = 2` is the `n` in the Minkowski bound `M K`.
+- **Result 3 (API correction)**: the prior STATE-SYNC chain's assumed capstone bearer `isPrincipalIdealRing_of_abs_discr_lt` (claimed at ClassNumber.lean:198) **DOES NOT EXIST** in Mathlib v4.26.0. Real route from ClassNumber.lean source: `classNumber_eq_one_iff` + `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`, needing discr=8, nrComplexPlaces=0, finrank=2, ⌊M K⌋₊=1. Capstone docstring (L81–105) rewritten with the corrected route.
+- **Infra**: B1 disk RED→GREEN (79 Gi free at S8 vs S7's 2.0 Gi). B3 `.lake` circular self-symlink downgraded RED→YELLOW — IRRELEVANT to Docker builds (docker-build.sh mounts a named volume `lean-mathlib-cache` at `/workspace/proofs/.lake/build`, shadowing the host symlink). This resolves the long-standing "cannot build" premise of S2–S7.
+
+### Remaining capstone sub-targets (each its own future ACT iteration, each needs a Docker compile)
+
+1. `discr Q_sqrt2 = 8` — the crux; `Algebra.discr` trace-form on the `{1, √2}` basis or a Mathlib quadratic-discriminant lemma (verify existence at v4.26.0).
+2. `nrComplexPlaces Q_sqrt2 = 0` (Q(√2) totally real).
+3. `⌊M K⌋₊ = 1` — real-arithmetic reduction from `finrank = 2` (done) + discr=8 + nrComplexPlaces=0.
+4. capstone via `classNumber_eq_one_iff` + `isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc` with vacuous prime interval (`Icc 1 1` has no primes).
+
+### Docker status at this STATE-SYNC (researcher-4, 2026-06-13)
+
+Docker is **DOWN/unreachable again** today (`docker info` times out; disk healthy at 18% used / 57 Gi free). S8's build path is PROVEN working, so the gate is purely Docker availability, not a code/infra defect. Per S8's `nextAction`: do NOT ship a `gh api`-only STATE-SYNC for new claims — every future ACT iteration should compile via `docker-build.sh` and report the true `[7744/7744]` result. Next-claim guidance: if Docker is up, proceed with sub-target (1) `discr Q_sqrt2 = 8`; if Docker is down, release-and-cycle (this entry already absorbs the S8 delta — no further doc-sync needed).
 
 ## Iteration 15 (researcher-1, 2026-06-02) — S7 STATE-SYNC
 


### PR DESCRIPTION
## Summary

`research/problems/sqrt2-minpoly-oq-03/state.md` head was stale at **Iteration 15 / S7 STATE-SYNC** (2026-06-02) while the tracked JSON (`src/data/research/problems/sqrt2-minpoly-oq-03.json`) and the Lean source (`proofs/Proofs/Sqrt2MinpolyOQ03.lean`) on `main` were already at **Iteration 16 / S8 BUILD-VERIFIED** (researcher-2, 2026-06-12).

The S8 PR shipped the `.lean` lemmas + JSON `currentState` bump but never updated `state.md`, leaving the head describing a pre-S8 world ("2 RED blockers", "paste-ready 75-LOC skeleton") that S8 had already superseded.

This PR syncs `state.md` to match `main`. **Pure doc-sync: 0 Lean edits, 0 JSON edits.**

## What changed

- `state.md` head: Phase / Last Updated / Iteration 15 → 16.
- Inserted the missing **Iteration 16 (S8 BUILD-VERIFIED)** block recording:
  - First real Docker compile in this problem's history — clean `[7744/7744]`, instance stack (Field/Algebra ℚ/NumberField for `AdjoinRoot (X²−2)`) compiles, no Mathlib drift.
  - 2 build-verified lemmas: `X_sq_sub_two_ne_zero`, `Q_sqrt2_finrank = 2`.
  - API correction: `isPrincipalIdealRing_of_abs_discr_lt` does NOT exist in Mathlib v4.26.0; corrected route documented.
  - Infra: B1 disk RED→GREEN, B3 `.lake` symlink RED→YELLOW (irrelevant to Docker builds).
  - 4 remaining capstone sub-targets (discr=8, nrComplexPlaces=0, ⌊M K⌋₊=1, capstone).
- New session note `sessions/2026-06-13-s8-state-sync-record-build-verified.md`.

## Why not flag blocked

A genuine build-verified ACT (S8) happened on 2026-06-12 — this is not PREP churn deferring a build. The slug is healthily in-progress; `status` correctly stays `active`. The only remaining gate is Docker availability (down today, up 2026-06-12, host disk healthy) — transient infra, not a code defect.

## Test plan

- [x] Doc-only change; no Lean source or build affected.
- [x] state.md head iteration now matches JSON `currentState.iteration` (16) on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)