### PR TITLE
research(frobenius-number-oq-02): sync stale leanFiles to source state

### DIFF
--- a/src/data/research/problems/frobenius-number-oq-02.json
+++ b/src/data/research/problems/frobenius-number-oq-02.json
@@ -53,7 +53,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.184Z",
-  "lastUpdate": "2026-05-29T19:14:09.184Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [
@@ -93,8 +93,8 @@
     {
       "path": "Proofs/FrobeniusNumberOQ03.lean",
       "filename": "FrobeniusNumberOQ03.lean",
-      "lineCount": 226,
-      "theoremCount": 15,
+      "lineCount": 441,
+      "theoremCount": 27,
       "axiomCount": 0,
       "defCount": 2,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `FrobeniusNumberOQ03.lean` in `frobenius-number-oq-02.json` was frozen at iteration 1 (2026-05-29: 226 lines / 15 theorems) while the shared source file has since grown to **441 lines / 27 theorems** on `origin/main` (last touched 2026-06-13).

The sibling slug `frobenius-number-oq-03` (which references the same file) already tracks the current source; this PR syncs the lagging `oq-02` entry only.

## Verification (build-free, Docker down)
- Recomputed all 5 metrics against `origin/main:proofs/Proofs/FrobeniusNumberOQ03.lean` via the canonical `enrich-research.ts` regexes: **441 / 27 / 0 / 2 / 0**.
- 0 `private theorem`/`private lemma` → the +12 theorems is genuine public growth, not the strict-vs-private convention artifact.
- Comment-stripped recount confirms real sorry=0, axiom=0 (no docstring false-positives).
- axiom (0), def (2), sorry (0) unchanged → zero docstring-FP risk.

Scoped to the mechanical `leanFiles` block + `lastUpdate`; research narrative left untouched.

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics match `origin/main` source via canonical regexes