### PR TITLE
research(erdos-854): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-854.json
+++ b/src/data/research/problems/erdos-854.json
@@ -67,15 +67,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T10:25:45.156Z",
-  "lastUpdate": "2026-03-13T07:52:17.053Z",
+  "lastUpdate": "2026-06-10T09:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos854Problem.lean",
       "filename": "Erdos854Problem.lean",
-      "lineCount": 195,
-      "theoremCount": 13,
+      "lineCount": 234,
+      "theoremCount": 19,
       "axiomCount": 4,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

The research-pool JSON (`src/data/research/problems/erdos-854.json`) `leanFiles` block was frozen at iteration 1 (lineCount 195 / theoremCount 13, lastUpdate 2026-03-13) while the Lean source `Proofs/Erdos854Problem.lean` advanced to 234 lines / 19 theorems on `origin/main` (landed in the `d8284214` squash).

This syncs the stale mechanical metrics to the current source:
- `lineCount` 195 → 234
- `theoremCount` 13 → 19
- `axiomCount` (4), `defCount` (8), `sorryCount` (0) — **unchanged**, already correct
- `lastUpdate` → source landing date

## Why this is clean

- The +6 theorem delta is **genuine public growth**, not the strict-vs-private counting artifact: the file has 3 `private` theorems, excluded from BOTH the old (13) and new (19) strict `^(theorem|lemma) ` counts.
- Comment-stripped source recount confirms real sorry = 0 (zero docstring false-positive risk); axiom = 4 matches.
- The gallery `meta.json` `leanFile` is already current (233/22) — independent artifact; only the research-pool JSON lagged.

Scope is strictly the 3 drifted/metadata lines; narrative untouched.

## Test plan

- [x] Recomputed all 5 metrics against `origin/main` source via the `enrich-research.ts` conventions (lineCount = split('\n').length, theoremCount = `^(theorem|lemma) `, axiomCount = `^axiom `, defCount = `^(def|noncomputable def|opaque def) `, sorryCount = `\bsorry\b`-all)
- [x] Verified no existing open PR for this slug

🤖 Generated with [Claude Code](https://claude.com/claude-code)