### PR TITLE
research(angle-trisection): META-SYNC — attribute transitive axiom to hermite_lindemann

### DIFF
--- a/src/data/proofs/angle-trisection/meta.json
+++ b/src/data/proofs/angle-trisection/meta.json
@@ -2,7 +2,7 @@
   "id": "angle-trisection",
   "title": "Impossibility of Trisecting an Angle",
   "slug": "angle-trisection",
-  "description": "The three classical Greek impossibility problems resolved in one file (Wiedijk #8): angle trisection, cube doubling, and circle squaring. Wantzel's 1837 algebraic criterion ($\\cos(20\u00b0)$ satisfies an irreducible cubic $8x^3-6x-1$, degree 3 $\\neq 2^n$) settles the first two; Lindemann's transcendence of $\\pi$ (1882, axiomatized in companion file) settles the third. 383 lines, 1 axiom (from PiTranscendental.lean), 0 sorries.",
+  "description": "The three classical Greek impossibility problems resolved in one file (Wiedijk #8): angle trisection, cube doubling, and circle squaring. Wantzel's 1837 algebraic criterion ($\\cos(20\u00b0)$ satisfies an irreducible cubic $8x^3-6x-1$, degree 3 $\\neq 2^n$) settles the first two; Lindemann's transcendence of $\\pi$ (1882, axiomatized in companion file) settles the third. 383 lines, 1 axiom (transitive: HermiteLindemann.hermite_lindemann), 0 sorries.",
   "meta": {
     "author": "Pierre Wantzel (1837)",
     "sourceUrl": "https://en.wikipedia.org/wiki/Angle_trisection",
@@ -86,7 +86,7 @@
       }
     ],
     "mathlib_version": "4.26.0",
-    "assumptions": "1 axiom inherited from PiTranscendental.lean: lindemann_theorem (Lindemann's theorem \u2014 e^\u03b1 is transcendental for nonzero algebraic \u03b1 \u2208 \u2102). Used via pi_transcendental_over_rationals to prove circle squaring is impossible. 0 own axioms. 0 sorries.",
+    "assumptions": "1 axiom (transitive): HermiteLindemann.hermite_lindemann (Hermite-Lindemann theorem \u2014 e^\u03b1 is transcendental for nonzero algebraic \u03b1 \u2208 \u2102). Reached through PiTranscendental.lindemann_theorem (a proved theorem since 2026-06-05, no longer an axiom) and pi_transcendental_over_rationals to prove circle squaring is impossible. 0 own axioms. 0 sorries.",
     "theoremCount": 23,
     "definitionCount": 6
   },
@@ -228,7 +228,7 @@
       "startLine": 155,
       "endLine": 215,
       "summary": "Part IV: defines `IsConstructible` (degree divides $2^n$), proves `wantzel_theorem` (from the definition of constructibility and degree theory), proves `trisectionPolynomial_irreducible` (via Eisenstein criterion, imported from AngleTrisectionCos20Gal), and obtains `lindemann_pi_transcendental` from the PiTranscendental import. Both wantzel_theorem and trisectionPolynomial_irreducible were originally axiomatized but are now fully proved.",
-      "mathContext": "Wantzel's criterion: $\\alpha$ constructible $\\Rightarrow [\\mathbb{Q}(\\alpha) : \\mathbb{Q}]$ divides $2^n$. Both key results (Wantzel's theorem and trisection polynomial irreducibility) are now proved, not axiomatized. The only remaining axiom is transitive: `pi_transcendental` from PiTranscendental.lean, used for circle squaring."
+      "mathContext": "Wantzel's criterion: $\\alpha$ constructible $\\Rightarrow [\\mathbb{Q}(\\alpha) : \\mathbb{Q}]$ divides $2^n$. Both key results (Wantzel's theorem and trisection polynomial irreducibility) are now proved, not axiomatized. The only remaining axiom is transitive: `hermite_lindemann` from HermiteLindemann.lean (reached via PiTranscendental's now-proved `lindemann_theorem`), used for circle squaring."
     },
     {
       "id": "number-theory",


### PR DESCRIPTION
## Summary

The `angle-trisection` gallery meta named **`lindemann_theorem` (PiTranscendental.lean)** as its single inherited axiom. That declaration is no longer an axiom — it was discharged to a proved `theorem` on 2026-06-05 (PiTranscendental S8), derived from `HermiteLindemann.hermite_lindemann`. The sole transitive assumption of the angle-trisection proof is now **`HermiteLindemann.hermite_lindemann`** (the only `^axiom` in the import chain; `grep -c "^axiom " HermiteLindemann.lean` = 1, PiTranscendental.lean = 0).

This brings three stale attribution strings in line with the actual source **and** with the already-correct `pi-transcendental` meta (which reads "1 axiom (transitive): HermiteLindemann.hermite_lindemann"):

- `description` — "1 axiom (from PiTranscendental.lean)" → "1 axiom (transitive: HermiteLindemann.hermite_lindemann)"
- `meta.assumptions` — re-attributed `lindemann_theorem` → `hermite_lindemann`, noting `lindemann_theorem` is now a proved theorem
- Part-IV `mathContext` — "remaining axiom ... `pi_transcendental`" (also a proved theorem, not an axiom) → `hermite_lindemann` from HermiteLindemann.lean

**Unchanged (and correct):** `axiomCount: 1`, `status: axiomatized`, `badge: axiom`, `sorries: 0`. This is a documentation accuracy fix only — no axiom-count change, no claim inflation.

## Why now

Build-free STATE-SYNC during the Docker/Aristotle verification blackout (2026-06-13). Source is on `main`; only the meta prose lagged the S8 axiom discharge.

## Test plan

- [x] `jq -e .` validates the edited meta.json
- [x] `grep -c "^axiom "` confirms HermiteLindemann.lean = 1, PiTranscendental.lean = 0
- [x] No change to axiomCount/status/badge/sorries

🤖 Generated with [Claude Code](https://claude.com/claude-code)