### PR TITLE
research: STATE-SYNC 2 gallery-verified completions → status=completed

### DIFF
--- a/src/data/research/problems/angle-trisection-oq-05-oq-02.json
+++ b/src/data/research/problems/angle-trisection-oq-05-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "angle-trisection-oq-05-oq-02",
   "title": "angle-trisection-oq-05-oq-02",
-  "phase": "NEW",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {

--- a/src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-03.json
+++ b/src/data/research/problems/law-of-cosines-oq-01-oq-01-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "law-of-cosines-oq-01-oq-01-oq-03",
   "title": "Polar triangle construction and dual spherical law of cosines",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {


### PR DESCRIPTION
## Summary
Two research problems whose Lean proofs are complete and gallery-verified, but whose top-level research-JSON `status`/`phase` lagged behind their own `currentState.phase=COMPLETED`. This is the internal-inconsistency completion-sync pattern (top-level fields lag `currentState`).

| Slug | Before | After | Gallery | Source (comment-stripped) |
|------|--------|-------|---------|---------------------------|
| `law-of-cosines-oq-01-oq-01-oq-03` | active / OBSERVE | completed / COMPLETED | verified, 0 sorries, 0 ax | `LawOfCosinesOQ01OQ01OQ03.lean` 0 sorry / 0 axiom |
| `angle-trisection-oq-05-oq-02` | active / NEW | completed / COMPLETED | verified, 0 sorries, 0 ax | `AngleTrisectionOQ05OQ02.lean` 0 sorry / 0 axiom |

Evidence:
- **law-of-cosines**: `currentState.phase=COMPLETED` since 2026-05-08, final axiom `polar_angle_eq` eliminated in Session 4; `nextAction` was *"Wait for CI to confirm the build, then close this research thread."* Gallery meta is `verified` and survived a 2026-06-10 audit.
- **angle-trisection-oq-05-oq-02**: `currentState.focus="COMPLETE — 0 sorries, 0 axioms"`; gallery meta `verified`.

## Test plan
- [x] Comment-stripped `sorry`/`axiom` grep on both Lean sources → 0/0
- [x] Gallery `meta.json` confirms `status=verified`, `sorries=0`, `axiomCount=0`
- [x] Diff touches only top-level `status`/`phase`; no Lean changes
- No Docker build required (build-free state-sync; verification infra is down)

🤖 Generated with [Claude Code](https://claude.com/claude-code)