### PR TITLE
research(completion-statesync): flip 14 gallery-verified research JSONs active→completed

### DIFF
--- a/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
+++ b/src/data/research/problems/amgm-inequality-oq-02-oq-01-oq-02.json
@@ -1,8 +1,8 @@
 {
   "slug": "amgm-inequality-oq-02-oq-01-oq-02",
   "title": "Off-Diagonal Symmetry in Symmetric Functions",
-  "phase": "DONE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -76,7 +76,7 @@
     "mathlib": []
   },
   "started": "2026-04-13T16:00:00.000Z",
-  "lastUpdate": "2026-04-13T16:00:00.000Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "leanFiles": [
     {
       "path": "Proofs/AmgmInequalityOQ02.lean",

--- a/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
+++ b/src/data/research/problems/arithmetic-series-oq-02-oq-02-oq-03-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "arithmetic-series-oq-02-oq-02-oq-03-oq-01",
   "title": "Arithmetic Series: Pólya Enumeration Theorem",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "A",
   "path": "full",
   "problemStatement": {
@@ -78,7 +78,7 @@
     "mathlib": []
   },
   "started": "2026-04-04T05:15:05.955Z",
-  "lastUpdate": "2026-04-04T05:15:05.955Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 7,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/birthday-problem-oq-02-oq-01.json
+++ b/src/data/research/problems/birthday-problem-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "birthday-problem-oq-02-oq-01",
   "title": "Can the matching lower bound $\\prod(1-i/d) \\ge \\exp(-k(k-1)/(2d) - k^2(k-1)^2...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -73,7 +73,7 @@
     "mathlib": []
   },
   "started": "2026-03-26T20:00:24.431Z",
-  "lastUpdate": "2026-04-27T00:00:00.000Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 5,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/circumference-via-differentiation-oq-03.json
+++ b/src/data/research/problems/circumference-via-differentiation-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "circumference-via-differentiation-oq-03",
   "title": "Riemannian area-circumference duality via the co-area formula",
-  "phase": "ACT-VERIFIED",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -147,7 +147,7 @@
     ]
   },
   "started": "2026-05-12T22:55:00.000Z",
-  "lastUpdate": "2026-06-10T04:55:00Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/derangements-oq-02-oq-02.json
+++ b/src/data/research/problems/derangements-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "derangements-oq-02-oq-02",
   "title": "Prove derangement generating function via Stirling numbers",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -92,7 +92,7 @@
     "mathlib": []
   },
   "started": "2026-04-03T02:57:02.771Z",
-  "lastUpdate": "2026-04-03T04:00:00.000Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/erdos-183.json
+++ b/src/data/research/problems/erdos-183.json
@@ -1,8 +1,8 @@
 {
   "slug": "erdos-183",
   "title": "Erdős #183",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -82,7 +82,7 @@
     "mathlib": []
   },
   "started": "2026-01-12T10:00:45.598Z",
-  "lastUpdate": "2026-06-10T02:47:38Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [

--- a/src/data/research/problems/frobenius-number-oq-01.json
+++ b/src/data/research/problems/frobenius-number-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "frobenius-number-oq-01",
   "title": "Frobenius Number: Count of Non-Representable Integers = (a-1)(b-1)/2",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -98,7 +98,7 @@
     ]
   },
   "started": "2026-05-06T16:07:08+03:00",
-  "lastUpdate": "2026-05-08T03:30:00Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 6,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/greens-theorem-oq-01-oq-01.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-01.json
@@ -1,8 +1,8 @@
 {
   "slug": "greens-theorem-oq-01-oq-01",
   "title": "Can Fubini be proved from Mathlib's MeasureTheory",
-  "phase": "OBSERVE",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -78,7 +78,7 @@
     "mathlib": []
   },
   "started": "2026-03-29T04:28:18.978Z",
-  "lastUpdate": "2026-03-29T04:28:18.987Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "leanFiles": [
     {
       "path": "Proofs/GreensTheorem.lean",

--- a/src/data/research/problems/inclusion-exclusion-oq-03.json
+++ b/src/data/research/problems/inclusion-exclusion-oq-03.json
@@ -1,8 +1,8 @@
 {
   "slug": "inclusion-exclusion-oq-03",
   "title": "Efficient Inclusion-Exclusion Computation",
-  "phase": "ACT",
-  "status": "active",
+  "phase": "COMPLETED",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -98,7 +98,7 @@
     "mathlib": []
   },
   "started": "2026-03-22T04:19:59.477Z",
-  "lastUpdate": "2026-03-22T16:30:00.000Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "leanFiles": [
     {
       "path": "Proofs/InclusionExclusion.lean",

--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "lagrange-theorem-oq-02-oq-02",
   "title": "Formalize the class equation |G| = |Z(G)| + Σ [G : C_G(xᵢ)] (summing over non...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -77,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-05-05T02:57:44.813Z",
-  "lastUpdate": "2026-05-05T02:57:44.813Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [

--- a/src/data/research/problems/sum-of-kth-powers-oq-02.json
+++ b/src/data/research/problems/sum-of-kth-powers-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "sum-of-kth-powers-oq-02",
   "title": "Sum of Powers: Extension to Non-Integer Exponents",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -77,7 +77,7 @@
     ]
   },
   "started": "2026-03-22T16:23:16.662Z",
