### PR TITLE
research(erdos-5-prime-gaps): sync stale leanFiles to source state

### DIFF
--- a/src/data/research/problems/erdos-5-prime-gaps.json
+++ b/src/data/research/problems/erdos-5-prime-gaps.json
@@ -66,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T09:10:09.148Z",
-  "lastUpdate": "2026-01-13T16:22:40.291Z",
+  "lastUpdate": "2026-06-10T02:47:38.000Z",
   "completed": "2026-01-13T16:22:40.291Z",
   "significance": 7,
   "tractability": 6,
@@ -74,8 +74,8 @@
     {
       "path": "Proofs/Erdos5PrimeGaps.lean",
       "filename": "Erdos5PrimeGaps.lean",
-      "lineCount": 573,
-      "theoremCount": 29,
+      "lineCount": 708,
+      "theoremCount": 36,
       "axiomCount": 3,
       "defCount": 9,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- The research-pool JSON `leanFiles` block for `erdos-5-prime-gaps` was frozen at its iteration-1 snapshot (573 lines / 29 theorems) while `proofs/Proofs/Erdos5PrimeGaps.lean` on `main` has advanced to **708 lines / 36 theorems**.
- Synced `lineCount` 573→708 and `theoremCount` 29→36. `axiomCount` (3), `defCount` (9), and `sorryCount` (0) were already correct.
- Bumped `lastUpdate` to the source file's last-commit date on `main` (2026-06-10).

## Why this is a clean sync (not a counting artifact)
- The file has **0 private theorems**, so the +7 theorem delta is genuine public-theorem growth — not the strict-`^(theorem|lemma) ` vs `private` convention difference.
- `sorryCount` is unchanged at 0 (verified after stripping block/line comments — no docstring false-positives), and the 3 axioms are real (comment-stripped count = 3).
- Scope kept tight to the mechanical `leanFiles` block + `lastUpdate`; narrative/`currentState` left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)