### PR TITLE
research(erdos-1093): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-1093.json
+++ b/src/data/research/problems/erdos-1093.json
@@ -65,15 +65,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T14:52:37.979Z",
-  "lastUpdate": "2026-03-13T07:52:17.057Z",
+  "lastUpdate": "2026-06-10T00:00:00.000Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1093Problem.lean",
       "filename": "Erdos1093Problem.lean",
-      "lineCount": 224,
-      "theoremCount": 38,
+      "lineCount": 258,
+      "theoremCount": 44,
       "axiomCount": 1,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- Research-pool JSON `leanFiles` for `erdos-1093` was frozen at an iteration-2 snapshot (224 lines / 38 theorems) while the `origin/main` source `Erdos1093Problem.lean` had advanced to **258 lines / 44 theorems**.
- Delta is genuine public-theorem growth: **+34 lines, +6 theorems** (0 private theorems in the file, so the strict `^(theorem|lemma) ` count reflects real new public theorems); `axiomCount`/`defCount`/`sorryCount` unchanged at 1/6/0 — zero docstring false-positive risk.
- Scoped to `leanFiles` + `lastUpdate` (→ 2026-06-10, the source's last-commit date on `origin/main`); narrative/`currentState` untouched.

## Context
Build-free state-sync during the Docker/Aristotle verification blackout. The gallery `meta.json` `leanFile` block is an independent artifact maintained by the deployer/auditor; only the research-pool JSON lagged.

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics recomputed from `origin/main` source via the canonical `enrich-research.ts` regexes
- [x] No source files changed; no build required

🤖 Generated with [Claude Code](https://claude.com/claude-code)