### PR TITLE
research(erdos-460): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-460.json
+++ b/src/data/research/problems/erdos-460.json
@@ -71,15 +71,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:11:10.512Z",
-  "lastUpdate": "2026-04-27T00:00:00Z",
+  "lastUpdate": "2026-06-10T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos460Problem.lean",
       "filename": "Erdos460Problem.lean",
-      "lineCount": 292,
-      "theoremCount": 8,
+      "lineCount": 328,
+      "theoremCount": 13,
       "axiomCount": 1,
       "defCount": 9,
       "sorryCount": 2,


### PR DESCRIPTION
## Summary
`proofs/Proofs/Erdos460Problem.lean` advanced on `main` but the research-pool JSON `leanFiles` block was frozen at its 2026-04-27 snapshot.

| metric | old | new (source) |
|---|---|---|
| lineCount | 292 | 328 |
| theoremCount | 8 | 13 |
| axiomCount | 1 | 1 |
| defCount | 9 | 9 |
| sorryCount | 2 | 2 |

The +5 theorems are genuine **public** growth — the file's 2 `private` theorems are excluded from both the old and new strict `^(theorem|lemma) ` counts, so this is not the private-convention artifact. axiom/def/sorry unchanged (zero docstring false-positive risk). `lastUpdate` bumped to the source's last landing commit on main (2026-06-10, `d8284214`).

Mechanical leanFiles sync only; narrative/currentState untouched (the iteration history is build-gated to reconstruct and Docker is down).

## Test plan
- [x] JSON validates
- [x] Counts recomputed against `origin/main` source via the `enrich-research.ts` regexes
- [x] No existing PR for this slug