### PR TITLE
research: fix 2 broken relatedProofs xrefs to renamed gallery slugs

### DIFF
--- a/src/data/research/problems/erdos-268.json
+++ b/src/data/research/problems/erdos-268.json
@@ -103,7 +103,7 @@
     "erdos-2",
     "erdos-26",
     "erdos-268",
-    "harmonic-series"
+    "harmonic-divergence"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/sqrt2-plus-sqrt3-irrational-oq-01.json
+++ b/src/data/research/problems/sqrt2-plus-sqrt3-irrational-oq-01.json
@@ -84,7 +84,7 @@
     "relatedProofs": [
         "sqrt2-plus-sqrt3-irrational",
         "sqrt2-plus-sqrt3-irrational-oq-03",
-        "irrational-sqrt-2",
+        "sqrt2-irrational",
         "cube-root-2-irrational"
     ],
     "references": {


### PR DESCRIPTION
## Summary
Two research-problem trackers link related gallery proofs by **legacy descriptive slug names** that no longer resolve, producing dead links / 404s on the research card. Each is renamed to the existing gallery slug that proves the identical theorem (title-verified):

| File | Stale slug | → Existing gallery slug | Gallery title |
|------|-----------|------------------------|---------------|
| `sqrt2-plus-sqrt3-irrational-oq-01` | `irrational-sqrt-2` | `sqrt2-irrational` | Irrationality of Square Roots |
| `erdos-268` | `harmonic-series` | `harmonic-divergence` | Divergence of the Harmonic Series |

Both targets exist in `src/data/proofs/`. Left erdos-268's `harmonic-series` **topic tag** untouched (it's a tag, not an xref).

## Why durable / not churn
`enrich-research.ts` union-merges `relatedProofs` and only auto-adds **valid** gallery slugs, so it never resurrects the stale names. This is the same durable class as previously-merged xref fixes (#23334, #23321), distinct from deployer-regenerated `leanFiles` churn.

## Scope notes
- Build-free (Docker + Aristotle verification blackout — no Lean changes).
- A third dangling xref (`infinitude-primes-4k1-oq-03`: `sum-of-two-squares`→`fermat-two-squares`) was **excluded** to avoid contending with open PR #22953, which edits the same JSON.
- The remaining ~18 dangling relatedProofs are references to proofs that don't exist at all (`pigeonhole`, `catalan`, `gaussian-integers`, …) or ambiguous multi-candidate renames — judgment-heavy, intentionally not touched.

## Test plan
- [x] Both JSONs parse (`jq -e .`)
- [x] Both rename targets exist as gallery dirs under `src/data/proofs/`
- [x] No open-PR collision on the two touched slugs