### PR TITLE
research(lagrange-four-squares-waring-g2-oq-01): STATE-SYNC — register CountingG7 in leanFiles

### DIFF
--- a/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
+++ b/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
@@ -199,6 +199,17 @@
       "sorryCount": 0,
       "isAristotle": false,
       "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeFourSquaresWaringG2OQ01CountingG6.lean"
+    },
+    {
+      "path": "Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean",
+      "filename": "LagrangeFourSquaresWaringG2OQ01CountingG7.lean",
+      "lineCount": 139,
+      "theoremCount": 1,
+      "axiomCount": 0,
+      "defCount": 1,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/LagrangeFourSquaresWaringG2OQ01CountingG7.lean"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- The S7 ACT file `CountingG7.lean` (g(7) ≥ 143 lower bound, PR #22968 merged 2026-06-13) is on `origin/main` and described throughout the research JSON's `knowledge` section, but the `leanFiles` metrics array still listed only 5 of the 6 Lean files.
- Appends the missing `CountingG7` entry: `lineCount` 139, `theoremCount` 1, `axiomCount` 0, `defCount` 1, `sorryCount` 0 — matching the established convention of its 5 siblings (the lone `sorry` token in the file is the docstring word "sorry-free", consistent with siblings whose committed `sorryCount` is also 0).
- Build-free metadata reconciliation; no Lean changes.

## Test plan
- [x] JSON parses (`python3 -c json.load`)
- [x] `leanFiles` now has 6 entries, including `CountingG7`
- [x] Single-file diff (+11 lines), no unrelated churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)