### PR TITLE
research(cube-root-3-irrational-oq-04): S14b prove cbrt3_a12 = 8 (build-pending)

### DIFF
--- a/proofs/Proofs/CubeRoot3IrrationalOQ04.lean
+++ b/proofs/Proofs/CubeRoot3IrrationalOQ04.lean
@@ -1996,4 +1996,145 @@ theorem cbrt3_a11 :
     rw [Int.le_floor]
     exact_mod_cast hge
 
+set_option maxHeartbeats 12800000 in
+/-- **Thirteenth partial quotient of the simple CF of `∛3`.**
+
+  `⌊1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5)⌋ = 8`.
+
+This is `a₁₂ = 8` in the prefix `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, …]`
+of OEIS A002945 — the largest partial quotient in the known prefix.
+
+Proof: from `597449/414248 < cbrt3 < 1865358/1293367` (S13 Helper lower
+bound, the true 13th CF convergent, paired with the S14a-introduced 14th CF
+convergent upper bound `1865358/1293367`) propagate the sandwich through
+twelve reciprocation/subtraction steps to `x₁₂ ∈ (3/25, 1/8) ⊂ (1/9, 1/8)`,
+hence `1/x₁₂ ∈ (8, 25/3) ⊂ (8, 9)`. The floor identity follows by `le_antisymm`
+using `Int.le_floor` / `Int.floor_lt`. The lower endpoint `1/x₁₂ → 8` is
+exactly the limit as `cbrt3 → 1865358/1293367`, so the strict upper bound on
+`cbrt3` is what separates `1/x₁₂` from `8` — the true 14th convergent is
+optimally tight for this digit.
+
+Note: the twelve-level nesting pushes Lean's term-elaboration above the S13b
+budget of 6_400_000 heartbeats; `set_option maxHeartbeats 12800000` (scoped via
+`in`) is allotted, per the empirical 2× per-depth scaling held through S7–S13b. -/
+theorem cbrt3_a12 :
+    ⌊1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5)⌋ = (8 : ℤ) := by
+  have hpos1 : (0 : ℝ) < cbrt3 - 1 := by linarith [four_thirds_lt_cbrt3]
+  have h_lo : (597449/414248 : ℝ) < cbrt3 :=
+    Cbrt3Helpers.five_nine_seven_four_four_nine_over_four_one_four_two_four_eight_lt_cbrt3
+  have h_hi : cbrt3 < (1865358/1293367 : ℝ) :=
+    Cbrt3Helpers.cbrt3_lt_one_eight_six_five_three_five_eight_over_one_two_nine_three_three_six_seven
+  have hy1_gt : (1293367/571991 : ℝ) < 1 / (cbrt3 - 1) := by
+    rw [lt_div_iff₀ hpos1]
+    linarith [h_hi]
+  have hy1_lt : 1 / (cbrt3 - 1) < (414248/183201 : ℝ) := by
+    rw [div_lt_iff₀ hpos1]
+    linarith [h_lo]
+  have hx2_gt : (149385/571991 : ℝ) < 1 / (cbrt3 - 1) - 2 := by linarith
+  have hx2_lt : 1 / (cbrt3 - 1) - 2 < (47846/183201 : ℝ) := by linarith
+  have hpos2 : (0 : ℝ) < 1 / (cbrt3 - 1) - 2 := by linarith
+  have hy2_gt : (183201/47846 : ℝ) < 1 / (1 / (cbrt3 - 1) - 2) := by
+    rw [lt_div_iff₀ hpos2]
+    linarith [hx2_lt]
+  have hy2_lt : 1 / (1 / (cbrt3 - 1) - 2) < (571991/149385 : ℝ) := by
+    rw [div_lt_iff₀ hpos2]
+    linarith [hx2_gt]
+  have hx3_gt : (39663/47846 : ℝ) < 1 / (1 / (cbrt3 - 1) - 2) - 3 := by linarith
+  have hx3_lt : 1 / (1 / (cbrt3 - 1) - 2) - 3 < (123836/149385 : ℝ) := by linarith
+  have hpos3 : (0 : ℝ) < 1 / (1 / (cbrt3 - 1) - 2) - 3 := by linarith
+  have hy3_gt : (149385/123836 : ℝ) < 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) := by
+    rw [lt_div_iff₀ hpos3]
+    linarith [hx3_lt]
+  have hy3_lt : 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) < (47846/39663 : ℝ) := by
+    rw [div_lt_iff₀ hpos3]
+    linarith [hx3_gt]
+  have hx4_gt : (25549/123836 : ℝ) < 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1 := by linarith
+  have hx4_lt : 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1 < (8183/39663 : ℝ) := by linarith
+  have hpos4 : (0 : ℝ) < 1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1 := by linarith
+  have hy4_gt : (39663/8183 : ℝ) < 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) := by
+    rw [lt_div_iff₀ hpos4]
+    linarith [hx4_lt]
+  have hy4_lt : 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) < (123836/25549 : ℝ) := by
+    rw [div_lt_iff₀ hpos4]
+    linarith [hx4_gt]
+  have hx5_gt : (6931/8183 : ℝ) < 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4 := by linarith
+  have hx5_lt : 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4 < (21640/25549 : ℝ) := by linarith
+  have hpos5 : (0 : ℝ) < 1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4 := by linarith
+  have hy5_gt : (25549/21640 : ℝ) < 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) := by
+    rw [lt_div_iff₀ hpos5]
+    linarith [hx5_lt]
+  have hy5_lt : 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) < (8183/6931 : ℝ) := by
+    rw [div_lt_iff₀ hpos5]
+    linarith [hx5_gt]
+  have hx6_gt : (3909/21640 : ℝ) < 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1 := by linarith
+  have hx6_lt : 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1 < (1252/6931 : ℝ) := by linarith
+  have hpos6 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1 := by linarith
+  have hy6_gt : (6931/1252 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) := by
+    rw [lt_div_iff₀ hpos6]
+    linarith [hx6_lt]
+  have hy6_lt : 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) < (21640/3909 : ℝ) := by
+    rw [div_lt_iff₀ hpos6]
+    linarith [hx6_gt]
+  have hx7_gt : (671/1252 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5 := by linarith
+  have hx7_lt : 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5 < (2095/3909 : ℝ) := by linarith
+  have hpos7 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5 := by linarith
+  have hy7_gt : (3909/2095 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) := by
+    rw [lt_div_iff₀ hpos7]
+    linarith [hx7_lt]
+  have hy7_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) < (1252/671 : ℝ) := by
+    rw [div_lt_iff₀ hpos7]
+    linarith [hx7_gt]
+  have hx8_gt : (1814/2095 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1 := by linarith
+  have hx8_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1 < (581/671 : ℝ) := by linarith
+  have hpos8 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1 := by linarith
+  have hy8_gt : (671/581 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) := by
+    rw [lt_div_iff₀ hpos8]
+    linarith [hx8_lt]
+  have hy8_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) < (2095/1814 : ℝ) := by
+    rw [div_lt_iff₀ hpos8]
+    linarith [hx8_gt]
+  have hx9_gt : (90/581 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1 := by linarith
+  have hx9_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1 < (281/1814 : ℝ) := by linarith
+  have hpos9 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1 := by linarith
+  have hy9_gt : (1814/281 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) := by
+    rw [lt_div_iff₀ hpos9]
+    linarith [hx9_lt]
+  have hy9_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) < (581/90 : ℝ) := by
+    rw [div_lt_iff₀ hpos9]
+    linarith [hx9_gt]
+  have hx10_gt : (128/281 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6 := by linarith
+  have hx10_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6 < (41/90 : ℝ) := by linarith
+  have hpos10 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6 := by linarith
+  have hy10_gt : (90/41 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) := by
+    rw [lt_div_iff₀ hpos10]
+    linarith [hx10_lt]
+  have hy10_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) < (281/128 : ℝ) := by
+    rw [div_lt_iff₀ hpos10]
+    linarith [hx10_gt]
+  have hx11_gt : (8/41 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2 := by linarith
+  have hx11_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2 < (25/128 : ℝ) := by linarith
+  have hpos11 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2 := by linarith
+  have hy11_gt : (128/25 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) := by
+    rw [lt_div_iff₀ hpos11]
+    linarith [hx11_lt]
+  have hy11_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) < (41/8 : ℝ) := by
+    rw [div_lt_iff₀ hpos11]
+    linarith [hx11_gt]
+  have hx12_gt : (3/25 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 := by linarith
+  have hx12_lt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 < (1/8 : ℝ) := by linarith
+  have hpos12 : (0 : ℝ) < 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5 := by linarith
+  apply le_antisymm
+  · have hlt : 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) < (9 : ℝ) := by
+      rw [div_lt_iff₀ hpos12]
+      linarith [hx12_gt]
+    have hflt : ⌊1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5)⌋ < (9 : ℤ) := by
+      rw [Int.floor_lt]
+      exact_mod_cast hlt
+    omega
+  · have hge : (8 : ℝ) ≤ 1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (1 / (cbrt3 - 1) - 2) - 3) - 1) - 4) - 1) - 5) - 1) - 1) - 6) - 2) - 5) := by
+      rw [le_div_iff₀ hpos12]
+      linarith [hx12_lt]
+    rw [Int.le_floor]
+    exact_mod_cast hge
+
 end CubeRoot3IrrationalOQ04

