### PR TITLE
research(erdos-1210): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-1210.json
+++ b/src/data/research/problems/erdos-1210.json
@@ -85,10 +85,10 @@
     {
       "path": "Proofs/Erdos1210Problem.lean",
       "filename": "Erdos1210Problem.lean",
-      "lineCount": 179,
-      "theoremCount": 11,
+      "lineCount": 231,
+      "theoremCount": 14,
       "axiomCount": 1,
-      "defCount": 3,
+      "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos1210Problem.lean"


### PR DESCRIPTION
## Summary
- The research-pool JSON `leanFiles` block for `erdos-1210` was frozen at lineCount 179 / theoremCount 11 / defCount 3 while the merged source `Erdos1210Problem.lean` had grown to **231 lines, 14 theorems, 4 defs** (commit `9cc158b`).
- Synced the 3 stale metrics. `axiomCount=1` and `sorryCount=0` are unchanged.

## Why this is a clean sync
- All theorem growth (+3) is **public** — the file has 0 private theorems, so this is genuine new-theorem growth, not the strict-`^(theorem|lemma) `-vs-private counting artifact.
- Comment-stripped recount confirms real `sorry=0` / `axiom=1` (no docstring false positives).
- Scope is strictly the mechanical `leanFiles` metrics; the JSON narrative and `lastUpdate` (recently advanced by a STATE-SYNC) are left untouched.
- The gallery `meta.json` is a separate, already-synced artifact; only the research-pool JSON lagged.

## Test plan
- [x] JSON validates (`python3 -c json.load`)
- [x] Metrics recomputed against `origin/main` source via the canonical `enrich-research.ts` regexes
- [ ] No build required — data-only, build-free change