### PR TITLE
research(registry): phase=COMPLETED on 4 graduated slugs missed by #23299

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -5341,7 +5341,7 @@
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-05",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-22T03:02:07.201Z",
       "status": "graduated",
@@ -5836,7 +5836,7 @@
     },
     {
       "slug": "brouwer-fixed-point-oq-04",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-24T00:48:59.817Z",
       "status": "graduated",
@@ -16091,7 +16091,7 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "full",
       "started": "2026-04-13T13:56:39.000Z",
       "status": "graduated",
@@ -16241,7 +16241,7 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01-incomplete-01",
-      "phase": "COMPLETED",
+      "phase": "OBSERVE",
       "path": "fast",
       "started": "2026-04-13T22:43:37.486Z",
       "status": "graduated",

--- a/research/registry.json
+++ b/research/registry.json
@@ -70,7 +70,7 @@
     },
     {
       "slug": "hurwitz-three-square-impossibility",
-      "phase": "ORIENT",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2025-12-30T16:59:27-08:00",
       "status": "graduated",
@@ -5341,7 +5341,7 @@
     },
     {
       "slug": "cayley-hamilton-minpoly-oq-05",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-22T03:02:07.201Z",
       "status": "graduated",
@@ -5836,7 +5836,7 @@
     },
     {
       "slug": "brouwer-fixed-point-oq-04",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-03-24T00:48:59.817Z",
       "status": "graduated",
@@ -10922,7 +10922,7 @@
     },
     {
       "slug": "amgm-inequality-oq-03-oq-03-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-03T07:37:00.135Z",
       "status": "graduated",
@@ -15663,7 +15663,7 @@
     },
     {
       "slug": "erdos-1169-oq-04",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T00:54:20.757Z",
       "status": "graduated",
@@ -16091,7 +16091,7 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-13T13:56:39.000Z",
       "status": "graduated",
@@ -16241,7 +16241,7 @@
     },
     {
       "slug": "ptolemys-theorem-oq-01-incomplete-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2026-04-13T22:43:37.486Z",
       "status": "graduated",
@@ -16392,7 +16392,7 @@
     },
     {
       "slug": "binomial-theorem-oq-03-oq-01",
-      "phase": "OBSERVE",
+      "phase": "COMPLETED",
       "path": "full",
       "started": "2026-04-14T17:49:44.227Z",
       "status": "graduated",


### PR DESCRIPTION
## Summary

Complements open PR #23299 (which flips 9 graduated-but-stale-phase slugs). This PR covers **4 additional `status: graduated` entries that #23299 missed**, each of which has its source research JSON (`src/data/research/problems/<slug>.json`) independently recording `phase: COMPLETED`:

- `hurwitz-three-square-impossibility` (registry was `ORIENT`)
- `erdos-1169-oq-04` (registry was `OBSERVE`)
- `amgm-inequality-oq-03-oq-03-incomplete-01` (registry was `OBSERVE`)
- `binomial-theorem-oq-03-oq-01` (registry was `OBSERVE`)

## Why it matters

`build.ts:updateRegistryFields` overwrites the committed research JSON's `phase` with the **registry** phase on every build, and `ResearchCard.tsx` renders `status` badge and `phase` pill independently — so these graduated proofs publicly display a phase pill (`OBSERVE`/`ORIENT`) that contradicts their own graduated badge. Durable (won't self-heal); registry is canonical for the public phase.

## Scope discipline

- Originally proposed 8 slugs; trimmed the 4 that overlap with #23299 to avoid duplicate edits.
- Used a stricter criterion than #23299: only flip where the **source JSON phase is already COMPLETED**. I deliberately did *not* include `erdos-1137` / `cramers-rule-oq-03` / `fair-games-theorem-oq-02-oq-01` / `shannon-channel-coding-oq-02-oq-04` / `erdos-476` (in #23299) because their source phase is `OBSERVE`/`ACT` — see cross-check comment on #23299.
- Excluded `erdos-1019-incomplete-01` entirely: source `progressSummary` says "Eliminated 3 of 5 sorries" (2 remain) despite `status: graduated`.

## Test plan

- [x] `jq empty research/registry.json` (valid JSON)
- [x] Diff is exactly 4 `phase` field changes on `status: graduated` entries