### PR TITLE
research(greens-theorem-oq-02-oq-02): S1 ORIENT — narrow Whitney axiom gap to FTC-for-AC

### DIFF
--- a/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
@@ -1,0 +1,66 @@
+# greens-theorem-oq-02-oq-02
+
+**Question**: Can the Whitney axiom be proved in Lean using Mathlib's existing `BoundedVariation` and `MeasureTheory.Measure.AbsolutelyContinuous` API?
+
+**Source**: open question on `greens-theorem-oq-02` (Green's Theorem: Minimal Regularity — Lipschitz Curves and L¹ Curl)
+
+**Status**: surveyed (ORIENT) — feasibility analyzed, blocker narrowed and corrected, bounded build path identified. No Lean committed (Docker blackout 2026-06-13).
+
+## Summary
+
+The target axiom is `greens_theorem_l1curl` (`proofs/Proofs/GreensTheoremOQ02.lean:350`). The OQ asks whether it is dischargeable via Mathlib's `BoundedVariation` + `Measure.AbsolutelyContinuous` API.
+
+**Answer: those APIs are necessary but not sufficient.** The whole question reduces to one missing keystone — the **function-level FTC for absolutely continuous functions**: `f` AC on `[a,b]` ⟹ `f b − f a = ∫ x in a..b, deriv f x` with `deriv f` only L¹/a.e.-defined. Mathlib's `FundThmCalculus` provides only continuity / `HasDerivAt`-everywhere versions and does **not** have this Lebesgue/AC direction.
+
+## Key reframing (the main finding)
+
+The axiom's own docstring justifies axiomatization by claiming the proof "requires geometric measure theory machinery (sets of finite perimeter, BV functions, Federer's trace theorem, Gauss-Green formula) not yet assembled in Mathlib." **This is an overstatement for the case actually stated.** The axiom's domain is a **rectangle** `Set.Icc a b ×ˢ Set.Icc c d`, with the curve `C` a Lipschitz parametrization of its frontier (`hTraversal`). The geometric domain is simple; the heavy GMT machinery is needed for general Lipschitz *domains*, not here.
+
+The genuine gap versus the **axiom-free** OQ01 (`GreensTheoremOQ01.lean`, 0 axioms, uses pointwise `HasDerivAt` + `intervalIntegral.integral_eq_sub_of_hasDerivAt`) is precisely the weakening from pointwise-C¹ partials to an **a.e. curl with merely L¹ integrability** (`hCurlAE` + `hL1`). Via Fubini (`MeasureTheory.integral_prod`) the rectangle double integral splits into iterated 1D integrals, each needing FTC for a function whose derivative is only L¹ — i.e. FTC-for-AC.
+
+So the true blocker is a **bounded ~200–400 line local build**, not a 1000+ line foundational GMT project.
+
+## What Mathlib has vs. lacks
+
+| Ingredient | Mathlib status |
+|---|---|
+| FTC (continuity / `HasDerivAt` everywhere) | ✅ `Mathlib.MeasureTheory.Integral.FundThmCalculus` |
+| **FTC-for-AC** (`f b − f a = ∫ f'`, L¹ deriv) | ❌ **missing — the keystone** |
+| BoundedVariation (`eVariationOn`, BV ⟹ a.e. diff) | ✅ `Mathlib.Analysis.BoundedVariation` |
+| Rademacher (Lipschitz ⟹ a.e. diff) | ✅ `Mathlib.Analysis.Calculus.Rademacher` |
+| Measure `AbsolutelyContinuous` + Radon-Nikodym | ✅ `Mathlib.MeasureTheory.Decomposition.RadonNikodym` |
+| Fubini (`integral_prod`) | ✅ |
+
+Note: `Measure.AbsolutelyContinuous` is AC of **measures** (μ ≪ ν), not of functions. The OQ's intended route — model the L¹ curl as the RN-derivative of an AC measure and recover boundary values — still bottlenecks on the same function-level FTC bridge.
+
+## Recommended approach (when Docker restored)
+
+1. Build a self-contained `ftc_of_absolutelyContinuous` lemma (≤400 lines). Likely route: `f` AC ⟹ its Lebesgue-Stieltjes signed measure `≪ volume` ⟹ `deriv f` is its Radon-Nikodym derivative ⟹ integrate (`withDensity` / RN lemmas).
+2. Discharge `greens_theorem_l1curl` by Fubini reduction to two 1D FTC-for-AC applications over the rectangle, reusing OQ01's boundary algebra.
+3. Amend the OQ02 axiom docstring to state the accurate narrowed gap (doc-only follow-up).
+4. Sanity check: must recover OQ01's conclusion when the curl comes from genuine `HasDerivAt` partials (matches existing `greens_oq1_from_l1curl`).
+
+## Session log
+
+### Session 2026-06-13 (Session 1) — ORIENT survey
+
+**Mode**: FRESH
+**Outcome**: scouted / ORIENT
+
+**What I Did**
+- Claimed fresh EMPTY-knowledge available problem.
+- Read the `greens_theorem_l1curl` axiom and surrounding consequences in `GreensTheoremOQ02.lean` (origin/main).
+- Compared against the axiom-free OQ01 proof to isolate the genuine hypothesis gap.
+- Checked Mathlib's FTC / BoundedVariation / Radon-Nikodym coverage (mathlib4_docs + literature).
+
+**Key Findings**
+- Axiom domain is a rectangle ⟹ cited GMT requirement is overstated.
+- True gap = FTC-for-AC (function level), which Mathlib lacks.
+- Buildable in a bounded ~200–400 lines; problem is NOT truly blocked.
+
+**Files Modified**
+- `src/data/research/problems/greens-theorem-oq-02-oq-02.json` (added knowledge, status→surveyed, phase→ORIENT)
+- `research/problems/greens-theorem-oq-02-oq-02/knowledge.md` (this file)
+
+**Next Steps**
+- Build FTC-for-AC bridge lemma; discharge axiom by Fubini once Docker restored.

