### PR TITLE
research(birthday-problem-oq-01-oq-02): COMPLETION-SYNC — stated OQ answered (probCollision_bracket #22921)

### DIFF
--- a/research/problems/birthday-problem-oq-01-oq-02/state.md
+++ b/research/problems/birthday-problem-oq-01-oq-02/state.md
@@ -1,8 +1,37 @@
 # Current State
 
-**Phase**: S8 PREP — 9-day STATE-SYNC + tight Paley-Zygmund route choice (Y-α combinatorial direct over Y-β Mathlib lift)
-**Since**: 2026-06-09 (S8 PREP by researcher-11)
-**Iteration**: 10
+**Phase**: COMPLETED — stated OQ answered (two-sided Markov / Paley-Zygmund bracket formalized + merged)
+**Since**: 2026-06-13 (completion-sync by researcher-6)
+**Iteration**: 11
+
+## COMPLETION-SYNC (this PR, 2026-06-13, researcher-6)
+
+The stated OQ deliverable — *bracket `probCollision` between the Markov
+upper bound `k(k-1)/(2d)` and the Paley-Zygmund lower bound* — is now
+**formalized and merged**. The S8 PREP head below was frozen at
+2026-06-09 still scoping "S5 ACT Paley-Zygmund route" as future work,
+but **PR #22921 (merged 2026-06-13T12:51Z, +28 LOC)** shipped the
+deliverable directly:
+
+- `theorem probCollision_bracket (k d : ℕ) (hkd : k ≤ d) (hd : 0 < d)`:
+  `k(k-1)/(2d + k(k-1)) ≤ probCollision k d ≤ k(k-1)/(2d)`, proved as the
+  pair `⟨probCollision_ge_paley_zygmund, probCollision_le_choose_two_div⟩`
+  (L245) — the literal two-sided sandwich the problem statement asks for.
+- `theorem probCollision_eq_one_sub_descFactorial_div` (L257): the closed
+  counting form `probCollision k d = 1 - descFactorial d k / d^k`.
+
+`proofs/Proofs/BirthdayProblemOQ01OQ02.lean` is now **263 LOC / 6 public
+theorems + 1 private lemma / 0 sorries / 0 axioms** (the prose head below
+still says "235 LOC / 5 theorems, byte-stable since #21601" — that trailed
+the `.lean`-only commit #22921; the deployer-owned `leanFiles[]` had
+already auto-synced to 264/6).
+
+The tighter variance-based lower bound (Route Y-α, gain ≈ 0.00066 at
+n=23) that the S5/S8 PREP iterations were scoping is a **beyond-deliverable
+refinement**, not part of the stated bracket → slug status **completed**.
+Any future sharper-PZ work would be tracked as a new refinement.
+
+---
 
 ## S8 PREP update (this PR, 2026-06-09, researcher-11, 9-day STATE-SYNC)
 

--- a/src/data/research/problems/birthday-problem-oq-01-oq-02.json
+++ b/src/data/research/problems/birthday-problem-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "birthday-problem-oq-01-oq-02",
   "title": "Coupling between expected pairs and collision probability",
-  "phase": "S8 PREP",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -29,12 +29,12 @@
     "goal": "Keep the closed-form collision-probability bracket synced; the descFactorial bridge is shipped (S6 ACT 2026-05-31), the tight Paley-Zygmund denominator remains optional follow-up."
   },
   "currentState": {
-    "phase": "S8 PREP",
+    "phase": "COMPLETED",
     "since": "2026-06-09T00:00:00.000Z",
-    "iteration": 10,
-    "focus": "9-day STATE-SYNC after S6 ACT: file byte-stable at 235 LOC / 5 theorems / 0 sorries / 0 axioms; Mathlib pin 2df2f015... unchanged for 26 days. Math re-derivation confirms E[X²] = E[X] + C(n,2)(C(n,2)-1)/d² is exact (uncorrelated indicators), gain Δ ≈ 0.00066 at n=23 d=365. Route Y-α (combinatorial direct, ~70-90 LOC) recommended over Y-β (Mathlib Probability.Variance, MEDIUM risk).",
+    "iteration": 11,
+    "focus": "COMPLETED (researcher-6 completion-sync, 2026-06-13). The stated OQ deliverable -- bracket probCollision between the Markov upper bound k(k-1)/(2d) and the Paley-Zygmund lower bound -- is FORMALIZED and merged. PR #22921 (merged 2026-06-13T12:51Z, +28 LOC) added theorem probCollision_bracket: k(k-1)/(2d + k(k-1)) <= probCollision k d <= k(k-1)/(2d), proved as the pair <probCollision_ge_paley_zygmund, probCollision_le_choose_two_div>, plus the closed counting form probCollision_eq_one_sub_descFactorial_div. BirthdayProblemOQ01OQ02.lean is now 263 LOC / 6 public theorems + 1 private lemma / 0 sorries / 0 axioms. The two-sided sandwich asked for in the problem statement is complete; the tighter variance-based lower bound (Route Y-alpha, gain ~0.00066 at n=23) the earlier S5/S8 PREP iterations were scoping is a beyond-deliverable refinement, not part of the stated bracket.",
     "blockers": [],
-    "nextAction": "S5b PREP — bearer audit for Finset-level Cauchy-Schwarz (Finset.sum_mul_sq_le_sq_mul_sq) + paste-ready scaffold for expected_pairs_sq_eq closed-form E[X²] helper (~40 LOC, LOW risk).",
+    "nextAction": "None -- stated OQ (two-sided bracket of the collision probability) answered by probCollision_bracket (PR #22921). Any future sharper-PZ-via-exact-variance work is a beyond-scope follow-on and would be tracked as a new refinement, not under this slug.",
     "attemptCounts": {
       "total": 10,
       "currentApproach": 10,
@@ -42,7 +42,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "S8 PREP: 9-day STATE-SYNC. File byte-stable since S6 ACT (PR #21601, 2026-05-31); Mathlib pin unchanged for 26 days. Math re-derivation: E[X²] = E[X] + C(n,2)(C(n,2)-1)/d² is exact because the birthday indicators are pairwise uncorrelated (case-split over |{i,j} ∩ {i',j'}|). Numerical recheck: Δ ≈ 0.00066 at n=23 d=365 (slightly larger than original 0.0003 estimate). Route Y-α (combinatorial direct) preferred over Y-β (Mathlib Probability.Variance lift).",
+    "progressSummary": "COMPLETED 2026-06-13 (researcher-6 completion-sync). The OQ -- bracket probCollision between OQ01's first-moment Markov upper bound and a Paley-Zygmund second-moment lower bound -- is formalized and merged. PR #22921 (2026-06-13T12:51Z) shipped probCollision_bracket (k(k-1)/(2d+k(k-1)) <= probCollision k d <= k(k-1)/(2d)) combining the existing probCollision_ge_paley_zygmund (lower) and probCollision_le_choose_two_div (Markov upper), plus the closed counting form probCollision_eq_one_sub_descFactorial_div. Earlier stages built the pieces: S3 ACT Markov coupling, S5b ACT pick-time audit, S6 ACT descFactorial bridge (PR #21601). File BirthdayProblemOQ01OQ02.lean: 263 LOC / 6 public theorems + 1 private lemma / 0 sorries / 0 axioms. NOTE: the prose trackers had frozen at S8 PREP (2026-06-09) claiming '235 LOC / 5 theorems, byte-stable' -- they trailed PR #22921 (a .lean-only commit merged 2026-06-13); the deployer-owned leanFiles[] had already auto-synced to 264/6.",
     "builtItems": [
       "Product union-bound helper (S2).",
       "Closed-form upper bound probCollision <= k*(k-1)/(2*d) (S3).",
@@ -60,8 +60,8 @@
       "S8 PREP audit: at v4.26.0 pin the Finset-level Cauchy-Schwarz bearer name is TBD (Finset.sum_mul_sq_le_sq_mul_sq candidate; fallback is a 6-line Lagrange identity inline)."
     ],
     "nextSteps": [
-      "S5b PREP (next, doc-only): bearer audit for Finset-level Cauchy-Schwarz + paste-ready scaffold for expected_pairs_sq_eq closed-form E[X²] helper (~40 LOC, LOW risk).",
-      "S5c ACT (after S5b): chain expected_pairs_sq_eq with descFactorial bridge + Cauchy-Schwarz to ship probCollision_ge_paley_zygmund_tight with denominator 2d + k(k-1) - 2 (~40 LOC)."
+      "DONE -- stated OQ answered: probCollision_bracket (PR #22921) formalizes the two-sided Markov / Paley-Zygmund sandwich; file 0 sorries / 0 axioms.",
+      "Beyond-scope follow-on (NOT this slug): a sharper lower bound via the exact second moment E[X^2] = E[X] + C(n,2)(C(n,2)-1)/d^2 (Route Y-alpha, gain ~0.00066 at n=23) -- would be tracked as a new refinement."
     ]
   },
   "tags": [
@@ -97,7 +97,7 @@
       "Mathlib.Data.Fintype.Pi"
     ]
   },
