### PR TITLE
research(erdos-467): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-467.json
+++ b/src/data/research/problems/erdos-467.json
@@ -64,15 +64,15 @@
     "mathlib": []
   },
   "started": "2026-01-13T04:11:10.513Z",
-  "lastUpdate": "2026-03-13T07:52:17.049Z",
+  "lastUpdate": "2026-06-10T02:47:38.000Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos467Problem.lean",
       "filename": "Erdos467Problem.lean",
-      "lineCount": 251,
-      "theoremCount": 23,
+      "lineCount": 278,
+      "theoremCount": 25,
       "axiomCount": 1,
       "defCount": 6,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Research-pool JSON `leanFiles` for **erdos-467** was frozen at iteration 1 (`251` lines / `23` theorems, `lastUpdate` 2026-03-13) while the merged source `Erdos467Problem.lean` advanced to **278 lines / 25 theorems** via the 2026-06-10 landing commit `d8284214`.

- **lineCount** 251 → 278 (+27)
- **theoremCount** 23 → 25 (+2, genuine public growth — 0 private declarations, so not the strict-vs-private convention artifact)
- axiomCount (1), defCount (6), sorryCount (0) **unchanged**
- comment-stripped recount confirms real sorry=0 / axiom=1 (no docstring false-positives)
- `lastUpdate` bumped to the source's last-commit date on main (2026-06-10)

Scope is strictly the two drifted `leanFiles` metrics + `lastUpdate`; narrative/`currentState` left untouched. Build-free metric sync during the verification blackout (Docker down).

## Test plan
- [x] JSON validates (`json.load`)
- [x] Source metrics recomputed via `enrich-research.ts:144` conventions against `git show origin/main:proofs/Proofs/Erdos467Problem.lean`
- [x] No open/duplicate leanFiles sync PR for this slug