### PR TITLE
research(sum-of-divisors-oq-02): flag BLOCKED — S5–S7 ACT stack unverified, Docker-gated

### DIFF
--- a/research/problems/sum-of-divisors-oq-02/state.md
+++ b/research/problems/sum-of-divisors-oq-02/state.md
@@ -1,5 +1,7 @@
 # Current State
 
+> **⛔ BLOCKED (2026-06-13, researcher-6):** Docker daemon outage + Aristotle 404s persist. The S5/S6/S7 ACT sorry-discharges (#19562/#19644/#22238) have never been Docker-verified (build-pending 9–28 days; only S4 verified). The 2 remaining sorries (Step 6 `cofactor_one_and_prime`, top-level `euler_converse_self_contained`) each need ≥1 Docker build + verification of the unverified S5–S7 stack to land safely. All forward progress strictly Docker-gated → status set `blocked` until Docker recovers. Trackers (state.md/JSON) are in sync with source (161 LOC, 2 real sorries, 0 axioms); the only stale artifact is the deployer-owned `leanFiles[]`.
+
 **Phase**: ACT (S7 ACT shipped Step 5 `sigma_eq_self_add_cofactor`; 3-LOC tactic body via `Nat.eq_of_mul_eq_mul_left` + `← succ_mersenne` `rw` chain; sorry 3 → 2; build pending — Docker daemon down)
 **Since**: 2026-06-04T00:00:00Z (S7 ACT)
 **Iteration**: 8

--- a/src/data/research/problems/sum-of-divisors-oq-02.json
+++ b/src/data/research/problems/sum-of-divisors-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "sum-of-divisors-oq-02",
   "title": "Euler's Converse: Every Even Perfect Number is Mersenne-Form",
   "phase": "ACT",
-  "status": "in-progress",
+  "status": "blocked",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -31,7 +31,9 @@
     "iteration": 8,
     "focus": "S7 ACT (researcher-1, 2026-06-04T00:00Z): replaced line-115 `sorry` in sigma_eq_self_add_cofactor (Step 5) with 3-LOC tactic-mode body: `have hpos : 0 < mersenne (k + 1) := mersenne_pos.mpr (Nat.succ_pos k); refine Nat.eq_of_mul_eq_mul_left hpos ?_; rw [h_eq, mul_add, ← hm, ← succ_mersenne (k + 1), add_mul, one_mul]`. The 6-step rw chain reduces both sides to `mersenne (k+1) * m + m = mersenne (k+1) * m + m` (closed by rfl). proofs/Proofs/SumOfDivisorsOQ02.lean 138 → ~158 LOC (+~20: 3 LOC tactic body + ~17 LOC docstring expansion documenting provenance + bearer pins + build-pending qualifier + fallbacks). Sorry count 3 → 2 (Step 5 closed). Axiom count 0 → 0. Build pending — Docker daemon unavailable. Bearer pins (`mersenne_pos` at LucasLehmer.lean:64, `succ_mersenne` at LucasLehmer.lean:102, `Nat.eq_of_mul_eq_mul_left` from Lean core) verified 0-drift at unchanged Mathlib SHA 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67 via gh api raw fetch this session.",
     "activeApproach": "Pedagogical self-contained refactor of Mathlib Archive bundled proof into named intermediate lemmas.",
-    "blockers": [],
+    "blockers": [
+      "B-INFRA Docker daemon outage (`timeout 8 docker info` exits 124 — Server section unresponsive) + Aristotle backend 404s, persisting 2026-06-13. The S5 ACT (#19562), S6 ACT (#19644) and S7 ACT (#22238) sorry-discharges have NEVER been Docker-verified (build-pending 9–28 days); only S4 was verified (3063 jobs). The 2 remaining sorries — Step 6 `cofactor_one_and_prime` (~15-20 LOC) and top-level `euler_converse_self_contained` — each need >=1 Docker build plus verification of the existing S5–S7 stack to land safely. All forward progress strictly Docker-gated -> slug set blocked until Docker recovers."
+    ],
     "nextAction": "Step 6 ACT (next): close cofactor_one_and_prime (L127 post-S7-ACT) per S3 PREP §2.3 / knowledge.md Step 6 plan — Nat.sum_divisors_eq_sum_properDivisors_add_self expands σ(m) = m + ∑ properDivisors; m + c = m + ∑ propers gives ∑ propers = c. Since c ∣ m and c < m, c is itself a proper divisor; ∑ propers ≥ c with equality iff properDivisors m = {c}. Combined with 1 ∣ m forces c = 1 and properDivisors m = {1}, the latter ↔ m.Prime via Nat.sum_properDivisors_eq_one_iff_prime. Estimated ~15-20 LOC. After Step 6: top-level euler_converse_self_contained ACT (L136 post-S7-ACT) chains the 6 steps via Archive eq_two_pow_mul_odd to split n = 2^k * m with m odd. Build verification of this S7 ACT + sibling S5 ACT #19562 + S6 ACT #19644 deferred to next docker-available iteration; single Docker-iter expected per S6 PREP §3.1.",
     "attemptCounts": {
       "total": 7,


### PR DESCRIPTION
## Summary

Flags `sum-of-divisors-oq-02` (Euler's-converse self-contained, RICH 16, research-pool) as **blocked** during the persistent 2026-06-13 Docker/Aristotle verification blackout.

## Why blocked

- The proof has a healthy ACT cadence (S4→S7, one step-lemma discharged per stage), **but only S4 ACT was Docker-verified** (3063 jobs clean).
- **S5 ACT (#19562), S6 ACT (#19644), S7 ACT (#22238)** sorry-discharges have been **build-pending 9–28 days** — never verified because Docker has been down/intermittent.
- The 2 remaining sorries — Step 6 `cofactor_one_and_prime` (~15-20 LOC, scoped in S3 PREP) and top-level `euler_converse_self_contained` — each require ≥1 Docker build **plus** verification of the unverified S5–S7 stack to land safely. Writing more unverified Lean on top of an unverifiable 3-discharge stack risks shipping plausible-but-broken proofs.
- → All forward progress is strictly Docker-gated. Setting `blocked` stops claim-random re-handing the slug during the blackout.

## What this PR changes (build-free, doc-only)

- `state.md`: one-line ⛔ BLOCKED banner.
- `<slug>.json`: `status` `in-progress` → `blocked`; `currentState.blockers` records the build-gate (was `[]`).

## Tracker integrity note

state.md + JSON `currentState` are already **in sync** with the real source on `origin/main` (161 LOC, 2 real proof-position sorries at L150/L159, 0 axioms) — no audit drift. The only stale artifact is the deployer-owned `leanFiles[]` (lineCount 138, sorryCount 5), left untouched per convention.

No Lean changes; no build required.