### PR TITLE
research(frobenius-number): strip dead relatedProofs xref to graduated slug

### DIFF
--- a/src/data/research/problems/frobenius-number-oq-01.json
+++ b/src/data/research/problems/frobenius-number-oq-01.json
@@ -79,8 +79,7 @@
     "completed-research"
   ],
   "relatedProofs": [
-    "frobenius-number",
-    "frobenius-two-coprime"
+    "frobenius-number"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/frobenius-number-oq-03.json
+++ b/src/data/research/problems/frobenius-number-oq-03.json
@@ -107,8 +107,7 @@
     ],
     "relatedProofs": [
         "frobenius-number",
-        "frobenius-number-oq-01",
-        "frobenius-two-coprime"
+        "frobenius-number-oq-01"
     ],
     "references": {
         "papers": [


### PR DESCRIPTION
## Summary
- `frobenius-two-coprime` (research slug, status `graduated`) graduated into the gallery proof **`frobenius-number`** (gallery title "Frobenius Number for Two Coprime Integers"). There is no `/proof/frobenius-two-coprime` page, so the `relatedProofs` entry renders as a dead link.
- Stripped the dead pre-graduation ref from two descendant problems. Both already list the live `frobenius-number`, so the removal is **lossless** — the concept stays linked via its canonical graduated slug.

## Files
- `frobenius-number-oq-01.json`: `["frobenius-number", "frobenius-two-coprime"]` → `["frobenius-number"]`
- `frobenius-number-oq-03.json`: drops trailing `"frobenius-two-coprime"`, keeps `frobenius-number` + `frobenius-number-oq-01`

## Verification
- Confirmed no `src/data/proofs/frobenius-two-coprime/` gallery dir exists.
- Confirmed gallery `frobenius-number` is the graduated form (same concept).
- JSON validated; no open PR touches these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)