### PR TITLE
research(infinitude-primes-4k1-oq-03): repoint dead xref sum-of-two-squares → fermat-two-squares

### DIFF
--- a/src/data/research/problems/infinitude-primes-4k1-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-4k1-oq-03.json
@@ -91,7 +91,7 @@
     "infinitude-primes",
     "infinitude-primes-4k3",
     "prime-number-theorem",
-    "sum-of-two-squares",
+    "fermat-two-squares",
     "dirichlets-theorem"
   ],
   "references": {


### PR DESCRIPTION
## Summary
- `relatedProofs` in `infinitude-primes-4k1-oq-03.json` contained `sum-of-two-squares`, which matches **no** gallery proof or research slug (dead link).
- The gallery proof of that exact theorem exists under slug **`fermat-two-squares`** (`title: "Fermat's Sum of Two Squares"`).
- Repointed the dead ref to `fermat-two-squares`, restoring the intended working cross-reference (primes ≡1 mod 4 ⇔ sums of two squares).

## Notes
- Lossless, data-only, **build-free**. Docker + Aristotle both unavailable this session.
- Durable: concept `relatedProofs` are not auto-regenerated by `research:enrich` (that step only adds shared-leanFile proofs), so this manual repoint persists.
- Not overlapping with the open xref PRs #23348/#23349/#23350/#23351.

## Test plan
- [x] `git diff` touches only `infinitude-primes-4k1-oq-03.json` (single token)
- [x] `fermat-two-squares` slug exists (`src/data/proofs/fermat-two-squares/meta.json`)
- [x] no duplicate entry introduced; JSON parses