### PR TITLE
research(erdos-324): sync stale leanFiles metrics to merged source

### DIFF
--- a/src/data/research/problems/erdos-324.json
+++ b/src/data/research/problems/erdos-324.json
@@ -61,15 +61,15 @@
     "mathlib": []
   },
   "started": "2026-01-12T23:55:09.604Z",
-  "lastUpdate": "2026-03-13T07:52:17.046Z",
+  "lastUpdate": "2026-06-10T00:00:00.000Z",
   "significance": 7,
   "tractability": 5,
   "leanFiles": [
     {
       "path": "Proofs/Erdos324Problem.lean",
       "filename": "Erdos324Problem.lean",
-      "lineCount": 273,
-      "theoremCount": 11,
+      "lineCount": 304,
+      "theoremCount": 13,
       "axiomCount": 1,
       "defCount": 7,
       "sorryCount": 0,


### PR DESCRIPTION
## Summary
Sync the research-pool JSON `leanFiles` block for `erdos-324`, frozen at iter-1 state (2026-03-13), to the merged `Erdos324Problem.lean` source.

| metric | JSON (old) | source (now) |
|--------|-----------|--------------|
| lineCount | 273 | 304 (+31) |
| theoremCount | 11 | 13 (+2) |
| defCount | 7 | 7 |
| axiomCount | 1 | 1 |
| sorryCount | 0 | 0 |

`lastUpdate` bumped 2026-03-13 → 2026-06-10 (source's last-touched commit on `main`).

## Notes
- Mechanical `leanFiles` + `lastUpdate` sync only — narrative/prose fields untouched.
- Comment-stripped recount confirms **real** sorry=0, axiom=1 (no docstring false-positives).
- The +2 theorem growth is **genuine public theorems**: 1 private theorem is excluded by the strict `^(theorem|lemma) ` convention from both the old and new counts, so this is real source growth, not the private-convention artifact.
- Gallery `meta.json` `leanFile` is a separate artifact (deployer/auditor-owned); this PR only touches the research-pool JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)