### PR TITLE
research(cayley-hamilton-minpoly-oq-02-oq-02-oq-01): dedup duplicate registry entry

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -14349,14 +14349,6 @@
       "lastUpdate": "2026-04-05T15:44:05.092Z"
     },
     {
-      "slug": "cayley-hamilton-minpoly-oq-02-oq-02-oq-01",
-      "phase": "OBSERVE",
-      "path": "full",
-      "started": "2026-04-05T15:44:05.093Z",
-      "status": "active",
-      "lastUpdate": "2026-04-05T20:08:48.027Z"
-    },
-    {
       "slug": "cevas-theorem-non-euclidean-oq-03",
       "phase": "NEW",
       "path": "full",


### PR DESCRIPTION
## Summary
`research/registry.json` contained **two entries** for slug `cayley-hamilton-minpoly-oq-02-oq-02-oq-01`, both `active`/`OBSERVE`:
- a thin deployer-format stub (`started`/`lastUpdate` only)
- the canonical seeker entry (`title`/`tier`/`significance`/`tractability`/`tags`/`source`/`parentProof`)

This is unambiguous data corruption — one slug, two contradictory records.

## Why it's not self-healing
`scripts/research/sync-data.ts` builds `registryBySlug = new Map(...)` from `registry.problems`. With duplicate slugs the Map keeps only the **last** occurrence and all updates target that one; the orphan is never read or removed. Every `chore: sync` run therefore leaves the duplicate intact. Manual dedup is durable.

## Change
Remove the thin stub (8 lines), keeping the richer seeker entry. No proof, build, or gallery change — pure registry data-integrity fix. `2469 → 2468` problems; JSON validated.

## Test plan
- [x] `jq empty research/registry.json` (valid JSON)
- [x] cayley slug entry count `2 → 1`; surviving entry retains full seeker metadata
- [x] No other slug affected (single-entry diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)