### PR TITLE
research: drop 5 dangling relatedProofs xrefs to never-created sibling slugs

### DIFF
--- a/src/data/research/problems/erdos-1-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02-oq-02.json
@@ -71,8 +71,7 @@
   ],
   "relatedProofs": [
     "erdos-1",
-    "erdos-1-oq-02",
-    "erdos-1-oq-02-oq-01"
+    "erdos-1-oq-02"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -93,7 +93,6 @@
     "prob-method-expectation",
     "prob-method-alteration",
     "lovasz-local-lemma-oq-01",
-    "lovasz-local-lemma-oq-03",
     "lovasz-local-lemma-oq-04"
   ],
   "references": {

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -77,7 +77,6 @@
   "relatedProofs": [
     "sperner-simplicial-instance",
     "sperner-simplicial-bridge-oq-01",
-    "sperner-simplicial-instance-oq-02",
     "sperner-simplicial-instance-oq-05",
     "sperner-mathlib",
     "sperner-mathlib4"

--- a/src/data/research/problems/zsqrtd-neg-two-oq-03.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03.json
@@ -101,8 +101,6 @@
   ],
   "relatedProofs": [
     "zsqrtd-neg-two",
-    "zsqrtd-neg-two-oq-01",
-    "zsqrtd-neg-two-oq-02",
     "three-squares-theorem",
     "fermat-two-squares",
     "fermat-two-squares-oq-01"


### PR DESCRIPTION
## Summary
Strips 5 broken `relatedProofs` entries whose target slugs have **zero history across all branches** (planned siblings that were never created), producing broken gallery links:

| File | Dropped dangling target(s) |
|------|---------------------------|
| `zsqrtd-neg-two-oq-03` | `zsqrtd-neg-two-oq-01`, `zsqrtd-neg-two-oq-02` |
| `sperner-simplicial-instance-oq-01` | `sperner-simplicial-instance-oq-02` |
| `erdos-1-oq-02-oq-02` | `erdos-1-oq-02-oq-01` |
| `prob-method-lovasz-local-oq-01` | `lovasz-local-lemma-oq-03` |

Same surgical pattern as recently-merged #23347 (drop dangling xref). Build-free, data-only.

## Verification
- Each dangling target confirmed never-created: `git log --all -- <path>` → 0 hits.
- Valid set built from gallery `meta.json` slugs + research problem ids/slugs (3143 entries).
- Post-edit re-scan: all 4 files have **0 remaining broken xrefs**; surviving entries all resolve.
- All 4 files remain valid JSON; surgical line removals only (no encoding/prose churn).

## Test plan
- [x] `python3 -c json.load` passes on all 4 files
- [x] broken-xref residual scan = 0 for edited files
- [ ] No Lean build required (data-only)