### PR TITLE
research: repoint 3 dead relatedProofs xrefs to live canonical ancestors

### DIFF
--- a/src/data/research/problems/cube-root-3-irrational-oq-02.json
+++ b/src/data/research/problems/cube-root-3-irrational-oq-02.json
@@ -65,7 +65,7 @@
     "irreducibility"
   ],
   "relatedProofs": [
-    "cube-root-2-irrational-oq-03",
+    "cube-root-2-irrational",
     "cube-root-3-irrational",
     "cube-root-3-irrational-oq-02"
   ],

--- a/src/data/research/problems/inverse-galois-a5-oq-01.json
+++ b/src/data/research/problems/inverse-galois-a5-oq-01.json
@@ -101,7 +101,7 @@
     "inverse-galois-f20",
     "inverse-galois-oq-01",
     "inverse-galois-oq-02",
-    "inverse-galois-oq-06-oq-01"
+    "inverse-galois-oq-06"
   ],
   "tags": [
     "alternating-group",

--- a/src/data/research/problems/lagrange-theorem-oq-02-oq-02-oq-01.json
+++ b/src/data/research/problems/lagrange-theorem-oq-02-oq-02-oq-01.json
@@ -77,7 +77,7 @@
     "lagrange-theorem-oq-02",
     "lagrange-theorem-oq-02-oq-01",
     "lagrange-theorem-oq-02-oq-02",
-    "burnside-counting-oq-03-oq-03"
+    "burnside-counting-oq-03"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary

Three research-problem `relatedProofs` arrays pointed to dead slugs (no gallery `/proof/` page). Each dead ref is a never-published or removed OQ **child**, and its live parent/base proof was **not already present** in the same list — so repointing to the canonical ancestor preserves the cross-reference rather than dropping it.

| File | Dead ref | Repointed to |
|------|----------|--------------|
| `inverse-galois-a5-oq-01` | `inverse-galois-oq-06-oq-01` (removed, parent absent) | `inverse-galois-oq-06` |
| `cube-root-3-irrational-oq-02` | `cube-root-2-irrational-oq-03` (removed, base absent) | `cube-root-2-irrational` |
| `lagrange-theorem-oq-02-oq-02-oq-01` | `burnside-counting-oq-03-oq-03` (never published, parent absent) | `burnside-counting-oq-03` |

All three targets are live gallery proofs (`src/data/proofs/<slug>/meta.json` present) and were verified **not already in** their respective lists (no duplication). Files confirmed uncovered by any open PR via `gh pr list --json files`.

## Test plan

- [x] `jq empty` passes on all 3 files
- [x] All repoint targets resolve to live gallery dirs
- [x] No new dead refs introduced; net broken-xref count drops by 3