### PR TITLE
research: STATE-SYNC — de-stale 5 COMPLETED/graduated trackers to 0-sorry verified/axiomatized source

### DIFF
--- a/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean
+++ b/proofs/Proofs/CayleyHamiltonCyclicVectorAllFields.lean
@@ -19,21 +19,21 @@
      p_i^{e_i} | r by pow_irred_dvd_of_annihilated. Then ∏ p_i^{e_i} | r by
      pairwise coprimality, so deg(r) ≥ n — contradiction with deg(r) < n.
 
-  3. **[Sorry: routine]** Factorization bridge: Every monic polynomial of positive
+  3. **[Proved]** Factorization bridge: Every monic polynomial of positive
      degree over a field factors into coprime monic irreducible prime powers.
-     This is a standard consequence of K[X] being a UFD. The sorry is strictly
-     routine Mathlib API work, NOT a mathematical assumption.
+     This is a standard consequence of K[X] being a UFD.
 
-  ## Status: 0 axioms, 1 sorry (polynomial factorization bridge)
+  ## Status: 0 axioms, 0 sorries (fully verified)
 
-  The mathematical content is fully verified. The single sorry is a routine
-  application of UniqueFactorizationMonoid.normalizedFactors in Mathlib.
+  The mathematical content is fully verified. The factorization bridge
+  (`monic_factored_form`) is a proved theorem built on Mathlib's
+  UniqueFactorizationMonoid factorization API.
 
   ## Why V2 is Stronger than V1
 
   V1's axiom (RCF similarity) required the structure theorem for finitely
   generated modules over a PID — ~800 lines to formalize, fundamentally deep.
-  V2's sorry is ~50 lines of Mathlib API navigation — routine and Aristotle-suitable.
+  V2 discharges the factorization bridge directly via Mathlib API — no axiom, no sorry.
 
   ## Related Gallery Entries
 
@@ -250,17 +250,15 @@ finitely generated modules over PIDs.
 - `nonderogatory_has_cyclic_vector_finite`: finite field corollary
 - `cyclic_iff_not_killed_below_degree`: characterization corollary
 
-**The one sorry**:
-- `monic_factored_form`: monic polynomial factors into coprime prime powers
-  This is a routine consequence of K[X] being a UFD (UniqueFactorizationMonoid).
-  NOT a mathematical assumption — purely Mathlib API navigation.
-  Estimated: ~50 lines using normalizedFactors + Finset.equivFin.
-  Suitable for Aristotle submission.
+**The factorization bridge (proved)**:
+- `monic_factored_form`: monic polynomial factors into coprime prime powers.
+  A consequence of K[X] being a UFD (UniqueFactorizationMonoid), discharged via
+  monic_irreducible_multiset_factorization + finset_factorization_from_multiset.
 
 **V1 → V2 delta**:
 - Removed: `axiom nonderogatory_similar_companion` (RCF similarity, ~800 lines to prove)
-- Added: `sorry` in `monic_factored_form` (routine Mathlib API, ~50 lines to prove)
-- Net: Deep mathematical axiom → routine API sorry
+- Replaced by: proved theorem `monic_factored_form` (Mathlib UFM API)
+- Net: Deep mathematical axiom → fully proved, axiom-free and sorry-free
 -/
 
 end CayleyHamiltonCyclicVectorAllFields

--- a/proofs/Proofs/PtolemysTheoremOQ01.lean
+++ b/proofs/Proofs/PtolemysTheoremOQ01.lean
@@ -17,7 +17,7 @@ proportionality characterization), we establish:
    R = (z₂-z₃)(z₁-z₄) / ((z₁-z₂)(z₃-z₄)) is always real (proved algebraically).
 
 2. **Positivity for CCW order**: For four unit-circle points in counterclockwise order,
-   R > 0 (the ratio is a positive real). [sorry: requires inscribed angle theorem]
+   R > 0 (the ratio is a positive real). [proved via half-angle sine factorization]
 
 3. **Ptolemy equality for concyclic CCW points**: Combining the above with
    `ptolemy_equality_of_proportional`, four unit-circle points in CCW order satisfy
@@ -461,7 +461,7 @@ are equivalent:
 
 The present file proves:
 - (3 → 2 → 1): If R > 0, Ptolemy equality holds (algebraic)
-- (4 → 3): If CCW concyclic, R > 0 [requires `ptolemy_ratio_pos_of_ccw`, currently sorry]
+- (4 → 3): If CCW concyclic, R > 0 [proved via `ptolemy_ratio_pos_of_ccw`]
 - Unit circle cross-ratio is always real (1 → 3 for unit circle case), proved algebraically
 -/
 

--- a/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json
+++ b/src/data/research/problems/cayley-hamilton-cyclic-vector-all-fields.json
@@ -19,9 +19,9 @@
     "phase": "COMPLETED",
     "since": "2026-04-25T13:30:37+02:00",
     "iteration": 2,
