### PR TITLE
research(triangular-reciprocals-oq-02): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/triangular-reciprocals-oq-02.json
+++ b/src/data/research/problems/triangular-reciprocals-oq-02.json
@@ -79,15 +79,15 @@
     "mathlib": []
   },
   "started": "2026-04-06T03:14:36.241Z",
-  "lastUpdate": "2026-06-12T22:30:00-07:00",
+  "lastUpdate": "2026-06-13T05:51:00-07:00",
   "significance": 5,
   "tractability": 7,
   "leanFiles": [
     {
       "path": "Proofs/TriangularReciprocalsOQ02.lean",
       "filename": "TriangularReciprocalsOQ02.lean",
-      "lineCount": 318,
-      "theoremCount": 9,
+      "lineCount": 354,
+      "theoremCount": 13,
       "axiomCount": 0,
       "defCount": 0,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research-pool JSON `leanFiles` for `triangular-reciprocals-oq-02` was frozen at **318 lines / 9 theorems** while the merged source (`TriangularReciprocalsOQ02.lean`, last touched by #22918 "closed-form series values + k=4 case") is at **354 lines / 13 theorems**.

- `lineCount` 318 → 354 (+36)
- `theoremCount` 9 → 13 (+4 public theorems)
- `axiomCount` / `defCount` / `sorryCount` unchanged at 0
- `lastUpdate` → source last-commit date on main (2026-06-13)

## Why this is a clean sync (not an artifact)
- All 13 theorems are **public** (0 `private` theorems/lemmas) → the +4 is genuine public growth, not the strict-`^(theorem|lemma) `-vs-private counting artifact.
- Comment-stripped real sorry = 0 and real axiom = 0 → no docstring false-positives.
- The gallery `meta.json` `leanFile` was **already** synced (353 wc-l / 13 theorems); only the independent research-pool JSON lagged.

Metrics recomputed via the canonical `enrich-research.ts` regexes against `origin/main` source. Scoped strictly to the 3 drifted fields; narrative untouched.

## Test plan
- [x] JSON validates (`python3 -c "import json; json.load(...)"`)
- [x] Metrics verified against `git show origin/main:proofs/Proofs/TriangularReciprocalsOQ02.lean`
- [ ] No build required (data-only leanFiles sync; Lean source unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)