### PR TITLE
research(hilbert-15-oq-02): S5 add dual Pieri formula (2-row LR) [build-pending]

### DIFF
--- a/proofs/Proofs/Hilbert15OQ02.lean
+++ b/proofs/Proofs/Hilbert15OQ02.lean
@@ -501,6 +501,48 @@ theorem lr_pieri_converse (ν μ : Partition2) (k : ℕ)
   simp only [Partition2.size, Nat.add_zero, min_def] at h
   split_ifs at h <;> refine ⟨⟨?_, ?_, ?_⟩, ?_⟩ <;> omega
 
+/-- A 2-row skew shape `ν/μ` is a **vertical strip of size 2** when it has
+    exactly one cell in each row: `ν.a = μ.a + 1` and `ν.b = μ.b + 1`.
+    No two of the two skew cells share a row, which is the defining property
+    of a vertical strip (the transpose notion to a horizontal strip). -/
+def isVerticalStrip2 (ν μ : Partition2) : Prop :=
+  ν.a = μ.a + 1 ∧ ν.b = μ.b + 1
+
+/-- **Dual Pieri formula** for 2-row partitions (multiplication by the
+    elementary symmetric function `e₂ = s₍₁,₁₎`).
+
+    If `ν/μ` is a vertical strip of size 2, then `c^ν_{(1,1), μ} = 1`. The
+    dual Pieri rule governs multiplication by an elementary symmetric
+    function: `e_k · s_μ = Σ_ν s_ν` where `ν/μ` ranges over vertical strips
+    of size `k`. For `k = 2` and 2-row partitions the only vertical strip is
+    one cell per row (`ν.a = μ.a + 1`, `ν.b = μ.b + 1`); the ballot reading of
+    the content `(1,1)` then forces `k₁ = r₁ = 1`, so the unique tableau is
+    valid. This is the `λ ↔ λ'` transpose companion of `lr_pieri`. -/
+theorem lr_pieri_dual (ν μ : Partition2) (h : isVerticalStrip2 ν μ) :
+    lrCoeff2 ν ⟨1, 1, le_refl _⟩ μ = 1 := by
+  obtain ⟨ha, hb⟩ := h
+  have hν := ν.dec; have hμ := μ.dec
+  unfold lrCoeff2
+  simp only [Partition2.size, min_def]
+  split_ifs <;> omega
+
+/-- **Dual Pieri converse**: `c^ν_{(1,1), μ} = 1` implies `ν/μ` is a vertical
+    strip of size 2.
+
+    For the column content `λ = (1,1)`, the ballot condition forces exactly
+    one skew cell in each row: `r₁ = 1` (a second cell in row 1 would need a
+    `2` before any `1`, breaking the ballot word; an empty row 1 leaves the
+    row-2 `2` unmatched). With the size constraint this pins
+    `ν.a = μ.a + 1 ∧ ν.b = μ.b + 1`. -/
+theorem lr_pieri_dual_converse (ν μ : Partition2)
+    (h : lrCoeff2 ν ⟨1, 1, le_refl _⟩ μ = 1) :
+    isVerticalStrip2 ν μ := by
+  have hν := ν.dec; have hμ := μ.dec
+  unfold isVerticalStrip2
+  unfold lrCoeff2 at h
+  simp only [Partition2.size, min_def] at h
+  split_ifs at h <;> omega
+
 /-! ## Summary
 
 This file provides:
@@ -521,7 +563,9 @@ This file provides:
    2-row partitions — Schur function multiplication is commutative.
 
 6. **Pieri formula** (`lr_pieri`, `lr_pieri_converse`): `c^ν_{(k,0),μ} = 1`
-   iff `ν/μ` is a horizontal strip of size `k`.
+   iff `ν/μ` is a horizontal strip of size `k`. The **dual Pieri formula**
+   (`lr_pieri_dual`, `lr_pieri_dual_converse`): `c^ν_{(1,1),μ} = 1` iff
+   `ν/μ` is a vertical strip of size 2 — multiplication by `e₂ = s₍₁,₁₎`.
 
 7. **0 axioms**: All complexity results are theorems (vacuous formal content).
 

--- a/research/problems/hilbert-15-oq-02/state.md
+++ b/research/problems/hilbert-15-oq-02/state.md
@@ -1,8 +1,37 @@
 # Current State
 
