### PR TITLE
research(arithmetic-series multichoose): S2 STATE-SYNC — reconcile knowledge.md with shipped proof

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/knowledge.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/knowledge.md
@@ -4,6 +4,34 @@ Insights accumulated during research on this problem.
 
 ---
 
+## ⚠️ STATE-SYNC NOTICE (2026-06-13) — the Lean file ALREADY EXISTS
+
+> A later ACT session (PR #23066, merged 2026-06-13T21:51Z) **already created**
+> `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` with a **complete**
+> proof (0 `sorry`, 0 `axiom`, 7 theorems). It is Docker-unverified only because
+> of the 2026-06-13 build blackout, and is intentionally NOT yet registered in
+> `proofs/Proofs.lean`.
+>
+> **The committed file uses the ASCENDING-factorial route, not the descending
+> draft embedded below.** It rewrites via the grandparent's `ascFactorial_eq_prod`
+> + Mathlib's `Nat.ascFactorial_eq_factorial_mul_choose`, with an explicit
+> `n = 0` / `n = m+1` case split (the `n=0` corner is degenerate). It states the
+> LHS as `Nat.choose (n+k-1) k * k!` directly rather than via `Nat.multichoose`.
+>
+> Consequences for the notes below:
+> * The **"Dead Ends"** entry that calls the ascending route a dead end and says
+>   "Prefer the descending-factorial reduction" is **superseded** — the ascending
+>   route is what actually shipped and is sound on paper. Both routes remain
+>   Docker-unverified; neither is confirmed against the pinned Mathlib lemma names.
+> * The Session-1 **"Next ACT step: drop the draft into [the .lean file]"** is
+>   **stale** — that file exists. The real remaining work is just: Docker-verify
+>   the existing file, fix any lemma-name drift, register it in `Proofs.lean`,
+>   and add the gallery entry. See Session 2 below.
+> * The embedded descending draft (`Insights → Draft proof`) is retained as an
+>   **unimplemented alternative**, not the live source of truth.
+
+---
+
 ## Problem Understanding
 
 **Target (multiset-coefficient identity).** Let `multichoose n k = C(n+k-1, k)` count
@@ -102,13 +130,19 @@ spellings. Names to confirm against the pinned Mathlib once a build is available
 
 ---
 
-## Dead Ends
+## Approach comparison (NOT a dead end — see STATE-SYNC notice)
 
 - Routing through `Nat.ascFactorial_eq_factorial_mul_choose` (as the grandparent
-  `ArithmeticSeriesOQ02OQ04` does) is possible but carries an `n ↦ n+1` index shift
-  (`C(n+k, k) * k! = ascFactorial (n+1) k`) that makes the `multichoose n k` (which is
-  `C(n+k-1, k)`) bridge less direct than the `choose_descFactorial`-at-`(n+k-1)` route
-  above. Prefer the descending-factorial reduction.
+  `ArithmeticSeriesOQ02OQ04` does) carries an `n ↦ n+1` index shift
+  (`C(n+k, k) * k! = ascFactorial (n+1) k`), so the `n = 0` corner must be handled
+  separately (a one-line degenerate case). The descending route below
+  (`choose_descFactorial`-at-`(n+k-1)` + `prod_range_reflect`) avoids the case
+  split but relies on a `range`-membership `omega` discharge for the reindexing.
+  **Both are valid.** The committed `.lean` file (#23066) took the ascending route
+  with the `n=0`/`n=m+1` split; this knowledge.md's embedded draft took the
+  descending route. Neither has been Docker-verified yet. The earlier
+  "prefer descending / ascending is a dead end" judgement did not survive the
+  ACT session and should not be treated as binding.
 
 ---
 
@@ -128,3 +162,28 @@ spellings. Names to confirm against the pinned Mathlib once a build is available
   `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean`, run
   `./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01`, fix any
   lemma-name drift, then add the gallery entry `src/data/proofs/arithmetic-series-oq-02-oq-04-oq-01-oq-01/`.
+  > **SUPERSEDED — see Session 2.** A separate ACT session (#23066) already created
+  > the `.lean` file (using the ascending route), so "drop the draft into [file]" is
+  > moot; only Docker-verification + registration + gallery entry remain.
+
+### Session 2026-06-13 (Session 2) — STATE-SYNC
+
+**Mode**: REVISIT · **Outcome**: tracker corrected (no proof change)
+
+- Discovered that the ORIENT survey (this knowledge.md, PR #23089, merged 19:02Z)
+  and the ACT implementation (PR #23066, merged 21:51Z) **diverged**: the survey
+  recommended the descending-factorial route and flagged ascending as a dead end,
+  but the ACT session shipped `ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` using the
+  **ascending** route with an `n=0`/`n=m+1` case split. The ACT session did not
+  update this knowledge.md, leaving it self-contradictory.
+- Verified the committed file on `origin/main`: 125 lines, **0 `sorry`, 0 `axiom`,
+  7 theorems** (main identity + `_one/_two/_three` specializations + 3
+  `native_decide` checks). The mathematics of the ascending reduction checks out
+  on paper; it remains **Docker-unverified** (build blackout persists — `docker
+  info` times out this session).
+- Added the STATE-SYNC notice at the top and corrected the "Dead Ends" framing.
+  No `.lean` or `meta.json` changes — this is a documentation-consistency fix only.
+- **Real remaining work (unchanged blockers):** Docker-verify the existing file,
+  reconcile any Mathlib lemma-name drift (`Nat.ascFactorial_eq_factorial_mul_choose`,
+  the parent's `ascFactorial_eq_prod`), register in `Proofs.lean`, add the gallery
+  entry. All Docker-gated.


### PR DESCRIPTION
## Summary

Documentation-consistency fix for `arithmetic-series-oq-02-oq-04-oq-01-oq-01`
(multiset-coefficient / rising-factorial identity).

Two sessions diverged on this slug:
- **#23089** (ORIENT survey, merged 19:02Z) wrote `knowledge.md` with a *descending*-factorial draft and explicitly flagged the *ascending* route as a **dead end** ("prefer the descending-factorial reduction"). Its closing step read: "Next ACT step: drop the draft into the `.lean` file."
- **#23066** (ACT, merged 21:51Z, later) actually **created** `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` using the **ascending** route (with an `n=0`/`n=m+1` case split) — and did **not** update `knowledge.md`.

Result on `main`: a self-contradictory tracker that calls the actually-shipped route a dead end and tells a future session to write a file that already exists.

## What this PR does (doc-only)

- Adds a **STATE-SYNC notice** at the top of `knowledge.md` recording that the `.lean` file already exists (verified on `origin/main`: 125 lines, **0 `sorry` / 0 `axiom` / 7 theorems**), uses the ascending route, and is Docker-unverified only because of the 2026-06-13 build blackout.
- Rewrites the "Dead Ends" entry into a neutral **approach comparison** (both routes valid; neither Docker-verified).
- Marks the stale "next step: write the file" as superseded and adds a **Session 2** log entry capturing the real remaining work: Docker-verify → reconcile lemma-name drift → register in `Proofs.lean` → add gallery entry.

No `.lean` or `meta.json` changes. No proof claim is added or strengthened; both drafts remain Docker-unverified.

## Test plan

- [x] `git show origin/main:proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` → 0 sorry / 0 axiom / 7 theorems (comment-stripped count)
- [x] No build-affecting files touched (the `.lean` file is intentionally still unregistered in `Proofs.lean`)
- [ ] Docker build of the proof file — blocked by the 2026-06-13 outage (`docker info` times out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)