-  "lastUpdate": "2026-03-23T16:00:00.000Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "leanFiles": [
     {
       "path": "Proofs/SumOfKthPowers.lean",

--- a/src/data/research/problems/triangle-angle-sum-oq-03.json
+++ b/src/data/research/problems/triangle-angle-sum-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "triangle-angle-sum-oq-03",
   "title": "Triangle Angle Sum: Mathlib Angle Function Degenerate Cases",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -66,7 +66,7 @@
     "mathlib": []
   },
   "started": "2026-04-22T13:03:46.506Z",
-  "lastUpdate": "2026-04-26T18:30:00+02:00",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "significance": 6,
   "tractability": 7,
   "leanFiles": [

--- a/src/data/research/problems/vietas-formulas-oq-03-oq-01.json
+++ b/src/data/research/problems/vietas-formulas-oq-03-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "vietas-formulas-oq-03-oq-01",
   "title": "Generalize to $n$ variables using `MvPolynomial",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -87,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-03-29T04:28:18.978Z",
-  "lastUpdate": "2026-04-27T17:14:40Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "leanFiles": [
     {
       "path": "Proofs/VietasFormulas.lean",

--- a/src/data/research/problems/wilsons-theorem-oq-03.json
+++ b/src/data/research/problems/wilsons-theorem-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "wilsons-theorem-oq-03",
   "title": "What is the exact power of $p$ dividing $n!$? (Legendre's Formula)",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "completed",
   "tier": "B",
   "path": "fast",
   "problemStatement": {
@@ -99,7 +99,7 @@
     ]
   },
   "started": "2026-04-05T00:00:00.000Z",
-  "lastUpdate": "2026-04-05T00:00:00.000Z",
+  "lastUpdate": "2026-06-14T01:06:09Z",
   "leanFiles": [
     {
       "path": "Proofs/WilsonsTheorem.lean",


### PR DESCRIPTION
## Summary

STATE-SYNC of 14 research problem JSONs whose top-level `status`/`phase` lagged at `active`/`OBSERVE`/`ACT` while:
- the same JSON's `currentState` already declares completion (`nextAction` = "None — proof complete", "release as completed", "Entry is COMPLETED in the gallery"), and
- the gallery `src/data/proofs/<slug>/meta.json` is `status: verified` with **0 sorries / 0 axioms**.

`build.ts` preserves existing research JSON state (it does not self-heal `status`), so this internal inconsistency is durable and must be corrected by hand. This is the documented Docker-down build-free win.

## Discriminator applied
- Top-level `status` ∈ {active, in-progress}, `currentState.phase` ∈ {COMPLETED, DONE, ACT-VERIFIED, ...}.
- Gallery meta `status=verified`, `sorries=0`.
- `currentState.nextAction`/`focus` shows GENUINE completion of the general theorem — **excluded** placeholder stubs ("Begin problem exploration", "Read problem.md"), OQ-open sub-proofs (cayley-hamilton-reduction Phase 2 open, ptolemy sorry→Aristotle), and Docker-build-pending entries.

## Synced slugs (14)
amgm-inequality-oq-02-oq-01-oq-02, arithmetic-series-oq-02-oq-02-oq-03-oq-01, birthday-problem-oq-02-oq-01, circumference-via-differentiation-oq-03, derangements-oq-02-oq-02, erdos-183, frobenius-number-oq-01, greens-theorem-oq-01-oq-01, inclusion-exclusion-oq-03, lagrange-theorem-oq-02-oq-02, sum-of-kth-powers-oq-02, triangle-angle-sum-oq-03, vietas-formulas-oq-03-oq-01, wilsons-theorem-oq-03.

## Changes
Each file: `status` → `completed`, `phase` → `COMPLETED`, `lastUpdate` bumped. No Lean/source changes — metadata only, no build required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)