### PR TITLE
research(desargues-theorem-oq-02-oq-02): populate stub leanFiles metrics from source

### DIFF
--- a/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
+++ b/src/data/research/problems/desargues-theorem-oq-02-oq-02.json
@@ -88,6 +88,11 @@
     {
       "path": "Proofs/DesarguesTheoremOQ02.lean",
       "filename": "DesarguesTheoremOQ02.lean",
+      "lineCount": 333,
+      "theoremCount": 35,
+      "axiomCount": 0,
+      "defCount": 21,
+      "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/DesarguesTheoremOQ02.lean"
     }


### PR DESCRIPTION
## Summary
The research-pool JSON for `desargues-theorem-oq-02-oq-02` carried a **path-only stub** leanFiles entry for `DesarguesTheoremOQ02.lean` — no metric fields at all — while the merged source on `origin/main` holds substantial untracked content.

Populated the five metric fields from a comment-stripped recompute of the `origin/main` source using the canonical `enrich-research.ts` conventions:

| field | value |
|-------|-------|
| lineCount | 333 |
| theoremCount | 35 |
| axiomCount | 0 |
| defCount | 21 |
| sorryCount | 0 |

real (comment-stripped) sorry = 0, axiom = 0 — no docstring false-positives. The `+35` theoremCount is genuine public growth (only 2 `private` lemmas in the file, excluded by the strict `^(theorem|lemma) ` convention on both sides).

## Notes
- Build-free metadata sync during the 2026-06-13 verification blackout (Docker down + Aristotle 404). No source or proof changes.
- Scoped to the `leanFiles` block only; `status`/`currentState` (blocked/ORIENT) left untouched — the slug's open question remains build-gated.
- Field order matches the deployer's `enrich-research.ts` emission (path, filename, metrics, isAristotle, githubUrl).

## Test plan
- [x] `python3 -c "import json; json.load(...)"` — JSON valid
- [x] Metrics recomputed against `origin/main` source via the exact enrich-research.ts regexes