### PR TITLE
research(skolem-noether-csa): S3 AUDIT — fix stale theoremCount 12→14, flag axiom OQ blocked

### DIFF
--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/knowledge.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/knowledge.md
@@ -73,3 +73,50 @@
 1. Verify Docker build passes — the 3 new theorems use only `mul_assoc`, `Units.mul_inv`, `Units.inv_mul`, `Units.val_mul`, `mul_inv_rev`, `mul_one`, `one_mul`, and `simp only [mul_assoc]` for non-commutative reassociation. All standard.
 2. Future work: extend the torsor structure to a `MulAction` of `Subalgebra.centralizer (g.range)` on the witness set, and a `Setoid`-quotient structure relating witnesses up to centralizer action.
 3. Long-term: still need to prove the `skolemNoether_module_iso` axiom (Wedderburn + Isotypic decomposition, ~200-300 lines).
+
+---
+
+## Session 2026-06-13 (Session 3) — AUDIT (build blackout)
+
+**Mode**: AUDIT / STATE-SYNC (no Lean change — Docker verification infra down)
+**Outcome**: corrected stale gallery counts; flagged OQ blocked pending Docker.
+
+### What I Did
+- Audited `proofs/Proofs/SkolemNoetherCSA.lean` against its gallery `meta.json`.
+- Found the published `theoremCount` was **stale at 12** while the source proves
+  **14** theorems by the canonical `^(theorem|lemma) ` convention used in
+  `scripts/research/enrich-research.ts`. Both counting conventions (column-0 and
+  include-namespaced) agree on 14 — there are no indented/private theorems — so 12
+  matched neither convention and was simply wrong.
+- Root cause: the Session-2 narrative recorded "theorem counts (9 → 12)" but the
+  actual delta was 11 → 14 (the 3 `IsConjugate.refl/symm/trans` equivalence-relation
+  theorems were not counted, even though they are listed in `originalContributions`).
+- Fixed `meta.json` in both the `meta` block and the `leanFile` block:
+  `theoremCount` 12 → 14, `lineCount` 392 → 394 (`lines.length` = 393 newlines + 1).
+  `axiomCount` (1), `definitionCount` (2), `sorries` (0) were already correct.
+
+### The 14 theorems
+rightBLinear_is_leftMul, rightBLinear_symm_is_leftMul, isUnit_of_rightBLinear_equiv,
+skolemNoether_general, aut_is_inner, conjugate_iff_same_image, IsConjugate.refl,
+IsConjugate.symm, IsConjugate.trans, skolemNoether_isConjugate,
+conjugateSetoid_single_class, witness_diff_centralizes, witness_mul_centralizer,
+witness_set_torsor.
+
+### Status of the open question
+The sole remaining gap is discharging the axiom `skolemNoether_module_iso`
+(the two A-module structures on B, via f and g, are isomorphic by a right-B-linear
+K-linear bijection). This is BLOCKED during the 2026-06-13 verification blackout:
+- **Research-hard** (~200-300 lines): needs Wedderburn-Artin
+  (`IsSimpleRing.exists_ringEquiv_matrix_divisionRing`, B ≅ Mₙ(D)) + isotypic
+  decomposition (`IsSimpleRing.isIsotypic`, forcing B_f ≅ B_g as A-modules) +
+  a bimodule-extension argument using centrality of K in B.
+- **Build-gated**: Docker build infra is down; unverifiable Lean should not be
+  shipped. Resume the axiom discharge once Docker is restored.
+
+### Files Modified
+- `src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json`
+  (theoremCount 12 → 14, lineCount 392 → 394, in both blocks)
+- `research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/state.md`
+  (phase → BLOCKED, iteration 3)
+- `research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/knowledge.md`
+  (this entry)

--- a/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/state.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/state.md
@@ -1,27 +1,44 @@
 # Current State
 
-**Phase**: REFINE
-**Since**: 2026-06-06T12:30:00+00:00
-**Iteration**: 2
+**Phase**: BLOCKED
+**Since**: 2026-06-13T00:00:00+00:00
+**Iteration**: 3
 
 ## Current Focus
 
-Witness ambiguity / torsor structure for Skolem-Noether conjugating units.
+AUDIT of published gallery entry + status reconciliation. The deliverable
+(axiomatized general Skolem-Noether for CSAs: 1 axiom, 0 sorries, 14 proved
+theorems) is complete and on `main`. The remaining open question is discharging
+the single axiom `skolemNoether_module_iso`.
 
 ## Active Approach
 
