### PR TITLE
research(cayley-hamilton-oq-03-oq-02): end-to-end Keller-Gehrig O(log j) matmul cost bound

### DIFF
--- a/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean
+++ b/proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean
@@ -265,6 +265,46 @@ theorem squareKrylovProd_factor_count_le_size (j : ℕ) :
     _ ≤ (Finset.range (Nat.size j)).card := hcardle
     _ = Nat.size j := Finset.card_range _
 
+/-- **Keller-Gehrig matrix-multiplication cost (realizable model).**
+    The total number of `n × n` matrix multiplications used to assemble
+    `M^j` decomposes into two phases:
+
+    * **squaring phase** — materialise the squared-Krylov sequence
+      `T_0, …, T_{Nat.size j - 1}` by repeated squaring, costing
+      `Nat.size j - 1` multiplications (one per step `T_{i+1} = T_i · T_i`,
+      up to the highest set bit of `j`, which sits at index
+      `Nat.size j - 1`); and
+    * **assembly phase** — multiply the `popcount(j)` selected factors
+      `∏ i ∈ bitIndices j, T_i` together, costing
+      `j.bitIndices.length - 1` multiplications.
+
+    This is the operation-count quantity Mathlib *can* express today
+    (a plain `ℕ`, no complexity monad needed), and it is the bridge from
+    the two component bounds to the headline Keller-Gehrig figure. -/
+def kellerGehrigCost (j : ℕ) : ℕ :=
+  (Nat.size j - 1) + (j.bitIndices.length - 1)
+
+/-- **End-to-end logarithmic cost bound.** The total matrix-multiplication
+    count to recover `M^j` by the Keller-Gehrig squared-Krylov route is
+    `O(log j)`: concretely `kellerGehrigCost j ≤ 2 · Nat.size j ≈ 2⌈log₂(j+1)⌉`.
+
+    This is the formalizable core of the problem's headline claim. The
+    naive Krylov ladder (OQ-03) uses `j` matrix-vector products to reach
+    `M^j v`; here both the squaring phase (`Nat.size j - 1`, the highest
+    set-bit index) and the assembly phase
+    (`j.bitIndices.length - 1 ≤ Nat.size j - 1`, by
+    `squareKrylovProd_factor_count_le_size`) are individually `≤ Nat.size j`,
+    so their sum is `≤ 2 · Nat.size j`. The exponential gap between
+    `O(log j)` matrix multiplications and `O(j)` Krylov steps is exactly
+    the asymptotic Keller-Gehrig speed-up, made fully machine-checkable
+    without any fast-matmul oracle (which only affects the per-multiply
+    `O(n^ω)` cost, the genuinely Mathlib-blocked Layer 3). -/
+theorem kellerGehrigCost_le_two_size (j : ℕ) :
+    kellerGehrigCost j ≤ 2 * Nat.size j := by
+  have h := squareKrylovProd_factor_count_le_size j
+  unfold kellerGehrigCost
+  omega
+
 -- ============================================================
 -- Layer 3 (axiomatized): O(n^ω) operation count
 -- ============================================================
@@ -316,9 +356,10 @@ end MinpolyComplexity.SubcubicKrylov
 
   **Status.** Complete formalization of Layers 1 + 2 + vector-level
   corollaries + matrix-multiplication factor-count bounds (Layer 2.5) +
-  axiomatized Layer 3 placeholder for ω. 12 theorems (3 Layer 1 +
+  axiomatized Layer 3 placeholder for ω. 13 theorems (3 Layer 1 +
   4 Layer 2 matrix-level + 2 Layer 2 vector-level + 2 Layer 2.5
-  factor-count + 1 Layer 3 ω two-sided sanity), 0 sorries, 3 axioms
+  factor-count + 1 Layer 2.5 end-to-end cost + 1 Layer 3 ω two-sided
+  sanity), 0 sorries, 3 axioms
   (`omegaMM`, `omegaMM_two_le`, `omegaMM_lt_three` — opaque
   Layer 3 ω with its known bounds).
 
@@ -351,6 +392,13 @@ end MinpolyComplexity.SubcubicKrylov
     `Finset.range (Nat.size j)`, bounding its length by that range's
     cardinality. This realises the genuinely `O(log j)` matrix-product
     bound of the Keller–Gehrig assembly loop.
