### PR TITLE
research: fix broken xref slug fundamental-theorem-arithmetic → fundamental-arithmetic

### DIFF
--- a/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/meta.json
+++ b/src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/meta.json
@@ -165,7 +165,7 @@
       "description": "Abel-Ruffini Theorem (insolubility of the general quintic) — the failure of unique factorization in cyclotomic integers ℤ[ζₚ] (discovered by Kummer, 1844) was the historical crisis that motivated ideal theory and the Dedekind domain framework. Abel-Ruffini's Galois-theoretic proof works in polynomial rings k[x] which ARE UFDs (via the instance chain formalized here), while the quintic's insolubility concerns the splitting field structure. The contrast illuminates the scope of the ED→UFD theorem: it governs the ring structure, not the Galois group action."
     },
     {
-      "targetId": "fundamental-theorem-arithmetic",
+      "targetId": "fundamental-arithmetic",
       "relationship": "generalization-of",
       "description": "Fundamental Theorem of Arithmetic (ℤ) — the base case that this entry generalizes. The FTA states that every integer has a unique prime factorization (up to sign); this entry extends that to all Euclidean domains R via Mathlib's instance chain. The `UniqueFactorizationMonoid ℤ` inference in this file is literally a one-line proof of the FTA as a special case."
     }

--- a/src/data/proofs/erdos-883/meta.json
+++ b/src/data/proofs/erdos-883/meta.json
@@ -179,7 +179,7 @@
       "description": "Another Erdős extremal combinatorics problem with a sharp threshold — both study when a graph property is forced above a critical density"
     },
     {
-      "targetId": "fundamental-theorem-arithmetic",
+      "targetId": "fundamental-arithmetic",
       "relationship": "foundational",
       "description": "Coprimality (gcd = 1) is the coprime graph's edge predicate; the multiplicative structure of integers (prime factorization) determines which pairs are coprime and shapes the graph's density above the threshold"
     }

--- a/src/data/research/problems/infinitude-primes-4k1-oq-01.json
+++ b/src/data/research/problems/infinitude-primes-4k1-oq-01.json
@@ -73,7 +73,7 @@
   "relatedProofs": [
     "infinitude-primes",
     "infinitude-primes-4k1",
-    "fundamental-theorem-arithmetic",
+    "fundamental-arithmetic",
     "pythagorean-theorem"
   ],
   "references": {


### PR DESCRIPTION
## Summary

Three references targeted the non-existent gallery slug `fundamental-theorem-arithmetic`. The actual gallery entry is **`fundamental-arithmetic`** ("Fundamental Theorem of Arithmetic", `status=verified`), already referenced correctly by **92 other** cross-references. These three were dead links.

Fixed:
- `src/data/proofs/bezout-identity-oq-02-oq-01-oq-02/meta.json` — crossReference targetId (`generalization-of`)
- `src/data/proofs/erdos-883/meta.json` — crossReference targetId (`foundational`)
- `src/data/research/problems/infinitude-primes-4k1-oq-01.json` — `relatedProofs` slug list

## Why this is durable (build-free)

- Gallery `crossReferences` are authored content preserved verbatim by `generate-gallery.ts` (not regenerated), so a wrong targetId persists indefinitely.
- Research-JSON `relatedProofs` is **union-merged, never pruned** by `enrich-research.ts` (lines 346–351), so the stale slug would survive every rebuild; the enricher only auto-detects valid gallery slugs, so it won't re-add the bad one.

No Lean build required (Docker blackout). Pure data correctness fix.

## Verification
- `grep -rl 'fundamental-theorem-arithmetic' src/data/` → none remaining
- All three files validate with `jq empty`
- Target `src/data/proofs/fundamental-arithmetic/` exists

## Test plan
- [x] JSON validity (`jq empty`) on all 3 files
- [x] Bad slug fully eliminated from `src/data/`
- [x] Replacement slug resolves to an existing gallery entry