### PR TITLE
research(motivic-flag-maps-oq-03): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/motivic-flag-maps-oq-03.json
+++ b/src/data/research/problems/motivic-flag-maps-oq-03.json
@@ -101,13 +101,13 @@
     "mathlib": []
   },
   "started": "2026-05-12T21:11:00Z",
-  "lastUpdate": "2026-05-12T21:11:00Z",
+  "lastUpdate": "2026-06-10T00:00:00Z",
   "leanFiles": [
     {
       "path": "Proofs/MotivicFlagMaps.lean",
       "filename": "MotivicFlagMaps.lean",
-      "lineCount": 438,
-      "theoremCount": 26,
+      "lineCount": 502,
+      "theoremCount": 30,
       "axiomCount": 2,
       "defCount": 17,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC. The research-pool JSON `leanFiles` block for `motivic-flag-maps-oq-03` was frozen at **438 lines / 26 theorems** while the source `proofs/Proofs/MotivicFlagMaps.lean` on `main` is at **502 / 30** (+64 lines, +4 theorems; axiom 2 / def 17 / sorry 0 unchanged).

- The file has **0 private theorems**, so the +4 is genuine public-theorem growth — not the strict-`^(theorem|lemma) `-vs-`private` counting artifact.
- Comment-stripped recount confirms real sorry=0 / axiom=2 (no docstring false-positives).
- Metrics recomputed with the canonical `enrich-research.ts` regexes.
- `lastUpdate` bumped to the source's last-touched commit on `main` (2026-06-10).

Scoped strictly to the mechanical `leanFiles` + `lastUpdate` fields; prose/narrative untouched. No Lean build required (Docker blackout).

## Test plan
- [x] JSON validates (`json.load`)
- [x] Metrics match source via canonical regexes
- [x] No open PR already covers this slug