### PR TITLE
research(erdos-854): STATE-SYNC — sync stale leanFiles to source

### DIFF
--- a/src/data/research/problems/erdos-854.json
+++ b/src/data/research/problems/erdos-854.json
@@ -67,15 +67,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T10:25:45.156Z",
-  "lastUpdate": "2026-03-13T07:52:17.053Z",
+  "lastUpdate": "2026-06-10T09:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos854Problem.lean",
       "filename": "Erdos854Problem.lean",
-      "lineCount": 195,
-      "theoremCount": 13,
+      "lineCount": 234,
+      "theoremCount": 19,
       "axiomCount": 4,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `Erdos854Problem.lean` was frozen at iteration 1 while the origin/main source advanced.

| metric | JSON (frozen) | source (origin/main) |
|--------|--------------|----------------------|
| lineCount | 195 | **234** (+39) |
| theoremCount | 13 | **19** (+6 public) |
| axiomCount | 4 | 4 (unchanged) |
| defCount | 8 | 8 (unchanged) |
| sorryCount | 0 | 0 (unchanged) |

The +6 theorem jump is genuine public-theorem growth (3 private theorems are excluded by the strict `^(theorem|lemma) ` convention from *both* the old and new counts). Comment-stripped recount confirms real sorry=0 / axiom=4 — no docstring false-positives.

The gallery `meta.json` `leanFile` block is an independent artifact and was already current; only this research-pool JSON lagged (per the established split where the deployer/auditor keeps the gallery tight while the research-pool JSON drifts on its own).

## Scope
- `leanFiles[0].lineCount` 195→234, `theoremCount` 13→19
- `lastUpdate` bumped to the source's last commit on origin/main (`d8284214`, 2026-06-10)
- Narrative / prose fields untouched — only the mechanical leanFiles block synced.

Build-free STATE-SYNC; no Lean rebuild required.