### PR TITLE
research(waring-g2-oq-01): strip dangling relatedProofs xref four-square-representations

### DIFF
--- a/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
+++ b/src/data/research/problems/lagrange-four-squares-waring-g2-oq-01.json
@@ -110,7 +110,6 @@
     "lagrange-four-squares-oq-01",
     "lagrange-four-squares-oq-01-oq-01",
     "four-square-distribution",
-    "four-square-representations",
     "fermat-two-squares-oq-01",
     "fermats-last-theorem"
   ],


### PR DESCRIPTION
## Summary
Build-free metadata correctness fix for `lagrange-four-squares-waring-g2-oq-01`.

`relatedProofs` listed `four-square-representations`, a gallery entry that was added in batch 9 (`f89f524ddad`) and later removed. It exists nowhere in `origin/main`:
- no `src/data/proofs/four-square-representations/` dir
- no `src/data/research/problems/four-square-representations.json`
- `git cat-file -e origin/main:.../meta.json` → not in tree

Its live conceptual equivalent `four-square-distribution` is **already present** in the same `relatedProofs` list, so removing the dangling entry is non-lossy.

## Scope
- 1 line deleted from one research-problem JSON
- 0 Lean changes, 0 axiom/sorry changes, no build required

## Test plan
- [x] JSON validates (`python3 -c json.load`)
- [x] Removed slug confirmed absent from gallery + research dirs and from `origin/main` tree
- [x] Conceptual sibling `four-square-distribution` retained in list