### PR TITLE
research: registry STATE-SYNC — flip 20 blocked trackers' stale registry phase to BLOCKED

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -16286,7 +16286,7 @@
     },
     {
       "slug": "erdos-263",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-13T22:43:37.492Z",
       "status": "active",
@@ -16410,7 +16410,7 @@
     },
     {
       "slug": "birthday-problem-oq-03-oq-01-oq-02-oq-01",
-      "phase": "ACT-READY",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
       "status": "active",
@@ -16489,7 +16489,7 @@
     },
     {
       "slug": "sperner-ndim-oq-05",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-04-14T21:25:05.895Z",
       "status": "active",
@@ -17958,7 +17958,7 @@
     },
     {
       "slug": "erdos-455-oq-04",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-05-12T15:34:56-07:00",
       "status": "active"
@@ -18004,7 +18004,7 @@
     },
     {
       "slug": "sperner-ndim-mathlib-oq-02",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.827Z",
       "status": "active",
@@ -18257,7 +18257,7 @@
     },
     {
       "slug": "hilbert-11-oq-02",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.885Z",
       "status": "active",
@@ -18374,7 +18374,7 @@
     },
     {
       "slug": "shannon-channel-coding-oq-02-oq-01-oq-01",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.889Z",
       "status": "active",
@@ -18435,7 +18435,7 @@
     },
     {
       "slug": "minpoly-charpoly-oq-03",
-      "phase": "NEW",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.893Z",
       "status": "active",
@@ -18629,7 +18629,7 @@
     },
     {
       "slug": "roth-theorem-oq-02",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.899Z",
       "status": "active",
@@ -18637,7 +18637,7 @@
     },
     {
       "slug": "weak-goldbach-oq-03",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.899Z",
       "status": "active",
@@ -18680,7 +18680,7 @@
     },
     {
       "slug": "godel-second-incompleteness-oq02-oq-02",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.900Z",
       "status": "active",
@@ -18785,7 +18785,7 @@
     },
     {
       "slug": "infinitude-primes-4k1-oq-03",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.906Z",
       "status": "active",
@@ -18953,7 +18953,7 @@
     },
     {
       "slug": "central-limit-theorem-oq-01-oq-01-oq-04-oq-01",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.912Z",
       "status": "active",
@@ -19316,7 +19316,7 @@
     },
     {
       "slug": "inverse-galois-d4-oq-03",
-      "phase": "NEW",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.929Z",
       "status": "active",
@@ -19438,7 +19438,7 @@
     },
     {
       "slug": "minpoly-charpoly-oq-02",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.933Z",
       "status": "active",
@@ -19603,7 +19603,7 @@
     },
     {
       "slug": "triangle-inequality-oq-04-oq-01",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.946Z",
       "status": "active",
@@ -19654,7 +19654,7 @@
     },
     {
       "slug": "product-of-segments-of-chords-oq-03",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.948Z",
       "status": "active",
@@ -19695,7 +19695,7 @@
     },
     {
       "slug": "halting-problem-oq-03",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.952Z",
       "status": "active",
@@ -19988,7 +19988,7 @@
     },
     {
       "slug": "hurwitz-theorem-wip-01",
-      "phase": "NEW",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:51.985Z",
       "status": "active",
@@ -21393,7 +21393,7 @@
     },
     {
       "slug": "gauss-wilson-non-cyclic-oq-02",
-      "phase": "OBSERVE",
+      "phase": "BLOCKED",
       "path": "full",
       "started": "2026-06-13T12:52:52.056Z",
       "status": "active",


### PR DESCRIPTION
## Summary

20 active problems carry a fully consistent **blocked** signal in their `src/data/research/problems/<slug>.json` (top-level `phase=BLOCKED`, `status=blocked`, and `currentState.phase=BLOCKED`), but `research/registry.json` still showed a stale `OBSERVE` / `NEW` / `ACT-READY` phase. Since `build.ts` merges registry phase into the public gallery listings (and never reads back from the src JSON), the website presented these genuinely-blocked problems as in-progress.

This is the same **reverse-drift** fix merged in #23288 (which flipped 2 such entries). Build-free, uncontended (verified no open PR touches `research/registry.json`), and durable (registry is authoritative for deployed phase; it is not deployer-self-healing for the phase field).

Registry `status` is left `active` to match the #23288 precedent — only `phase` is synced.

### Slugs flipped (registry phase → BLOCKED)
- birthday-problem-oq-03-oq-01-oq-02-oq-01 (was ACT-READY)
- central-limit-theorem-oq-01-oq-01-oq-04-oq-01, erdos-263, erdos-455-oq-04, gauss-wilson-non-cyclic-oq-02, godel-second-incompleteness-oq02-oq-02, halting-problem-oq-03, hilbert-11-oq-02, infinitude-primes-4k1-oq-03, product-of-segments-of-chords-oq-03, roth-theorem-oq-02, shannon-channel-coding-oq-02-oq-01-oq-01, sperner-ndim-mathlib-oq-02, sperner-ndim-oq-05, triangle-inequality-oq-04-oq-01, weak-goldbach-oq-03 (were OBSERVE)
- hurwitz-theorem-wip-01, inverse-galois-d4-oq-03, minpoly-charpoly-oq-03 (were NEW)
- minpoly-charpoly-oq-02 (was OBSERVE)

## Test plan
- [x] `git diff` shows exactly 20 insertions / 20 deletions, all on `"phase"` lines (no key reordering, no status changes)
- [x] Each slug's src research-JSON confirmed `phase=BLOCKED` + `status=blocked` on origin/main
- [x] No open PR touches `research/registry.json` (contention check)
- [ ] Build-free; no Lean compilation required (Docker blackout)