### PR TITLE
audit(bezout-identity-oq-03): re-audit clean — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -874,9 +874,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T16:43:30Z",
+      "lastAudited": "2026-06-14T06:58:20Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01": {


### PR DESCRIPTION
## Gallery Integrity Audit — clean

Re-audit of **bezout-identity-oq-03** (CRT via Bézout's Identity for Integers).

### Verification against `proofs/Proofs/BezoutIdentityOQ03.lean`
| Check | meta.json | Lean source | ✓ |
|-------|-----------|-------------|---|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 `axiom` decls | ✓ |
| True stubs | — | 0 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 1 | 1 | ✓ |
| lineCount | 276 | 276 | ✓ |

### Tier / narrative classification
- **Tier B** (formalized using Mathlib): core relies on `Int.gcd_eq_gcd_ab` (Bézout) and `IsCoprime.mul_dvd`.
- `badge: "mathlib"` is correct — no `original`/`verified` overclaim.
- Overview explicitly credits the Mathlib dependencies (no delegation opacity).
- `originalContributions` scoped to the genuinely independent work (explicit CRT construction, computable `crtInt` with correctness, `isCoprime_of_gcd_eq_one` bridge).
- Real existence + uniqueness theorems are proved (not a vacuous/inequality stub).

No issues found. Tracker `auditCount` 4→5, `result` clean.

---
Discovered during periodic gallery integrity audit.