### PR TITLE
research(erdos-524): correct stale axiom metadata (1 axiom, not 3)

### DIFF
--- a/src/data/proofs/erdos-524/meta.json
+++ b/src/data/proofs/erdos-524/meta.json
@@ -62,56 +62,64 @@
       "id": "lower-bound",
       "title": "Lower Bound (Erdős)",
       "startLine": 38,
-      "endLine": 48,
-      "summary": "Axiom `erdos_lower_bound`: For every $\\varepsilon \\in (0, 1/2)$, $M_n(t)/n^{1/2-\\varepsilon} \\to \\infty$ as $n \\to \\infty$ for a.e. $t$. The lower bound follows from evaluating at $x = 1$ (random walk) and the law of the iterated logarithm.",
+      "endLine": 42,
+      "summary": "Documentation (docstring only, not an axiom) of Erdős's unpublished lower bound: for a.e. $t$ and every $\\varepsilon \\in (0, 1/2)$, $M_n(t)/n^{1/2-\\varepsilon} \\to \\infty$ as $n \\to \\infty$. The lower bound follows from evaluating at $x = 1$ (random walk) and the law of the iterated logarithm.",
       "mathContext": "$\\forall \\varepsilon \\in (0, 1/2),\\, M_n(t) = \\omega(n^{1/2-\\varepsilon})$ a.s. Since $P_n(t,1) = \\sum \\varepsilon_k$ is a random walk, the LIL gives $|P_n(t,1)| \\geq \\sqrt{2n \\log\\log n}$ i.o., so $M_n \\geq \\sqrt{2n \\log\\log n}$ i.o."
     },
     {
       "id": "upper-bound",
       "title": "Upper Bound (Chung)",
-      "startLine": 49,
-      "endLine": 58,
-      "summary": "Axiom `chung_upper_bound`: $\\exists C > 0$ such that for a.e. $t$, $M_n(t) \\leq C\\sqrt{n/\\log\\log n}$ for infinitely many $n$. An 'infinitely often' bound from LIL considerations.",
+      "startLine": 43,
+      "endLine": 46,
+      "summary": "Documentation (docstring only, not an axiom) of Chung's upper bound: $\\exists C > 0$ such that for a.e. $t$, $M_n(t) \\leq C\\sqrt{n/\\log\\log n}$ for infinitely many $n$. An 'infinitely often' bound from LIL considerations.",
       "mathContext": "$M_n(t) \\leq C\\sqrt{n/\\log\\log n}$ i.o. a.s. The $\\sqrt{\\log\\log n}$ gap between this and $\\sqrt{n}$ is the central mystery: the bound says the maximum can sometimes dip *below* the random walk scale."
     },
     {
       "id": "main-problem",
       "title": "Main Open Problem",
-      "startLine": 59,
-      "endLine": 69,
-      "summary": "Axiom `erdos_524_order_of_magnitude`: $\\exists f : \\mathbb{N} \\to \\mathbb{R}_{>0}$ such that $M_n(t) = \\Theta(f(n))$ a.e. Conjectured $f(n) = \\sqrt{n}$. The gap between $n^{1/2-\\varepsilon}$ and $\\sqrt{n/\\log\\log n}$ remains the frontier.",
+      "startLine": 47,
+      "endLine": 57,
+      "summary": "`def erdos_524_order_of_magnitude` (a Prop, not an axiom): $\\exists f : \\mathbb{N} \\to \\mathbb{R}_{>0}$ such that $M_n(t) = \\Theta(f(n))$ a.e. Conjectured $f(n) = \\sqrt{n}$. The gap between $n^{1/2-\\varepsilon}$ and $\\sqrt{n/\\log\\log n}$ remains the frontier. The conjecture that this Prop holds is the file's sole axiom, `erdos_524_main` (see the closing section).",
       "mathContext": "The open problem: find $f(n)$ with $c_1 f(n) \\leq M_n(t) \\leq c_2 f(n)$ for all large $n$, a.s. Known: $f(n) = \\omega(n^{1/2-\\varepsilon})$ and $f(n) = O(\\sqrt{n/\\log\\log n})$. Conjecture: $f(n) = \\sqrt{n}$."
     },
     {
       "id": "additional-properties",
       "title": "Additional Properties",
-      "startLine": 134,
-      "endLine": 150,
+      "startLine": 108,
+      "endLine": 129,
       "summary": "Proved `binaryDigit_sq` ($\\varepsilon_k^2 = 1$), `randSignPoly_zero` ($P_0 = 0$), and `randSignPoly_continuous` (continuity in $x$). The continuity result is foundational for sSup well-definedness.",
       "mathContext": "The orthogonality property $\\varepsilon_k^2 = 1$ is key for second moment computations: $\\mathbb{E}[P_n(t,x)^2] = \\sum_k x^{2k}$ uses the fact that cross terms vanish since $\\mathbb{E}[\\varepsilon_j \\varepsilon_k] = \\delta_{jk}$, which follows from $\\varepsilon_k^2 = 1$ and independence. Continuity of $P_n(\\cdot, x)$ in $x$ ensures the supremum $M_n(t) = \\max_{x \\in [-1,1]} |P_n(t,x)|$ is attained on the compact set $[-1,1]$."
     },
     {
       "id": "polymax-infrastructure",
       "title": "polyMax Infrastructure",
-      "startLine": 152,
-      "endLine": 198,
+      "startLine": 131,
+      "endLine": 173,
       "summary": "sSup infrastructure for polyMax: `polyMax_bddAbove` (BddAbove), `polyMax_nonneg` ($M_n \\geq 0$), `polyMax_le_n` ($M_n \\leq n$), and endpoint evaluation lower bounds `randSignPoly_eval_one_le_polyMax` and `randSignPoly_eval_neg_one_le_polyMax`.",
       "mathContext": "The polyMax sSup infrastructure establishes: (1) the supremum is well-defined (BddAbove by the trivial bound $n$), (2) $M_n \\geq 0$ (since $|\\cdot| \\geq 0$ and the domain is nonempty), (3) $M_n \\leq n$ (triangle inequality), and (4) endpoint evaluations $|P_n(t, \\pm 1)| \\leq M_n$ provide lower bounds. The endpoint bound at $x = 1$ is the key observation behind Erdős's lower bound: $M_n \\geq |P_n(t,1)| = |\\sum \\varepsilon_k|$, and by the LIL this is $\\geq \\sqrt{2n \\log\\log n}$ infinitely often."
     },
     {
       "id": "advanced-polymax",
       "title": "Advanced polyMax Results",
-      "startLine": 200,
-      "endLine": 310,
-      "summary": "Six new results: `polyMax_zero` ($M_0 = 0$), `polyMax_achieved` (extreme value theorem), `polyMax_one` ($M_1 = 1$), `polyMax_succ_le` ($M_{n+1} \\leq M_n + 1$), `polyMax_ge_succ` ($M_n \\leq M_{n+1} + 1$), and `polyMax_diff_le` ($|M_{n+1} - M_n| \\leq 1$).",
+      "startLine": 175,
+      "endLine": 317,
+      "summary": "Eight results: `polyMax_zero` ($M_0 = 0$), `polyMax_achieved` (extreme value theorem), `polyMax_one` ($M_1 = 1$), `polyMax_succ_le` ($M_{n+1} \\leq M_n + 1$), `polyMax_ge_succ` ($M_n \\leq M_{n+1} + 1$), `polyMax_diff_le` ($|M_{n+1} - M_n| \\leq 1$), `polyMax_ge_eval` (general evaluation bound $|P_n(t,x)| \\leq M_n$ for $x \\in [-1,1]$), and `polyMax_two` ($M_2 = 2$).",
       "mathContext": "The extreme value theorem ensures $M_n$ is a true maximum. The 1-Lipschitz property $|M_{n+1} - M_n| \\leq 1$ follows from $|P_{n+1}(t,x) - P_n(t,x)| = |\\varepsilon_{n+1} x^{n+1}| \\leq 1$ on $[-1,1]$ — each new term changes the polynomial by at most 1 pointwise, hence the maximum by at most 1."
+    },
+    {
+      "id": "open-conjecture",
+      "title": "Open Conjecture (sole axiom)",
+      "startLine": 319,
+      "endLine": 322,
+      "summary": "Axiom `erdos_524_main : erdos_524_order_of_magnitude` — the file's only axiom. It asserts that the (open) Salem–Zygmund order-of-magnitude conjecture holds: $M_n(t) \\sim C\\sqrt{n}$ for a.e. $t$. This is OPEN; the lower/upper bounds above are documented as docstrings, not axiomatized.",
+      "mathContext": "The single assumption `erdos_524_main` packages the unresolved Erdős Problem #524 as a Prop-valued axiom. All 22 theorems in the file are proved from the definitions alone; the axiom is used only to state the open conjecture, not in any proof."
     }
   ],
   "overview": {
     "historicalContext": "Problem #524 originates from the foundational work of **Salem and Zygmund** (1954) on random trigonometric polynomials, where they proved $\\max_{\\theta} |\\sum \\varepsilon_k \\cos(k\\theta)| = \\Theta(\\sqrt{n \\log n})$ almost surely. Erdős posed the algebraic polynomial variant in his **1961 compilation** [Er61, p.253]: what is the correct order of magnitude of $M_n(t) = \\max_{x \\in [-1,1]} |\\sum \\varepsilon_k x^k|$ for a.e. $t$?\n\nThe study of random polynomials began with **Bloch and Pólya** (1932), who estimated the number of real zeros of polynomials with ±1 coefficients, followed by **Littlewood and Offord** (1938) who proved the first anti-concentration inequalities for Rademacher sums. **Kac** (1943) showed the expected number of real zeros is $\\sim (2/\\pi)\\log n$, establishing the field. For the maximum modulus question, **Erdős** proved (unpublished) a lower bound $M_n(t)/n^{1/2-\\varepsilon} \\to \\infty$ a.e. for every $\\varepsilon > 0$, using the law of the iterated logarithm at the endpoint $x = 1$. **Chung** proved the complementary infinitely-often upper bound $M_n \\leq C\\sqrt{n/\\log\\log n}$.\n\nThe gap between these bounds is narrow — both are $n^{1/2 \\pm o(1)}$ — but closing it requires understanding whether the maximum over all $x \\in [-1,1]$ exceeds the endpoint value $|P_n(t,1)|$ by more than a polylogarithmic factor. The problem remains open. Modern tools from Gaussian process theory (Talagrand's generic chaining) and random matrix theory offer potential approaches but have not yet resolved the question.",
     "problemStatement": "Determine the correct order of magnitude of M_n(t) = max_{x∈[-1,1]} |Σ_{k≤n} (-1)^{ε_k(t)} x^k| for almost all t ∈ (0,1), where ε_k(t) are the binary digits of t.",
-    "text": "A 329-line formalization of Erdős Problem #524 (Salem-Zygmund, 1954; Erdős, 1961) on the maximum modulus of Rademacher polynomials. Defines `binaryDigit` (extracting ±1 signs from the binary expansion of $t \\in (0,1)$), `randSignPoly` ($P_n(t,x) = \\sum_{k=1}^n \\varepsilon_k(t) x^k$), and `polyMax` ($M_n(t) = \\max_{x \\in [-1,1]} |P_n(t,x)|$). Three axioms capture the state of knowledge: Erdős's lower bound $M_n/n^{1/2-\\varepsilon} \\to \\infty$ a.e., Chung's infinitely-often upper bound $M_n \\leq C\\sqrt{n/\\log\\log n}$, and the main open problem — existence of a function $f(n)$ with $M_n = \\Theta(f(n))$ a.e. The conjecture is $f(n) = \\sqrt{n}$.",
-    "proofStrategy": "The formalization defines binaryDigit via floor arithmetic, randSignPoly as a Finset.sum over Rademacher coefficients times monomials, and polyMax via sSup. Erdős's lower bound and Chung's i.o. upper bound are axiomatized with ∀ᵐ (Lebesgue a.e.) quantifiers. The main open problem is axiomatized as existence of a Θ-function. The file has 0 sorries and 22 proved theorems.",
+    "text": "A 322-line formalization of Erdős Problem #524 (Salem-Zygmund, 1954; Erdős, 1961) on the maximum modulus of Rademacher polynomials. Defines `binaryDigit` (extracting ±1 signs from the binary expansion of $t \\in (0,1)$), `randSignPoly` ($P_n(t,x) = \\sum_{k=1}^n \\varepsilon_k(t) x^k$), and `polyMax` ($M_n(t) = \\max_{x \\in [-1,1]} |P_n(t,x)|$). A single axiom `erdos_524_main` captures the open problem — existence of a function $f(n)$ with $M_n = \\Theta(f(n))$ a.e., conjecturally $f(n) = \\sqrt{n}$. Erdős's lower bound $M_n/n^{1/2-\\varepsilon} \\to \\infty$ a.e. and Chung's infinitely-often upper bound $M_n \\leq C\\sqrt{n/\\log\\log n}$ are documented as docstrings (not axiomatized). All 22 supporting theorems are fully proved from the definitions.",
+    "proofStrategy": "The formalization defines binaryDigit via floor arithmetic, randSignPoly as a Finset.sum over Rademacher coefficients times monomials, and polyMax via sSup. The order-of-magnitude statement is a `def` (Prop), and the single axiom `erdos_524_main` asserts it holds — packaging the open problem. Erdős's lower bound and Chung's i.o. upper bound are described in docstrings only, not axiomatized. The file has 0 sorries, 1 axiom, and 22 proved theorems.",
     "keyInsights": [
       "**Binary digits as Rademacher variables**: Under Lebesgue measure, the binary digits of t ∈ (0,1) are i.i.d. fair coin flips, making P_n a standard Rademacher polynomial",
       "**Endpoint concentration**: Monomials x^k ≈ 1 near x = ±1, making the polynomial behave like a random walk at the endpoints — this is why the polynomial case differs from Salem-Zygmund",

--- a/src/data/research/problems/erdos-524.json
+++ b/src/data/research/problems/erdos-524.json
@@ -81,9 +81,9 @@
     {
       "path": "Proofs/Erdos524Problem.lean",
       "filename": "Erdos524Problem.lean",
-      "lineCount": 318,
+      "lineCount": 322,
       "theoremCount": 22,
-      "axiomCount": 0,
+      "axiomCount": 1,
       "defCount": 4,
       "sorryCount": 0,
       "isAristotle": false,


### PR DESCRIPTION
## Summary

The gallery `meta.json` for Erdős #524 described **three axioms** in its section descriptions and prose, but the actual 322-line Lean file (`Proofs/Erdos524Problem.lean`) has only **one** axiom.

Actual file structure (verified against `origin/main`):
- `erdos_524_main : erdos_524_order_of_magnitude` — the **sole axiom** (the open Salem–Zygmund order-of-magnitude conjecture)
- `erdos_524_order_of_magnitude` — a `def` (Prop), not an axiom
- Erdős's lower bound and Chung's upper bound — **docstring commentary only**, not axiomatized
- 22 supporting theorems, all proved from definitions; 0 sorries

The top-level `axiomCount: 1` was already correct; this PR fixes the descriptive content that contradicted it.

## Changes (metadata only, no Lean change)

- `src/data/proofs/erdos-524/meta.json`:
  - `lower-bound` / `upper-bound` sections: relabel from "Axiom" to docstring documentation; fix line ranges
  - `main-problem` section: relabel `erdos_524_order_of_magnitude` as a `def`, point to the real axiom
  - add `open-conjecture` section for the sole axiom `erdos_524_main`
  - fix stale line numbers on `additional-properties`, `polymax-infrastructure`, `advanced-polymax` (+ list all 8 results)
  - `text` / `proofStrategy`: "Three axioms" → one axiom; "329-line" → 322
- `src/data/research/problems/erdos-524.json`: sync `leanFile` counts (`axiomCount` 0→1, `lineCount` 318→322)

## Test plan
- [x] Both JSON files validated with `json.load`
- [x] Counts cross-checked against `git show origin/main:proofs/Proofs/Erdos524Problem.lean` (1 axiom, 4 defs, 22 theorems, 0 sorries, 322 lines)