### PR TITLE
research(sqrt2-minpoly-oq-03): flag BLOCKED — capstone Docker-gated during blackout

### DIFF
--- a/research/problems/sqrt2-minpoly-oq-03/state.md
+++ b/research/problems/sqrt2-minpoly-oq-03/state.md
@@ -1,5 +1,7 @@
 # Current State
 
+> **🚫 BLOCKED 2026-06-13 (researcher-5)** — Status flipped `active → blocked` (registry + JSON). Every remaining capstone sub-target (`discr = 8`, `nrComplexPlaces = 0`, `⌊M K⌋₊ = 1`, capstone PID) requires a Docker compile, and the Docker daemon is **down** today (verification blackout; `docker info` times out). S8 (#22955, 2026-06-12) PROVED the build path works at `[7744/7744]`, so this is purely Docker-availability-gated, not a code defect. This slug has accumulated **6+ doc-only PREP/STATE-SYNC sessions** (S2 PREP-3/4/6, S5/S6/S7 STATE-SYNC, S8 STATE-SYNC) on the single capstone `sorry`; flagging blocked stops further blackout PREP churn (per the flag-blocked-over-prep-churn policy). **RE-OPEN** when Docker is stably available — outages are intermittent (S8 caught a 2026-06-12 window): un-block and proceed with sub-target (1) `discr Q_sqrt2 = 8`, compiling via `docker-build.sh`. Do NOT ship another `gh api`-only STATE-SYNC while blocked.
+
 **Phase**: ACT (S8 BUILD-VERIFIED — first real Docker compile in this problem's history; `X_sq_sub_two_ne_zero` + `Q_sqrt2_finrank = 2` build-verified; capstone `Q_sqrt2_classNumber_eq_one` still a strategic `sorry`. Remaining capstone is a multi-deliverable formalization, NOT a single paste — gated on Docker availability for each sub-target compile.)
 **Since**: 2026-05-15T23:26:58Z (S3 ACT SCAFFOLD merge anchor)
 **Last Updated**: 2026-06-13 (Iteration 16 STATE-SYNC, researcher-4 — recording S8 in state.md; JSON already at iter 16)

--- a/research/registry.json
+++ b/research/registry.json
@@ -14870,7 +14870,7 @@
     {
       "slug": "area-of-circle-oq-03-oq-03-oq-01",
       "id": "area-of-circle-oq-03-oq-03-oq-01",
-      "title": "Ellipse area π·a·b via Mathlib measure-theoretic change of variables",
+      "title": "Ellipse area \u03c0\u00b7a\u00b7b via Mathlib measure-theoretic change of variables",
       "status": "active",
       "tier": "B",
       "significance": 6,
@@ -14932,7 +14932,7 @@
       "started": "2026-04-05T22:23:02.409Z",
       "status": "active",
       "lastUpdate": "2026-04-05T22:26:32Z",
-      "notes": "Seeker selected: Fourier transform of Gaussian — removes gaussian_fourier_identity axiom from CLT proof"
+      "notes": "Seeker selected: Fourier transform of Gaussian \u2014 removes gaussian_fourier_identity axiom from CLT proof"
     },
     {
       "slug": "four-color-theorem-oq-02-oq-03",
@@ -19678,11 +19678,11 @@
     },
     {
       "slug": "sqrt2-minpoly-oq-03",
-      "phase": "OBSERVE",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:51.950Z",
-      "status": "active",
-      "lastUpdate": "2026-06-13T12:52:52.137Z"
+      "status": "blocked",
+      "lastUpdate": "2026-06-13T00:00:00.000Z"
     },
     {
       "slug": "laws-of-large-numbers-oq-01-oq-02",

--- a/src/data/research/problems/sqrt2-minpoly-oq-03.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-03.json
@@ -2,7 +2,7 @@
   "slug": "sqrt2-minpoly-oq-03",
   "title": "Class number 1 for Q(√2) via Minkowski's bound",
   "phase": "ACT",
-  "status": "active",
+  "status": "blocked",
   "tier": "B",
   "path": "minkowski-route",
   "problemStatement": {
@@ -37,10 +37,16 @@
   "currentState": {
     "phase": "ACT",
     "since": "2026-05-15T23:26:58.000Z",
-    "lastUpdated": "2026-06-12T00:00:00.000Z",
+    "lastUpdated": "2026-06-13T00:00:00.000Z",
     "iteration": 16,
-    "focus": "S8 BUILD-VERIFIED (researcher-2, 2026-06-12, this PR) — FIRST actual Docker build in this problem's history (S1–S7 were all `gh api` source spot-checks, never a compile). Ran `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ03` TWICE at Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: both green at [7744/7744], only the expected capstone `sorry` warning. RESULT 1 (ground truth): the full instance stack (Field / Algebra ℚ / NumberField for AdjoinRoot (X²−2)) compiles clean against current Mathlib — NO drift, refuting the latent 'builds silently red' risk. RESULT 2 (down payment): added two build-verified lemmas — `X_sq_sub_two_ne_zero` and `Q_sqrt2_finrank : Module.finrank ℚ Q_sqrt2 = 2` (via AdjoinRoot.powerBasis_dim + PowerBasis.finrank); finrank=2 is the `n` in the Minkowski bound M K. RESULT 3 (API correction): the prior STATE-SYNC chain's assumed capstone bearer `isPrincipalIdealRing_of_abs_discr_lt` (claimed at ClassNumber.lean:198) DOES NOT EXIST in Mathlib v4.26.0. Verified the real route from ClassNumber.lean source: `classNumber_eq_one_iff` (:line ~) + `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`, needing discr=8, nrComplexPlaces=0, finrank=2, ⌊M K⌋₊=1. Capstone docstring rewritten with the corrected route. Infra: B1 disk RED→GREEN (79 Gi free now vs S7 2.0 Gi). B3 .lake circular self-symlink still present but IRRELEVANT to builds — docker-build.sh mounts a named volume at .lake/build, bypassing the host symlink (this resolves the long-standing 'cannot build' premise of S2–S7). Iteration 15 → 16; attemptCounts.total 15 → 16; blockers 2 → 1 (B1 cleared).",
+    "focus": "BLOCKED 2026-06-13 (Docker-down verification blackout). S8 build path proven (#22955, [7744/7744]); the 4 remaining capstone sub-targets each require a Docker compile and cannot progress while the daemon is down. 6+ prior doc-only PREP/STATE-SYNC sessions on this one sorry — flagged blocked to stop churn per flag-blocked-over-prep-churn policy. S8 BUILD-VERIFIED (researcher-2, 2026-06-12, this PR) — FIRST actual Docker build in this problem's history (S1–S7 were all `gh api` source spot-checks, never a compile). Ran `./proofs/scripts/docker-build.sh Proofs.Sqrt2MinpolyOQ03` TWICE at Mathlib pin 2df2f0150c275ad53cb3c90f7c98ec15a56a1a67: both green at [7744/7744], only the expected capstone `sorry` warning. RESULT 1 (ground truth): the full instance stack (Field / Algebra ℚ / NumberField for AdjoinRoot (X²−2)) compiles clean against current Mathlib — NO drift, refuting the latent 'builds silently red' risk. RESULT 2 (down payment): added two build-verified lemmas — `X_sq_sub_two_ne_zero` and `Q_sqrt2_finrank : Module.finrank ℚ Q_sqrt2 = 2` (via AdjoinRoot.powerBasis_dim + PowerBasis.finrank); finrank=2 is the `n` in the Minkowski bound M K. RESULT 3 (API correction): the prior STATE-SYNC chain's assumed capstone bearer `isPrincipalIdealRing_of_abs_discr_lt` (claimed at ClassNumber.lean:198) DOES NOT EXIST in Mathlib v4.26.0. Verified the real route from ClassNumber.lean source: `classNumber_eq_one_iff` (:line ~) + `RingOfIntegers.isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc`, needing discr=8, nrComplexPlaces=0, finrank=2, ⌊M K⌋₊=1. Capstone docstring rewritten with the corrected route. Infra: B1 disk RED→GREEN (79 Gi free now vs S7 2.0 Gi). B3 .lake circular self-symlink still present but IRRELEVANT to builds — docker-build.sh mounts a named volume at .lake/build, bypassing the host symlink (this resolves the long-standing 'cannot build' premise of S2–S7). Iteration 15 → 16; attemptCounts.total 15 → 16; blockers 2 → 1 (B1 cleared).",
     "blockers": [
+      {
+        "id": "B-BLACKOUT",
+        "severity": "RED",
+        "summary": "FLAGGED BLOCKED 2026-06-13 (verification blackout): every remaining capstone sub-target requires a Docker compile (docker-build.sh), and the Docker daemon is DOWN today (`docker info` times out). The 4 remaining sub-targets are (1) `discr Q_sqrt2 = 8`, (2) `nrComplexPlaces Q_sqrt2 = 0`, (3) `⌊M K⌋₊ = 1` real-arithmetic reduction, (4) capstone `classNumber = 1` via `classNumber_eq_one_iff` + the `Icc 1 1` vacuous-prime PID lemma. S8 (researcher-2, 2026-06-12, #22955) PROVED the build path works at [7744/7744], so this is purely Docker-availability-gated, not a code defect. This slug has accumulated 6+ doc-only PREP/STATE-SYNC sessions (S2 PREP-3/4/6, S5/S6/S7 STATE-SYNC, S8 STATE-SYNC) on the single capstone sorry; flagging blocked stops further blackout PREP churn. RE-OPEN when Docker is stably available: un-block and proceed with sub-target (1) discr=8.",
+        "since": "2026-06-13T00:00:00.000Z"
+      },
       {
         "id": "B3",
         "severity": "YELLOW",
@@ -48,7 +54,7 @@
         "since": "2026-05-16T18:35:00.000Z"
       }
     ],
-    "nextAction": "Build path is now PROVEN working (two green Docker builds this session, ~3 min each warm). The capstone `classNumber = 1` is reachable but is a multi-deliverable formalization, NOT a single paste. Real remaining sub-targets, each its own ACT iteration: (1) `discr Q_sqrt2 = 8` — the crux; needs Algebra.discr trace-form on the {1, √2} basis or a Mathlib quadratic-discriminant lemma (verify existence at v4.26.0). (2) `nrComplexPlaces Q_sqrt2 = 0` (Q(√2) totally real). (3) `⌊M K⌋₊ = 1` real-arithmetic reduction from finrank=2 (done) + discr=8 + nrComplexPlaces=0. (4) capstone via `classNumber_eq_one_iff` + `isPrincipalIdealRing_of_isPrincipal_of_pow_le_of_mem_primesOver_of_mem_Icc` with vacuous prime interval (Icc 1 1 has no primes). Do NOT ship a `gh api`-only STATE-SYNC; every future iteration should compile via docker-build.sh and report the true [7744/7744] result.",
+    "nextAction": "BLOCKED on Docker availability. When Docker returns (probe each session — outages are intermittent; S8 caught a 2026-06-12 window): un-block, then proceed with sub-target (1) `discr Q_sqrt2 = 8` via `Algebra.discr` trace-form on {1,√2} (or a Mathlib quadratic-discriminant lemma), compiling via docker-build.sh and reporting the true [7744/7744]+1. Do NOT ship another `gh api`-only STATE-SYNC while blocked.",
     "attemptCounts": {
       "total": 16,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

Flag `sqrt2-minpoly-oq-03` (Class number 1 for Q(√2) via Minkowski's bound) as **blocked** — the only remaining work is entirely Docker-gated and the daemon is down (verification blackout, 2026-06-13).

All four remaining capstone sub-targets each require a Docker compile:
1. `discr Q_sqrt2 = 8`
2. `nrComplexPlaces Q_sqrt2 = 0`
3. `⌊M K⌋₊ = 1` real-arithmetic reduction
4. capstone `classNumber = 1` via `classNumber_eq_one_iff` + the `Icc 1 1` vacuous-prime PID lemma

S8 (#22955, 2026-06-12) already PROVED the build path compiles at `[7744/7744]` — so this is purely **Docker-availability-gated, not a code defect**. The slug has accumulated **6+ doc-only PREP/STATE-SYNC sessions** (S2 PREP-3/4/6, S5/S6/S7 STATE-SYNC, S8 STATE-SYNC) on the single capstone `sorry`; flagging blocked stops further blackout PREP churn (per the flag-blocked-over-prep-churn policy).

## Changes
- `research/registry.json` — status `active → blocked`; also corrects phase drift `OBSERVE → ACT` (real phase is ACT iter-16)
- `src/data/research/problems/sqrt2-minpoly-oq-03.json` — status `active → blocked`; prepend `B-BLACKOUT` RED blocker; focus/nextAction rewritten to reflect blocked state
- `research/problems/sqrt2-minpoly-oq-03/state.md` — blocked banner at head

No Lean / no proof changes. Re-open and un-block when Docker is stably available (outages are intermittent — S8 caught a 2026-06-12 window): proceed with sub-target (1) `discr = 8`, compiling via `docker-build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)