### PR TITLE
audit(erdos-382): restore theoremCount 11 → 18 (private lemmas undercounted)

### DIFF
--- a/src/data/proofs/erdos-382/meta.json
+++ b/src/data/proofs/erdos-382/meta.json
@@ -67,7 +67,7 @@
     "axiomCount": 1,
     "lineCount": 659,
     "assumptions": "1 axiom: ramachandra_bound. 0 sorries.",
-    "theoremCount": 11,
+    "theoremCount": 18,
     "definitionCount": 9
   },
   "overview": {
@@ -208,7 +208,7 @@
     "namespace": "Erdos382",
     "lineCount": 659,
     "axiomCount": 1,
-    "theoremCount": 11,
+    "theoremCount": 18,
     "definitionCount": 9,
     "path": "Proofs/Erdos382Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Integrity Issue

**Proof**: erdos-382
**Problem**: `theoremCount` was reduced 18 → 11 by #23392 based on a grep that missed 7 `private lemma` declarations.

## Evidence

`Proofs/Erdos382Problem.lean` (comment-stripped) declares:
- 11 public `theorem`
- 7 `private lemma` (foldl_max_*, primeFactorsList_ne_nil, factorization_finset_prod_id, log_sq_lt_rpow)
- **= 18 declarations**

#23392's commit message asserted "11 theorems (0 lemmas)" — it grepped only `^theorem`/`^lemma` and never matched the `private ` prefix.

**Gallery convention counts private lemmas** — confirmed by sibling files corrected in the same recent batch:
- erdos-341: `theoremCount` 11 = 8 theorem + 3 private lemma
- erdos-1062: `theoremCount` 10 = 9 theorem + 1 private lemma

So the original 18 was correct; #23392 introduced a 39% undercount.

## Fix

Restore `theoremCount` to 18 in both the `meta` and `leanFile` blocks. Data-only; build unaffected. axiomCount (1), sorries (0), definitionCount (9) all verified accurate.

---
Discovered during gallery integrity audit.