### PR TITLE
research: STATE-SYNC — retire stale sorry steps on 2 source-verified 0-sorry slugs (schauder, sylow)

### DIFF
--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
@@ -14,12 +14,12 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Built proof framework for Kakutani from Brouwer. Identified three independent axioms (Brouwer, approximate selections, sequential compactness). Framework has 2 sorries for the combination arguments. Main Mathlib gap: partition of unity for approximate selections.",
+    "progressSummary": "SURVEYED: Built proof framework for Kakutani from Brouwer. Identified three independent axioms (Brouwer, approximate selections, sequential compactness). Framework now has 0 sorries: kakutani_from_brouwer is proved; brouwer_unit_ball and approx_selection_exists remain as axioms. Main Mathlib gap: partition of unity for approximate selections.",
     "builtItems": [
       "Created SchauderFixedPointOQ03OQ01.lean with proof framework",
       "Defined IsApproxSelection for ε-approximate continuous selections",
       "Axiomatized three key lemmas: Brouwer, approx selections, seq compactness",
-      "Outlined kakutani_from_brouwer proof (sorry)",
+      "Proved kakutani_from_brouwer (the main Kakutani-from-Brouwer reduction)",
       "Created gallery entry with meta.json, index.ts"
     ],
     "insights": [
@@ -35,7 +35,6 @@
       "Sequential compactness equivalence for compact metric spaces"
     ],
     "nextSteps": [
-      "Complete the sorry in kakutani_from_brouwer with metric space calculations",
       "Prove approx_selection_exists using partition of unity",
       "Check if Mathlib's Brouwer can be extended to compact convex sets"
     ]

--- a/src/data/research/problems/sylow-theorems-oq-02.json
+++ b/src/data/research/problems/sylow-theorems-oq-02.json
@@ -46,7 +46,7 @@
     "lines": 298
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: 298-line formalization with 7 proved theorems, 5 axioms, 1 sorry",
+    "progressSummary": "COMPLETE: 298-line formalization with 7 proved theorems, 5 axioms, 0 sorries (sylowProP_normal_of_unique now proved)",
     "builtItems": [
       "IsProfiniteGroup structure",
       "IsProP class",
@@ -65,7 +65,6 @@
       "No pro-p group type"
     ],
     "nextSteps": [
-      "Prove sylowProP_normal_of_unique (1 sorry)",
       "Build inverse limit construction"
     ]
   },


### PR DESCRIPTION
## Summary
Knowledge-block STATE-SYNC (build-free). Original 6-slug PR went CONFLICTING after siblings merged; 4 slugs (bezout-identity-oq-04-oq-01, erdos-1027-oq-01, shapley-folkman, sperner-ndim-oq-03) are already synced on `main`. Trimmed to the 2 genuine residuals, rebased onto current `main` → mergeable.

- **schauder-fixed-point-oq-03-oq-01**: `kakutani_from_brouwer` is proved (SchauderFixedPointOQ03OQ01.lean grep-verified 0 sorries, 2 axioms). Retired the "complete the sorry" nextStep + stale builtItem; progressSummary now reflects 0 sorries.
- **sylow-theorems-oq-02**: `sylowProP_normal_of_unique` is proved (SylowTheoremOQ02.lean grep-verified 0 sorries). Retired the "prove the sorry" nextStep; progressSummary sorry count 1→0.

Axiom claims left untouched (out of scope). No Lean source changes.

## Test plan
- [x] `jq empty` validates both JSON files
- [x] Source `.lean` files confirmed 0-sorry via comment-stripped grep