### PR TITLE
research(hurwitz-theorem-wip-01): strip 2 dead relatedProofs xrefs to graduated slugs

### DIFF
--- a/src/data/research/problems/hurwitz-theorem-wip-01.json
+++ b/src/data/research/problems/hurwitz-theorem-wip-01.json
@@ -88,9 +88,7 @@
     "blocked-on-mathlib"
   ],
   "relatedProofs": [
-    "hurwitz-theorem",
-    "hurwitz-impossibility",
-    "hurwitz-three-square-impossibility"
+    "hurwitz-theorem"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
Strips two dead `relatedProofs` xrefs from `hurwitz-theorem-wip-01.json`:
- `hurwitz-impossibility` (title: "Hurwitz Quaternion Theorem")
- `hurwitz-three-square-impossibility` (title: "Hurwitz Three-Square Impossibility")

Both are research problems with status **`graduated`** and **no gallery page**, so the rendered `/proof/<slug>` links (ResearchProblemPage.tsx:397) 404. Both results graduated into the gallery proof **`hurwitz-theorem`** — "There are only four n-square identities: n = 1, 2, 4, 8 … reals, complex, quaternions, octonions" — which is **already present** in the same `relatedProofs` list. The strip is therefore lossless: navigability to the Hurwitz impossibility concept is preserved via the live `hurwitz-theorem` link.

## Verification
- `relatedProofs` before: `[hurwitz-theorem, hurwitz-impossibility, hurwitz-three-square-impossibility]`
- after: `[hurwitz-theorem]`
- `src/data/proofs/hurwitz-impossibility` and `…three-square-impossibility`: do not exist (no gallery pages)
- `src/data/proofs/hurwitz-theorem/meta.json`: exists, covers both results
- Only this one file references the two graduated slugs (repo-wide scan)
- JSON validated with `jq empty`

No build artifacts touched; data-only.