### PR TITLE
research(binary-gcd-oq-01): realign sections (5→7), drop phantom symmetry section

### DIFF
--- a/src/data/proofs/binary-gcd-oq-01/meta.json
+++ b/src/data/proofs/binary-gcd-oq-01/meta.json
@@ -58,7 +58,7 @@
     "historicalContext": "**Two Algorithms for the Same Problem**\n\nThe Euclidean algorithm — described in Book VII of Euclid's *Elements* (~300 BCE) — computes gcd(a,b) via repeated division: (a,b) → (b, a mod b). It is one of the oldest known algorithms. Gabriel Lamé's 1844 analysis in *Comptes Rendus* proved that the algorithm takes at most 5d steps where d is the number of decimal digits of the smaller input — one of the first formal complexity analyses in history, predating computer science by a century. Lamé's proof used the key insight that Fibonacci pairs (F_n, F_{n-1}) are the worst case: the quotient is always 1, forcing the maximum number of steps.\n\nBinary GCD (Stein's algorithm) was published by Josef Stein in 1967, though the core idea was known to programmers working on early binary computers. The algorithm replaces expensive division with bit shifts (halving by 2) and subtraction — operations that are far cheaper on binary hardware. On multi-precision integers (as used in cryptography), the savings are dramatic since division is O(n²) in the number of limbs while shifting is O(n).\n\nThe formal comparison formalized here reveals the asymmetry: Binary GCD uses *more* steps but cheaper ones; the total operation count (weighted by hardware cost) often favors Binary GCD for large inputs. This is a recurring theme in algorithm analysis: step count alone doesn't determine practical efficiency.",
     "problemStatement": "Compare the formal step counts of the Binary GCD algorithm and the Euclidean algorithm:\n1. Define step counting functions for both algorithms\n2. Compute concrete step counts for specific inputs\n3. Prove logarithmic upper bounds on both step counts\n4. Characterize the worst-case inputs (Fibonacci numbers for Euclidean)",
     "text": "Formal step count comparison between Binary GCD and the Euclidean algorithm.",
