### PR TITLE
research(registry): phase=COMPLETED on 4 cube-root slugs missed by #23299/#23300

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -30,7 +30,7 @@
     },
     {
       "slug": "cube-root-9-irrational",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2025-12-30T16:45:31-08:00",
       "status": "graduated",
@@ -40,7 +40,7 @@
     },
     {
       "slug": "cube-root-6-irrational",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2025-12-30T16:46:33-08:00",
       "status": "graduated",
@@ -50,7 +50,7 @@
     },
     {
       "slug": "cube-root-7-irrational",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2025-12-30T16:46:33-08:00",
       "status": "graduated",
@@ -60,7 +60,7 @@
     },
     {
       "slug": "cube-root-10-irrational",
-      "phase": "ACT",
+      "phase": "COMPLETED",
       "path": "fast",
       "started": "2025-12-30T16:46:33-08:00",
       "status": "graduated",


### PR DESCRIPTION
## Summary
Flips the registry `phase` from stale `ACT` to `COMPLETED` for four graduated cube-root irrationality slugs:
- `cube-root-6-irrational`
- `cube-root-7-irrational`
- `cube-root-9-irrational`
- `cube-root-10-irrational`

## Why these are genuinely complete
Each is `status: graduated` with a `completed` timestamp (2025-12-30), and each has a sorry-free, axiom-free Lean proof:
- `proofs/Proofs/CubeRoot{6,7,9,10}Irrational.lean` — 79 lines, `grep -c sorry` = 0, `grep -c '^axiom '` = 0
- Each exposes a real general theorem `irrational_cbrtN : Irrational cbrtN` (plus `irrational_N_pow_one_three`).

## Why #23299/#23300 missed them
Those PRs flipped graduated slugs whose `src/data/research/problems/<slug>.json` had `currentState.phase == COMPLETED`. These four are **fast-path** slugs with no such source JSON, so that discriminator never fired. The graduated status + `completed` timestamp + verified Lean file is the equivalent signal here.

## Scope / safety
- Diff is exactly 4 lines (4 `phase` fields). JSON validated with `jq empty`.
- Disjoint from the other open registry PR (#23293 touches BLOCKED flips, not cube-root) and #22850 (touches cube-root-3-oq-04 only).
- Build-free STATE-SYNC: Docker verification infra is down (blackout 2026-06-13); no Lean build required since the proofs were already verified at graduation.

## Test plan
- [x] `jq empty research/registry.json` passes
- [x] `git diff --stat` = 4 insertions / 4 deletions, registry.json only
- [x] Confirmed 0 sorries / 0 axioms in all four `CubeRoot*Irrational.lean` files