### PR TITLE
research(leanFiles): backfill metric fields on metric-less entries (desargues, divisibility-by-three)

### DIFF
--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -88,6 +88,11 @@
     {
       "path": "Proofs/DesarguesTheoremOQ02.lean",
       "filename": "DesarguesTheoremOQ02.lean",
+      "lineCount": 333,
+      "theoremCount": 35,
+      "axiomCount": 0,
+      "defCount": 21,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DesarguesTheoremOQ02.lean"
     }

--- a/src/data/research/problems/divisibility-by-three-oq-01-oq-01.json
+++ b/src/data/research/problems/divisibility-by-three-oq-01-oq-01.json
@@ -92,18 +92,33 @@
     {
       "path": "Proofs/DivisibilityTruncationGeneralOQ01.lean",
       "filename": "DivisibilityTruncationGeneralOQ01.lean",
+      "lineCount": 160,
+      "theoremCount": 8,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityTruncationGeneralOQ01.lean"
     },
     {
       "path": "Proofs/DivisibilityRulesOQ01OQ01OQ01.lean",
       "filename": "DivisibilityRulesOQ01OQ01OQ01.lean",
+      "lineCount": 168,
+      "theoremCount": 9,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityRulesOQ01OQ01OQ01.lean"
     },
     {
       "path": "Proofs/DivisibilityByThreeOQ01.lean",
       "filename": "DivisibilityByThreeOQ01.lean",
+      "lineCount": 551,
+      "theoremCount": 56,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DivisibilityByThreeOQ01.lean"
     }


### PR DESCRIPTION
## Summary

Build-free STATE-SYNC during the verification blackout (Docker down, Aristotle 404). Two research-pool JSONs had `leanFiles` entries missing the 5 metric fields the canonical `enrich-research.ts` format requires. Of 17,120 `leanFiles` entries across the pool, only 5 lacked metrics — this fixes 4 of them (the 5th, `cevas-…`, is excluded because open draft #23172 is actively editing its JSON + source).

## Changes (purely additive, +20/-0)

Metrics computed from `origin/main` source via the exact `enrich-research.ts` regexes (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all, `lineCount = split('\n').length`):

| slug | file | L / T / A / D / S |
|------|------|-------------------|
| desargues-theorem-oq-02-oq-02 | DesarguesTheoremOQ02.lean | 333 / 35 / 0 / 21 / 0 |
| divisibility-by-three-oq-01-oq-01 | DivisibilityTruncationGeneralOQ01.lean | 160 / 8 / 0 / 0 / 0 |
| divisibility-by-three-oq-01-oq-01 | DivisibilityRulesOQ01OQ01OQ01.lean | 168 / 9 / 0 / 0 / 0 |
| divisibility-by-three-oq-01-oq-01 | DivisibilityByThreeOQ01.lean | 551 / 56 / 0 / 1 / 0 |

All five files are 0-sorry / 0-axiom (comment-stripped verified — no docstring false positives). No source, status, or narrative changes; field ordering matches the canonical entry shape.

## Test plan
- [x] Round-trip JSON preserves all other fields (diff is +20/-0)
- [x] Metric values verified against `origin/main` source through the canonical regexes
- [x] No conflicting open PR touches these two JSONs (cevas excluded for that reason)