### PR TITLE
research(binomial-theorem-oq-02...): fix end-section ranges to cover sum-transfer theorem

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-01/meta.json
@@ -98,14 +98,14 @@
       "id": "sec-examples",
       "title": "Concrete Computations",
       "startLine": 132,
-      "endLine": 155,
+      "endLine": 140,
       "summary": "Verifies: 3 compositions of 2 into Fin 2 parts, 6 into Fin 3 parts, dice multinomial = 6!."
     },
     {
       "id": "sec-sum-transfer",
       "title": "Sum Transfer via Bijection",
-      "startLine": 157,
-      "endLine": 170,
+      "startLine": 141,
+      "endLine": 184,
       "summary": "sum_composition_eq_piAntidiag_sum: any sum over Composition can be rewritten as a sum over piAntidiag. Key for applying the multinomial theorem."
     }
   ],


### PR DESCRIPTION
## Summary

Small section-range fix for `Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean` (185 lines, 0 axioms / 0 sorries / verified).

`sec-sum-transfer` claimed lines 157-170 but the theorem it documents — `sum_composition_eq_piAntidiag_sum` — is at line 145, and `sec-examples` (132-155) overlapped it, leaving lines 171-184 undocumented. Corrected:
- `sec-examples` 132-155 → 132-140 (the dice/computation examples)
- `sec-sum-transfer` 157-170 → 141-184 (the sum-transfer theorem + its docstring)

Counts were already correct: the file's 4 "sorry" tokens are docstring references to the *parent* file, not tactic sorries (the `verified`/`original` badge is accurate). Metadata only; no Lean change.

## Test plan
- [x] `meta.json` validated with `json.load`
- [x] Decl positions confirmed via `git show origin/main:proofs/Proofs/BinomialTheoremOQ02OQ01OQ01OQ01.lean`