### PR TITLE
research(build): restore slug/title for 77 stub research JSONs (fix /research/null cards)

### DIFF
--- a/scripts/research/build.ts
+++ b/scripts/research/build.ts
@@ -621,12 +621,39 @@ function loadExistingProblemJson(slug: string): ResearchProblem | null {
 }
 
 /**
+ * Best-effort human-readable title derived from a slug. Used only as a
+ * last-resort fallback when a stub JSON carries neither `title` nor `name`.
+ */
+function humanizeSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map(tok =>
+      /^oq$/i.test(tok)
+        ? 'OQ'
+        : /^\d+$/.test(tok)
+          ? tok
+          : tok.charAt(0).toUpperCase() + tok.slice(1)
+    )
+    .join(' ')
+}
+
+/**
  * Update registry-derived fields on an existing problem JSON.
  * The registry may have more current phase/status/dates than the committed JSON.
+ *
+ * Some committed JSONs are minimal stubs ({ id, knowledge, leanFiles, ... })
+ * that lack the canonical `slug`/`title` fields. The registry slug is
+ * authoritative here — the file was loaded as `<entry.slug>.json` — so restore
+ * it; otherwise `generateListing` emits `slug: null`, producing a gallery card
+ * that deep-links to `/research/null`. Fall back to the stub's `name`, then a
+ * humanized slug, so the card isn't blank either.
  */
 function updateRegistryFields(problem: ResearchProblem, entry: RegistryEntry): ResearchProblem {
+  const stubName = (problem as unknown as { name?: string }).name
   return {
     ...problem,
+    slug: problem.slug ?? entry.slug,
+    title: problem.title ?? stubName ?? humanizeSlug(entry.slug),
     phase: entry.phase,
     status: entry.status,
     path: entry.path,


### PR DESCRIPTION
## Summary
- 77 committed research-problem JSONs are minimal stubs (`{id, knowledge, leanFiles, relatedProofs}`) with **no `slug`/`title` key**. `updateRegistryFields` in `scripts/research/build.ts` never restored them, so the build emitted **79 `research-listings.json` entries with `slug: null`** → gallery cards that deep-link to `/research/null` (hard 404) and render blank titles.
- Nearly all 77 are `graduated`/`COMPLETED` proofs, so real finished work was surfacing as broken cards.
- Fix: restore the authoritative slug from the registry (the file is loaded as `<entry.slug>.json`), with a title fallback to the stub's `name` then a humanized slug. Healthy entries (where `problem.slug`/`title` already exist) are untouched via nullish (`??`) fallbacks.

## Root cause
`build.ts` iterates `registry.problems`, loads each committed `<slug>.json`, and merges registry fields. The merge restored phase/status/dates but **not** `slug`/`title`, so stub files (which lack those keys) produced `slug: null` listings.

## Verification (build-free — pure TS, no Lean/Docker)
Ran `npx tsx scripts/research/build.ts` before and after:
- Null-slug/title listing entries: **79 → 0**
- Listing count unchanged: **1976** (no entries dropped or added; only nullish fields populated)
- Sample: `amgm-inequality-oq-02-oq-01-oq-02-oq-01` → title "Full Newton-Girard Recurrence"; `erdos-73` → "Erdos 73" (humanized, no `name`)
- `tsc --noEmit` clean on the edited file.

## Test plan
- [ ] `pnpm build` regenerates `research-listings.json` with 0 null-slug entries
- [ ] Spot-check a previously-broken slug (e.g. `/research/amgm-inequality-oq-02-oq-01-oq-02-oq-01`) resolves and shows a title
- [ ] Confirm a healthy entry's slug/title is byte-identical to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)