### PR TITLE
research(erdos-335): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-335.json
+++ b/src/data/research/problems/erdos-335.json
@@ -108,15 +108,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T00:04:50.018Z",
-  "lastUpdate": "2026-05-13T11:30:00.000Z",
+  "lastUpdate": "2026-06-10T00:00:00.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos335Problem.lean",
       "filename": "Erdos335Problem.lean",
-      "lineCount": 320,
-      "theoremCount": 30,
+      "lineCount": 364,
+      "theoremCount": 32,
       "axiomCount": 3,
       "defCount": 8,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- The research-pool JSON `src/data/research/problems/erdos-335.json` `leanFiles` block was frozen at **320L / 30T** while the merged origin/main source `Erdos335Problem.lean` is at **364L / 32T** (axiom 3, def 8, sorry 0 unchanged).
- This is the "narrative advanced, leanFiles frozen" drift class: the JSON's own `knowledge.progressSummary` already documents *"32 theorems, 3 deep axioms, 0 sorries"* — only the mechanical block lagged.
- The file has 3 `private` theorems excluded from both old and new strict `^(theorem|lemma) ` counts, so the +2 is **genuine public-theorem growth**, not the private-convention artifact.
- `lastUpdate` set to the source's last-commit date on origin/main (2026-06-10, `d8284214`).

## Verification (build-free, blackout-safe)
- Metrics recomputed from `git show origin/main:proofs/Proofs/Erdos335Problem.lean` using the exact `enrich-research.ts` conventions: lineCount=`split('\n').length`, theoremCount=`^(theorem|lemma) `, axiomCount=`^axiom `, defCount=`^(def|noncomputable def|opaque def) `, sorryCount=all `\bsorry\b`.
- Comment-stripped real sorry = 0 (no docstring false positives).
- `Erdos335Problem.lean` maps exclusively to `erdos-335.json` (no shared-file collision).
- No other open PR touches this slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)