### PR TITLE
audit(bezout-identity-oq-03): re-audit clean — tracker bump

### DIFF
--- a/src/data/proofs/audit-tracker.json
+++ b/src/data/proofs/audit-tracker.json
@@ -874,9 +874,9 @@
       "result": "clean"
     },
     "bezout-identity-oq-03": {
-      "auditCount": 4,
+      "auditCount": 5,
       "issues": [],
-      "lastAudited": "2026-05-03T16:43:30Z",
+      "lastAudited": "2026-06-14T07:52:52Z",
       "result": "clean"
     },
     "bezout-identity-oq-03-oq-01": {
@@ -14702,11 +14702,9 @@
     },
     "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02": {
       "auditCount": 1,
-      "lastAudited": "2026-06-13T16:22:13Z",
+      "lastAudited": "2026-06-13T16:05:52Z",
       "result": "issues-fixed",
-      "issues": [
-        "conclusion.summary claimed 18 machine-checked theorems; source has 21 (matches theoremCount field) — fixed in this PR"
-      ]
+      "issues": []
     },
     "dissection-of-cubes-oq-03-oq-02": {
       "auditCount": 1,
@@ -15321,12 +15319,6 @@
       "auditCount": 1,
       "lastAudited": "2026-06-13T15:12:04Z",
       "result": "clean",
-      "issues": []
-    },
-    "arithmetic-series-oq-02-oq-04-oq-01-oq-03-oq-02-oq-03-oq-02": {
-      "auditCount": 1,
-      "lastAudited": "2026-06-13T16:05:52Z",
-      "result": "issues-fixed",
       "issues": []
     }
   },


### PR DESCRIPTION
## Gallery Integrity Audit

Re-audited **bezout-identity-oq-03** (CRT via Bézout's Identity for Integers).

### Verification (meta.json vs Proofs/BezoutIdentityOQ03.lean)

| Field | meta.json | Lean source | Match |
|-------|-----------|-------------|-------|
| sorries | 0 | 0 | ✓ |
| axiomCount | 0 | 0 | ✓ |
| theoremCount | 10 | 10 | ✓ |
| definitionCount | 1 | 1 | ✓ |
| lineCount | 276 | 276 | ✓ |
| True-stubs | — | 0 | ✓ |

- **Tier B** (formalized using Mathlib): core CRT construction builds on `Int.gcd_eq_gcd_ab` (Bézout) and `IsCoprime.mul_dvd`, both honestly credited in `mathlibDependencies` and `assumptions`.
- **badge=`mathlib`** — correct, not overclaiming `original`/`verified`.
- **status=`verified`** justified (0 sorries, 0 axioms, no True-stubs).
- Title appropriately qualified ("via Bézout's Identity"), no famous-theorem overclaim.

**Result: clean.** No integrity issues.

Tracker change also collapses a pre-existing malformed duplicate JSON key (`arithmetic-series-...-oq-02-oq-03-oq-02` appeared twice).

---
Discovered during gallery integrity audit.