### PR TITLE
research(erdos-659-oq-01-oq-02): flag BLOCKED — S10 ACT Docker-gated

### DIFF
--- a/research/problems/erdos-659-oq-01-oq-02/state.md
+++ b/research/problems/erdos-659-oq-01-oq-02/state.md
@@ -1,5 +1,7 @@
 # Current State
 
+**Status**: BLOCKED (2026-06-13, researcher-2) — the only remaining concrete next action is S10 ACT (paste the S9 PREP `(5, 7)` mixed-modulus recipe into `Erdos659OQ01OQ02.lean` and `docker-build`-verify). That is **Docker-gated** and the daemon is down (`docker info` times out). The math is settled: the `(5, 7)` recipe is paste-ready (`sessions/2026-06-13-s9-prep-5-7-axis-vs-plane-mixed-modulus-recipe.md`), and every other open candidate (`(5,13)`/`(7,13)`/`(11,13)` axis-vs-plane, full-rank Hasse-Minkowski safety, Θ(n^{2/3}) assembly) is likewise either Docker-gated paste-work or blocked on absent Mathlib v4.26.0 infrastructure. PREP/OBSERVE are saturated — a further doc-only memo would be churn. Re-open when Docker returns (paste + verify S9 PREP recipe at S10 ACT).
+
 **Phase**: PREP (S9 PREP — `(5, 7)` axis-vs-plane mixed-modulus recipe; doc-only)
 **Since**: 2026-06-13 (S9 PREP designs the next safe-pair discharge from the S8 menu)
 **Iteration**: 16 (was 15; S9 PREP designs `(5, 7)`)

--- a/src/data/research/problems/erdos-659-oq-01-oq-02.json
+++ b/src/data/research/problems/erdos-659-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "erdos-659-oq-01-oq-02",
   "title": "4-point-property distance bound in ℝ^d for d ≥ 3",
   "phase": "PREP",
-  "status": "active",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "parent": "erdos-659-oq-01",


### PR DESCRIPTION
## Summary
- Flips `erdos-659-oq-01-oq-02` status `active` → `blocked`.
- The slug's only concrete next action is **S10 ACT**: paste the S9 PREP `(5,7)` axis-vs-plane mixed-modulus recipe into `proofs/Proofs/Erdos659OQ01OQ02.lean` and `docker-build`-verify. **Docker daemon is down** (`docker info` times out), so no build can run.
- The math is settled and the recipe is paste-ready (`sessions/2026-06-13-s9-prep-5-7-axis-vs-plane-mixed-modulus-recipe.md`). Every other open candidate (`(5,13)`/`(7,13)`/`(11,13)` axis-vs-plane, full-rank Hasse-Minkowski safety, Θ(n^{2/3}) assembly) is likewise Docker-gated paste-work or blocked on absent Mathlib v4.26.0 infrastructure.
- PREP/OBSERVE are saturated; a further doc-only memo would be churn. Re-open when Docker returns.

## Changes
- `src/data/research/problems/erdos-659-oq-01-oq-02.json`: `status` → `blocked`
- `research/problems/erdos-659-oq-01-oq-02/state.md`: prepend a BLOCKED status banner

No Lean / meta.json / knowledge.md edits. Doc-only, build-free.

## Test plan
- [ ] No build required (status flag + state.md banner only)