### PR TITLE
Enrich gallery: remove 34 dead crossReference links

### DIFF
--- a/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-02/meta.json
@@ -61,11 +61,6 @@
   },
   "crossReferences": [
     {
-      "targetId": "amgm-inequality-oq-04-oq-01",
-      "relationship": "extends",
-      "description": "Reuses the rigorous `ellipticK` definition (Mathlib intervalIntegral). This file defines `ellipticE` analogously and adds the complementary modulus k' = √(1-k²) plus the Legendre relation."
-    },
-    {
       "targetId": "amgm-inequality-oq-04-oq-05",
       "relationship": "supports",
       "description": "OQ04OQ05 (Brent-Salamin) currently axiomatizes the symmetric Legendre relation `2KE - K² = π/2` at k = 1/√2. This file's `legendre_relation_symmetric` theorem (proved from the more general axiom) provides exactly that statement, enabling a future session to discharge the OQ04OQ05 axiom."

--- a/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
+++ b/src/data/proofs/amgm-inequality-oq-04-oq-05/meta.json
@@ -75,11 +75,6 @@
       "targetId": "leibniz-pi",
       "relationship": "contrast",
       "description": "Leibniz's series π/4 = 1 - 1/3 + 1/5 - ⋯ converges polynomially. The Brent-Salamin algorithm converges quadratically — each iteration doubles the digits. This makes it among the fastest known algorithms for computing π."
-    },
-    {
-      "targetId": "amgm-inequality-oq-04-oq-01",
-      "relationship": "related",
-      "description": "OQ04-OQ01 defines K(k) as a Mathlib interval integral and proves K(0)=π/2, K>0. This file re-axiomatizes K for self-containedness, but OQ04-OQ01's rigorous definition would replace the ellipticK axiom here."
     }
   ],
   "sections": [

--- a/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02-oq-04/meta.json
@@ -145,11 +145,6 @@
       "targetId": "ballot-problem",
       "relationship": "related",
       "description": "Grandparent: classical ballot theorem. The weighted case is a generalization attempt."
-    },
-    {
-      "targetId": "ballot-problem-oq-01-oq-02-oq-02",
-      "relationship": "related",
-      "description": "Sibling: LGV determinant for ordering probabilities. A different multi-candidate generalization."
     }
   ],
   "references": [

--- a/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-04-oq-01/meta.json
@@ -80,11 +80,6 @@
       "targetId": "ballot-problem",
       "relationship": "ancestor",
       "description": "Original Bertrand-1887 ballot problem entry; uses André's reflection principle (1887). This entry's bijective Chung-Feller approach is the structural complement to reflection — both prove ballot-style equalities, with bijection winning when one needs an explicit *witness* for each class."
-    },
-    {
-      "targetId": "catalan-numbers",
-      "relationship": "applies-to",
-      "description": "The Chung-Feller bijection gives a self-contained combinatorial proof that the n-th Catalan number is $\\binom{2n}{n}/(n+1)$ via two-way counting of balanced paths."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-01-oq-01/meta.json
@@ -124,23 +124,19 @@
         ]
     },
     "crossReferences": [
-        {
-            "proofId": "bezout-identity",
-            "relationship": "grandparent — Bézout identity statement and its basic Mathlib proof"
-        },
-        {
-            "proofId": "bezout-identity-oq-01",
-            "relationship": "parent — extended Euclidean algorithm with explicit Bézout coefficient computation using modular division"
-        },
-        {
-            "proofId": "binary-gcd-oq-01",
-            "relationship": "sibling — open questions about binary GCD algorithm variants and complexity"
-        },
-        {
-            "proofId": "binary-gcd-oq-01-oq-03",
-            "relationship": "sibling — further binary GCD variants and extended algorithms"
-        }
-    ],
+    {
+      "proofId": "bezout-identity",
+      "relationship": "grandparent — Bézout identity statement and its basic Mathlib proof"
+    },
+    {
+      "proofId": "bezout-identity-oq-01",
+      "relationship": "parent — extended Euclidean algorithm with explicit Bézout coefficient computation using modular division"
+    },
+    {
+      "proofId": "binary-gcd-oq-01",
+      "relationship": "sibling — open questions about binary GCD algorithm variants and complexity"
+    }
+  ],
     "leanFile": {
         "namespace": "BezoutIdentityOQ01OQ01",
         "lineCount": 188,

--- a/src/data/proofs/binary-gcd-oq-02-oq-02/meta.json
+++ b/src/data/proofs/binary-gcd-oq-02-oq-02/meta.json
@@ -192,11 +192,6 @@
       "description": "Parallel integer extension via natAbs reduction for the binary GCD algorithm; both this entry and `binary-gcd-oq-02` follow the same template and agree on every ℤ input via the shared `Int.gcd` bridge"
     },
     {
-      "targetId": "binary-gcd-oq-03-oq-01",
-      "relationship": "depends-on",
-      "description": "Imports the ℕ-level Lehmer GCD `lehmerGcd` and its correctness theorem `lehmerGcd_correct` from `LehmerGcdOQ01`"
-    },
-    {
       "targetId": "binary-gcd-oq-03-oq-02",
       "relationship": "related",
       "description": "Lehmer's leading-digit quotient-estimate accelerator (the substantive content of Lehmer 1938) is formalized in this sibling open question — orthogonal to the integer extension proved here"

--- a/src/data/proofs/birthday-problem-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-01/meta.json
@@ -136,11 +136,6 @@
       "targetId": "birthday-problem",
       "relationship": "extends",
       "description": "Extends the classic birthday problem (probability threshold at n=23) to the expected-pairs formulation (expectation threshold at n=28)"
-    },
-    {
-      "targetId": "birthday-problem-oq-01-oq-02",
-      "relationship": "child",
-      "description": "Further open questions extending the expected-pairs analysis"
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-01-oq-02-oq-03/meta.json
@@ -129,11 +129,6 @@
       "description": "Provides no_retraction_singular_homology and singular_homology_retraction_split — the homological engine used to derive BFP here"
     },
     {
-      "targetId": "sperner-lemma",
-      "relationship": "related",
-      "description": "Sperner's lemma provides a combinatorial proof of BFP via triangulation — an alternative chain requiring no homology axioms"
-    },
-    {
       "targetId": "intermediate-value-theorem",
       "relationship": "related",
       "description": "IVT is the 1-dimensional case of BFP; both are consequences of the topological connectedness of intervals / contractibility of balls"

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-02/meta.json
@@ -111,11 +111,6 @@
   ],
   "crossReferences": [
     {
-      "targetId": "brouwer-fixed-point-oq-04-oq-01",
-      "relationship": "related",
-      "description": "Alternative Nash existence proof via Kakutani FPT + Berge's maximum theorem (set-valued best-response correspondence). This file reduces axiom count from 2 to 1 by using Nash's original single-valued Brouwer argument."
-    },
-    {
       "targetId": "brouwer-fixed-point-oq-04",
       "relationship": "depends-on",
       "description": "Provides the brouwer_pi_compact_convex axiom (general Brouwer FPT) from which brouwer_product_simplex is proved, and the kakutani_fixed_point_axiom used in OQ-01."

--- a/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
+++ b/src/data/proofs/brouwer-fixed-point-oq-04-oq-04/meta.json
@@ -123,11 +123,6 @@
       "description": "Kakutani's theorem (OQ-04) is the set-valued generalization of Brouwer. This formalization provides its constructive content."
     },
     {
-      "targetId": "brouwer-fixed-point-oq-04-oq-01",
-      "relationship": "sibling",
-      "description": "Nash equilibrium existence (OQ-04-OQ-01) uses Kakutani; the Scarf algorithm can compute Nash equilibria."
-    },
-    {
       "targetId": "brouwer-fixed-point-oq-04-oq-03",
       "relationship": "sibling",
       "description": "Infinite-dimensional Kakutani (OQ-04-OQ-03); Scarf's algorithm extends to locally convex spaces via Fan-Glicksberg."

--- a/src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/cantors-theorem-oq-01-oq-03/meta.json
@@ -173,11 +173,6 @@
       "relationship": "related",
       "description": "CantorDiagonalizationOQ01OQ01OQ02.lean and CantorDiagonalizationOQ01OQ01OQ02OQ03.lean use Cardinal.lt_cof_power for analogous cofinality results. Together with this file, they form a small library of König-constraint applications.",
       "targetId": "cantor-diagonalization-oq-01-oq-01-oq-02"
-    },
-    {
-      "relationship": "tool",
-      "description": "Easton's theorem (1970) shows that the values 2^κ can take for regular κ are essentially anything consistent with monotonicity and König's constraint. The cf > 𝔠 lower bound here is the König half of Easton's characterization for κ = 𝔠.",
-      "targetId": "easton-theorem"
     }
   ],
   "references": [

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03/meta.json
@@ -303,11 +303,6 @@
       "description": "WIP01: full theorem with 1 axiom (rational canonical form). WIP03 provides the prime power case that WIP01 handles implicitly."
     },
     {
-      "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-02",
-      "relationship": "companion",
-      "description": "WIP02: squarefree case (axiom-free). WIP03 is the complementary prime power case. Together they cover all structural cases of the general theorem."
-    },
-    {
       "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
       "relationship": "related",
       "description": "Nonderogatory cyclic vector for infinite fields (axiom-free). WIP03 extends coverage to ALL fields including finite fields with no cardinality restriction."

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-04/meta.json
@@ -166,11 +166,6 @@
       "description": "WIP03 proved the single prime power case (minpoly = p^e). WIP04 reuses its `pow_irred_dvd_of_annihilated` lemma and lifts the result to arbitrary k pairwise-coprime prime power factors via CRT projections."
     },
     {
-      "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-02",
-      "relationship": "extends",
-      "description": "WIP02 proved the squarefree case (k pairwise coprime irreducible factors, all exponents 1). WIP04 generalizes by allowing arbitrary exponents, using the prime power divisibility induction on top of the same CRT projection scheme."
-    },
-    {
       "targetId": "cayley-hamilton-minpoly-oq-05-oq-01",
       "relationship": "related",
       "description": "Grandparent: nonderogatory cyclic vector for infinite fields (proved via union avoidance). WIP04 covers any field including small finite fields where union avoidance fails."

--- a/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-05/meta.json
@@ -222,11 +222,6 @@
       "description": "WIP01 used the nonderogatory_similar_to_companion axiom as a stand-in for rational canonical form. WIP05 eliminates this axiom entirely."
     },
     {
-      "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-02",
-      "relationship": "uses",
-      "description": "WIP02 (squarefree minpoly case) is the foundational case proved without module theory, using only CRT projections. WIP05's factorization-based approach reduces ultimately to WIP02 via WIP03 and WIP04."
-    },
-    {
       "targetId": "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-03",
       "relationship": "uses",
       "description": "WIP03 (prime-power case) handles individual factors $p_i^{e_i}$ via induction on the exponent. WIP05's product decomposition combines WIP03's handling of each summand in the primary decomposition."

--- a/src/data/proofs/cayley-hamilton-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-oq-01/meta.json
@@ -82,16 +82,6 @@
       "targetId": "cayley-hamilton-oq-02",
       "relationship": "complementary",
       "description": "OQ-02 uses the charpoly-based reduction (Cayley-Hamilton directly) for polynomial evaluation. OQ-01 (this file) proves the sharper minpoly-based reduction and shows they agree: `charpoly_mod_refines_to_minpoly` bridges the two approaches."
-    },
-    {
-      "targetId": "jordan-normal-form",
-      "relationship": "foundational",
-      "description": "The Jordan normal form decomposes K^n as a direct sum of cyclic K[X]-modules, each annihilated by a power of an irreducible polynomial. The minimal polynomial μ_M = ∏ pᵢ^{eᵢ} encodes the largest Jordan block size per eigenvalue — the formalization of Ann(M) = (μ_M) in this file is the algebraic foundation for the Jordan decomposition."
-    },
-    {
-      "targetId": "rational-canonical-form",
-      "relationship": "foundational",
-      "description": "The rational canonical form expresses K^n ≅ K[X]/(d₁) ⊕ ... ⊕ K[X]/(d_k) where d₁|...|d_k = μ_M. This file's annihilator ideal theorem (Ann(M) = (μ_M)) is the key input: the rational canonical form is exactly the cyclic decomposition of K^n as a K[X]-module with annihilator (μ_M)."
     }
   ],
   "sections": [

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-01/meta.json
@@ -106,11 +106,6 @@
       "description": "Parent proof via Eisenstein. This file derives the stronger degree statement as a corollary."
     },
     {
-      "targetId": "cube-root-2-irrational-oq-03",
-      "relationship": "depends",
-      "description": "Source of adjoin_nthRoot_finrank, isIntegral_nthRoot, minpoly_nthRoot_natDegree."
-    },
-    {
       "targetId": "cube-root-3-irrational-oq-02-oq-02",
       "relationship": "motivates",
       "description": "OQ-02 proves {1, ∛3, (∛3)²} linearly independent over ℚ — a consequence of [ℚ(∛3):ℚ] = 3."

--- a/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cube-root-3-irrational-oq-02-oq-02/meta.json
@@ -100,42 +100,37 @@
         }
     ],
     "crossReferences": [
-        {
-            "targetId": "cube-root-3-irrational-oq-02",
-            "relationship": "extends",
-            "description": "Parent proof via Eisenstein. This file uses minpoly_nthRoot_natDegree from CubeRoot2IrrationalOQ03 (which the parent also depends on) to get deg(minpoly ℚ α) = 3."
-        },
-        {
-            "targetId": "cube-root-3-irrational-oq-02-oq-01",
-            "relationship": "related",
-            "description": "Sibling entry proving [ℚ(∛3):ℚ] = 3 via adjoin_nthRoot_finrank. Linear independence of {1, α, α²} is a consequence of this degree-3 extension, but this file proves it directly without invoking the full field extension machinery."
-        },
-        {
-            "targetId": "cube-root-2-irrational-oq-03",
-            "relationship": "depends",
-            "description": "Source of minpoly_nthRoot_natDegree, the key lemma giving natDegree(minpoly ℚ α) = 3."
-        },
-        {
-            "targetId": "sqrt2-minpoly",
-            "relationship": "related",
-            "description": "Analogous result for √2: the minimal polynomial of √2 over ℚ is X² - 2 (degree 2). The same minpoly-divisibility argument applied here would prove {1, √2} is ℚ-linearly independent."
-        },
-        {
-            "targetId": "nth-root-irrational",
-            "relationship": "related",
-            "description": "General nth-root irrationality framework: the broader pattern this file specializes — for any n ≥ 2 and squarefree m, ⁿ√m has minimal polynomial X^n - m of degree n over ℚ."
-        },
-        {
-            "targetId": "sqrt2-irrational",
-            "relationship": "related",
-            "description": "Degree-2 sibling: irrationality of √2 corresponds to {1, √2} being ℚ-linearly independent (the n=2 instance of the power-basis theorem). The same minpoly-divisibility argument transports verbatim with n = 2 in place of n = 3."
-        },
-        {
-            "targetId": "sqrt2-plus-sqrt3-irrational",
-            "relationship": "related",
-            "description": "Multi-radical sibling: irrationality of √2 + √3 uses a degree-4 minpoly argument (over ℚ, the minimal polynomial of √2 + √3 is X⁴ − 10X² + 1). Same minpoly-divisibility template, applied at n = 4 and to a non-pure-power algebraic number."
-        }
-    ],
+    {
+      "targetId": "cube-root-3-irrational-oq-02",
+      "relationship": "extends",
+      "description": "Parent proof via Eisenstein. This file uses minpoly_nthRoot_natDegree from CubeRoot2IrrationalOQ03 (which the parent also depends on) to get deg(minpoly ℚ α) = 3."
+    },
+    {
+      "targetId": "cube-root-3-irrational-oq-02-oq-01",
+      "relationship": "related",
+      "description": "Sibling entry proving [ℚ(∛3):ℚ] = 3 via adjoin_nthRoot_finrank. Linear independence of {1, α, α²} is a consequence of this degree-3 extension, but this file proves it directly without invoking the full field extension machinery."
+    },
+    {
+      "targetId": "sqrt2-minpoly",
+      "relationship": "related",
+      "description": "Analogous result for √2: the minimal polynomial of √2 over ℚ is X² - 2 (degree 2). The same minpoly-divisibility argument applied here would prove {1, √2} is ℚ-linearly independent."
+    },
+    {
+      "targetId": "nth-root-irrational",
+      "relationship": "related",
+      "description": "General nth-root irrationality framework: the broader pattern this file specializes — for any n ≥ 2 and squarefree m, ⁿ√m has minimal polynomial X^n - m of degree n over ℚ."
+    },
+    {
+      "targetId": "sqrt2-irrational",
+      "relationship": "related",
+      "description": "Degree-2 sibling: irrationality of √2 corresponds to {1, √2} being ℚ-linearly independent (the n=2 instance of the power-basis theorem). The same minpoly-divisibility argument transports verbatim with n = 2 in place of n = 3."
+    },
+    {
+      "targetId": "sqrt2-plus-sqrt3-irrational",
+      "relationship": "related",
+      "description": "Multi-radical sibling: irrationality of √2 + √3 uses a degree-4 minpoly argument (over ℚ, the minimal polynomial of √2 + √3 is X⁴ − 10X² + 1). Same minpoly-divisibility template, applied at n = 4 and to a non-pure-power algebraic number."
+    }
+  ],
     "conclusion": {
         "summary": "{1, ∛3, (∛3)²} is ℚ-linearly independent via minpoly divisibility. 3 theorems, 0 sorries, 0 axioms.",
         "implications": "**Stronger than irrationality**: ∛3 ∉ ℚ says the degree-1 polynomial X - ∛3 has no ℚ coefficients. Linear independence says no nonzero degree-≤2 polynomial over ℚ has ∛3 as a root. This is equivalent to minpoly ℚ (∛3) having degree exactly 3.\n\n**Basis for the degree-3 extension**: Together with (∛3)³ = 3 ∈ ℚ, linear independence shows {1, ∛3, (∛3)²} spans ℚ(∛3) over ℚ. So {1, ∛3, (∛3)²} is a ℚ-basis for ℚ(∛3), giving an alternative proof of [ℚ(∛3):ℚ] = 3.\n\n**Generalizes**: The same minpoly divisibility argument works for any α with natDegree(minpoly ℚ α) = n: the set {1, α, ..., α^(n-1)} is ℚ-linearly independent.",

--- a/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-01/meta.json
@@ -131,11 +131,6 @@
       "id": "ehrhart-cube-proven",
       "relationship": "parent",
       "description": "Cube Ehrhart formula L([0,1]^d, n) = (n+1)^d, proved axiom-free via the Fintype bijection Fin d → Fin (n+1). This entry answers OQ-01 of that proof: both use Fintype cardinality, but the simplex uses multisets (Sym) while the cube uses functions."
-    },
-    {
-      "id": "ehrhart-polynomials",
-      "relationship": "ancestor",
-      "description": "General Ehrhart theory: L_P(n) is a polynomial of degree dim P for any convex lattice polytope P. This file provides an axiom-free proof of the formula for the standard simplex, a key motivating example."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -152,11 +152,6 @@
       "slug": "ehrhart-cube-proven-oq-01",
       "title": "Ehrhart Polynomial of the Standard Simplex",
       "relationship": "Sibling proof (OQ-01) using multisets Sym (Fin(d+1)) n for the simplex case."
-    },
-    {
-      "slug": "ehrhart-polynomials",
-      "title": "Ehrhart Polynomials for Lattice Polytopes",
-      "relationship": "General theory (axiomatized). This file provides an axiom-free proof for the cross-polytope."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/erdos-1023-oq-01-problem/meta.json
+++ b/src/data/proofs/erdos-1023-oq-01-problem/meta.json
@@ -139,11 +139,6 @@
       "targetId": "combinations-formula",
       "relationship": "foundational",
       "description": "The binomial coefficient $\\binom{n}{\\lfloor n/2 \\rfloor}$ appears as `middleLayer_card` — the size of the middle layer antichain. The formalization uses `Nat.centralBinom` from `Nat.Choose.Central` to compute this cardinality."
-    },
-    {
-      "targetId": "dilworth-theorem",
-      "relationship": "related",
-      "description": "Dilworth's theorem (1950) states that in any finite partially ordered set, the maximum antichain size equals the minimum number of chains needed to cover the poset. For the boolean lattice $2^{[n]}$, Dilworth gives maximum antichain size $= \\binom{n}{\\lfloor n/2 \\rfloor}$ (Sperner 1928). The present entry uses `middleLayer_antichain` but does not prove it is the *maximum* antichain."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/euler-identity-oq-01-oq-01-oq-01/meta.json
@@ -208,7 +208,7 @@
     },
     {
       "type": "related",
-      "id": "demoivre",
+      "id": "de-moivre",
       "description": "De Moivre's theorem (circleMap_npow / circleMap_zpow) is a one-line corollary of the homomorphism property + Complex.exp_int_mul."
     }
   ],

