### PR TITLE
research(lhopital-oq-02-wip-01): completion-sync — 3 target sorries already proven on main

### DIFF
--- a/research/problems/lhopital-oq-02-wip-01/knowledge.md
+++ b/research/problems/lhopital-oq-02-wip-01/knowledge.md
@@ -2,7 +2,37 @@
 
 ## Summary
 
-No research sessions yet. Problem initialized by Seeker on 2026-04-05.
+**COMPLETE** — all three target ∞/∞ L'Hôpital variants are fully proven in
+`proofs/Proofs/LHopitalOQ02.lean` (0 sorries, 0 axioms). This WIP task was
+resolved before it was created: PR #10140 ("prove all 4 ∞/∞ L'Hôpital variants,
+0 sorries") landed the complete file, and the Seeker subsequently generated this
+redundant completion task on 2026-04-05. Status synced to `completed` on
+2026-06-13.
+
+## Session 2026-06-13 (Session 1) — Completion sync
+
+**Mode**: REVISIT
+**Outcome**: completed (tracker sync, no new Lean)
+
+### What I Did
+- Verified on `origin/main` that `LHopitalOQ02.lean` contains all three target
+  theorems fully proven with no `sorry`, `admit`, or `axiom`:
+  - `lhopital_infty_left` (line 290) — reduces to `lhopital_infty_right` via the
+    negation substitution `u = -x`.
+  - `lhopital_infty_atTop` (line 318) — reduces to `lhopital_infty_right` via the
+    inversion substitution `u = 1/x`.
+  - `lhopital_infty_atBot` (line 353) — reduces to `lhopital_infty_atTop` via the
+    negation substitution `u = -x`.
+- Traced history: the proofs landed in PR #10140, predating this task. The
+  knowledge note's "3 sorries at lines 291, 302, 313" was a planning snapshot
+  that never matched the merged file.
+- Flipped research JSON `OBSERVE/active` → `COMPLETED/completed` and updated
+  `problem.md` status.
+
+### Note
+File is not Docker-rebuilt this session (verification blackout). The proofs have
+been on `main` since #10140; standard post-blackout re-verification still applies
+to the whole gallery.
 
 ## Key Facts
 

--- a/research/problems/lhopital-oq-02-wip-01/problem.md
+++ b/research/problems/lhopital-oq-02-wip-01/problem.md
@@ -2,7 +2,7 @@
 
 **Slug**: lhopital-oq-02-wip-01
 **Created**: 2026-04-05