-**Phase**: ACT (Session 4 — 2 universal-form zero lemmas added)
-**Since**: 2026-05-13 (Session 4, researcher-3)
-**Iteration**: 5
+**Phase**: ACT (Session 5 — dual Pieri formula added)
+**Since**: 2026-06-14 (Session 5, researcher-2)
+**Iteration**: 6
+
+## Session 5 (2026-06-14, ACT — dual Pieri formula, researcher-2)
+
+**Mode**: ACT. Discharged next-action #1 ("Pieri-dual `c^ν_{(1,1),μ}` via
+vertical-strip definition"). The file had the horizontal Pieri pair
+(`lr_pieri` / `lr_pieri_converse`, content `(k,0)` ↔ horizontal strip) but
+not the transpose companion (content `(1,1) = e₂` ↔ vertical strip). Added:
+
+  * `def isVerticalStrip2 ν μ := ν.a = μ.a + 1 ∧ ν.b = μ.b + 1`
+  * `lr_pieri_dual` — vertical strip ⟹ `c^ν_{(1,1),μ} = 1`
+  * `lr_pieri_dual_converse` — `c^ν_{(1,1),μ} = 1` ⟹ vertical strip
+
+Manually verified the LR-rule branch trace: with content `(1,1)`, the ballot
+word forces `r₁ = 1` (a 2nd row-1 cell needs a `2` before any `1`; an empty
+row 1 leaves the row-2 `2` unmatched), so `=1 ⟺ ν.a=μ.a+1 ∧ ν.b=μ.b+1`.
+Both directions close by the file's established `unfold; simp only
+[Partition2.size, min_def]; split_ifs <;> omega` pattern (no native_decide).
+
+**Counters**: theorems 27 → 29 (+2), defs 6 → 7 (+1: isVerticalStrip2),
+sorries 0 → 0, axioms 0 → 0, LOC 533 → 577. meta.json updated.
+
+**Build status**: NOT verified locally — Docker daemon **down** this session.
+Proof uses only `omega` (logic checkable by hand) and mirrors 4 existing
+theorems' tactic exactly, so drift risk is low. Shipped as **build-pending
+DRAFT**; defer machine-check to mechanic / CI. status stays `verified`
+(no sorries/axioms introduced; pending re-confirmation on build).
+
+Remaining next-actions (knowledge.md Session 4): `gr25_multiplicity_free`
+corollary (~native_decide), conjugate-symmetry for 2-row/2-col partitions.
 
 ## Current Focus
 

--- a/src/data/proofs/hilbert-15-oq-02/meta.json
+++ b/src/data/proofs/hilbert-15-oq-02/meta.json
@@ -19,12 +19,12 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 533,
+    "lineCount": 577,
     "assumptions": "Three complexity-theoretic theorems (lr_saturation_theorem, lr_positivity_in_P, lr_counting_sharp_P_complete) prove `True` as explicit placeholders — the complexity theory formalism is not available in Lean/Mathlib. The 2-row LR coefficient computation (lrCoeff2) and full Gr(2,4) multiplication table are fully verified via native_decide.",
     "dateAdded": "2026-04-12",
     "mathlib_version": "4.26.0",
-    "theoremCount": 27,
-    "definitionCount": 6
+    "theoremCount": 29,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Littlewood-Richardson coefficients c^nu_{lam,mu} are fundamental in algebraic combinatorics, governing the multiplication of Schur functions, tensor product decomposition of GL_n representations, and Schubert calculus on Grassmannians. The Knutson-Tao saturation theorem (1999) showed that testing positivity (c > 0) reduces to linear programming, placing it in P. Narayanan (2006) proved that exact computation of these coefficients is #P-complete, establishing one of the sharpest complexity separations in combinatorics.",
@@ -104,10 +104,10 @@
     ],
     "opens": [],
     "namespace": "LRComplexity",
-    "lineCount": 533,
+    "lineCount": 577,
     "axiomCount": 0,
-    "theoremCount": 27,
-    "definitionCount": 6,
+    "theoremCount": 29,
+    "definitionCount": 7,
     "path": "Proofs/Hilbert15OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

`Hilbert15OQ02.lean` formalizes Littlewood–Richardson coefficients for 2-row partitions (Gr(2,n)). It already proved the **horizontal Pieri** pair (`lr_pieri` / `lr_pieri_converse`): `c^ν_{(k,0),μ} = 1` iff `ν/μ` is a horizontal strip — multiplication by the complete homogeneous symmetric function `h_k`.

This PR adds the **transpose companion** — the **dual Pieri** formula (multiplication by the elementary symmetric function `e₂ = s₍₁,₁₎`, governing vertical strips):

```lean
def isVerticalStrip2 (ν μ : Partition2) : Prop := ν.a = μ.a + 1 ∧ ν.b = μ.b + 1

theorem lr_pieri_dual (ν μ : Partition2) (h : isVerticalStrip2 ν μ) :
    lrCoeff2 ν ⟨1, 1, le_refl _⟩ μ = 1

theorem lr_pieri_dual_converse (ν μ : Partition2)
    (h : lrCoeff2 ν ⟨1, 1, le_refl _⟩ μ = 1) : isVerticalStrip2 ν μ
```

**Math**: for column content `λ = (1,1)`, the reverse-row-reading ballot word forces exactly one skew cell per row (`r₁ = 1`): a second row-1 cell would read a `2` before any `1` (ballot fail), and an empty row 1 leaves the row-2 `2` unmatched. With the size constraint this pins `ν.a = μ.a+1 ∧ ν.b = μ.b+1`, so `c^ν_{(1,1),μ} = 1` exactly on vertical strips of size 2. This is the `λ ↔ λ'` transpose of the existing horizontal Pieri.

Both directions close by the file's established `unfold; simp only [Partition2.size, min_def]; split_ifs <;> omega` pattern — **pure `omega`, no `native_decide`** — so the logic is checkable by hand.

## Counters

- theorems 27 → 29 (+2)
- definitions 6 → 7 (+1: `isVerticalStrip2`)
- sorries 0 → 0, axioms 0 → 0
- LOC 533 → 577
- meta.json updated (theoremCount 29, definitionCount 7, lineCount 577)

## Build status

⚠️ **NOT verified locally** — Docker daemon is down this session (`docker info` times out). The proof is `omega`-only and mirrors 4 existing theorems' tactic exactly (low drift risk). **Draft pending machine-check** by mechanic / CI.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Hilbert15OQ02` — expect clean (0 sorries, 0 axioms, no new warnings)
- [ ] Confirm `lr_pieri_dual` / `lr_pieri_dual_converse` type-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)