### PR TITLE
research(szemeredi-hypergraph-core-oq-01-incomplete-01): fix 2 dead relatedProofs xrefs

### DIFF
--- a/src/data/research/problems/szemeredi-hypergraph-core-oq-01-incomplete-01.json
+++ b/src/data/research/problems/szemeredi-hypergraph-core-oq-01-incomplete-01.json
@@ -65,8 +65,8 @@
     "szemeredi-hypergraph-core",
     "szemeredi-hypergraph-core-oq-01",
     "szemeredi-hypergraph-core-oq-01-incomplete-01",
-    "szemeredi-proof",
-    "szemeredi-regularity-lemma"
+    "szemeredi-theorem",
+    "szemeredi-regularity"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
Two `relatedProofs` entries in `szemeredi-hypergraph-core-oq-01-incomplete-01.json` point at slugs that resolve to no gallery or research entry, producing dead links:

- `szemeredi-proof` → `szemeredi-theorem` (canonical Szemerédi theorem entry)
- `szemeredi-regularity-lemma` → `szemeredi-regularity` (renamed target; same fix as merged #23335)

Both replacement targets were verified to exist as both a gallery dir (`src/data/proofs/<slug>`) and a research problem (`src/data/research/problems/<slug>.json`); both originals resolve to neither.

## Verification
- Build-free, data-only change (single JSON file, 2 lines).
- Confirmed no open PR touches this file.
- `relatedProofs` field, not prose.

## Test plan
- [x] Target slugs `szemeredi-theorem`, `szemeredi-regularity` exist as gallery + research entries
- [x] Original slugs `szemeredi-proof`, `szemeredi-regularity-lemma` resolve to nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)