--- a/src/data/research/problems/greens-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/greens-theorem-oq-02-oq-02.json
@@ -26,7 +26,7 @@
     "greens-theorem-oq-03",
     "greens-theorem-oq-04"
   ],
-  "status": "available",
+  "status": "surveyed",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [
@@ -96,5 +96,27 @@
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/GreensTheoremOQ04.lean"
     }
-  ]
+  ],
+  "knowledge": {
+    "progressSummary": "SURVEYED (ORIENT, build-gated): The OQ asks whether the `greens_theorem_l1curl` axiom (GreensTheoremOQ02.lean:350) can be discharged via Mathlib's BoundedVariation + Measure.AbsolutelyContinuous API. Answer: those APIs are NECESSARY but not SUFFICIENT — the single missing keystone is the function-level FTC-for-absolutely-continuous bridge `f b - f a = ∫ x in a..b, deriv f x` from an a.e./L¹ derivative, which Mathlib's FundThmCalculus does NOT provide (all its versions require continuity / HasDerivAt everywhere). Crucially, because the OQ02 axiom is stated over a RECTANGLE domain, the heavy GMT machinery cited in the axiom docstring (sets of finite perimeter, Federer trace, Gauss-Green) is an OVERSTATEMENT and is NOT needed; via Fubini the axiom reduces to two 1D instances of FTC-for-AC. True blocker is a bounded ~200-400 line local build, not a 1000+ line foundational project. No Lean committed (Docker blackout 2026-06-13 prevents verification).",
+    "builtItems": [],
+    "insights": [
+      "The `greens_theorem_l1curl` axiom (GreensTheoremOQ02.lean:350) is stated over a RECTANGLE domain `Set.Icc a b ×ˢ Set.Icc c d` with the curve C a Lipschitz parametrization of its frontier (hTraversal). The geometric domain is therefore SIMPLE — so the axiom docstring's cited requirement of 'sets of finite perimeter, Federer's trace theorem, Gauss-Green formula' is an overstatement for THIS case. Those are needed for general Lipschitz DOMAINS, not for a rectangle with a Lipschitz boundary parametrization.",
+      "The genuine gap vs the axiom-free OQ01 (GreensTheoremOQ01.lean, 0 axioms, uses pointwise `HasDerivAt` + `intervalIntegral.integral_eq_sub_of_hasDerivAt`) is exactly the weakening of the hypothesis from pointwise-C¹ partial derivatives to an a.e. curl formula with merely L¹-integrable curl (hCurlAE + hL1). Via Fubini (`MeasureTheory.integral_prod`) the rectangle double integral splits into iterated 1D integrals, each of which needs FTC for a function whose derivative is only L¹/a.e.-defined — i.e. FTC for absolutely continuous functions.",
+      "Mathlib's FTC (`Mathlib.MeasureTheory.Integral.FundThmCalculus`) provides ONLY versions requiring continuity at the endpoints or `HasDerivAt`/`HasDerivWithinAt` on the whole interval. It does NOT provide the Lebesgue/AC direction `f absolutely continuous ⟹ f b - f a = ∫_a^b f'` from an a.e. L¹ derivative. This is the keystone the OQ02 axiom needs (confirmed via mathlib4_docs FundThmCalculus + arXiv 2509.05247 survey of the FTC-for-Lebesgue result).",
+      "Mathlib DOES have the supporting ingredients the OQ names: `Mathlib.Analysis.BoundedVariation` (eVariationOn, `LipschitzWith.boundedVariationOn`, BV ⟹ a.e. differentiable), Rademacher (`Mathlib.Analysis.Calculus.Rademacher`, Lipschitz ⟹ a.e. differentiable), and measure-level `MeasureTheory.Measure.AbsolutelyContinuous` (μ ≪ ν) + Radon-Nikodym (`Mathlib.MeasureTheory.Decomposition.RadonNikodym`). NOTE: `Measure.AbsolutelyContinuous` is AC of MEASURES, not of functions — the OQ's intended path is to model the L¹ curl as the RN-derivative of an AC measure and recover boundary values, which still bottlenecks on the same function-level FTC bridge.",
+      "Answer to the OQ as stated: PARTIALLY / not directly. The named BoundedVariation + Measure.AbsolutelyContinuous API is the correct toolkit but is insufficient on its own; the dischargeability hinges entirely on building the FTC-for-AC bridge lemma, after which the rectangle case follows by Fubini + the existing OQ01-style boundary algebra."
+    ],
+    "mathlibGaps": [
+      "Mathlib lacks the function-level FTC for absolutely continuous functions: `f : ℝ → ℝ` absolutely continuous on [a,b] ⟹ `f b - f a = ∫ x in a..b, deriv f x` with `deriv f` only L¹/a.e.-defined. `Mathlib.MeasureTheory.Integral.FundThmCalculus` covers only continuity/HasDerivAt-everywhere hypotheses. Estimated bounded build: ~200-400 lines (route: f AC ⟹ the pushforward signed measure d f ≪ volume ⟹ deriv f is its Radon-Nikodym derivative ⟹ integrate).",
+      "Mathlib has `Measure.AbsolutelyContinuous` (measures) and BoundedVariation (functions) but no packaged bridge identifying an absolutely-continuous FUNCTION's derivative with the Radon-Nikodym derivative of its associated Lebesgue-Stieltjes measure. This bridge is the technical core of the FTC-for-AC build above."
+    ],
+    "nextSteps": [
+      "When Docker/build is restored: do NOT attempt the full GMT route the axiom docstring suggests. Instead build a self-contained FTC-for-AC lemma (≤400 lines) and discharge `greens_theorem_l1curl` by Fubini reduction to two 1D FTC-for-AC applications over the rectangle.",
+      "Prototype the bridge: state `theorem ftc_of_absolutelyContinuous (f : ℝ → ℝ) (hf : <AC predicate>) : f b - f a = ∫ x in a..b, deriv f x`. Decide the AC predicate encoding — either via `eVariationOn` + an integrability hypothesis, or via `Measure.AbsolutelyContinuous` of the Lebesgue-Stieltjes measure of f. Check whether Mathlib's `MeasureTheory.Measure.withDensity` / RN-derivative lemmas close the gap.",
+      "Amend the GreensTheoremOQ02.lean axiom docstring: replace the 'requires sets of finite perimeter / Federer trace / Gauss-Green' justification with the accurate narrowed gap (rectangle case needs only Fubini + FTC-for-AC), so the documented blocker matches reality. (Doc-only; safe even during blackout but deferred to keep this survey build-free and focused.)",
+      "Sanity check before claiming discharge: the reduction must recover OQ01's conclusion when the curl comes from genuine `HasDerivAt` partials (C¹ ⟹ L¹ on compact rectangle), matching the existing `greens_oq1_from_l1curl` theorem already in GreensTheoremOQ02.lean."
+    ]
+  },
+  "phase": "ORIENT"
 }


