### PR TITLE
research(e-transcendental-oq-03): realign sections to PART markers (6→7)

### DIFF
--- a/src/data/proofs/e-transcendental-oq-03/meta.json
+++ b/src/data/proofs/e-transcendental-oq-03/meta.json
@@ -65,51 +65,59 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Setup",
+      "startLine": 1,
+      "endLine": 77,
+      "summary": "Module docstring defining the irrationality measure and stating the result μ(e) = 2, with references, `maxHeartbeats`/`noncomputable` options, `open Real`, and the `ETranscendentalOQ03` namespace.",
+      "mathContext": "The irrationality measure $\\mu(x) = \\sup\\{p : \\text{LiouvilleWith}(p, x)\\}$; the file proves $\\mu(e) = 2$."
+    },
+    {
       "id": "liouville-with",
-      "title": "Irrationality Measure via LiouvilleWith",
-      "startLine": 64,
-      "endLine": 79,
+      "title": "Part I — Irrationality Measure via LiouvilleWith",
+      "startLine": 78,
+      "endLine": 96,
       "summary": "Connection between irrationality measure and Mathlib's LiouvilleWith: mu(x) = sup{p : LiouvilleWith p x}.",
       "mathContext": "The irrationality measure $\\mu(x) = \\sup\\{p \\in \\mathbb{R} : \\text{LiouvilleWith}(p, x)\\}$. So $\\mu(x) = 2$ iff LiouvilleWith 2 x and $\\neg$ LiouvilleWith p x for p > 2."
     },
     {
       "id": "lower-bound",
-      "title": "Lower Bound: mu(e) >= 2",
-      "startLine": 80,
-      "endLine": 102,
-      "summary": "By Dirichlet's approximation theorem, every irrational has irrationality measure >= 2.",
+      "title": "Part II — Lower Bound: mu(e) >= 2",
+      "startLine": 97,
+      "endLine": 212,
+      "summary": "Proves the lower bound: `rat_approx_bounded_den_finite` and `irrational_liouvilleWith_two` give that every irrational has measure ≥ 2 (Dirichlet), and `e_liouvilleWith_two` instantiates this for e.",
       "mathContext": "Dirichlet's theorem: for irrational $\\alpha$ and $N \\geq 1$, $\\exists p/q$ with $1 \\leq q \\leq N$ and $|\\alpha - p/q| < 1/(qN) \\leq 1/q^2$. This gives infinitely many such approximations, so LiouvilleWith 2 $\\alpha$."
     },
     {
       "id": "upper-bound",
-      "title": "Upper Bound: mu(e) <= 2",
-      "startLine": 103,
-      "endLine": 139,
-      "summary": "From the regular continued fraction of e = [2; 1, 2, 1, 1, 4, ...], the partial quotients grow linearly, bounding approximation quality to quadratic.",
-      "mathContext": "The CF $e = [2; 1, 2k, 1]_{k \\geq 1}$ has $a_n = O(n)$, so $q_{n+1} \\leq (a_{n+1}+1)q_n$ gives $q_n \\leq C^n$. Best approximation: $|e - p_n/q_n| \\asymp 1/(q_n q_{n+1})$. Since $q_{n+1}/q_n$ is bounded, $|e - p_n/q_n| \\geq c/q_n^2$, giving $\\mu(e) \\leq 2$."
+      "title": "Part III — Upper Bound: mu(e) <= 2",
+      "startLine": 213,
+      "endLine": 249,
+      "summary": "The upper bound `e_not_liouvilleWith_gt_two` (¬LiouvilleWith p e for p > 2) — the file's sole axiom, justified in the docstring by the continued fraction of e (partial quotients grow linearly, bounding approximation to quadratic).",
+      "mathContext": "The CF $e = [2; 1, 2k, 1]_{k \\geq 1}$ has $a_n = O(n)$, so $q_{n+1} \\leq (a_{n+1}+1)q_n$ gives $q_n \\leq C^n$. Best approximation: $|e - p_n/q_n| \\asymp 1/(q_n q_{n+1})$. Since $q_{n+1}/q_n$ is bounded, $|e - p_n/q_n| \\geq c/q_n^2$, giving $\\mu(e) \\leq 2$. Axiomatized as `e_not_liouvilleWith_gt_two`."
     },
     {
       "id": "main-result",
-      "title": "Main Result: mu(e) = 2",
-      "startLine": 140,
-      "endLine": 150,
-      "summary": "Combining lower and upper bounds: the irrationality measure of e is exactly 2.",
-      "mathContext": "$\\mu(e) = 2$ since LiouvilleWith 2 (exp 1) holds (Dirichlet) and $\\neg$ LiouvilleWith p (exp 1) for p > 2 (CF analysis)."
+      "title": "Part IV — Main Result: mu(e) = 2",
+      "startLine": 250,
+      "endLine": 261,
+      "summary": "`e_irrationality_measure_eq_two`: combining the lower and upper bounds, the irrationality measure of e is exactly 2.",
+      "mathContext": "$\\mu(e) = 2$ since LiouvilleWith 2 (exp 1) holds (Dirichlet) and $\\neg$ LiouvilleWith p (exp 1) for p > 2 (the axiom)."
     },
     {
       "id": "consequences",
-      "title": "Consequences",
-      "startLine": 151,
-      "endLine": 170,
-      "summary": "e is not a Liouville number (proved from the upper bound), and e is irrational (from the lower bound).",
+      "title": "Part V — Consequences",
+      "startLine": 262,
+      "endLine": 278,
+      "summary": "`e_not_liouville` (e is not a Liouville number, from the upper bound) and `e_irrational_from_measure` (e is irrational, from the lower bound).",
       "mathContext": "Since $\\mu(e) = 2 < \\infty$, $e$ is not Liouville (Liouville numbers have $\\mu = \\infty$). From LiouvilleWith 2 e with 2 > 1, irrationality of e follows."
     },
     {
       "id": "context",
-      "title": "Context and Comparisons",
-      "startLine": 171,
-      "endLine": 206,
-      "summary": "Comparison of irrationality measures across mathematical constants and discussion of why mu(e) = 2 is remarkable despite being the generic value.",
+      "title": "Part VI — Context and Comparisons",
+      "startLine": 279,
+      "endLine": 312,
+      "summary": "Docstring comparison of irrationality measures across mathematical constants and discussion of why mu(e) = 2 is remarkable despite being the generic value.",
       "mathContext": "$\\mu(\\text{rational}) = 1$, $\\mu(\\text{algebraic irrational}) = 2$ (Roth), $\\mu(e) = \\mu(e^2) = 2$, $2 \\leq \\mu(\\pi) \\leq 7.103$, $\\mu(\\text{Liouville}) = \\infty$. Almost all reals have $\\mu = 2$ (Khinchin)."
     }
   ],


