### PR TITLE
research(lagrange-four-squares-waring-g2-oq-01): META-SYNC — register G6/G7 in leanFile.additionalFiles

### DIFF
--- a/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
+++ b/src/data/proofs/lagrange-four-squares-waring-g2/meta.json
@@ -162,6 +162,24 @@
         "sorries": 0,
         "theoremCount": 1,
         "definitionCount": 1
+      },
+      {
+        "path": "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG6.lean",
+        "description": "Waring's Problem OQ-01, k=6 lower bound: sorry-free, axiom-free proof of g(6) ≥ 73 via counting+omega (parallel to the G4/G5 ACTs, applied to the 2-equation system n0+n1+n2=72 ∧ n1+64·n2=703; the Mahler witness 703 = 2^6·11 − 1 is infeasible by 1).",
+        "lineCount": 158,
+        "axiomCount": 0,
+        "sorries": 0,
+        "theoremCount": 1,
+        "definitionCount": 1
+      },
+      {
+        "path": "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean",
+        "description": "Waring's Problem OQ-01, k=7 lower bound: sorry-free, axiom-free proof of g(7) ≥ 143 via counting+omega (parallel to the G4/G5/G6 ACTs, applied to the 2-equation system n0+n1+n2=142 ∧ n1+128·n2=2175; the Mahler witness 2175 = 2^7·17 − 1 is infeasible by 1).",
+        "lineCount": 139,
+        "axiomCount": 0,
+        "sorries": 0,
+        "theoremCount": 1,
+        "definitionCount": 1
       }
     ]
   },


### PR DESCRIPTION
## Summary
Completes the S23 companion-file reconciliation (#23167) for `lagrange-four-squares-waring-g2-oq-01`.

#23167 added the G6/G7 counting companions to the `meta.additionalFiles` path string-list, but the parallel **`leanFile.additionalFiles`** detailed object array (path + per-file counts) was left stopped at G5. The G6/G7 `.lean` files exist on `main` and have no detailed entry.

This PR adds the two missing object entries with counts verified directly against `origin/main` source:

| File | lines | theorems | defs | axioms | sorries |
|------|------:|---------:|-----:|-------:|--------:|
| `…CountingG6.lean` (g(6) ≥ 73) | 158 | 1 | 1 | 0 | 0 |
| `…CountingG7.lean` (g(7) ≥ 143) | 139 | 1 | 1 | 0 | 0 |

Both are sorry-free, axiom-free counting+omega lower bounds (PRs #22751 / #22968).

## Test plan
- [x] Diff is exactly the two appended entries — no unicode-escape churn, trailing newline preserved
- [x] Counts computed from `git show origin/main:` source (comment-stripped grep)
- [x] Doc/meta-only — no Docker build required

🤖 Generated with [Claude Code](https://claude.com/claude-code)