### PR TITLE
research(szemeredi-full): document monotonicity corollaries (8→9 sections)

### DIFF
--- a/src/data/proofs/szemeredi-full/meta.json
+++ b/src/data/proofs/szemeredi-full/meta.json
@@ -139,9 +139,17 @@
       "id": "full-theorem",
       "title": "Full Szemeredi Theorem Assembly",
       "startLine": 315,
-      "endLine": 335,
+      "endLine": 342,
       "summary": "Assembles the full theorem via `Nat.lt_or_ge k 4` and `interval_cases k`. For k<4, enumerates k=1,2,3 with their dedicated proofs. For k>=4, invokes the axiom. The corollary `dense_set_has_long_ap` provides a readable API entry point. This modular structure ensures future k>=4 proofs need only replace one axiom.",
       "mathContext": "$\\text{szemeredi\\_theorem} : \\text{SzemerediTheorem}$, proved by cases $k \\in \\{1,2,3\\}$ plus axiom for $k \\geq 4$."
+    },
+    {
+      "id": "monotonicity-corollaries",
+      "title": "Monotonicity Corollaries",
+      "startLine": 343,
+      "endLine": 373,
+      "summary": "Structural corollaries proved from the definitions: `hasAP_mono` (longer-AP containment implies shorter), `hasAP_superset` (AP membership is monotone in the set), `szemeredi_mono` (the density conclusion descends from k to j ≤ k), and `ap_free_density_bound`.",
+      "mathContext": "$j \\le k$: $\\text{HasAPOfLength}(S,k) \\Rightarrow \\text{HasAPOfLength}(S,j)$; $S \\subseteq T$: $\\text{HasAPOfLength}(S,k) \\Rightarrow \\text{HasAPOfLength}(T,k)$."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary

The Szemerédi gallery entry (`Proofs/SzemerediTheorem.lean`, 374 lines, 1 axiom / 0 sorries / 16 theorems) had 8 sections ending at line 335, leaving 4 theorems at lines 343-373 undocumented: `hasAP_mono`, `hasAP_superset`, `szemeredi_mono`, `ap_free_density_bound`.

- Extended `full-theorem` 335 → 342 (to fully cover `dense_set_has_long_ap`).
- Added a `monotonicity-corollaries` section (343-373).

The existing 8 sections were already well-aligned (no drift). Top-level counts and `assumptions` were already accurate. Metadata only; no Lean change.

## Test plan
- [x] `meta.json` validated with `json.load` (9 sections)
- [x] Decl positions confirmed via `git show origin/main:proofs/Proofs/SzemerediTheorem.lean`
- [x] Counts (1 axiom `szemeredi_k_ge_4`, 16 theorems) match the file