### PR TITLE
research(sperner-simplicial-bridge-oq-01): sync stale leanFiles to merged source state

### DIFF
--- a/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
@@ -115,14 +115,14 @@
         ]
     },
     "started": "2026-05-12T17:55:00.000Z",
-    "lastUpdate": "2026-05-16T19:08:00.000Z",
+    "lastUpdate": "2026-06-10T09:47:38.000Z",
     "significance": 6,
     "tractability": 5,
     "leanFiles": [
         {
             "path": "proofs/Proofs/SpernerSimplicialBridgeOQ01.lean",
-            "lineCount": 216,
-            "theoremCount": 8,
+            "lineCount": 271,
+            "theoremCount": 14,
             "definitionCount": 3,
             "sorryCount": 0,
             "axiomCount": 0


### PR DESCRIPTION
## Summary

The research-pool JSON `leanFiles` block for `sperner-simplicial-bridge-oq-01` was frozen at the S15 STATE-SYNC state (216 lines / 8 theorems, 2026-05-16) while the merged source `proofs/Proofs/SpernerSimplicialBridgeOQ01.lean` on `main` has since advanced to **271 lines / 14 theorems**.

| metric | JSON (stale) | source (main) |
|--------|-------------|---------------|
| lineCount | 216 | **271** |
| theoremCount | 8 | **14** |
| definitionCount | 3 | 3 |
| axiomCount | 0 | 0 |
| sorryCount | 0 | 0 |

+55 lines, +6 public theorems. `definitionCount`, `axiomCount`, `sorryCount` unchanged.

## Verification

- `private (theorem|lemma)` count in source = **0** → the +6 is genuine public-theorem growth, not the strict-`^(theorem|lemma) `-vs-private convention artifact.
- Comment-stripped recount confirms **real sorry = 0, real axiom = 0** (no docstring false positives).
- Counts match the canonical `enrich-research.ts` regexes; the deployer's regeneration produces the same theoremCount = 14 (raw `^(theorem|lemma) ` without comment-stripping).
- `lastUpdate` bumped to the source's last-touched commit on `main` (`d8284214`, 2026-06-10).

## Scope

Mechanical `leanFiles` + `lastUpdate` sync only. The gallery `meta.json` `leanFile` block is maintained independently. Narrative/prose fields left untouched — build verification remains gated by the ongoing Docker outage, so only the mechanical block is synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)