### PR TITLE
research(erdos-218): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-218.json
+++ b/src/data/research/problems/erdos-218.json
@@ -74,15 +74,15 @@
     "mathlib": []
   },
   "started": "2026-01-12T16:05:28.188Z",
-  "lastUpdate": "2026-05-13T12:00:00Z",
+  "lastUpdate": "2026-06-10T12:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos218Problem.lean",
       "filename": "Erdos218Problem.lean",
-      "lineCount": 419,
-      "theoremCount": 22,
+      "lineCount": 493,
+      "theoremCount": 28,
       "axiomCount": 2,
       "defCount": 12,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Single-file metadata sync. The `erdos-218` research-pool JSON `leanFiles` block was frozen at `lineCount 419 / theoremCount 22` while the origin/main source `Erdos218Problem.lean` is at `493 / 28`.

The **+6 theorems** are genuine public growth from merged **PR #22520** ("repair Mathlib v4.26 build + 6 structural lemmas"):
- 28 strict public `theorem`/`lemma` declarations (2 private, excluded from both old and new strict counts) → the jump is real public growth, **not** the strict-vs-private convention artifact (which would be a theorem *drop* at flat line count).
- `axiomCount` (2, literal `^axiom ` grep), `defCount` (12), `sorryCount` (0) all **unchanged** — comment-stripped recount confirms real sorry=0 / axiom=2 (zero docstring false-positive risk).

The **gallery `meta.json` leanFile is already synced** (theoremCount 28); only the research-pool JSON lagged — they are independent artifacts. Bumped `lastUpdate` to the source's last-touched commit date on `main` (2026-06-10).

## Test plan

- [x] JSON validates (`json.load`)
- [x] Metrics recomputed via the exact `enrich-research.ts` regexes against `origin/main` source
- [x] Comment-stripped sorry/axiom recount = 0/2 (no docstring FP)
- [x] Tightly scoped: 2 metric fields + lastUpdate, narrative untouched
- [ ] Lean build verification deferred (Docker down — verification blackout 2026-06-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)