### PR TITLE
research(erdos-1166, erdos-131-oq-01): STATE-SYNC stale knowledge blocks to 0-sorry source

### DIFF
--- a/src/data/research/problems/erdos-1166.json
+++ b/src/data/research/problems/erdos-1166.json
@@ -60,7 +60,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Fill sorry in erdos1166_from_ingredients via plateau analysis (requires maxVisitCount monotonicity + Finset counting)",
+      "All theorems sorry-free (erdos1166_from_ingredients now proved); 3 remaining axioms encode deep probabilistic inputs (asProbFilter, mostVisited_bounded_eventually, erdosTaylor_constant) absent from Mathlib",
       "Potential: convert AlmostSurely/almostSurely_mono/almostSurely_and to structure (3→3 structure fields, no net change)"
     ],
     "markdown": "# Erdős #1166 - Knowledge Base\n\n## Problem Statement\n\nProblem statement not found\n\n## Status\n\n**Erdős Database Status**: OPEN\n\n**Tractability Score**: 6/10\n**Aristotle Suitable**: No\n\n## Tags\n\n- erdos\n\n## Related Problems\n\n- Problem #2000\n- Problem #83\n- Problem #888\n- Problem #2\n- Problem #39\n- Problem #1\n\n## References\n\n- (None available)\n\n## Sessions\n\n(No research sessions yet)\n\n---\n\n*Generated from erdosproblems.com on 2026-01-15*\n"

--- a/src/data/research/problems/erdos-131-oq-01.json
+++ b/src/data/research/problems/erdos-131-oq-01.json
@@ -38,7 +38,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added sorry-free structural lemma (one_not_in_large_nondividing) and 3-element constructive example ({2,4,5} is non-dividing, proving F(5)≥3). 6 sorries remain (all deep published results).",
+    "progressSummary": "PROGRESS: Added sorry-free structural lemma (one_not_in_large_nondividing) and 3-element constructive example ({2,4,5} is non-dividing, proving F(5)≥3). Now 0 sorries; 2 axioms (pham_zakharov_upper_bound, csaba_lower_bound) encode the deep published bounds.",
     "builtItems": [
       "exp_three_fourths_gt_two: exp(3/4) > 2 via Taylor sum",
       "log_two_lt: log 2 < 3/4",
@@ -63,7 +63,7 @@
       "Finset.eq_of_subset_of_card_le is the key Mathlib lemma for showing S = erase set from cardinality"
     ],
     "nextSteps": [
-      "6 remaining sorries are deep published results (ELRSS, Pham-Zakharov, Csaba, Straus bounds) - not provable from current Mathlib"
+      "Deep published bounds (ELRSS, Pham-Zakharov, Csaba, Straus) are not provable from current Mathlib; now encoded as 2 axioms (pham_zakharov_upper_bound, csaba_lower_bound) rather than sorries"
     ]
   },
   "tags": [

--- a/src/data/research/problems/erdos-131-oq-01.json
+++ b/src/data/research/problems/erdos-131-oq-01.json
@@ -30,7 +30,7 @@
     "since": "2026-03-20",
     "iteration": 2,
     "focus": "Prove straus_constant_value numerical bound",
-    "nextAction": "5 sorries remain (proved original_question_answered_no from pham_zakharov_upper_bound)",
+    "nextAction": "0 sorries remain; deep published bounds encoded as 2 axioms (pham_zakharov_upper_bound, csaba_lower_bound)",
     "attemptCounts": {
       "total": 2,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

Two research trackers describe remaining `sorry`s that no longer exist in the Lean source — build-free knowledge-block STATE-SYNC during the verification blackout.

- **erdos-1166**: `nextSteps[0]` said *"Fill sorry in erdos1166_from_ingredients via plateau analysis"*, but that theorem is now fully proved (`proofs/Proofs/Erdos1166Problem.lean:414`, 0 sorries). Replaced with an accurate statement: all theorems sorry-free, 3 axioms remain encoding deep probabilistic inputs (`asProbFilter`, `mostVisited_bounded_eventually`, `erdosTaylor_constant`).
- **erdos-131-oq-01**: `progressSummary` and `nextSteps[0]` claimed *"6 sorries remain (all deep published results)"*, but source has 0 sorries with the deep bounds now encoded as 2 axioms (`pham_zakharov_upper_bound`, `csaba_lower_bound`). Updated both to reflect 0 sorries / 2 axioms.

## Verification

- `grep -cE '\bsorry\b'` = 0 (real code) on both `Erdos1166Problem.lean` and `Erdos131Problem.lean`
- Gallery meta for both: `sorries=0`, `additionalFiles=[]`
- No source / Lean changes — JSON knowledge blocks only
- Durable: `build.ts` preserves the `knowledge` block for existing problems (won't be regenerated away); shown on the public ResearchCard

## Test plan

- [x] `jq -e .` validates both JSON files
- [x] No open PRs touch these two slugs (checked `gh pr list --state all`)