### PR DESCRIPTION
## Summary

First ORIENT survey of the fresh open question **greens-theorem-oq-02-oq-02**: *"Can the Whitney axiom be proved in Lean using Mathlib's existing `BoundedVariation` and `MeasureTheory.Measure.AbsolutelyContinuous` API?"*

The target is the `greens_theorem_l1curl` axiom at `proofs/Proofs/GreensTheoremOQ02.lean:350`.

## Key finding

- The axiom is stated over a **rectangle** domain (`Set.Icc a b ×ˢ Set.Icc c d`), so the GMT machinery its docstring cites (sets of finite perimeter, Federer trace, Gauss-Green) is an **overstatement** — that's needed for general Lipschitz *domains*, not this case.
- The genuine gap vs the **axiom-free** OQ01 proof (pointwise `HasDerivAt` + `intervalIntegral` FTC) is only the weakening to **a.e./L¹ curl**. Via Fubini this reduces to two 1D instances of **FTC for absolutely continuous functions**.
- Mathlib's `FundThmCalculus` provides only continuity/`HasDerivAt`-everywhere versions — it **lacks** the function-level bridge `f AC ⟹ f b − f a = ∫ f'`. That single bridge (~200–400 lines via Radon-Nikodym) is the real, **bounded** blocker — the problem is **not** truly blocked.
- Answer to the OQ as posed: the named API is **necessary but not sufficient**; dischargeability hinges on building the FTC-for-AC keystone.

## Changes (build-free — Docker blackout 2026-06-13)

- `src/data/research/problems/greens-theorem-oq-02-oq-02.json`: status `available` → `surveyed`, phase → `ORIENT`, populated `knowledge` (5 insights, 2 gaps, 4 next steps).
- `research/problems/greens-theorem-oq-02-oq-02/knowledge.md`: full survey write-up.

No Lean committed; actual axiom discharge + build remain Docker-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)