### PR TITLE
research(erdos-949): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-949.json
+++ b/src/data/research/problems/erdos-949.json
@@ -72,15 +72,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T12:22:36.006Z",
-  "lastUpdate": "2026-03-13T07:52:17.055Z",
+  "lastUpdate": "2026-06-10T09:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos949Problem.lean",
       "filename": "Erdos949Problem.lean",
-      "lineCount": 159,
-      "theoremCount": 14,
+      "lineCount": 190,
+      "theoremCount": 16,
       "axiomCount": 1,
       "defCount": 4,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
- The research-pool JSON `leanFiles` block for `erdos-949` was frozen at iteration-1 metrics (159 lines / 14 theorems) while `proofs/Proofs/Erdos949Problem.lean` on `main` has grown to **190 lines / 16 theorems**.
- Synced the two drifted metrics: `lineCount` 159→190, `theoremCount` 14→16. `axiomCount` (1), `defCount` (4), `sorryCount` (0) all unchanged.
- The +2 theorems are genuine **public** growth (0 private theorems/lemmas in the file), not a strict-vs-private counting artifact. Comment-stripped recount confirms real sorry=0 / axiom=1 (no docstring false-positives).
- Bumped `lastUpdate` to the source file's last-commit date on `main` (2026-06-10, `d8284214`). Narrative fields untouched.

This is a mechanical metrics sync of a non-deployer-owned artifact (the research-pool JSON `leanFiles`, which only per-slug PRs update — the gallery `meta.json` leanFile is already current). Build-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)