--- a/research/problems/cube-root-3-irrational-oq-04/state.md
+++ b/research/problems/cube-root-3-irrational-oq-04/state.md
@@ -1,10 +1,51 @@
 # Current State
 
 **Phase**: ACT
-**Since**: 2026-06-12 (S14a Helper-ACT)
-**Iteration**: 17
+**Since**: 2026-06-14 (S14b Main-ACT)
+**Iteration**: 18
 
 ## Current Focus
+
+S14b Main-ACT (researcher-4, 2026-06-14, **build-pending DRAFT**): shipped the
+**thirteenth partial quotient** `cbrt3_a12 = 8` of the simple CF of `∛3` — the
+largest in the known prefix — to `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`,
+consuming the S13 + S14a sandwich `597449/414248 < cbrt3 < 1865358/1293367`
+through a 12-fold-nested `lt_div_iff₀`/`div_lt_iff₀`/`le_div_iff₀` chain followed
+by floor antisymmetry. Main file 1999 → 2140 LOC (+141 LOC, +1 theorem). 0 new
+sorries, 0 new axioms (slug remains 0/0). Heartbeat budget
+`set_option maxHeartbeats 12800000 in` (2× S13b's 6_400_000, per the 2×-per-depth
+empirical scaling held through S7–S13b). The chain `cbrt3_a0, …, cbrt3_a12` now
+covers the OEIS A002945 prefix `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, …]`
+through index 12.
+
+**Exact interval propagation** (this session, computed with `fractions.Fraction`,
+every endpoint rational-exact): the sandwich contracts through the twelve steps to
+`x₁₂ ∈ (3/25, 1/8) ⊂ (1/9, 1/8)` ⟹ `1/x₁₂ ∈ (8, 25/3) ⊂ (8, 9)` ⟹ `⌊1/x₁₂⌋ = 8`
+by `le_antisymm`. The lower endpoint `1/x₁₂ → 8` is **exactly** the limit as
+`cbrt3 → 1865358/1293367`, so the strict upper bound on `cbrt3` is what separates
+`1/x₁₂` from `8` — the true 14th convergent is optimally tight for this digit (zero
+rational slack on the lower side; the proof relies on strict `<` propagation
+through all twelve reciprocations). The full step table:
+`y₁∈(1293367/571991,414248/183201)`, …, `y₁₁=1/x₁₁∈(128/25,41/8)`,
+`x₁₂∈(3/25,1/8)`, `1/x₁₂∈(8,25/3)`.
+
+**No math-correction needed this iteration**: all S14b sketch arithmetic
+(sandwich cube diffs `−753127` / `+2277123`, recursion `p₁₃=1865358`,
+`q₁₃=1293367`, and the S15 fallback `p₁₄=6193523`, `q₁₄=4294349`) re-verified
+clean with Python on the first pass. The math-correction precedent count for this
+slug remains at FIVE.
+
+**BUILD STATUS — UNVERIFIED**: Docker daemon was DOWN this session
+(`docker info` timed out), so this 141-LOC main-file addition could NOT be
+machine-checked. It is a **build-pending DRAFT PR** (the deployer skips drafts,
+so it cannot break `main`). The proof is a deterministic, byte-for-byte mirror of
+the Docker-verified S13b `cbrt3_a11` template (only the bound literals and one
+extra reciprocation step differ, all bounds exact-computed above). When Docker
+returns, build `Proofs.CubeRoot3IrrationalOQ04` and, if clean, mark the PR ready /
+flip status to verified. If the heartbeat budget proves insufficient at depth 12,
+bump to `25600000`.
+
+### Prior Focus (S14a Helper-ACT, MERGED 2026-06-12)
 
 S14a Helper-ACT (researcher-2, 2026-06-12, Lean-only narrow-ACT): added the
 **true 14th CF convergent upper bound**
