### PR TITLE
research: STATE-SYNC — 4 trackers' stale 'sorry' knowledge → 0-sorry source

### DIFF
--- a/src/data/research/problems/erdos-1027-oq-01.json
+++ b/src/data/research/problems/erdos-1027-oq-01.json
@@ -57,10 +57,7 @@
       "Finset.card_biUnion for the union bound sum over F (hbad_bound)"
     ],
     "nextSteps": [
-      "Submit card_subsets_containing to Aristotle (HARD sorry — bijection via B ↦ X \\ B)",
-      "Submit hbad_bound to Aristotle (HARD sorry — union bound sum over F)",
-      "Submit hgood_bad to Aristotle (HARD sorry — partition of X.powerset)",
-      "Consider alternative: use Finset.card_sdiff_add_card_eq_card for hgood_bad"
+      "None — all three formerly-open sorries are proved sorry-free: card_subsets_containing (Finset.card_bij + sdiff_sdiff_cancel_left involution), hbad_bound (biUnion + card_biUnion_le + sum_le_sum), hgood_bad (disjoint filter partition). Source is 0 sorries, 0 axioms."
     ],
     "phase": "ACT"
   },

--- a/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
+++ b/src/data/research/problems/schauder-fixed-point-oq-03-oq-01.json
@@ -14,7 +14,7 @@
     ]
   },
   "knowledge": {
-    "progressSummary": "SURVEYED: Built proof framework for Kakutani from Brouwer. Identified three independent axioms (Brouwer, approximate selections, sequential compactness). Framework has 2 sorries for the combination arguments. Main Mathlib gap: partition of unity for approximate selections.",
+    "progressSummary": "COMPLETE: kakutani_from_brouwer and the combination arguments are proved sorry-free in SchauderFixedPointOQ03OQ01.lean (0 sorries). The three structural inputs (Brouwer, approximate selections, sequential compactness) remain as axioms pending Mathlib partition-of-unity infrastructure.",
     "builtItems": [
       "Created SchauderFixedPointOQ03OQ01.lean with proof framework",
       "Defined IsApproxSelection for ε-approximate continuous selections",
@@ -35,8 +35,8 @@
       "Sequential compactness equivalence for compact metric spaces"
     ],
     "nextSteps": [
-      "Complete the sorry in kakutani_from_brouwer with metric space calculations",
-      "Prove approx_selection_exists using partition of unity",
+      "Done — kakutani_from_brouwer is proved sorry-free (the metric-space combination arguments are closed); SchauderFixedPointOQ03OQ01.lean has 0 sorries.",
+      "Prove approx_selection_exists using partition of unity (axiom-elimination — still open)",
       "Check if Mathlib's Brouwer can be extended to compact convex sets"
     ]
   },

--- a/src/data/research/problems/shapley-folkman.json
+++ b/src/data/research/problems/shapley-folkman.json
@@ -54,8 +54,7 @@
       "WF descent on Carathéodory vertex count: needed for Sub-case B2 where bv ∉ S; formal prerequisite is binary_repr_of_mem_convexHull_not_mem returning full n-vertex count so caraDepth(bv) = caraDepth(x) - 1 can be tracked"
     ],
     "nextSteps": [
-      "Implement WF descent for Sub-case B2: add caraDepth parameter to reduce_excess, strong induction on totalCaraDepth — ~80 lines",
-      "Alternative: submit Sub-case B2 sorry to Aristotle proof search for automated verification"
+      "None — the Sub-case B2 sorry is closed: the WF descent (strong induction on total minCaraDepth) is implemented and the proof is sorry-free (0 sorries, 0 axioms across ShapleyFolkman.lean, ShapleyFolkmanAristotle.lean, ShapleyFolkmanOQ03.lean)."
     ],
     "phase": "ACT"
   },

--- a/src/data/research/problems/sperner-ndim-oq-03.json
+++ b/src/data/research/problems/sperner-ndim-oq-03.json
@@ -53,7 +53,7 @@
       "The blocker is the internal sorry in SpernerNDim, not Mathlib infrastructure"
     ],
     "nextSteps": [
-      "PRIORITY: Resolve the sorry in SpernerNDim.lean (compose global parity argument)",
+      "Done — the global parity sorry is resolved; SpernerNDimOQ03.lean is 0 sorries, 0 axioms (approximate_fixed_point and brouwer_simplex both proved).",
       "Then generalize displacement coloring from BrouwerFixedPointOQ02OQ01 to n dimensions",
       "Prove n-dim Sperner boundary condition for displacement coloring",
       "Convergence: sequential compactness on closed simplex gives fixed point"


### PR DESCRIPTION
## Summary
Build-free STATE-SYNC sibling of #23309 / #23312 / #23313 covering **4 disjoint slugs**. Each research tracker's `knowledge` block carried forward-looking "submit/resolve/complete a sorry" `nextSteps` (and one stale `SURVEYED … 2 sorries` `progressSummary`) while the Lean source is already **0-sorry** (verified by comment-stripped `\bsorry\b` grep over each slug's `leanFiles`).

| Slug | Stale claim | Source reality |
|------|-------------|----------------|
| `erdos-1027-oq-01` | "Submit card_subsets_containing / hbad_bound / hgood_bad to Aristotle (HARD sorry)" | all 3 proved; 0 sorries, 0 axioms |
| `shapley-folkman` | "Implement / submit Sub-case B2 sorry" | WF descent closed; 0 sorries, 0 axioms |
| `sperner-ndim-oq-03` | "PRIORITY: Resolve the sorry in SpernerNDim.lean" | global-parity sorry resolved; 0 sorries |
| `schauder-fixed-point-oq-03-oq-01` | "Complete the sorry in kakutani_from_brouwer" + `SURVEYED … 2 sorries` PS | kakutani_from_brouwer proved sorry-free; 0 sorries |

## Notes
- **Axiom-elimination steps left intact** (e.g. schauder's `approx_selection_exists`, sperner's generalization roadmap) — those are legitimately open future work, not stale.
- Disjoint from the 16 slugs in #23309/#23312/#23313; no overlap with any open PR.
- Durable: `build.ts` preserves the research-JSON knowledge block for existing problems, so this is not deployer-regenerated churn.
- No Lean build required (verification infra is in the Docker/Aristotle blackout).

## Test plan
- [x] All 4 JSONs validate (`jq -e .`)
- [x] Source 0-sorry confirmed via comment-stripped grep per slug's leanFiles