### PR TITLE
research(chebyshev-bounds-oq-04-oq-01): de-stale Lean header (Iter 1/OBSERVE → Iter 5a-β-1)

### DIFF
--- a/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
+++ b/proofs/Proofs/ChebyshevBoundsOQ04OQ01.lean
@@ -7,16 +7,23 @@
   function) elementarily, removing the axiom `chebyshevPsi_asymptotic`
   from `ChebyshevBoundsOQ04.lean`.
 
-  ## Status: Iteration 1 / OBSERVE
+  ## Status: Iteration 5a-β-1 (Lean source frozen) — 18 theorems, 4 defs,
+  0 sorries, 0 axioms. Tracker phase: PREP toward Iter 5a-β-2 (weak Mertens
+  M1 estimate |Σ_{d ≤ N} μ(d)/d| ≤ 1 + log N via Abel summation).
 
   This file scaffolds the Selberg-Erdős 1949 elementary proof strategy.
   Concretely, it:
 
   - Defines the Selberg auxiliary function
         Λ₂(n) = Λ(n)·log n + (Λ ∗ Λ)(n),
-    where Λ ∗ Λ denotes Dirichlet convolution.
-  - Defines the Selberg partial sum S₂(N) = Σ_{n ≤ N} Λ₂(n).
-  - Proves routine non-negativity, base-value, and monotonicity lemmas.
+    where Λ ∗ Λ denotes Dirichlet convolution, the Selberg partial sum
+    S₂(N) = Σ_{n ≤ N} Λ₂(n), and the Mertens partial sum M(N) = Σ_{d ≤ N} μ(d).
+  - Proves routine non-negativity, base-value, monotonicity, and prime-value
+    lemmas for Λ₂ (including the clean closed form Λ₂(p) = (log p)²).
+  - Proves Selberg's dual identity Σ_{d ∣ n} Λ₂(d) = (log n)² (Iter 3) and its
+    Möbius-inverse literal form Λ₂(n) = Σ_{d ∣ n} μ(d)·log²(n/d) (Iter 4),
+    together with the bridge lemma `vonMangoldtConv_eq_mul`.
+  - Proves the trivial linear Mertens bound |M(N)| ≤ N (Iter 5a-β-1).
   - Documents the elementary-PNT roadmap and identifies Mathlib gaps.
 
   No new axioms are added; the parent file's `chebyshevPsi_asymptotic`


### PR DESCRIPTION
## Summary

Docstring-only sync of the `ChebyshevBoundsOQ04OQ01.lean` header, which had drifted badly out of date.

The leading comment block still announced **"## Status: Iteration 1 / OBSERVE"** and its "Concretely, it:" bullet list described only the Iteration-1 deliverables (Selberg auxiliary function, partial sum, basic non-negativity/monotonicity lemmas). The file body and the research tracker have moved far past that:

- research JSON: `iteration: 7`, `currentState` frozen at **Iter 5a-β-1** (PREP toward Iter 5a-β-2, weak Mertens M1)
- actual Lean source: 18 theorems, 4 defs, **0 sorries, 0 axioms**, including the central Iter 3-4 results that the header omitted entirely.

Updated the header to reflect the true state and enumerate the real deliverables:
- Selberg's dual identity `Σ_{d∣n} Λ₂(d) = (log n)²` (Iter 3)
- its Möbius-inverse literal form `Λ₂(n) = Σ_{d∣n} μ(d)·log²(n/d)` (Iter 4) + bridge lemma
- the trivial linear Mertens bound `|M(N)| ≤ N` (Iter 5a-β-1)

## Scope & safety

- **Comment-only.** The entire diff lives inside the leading `/- ... -/` docstring (lines 7-23), before the first `import` (line 75). No code, defs, or proofs touched.
- Build-safe during the current Docker verification blackout — nothing to compile.
- The open target (`chebyshevPsi_asymptotic`) remains axiomatized in the parent file; this is genuine WIP scaffolding, not a completion claim. Status/badge in gallery meta (`formalized`/`wip`) is accurate and unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)