--- a/src/data/proofs/euler-totient-oq-01/meta.json
+++ b/src/data/proofs/euler-totient-oq-01/meta.json
@@ -161,11 +161,6 @@
       "description": "Structural Properties of φ: parity, divisibility, and the product formula φ(n) = n·∏_{p|n}(1-1/p). These structural results, combined with λ(n) | φ(n) proved here, determine when Carmichael's function equals Euler's totient: λ(n) = φ(n) iff (ℤ/nℤ)* is cyclic, which can be detected from n's prime factorization structure."
     },
     {
-      "targetId": "fermat-little-theorem",
-      "relationship": "generalization-of",
-      "description": "Fermat's Little Theorem: a^(p-1) ≡ 1 (mod p) for prime p and gcd(a,p)=1. This is the special case λ(p) = p-1, proved here as carmichael_prime. The Carmichael function unifies Fermat's little theorem (prime case), Euler's theorem (λ(n) | φ(n)), and the exact minimal exponent — all as consequences of the group exponent Monoid.exponent."
-    },
-    {
       "targetId": "bezout-identity-oq-03",
       "relationship": "related",
       "description": "Chinese Remainder Theorem — CRT gives the product formula λ(p₁^k₁ · p₂^k₂ · ... ) = lcm(λ(p₁^k₁), λ(p₂^k₂), ...), which follows because (ℤ/nℤ)* ≅ ∏(ℤ/pᵢ^kᵢ ℤ)* and the exponent of a direct product is the lcm of component exponents. The CRT isomorphism (formalized in bezout-identity-oq-03) is the structural bridge between the component-wise computation of λ and the global value."

--- a/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-defs-oq-04/meta.json
@@ -117,11 +117,6 @@
       "targetId": "feuerbachs-theorem",
       "relationship": "related",
       "description": "the full Feuerbach theorem including incircle tangency, which this bridge enables reformulating"
-    },
-    {
-      "targetId": "feuerbachs-theorem-defs-oq-03",
-      "relationship": "sibling",
-      "description": "OQ-03 proves Feuerbach point uniqueness; this file provides the Mathlib sphere reformulation that enables Mathlib-compatible uniqueness proofs"
     }
   ],
   "leanFile": {

--- a/src/data/proofs/frobenius-number-oq-01/meta.json
+++ b/src/data/proofs/frobenius-number-oq-01/meta.json
@@ -142,11 +142,6 @@
       "targetId": "frobenius-number",
       "relationship": "extends",
       "description": "Direct parent: provides the Frobenius number formula $g(a, b) = ab - a - b$ via `sylvester_frobenius`. This file uses $\\neg\\text{Rep}(g)$ (the largest non-representable element) as the +1 contribution to the count."
-    },
-    {
-      "targetId": "frobenius-number-oq-02",
-      "relationship": "uses",
-      "description": "Sibling: provides the Frobenius symmetry $\\text{Rep}(k) \\Leftrightarrow \\neg\\text{Rep}(g - k)$ for $0 < k < g$ via `frobenius_symmetry`. This biconditional is the *only* non-elementary input to the bijection lemma."
     }
   ],
   "references": [

--- a/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
+++ b/src/data/proofs/fundamental-theorem-algebra-oq-04-oq-04/meta.json
@@ -169,11 +169,6 @@
       "proofId": "nth-root-irrational-oq-01",
       "relationship": "sibling",
       "description": "Provides `eisenstein_X_pow_sub_prime` used to prove `Xn_sub_p_irred_Q` (irreducibility of X^n - p over ℚ via Gauss's lemma from ℤ-irreducibility)."
-    },
-    {
-      "proofId": "triangle-inequality-oq-02",
-      "relationship": "related",
-      "description": "Formalizes the p-adic ultrametric inequality $|x+y|_p \\leq \\max(|x|_p, |y|_p)$, demonstrating Mathlib's ℚ_[p] infrastructure. The ultrametric is the analytic foundation underlying the Newton polygon argument used here."
     }
   ],
   "leanFile": {

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -161,12 +161,6 @@
       "relation": "Direct parent. Establishes the three real-valued `intervalIntegral_swap` theorems. This OQ-03 sibling generalizes them to Banach codomain E by verbatim port (this file)."
     },
     {
-      "type": "sibling",
-      "slug": "greens-theorem-oq-01-oq-01-oq-02-oq-01",
-      "title": "n-dim intervalIntegral_swap via Measure.pi (sibling S1)",
-      "relation": "Sibling OQ-01 explores the n-dimensional generalization (∫ over n-fold product). This OQ-03 focuses on the codomain (Banach E) at fixed dimension 2."
-    },
-    {
       "type": "ancestor",
       "slug": "greens-theorem",
       "title": "Green's Theorem (line integrals around closed curves)",

--- a/src/data/proofs/hilbert-11-oq-02/meta.json
+++ b/src/data/proofs/hilbert-11-oq-02/meta.json
@@ -225,11 +225,6 @@
       "description": "Parent gallery entry. hilbert-11 formalizes the Hasse-Minkowski theorem for quadratic forms (the local-global principle holds in degree 2). This entry shows that the Hasse principle FAILS in degree 3 — specifically for the Selmer cubic. Together they sandwich the local-global principle: it works for quadratics but is no longer automatic in higher degree."
     },
     {
-      "targetId": "hilbert-11-oq-01",
-      "relationship": "related",
-      "description": "Sibling open-question entry on the refined Hasse-Minkowski theorem. Both files axiomatize a deep arithmetic input on top of the Hasse-principle framework; this entry localizes the OQ to the Selmer cubic counterexample, while OQ-01 sharpens the Hasse-Minkowski statement."
-    },
-    {
       "targetId": "e-transcendental-oq-02",
       "relationship": "related",
       "description": "Same axiomatization pattern: a deep open or classical theorem (Selmer 1951 / e is absolutely normal) is encoded as an axiom, with all the elementary surrounding framework proved unconditionally. Both entries use `Prop := True` as a documented placeholder for an open conjecture whose full statement requires Mathlib infrastructure not yet present."

--- a/src/data/proofs/lagrange-four-squares-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-02/meta.json
@@ -87,11 +87,6 @@
       "targetId": "lagrange-four-squares-oq-01",
       "relationship": "sibling",
       "description": "Four-square distribution open question 1 — the companion file establishing the basic distribution analysis that this file extends with general type-family theorems."
-    },
-    {
-      "targetId": "jacobis-four-square-theorem",
-      "relationship": "related",
-      "description": "Jacobi's formula r₄(n) = 8·Σ_{4∤d|n} d (1834) — the exact formula for the total representation count whose distribution among types is analyzed here."
     }
   ],
   "sections": [

--- a/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
+++ b/src/data/proofs/lagrange-theorem-oq-01-oq-03/meta.json
@@ -101,11 +101,6 @@
       "proofId": "lagrange-theorem",
       "relationship": "extends",
       "description": "Lagrange's theorem (every subgroup order divides |G|) is the starting point; Hall's theorem is the deepest partial converse"
-    },
-    {
-      "proofId": "cauchy-theorem",
-      "relationship": "uses",
-      "description": "Cauchy's theorem provides the prime case of Hall's theorem directly"
     }
   ],
   "sections": [

--- a/src/data/proofs/law-of-cosines-oq-03/meta.json
+++ b/src/data/proofs/law-of-cosines-oq-03/meta.json
@@ -76,11 +76,6 @@
       "targetId": "law-of-cosines-oq-01",
       "relationship": "sibling",
       "description": "Spherical law of cosines: cos(c) = cos(a)cos(b) + sin(a)sin(b)cos(C) — the positive-curvature analogue. Together with the hyperbolic law, these three form the complete picture for constant-curvature spaces."
-    },
-    {
-      "targetId": "gauss-bonnet",
-      "relationship": "related",
-      "description": "Gauss-Bonnet theorem — establishes that the area of a hyperbolic triangle equals its angular defect π-(A+B+C), connecting the angular defect theorem here to differential geometry."
     }
   ],
   "sections": [

--- a/src/data/proofs/ramsey-r4k/meta.json
+++ b/src/data/proofs/ramsey-r4k/meta.json
@@ -225,11 +225,6 @@
       "description": "The parent entry formalizes the general Ramsey theorem $R(r,s) < \\infty$ for all $r,s$. This entry specializes to off-diagonal $R(4,k)$ and proves quantitative upper bounds via the Pascal recursion and the Erdős-Szekeres binomial bound $\\binom{k+2}{3}$"
     },
     {
-      "targetId": "probabilistic-method",
-      "relationship": "related",
-      "description": "The probabilistic method (Erdős 1947) gives lower bounds for Ramsey numbers via the first-moment method. This entry's Part VIII sets up the `expectedCliqueTerm` framework for this calculation. The full Lovász local lemma (used for asymptotically sharper bounds) would extend this infrastructure"
-    },
-    {
       "targetId": "combinations-formula",
       "relationship": "uses",
       "description": "The Erdős-Szekeres bound $R(4,k) \\leq \\binom{k+2}{3}$ is the central formula in this file. The cubic bound proof uses `choose_le_pow_three : ∀ n, C(n,3) ≤ n³` — a binomial coefficient inequality proved by induction on $n$"

--- a/src/data/proofs/russell-1-plus-1-oq-04/meta.json
+++ b/src/data/proofs/russell-1-plus-1-oq-04/meta.json
@@ -153,11 +153,6 @@
       "targetId": "cantor-diagonalization",
       "relationship": "related",
       "description": "Both entries explore the *expressive power* of formal systems by separating their *computational content* from their *propositional content*. Cantor's diagonal shows the limits of any enumeration (a propositional impossibility); this entry refines `1+1=2 := rfl` (a propositional triviality) into a non-trivial *computational* taxonomy depending on representation."
-    },
-    {
-      "targetId": "ackermann-function",
-      "relationship": "related",
-      "description": "Ackermann's function is the canonical example of a primitive-recursive-vs.-recursive boundary. This entry's representation-dependent rule analysis hints at a finer hierarchy: not just *what is computable* (Ackermann's signature concern) but *what kernel rules suffice* — a refinement of recursion-theoretic complexity into reduction-rule complexity."
     }
   ],
   "mainTheorems": [

--- a/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-mathlib-oq-01/meta.json
@@ -198,11 +198,6 @@
       "description": "Provides the Freudenthal pseudomanifold proof and `prefixSet_card_eq` (cardinality of prefix sets), used in `prefixSet_inj`."
     },
     {
-      "targetId": "sperner-lemma",
-      "relationship": "specializes-to",
-      "description": "Sperner's lemma for the Freudenthal triangulation of $[0,1]^n$ is a special case of the classical Sperner lemma, with the specific triangulation made explicit."
-    },
-    {
       "targetId": "brouwer-fixed-point",
       "relationship": "implies",
       "description": "Sperner's lemma on the Freudenthal triangulation implies Brouwer's fixed-point theorem for $[0,1]^n$ via the standard reduction (Knaster–Kuratowski–Mazurkiewicz)."

--- a/src/data/proofs/szemeredi-full-oq-02/meta.json
+++ b/src/data/proofs/szemeredi-full-oq-02/meta.json
@@ -123,11 +123,6 @@
       "description": "Builds on SzemerediTheorem.lean's ap_free_density_bound (ε-N₀ form) to derive the Filter.Tendsto/IsLittleO asymptotic form — the key bridge from quantitative to asymptotic"
     },
     {
-      "targetId": "szemeredi-full-oq-01",
-      "relationship": "related",
-      "description": "The Furstenberg ergodic approach to Szemerédi — an alternative proof route connecting arithmetic progressions to measure-preserving systems and recurrence, with entirely different infrastructure needs"
-    },
-    {
       "targetId": "roth-theorem-k3",
       "relationship": "foundational",
       "description": "Roth's 1953 theorem: k=3 AP-free subsets of {1,...,N} have |A| = o(N). This is the k=3 case of Szemerédi; the file uses Mathlib's `rothNumberNat_isLittleO_id` as the direct formalization"


### PR DESCRIPTION
## Summary
The `crossReferences` field on each proof renders as a clickable "Related Proofs" link to `/proof/<targetId>` (`src/components/proof/ProofConclusion.tsx:192`, `ProofOverview.tsx`). A scan of all 2447 gallery entries found **34 crossReferences pointing to slugs with no gallery directory** — each produces a dead link that lands on a "proof not found" page. (Prior xref scans targeted `relatedProofs`; this field was uncovered.)

- **Removed 34 dead-link crossReferences** across 34 entries. Targets fall into two groups, both confirmed to have no gallery directory:
  - never-created sibling/WIP entries (e.g. `amgm-inequality-oq-04-oq-01`, `binary-gcd-oq-03-oq-01`, `cayley-hamilton-minpoly-...-wip-02`, `szemeredi-full-oq-01`, `brouwer-fixed-point-oq-04-oq-01`)
  - concept references with no gallery page (`catalan-numbers`, `jordan-normal-form`, `rational-canonical-form`, `probabilistic-method`, `gauss-bonnet`, `ackermann-function`, `easton-theorem`, `dilworth-theorem`, `jacobis-four-square-theorem`, `sperner-lemma`, `fermat-little-theorem`, `ehrhart-polynomials`, `cauchy-theorem`, `triangle-inequality-oq-02`)
- **Repointed** `euler-identity-oq-01-oq-01-oq-01`: `demoivre` → `de-moivre` (the existing entry; only safe normalization — all other broken targets fuzzy-match *different* theorems, so repointing would create plausible-but-wrong links).

## Validation
Data-only JSON change touching only `crossReferences` blocks (45 insertions / 215 deletions). All 34 files re-parse as valid JSON. `pnpm annotations:build`, `research:build`, `research:enrich`, and `tsc -b` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)