### PR TITLE
research(frobenius-number): strip dead relatedProofs xref frobenius-two-coprime

### DIFF
--- a/src/data/research/problems/frobenius-number-oq-01.json
+++ b/src/data/research/problems/frobenius-number-oq-01.json
@@ -79,8 +79,7 @@
     "completed-research"
   ],
   "relatedProofs": [
-    "frobenius-number",
-    "frobenius-two-coprime"
+    "frobenius-number"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/frobenius-number-oq-03.json
+++ b/src/data/research/problems/frobenius-number-oq-03.json
@@ -107,8 +107,7 @@
     ],
     "relatedProofs": [
         "frobenius-number",
-        "frobenius-number-oq-01",
-        "frobenius-two-coprime"
+        "frobenius-number-oq-01"
     ],
     "references": {
         "papers": [


### PR DESCRIPTION
## Summary
- Strips the dead `frobenius-two-coprime` `relatedProofs` xref from `frobenius-number-oq-01.json` and `frobenius-number-oq-03.json`.
- `frobenius-two-coprime` was never a gallery proof slug (`git log --all` → 0 hits), so it rendered as a broken `/proof/frobenius-two-coprime` link.
- The proof it refers to is published as **`frobenius-number`** (gallery meta title: *"Frobenius Number for Two Coprime Integers"*), which **both files already list** in `relatedProofs`. The removal is therefore lossless — no concept reference is lost.

## Verification
- `jq` confirms valid JSON; `relatedProofs` now `["frobenius-number"]` and `["frobenius-number","frobenius-number-oq-01"]` respectively.
- No overlap with open PRs: #23358/#23363 touch `src/data/proofs/frobenius-number-oq-01/meta.json` (gallery `crossReferences`), a different file from the research `problems/*.json` edited here.

Build-free data-only change.