-    "proofStrategy": "1. Define recursive step counters matching the algorithm structure\n2. Prove basic properties (symmetry, zero cases)\n3. Use native_decide for concrete examples\n4. State logarithmic bounds (Lamé for Euclidean, bit-length for Binary GCD)",
+    "proofStrategy": "1. Define recursive step counters matching the algorithm structure\n2. Prove basic properties (zero base cases; euclidSteps_eq_ordered reduces to the max/min-ordered form)\n3. Use native_decide for concrete examples\n4. Prove logarithmic bounds (Lamé for Euclidean via GCDAlgorithmOQ01, log-potential bound for Binary GCD)",
     "keyInsights": [
       "Binary GCD uses more steps than Euclidean (5 vs 2 for gcd(12,8), 10 vs 6 for gcd(100,37)) but each step is O(1) bit operations vs O(n) for division in multi-precision",
       "Fibonacci consecutive pairs are worst-case for Euclidean: gcd(F_{n+1}, F_n) takes exactly n steps since each quotient F_{n+1}/F_n ≈ φ; the concrete example gcd(89,55) takes 9 Euclidean vs 8 Binary steps",
@@ -74,44 +74,59 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 19,
+      "summary": "Module docstring (Binary GCD vs Euclidean step-count comparison, references Stein 1967 / Lamé 1844 / Knuth), imports including GCDAlgorithmOQ01, and the BinaryGcdOQ01 namespace.",
+      "mathContext": "Compares step counts of Stein's binary GCD against the Euclidean algorithm, with asymptotic bounds."
+    },
+    {
       "id": "euclidean-steps",
       "title": "Euclidean Algorithm Step Count",
-      "startLine": 28,
-      "endLine": 55,
-      "summary": "Defines euclidSteps and proves base cases (zero inputs, divisibility).",
+      "startLine": 20,
+      "endLine": 34,
+      "summary": "Defines `euclidSteps` (recursive, handling the a<b swap internally) with a termination_by a+b proof.",
       "mathContext": "The Euclidean algorithm: gcd(a,b) = gcd(b, a mod b). Each mod operation counts as one step."
     },
     {
       "id": "binary-gcd-steps",
       "title": "Binary GCD Step Count",
-      "startLine": 57,
-      "endLine": 90,
-      "summary": "Defines binaryGcdSteps matching the four cases of Stein's algorithm.",
+      "startLine": 35,
+      "endLine": 59,
+      "summary": "Defines `binaryGcdSteps` matching the cases of Stein's algorithm, plus the zero-base simp lemmas.",
       "mathContext": "Binary GCD cases: both even (extract 2), one even (drop 2), both odd (subtract and halve). Each case counts as one step."
     },
     {
       "id": "concrete",
       "title": "Concrete Step Counts",
-      "startLine": 92,
-      "endLine": 115,
+      "startLine": 60,
+      "endLine": 70,
       "summary": "Computes step counts for gcd(12,8), gcd(21,15), gcd(100,37), gcd(89,55) via native_decide.",
-      "mathContext": "Fibonacci inputs (89,55) are worst-case for Euclidean (9 steps). Binary GCD uses 11 steps on the same input."
+      "mathContext": "Fibonacci inputs (89,55) are worst-case for Euclidean (9 steps); binary GCD takes 8 steps on the same input."
     },
     {
-      "id": "symmetry",
-      "title": "Symmetry Proofs",
-      "startLine": 117,
-      "endLine": 155,
-      "summary": "Both step counts are symmetric: steps(a,b) = steps(b,a).",
-      "mathContext": "Symmetry follows from the symmetry of gcd: gcd(a,b) = gcd(b,a)."
+      "id": "lame-theorem",
+      "title": "Lamé's Theorem",
+      "startLine": 71,
+      "endLine": 126,
+      "summary": "`euclidSteps_eq_ordered` (private): euclidSteps a b = euclideanSteps (max a b) (min a b), bridging to GCDAlgorithmOQ01; then `euclidSteps_le_log` proves Lamé's logarithmic bound.",
+      "mathContext": "Lamé (1844): euclidSteps a b ≤ 2·log₂(min(a,b)) + 2, reusing the bound proved in GCDAlgorithmOQ01."
     },
     {
-      "id": "bounds",
-      "title": "Logarithmic Bounds",
-      "startLine": 157,
-      "endLine": 185,
-      "summary": "Proves Lamé's theorem and the Binary GCD logarithmic bound (0 sorries).",
-      "mathContext": "Lamé (1844): Euclidean steps ≤ O(log min(a,b)). Binary GCD: steps ≤ O(log a + log b)."
+      "id": "binary-gcd-bound",
+      "title": "Binary GCD Step Bound",
+      "startLine": 127,
+      "endLine": 205,
+      "summary": "`binaryGcdSteps_le_log`: the binary GCD logarithmic bound, proved by strong induction with a log₂a + log₂b potential that decreases by ≥1 each step (0 sorries).",
+      "mathContext": "binaryGcdSteps a b ≤ 2·(log₂ a + log₂ b) + 2."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 206,
+      "endLine": 215,
+      "summary": "Closing docstring recapping the verified comparison: both logarithmic bounds proved, 0 axioms / 0 sorries."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Metadata fixes for `Proofs/BinaryGcdOQ01.lean` (215 lines, 0 axioms / 0 sorries).

- **Phantom section removed**: the meta had a "symmetry" section claiming "both step counts are symmetric: steps(a,b) = steps(b,a)", but the file proves no symmetry theorem (it has `euclidSteps_eq_ordered` about max/min ordering). Replaced with the actual `lame-theorem` section.
- **Misaligned ranges**: sections were shifted ~30 lines early, leaving the binary-GCD bound proof tail and summary undocumented. Remapped to the file's `/-! ## ` markers: preamble 1-19, euclidean-steps 20-34, binary-gcd-steps 35-59, concrete 60-70, lame-theorem 71-126, binary-gcd-bound 127-205, summary 206-215.
- **Factual fix**: the concrete section's mathContext claimed binary GCD takes "11 steps" on (89,55), but the file's own `native_decide` example asserts `binaryGcdSteps 89 55 = 8`. Also removed the "symmetry" reference from `proofStrategy`.

Counts (0 axioms, 0 sorries) were already accurate. Metadata only; no Lean change.

## Test plan
- [x] `meta.json` validated with `json.load` (7 sections)
- [x] Ranges + step counts cross-checked against `git show origin/main:proofs/Proofs/BinaryGcdOQ01.lean`