### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): gallery sections-realign + S14a.2 state.md sync

### DIFF
--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -1,17 +1,29 @@
 # Current State
 
-**Phase**: REDESIGN-IN-PROGRESS (S14a ACT shipped — boundary helpers for `QuantileBracketingGrid`; S14b proves interior existence)
-**Since**: 2026-06-09 (S14a ACT, this session)
-**Iteration**: 12 ACT + 7 doc-only PREP/OBSERVE/STATE-SYNC. **S14a ACT
-(researcher-4, 2026-06-09) ships the two boundary-node existence
-helpers `trueCDF_exists_le` / `trueCDF_exists_ge` plus the private
-bridge `trueCDF_eq_cdf_map'`** in
+**Phase**: REDESIGN-IN-PROGRESS (S14a.2 ACT shipped — `leftLim` upper-bracket lemma for `QuantileBracketingGrid`; S14b proves the right-continuous half + interior existence)
+**Since**: 2026-06-12 (S14a.2 ACT)
+**Iteration**: 12 ACT + 7 doc-only PREP/OBSERVE/STATE-SYNC. **S14a.2 ACT
+(researcher-2, 2026-06-12, PR #22958) proves the generic monotone
+upper-bracket lemma `leftLim_le_of_forall_lt`** in
 `Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`
+(216 → 239 lines, +1 public lemma, 0 axioms, 0 sorries, Docker 3113
+jobs clean). Statement: for `Monotone F : ℝ → ℝ`,
+`(∀ x < q, F x ≤ p) → Function.leftLim F q ≤ p`, via
+`le_of_tendsto (hF.tendsto_leftLim q)` on the left-neighbourhood filter.
+This supplies the `leftLim F qⱼ₊₁ ≤ (j+1)ε` half of the S14 `step_le`
+bound with no continuity hypothesis.
+
+**S14a ACT (researcher-4, 2026-06-09)** previously shipped the two
+boundary-node existence helpers `trueCDF_exists_le` / `trueCDF_exists_ge`
+plus the private bridge `trueCDF_eq_cdf_map'` in the same companion
 (154 → 216 lines, +2 public lemmas + 1 private bridge, 0 axioms, 0
-sorries, Docker 3113 jobs clean). These discharge the `left_le` /
-`right_ge` fields of `QuantileBracketingGrid` directly via Mathlib's
-`ProbabilityTheory.tendsto_cdf_atBot` / `tendsto_cdf_atTop`; S14b
-constructs the interior quantile nodes and proves `step_le` + `mono`.
+sorries, Docker clean). These discharge the `left_le` / `right_ge`
+fields of `QuantileBracketingGrid` directly via Mathlib's
+`ProbabilityTheory.tendsto_cdf_atBot` / `tendsto_cdf_atTop`. **S14b**
+remains: prove the right-continuous half `jε ≤ F qⱼ` at the quantile
+node `qⱼ = sInf {x | jε ≤ F x}`, combine with `leftLim_le_of_forall_lt`
+to get the per-pair `step_le` bound, then assemble
+`quantileBracketingGrid_exists`.
 
 **S13 ACT (PR #22044, researcher-1, 2026-06-02)** previously shipped
 the typed scaffold `QuantileBracketingGrid` in a new companion file

--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -88,49 +88,49 @@
       "id": "sec-header",
       "title": "Header Docstring and Imports",
       "startLine": 1,
-      "endLine": 41,
+      "endLine": 46,
       "summary": "Module docstring states the file's purpose: discharge two of the three Glivenko–Cantelli axioms (`thresholdIndicator_integrable`, `integral_thresholdIndicator_eq_cdf`) by proving them from Mathlib's measure-theoretic API. Lists the four key Mathlib lemmas used (`Integrable.mono'`, `integral_indicator`, `integral_const`, `Measure.restrict_apply`) and records the resulting axiom-count reduction 3 → 1. Imports the parent `Proofs.LawsOfLargeNumbersOQ04` (for `thresholdIndicator`, `trueCDF`, `empiricalCDF`, and the structural independence/identity lifts), `Mathlib.MeasureTheory.Integral.Bochner.Set` (for `integral_indicator`), and `Mathlib.Tactic`. Opens `MeasureTheory`, `ProbabilityTheory`, `Set` and enters the `GlivenkoCantelli` namespace.",
       "mathContext": "Goal: replace `axiom thresholdIndicator_integrable` and `axiom integral_thresholdIndicator_eq_cdf` from the parent file with theorems whose proofs use only Mathlib. Result: $\\mathrm{axiomCount}_{\\mathrm{parent}} : 3 \\to 1$, with only the bracketing-uniformity axiom remaining open."
     },
     {
       "id": "sec-axiom-1",
       "title": "Proof of Axiom 1 — Threshold Indicators Are Integrable",
-      "startLine": 43,
-      "endLine": 63,
+      "startLine": 47,
+      "endLine": 68,
       "summary": "Theorem `thresholdIndicator_integrable_proved`: on a probability space, the threshold indicator $\\omega \\mapsto \\mathbf{1}_{X_0(\\omega) \\leq x}$ is integrable. Strategy: apply `Integrable.mono' (integrable_const (1 : ℝ))` — the constant function 1 is integrable on a finite measure space, and the indicator is dominated by it (values ∈ {0, 1}). The two side conditions are: (a) AEMeasurability via `(measurable_iic_indicator x).comp (hX 0)` (composition of a measurable random variable with the Borel indicator of $(-\\infty, x]$), and (b) the pointwise norm bound `‖indicator ω‖ ≤ 1`, discharged by `filter_upwards`/`split_ifs` into the two cases $X_0(\\omega) \\leq x$ and $X_0(\\omega) > x$.",
       "mathContext": "$\\|\\mathbf{1}_{X_0(\\omega) \\leq x}\\| \\leq 1 \\;\\text{a.e.}$; combined with $\\int_\\Omega 1 \\, d\\mu = 1 < \\infty$, `Integrable.mono'` produces $\\int_\\Omega |\\mathbf{1}_{X_0(\\omega) \\leq x}| \\, d\\mu \\leq 1 < \\infty$."
     },
     {
       "id": "sec-preimage-lemma",
       "title": "Preimage Indicator Factorization",
-      "startLine": 65,
-      "endLine": 75,
+      "startLine": 69,
+      "endLine": 80,
       "summary": "Private lemma `thresholdIndicator_eq_preimage_indicator_fun`: pointwise equality $\\mathbf{1}_{X_0(\\omega) \\leq x} = (X_0^{-1}((-\\infty, x])).\\mathrm{indicator}\\,(\\lambda \\_, 1)\\,\\omega$. Proved by `ext`/`simp only [thresholdIndicator, Set.indicator, Set.mem_preimage, Set.mem_Iic]`. This is the algebraic step that bridges from a real-valued function-of-a-random-variable indicator (range-side) to a set-of-the-domain indicator (domain-side), unlocking `integral_indicator`. The lemma is `private` because it is purely a rewrite consumed only inside the next theorem.",
       "mathContext": "$\\mathbf{1}_{X_0(\\omega) \\in (-\\infty, x]} = \\mathbf{1}_{\\omega \\in X_0^{-1}((-\\infty, x])}$ — definitional, but the orientation matters: `integral_indicator` requires the indicator of a *subset of the integration domain*, not of the codomain."
     },
     {
       "id": "sec-axiom-2",
       "title": "Proof of Axiom 2 — Integral of Indicator Equals CDF",
-      "startLine": 77,
-      "endLine": 103,
+      "startLine": 81,
+      "endLine": 107,
       "summary": "Theorem `integral_thresholdIndicator_eq_cdf_proved`: $\\mathbb{E}[\\mathbf{1}_{X_0 \\leq x}] = F(x)$ where $F$ is `trueCDF X μ`. Five-step proof: (1) establish `MeasurableSet (X 0 ⁻¹' Iic x)` from `(hX 0) measurableSet_Iic`; (2) `simp_rw thresholdIndicator_eq_preimage_indicator_fun` to convert to the preimage-indicator form; (3) `rw integral_indicator hms` to convert the integral over $\\Omega$ of an indicator to a set integral over the preimage with the constant integrand 1; (4) chain `integral_const` + `Measure.restrict_apply MeasurableSet.univ` + `Set.univ_inter` + `smul_eq_mul` + `mul_one` to evaluate $\\int_{\\Omega \\cap s} 1 \\, d\\mu = (\\mu \\, s).\\mathrm{toReal}$; (5) `simp only [trueCDF]; congr 1; ext ω; simp [...]` to identify the preimage set $X_0^{-1}((-\\infty, x])$ with the trueCDF set $\\{\\omega \\mid X_0(\\omega) \\leq x\\}$.",
       "mathContext": "$\\int_\\Omega \\mathbf{1}_{X_0 \\leq x}\\,d\\mu = \\int_{X_0^{-1}((-\\infty, x])} 1\\,d\\mu = \\mu\\bigl(X_0^{-1}((-\\infty, x])\\bigr).\\mathrm{toReal} = \\mu\\bigl(\\{\\omega \\mid X_0(\\omega) \\leq x\\}\\bigr).\\mathrm{toReal} = F(x)$."
     },
     {
       "id": "sec-pointwise-corollary",
       "title": "Application — Axiom-Free Pointwise Convergence",
-      "startLine": 105,
-      "endLine": 135,
+      "startLine": 108,
+      "endLine": 140,
       "summary": "Theorem `empiricalCDF_pointwise_convergence_no_axiom`: for each fixed $x$, $F_n(x) \\to F(x)$ a.s. Composes the two newly-proved lemmas with the parent file's structural lifts (`thresholdIndicator_pairwise_indep`, `thresholdIndicator_identDistrib`) plus Mathlib's `strong_law_ae_real`. Step-by-step: get integrability from `thresholdIndicator_integrable_proved`, get pairwise independence and identical distribution from the parent's structural lifts (these are not integration axioms — just rewrites of indep/i.d. through the indicator function), apply SLLN, substitute the integral identity from `integral_thresholdIndicator_eq_cdf_proved` to identify the limit with $F(x)$, then `convert hω using 1; ext n; simp [empiricalCDF_eq_mean]` to extract the empirical-mean form. Result: pointwise GC has zero remaining integration axioms — only the bracketing-uniformity step is still open.",
       "mathContext": "$\\forall x \\in \\mathbb{R} \\colon \\quad F_n(x) := \\frac{1}{n}\\sum_{i=1}^n \\mathbf{1}_{X_i \\leq x} \\xrightarrow[n \\to \\infty]{\\text{a.s.}} F(x).$ The SLLN is applied to the i.i.d. indicator sequence; the limit $\\mathbb{E}[\\mathbf{1}_{X_0 \\leq x}]$ is identified with $F(x)$ via Axiom 2 (now a theorem)."
     },
     {
       "id": "sec-axiom-status",
       "title": "Axiom Status Summary",
-      "startLine": 137,
-      "endLine": 158,
-      "summary": "Closing block: enumerates the parent file's three axioms with status flags — `thresholdIndicator_integrable` ✓ proved, `integral_thresholdIndicator_eq_cdf` ✓ proved, `glivenko_cantelli_uniform` ✗ remains. Notes that the remaining axiom is mathematically genuine: the uniformity step requires choosing finitely many CDF continuity points with controlled jump sizes plus a finite-intersection-of-pointwise-convergence-events argument — infrastructure for the first piece (a constructive ε-cover by continuity points of a monotone $F$) is not yet present in Mathlib 4.26. Records the headline corollary `empiricalCDF_pointwise_convergence_no_axiom` as the file's take-away.",
-      "mathContext": "Axiom-elimination ledger: $\\{\\mathrm{integrable}, \\mathrm{integral{=}CDF}, \\mathrm{uniform}\\} \\to \\{\\mathrm{uniform}\\}$. The remaining axiom is the only piece that depends on Mathlib infrastructure not yet in 4.26."
+      "startLine": 141,
+      "endLine": 180,
+      "summary": "Closing block (`/-` comment): updated axiom-elimination ledger reflecting the chain's evolution. `thresholdIndicator_integrable` ✓ proved here; `integral_thresholdIndicator_eq_cdf` ✓ proved here; `glivenko_cantelli_uniform` ✓ proved in the bracketing companion `LawsOfLargeNumbersOQ04OQ03Bracketing.lean` from the smaller real-analytic axiom `bracketingGrid_exists` (S4–S6), with the parent's axiom retired in S7. Records that `bracketingGrid_exists` was ✗ refuted in the S10 ACT (PR #20969, `bracketingGrid_exists_false : False`, build-verified) because the structure is provably empty for any CDF with an atom of mass `> ε`, and that `QuantileBracketingGrid` (S13 scaffold in the quantile companion) is the redesigned `Function.leftLim`-based structure that handles atomic CDFs. Emphasizes the headline corollary `empiricalCDF_pointwise_convergence_no_axiom` is independent of this design pivot and remains fully proved from Mathlib without integration axioms.",
+      "mathContext": "Axiom-elimination ledger: $\\{\\mathrm{integrable}, \\mathrm{integral{=}CDF}, \\mathrm{uniform}\\} \\to \\varnothing$ for this file's transitive closure (imports only `LawsOfLargeNumbersOQ04` + Mathlib). The chain's sole remaining axiom `bracketingGrid_exists` lives in the separately-imported bracketing companion and is the subject of the ongoing quantile redesign."
     }
   ],
   "mainTheorems": [


### PR DESCRIPTION
## Summary

Build-free tracker/meta audit during the Docker verification blackout (claimed `laws-of-large-numbers-oq-04-oq-03`, RICH 29). Two co-located fixes for one triple-tracker slug; no Lean changes.

### 1. Gallery `meta.json` — sections realign + stale-prose refresh
- All 6 `sections[]` ranges were shifted ~4–22 lines early and the **Axiom Status Summary** section ended at L158 while the source is **180 lines**. Realigned to the real `-- ===` banners → now tiles **L1–180** contiguously.
- The `sec-axiom-status` summary/mathContext were factually stale: they claimed `glivenko_cantelli_uniform ✗ remains` blocked on a Mathlib-4.26 ε-cover gap. The source now documents that lemma **proved (S7)**, `bracketingGrid_exists` **refuted (S10, PR #20969)**, and the **QuantileBracketingGrid** redesign (S13+). Refreshed to match.
- **Unchanged (already correct):** lineCount 180, theoremCount 4, definitionCount 0, sorries 0. The `meta.axiomCount=1` (slug-level transitive: bracketing companion's open axiom) vs `leanFile.axiomCount=0` (this file imports only `LawsOfLargeNumbersOQ04` + Mathlib, 0 literal axioms) split is the expected meta-vs-leanFile convention, **left as-is**. Status/badge left `axiomatized`/`axiom` — not promoted (can't Docker-verify during blackout; overall OQ axiom gap genuinely open).

### 2. `state.md` — merge-skipped-state.md sync
The **S14a.2 ACT** (#22958, researcher-2, 2026-06-12) added `leftLim_le_of_forall_lt` (QuantileBracketing **216→239 LOC**, Docker 3113 jobs clean) and updated the JSON twin but never touched `state.md`, which still led with S14a (216 LOC). Prepended the S14a.2 block + refined the S14b next-step. `leanFiles[]` left untouched (deployer-owned; synced by #23040).

## Test plan
- [x] `meta.json` JSON-valid; diff is 13 line-range + 2 prose lines only (no UTF-8 escape churn — `ensure_ascii=False` round-trip verified)
- [x] Section ranges verified against `git show origin/main:proofs/Proofs/LawsOfLargeNumbersOQ04OQ03.lean` banners
- [x] S14a.2 lemma `leftLim_le_of_forall_lt` confirmed present at L233 of the QuantileBracketing companion on origin/main
- [ ] No Lean build (doc/meta only; Docker blackout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)