### PR TITLE
research(szemeredi-core-oq-04): META-SYNC leanFiles + relatedProofs linkage

### DIFF
--- a/src/data/research/problems/szemeredi-core-oq-04.json
+++ b/src/data/research/problems/szemeredi-core-oq-04.json
@@ -177,5 +177,66 @@
     "mathlib-gap",
     "scaffold"
   ],
-  "lastUpdate": "2026-06-12"
+  "lastUpdate": "2026-06-12",
+  "leanFiles": [
+    {
+      "path": "Proofs/SzemerediCore.lean",
+      "filename": "SzemerediCore.lean",
+      "lineCount": 111,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 4,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCore.lean"
+    },
+    {
+      "path": "Proofs/SzemerediCoreOQ01.lean",
+      "filename": "SzemerediCoreOQ01.lean",
+      "lineCount": 844,
+      "theoremCount": 10,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 1,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ01.lean"
+    },
+    {
+      "path": "Proofs/SzemerediCoreOQ01Aristotle.lean",
+      "filename": "SzemerediCoreOQ01Aristotle.lean",
+      "lineCount": 380,
+      "theoremCount": 3,
+      "axiomCount": 0,
+      "defCount": 0,
+      "sorryCount": 0,
+      "isAristotle": true,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ01Aristotle.lean"
+    },
+    {
+      "path": "Proofs/SzemerediCoreOQ03.lean",
+      "filename": "SzemerediCoreOQ03.lean",
+      "lineCount": 186,
+      "theoremCount": 0,
+      "axiomCount": 1,
+      "defCount": 5,
+      "sorryCount": 0,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ03.lean"
+    },
+    {
+      "path": "Proofs/SzemerediCoreOQ04.lean",
+      "filename": "SzemerediCoreOQ04.lean",
+      "lineCount": 1124,
+      "theoremCount": 62,
+      "axiomCount": 0,
+      "defCount": 11,
+      "sorryCount": 24,
+      "isAristotle": false,
+      "githubUrl": "https://github.com/rjwalters/lean-genius/blob/main/proofs/Proofs/SzemerediCoreOQ04.lean"
+    }
+  ],
+  "relatedProofs": [
+    "szemeredi-core",
+    "szemeredi-core-oq-01"
+  ]
 }


### PR DESCRIPTION
## Summary
- The `szemeredi-core-oq-04` research JSON had **no `leanFiles` key** while its 5 associated Lean sources all exist on `main`.
- Ran `scripts/research/enrich-research.ts` and committed **only this claimed problem's** generated output.
- Adds 5 `leanFiles` entries (line/theorem/def/sorry counts read from source) + 2 `relatedProofs` (`szemeredi-core`, `szemeredi-core-oq-01`).

## Notes
- Data-only, **build-free** (no `.lean` changes). Docker + Aristotle were both unavailable this session.
- `sorryCount` values are the generator's faithful per-line `\bsorry\b` count (comment-inclusive), consistent with how all other dataset entries are computed. Semantic obligation count for OQ04 remains 4 real `sorry`s, tracked in the `knowledge`/`currentState` fields.
- Same pattern as prior accepted leanFiles syncs (#23345 borsuk, #23343 waring).

## Test plan
- [x] `git diff` touches only `src/data/research/problems/szemeredi-core-oq-04.json`
- [x] leanFiles paths/counts match `proofs/Proofs/Szemeredi*.lean` sources