### PR TITLE
research(erdos-160): realign section ranges to # Part markers + fix h(N) phantom-axiom prose

### DIFF
--- a/src/data/proofs/erdos-160/meta.json
+++ b/src/data/proofs/erdos-160/meta.json
@@ -36,64 +36,64 @@
     {
       "id": "imports",
       "title": "Imports and Setup",
-      "startLine": 21,
-      "endLine": 30,
+      "startLine": 1,
+      "endLine": 33,
       "summary": "Imports Mathlib libraries for natural numbers, finite sets, real numbers, and tactics. Opens `Finset` and creates the `Erdos160` namespace.",
       "mathContext": "Mathematical content: Imports Mathlib libraries for natural numbers, finite sets, real numbers, and tactics. Opens `Finset` and creates the `Erdos160` namespace."
     },
     {
       "id": "definitions",
       "title": "Basic Definitions",
-      "startLine": 31,
-      "endLine": 58,
+      "startLine": 34,
+      "endLine": 61,
       "summary": "Defines 4-APs (`Is4AP`), color counting (`colorCount4`), the 3-diversity condition (`Is3DiverseOn4AP`), and the achievability predicate (`Achievable`).",
       "mathContext": "Formal definition: Defines 4-APs (`Is4AP`), color counting (`colorCount4`), the 3-diversity condition (`Is3DiverseOn4AP`), and the achievability predicate (`Achievable`)."
     },
     {
       "id": "structural",
       "title": "Structural Properties",
-      "startLine": 59,
-      "endLine": 89,
+      "startLine": 62,
+      "endLine": 106,
       "summary": "Proves trivial achievability for $n = 0$ and $n \\le 3$, color monotonicity, and $n$-monotonicity. Establishes that achievability is well-behaved.",
       "mathContext": "Verified: Proves trivial achievability for $n = 0$ and $n \\le 3$, color monotonicity, and $n$-monotonicity. Establishes that achievability is well-behaved."
     },
     {
       "id": "h-function",
       "title": "The Function h(N)",
-      "startLine": 90,
-      "endLine": 157,
-      "summary": "Axiomatizes $h(N)$ as the minimum colors for 3-diverse coloring. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring.",
-      "mathContext": "Verified: Axiomatizes $h(N)$ as the minimum colors for 3-diverse coloring. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring."
+      "startLine": 107,
+      "endLine": 175,
+      "summary": "Defines $h(N)$ constructively via `sInf` (well-ordering of ℕ) as the minimum colors for 3-diverse coloring — not an axiom. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring.",
+      "mathContext": "Verified: $h(N)$ is a constructive `def` (via `sInf`), eliminating 3 former axioms. Proves $h(N) \\ge 1$ for $N \\ge 4$, monotonicity, $h(0) = 0$, $h(N) \\le 1$ for $N \\le 3$, and $h(N) \\le N$ via the identity coloring."
     },
     {
       "id": "upper-bounds",
       "title": "Known Upper Bounds",
-      "startLine": 158,
-      "endLine": 173,
+      "startLine": 176,
+      "endLine": 191,
       "summary": "Axiomatizes $h(N) \\le C N^{2/3}$ (LeechLattice) and the improved $h(N) \\le C N^{\\log 3/\\log 22 + \\varepsilon}$ (Hunter, $\\approx N^{0.356}$).",
       "mathContext": "Axiomatized: Axiomatizes $h(N) \\le C N^{2/3}$ (LeechLattice) and the improved $h(N) \\le C N^{\\log 3/\\log 22 + \\varepsilon}$ (Hunter, $\\approx N^{0.356}$)."
     },
     {
       "id": "lower-bounds",
       "title": "Known Lower Bounds",
-      "startLine": 174,
-      "endLine": 184,
+      "startLine": 192,
+      "endLine": 202,
       "summary": "Axiomatizes $h(N) \\ge \\exp(c(\\log N)^{1/9})$ via Hunter's reduction from 3-AP-free set bounds (Kelley\u2013Meka 2023).",
       "mathContext": "Axiomatized: Axiomatizes $h(N) \\ge \\exp(c(\\log N)^{1/9})$ via Hunter's reduction from 3-AP-free set bounds (Kelley\u2013Meka 2023)."
     },
     {
       "id": "consequences",
       "title": "Consequences",
-      "startLine": 185,
-      "endLine": 204,
+      "startLine": 203,
+      "endLine": 235,
       "summary": "Derives sublinear growth, unboundedness of $h$, and the numerical fact $\\log 3/\\log 22 < 2/3$ confirming Hunter improves LeechLattice.",
       "mathContext": "Verified: Derives sublinear growth, unboundedness of $h$, and the numerical fact $\\log 3/\\log 22 < 2/3$ confirming Hunter improves LeechLattice."
     },
     {
       "id": "main-problem",
       "title": "The Open Problem and Summary",
-      "startLine": 205,
-      "endLine": 225,
+      "startLine": 236,
+      "endLine": 256,
       "summary": "States ErdosProblem160 asking for the true growth rate of $h(N)$. Summary theorem packages both known bounds into a conjunction.",
       "mathContext": "Verified: States ErdosProblem160 asking for the true growth rate of $h(N)$. Summary theorem packages both known bounds into a conjunction."
     }
