### PR TITLE
research(erdos-951): sync stale leanFiles metrics to source

### DIFF
--- a/src/data/research/problems/erdos-951.json
+++ b/src/data/research/problems/erdos-951.json
@@ -88,17 +88,17 @@
     "mathlib": []
   },
   "started": "2026-01-15T12:22:36.006Z",
-  "lastUpdate": "2026-06-04T00:00:00Z",
+  "lastUpdate": "2026-06-10T00:00:00Z",
   "significance": 6,
   "tractability": 4,
   "leanFiles": [
     {
       "path": "Proofs/Erdos951Problem.lean",
       "filename": "Erdos951Problem.lean",
-      "lineCount": 339,
-      "theoremCount": 15,
+      "lineCount": 392,
+      "theoremCount": 17,
       "axiomCount": 0,
-      "defCount": 10,
+      "defCount": 9,
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/Erdos951Problem.lean"


### PR DESCRIPTION
## Summary
- The research-pool JSON `leanFiles` block for `erdos-951` (parent slug) was frozen at lineCount 339 / theoremCount 15 / defCount 10 while the merged source `Erdos951Problem.lean` is at **392 lines, 17 theorems, 9 defs** (commit `d8284214`).
- Synced the 3 stale metrics. `axiomCount=0` and `sorryCount=0` are unchanged.

## Why this is a clean sync
- The file has exactly 1 private theorem, excluded from both the old (15) and new (17) strict `^(theorem|lemma) ` counts → the +2 is **genuine public-theorem growth**, not the strict-vs-private counting artifact.
- Comment-stripped recount confirms real `sorry=0` / `axiom=0` (no docstring false positives).
- `lastUpdate` bumped to the source landing date (2026-06-10); the JSON narrative is left untouched.
- The oq-05 child slug was synced separately in #23170 (merged); only the parent research-pool JSON lagged.
- No open PRs contend this slug's source.

## Test plan
- [x] JSON validates (`python3 -c json.load`)
- [x] Metrics recomputed against `origin/main` source via the canonical `enrich-research.ts` regexes
- [ ] No build required — data-only, build-free change