### PR TITLE
research(elementary-quadratic-reciprocity-oq-03...): fix kroneckerTwo correctness bug at a≡7 (mod 8) [build-pending]

### DIFF
--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean
@@ -30,10 +30,15 @@ def kroneckerNegOne (a : ℤ) : ℤ :=
   if a < 0 then -1 else 1
 
 /-- The Kronecker symbol at n = 2.
-    χ(a, 2) = 0 if a is even, 1 if a ≡ ±1 (mod 8), -1 if a ≡ ±3 (mod 8). -/
+    χ(a, 2) = 0 if a is even, 1 if a ≡ ±1 (mod 8), -1 if a ≡ ±3 (mod 8).
+
+    Note: `a % 8` uses T-division (`Int.emod`), so for positive `a ≡ 7 (mod 8)`
+    we have `a % 8 = 7` (not `-1`). Since `7 ≡ -1 (mod 8)`, the `a % 8 = 7` and
+    `a % 8 = -7` cases must be listed explicitly to give the correct value `+1`
+    (cross-checked against Mathlib's `χ₈` in OQ-04). -/
 def kroneckerTwo (a : ℤ) : ℤ :=
   if a % 2 = 0 then 0
-  else if a % 8 = 1 ∨ a % 8 = -1 then 1
+  else if a % 8 = 1 ∨ a % 8 = 7 ∨ a % 8 = -1 ∨ a % 8 = -7 then 1
   else -1
 
 /-- The Kronecker symbol at n = 0: χ(a, 0) = 1 if |a| = 1, else 0. -/
@@ -122,9 +127,7 @@ theorem kroneckerSym_one_left (n : ℤ) : kroneckerSym 1 n = 1 := by
   split
   · simp [kroneckerZero]
   · next h =>
-    have hkt : kroneckerTwo 1 = 1 := by
-      simp only [kroneckerTwo, show (1 : ℤ) % 2 ≠ 0 from by omega, ite_false,
-        show ((1 : ℤ) % 8 = 1 ∨ (1 : ℤ) % 8 = -1) from Or.inl rfl, ite_true]
+    have hkt : kroneckerTwo 1 = 1 := by norm_num [kroneckerTwo]
     have hkn : kroneckerNegOne 1 = 1 := by simp [kroneckerNegOne]
     split <;> simp [hkt, hkn, one_pow, jacobiSym.one_left]
 

--- a/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean
+++ b/proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean
@@ -9,16 +9,18 @@ The gallery's `ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean` defines
 ## Answer
 
 Mathlib 4.26.0 has NO built-in Kronecker symbol — only `jacobiSym` for odd n.
-The gallery definition fills a genuine gap, but `kroneckerTwo` has a correctness
-issue for positive a ≡ 7 (mod 8):
+The gallery definition fills a genuine gap. This file originally identified a
+correctness issue in `kroneckerTwo` for positive a ≡ 7 (mod 8):
 
   The condition `a % 8 = -1` uses T-div mod. For positive integers,
-  `(7 : ℤ) % 8 = 7` (not -1), so the gallery's `kroneckerTwo 7 = -1`
-  but the correct Kronecker value is (7|2) = 1.
+  `(7 : ℤ) % 8 = 7` (not -1), so the old `kroneckerTwo 7` returned -1
+  while the correct Kronecker value is (7|2) = 1.
 
-This file provides:
+That bug has now been fixed in the parent file: `kroneckerTwo` lists the
+`a % 8 = 7` and `a % 8 = -7` cases explicitly. This file retains the
+independent `kroneckerTwoFixed` development as a χ₈ cross-check:
 1. Documentation of the Mathlib gap
-2. Corrected `kroneckerTwoFixed` using `a % 8 = 7`
+2. `kroneckerTwoFixed` using `a % 8 = 7` (matches the corrected parent def)
 3. Verification against Mathlib's `χ₈` on concrete values
 4. Full proof of multiplicativity of `kroneckerTwoFixed`
 -/
@@ -66,8 +68,8 @@ example : kroneckerTwoFixed 3 = χ₈ 3 := by native_decide
 example : kroneckerTwoFixed 5 = χ₈ 5 := by native_decide
 example : kroneckerTwoFixed 7 = χ₈ 7 := by native_decide
 
--- The key discrepancy: gallery's kroneckerTwo 7 = -1 (WRONG)
--- Our fix: kroneckerTwoFixed 7 = 1 (CORRECT)
+-- The key discrepancy (now fixed in the parent): the old kroneckerTwo 7 = -1
+-- was WRONG; both kroneckerTwoFixed 7 and the corrected parent give 1 (CORRECT)
 theorem kroneckerTwoFixed_seven : kroneckerTwoFixed 7 = 1 := by
   norm_num [kroneckerTwoFixed]
 
@@ -135,7 +137,8 @@ theorem kroneckerTwoFixed_agrees_jacobi :
 
 /-- **Summary**:
     - Mathlib has no Kronecker symbol (only Jacobi for odd n)
-    - Gallery's `kroneckerTwo` is incorrect at a ≡ 7 (mod 8): uses T-mod -1
+    - The old `kroneckerTwo` was incorrect at a ≡ 7 (mod 8) (T-mod -1); the
+      parent def is now corrected to list a % 8 = 7 and a % 8 = -7
     - `kroneckerTwoFixed` with `a % 8 = 7` is correct and agrees with χ₈
     - Multiplicativity holds: (ab|2) = (a|2) · (b|2) -/
 theorem summary :


### PR DESCRIPTION
## Summary
Fixes a genuine **correctness bug** in the published gallery proof's `kroneckerTwo` (the Kronecker symbol at n=2), surfaced by the OQ-04 comparison file.

The definition used `a % 8 = 1 ∨ a % 8 = -1` for the `+1` case. Lean's `Int.emod` is T-division, so for positive `a ≡ 7 (mod 8)` we get `a % 8 = 7` (never `-1`) → the old `kroneckerTwo 7 = -1`. But the correct Kronecker value is `(7|2) = +1`, since `7 ≡ -1 (mod 8)` and `±1 mod 8` are quadratic residues mod 8. Mathlib's `χ₈ 7 = 1` (verified in OQ-04).

### Fix
```lean
-- before
else if a % 8 = 1 ∨ a % 8 = -1 then 1
-- after
else if a % 8 = 1 ∨ a % 8 = 7 ∨ a % 8 = -1 ∨ a % 8 = -7 then 1
```
This matches the `kroneckerTwoFixed` already proved correct against `χ₈` in `...OQ01OQ01OQ04.lean`.

### Blast radius (small)
- `kroneckerTwo_values` — structural `split`, unaffected.
- `kroneckerSym_one` / `kroneckerSym_neg_one` — use `kroneckerTwo a ^ 0`, value-independent.
- `kroneckerSym_one_left` — only value-dependent site (`kroneckerTwo 1 = 1`); rewrote its fragile hardcoded-disjunction `simp only` as `norm_num [kroneckerTwo]`.
- Parent gallery `meta.json` already describes the correct math (`a ≡ ±1 mod 8 → 1, since 1,7,9,15... are squares mod 8`) — no metadata change needed; the code now matches the description.

### Files
- `proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01.lean` — def fix + docstring + robust `hkt` proof
- `proofs/Proofs/ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04.lean` — narrative updated present→past tense ("now fixed in parent"), comment-only

## Build status
**Build-pending DRAFT**: Docker unavailable here to machine-check. The one re-proved obligation (`kroneckerTwo 1 = 1`) mirrors OQ-04's verified `kroneckerTwoFixed_seven := by norm_num [kroneckerTwoFixed]` on an identically-shaped def. Undraft after a Docker build confirms.

## Test plan
- [ ] `./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ01OQ01`
- [ ] `./proofs/scripts/docker-build.sh Proofs.ElementaryQuadraticReciprocityOQ03OQ01OQ01OQ04`