### PR TITLE
research(pascals-hexagon-oq-03): fix 2 malformed relatedProofs slugs (embedded free text)

### DIFF
--- a/src/data/research/problems/pascals-hexagon-oq-03.json
+++ b/src/data/research/problems/pascals-hexagon-oq-03.json
@@ -109,8 +109,8 @@
     "research"
   ],
   "relatedProofs": [
-    "pascals-hexagon (parent gallery entry, Wiedijk #28)",
-    "abel-ruffini-galois-extensions (S_6 cardinality work — shares `card_s6 = 720` pattern)"
+    "pascals-hexagon",
+    "abel-ruffini-galois-extensions"
   ],
   "references": [
     "Pascal, *Essai pour les coniques* (1639) — original Pascal hexagon theorem.",


### PR DESCRIPTION
## Summary
Two `relatedProofs` entries in `pascals-hexagon-oq-03.json` had descriptive prose embedded directly in the slug string, so neither resolved to a gallery slug:

- `"pascals-hexagon (parent gallery entry, Wiedijk #28)"` → `"pascals-hexagon"`
- `"abel-ruffini-galois-extensions (S_6 cardinality work — shares \`card_s6 = 720\` pattern)"` → `"abel-ruffini-galois-extensions"`

Both bare slugs exist in the gallery, so stripping the annotation turns two dead xrefs into live links.

## Notes
- Build-free data fix; durable (build.ts preserves committed `src/data` research JSON; enrich-research union-merge never prunes).
- No open PR touches this file's xrefs (recent pascals-hexagon PRs are all merged section/enrichment work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)