### PR TITLE
research(bounded-prime-gaps-oq-01-oq-03): S2 COMPLETION-SYNC — k=50 min diameter = 246 (axiomatized)

### DIFF
--- a/research/problems/bounded-prime-gaps-oq-01-oq-03/state.md
+++ b/research/problems/bounded-prime-gaps-oq-01-oq-03/state.md
@@ -1,6 +1,31 @@
 # Current State
 
-**Phase**: AXIOMATIZED — structurally complete; conjecture isolated as transitive axiom from sibling slug
+**Phase**: COMPLETED (axiomatized) — the stated OQ is fully answered; only assumption is a cited external-computation axiom
+**Since**: 2026-06-13 (S2 COMPLETION-SYNC, researcher-1)
+**Iteration**: 2 (COMPLETION-SYNC)
+
+## S2 COMPLETION-SYNC (researcher-1, 2026-06-13)
+
+The stated open question — *determine the minimum admissible 50-tuple diameter*
+— is **answered: it is exactly 246**, proved in both directions by
+`oq01_k50_diameter_is_exactly_246` (achievability via `table_k50`; tightness via
+`engelsma_lower_bound`). The only remaining assumption is the transitive axiom
+`engelsma_lower_bound` (Engelsma's 2005 exhaustive admissible-tuple computation,
+imported from sibling `BoundedPrimeGapsOQ03.lean`) — a cited external
+computational result, reasonably axiomatized per the project axiom-integrity
+policy, not a tractable in-Lean gap.
+
+AUDIT (build-free, blackout 2026-06-13): source `BoundedPrimeGapsOQ01OQ03.lean`
+and `meta.json` are fully consistent — 155 lines, 9 theorems (both conventions
+agree; no private/indented), 0 local axioms (1 transitive → meta.axiomCount=1,
+leanFile.axiomCount=0 per convention), 0 real sorries. No drift to fix.
+
+Pool workflow status was stale at `in-progress`; promoted to `completed`. The
+verification status stays `axiomatized` / badge `axiom` (unchanged).
+
+---
+
+**Phase (S1)**: AXIOMATIZED — structurally complete; conjecture isolated as transitive axiom from sibling slug
 **Since**: 2026-06-04 (S1 STATE-SYNC, researcher-1, doc-only refresh of stale stub)
 **Iteration**: 1 (STATE-SYNC)
 


### PR DESCRIPTION
## Summary
State-sync only — **no Lean change** (verification blackout, Docker down).

`bounded-prime-gaps-oq-01-oq-03` asks: *determine the minimum admissible 50-tuple diameter*. This is **fully answered: it is exactly 246**, proved both directions in `Proofs/BoundedPrimeGapsOQ01OQ03.lean`:
- **Achievability**: `table_k50` exhibits an admissible 50-tuple of diameter 246 (Engelsma's tuple).
- **Tightness**: `oq01_upper_bound_is_tight` / `oq01_k50_diameter_is_exactly_246` show no admissible 50-tuple has diameter < 246, via the transitive axiom `engelsma_lower_bound`.

The sole remaining assumption is `engelsma_lower_bound` — Engelsma's cited 2005 exhaustive admissible-tuple computation (imported from sibling `BoundedPrimeGapsOQ03.lean`). This is a literature-cited external computational result, reasonably axiomatized per the project axiom-integrity policy, not a tractable in-Lean gap.

Promotes the stale pool workflow status `in-progress` → `completed`. The verification status stays `axiomatized` / badge `axiom` (unchanged).

## Audit (build-free)
- `wc -l` → 155 (meta 155 ✓); `^(theorem|lemma) ` → 9 (meta 9 ✓, both conventions agree)
- local `^axiom ` → 0 (leanFile.axiomCount 0 ✓); transitive axiom `engelsma_lower_bound` → meta.axiomCount 1 ✓ (per [axiomCount convention](../CLAUDE.md))
- comment-stripped `sorry` → 0 ✓ (0 raw hits)
- meta.json and source fully consistent — no drift

## Test plan
- [x] Counts verified by grep against source
- [x] OQ answered in both directions (achievability + tightness)
- [ ] Docker build (n/a — no Lean change; last built on main pre-blackout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)