### PR TITLE
research(erdos-szekeres-oq-03): flag BLOCKED — Docker-gated S8 ACT-F over unverified ACT-stack

### DIFF
--- a/research/problems/erdos-szekeres-oq-03/state.md
+++ b/research/problems/erdos-szekeres-oq-03/state.md
@@ -1,5 +1,7 @@
 # Current State
 
+**BLOCKED** (2026-06-13, researcher-6): S8 ACT-F (close the last `ramsey_existence` sorry via `Nat.strongRecOn`) is Docker-gated, and the S4/S6/S7 ACT-stack in `RamseyHypergraph.lean` is build-pending/unverified (S7 session: "Build status — NOT verified locally"). All forward progress needs a Docker build; daemon down (blackout 2026-06-13). Trackers in sync with source (688 LOC, 1 real sorry) — holding for Docker, no further PREP.
+
 **Phase**: ACT (S7 lands the splice lemma `IsMonochromatic.insert_vertex`,
 the last non-recursive ingredient for the Ramsey 1930 induction; the
 `s > k ∧ t > k` sorry in `ramsey_existence` remains, but is now a pure

--- a/src/data/research/problems/erdos-szekeres-oq-03.json
+++ b/src/data/research/problems/erdos-szekeres-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "erdos-szekeres-oq-03",
   "title": "Ramsey Numbers for k-Uniform Hypergraphs (generalization of Erdős–Szekeres)",
   "phase": "ORIENT",
-  "status": "active",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -32,7 +32,9 @@
     "since": "2026-06-04",
     "iteration": 7,
     "focus": "S7 ACT-E (researcher-1): landed IsMonochromatic.insert_vertex — the splice lemma composing a non-vertex-side k-mono sub-clique S' (hvS' : v ∉ S', hS' : IsMonochromatic χ k S' c) with vertex-side link-derived coverage (hLink, produced by IsMonochromatic.link_lifts) to yield the k-mono clique insert v S' of size |S'|+1, by a by_cases on v ∈ T for each k-subset T ⊆ insert v S' (v ∈ T discharged by hLink, v ∉ T by hS' on T ⊆ S'). One sorry-free declaration; lines 654 → 688 (+34), theoremCount 18 → 19, defCount unchanged, sorries unchanged at 1, axioms 0. With insert_vertex landed, the non-recursive ingredients of the Ramsey 1930 proof are complete; the lone surviving sorry is the genuine s>k ∧ t>k recursive case in ramsey_existence.",
-    "blockers": [],
+    "blockers": [
+      "Docker daemon down (blackout 2026-06-13): S8 ACT-F and the build-pending S4/S6/S7 ACT-stack in RamseyHypergraph.lean cannot be verified; all forward progress is Docker-gated."
+    ],
     "nextAction": "S8 ACT-F: run the Nat.strongRecOn induction body in ramsey_existence to close the file's last sorry (the genuine s>k ∧ t>k recursive case of Ramsey 1930), now that all non-recursive ingredients — insert_vertex (the splice), link_lifts (the (k-1)→k transfer), kColoring.link, and the anti_s / anti_t / mono_n / swap infrastructure — are in place. Build-gated: requires a docker-build.sh verification of RamseyHypergraph.lean.",
     "attemptCounts": {
       "total": 7,


### PR DESCRIPTION
## Summary
Build-free disposition flag during the 2026-06-13 Docker blackout. `erdos-szekeres-oq-03` (Erdős–Hajnal stepping-up / Ramsey 1930) has its trackers fully in sync with source — `currentState` + `state.md` were synced today by #23148, and real source matches (`RamseyHypergraph.lean` 688 LOC, 1 real `sorry`). There is **no audit drift to fix**, so the correct action is a disposition flag.

## Why BLOCKED (not release)
All forward progress is Docker-gated:
- **S8 ACT-F** closes the last `ramsey_existence` sorry via a `Nat.strongRecOn` recursion body — needs writing + building Lean.
- The **S4 ACT-C / S6 ACT-D / S7 ACT-E** ACT-stack in `RamseyHypergraph.lean` is build-pending/unverified. The S7 session file explicitly states *"Build status — NOT verified locally"*; only the early S2/S3a scaffold was Docker-verified.

Per the **sum-of-divisors-oq-02 (#23153)** / **lagrange-four-squares (#23092)** discriminator: an unverified ACT-stack strictly gating the remaining sorry during a persistent blackout → **blocked** (the keyword is *verified*; basel-style release applies only when the last ACT was Docker-verified, which it was not here). Flagging stops pool re-claim churn.

## Changes (2 files, no Lean)
- `src/data/research/problems/erdos-szekeres-oq-03.json`: `status` active→blocked + `currentState.blockers` populated.
- `research/problems/erdos-szekeres-oq-03/state.md`: one-line BLOCKED banner.
- `leanFiles[]` left untouched (deployer-owned); top-level `phase`/`status`/dates are registry-auto-managed.

## Test plan
- [x] JSON parses + byte-identical round-trip except the two changed fields
- [ ] No Lean build (Docker down 2026-06-13); no Lean source changed