### PR TITLE
research(cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01): strip dead relatedProofs xref to never-published incomplete sibling

### DIFF
--- a/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01.json
+++ b/src/data/research/problems/cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01.json
@@ -95,7 +95,6 @@
     "cayley-hamilton-minpoly-oq-05-oq-01",
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-01",
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04",
-    "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-incomplete-01",
     "cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01"
   ],
   "references": [


### PR DESCRIPTION
## Summary
- Strip one dead `relatedProofs` cross-reference in `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-wip-01.json`.
- The removed slug `cayley-hamilton-minpoly-oq-05-oq-01-oq-04-incomplete-01` was never published to the gallery (no `src/data/proofs/` dir), so the rendered `/proof/` link is dead.
- Lossless: the parent slug `cayley-hamilton-minpoly-oq-05-oq-01-oq-04` is already present in the same `relatedProofs` array, fully covering the concept.

## Context
Blackout session (Aristotle proof search returns "Resource not found", Docker build unavailable). Build-free gallery-integrity fix. A fresh research-JSON `relatedProofs` scan against the published-slug validset showed this `-incomplete-01` ref is the only occurrence and is not touched by any other open xref PR (#23349/#23350/#23354/#23355/#23356/#23357/#23358).

## Test plan
- [x] `jq empty` validates the edited JSON
- [x] `git diff` shows a single-line deletion, no other changes
- [x] Confirmed parent slug `...-oq-04` remains in the array (lossless)