### PR TITLE
research(cramers-rule): strip dead relatedProofs xref to unpublished sibling

### DIFF
--- a/src/data/research/problems/cramers-rule-oq-01-oq-02.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-02.json
@@ -91,7 +91,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",

--- a/src/data/research/problems/cramers-rule-oq-01-oq-04.json
+++ b/src/data/research/problems/cramers-rule-oq-01-oq-04.json
@@ -44,7 +44,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",

--- a/src/data/research/problems/cramers-rule-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-01.json
@@ -47,7 +47,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",

--- a/src/data/research/problems/cramers-rule-oq-02-oq-01.json
+++ b/src/data/research/problems/cramers-rule-oq-02-oq-01.json
@@ -40,7 +40,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",

--- a/src/data/research/problems/cramers-rule-oq-02.json
+++ b/src/data/research/problems/cramers-rule-oq-02.json
@@ -54,7 +54,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",

--- a/src/data/research/problems/cramers-rule-oq-03.json
+++ b/src/data/research/problems/cramers-rule-oq-03.json
@@ -65,7 +65,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",

--- a/src/data/research/problems/cramers-rule-oq-04.json
+++ b/src/data/research/problems/cramers-rule-oq-04.json
@@ -149,7 +149,6 @@
   "relatedProofs": [
     "cramers-rule",
     "cramers-rule-oq-01",
-    "cramers-rule-oq-01-oq-01",
     "cramers-rule-oq-01-oq-02",
     "cramers-rule-oq-01-oq-02-oq-01",
     "cramers-rule-oq-01-oq-03",


### PR DESCRIPTION
## Summary
Removes the broken `cramers-rule-oq-01-oq-01` cross-reference from 7 sibling research problems (`cramers-rule-oq-01`, `-oq-01-oq-02`, `-oq-01-oq-04`, `-oq-02`, `-oq-02-oq-01`, `-oq-03`, `-oq-04`).

## Why
`ResearchProblemPage.tsx` renders each `relatedProofs` slug as a `<Link to={/proof/${slug}}>`. There is no gallery proof at `src/data/proofs/cramers-rule-oq-01-oq-01/` (the family roster jumps `oq-01 → oq-01-oq-02`), so the link 404s — a dead link on 7 rendered research pages. The slug is a `completed` research problem that was never published to the gallery; it is the only non-gallery entry in otherwise all-valid rosters.

## Why this is safe / durable
The enricher (`scripts/research/enrich-research.ts`) merges `relatedProofs` as a **union of existing + auto-detected** entries — it only ever adds detected gallery proofs and never re-introduces a stale ref to a non-existent proof. So this strip is durable and self-healing: if a gallery proof for `cramers-rule-oq-01-oq-01` is ever published, detection re-adds the link automatically; if not, it stays correctly removed.

Build-free, data-only (7 single-line deletions). Mirrors merged precedent #23347.

## Test plan
- [x] All 7 files remain valid JSON (`jq` validated)
- [x] Phantom slug removed from `relatedProofs`, all other (valid) entries preserved
- [x] Gallery `relatedProofs` vein already clean (no gallery meta references this slug)