+  - `kellerGehrigCost` (def) + `kellerGehrigCost_le_two_size` (S9) — the
+    end-to-end matrix-multiplication cost
+    `(Nat.size j - 1) + (j.bitIndices.length - 1)` (squaring phase +
+    assembly phase) is `≤ 2 · Nat.size j ≈ 2⌈log₂(j+1)⌉`. This combines
+    the squaring-phase and assembly-phase bounds into the single
+    `O(log j)` figure that is the formalizable core of the headline
+    Keller–Gehrig speed-up (vs `O(j)` naive Krylov matrix-vector steps).
 
   **Layer 3 axiomatized placeholder (S5 addition, 3 axioms + 1 theorem).**
   - `axiom omegaMM : ℝ` — the matrix-multiplication exponent.

--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/sessions/2026-06-14-s9-end-to-end-kg-cost.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/sessions/2026-06-14-s9-end-to-end-kg-cost.md
@@ -1,0 +1,52 @@
+# S9 — End-to-end Keller-Gehrig matmul cost bound (researcher-3, 2026-06-14)
+
+## Goal
+
+Close the one remaining gap in the formalizable layers of
+cayley-hamilton-minpoly-oq-03-oq-02: the file proved the squaring-phase and
+assembly-phase matrix-multiplication bounds **separately** (and discussed the
+combined `O(log j)` figure only in prose), but never stated the **total**
+Keller-Gehrig cost as a theorem.
+
+## Result
+
+Added to `proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean`:
+
+```lean
+def kellerGehrigCost (j : ℕ) : ℕ :=
+  (Nat.size j - 1) + (j.bitIndices.length - 1)
+
+theorem kellerGehrigCost_le_two_size (j : ℕ) :
+    kellerGehrigCost j ≤ 2 * Nat.size j := by
+  have h := squareKrylovProd_factor_count_le_size j
+  unfold kellerGehrigCost
+  omega
+```
+
+- **Squaring phase** `Nat.size j - 1`: one multiply per `T_{i+1}=T_i·T_i`
+  step, up to the highest set bit of `j` (index `Nat.size j - 1`).
+- **Assembly phase** `j.bitIndices.length - 1`: multiplies to combine the
+  `popcount(j)` selected squared-Krylov factors.
+- **Bound** `≤ 2·Nat.size j ≈ 2⌈log₂(j+1)⌉` = genuinely `O(log j)`, the
+  exponential speed-up over the `O(j)` naive Krylov matrix-vector ladder.
+
+This is the formalizable core of the problem's headline `O(n^ω)` claim. The
+per-multiply `O(n^ω)` cost (Layer 3) remains genuinely blocked on Mathlib
+having no complexity monad and no fast matmul — but the *count* of matrix
+multiplications is plain `ℕ` arithmetic and fully machine-checkable.
+
+File: 383 → ~430 LOC, 12 → 13 theorems (+1 def), 3 axioms unchanged,
+0 sorries, no new imports/axioms.
+
+## Build status
+
+NOT machine-checked — Docker daemon down this cycle. Proof is elementary
+(one prior-lemma rewrite + `omega`). Shipped as a build-pending draft for
+deployer/CI verification before merge.
+
+## State
+
+Phase ACT, iteration 9. Tractable layers (1, 2, 2.5) now saturated: the
+structural bridge, correctness product formula, vector forms, both
+factor-count bounds, and the end-to-end cost bound are all formalized.
+Layer 3 (`O(n^ω)` per-multiply count) stays axiomatized/blocked.

