### PR TITLE
research: STATE-SYNC 9 gallery-verified completions → status=completed

### DIFF
--- a/src/data/research/problems/angle-trisection-oq-04-oq-04.json
+++ b/src/data/research/problems/angle-trisection-oq-04-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "angle-trisection-oq-04-oq-04",
   "title": "Regular polygons constructible with origami but not marked ruler",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-29T19:14:09.072Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/AngleTrisectionOQ04OQ04.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. 23-gon separating witness + exists_ngon_at_each_level.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -84,7 +84,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.072Z",
-  "lastUpdate": "2026-05-29T19:14:09.072Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/angle-trisection-oq-05-oq-03.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "angle-trisection-oq-05-oq-03",
   "title": "Minimum simultaneous folds to solve polynomial equation",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-29T19:14:09.072Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/AngleTrisectionOQ05OQ03.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. minFoldLevel computed for instances + minFoldLevel_unbounded.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -84,7 +84,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.072Z",
-  "lastUpdate": "2026-05-29T19:14:09.072Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [

--- a/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-02-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "cauchy-schwarz-oq-02-oq-02",
   "title": "Bessel Inequality in Infinite Dimensions",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-06T14:45:58.508Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/CauchySchwarzOQ02OQ02.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. bessel_inequality / bessel_general for infinite-dim orthonormal systems.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -87,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-05-06T14:45:58.508Z",
