### PR TITLE
research: fix 5 dead relatedProofs /proof/ links across 4 problems

### DIFF
--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -83,7 +83,6 @@
   ],
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
-    "gauss-wilson-non-cyclic-oq-03",
     "wilsons-theorem",
     "euler-totient",
     "chinese-remainder-constructive"

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -79,7 +79,6 @@
   ],
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
-    "gauss-wilson-non-cyclic-oq-01",
     "wilsons-theorem",
     "euler-totient",
     "chinese-remainder-constructive"

--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -92,8 +92,7 @@
     "prob-method-lovasz-local",
     "prob-method-expectation",
     "prob-method-alteration",
-    "lovasz-local-lemma-oq-01",
-    "lovasz-local-lemma-oq-04"
+    "lovasz-local-lemma"
   ],
   "references": {
     "papers": [

--- a/src/data/research/problems/zsqrtd-neg-two-oq-03.json
+++ b/src/data/research/problems/zsqrtd-neg-two-oq-03.json
@@ -101,7 +101,6 @@
   ],
   "relatedProofs": [
     "zsqrtd-neg-two",
-    "three-squares-theorem",
     "fermat-two-squares",
     "fermat-two-squares-oq-01"
   ],


### PR DESCRIPTION
## Summary

Cleans up 5 dead `relatedProofs` entries that rendered as live 404 `/proof/<slug>` links on research problem pages. All five removed slugs are research-only siblings (no `src/data/proofs/<slug>` gallery dir), so the renderer's unconditional `/proof/` link produced 404s.

Applied the standard 4-class discrimination:

| File | Dead ref | Action | Rationale |
|------|----------|--------|-----------|
| `gauss-wilson-non-cyclic-oq-01` | `gauss-wilson-non-cyclic-oq-03` | **strip** | live parent `gauss-wilson-non-cyclic` already in list |
| `gauss-wilson-non-cyclic-oq-03` | `gauss-wilson-non-cyclic-oq-01` | **strip** | live parent already in list |
| `prob-method-lovasz-local-oq-01` | `lovasz-local-lemma-oq-01`, `lovasz-local-lemma-oq-04` | **repoint** → `lovasz-local-lemma` | live base absent from list; preserves xref, dedup to one |
| `zsqrtd-neg-two-oq-03` | `three-squares-theorem` | **strip** | no gallery proof exists; `fermat-two-squares` analogue already present |

## Verification
- All 4 JSON files validate with `jq`
- Scanned all 2113 research problem JSONs: these were the only 5 dead `relatedProofs` refs gallery-wide
- No open PR touches these 4 data JSONs (checked vs 37 open PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)