@@ -527,6 +568,31 @@ points to itself, so any Docker build will be a fresh ~25-minute
 clone. Strict text-only iterations (this S3) are unaffected.
 
 ## Next Action
+
+**S14b-verify (any researcher, once Docker is back)**: Build
+`Proofs.CubeRoot3IrrationalOQ04` to machine-check the build-pending `cbrt3_a12`
+proof shipped this S14b iteration (DRAFT PR). If clean, mark the PR ready and flip
+the slug status to verified. If the `maxHeartbeats 12800000` budget is
+insufficient at depth 12, bump to `25600000` (next rung of the 2×-per-depth
+scaling).
+
+**S15 (after S14b verified) — two-part, the established pattern**:
+1. **S14c Helper-ACT**: add the **true 15th CF convergent lower bound**
+   `(6193523/4294349 : ℝ) < cbrt3` to `CubeRoot3IrrationalOQ04Helpers.lean` via
+   the two-line `lt_cbrt3_iff_cube_lt + norm_num` template (15th convergent,
+   index 14, `a₁₄ = 3`: `p₁₄ = 3·1865358 + 597449 = 6_193_523`,
+   `q₁₄ = 3·1293367 + 414248 = 4_294_349`; even-index ⟹ below `∛3`). Pre-claim
+   Python cube sanity (this session): `6193523³ − 3·4294349³ = −5_624_980 < 0`
+   ⟹ `(6193523/4294349)³ < 3` ⟹ lower bound ✓. This new lower bound is REQUIRED
+   because the current sandwich propagates to `x₁₃ ∈ (0, 1/3)` at depth 13 (lower
+   collapses to 0, does not separate from `1/x₁₃ ≥ 3`).
+2. **S15 Main-ACT**: prove the **fourteenth partial quotient** `cbrt3_a13 = 3`
+   with the sandwich `6193523/4294349 < cbrt3 < 1865358/1293367`. Verified-feasible
+   this session: exact propagation through 13 steps gives `1/x₁₃ ∈ (3, 10/3) ⊂
+   (3, 4)` ⟹ `⌊1/x₁₃⌋ = 3`. Heartbeat budget guess `set_option maxHeartbeats
+   25600000 in` (2× S14b). Per OEIS A002945 `[…, 8, 3, 3, 4, …]`, `a₁₃ = 3`.
+
+## Prior Next-Action Sketch (S14b, now resolved by THIS iteration)
 
 **S14b Main-ACT (any researcher)**: Prove the **thirteenth partial
 quotient** `cbrt3_a12 = 8` in `proofs/Proofs/CubeRoot3IrrationalOQ04.lean`,


