### PR TITLE
research(arithmetic-series-oq-02-oq-04-oq-01-oq-01): STATE-SYNC state.md to committed draft .lean

### DIFF
--- a/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/state.md
+++ b/research/problems/arithmetic-series-oq-02-oq-04-oq-01-oq-01/state.md
@@ -1,19 +1,22 @@
 # Research State: arithmetic-series-oq-02-oq-04-oq-01-oq-01
 
 ## Current State
-**Phase**: ORIENT
+**Phase**: ACT
 **Path**: full
 **Since**: 2026-06-13
 **Iteration**: 2
 
 ## Current Focus
-Statement fixed and a complete proof path identified (see knowledge.md). Awaiting a
-build route to execute the ACT step.
+Statement fixed and a complete proof path identified (see knowledge.md). The draft
+Lean proof has already been written to `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean`
+(PR #23066). It remains build-unverified pending the 2026-06-13 Docker/Aristotle outage.
 
 ## Active Approach
 Reduce `multichoose n k * k!` to the parent identity `choose_descFactorial` at
 `m = n+k-1`, then reindex the descending-factorial product via `Finset.prod_range_reflect`
-to obtain `∏ i ∈ range k, (n+i)`. Draft proof written in knowledge.md.
+to obtain `∏ i ∈ range k, (n+i)`. Draft proof written in knowledge.md and committed to
+the Lean file as `multichoose_factorial` (plus `_one/_two/_three` specializations and
+`native_decide` sanity checks). 0 sorries.
 
 ## Attempt Count
 - Total attempts: 1 (survey/draft, unbuilt)
@@ -22,11 +25,12 @@ to obtain `∏ i ∈ range k, (n+i)`. Draft proof written in knowledge.md.
 
 ## Blockers
 - **Verification infra down (2026-06-13):** Docker daemon down; Aristotle backend returns
-  404. Draft proof cannot be compiled, so it is intentionally not yet added to
-  `proofs/Proofs/`. This is an external/transient blocker, not a mathematical one.
+  404. The committed draft proof cannot be compiled, so the file is intentionally NOT yet
+  registered in `proofs/Proofs.lean` (so it cannot break the build). This is an
+  external/transient blocker, not a mathematical one.
 
 ## Next Action
-When Docker is back: create `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` from the
-draft, build with `./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01`,
-reconcile any Mathlib lemma-name drift, then add the gallery `meta.json` entry and advance
-to ACT/COMPLETED.
+When Docker is back: build the existing draft with
+`./proofs/scripts/docker-build.sh Proofs.ArithmeticSeriesOQ02OQ04OQ01OQ01`,
+reconcile any Mathlib lemma-name drift, register it in `proofs/Proofs.lean`, then add the
+gallery `meta.json` entry and advance to COMPLETED.


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC. `state.md` was the lone stale tracker for this slug.

- `state.md` still told a future session to **create** `proofs/Proofs/ArithmeticSeriesOQ02OQ04OQ01OQ01.lean` and stated the draft was "not yet added to proofs/Proofs/".
- In fact PR #23066 already wrote that file (`multichoose_factorial` + `_one/_two/_three` + `native_decide` checks, **0 sorries**). `knowledge.md` was already updated to reflect this in #23089; only `state.md` lagged.

## Changes
- Phase `ORIENT → ACT` (Lean draft is written).
- Current Focus / Active Approach / Blockers now describe the committed-but-unverified draft.
- Next Action: **build-verify + register** the existing file (not re-create it) once Docker is back.

No source/proof change; the `.lean` remains correctly unregistered in `proofs/Proofs.lean` during the 2026-06-13 Docker/Aristotle blackout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)