### PR TITLE
research: STATE-SYNC — retire stale 'resolve sorry' knowledge for 2 completed slugs

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
@@ -14,7 +14,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Built proof framework for Kakutani from Brouwer. Identified three independent axioms (Brouwer, approximate selections, sequential compactness). Framework has 2 sorries for the combination arguments. Main Mathlib gap: partition of unity for approximate selections.",
+    "progressSummary": "PROGRESS: kakutani_from_brouwer is end-to-end sorry-free (the combination arguments are discharged; PR #17654). Two assumptions remain as axioms in SchauderFixedPointOQ03OQ01.lean: brouwer_unit_ball and approx_selection_exists. Main Mathlib gap: partition of unity for approximate selections.",
     "builtItems": [
       "Created SchauderFixedPointOQ03OQ01.lean with proof framework",
       "Defined IsApproxSelection for ε-approximate continuous selections",
@@ -35,9 +35,8 @@
       "Sequential compactness equivalence for compact metric spaces"
     ],
     "nextSteps": [
-      "Complete the sorry in kakutani_from_brouwer with metric space calculations",
-      "Prove approx_selection_exists using partition of unity",
-      "Check if Mathlib's Brouwer can be extended to compact convex sets"
+      "Eliminate the approx_selection_exists axiom (SchauderFixedPointOQ03OQ01.lean:563) using partition of unity",
+      "Eliminate the brouwer_unit_ball axiom (SchauderFixedPointOQ03OQ01.lean:196) / check if Mathlib's Brouwer extends to compact convex sets"
     ]
   },
   "tags": [

--- a/src/data/research/problems/sperner-ndim-oq-03.json
+++ b/src/data/research/problems/sperner-ndim-oq-03.json
@@ -49,15 +49,9 @@
       "FSimplex mesh bound ≤ 1/N follows from countPerm ∈ {0,1} (permutation injectivity)"
     ],
     "mathlibGaps": [
-      "No direct gap - Bolzano-Weierstrass and compact simplex are in Mathlib",
-      "The blocker is the internal sorry in SpernerNDim, not Mathlib infrastructure"
+      "No direct gap - Bolzano-Weierstrass and compact simplex are in Mathlib"
     ],
-    "nextSteps": [
-      "PRIORITY: Resolve the sorry in SpernerNDim.lean (compose global parity argument)",
-      "Then generalize displacement coloring from BrouwerFixedPointOQ02OQ01 to n dimensions",
-      "Prove n-dim Sperner boundary condition for displacement coloring",
-      "Convergence: sequential compactness on closed simplex gives fixed point"
-    ],
+    "nextSteps": [],
     "markdown": "# Knowledge Base: sperner-ndim-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

Two **completed** research trackers carried forward-looking "resolve the sorry"
knowledge text that the merged Lean source has already discharged. This corrects
the trackers to match source (build-free; durable since `build.ts` preserves
research-JSON `knowledge` for existing problems).

### sperner-ndim-oq-03
- `SpernerNDimOQ03.lean` and parent `SpernerNDim.lean` are both **0-sorry / 0-axiom**; `progressSummary` already says COMPLETED ("derives exact Brouwer FPT via compact simplex minimization").
- All 4 `nextSteps` (incl. `"PRIORITY: Resolve the sorry in SpernerNDim.lean"`) describe work the summary says is done → retired (`nextSteps: []`).
- Removed the stale `mathlibGap` `"The blocker is the internal sorry in SpernerNDim"`.

### schauder-fixed-point-oq-03-oq-01
- `kakutani_from_brouwer` (SchauderFixedPointOQ03OQ01.lean:1393) is **end-to-end sorry-free** (3 `sorry` greps are docstrings stating exactly that; PR #17654).
- Corrected `progressSummary` "Framework has 2 sorries for the combination arguments" → 0 sorries, 2 remaining **axioms** (`brouwer_unit_ball`, `approx_selection_exists`).
- Dropped the stale nextStep `"Complete the sorry in kakutani_from_brouwer"`; **kept** the two genuine axiom-elimination goals (those axioms are still live).

Disjoint from open knowledge-sync PRs #23313 / #23312 / #23309.

## Test plan
- [x] `jq empty` validates both JSON files
- [x] Verified source sorry/axiom counts by comment-stripped grep
- [ ] No Lean build required (tracker-only change; Docker blackout)