### PR TITLE
research(amgm-inequality-oq-04-oq-03): S5 BLOCKED + JSON STATE-SYNC

### DIFF
--- a/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-13-s5-blocked-docker-outage.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/sessions/2026-06-13-s5-blocked-docker-outage.md
@@ -1,0 +1,48 @@
+# S5 — BLOCKED + JSON STATE-SYNC (researcher-2, 2026-06-13)
+
+**Mode.** STATUS-FLIP + STATE-SYNC (doc-only). Base SHA `8e86e7b0527`
+(origin/main). Status `active`/`ACT` → `blocked`/`BLOCKED`.
+
+## §0 Why this fires
+Claimed `amgm-inequality-oq-04-oq-03` (Gauss AGM ↔ elliptic K, RICH). Two
+issues: (1) the JSON tracker lagged state.md by ~2 sessions; (2) the remaining
+work is build-gated and Docker is down.
+
+## §1 INFRA — RED
+- Docker: `timeout 5 docker info` → exit 124 (Server unresponsive). Fleet-wide
+  outage; same B1 daemon-hang cleared 2026-05-30, down again.
+- Disk: `df -h /` → 17% used. Recovered.
+- Aristotle: 404s per fleet memory.
+
+## §2 JSON drift corrected
+JSON tracker was at `iteration: 3`, `lastUpdate: 2026-06-02`, focus/nextAction
+describing the S3 "pick a discharge leg" choice — but state.md had already
+advanced through S4a (x-independent M-test bound) and S4b (M-test packaging on
+closed balls), both 2026-06-09, and noted S3 Wallis was already shipped
+(`wallisHalf_even`, PR #22046). Synced JSON focus/nextAction/iteration→6/
+lastUpdate→2026-06-13 forward to the S4b reality, and set status blocked in the
+same edit (per [[reference-buildts-preserves-research-json]] the JSON status/
+currentState is preserved by build.ts → this sync is non-self-healing).
+
+## §3 Current proof state
+- `AmgmInequalityOQ04OQ03.lean`: 315 LOC, **1 axiom** `ellipticK_eq_hyp2F1`
+  (L149 — the problem's *stated* hypergeometric-series identity hypothesis,
+  legitimate, not a defect), **0 real sorries**.
+- `AmgmInequalityOQ04OQ03Wallis.lean`: 100 LOC, 0 axioms, 0 sorries.
+- Done legs: §6 `summable_hyp2F1` (S2), §7 x-independent M-test bound (S4a),
+  M-test packaging on closed balls — `summable_hyp2F1_on_closedBall` +
+  `hyp2F1_mtest_inputs_on_closedBall` (S4b, Docker-verified).
+
+## §4 Why blocked
+Next leg: S5 `TendstoUniformlyOn` wrap via Mathlib `tendstoUniformlyOn_tsum`
+(near-mechanical per state.md S4b), then combine legs toward the Gauss AGM ↔ K
+identity. Each candidate needs a Docker build; none available during the outage.
+No `.lean` shipped — refining the recipe further would be PREP churn (per
+[[feedback-flag-blocked-over-prep-churn]]).
+
+## §5 Unblock trigger
+`timeout 10 docker info --format '{{.ServerVersion}}'` exits 0 → resume S5 ACT.
+
+## §6 Ship scope
+3 files: this memo, `state.md` (S5 block + markers), JSON tracker. No `.lean`,
+no sibling edits. No gallery `meta.json` (this slug has no gallery entry).

--- a/research/problems/amgm-inequality-oq-04-oq-03/state.md
+++ b/research/problems/amgm-inequality-oq-04-oq-03/state.md
@@ -1,10 +1,49 @@
 # Research State: amgm-inequality-oq-04-oq-03
 
 ## Current State
-**Phase**: ACT
+**Phase**: BLOCKED (S5 — renewed Docker outage; remaining discharge legs Docker-gated)
 **Path**: fast
-**Since**: 2026-06-01 (S2 ACT — researcher-1) → 2026-06-09 (S4b ACT, this session)
-**Iteration**: 5
+**Since**: 2026-06-01 (S2 ACT — researcher-1) → 2026-06-13 (S5 BLOCKED, this session)
+**Iteration**: 6
+
+## S5 — BLOCKED + JSON STATE-SYNC 2026-06-13 (researcher-2)
+
+**Mode.** STATUS-FLIP + STATE-SYNC (doc-only; no `.lean` shipped). Status
+`active`/`ACT` → `blocked`/`BLOCKED`. Base SHA `8e86e7b0527` (origin/main).
+
+**INFRA — RED.** Renewed Docker daemon outage: `timeout 5 docker info`
+exits 124 (Server section unresponsive) — fleet-wide, same pathology that
+cleared 2026-05-30 and is down again. Disk RECOVERED (17% used). Aristotle
+404s. No build route.
+
+**JSON drift corrected.** The JSON tracker
+(`src/data/research/problems/amgm-inequality-oq-04-oq-03.json`) was stale at
+iteration 3 / lastUpdate 2026-06-02 while state.md had advanced through S4a/S4b
+(2026-06-09). Synced the JSON focus/nextAction/iteration/lastUpdate forward to
+the actual S4b state and set status blocked in the same edit.
+
+**Current proof state (unchanged from S4b).** `AmgmInequalityOQ04OQ03.lean`:
+315 LOC, **1 axiom** (`ellipticK_eq_hyp2F1`, L149 — the problem's *stated*
+hypergeometric-series identity hypothesis, legitimate per the problem
+statement), **0 real sorries**. Companion `AmgmInequalityOQ04OQ03Wallis.lean`:
+100 LOC, 0 axioms, 0 sorries (S3 `wallisHalf_even` shipped via PR #22046).
+Discharge legs done: §6 `summable_hyp2F1` (S2), §7 x-independent M-test bound
+(S4a), M-test packaging on closed balls (S4b, Docker-verified).
+
+**Why blocked, not ACT.** The next leg — S5 `TendstoUniformlyOn` wrap via
+Mathlib `tendstoUniformlyOn_tsum`, then combining the legs toward the Gauss
+AGM-limit ↔ elliptic K identity — is Lean proof work; every candidate needs a
+Docker build to verify. None available during the outage.
+
+**Unblock trigger.** `timeout 10 docker info --format '{{.ServerVersion}}'`
+exits 0 → resume S5 ACT from the M-test inputs (`hyp2F1_mtest_inputs_on_closedBall`).
+
+**Ship scope.** 3 files — `state.md` (this block + markers), JSON tracker
+(status/phase/focus/nextAction/iteration 3→6/attemptCounts/lastUpdate + Docker
+blocker), new memo `sessions/2026-06-13-s5-blocked-docker-outage.md`. NO `.lean`
+edits, NO sibling edits.
+
+---
 
 ## Current Focus
 

--- a/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
+++ b/src/data/research/problems/amgm-inequality-oq-04-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "amgm-inequality-oq-04-oq-03",
   "title": "Gauss AGM Theorem via Hypergeometric Elliptic Integral Identity",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -30,13 +30,15 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-06-02T00:55:00Z",
-    "iteration": 3,
-    "focus": "S2 ACT (this session, researcher-1, Lean +64 LOC). Added section Summability of the Hypergeometric Series to Proofs/AmgmInequalityOQ04OQ03.lean (158 -> 222 LOC, 0 new axioms, 0 sorries). Three lemmas: centralBinom_le_four_pow (Mathlib v4.26.0 has only the lower bound four_pow_lt_mul_centralBinom; this fills the upper-bound gap via Nat.sum_range_choose), hypCoeff_le_one (direct corollary), summable_hyp2F1 (the headline: Summable (fun n => hypCoeff n * x^n) for |x| < 1, by absolute comparison with the geometric series + Summable.of_norm). Closes the summability leg of the five-leg ellipticK_eq_hyp2F1 discharge plan; structural prerequisite for the DCT-style sum/integral interchange step.",
+    "iteration": 6,
+    "focus": "S5 BLOCKED + STATE-SYNC (researcher-2, 2026-06-13): renewed Docker daemon outage (`timeout 5 docker info` exits 124) makes the remaining discharge legs unverifiable. Also syncs the JSON tracker forward from its stale iteration-3/2026-06-02 reading to the actual state.md S4b state (2026-06-09): S3 Wallis closed form was already shipped (wallisHalf_even, PR #22046, in AmgmInequalityOQ04OQ03Wallis.lean); S4a added the x-independent per-term M-test bound (hypCoeff_mul_pow_abs_le_of_abs_le); S4b added the M-test packaging on closed balls (summable_hyp2F1_on_closedBall + hyp2F1_mtest_inputs_on_closedBall), Docker-verified, 0 new axioms / 0 new sorries. AmgmInequalityOQ04OQ03.lean: 315 LOC, 1 axiom (ellipticK_eq_hyp2F1 — the problem's STATED hypergeometric-series identity hypothesis, legitimate per the problem statement), 0 real sorries. Status active->blocked: the next leg (S5 TendstoUniformlyOn wrap via tendstoUniformlyOn_tsum, then combining legs to the Gauss AGM<->K main result) is Lean proof work requiring Docker builds, unavailable during the outage.",
     "activeApproach": "Power-series realization of 2F1 with central-binomial coefficients c_n = (centralBinom n / 4^n)^2, building on the verified ellipticK from oq-04-oq-01. S2 ACT adds the summability infrastructure via central-binomial upper bound + geometric comparison.",
-    "blockers": [],
-    "nextAction": "S3 ACT - pick one discharge leg. Recommended (easiest first): (1) Wallis closed form int_0^(pi/2) sin^(2n) = (pi/2) * centralBinom n / 4^n via Mathlib.integral_sin_pow recurrence (~50-100 LOC); (2) binomial series (1-u)^(-1/2) = sum centralBinom n / 4^n u^n for |u|<1 (~80-150 LOC); (3) uniform summability of hyp2F1 on compact k-subsets via TendstoUniformlyOn (~30 LOC). S2 ACT's summable_hyp2F1 is input to all three. S6 final discharge composes Wallis + binomial series + uniform summability via DCT.",
+    "blockers": [
+      "B-INFRA Docker daemon outage at S5 entry 2026-06-13: `timeout 5 docker info` exits 124 (Server section unresponsive). Fleet-wide outage (same pathology cleared 2026-05-30, down again). Disk recovered (17% used). Aristotle backend 404s. Every remaining discharge leg (S5 TendstoUniformlyOn wrap + leg-combination toward Gauss AGM<->K) is Lean proof work needing >=1 Docker build to verify -> slug set blocked until Docker recovers."
+    ],
+    "nextAction": "WHEN Docker recovers (`timeout 10 docker info` exit 0): resume S5 ACT — wrap the S4b M-test inputs (hyp2F1_mtest_inputs_on_closedBall) into TendstoUniformlyOn via Mathlib's tendstoUniformlyOn_tsum (near-mechanical per state.md S4b), then continue combining the discharged legs (Wallis closed form + binomial series ₂F₁ realization) toward the Gauss AGM-limit <-> elliptic K identity. Each leg needs a Docker build. Spec/legs detailed in state.md (Active Approach) + knowledge.md.",
     "attemptCounts": {
-      "total": 3,
+      "total": 6,
       "currentApproach": 2,
       "approachesTried": 1
     }
@@ -123,7 +125,7 @@
     ]
   },
   "started": "2026-04-04T09:42:47.007Z",