-  "lastUpdate": "2026-05-06T14:45:58.508Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/feuerbachs-theorem-defs-oq-04.json
+++ b/src/data/research/problems/feuerbachs-theorem-defs-oq-04.json
@@ -1,8 +1,8 @@
 {
   "slug": "feuerbachs-theorem-defs-oq-04",
   "title": "Feuerbach's Theorem: Connect to Mathlib Affine Geometry Framework",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T13:03:46.505Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/FeuerbachsTheoremDefsOQ04.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. ninePoints_all_on_sphere via Mathlib sphere formulation.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -53,7 +53,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.505Z",
-  "lastUpdate": "2026-04-22T13:03:46.505Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 7,
   "tractability": 7,
   "leanFiles": [

--- a/src/data/research/problems/infinitude-primes-4k3-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-4k3-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "infinitude-primes-4k3-oq-03",
   "title": "Infinitely Many Primes ≡ 1 (mod 4) — Elementary Proof",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "OBSERVE",
-    "since": "2026-04-21T21:39:52+02:00",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial problem understanding. Read problem.md and gather context.",
+    "focus": "STATE-SYNC: gallery proof Proofs/InfinitudePrimes4k3OQ03.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. infinitely_many_primes_1_mod_4 proves the harder ≡1 mod 4 direction.",
     "blockers": [],
-    "nextAction": "Read problem.md thoroughly and acquire full context.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -54,7 +54,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.188Z",
-  "lastUpdate": "2026-05-29T19:14:09.237Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "leanFiles": [
     {
       "path": "Proofs/InfinitudePrimes4k3.lean",

--- a/src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "law-of-cosines-oq-01-oq-01-oq-03",
   "title": "Polar triangle construction and dual spherical law of cosines",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -19,14 +19,14 @@
   },
   "currentState": {
     "phase": "COMPLETED",
-    "since": "2026-05-08T16:55:00Z",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 4,
-    "focus": "Final axiom `polar_angle_eq` eliminated in Session 4 (PR pending).",
+    "focus": "STATE-SYNC: gallery proof Proofs/LawOfCosinesOQ01OQ01OQ03.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. dual_spherical_law_of_cosines general theorem.",
     "activeApproach": "(N/A — research target completed.) Build verification pending.",
     "blockers": [
       "None mathematical. CI Docker build pending; if `proofs/.lake` cache is cold the"
     ],
-    "nextAction": "Wait for CI to confirm the build, then close this research thread.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 4,
       "currentApproach": 1,
@@ -66,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.190Z",
-  "lastUpdate": "2026-05-29T19:14:09.238Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/picks-theorem-oq-02.json
+++ b/src/data/research/problems/picks-theorem-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "picks-theorem-oq-02",
   "title": "Can the GCD boundary formula (lattice points on a segment = gcd(Δx, Δy) + 1) ...",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -18,12 +18,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-29T19:14:09.125Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/PicksTheoremOQ02.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. Main theorem card_segmentPoints: card(segmentPoints a b)=gcd(a,b)+1.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -59,7 +59,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.125Z",
-  "lastUpdate": "2026-05-29T19:14:09.125Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/solution-of-cubic-oq-05.json
+++ b/src/data/research/problems/solution-of-cubic-oq-05.json
@@ -1,8 +1,8 @@
 {
   "slug": "solution-of-cubic-oq-05",
   "title": "Solution of the Cubic: Connection to Quartic via Resolvent Cubic",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T13:03:46.506Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/SolutionOfCubicOQ05.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. Tschirnhaus reduction + Cardano-Ferrari resolvent connection fully formalized.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -57,7 +57,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.506Z",
-  "lastUpdate": "2026-04-22T13:03:46.506Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/sqrt2-minpoly-oq-02.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "sqrt2-minpoly-oq-02",
   "title": "Minimal Polynomial of k-th Roots: minpoly ℚ (n^(1/k)) = X^k - n via Eisenstein",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "A",
   "path": "fast",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-04-22T21:55:56.657Z",
+    "phase": "COMPLETED",
+    "since": "2026-06-13T00:00:00Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "STATE-SYNC: gallery proof Proofs/Sqrt2MinpolyOQ02.lean is verified (0 sorries, 0 axioms) and fully proves the stated question. Research tracker was stale; flipped active→completed to match published gallery verdict. minpoly_kthRoot_of_squarefree general k-th root via Eisenstein.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — completed and gallery-verified.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -54,7 +54,7 @@
     "mathlib": []
   },
   "started": "2026-04-25T12:53:24.124Z",
-  "lastUpdate": "2026-04-25T12:53:24.205Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 7,
   "tractability": 8,
   "leanFiles": [


### PR DESCRIPTION
## Summary

Nine research problems carry **verified gallery proofs** (0 sorries, 0 axioms) but their research tracker (`src/data/research/problems/<id>.json`) was still `active`/`NEW`. This PR flips them to `completed`/`COMPLETED` so the tracker matches the already-published gallery verdict.

**Build-free / no new verification claim** — Docker is down this session; these slugs were verified by prior successful builds (gallery `meta.status = verified`). This only syncs stale tracker state.

| slug | gallery main theorem |
|------|----------------------|
| picks-theorem-oq-02 | `card_segmentPoints`: card(segmentPoints a b) = gcd(a,b)+1 |
| solution-of-cubic-oq-05 | Tschirnhaus reduction + Cardano–Ferrari resolvent bridge |
| cauchy-schwarz-oq-02-oq-02 | `bessel_inequality` / `bessel_general` (infinite dim) |
| infinitude-primes-4k3-oq-03 | `infinitely_many_primes_1_mod_4` |
| angle-trisection-oq-04-oq-04 | `exists_ngon_at_each_level` + 23-gon separation |
| angle-trisection-oq-05-oq-03 | `minFoldLevel_unbounded` |
| law-of-cosines-oq-01-oq-01-oq-03 | `dual_spherical_law_of_cosines` |
| feuerbachs-theorem-defs-oq-04 | `ninePoints_all_on_sphere` |
| sqrt2-minpoly-oq-02 | `minpoly_kthRoot_of_squarefree` (Eisenstein) |

## Method / honesty

- Each gallery file was individually checked to contain a **genuine general main theorem** matching the stated open question — not just helper lemmas + `native_decide` witnesses.
- Slugs whose gallery proof only covers a *fragment* of a still-open question were **deliberately excluded** (e.g. `erdos-1054-oq-02`, whose verified file proves divisor lemmas + computational Goldbach witnesses, not "limsup f(n)/n = ∞"; `sperner-...-oq-05`, whose tracker still lists open sub-goals; `schroeder-bernstein-oq-01`, a genuinely open "right categorical hypothesis" question).

## Test plan

- [x] All 9 files remain valid JSON
- [x] Diff limited to `status` / `phase` / `currentState` / `lastUpdate` fields
- [ ] No Lean build required (data-only)