### PR TITLE
research(erdos-345): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-345.json
+++ b/src/data/research/problems/erdos-345.json
@@ -65,15 +65,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:53:52.153Z",
-  "lastUpdate": "2026-03-29T20:45:00Z",
+  "lastUpdate": "2026-06-10T02:47:38Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos345Problem.lean",
       "filename": "Erdos345Problem.lean",
-      "lineCount": 200,
-      "theoremCount": 10,
+      "lineCount": 227,
+      "theoremCount": 14,
       "axiomCount": 5,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `src/data/research/problems/erdos-345.json` `leanFiles` block was frozen at the iteration-1 state (lineCount 200, theoremCount 10, lastUpdate 2026-03-29) while `proofs/Proofs/Erdos345Problem.lean` advanced to lineCount 227 / theoremCount 14 on `origin/main` (source last touched 2026-06-10, commit `d8284214`).

This is a mechanical metrics sync only — no narrative/prose changes.

## Details
- **+27 lines, +4 theorems** — all genuine **public** growth (0 private declarations, so not the strict-`^(theorem|lemma) `-vs-private convention artifact).
- `axiomCount` / `defCount` / `sorryCount` **unchanged** at 5 / 5 / 0. Comment-stripped recount confirms real axiom = 5, real sorry = 0 (no docstring false positives).
- `lastUpdate` bumped to the source's last-commit date on `origin/main` (2026-06-10), tying metadata to a real event.
- Gallery `meta.json` is a separate artifact and not touched here.

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics recomputed from `origin/main` source via the canonical `enrich-research.ts` regexes
- [x] No prose/status fields modified