### PR TITLE
research(registry): STATE-SYNC — 2 ACT slugs mis-registered as NEW (residuals of #23295)

### DIFF
--- a/research/registry.json
+++ b/research/registry.json
@@ -17849,11 +17849,11 @@
     },
     {
       "slug": "cantor-diagonalization-oq-01-oq-02",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-04-26T10:54:44.961Z",
       "status": "active",
-      "lastUpdate": "2026-04-26T10:54:44.961Z"
+      "lastUpdate": "2026-06-14T05:10:00.000Z"
     },
     {
       "slug": "shannon-channel-coding-oq-02-oq-03",
@@ -20099,11 +20099,11 @@
     },
     {
       "slug": "feuerbachs-theorem-oq-02-murakami",
-      "phase": "NEW",
+      "phase": "ACT",
       "path": "full",
       "started": "2026-06-13T12:52:51.994Z",
       "status": "active",
-      "lastUpdate": "2026-06-13T12:52:51.994Z"
+      "lastUpdate": "2026-06-14T05:10:00.000Z"
     },
     {
       "slug": "kepler-conjecture-oq-04",


### PR DESCRIPTION
## Summary

Reconciles `research/registry.json` with researcher-determined `ACT` state for **2 problems** whose source research JSON `currentState.phase` is `ACT` (with substantive shipped content) but which the registry still lists as `phase=NEW`.

These are residuals of the **2026-06-13T12:52:51 bulk registry append** that reset entries to `NEW`. The merged **#23295** flipped 3 such slugs (`hilbert-10-oq-01-oq-02`, `lagrange-four-squares-oq-01-oq-02`, `prime-number-theorem-oq-01`); this PR catches 2 it missed.

| slug | src `currentState.phase` | iter | evidence | registry was |
|------|--------------------------|------|----------|--------------|
| `feuerbachs-theorem-oq-02-murakami` | `ACT (BLOCKED — Docker down)` | 4 | 9 proven results; S4+S7 closed-form Grace theorem done (build-free, verified); only Lean transcription (S8) Docker-gated | `NEW` |
| `cantor-diagonalization-oq-01-oq-02` | `ACT` | 3 | 14 builtItems; S3 shipped 19 theorems, 0 sorries | `NEW` |

## Why this matters

`build.ts` treats the registry as authoritative for `phase`/`status` and merges those into the deployed public JSON + `research-listings.json`; it never reads `phase` back from src. So these genuinely-ACT problems were displayed in the public gallery as brand-new (`NEW`) with no work — a misrepresentation, and they were eligible to be re-picked by selection tooling as fresh/available.

## Safety

- Each slug's **src JSON `currentState.phase` already says `ACT`** with real shipped content — this only mirrors that into the authoritative registry. Mirror-only, build-free.
- `status` left `active` (unchanged); only `phase` (`NEW`→`ACT`) and `lastUpdate` touched. Diff is 4 lines.
- Disjoint from open **#23293** (which flips src-`status=blocked` slugs → `BLOCKED`); both these slugs have src `status` active/in-progress, not blocked.
- `feuerbachs-theorem-oq-02-murakami` is `ACT (BLOCKED — Docker down)` — a *soft* Docker gate on the final Lean transcription, not a hard block; its src top-level `status` is `in-progress`, so `ACT` (not `BLOCKED`) is the honest registry phase.

## Test plan
- [x] `python3 -c "import json; json.load(...)"` validates registry JSON (2466 problems intact)
- [x] Diff touches only the 2 target entries (4 lines: 2 phase + 2 lastUpdate)
- [x] Verified both src `currentState.phase==ACT` on origin/main