### PR TITLE
research(minkowski-theorem-oq-04): S31 COMPLETION-SYNC — promote to completed

### DIFF
--- a/research/problems/minkowski-theorem-oq-04/sessions/2026-06-13-s31-completion-sync.md
+++ b/research/problems/minkowski-theorem-oq-04/sessions/2026-06-13-s31-completion-sync.md
@@ -1,0 +1,53 @@
+# S31 — COMPLETION-SYNC (researcher-2, 2026-06-13)
+
+**Mode.** COMPLETION-SYNC (doc-only). Base SHA `8e86e7b0527` (origin/main).
+Status flipped `active`/`ACT` → `completed`/`COMPLETED`.
+
+## §0 Why this fires
+Claimed `minkowski-theorem-oq-04` (RICH). The research tracker read
+`active`/`ACT` (iteration 30, last touched 2026-06-02), but the stated
+problem is already proved and gallery-verified — a status lag.
+
+## §1 The stated problem is solved
+OQ04 problem statement: Blichfeldt's theorem (1914) — any measurable
+S ⊆ ℝⁿ with vol(S) > k contains k+1 distinct points whose pairwise
+differences lie in ℤⁿ; plus the Minkowski corollary.
+
+Evidence (all on origin/main):
+- `proofs/Proofs/MinkowskiTheoremOQ04.lean`: 0 real sorries, 0 axioms,
+  17 theorems, 1126 LOC.
+- Gallery `src/data/proofs/minkowski-theorem-oq-04/meta.json`: status
+  `verified`, badge `original`, sorries 0, axiomCount 0, lineCount 1126,
+  theoremCount 17 (S30's mechanic-pending count bumps have landed).
+- Matching theorems:
+  - `blichfeldt_general_finset` (L720): Finset of card k+1 ⊆ S, pairwise
+    differences in `stdLattice n` (= ℤⁿ). Exactly the problem statement.
+  - `blichfeldt_general_pairwise` (L683): adds `i ≠ j → pts i - pts j ≠ 0`
+    (the "distinct points" clause).
+  - `minkowski_from_blichfeldt` (L764): the convex centrally-symmetric
+    vol > 2ⁿ ⇒ nonzero lattice point corollary.
+
+## §2 Out of scope — optional follow-on
+The tracker's open item is the general-LATTICE generalization program
+(S23 roadmap): replace `stdLattice n` with `Submodule.span ℤ (Set.range b)`
+for an arbitrary basis `b`.
+- PR-A (S27): `volume_eq_setLIntegral_indicator_tsum_lattice` — landed.
+- PR-B (S30): `blichfeldt_general_lattice` — landed (Docker 3075 jobs clean).
+- PR-C (pending): `minkowski_general_k_lattice` (~50 LOC, paste-ready in
+  `s23-lattice-generalization-spec.md §2.2`).
+
+This generalization is **beyond the stated OQ04** and is Docker-gated:
+`timeout 5 docker info` exits 124 at S31 entry (daemon down — same fleet-wide
+outage). It can resume as follow-on; it does not block completion of the
+stated problem.
+
+## §3 Decision
+Per the status-sync rule (main theorem proves the problem statement →
+completed; cf. cramers-rule-oq-03-oq-03, euler-totient completion-syncs),
+flip `active` → `completed`. Doc-only, no `.lean`.
+
+## §4 Ship scope
+3 files: this memo, `state.md` (S31 block + markers), JSON tracker
+(status/phase/focus/nextAction/iteration 30→31/attemptCounts 29→30/
+lastUpdate). No `.lean`, no sibling edits, no gallery `meta.json` touch
+(already verified + count-synced).

--- a/research/problems/minkowski-theorem-oq-04/state.md
+++ b/research/problems/minkowski-theorem-oq-04/state.md
@@ -1,11 +1,48 @@
 # Research State: minkowski-theorem-oq-04
 
 ## Current State
-**Phase**: ACT (S30 PR-B landed Docker-clean; PR-C is the only remaining S24 ACT — bearers and helpers all in scope; infra GREEN since 2026-06-02)
+**Phase**: COMPLETED (S31 COMPLETION-SYNC — stated OQ04 (Blichfeldt for ℤⁿ + Minkowski corollary) fully proved & gallery-verified; general-lattice generalization is optional Docker-gated follow-on)
 **Path**: full
-**Since**: 2026-06-02T00:25:00Z (S30 ACT PR-B — `blichfeldt_general_lattice` shipped; Docker 3075 jobs clean)
-**Last Updated**: 2026-06-02 (S30 ACT PR-B — Lean +139 LOC, 1126 lines, 17 theorems, build-verified; B1/B2 CLEARED)
-**Iteration**: 30 (S30 ACT PR-B — researcher-1)
+**Since**: 2026-06-13 (S31 COMPLETION-SYNC — status active → completed)
+**Last Updated**: 2026-06-13 (S31 COMPLETION-SYNC — researcher-2; MinkowskiTheoremOQ04.lean 0 sorries / 0 axioms / 17 theorems / 1126 LOC, gallery meta status=verified badge=original counts synced 1126/17; `blichfeldt_general_finset` + `blichfeldt_general_pairwise` + `minkowski_from_blichfeldt` match the problem statement exactly; PR-C general-lattice ext is beyond-scope + Docker-gated [daemon down, timeout 124] and does not block completion). Prior: 2026-06-02 (S30 ACT PR-B)
+**Iteration**: 31 (S31 COMPLETION-SYNC — researcher-2)
+
+## S31 — COMPLETION-SYNC 2026-06-13 (researcher-2)
+
+**Mode.** COMPLETION-SYNC (doc-only; no `.lean` shipped). Status flipped
+`active`/`ACT` → `completed`/`COMPLETED`. Base SHA `8e86e7b0527` (origin/main).
+
+**Finding.** The stated OQ04 problem is Blichfeldt's theorem (1914) for the
+integer lattice: *any measurable S ⊆ ℝⁿ with vol(S) > k contains k+1 distinct
+points whose pairwise differences lie in ℤⁿ*, plus the Minkowski corollary.
+This is **fully proved and gallery-verified**:
+- `MinkowskiTheoremOQ04.lean`: 0 sorries, 0 axioms, 17 theorems, 1126 LOC.
+- Gallery `meta.json`: status `verified`, badge `original`, counts already
+  synced (lineCount 1126, theoremCount 17 — the S30 mechanic-pending items
+  have landed).
+- `blichfeldt_general_finset` (L720, Finset k+1 form, pairwise diffs in
+  `stdLattice n`) + `blichfeldt_general_pairwise` (L683, adds distinctness)
+  match the problem statement exactly; `minkowski_from_blichfeldt` (L764)
+  gives the convex-symmetric corollary.
+
+The research tracker was lagging at `active` (last touched 2026-06-02, S30).
+Per the status-sync rule (main theorem proves the problem statement →
+completed), flipped to `completed`.
+
+**Out of scope (optional follow-on).** The general-LATTICE generalization
+(basis-parametric `blichfeldt_general_lattice` shipped S30; pending PR-C
+`minkowski_general_k_lattice`, paste-ready in
+`s23-lattice-generalization-spec.md §2.2`) extends the result from ℤⁿ to an
+arbitrary lattice basis. This is **beyond the stated OQ04** and is Docker-gated
+(daemon down at S31 entry: `timeout 5 docker info` exits 124). It can resume as
+follow-on without affecting the completed status.
+
+**Ship scope.** 3 files — `state.md` (this block + markers), JSON tracker
+(status/phase/focus/nextAction/iteration 30→31/attemptCounts/lastUpdate), new
+memo `sessions/2026-06-13-s31-completion-sync.md`. NO `.lean` edits, NO sibling
+edits, NO gallery `meta.json` touch (already verified + synced).
+
+---
 
 ## S30 — S30 ACT PR-B 2026-06-02 (researcher-1)
 

--- a/src/data/research/problems/minkowski-theorem-oq-04.json
+++ b/src/data/research/problems/minkowski-theorem-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "minkowski-theorem-oq-04",
   "title": "Blichfeldt's Theorem: k+1 Congruent Points When vol > k",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -18,12 +18,12 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-02T00:25:00Z",
-    "iteration": 30,
-    "focus": "S30 ACT PR-B (researcher-1, 2026-06-02): shipped `blichfeldt_general_lattice` to `MinkowskiTheoremOQ04.lean:441` (post-edit numbering) via mechanical S23 §4 substitution from `blichfeldt_general` — `stdLattice n → Submodule.span ℤ (Set.range b)`, `stdFundDomain n → ZSpan.fundamentalDomain b`, `volume_eq_setLIntegral_indicator_tsum → volume_eq_setLIntegral_indicator_tsum_lattice b` (the S27 PR-A helper). Hypothesis form `(k : ENNReal) * volume (ZSpan.fundamentalDomain b) < volume s` per S23 §5 (covolume term abstract; the `stdLattice_covolume = 1` reduction is the only `stdLattice`-specific step in `blichfeldt_general` and is the substitution target). Docker 3075-job clean on first try (pin SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`, unchanged since S25/S26/S27/S28/S29). Pre-flight INFRA at S30: B1 (Docker hung 19.9h at S29) CLEARED — full Server: section returned; B2 (disk RED 3.4 Gi at S29) CLEARED — 55 Gi avail. Source file 987 → 1126 LOC (+139), 16 → 17 theorems, 0 sorries, 0 axioms. +1 `#check BlichfeldtTheorem.blichfeldt_general_lattice` at :1117. Mechanic territory deferred: `meta.json.lineCount 987 → 1126`, `meta.json.theoremCount 16 → 17`, `mainTheorems[]` rich entry for `blichfeldt_general_lattice`. PR-C (`minkowski_general_k_lattice`, ~50 LOC) is the last remaining S24 ACT — paste-ready in S23 §2.2, bearers B3 + B4 enter scope.",
+    "iteration": 31,
+    "focus": "S31 COMPLETION-SYNC (researcher-2, 2026-06-13): the STATED OQ04 problem — Blichfeldt's theorem for the integer lattice Z^n (any measurable S with vol(S) > k contains k+1 distinct points with pairwise differences in Z^n) plus the Minkowski corollary — is FULLY PROVED and gallery-verified. MinkowskiTheoremOQ04.lean has 0 sorries, 0 axioms, 17 theorems (1126 LOC); gallery meta.json status=verified, badge=original, counts already synced (1126/17). The problem statement is matched exactly by blichfeldt_general_finset (Finset k+1 form, pairwise diffs in stdLattice n) + blichfeldt_general_pairwise (adds distinctness) + minkowski_from_blichfeldt (convex-symmetric corollary). Flipped status active->completed. The general-LATTICE generalization (basis-parametric blichfeldt_general_lattice shipped S30, and the pending PR-C minkowski_general_k_lattice) is optional extension work BEYOND the stated problem; it is Docker-gated (daemon down at S31 entry, timeout 124) and can resume as follow-on without blocking completion of the stated OQ04.",
     "blockers": [],
-    "nextAction": "S24 ACT PR-C (`minkowski_general_k_lattice`, ~50 LOC) — last remaining S24 ACT after PR-A (S27) and PR-B (this S30). Paste-ready Lean in `s23-lattice-generalization-spec.md §2.2`. Bearers B3 (`exists_ne_zero_mem_lattice_of_measure_mul_two_pow_lt_measure`) + B4 (`Module.finrank_fin_fun`) enter scope; both pinned in S25 manifest at SHA `2df2f0150c275ad53cb3c90f7c98ec15a56a1a67`. Half-scaling + central-symmetry + convexity reduction onto PR-B's `blichfeldt_general_lattice`. Insertion site: after `minkowski_general_k` at :719. Next picker: (a) verify Docker GREEN: `timeout 10 docker info 2>&1 | grep -E \"^Server:\" -A 5`; (b) verify disk ≥ 5 Gi; (c) IF BOTH GREEN: paste S23 §2.2 and ship via `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04` (~12 min cold start); (d) IF EITHER RED: ship doc-only S31 STATE-SYNC. Mechanic-pending after S30 lands: `meta.json.lineCount 987 → 1126`, `meta.json.theoremCount 16 → 17`, `mainTheorems[]` rich entry for `blichfeldt_general_lattice`. Anti-scope retained from S23/S24: no `_symm`, no `_five_points`, no wrapper-square closers.",
+    "nextAction": "DONE for the stated problem — no further action required to close OQ04. OPTIONAL follow-on (not blocking, tracked here for continuity): the general-lattice generalization PR-C `minkowski_general_k_lattice` (~50 LOC, paste-ready in s23-lattice-generalization-spec.md §2.2) extends Minkowski from Z^n to an arbitrary lattice basis b; it is Docker-gated (daemon down at S31, `timeout 5 docker info` exits 124). If pursued, verify Docker GREEN first (`timeout 10 docker info` exit 0), then ship via `./proofs/scripts/docker-build.sh Proofs.MinkowskiTheoremOQ04`. This generalization is beyond the stated OQ04 and does not affect the completed status.",
     "attemptCounts": {
-      "total": 29,
+      "total": 30,
       "currentApproach": 14,
       "approachesTried": 0
     },
@@ -151,5 +151,5 @@
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/MinkowskiTheoremOQ04.lean"
     }
   ],
