### PR TITLE
research: strip dead relatedProofs xref (binary-gcd-oq-01-oq-04-oq-03)

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json
@@ -65,8 +65,7 @@
   "tags": ["gcd", "complexity", "matrix-invariant", "continuant", "blackout-survey", "cost-model-gated"],
   "relatedProofs": [
     "bezout-identity",
-    "bezout-identity-oq-01-oq-01-oq-01",
-    "binary-gcd-oq-01-oq-04-oq-03"
+    "bezout-identity-oq-01-oq-01-oq-01"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
Removes one dead `relatedProofs` cross-reference in `bezout-identity-oq-01-oq-01-oq-01-oq-02.json` pointing to `binary-gcd-oq-01-oq-04-oq-03`, a slug that exists in **neither** the gallery (`src/data/proofs/`) nor the research problem set (`src/data/research/problems/`) — a never-created child OQ. Leaving it produces a dead link in the gallery "related proofs" UI.

## Scope note
This PR was reduced to the single bezout file after discovering the four other dangling-sibling strips (zsqrtd / erdos / lovasz / sperner) are already covered by open PR #23349. This is the non-overlapping remainder.

## Notes
- Build-free data hygiene; no `.lean` files touched.
- JSON re-validated with `jq`; minimal diff (1 deletion + preceding comma fix), original encoding preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)