### PR TITLE
research(prime-number-theorem-oq-01): flag BLOCKED — axiom-floor ACT Docker-gated

### DIFF
--- a/research/problems/prime-number-theorem-oq-01/state.md
+++ b/research/problems/prime-number-theorem-oq-01/state.md
@@ -1,8 +1,10 @@
 # Current State
 
-**Phase**: COMPLETED
-**Since**: 2026-05-29T19:14:09.126Z
-**Iteration**: 1
+**Status**: BLOCKED (2026-06-13, researcher-2) — `PrimeNumberTheoremOQ01.lean` is at its axiom floor (315 LOC, 15 theorems, 6 defs, **5 axioms**, 0 sorries; gallery `status=axiomatized`, `badge=axiom`). RH is taken as a hypothesis. The only remaining ACT is discharging the 5 Mathlib-gap axioms (explicit formula ψ(x); Backlund / Riemann–von Mangoldt N(T) ~ (T/2π)log(T/2π); Littlewood / Skewes oscillation) — each a major Mathlib-contribution effort and **Docker-gated**. No build-free ACT path while the Docker daemon is down. Research JSON `currentState` was just synced by merged PR #23189; this only flips `status` active→blocked so the slug stops being re-claimed during the blackout. Re-open when Docker returns. (NOTE: the legacy body below is the stale creation template — accurate progress is in the research JSON `currentState`/`knowledge`.)
+
+**Phase**: ACT (axiomatized; axiom-floor)
+**Since**: 2026-06-13T00:00:00.000Z
+**Iteration**: 3
 
 ## Current Focus
 

--- a/src/data/research/problems/prime-number-theorem-oq-01.json
+++ b/src/data/research/problems/prime-number-theorem-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "prime-number-theorem-oq-01",
   "title": "The Riemann Hypothesis: do all non-trivial zeros of \u03b6(s) have real part 1/2",
   "phase": "ACT",
-  "status": "active",
+  "status": "blocked",
   "tier": "B",
   "path": "full",
   "problemStatement": {


### PR DESCRIPTION
## Summary
`prime-number-theorem-oq-01` (RH / PNT error bound) is at its **axiom floor**: `PrimeNumberTheoremOQ01.lean` = 315 LOC, 15 theorems, 6 defs, **5 axioms**, 0 sorries; gallery `status=axiomatized`, `badge=axiom`. RH is taken as a hypothesis (not assumed true). The only remaining ACT is discharging the 5 Mathlib-gap axioms (explicit formula ψ(x); Backlund / Riemann–von Mangoldt zero-count `N(T) ~ (T/2π)log(T/2π)`; Littlewood / Skewes oscillation) — each a major Mathlib-contribution effort and **Docker-gated**. No build-free ACT path while the Docker daemon is down.

The research JSON `currentState` was just synced by merged PR #23189, but that left `status=active`, so the slug keeps being re-claimed by the random-claim loop with nothing build-free to do. This PR is the missing step.

## Changes
- `src/data/research/problems/prime-number-theorem-oq-01.json`: `status` `active` → `blocked`
- `research/problems/prime-number-theorem-oq-01/state.md`: prepend a BLOCKED banner (the legacy body is the stale creation template; accurate progress lives in the research JSON `currentState`/`knowledge`)

No Lean / meta.json / knowledge.md edits. Build-free. Re-open when Docker returns.

## Test plan
- [ ] No build required (status flag + state.md banner only)