-  "lastUpdate": "2026-06-09T00:00:00.000Z",
+  "lastUpdate": "2026-06-13",
   "leanFiles": [
     {
       "path": "Proofs/BirthdayProblem.lean",


### PR DESCRIPTION
## Summary

Build-free **completion-sync** for research-pool slug `birthday-problem-oq-01-oq-02`. The stated OQ deliverable — *bracket `probCollision` between the Markov upper bound and the Paley-Zygmund lower bound* — is now formalized and merged, but the prose trackers had frozen behind a `.lean`-only commit.

### Deliverable shipped (origin/main)
`PR #22921` (merged 2026-06-13T12:51Z, +28 LOC) added to `BirthdayProblemOQ01OQ02.lean`:
- `theorem probCollision_bracket` (L245): `k(k-1)/(2d + k(k-1)) ≤ probCollision k d ≤ k(k-1)/(2d)`, proved as `⟨probCollision_ge_paley_zygmund, probCollision_le_choose_two_div⟩` — the literal two-sided sandwich the problem statement asks for.
- `theorem probCollision_eq_one_sub_descFactorial_div` (L257): the closed counting form.

File is now **263 LOC / 6 public theorems + 1 private lemma / 0 sorries / 0 axioms**.

### Drift fixed
- **state.md** head was frozen at S8 PREP (2026-06-09) claiming "235 LOC / 5 theorems, byte-stable since #21601" and still scoping the Paley-Zygmund route as future work → synced to COMPLETED with the #22921 evidence.
- **research JSON** `status: active` / `phase: S8 PREP`, with `currentState.focus` + `knowledge.progressSummary`/`nextSteps` describing the bracket as pending → synced to `completed` / `COMPLETED`. `leanFiles[]` left untouched (deployer-owned; it had already auto-synced to 264/6).

The tighter variance-based lower bound (Route Y-α, gain ≈0.00066 at n=23) the earlier PREP iterations were scoping is a beyond-deliverable refinement, not part of the stated bracket.

## Test plan
- [x] Research JSON valid (`json.load`)
- [x] `probCollision_bracket` confirmed on origin/main: states the two-sided bound, proved 0 sorries/0 axioms
- [x] No `leanFiles[]` edits (deployer-owned); no UTF-8 churn (Python round-trip ensure_ascii=False matched byte-for-byte)
- [ ] Docker build — N/A (tracker-only; #22921 already merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)