### PR TITLE
research: strip 15 dangling 404 relatedProofs xrefs + 1 rename

### DIFF
--- a/src/data/research/problems/ballot-problem-oq-02-oq-05.json
+++ b/src/data/research/problems/ballot-problem-oq-02-oq-05.json
@@ -105,11 +105,8 @@
     "ballot-problem",
     "ballot-problem-oq-01",
     "ballot-problem-oq-03-oq-01",
-    "arcsine-law",
     "central-limit-theorem",
-    "central-limit-theorem-oq-04",
-    "kolmogorov-smirnov",
-    "catalan-numbers"
+    "central-limit-theorem-oq-04"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/erdos-szekeres-oq-01.json
+++ b/src/data/research/problems/erdos-szekeres-oq-01.json
@@ -87,8 +87,7 @@
   ],
   "relatedProofs": [
     "erdos-szekeres",
-    "ramseys-theorem",
-    "pigeonhole-principle"
+    "ramseys-theorem"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/erdos-szekeres-oq-02.json
+++ b/src/data/research/problems/erdos-szekeres-oq-02.json
@@ -78,8 +78,7 @@
   ],
   "relatedProofs": [
     "erdos-szekeres",
-    "ramseys-theorem",
-    "pigeonhole-principle"
+    "ramseys-theorem"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -84,9 +84,7 @@
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
     "gauss-wilson-non-cyclic-oq-03",
-    "wilsons-theorem",
-    "fermat-little-theorem",
-    "chinese-remainder-theorem"
+    "wilsons-theorem"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -80,9 +80,7 @@
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
     "gauss-wilson-non-cyclic-oq-01",
-    "wilsons-theorem",
-    "chinese-remainder-theorem",
-    "fermat-little-theorem"
+    "wilsons-theorem"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-01.json
+++ b/src/data/research/problems/greens-theorem-oq-01-oq-01-oq-02-oq-01.json
@@ -74,7 +74,6 @@
     "greens-theorem-oq-01-oq-01",
     "greens-theorem-oq-01-oq-01-oq-02",
     "greens-theorem-oq-01-oq-01-oq-03",
-    "fundamental-theorem-calculus-stokes",
     "erdos-1001-oq-03"
   ],
   "references": {

--- a/src/data/research/problems/infinitude-primes-4k1-oq-03.json
+++ b/src/data/research/problems/infinitude-primes-4k1-oq-03.json
@@ -91,7 +91,7 @@
     "infinitude-primes",
     "infinitude-primes-4k3",
     "prime-number-theorem",
-    "sum-of-two-squares",
+    "fermat-two-squares",
     "dirichlets-theorem"
   ],
   "references": {

--- a/src/data/research/problems/randomized-maxcut-oq-03.json
+++ b/src/data/research/problems/randomized-maxcut-oq-03.json
@@ -78,8 +78,7 @@
     "randomized-maxcut",
     "randomized-maxcut-oq-01",
     "randomized-maxcut-oq-02",
-    "randomized-maxcut-oq-04",
-    "goemans-williamson-max-cut"
+    "randomized-maxcut-oq-04"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/shannon-entropy-oq-01.json
+++ b/src/data/research/problems/shannon-entropy-oq-01.json
@@ -102,8 +102,7 @@
   "relatedProofs": [
     "shannon-entropy",
     "shannon-entropy-oq-02",
-    "shannon-entropy-oq-03",
-    "shannon-entropy-ssa"
+    "shannon-entropy-oq-03"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/sperner-mathlib-oq-01.json
+++ b/src/data/research/problems/sperner-mathlib-oq-01.json
@@ -91,9 +91,7 @@
     "sperner-mathlib",
     "sperner-simplicial-bridge-oq-01",
     "sperner-simplicial-instance-oq-05",
-    "sperner-ndim-mathlib-oq-01",
-    "sperner-freudenthal",
-    "sperner-grid"
+    "sperner-ndim-mathlib-oq-01"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/sqrt2-minpoly-oq-03.json
+++ b/src/data/research/problems/sqrt2-minpoly-oq-03.json
@@ -150,7 +150,6 @@
     "sqrt2-minpoly",
     "sqrt2-minpoly-oq-01",
     "sqrt2-minpoly-oq-02",
-    "gaussian-integers",
     "zsqrtd-neg-two"
   ],
   "provenance": {


### PR DESCRIPTION
## Summary
The `relatedProofs` array renders in `ResearchProblemPage.tsx` (L394-405) as an unconditional clickable `<Link to={/proof/<slug>}>` with **no existence check**. Any entry whose slug has no gallery page is therefore a live, clickable **404**.

This strips 15 such dead links across 11 research problems. Each removed target has **never existed as a gallery proof in any commit** (verified via `git log --all --diff-filter=A -- src/data/proofs/<slug>/meta.json` = 0), so the links are permanently dead, not pending-creation.

| Source problem | Removed dead targets |
|---|---|
| ballot-problem-oq-02-oq-05 | arcsine-law, kolmogorov-smirnov, catalan-numbers |
| erdos-szekeres-oq-01 / -oq-02 | pigeonhole-principle |
| gauss-wilson-non-cyclic-oq-01 / -oq-03 | fermat-little-theorem, chinese-remainder-theorem |
| greens-theorem-oq-01-oq-01-oq-02-oq-01 | fundamental-theorem-calculus-stokes |
| randomized-maxcut-oq-03 | goemans-williamson-max-cut |
| shannon-entropy-oq-01 | shannon-entropy-ssa |
| sperner-mathlib-oq-01 | sperner-freudenthal, sperner-grid |
| sqrt2-minpoly-oq-03 | gaussian-integers |

**One rename instead of a strip** (lossless — clear existing equivalent):
- `infinitude-primes-4k1-oq-03`: `sum-of-two-squares` → `fermat-two-squares` (verified existing gallery slug; same theorem)

## Scope / safety
- Only **DANGLING-NOWHERE** targets touched (no gallery page *and* no research problem of that slug). Sibling refs that point to real research problems — which may gain gallery pages later — are deliberately **left intact** to avoid lossy removal of forward references.
- **No overlap** with concurrently-open xref PRs: #23350 (`bezout → binary-gcd-oq-01-oq-04-oq-03`) and #23351 (`waring → four-square-representations`) — those targets are excluded here. Verified no other open PR touches these 11 files.
- Metadata-only, **build-free**. JSON validity re-checked on all 11 files.

## Test plan
- [x] `jq empty` passes on all 11 edited files
- [x] `git log --all` confirms 0 prior creation for every stripped slug
- [x] `fermat-two-squares` confirmed as an existing gallery slug
- [x] diff contains only `relatedProofs` entry changes (no unicode/format churn)