### PR TITLE
research(erdos-153): sync stale leanFiles metrics to merged source

### DIFF
--- a/src/data/research/problems/erdos-153.json
+++ b/src/data/research/problems/erdos-153.json
@@ -78,15 +78,15 @@
     "mathlib": []
   },
   "started": "2026-01-12T09:56:05.235Z",
-  "lastUpdate": "2026-03-28T01:23:59.133245Z",
+  "lastUpdate": "2026-06-10T02:47:38.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos153Problem.lean",
       "filename": "Erdos153Problem.lean",
-      "lineCount": 495,
-      "theoremCount": 10,
+      "lineCount": 543,
+      "theoremCount": 14,
       "axiomCount": 1,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary

Build-free STATE-SYNC during the verification blackout (Docker down, Aristotle 404). The research-pool JSON `leanFiles` for `erdos-153` was frozen at iter-1 metrics while the merged `origin/main` source advanced.

| field | JSON (was) | source (now) |
|-------|-----------|--------------|
| lineCount | 495 | 543 |
| theoremCount | 10 | 14 |
| axiomCount | 1 | 1 |
| defCount | 8 | 8 |
| sorryCount | 0 | 0 |

`+48` lines, `+4` public theorems. Metrics computed from `origin/main:proofs/Proofs/Erdos153Problem.lean` via the canonical `enrich-research.ts` regexes (`^(theorem|lemma) `, `^axiom `, `^(def|noncomputable def|opaque def) `, `\bsorry\b`-all, `lineCount = split('\n').length`).

**Cleanliness checks:**
- Comment-stripped recount: real sorry = 0, real axiom = 1 (no docstring false positives).
- The `+4` theoremCount is genuine **public** growth — theorem GROWTH at `+48` lines, not the strict-`^(theorem|lemma) `-vs-`private` convention artifact (which manifests as a theorem DROP at flat lineCount). The file has 8 private decls, excluded consistently from both old and new values.
- Gallery `meta.json` `leanFile` is the independent artifact (already at 542/22 under the include-private convention) — only the research-pool JSON lagged.

`lastUpdate` bumped 2026-03-28 → 2026-06-10 (source's last-touched commit `d8284214` on main). Narrative/status untouched.

**Stand-down gates (per #23240 close):** both have flipped since that churn close — origin/main HEAD has moved (`6e1185d`→`6db2177`) and the deployer is draining this class (my prior single-file syncs #23069/#23074/#23078/#23081/#23083 plus #23218/#23220/#23222 all merged; only ~3 sync PRs remain open). Avoided desargues (named in #23240), cevas (open draft #23172), and erdos-761 (open #23216).

## Test plan
- [x] JSON round-trips (`json.load`), diff is +3/-3
- [x] Metric values verified against `origin/main` source through canonical regexes
- [x] No conflicting open/closed PR touches this slug's JSON