-Added 3 hypothesis-free theorems characterizing the witness set as a left coset
-of the centralizer of g(A) in Bˣ (witness_diff_centralizes,
-witness_mul_centralizer, witness_set_torsor). Independent of the
-skolemNoether_module_iso axiom.
+Audit only this iteration. Corrected stale gallery `meta.json` counts
+(theoremCount 12 → 14, lineCount 392 → 394) to match the canonical
+`^(theorem|lemma) ` / `lines.length` conventions in
+`scripts/research/enrich-research.ts`. Session-2 hand-count "9 → 12" was wrong;
+the file proves 14 theorems (rightBLinear_is_leftMul, rightBLinear_symm_is_leftMul,
+isUnit_of_rightBLinear_equiv, skolemNoether_general, aut_is_inner,
+conjugate_iff_same_image, IsConjugate.refl/symm/trans, skolemNoether_isConjugate,
+conjugateSetoid_single_class, witness_diff_centralizes, witness_mul_centralizer,
+witness_set_torsor).
 
 ## Blockers
 
-None.
+Discharging `skolemNoether_module_iso` (the Wedderburn-Artin + isotypic module
+isomorphism step) is the only remaining gap. It is BLOCKED on two fronts during
+the 2026-06-13 verification blackout:
+1. **Research-hard**: estimated ~200-300 lines using
+   `IsSimpleRing.exists_ringEquiv_matrix_divisionRing` and
+   `IsSimpleRing.isIsotypic` plus a bimodule-extension argument.
+2. **Build-gated**: Docker build infra is down, so any such proof cannot be
+   machine-checked. Writing unverifiable research-level Lean would be premature.
 
 ## Next Action
 
-Verify Docker build, push PR, optionally proceed to MulAction formulation.
+When Docker is restored: attempt to discharge `skolemNoether_module_iso` via
+Wedderburn-Artin (B ≅ Mₙ(D)) + isotypic decomposition (B_f ≅ B_g as A-modules)
++ bimodule extension via centrality of K in B. Until then, leave at axiom floor.
 
 ## Attempt Counts
 

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -70,8 +70,8 @@
       "Build repair: fixed pre-existing bugs blocking compilation — conjugate_iff_same_image used wrong unit (u⁻¹ instead of u), skolemNoether_general's calc used commutative-ring `ring` on non-commutative B (replaced with explicit mul_assoc / Units.inv_mul / one_mul rewrites), and aut_is_inner's AlgHom.id required explicit type args (AlgHom.id K B)",
       "Infrastructure audit: identified 5 Mathlib v4.26 building blocks sufficient to prove the axiom"
     ],
-    "lineCount": 392,
-    "theoremCount": 12,
+    "lineCount": 394,
+    "theoremCount": 14,
     "definitionCount": 2
   },
   "overview": {
@@ -182,9 +182,9 @@
     ],
     "opens": [],
     "namespace": "SkolemNoetherCSA",
-    "lineCount": 392,
+    "lineCount": 394,
     "axiomCount": 1,
-    "theoremCount": 12,
+    "theoremCount": 14,
     "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/SkolemNoetherCSA.lean"


### PR DESCRIPTION
## Summary
Audit-only iteration on `cayley-hamilton-minpoly-oq-02-oq-01-oq-01-oq-01`
(general Skolem-Noether for central simple algebras, `Proofs/SkolemNoetherCSA.lean`).
**No Lean change** — Docker build infra is down during the 2026-06-13 verification blackout.

- **Stale count fix**: the gallery `meta.json` reported `theoremCount: 12`, but the source proves **14** theorems by the canonical `^(theorem|lemma) ` convention in `scripts/research/enrich-research.ts`. Both counting conventions (column-0 and include-namespaced) agree on 14 — there are no indented/private theorems — so 12 matched neither and was simply wrong. The Session-2 hand-count "9→12" omitted the 3 `IsConjugate.refl/symm/trans` equivalence-relation theorems (which are listed in `originalContributions`). Corrected `theoremCount` 12→14 and `lineCount` 392→394 in both the `meta` and `leanFile` blocks. `axiomCount` (1), `definitionCount` (2), `sorries` (0) were already correct.
- **Status reconciliation**: the only remaining gap is discharging the axiom `skolemNoether_module_iso` (Wedderburn-Artin + isotypic module isomorphism, ~200-300 lines). This is both research-hard and build-gated, so `state.md` is flagged **BLOCKED** pending Docker restoration.

## The 14 theorems
`rightBLinear_is_leftMul`, `rightBLinear_symm_is_leftMul`, `isUnit_of_rightBLinear_equiv`, `skolemNoether_general`, `aut_is_inner`, `conjugate_iff_same_image`, `IsConjugate.refl`, `IsConjugate.symm`, `IsConjugate.trans`, `skolemNoether_isConjugate`, `conjugateSetoid_single_class`, `witness_diff_centralizes`, `witness_mul_centralizer`, `witness_set_torsor`.

## Test plan
- [x] `grep -cE "^(theorem|lemma) " proofs/Proofs/SkolemNoetherCSA.lean` → 14
- [x] `grep -c "^axiom " …` → 1 (unchanged), `\bsorry\b` → 0 (unchanged)
- [x] meta.json edits limited to count fields; no semantic claim changes
- [ ] Docker build (blocked — infra down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)