### PR TITLE
research(erdos-szekeres-oq-01): S4 ORIENT — Mathlib Archive offers a simpler axiom-discharge path

### DIFF
--- a/research/problems/erdos-szekeres-oq-01/knowledge.md
+++ b/research/problems/erdos-szekeres-oq-01/knowledge.md
@@ -6,16 +6,80 @@ Insights accumulated during research on this problem.
 
 ## Problem Understanding
 
-[Initial observations about the problem will be recorded here]
+**Target**: discharge `erdos_szekeres_existence_axiom` in `proofs/Proofs/ErdosSzekeres.lean`
+(line 200), converting it from an `axiom` to a proved `theorem`. This reduces the parent
+`erdos-szekeres` gallery entry from 2 axioms to 1 (the remaining axiom,
+`erdos_szekeres_tight_axiom` at line 235, is out of scope here).
+
+The parent encodes sequences as `Sequence α n := Fin n → α` and subsequences as the
+structures `IncreasingSubseq f k` / `DecreasingSubseq f k`, each carrying
+`positions : Fin k → Fin n` that is `StrictMono` with `StrictMono (f ∘ positions)`
+(resp. `StrictAnti`).
+
+**Two approaches are on the table** (see `problem.md`): the in-progress bottom-up
+Approach B (#22772) and the newly-surveyed Archive-import Approach A.
 
 ---
 
 ## Insights
 
-[Insights from research attempts will be accumulated here]
+### S3 ORIENT (2026-06-13, researcher-1) — Mathlib already proves the core (Approach A)
+
+- **`Theorems100.erdos_szekeres`** in the Mathlib **Archive**
+  (`Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean`) is a *fully proved*
+  Erdős–Szekeres theorem (no axioms), using the same pigeonhole-on-pairs argument the
+  parent's docstring describes — i.e. it already contains the exact content Approach B is
+  hand-rebuilding. Signature:
+  ```lean
+  theorem erdos_szekeres {α β} [Fintype α] [LinearOrder α] [LinearOrder β]
+      {r s : ℕ} {f : α → β} (hn : r * s < Fintype.card α) (hf : Injective f) :
+      (∃ t : Finset α, r < t.card ∧ StrictMonoOn f ↑t) ∨
+      (∃ t : Finset α, s < t.card ∧ StrictAntiOn f ↑t)
+  ```
+- **The Archive is importable here**: `proofs/Proofs/BallotProblem.lean` already imports
+  `Archive.Wiedijk100Theorems.BallotProblem`. The lakefile requires `mathlib`, and the
+  Archive ships with it, so `import Archive.Wiedijk100Theorems.AscendingDescendingSequences`
+  is expected to resolve (confirm at build time).
+- **Bound reconciliation is exact** under the index shift `r ↦ r-1`, `s ↦ s-1`:
+  Archive's `(r-1)*(s-1) < Fintype.card (Fin n) = n` ⟺ parent's `n ≥ (r-1)*(s-1)+1`.
+  Archive's conclusion `(r-1) < t.card` ⟺ `r ≤ t.card`.
+- **Structure conversion bearer**: `Finset.orderEmbOfCardLe (t : Finset α) (h : k ≤ t.card)
+  : Fin k ↪o α` gives a strictly-monotone `Fin k → α` with image ⊆ `t`
+  (Mathlib `Data/Finset/Sort.lean`, mathlib3 `order_emb_of_card_le`). Composing the
+  `StrictMonoOn f ↑t` witness with this embedding yields the parent's
+  `StrictMono (f ∘ positions)` via `StrictMonoOn.comp_strictMono`.
+
+### Recommended ACT plan for Approach A
+
+1. `import Archive.Wiedijk100Theorems.AscendingDescendingSequences`.
+2. In the discharging theorem (same signature as `erdos_szekeres_existence_axiom`):
+   apply `Theorems100.erdos_szekeres (α := Fin n) (β := α) (r := r-1) (s := s-1) f`
+   with the bound rewritten via `Fintype.card_fin` + `omega`.
+3. Case-split the disjunction; in each case take `t` and build
+   `positions := Finset.orderEmbOfCardLe t (by omega : r ≤ t.card)`, then assemble the
+   `IncreasingSubseq` / `DecreasingSubseq` structure (`strictMono_values` from
+   `StrictMonoOn.comp_strictMono`).
+4. Replace the `axiom` with this theorem.
+
+### Strategic note vs Approach B
+
+Approach B (#22772, ACT-1 done) is hand-building `maxIncLen`/`maxDecLen` +
+`HasIncreasingEndingAt` infrastructure (lines 99–174 of the parent) and still owes the
+position→pair injectivity lemma (`maxIncLen_lt_of_lt`) plus the final pigeonhole. If
+Approach A's import resolves, it discharges the axiom with ~30–50 LOC of plumbing instead,
+making the in-progress bottom-up scaffold unnecessary for the *axiom-discharge* goal.
+Worth prototyping Approach A before committing to Approach B's ACT-2.
 
 ---
 
 ## Dead Ends
 
-[Approaches known not to work will be documented here]
+- (none recorded yet). Approach B is *viable but likely dominated* by Approach A for the
+  axiom-discharge goal — not a dead end, just more code than necessary if A typechecks.
+
+---
+
+## Build status
+
+ACT (either approach) is **build-gated** and not attempted during the 2026-06-13 Docker
+blackout. Prototype Approach A and Docker-verify once build infra is restored.

--- a/research/problems/erdos-szekeres-oq-01/problem.md
+++ b/research/problems/erdos-szekeres-oq-01/problem.md
@@ -1,111 +1,174 @@
-# Problem: [Problem Title]
+# Problem: Discharge the Erdős–Szekeres existence axiom (pigeonhole over pairs)
 
 **Slug**: erdos-szekeres-oq-01
 **Created**: 2026-04-05T19:30:46-07:00
-**Status**: Active
-**Source**: user-request <!-- gallery-gap | proof-suggestion | user-request | external -->
+**Status**: Active — ACT in progress (Approach B, #22772); Approach A surveyed 2026-06-13
+**Source**: user-request
 
 ## Problem Statement
 
 ### Formal Statement
 
-$$
-\text{[LaTeX formulation of the theorem/conjecture]}
-$$
+The gallery parent `proofs/Proofs/ErdosSzekeres.lean` states the existence direction
+as an **axiom**:
+
+```lean
+axiom erdos_szekeres_existence_axiom {α : Type*} [LinearOrder α] {n : ℕ}
+    (f : Sequence α n) (hf : Injective f) (r s : ℕ) (hr : r ≥ 1) (hs : s ≥ 1)
+    (hn : n ≥ (r - 1) * (s - 1) + 1) :
+    (∃ sub : IncreasingSubseq f r, True) ∨ (∃ sub : DecreasingSubseq f s, True)
+```
+
+where `Sequence α n := Fin n → α` and `IncreasingSubseq f k` is a structure carrying
+`positions : Fin k → Fin n` with `StrictMono positions` and `StrictMono (f ∘ positions)`
+(`DecreasingSubseq` likewise with `StrictAnti (f ∘ positions)`).
+
+**Goal**: replace `erdos_szekeres_existence_axiom` with a proved `theorem`, reducing
+the parent's axiom count from 2 to 1.
 
 ### Plain Language
 
-[Explain what we're trying to prove in accessible terms]
+The parent gallery proof "Erdős–Szekeres Theorem" (Wiedijk #73) currently *assumes*
+the core existence statement (any sequence of `(r-1)(s-1)+1` distinct elements has an
+increasing subsequence of length `r` or a decreasing one of length `s`) as an axiom,
+deferring the pigeonhole-over-pairs argument. This problem asks to actually prove it.
 
 ### Why This Matters
 
-[Significance of the problem - mathematical importance, applications, connections]
+Removing an axiom from a Wiedijk-100 gallery entry upgrades it from `axiomatized`
+toward `verified`. The existence direction is the mathematical heart of the theorem;
+axiomatizing it is the weakest part of the current formalization.
 
 ## Known Results
 
 ### What's Already Proven
 
-- [Related theorem 1] — [citation/location]
-- [Related theorem 2] — [citation/location]
+- **In this slug (origin/main, Approach B, #22772)**: `maxIncLen` / `maxDecLen` (via
+  `Nat.findGreatest`), singleton witnesses `hasIncreasingEndingAt_one` /
+  `hasDecreasingEndingAt_one`, and lower bounds `one_le_maxIncLen` / `one_le_maxDecLen`.
+  Parent file 281 → 344 LOC, Docker-verified, axiom count still 2. The remaining burden
+  is the position→pair injectivity (the `maxIncLen_lt_of_lt` extension lemma).
+- **`Theorems100.erdos_szekeres`** — Mathlib **Archive**
+  (`Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean`). The full
+  Erdős–Szekeres theorem, *proved* (no axioms), via the same pigeonhole-on-pairs argument:
+  ```lean
+  theorem erdos_szekeres {α : Type*} {β : Type*} [Fintype α]
+      [LinearOrder α] [LinearOrder β] {r s : ℕ} {f : α → β}
+      (hn : r * s < Fintype.card α) (hf : Function.Injective f) :
+      (∃ t : Finset α, r < t.card ∧ StrictMonoOn f ↑t) ∨
+      (∃ t : Finset α, s < t.card ∧ StrictAntiOn f ↑t)
+  ```
+- **The Archive is importable in this project**: `proofs/Proofs/BallotProblem.lean`
+  already does `import Archive.Wiedijk100Theorems.BallotProblem`, so
+  `import Archive.Wiedijk100Theorems.AscendingDescendingSequences` is available.
+- `Finset.orderEmbOfCardLe (s : Finset α) (h : k ≤ s.card) : Fin k ↪o α` — order
+  embedding whose image is contained in `s` (Mathlib `Data/Finset/Sort.lean`). Bridges
+  Archive's `Finset` conclusion to the parent's `Fin k → Fin n` structure.
 
 ### What's Still Open
 
-- [Open question 1]
-- [Open question 2]
+- **Approach B**: the position→pair injectivity (`maxIncLen_lt_of_lt`) + the final
+  pigeonhole assembly.
+- **Approach A**: the type/structure *adaptation* from `Theorems100.erdos_szekeres`
+  (`f : α → β`, `Fintype α`, `Finset α` conclusion) to the parent's `Sequence α n` /
+  `IncreasingSubseq` structure form. No new mathematics — pure Lean plumbing.
 
 ### Our Goal
 
-[Specific scope of what we're attempting — which piece of the puzzle]
+Discharge `erdos_szekeres_existence_axiom` only. The second axiom
+`erdos_szekeres_tight_axiom` (sharpness of the bound) is **out of scope** for this slug.
 
 ## Related Gallery Proofs
 
 | Proof | Relevance | Techniques |
 |-------|-----------|------------|
-| [proof-slug-1] | [why related] | [techniques used] |
-| [proof-slug-2] | [why related] | [techniques used] |
+| `erdos-szekeres` | Parent — the axiom we are discharging | pigeonhole, order theory |
+| `ballot-problem` | Precedent for importing `Archive.Wiedijk100Theorems.*` | Archive reuse |
+| `pigeonhole-principle` | Underlying technique of both approaches | Finset cardinality |
 
 ## Initial Thoughts
 
 ### Potential Approaches
 
-1. **Approach A**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+1. **Approach B (ACTIVE, in progress #22772): bottom-up pair tracking.**
+   Hand-build `maxIncLen`/`maxDecLen`, prove the extension lemma `maxIncLen_lt_of_lt`
+   (the position→pair map is injective), then pigeonhole on the `(r-1)×(s-1)` grid.
+   - Status: ACT-1 done (defs + singleton witnesses + lower bounds, Docker-verified).
+   - Risk: ~150+ LOC total; the injectivity lemma is the main remaining effort.
 
-2. **Approach B**: [brief description]
-   - Why it might work: ...
-   - Risk: ...
+2. **Approach A (SURVEYED 2026-06-13, candidate to supersede B): import the Archive.**
+   - Instantiate `Theorems100.erdos_szekeres` with `α := Fin n`, `β := α`, and the
+     **index shift** `r ↦ r-1`, `s ↦ s-1`. Then Archive's hypothesis becomes
+     `(r-1)*(s-1) < Fintype.card (Fin n) = n`, i.e. exactly the parent's
+     `n ≥ (r-1)*(s-1)+1`. Archive's conclusion becomes `t.card ≥ r`.
+   - Convert each disjunct: from `t : Finset (Fin n)` with `r ≤ t.card` and
+     `StrictMonoOn f ↑t`, build `positions := Finset.orderEmbOfCardLe t (h : r ≤ t.card)`.
+     `positions` is `StrictMono` (order embedding) and lands in `↑t`, so
+     `StrictMono (f ∘ positions)` follows from `StrictMonoOn.comp_strictMono` plus the
+     range-⊆-`t` fact (`Finset.range_orderEmbOfCardLe` / membership lemma).
+   - Why it may be better: reuses ~80 LOC of already-verified Mathlib; the only work is
+     ~30–50 LOC of structure repackaging, vs Approach B's full bottom-up build.
+   - Risk: the order-embedding range/membership lemma name needs build-time confirmation;
+     minor `Fintype.card_fin` and `r-1 < c ↔ r ≤ c` bookkeeping.
+
+   **Recommendation**: before investing further in Approach B's ACT-2, spend one ACT
+   session prototyping Approach A — if the import resolves and the conversion typechecks,
+   it discharges the axiom with far less code.
 
 ### Key Difficulties
 
-- [Difficulty 1]
-- [Difficulty 2]
+- (Approach A) the index/off-by-one bridge between "subsequence length `r`" (parent) and
+  "`r < card`, i.e. length `> r`" (Archive). Resolved cleanly by the `r ↦ r-1` shift.
+- (Approach A) converting a `StrictMonoOn`-on-a-`Finset` witness into a
+  `StrictMono (Fin r → Fin n)` witness — handled by `Finset.orderEmbOfCardLe`.
+- (Approach B) the injectivity of the position→pair map.
 
 ### What Would a Proof Need?
 
-- Key lemma 1: ...
-- Key lemma 2: ...
-- Technical requirements: ...
+- (A) `Theorems100.erdos_szekeres` (import the Archive) + `Finset.orderEmbOfCardLe`
+  + `StrictMonoOn.comp_strictMono` + `Fintype.card_fin` + `omega`.
+- (B) `maxIncLen_lt_of_lt` extension lemma + the existing `maxIncLen`/`maxDecLen` scaffold.
 
 ## Tractability Assessment
 
-**Difficulty**: Low | Medium | High | Moonshot
+**Difficulty**: Low–Medium (Approach A); Medium (Approach B).
 
 **Justification**:
-- [Reason for assessment]
-- [Similar problems that have been solved]
-- [Techniques available in Mathlib]
+- The hard mathematics is **already in Mathlib's Archive** and importable here — Approach A
+  reduces the task to type/structure adaptation comparable to other
+  `Archive.Wiedijk100Theorems.*` reuse PRs in this repo (e.g. ballot-problem).
 
 **Estimated Effort**:
-- Exploration: [hours/days]
-- If tractable: [days/weeks]
-- If hard: [unknown]
+- Exploration: done (this ORIENT survey of Approach A).
+- If tractable (Approach A): ~1 ACT session once Docker build infra is available.
+- Blocker: discharge is build-gated; ACT should wait for Docker (blackout 2026-06-13).
 
 ## References
 
-### Papers
-- [Author, Title, Year] — [brief note]
-
 ### Online Resources
-- [URL] — [description]
+- https://leanprover-community.github.io/mathlib4_docs/Archive/Wiedijk100Theorems/AscendingDescendingSequences.html — `Theorems100.erdos_szekeres`
+- https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93Szekeres_theorem — statement & history
 
 ### Mathlib
-- [Relevant Mathlib module] — [what it provides]
+- `Archive.Wiedijk100Theorems.AscendingDescendingSequences` — proved Erdős–Szekeres
+- `Mathlib.Data.Finset.Sort` — `Finset.orderEmbOfCardLe`
+- `Mathlib.Order.Monotone.Basic` — `StrictMonoOn.comp_strictMono`
 
 ## Metadata
 
 ```yaml
 tags:
-  - number-theory  # or: algebra, analysis, topology, combinatorics, etc.
-  - prime-gaps
-  - sieve-methods
+  - combinatorics
+  - order-theory
+  - pigeonhole
 related_proofs:
-  - infinitude-of-primes
-  - sieve-of-eratosthenes
-difficulty: medium
-source: proof-suggestion
+  - erdos-szekeres
+  - ballot-problem
+  - pigeonhole-principle
+difficulty: low-medium
+source: user-request
 created: 2026-04-05T19:30:46-07:00
 ```
 
 **Significance**: 6/10
-**Tractability**: 7/10
+**Tractability**: 8/10 (raised from 7 — Mathlib Archive already proves the core; importable here)

--- a/research/problems/erdos-szekeres-oq-01/state.md
+++ b/research/problems/erdos-szekeres-oq-01/state.md
@@ -1,10 +1,10 @@
 # Research State: erdos-szekeres-oq-01
 
 ## Current State
-**Phase**: ACT
+**Phase**: ACT (Approach B in progress) + S4 ORIENT note (Approach A surveyed 2026-06-13)
 **Path**: full
-**Since**: 2026-06-10T02:55:00-07:00
-**Iteration**: 3
+**Since**: 2026-06-13 (S4 ORIENT, researcher-1; ACT-1 since 2026-06-10)
+**Iteration**: 4 (S1 OBSERVE → S2 ACT-1 #22772 → S3 ACT-1 cont. → S4 ORIENT Approach-A survey)
 
 ## Current Focus
 ACT-1 complete (S2, #22772): `maxIncLen`/`maxDecLen` defined via `Nat.findGreatest`
@@ -23,19 +23,45 @@ run of length `s` exist, all pairs lie in the grid `(r-1) × (s-1)`; the pigeonh
 on an injective position→pair map yields the Erdős–Szekeres bound. The remaining
 formal burden is the injectivity of that map.
 
+## Alternative Approach (Approach A — surveyed S4, 2026-06-13, researcher-1)
+
+Mathlib's **Archive** already *proves* Erdős–Szekeres: `Theorems100.erdos_szekeres`
+in `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean` (no axioms, same
+pigeonhole-on-pairs argument). The Archive is importable here (precedent:
+`proofs/Proofs/BallotProblem.lean` imports `Archive.Wiedijk100Theorems.BallotProblem`).
+
+Discharge path: `import` the Archive theorem, instantiate with `α := Fin n`, `β := α`,
+index shift `r ↦ r-1`, `s ↦ s-1` (makes the bound `(r-1)(s-1) < n` match the parent's
+`n ≥ (r-1)(s-1)+1` exactly), then convert each `Finset (Fin n)` / `StrictMonoOn`
+disjunct into the parent's `IncreasingSubseq` / `DecreasingSubseq` structure via
+`Finset.orderEmbOfCardLe` + `StrictMonoOn.comp_strictMono`. See `problem.md` and
+`knowledge.md` (S3/S4 ORIENT) for full detail.
+
+This would discharge the axiom in ~30–50 LOC of plumbing, making Approach B's
+bottom-up `maxIncLen`/`maxDecLen` scaffold unnecessary for the axiom-discharge goal.
+**Recommendation**: prototype Approach A before investing further ACT in Approach B.
+
 ## Attempt Count
-- Total attempts: 2
+- Total attempts: 2 (both Approach B, ACT-1)
 - Current approach attempts: 2
-- Approaches tried: 1
+- Approaches tried: 2 (B in progress; A surveyed, not yet attempted in Lean)
 
 ## Blockers
-None. (Next step is build-gated on Docker availability for verification.)
+ACT (either approach) is build-gated on Docker availability (2026-06-13 blackout) for
+verification; ORIENT/PREP only until restored.
 
 ## Next Action
-ACT-2: Prove the key extension lemma `maxIncLen_lt_of_lt` — for `i < j : Fin n`
-with `f i < f j`, `maxIncLen f i < maxIncLen f j`. Strategy: extract witness
-`k : Fin L → Fin n` from `HasIncreasingEndingAt f i L`; define `k'` on `Fin (L+1)`
-appending `j` after `k`'s end-position `i` (using the refactored predicate
-requirement `j.val = L` for the last index); verify `StrictMono` positions and
-values, then `Nat.le_findGreatest` gives `maxIncLen f j ≥ L+1`. Symmetric for
-`maxDecLen` under `f j < f i`. Target +60–100 LOC.
+**First** (recommended): ACT — prototype **Approach A**. Add
+`import Archive.Wiedijk100Theorems.AscendingDescendingSequences` to
+`proofs/Proofs/ErdosSzekeres.lean`, replace `erdos_szekeres_existence_axiom` with a
+proved theorem per `knowledge.md` → "Recommended ACT plan for Approach A", then
+`./proofs/scripts/docker-build.sh Proofs.ErdosSzekeres`. If the import or conversion
+fails, fall back to **Approach B** ACT-2:
+
+ACT-2 (Approach B fallback): Prove the key extension lemma `maxIncLen_lt_of_lt` — for
+`i < j : Fin n` with `f i < f j`, `maxIncLen f i < maxIncLen f j`. Strategy: extract
+witness `k : Fin L → Fin n` from `HasIncreasingEndingAt f i L`; define `k'` on
+`Fin (L+1)` appending `j` after `k`'s end-position `i` (using the refactored predicate
+requirement `j.val = L` for the last index); verify `StrictMono` positions and values,
+then `Nat.le_findGreatest` gives `maxIncLen f j ≥ L+1`. Symmetric for `maxDecLen` under
+`f j < f i`. Target +60–100 LOC.


### PR DESCRIPTION
## Summary
ORIENT survey of `erdos-szekeres-oq-01` (discharge the parent's `erdos_szekeres_existence_axiom`). Key finding:

- **Mathlib's Archive already proves Erdős–Szekeres** — `Theorems100.erdos_szekeres` in `Archive/Wiedijk100Theorems/AscendingDescendingSequences.lean` (no axioms, same pigeonhole-on-pairs argument).
- **It's importable in this project** — `proofs/Proofs/BallotProblem.lean` already imports `Archive.Wiedijk100Theorems.BallotProblem`.
- **The bound matches exactly** under the index shift `r ↦ r-1`, `s ↦ s-1`: Archive's `(r-1)(s-1) < Fintype.card (Fin n) = n` ⟺ the parent's `n ≥ (r-1)(s-1)+1`.
- **Structure conversion**: `Finset.orderEmbOfCardLe` + `StrictMonoOn.comp_strictMono` turn Archive's `Finset`/`StrictMonoOn` conclusion into the parent's `IncreasingSubseq` structure (~30–50 LOC).

This **Approach A** may supersede the in-progress bottom-up **Approach B** (#22772, hand-built `maxIncLen`/`maxDecLen` scaffold, ACT-1 done) for the axiom-discharge goal — recommend prototyping A before further investing in B's ACT-2.

## Changes
- Filled the stub `problem.md` (was the unfilled template) with the real statement, both approaches, and tractability.
- Added S3/S4 ORIENT insights to the empty `knowledge.md` (exact Archive signature, bound reconciliation, conversion bearers, ACT plan).
- Added an "Alternative Approach (A)" section + revised Next Action to `state.md`, **preserving** the existing ACT-3 / #22772 content.

## Verification status
Doc-only (research trackers). No Lean source / gallery / axiom change. ACT for either approach is build-gated by the 2026-06-13 Docker blackout; the state.md flags the prototype-A-first plan for when build infra returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)