### PR TITLE
research(sperner-simplicial-bridge-oq-01): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-bridge-oq-01.json
@@ -115,14 +115,14 @@
         ]
     },
     "started": "2026-05-12T17:55:00.000Z",
-    "lastUpdate": "2026-05-16T19:08:00.000Z",
+    "lastUpdate": "2026-06-10T09:47:38.000Z",
     "significance": 6,
     "tractability": 5,
     "leanFiles": [
         {
             "path": "proofs/Proofs/SpernerSimplicialBridgeOQ01.lean",
-            "lineCount": 216,
-            "theoremCount": 8,
+            "lineCount": 271,
+            "theoremCount": 14,
             "definitionCount": 3,
             "sorryCount": 0,
             "axiomCount": 0


### PR DESCRIPTION
## Summary
The research-pool `leanFiles` block for `sperner-simplicial-bridge-oq-01` lagged the merged source. Synced the two stale mechanical metrics to current `origin/main` source state.

| metric | stale | source |
|--------|------:|------:|
| lineCount | 216 | 271 |
| theoremCount | 8 | 14 |
| definitionCount | 3 | 3 (unchanged) |
| axiomCount | 0 | 0 (unchanged) |
| sorryCount | 0 | 0 (unchanged) |

- `+55` lines, `+6` public theorems from merged source growth (`d8284214`, 2026-06-10).
- `grep -cE '^private (theorem|lemma) '` = 0 → the theorem growth is genuine public declarations, not the strict-vs-private counting artifact.
- Counts recomputed per `enrich-research.ts` conventions (`lineCount = content.split('\n').length`, `theoremCount = /^(theorem|lemma) /`). Note: theoremCount 14 faithfully includes one module-docstring line beginning "lemma " — matching the canonical regeneration script, which does not strip comments.
- Comment-stripped recount confirms real sorry=0 / axiom=0 (zero docstring false-positives).
- Gallery `meta.json` `leanFile` is an independent artifact and is already current.
- Scoped strictly to `leanFiles` + `lastUpdate`; narrative untouched.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — JSON valid
- [x] Counts verified against `git show origin/main:proofs/Proofs/SpernerSimplicialBridgeOQ01.lean`
- [ ] Build-free data sync; no Lean rebuild required

🤖 Generated with [Claude Code](https://claude.com/claude-code)