### PR DESCRIPTION
## Summary

The e-transcendental (μ(e)=2) gallery entry (`Proofs/ETranscendentalOQ03.lean`, 312 lines, 1 axiom / 0 sorries) had all 6 sections shifted ~110 lines earlier than their actual content. Sections ended at line 206, leaving the last ~106 lines undocumented — including the **sole axiom** `e_not_liouvilleWith_gt_two` (L247) and 4 theorems.

Remapped each section to the file's `PART N` markers and added a preamble:

| section | lines |
|---|---|
| preamble | 1–77 |
| liouville-with (Part I) | 78–96 |
| lower-bound (Part II) | 97–212 |
| upper-bound (Part III) | 213–249 |
| main-result (Part IV) | 250–261 |
| consequences (Part V) | 262–278 |
| context (Part VI) | 279–312 |

Also named the concrete results per section and noted that the upper bound (`e_not_liouvilleWith_gt_two`) is the axiomatized result. Top-level counts (1 axiom, 0 sorries) were already accurate.

## Test plan
- [x] `meta.json` validated with `json.load` (7 sections)
- [x] Ranges mapped to the file's `PART N` markers via `git show origin/main:proofs/Proofs/ETranscendentalOQ03.lean`
- [x] Confirmed sole axiom `e_not_liouvilleWith_gt_two` at L247