### PR TITLE
research(erdos-5-prime-gaps): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-5-prime-gaps.json
+++ b/src/data/research/problems/erdos-5-prime-gaps.json
@@ -66,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T09:10:09.148Z",
-  "lastUpdate": "2026-01-13T16:22:40.291Z",
+  "lastUpdate": "2026-06-10",
   "completed": "2026-01-13T16:22:40.291Z",
   "significance": 7,
   "tractability": 6,
@@ -74,8 +74,8 @@
     {
       "path": "Proofs/Erdos5PrimeGaps.lean",
       "filename": "Erdos5PrimeGaps.lean",
-      "lineCount": 573,
-      "theoremCount": 29,
+      "lineCount": 708,
+      "theoremCount": 36,
       "axiomCount": 3,
       "defCount": 9,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `erdos-5-prime-gaps` was frozen at iteration 1 (573 lines / 29 theorems, `lastUpdate` 2026-01-13) while `proofs/Proofs/Erdos5PrimeGaps.lean` on `main` has grown to **708 lines / 36 theorems** (axiom 3 / def 9 / sorry 0 unchanged).

- `lineCount` 573 → 708
- `theoremCount` 29 → 36
- `lastUpdate` → 2026-06-10 (source last-touched commit on main)

## Why this is a clean, faithful sync
- **Genuine public-theorem growth, not an artifact.** The file has 0 `private theorem`/`lemma` declarations, so the strict `^(theorem|lemma) ` count (used by `enrich-research.ts`) reflects real new public theorems on both sides — not the strict-vs-private convention artifact.
- **No docstring false-positive.** Comment-stripped recount confirms real `sorry`=0 and real `axiom`=3 (the 3 axioms package known deep prime-gap inputs, unchanged).
- **Independent-artifact split.** The gallery `meta.json` `leanFile` is already at 708/36 — only the research-pool JSON lagged. Scope is strictly the two drifted metric numbers + `lastUpdate`; the narrative is untouched.

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics recomputed against `origin/main` source via the `enrich-research.ts` regexes
- [x] Diff limited to 3 lines (2 metrics + lastUpdate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)