### PR TITLE
research(gauss-wilson-non-cyclic): repoint dead CRT xref to canonical gallery slug

### DIFF
--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -86,7 +86,7 @@
     "gauss-wilson-non-cyclic-oq-03",
     "wilsons-theorem",
     "fermat-little-theorem",
-    "chinese-remainder-theorem"
+    "chinese-remainder-constructive"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -81,7 +81,7 @@
     "gauss-wilson-non-cyclic",
     "gauss-wilson-non-cyclic-oq-01",
     "wilsons-theorem",
-    "chinese-remainder-theorem",
+    "chinese-remainder-constructive",
     "fermat-little-theorem"
   ],
   "references": {


### PR DESCRIPTION
## Summary
Two `gauss-wilson-non-cyclic` research OQ files cross-reference `chinese-remainder-theorem` in `relatedProofs`, but that slug was never created (no research JSON, no gallery page) — the rendered `/proof/chinese-remainder-theorem` link 404s.

The canonical Chinese Remainder Theorem gallery proof exists under slug **`chinese-remainder-constructive`** (title: "Chinese Remainder Theorem (Constructive)"). This PR repoints the dead reference to it, **restoring a correct working cross-reference** rather than dropping the connection.

- `gauss-wilson-non-cyclic-oq-01.json`: `chinese-remainder-theorem` → `chinese-remainder-constructive`
- `gauss-wilson-non-cyclic-oq-03.json`: `chinese-remainder-theorem` → `chinese-remainder-constructive`

Same class as prior repoint #23355 (renamed/canonical-slug fix). Uncontested: the dead slug is a never-created *concept* (no JSON), so there is no growing-OQ-family loss concern.

## Verification
- Confirmed `chinese-remainder-theorem` has no gallery dir and no research JSON (dead link).
- Confirmed `src/data/proofs/chinese-remainder-constructive/meta.json` exists with `slug: chinese-remainder-constructive`, title "Chinese Remainder Theorem (Constructive)".
- Both edited JSON files re-validated with `jq`.
- `fermat-little-theorem` (also dead in these arrays) left untouched — no canonical gallery target exists for it.

## Test plan
- [ ] Deployer build regenerates gallery; `/proof/chinese-remainder-constructive` resolves from both gauss-wilson OQ pages.