### PR TITLE
research(angle-trisection-cos-20-gal-oq-01-oq-02): correct stale sorry-claims in completed Gal-order proof

### DIFF
--- a/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02.lean
@@ -431,7 +431,10 @@ The results in this file together with the parent gallery entries establish:
 2. **n=7** [OQ-01]: |Gal(8X³-4X²-4X+1/ℚ)| = 3 = φ(14)/2
 3. **n=9** [Cos20Gal]: |Gal(8X³-6X-1/ℚ)| = 3 = φ(18)/2
 
-The general formula φ(2n)/2 follows from cyclotomic field theory (sorry for full proof).
+The general formula φ(2n)/2 for all n ≥ 3 is proved sorry-free from cyclotomic field
+theory in the child file `AngleTrisectionCos20GalOQ01OQ02OQ02` (theorem
+`gal_order_eq_totient_div2_general`); this file keeps the n=5 case and a tautological
+placeholder for the general statement.
 The key simplification for n=5 over n=7,9: the second root is β = 1/2 - α (Vieta's),
 avoiding the more complex algebraic identities needed for the cubic cases.
 -/

--- a/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean
+++ b/proofs/Proofs/AngleTrisectionCos20GalOQ01OQ02OQ02.lean
@@ -97,7 +97,7 @@ theorem cos_pi_extension_degree (n : ℕ) (hn : 3 ≤ n) :
   rwa [cos_pi_eq_cos_2pi_div_2n n (by omega)]
 
 -- ============================================================================
--- § 4. Splitting Field Degree (with sorry — normality step)
+-- § 4. Splitting Field Degree (SORRY-FREE — normality step formalized below)
 -- ============================================================================
 
 /-- The splitting field of minpoly ℚ (cos(π/n)) has degree φ(2n)/2 over ℚ.
@@ -116,9 +116,9 @@ theorem cos_pi_extension_degree (n : ℕ) (hn : 3 ≤ n) :
 
     Both bounds yield finrank ℚ SplittingField = φ(2n)/2.
 
-    **Remaining work**: Formalize that conjSubgroup(2n) is a normal subgroup of
-    the Galois group of CyclotomicField(2n,ℚ), and derive IsGalois ℚ K for K =
-    maxRealSubfield(2n). Estimated: ~80 lines using Mathlib's abelian group theory. -/
+    **Status**: complete and sorry-free. The normality of conjSubgroup(2n) in the
+    abelian Galois group of CyclotomicField(2n,ℚ), and the resulting IsGalois ℚ K
+    for K = maxRealSubfield(2n), are formalized in the proof body below (§ A). -/
 private theorem cos_pi_splitting_finrank (n : ℕ) (hn : 3 ≤ n) :
     Module.finrank ℚ (minpoly ℚ (Real.cos (Real.pi / ↑n))).SplittingField =
     Nat.totient (2 * n) / 2 := by
@@ -246,7 +246,8 @@ private theorem cos_pi_splitting_finrank (n : ℕ) (hn : 3 ≤ n) :
     AngleTrisectionCos20GalOQ01OQ02.gal_order_eq_totient_div2_general.
 
     The degree part (natDegree = φ(2n)/2) is fully proved above.
-    The Galois order part reduces to the splitting field degree (one sorry). -/
+    The Galois order part reduces to the splitting field degree, which is
+    established sorry-free in `cos_pi_splitting_finrank`. -/
 theorem cos_pi_gal_card (n : ℕ) (hn : 3 ≤ n) :
     Fintype.card (minpoly ℚ (Real.cos (Real.pi / ↑n))).Gal =
     Nat.totient (2 * n) / 2 := by
@@ -273,7 +274,8 @@ theorem cos_pi_gal_card (n : ℕ) (hn : 3 ≤ n) :
     in AngleTrisectionCos20GalOQ01OQ02, answering the open question affirmatively:
     IsCyclotomicExtension infrastructure is sufficient to prove the formula.
 
-    The degree half is fully proved; the Galois order half has one documented sorry. -/
+    Both halves are fully proved: the degree half (natDegree = φ(2n)/2) and the
+    Galois order half (via the sorry-free `cos_pi_splitting_finrank`). -/
 theorem gal_order_eq_totient_div2_general (n : ℕ) (hn : 3 ≤ n) :
     Fintype.card (minpoly ℚ (Real.cos (Real.pi / ↑n))).Gal =
     Nat.totient (2 * n) / 2 :=


### PR DESCRIPTION
## Summary

Comment-only STATE-SYNC. The child file `AngleTrisectionCos20GalOQ01OQ02OQ02` proves the general formula `|Gal(minpoly ℚ (cos(π/n)))| = φ(2n)/2` for **all n ≥ 3, fully sorry-free** — `cos_pi_splitting_finrank` formalizes the `conjSubgroup` normality + `IsGalois` steps in its proof body and closes with `omega` (gallery entry `angle-trisection-cos-20-gal-oq-01-oq-02-oq-02` is `verified`, 0 sorries, 0 axioms on main).

Several docstrings/section comments were **stale**, still describing a sorry that no longer exists:
- `§ 4 ... (with sorry — normality step)` → now `SORRY-FREE`
- `**Remaining work**: Formalize that conjSubgroup(2n) is a normal subgroup ...` → now `**Status**: complete and sorry-free`
- `... reduces to the splitting field degree (one sorry)` → now references the sorry-free lemma
- `... the Galois order half has one documented sorry` → now `Both halves are fully proved`

The parent file (`AngleTrisectionCos20GalOQ01OQ02`) also had closing prose claiming the general formula needs `(sorry for full proof)`; corrected to point at the child's completed `gal_order_eq_totient_div2_general`.

## Why

False "sorry" claims in `verified` proof files are a gallery-integrity hazard (they read as incomplete to auditors/readers when the proof is in fact complete). No code changed — comments do not affect Lean compilation, so this is build-safe during the current Docker-verification outage.

## Test plan
- [x] No code lines changed (comment/docstring-only diff)
- [x] Confirmed all `sorry`/`admit` tokens in both files are inside comments; proof bodies are complete on `origin/main`
- [ ] Full `lake` build deferred (Docker verification infra down 2026-06-13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)