### PR TITLE
research: STATE-SYNC — retire stale sorry-closing knowledge on 2 COMPLETED 0-sorry slugs

### DIFF
--- a/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
+++ b/src/data/research/problems/abel-ruffini-galois-extensions-oq-04.json
@@ -38,8 +38,6 @@
       "JordanHolderLattice (Subgroup G) instance: marked as TODO in Mathlib.Order.JordanHolder"
     ],
     "nextSteps": [
-      "Close maximality sorry in isMaximal_inf_left_of_isMaximal_sup: use IsSimpleGroup transfer through second_iso MulEquiv",
-      "Submit maximality sorry to Aristotle (HARD classification)",
       "Contribute JordanHolderLattice (Subgroup G) to Mathlib after proof is complete"
     ]
   },

--- a/src/data/research/problems/erdos-817.json
+++ b/src/data/research/problems/erdos-817.json
@@ -29,11 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: 4→2 sorries in Erdos817Problem.lean. g3_one proved (subsetSums {1}={0,1} by decide, 3-AP-free by interval_cases). g3_two CORRECTED from =2 to =3 with full proof. g_ge_n structure filled (sorry only for nonemptiness). g3_le_exp still sorry (hard: needs carry argument for base-3 AP-freeness).",
+    "progressSummary": "COMPLETE: Erdos817Problem.lean is 0 sorries, 0 axioms. g3_one (g 3 1 = 1) and g3_two (g 3 2 = 3, corrected from the original =2) proved; g_ge_n (lower bound g k n ≥ n for k≥3, n≥1) proved with the geometric nonemptiness witness A = {3^0,...,3^{n-1}}; g3_le_exp (upper bound g_3(n) ≤ 3^n) proved via the base-3 {0,1}-digit AP-freeness argument.",
     "builtItems": [
       "g3_one: proved g 3 1 = 1 (Erdos817Problem.lean:191-219)",
       "g3_two: corrected to g 3 2 = 3 with full proof, including hfail2 (only valid N for n=2 requires N≥3)",
-      "g_ge_n: structural proof with sorry only for nonemptiness of ValidNs k n"
+      "g_ge_n: proved g k n ≥ n for k≥3, n≥1; nonemptiness of ValidNs discharged with the explicit AP-free witness A = {3^0,...,3^{n-1}}",
+      "g3_le_exp: proved upper bound g_3(n) ≤ 3^n via base-3 {0,1}-digit AP-freeness of the subset sums of {3^0,...,3^{n-1}}"
     ],
     "insights": [
       "g3_two = 3 (not 2 as originally stated): {1,2}⊆{1,...,2} has sums {0,1,2,3} containing 3-AP; {1,3}⊆{1,...,3} has sums {0,1,3,4} which is 3-AP-free",
@@ -42,15 +43,9 @@
       "g_ge_n structure: Nat.le_sInf needs nonemptiness + (∀ N ∈ ValidNs, N ≥ n). Easy part: N ≥ n by card_le_card + Nat.card_Icc. Hard part: nonemptiness requires explicit AP-free set",
       "g_ge_n nonemptiness: likely provable using geometric set {k^0,...,k^{n-1}} but AP-freeness of base-k {0,1}-digit numbers needs a carry/positional argument"
     ],
-    "mathlibGaps": [
-      "Nonemptiness of ValidNs k n for general k≥3, n≥1 — needs AP-free set construction (base-k geometric set)",
-      "g3_le_exp: upper bound g_3(n) ≤ 3^n — needs showing {3^0,...,3^{n-1}} subset sums are 3-AP-free (positional/carry argument)"
-    ],
+    "mathlibGaps": [],
     "nextSteps": [
-      "Try proving nonemptiness of ValidNs 3 n using A = {3^0,...,3^{n-1}} ⊆ Icc 1 (3^n)",
-      "For AP-freeness of geometric set sums: use induction on n, with the observation that the nth element 3^{n-1} creates a gap too large for any AP to bridge",
-      "Alternative for g_ge_n: state as hypothesis or use a separate lemma validSet_exists (k n : ℕ) : ∃ N, N ∈ ValidNs k n",
-      "Submit g_ge_n nonemptiness sorry to Aristotle — it may be within reach via Finset induction"
+      "Open (the Erdős 817 question): establish a matching lower bound g_3(n) ≫ 3^n — the upper bound g_3(n) ≤ 3^n is proved, but the only proved lower bound is the trivial g_k(n) ≥ n"
     ]
   },
   "tags": [


### PR DESCRIPTION
## Summary

Build-free STATE-SYNC during the Docker/Aristotle verification outage. Two COMPLETED-phase research trackers carried knowledge-block claims about closing `sorry`s that no longer exist in their (0-sorry) Lean sources.

### abel-ruffini-galois-extensions-oq-04 — status `verified`, source 0/0
- Removed two stale `nextSteps`: "Close maximality sorry in `isMaximal_inf_left_of_isMaximal_sup`" and "Submit maximality sorry to Aristotle".
- The slug's own `progressSummary`/`builtItems` already record this as discharged ("sorry closed", "maximality step discharged"), and `AbelRuffiniGaloisExtensionsOQ04.lean` is sorry-free (the lemma is a proved structure field at line 98).
- Kept the genuinely-forward step (contribute `JordanHolderLattice (Subgroup G)` to Mathlib).

### erdos-817 — status `axiomatized`, source 0 sorries / 0 axioms
- `progressSummary`, `builtItems`, `mathlibGaps`, and `nextSteps` still claimed `g_ge_n` and `g3_le_exp` carried sorries ("4→2 sorries", "g3_le_exp still sorry"). Both are fully proved in `Erdos817Problem.lean`: `g_ge_n` discharges nonemptiness with the geometric witness A = {3^0,…,3^{n-1}} (line 354); `g3_le_exp` (line 371) proves g₃(n) ≤ 3ⁿ via the base-3 {0,1}-digit AP-freeness argument.
- Synced the knowledge block to the proved state; replaced the moot sorry-closing `nextSteps` with the genuine open direction (matching lower bound g₃(n) ≫ 3ⁿ).

## Verification
- Both files re-validated as parseable JSON.
- Data-file only; no Lean source touched, so safe under the current Docker outage (no build required).
- `shapley-folkman` (same vein) intentionally excluded — already covered by open PR #23317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)