### PR TITLE
research(lebesgue-measure-oq-01-oq-03): completion-sync stale status

### DIFF
--- a/src/data/research/problems/lebesgue-measure-oq-01-oq-03.json
+++ b/src/data/research/problems/lebesgue-measure-oq-01-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "lebesgue-measure-oq-01-oq-03",
   "title": "Can the result be extended to show that the indicator of any Borel set with m...",
   "phase": "COMPLETED",
-  "status": "in-progress",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "NEW",
+    "phase": "COMPLETED",
     "since": "2026-05-03T07:32:10.537Z",
     "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "focus": "Proof complete: indicator of any null set has integral zero (fully general).",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "None — proof complete and verified in gallery (LebesgueMeasureOQ01OQ03.lean, 15 theorems, 0 sorries, 0 axioms).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC. The research tracker for `lebesgue-measure-oq-01-oq-03` carried a stale top-level `status: "in-progress"` (and an initial NEW-stub `currentState`) even though the proof is fully complete:

- `proofs/Proofs/LebesgueMeasureOQ01OQ03.lean` — 15 **general** theorems (main result: ∫ 𝟙_S dμ = 0 for **any** null set S, in any measure space), 0 sorries, 0 axioms, no `native_decide`.
- Gallery `meta.json` status is `verified`.
- The tracker's own `phase`, `knowledge.progressSummary`, `builtItems`, and `insights` already describe completion — only `status` and `currentState` lagged.

Per `build.ts`, these research-JSON fields are preserved (non-self-healing), so the stale status would never auto-correct.

## Changes
- `status`: `in-progress` → `completed`
- `currentState`: NEW seeker stub → COMPLETED with accurate focus/nextAction

No Lean or gallery changes. 4 lines.

## Test plan
- [x] JSON validates
- [x] No `loom:review-requested` label (math PR, deployer merges directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)