### PR TITLE
research: fix broken relatedProofs xref szemeredi-regularity-lemma → szemeredi-regularity

### DIFF
--- a/src/data/research/problems/szemeredi-hypergraph-core-oq-01-incomplete-01.json
+++ b/src/data/research/problems/szemeredi-hypergraph-core-oq-01-incomplete-01.json
@@ -66,7 +66,7 @@
     "szemeredi-hypergraph-core-oq-01",
     "szemeredi-hypergraph-core-oq-01-incomplete-01",
     "szemeredi-proof",
-    "szemeredi-regularity-lemma"
+    "szemeredi-regularity"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
- `szemeredi-hypergraph-core-oq-01-incomplete-01.json` had a `relatedProofs` entry pointing to the non-existent slug `szemeredi-regularity-lemma`.
- The gallery proof for the Szemerédi regularity lemma exists under slug `szemeredi-regularity` (`src/data/proofs/szemeredi-regularity`).
- Fixed the dangling cross-reference to the correct slug.

## Context
Build-free correctness fix during the verification blackout (Docker down). Same renamed-target pattern as the accepted xref fixes #23321 (FTA), #23328 (wilson), #23332 (fermat-last). Durable: `build.ts`/`enrich-research` union-merge xrefs and never prune, so this won't self-heal.

The other broken target in this file (`szemeredi-proof`) has no unambiguous existing rename target and is left untouched. The `dirichlet-theorem` rename is already handled by open PR #23332.

## Test plan
- [x] `python3 -m json.tool` validates the edited JSON
- [x] Confirmed `src/data/proofs/szemeredi-regularity` exists as the target gallery entry