### PR TITLE
research(sperner-simplicial-instance-oq-05): COMMENT-SYNC stale S7 discharge docstring

### DIFF
--- a/proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean
+++ b/proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean
@@ -131,14 +131,14 @@ endpoint condition. -/
 
 /-! ## S7 ACT — Structural Reduction Lemmas
 
-Three reduction-by-definition lemmas that future S8+ discharge of
-`scarfWalk_isPanchromatic` will need. Plus a kernel-level `decide`
-verification on a concrete 3-cell instance.
+Three reduction-by-definition lemmas that the S8 discharge of
+`scarfWalk_isPanchromatic` (now complete) relied on. Plus a
+kernel-level `decide` verification on a concrete 3-cell instance.
 
-These do not close the existing sorry but each is a syntactic
-fact about `scarfWalk` / `scarfWalkAux` that the discharge will
-unfold over. Recording them as named lemmas avoids re-proving the
-same `rfl` / `split_ifs` micro-steps inside the larger discharge. -/
+Each is a syntactic fact about `scarfWalk` / `scarfWalkAux` that the
+discharge unfolds over. Recording them as named lemmas avoids
+re-proving the same `rfl` / `split_ifs` micro-steps inside the larger
+discharge. -/
 
 /-- Unfolding lemma: `scarfWalk` is `scarfWalkAux` at fuel `m`. -/
 theorem scarfWalk_eq_scarfWalkAux (hm : 0 < m) (start : Fin m) (k : Fin 2)


### PR DESCRIPTION
## Summary

Comment-only sync of a stale docstring in `proofs/Proofs/SpernerSimplicialInstanceOQ05Scarf1d.lean`.

The "S7 ACT — Structural Reduction Lemmas" section header (written at S7) still framed the S8 discharge of `scarfWalk_isPanchromatic` as **future** work ("future S8+ discharge ... will need") and referenced **"the existing sorry"**. That sorry is gone:

- PR #22900 (S8 ACT, 2026-06-13, Docker-verified 1098/1098) discharged `scarfWalk_isPanchromatic` with the corrected start-relative hypothesis `c start.val ≠ c m`.
- `SpernerSimplicialInstanceOQ05Scarf1d.lean` is now **0 sorries / 0 axioms** (the only raw `sorry` grep hit was this stale prose).
- The file header (line 29) and the "## Soundness" note already correctly describe the theorem as proved — only this one section lagged.

Updated the tense to "the S8 discharge ... (now complete) relied on".

## Why build-free / safe

Change is entirely within a `/-! ... -/` documentation block — no declarations, tactics, or signatures touched. Cannot affect compilation. Docker is currently down (blackout), so no new Lean was verified; none was added.

## Test plan

- [x] Diff is comment-only (8 lines inside the docstring block)
- [x] Confirmed `scarfWalk_isPanchromatic` (L241) is a proved theorem, consumed by `exists_panchromatic_constructive` (L278)
- [x] Confirmed file has 0 real sorries (only the now-fixed prose mention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)