### PR TITLE
research(erdos-530): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-530.json
+++ b/src/data/research/problems/erdos-530.json
@@ -84,15 +84,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:39:49.623Z",
-  "lastUpdate": "2026-04-28T00:00:00Z",
+  "lastUpdate": "2026-06-10T00:00:00Z",
   "significance": 5,
   "tractability": 3,
   "leanFiles": [
     {
       "path": "Proofs/Erdos530Problem.lean",
       "filename": "Erdos530Problem.lean",
-      "lineCount": 382,
-      "theoremCount": 15,
+      "lineCount": 431,
+      "theoremCount": 16,
       "axiomCount": 2,
       "defCount": 5,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `erdos-530` was frozen at iteration 2 (`382` lines / `15` theorems) while the merged source `Erdos530Problem.lean` on `main` is at `431` lines / `16` theorems.

- lineCount `382 → 431` (+49 real source lines)
- theoremCount `15 → 16` (+1 genuine **public** theorem; `private`=1, excluded from both old and new strict `^(theorem|lemma) ` counts → not the strict-vs-private artifact)
- axiomCount `2`, defCount `5`, sorryCount `0` — unchanged
- comment-stripped recount confirms real sorry=0 / axiom=2 (no docstring false-positive)
- `lastUpdate → 2026-06-10` (source last-commit `d8284214`)

Gallery `meta.json` `leanFile` is already current; only the independent research-pool JSON lagged. Scoped strictly to the two stale metrics + `lastUpdate`; narrative untouched.

## Test plan
- [x] Verified source metrics via `git archive origin/main` recompute against `enrich-research.ts` conventions
- [x] No open duplicate PR for this slug
- [x] Build-free metadata-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)