### PR TITLE
research: fix broken relatedProofs xref wilson-theorem → wilsons-theorem

### DIFF
--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -83,7 +83,7 @@
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
     "gauss-wilson-non-cyclic-oq-03",
-    "wilson-theorem",
+    "wilsons-theorem",
     "fermat-little-theorem",
     "chinese-remainder-theorem"
   ],

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -80,7 +80,7 @@
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
     "gauss-wilson-non-cyclic-oq-01",
-    "wilson-theorem",
+    "wilsons-theorem",
     "chinese-remainder-theorem",
     "fermat-little-theorem"
   ],


### PR DESCRIPTION
## Summary
Two `gauss-wilson-non-cyclic` research trackers list the dead slug `wilson-theorem` in their `relatedProofs`. The canonical gallery entry is `wilsons-theorem` (the `src/data/proofs/wilsons-theorem/` directory exists). This is the same clean *renamed-target-that-exists* class as the FTA fix in #23321 — the only durable subset of the broken-xref vein.

## Changes
- `gauss-wilson-non-cyclic-oq-01.json`: relatedProofs `wilson-theorem` → `wilsons-theorem`
- `gauss-wilson-non-cyclic-oq-03.json`: relatedProofs `wilson-theorem` → `wilsons-theorem`

Two-line diff, both files valid JSON. Other broken targets in these arrays (`chinese-remainder-theorem`, `fermat-little-theorem`) have no unambiguous existing gallery slug and are intentionally left untouched.

Build-free during the verification blackout (Docker down). `relatedProofs` is preserved by build.ts / union-merged by enrich-research, so this fix is durable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)