### PR TITLE
research(erdos-153): sync stale leanFiles to merged source state

### DIFF
--- a/src/data/research/problems/erdos-153.json
+++ b/src/data/research/problems/erdos-153.json
@@ -78,15 +78,15 @@
     "mathlib": []
   },
   "started": "2026-01-12T09:56:05.235Z",
-  "lastUpdate": "2026-03-28T01:23:59.133245Z",
+  "lastUpdate": "2026-06-10T09:47:38Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos153Problem.lean",
       "filename": "Erdos153Problem.lean",
-      "lineCount": 495,
-      "theoremCount": 10,
+      "lineCount": 543,
+      "theoremCount": 14,
       "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `Erdos153Problem.lean` was frozen at `495 lines / 10 theorems` (lastUpdate 2026-03-28, iteration 1) while the merged `origin/main` source has grown to `543 lines / 14 theorems`.

| metric | stale JSON | source (origin/main) |
|--------|-----------|----------------------|
| lineCount | 495 | **543** |
| theoremCount | 10 | **14** |
| axiomCount | 1 | 1 |
| defCount | 8 | 8 |
| sorryCount | 0 | 0 |

The `+4` theorems are **genuine public growth**, not the strict-vs-private counting artifact: the file has 8 `private` theorems excluded from both the old and new strict `^(theorem|lemma) ` counts (the canonical `enrich-research.ts:144` convention), so the strict count genuinely moved 10→14 alongside +48 real source lines.

Comment-stripped recount confirms real `sorry=0`, `axiom=1` (no docstring false positives). `lastUpdate` bumped to the source's landing commit `d8284214` (2026-06-10) on `origin/main`.

## Scope
- Mechanical `leanFiles` sync + `lastUpdate` only. Narrative untouched (Docker down → build unverifiable; sync only what the source mechanically verifies).
- The gallery `meta.leanFile` is a separate artifact and already tracks the growth (its `22` uses the include-private convention).

## Test plan
- [x] JSON validates (`json.load`)
- [x] Counts recomputed via the exact `enrich-research.ts` regexes against `git archive origin/main`
- [x] Private-theorem artifact check (growth is genuine, not convention drift)