### PR TITLE
research: STATE-SYNC — retire stale sorry-closing knowledge on 2 SOLVED slugs

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
@@ -38,8 +38,6 @@
       "JordanHolderLattice (Subgroup G) instance: marked as TODO in Mathlib.Order.JordanHolder"
     ],
     "nextSteps": [
-      "Close maximality sorry in isMaximal_inf_left_of_isMaximal_sup: use IsSimpleGroup transfer through second_iso MulEquiv",
-      "Submit maximality sorry to Aristotle (HARD classification)",
       "Contribute JordanHolderLattice (Subgroup G) to Mathlib after proof is complete"
     ]
   },

--- a/src/data/research/problems/erdos-817.json
+++ b/src/data/research/problems/erdos-817.json
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 4→2 sorries in Erdos817Problem.lean. g3_one proved (subsetSums {1}={0,1} by decide, 3-AP-free by interval_cases). g3_two CORRECTED from =2 to =3 with full proof. g_ge_n structure filled (sorry only for nonemptiness). g3_le_exp still sorry (hard: needs carry argument for base-3 AP-freeness).",
+    "progressSummary": "COMPLETE: Erdos817Problem.lean is 0 sorries / 0 axioms. g3_one, g3_two (=3), g_ge_n (g k n ≥ n), and g3_le_exp (g 3 n ≤ 3^n) all proved; the earlier nonemptiness and base-3 AP-freeness sorries are discharged.",
     "builtItems": [
       "g3_one: proved g 3 1 = 1 (Erdos817Problem.lean:191-219)",
       "g3_two: corrected to g 3 2 = 3 with full proof, including hfail2 (only valid N for n=2 requires N≥3)",
@@ -46,12 +46,7 @@
       "Nonemptiness of ValidNs k n for general k≥3, n≥1 — needs AP-free set construction (base-k geometric set)",
       "g3_le_exp: upper bound g_3(n) ≤ 3^n — needs showing {3^0,...,3^{n-1}} subset sums are 3-AP-free (positional/carry argument)"
     ],
-    "nextSteps": [
-      "Try proving nonemptiness of ValidNs 3 n using A = {3^0,...,3^{n-1}} ⊆ Icc 1 (3^n)",
-      "For AP-freeness of geometric set sums: use induction on n, with the observation that the nth element 3^{n-1} creates a gap too large for any AP to bridge",
-      "Alternative for g_ge_n: state as hypothesis or use a separate lemma validSet_exists (k n : ℕ) : ∃ N, N ∈ ValidNs k n",
-      "Submit g_ge_n nonemptiness sorry to Aristotle — it may be within reach via Finset induction"
-    ]
+    "nextSteps": []
   },
   "tags": [
     "erdos-problems",


### PR DESCRIPTION
## Summary
Two `status=completed` research trackers still describe open sorries that are already discharged in source (0 sorries / 0 axioms). Build-free knowledge sync.

- **abel-ruffini-galois-extensions-oq-04**: `progressSummary` already says "0 axioms / 0 sorries ... including the maximality step", but two `nextSteps` still told us to close/submit the maximality sorry in `isMaximal_inf_left_of_isMaximal_sup` — proved at `AbelRuffiniGaloisExtensionsOQ04.lean:98`. Pruned both stale steps; kept the genuine Mathlib-contribution follow-up.
- **erdos-817**: `progressSummary` claimed "4→2 sorries ... g3_le_exp still sorry", but `Erdos817Problem.lean` is 0 sorries with `g_ge_n` (l.304) and `g3_le_exp` (l.371) both proved. Updated summary to COMPLETE; cleared the 4 stale sorry-closing `nextSteps`.

## Verification
- Comment-stripped `\bsorry\b` / `^axiom ` grep over both proof files: 0 / 0.
- Neither slug is covered by an existing open PR.
- Both JSON files validate (`jq empty`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)