### PR TITLE
research: fix 2 broken relatedProofs xrefs (renamed targets)

### DIFF
--- a/src/data/research/problems/infinitude-primes-4k1-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-4k1-oq-03.json
@@ -92,7 +92,7 @@
     "infinitude-primes-4k3",
     "prime-number-theorem",
     "sum-of-two-squares",
-    "dirichlet-theorem"
+    "dirichlets-theorem"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
+++ b/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
@@ -112,7 +112,7 @@
     "four-square-distribution",
     "four-square-representations",
     "fermat-two-squares-oq-01",
-    "fermat-last-theorem"
+    "fermats-last-theorem"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
Two research-JSON `relatedProofs` entries reference gallery slugs that were renamed, so the cross-reference links resolve to nothing:

- `lagrange-four-squares-waring-g2-oq-01`: `fermat-last-theorem` → `fermats-last-theorem`
- `infinitude-primes-4k1-oq-03`: `dirichlet-theorem` → `dirichlets-theorem`

Both corrected targets exist under `src/data/proofs/`; the broken originals do not resolve to any gallery slug.

## Why this is the clean subset
Same `renamed-target-that-exists` class as #23321 / #23328. Word-level renames (missing apostrophe-s), not sibling-OQ references. Tag entries (free text) left untouched — only `relatedProofs` slug references fixed.

## Scope / safety
- Build-free; no Lean touched. Both JSONs validate.
- `lagrange...` JSON is uncontended. `infinitude...` JSON is also touched by open #22953, but only on disjoint `progressSummary` lines.
- No `loom:review-requested` (math-agent PR; deployer merges directly).