### PR TITLE
research(desargues-theorem-oq-02-oq-02): flag BLOCKED — only build-gated ACT remains

### DIFF
--- a/research/problems/desargues-theorem-oq-02-oq-02/state.md
+++ b/research/problems/desargues-theorem-oq-02-oq-02/state.md
@@ -1,7 +1,7 @@
 # Research State: desargues-theorem-oq-02-oq-02
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ORIENT (BLOCKED — verification blackout)
 **Path**: full
 **Since**: 2026-06-13
 **Iteration**: 1
@@ -31,6 +31,13 @@ Two-layer formalization (see knowledge.md "Recommended Lean Plan"):
   backend returns 404 — both confirmed live this session. No Lean committed; the
   ACT phase (writing `DesarguesTheoremOQ02OQ02.lean`) is build-gated until infra
   returns.
+- **Flagged BLOCKED (researcher-4, 2026-06-13):** the S1 SURVEY is complete (math
+  resolved, Mathlib API confirmed, 4-part Lean plan + dead-ends documented) and
+  all trackers are in sync. The sole remaining work is build-gated ACT — even the
+  cheapest milestone (Part A finite `10₃` self-duality by `decide`) requires a
+  compile to certify the incidence matrix / duality permutation. No build-free
+  ACT path exists, so the slug is parked out of the claimable pool to avoid
+  re-draw churn during the blackout. Re-open when Docker/Aristotle return.
 
 ## Next Action
 When build infra returns: create `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean`

--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "desargues-theorem-oq-02-oq-02",
   "title": "Can we formalize the self-duality property of Desargues's theorem explicitly?",
   "phase": "ORIENT",
-  "status": "surveyed",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {


### PR DESCRIPTION
## Summary
Flag `desargues-theorem-oq-02-oq-02` (MODERATE 10) **blocked** during the 2026-06-13 verification blackout.

- The S1 SURVEY (#23111, merged) is **complete**: self-duality resolved on paper (plane-dual of Desargues = its converse), Mathlib `Configuration.ProjectivePlane`/`Configuration.Dual` API confirmed with line numbers, a 4-part Lean plan and dead-ends documented in knowledge.md.
- `state.md` and the research-JSON `currentState` are **in sync** at iteration 1 — no STATE-SYNC drift. No gallery `meta.json` exists — no meta-audit applies.
- The **only** remaining work is writing `proofs/Proofs/DesarguesTheoremOQ02OQ02.lean`. Even the cheapest milestone (Part A: finite `10₃` self-duality by `decide`) needs a compile to certify the incidence matrix / duality permutation — no build-free ACT path exists.
- Docker daemon down + Aristotle backend 404 both confirmed live this session.

Flip top-level `status` surveyed→blocked + record the flag in `state.md` so the slug is parked out of the claimable pool and stops generating re-draw churn. Re-open when build infra returns.

## Changes
- `src/data/research/problems/desargues-theorem-oq-02-oq-02.json`: `status` surveyed→blocked
- `research/problems/desargues-theorem-oq-02-oq-02/state.md`: Phase header + BLOCKED blocker entry

## Test plan
- [x] JSON validates (`python3 -m json.tool`)
- [x] Doc/data-only change; no Lean source touched, no build impact