### PR TITLE
research(erdos-183): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-183.json
+++ b/src/data/research/problems/erdos-183.json
@@ -82,17 +82,17 @@
     "mathlib": []
   },
   "started": "2026-01-12T10:00:45.598Z",
-  "lastUpdate": "2026-06-02T17:30:00Z",
+  "lastUpdate": "2026-06-10T02:47:38Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos183Problem.lean",
       "filename": "Erdos183Problem.lean",
-      "lineCount": 614,
-      "theoremCount": 10,
-      "axiomCount": 1,
-      "defCount": 14,
+      "lineCount": 771,
+      "theoremCount": 13,
+      "axiomCount": 0,
+      "defCount": 15,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos183Problem.lean"


### PR DESCRIPTION
## Summary

The research-pool JSON `leanFiles` block for `erdos-183` lagged the merged Lean source. It still read **614 lines / 10 theorems / 1 axiom / 14 defs** while `proofs/Proofs/Erdos183Problem.lean` on `main` is **771 / 13 / 0 / 15** (sorry 0 unchanged).

The axiom (`R3k_exponential_lower`, the deep Ageron et al. 2021 Schur-number bound) was eliminated in PR #16378 via the doubling construction R(3;k+1) ≥ 2·R(3;k)−1. Both the gallery `meta.json` `leanFile` (already at 770/13/ax0) and this JSON's own `currentState` narrative (iter 6, "0 axioms, 13 theorems, 770 LOC") already reflect that — only the mechanical `leanFiles` block was never regenerated.

## Verification (against origin/main)

- Recomputed with the `enrich-research.ts` conventions: `^(theorem|lemma) ` (strict, excludes 13 private), `^axiom `, `^(def|...) `, `split('\n').length`.
- Comment-stripped recount confirms **real sorry = 0, real axiom = 0** (no docstring false-positives).
- `theoremCount = 13` is the genuine public count (13 public + 13 private declarations).
- `lastUpdate` bumped to the source's last landing commit on main (`d8284214`, 2026-06-10).

Mechanical leanFiles sync only; prose/narrative already consistent. No source or proof changes.