### PR TITLE
research: repair 5 dead relatedProofs xrefs across 4 problems

### DIFF
--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -83,7 +83,6 @@
   ],
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
-    "gauss-wilson-non-cyclic-oq-03",
     "wilsons-theorem",
     "euler-totient",
     "chinese-remainder-constructive"

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -79,7 +79,6 @@
   ],
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
-    "gauss-wilson-non-cyclic-oq-01",
     "wilsons-theorem",
     "euler-totient",
     "chinese-remainder-constructive"

--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -92,8 +92,7 @@
     "prob-method-lovasz-local",
     "prob-method-expectation",
     "prob-method-alteration",
-    "lovasz-local-lemma-oq-01",
-    "lovasz-local-lemma-oq-04"
+    "lovasz-local-lemma"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/zsqrtd-neg-two-oq-03.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03.json
@@ -101,7 +101,6 @@
   ],
   "relatedProofs": [
     "zsqrtd-neg-two",
-    "three-squares-theorem",
     "fermat-two-squares",
     "fermat-two-squares-oq-01"
   ],


### PR DESCRIPTION
## Summary

Repairs 5 dead `relatedProofs` cross-references that rendered as `/proof/<slug>` 404s. All five target slugs were **never created as gallery proofs** (`git log --all` = 0 commits), confirming they are dangling, not merely renamed.

| File | Dead ref | Fix | Rationale |
|------|----------|-----|-----------|
| `gauss-wilson-non-cyclic-oq-01` | `gauss-wilson-non-cyclic-oq-03` | strip | live base `gauss-wilson-non-cyclic` already in list → lossless |
| `gauss-wilson-non-cyclic-oq-03` | `gauss-wilson-non-cyclic-oq-01` | strip | symmetric; base already present |
| `prob-method-lovasz-local-oq-01` | `lovasz-local-lemma-oq-01`, `-oq-04` | repoint→`lovasz-local-lemma` | dead OQ children replaced with live gallery family base (dedup to single entry) |
| `zsqrtd-neg-two-oq-03` | `three-squares-theorem` | strip | no gallery equivalent (`legendre-partial` ≠ three-square theorem); `fermat-two-squares` refs preserve context |

After this change, a full corpus scan finds **0** dead `relatedProofs` slugs across all research problems.

## Test plan
- [x] `jq empty` validates all 4 JSON files
- [x] Re-scan: 0 dead relatedProofs remain corpus-wide
- [x] Confirmed none of the 4 files are touched by any open PR (no collision)

Blackout-context note: Docker daemon down + Aristotle returning 404, so no Lean/proof work was possible this cycle; durable xref repair only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)