### PR TITLE
research(minpoly-charpoly-oq-03): S15 — flag BLOCKED (verification blackout)

### DIFF
--- a/research/problems/minpoly-charpoly-oq-03/sessions/2026-06-13-s15-status-sync-blocked.md
+++ b/research/problems/minpoly-charpoly-oq-03/sessions/2026-06-13-s15-status-sync-blocked.md
@@ -1,0 +1,57 @@
+# S15 STATUS-SYNC — flag BLOCKED (verification blackout)
+
+**Agent**: researcher-1
+**Date**: 2026-06-13
+**Phase**: BLOCKED
+**Iteration**: 15
+
+## Summary
+
+Flagged `minpoly-charpoly-oq-03` BLOCKED and synced the gallery
+`meta.json` line count to source. No Lean source touched.
+
+## Why BLOCKED
+
+The sole remaining sorry — `rational_canonical_form_exists`
+(`Proofs/MinpolyCharpolyOQ03.lean:232`) — is dischargeable only via the
+OQ-03-OQ-02 elementary-divisors → invariant-factors regrouping (~340 LOC
+of new Lean, S11 PREP §6 / PR #18668). That is substantive
+build-dependent work, and both verification routes are down this cycle:
+
+- **Docker daemon HUNG** — `docker info` times out and is killed
+  (exit 144); Lean builds are unverifiable.
+- **Aristotle backend 404** — MCP server connects but proof jobs fail.
+- **CI does not build Lean** — a blind ACT on the 340-LOC regrouping
+  could silently break the currently-green file.
+
+Per the flag-BLOCKED-over-PREP-churn rule (14 prior iterations: 1
+OBSERVE scaffold + a long series of PREP / statement-only ACT passes
+around one build-gated sorry), this flags the slug blocked instead of
+adding another doc memo. Sibling `minpoly-charpoly-oq-02` was flagged
+BLOCKED today for the identical reason (PR #23025).
+
+## Changes
+
+1. `src/data/research/problems/minpoly-charpoly-oq-03.json`:
+   `phase` ACT→BLOCKED, `status` in-progress→blocked, `currentState`
+   updated (iteration 13→15, blockers populated, nextAction = unblock
+   recipe). `leanFiles` left for the deployer's `enrich-research.ts`
+   auto-regen.
+2. `src/data/proofs/minpoly-charpoly-oq-03/meta.json`: `lineCount`
+   631→639 in both places, matching the actual 639-line origin/main
+   source (`wc -l` convention; parent `minpoly-charpoly` confirms it:
+   meta 246 = wc 246). theoremCount (22), sorries (1), axiomCount (0)
+   were already correct.
+3. `state.md`: header → BLOCKED, S15 note + unblock recipe.
+
+## Unblock recipe
+
+When Docker is restored: implement OQ-03-OQ-02 Route B regrouping
+(S11 PREP §6 cheat-sheet, PR #18668), ~340 LOC in a new file
+`Proofs/MinpolyCharpolyOQ03OQ02.lean`. On completion the
+`xModule_has_invariantFactorChain` sorry in
+`MinpolyCharpolyOQ03OQ01.lean` collapses to a ~5-line glue import and
+`rational_canonical_form_exists` can be discharged. The
+`c.lastFactor = M.minpoly` follow-up (~15-30 LOC via
+`annihilator_top_eq_ker_aeval`, S11 PREP §7) becomes available once a
+chain `c` exists.

--- a/research/problems/minpoly-charpoly-oq-03/state.md
+++ b/research/problems/minpoly-charpoly-oq-03/state.md
@@ -1,10 +1,57 @@
 # Current State
 
-**Phase**: ACT (S14 strong-form statement upgrade landed; OQ-03-OQ-02 invariant-factor decomposition + lastFactor=minpoly follow-up are the remaining sub-OQs)
-**Since**: 2026-06-04 (S14 ACT strong-form statement upgrade, researcher-1; discharges next-action option 3)
-**Iteration**: 14
+**Phase**: BLOCKED (S15 STATUS-SYNC — flagged blocked on the verification blackout; the only remaining work, OQ-03-OQ-02 regrouping, is build-gated)
+**Since**: 2026-06-13 (S15 STATUS-SYNC, researcher-1)
+**Iteration**: 15
 
-## Current Focus
+## S15 STATUS-SYNC (this iteration) — flag BLOCKED
+
+researcher-1, 2026-06-13. No Lean source touched (sorry count 1,
+axiom count 0, theoremCount 22 unchanged).
+
+**Why blocked**: the sole remaining sorry —
+`rational_canonical_form_exists` (line 232) — is dischargeable only
+through the OQ-03-OQ-02 elementary-divisors → invariant-factors
+regrouping (~340 LOC of new Lean in
+`Proofs/MinpolyCharpolyOQ03OQ02.lean`, sketched in S11 PREP §6,
+PR #18668). That is substantive build-dependent work. Both
+verification routes are down this cycle:
+
+* Docker daemon HUNG — `docker info` times out / is killed (exit 144);
+  Lean builds are unverifiable.
+* Aristotle backend 404 (MCP server connects but proof jobs fail).
+* CI does not build Lean, so a blind ACT on the 340-LOC regrouping
+  could silently break the currently-green file.
+
+Per the flag-BLOCKED-over-PREP-churn rule (14 prior iterations: 1
+OBSERVE scaffold + a long series of PREP / statement-only ACT passes
+around one build-gated sorry), this iteration flags the slug blocked
+rather than adding another doc memo. The sibling
+`minpoly-charpoly-oq-02` was flagged BLOCKED today for the identical
+reason (PR #23025).
+
+**Bundled meta-sync (build-free)**: corrected the gallery
+`meta.json` `lineCount` 631 → 639 (both the top-level `meta.lineCount`
+and `leanFile.lineCount`) to match the actual 639-line origin/main
+source of `Proofs/MinpolyCharpolyOQ03.lean`. The gallery meta line
+count had drifted 8 lines stale relative to source (`wc -l` = 639;
+parent `minpoly-charpoly` confirms the `wc -l` convention, meta 246 =
+wc 246). theoremCount (22), sorries (1) and axiomCount (0) in the
+gallery meta were already correct and are left unchanged. The
+research-JSON `leanFiles` array is intentionally NOT hand-synced here
+— the deployer's `enrich-research.ts` regenerates those counts from
+source automatically.
+
+**Unblock recipe** (for the next ACT picker, once Docker is back):
+implement OQ-03-OQ-02 Route B regrouping (S11 PREP §6 cheat-sheet in
+PR #18668). On completion the `xModule_has_invariantFactorChain` sorry
+in `MinpolyCharpolyOQ03OQ01.lean` collapses to a ~5-line glue import
+and `rational_canonical_form_exists` can be discharged. The
+`c.lastFactor = M.minpoly` follow-up (~15-30 LOC via
+`annihilator_top_eq_ker_aeval`, S11 PREP §7) becomes available once a
+chain `c` exists.
+
+## S14 Focus (prior iteration)
 
 S14 ACT (researcher-1, 2026-06-04) discharges next-action option 3
 (strong-form statement upgrade): extends `rational_canonical_form_exists`

--- a/src/data/proofs/minpoly-charpoly-oq-03/meta.json
+++ b/src/data/proofs/minpoly-charpoly-oq-03/meta.json
@@ -22,7 +22,7 @@
     "badge": "research",
     "sorries": 1,
     "axiomCount": 0,
-    "lineCount": 631,
+    "lineCount": 639,
     "assumptions": "0 axioms; 1 sorry guarding the proof of `rational_canonical_form_exists`. The sorry is the four-sub-OQ scaffold's main deliverable (S1 OBSERVE → S2+ ACT) plus the lastFactor=minpoly follow-up. The statement itself is unconditional. Imports: `Mathlib.LinearAlgebra.Matrix.Charpoly.Basic`, `Mathlib.LinearAlgebra.Matrix.Charpoly.Minpoly`, `Mathlib.Algebra.Polynomial.Monic`, `Mathlib.Tactic`, `Proofs.MinpolyCharpoly`. S13 added Part 7 — the firstFactor-side mirror to Parts 5–6 — yielding the structural sandwich k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor) on the abstract InvariantFactorChain. S14 (this iteration, 2026-06-04) strengthens the rational_canonical_form_exists statement to additionally assert `c.lastFactor = M.minpoly`, sorry-preserved (state.md next-action option 3).",
     "mathlib_version": "4.26.0",
     "dateAdded": "2026-05-12",
@@ -153,7 +153,7 @@
       "BigOperators"
     ],
     "namespace": "MinpolyCharpolyOQ03",
-    "lineCount": 631,
+    "lineCount": 639,
     "axiomCount": 0,
     "theoremCount": 22,
     "definitionCount": 3,

--- a/src/data/research/problems/minpoly-charpoly-oq-03.json
+++ b/src/data/research/problems/minpoly-charpoly-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "minpoly-charpoly-oq-03",
   "title": "Rational Canonical Form via Minimal-Polynomial Invariant Factors",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -28,15 +28,19 @@
     "goal": "Statement and proof of `rational_canonical_form_exists`: every square matrix M over a field F admits an invariant-factor chain (p_1, ..., p_k) with product charpoly(M), last entry minpoly(M), and similarity to the block diagonal of the companion matrices."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-02T19:00:00Z",
-    "iteration": 13,
-    "focus": "S13 ACT firstFactor-side mirror pass on InvariantFactorChain — discharges S6 PREP (PR #18425) option-4 firstFactor design. Adds Part 7 (+140 LOC) with InvariantFactorChain.firstFactor + 4 public mirror lemmas + 2 private helpers, sorry-free, no new imports. Yields the two-sided sandwich k · deg(firstFactor) ≤ deg(prodFactors) ≤ k · deg(lastFactor) on the abstract InvariantFactorChain F (the dual of S5's upper bound). Sorry count unchanged (1 on rational_canonical_form_exists). Build-pending per S2/S3/S4/S5 convention.",
-    "blockers": [],
-    "nextAction": "S14 options (one of, recommended order unchanged from S12): (1) OQ-03-OQ-02 ACT (Route B) — implement elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668), ~340 LOC in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean; (2) c.lastFactor = M.minpoly follow-up — independent ~15-30 LOC ACT on MinpolyCharpolyOQ03.lean (S11 PREP §7); (3) Strong-form statement upgrade — extend rational_canonical_form_exists to assert c.lastFactor = M.minpoly, sorry-preserved (~5 lines); (4) prodFactors_natDegree_sandwich named corollary — pair the S5 upper bound and S13 lower bound into a single public theorem, but only if a caller actually needs it (S6 PREP §6 deferred this as anti-target until justified by a consumer).",
+    "phase": "BLOCKED",
+    "since": "2026-06-13T00:00:00Z",
+    "iteration": 15,
+    "focus": "S15 STATUS-SYNC — flag BLOCKED on the verification blackout. The sole remaining sorry (rational_canonical_form_exists, line 232) is dischargeable only via the OQ-03-OQ-02 elementary-divisors→invariant-factors regrouping (~340 LOC new Lean), which is build-dependent. Both verification routes are down (Docker daemon HUNG — `docker info` times out; Aristotle backend 404), and CI does not build Lean, so a blind edit could silently break the currently-green file. Per the flag-BLOCKED-over-PREP-churn rule (14 iters: 1 OBSERVE + multiple PREP/statement-only ACTs around one build-gated sorry), this flags blocked rather than adding doc memo #N. Sibling minpoly-charpoly-oq-02 was flagged BLOCKED today for the identical reason (PR #23025). Also synced gallery meta.json lineCount 631→639 to the actual origin/main source.",
+    "blockers": [
+      "Docker daemon HUNG (`docker info` times out / killed exit 144) — Lean builds unverifiable.",
+      "Aristotle backend 404 (MCP connects but proof jobs fail).",
+      "CI does not build Lean — blind ACT on the 340-LOC OQ-03-OQ-02 regrouping could silently break the green file."
+    ],
+    "nextAction": "UNBLOCK when Docker is restored: implement OQ-03-OQ-02 ACT (Route B) — the elementary-divisors → invariant-factors regrouping algorithm sketched in S11 PREP §6 (PR #18668), ~340 LOC in a new file Proofs/MinpolyCharpolyOQ03OQ02.lean. On completion the xModule_has_invariantFactorChain sorry collapses to a ~5-line glue import and rational_canonical_form_exists can be discharged. Independent follow-ups available once a chain exists: c.lastFactor = M.minpoly (~15-30 LOC, S11 PREP §7 via annihilator_top_eq_ker_aeval). All require a working Docker build (~45 min cold per .lake self-symlink trap).",
     "attemptCounts": {
-      "total": 13,
-      "currentApproach": 13,
+      "total": 15,
+      "currentApproach": 15,
       "approachesTried": 1
     }
   },


### PR DESCRIPTION
## Summary

- **Flag BLOCKED**: the sole remaining sorry `rational_canonical_form_exists` (`Proofs/MinpolyCharpolyOQ03.lean:232`) is dischargeable only via the ~340-LOC OQ-03-OQ-02 elementary-divisors→invariant-factors regrouping (S11 PREP §6, PR #18668), which is build-dependent. Both verification routes are down this cycle (**Docker daemon HUNG** — `docker info` times out / killed exit 144; **Aristotle backend 404**), and CI does not build Lean, so a blind ACT could silently break the currently-green file.
- Per the **flag-BLOCKED-over-PREP-churn** rule (14 iters: 1 OBSERVE scaffold + a long PREP/statement-only series around one build-gated sorry), this flags the slug blocked instead of adding another doc memo. Sibling `minpoly-charpoly-oq-02` was flagged BLOCKED today for the identical reason (PR #23025).
- **Bundled build-free meta-sync**: gallery `meta.json` `lineCount` 631→639 (both `meta.lineCount` and `leanFile.lineCount`) to match the actual 639-line origin/main source. `wc -l` convention confirmed against parent `minpoly-charpoly` (meta 246 = wc 246). theoremCount (22), sorries (1), axiomCount (0) were already correct.

## Changes

- `src/data/research/problems/minpoly-charpoly-oq-03.json`: phase ACT→BLOCKED, status in-progress→blocked, currentState updated (iteration 13→15, blockers populated, nextAction = unblock recipe). `leanFiles` left for the deployer's `enrich-research.ts` auto-regen.
- `src/data/proofs/minpoly-charpoly-oq-03/meta.json`: lineCount 631→639 (×2).
- `state.md` + new `sessions/2026-06-13-s15-status-sync-blocked.md`.

**No Lean source touched** (sorry 1, axiom 0, theoremCount 22 unchanged).

## Unblock recipe

When Docker is restored: implement OQ-03-OQ-02 Route B regrouping (S11 PREP §6 cheat-sheet, PR #18668) in a new file `Proofs/MinpolyCharpolyOQ03OQ02.lean`. On completion the `xModule_has_invariantFactorChain` sorry collapses to a ~5-line glue import and `rational_canonical_form_exists` can be discharged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)