### PR TITLE
research(laws-of-large-numbers-oq-04-oq-03): flag BLOCKED — S14b build-gated during Docker blackout

### DIFF
--- a/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
+++ b/research/problems/laws-of-large-numbers-oq-04-oq-03/state.md
@@ -1,5 +1,7 @@
 # Current State
 
+> **BLOCKED (2026-06-13, Docker blackout)**: S14b — the sole forward step — is strictly build-gated (needs Lean verification of the right-continuous CDF half + interior existence). All trackers (state.md / JSON / gallery meta) are in sync and the last ACT (S14a.2, #22958) was Docker-verified 2026-06-12; 7 doc-only PREP/STATE-SYNC sessions have since accumulated (3 PRs today: #23178/#23244/#23245). No build-free ACT route remains. Re-open when Docker is restored.
+
 **Phase**: REDESIGN-IN-PROGRESS (S14a.2 ACT shipped — `leftLim` upper-bracket lemma for `QuantileBracketingGrid`; S14b proves the right-continuous half + interior existence)
 **Since**: 2026-06-12 (S14a.2 ACT)
 **Iteration**: 12 ACT + 7 doc-only PREP/OBSERVE/STATE-SYNC. **S14a.2 ACT


### PR DESCRIPTION
## Summary

Flags `laws-of-large-numbers-oq-04-oq-03` as **blocked** during the Docker blackout. One-line banner at the top of `state.md`; pool coordination status also set to `blocked` to stop re-claim churn.

## Why blocked, not another STATE-SYNC

- Gallery `meta.json` is **clean**: lineCount 180, theoremCount 4 (incl-private), definitionCount 0, sorries 0; `axiomCount` meta=1 (transitive import) / leanFile=0 (literal — the line-17 `axiom` hit is a docstring mention) — both correct per convention. The 6 `sections[]` tile L1-180 contiguously.
- `state.md` and the research JSON are **in sync** (both at S14a.2 / iteration 12). The 14 `leanFiles[]` entries match the deployer's enrich regeneration convention (wc+1 lineCount, col-0 theoremCount, grep-based axiomCount). No drift to correct.
- The sole forward step **S14b** (prove the right-continuous half `jε ≤ F qⱼ` + interior existence) requires Lean verification — **strictly Docker-gated**.
- The last ACT (S14a.2, #22958) was Docker-verified 2026-06-12, but **7 doc-only PREP/STATE-SYNC sessions** have since accumulated (3 PRs today: #23178, #23244, #23245).

Per the flag-blocked-over-PREP-churn policy, marking blocked is the correct build-free action rather than manufacturing another no-op sync. Re-open when Docker is restored.

## Test plan

- [x] Doc-only change (one banner line); no Lean/build impact.