### PR TITLE
research(erdos-761): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-761.json
+++ b/src/data/research/problems/erdos-761.json
@@ -105,15 +105,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T08:25:36.657Z",
-  "lastUpdate": "2026-03-27T22:30:00.000Z",
+  "lastUpdate": "2026-06-10T02:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos761Problem.lean",
       "filename": "Erdos761Problem.lean",
-      "lineCount": 259,
-      "theoremCount": 6,
+      "lineCount": 315,
+      "theoremCount": 10,
       "axiomCount": 2,
       "defCount": 6,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `erdos-761` was frozen at iter-6 (259 lines, 6 theorems) while the merged source `proofs/Proofs/Erdos761Problem.lean` on `main` is at **315 lines / 10 public theorems** — a +56 line, +4 theorem drift introduced by the `d8284214` landing.

- `lineCount` 259 → 315
- `theoremCount` 6 → 10 (strict `^(theorem|lemma) `; 1 private excluded from both old & new, so the +4 is genuine public growth, **not** the strict-vs-private artifact)
- `axiomCount` / `defCount` / `sorryCount` unchanged (2 / 6 / 2)
- comment-stripped real sorry = 0, real axiom = 2 → no docstring false-positive
- `lastUpdate` → 2026-06-10 (source last-commit `d8284214` on `main`)

The gallery `meta.json` `leanFile` is **already** at 314/10 (independent artifact); only the research-pool JSON lagged. Scoped strictly to the 2 drifted metrics + `lastUpdate`; narrative untouched.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — JSON valid
- [x] Metrics recomputed from `origin/main` source via the `enrich-research.ts` conventions (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all, `lineCount = split('\n').length`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)