### PR TITLE
research(erdos-411): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-411.json
+++ b/src/data/research/problems/erdos-411.json
@@ -83,15 +83,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T02:38:27.587Z",
-  "lastUpdate": "2026-05-13T00:00:00.000Z",
+  "lastUpdate": "2026-06-10T00:00:00.000Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos411Problem.lean",
       "filename": "Erdos411Problem.lean",
-      "lineCount": 397,
-      "theoremCount": 30,
+      "lineCount": 492,
+      "theoremCount": 35,
       "axiomCount": 0,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research-pool JSON `leanFiles` for `Erdos411Problem.lean` was frozen at **397/30** while the merged `origin/main` source is at **492/35** (+95 lines, +5 public theorems; axiom 0 / def 6 / sorry 0 unchanged).

- The +5 theorem delta is **genuine public-theorem growth** — the file has 4 `private` theorems excluded from *both* old (30) and new (35) counts by the strict `^(theorem|lemma) ` convention, so this is not the strict-vs-private artifact.
- Comment-stripped recount confirms **real sorry=0 / axiom=0** (no docstring false-positives).
- Gallery `meta.json` `leanFile` is an independent artifact; only the research-pool JSON lagged.

Scoped strictly to the two drifted metrics + `lastUpdate` (source last touched 2026-06-10, `d8284214`). No narrative changes.

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics recomputed from `origin/main` source via the exact `enrich-research.ts` regexes
- [ ] No build required (data-only; Docker verification not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)