### PR TITLE
research(erdos-891): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-891.json
+++ b/src/data/research/problems/erdos-891.json
@@ -80,15 +80,15 @@
     "mathlib": []
   },
   "started": "2026-01-15T10:57:29.901Z",
-  "lastUpdate": "2026-03-24T17:30:00Z",
+  "lastUpdate": "2026-06-10T09:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos891Problem.lean",
       "filename": "Erdos891Problem.lean",
-      "lineCount": 401,
-      "theoremCount": 29,
+      "lineCount": 440,
+      "theoremCount": 30,
       "axiomCount": 0,
       "defCount": 11,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
The research-pool JSON `leanFiles` block for `erdos-891` lagged the merged source. Synced the two stale metrics + `lastUpdate`.

- `lineCount` 401 → 440 (+39)
- `theoremCount` 29 → 30 (+1 public)
- `axiomCount` 0, `defCount` 11, `sorryCount` 0 — unchanged
- `lastUpdate` 2026-03-24 → 2026-06-10 (source last-commit `d8284214`)

## Verification (build-free)
- Comment-stripped recount of `Erdos891Problem.lean` confirms real `sorry`=0, `axiom`=0 (no docstring false-positives).
- The `+1` theorem is genuine public growth: 5 private declarations are excluded from both the old and new strict `^(theorem|lemma) ` counts.
- Gallery `meta.json` `leanFile` is a separate artifact; only the research-pool JSON lagged.
- Docker verification infra is down; this is a mechanical metric sync requiring no build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)