### PR TITLE
research: fix 2 broken relatedProofs xrefs to renamed gallery slugs

### DIFF
--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -80,7 +80,7 @@
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
     "gauss-wilson-non-cyclic-oq-01",
-    "wilson-theorem",
+    "wilsons-theorem",
     "chinese-remainder-theorem",
     "fermat-little-theorem"
   ],

--- a/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
+++ b/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
@@ -112,7 +112,7 @@
     "four-square-distribution",
     "four-square-representations",
     "fermat-two-squares-oq-01",
-    "fermat-last-theorem"
+    "fermats-last-theorem"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
Two research-problem trackers linked related gallery proofs by stale slug names that no longer resolve, producing dead links (404) on the research card's "Related Proofs" section:

- `lagrange-four-squares-waring-g2-oq-01`: `fermat-last-theorem` → `fermats-last-theorem`
- `gauss-wilson-non-cyclic-oq-03`: `wilson-theorem` → `wilsons-theorem`

Both corrected targets exist in `src/data/proofs/`.

## Why it's durable
`scripts/research/enrich-research.ts` union-merges `relatedProofs` and only auto-adds slugs detected as **valid** gallery proofs, so it will never resurrect the stale names. The corrected slugs survive regeneration.

## Scope notes
- Build-free (Docker + Aristotle verification blackout); no Lean touched.
- Limited to the two high-confidence pluralization renames on files with **no open-PR contention**. The FTA rename (`fundamental-theorem-arithmetic`→`fundamental-arithmetic`) is already covered by #23321; the `dirichlet-theorem` and `gauss-wilson-non-cyclic-oq-01` cases live in files under active edit (#22953, #23311) and were left out to avoid conflicts.
- Other broken xrefs (e.g. `chinese-remainder-theorem`, `fermat-little-theorem`, `catalan-numbers`) reference concepts with no gallery entry and are judgment-heavy — intentionally not touched here.

## Test plan
- [x] `jq empty` validates both JSON files
- [x] Both target slugs exist as directories under `src/data/proofs/`