### PR TITLE
research: STATE-SYNC — retire 5 stale 'fill sorry' knowledge entries on 3 sorry-free slugs

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-04-oq-01.json
+++ b/src/data/research/problems/bezout-identity-oq-04-oq-01.json
@@ -9,7 +9,7 @@
     "question": "Can the parametric solution extend to systems of linear Diophantine equations (matrix form Ax = b over ℤ), characterizing the full solution lattice via the Smith Normal Form?"
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Built Smith Normal Form infrastructure in Lean 4. Defined SmithNormalForm structure with unimodular matrices, diagonal form, and invariant factor chain. Axiomatized SNF existence and solvability criterion. Proved bezout_from_snf (classical Bézout recovery), null space ℤ-submodule structure, and affine lattice characterization of solution sets. 2 axioms, 1 sorry, 11 proved theorems.",
+    "progressSummary": "COMPLETED: Built Smith Normal Form infrastructure in Lean 4. Defined SmithNormalForm structure with unimodular matrices, diagonal form, and invariant factor chain. Axiomatized SNF existence and solvability criterion. Proved bezout_from_snf (classical Bézout recovery), null space ℤ-submodule structure, and affine lattice characterization of solution sets. 2 axioms, 0 sorries, 11 proved theorems (snf_1x2_invariant_factor proved sorry-free).",
     "builtItems": [
       "Created proofs/Proofs/BezoutIdentityOQ04OQ01.lean (335 lines)",
       "IsUnimodular predicate with closure properties (identity, product)",
@@ -33,8 +33,7 @@
       "No integer matrix reduction algorithm"
     ],
     "nextSteps": [
-      "Prove snf_1x2_invariant_factor (sorry) — connect 1×2 SNF to gcd",
-      "Consider constructive SNF existence proof (~500 lines of Euclidean reduction)",
+      "Eliminate snf_existence axiom: constructive SNF existence proof (~500 lines of Euclidean reduction)",
       "Extend to PID generalization (bezout-identity-oq-02-oq-02 connection)"
     ]
   },

--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
@@ -9,7 +9,7 @@
     "question": "Can the Lawvere fixed-point theorem be formalized in a topos-theoretic setting in Lean?"
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Generalized Lawvere FPT to abstract evaluation structure. Proved core theorem, diagonal lemma, type-theoretic recovery, and 3 concrete instances. Sketched categorical framework (2 sorries). 0 axioms, 14 proved theorems, 294 lines.",
+    "progressSummary": "COMPLETED: Generalized Lawvere FPT to abstract evaluation structure. Proved core theorem, diagonal lemma, type-theoretic recovery, and 3 concrete instances. Categorical framework complete (0 sorries, lawvere_categorical proved). 0 axioms, 14 proved theorems, 294 lines.",
     "builtItems": [
       "proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean (294 lines)",
       "EvalStructure and IsPointSurjective definitions",
@@ -30,7 +30,6 @@
       "No Lawvere fixed-point theorem in Mathlib's category theory"
     ],
     "nextSteps": [
-      "Prove lawvere_categorical without sorry (connect CategoricalEval to EvalStructure)",
       "Use Mathlib CartesianClosed + ihom for full CCC version",
       "Derive Rice's theorem as a Lawvere instance"
     ]

--- a/src/data/research/problems/erdos-1027-oq-01.json
+++ b/src/data/research/problems/erdos-1027-oq-01.json
@@ -57,10 +57,8 @@
       "Finset.card_biUnion for the union bound sum over F (hbad_bound)"
     ],
     "nextSteps": [
-      "Submit card_subsets_containing to Aristotle (HARD sorry — bijection via B ↦ X \\ B)",
-      "Submit hbad_bound to Aristotle (HARD sorry — union bound sum over F)",
-      "Submit hgood_bad to Aristotle (HARD sorry — partition of X.powerset)",
-      "Consider alternative: use Finset.card_sdiff_add_card_eq_card for hgood_bad"
+      "Optional refactor: hgood_bad could alternatively use Finset.card_sdiff_add_card_eq_card (current proof: disjoint filter partition, already sorry-free)",
+      "Optional: upstream card_subsets_containing involution bijection (B ↦ X \\ B) to Mathlib"
     ],
     "phase": "ACT"
   },


### PR DESCRIPTION
## Summary

Three `completed`/`graduated` research trackers carried `nextSteps` (and two carried `progressSummary` counts) telling future sessions to *fill a sorry* in a lemma that is **already proved sorry-free** on `main`. Comment-stripped `\bsorry\b` grep returns **0** in all three source files. This is the same accepted STATE-SYNC vein as #23309 / #23312 / #23313 / #23317 / #23318 — verified **disjoint** from their slug sets.

| Slug | Stale claim | Reality (verified on `origin/main`) |
|------|-------------|-------------------------------------|
| `bezout-identity-oq-04-oq-01` | nextStep "Prove `snf_1x2_invariant_factor` (sorry)"; summary "1 sorry" | Proved at `BezoutIdentityOQ04OQ01.lean:212` (real `simp`/`omega`/`exact` proof); file 0-sorry |
| `cantor-diagonalization-oq-03-oq-01` | nextStep "Prove `lawvere_categorical` without sorry"; summary "(2 sorries)" | Proved at `CantorDiagonalizationOQ03OQ01.lean:220`; file 0-sorry, 0 axioms |
| `erdos-1027-oq-01` | 3× nextStep "Submit … to Aristotle (HARD sorry)" | `card_subsets_containing` / `hbad_bound` / `hgood_bad` all proved in `Erdos1027OQ01.lean`; progressSummary itself already said "0 sorries". Corroborated by merged #10608 ("0 sorries, status verified") |

For each slug I retired only the stale sorry-claiming entries, preserving genuine forward-looking items (axiom elimination, Mathlib upstreaming, refactor ideas), and corrected the two stale sorry counts in `progressSummary`.

## Verification (build-free)
- Resolved each slug's source `.lean`, stripped block + line comments, grepped `\bsorry\b` → **0** in all three.
- Confirmed each named lemma exists with a real tactic proof (not `axiom`/`True`-stub).
- **Excluded** `dissection-of-cubes-oq-03-oq-02`: its `smallest_above_is_smaller` nextStep is **not** stale — that lemma still has a real `sorry` in the parent `DissectionOfCubesOQ03.lean:~390`.
- jq round-trips were byte-identical before edits, so diffs are minimal (5 insertions / 9 deletions).
- Durable: `build.ts` preserves the `knowledge` block for existing problems (not deployer-regenerated).

No Lean/Docker build required. Math-agent PR — no `loom:review-requested`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)