### PR TITLE
research: drop dangling laws-of-large-numbers-oq-02 xref

### DIFF
--- a/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
+++ b/src/data/proofs/laws-of-large-numbers-oq-01-oq-01/meta.json
@@ -130,7 +130,6 @@
   "relatedProofs": [
     "laws-of-large-numbers",
     "laws-of-large-numbers-oq-01",
-    "laws-of-large-numbers-oq-02",
     "laws-of-large-numbers-oq-03"
   ],
   "sections": [


### PR DESCRIPTION
## Summary
The gallery entry `laws-of-large-numbers-oq-01-oq-01` (SLLN Necessity) listed `laws-of-large-numbers-oq-02` in its `relatedProofs`, but no such slug exists — the family has oq-01, oq-03, oq-04 with a gap at oq-02 (never created). The reference rendered as a dead cross-link.

This drops the single dangling entry. Build-free, data-only.

## Verification
- jq scan of all 2446 gallery slugs vs every `relatedProofs` ref: `laws-of-large-numbers-oq-02` was the only broken distinct reference.
- Confirmed no `laws-of-large-numbers-oq-02` directory/slug on origin/main.
- No other open PR touches this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)