-  "lastUpdate": "2026-06-02T00:25:00Z"
+  "lastUpdate": "2026-06-13"
 }


### PR DESCRIPTION
## Summary

Promotes `minkowski-theorem-oq-04` (Blichfeldt's theorem) from `active` → `completed`. The stated problem is fully proved and gallery-verified; the research tracker was lagging.

- **Stated OQ04** = Blichfeldt's theorem (1914) for ℤⁿ (measurable S with vol > k contains k+1 distinct points with pairwise differences in ℤⁿ) + the Minkowski corollary.
- **Proved & verified on main:** `MinkowskiTheoremOQ04.lean` — 0 sorries, 0 axioms, 17 theorems, 1126 LOC. Gallery `meta.json`: status `verified`, badge `original`, counts synced (1126 / 17).
- **Matching theorems:** `blichfeldt_general_finset` (L720, Finset k+1 / pairwise diffs in `stdLattice n`), `blichfeldt_general_pairwise` (L683, distinctness), `minkowski_from_blichfeldt` (L764, convex-symmetric corollary).
- **Out of scope (optional follow-on):** the general-lattice generalization PR-C `minkowski_general_k_lattice` (paste-ready in `s23-lattice-generalization-spec.md §2.2`) extends ℤⁿ → arbitrary lattice basis; it is beyond the stated problem and Docker-gated (daemon down, `timeout 5 docker info` exits 124). Does not block completion.

## Changes (doc-only)

- JSON tracker — status `active`→`completed`, phase `ACT`→`COMPLETED`, focus/nextAction rewritten, iteration 30→31, attemptCounts.total 29→30, lastUpdate→2026-06-13.
- `state.md` — prepended S31 COMPLETION-SYNC block; updated Phase/Since/Last Updated/Iteration markers.
- New session memo `sessions/2026-06-13-s31-completion-sync.md`.

No `.lean` edits, no sibling-slug edits, no gallery `meta.json` touch (already verified + count-synced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)