### PR TITLE
research(area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01): S2 flag BLOCKED

### DIFF
--- a/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
+++ b/research/problems/area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01/state.md
@@ -2,13 +2,17 @@
 
 ## Current State
 **Phase**: ORIENT
+**Status**: BLOCKED
 **Path**: full
 **Since**: 2026-06-13
 **Iteration**: 2
 
 ## Current Focus
 Feasibility of discharging the `exists_nice_reparam` axiom via the inverse function theorem.
-ORIENT survey complete — see knowledge.md (session 2026-06-13 s01).
+ORIENT survey complete — see knowledge.md (session 2026-06-13 s01). Flagged BLOCKED: the
+only remaining route is a ~400-800 line build-gated construction that also requires amending
+the parent proof's `SmoothClosedCurve` definition first (see Blockers). Not actionable during
+the current verification blackout (Docker down + Aristotle 404). Do not re-survey.
 
 ## Active Approach
 None viable as-stated. The IFT route is blocked by two specification gaps in the parent
@@ -29,5 +33,9 @@ proof (`proofs/Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean`):
   ~400-800 line arc-length construction is unverifiable this session.
 
 ## Next Action
-Propose the two parent-proof amendments (regularity field + reparametrization restatement),
-then attempt the IFT-based arc-length construction once the build harness returns.
+BLOCKED — revisit only once the verification harness (Docker / Aristotle) returns. When it
+does: (1) propose the two parent-proof amendments (regularity field + reparametrization
+restatement), then (2) attempt the IFT-based arc-length construction (~400-800 lines).
+Note: the parent proof is already honestly classified `axiomatized` (axiomCount=5, matching
+source), so Gap 2's circularity is disclosed via the axiom badge — no meta-integrity fix is
+needed, only the eventual axiom discharge.


### PR DESCRIPTION
## Summary
- Flags the OQ slug `area-of-circle-oq-01-oq-02-oq-02-oq-01-oq-01` as **BLOCKED** in `state.md`.
- The s01 ORIENT survey (2026-06-13) already established that discharging the parent's `exists_nice_reparam` axiom "from the inverse function theorem" is **not** the low-effort wiring task the pool metadata (tractability 8/10) suggested.

## Why blocked
1. **Build-gated.** The viable route is a ~400–800 line arc-length construction (define rescaled arc-length map, prove it is a C¹ diffeomorphism via Mathlib IFT, prove reparametrization-invariance of arc length and signed area). Unverifiable during the current Docker-down + Aristotle-404 blackout.
2. **Requires parent amendment first.** `SmoothClosedCurve` has no regularity field (`|γ'(t)|>0`), which the IFT requires; and `exists_nice_reparam` does not tie `γ'` to `γ`, so as stated it is logically at least as strong as the isoperimetric inequality it is used to prove (circularity). Both must be fixed in the parent before the IFT route is sound.

## Not a meta-integrity bug
Confirmed the parent proof `area-of-circle-oq-01-oq-02-oq-02-oq-01` is already honestly classified `axiomatized` / badge `axiom` with `axiomCount=5`, matching the 5 axioms in `Proofs/AreaOfCircleOQ01OQ02OQ02OQ01.lean`. Gap 2's circularity is therefore disclosed via the axiom badge — no overclaim to fix, only the eventual axiom discharge (deferred until the harness returns).

## Test plan
- [x] Doc-only change to `state.md`; no Lean source touched, no build required.
- [x] Verified parent meta `.meta.axiomCount` (5) == source `^axiom ` count (5).