### PR TITLE
research(cantor-diagonalization-oq-03-oq-01): STATE-SYNC stale knowledge to 0-sorry source

### DIFF
--- a/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
+++ b/src/data/research/problems/cantor-diagonalization-oq-03-oq-01.json
@@ -9,7 +9,7 @@
     "question": "Can the Lawvere fixed-point theorem be formalized in a topos-theoretic setting in Lean?"
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: Generalized Lawvere FPT to abstract evaluation structure. Proved core theorem, diagonal lemma, type-theoretic recovery, and 3 concrete instances. Sketched categorical framework (2 sorries). 0 axioms, 14 proved theorems, 294 lines.",
+    "progressSummary": "COMPLETED: Generalized Lawvere FPT to abstract evaluation structure. Proved core theorem, diagonal lemma, type-theoretic recovery, and 3 concrete instances. Categorical framework completed sorry-free (lawvere_categorical now proved by reducing to lawvere_abstract). 0 axioms, 14 proved theorems, 294 lines.",
     "builtItems": [
       "proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean (294 lines)",
       "EvalStructure and IsPointSurjective definitions",
@@ -30,7 +30,6 @@
       "No Lawvere fixed-point theorem in Mathlib's category theory"
     ],
     "nextSteps": [
-      "Prove lawvere_categorical without sorry (connect CategoricalEval to EvalStructure)",
       "Use Mathlib CartesianClosed + ihom for full CCC version",
       "Derive Rice's theorem as a Lawvere instance"
     ]


### PR DESCRIPTION
## Summary
Single-slug build-free STATE-SYNC. The research tracker's `knowledge` block lagged the shipped Lean source:

- `progressSummary` claimed the categorical framework was "Sketched ... (2 sorries)"
- `nextSteps[0]` still asked to "Prove lawvere_categorical without sorry"

But `proofs/Proofs/CantorDiagonalizationOQ03OQ01.lean` is **0 sorries / 0 axioms**, `status=completed`, and the file's own closing docstring states: *"lawvere_categorical is now proved ... All theorems are fully proved."*

## Change
- Sync `progressSummary` to reflect the completed sorry-free categorical framework.
- Retire the stale `Prove lawvere_categorical without sorry` step.
- **Preserve** the two genuine future-extension steps (full CCC version via Mathlib `CartesianClosed`+`ihom`; deriving Rice's theorem as a Lawvere instance).

## Notes
- Build-free (no Lean rebuild needed; Docker blackout-safe).
- `build.ts` preserves `knowledge` for existing problems, so this is durable and **not** regenerated by the deployer.
- Disjoint from the other open knowledge-sorry-sync PRs (#23309/#23312/#23313/#23319).

## Test plan
- [x] JSON validates (`json.load`)
- [x] Diff is minimal (3 lines, no reformatting)
- [x] Source confirmed 0-sorry / 0-axiom, comment-stripped