### PR TITLE
research(erdos-101-oq-01): S16 add surrogate Θ(n²) lower bound [build-pending]

### DIFF
--- a/proofs/Proofs/Erdos101OQ01.lean
+++ b/proofs/Proofs/Erdos101OQ01.lean
@@ -252,6 +252,43 @@ theorem maxFourPointLines_isBigO_n_squared :
   have hsq : ((n * n : ℕ) : ℝ) = (n : ℝ)^2 := by push_cast; ring
   linarith
 
+/-- **The elementary surrogate is `Ω(n²)`**: `(n:ℝ)² = O(maxFourPointLines n)`
+at infinity. Since `maxFourPointLines n = n(n-1)/12 ∼ n²/12`, the bound grows
+quadratically from below as well as above (witnessed here by the constant
+`24`, valid for `n ≥ 6`).
+
+Together with `maxFourPointLines_isBigO_n_squared` this shows the elementary
+double-counting surrogate is exactly `Θ(n²)` — in particular it is **not**
+`o(n²)`. This is the precise content of the file's remark that the known
+rates (`n²`, `n(n-1)/12`) are `Θ(n²)`: closing OQ-01 requires a genuinely
+sub-quadratic refinement that the elementary bound cannot supply. -/
+theorem n_squared_isBigO_maxFourPointLines :
+    Asymptotics.IsBigO Filter.atTop
+      (fun n : ℕ => (n : ℝ) ^ 2)
+      (fun n : ℕ => (maxFourPointLines n : ℝ)) := by
+  rw [Asymptotics.isBigO_iff]
+  refine ⟨24, ?_⟩
+  rw [Filter.eventually_atTop]
+  refine ⟨6, fun n hn => ?_⟩
+  rw [Real.norm_of_nonneg (by positivity), Real.norm_of_nonneg (by positivity)]
+  unfold maxFourPointLines
+  set a : ℕ := n * (n - 1) with ha
+  -- ℕ floor-division lower bound (omega knows `a = 12*(a/12) + a%12`, `a%12 < 12`).
+  have h12 : a ≤ 12 * (a / 12) + 11 := by omega
+  have hn1 : 1 ≤ n := by omega
+  -- `(a : ℝ) = (n : ℝ)² - n` (valid since `n ≥ 1`).
+  have hacast : (a : ℝ) = (n : ℝ) ^ 2 - (n : ℝ) := by
+    rw [ha, Nat.cast_mul, Nat.cast_sub hn1, Nat.cast_one]; ring
+  -- Real lower bound on the integer quotient `a / 12`.
+  have hqcast : (a : ℝ) - 11 ≤ 12 * ((a / 12 : ℕ) : ℝ) := by
+    have hc : (a : ℝ) ≤ ((12 * (a / 12) + 11 : ℕ) : ℝ) := by exact_mod_cast h12
+    push_cast at hc; linarith
+  have hnR : (6 : ℝ) ≤ (n : ℝ) := by exact_mod_cast hn
+  have h1 : (0 : ℝ) ≤ (n : ℝ) - 6 := by linarith
+  have h2 : (0 : ℝ) ≤ (n : ℝ) + 4 := by positivity
+  have hkey : (0 : ℝ) ≤ ((n : ℝ) - 6) * ((n : ℝ) + 4) := mul_nonneg h1 h2
+  nlinarith [hqcast, hacast, hkey, hnR]
+
 /-- Per-`P` corollary: for every no-five-collinear planar point set `P`,
 `fourPointLineCount P ≤ maxFourPointLines |P|`. The `NoFiveCollinear`
 hypothesis is load-bearing — without it, `P` could place 9 points on a
@@ -500,8 +537,10 @@ The conjecture would imply (via `bounds_at_rate_*`) that there exists
 a witness rate `g : ℕ → ℝ` with `g n = o(n²)` and
 `fourPointLineCount P ≤ g n` for every no-five-collinear `P` of size
 `n`. The known rates `n²`, `n(n-1)/12` are *not* `o(n²)` — they are
-$\Theta(n^2)$ — so the open content is precisely a sub-quadratic
-quantitative refinement.
+$\Theta(n^2)$ (the surrogate `maxFourPointLines` is bounded above by
+`(n:ℝ)²` via `maxFourPointLines_isBigO_n_squared` and below via
+`n_squared_isBigO_maxFourPointLines`) — so the open content is precisely
+a sub-quadratic quantitative refinement.
 
 ## Solymosi–Stojaković lower bound (existence statement)
 

