### PR TITLE
research: registry STATE-SYNC — flip erdos-1151-oq-04 + bertrands-postulate-oq-02 to BLOCKED

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -16259,11 +16259,11 @@
     },
     {
       "slug": "erdos-1151-oq-04",
-      "phase": "ACT",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-13T22:43:37.485Z",
-      "status": "active",
-      "lastUpdate": "2026-05-16T15:56:00.000Z"
+      "status": "blocked",
+      "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
       "slug": "ptolemys-theorem-oq-01-incomplete-01",
@@ -17007,11 +17007,11 @@
     },
     {
       "slug": "bertrands-postulate-oq-02",
-      "phase": "ACT",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-22T13:25:38.489Z",
-      "status": "active",
-      "lastUpdate": "2026-06-10T01:49:53.680Z"
+      "status": "blocked",
+      "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
       "slug": "bounded-prime-gaps-oq-02",


### PR DESCRIPTION
## Summary
Two ACT-tier research problems were flagged **blocked** in their source research JSON by prior sessions (Docker-gated, 2026-06-13 verification blackout), but `research/registry.json` still listed them as `active`/`ACT`.

| slug | src JSON | registry (before) |
|------|----------|-------------------|
| erdos-1151-oq-04 | blocked / BLOCKED | active / ACT |
| bertrands-postulate-oq-02 | blocked / BLOCKED | active / ACT |

## Why this matters
`scripts/research/build.ts` (`updateRegistryFields`, L627) treats the **registry** as authoritative for `phase`/`status` and merges those fields into the deployed `public/data/research/<slug>.json` and `research-listings.json` (L809–824). It does **not** read status back from src. So:
- the gallery/listings displayed both genuinely-blocked problems as **active**, and
- the stale registry status would let problem-selection tooling re-pick them.

This flips both registry entries to `status=blocked`, `phase=BLOCKED`, matching the researcher-determined state and the existing `euler-polyhedral-formula-oq-02-oq-01-wip-01` precedent (#23084).

Both remaining sorries are Docker-gated:
- **erdos-1151-oq-04** — S38 (#23048): 1 sorry, build-verify clean, Banach–Steinhaus discharge needs Docker.
- **bertrands-postulate-oq-02** — S7 (#23033): dead-axiom removal + S5-ACT-A analytic half, both build-dependent.

## Test plan
- [x] `jq` confirms both entries now `blocked`/`BLOCKED` with refreshed `lastUpdate`.
- [x] Build-free change — no Lean/proof edits; registry JSON only.
- [x] No overlap with open registry PR #23278 (graduation/dedup, disjoint slugs).