### PR TITLE
research(erdos-951-oq-05): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-951-oq-05.json
+++ b/src/data/research/problems/erdos-951-oq-05.json
@@ -66,13 +66,13 @@
     "mathlib": []
   },
   "started": "2026-03-30T07:24:09.592Z",
-  "lastUpdate": "2026-03-30T07:24:09.603Z",
+  "lastUpdate": "2026-06-10T09:47:38.000Z",
   "leanFiles": [
     {
       "path": "Proofs/Erdos951Problem.lean",
       "filename": "Erdos951Problem.lean",
-      "lineCount": 260,
-      "theoremCount": 9,
+      "lineCount": 392,
+      "theoremCount": 17,
       "axiomCount": 0,
       "defCount": 9,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Research-pool JSON `leanFiles` for `Erdos951Problem.lean` was frozen at **260 lines / 9 theorems** (lastUpdate 2026-03-30) while the source on `main` is at **392 lines / 17 theorems** — +132 lines, +8 public theorems the block never tracked.
- `axiomCount` (0), `defCount` (9), `sorryCount` (0) all unchanged.
- The shared parent (`erdos-951`) gallery meta was already synced in #22799; only this OQ-child's research-pool JSON lagged independently (separate artifacts).

## Verification (build-free, Docker blackout)
- Recomputed all 5 metrics from `git archive origin/main` source via the `enrich-research.ts` conventions (`^(theorem|lemma) ` strict, `split('\n').length`).
- `grep -cE '^private (theorem|lemma) '` = 1, excluded from BOTH old (9) and new (17) → the +8 is genuine **public** growth, not the strict-vs-private artifact (which is a theorem *drop* at flat line count).
- Comment-stripped recount confirms real `sorry`=0 / `axiom`=0 (no docstring false-positives).
- `lastUpdate` set to source last-commit date on main (2026-06-10, `d8284214`).

Scoped strictly to the two drifted metrics + `lastUpdate`; narrative untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)