### PR TITLE
research: STATE-SYNC — 5 trackers' stale 'sorry remaining' knowledge → 0-sorry source

### DIFF
--- a/src/data/research/problems/burnside-counting-oq-03.json
+++ b/src/data/research/problems/burnside-counting-oq-03.json
@@ -30,7 +30,7 @@
     "phase": "ACT",
     "since": "2026-04-03T22:29:17.627Z",
     "iteration": 1,
-    "focus": "Complete orbit bijection proof for polya_cyclic_fixed_count",
+    "focus": "Orbit bijection proof complete: polya_cyclic_fixed_count and fixed_factors_through_mod both proved sorry-free.",
     "blockers": [],
     "nextAction": "Begin problem exploration.",
     "attemptCounts": {
@@ -40,14 +40,14 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: polya_sum_identity proved (sorry closed). 2 sorries remain: orbit structure theorem and fixed-point count bijection",
+    "progressSummary": "COMPLETE: polya_sum_identity, the orbit structure theorem (fixed_factors_through_mod), and the fixed-point count bijection (polya_cyclic_fixed_count) are all proved. Main file 0 sorries; companion BurnsideCountingOQ03OQ03.lean also 0 sorries.",
     "builtItems": [
       "addOrderOf_rotation: addOrderOf r = n/gcd(n,r.val) (proved)",
       "IsFixed: computable fixed-coloring predicate",
       "fp_count_rot{0,1,2,3}_4_2: concrete counts 16,2,4,2 by native_decide",
       "fp_sum_binary4: Burnside sum=24 (proved, not axiom)",
       "polya_sum_Z4_binary, polya_divisor_sum_Z4_binary: Polya sums proved",
-      "BurnsideCountingOQ03.lean: 230 lines, 7 proved + 4 sorry theorems",
+      "BurnsideCountingOQ03.lean: 404 lines, 16 theorems all proved (0 sorry)",
       "Proved polya_sum_identity (§5): Σ_{r:Fin n} k^gcd(r,n) = Σ_{d|n} φ(n/d)·k^d via fiber decomposition + bijection proof in BurnsideCountingOQ03.lean:229",
       "Proved fiber_card_eq_totient (helper): |{r:Fin n | gcd(r,n)=d}| = φ(n/d) via explicit bijection r↦r.val/d using Nat.coprime_div_gcd_div_gcd"
     ],
@@ -64,8 +64,7 @@
       "Σ_r k^gcd reindexing needs IsCyclic.card_orderOf_eq_totient applied carefully"
     ],
     "nextSteps": [
-      "Prove fixed_factors_through_mod: orbit = cosets of <r> in ZMod n (ZMod arithmetic, Bezout)",
-      "Prove polya_cyclic_fixed_count: |Fix(r)| = k^gcd(r,n) bijection (uses fixed_factors_through_mod)"
+      "None — both fixed_factors_through_mod (orbit = cosets of <r> in ZMod n) and polya_cyclic_fixed_count (|Fix(r)| = k^gcd(r,n) bijection) are proved sorry-free"
     ]
   },
   "tags": [

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-02-oq-02.json
@@ -35,7 +35,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: CayleyHamiltonMinpolyOQ02OQ02.lean (~250 lines, 12 theorems, 0 axioms, 3 sorries). Defines counterexample matrices (Jordan types [2,2] vs [2,1,1]), proves nilpotency, establishes same minpoly X^2, and proves non-similarity via intertwining/pigeonhole argument. The 3 sorries are in minpoly minimality (classifying monic divisors of X^2) and intertwining constraint extraction (Fin 4 sum computation).",
+    "progressSummary": "COMPLETE: CayleyHamiltonMinpolyOQ02OQ02.lean (~250 lines, 12 theorems, 0 axioms, 0 sorries). Defines counterexample matrices (Jordan types [2,2] vs [2,1,1]), proves nilpotency, establishes same minpoly X^2, and proves non-similarity via intertwining/pigeonhole argument. The previously-open minpoly minimality step (classifying monic divisors of X^2) and intertwining constraint extraction (Fin 4 sum computation) are now both proved sorry-free.",
     "builtItems": [
       "matA: Jordan type [2,2] — two 2x2 nilpotent blocks",
       "matB: Jordan type [2,1,1] — one 2x2 and two 1x1 blocks",
@@ -43,9 +43,9 @@
       "matA_ne_zero, matB_ne_zero: nonzero proofs",
       "matA_annihilated, matB_annihilated: X^2 annihilation",
       "matA_not_annihilated_by_X, matB_not_annihilated_by_X: X doesn't annihilate",
-      "minpoly_matA, minpoly_matB: minpoly = X^2 (sorry in minimality step)",
+      "minpoly_matA, minpoly_matB: minpoly = X^2 (minimality step proved)",
       "same_minpoly: both share minpoly X^2",
-      "intertwining_forces_zeros: AP=PB forces 6 zeros in P (sorry in extraction)",
+      "intertwining_forces_zeros: AP=PB forces 6 zeros in P (extraction proved)",
       "det_intertwiner_zero: det(P) = 0 via pigeonhole on Leibniz formula",
       "not_similar: main theorem — A and B are not similar"
     ],
@@ -62,9 +62,7 @@
       "Fin.sum_univ_four might not be a named lemma — need Fin.sum_univ_succ unfolding"
     ],
     "nextSteps": [
-      "Fill in sorry for minpoly minimality step using polynomial division with remainder",
-      "Fill in sorry for intertwining constraint extraction using fin_cases/simp",
-      "Submit intertwining_forces_zeros to Aristotle as a companion file target"
+      "None — counterexample complete (0 sorries, 0 axioms, gallery status=verified); minpoly minimality and intertwining extraction both discharged"
     ]
   },
   "tags": [

--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-03.json
@@ -39,7 +39,7 @@
     "blockers": [
       "Structure theorem for f.g. modules over PIDs not in Mathlib v4.26"
     ],
-    "nextAction": "Prove orbit dimension bound; attempt countable union avoidance for uncountable fields",
+    "nextAction": "Orbit dimension bound proved (cyclicSubspace_le_minpoly_degree); remaining direction is countable-union avoidance for uncountable fields",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,
@@ -47,7 +47,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added finiteSpan_le_cyclicSubspace lemma (proved). Documented proof strategy for orbit dimension bound. 3 sorries remain.",
+    "progressSummary": "PROGRESS: Added finiteSpan_le_cyclicSubspace lemma (proved) and proved the orbit dimension bound cyclicSubspace_le_minpoly_degree. File is now 0 sorries, 0 axioms. Open research directions (countable-union avoidance, PID structure theorem) remain conceptual, not sorries.",
     "builtItems": [
       "proofs/Proofs/CayleyHamiltonMinpolyOQ05OQ01OQ03.lean (262 lines)",
       "src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-03/ (gallery data)",
@@ -67,7 +67,6 @@
       "Smith normal form"
     ],
     "nextSteps": [
-      "Prove cyclicSubspace_le_minpoly_degree (orbit dimension bound)",
       "Investigate countable union avoidance for specific module-theoretic subspaces",
       "Connect to Mathlib Module.IsTorsion for torsion K[X]-modules"
     ]

--- a/src/data/research/problems/erdos-1126-oq-01.json
+++ b/src/data/research/problems/erdos-1126-oq-01.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Formalized extensions of de Bruijn-Jurkat to multiplicative, Jensen, and derivation equations. 12 theorems (10 proved, 2 sorry), 6 axioms, 388 lines.",
+    "progressSummary": "COMPLETED: Formalized extensions of de Bruijn-Jurkat to multiplicative, Jensen, and derivation equations. 12 theorems (all proved, 0 sorry), 6 axioms, 388 lines. The former almost-Jensen a.e.-doubling reduction is now axiom ae_double_of_almost_jensen; log_of_mul_is_additive is proved directly.",
     "builtItems": [
       "IsJensen definition in Erdos1126OQ01Problem.lean",
       "IsMultiplicative definition in Erdos1126OQ01Problem.lean",
@@ -54,7 +54,7 @@
     ],
     "mathlibGaps": [],
     "nextSteps": [
-      "Prove the 2 remaining sorries (almost_jensen reduction, log_of_mul_is_additive)",
+      "No remaining sorries; log_of_mul_is_additive proved, almost-Jensen a.e. reduction encoded as axiom ae_double_of_almost_jensen",
       "Create Aristotle companion file for routine lemmas",
       "Connect to Mathlib ConvexOn for Jensen-convexity relationship"
     ]

--- a/src/data/research/problems/fourier-series-oq-03.json
+++ b/src/data/research/problems/fourier-series-oq-03.json
@@ -16,15 +16,13 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "ACT",
+    "phase": "COMPLETED",
     "since": "2026-03-06",
     "iteration": 2,
-    "focus": "Proved 3 of 4 sorries. Remaining sorry is the main Dirichlet convergence theorem.",
+    "focus": "All 4 sorries discharged. Main theorem dirichlet_pointwise_convergence is proved; the hard integral-analysis step (BV localization / Riemann-Lebesgue) is encapsulated in axiom dirichlet_localization. File is 0-sorry; gallery graduated.",
     "activeApproach": "Proving Dirichlet kernel properties and consequence chain.",
-    "blockers": [
-      "Main theorem (`dirichlet_pointwise_convergence`) requires ~300 lines of integral analysis"
-    ],
-    "nextAction": "The remaining sorry requires:",
+    "blockers": [],
+    "nextAction": "None — file is 0-sorry (gallery graduated); the BV localization step is encoded as axiom dirichlet_localization rather than a sorry.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 1,


### PR DESCRIPTION
## Summary

Build-free STATE-SYNC during the verification blackout (Docker down, Aristotle 404). Five research-JSON knowledge blocks still asserted remaining sorries ("Fill in sorry", "N sorries remain", "The remaining sorry requires:"), but their primary Lean sources are **0-sorry on `main`**. `build.ts` preserves research-JSON `knowledge`/`currentState` for existing problems, so this stale text is durable and surfaces on the public ResearchCard.

Each edit verified against the actual source (grep `\bsorry\b` = 0) and the named theorems confirmed present + proved:

| slug | reality on main | stale claim fixed |
|------|-----------------|-------------------|
| `cayley-hamilton-minpoly-oq-02-oq-02` | 0 sorries / 0 axioms; minpoly-minimality + intertwining extraction proved | progressSummary "3 sorries", 2× "Fill in sorry", builtItems "(sorry in …)" |
| `cayley-hamilton-minpoly-oq-05-oq-01-oq-03` | 0 sorries / 0 axioms; `cyclicSubspace_le_minpoly_degree` proved | "3 sorries remain", "Prove orbit dimension bound" |
| `burnside-counting-oq-03` | main + companion both 0 sorries; `fixed_factors_through_mod`, `polya_cyclic_fixed_count` proved | "2 sorries remain", 2× "Prove …", builtItems "7 proved + 4 sorry" |
| `erdos-1126-oq-01` | 0 sorries; `log_of_mul_is_additive` proved, almost-Jensen reduction now axiom `ae_double_of_almost_jensen` | "(10 proved, 2 sorry)", "Prove the 2 remaining sorries" |
| `fourier-series-oq-03` (graduated) | 0 sorries; `dirichlet_pointwise_convergence` proved, BV localization = axiom `dirichlet_localization` | focus "Remaining sorry is the main Dirichlet theorem", `nextAction` "The remaining sorry requires:", currentState.phase ACT→COMPLETED |

Disjoint from open #23309 (erdos-1166, erdos-131-oq-01), which works the same vein on different slugs. No code/Lean changes; JSON only.

## Test plan
- [x] All 5 JSON files parse (`jq empty`)
- [x] Each primary source confirmed 0-sorry via grep on fresh `origin/main` base
- [x] Named theorems confirmed present as proved declarations (not sorry/axiom where claimed proved)
- [ ] Lean build verification blocked — Docker down (blackout); no Lean source changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)