### PR TITLE
research(sperner-ndim-oq-03): retire 4 stale pre-completion nextSteps

### DIFF
--- a/src/data/research/problems/sperner-ndim-oq-03.json
+++ b/src/data/research/problems/sperner-ndim-oq-03.json
@@ -52,12 +52,7 @@
       "No direct gap - Bolzano-Weierstrass and compact simplex are in Mathlib",
       "The blocker is the internal sorry in SpernerNDim, not Mathlib infrastructure"
     ],
-    "nextSteps": [
-      "PRIORITY: Resolve the sorry in SpernerNDim.lean (compose global parity argument)",
-      "Then generalize displacement coloring from BrouwerFixedPointOQ02OQ01 to n dimensions",
-      "Prove n-dim Sperner boundary condition for displacement coloring",
-      "Convergence: sequential compactness on closed simplex gives fixed point"
-    ],
+    "nextSteps": [],
     "markdown": "# Knowledge Base: sperner-ndim-oq-03\n\nInsights accumulated during research on this problem.\n\n---\n\n## Problem Understanding\n\n[Initial observations about the problem will be recorded here]\n\n---\n\n## Insights\n\n[Insights from research attempts will be accumulated here]\n\n---\n\n## Dead Ends\n\n[Approaches known not to work will be documented here]\n"
   },
   "tags": [


### PR DESCRIPTION
## Summary

`sperner-ndim-oq-03` is fully solved — `status=completed`, `phase=COMPLETED`, `currentState.focus="Both sorries proved. File has 0 sorries, 0 axioms."`, and `progressSummary` records exact Brouwer FPT derived (Sperner + displacement coloring transfer + compact simplex minimization) with 0 sorries in `SpernerNDimOQ03.lean`.

Despite that, `knowledge.nextSteps` still held the verbatim **pre-completion plan**, every item of which is already achieved:

- "PRIORITY: Resolve the sorry in SpernerNDim.lean" — that file is now **0-sorry / 0-axiom** (verified)
- "generalize displacement coloring to n dimensions" — done (`approximate_fixed_point`)
- "prove n-dim Sperner boundary condition" — done
- "Convergence: sequential compactness on closed simplex" — done (`brouwer_simplex`, compact minimization)

This PR empties the four stale forward-looking steps. Historical `insights` / `mathlibGaps` are left untouched.

## Context

Build-free STATE-SYNC during the Docker/Aristotle verification blackout. Durable: `build.ts` preserves `knowledge` for existing problems, so this won't be regenerated away. Single-slug, same accepted class as #23311 (gauss-wilson) and #23317. No `loom:review-requested` (math PR — deployer merges directly).

## Test plan

- [x] `jq -e '.knowledge.nextSteps == []'` passes
- [x] One-field diff (1 insertion, 6 deletions)
- [x] No open PR touches this slug (uncontended)