### PR TITLE
research(basel-oq-01-01-02-02): S23 — flag BLOCKED (verification blackout)

### DIFF
--- a/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
+++ b/research/problems/basel-problem-oq-01-oq-01-oq-02-oq-02/state.md
@@ -1,6 +1,37 @@
 # Current State
 
-**Phase**: STATE-SYNC (S22 — pre-S23-ACT bearer pin: `Nat.factorization_prod_pow_eq_self` + 2 support bearers verified at byte-stable Mathlib SHA; S21 build status reconfirmed CLEAN by hash inspection; INFRA all GREEN; 0 Lean diff)
+**Phase**: BLOCKED (verification blackout — flagged 2026-06-13, researcher-1)
+**Since**: 2026-06-13
+**Iteration**: 23
+
+## S23 — BLOCKED (Docker-gated ACT after 4+ doc-only PREP/STATE-SYNC sessions)
+
+Flagged `blocked` 2026-06-13 during the verification blackout (Docker daemon
+down — `docker info` exit 124; Aristotle backend 404 — `prove` smoke-test returns
+`Resource not found.`).
+
+**Why blocked, not churned further:** the gallery file
+`proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean` is already complete and
+verified CLEAN at S21 (972 lines, 0 sorries, 0 axioms, 3058/3058 jobs). Every
+remaining step is Docker-gated *new Lean*:
+- **S23 ACT** `mul_choose_dvd_lcmRange` (~30–40 LOC, the general-prime-power
+  analogue of S15's `Nat.prod_pow_factorization_choose`, via the now-pinned
+  bearers 17–19 `Nat.factorization_prod_pow_eq_self` / `Nat.support_factorization`
+  / `Nat.factorization_eq_zero_of_lt`).
+- **Long-tail** vdP §6 `denominator_control` discharge (~80–150 LOC).
+
+Both require a build to verify and cannot land during the blackout. Sessions
+S17 (PREP), S18 (PREP), S19 (STATE-SYNC), S22 (STATE-SYNC) have already pinned
+every bearer the S23 ACT needs; further doc-only iterations would be pure churn
+(per the project's flag-BLOCKED-over-PREP-churn policy). The next-ACT skeleton is
+paste-ready below.
+
+**Unblock condition:** Docker returns → `./proofs/scripts/docker-build.sh
+Proofs.BaselProblemOQ01OQ01OQ02OQ02` to baseline, then paste the S23 helper.
+
+---
+
+## (historical) Phase: STATE-SYNC (S22 — pre-S23-ACT bearer pin: `Nat.factorization_prod_pow_eq_self` + 2 support bearers verified at byte-stable Mathlib SHA; S21 build status reconfirmed CLEAN by hash inspection; INFRA all GREEN; 0 Lean diff)
 **Since**: 2026-06-10T04:25:00Z
 **Iteration**: 22
 


### PR DESCRIPTION
## Summary

Flags `basel-problem-oq-01-oq-01-oq-02-oq-02` as **blocked** for the duration of
the 2026-06-13 verification blackout. Doc-only (state.md banner); status also set
to `blocked` in the live pool.

**Rationale.** The gallery file `proofs/Proofs/BaselProblemOQ01OQ01OQ02OQ02.lean`
is already complete and verified CLEAN at S21 (972 lines, **0 sorries, 0 axioms**,
3058/3058 jobs). Every remaining step is Docker-gated *new Lean*:

- **S23 ACT** `mul_choose_dvd_lcmRange` (~30–40 LOC) — bearers 17–19 already
  pinned across S17–S22.
- **Long-tail** vdP §6 `denominator_control` discharge (~80–150 LOC).

Neither can be verified during the blackout (`docker info` exit 124; Aristotle
`prove` → `Resource not found.`). Sessions **S17 (PREP), S18 (PREP), S19
(STATE-SYNC), S22 (STATE-SYNC)** have already pinned every Mathlib bearer the
S23 ACT needs — further doc-only iterations would be pure churn, so this flags
blocked per the flag-BLOCKED-over-PREP-churn policy rather than writing another
PREP memo.

**Unblock:** Docker returns → `./proofs/scripts/docker-build.sh
Proofs.BaselProblemOQ01OQ01OQ02OQ02` to baseline, then paste the S23 helper
from the (paste-ready) skeleton preserved in state.md.

## Test plan
- [x] No Lean change; gallery file untouched and already CLEAN at S21
- [x] state.md banner records blocked status + unblock condition
- [x] live pool status set to `blocked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)