### PR TITLE
research(erdos-1054-oq-02): sync stale NEW stub to verified structural progress

### DIFF
--- a/src/data/research/problems/erdos-1054-oq-02.json
+++ b/src/data/research/problems/erdos-1054-oq-02.json
@@ -1,41 +1,70 @@
 {
   "slug": "erdos-1054-oq-02",
   "title": "Is limsup f(n)/n = ∞",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
   "problemStatement": {
-    "formal": "\\text{(formal statement to be added)}",
-    "plain": "Formal investigation in number theory: Is limsup f(n)/n = ∞.",
+    "formal": "\\limsup_{n\\to\\infty} f(n)/n = \\infty,\\ \\text{where } f(n) \\text{ is the least } m \\ge 1 \\text{ with } n \\in \\mathrm{partialDivisorSums}(m).",
+    "plain": "Let f(n) be the least m for which n appears as a partial sum of the smallest divisors of m. Does f(n)/n grow without bound (limsup = ∞)?",
     "whyMatters": [
-      "Research value"
+      "Connects representability by partial divisor sums to Goldbach's conjecture",
+      "Tao's work suggests f(n)/n can be large; the limsup question probes the sharp growth rate"
     ]
   },
   "knownResults": {
-    "proven": [],
-    "open": [],
-    "goal": ""
+    "proven": [
+      "divisor_of_prime_product / divisors_prime_product / card_divisors_prime_product: divisors of q·p for distinct primes q<p are exactly {1,q,p,qp} (τ(qp)=4)",
+      "goldbach_implies_representable: if n-1=q+p with q<p prime and n∈partialDivisorSums(qp), then n is representable",
+      "witnesses_6_to_20 and f_bounds_via_goldbach: explicit prime-product witnesses and f-bounds for n∈[6,20]"
+    ],
+    "open": [
+      "Unconditional limsup f(n)/n = ∞ (the OQ itself)",
+      "Goldbach ⇒ all odd n≥7 representable (conditional on Goldbach, not in Mathlib)",
+      "Complete classification that 0, 2, 5 are the only non-representable values",
+      "Representability of even n not of the form p+1"
+    ],
+    "goal": "Prove limsup f(n)/n = ∞ unconditionally."
   },
   "currentState": {
-    "phase": "NEW",
-    "since": "2026-05-29T19:14:09.106Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
-    "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "phase": "ACT",
+    "since": "2026-06-13T00:00:00Z",
+    "iteration": 2,
+    "focus": "Verified structural infrastructure exists in Erdos1054OQ02.lean (308 lines, 17 theorems, 0 sorries, 0 axioms, gallery status=verified): divisor classification for products of two distinct primes, the Goldbach⇒representability reduction, and explicit prime-product witnesses / f-bounds for n∈[6,20]. This is structural progress only — the limsup f(n)/n=∞ open question is NOT resolved.",
+    "blockers": [
+      "The unconditional limsup result requires an analytic/sieve argument forcing a large minimal prime in every divisor-sum representation — beyond the current elementary structural lemmas",
+      "The 'all odd n≥7 representable' direction is conditional on Goldbach's conjecture (unavailable in Mathlib)"
+    ],
+    "nextAction": "Attempt the unconditional limsup f(n)/n=∞ via constructing n whose every partial-divisor-sum representation forces a large witness m (analytic number theory); alternatively formalize the complete non-representable classification {0,2,5}. Structural infrastructure is already verified and available.",
     "attemptCounts": {
-      "total": 0,
-      "currentApproach": 0,
-      "approachesTried": 0
+      "total": 1,
+      "currentApproach": 1,
+      "approachesTried": 1
     }
   },
   "knowledge": {
-    "progressSummary": "",
-    "builtItems": [],
-    "insights": [],
-    "mathlibGaps": [],
-    "nextSteps": []
+    "progressSummary": "STRUCTURAL PROGRESS (OQ OPEN): Erdos1054OQ02.lean verified 0-sorry/0-axiom (17 theorems) — divisor classification for q·p, Goldbach⇒representability reduction, explicit witnesses and f-bounds for n∈[6,20]. The limsup f(n)/n=∞ question itself remains open.",
+    "builtItems": [
+      "divisor_of_prime_product (Proofs/Erdos1054OQ02.lean:53): every divisor of q·p (distinct primes q<p) lies in {1,q,p,qp}",
+      "divisors_prime_product, card_divisors_prime_product (Proofs/Erdos1054OQ02.lean:74,96): divisor set = {1,q,p,qp}, τ(qp)=4",
+      "small_divisors_of_prime_product (Proofs/Erdos1054OQ02.lean:112): divisors of qp below p are 1 or q",
+      "goldbach_implies_representable (Proofs/Erdos1054OQ02.lean:165): n-1=q+p (q<p prime) ∧ n∈partialDivisorSums(qp) ⇒ n representable",
+      "witnesses_6_to_20, f_bounds_via_goldbach (Proofs/Erdos1054OQ02.lean:178,205): explicit prime-product witnesses and f-bounds for n∈[6,20]"
+    ],
+    "insights": [
+      "Representability reduces to Goldbach: if n-1=q+p for primes q<p then m=qp has sorted divisors [1,q,p,qp], whose third partial sum is 1+q+p=n, so n∈partialDivisorSums(qp). Hence Goldbach ⇒ all odd n≥7 representable.",
+      "f(n)/n via the Goldbach witness ≈ qp/(q+p): bounded (≈2) when the small prime q≈2,3, but ≈n/4 (unbounded) when q≈p≈n/2 — consistent with the conjectured limsup f(n)/n=∞.",
+      "The verified Lean file is STRUCTURAL progress, NOT a resolution: the limsup question, the unconditional Goldbach reduction, and the complete non-representable classification all remain open (see file Section 9)."
+    ],
+    "mathlibGaps": [
+      "Goldbach's conjecture is not available in Mathlib, so the 'all odd n≥7 representable' direction is only conditional"
+    ],
+    "nextSteps": [
+      "Attempt unconditional limsup f(n)/n=∞ by constructing n forcing a large minimal prime in every divisor-sum representation (analytic/sieve argument beyond the structural lemmas)",
+      "Formalize the complete classification that 0, 2, 5 are the only non-representable values",
+      "Handle representability of even n not of the form p+1"
+    ]
   },
   "tags": [
     "erdos",
@@ -58,7 +87,7 @@
     "mathlib": []
   },
   "started": "2026-05-29T19:14:09.105Z",
-  "lastUpdate": "2026-05-29T19:14:09.105Z",
+  "lastUpdate": "2026-06-13T00:00:00Z",
   "significance": 6,
   "tractability": 5,
   "leanFiles": [


### PR DESCRIPTION
## Summary
- The `erdos-1054-oq-02` research tracker was an auto-generated **NEW-phase stub** (focus "Initial exploration", `nextAction` "Begin problem exploration", iteration 1, 0 attempts, empty `knowledge`, placeholder formal statement).
- Meanwhile `proofs/Proofs/Erdos1054OQ02.lean` already exists, **gallery status `verified`**: 308 lines, 17 theorems, **0 sorries / 0 axioms** — divisor classification for products of two distinct primes, the Goldbach⇒representability reduction, and explicit prime-product witnesses / f-bounds for n∈[6,20].
- This PR syncs the tracker to reality: `phase` NEW→**ACT**, populates `problemStatement`, `knownResults`, and `knowledge` (built items with file:line, insights, Mathlib gaps, next steps), bumps `lastUpdate`.

## Honesty note (no overclaim)
- `status` stays **`active`**. The open question — `limsup f(n)/n = ∞`, the unconditional Goldbach reduction, and the complete non-representable classification ({0,2,5}) — is genuinely **unresolved**. The verified Lean file is *structural progress only* (its own header and Section 9 say so). This is **not** a completion flip.

## Test plan
- [x] `jq empty` validates the JSON
- [x] Build-free change (research-JSON metadata only); Docker daemon is down so no Lean rebuild attempted
- [x] `leanFiles` array left untouched (deployer-regenerated)