### PR TITLE
research(feuerbachs-theorem-oq-01-oq-03): S1 ORIENT — survey existing proof, flag integration gap

### DIFF
--- a/research/problems/feuerbachs-theorem-oq-01-oq-03/knowledge.md
+++ b/research/problems/feuerbachs-theorem-oq-01-oq-03/knowledge.md
@@ -1,0 +1,60 @@
+# Feuerbach via Inversive Geometry (feuerbachs-theorem-oq-01-oq-03)
+
+**Open question**: Can Feuerbach's tangency configuration be understood via
+inversive geometry centered at the Feuerbach point?
+
+## Summary
+
+The Lean proof source already exists and is complete: `proofs/Proofs/FeuerbachsTheoremOQ01OQ03.lean`
+(287 lines, **0 sorries, 0 axioms** in source) builds an inversive-geometry
+framework and answers the OQ affirmatively. However, the slug had no research
+bookkeeping and no gallery `meta.json`, and the research tracker still listed it
+as `available`. This session is an ORIENT survey reconciling that state.
+
+## What the existing proof establishes
+
+Working in `Point := ℝ × ℝ` with `dot`/`normSq` and an inversion map
+`invert r P = (r²/normSq P) • P`:
+
+1. **Inversion basics** — `invert_normSq`, `invert_involution` (φ_r is an
+   involution off the origin), `dot_invert_self`.
+2. **Circle-to-line** (`invert_circle_to_line`): a circle through the origin
+   O, i.e. `|P|² = 2(P·C)`, maps under φ_r to the line `φ_r(P)·C = r²/2`;
+   converse `line_to_circle`.
+3. **Parallel lines** (`invert_parallel_lines`): two origin-circles with
+   collinear centers C₁=λ₁e, C₂=λ₂e map to the parallel lines
+   `Q·e = r²/(2λ₁)` and `Q·e = r²/(2λ₂)`.
+4. **Feuerbach collinearity** (`feuerbach_centers_collinear`): the Feuerbach
+   point F, incenter I, and nine-point center N are collinear
+   (`incenter_feuerbach_dir`, `ninepoint_feuerbach_dir`,
+   `feuerbachPoint_coords`).
+5. **Framework assembly** (`feuerbach_inversive_framework`).
+
+This is the inversive-geometry reading the OQ asks for: tangency of the incircle
+and nine-point circle becomes "two circles through O map to parallel lines"
+under inversion centered at the tangency (Feuerbach) point.
+
+## Status assessment (2026-06-13)
+
+| Aspect | State |
+|--------|-------|
+| Lean source | Complete on origin/main: 0 sorries, 0 axioms |
+| Docker build verification | **UNCONFIRMED** — no gallery `meta.json` records a `verified` status, and the file's last commit is an unrelated audit batch (#22746), not a build. Docker is down (verification blackout), so cannot confirm now. |
+| Gallery integration | **MISSING** — no `src/data/proofs/feuerbachs-theorem-oq-01-oq-03/` directory. |
+| Research tracker | Was `available` (stale) — corrected to `in-progress` to reflect that source exists but integration/verification is pending. |
+
+## Next steps (post-Docker)
+
+1. `./proofs/scripts/docker-build.sh Proofs.FeuerbachsTheoremOQ01OQ03` to confirm
+   the source compiles against current Mathlib.
+2. If it builds clean: create `src/data/proofs/feuerbachs-theorem-oq-01-oq-03/meta.json`
+   (status `verified`, badge `original`, 0 sorries, 0 axioms) so the proof
+   surfaces in the gallery; then flip tracker status to `completed`.
+3. If it fails on Mathlib drift: repair, otherwise the inversive framework is
+   mathematically complete and the fix should be mechanical.
+
+## References
+
+- Lean: `proofs/Proofs/FeuerbachsTheoremOQ01OQ03.lean`, depends on `Proofs.FeuerbachsTheoremDefs`
+- Parent: `src/data/proofs/feuerbachs-theorem-oq-01/`
+- Gallery: Feuerbach's theorem family (`feuerbachs-theorem`, `-oq-01`, `-oq-02`, `-oq-05`)

--- a/src/data/research/problems/feuerbachs-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/feuerbachs-theorem-oq-01-oq-03.json
@@ -24,7 +24,7 @@
     "feuerbachs-theorem-oq-02",
     "feuerbachs-theorem-oq-05"
   ],
-  "status": "available",
+  "status": "in-progress",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [
@@ -138,5 +138,7 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/FeuerbachsTheoremOQ05.lean"
     }
-  ]
+  ],
+  "phase": "ORIENT",
+  "currentState": "Lean source complete (FeuerbachsTheoremOQ01OQ03.lean, 287 lines, 0 sorries/0 axioms) but build-unverified (no gallery meta, Docker down) and not gallery-integrated. ORIENT survey 2026-06-13; next: Docker build + create meta.json post-blackout."
 }


### PR DESCRIPTION
## Summary
Build-free ORIENT survey during the Docker/Aristotle verification blackout.

The Lean source for this open question **already exists complete** on origin/main — `proofs/Proofs/FeuerbachsTheoremOQ01OQ03.lean` (287 lines, **0 sorries, 0 axioms**) builds the inversive-geometry framework: inversion basics, circle↔line under inversion, parallel-lines image of collinear-center origin-circles, and Feuerbach-point/incenter/nine-point-center collinearity — answering the OQ affirmatively.

However the slug had **no research bookkeeping, no gallery `meta.json`, and a stale tracker status `available`**, so it would keep being re-claimed as a fresh problem.

## Change
- Add `research/problems/feuerbachs-theorem-oq-01-oq-03/knowledge.md` documenting what the proof establishes and the two remaining gaps.
- Correct tracker: `status` `available` → `in-progress`, `phase` → `ORIENT`, backfill `currentState`.

## Honesty note
Deliberately **not** marked `completed`/`verified`: the source is 0-sorry/0-axiom, but its build is **unconfirmed** (no gallery meta records a `verified` status; last touch is an unrelated audit commit; Docker is down). Two post-blackout steps remain:
1. `docker-build.sh Proofs.FeuerbachsTheoremOQ01OQ03` to confirm it compiles.
2. Create `src/data/proofs/feuerbachs-theorem-oq-01-oq-03/meta.json` for gallery integration, then flip to `completed`.

No Lean/build changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)