### PR TITLE
research(greens-oq-02-oq-02): correct axiom docstring blocker + flag blocked

### DIFF
--- a/proofs/Proofs/GreensTheoremOQ02.lean
+++ b/proofs/Proofs/GreensTheoremOQ02.lean
@@ -320,9 +320,20 @@ The proof uses:
 3. Pass to the limit using L¹ convergence of the curl and rectifiability
    of the Lipschitz boundary
 
-In Lean, we axiomatize this theorem because the full proof requires
-geometric measure theory machinery (sets of finite perimeter, BV functions,
-Federer's trace theorem, Gauss-Green formula) not yet assembled in Mathlib.
+In Lean, we axiomatize this theorem. NOTE on the actual blocker: while the
+GENERAL Whitney theorem (arbitrary Lipschitz domain) does require geometric
+measure theory machinery (sets of finite perimeter, BV functions, Federer's
+trace theorem, Gauss-Green formula), THIS axiom is stated only over a
+RECTANGLE domain -- the `hTraversal` hypothesis forces the curve C onto
+`frontier (Set.Icc a b ×ˢ Set.Icc c d)`. For a rectangle the GMT machinery is
+NOT needed: by Fubini (`MeasureTheory.integral_prod`) the double integral
+splits into iterated 1D integrals, reducing the axiom to two instances of the
+Fundamental Theorem of Calculus for absolutely continuous functions
+(`f b - f a = ∫ x in a..b, deriv f x` with `deriv f` only L¹/a.e.-defined).
+Mathlib's `MeasureTheory.Integral.FundThmCalculus` provides only versions
+requiring continuity / `HasDerivAt` everywhere, so the single genuine gap is
+this FTC-for-AC bridge (a bounded ~200-400 line build via `BoundedVariation`
++ Radon-Nikodym), not the full GMT project the references below describe.
 -/
 
 /-  **Whitney's theorem** (minimal regularity for Green's theorem).

--- a/src/data/research/problems/greens-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/greens-theorem-oq-02-oq-02.json
@@ -26,7 +26,7 @@
     "greens-theorem-oq-03",
     "greens-theorem-oq-04"
   ],
-  "status": "surveyed",
+  "status": "blocked",
   "selectedDate": "2026-04-12",
   "selectedBy": "seeker",
   "leanFiles": [
@@ -114,9 +114,10 @@
     "nextSteps": [
       "When Docker/build is restored: do NOT attempt the full GMT route the axiom docstring suggests. Instead build a self-contained FTC-for-AC lemma (≤400 lines) and discharge `greens_theorem_l1curl` by Fubini reduction to two 1D FTC-for-AC applications over the rectangle.",
       "Prototype the bridge: state `theorem ftc_of_absolutelyContinuous (f : ℝ → ℝ) (hf : <AC predicate>) : f b - f a = ∫ x in a..b, deriv f x`. Decide the AC predicate encoding — either via `eVariationOn` + an integrability hypothesis, or via `Measure.AbsolutelyContinuous` of the Lebesgue-Stieltjes measure of f. Check whether Mathlib's `MeasureTheory.Measure.withDensity` / RN-derivative lemmas close the gap.",
-      "Amend the GreensTheoremOQ02.lean axiom docstring: replace the 'requires sets of finite perimeter / Federer trace / Gauss-Green' justification with the accurate narrowed gap (rectangle case needs only Fubini + FTC-for-AC), so the documented blocker matches reality. (Doc-only; safe even during blackout but deferred to keep this survey build-free and focused.)",
+      "DONE (2026-06-13, doc-only): Amended the GreensTheoremOQ02.lean axiom docstring (the 'Part IV' block above the axiom) to replace the overstated 'requires sets of finite perimeter / Federer trace / Gauss-Green' justification with the accurate narrowed gap — rectangle case needs only Fubini + FTC-for-AC. Documented blocker now matches reality.",
       "Sanity check before claiming discharge: the reduction must recover OQ01's conclusion when the curl comes from genuine `HasDerivAt` partials (C¹ ⟹ L¹ on compact rectangle), matching the existing `greens_oq1_from_l1curl` theorem already in GreensTheoremOQ02.lean."
-    ]
+    ],
+    "blockedReason": "BLOCKED (2026-06-13, Docker verification blackout): The ORIENT survey is complete and the only build-free follow-up (docstring accuracy amendment) is now done. The single remaining gap — the FTC-for-AC bridge lemma + Fubini reduction — is a bounded ~200-400 line LOCAL BUILD that cannot be verified while Docker is down. Re-open when Docker is restored."
   },
   "phase": "ORIENT"
 }


### PR DESCRIPTION
## Summary

Build-free documentation accuracy fix + status flag for `greens-theorem-oq-02-oq-02` during the 2026-06-13 Docker verification blackout.

**Doc correction (comment-only, `GreensTheoremOQ02.lean`):** The `greens_theorem_l1curl` axiom docstring justified axiomatization by claiming the full proof requires geometric measure theory (sets of finite perimeter, BV, Federer trace, Gauss-Green). The ORIENT survey (merged PR #23258) established this is an **overstatement for this axiom**: the `hTraversal` hypothesis forces the curve `C` onto `frontier (Set.Icc a b ×ˢ Set.Icc c d)` — a **rectangle**. For a rectangle, Fubini (`MeasureTheory.integral_prod`) splits the double integral into two 1D FTC instances, reducing the gap to **FTC for absolutely continuous functions** (a bounded ~200–400 line build via `BoundedVariation` + Radon-Nikodym), not the full GMT project. The docstring now states the accurate narrowed blocker.

**Status flag:** Set `status: blocked`. The survey is complete and its only build-free follow-up (this docstring amendment) is now done; the remaining FTC-for-AC bridge lemma requires a local Lean build, which is unverifiable while Docker is down.

## Test plan
- [x] JSON validates (`json.load`)
- [x] Edit is comment-only in the `.lean` file (no proof/term changes) — build-safe
- [ ] Re-open and attempt the FTC-for-AC bridge when Docker is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)