### PR TITLE
research: strip dead relatedProofs xref to unpublished binary-gcd sibling

### DIFF
--- a/src/data/research/problems/binary-gcd-oq-02-oq-02.json
+++ b/src/data/research/problems/binary-gcd-oq-02-oq-02.json
@@ -76,7 +76,6 @@
     "binary-gcd-oq-02",
     "binary-gcd-oq-02-oq-01",
     "binary-gcd-oq-03",
-    "binary-gcd-oq-03-oq-01",
     "binary-gcd-oq-03-oq-02"
   ],
   "references": {


### PR DESCRIPTION
## Summary
Removes the broken `binary-gcd-oq-03-oq-01` cross-reference from `binary-gcd-oq-02-oq-02`'s `relatedProofs`. It renders as a `/proof/binary-gcd-oq-03-oq-01` Link in `ResearchProblemPage` but no gallery proof exists for that slug (it is a completed-but-unpublished OQ sibling), so the link 404s.

## Why it's safe
- **Lossless**: the immediate gallery parent `binary-gcd-oq-03` and a published sibling `binary-gcd-oq-03-oq-02` both remain in the list, so the subfamily stays reachable.
- **Durable + self-healing**: the enricher's `relatedProofs` merge is union-only and never re-adds undetected refs; if the proof is later published, detection re-adds the ref automatically.
- **Build-free, data-only.** No Lean changes. Mirrors #23347 / #23353.

## Note on scope
Originally batched 5 strips; the other 4 (basel, hilbert-11, minpoly-charpoly, sylow-theorems) were concurrently shipped with identical strips in #23368, so this PR is reduced to the one non-overlapping file.

## Test plan
- [x] File validates as JSON (`jq empty`)
- [x] Zero remaining broken `relatedProofs` (slug ∉ gallery dir set)
- [x] Source file not touched by any other open PR (no conflict)