-    "focus": "Gallery entry CayleyHamiltonCyclicVectorAllFields.lean V2 (axiom-free): 0 axioms, 1 sorry (monic_factored_form, routine ~50-line Mathlib UFM API). Eliminated RCF similarity axiom by routing through WIP04 primary decomposition (PR #13041, 2026-04-27).",
+    "focus": "Gallery entry CayleyHamiltonCyclicVectorAllFields.lean V2: 0 axioms, 0 sorries (gallery status=verified). monic_factored_form is now a fully-proved theorem (via monic_irreducible_multiset_factorization + finset_factorization_from_multiset), no longer a sorry. Eliminated RCF similarity axiom by routing through WIP04 primary decomposition (PR #13041, 2026-04-27).",
     "blockers": [],
-    "nextAction": "Submit monic_factored_form (routine UFM/normalizedFactors API) to Aristotle to reach 0 sorries / 0 axioms.",
+    "nextAction": "None — proof is complete (0 sorries / 0 axioms, gallery status=verified). Maintenance only.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -25,9 +25,9 @@
     "phase": "COMPLETED",
     "since": "2026-03-27T00:00:00Z",
     "iteration": 1,
-    "focus": "Formalize the standard 4x4 nilpotent counterexample",
+    "focus": "4x4 nilpotent counterexample formalized: CayleyHamiltonMinpolyOQ02OQ02.lean is 0 sorries / 0 axioms (gallery status=verified). A (Jordan [2,2]) and B (Jordan [2,1,1]) share charpoly X⁴ and minpoly X² yet are non-similar (det of any intertwiner is 0 by a Leibniz/pigeonhole argument).",
     "blockers": [],
-    "nextAction": "Fill in sorry for minpoly minimality step and intertwining constraints",
+    "nextAction": "None — counterexample complete (0 sorries / 0 axioms, gallery status=verified). Maintenance only.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,

--- a/src/data/research/problems/erdos-363-incomplete-01.json
+++ b/src/data/research/problems/erdos-363-incomplete-01.json
@@ -8,11 +8,9 @@
     "phase": "COMPLETED",
     "since": "2026-03-28T20:35:00Z",
     "iteration": 1,
-    "focus": "Fixed false theorem statement (missing nonzero hypothesis).",
-    "blockers": [
-      "Product reindexing (Icc → range) for full proof"
-    ],
-    "nextAction": "Prove product equivalence to eliminate last sorry",
+    "focus": "Axiomatized-complete: source has 0 sorries and 3 axioms (pomerance_observation, ulas_theorem, erdos_selfridge). Earlier product-reindexing sorry no longer present in source.",
+    "blockers": [],
+    "nextAction": "Reduce axiom count if Mathlib gains support for the Ulas / Erdős–Selfridge bounds (no sorries remain).",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -20,7 +18,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Fixed single_block_not_square theorem statement — added required nonzero hypothesis (original was FALSE for intervals containing 0, e.g. [0,1] has product 0 = 0²). Sorry remains for product reindexing (connecting Icc-indexed and range-indexed products).",
+    "progressSummary": "COMPLETE (axiomatized): source has 0 sorries and 3 axioms (pomerance_observation, ulas_theorem, erdos_selfridge). The product-reindexing sorry is no longer present; an earlier 5-axiom listing was superseded by a source refactor.",
     "builtItems": [
       "Fixed single_block_not_square: added hne : I.product ≠ 0 hypothesis"
     ],
@@ -28,11 +26,11 @@
       "Original theorem was FALSE: [0,1] has product 0 = 0², so isPerfectSquare holds",
       "Erdős-Selfridge axiom has nonzero hypothesis — theorem needs it too",
       "Product reindexing (∏ m ∈ Icc(a, a+n-1) = ∏ i ∈ range(n), (a+i)) is the main gap",
-      "File has 5 axioms (erdos_selfridge, sawhney, ulas, bauer_bennett, bennett_van_luijk)"
+      "Source now carries 3 axioms (pomerance_observation, ulas_theorem, erdos_selfridge); the earlier 5-axiom listing (erdos_selfridge/sawhney/ulas/bauer_bennett/bennett_van_luijk) was superseded by a refactor"
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove product reindexing via Finset.prod_bij or similar"
+      "Reduce axiom count (Ulas / Erdős–Selfridge bounds) — product reindexing already discharged (0 sorries)"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-45-incomplete-01.json
+++ b/src/data/research/problems/erdos-45-incomplete-01.json
@@ -8,10 +8,9 @@
     "phase": "COMPLETED",
     "since": "2026-03-28T20:25:00Z",
     "iteration": 1,
