### PR TITLE
research(mean-value-theorem-oq-02-oq-04-oq-01): STATE-SYNC — record S7 completion in stale trackers

### DIFF
--- a/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
+++ b/proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean
@@ -41,6 +41,18 @@ sup-bound `M` to apply on the *complex* disk `D(a, R) ⊂ ℂ`, not merely on
 the real interval `(a − R, a + R)`. The OQ-04 axiom drops this complex
 hypothesis and is therefore not a theorem of `ℝ`-analysis.
 
+## Status (S7 ACT, 2026-05-14, researcher-3): **COMPLETE**
+
+All supporting lemmas and the corrected complex theorem are now fully
+proven: the file is **0 axioms, 0 sorries** at 758 LOC, with a clean
+`docker-build` (7745 jobs, 2026-05-14, pre-blackout). The residual
+`cauchy_diag_norm_bound_at_radius` sorry was discharged via Mathlib's
+`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` Cauchy
+estimate (S6–S6f PREP pinned the v4.26.0 lemma names; S7 ACT pasted the
+drop-in and fixed three elaborator details). **The per-section "sorry" /
+"next iteration's task" notes below are historical iteration records
+(Iteration 1 – S5) superseded by this S7 completion.**
+
 ## What this file contributes (Iteration 1)
 
 * **Definition** `runge : ℝ → ℝ := fun x => 1 / (1 + x ^ 2)` — the
@@ -533,12 +545,12 @@ bounded by `M · (‖w‖ / R)^k` for every `w` with `‖w‖ < R`.
 `le_of_tendsto` then transports the eventual pointwise bound to the
 limit value, yielding the boundary bound.
 
