### PR TITLE
research(roth-theorem-k3): STATE-SYNC stale in-progress→completed

### DIFF
--- a/src/data/research/problems/roth-theorem-k3.json
+++ b/src/data/research/problems/roth-theorem-k3.json
@@ -1,8 +1,8 @@
 {
   "slug": "roth-theorem-k3",
   "title": "Roth's Theorem (Szemeredi k=3)",
-  "phase": "ACT",
-  "status": "in-progress",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "S",
   "path": "full",
   "problemStatement": {
@@ -16,7 +16,7 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-03-21",
     "iteration": 17,
     "focus": "Session 17: Removed 178 lines of dead code containing the only sorry (density_increment_dirichlet Case 2, density_chain, roth_threshold). File now 0 sorries, 0 axioms — fully verified.",
@@ -150,7 +150,7 @@
     "mathlib": []
   },
   "started": "2026-03-22T06:10:36.236Z",
-  "lastUpdate": "2026-03-23T22:00:00Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 9,
   "tractability": 6
 }


### PR DESCRIPTION
## Summary
- Research tracker `src/data/research/problems/roth-theorem-k3.json` was stuck at `in-progress`/`ACT` while the work is complete.
- Gallery meta (`src/data/proofs/roth-theorem-k3/meta.json`) is already `verified`: 0 sorries, 0 axioms.
- Source `proofs/Proofs/RothTheorem.lean` confirmed sorry-free / axiom-free; main theorem `roth_density_bound` (L1372) is a genuine statement of Roth's theorem (density δ>0 ⟹ contains a 3-AP), proved by reduction to Mathlib's `roth_3ap_theorem_nat`.
- iteration-17 `focus` already records the last sorry being removed — the tracker status simply lagged.

Flips top-level + `currentState` `phase` to `COMPLETED`, `status` to `completed`, and bumps `lastUpdate`. **No Lean changes** — build-free metadata sync.

## Test plan
- [x] Verified source has 0 sorries / 0 axioms
- [x] Confirmed main theorem is non-vacuous and matches the stated problem
- [x] Gallery meta already verified — no overclaim introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)