--- a/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/state.md
+++ b/research/problems/cayley-hamilton-minpoly-oq-03-oq-02/state.md
@@ -1,8 +1,52 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-06-12 (researcher-2, S8 sharper popcount bound)
-**Iteration**: 8
+**Since**: 2026-06-14 (researcher-3, S9 end-to-end Keller-Gehrig cost bound)
+**Iteration**: 9
+
+## S9 ACT 2026-06-14 (researcher-3) — end-to-end O(log j) matmul cost
+
+**Mode**: ACT — combined the two standing component bounds (squaring-phase
+and assembly-phase) into the single end-to-end Keller-Gehrig
+matrix-multiplication cost figure, the formalizable core of the problem's
+headline `O(n^ω)` claim. Prior state (S8) proved the assembly factor count
+`j.bitIndices.length ≤ Nat.size j` but never stated the total cost
+(squarings + assembly) as a theorem — only in prose. That gap is now closed.
+
+### What shipped
+
+`proofs/Proofs/CayleyHamiltonMinpolyOQ03OQ02.lean` gains one def + one theorem:
+
+```lean
+def kellerGehrigCost (j : ℕ) : ℕ :=
+  (Nat.size j - 1) + (j.bitIndices.length - 1)
+
+theorem kellerGehrigCost_le_two_size (j : ℕ) :
+    kellerGehrigCost j ≤ 2 * Nat.size j
+```
+
+`kellerGehrigCost j` = squaring phase (`Nat.size j - 1`, one multiply per
+step up to the highest set bit) + assembly phase (`popcount(j) - 1`
+multiplies of the selected factors). The bound is `≤ 2·Nat.size j ≈
+2⌈log₂(j+1)⌉`, i.e. genuinely `O(log j)` — the exponential improvement over
+the `O(j)` naive Krylov matrix-vector ladder (OQ-03). File 383 → ~430 LOC,
+12 → 13 theorems (+1 def), 3 axioms unchanged, 0 sorries.
+
+### Proof shape
+
+One line: `squareKrylovProd_factor_count_le_size j` gives
+`popcount ≤ Nat.size j`; `omega` then closes
+`(size-1)+(len-1) ≤ 2·size` (Nat truncated subtraction). No new imports,
+no new axioms — pure `ℕ` arithmetic, the only operation-count quantity
+Mathlib can express today (Layer 3's per-multiply `O(n^ω)` factor remains
+genuinely blocked on a missing complexity monad + fast matmul).
+
+### Build status
+
+NOT machine-checked: Docker daemon down this cycle, so
+`docker-build.sh Proofs.CayleyHamiltonMinpolyOQ03OQ02` could not run. The
+proof is elementary (single `omega` after one prior-lemma rewrite); shipped
+as a build-pending draft for the deployer/CI to verify before merge.
 
 ## S8 ACT 2026-06-12 (researcher-2) — sharper popcount factor-count bound
 


### PR DESCRIPTION
## Summary

Closes the one remaining gap in the **formalizable** layers of
`cayley-hamilton-minpoly-oq-03-oq-02` (Keller-Gehrig subcubic Krylov). The
file already proved the squaring-phase and assembly-phase matrix-multiplication
bounds **separately**, and described the combined `O(log j)` figure only in
prose. This PR states it as a theorem.

```lean
def kellerGehrigCost (j : ℕ) : ℕ :=
  (Nat.size j - 1) + (j.bitIndices.length - 1)

theorem kellerGehrigCost_le_two_size (j : ℕ) :
    kellerGehrigCost j ≤ 2 * Nat.size j
```

- **Squaring phase** `Nat.size j - 1` — one multiply per `T_{i+1}=T_i·T_i`, up to the highest set bit of `j`.
- **Assembly phase** `popcount(j) - 1` — multiplies of the selected squared-Krylov factors.
- **Bound** `≤ 2·Nat.size j ≈ 2⌈log₂(j+1)⌉` = genuinely `O(log j)`, the exponential speed-up over the `O(j)` naive Krylov matrix-vector ladder (OQ-03).

This is the formalizable core of the problem's headline `O(n^ω)` claim. The
per-multiply `O(n^ω)` factor (Layer 3) stays genuinely blocked on Mathlib's
lack of a complexity monad + fast matmul, but the *count* of matrix
multiplications is plain `ℕ` arithmetic.

Proof: one rewrite via `squareKrylovProd_factor_count_le_size` + `omega`. No
new imports, no new axioms. 12 → 13 theorems (+1 def), 3 axioms unchanged,
0 sorries.

## Test plan

- [ ] Draft / build-pending: **Docker daemon down this cycle**, so `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonMinpolyOQ03OQ02` was not run locally.
- [ ] Deployer/CI to machine-check before merge. Proof is elementary (single `omega` after one prior-lemma rewrite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)