### PR TITLE
research: strip 2 self-referential relatedProofs xrefs

### DIFF
--- a/src/data/research/problems/triangle-inequality-oq-02.json
+++ b/src/data/research/problems/triangle-inequality-oq-02.json
@@ -57,7 +57,6 @@
   ],
   "relatedProofs": [
     "triangle-inequality",
-    "triangle-inequality-oq-02",
     "triangle-inequality-oq-03",
     "triangle-inequality-oq-04"
   ],

--- a/src/data/research/problems/yang-mills-mass-gap.json
+++ b/src/data/research/problems/yang-mills-mass-gap.json
@@ -302,8 +302,7 @@
     "open-conjecture"
   ],
   "relatedProofs": [
-    "yang-mills",
-    "yang-mills-mass-gap"
+    "yang-mills"
   ],
   "references": {
     "papers": [],


### PR DESCRIPTION
## Summary
- `triangle-inequality-oq-02` and `yang-mills-mass-gap` each listed their **own slug** in `relatedProofs`.
- Neither slug has a gallery dir (`src/data/proofs/<slug>/`), so the self-link renders as a dead `/proof/` link.
- Removed only the self-reference from each; all valid sibling xrefs are preserved.

## Why this is distinct
Self-references are a separate, unambiguously-lossless category — untouched by the open xref PRs (#23353–57, #23349–51 target sibling/concept slugs; #23358 is gallery `crossReference`). A proof relating to itself carries no information.

## Verification
- `jq -e .` confirms both JSONs remain valid.
- Net change: `triangle-inequality-oq-02` → `[triangle-inequality, -oq-03, -oq-04]`; `yang-mills-mass-gap` → `[yang-mills]`.
- Build-free (research JSON data only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)