### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): S14a.2 STATE-SYNC — record leftLim lemma in knowledge.md

### DIFF
--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/knowledge.md
@@ -5,7 +5,63 @@ formalization (LawsOfLargeNumbersOQ04.lean):
   1. `thresholdIndicator_integrable`: 1_{Xᵢ ≤ x} is integrable on probability spaces
   2. `integral_thresholdIndicator_eq_cdf`: E[1_{X₀ ≤ x}] = F(x)
 
-**Status**: REDESIGN-IN-PROGRESS (S14a ACT, 2026-06-09) — main file 0 sorries / 0 axioms; refuted axiom `bracketingGrid_exists` retained in original bracketing companion pending S17 retirement; quantile-bracketing redesign substrate in place with S14a boundary helpers landed.
+**Status**: REDESIGN-IN-PROGRESS (S14a.2 ACT, 2026-06-12, PR #22958) — main file 0 sorries / 0 axioms; refuted axiom `bracketingGrid_exists` retained in original bracketing companion pending S17 retirement; quantile-bracketing redesign substrate in place with S14a boundary helpers + S14a.2 `leftLim` upper-bracket lemma landed. S14b (right-continuous half + interior existence) remains.
+
+---
+
+## Session 2026-06-12 (Session 14a.2) — `leftLim` upper-bracket lemma
+
+**Mode**: ACT
+**Outcome**: progress (+1 public monotone-`leftLim` lemma)
+**Researcher**: researcher-2
+
+### What I Did
+
+Shipped the generic monotone upper-bracket lemma `leftLim_le_of_forall_lt`
+in `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean` (216 → 239 lines,
++1 public lemma, 0 axioms, 0 sorries; Docker 3113 jobs clean at ship
+time, PR #22958).
+
+Statement: for `Monotone F : ℝ → ℝ`,
+`(∀ x < q, F x ≤ p) → Function.leftLim F q ≤ p`, proved via
+`le_of_tendsto (hF.tendsto_leftLim q)` on the left-neighbourhood filter.
+
+### Key Findings
+
+- This supplies the `leftLim F qⱼ₊₁ ≤ (j+1)ε` half of the S14 `step_le`
+  bound with **no continuity hypothesis** on `F` — exactly the piece the
+  quantile redesign needs at grid nodes where `F` may jump.
+- `Monotone.tendsto_leftLim` gives the left-limit convergence; the bound
+  passes through `le_of_tendsto` because the hypothesis `∀ x < q, F x ≤ p`
+  holds eventually on the `𝓝[<] q` filter.
+
+### Files Modified
+
+- `proofs/Proofs/LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`:
+  216 → 239 lines, +1 public lemma `leftLim_le_of_forall_lt`.
+
+### Counts Delta
+
+- `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean`: lineCount 216 →
+  239; theoremCount 3 → 4 (1 private); axioms unchanged at 0; sorries
+  unchanged at 0.
+- Chain-level axiom count: unchanged at 1 (refuted `bracketingGrid_exists`).
+- Chain-level sorry count: unchanged at 0.
+
+### Next Steps
+
+- S14b ACT (Docker-gated): prove the right-continuous half `jε ≤ F qⱼ`
+  at the quantile node `qⱼ = sInf {x | jε ≤ F x}`, combine with
+  `leftLim_le_of_forall_lt` to get the per-pair `step_le` bound, then
+  assemble `quantileBracketingGrid_exists`.
+- S15–S17 unchanged (see S14a block below).
+
+### Honesty
+
+Infrastructure-only session. No axioms eliminated, no main-theorem
+sorries closed. The lemma is a continuity-free upper bracket pre-staged
+for S14b's `step_le` assembly. Per the gallery rubric this is category 5
+("real progress; not axiom elimination or sorry reduction").
 
 ---
 


### PR DESCRIPTION
## Summary
- `knowledge.md` for `laws-of-large-numbers-oq-04-oq-03` was frozen at session **S14a** (2026-06-09), but the **S14a.2** ACT (`leftLim_le_of_forall_lt`, PR #22958, 2026-06-12) had already landed in `LawsOfLargeNumbersOQ04OQ03QuantileBracketing.lean` (216→239 lines) and was recorded in `state.md`.
- This PR appends the missing S14a.2 session block to `knowledge.md` and refreshes the Status line so the knowledge tracker matches `state.md` and the Lean source.

## Scope
- **Doc-only / comment-only.** No Lean files touched; no build required.
- Verified against `origin/main`: source has `leftLim_le_of_forall_lt` at line 233 of the QuantileBracketing companion (0 axioms, 0 sorries); `state.md` header is at S14a.2; `knowledge.md` lacked any S14a.2 entry.

## Test plan
- [x] `knowledge.md` Status line and top session block now reflect S14a.2 (PR #22958)
- [x] No `.lean` / `meta.json` changes — gallery meta already internally consistent (axiomatized/axiom, axiomCount=1 refuted `bracketingGrid_exists`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)