@@ -102,7 +102,7 @@
     "historicalContext": "Erd\u0151s and Freud originally studied colorings of $\\{1,\\ldots,N\\}$ where arithmetic progressions are constrained in their color usage, extending the classical van der Waerden theorem from monochromatic to rainbow-type conditions. The specific version for 4-APs with at least 3 colors was formalized on the Erd\u0151s Problems website. Progress on this problem has come from unexpected sources: the user 'LeechLattice' on MathOverflow gave the first polynomial upper bound $h(N) = O(N^{2/3})$, and Zachary Hunter subsequently improved this to $O(N^{\\log 3/\\log 22}) \\approx O(N^{0.356})$ using a recursive construction. The lower bound was dramatically improved by the Kelley\u2013Meka breakthrough (2023) on 3-AP-free sets, which showed $r_3(N) \\le N \\exp(-c(\\log N)^{1/12})$. Hunter observed that this implies $h(N) \\ge \\exp(c(\\log N)^{1/9})$, a superpolynomial lower bound. The gap between polynomial upper and superlogarithmic lower bounds remains enormous and is one of the most striking open problems in quantitative Ramsey theory for arithmetic progressions.",
     "problemStatement": "Let $h(N)$ be the minimum $k$ such that $\\{1,\\ldots,N\\}$ can be $k$-colored so that every 4-term arithmetic progression uses at least 3 distinct colors. Estimate $h(N)$. Current bounds: $\\exp(c(\\log N)^{1/9}) \\le h(N) \\le O(N^{\\log 3/\\log 22 + o(1)})$.",
     "text": "Let h(N) be the minimum colors so that every 4-AP in {1,...,N} uses \u2265 3 colors. Known: exp(c(log N)^{1/9}) \u2264 h(N) \u2264 N^{log3/log22+o(1)}. Close the gap. Open.",
-    "proofStrategy": "The formalization first defines the combinatorial setup: 4-APs, the 3-diversity condition, and achievability. It then axiomatizes $h(N)$ as the minimum achievable color count and proves basic properties (monotonicity, trivial bounds, $h(N) \\le N$). The known upper bounds (LeechLattice's $N^{2/3}$ and Hunter's $N^{0.356}$) and the lower bound ($\\exp(c(\\log N)^{1/9})$ via Kelley\u2013Meka) are axiomatized. Consequences (sublinearity, unboundedness) are derived. The open problem asks for the true growth rate.",
+    "proofStrategy": "The formalization first defines the combinatorial setup: 4-APs, the 3-diversity condition, and achievability. It then defines $h(N)$ constructively via `sInf` as the minimum achievable color count (not an axiom) and proves basic properties (monotonicity, trivial bounds, $h(N) \\le N$). The known upper bounds (LeechLattice's $N^{2/3}$ and Hunter's $N^{0.356}$) and the lower bound ($\\exp(c(\\log N)^{1/9})$ via Kelley\u2013Meka) are axiomatized. Consequences (sublinearity, unboundedness) are derived. The open problem asks for the true growth rate.",
     "keyInsights": [
       "**3-diversity is strictly stronger than anti-monochromatic**: Requiring $\\ge 3$ colors on every 4-AP is much harder to achieve than $\\ge 2$, creating a rich extremal problem between trivial and rainbow colorings",
       "**The identity coloring gives $h(N) \\le N$, but $h$ grows much slower**: The proved bounds show $h(N) = O(N^{0.356})$, so most of the $N$ colors are unnecessary \u2014 the optimal coloring reuses colors heavily",


### PR DESCRIPTION
## Summary

Metadata-accuracy fixes for the Erdős #160 gallery entry (`Proofs/Erdos160Problem.lean`, 3 axioms / 2 sorries / 16 theorems / 256 lines).

**1. Stale section ranges.** All 8 section ranges were misaligned; the back half was systematically shifted so the 3 bound axioms fell under wrong labels and the entire open-problem section was undocumented. Remapped to the file's `# Part N` markers:

| section | lines |
|---|---|
| imports | 1–33 |
| definitions | 34–61 |
| structural | 62–106 |
| h-function | 107–175 |
| upper-bounds | 176–191 |
| lower-bounds | 192–202 |
| consequences | 203–235 |
| main-problem | 236–256 |

Previously the last section ended at line 225, leaving `hunter_improves_leechlattice` (L226), `ErdosProblem160` def (L243), and `summary` (L249) undocumented.

**2. Phantom-axiom prose.** The `h-function` summary/mathContext and `proofStrategy` said `h(N)` is "axiomatized", but it is a constructive `def` via `sInf` — the file docstring notes this "eliminat[ed] 3 former axioms (h, h_achievable, h_minimal)". Corrected. The upper/lower-bound "axiomatized" mentions are accurate (those are the 3 real axioms) and were left unchanged.

Top-level counts and the `assumptions` field were already accurate.

## Test plan
- [x] `meta.json` validated with `json.load` (8 sections)
- [x] Ranges mapped to the file's `# Part N` markers via `git show origin/main:proofs/Proofs/Erdos160Problem.lean`
- [x] Confirmed 3 axioms (L182/188/199), 2 sorries (L213/220), and `h` as a `def` (L128)