### PR TITLE
research: STATE-SYNC — retire stale nextSteps on 2 SOLVED slugs

### DIFF
--- a/src/data/research/problems/erdos-622-oq-04.json
+++ b/src/data/research/problems/erdos-622-oq-04.json
@@ -58,9 +58,9 @@
       "Need neighborhood-restricted degree summation (handshaking for induced subgraphs)"
     ],
     "nextSteps": [
-      "Prove absorbing_pair_exists: existence follows from common_neighbors_ge + adjacency in N(w)",
-      "Prove erdos_faudree_absorbing_pairs_ge: count edges in induced subgraph on N(w)",
-      "Submit 2 sorries to Aristotle for automated proof search"
+      "DONE: absorbing_pair_exists was proved via the common-neighborhood bound (fixed flipped hypothesis |V|+2 ≤ 2d). Kept for record.",
+      "DONE: erdos_faudree_absorbing_pairs_ge was proved via the injection argument u ↦ (u, choose(N(u) ∩ N(w))). Kept for record.",
+      "DONE: no sorries remain to submit — Erdos622OQ04.lean / Erdos622Problem.lean are 0-sorry/0-axiom (9 theorems, 4 definitions); slug status is completed. No live next step — SOLVED."
     ]
   },
   "tags": [

--- a/src/data/research/problems/shapley-folkman.json
+++ b/src/data/research/problems/shapley-folkman.json
@@ -54,8 +54,8 @@
       "WF descent on Carathéodory vertex count: needed for Sub-case B2 where bv ∉ S; formal prerequisite is binary_repr_of_mem_convexHull_not_mem returning full n-vertex count so caraDepth(bv) = caraDepth(x) - 1 can be tracked"
     ],
     "nextSteps": [
-      "Implement WF descent for Sub-case B2: add caraDepth parameter to reduce_excess, strong induction on totalCaraDepth — ~80 lines",
-      "Alternative: submit Sub-case B2 sorry to Aristotle proof search for automated verification"
+      "DONE (PR #12242): the Sub-case B2 WF descent was implemented via well-founded induction on total minCaraDepth; Docker build passes. Kept for record.",
+      "DONE: no Sub-case B2 sorry remains to submit — ShapleyFolkman.lean / ShapleyFolkmanAristotle.lean / ShapleyFolkmanOQ03.lean are 0-sorry; slug status is completed/COMPLETED. No live next step — SOLVED."
     ],
     "phase": "ACT"
   },


### PR DESCRIPTION
## Summary
Two research trackers carry `status=completed`, 0-sorry/0-axiom source, yet their `knowledge.nextSteps` still list forward-looking work the `progressSummary` records as already done:

- **erdos-622-oq-04** — steps said "Prove absorbing_pair_exists", "Prove erdos_faudree_absorbing_pairs_ge", "Submit 2 sorries to Aristotle". progressSummary: *"COMPLETED: All sorries eliminated... 0 sorries, 0 axioms, 9 theorems."* Source `Erdos622OQ04.lean` / `Erdos622Problem.lean` verified 0 real `sorry`.
- **shapley-folkman** — steps said "Implement WF descent for Sub-case B2 (~80 lines)", "submit Sub-case B2 sorry to Aristotle". progressSummary: *"COMPLETE: 0 sorries. WF induction on total minCaraDepth. Docker build passes. PR #12242."* Source `ShapleyFolkman{,Aristotle,OQ03}.lean` verified 0 real `sorry`.

Each superseded step replaced with a `DONE(...)` record + a `SOLVED` closing note — same convention as merged #23311 / #23289.

## Why build-free & durable
- No Lean touched; only `knowledge.nextSteps` prose. `build.ts` preserves the knowledge block for existing problems, so this is not deployer-self-healing churn.
- Disjoint from the in-flight knowledge-sync PRs (#23309 / #23312 / #23313) — no slug overlap.

## Test plan
- [x] `jq -e .` valid on both JSONs
- [x] `\bsorry\b` grep = 0 on all 5 source `.lean` files
- [x] Branched off fresh `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)