### PR TITLE
research: strip 2 dead self-referential relatedProofs xrefs

### DIFF
--- a/src/data/research/problems/triangle-inequality-oq-02.json
+++ b/src/data/research/problems/triangle-inequality-oq-02.json
@@ -57,7 +57,6 @@
   ],
   "relatedProofs": [
     "triangle-inequality",
-    "triangle-inequality-oq-02",
     "triangle-inequality-oq-03",
     "triangle-inequality-oq-04"
   ],

--- a/src/data/research/problems/yang-mills-mass-gap.json
+++ b/src/data/research/problems/yang-mills-mass-gap.json
@@ -302,8 +302,7 @@
     "open-conjecture"
   ],
   "relatedProofs": [
-    "yang-mills",
-    "yang-mills-mass-gap"
+    "yang-mills"
   ],
   "references": {
     "papers": [],


### PR DESCRIPTION
## Summary
Two research-problem JSONs list their **own slug** in `relatedProofs`, producing dead self-links:
- `triangle-inequality-oq-02` → `triangle-inequality-oq-02`
- `yang-mills-mass-gap` → `yang-mills-mass-gap`

`relatedProofs` entries render as `/proof/<slug>` links. Neither slug has a gallery proof directory under `src/data/proofs/`, so each self-reference is a broken link. A page linking to itself in "related proofs" is also pointless.

Valid parent/sibling links are retained:
- triangle-inequality-oq-02: `triangle-inequality`, `triangle-inequality-oq-03`, `triangle-inequality-oq-04`
- yang-mills-mass-gap: `yang-mills`

## Verification
- Confirmed via `ls src/data/proofs/` that `triangle-inequality-oq-02` and `yang-mills-mass-gap` are not gallery proof slugs (dead targets).
- Confirmed retained links resolve to existing gallery dirs.
- Both JSON files re-parsed successfully after edit (`json.load`).
- Data-only change; no Lean build affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)