### PR TITLE
research(shapley-folkman-oq-01): sync stale header docstring to S20 source state

### DIFF
--- a/proofs/Proofs/ShapleyFolkmanOQ01.lean
+++ b/proofs/Proofs/ShapleyFolkmanOQ01.lean
@@ -22,9 +22,13 @@
   particular no infinite-dim extension that bounds the excess count by a fixed
   finite number — can hold.
 
-  Status: S2-A ACT-1 scaffold. Three named results, all proofs `sorry`-stubbed,
-  pending Lake build verification. See README in `research/problems/...` for the
-  proof skeleton (S3 PREP §3.1 helper, S3 PREP §4 coordinate-eval route).
+  Status: built out across S2–S20. The Approach-C result is fully assembled —
+  `no_universal_shapley_folkman_bound` (capstone), `exists_tight_decomposition`,
+  `tight_excess_count`/`tight_excess_eq_finrank`, plus the `Decomposition.map`
+  transport core — with **no `sorry`** remaining in any proof body. Build
+  verification is pending a Docker `lake` build (Docker daemon down per the
+  2026-06-13 blackout); see `research/problems/...` state.md for the per-session
+  bearer-pinning and fallback registers.
 -/
 
 import Mathlib.Analysis.Normed.Module.Convex


### PR DESCRIPTION
## Summary
- The `ShapleyFolkmanOQ01.lean` file-header `Status:` line still described the original **S2-A scaffold** ("Three named results, all proofs `sorry`-stubbed"), which has been false for many sessions.
- The file is now **395 LOC with 12 proved declarations** (capstone `no_universal_shapley_folkman_bound`, `exists_tight_decomposition`, `tight_excess_count`/`tight_excess_eq_finrank`, and the `Decomposition.map` transport core) and **zero proof-body `sorry`** (the only `sorry` token in the file was inside that stale docstring).
- This PR updates the docstring to reflect the current state. **Comment-only — no proof body changes.**
- Build verification remains Docker-gated per the 2026-06-13 verification blackout; the docstring does not claim verified status, matching the honest "build UNVERIFIED locally" framing in the slug's state.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)