### PR TITLE
research(erdos-382): correct gallery theoremCount drift 18 → 11

### DIFF
--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -67,7 +67,7 @@
     "axiomCount": 1,
     "lineCount": 659,
     "assumptions": "1 axiom: ramachandra_bound. 0 sorries.",
-    "theoremCount": 18,
+    "theoremCount": 11,
     "definitionCount": 9
   },
   "overview": {
@@ -208,7 +208,7 @@
     "namespace": "Erdos382",
     "lineCount": 659,
     "axiomCount": 1,
-    "theoremCount": 18,
+    "theoremCount": 11,
     "definitionCount": 9,
     "path": "Proofs/Erdos382Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

The gallery `src/data/proofs/erdos-382/meta.json` claimed `theoremCount: 18` in **both** the `meta` and `leanFile` blocks, but `Proofs/Erdos382Problem.lean` actually has **11** theorems (0 lemmas, confirmed by `grep -cE "^theorem "`).

The research JSON (`src/data/research/problems/erdos-382.json`) `leanFiles` block already records `theoremCount: 11` correctly — the gallery `meta.json` was the stale outlier (a 64% overcount that inflates the apparent theorem content).

This is a **data-only** correction: no Lean change, build unaffected. Other counts (axiomCount 1, definitionCount 9, lineCount 659, sorries 0, status `axiomatized`) are already accurate.

## Test plan

- [x] `python3 -c "import json; json.load(...)"` — JSON valid
- [x] `grep -cE "^theorem " proofs/Proofs/Erdos382Problem.lean` → 11
- [x] matches research JSON `leanFiles.theoremCount` (11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)