### PR TITLE
research: strip 1 / repoint 2 dead relatedProofs xrefs

### DIFF
--- a/src/data/research/problems/cube-root-3-irrational-oq-02.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-02.json
@@ -65,7 +65,7 @@
     "irreducibility"
   ],
   "relatedProofs": [
-    "cube-root-2-irrational-oq-03",
+    "cube-root-2-irrational",
     "cube-root-3-irrational",
     "cube-root-3-irrational-oq-02"
   ],

--- a/src/data/research/problems/inverse-galois-a5-oq-01.json
+++ b/src/data/research/problems/inverse-galois-a5-oq-01.json
@@ -100,8 +100,7 @@
     "inverse-galois-d4-oq-03",
     "inverse-galois-f20",
     "inverse-galois-oq-01",
-    "inverse-galois-oq-02",
-    "inverse-galois-oq-06-oq-01"
+    "inverse-galois-oq-02"
   ],
   "tags": [
     "alternating-group",

--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-02-oq-01.json
@@ -77,7 +77,7 @@
     "lagrange-theorem-oq-02",
     "lagrange-theorem-oq-02-oq-01",
     "lagrange-theorem-oq-02-oq-02",
-    "burnside-counting-oq-03-oq-03"
+    "burnside-counting"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary

Three research-JSON `relatedProofs` entries referenced gallery slugs that **never existed on origin/main** (verified with `git log origin/main -- src/data/proofs/<slug>/meta.json`). `relatedProofs` render as `/proof/<slug>` links, so each was a dead link.

| File | Dead ref | Fix | Why clean |
|------|----------|-----|-----------|
| `inverse-galois-a5-oq-01` | `inverse-galois-oq-06-oq-01` | **strip** | base `inverse-galois` + 6 siblings already live in same array |
| `cube-root-3-irrational-oq-02` | `cube-root-2-irrational-oq-03` | **repoint → `cube-root-2-irrational`** | live base; no other cube-root-2 ref present, so repoint preserves the cross-family link |
| `lagrange-theorem-oq-02-oq-02-oq-01` | `burnside-counting-oq-03-oq-03` | **repoint → `burnside-counting`** | live base; no other burnside ref present |

Strip is lossless (a live family member already covers the family); repoints preserve intent by pointing at the live base instead of dropping the cross-reference.

All three target bases verified **live on origin/main**. Deduped against open xref PRs (#23349 / #23350 / #23357 / #23368 / #23369) — the `binary-gcd-oq-03-oq-01` strip I initially included was dropped because #23369 already covers it.

## Test plan
- [x] `jq empty` passes on all 3 files
- [x] zero broken `relatedProofs` refs remain in the 3 files (checked against `ls src/data/proofs`)
- [x] no duplicate refs introduced by repoints
- [x] no overlap with open xref PRs