-    "focus": "Assessed — sorry and axioms are all deep results.",
+    "focus": "Axiomatized-complete: source has 0 sorries and 3 axioms (sawhney_upper_bound, sawhney_lower_bound, case_k_2). Earlier croot_existence sorry no longer present in source.",
     "blockers": [
-      "croot_existence: probabilistic method (Croot)",
-      "case_k_2 axiom could be proved computationally but needs reformulation"
+      "case_k_2 axiom could be discharged computationally but needs finite-domain reformulation"
     ],
     "nextAction": "Convert case_k_2 axiom to theorem via finite check",
     "attemptCounts": {
@@ -21,7 +20,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: 1 sorry (croot_existence — deep), 3 axioms. The case_k_2 axiom (HasKEgyptianProperty 120 2) is the most tractable: it's a finite combinatorial check over 2^15 colorings of properDivisors(120). But the ∀ c : ℕ → Fin 2 quantifier has infinite domain, requiring reformulation before decide/native_decide.",
+    "progressSummary": "COMPLETE (axiomatized): source has 0 sorries and 3 axioms (sawhney_upper_bound, sawhney_lower_bound, case_k_2). The croot_existence sorry is no longer present; case_k_2 remains a candidate for computational discharge.",
     "builtItems": [],
     "insights": [
       "properDivisors(120) = {1,2,3,4,5,6,8,10,12,15,20,24,30,40,60} — 15 elements",
@@ -31,8 +30,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Reformulate case_k_2 to use finite domain (Fin 15 → Fin 2) and prove via native_decide",
-      "The main sorry (croot_existence) is beyond current formalization capacity"
+      "Reformulate case_k_2 to use finite domain (Fin 15 → Fin 2) and prove via native_decide"
     ]
   },
   "tags": [

--- a/src/data/research/problems/ptolemys-theorem-oq-01.json
+++ b/src/data/research/problems/ptolemys-theorem-oq-01.json
@@ -19,12 +19,9 @@
     "phase": "COMPLETED",
     "since": "2026-04-13T20:56:21.000Z",
     "iteration": 1,
-    "focus": "Created PtolemysTheoremOQ01.lean: cross-ratio reality theorem + concyclicity characterization",
-    "blockers": [
-      "unit_star_eq_inv needs exact Mathlib name for Complex.mul_conj normalization",
-      "ptolemy_ratio_pos_of_ccw requires inscribed angle/trig argument with Complex.exp"
-    ],
-    "nextAction": "Submit ptolemy_ratio_pos_of_ccw sorry to Aristotle; resolve unit_star_eq_inv API",
+    "focus": "PtolemysTheoremOQ01.lean complete: cross-ratio reality theorem + concyclicity characterization, 0 sorries / 0 axioms (gallery status=verified). ptolemy_ratio_pos_of_ccw is now fully proved (half-angle sine factorization via exp_diff_factor), no longer a sorry.",
+    "blockers": [],
+    "nextAction": "None — proof is complete (0 sorries / 0 axioms, gallery status=verified). Maintenance only.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

Five research trackers were marked COMPLETED (registry: graduated, or axiomatized-final) but their `currentState.focus`/`nextAction` still pointed at a sorry/axiom that no longer exists in source. `build.ts` preserves `currentState` from the src JSON and the research gallery renders it — so these stale instructions ("eliminate last sorry", "submit sorry to Aristotle", "fill in sorry") are a visible, credibility-damaging contradiction against a 0-sorry proof.

Each fix is verified against the **actual Lean source**, not the tracker.

| slug | source state (verified) | stale tracker text removed |
|------|-------------------------|----------------------------|
| `erdos-363-incomplete-01` | 0 sorries, 3 axioms (axiomatized) | "eliminate last product-reindexing sorry" |
| `erdos-45-incomplete-01` | 0 sorries, 3 axioms (axiomatized) | "eliminate last croot_existence sorry" |
| `cayley-hamilton-cyclic-vector-all-fields` | 0 sorries, 0 axioms (verified) | "submit monic_factored_form sorry to Aristotle" |
| `cayley-hamilton-minpoly-oq-02-oq-02` | 0 sorries, 0 axioms (verified) | "fill in sorry for minpoly minimality step" |
| `ptolemys-theorem-oq-01` | 0 sorries, 0 axioms (verified) | "submit ptolemy_ratio_pos_of_ccw sorry to Aristotle" |

For the latter three, the named lemmas (`monic_factored_form`, the 4×4 nilpotent counterexample, `ptolemy_ratio_pos_of_ccw`) are confirmed fully proved in source. Also corrected stale `## Status: ... 1 sorry` / `currently sorry` docstrings in `CayleyHamiltonCyclicVectorAllFields.lean` and `PtolemysTheoremOQ01.lean`.

## Why durable (not churn)
- `build.ts` preserves `currentState`/`knowledge` from src JSON (only merges registry phase/status/dates) → not deployer-self-healing.
- `.lean` edits are comment-only (docstrings) → build-safe, no metric changes.
- Top-level `phase`/`status` left untouched (registry-canonical; src-side drift is benign).
- registry.json **not** edited → no contention with the concurrent registry STATE-SYNC PRs (#23293/#23303/#23306).

## Test plan
- [x] `jq`/`python -c json.load` validate all 3 edited research JSONs
- [x] grep confirms no proof-term `sorry` in the named source files; remaining "sorry" mentions are negations ("sorry-free", "no sorry")
- [ ] Docker build not run (blackout: daemon unresponsive) — changes are build-free by construction

🤖 Generated with [Claude Code](https://claude.com/claude-code)