### PR TITLE
research(registry): STATE-SYNC — flip 9 graduated proofs' stale phase → COMPLETED

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -2670,7 +2670,7 @@
     },
     {
       "slug": "erdos-1137",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-01-15T15:52:59.263Z",
       "status": "graduated",
@@ -5341,7 +5341,7 @@
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-05",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-22T03:02:07.201Z",
       "status": "graduated",
@@ -5836,7 +5836,7 @@
     },
     {
       "slug": "brouwer-fixed-point-oq-04",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-24T00:48:59.817Z",
       "status": "graduated",
@@ -5854,7 +5854,7 @@
     },
     {
       "slug": "cramers-rule-oq-03",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-24T00:48:59.817Z",
       "status": "graduated",
@@ -15681,7 +15681,7 @@
     },
     {
       "slug": "fair-games-theorem-oq-02-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "graduated",
@@ -15973,7 +15973,7 @@
     },
     {
       "slug": "shannon-channel-coding-oq-02-oq-04",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T00:54:20.862Z",
       "status": "graduated",
@@ -16091,7 +16091,7 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T13:56:39.000Z",
       "status": "graduated",
@@ -16241,7 +16241,7 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-13T22:43:37.486Z",
       "status": "graduated",
@@ -16321,7 +16321,7 @@
     },
     {
       "slug": "erdos-476",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T22:43:37.493Z",
       "status": "graduated",


### PR DESCRIPTION
## Summary

The registry holds a clean invariant **`status=graduated ⟺ phase=COMPLETED`**: 1701 entries satisfy it and there are **0 inverse violations** (every `COMPLETED`-phase entry is `graduated`). But **21** entries violate it the other way — `status=graduated` while `phase ∈ {OBSERVE, ACT, ORIENT}`.

This PR fixes the **9** violations that have a real, complete gallery proof (`src/data/proofs/<slug>/meta.json`, 0 sorries, `verified` or `axiomatized`):

| slug | phase | meta.status |
|------|-------|-------------|
| erdos-1137 | ACT→COMPLETED | axiomatized 0s/1ax |
| brouwer-fixed-point-oq-04 | OBSERVE→COMPLETED | axiomatized 0s/4ax |
| cayley-hamilton-minpoly-oq-05 | OBSERVE→COMPLETED | verified 0s/0ax |
| cramers-rule-oq-03 | OBSERVE→COMPLETED | verified 0s/0ax |
| erdos-476 | OBSERVE→COMPLETED | axiomatized 0s/1ax |
| fair-games-theorem-oq-02-oq-01 | OBSERVE→COMPLETED | verified 0s/0ax |
| ptolemys-theorem-oq-01 | OBSERVE→COMPLETED | verified 0s/0ax |
| ptolemys-theorem-oq-01-incomplete-01 | OBSERVE→COMPLETED | verified 0s/0ax |
| shannon-channel-coding-oq-02-oq-04 | OBSERVE→COMPLETED | axiomatized 0s/4ax |

## Why

The registry is authoritative for deployed phase — `build.ts` merges `registry → public listings` and never reads back. So these graduated, merged proofs were being surfaced at phase `OBSERVE` ("surveyed only, no proof"), contradicting their actual completed state. Build-free STATE-SYNC, safe during the 2026-06-13 verification blackout (Docker down).

## Out of scope

The other **12** graduated-but-phase-stale slugs have **no gallery dir** (`cube-root-{6,7,9,10}-irrational`, `pascals-hexagon-oq-01`, `continuum-hypothesis-incomplete-01`, `hurwitz-three-square-impossibility`, `binomial-theorem-oq-03-oq-01`, `amgm-...-incomplete-01`, `erdos-1019-incomplete-01`, `erdos-1132-oq-01`, `erdos-1169-oq-04`). Several have a `.lean` but aren't gallery-integrated, so `graduated` itself is questionable — flipping their phase would launder an unverifiable claim. Left for separate gallery-integration / graduate-process review.

## Test plan
- [x] `jq` invariant check: graduated-and-not-COMPLETED count 21 → 12 after patch
- [x] Diff is exactly 9 `phase` field edits, no other registry changes
- [x] Each fixed slug confirmed to have `meta.sorries == 0` and an existing `.lean`

🤖 Generated with [Claude Code](https://claude.com/claude-code)