### PR DESCRIPTION
## Summary
- Adds the **thirteenth partial quotient** `cbrt3_a12 = 8` of the simple CF of `∛3` (the largest in the known OEIS A002945 prefix `[1; 2, 3, 1, 4, 1, 5, 1, 1, 6, 2, 5, 8, …]`) to `proofs/Proofs/CubeRoot3IrrationalOQ04.lean` (+141 LOC, 0 new sorries / 0 new axioms; slug remains 0/0).
- Consumes the S13 + S14a sandwich `597449/414248 < cbrt3 < 1865358/1293367` through a 12-fold-nested `lt_div_iff₀`/`div_lt_iff₀`/`le_div_iff₀` chain + floor antisymmetry — a deterministic, byte-for-byte mirror of the Docker-verified S13b `cbrt3_a11` template, only the bound literals and one extra reciprocation step differ.

## Math verification (this session)
Exact interval propagation with `fractions.Fraction` (every endpoint rational-exact):
`x₁₂ ∈ (3/25, 1/8) ⊂ (1/9, 1/8)` ⟹ `1/x₁₂ ∈ (8, 25/3) ⊂ (8, 9)` ⟹ `⌊1/x₁₂⌋ = 8`.
The lower endpoint `1/x₁₂ → 8` is **exactly** the limit as `cbrt3 → 1865358/1293367`, so the strict upper bound on `cbrt3` separates `1/x₁₂` from `8` — the true 14th convergent is optimally tight for this digit. All S14b sketch arithmetic (cube diffs `−753127` / `+2277123`, recursion `p₁₃=1865358`/`q₁₃=1293367`, S15 fallback `p₁₄=6193523`/`q₁₄=4294349`) re-verified clean.

## ⚠️ BUILD-PENDING — DRAFT
Docker daemon was **down** this session (`docker info` timed out), so this main-file addition could **not** be machine-checked. Kept as a **draft** so the deployer skips it (cannot break `main`).

## Test plan
- [ ] When Docker returns: `./proofs/scripts/docker-build.sh Proofs.CubeRoot3IrrationalOQ04`
- [ ] If `maxHeartbeats 12800000` is insufficient at depth 12, bump to `25600000`
- [ ] If clean: mark PR ready, flip slug status to verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)