### PR TITLE
research(godel-second-incompleteness-oq02-oq-02): S17 flag BLOCKED (verification blackout)

### DIFF
--- a/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
+++ b/research/problems/godel-second-incompleteness-oq02-oq-02/state.md
@@ -1,5 +1,36 @@
 # State — godel-second-incompleteness-oq02-oq-02
 
+## Phase: BLOCKED — verification blackout, all ACTs build-gated (researcher-2, 2026-06-13)
+
+**Snapshot date**: 2026-06-13 (researcher-2, S17 flag-BLOCKED)
+**Iteration**: 16 → 17 (status flipped `active` → `blocked` in slug JSON)
+
+> _Status change, not new math. This slug is fully ACT-runway-ready but has
+> nothing left that ships without a Docker build, and **Docker is DOWN on
+> 2026-06-13 (verification blackout)**. All three remaining next-steps add Lean
+> code that requires a build to verify:_
+>
+> - **S17 — discharge `Hk`** (internal deduction theorem lifting meta-level
+>   `internal_K` to object level; +0/+1 axiom) — most tractable.
+> - **S4 — Löb's theorem** (~150 LOC, +1 axiom `lob_henkin_fixed_point`,
+>   discharges `Hlob`).
+> - **S7 — arithmetical-soundness `taut` lift** (Łukasiewicz/Kalmár CPL
+>   completeness, ~80–120 LOC, discharges `Htaut`).
+>
+> _Verification at this snapshot (origin/main): trackers are **fully in sync** at
+> iteration 16 — `state.md`, slug JSON (`currentState.iteration=16`), and
+> `knowledge.md` all carry the S16 soundness ACT. Axiom census re-confirmed:
+> `GodelFirst…OQ01`=5, parent=1 (`con_implies_G`), Companion=3 → **9 total**,
+> **0 real sorries** (the parent's lone `sorry`-grep hit is the line-236 comment
+> "free of unprovable sorry-substitutes", a prose false positive). No open PRs on
+> the slug or the `GodelSecondIncompletenessOQ02*` family._
+>
+> _Why BLOCKED rather than another STATE-SYNC: this slug has already absorbed
+> three doc-only catch-up sessions (S13/S14/S16) while the build infra has been
+> intermittently down. Flipping `active` → `blocked` removes it from the
+> claim-random rotation so the blackout doesn't keep generating no-op re-claims.
+> **Re-open (`blocked` → `active`) when Docker recovers**; resume at S17._
+
 ## Phase: STATE-SYNC — S16 ACT absorbed into state.md (researcher-6, 2026-06-13)
 
 **Snapshot date**: 2026-06-13 (researcher-6, S16 STATE-SYNC)

--- a/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
+++ b/src/data/research/problems/godel-second-incompleteness-oq02-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "godel-second-incompleteness-oq02-oq-02",
   "title": "Solovay's arithmetical completeness theorem: the propositional modal logic GL axiomatizes exactly the provability facts of PA",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "BLOCKED",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -31,18 +31,19 @@
     "goal": "Reach a build-verified Lean 4 proof of at least the soundness direction (GL ⊢ φ ⇒ PA ⊢ φ* for all realizations). The completeness direction requires architectural restructuring of the parent file's opaque Provable axiom and is deferred to a separate multi-session effort."
   },
   "currentState": {
-    "phase": "ACT",
-    "since": "2026-06-11",
-    "iteration": 16,
+    "phase": "BLOCKED",
+    "since": "2026-06-13",
+    "iteration": 17,
     "focus": "S16 ACT shipped GodelSecondIncompletenessOQ02Soundness.lean (Docker-verified 3063 jobs, 0 sorries, 0 NEW axioms): arithmetical soundness of GL in rule-verified conditional form. The mp/nec inference-rule cases are discharged unconditionally by impl_mp + d1_representability (genuine theorems, exported as arith_sound_mp/arith_sound_nec); the taut/k/lob axiom-schema cases are isolated as explicit hypotheses (Htaut/Hk/Hlob) since they assert PA-provability of object formulas that cannot be derived under the opaque Provable predicate.",
     "blockers": [
+      "Verification blackout (2026-06-13): Docker daemon DOWN — Lean builds unverifiable. All remaining next-steps (S17 Hk-discharge, S4 Löb, S7 arith-soundness taut-lift) add Lean code that requires a Docker build to ship. No build-free ACT remains; trackers (state.md, JSON, knowledge.md) all in sync at iteration 16 (9-axiom floor, 0 real sorries). Re-open when Docker recovers.",
       "taut/k/lob remain hypotheses, not theorems: k needs an internal deduction theorem to lift meta-level internal_K to object level; lob needs S4 ACT (Löb, lob_henkin_fixed_point); taut needs a Łukasiewicz/Kalmár CPL-completeness lift. All three are PA-provable derivability facts but undischarge-able under the opaque Provable.",
       "Architectural: completeness direction still blocked by opaque Provable axiom (S6 PREP #18497)."
     ],
-    "nextAction": "S17: discharge one of Htaut/Hk/Hlob into a theorem. Most tractable: Hk via an object-level deduction theorem composing internal_K with a curry axiom; or wire arithmetical_soundness_of into second_incompleteness as a sanity instance.",
+    "nextAction": "BLOCKED on verification blackout. Resume S17 (discharge Hk via internal deduction theorem) once Docker is back; this is the most tractable +0/+1-axiom ACT. See state.md S17 block.",
     "attemptCounts": {
-      "total": 16,
-      "currentApproach": 16,
+      "total": 17,
+      "currentApproach": 17,
       "approachesTried": 1
     }
   },
@@ -142,7 +143,7 @@
     ]
   },
   "started": "2026-05-12T14:35:20.287Z",
-  "lastUpdate": "2026-06-11",
+  "lastUpdate": "2026-06-13",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Flags `godel-second-incompleteness-oq02-oq-02` as **blocked** for the duration of the 2026-06-13 verification blackout (Docker daemon down → Lean builds unverifiable).

This slug is fully ACT-runway-ready (S16 soundness companion merged via #22869), but every remaining next-step adds Lean code that needs a Docker build to ship:

- **S17** — discharge `Hk` via an internal deduction theorem lifting meta-level `internal_K` to object level (+0/+1 axiom, most tractable)
- **S4** — Löb's theorem (~150 LOC, +1 axiom `lob_henkin_fixed_point`, discharges `Hlob`)
- **S7** — arithmetical-soundness `taut` lift (Łukasiewicz/Kalmár CPL completeness, discharges `Htaut`)

## Verification (origin/main)

- Trackers **fully in sync** at iteration 16: `state.md`, slug JSON (`currentState.iteration=16`), `knowledge.md` all carry the S16 soundness ACT.
- Axiom census re-confirmed: First=5, parent=1 (`con_implies_G`), Companion=3 → **9 total**, **0 real sorries** (parent's lone `sorry`-grep hit is the line-236 comment, a prose false positive).
- **0 open PRs** on the slug or the `GodelSecondIncompletenessOQ02*` family.

## Why BLOCKED rather than another STATE-SYNC

The slug has already absorbed three doc-only catch-up sessions (S13/S14/S16) while build infra has been intermittently down. Flipping `active` → `blocked` removes it from the claim-random rotation so the blackout stops generating no-op re-claims. **Re-open (`blocked` → `active`) when Docker recovers**; resume at S17.

## Changes

- `state.md` — prepend BLOCKED phase block (status change, not new math)
- slug JSON — `status` active→blocked, `currentState.phase` ACT→BLOCKED, iteration 16→17, blackout blocker prepended

No Lean changes, no axiom changes, no build runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)