### PR TITLE
research(prob-method-second-moment-oq-02): fix malformed leanFile.path doubled prefix

### DIFF
--- a/src/data/proofs/prob-method-second-moment-oq-02/meta.json
+++ b/src/data/proofs/prob-method-second-moment-oq-02/meta.json
@@ -229,7 +229,7 @@
     }
   ],
   "leanFile": {
-    "path": "proofs/Proofs/ProbMethodSecondMomentOQ02.lean",
+    "path": "Proofs/ProbMethodSecondMomentOQ02.lean",
     "imports": [
       "Mathlib",
       "Proofs.ProbMethodSecondMoment"


### PR DESCRIPTION
## Summary
Singleton data-integrity fix found during a blackout build-free meta↔source audit.

`src/data/proofs/prob-method-second-moment-oq-02/meta.json` stored its top-level
`leanFile.path` as `proofs/Proofs/ProbMethodSecondMomentOQ02.lean` — a **doubled
`proofs/` prefix**. This is:

- The **only** slug of 2435 gallery metas to deviate from the universal
  `Proofs/...` convention (paths are relative to the `proofs/` directory, per the
  doc comment at `src/types/proof.ts:367`).
- **Internally self-contradictory**: the same file's `meta.proofRepoPath` was
  already correct (`Proofs/ProbMethodSecondMomentOQ02.lean`).

Corrected `leanFile.path` to match. The actual source exists at
`proofs/Proofs/ProbMethodSecondMomentOQ02.lean`, so the conventional relative
form is `Proofs/ProbMethodSecondMomentOQ02.lean`.

## Why this is durable (not churn)
No deployer script writes the singular gallery `meta.leanFile.path` — it is a
curated/import-time field (`enrich-research.ts` only regenerates the research-JSON
`leanFiles` *array*, computing `Proofs/${filename}`). So this anomaly does not
self-heal and is distinct from the count-sync class.

## Scope
- 1 file, 1 line. JSON re-validated with `jq`.
- Build-free; no Lean rebuild required (blackout-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)