### PR TITLE
research(registry): flip 4 mis-graduated incomplete OQ slugs graduated→active

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -5848,9 +5848,8 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-24T00:48:59.817Z",
-      "status": "graduated",
-      "lastUpdate": "2026-04-04T18:43:45-07:00",
-      "completed": "2026-03-24T15:15:41.765Z"
+      "status": "active",
+      "lastUpdate": "2026-06-14T04:41:35.000Z"
     },
     {
       "slug": "cramers-rule-oq-03",
@@ -6010,9 +6009,8 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-24T00:48:59.902Z",
-      "status": "graduated",
-      "lastUpdate": "2026-03-26T22:04:50-07:00",
-      "completed": "2026-03-24T15:15:41.794Z"
+      "status": "active",
+      "lastUpdate": "2026-06-14T04:41:35.000Z"
     },
     {
       "slug": "erdos-102-oq-03",
@@ -6190,9 +6188,8 @@
       "phase": "OBSERVE",
       "path": "full",
       "started": "2026-03-24T00:48:59.907Z",
-      "status": "graduated",
-      "lastUpdate": "2026-04-05T13:26:15-07:00",
-      "completed": "2026-03-24T16:23:55.819Z"
+      "status": "active",
+      "lastUpdate": "2026-06-14T04:41:35.000Z"
     },
     {
       "slug": "erdos-1179-oq-01",
@@ -8800,9 +8797,8 @@
       "phase": "ACT",
       "path": "full",
       "started": "2026-03-29T23:39:50-07:00",
-      "status": "graduated",
-      "completed": "2026-03-30T09:24:56.478Z",
-      "lastUpdate": "2026-04-13T16:27:42-07:00"
+      "status": "active",
+      "lastUpdate": "2026-06-14T04:41:35.000Z"
     },
     {
       "slug": "pi-transcendental-oq-04",


### PR DESCRIPTION
## Summary

Four research open-question problems are marked `status=graduated` (with a March `completed` date) in `research/registry.json`, yet are **demonstrably incomplete** — their own registry `phase` is still OBSERVE/ACT and their committed Lean source still carries the very axioms/sorries the OQ targets:

| slug | source state | OQ goal |
|------|-------------|---------|
| `continuum-hypothesis-incomplete-01` | `ContinuumHypothesis.lean`: **4 axioms** | reduce those 4 axioms |
| `erdos-1019-incomplete-01` | `Erdos1019*.lean`: **1+6 sorries, 3 axioms** | complete proof (slug literally says "incomplete") |
| `erdos-1132-oq-01` | `Erdos1132*.lean`: **2 axioms + 2 sorries** | axiom reduction |
| `pascals-hexagon-oq-01` | `PascalsHexagon.lean`: **2 sorries + 1 axiom** | prove the Cayley-Bacharach axiom |

The src research JSONs already say `status: active`, phase OBSERVE/ACT, with documented open bottlenecks ("Sylvester law is next bottleneck", "before choosing an axiom-reduction").

## Why this matters

`build.ts` `updateRegistryFields` overwrites each problem's **public listing** status with the registry status (`scripts/research/build.ts:631`), so these incomplete problems render as **graduated/completed** in the research gallery while simultaneously showing phase OBSERVE/ACT — a visible contradiction and a credibility-damaging overclaim.

## Why it's durable (not churn)

`sync-data.ts` only ever **promotes** registry status to `graduated`/`blocked` — there is no demotion path — and it derives status from the candidate pool (absent) and gallery `meta.json` (none exist for these slugs). So the registry will not self-heal here, and it will not auto-revert this fix.

## Relationship to in-flight work

This is the inverse half of the same 8-slug `graduated`-but-non-`COMPLETED`-phase anomaly that #23299 / #23300 / #23303 are cleaning up: the 4 cube-root slugs are genuinely complete (phase→COMPLETED, #23303); these 4 are genuinely incomplete (status→active). Disjoint slug/field set from #23303 and #23293.

## Changes

- 4 entries: `status: graduated → active`, removed the spurious `completed` date, bumped `lastUpdate`. Phase left untouched (already correct).

## Test plan

- [x] `jq empty research/registry.json` — valid JSON
- [x] Diff limited to exactly the 4 entries (8 ins / 12 del)
- [x] Build-free; verified incompleteness by grepping committed `proofs/Proofs/*.lean` during the Docker verification blackout

🤖 Generated with [Claude Code](https://claude.com/claude-code)