### PR TITLE
research(erdos-460): sync stale leanFiles to merged source (292/8 -> 328/13)

### DIFF
--- a/src/data/research/problems/erdos-460.json
+++ b/src/data/research/problems/erdos-460.json
@@ -71,15 +71,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:11:10.512Z",
-  "lastUpdate": "2026-04-27T00:00:00Z",
+  "lastUpdate": "2026-06-10T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos460Problem.lean",
       "filename": "Erdos460Problem.lean",
-      "lineCount": 292,
-      "theoremCount": 8,
+      "lineCount": 328,
+      "theoremCount": 13,
       "axiomCount": 1,
       "defCount": 9,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC during the verification blackout (Docker down, Aristotle 404).

The research-pool JSON `leanFiles` block for `Erdos460Problem.lean` was frozen at an iter-3 snapshot (`lineCount` 292, `theoremCount` 8) while the merged source on `origin/main` is at **328 lines / 13 public theorems**.

## Drift detail
| metric | JSON (stale) | source (origin/main) |
|--------|-----|--------|
| lineCount | 292 | **328** |
| theoremCount | 8 | **13** |
| axiomCount | 1 | 1 (unchanged) |
| defCount | 9 | 9 (unchanged) |
| sorryCount | 2 | 2 (unchanged) |

Pure-growth drift — `axiom`/`def`/`sorry` all unchanged, so **zero docstring false-positive risk**. The +5 theorems are genuine public-declaration growth: the file has 2 `private` decls, excluded from both the old (8) and new (13) counts by the canonical strict `^(theorem|lemma) ` convention in `enrich-research.ts`, so this is real source growth, not a private-convention artifact.

`lastUpdate` bumped 2026-04-27 → 2026-06-10 (the source's last-commit date on `main`).

Scope: `leanFiles` + `lastUpdate` only. Narrative/prose fields untouched (the iter-3→current history is build-gated to reconstruct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)