### PR TITLE
research(sperner-simplicial-bridge-oq-01): sync stale leanFiles to source state

### DIFF
--- a/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
@@ -115,14 +115,14 @@
         ]
     },
     "started": "2026-05-12T17:55:00.000Z",
-    "lastUpdate": "2026-05-16T19:08:00.000Z",
+    "lastUpdate": "2026-06-10T02:47:38.000Z",
     "significance": 6,
     "tractability": 5,
     "leanFiles": [
         {
             "path": "proofs/Proofs/SpernerSimplicialBridgeOQ01.lean",
-            "lineCount": 216,
-            "theoremCount": 8,
+            "lineCount": 271,
+            "theoremCount": 14,
             "definitionCount": 3,
             "sorryCount": 0,
             "axiomCount": 0


### PR DESCRIPTION
## Summary

The research-pool JSON (`src/data/research/problems/sperner-simplicial-bridge-oq-01.json`) `leanFiles` block was frozen at iteration-15 values while the merged origin/main source advanced through S17/S18 (#22032, #22061).

- `lineCount` 216 → 271
- `theoremCount` 8 → 14
- `definitionCount` / `sorryCount` / `axiomCount` unchanged (3 / 0 / 0)
- `lastUpdate` → 2026-06-10 (source landing commit `d8284214` on main)

## Why this is a clean sync

- All 6 new theorems are **public** — `grep -cE '^private (theorem|lemma) '` = 0 — so the 8→14 jump is genuine growth, not the strict-`^(theorem|lemma) `-vs-private counting artifact.
- Comment-stripped recount confirms **0 real sorry / 0 real axiom** (no docstring false-positives).
- Metrics recomputed from `git archive origin/main` source via the exact `enrich-research.ts` regexes.
- The gallery `meta.json` `leanFile` block is a separate artifact (kept tight by deployer/auditor); this PR touches only the research-pool JSON. Narrative/`currentState` left untouched.

Build-free metadata sync (verification blackout: Docker down, Aristotle 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)