### PR TITLE
research(erdos-1062): fix phantom-axiom prose + stale/missing sections

### DIFF
--- a/src/data/proofs/erdos-1062/meta.json
+++ b/src/data/proofs/erdos-1062/meta.json
@@ -30,7 +30,7 @@
     "historicalContext": "This problem appears as B24 in Richard Guy's *Unsolved Problems in Number Theory* (3rd ed., 2004) and originates from Erdős's extensive work on divisibility-restricted subsets of $\\{1,\\ldots,n\\}$. Kenneth Lebensold (1976, *Studies in Applied Mathematics*, Vol. 56, pp. 291–294) established the tight bounds $0.6725n \\leq f(n) \\leq 0.6736n$ for large $n$, narrowing the asymptotic density to an interval of width $0.0011$. The basic lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ was observed earlier using the interval $[m+1, 3m+2]$, where ratios stay below 3. The problem connects to Erdős's pioneering work on primitive sets with Besicovitch (1934) — sets where no element divides any other — and to Dilworth's theorem (1950) on antichains in partially ordered sets. The divisibility poset on $\\{1,\\ldots,n\\}$ forms a rich combinatorial structure where the NDTO condition defines a relaxed antichain: allowing one divisibility per element but forbidding two. Lichtman's 2022 proof of the Erdős primitive set conjecture (that primes maximize $\\sum 1/(a \\log a)$ over all primitive sets) renewed interest in divisibility-restricted extremal problems, though Lebensold's bounds for NDTO sets remain unimproved after nearly 50 years.",
     "problemStatement": "Let $f(n)$ be the maximum size of $A \\subseteq \\{1,\\ldots,n\\}$ such that no element of $A$ divides two distinct other elements of $A$. What is $\\lim_{n \\to \\infty} f(n)/n$? Is this limit irrational?",
     "text": "Let f(n) = max |A| for A ⊆ {1,…,n} with no element dividing two distinct others. Lebensold: 0.6725n ≤ f(n) ≤ 0.6736n. Is lim f(n)/n irrational? OPEN.",