-  "lastUpdate": "2026-06-02T00:55:00Z",
+  "lastUpdate": "2026-06-13",
   "leanFiles": [
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",


### PR DESCRIPTION
## Summary

Flags `amgm-inequality-oq-04-oq-03` (Gauss's AGM ↔ elliptic integral K) as **blocked** during the renewed Docker outage, and corrects a stale JSON tracker.

- **INFRA RED:** `timeout 5 docker info` exits 124 (daemon down — fleet-wide outage). Disk recovered (17% used). Aristotle 404s. No build route.
- **JSON drift corrected:** the JSON tracker lagged at iteration 3 / 2026-06-02 (S3 "pick a leg") while `state.md` had advanced through S4a + S4b (2026-06-09). Synced focus/nextAction/iteration→6/lastUpdate forward to the S4b reality and set status blocked.
- **Proof state:** `AmgmInequalityOQ04OQ03.lean` — 315 LOC, 1 axiom (`ellipticK_eq_hyp2F1`, the problem's *stated* hypergeometric-identity hypothesis — legitimate), 0 real sorries; Wallis companion 0/0. Done legs: §6 summable (S2), §7 x-independent M-test bound (S4a), M-test packaging on closed balls (S4b).
- **Why blocked:** the next leg (S5 `TendstoUniformlyOn` wrap + leg-combination toward the AGM↔K identity) is Lean proof work needing Docker builds.
- **Unblock:** `timeout 10 docker info --format '{{.ServerVersion}}'` exits 0.

## Changes (doc-only)

- JSON tracker — status `active`→`blocked`, phase `ACT`→`BLOCKED`, focus/nextAction synced + blocked, iteration 3→6, attemptCounts.total 3→6, lastUpdate→2026-06-13, Docker blocker added.
- `state.md` — prepended S5 BLOCKED + STATE-SYNC block; updated markers.
- New session memo `sessions/2026-06-13-s5-blocked-docker-outage.md`.

No `.lean` edits, no sibling-slug edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)