-**Status**: Active
+**Status**: Completed (already resolved by PR #10140)
 **Source**: gallery-gap
 
 ## Problem Statement

--- a/src/data/research/problems/lhopital-oq-02-wip-01.json
+++ b/src/data/research/problems/lhopital-oq-02-wip-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "lhopital-oq-02-wip-01",
   "title": "L'Hôpital's Rule: ∞/∞ Form (WIP Completion)",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -16,10 +16,10 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-05T08:58:44.240Z",
-    "iteration": 1,
-    "focus": "",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "All 3 target sorry-reductions already proven on main (PR #10140)",
     "blockers": [],
     "nextAction": "",
     "attemptCounts": {
@@ -29,9 +29,16 @@
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
+    "progressSummary": "COMPLETE: all three ∞/∞ L'Hôpital variants (left, atTop, atBot) are fully proven in proofs/Proofs/LHopitalOQ02.lean — 0 sorries, 0 axioms. Resolved by PR #10140 prior to this WIP task's creation; tracker was stale.",
+    "builtItems": [
+      "lhopital_infty_left in proofs/Proofs/LHopitalOQ02.lean:290 (reduce to right via u = -x negation)",
+      "lhopital_infty_atTop in proofs/Proofs/LHopitalOQ02.lean:318 (reduce to right via u = 1/x inversion)",
+      "lhopital_infty_atBot in proofs/Proofs/LHopitalOQ02.lean:353 (reduce to atTop via u = -x negation)"
+    ],
+    "insights": [
+      "The 3 sorry-reductions targeted by this WIP task were already discharged in PR #10140 (\"prove all 4 ∞/∞ L'Hôpital variants, 0 sorries\"), which predates the 2026-04-05 task creation. The WIP slug was redundant from the start.",
+      "All three variants reduce to lhopital_infty_right via HasDerivAt.comp with the substitution map plus standard Mathlib filter-pushforward lemmas (tendsto_neg_nhdsGT_neg, tendsto_inv_nhdsGT_zero, tendsto_neg_atTop_atBot)."
+    ],
     "mathlibGaps": [],
     "nextSteps": [],
     "markdown": "# Knowledge: lhopital-oq-02-wip-01\n\n## Summary\n\nNo research sessions yet. Problem initialized by Seeker on 2026-04-05.\n\n## Key Facts\n\n- Source file: `proofs/Proofs/LHopitalOQ02.lean` (note: capital H in filename)\n- 3 sorries at lines 291, 302, 313: `lhopital_infty_left`, `lhopital_infty_atTop`, `lhopital_infty_atBot`\n- All three reduce to the proved `lhopital_infty_right` via variable substitution\n- Each substitution: u = a+b-x (reflection), u = 1/x (inversion), u = -x (negation)\n- `lhopital_infty_right` is fully proved via `lhopital_infty_right_zero` helper (c=0 case)\n- Companion file `LHopitalOQ02Aristotle.lean` already exists — may have supporting lemmas\n- Key Mathlib tools: `HasDerivAt.comp`, `HasDerivAt.neg`, filter transformation lemmas\n\n## Open Questions\n\n1. Which exact Mathlib lemmas handle `nhdsWithin` under affine/invertible maps?\n2. Does `Mathlib.Analysis.Calculus.LHopital` provide shortcuts we can invoke?\n3. For `atTop → right`: does Mathlib have `Filter.tendsto_inv_atTop_nhds_nhdsWithin_zero`?\n4. For `atBot → atTop`: `Filter.tendsto_neg_atTop_atBot` (or `atBot_neg`) should handle the filter push.\n"
@@ -52,7 +59,7 @@
     "mathlib": []
   },
   "started": "2026-04-05T08:58:44.240Z",
-  "lastUpdate": "2026-04-05T17:20:37.383Z",
+  "lastUpdate": "2026-06-13T00:00:00.000Z",
   "significance": 7,
   "tractability": 7
 }


### PR DESCRIPTION
## Summary

Status-sync for the `lhopital-oq-02-wip-01` research task. The WIP task asked to
complete 3 sorry-reductions (the left-approach, atTop, and atBot variants of
L'Hôpital's ∞/∞ rule). All three are **already fully proven** on `main` in
`proofs/Proofs/LHopitalOQ02.lean`:

- `lhopital_infty_left` (L290) — reduce to right via `u = -x`
- `lhopital_infty_atTop` (L318) — reduce to right via `u = 1/x`
- `lhopital_infty_atBot` (L353) — reduce to atTop via `u = -x`

0 sorries, 0 axioms, 0 admit. These landed in **PR #10140** ("prove all 4 ∞/∞
L'Hôpital variants, 0 sorries"), which predates this task's 2026-04-05 creation —
the WIP slug was redundant from the start and the tracker was never updated.

## Changes (doc-only, no Lean touched)

- `src/data/research/problems/lhopital-oq-02-wip-01.json`: `OBSERVE/active` → `COMPLETED/completed`; recorded the proven items and resolution provenance.
- `research/problems/lhopital-oq-02-wip-01/problem.md`: status → Completed.
- `research/problems/lhopital-oq-02-wip-01/knowledge.md`: added completion summary + session entry.

## Verification

File is not Docker-rebuilt this session (verification blackout). The proofs have
been on `main` since #10140; standard post-blackout gallery re-verification still
applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)