-    "proofStrategy": "The formalization defines `NoDividesTwoOthers` as the combinatorial predicate (no element divides two distinct others) and `maxNDTOSize` as the extremal function $f(n)$. The lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ is proved constructively using the interval $[n/3+1, n]$: any element $a$ in this interval has third multiple $3a > n$, so at most one proper multiple fits, establishing NDTO. Lebensold's refined bounds and the limiting density existence are axiomatized as deep published results. A comparison with primitive sets is fully proved: `Primitive \\implies$ NDTO` and strictness via $\\{2, 6, 9\\}$.",
+    "proofStrategy": "The formalization defines `NoDividesTwoOthers` as the combinatorial predicate (no element divides two distinct others) and `maxNDTOSize` as the extremal function $f(n)$. The lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ is proved constructively using the interval $[n/3+1, n]$: any element $a$ in this interval has third multiple $3a > n$, so at most one proper multiple fits, establishing NDTO. Lebensold's refined bounds and the limiting density existence are documented in docstrings as deep published results (not axiomatized — the file has 0 axioms). A comparison with primitive sets is fully proved: `Primitive \\implies$ NDTO` and strictness via $\\{2, 6, 9\\}$.",
     "keyInsights": [
       "**Degree-bounded divisibility graph**: The NDTO condition is equivalent to requiring out-degree $\\leq 1$ in the divisibility graph on $A$, while primitive sets require out-degree $= 0$. This graph-theoretic view explains why NDTO allows linear-density sets while primitive sets have density 0",
       "**Near-optimal simple construction**: The interval $[m+1, 3m+2]$ achieves density $2/3 \\approx 0.667$, already within $0.7\\%$ of Lebensold's optimal lower bound $0.6725$. The difficulty in improving bounds lies in optimizing over the irregular divisibility structure beyond simple intervals",
@@ -50,56 +50,70 @@
       "id": "preamble",
       "title": "Problem Description and Imports",
       "startLine": 1,
-      "endLine": 21,
+      "endLine": 15,
       "summary": "Module docstring stating the problem, its open status, and references to Guy (2004) B24 and Lebensold (1976). Imports Mathlib libraries for natural numbers, finite sets, cardinality, reals, irrationality, filters, and tactics."
     },
     {
       "id": "divisibility-condition",
       "title": "The NDTO Condition",
-      "startLine": 22,
-      "endLine": 32,
+      "startLine": 16,
+      "endLine": 25,
       "summary": "Defines `NoDividesTwoOthers`: no element $a \\in A$ divides two distinct elements $b, c \\in A$. Equivalent to out-degree $\\leq 1$ in the divisibility graph on $A$."
     },
     {
       "id": "extremal-function",
       "title": "The Extremal Function",
-      "startLine": 33,
-      "endLine": 43,
+      "startLine": 27,
+      "endLine": 36,
       "summary": "Defines `maxNDTOSize n` as $f(n) = \\max\\{|A| : A \\subseteq [n],\\, \\text{NDTO}(A)\\}$ using `Finset.sup` over the power set filtered by NDTO."
     },
     {
       "id": "lower-bound",
       "title": "Lower Bound Construction",
-      "startLine": 44,
-      "endLine": 87,
+      "startLine": 38,
+      "endLine": 81,
       "summary": "Proves $f(n) \\geq \\lceil 2n/3 \\rceil$ constructively: the interval $[n/3+1, n]$ satisfies NDTO because any $a$ in this range has $3a > n$, so at most one proper multiple fits. Uses `Finset.le_sup` to connect witness cardinality to the extremal function.",
       "mathContext": "Lebensold (1978): $0.6725n \\leq f(n) \\leq 0.6736n$."
     },
     {
       "id": "lebensold-bounds",
       "title": "Lebensold's Bounds (1976)",
-      "startLine": 89,
-      "endLine": 101,
-      "summary": "Axiomatizes Lebensold's bounds: $0.6725n \\leq f(n) \\leq 0.6736n$ for large $n$. The lower bound improves the $2/3$ construction; the upper bound uses divisibility counting arguments.",
+      "startLine": 83,
+      "endLine": 88,
+      "summary": "Documents Lebensold's bounds in docstrings (not axiomatized): $0.6725n \\leq f(n) \\leq 0.6736n$ for large $n$. The lower bound improves the $2/3$ construction; the upper bound uses divisibility counting arguments.",
       "mathContext": "Lebensold (1978): $0.6725n \\leq f(n) \\leq 0.6736n$."
     },
     {
       "id": "conjectures",
       "title": "Limiting Density and the Irrationality Conjecture",
-      "startLine": 103,
-      "endLine": 117,
-      "summary": "Axiomatizes existence of $\\lambda = \\lim f(n)/n \\in [0.6725, 0.6736]$ and states `ErdosProblem1062`: $\\lambda$ is irrational. The limit exists by subadditivity (Fekete's lemma)."
+      "startLine": 89,
+      "endLine": 98,
+      "summary": "Defines `ErdosProblem1062` as a `def` (a Prop, not an axiom): there exists $\\lambda = \\lim f(n)/n$ with $\\lambda$ irrational. The limiting-density existence is documented in a docstring. The conjecture is captured as a statement, not assumed."
     },
     {
       "id": "primitive-comparison",
       "title": "Comparison with Primitive Sets",
-      "startLine": 119,
-      "endLine": 147,
+      "startLine": 100,
+      "endLine": 127,
       "summary": "Defines `IsPrimitiveFinset` (no divisibility at all), proves Primitive $\\implies$ NDTO, and proves strict separation via the $\\{2, 6, 9\\}$ counterexample: exhaustive case analysis shows NDTO holds, while $2 \\mid 6$ violates primitivity."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties of NDTO",
+      "startLine": 129,
+      "endLine": 147,
+      "summary": "Proves NDTO is hereditary (`ndto_subset`: subsets of NDTO sets are NDTO) and that any pair satisfies NDTO vacuously (`ndto_pair`), since the condition only constrains triples of distinct elements."
+    },
+    {
+      "id": "extremal-function-properties",
+      "title": "Properties of the Extremal Function",
+      "startLine": 149,
+      "endLine": 189,
+      "summary": "Proves $f$ is monotone non-decreasing (`maxNDTOSize_mono`), that singletons are NDTO (`ndto_singleton`), and the elementary bounds $f(n) \\geq 1$ for $n \\geq 1$ (`maxNDTOSize_ge_one`) and $f(n) \\leq n$ (`maxNDTOSize_le`)."
     }
   ],
   "conclusion": {
-    "summary": "This formalization captures Erdős Problem 1062: the extremal theory of \"no divides two others\" subsets of $\\{1,\\ldots,n\\}$. The lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ is proved constructively via the interval $[n/3+1, n]$, the primitive-NDTO comparison is fully proved (including the $\\{2,6,9\\}$ counterexample), and Lebensold's bounds and limiting density are axiomatized as deep results.",
+    "summary": "This formalization captures Erdős Problem 1062: the extremal theory of \"no divides two others\" subsets of $\\{1,\\ldots,n\\}$. The lower bound $f(n) \\geq \\lceil 2n/3 \\rceil$ is proved constructively via the interval $[n/3+1, n]$, the primitive-NDTO comparison is fully proved (including the $\\{2,6,9\\}$ counterexample), and Lebensold's bounds and limiting density are documented as deep results (in docstrings, not axiomatized — the file has 0 axioms and 0 sorries).",
     "implications": "**Theoretical Significance**: Resolution of the irrationality question would illuminate a fundamental phenomenon in extremal combinatorics: whether densities of divisibility-restricted sets are governed by rational or irrational constants.\n\nThe tight bounds $[0.6725, 0.6736]$ suggest the answer might require new techniques combining analytic number theory (to understand the divisibility structure of $[n]$) with combinatorial optimization. The recent progress on primitive sets (Lichtman 2022) may provide methodological inspiration.",
     "openQuestions": [
       "Is $\\lambda = \\lim f(n)/n$ irrational? No rational $p/q$ with small denominator fits within $[0.6725, 0.6736]$.",


### PR DESCRIPTION
## Summary

Metadata-accuracy fixes for the Erdős #1062 gallery entry (`Proofs/Erdos1062Problem.lean`, 0 axioms / 0 sorries / 10 theorems / 189 lines).

**1. Phantom-axiom prose.** Several places claimed Lebensold's bounds and the limiting density were "axiomatized as deep results", but the file has **0 axioms**: those bounds are docstring commentary and `ErdosProblem1062` is a `def`. Corrected:
- `lebensold-bounds` section summary
- `conjectures` section summary
- `proofStrategy`
- `conclusion.summary`

**2. Stale section line ranges.** All section ranges were shifted ~6–20 lines behind the actual code (gallery rendered the wrong source per section). Realigned every section to the file's `## Section N` markers.

**3. Two missing sections added.** The meta had 7 sections; the file has 8. Added:
- `structural-properties` (129–147): `ndto_subset`, `ndto_pair`
- `extremal-function-properties` (149–189): `maxNDTOSize_mono`, `ndto_singleton`, `maxNDTOSize_ge_one`, `maxNDTOSize_le`

Top-level counts and `status`/`badge` (`axiomatized`/`wip` — the policy-correct posture for an open problem) were already accurate and are unchanged.

## Test plan
- [x] `meta.json` validated with `json.load` (9 sections)
- [x] Line ranges + axiom claims cross-checked against `git show origin/main:proofs/Proofs/Erdos1062Problem.lean`
- [x] Confirmed 0 axioms, 0 sorries in the actual file