--- a/research/problems/erdos-101-oq-01/state.md
+++ b/research/problems/erdos-101-oq-01/state.md
@@ -1,9 +1,42 @@
 # Current State
 
-**Phase**: ACT (S15 BUILD-VERIFY — S14's "NOT verified locally" qualifier cleared; Docker GREEN on origin/main)
-**Since**: 2026-06-12 (S15 BUILD-VERIFY confirms S14 ACT)
-**Iteration**: 15
-**Last Updated**: 2026-06-12 (researcher-2, S15 BUILD-VERIFY)
+**Phase**: ACT (S16 — Θ(n²) lower half of the surrogate added; backs the prose "Θ(n²)" claim)
+**Since**: 2026-06-14 (S16 ACT)
+**Iteration**: 16
+**Last Updated**: 2026-06-14 (researcher-2, S16 ACT, build-pending)
+
+## Session 16 (2026-06-14, ACT — surrogate Θ(n²) lower bound, researcher-2)
+
+**Mode**: ACT. The file proved the surrogate `maxFourPointLines n = n(n-1)/12`
+is `O(n²)` (`maxFourPointLines_isBigO_n_squared`) but the **reverse** direction
+— asserted in prose at the "## OPEN refinement" docstring as "the known rates
+`n²`, `n(n-1)/12` are *not* `o(n²)` — they are Θ(n²)" — had **no backing
+theorem**. Added it:
+
+```lean
+theorem n_squared_isBigO_maxFourPointLines :
+    Asymptotics.IsBigO Filter.atTop
+      (fun n : ℕ => (n : ℝ) ^ 2) (fun n : ℕ => (maxFourPointLines n : ℝ))
+```
+
+Proof: `isBigO_iff` with constant `24`, valid for `n ≥ 6`; the ℕ floor-division
+lower bound `a ≤ 12*(a/12)+11` (omega) lifts to `12*(a/12 : ℝ) ≥ a - 11`, and
+with `(a:ℝ) = n² - n` the residual `n² ≤ 2n² - 2n - 22` closes by `nlinarith`
+on `(n-6)(n+4) ≥ 0`. Together with the existing forward `IsBigO` this is exactly
+`Θ(n²)`, so the trivial bound is provably **not** `o(n²)` — confirming the open
+content of OQ-01 is a genuinely sub-quadratic refinement. The two OPEN sorries
+(`erdos_101_oq_01`, `solymosi_stojakovic_lower_bound`) are **untouched**.
+
+**Counters**: theorems 20 → 21 (+1), sorries 2 → 2, axioms 0 → 0, LOC 762 → 801.
+meta.json updated (theoremCount 21, substantiveTheoremCount 18, lineCount 801).
+
+**Build status**: NOT verified locally — Docker daemon is **down** this session
+(`docker info` times out). Aristotle only fills sorries (it would target the two
+OPEN conjectures, which is wrong), so it is not a verification path here. Shipped
+as a **build-pending DRAFT**; proof mirrors the file's own proven idioms
+(`Asymptotics.isBigO_iff`, `Real.norm_of_nonneg`, `Filter.eventually_atTop`,
+`Nat.cast_sub`, omega floor-division) to minimise drift risk. Defer machine-check
+to mechanic / CI / next Docker-up session.
 
 ## Session 15 (2026-06-12, BUILD-VERIFY — clears S14 "NOT verified locally", researcher-2)
 

--- a/src/data/proofs/erdos-101-oq-01/meta.json
+++ b/src/data/proofs/erdos-101-oq-01/meta.json
@@ -24,12 +24,12 @@
     "erdosProblemStatus": "open",
     "dateAdded": "2026-05-11",
     "axiomCount": 0,
-    "lineCount": 762,
+    "lineCount": 801,
     "assumptions": "2 sorries: (1) erdos_101_oq_01 (the main open conjecture, $100 Erdős prize, primary ε–N form); (2) solymosi_stojakovic_lower_bound (the 2013 lower bound, recorded statement — construction itself uses algebraic geometry over finite fields and is deferred). The Mathlib-idiom form erdos_101_oq_01_isLittleO is no longer an independent sorry: it is *derived* from the main conjecture via the chain erdos_101_oq_01_conjecture → rate_form ↔ isLittleO_form (lemmas erdos_101_oq_01_conjecture_iff_rate_form and erdos_101_oq_01_rate_form_iff_isLittleO), so the file's open content is the single primary conjecture plus the deferred Solymosi–Stojaković construction. S14 (2026-06-03) unifies the S12 surrogate `maxFourPointLines` with the S13 genuine sup `maxCountAtSize` via the pointwise bridge `maxCountAtSize_le_maxFourPointLines` (uniform lift of `improved_upper_bound`) and propagates the `O(n²)` certificate to the sup via `maxCountAtSize_isBigO_n_squared`. S3 (2026-05-12) discharged the S2 corollary `erdos_three_halves_conjecture_refuted` from the lower bound via elementary real-analysis arithmetic (specialising to $C = 1/2$, using `Real.exp_one_lt_d9` to get $\\log m > 1$ for $m \\geq 3$, then `Real.rpow_lt_rpow_of_exponent_lt`). All other supporting lemmas (small-case bound, real-valued $O(n^2)$ trivial bound, $n^2/12$ rate witness, IsBigO certificates for surrogate + true sup, isLittleOh ↔ Mathlib IsLittleO bridge) are unconditional and axiom-free. 0 axioms remain — every assumption is a deferred proof obligation rather than a permanent axiomatisation.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 7,
-    "substantiveTheoremCount": 17
+    "substantiveTheoremCount": 18
   },
   "sections": [
     {
@@ -161,9 +161,9 @@
       "Classical"
     ],
     "namespace": "Erdos101OQ01",
-    "lineCount": 762,
+    "lineCount": 801,
     "axiomCount": 0,
-    "theoremCount": 20,
+    "theoremCount": 21,
     "definitionCount": 7,
     "path": "Proofs/Erdos101OQ01.lean",
     "sorries": 2


### PR DESCRIPTION
## Summary

Erdős #101 OQ-01 (the \$100 *four-point lines are o(n²)* open question) is a mature, saturated formalization: 762 LOC, 2 sorries that are **genuinely open mathematics** (the conjecture itself + the Solymosi–Stojaković 2013 lower bound). Metadata is accurate; the open sorries are not closable by routine ACT.

This PR fills one **prose-only gap**. The file proved the elementary surrogate `maxFourPointLines n = n(n-1)/12` is `O(n²)` (`maxFourPointLines_isBigO_n_squared`), but the docstring claim that the known rates are *"Θ(n²) — not o(n²)"* had **no backing theorem**. Added the reverse direction:

```lean
theorem n_squared_isBigO_maxFourPointLines :
    Asymptotics.IsBigO Filter.atTop
      (fun n : ℕ => (n : ℝ) ^ 2)
      (fun n : ℕ => (maxFourPointLines n : ℝ))
```

Together with the existing forward `IsBigO`, this establishes `Θ(n²)`, so the elementary double-counting bound is provably **not** `o(n²)` — confirming the open content of OQ-01 is a genuinely sub-quadratic refinement the trivial bound cannot supply.

**Proof sketch**: `isBigO_iff` with constant `24` (valid `n ≥ 6`); ℕ floor-division lower bound `a ≤ 12·(a/12)+11` (omega) lifts to `12·(a/12 : ℝ) ≥ a − 11`; with `(a:ℝ) = n² − n` the residual `n² ≤ 2n² − 2n − 22` closes by `nlinarith` on `(n−6)(n+4) ≥ 0`.

The two OPEN sorries are **untouched**.

## Counters

- theorems 20 → 21 (+1)
- sorries 2 → 2 (unchanged — both genuinely open)
- axioms 0 → 0
- LOC 762 → 801
- meta.json: theoremCount 21, substantiveTheoremCount 18, lineCount 801

## Build status

⚠️ **NOT verified locally** — Docker daemon is down this session (`docker info` times out). Aristotle only fills sorries (it would wrongly target the two open conjectures), so it is not a verification path here. The proof deliberately mirrors the file's own proven idioms (`Asymptotics.isBigO_iff`, `Real.norm_of_nonneg`, `Filter.eventually_atTop`, `Nat.cast_sub`, omega floor-division) to minimise drift risk. **Draft pending machine-check** by mechanic / CI / next Docker-up session.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos101OQ01` — expect only the 2 pre-existing OPEN-sorry warnings (lines for `erdos_101_oq_01`, `solymosi_stojakovic_lower_bound`)
- [ ] Confirm `n_squared_isBigO_maxFourPointLines` type-checks with no new sorry/axiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)