### PR TITLE
research(transcendence-galleries): sync stale meta.theoremCount to source

### DIFF
--- a/src/data/proofs/e-transcendental/meta.json
+++ b/src/data/proofs/e-transcendental/meta.json
@@ -48,7 +48,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "theoremCount": 12,
+    "theoremCount": 13,
     "definitionCount": 0
   },
   "overview": {

--- a/src/data/proofs/hermite-lindemann/meta.json
+++ b/src/data/proofs/hermite-lindemann/meta.json
@@ -42,7 +42,7 @@
     "lineCount": 390,
     "assumptions": "1 axiom: hermite_lindemann (deep analytic number theory, not in Mathlib). All corollaries (e transcendence, π transcendence) are now proved from this single axiom via Euler's identity and algebraic closure properties.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 5,
     "definitionCount": 1
   },
   "overview": {

--- a/src/data/proofs/pi-transcendental/meta.json
+++ b/src/data/proofs/pi-transcendental/meta.json
@@ -42,7 +42,7 @@
     "lineCount": 457,
     "assumptions": "1 axiom (transitive): HermiteLindemann.hermite_lindemann (Hermite-Lindemann theorem). Local axiom lindemann_theorem discharged via IsFractionRing.isAlgebraic_iff bridge to hermite_lindemann (S8 ACT, 2026-06-05). pi_transcendental now proved from theorem lindemann_theorem via Euler s identity. All other results proved from these.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 18,
+    "theoremCount": 19,
     "definitionCount": 0
   },
   "overview": {


### PR DESCRIPTION
## Summary
Count-only metadata STATE-SYNC. Three single-file transcendence galleries had a curated `meta.theoremCount` that lagged the actual Lean source by exactly 1:

| slug | meta (was) | source / leanFile |
|------|-----------|-------------------|
| e-transcendental | 12 | **13** |
| hermite-lindemann | 4 | **5** |
| pi-transcendental | 18 | **19** |

In each case the deployer-regenerated `leanFile.theoremCount` already carries the correct value, and comment-stripped source counts agree across every convention (col-0, any-indent, include-private). `meta.theoremCount` is the sole mechanical count (no `substantiveTheoremCount`), so the off-by-one is genuinely stale, and since `meta` is curated (not auto-regenerated) it will not self-heal.

All three are single-file (no companion `additionalFiles`), so there is no chain-aggregate ambiguity.

## Verification
- JSON re-parsed clean for all three files.
- No Lean changes; no build required. (Docker verification infra is down this session regardless.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)