### PR TITLE
research: fix broken relatedProofs xref szemeredi-regularity-lemma → szemeredi-regularity

### DIFF
--- a/src/data/research/problems/szemeredi-hypergraph-core-oq-01-incomplete-01.json
+++ b/src/data/research/problems/szemeredi-hypergraph-core-oq-01-incomplete-01.json
@@ -66,7 +66,7 @@
     "szemeredi-hypergraph-core-oq-01",
     "szemeredi-hypergraph-core-oq-01-incomplete-01",
     "szemeredi-proof",
-    "szemeredi-regularity-lemma"
+    "szemeredi-regularity"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
`relatedProofs` in `szemeredi-hypergraph-core-oq-01-incomplete-01.json` pointed at the non-existent slug `szemeredi-regularity-lemma`. The canonical gallery slug for that proof is `szemeredi-regularity`. Corrected the single entry.

## Rationale
- Target slug `szemeredi-regularity` confirmed present in `src/data/proofs/`.
- No duplicate created (it was not already in the array).
- Only the `relatedProofs` array touched; `tags` left untouched.
- Same accepted class as merged #23321 / #23328 / #23332 / #23334. Scope was reduced to this one remaining residual after confirming the fermat-last / dirichlet renames were already merged via #23332.

Build-free data fix — restores a broken gallery cross-link. Verification infra (Docker/Aristotle) is down; no Lean build involved.

## Test plan
- [x] `jq -e .` validates the JSON file
- [x] `szemeredi-regularity` confirmed to exist as a gallery slug
- [x] Diff is exactly one line