### PR TITLE
research(spherical-law-of-cosines-oq-02): sync leanFiles to merged S5 source

### DIFF
--- a/src/data/research/problems/spherical-law-of-cosines-oq-02.json
+++ b/src/data/research/problems/spherical-law-of-cosines-oq-02.json
@@ -86,8 +86,8 @@
     {
       "path": "Proofs/SphericalLawOfCosinesOQ05.lean",
       "filename": "SphericalLawOfCosinesOQ05.lean",
-      "lineCount": 413,
-      "theoremCount": 16,
+      "lineCount": 690,
+      "theoremCount": 38,
       "axiomCount": 0,
       "defCount": 1,
       "sorryCount": 1,


### PR DESCRIPTION
## Summary
Sync the research-pool `leanFiles` block for `spherical-law-of-cosines-oq-02` to the current merged source on `main`.

`SphericalLawOfCosinesOQ05.lean` advanced via PR #22862 (S5 — haversine bijection [0,π] ≃ [0,1], 0 axioms / 0 sorries) and grew **413→690 lines, 16→38 theorems**, but the research-pool JSON `leanFiles` entry was frozen at the pre-S5 numbers.

- All 38 theorems are **public** (`grep -cE '^private '` = 0) → the +22 is genuine new-theorem growth, **not** the strict-`^(theorem|lemma) `-vs-private convention artifact.
- `axiomCount` (0), `defCount` (1), `sorryCount` (1) unchanged → no docstring-`sorry` false-positive risk.
- The companion `SphericalLawOfCosines.lean` entry (342/24/0/7/0) was already in sync — left untouched.

Mechanical leanFiles sync only; narrative/status fields untouched.

## Test plan
- [x] `python3 -m json.tool` validates the edited JSON
- [x] Each metric recomputed against `git show origin/main:proofs/Proofs/SphericalLawOfCosinesOQ05.lean` via the exact `enrich-research.ts` regexes
- [x] Diff is exactly 2 lines (lineCount + theoremCount)

🤖 Generated with [Claude Code](https://claude.com/claude-code)