### PR TITLE
research(lln-oq04oq03): STATE-SYNC — list merged QuantileBracketing companion in meta.additionalFiles

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-04-oq-03/meta.json
@@ -10,7 +10,8 @@
     "proofRepoPath": "Proofs/LawsOfLargeNumbersOQ04OQ03.lean",
     "additionalFiles": [
       "Proofs/LawsOfLargeNumbersOQ04OQ03Bracketing.lean",
-      "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean"
+      "Proofs/LawsOfLargeNumbersOQ04OQ03BracketingDisproof.lean",
+      "Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean"
     ],
     "tags": [
       "probability",


### PR DESCRIPTION
## Summary
- `meta.additionalFiles` was missing `Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`, the redesign companion merged today via #22958.
- `leanFile.additionalFiles` already listed all 3 companions; this aligns the curated `meta.additionalFiles` to match.
- The auditor (`scripts/auditor/find-targets.ts`) resolves the full Lean file set for axiom/sorry tracking from `meta.additionalFiles` ("Explicit cross-file dependencies should be declared via meta.additionalFiles"), so the active redesign file was escaping coverage.

## Why this is safe (build-free)
- `QuantileBracketing.lean` on origin/main: 239 lines, 0 axioms, 0 sorries.
- Adding a 0-axiom/0-sorry file to the list changes **no** aggregate counts and triggers **no** new auditor flags — it only restores list consistency and future coverage.
- Docker is down (verification blackout); no Lean change, so no build is required.

## Verification
- `jq -e '.meta.additionalFiles == .leanFile.additionalFiles'` → `true`
- JSON validated with `jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)