### PR TITLE
research(completion-statesync): sync 8 graduated trackers' stale status active→graduated

### DIFF
--- a/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
+++ b/src/data/research/problems/abel-ruffini-oq-04-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "abel-ruffini-oq-04-oq-02",
   "title": "S₂, S₃, S₄ Are Solvable: Complete Classification",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -82,7 +82,7 @@
     ]
   },
   "started": "2026-03-27T00:00:00Z",
-  "lastUpdate": "2026-03-27T00:00:00Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "significance": 7,
   "tractability": 9,
   "leanFiles": [

--- a/src/data/research/problems/bezout-identity-oq-03-oq-04.json
+++ b/src/data/research/problems/bezout-identity-oq-03-oq-04.json
@@ -2,7 +2,7 @@
   "slug": "bezout-identity-oq-03-oq-04",
   "title": "Is there an efficient verified computation of crtInt that avoids modular redu...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -82,7 +82,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T22:57:01.594Z",
-  "lastUpdate": "2026-03-28T22:57:01.613Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "leanFiles": [
     {
       "path": "Proofs/BezoutIdentity.lean",

--- a/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
+++ b/src/data/research/problems/cauchy-schwarz-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "cauchy-schwarz-oq-01-oq-02",
   "title": "Gram-Schmidt Orthogonalization via Cauchy-Schwarz",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "B",
   "path": "full",
   "problemStatement": {
@@ -96,7 +96,7 @@
     "mathlib": []
   },
   "started": "2026-03-27T00:00:00Z",
-  "lastUpdate": "2026-03-27T00:00:00Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "significance": 5,
   "tractability": 6,
   "leanFiles": [

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "cayley-hamilton-minpoly-oq-02-oq-03",
   "title": "Can the full similarity invariance of the rational canonical form be formaliz...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -76,7 +76,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T22:57:01.595Z",
-  "lastUpdate": "2026-03-28T22:57:01.614Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "leanFiles": [
     {
       "path": "Proofs/CayleyHamiltonMinpolyOQ01.lean",

--- a/src/data/research/problems/central-limit-theorem-oq-01-oq-03.json
+++ b/src/data/research/problems/central-limit-theorem-oq-01-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "central-limit-theorem-oq-01-oq-03",
   "title": "How do stable distributions appear in free probability theory (non-commutativ...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -65,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T22:57:01.595Z",
-  "lastUpdate": "2026-03-28T22:57:01.614Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "leanFiles": [
     {
       "path": "Proofs/CentralLimitTheorem.lean",

--- a/src/data/research/problems/cube-root-3-irrational-oq-02-oq-01.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-02-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "cube-root-3-irrational-oq-02-oq-01",
   "title": "[ℚ(∛3):ℚ] = 3 as Corollary of Eisenstein Approach",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "B",
   "path": "full",
   "significance": 6,

--- a/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01.json
+++ b/src/data/research/problems/descartes-rule-of-signs-oq-01-oq-01.json
@@ -2,7 +2,7 @@
   "slug": "descartes-rule-of-signs-oq-01-oq-01",
   "title": "Can the parity result be proved using Mathlib's existing complex root theory ...",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -65,7 +65,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T22:57:01.595Z",
-  "lastUpdate": "2026-03-28T22:57:01.614Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "leanFiles": [
     {
       "path": "Proofs/DescartesRuleOfSigns.lean",

--- a/src/data/research/problems/euler-polyhedral-formula-oq-01-oq-02.json
+++ b/src/data/research/problems/euler-polyhedral-formula-oq-01-oq-02.json
@@ -2,7 +2,7 @@
   "slug": "euler-polyhedral-formula-oq-01-oq-02",
   "title": "Four Color Theorem Lean feasibility and small coloring cases",
   "phase": "COMPLETED",
-  "status": "active",
+  "status": "graduated",
   "tier": "C",
   "path": "full",
   "problemStatement": {
@@ -77,7 +77,7 @@
     "mathlib": []
   },
   "started": "2026-03-28T22:57:01.595Z",
-  "lastUpdate": "2026-03-28T22:57:01.614Z",
+  "lastUpdate": "2026-06-14T01:14:16Z",
   "leanFiles": [
     {
       "path": "Proofs/EulerPolyhedralFormula.lean",


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC during the verification blackout (Docker down, disk 99%).

Eight research trackers are fully complete but their src `status` field lagged at `"active"`, keeping graduated problems in the claimable pool. For each slug:
- src `phase` = `COMPLETED` and `currentState.phase` = `COMPLETED`
- canonical `research/registry.json` declares `status` = `graduated`
- gallery `meta.json` is `status: verified`, 0 sorries, 0 axioms

`build.ts` merges registry status into built output but never writes it back to src, so the stale `active` field persists until corrected manually. This PR aligns src to the canonical registry (`active` → `graduated`).

## Slugs synced
- abel-ruffini-oq-04-oq-02
- bezout-identity-oq-03-oq-04
- cauchy-schwarz-oq-01-oq-02
- cayley-hamilton-minpoly-oq-02-oq-03
- central-limit-theorem-oq-01-oq-03
- cube-root-3-irrational-oq-02-oq-01
- descartes-rule-of-signs-oq-01-oq-01
- euler-polyhedral-formula-oq-01-oq-02

## Test plan
- [x] All 8 files validate as JSON (`python -m json.tool`)
- [x] Each flip confirmed against registry (canonical = graduated) + gallery meta (verified 0/0)
- [x] No Lean build required (data-only state-sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)