### PR TITLE
research: fix 2 prose-contaminated relatedProofs xrefs in pascals-hexagon-oq-03

### DIFF
--- a/src/data/research/problems/pascals-hexagon-oq-03.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03.json
@@ -109,8 +109,8 @@
     "research"
   ],
   "relatedProofs": [
-    "pascals-hexagon (parent gallery entry, Wiedijk #28)",
-    "abel-ruffini-galois-extensions (S_6 cardinality work — shares `card_s6 = 720` pattern)"
+    "pascals-hexagon",
+    "abel-ruffini-galois-extensions"
   ],
   "references": [
     "Pascal, *Essai pour les coniques* (1639) — original Pascal hexagon theorem.",


### PR DESCRIPTION
## Summary
Both `relatedProofs` entries in `pascals-hexagon-oq-03.json` carried inline parenthetical prose, so neither resolved to a gallery slug:

- `"pascals-hexagon (parent gallery entry, Wiedijk #28)"` → `"pascals-hexagon"`
- `"abel-ruffini-galois-extensions (S_6 cardinality work — shares \`card_s6 = 720\` pattern)"` → `"abel-ruffini-galois-extensions"`

Both bare slugs exist as gallery proofs (`src/data/proofs/pascals-hexagon/`, `src/data/proofs/abel-ruffini-galois-extensions/`), so the cross-references now resolve.

Build-free, durable (relatedProofs is preserved/union-merged by the research build step). No Lean compilation involved.

## Test plan
- [x] `jq` confirms valid JSON
- [x] Both targets resolve to existing `src/data/proofs/<slug>/` directories
- [x] Uncontended — no open PR touches this file