### PR TITLE
research(lagrange-four-squares-waring-g2-oq-01): strip dangling relatedProofs xref

### DIFF
--- a/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
+++ b/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
@@ -110,7 +110,6 @@
     "lagrange-four-squares-oq-01",
     "lagrange-four-squares-oq-01-oq-01",
     "four-square-distribution",
-    "four-square-representations",
     "fermat-two-squares-oq-01",
     "fermats-last-theorem"
   ],


### PR DESCRIPTION
## Summary
- Strip the broken `four-square-representations` entry from `relatedProofs` in `lagrange-four-squares-waring-g2-oq-01.json`.
- That gallery entry (Jacobi's four-square theorem, added in batch 9 `f89f524ddad`) was later removed/superseded. It is the only dangling ref in this file.
- The same concept is already covered by the **present** `four-square-distribution` xref (live gallery entry: "Jacobi's Four-Square Formula r₄(n) = 8·σ*(n)"), so the strip is lossless — no other file references the removed slug.

## Verification
- Confirmed `four-square-representations` is absent from `origin/main` tree (`git ls-tree`).
- Confirmed only this JSON referenced it (`grep -rl`).
- All remaining 7 relatedProofs resolve to existing research/gallery slugs.
- Build-free, data-only, single-line deletion; valid JSON.