### PR TITLE
research: strip 6 dead relatedProofs xrefs to never-created sibling slugs

### DIFF
--- a/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json
+++ b/src/data/research/problems/bezout-identity-oq-01-oq-01-oq-01-oq-02.json
@@ -65,8 +65,7 @@
   "tags": ["gcd", "complexity", "matrix-invariant", "continuant", "blackout-survey", "cost-model-gated"],
   "relatedProofs": [
     "bezout-identity",
-    "bezout-identity-oq-01-oq-01-oq-01",
-    "binary-gcd-oq-01-oq-04-oq-03"
+    "bezout-identity-oq-01-oq-01-oq-01"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/erdos-1-oq-02-oq-02.json
+++ b/src/data/research/problems/erdos-1-oq-02-oq-02.json
@@ -71,8 +71,7 @@
   ],
   "relatedProofs": [
     "erdos-1",
-    "erdos-1-oq-02",
-    "erdos-1-oq-02-oq-01"
+    "erdos-1-oq-02"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -93,7 +93,6 @@
     "prob-method-expectation",
     "prob-method-alteration",
     "lovasz-local-lemma-oq-01",
-    "lovasz-local-lemma-oq-03",
     "lovasz-local-lemma-oq-04"
   ],
   "references": {

--- a/src/data/research/problems/sperner-simplicial-instance-oq-01.json
+++ b/src/data/research/problems/sperner-simplicial-instance-oq-01.json
@@ -77,7 +77,6 @@
   "relatedProofs": [
     "sperner-simplicial-instance",
     "sperner-simplicial-bridge-oq-01",
-    "sperner-simplicial-instance-oq-02",
     "sperner-simplicial-instance-oq-05",
     "sperner-mathlib",
     "sperner-mathlib4"

--- a/src/data/research/problems/zsqrtd-neg-two-oq-03.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03.json
@@ -101,8 +101,6 @@
   ],
   "relatedProofs": [
     "zsqrtd-neg-two",
-    "zsqrtd-neg-two-oq-01",
-    "zsqrtd-neg-two-oq-02",
     "three-squares-theorem",
     "fermat-two-squares",
     "fermat-two-squares-oq-01"


### PR DESCRIPTION
## Summary
Removes 6 `relatedProofs` cross-references that point to slugs which exist as **neither a gallery proof page nor a research problem**. Because `relatedProofs` renders an unconditional `<Link to={/proof/${slug}}>` (ResearchProblemPage.tsx:394-405), each dead entry is a clickable link that 404s.

All 6 targets were verified to have **never existed** as proof dirs (`git log --all -- src/data/proofs/<slug>/meta.json` → 0 commits), so they are hallucinated/never-created forward references, not renames — strip is the correct fix (nothing to retarget to).

| Removed ref | From file | Existing family |
|---|---|---|
| `zsqrtd-neg-two-oq-01`, `zsqrtd-neg-two-oq-02` | `zsqrtd-neg-two-oq-03` | {zsqrtd-neg-two, oq-03} |
| `sperner-simplicial-instance-oq-02` | `sperner-simplicial-instance-oq-01` | {instance, oq-05} |
| `lovasz-local-lemma-oq-03` | `prob-method-lovasz-local-oq-01` | {lovasz-local-lemma, oq-02} |
| `erdos-1-oq-02-oq-01` | `erdos-1-oq-02-oq-02` | {erdos-1, oq-02} |
| `binary-gcd-oq-01-oq-04-oq-03` | `bezout-identity-oq-01-oq-01-oq-01-oq-02` | binary-gcd-oq-01 family |

Build-free, data-only, JSON validated. Scoped conservatively: ~14 additional broken refs are generic concept names (e.g. `pigeonhole-principle`, `catalan-numbers`) with no unambiguous rename target, and ~24 reference real research problems that lack a proof page — both left untouched pending a separate decision.

## Test plan
- [x] `jq empty` validates all 5 edited JSON files
- [x] `grep` confirms 0 remaining references to the 6 removed slugs
- [x] diff is minimal (5 files, removals only)