### PR TITLE
research: fix 3 dead relatedProofs xrefs (gauss-wilson + lovasz)

### DIFF
--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-01.json
@@ -83,7 +83,6 @@
   ],
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
-    "gauss-wilson-non-cyclic-oq-03",
     "wilsons-theorem",
     "euler-totient",
     "chinese-remainder-constructive"

--- a/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
+++ b/src/data/research/problems/gauss-wilson-non-cyclic-oq-03.json
@@ -79,7 +79,6 @@
   ],
   "relatedProofs": [
     "gauss-wilson-non-cyclic",
-    "gauss-wilson-non-cyclic-oq-01",
     "wilsons-theorem",
     "euler-totient",
     "chinese-remainder-constructive"

--- a/src/data/research/problems/prob-method-lovasz-local-oq-01.json
+++ b/src/data/research/problems/prob-method-lovasz-local-oq-01.json
@@ -92,8 +92,7 @@
     "prob-method-lovasz-local",
     "prob-method-expectation",
     "prob-method-alteration",
-    "lovasz-local-lemma-oq-01",
-    "lovasz-local-lemma-oq-04"
+    "lovasz-local-lemma"
   ],
   "references": {
     "papers": [


### PR DESCRIPTION
## Summary
Removes three dead `/proof/<slug>` 404 links from research `relatedProofs` arrays. All removed slugs have **0 gallery-dir commits** in full git history (`git log --all`), so they render as dead 404 links via the unconditional relatedProofs renderer.

- **gauss-wilson-non-cyclic-oq-01** / **-oq-03**: strip the mutual dead sibling refs. Neither open-question child has a gallery proof, but the live base `gauss-wilson-non-cyclic` is already present in both lists — removal is lossless (the family stays reachable via the base).
- **prob-method-lovasz-local-oq-01**: repoint dead `lovasz-local-lemma-oq-01` and `lovasz-local-lemma-oq-04` to the live base `lovasz-local-lemma` (which was absent from the list), deduped to a single ref. Preserves the conceptual link.

Leaves `zsqrtd-neg-two-oq-03 → three-squares-theorem` untouched: that target exists as a research problem (research-only sibling that may graduate to a gallery proof).

## Verification
- All 3 JSON files validate (`json.load`)
- Post-edit `relatedProofs` contain only live gallery-proof slugs
- Based directly on `origin/main` (#23378); no unrelated drift
- These were the only 4 dead-ref files on origin/main; the other (zsqrtd) is intentionally left

Build-independent metadata fix (Docker daemon + Aristotle both down this cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)