### PR TITLE
research(registry): STATE-SYNC — 3 ACT slugs mis-registered as NEW

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -18012,11 +18012,11 @@
     },
     {
       "slug": "hilbert-10-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:51.828Z",
       "status": "active",
-      "lastUpdate": "2026-06-13T12:52:51.828Z"
+      "lastUpdate": "2026-06-14T03:04:16.000Z"
     },
     {
       "slug": "chebyshev-bounds-oq-04-oq-01",
@@ -18307,11 +18307,11 @@
     },
     {
       "slug": "lagrange-four-squares-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:51.887Z",
       "status": "active",
-      "lastUpdate": "2026-06-13T12:52:51.887Z"
+      "lastUpdate": "2026-06-14T03:04:16.000Z"
     },
     {
       "slug": "amgm-inequality-oq-04-oq-02",
@@ -19595,11 +19595,11 @@
     },
     {
       "slug": "prime-number-theorem-oq-01",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:51.946Z",
       "status": "active",
-      "lastUpdate": "2026-06-13T12:52:51.946Z"
+      "lastUpdate": "2026-06-14T03:04:16.000Z"
     },
     {
       "slug": "triangle-inequality-oq-04-oq-01",


### PR DESCRIPTION
## Summary

A bulk registry append on `2026-06-13T12:52:51Z` added 137 fresh entries to `research/registry.json`, all at `phase=NEW`. For 134 of them that is correct (genuinely new stubs / `oq`/`incomplete` variants). Three, however, already carry substantial **ACT-phase** work in their authoritative `src/data/research/problems/*.json` and Lean sources:

| slug | evidence (origin/main) |
|------|------------------------|
| `hilbert-10-oq-01-oq-02` | 33 sessions, `Hilbert10OQ01OQ02.lean` 3174 LOC, 90 theorems, 0 sorries, 1 axiom; src-JSON phase `ACT (iter 27a-δ)` |
| `lagrange-four-squares-oq-01-oq-02` | src-JSON phase `ACT`, 26 built items / 16 insights |
| `prime-number-theorem-oq-01` | src-JSON phase `ACT`, `PrimeNumberTheoremOQ01.lean` 315 LOC, 0 sorries, axiomatized |

`build.ts` merges the registry `phase` into the public listings and never writes back to `src`, so these rich problems are currently surfaced as `NEW`. This also lets the random picker keep re-treating near-complete ACT problems as fresh.

## Change

Flip `phase` `NEW → ACT` for exactly these 3 entries (and bump `lastUpdate`). No other entries touched.

- Durable: registry is authoritative for deployed phase; not deployer-self-healing.
- Build-free: matches the established #23278 / #23288 registry STATE-SYNC pattern. Safe during the Docker verification blackout.
- No conflict: neither open bundle PR (#22850, #23005) touches `registry.json`.

## Test plan
- [x] `jq` confirms the 3 entries now read `phase=ACT`, `status=active`
- [x] `git diff` shows only 6 changed lines (phase + lastUpdate × 3)
- [ ] No Lean build required (registry metadata only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)