### PR TITLE
research(erdos-1035): sync stale leanFiles to merged source state

### DIFF
--- a/src/data/research/problems/erdos-1035.json
+++ b/src/data/research/problems/erdos-1035.json
@@ -124,17 +124,17 @@
     ]
   },
   "started": "2026-01-15T13:59:18.137Z",
-  "lastUpdate": "2026-04-28T01:12:00Z",
+  "lastUpdate": "2026-06-10T02:47:38Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos1035Problem.lean",
       "filename": "Erdos1035Problem.lean",
-      "lineCount": 297,
-      "theoremCount": 17,
+      "lineCount": 380,
+      "theoremCount": 19,
       "axiomCount": 0,
-      "defCount": 8,
+      "defCount": 10,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1035Problem.lean"


### PR DESCRIPTION
## Summary
The research-pool JSON (`src/data/research/problems/erdos-1035.json`) `leanFiles` block was frozen at **297 lines / 17 theorems / 8 defs** (lastUpdate 2026-04-28) while the merged source `proofs/Proofs/Erdos1035Problem.lean` on `main` has grown to **380 / 19 / 10** (axiom 0, sorry 0 unchanged).

The gallery `meta.json` `leanFile` block already tracks the current state (379/20 — gallery uses a private-inclusive theorem convention); only the independent research-pool JSON lagged.

## Changes
- `leanFiles[0]`: lineCount 297→380, theoremCount 17→19, defCount 8→10 (axiomCount 0, sorryCount 0 unchanged)
- `lastUpdate`: 2026-04-28 → 2026-06-10 (source's last-touched commit on main)
- No narrative / status changes — mechanical sync only

## Verification
- Counts recomputed via `enrich-research.ts` conventions: strict `^(theorem|lemma) ` (excludes 1 private theorem → 19), `^(def|noncomputable def|opaque def) ` → 10, `lineCount = split('\n').length` → 380
- Comment-stripped recount confirms real sorry = 0, real axiom = 0 (no docstring false-positives)
- 0 open PRs touching this slug

Build-free metadata sync (Docker verification infra is down).