### PR TITLE
research(skolem-noether-csa): gallery sections-sync + research-JSON state-sync

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01",
   "title": "Can the more general Skolem-Noether theorem for arbitrary central simple alge...",
-  "phase": "NEW",
+  "phase": "REFINE",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,16 +16,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-05-05T02:57:44.795Z",
-    "iteration": 1,
-    "focus": "1-axiom formalization of general Skolem-Noether for CSAs",
+    "phase": "REFINE",
+    "since": "2026-06-06T12:30:00+00:00",
+    "iteration": 2,
+    "focus": "Witness ambiguity / torsor structure for Skolem-Noether conjugating units.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Verify Docker build, push PR, optionally proceed to MulAction formulation.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 2,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
@@ -90,7 +90,7 @@
     "mathlib": []
   },
   "started": "2026-05-05T02:57:44.794Z",
-  "lastUpdate": "2026-05-05T02:57:44.794Z",
+  "lastUpdate": "2026-06-06T12:30:00+00:00",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Build-free tracker audit (Docker blackout) of the Skolem-Noether CSA entry — slug `cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01`, source `proofs/Proofs/SkolemNoetherCSA.lean`.

### Gallery `meta.json`
- **`theoremCount` 12 → 14** and **`lineCount` 392 → 393** in both `.meta` and `.leanFile`. Confirmed against `origin/main` source: `grep -cE '^(theorem|lemma) '` = 14, `wc -l` = 393. Conventions verified against clean gallery samples (lineCount = `wc -l`, theoremCount = col-0 `^(theorem|lemma)`).
- **`sections[]`**: added the missing **"Conjugacy as an Equivalence Relation"** section (L221-290 — the `IsConjugate` equivalence-relation lemmas + `conjugateSetoid` + `conjugateSetoid_single_class`), which had fallen into the uncovered gap between Corollaries (ended L218) and Witness-Ambiguity (started L291). Realigned every section range to the `/-! ## ` banners so they now tile L41-393 contiguously.

### Research JSON
Was frozen at the seeker-stub default (`phase: NEW`, `currentState` ACT/iter 1, focus "1-axiom formalization…", nextAction "Begin problem exploration.", attempts 0/0/0) while `state.md` had advanced to **REFINE / iteration 2** (witness-torsor work — already present in source and in the gallery `originalContributions`). Synced `phase`, `currentState`, `attemptCounts`, `nextAction`, `lastUpdate` to `state.md`. `leanFiles` left untouched (deployer-owned).

No source/Lean changes; status stays `active` (the core axiom `skolemNoether_module_iso` remains the genuinely open question).

## Test plan
- [x] `jq empty` valid on both JSON files
- [x] sections tile L41-393 contiguously, each aligned to a source banner
- [x] numeric fields match `git show origin/main:` source counts