### PR TITLE
research(erdos-1139): fix stale section line ranges + phantom sorry claim

### DIFF
--- a/src/data/proofs/erdos-1139/meta.json
+++ b/src/data/proofs/erdos-1139/meta.json
@@ -100,40 +100,40 @@
     {
       "id": "structural-results",
       "title": "Structural Results on Semiprimes",
-      "startLine": 86,
-      "endLine": 105,
-      "summary": "Proves pq ≥ 4 for prime products and that semiprimes are almost-primes (sorry on Ω(pq) = 2, needs factorization multiplicativity).",
+      "startLine": 113,
+      "endLine": 135,
+      "summary": "Proves pq ≥ 4 for prime products and that semiprimes are almost-primes (Ω(pq) = 2, fully proved via factorization multiplicativity — no sorry).",
       "mathContext": "$p, q$ prime $\\Rightarrow pq \\geq 4$ and $\\Omega(pq) = 2$"
     },
     {
       "id": "counting",
       "title": "Counting: Primes ⊆ Almost-Primes",
-      "startLine": 107,
-      "endLine": 117,
+      "startLine": 137,
+      "endLine": 147,
       "summary": "Proves the set of primes up to N is contained in almostPrimesUpTo N, giving $\\pi_2(N) \\geq \\pi(N)$ and hence infinitude of almost-primes.",
       "mathContext": "$\\pi_2(N) \\geq \\pi(N) \\sim N/\\log N$"
     },
     {
       "id": "main-conjecture",
       "title": "The Main Conjecture (Open)",
-      "startLine": 119,
-      "endLine": 127,
+      "startLine": 149,
+      "endLine": 157,
       "summary": "Axiomatizes the open conjecture: for every C > 0 and K, there exists k ≥ K with gap gₖ > C log k, i.e., lim sup gₖ/log k = ∞.",
       "mathContext": "$\\forall C > 0,\\; \\forall K,\\; \\exists k \\geq K : g_k > C \\log k$"
     },
     {
       "id": "cube-gap",
       "title": "Gap Lower Bound from Consecutive Cubes",
-      "startLine": 129,
-      "endLine": 141,
+      "startLine": 159,
+      "endLine": 176,
       "summary": "Shows that multiples of 8 between consecutive cubes cannot be almost-primes (Ω(8k) ≥ 3), giving a structural source of gaps in the sequence.",
       "mathContext": "$8 \\mid m \\Rightarrow \\Omega(m) \\geq 3 > 2$"
     },
     {
       "id": "density",
       "title": "Hardy-Ramanujan Asymptotic Density",
-      "startLine": 143,
-      "endLine": 157,
+      "startLine": 178,
+      "endLine": 190,
       "summary": "Axiomatizes the Landau-Ramanujan counting asymptotic: π₂(N) ≥ c(1−ε)N log log N / log N for large N, quantifying almost-prime density.",
       "mathContext": "$\\pi_2(N) \\sim cN \\log \\log N / \\log N$"
     }


### PR DESCRIPTION
## Summary

The gallery `meta.json` for Erdős #1139 had **section line ranges shifted ~30 lines earlier** than the actual `Proofs/Erdos1139Problem.lean` content, so clicking a section in the rendered gallery showed the wrong source code. The summaries were correct; only the `startLine`/`endLine` values were stale (from file growth).

Corrected against the file's `-- ## Part N` markers:

| section | was | now | actual content |
|---|---|---|---|
| structural-results | 86–105 | 113–135 | semiprime lemmas |
| counting | 107–117 | 137–147 | `almostPrimes_contain_primes` |
| main-conjecture | 119–127 | 149–157 | `axiom erdos_1139` (L154) |
| cube-gap | 129–141 | 159–176 | `cube_gap_obstruction` |
| density | 143–157 | 178–190 | `axiom hardy_ramanujan_asymptotic` (L185) |

Also removed a stale "(sorry on Ω(pq) = 2)" note from the `structural-results` summary — `semiprime_isAlmostPrime` is fully proved (the file has **0 sorries**).

The top-level counts (2 axioms, 16 theorems, 0 sorries, 192 lines) and the `assumptions` field were already accurate and are unchanged.

## Test plan
- [x] `meta.json` validated with `json.load`
- [x] Line ranges cross-checked against `git show origin/main:proofs/Proofs/Erdos1139Problem.lean`
- [x] Confirmed both axioms (`erdos_1139` L154, `hardy_ramanujan_asymptotic` L185) and 0 sorries in the actual file