### PR TITLE
research(erdos-1018-oq-04-incomplete-01): rebuild sections to match file (5→8)

### DIFF
--- a/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
+++ b/src/data/proofs/erdos-1018-oq-04-incomplete-01/meta.json
@@ -55,40 +55,63 @@
       "id": "header-imports",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 39,
-      "summary": "Module header with imports, docstring, and namespace setup."
+      "endLine": 42,
+      "summary": "Module header with imports, docstring (this file resolves the parent's isEmbeddable sorry with a concrete definition), and the Erdos1018OQ04Completion namespace."
     },
     {
       "id": "concrete-def",
-      "title": "Concrete isEmbeddable Definition",
-      "startLine": 40,
-      "endLine": 65,
-      "summary": "Defines isEmbeddableConc via vertex maps φ : V → Fin d → ℝ with convex hull separation. Proves injectivity and monotonicity in d (higher-dimensional spaces only help).",
+      "title": "Part I — Concrete isEmbeddable Definition",
+      "startLine": 43,
+      "endLine": 59,
+      "summary": "Defines isEmbeddableConc via vertex maps φ : V → Fin d → ℝ with convex hull separation.",
       "mathContext": "H embeddable in ℝ^d iff ∃ injective φ : V → ℝ^d, ∀ e₁ ≠ e₂ ∈ H.edges: ConvHull(φ(e₁)) ∩ ConvHull(φ(e₂)) ⊆ ConvHull(φ(e₁ ∩ e₂))."
     },
     {
-      "id": "k3-k4-planar",
-      "title": "K₃ and K₄ Planarity",
-      "startLine": 80,
-      "endLine": 130,
-      "summary": "Provides explicit coordinate embeddings for K₃ (0,0),(1,0),(0,1) and K₄ (0,0),(3,0),(1,2),(2,2). Both injectivity and the non-crossing condition are fully proved using linear-functional projections on convex hulls.",
-      "mathContext": "K₃ at {(0,0),(1,0),(0,1)}: non-degenerate triangle. K₄ at {(0,0),(3,0),(1,2),(2,2)}: valid planar quadrilateral configuration."
+      "id": "properties-k3",
+      "title": "Part II — Properties of the Concrete Definition (incl. K₃)",
+      "startLine": 60,
+      "endLine": 233,
+      "summary": "Proves `embeddable_injective`, `embeddable_mono` (higher dimensions only help), and `K3_planar` via the explicit coordinate embedding (0,0),(1,0),(0,1) with linear-functional convex-hull arguments.",
+      "mathContext": "K₃ at {(0,0),(1,0),(0,1)}: non-degenerate triangle, embeddable in ℝ²."
+    },
+    {
+      "id": "k4-planar",
+      "title": "Part IV — K₄ is Planar",
+      "startLine": 234,
+      "endLine": 614,
+      "summary": "`K4_planar`: a fully-proved planar embedding of K₄ at (0,0),(3,0),(1,2),(2,2), establishing the non-crossing condition for all edge pairs via explicit linear functionals on convex hulls (a long, detailed proof).",
+      "mathContext": "K₄ at {(0,0),(3,0),(1,2),(2,2)}: valid planar configuration, embeddable in ℝ²."
+    },
+    {
+      "id": "graph-recovery",
+      "title": "Part V — Graph Case Recovery",
+      "startLine": 615,
+      "endLine": 635,
+      "summary": "Edge counts for complete graphs: `Kn_edges` (|E(K_n)| = C(n,2)), and the concrete `K5_edges`, `K3_edges`, `K4_edges`.",
+      "mathContext": "|E(K_n)| = \\binom{n}{2}; K5 has 10 edges, K3 has 3, K4 has 6."
     },
     {
       "id": "density",
-      "title": "Density Forces Non-Planarity",
-      "startLine": 150,
-      "endLine": 185,
-      "summary": "Proves n^(1+ε) eventually exceeds 3n (using n^ε → ∞), showing graphs with n^(1+ε) edges cannot be planar.",
-      "mathContext": "n^(1+ε) = n · n^ε → ∞ faster than 3n for ε > 0."
+      "title": "Part VI — Density and Non-Embeddability",
+      "startLine": 636,
+      "endLine": 672,
+      "summary": "`planar_graphs_edge_bound` (|E| ≤ 3|V| − 6, the file's sole sorry — Euler's formula, not yet in Mathlib) and `dense_graph_not_planar` (graphs with n^{1+ε} edges eventually exceed the planar bound).",
+      "mathContext": "Planar: |E| ≤ 3n − 6. For ε > 0, n^{1+ε} = n·n^ε eventually exceeds 3n − 6, so such graphs are non-planar."
     },
     {
       "id": "kostochka-pyber",
-      "title": "Kostochka-Pyber r=2 Case",
-      "startLine": 186,
-      "endLine": 220,
-      "summary": "Axiomatizes the r=2 case (Kostochka-Pyber 1988). Proves this implies the r=2 case of the main conjecture (up to the parent's sorry definition).",
-      "mathContext": "∀ε>0, ∃C,N: graphs on n≥N vertices with n^{1+ε} edges contain non-planar subgraph on ≤C vertices."
+      "title": "Part VII — Connection to Main Conjecture",
+      "startLine": 673,
+      "endLine": 709,
+      "summary": "The file's sole axiom `kostochka_pyber_r2` (the r=2 graph case, Kostochka–Pyber 1988) and `r2_implies_main_r2` deriving the r=2 case of the main conjecture from it.",
+      "mathContext": "∀ε>0, ∃C,N: graphs on n≥N vertices with n^{1+ε} edges contain a non-planar subgraph on ≤C vertices."
+    },
+    {
+      "id": "summary",
+      "title": "Part VIII — Summary",
+      "startLine": 710,
+      "endLine": 738,
+      "summary": "Closing docstring: the parent's isEmbeddable sorry is resolved (→ isEmbeddableConc); turanNumber and the planar edge bound remain as the remaining gaps."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The Erdős #1018 OQ-04 completion entry (`Proofs/Erdos1018OQ04Incomplete01.lean`, 738 lines, 1 axiom / 1 sorry) had 5 sections crammed into lines 1-220, leaving ~70% of the file undocumented: the large `K4_planar` proof (234-614), graph-case edge recovery, the density section (which contains the sole sorry at L652), the `kostochka_pyber_r2` axiom (L683), and the summary. The `k3-k4-planar` section also conflated K₃ (Part II) with K₄ (Part IV, a 375-line proof) while only covering K₃'s lines.

Rebuilt to the file's `## Part` markers:

| section | lines |
|---|---|
| header-imports | 1–42 |
| concrete-def (Part I) | 43–59 |
| properties-k3 (Part II) | 60–233 |
| k4-planar (Part IV) | 234–614 |
| graph-recovery (Part V) | 615–635 |
| density (Part VI) | 636–672 |
| kostochka-pyber (Part VII) | 673–709 |
| summary (Part VIII) | 710–738 |

Counts were already accurate (1 axiom `kostochka_pyber_r2`, 1 sorry `planar_graphs_edge_bound` at L652 — the other 8 "sorry" tokens are docstring references to the parent file). Metadata only; no Lean change.

## Test plan
- [x] `meta.json` validated with `json.load` (8 sections)
- [x] Section ranges + counts cross-checked against `git show origin/main:proofs/Proofs/Erdos1018OQ04Incomplete01.lean`