### PR TITLE
research(fodors-pressing-down): correct stale sorry claims — proof is verified, not formalized-with-sorry

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean
@@ -147,13 +147,13 @@ theorem diagInter_isClosedBelow {κ : Cardinal.{u}} {f : Ordinal.{u} → Set Ord
          lt_of_le_of_lt (le_max_left α β) hlt, hδγ⟩
 
 -- ============================================================================
--- § 5. Diagonal Intersection of Clubs is Unbounded (SORRY with Proof Sketch)
+-- § 5. Diagonal Intersection of Clubs is Unbounded (PROVED)
 -- ============================================================================
 
-/-- **Theorem (Unbounded Part — SORRY):** If every f(β) is a club, then diagInter f
+/-- **Theorem (Unbounded Part — PROVED):** If every f(β) is a club, then diagInter f
     is unbounded below κ.ord.
 
-    **Complete Proof Sketch (for the sorry):**
+    **Proof outline (matching the term below):**
 
     Given α₀ < κ.ord, construct a strictly increasing ω-sequence (α_n) by:
     - α_{n+1} ∈ ∩_{β ≤ α_n} f(β) with α_{n+1} > α_n and α_{n+1} < κ.ord
@@ -248,7 +248,7 @@ theorem diagInter_isUnbounded {κ : Cardinal.{u}} (hκ : κ.IsRegular) (hκ_unc 
 -- ============================================================================
 
 /-- For a regular uncountable κ, the diagonal intersection of a κ-indexed family
-    of clubs is itself a club. This combines the proved closed part with the sorry
+    of clubs is itself a club. This combines the proved closed part with the proved
     unbounded part. -/
 theorem diagInter_isClub {κ : Cardinal.{u}} (hκ : κ.IsRegular) (hκ_unc : ℵ₀ < κ)
     {f : Ordinal.{u} → Set Ordinal.{u}} (hf : ∀ β, β < κ.ord → IsClub κ (f β)) :
@@ -359,15 +359,17 @@ Both proofs use regularity in an essential way.
 
 ## What Remains (Future Work)
 
-1. **`diagInter_isUnbounded`** (the one sorry): needs `isClub_inter` (intersection of
-   finitely many clubs is a club) and an ω-sequence argument using `Ordinal.iSup_lt_ord`.
-   Estimated effort: ~80 lines.
+The core result is complete: `diagInter_isUnbounded`, `diagInter_isClub`, and
+`fodors_pressing_down` are all proved with no sorries and no axioms. The unbounded
+part is established directly via a `bump` operator (a `bsup` over β < δ+1) rather than
+a standalone finite-intersection lemma. Natural extensions:
 
-2. **`isClub_inter`**: prove that ∩(C₁, C₂) is a club. The "ping-pong" argument needs:
-   - Building an ω-sequence alternating between C₁ and C₂
-   - Showing the limit is < κ.ord (by `Ordinal.iSup_lt_ord`)
-   - Showing the limit is in C₁ ∩ C₂ (by the closed condition on each club)
-   Estimated effort: ~50 lines.
+1. **`isClub_inter`** as a reusable lemma: prove that ∩(C₁, C₂) is a club via the
+   "ping-pong" argument (alternating ω-sequence, sup < κ.ord by `Ordinal.iSup_lt_ord`,
+   limit in C₁ ∩ C₂ by closedness). The current file inlines an equivalent argument.
+
+2. **Club filter / stationary ideal**: show clubs generate a filter and that stationary
+   sets are exactly those not in the dual ideal.
 -/
 
 -- Type-check the main results

--- a/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-02-oq-03-oq-02/meta.json
@@ -2,11 +2,11 @@
   "id": "cantor-diagonalization-oq-02-oq-03-oq-02",
   "title": "Fodor's Pressing-Down Lemma for Regular Cardinals",
   "slug": "cantor-diagonalization-oq-02-oq-03-oq-02",
-  "description": "Formalizes Fodor's Pressing-Down Lemma (1956): for any uncountable regular cardinal \u03ba, every regressive function f on a stationary set S \u2286 \u03ba.ord is constant on a stationary subset of S. Defines club sets (closed unbounded subsets of ordinals below \u03ba.ord) and stationary sets. The key combinatorial tool is the diagonal intersection {\u03b1 | \u2200 \u03b2 < \u03b1, \u03b1 \u2208 f(\u03b2)}, shown to be a club when each f(\u03b2) is a club. The main theorem is fully proved from one remaining sorry (diagInter_isUnbounded, with complete proof sketch).",
+  "description": "Formalizes Fodor's Pressing-Down Lemma (1956): for any uncountable regular cardinal \u03ba, every regressive function f on a stationary set S \u2286 \u03ba.ord is constant on a stationary subset of S. Defines club sets (closed unbounded subsets of ordinals below \u03ba.ord) and stationary sets. The key combinatorial tool is the diagonal intersection {\u03b1 | \u2200 \u03b2 < \u03b1, \u03b1 \u2208 f(\u03b2)}, shown to be a club when each f(\u03b2) is a club. Both the closed and unbounded parts of the diagonal-intersection theorem are fully proved, so the main theorem is established with 0 sorries and 0 axioms.",
   "meta": {
     "author": "Lean Genius",
     "date": "2026-04-04",
-    "status": "formalized",
+    "status": "verified",
     "proofRepoPath": "Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean",
     "tags": [
       "set-theory",
@@ -57,10 +57,9 @@
     ]
   },
   "conclusion": {
-    "summary": "This file formalizes Fodor's pressing-down lemma for regular uncountable cardinals. The proof structure is complete: club sets and stationary sets are defined, the diagonal intersection operator is introduced and characterized, the closed part of the diagonal intersection theorem is fully proved, and Fodor's lemma follows once the one remaining sorry (diagInter_isUnbounded) is resolved. The sorry has a complete mathematical proof sketch in its docstring.",
+    "summary": "This file formalizes Fodor's pressing-down lemma for regular uncountable cardinals. The proof structure is complete: club sets and stationary sets are defined, the diagonal intersection operator is introduced and characterized, and both the closed part (diagInter_isClosedBelow) and the unbounded part (diagInter_isUnbounded) of the diagonal intersection theorem are fully proved. Fodor's lemma follows from diagInter_isClub. The file is complete with 0 sorries and 0 axioms.",
     "implications": "**Combinatorial set theory**: Fodor's lemma is the primary tool for proving that 'large' sets cannot be decomposed into 'small' pieces in a structured way. It underlies proofs of non-reflection for stationary sets and is used in Shelah's PCF theory.\n\n**Descriptive set theory**: The club filter and stationary ideal on \u03c9\u2081 are fundamental objects. Fodor's lemma shows the club filter is not \u03c3-generated from below.\n\n**Connection to parent proof**: This proof extends CantorDiagonalizationOQ02OQ03 from finding one diagonal ordinal to finding a stationary set of them. The `regular_sup_bounded` tool from the parent is exactly what the unbounded-part sorry needs.",
     "openQuestions": [
-      "Resolve the one sorry: prove `diagInter_isUnbounded` by formalizing (1) `isClub_inter` (intersection of two clubs is a club) via the ping-pong sequence construction, then (2) the \u03c9-sequence argument using `Ordinal.iSup_lt_ord`.",
       "Formalize the club filter: show that clubs generate a filter (finite intersection of clubs is a club), and that stationary sets are exactly the sets not in the dual ideal.",
       "Prove Silver's theorem using Fodor's lemma: if \u03ba is a singular cardinal of uncountable cofinality and GCH holds below \u03ba, then 2^\u03ba = \u03ba\u207a."
     ]
@@ -128,10 +127,10 @@
     },
     {
       "id": "unbounded-part",
-      "title": "\u00a75. Diagonal Intersection is Unbounded (SORRY)",
+      "title": "\u00a75. Diagonal Intersection is Unbounded (PROVED)",
       "startLine": 177,
       "endLine": 224,
-      "content": "diagInter_isUnbounded: if every f(\u03b2) is a club, then diagInter f is unbounded below \u03ba.ord. SORRY with complete proof sketch: build an \u03c9-sequence using regularity of \u03ba, take the sup (< \u03ba.ord by iSup_lt_ord), show the sup is in the diagonal intersection."
+      "content": "diagInter_isUnbounded: if every f(\u03b2) is a club, then diagInter f is unbounded below \u03ba.ord. PROVED: builds an \u03c9-sequence using regularity of \u03ba via a bump operator (bsup over \u03b2 < \u03b4+1), takes the sup (< \u03ba.ord by iSup_lt_ord_lift_of_isRegular), and shows the sup lies in the diagonal intersection."
     },
     {
       "id": "fodors-lemma",


### PR DESCRIPTION
## Summary

The gallery entry **Fodor's Pressing-Down Lemma for Regular Cardinals**
(`cantor-diagonalization-oq-02-oq-03-oq-02`) was **underclaiming** its own
status. The Lean source `proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean`
contains **no `sorry` tactic** — `diagInter_isUnbounded` is fully proved via a
`bump`/`bsup` ω-sequence construction (lines 173–244), and `fodors_pressing_down`
follows from `diagInter_isClub`. But the metadata and several docstrings still
described `diagInter_isUnbounded` as "the one remaining sorry", and `meta.status`
was `"formalized"`.

Ground truth (verified against source):
- `grep -ni sorry` → only docstring/comment mentions, **0 `sorry` tactics**
- **0 `axiom` declarations**, no assumption-carrying structures (the defs
  `IsClub`/`IsStationary`/`diagInter` are predicate/Set definitions)
- meta `sorries: 0`, `axiomCount: 0`, and `assumptions` already asserted
  "Fully machine-verified" — the only fields out of sync were `status` and the
  prose.

## Changes

`src/data/proofs/.../meta.json`
- `status`: `formalized` → `verified` (per axiom-integrity policy: 0 sorries,
  0 axioms, 0 structure-encoded assumptions; Fodor's lemma is a proved 1956
  theorem, not an open conjecture)
- `description`, §5 section title/content, `conclusion.summary`: drop the false
  "one remaining sorry" wording
- remove the now-resolved `"Resolve the one sorry"` open question (2 genuine
  future directions retained)

`proofs/Proofs/CantorDiagonalizationOQ02OQ03OQ02.lean` (comment/docstring-only)
- §5 header, `diagInter_isClub` docstring, "What Remains" section: `SORRY` → `PROVED`

## Test plan
- [x] `grep -ni sorry` on the Lean file returns no matches after edit
- [x] `python3 -m json.tool` confirms meta.json is valid; status=verified, sorries=0, axiomCount=0
- [x] `.lean` diff is entirely within comments/docstrings — no code change, no build impact
- [ ] Docker unavailable this cycle; not rebuilt. File graduated previously (built at promotion); edits are comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)