### PR TITLE
research(descartes-rule-of-signs-oq-02-oq-02): flag BLOCKED — both paths gated

### DIFF
--- a/research/problems/descartes-rule-of-signs-oq-02-oq-02/state.md
+++ b/research/problems/descartes-rule-of-signs-oq-02-oq-02/state.md
@@ -1,10 +1,11 @@
 # Research State: descartes-rule-of-signs-oq-02-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ORIENT (BLOCKED)
 **Path**: full
 **Since**: 2026-06-13
-**Iteration**: 2
+**Iteration**: 3
+**Status**: blocked — both forward paths are gated (see Blockers)
 
 ## Current Focus
 Feasibility surveyed. The `PolyChain` framework trivially hosts a Sturm chain (definitional,
@@ -29,7 +30,18 @@ is available (verification blackout 2026-06-13).
   definitional artifact cannot be build-verified this session.
 
 ## Next Action
-When Docker verification returns: create `proofs/Proofs/DescartesRuleOfSignsOQ02OQ02.lean`
-defining `sturmChain p : PolyChain (sturmLength p)` via the signed-remainder recursion and
-stating `axiom sturm_root_count`; confirm the chain definition compiles. See knowledge.md
-"Recommended Next Steps".
+**Slug flagged `blocked` 2026-06-13 (researcher-1, session iter-3).** ORIENT survey (PR #23130)
+is complete and on `main`; there is no remaining build-free work. Both forward paths are gated:
+
+1. **Scoped definitional artifact** (`sturmChain : PolyChain` + `axiom sturm_root_count`,
+   ~50–80 LOC): requires a Docker build to verify the signed-remainder recursion compiles and
+   terminates (well-founded on degree — the only non-trivial bookkeeping). Docker daemon is DOWN
+   (verification blackout 2026-06-13), so this cannot be written-and-verified this session;
+   shipping unverified Lean risks a non-compiling chain definition. **Gated on Docker.**
+2. **Fully verified Sturm theorem**: BLOCKED-scale (>1000 LOC, absent from Mathlib4 — present
+   only in Isabelle/Coq/PVS). Out of scope for the gallery pipeline.
+
+**Unblock when Docker verification returns:** create `proofs/Proofs/DescartesRuleOfSignsOQ02OQ02.lean`
+per knowledge.md "Recommended Next Steps" (definitional chain + parent-style axiom), confirm it
+compiles, then flip status back to in-progress/surveyed. Do NOT re-survey — the ORIENT analysis
+is complete and accurate.


### PR DESCRIPTION
## Summary
Flags `descartes-rule-of-signs-oq-02-oq-02` (Sturm's theorem via the `PolyChain` framework) as **blocked**. The ORIENT survey is complete on `main` (PR #23130); there is no remaining build-free work this session.

## Why blocked
Both forward paths are gated:
1. **Scoped definitional artifact** (`sturmChain : PolyChain` + parent-style `axiom sturm_root_count`, ~50–80 LOC) — requires a Docker build to verify the signed-remainder recursion compiles and terminates (well-founded on degree). **Docker daemon is DOWN** (verification blackout 2026-06-13); shipping unverified Lean risks a non-compiling chain definition.
2. **Fully verified Sturm theorem** — BLOCKED-scale (>1000 LOC, absent from Mathlib4; formalized only in Isabelle/Coq/PVS). Out of scope for the gallery pipeline.

## Change
Doc-only: `state.md` phase → `ORIENT (BLOCKED)`, records the gating analysis and an explicit unblock recipe for when Docker returns. No Lean, no gallery-meta changes.

## Unblock criteria
When Docker verification is restored: create `proofs/Proofs/DescartesRuleOfSignsOQ02OQ02.lean` per knowledge.md "Recommended Next Steps", confirm it compiles, flip status back. Do NOT re-survey — the ORIENT analysis is complete and accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)