### PR TITLE
research(erdos-1210): STATE-SYNC research JSON currentState S1→S3

### DIFF
--- a/src/data/research/problems/erdos-1210.json
+++ b/src/data/research/problems/erdos-1210.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1210",
   "title": "Erdős #1210",
-  "phase": "ACT",
+  "phase": "AXIOMATIZED",
   "status": "active",
   "tier": "A",
   "path": "full",
@@ -16,16 +16,16 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-04-16T17:10:06.887Z",
-    "iteration": 1,
-    "focus": "Formalized main conjecture, prime coprimality structure, and 11 structural theorems.",
+    "phase": "AXIOMATIZED",
+    "since": "2026-06-13T08:00:00Z",
+    "iteration": 3,
+    "focus": "S3: corrected the statement from erdosproblems.com/1210 (RHS = Mertens sum ∑_{p<n} 1/p, with a +O(1) additive term) and re-axiomatized erdos_1210 in honest existential-constant form (∃C, ∀n≥3, ∀ pairwise-coprime A, ∑ 1/(n-a) ≤ primeReciprocalSum n + C). Machine-checked the O(1) term is essential (n=5, A={4}: LHS=1 > 5/6). 14 theorems, 4 defs, 1 axiom, 0 sorries, 230 lines; gallery meta.json synced.",
     "blockers": [],
-    "nextAction": "Docker build verification.",
+    "nextAction": "S4 — explore an unconditional partial bound ∑_{a∈A} 1/(n-a) ≤ C·log log n for pairwise coprime A (via the at-most-one-even structure + a sieve/Mertens estimate). Build-gated; the conjecture itself is open and cannot be resolved by finite computation.",
     "attemptCounts": {
-      "total": 1,
+      "total": 3,
       "currentApproach": 1,
-      "approachesTried": 1
+      "approachesTried": 3
     }
   },
   "knowledge": {
@@ -78,7 +78,7 @@
     "mathlib": []
   },
   "started": "2026-04-16T17:10:06.887Z",
-  "lastUpdate": "2026-04-21T11:09:40.249Z",
+  "lastUpdate": "2026-06-13T21:00:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
The S3 ACT (PR #22965 — "correct the statement from source, re-axiomatize with O(1)") shipped the Lean source, `knowledge.md`, `state.md`, and gallery `meta.json`, but **not** the research-pool JSON. Its `currentState` was left frozen at **iteration 1 / phase ACT** (2026-04-16), describing the original mis-transcribed pre-S3 formalization. This is the classic ".lean+meta+state.md-only ACT PR leaves research JSON `currentState` stale" drift.

This PR syncs `currentState` forward to match `state.md` (iteration 3, phase AXIOMATIZED):
- `phase` ACT → AXIOMATIZED; `since` → 2026-06-13T08:00:00Z; `iteration` 1 → 3
- `focus` → S3 corrected-statement / honest O(1) re-axiomatization summary
- `nextAction` → S4 unconditional partial-bound exploration
- `attemptCounts.total` / `approachesTried` 1 → 3
- top-level `phase` → AXIOMATIZED, `lastUpdate` bumped

## Verification (build-free; Docker down 2026-06-13)
- All S3 deliverables confirmed present on `origin/main` source: `primeReciprocalSum`, `naive_statement_fails_at_five`, `corrected_statement_consistent_at_five`, `primeReciprocalSum_pos`, `pairwiseCoprime_at_most_one_even`, and the existential-constant `axiom erdos_1210`.
- Gallery `meta.json` already in sync with source (230 LOC, 14 thm, 4 def, 1 axiom, 0 sorry) — no meta-audit change needed.
- `leanFiles` (still 179/11) left untouched — deployer-owned (enrich-research.ts regenerates it).
- Single-file JSON change; `python3 json.load` validates.

## Test plan
- [x] JSON parses
- [x] currentState matches state.md iteration 3 / phase AXIOMATIZED
- [x] No source/meta edits (STATE-SYNC only)