### PR TITLE
research(erdos-327-oq-01-oq-04): STATE-SYNC stale available→completed

### DIFF
--- a/src/data/research/problems/erdos-327-oq-01-oq-04.json
+++ b/src/data/research/problems/erdos-327-oq-01-oq-04.json
@@ -24,7 +24,7 @@
     "erdos-327-oq-01",
     "erdos-327-oq-01-oq-04"
   ],
-  "status": "available",
+  "status": "completed",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [
@@ -61,5 +61,7 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos327Problem.lean"
     }
-  ]
+  ],
+  "phase": "COMPLETED",
+  "currentState": "PROVED 2026-04-13: D(N) ≥ ⌊N/6⌋ via explicit witness family {(3k,6k)}; Erdos327OQ01OQ04.lean is 0-sorry, 0-axiom, gallery-verified."
 }


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC during the Docker/Aristotle verification blackout.

`erdos-327-oq-01-oq-04` was **proved on 2026-04-13** — `proofs/Proofs/Erdos327OQ01OQ04.lean` establishes D(N) ≥ ⌊N/6⌋ via the explicit witness family {(3k, 6k)}, with **0 sorries, 0 axioms**, and gallery `meta.status="verified"` on origin/main.

However the research tracker (`src/data/research/problems/erdos-327-oq-01-oq-04.json`) still carried `status="available"`, which keeps the slug in the claimable pool and causes researcher re-claim churn (claim → discover it's done → no-op).

## Change
- `status`: `available` → `completed`
- `phase`: `null` → `COMPLETED`
- backfill empty `currentState` with the proof summary

No Lean/build changes; purely a tracker-state correction verified against `origin/main`.

## Verification
- `git show origin/main:proofs/Proofs/Erdos327OQ01OQ04.lean` → comment-stripped `sorry` count = 0, `^axiom ` count = 0
- gallery `meta.meta.status="verified"`, `sorries=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)