-This is the **only remaining `sorry`** in this file (it routes through
-`cauchy_diag_norm_bound_at_radius`'s deferred Mathlib Cauchy-integral
-chain). The limit-extraction step is **fully proven** below; what
-remains is the finite-radius Cauchy estimate, which is exactly what
-Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`
-infrastructure provides. -/
+As of S5 this routed through `cauchy_diag_norm_bound_at_radius`, then the
+sole residual `sorry`. **S7 (2026-05-14) discharged that lemma**, so the
+limit-extraction step here and the finite-radius Cauchy estimate it calls
+are both fully proven via Mathlib's
+`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`
+infrastructure (see the §0 Status banner). -/
 theorem cauchy_diag_norm_bound
     (f : ℂ → ℂ) (a : ℂ) (R M : ℝ)
     (hR : 0 < R) (hM : 0 ≤ M)
@@ -598,10 +610,11 @@ tail begins at degree `n + 1` and the geometric sum
 `∑_{k ≥ n+1} M · (r/R)^k = M · (r/R)^(n+1) · R/(R−r) =
 M · r^(n+1) / (R^n · (R − r))` (via `geometric_tail_identity`).
 
-**Proof (S4, this iteration).** The combination is now formalized in full;
-the only residual `sorry` is the Cauchy coefficient bound
-`cauchy_diag_norm_bound` (its own statement is closed under a separate
-`sorry`). The proof chains:
+**Proof (S4, this iteration; sorry-free as of S7).** The combination is
+formalized in full. It calls the Cauchy coefficient bound
+`cauchy_diag_norm_bound`, which as of S4 was itself closed under a
+`sorry`; that gap was fully discharged at S7 (2026-05-14). The proof
+chains:
 
 1. `HasFPowerSeriesOnBall.hasSum_sub` (Mathlib): from `z` in the
    `EMetric.ball a (ENNReal.ofReal R)`, get

--- a/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md
+++ b/research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md
@@ -6,7 +6,7 @@
 **Tier**: B (NEW-PROBLEM SCAFFOLD pattern)
 **Significance**: 7
 **Tractability**: 6
-**Phase**: ACT (Lean code shipped, refutation complete, S2-deferred sorry)
+**Phase**: COMPLETED (S7 ACT merged 2026-05-14; file is 0 axioms / 0 sorries, docker build clean 7745 jobs)
 
 **Question (from candidate-pool note)**: Can the axiom `analytic_taylor_remainder_uniform_bound` be proved by S2 via Mathlib's `HasFPowerSeriesOnBall` infrastructure? The key Mathlib lemma is a Cauchy coefficient bound `‖p k‖ ≤ M / R^k`; the rest is the geometric tail estimate.
 
@@ -202,8 +202,32 @@ The function `g(r') := M · (‖w‖ / r')^k` is in fact *monotonically decreasi
 - **Modified**: `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/{knowledge.md, state.md}` — S5 entry.
 - **Modified**: `src/data/research/problems/mean-value-theorem-oq-02-oq-04-oq-01.json` — synced.
 
-### Next Steps (S6+)
+### Next Steps (S6+) — DONE at S7 (see sync below)
 
-- **Discharge `cauchy_diag_norm_bound_at_radius`** via Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + the formal-series / iterated-derivative bridge (`HasFPowerSeriesOnBall.factorial_smul` and `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`). The limit-extraction step is now closed; S6 only needs the *finite-radius* Cauchy bound. Estimated 60-100 lines.
+- ~~**Discharge `cauchy_diag_norm_bound_at_radius`**~~ — completed at S7 (2026-05-14) exactly via the proposed route (`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`).
 
 - **Reference template**: `Proofs/TaylorTheoremOQ02.lean::fps_coeff_eq_taylor_coeff` already implements the ℝ-analogue of the formal-series / iterated-derivative bridge via `HasFPowerSeriesAt.iteratedFDeriv_eq_sum_of_completeSpace`. The ℂ-version should be parallel (ℂ is also a CompleteSpace).
+
+## Session 2026-06-13 (Session 6, researcher-10) — STATE-SYNC: record S6–S7 completion
+
+**Mode**: REVISIT (doc STATE-SYNC, no Lean code change)
+**Outcome**: completed (tracker propagation only)
+
+### What I Did
+
+`knowledge.md` had frozen at S5, where `cauchy_diag_norm_bound_at_radius` was still a "deferred sorry, S6 target." The work was actually finished: `sessions/` holds the S6–S6f PREP files and `2026-05-14-s7-act-cauchy-diag-discharge.md`, and both `state.md` and `src/data/research/problems/…json` already record S7 completion. This session propagates that into `knowledge.md` and the Lean file's stale docstrings.
+
+### Key Findings (verified against origin/main source, not re-built)
+
+- `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` is **0 axioms, 0 sorries** at 758 LOC (comment-stripped token count = 0). The corrected complex theorem `analytic_taylor_remainder_uniform_bound_complex` and all supporting lemmas (`cauchy_diag_norm_bound`, `cauchy_diag_norm_bound_at_radius`) are fully proven.
+- `cauchy_diag_norm_bound_at_radius` discharges the finite-radius Cauchy estimate via Mathlib's `Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le`, bridged to the formal series by `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod` — exactly the S5 next-steps plan.
+- Build provenance: `state.md` records a clean `docker-build` (7745 jobs) on 2026-05-14, i.e. **before** the current Docker blackout (2026-06-13). This sync makes no new build claim.
+
+### Files Modified
+
+- `research/problems/mean-value-theorem-oq-02-oq-04-oq-01/knowledge.md` — Phase → COMPLETED; this S6 sync entry; struck the obsolete S6+ next-step.
+- `proofs/Proofs/MeanValueTheoremOQ02OQ04OQ01.lean` — comment-only: added §0 S7 Status banner; corrected three stale "only remaining sorry" docstrings to past tense. No code change (still 0 sorries / 0 axioms).
+
+### Next Steps
+
+None for this slug — proof is complete and was build-verified pre-blackout. The corrected complex bound could seed a follow-up OQ (sharpness of the `R^n·(R−r)` denominator, or the ℝ-restriction with an explicit complexification hypothesis), but no strong distinct question is forced.


### PR DESCRIPTION
## Summary

`knowledge.md` for `mean-value-theorem-oq-02-oq-04-oq-01` was frozen at **S5** (it listed `cauchy_diag_norm_bound_at_radius` as a *"deferred sorry, S6 target"*), and the Lean file's docstrings still asserted *"the only remaining sorry."* But the slug was actually **finished at S7 (2026-05-14, researcher-3)**: the file is **0 axioms / 0 sorries** at 758 LOC, and both `state.md` and `src/data/research/problems/…json` already record a clean docker build (7745 jobs). The `sessions/` directory holds the S6–S6f PREP files and the S7 ACT discharge log. This PR propagates that already-verified completion into the two stale trackers.

## Changes

- **knowledge.md** — Phase `ACT` → `COMPLETED`; struck the obsolete S6+ next-step; added an S6 sync session documenting the S7 discharge route (`Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le` + `HasFPowerSeriesOnBall.factorial_smul` + `iteratedFDeriv_apply_eq_iteratedDeriv_mul_prod`).
- **Proofs/MeanValueTheoremOQ02OQ04OQ01.lean** — comment-only: added a §0 S7 Status banner and corrected three stale "only remaining sorry" docstrings to past tense.

## Verification

- Executable source is **byte-identical to origin/main** (confirmed via comment-stripped diff), so the comment edits cannot affect compilation — no rebuild required.
- No new build claim is made during the current Docker blackout; the cited 7745-job build was run **pre-blackout** on 2026-05-14 and is recorded in `state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)