### PR TITLE
audit: realign drifted gallery sections (erdos-761, erdos-196)

### DIFF
--- a/src/data/proofs/erdos-196/meta.json
+++ b/src/data/proofs/erdos-196/meta.json
@@ -47,73 +47,65 @@
   "sections": [
     {
       "id": "imports",
-      "title": "Imports and Permutation Type",
+      "title": "Imports and Module Overview",
       "startLine": 21,
-      "endLine": 30,
-      "summary": "Imports Mathlib for equivalences ($\\mathbb{N} \\equiv \\mathbb{N}$), monotonicity, and tactics. Defines `Perm` as the type of bijections on $\\mathbb{N}$."
+      "endLine": 26,
+      "summary": "Imports Mathlib for equivalences ($\\mathbb{N} \\equiv \\mathbb{N}$), monotonicity, and tactics, following the opening module docstring summarizing key results and references."
     },
     {
-      "id": "ap-definitions",
-      "title": "Arithmetic Progression Definitions",
-      "startLine": 33,
-      "endLine": 42,
-      "summary": "Defines IsAP3, IsAP4, IsAP5 via constant differences $b - a = c - b = \\cdots$ with strict ordering $a < b < c < \\cdots$.",
+      "id": "core-definitions",
+      "title": "Core Definitions",
+      "startLine": 27,
+      "endLine": 43,
+      "summary": "Defines `Perm` (the type of bijections on $\\mathbb{N}$) and the progression predicates IsAP3, IsAP4, IsAP5 via constant differences $b - a = c - b = \\cdots$ with strict ordering $a < b < c < \\cdots$.",
       "mathContext": "A $k$-term arithmetic progression: $a, a+d, a+2d, \\ldots, a+(k-1)d$ with common difference $d > 0$. Here $a < b < c$ and $b - a = c - b$."
     },
     {
       "id": "monotone-aps",
       "title": "Monotone APs in Permutations",
-      "startLine": 47,
-      "endLine": 60,
+      "startLine": 44,
+      "endLine": 61,
       "summary": "HasMonotone$k$AP$(\\pi)$: $\\exists$ monotone indices with values forming a $k$-AP. Covers 3, 4, and 5-term variants.",
       "mathContext": "$\\text{HasMonotone4AP}(\\pi) \\iff \\exists i_1 < i_2 < i_3 < i_4$ with $\\pi(i_1), \\pi(i_2), \\pi(i_3), \\pi(i_4)$ forming an AP (either increasing or decreasing)."
     },
     {
       "id": "conjecture",
       "title": "The Open Conjecture ($k = 4$)",
-      "startLine": 64,
-      "endLine": 67,
-      "summary": "ErdosProblem196: $\\forall \\pi: \\mathbb{N} \\equiv \\mathbb{N},$ HasMonotone4AP$(\\pi)$. The critical threshold question.",
+      "startLine": 62,
+      "endLine": 69,
+      "summary": "ErdosProblem196: $\\forall \\pi: \\mathbb{N} \\equiv \\mathbb{N},$ HasMonotone4AP$(\\pi)$. The critical threshold question, stated as a definition since it is open.",
       "mathContext": "Conjecture: every permutation $\\pi : \\mathbb{N} \\to \\mathbb{N}$ contains a monotone 4-term AP. OPEN."
     },
     {
-      "id": "degs-results",
-      "title": "DEGS Results ($k = 3$ and $k = 5$)",
-      "startLine": 72,
-      "endLine": 77,
-      "summary": "DEGS (1977): $k = 3$ always exists (axiom), $k = 5$ can be avoided (axiom). Establishes the $k = 4$ threshold.",
-      "mathContext": "DEGS (1977): $k = 3$ — every permutation has a monotone 3-AP. $k = 5$ — there exists a permutation avoiding all monotone 5-APs. So $k = 4$ is the threshold candidate."
-    },
-    {
-      "id": "implication",
-      "title": "4-AP Implies 3-AP (Proved)",
-      "startLine": 80,
-      "endLine": 89,
-      "summary": "Lean proof that the 4-AP conjecture implies the 3-AP theorem by extracting three terms and using `omega`.",
-      "mathContext": "If $\\pi$ has a monotone 4-AP $(a, a+d, a+2d, a+3d)$, then $(a, a+d, a+2d)$ is a monotone 3-AP. Proved in Lean via index extraction and `omega`."
+      "id": "known-results",
+      "title": "Known Results ($k = 3$, $k = 5$, and 4-AP $\\Rightarrow$ 3-AP)",
+      "startLine": 70,
+      "endLine": 85,
+      "summary": "Records the DEGS (1977) results in comments — $k = 3$ always exists, $k = 5$ can be avoided — and proves `conjecture_implies_3ap`: the 4-AP conjecture implies the 3-AP theorem by extracting three terms and using `omega`.",
+      "mathContext": "DEGS (1977): $k = 3$ — every permutation has a monotone 3-AP; $k = 5$ — there exists a permutation avoiding all monotone 5-APs, so $k = 4$ is the threshold candidate. The Lean theorem shows that if $\\pi$ has a monotone 4-AP $(a, a+d, a+2d, a+3d)$, then $(a, a+d, a+2d)$ is a monotone 3-AP."
     },
     {
       "id": "parity",
       "title": "Common Difference Parity Analysis",
-      "startLine": 94,
-      "endLine": 114,
-      "summary": "Odd/even CD definitions, LeSaulnier–Vijay odd-CD avoidance (2011), parity dichotomy (proved), and the structural equivalence to even-CD forcing.",
+      "startLine": 86,
+      "endLine": 130,
+      "summary": "Odd/even CD definitions, LeSaulnier–Vijay odd-CD avoidance (2011), the parity dichotomy `ap4_parity` (proved), and the structural equivalence `conjecture_equiv_even_forced` reducing the conjecture to even-CD forcing.",
       "mathContext": "LeSaulnier-Vijay (2011): odd-CD monotone 4-APs can be avoided. So the conjecture reduces to: can *even-CD* monotone 4-APs be avoided? Parity dichotomy proved in Lean."
     },
     {
       "id": "non-extendability",
       "title": "Non-Extendability Constraints",
-      "startLine": 128,
-      "endLine": 134,
-      "summary": "If no 4-AP exists, each 3-AP forbids a value at all later monotone positions — accumulating constraints toward a contradiction.",
+      "startLine": 131,
+      "endLine": 150,
+      "summary": "`non_extendable_constraint`: if no monotone 4-AP exists, each monotone 3-AP forbids the value $a + 3d$ at all later monotone positions — accumulating constraints toward a contradiction.",
       "mathContext": "If $(a, a+d, a+2d)$ is a monotone 3-AP in $\\pi$, then $a+3d$ cannot appear at a monotone position — a forbidden value constraint."
     },
     {
       "id": "erdos-szekeres",
       "title": "Erdős–Szekeres Connection",
-      "startLine": 138,
-      "endLine": 145,
-      "summary": "Erdős–Szekeres (1935): $n > (r-1)(s-1) \\implies$ monotone subsequence of length $r$ or $s$. Gives long monotone subsequences but not APs.",
+      "startLine": 151,
+      "endLine": 155,
+      "summary": "A closing contextual note (no theorem): Erdős–Szekeres (1935) — every sequence of $(r-1)(s-1)+1$ distinct numbers has a monotone subsequence of length $r$ or $s$. Gives long monotone subsequences but not APs.",
       "mathContext": "Erdős-Szekeres: every sequence of $> (r-1)(s-1)$ distinct reals has an increasing subsequence of length $r$ or decreasing of length $s$. Gives structure but not AP structure."
     }
   ],

--- a/src/data/proofs/erdos-761/meta.json
+++ b/src/data/proofs/erdos-761/meta.json
@@ -52,43 +52,36 @@
       "id": "sec-761-header",
       "title": "Problem Overview",
       "startLine": 30,
-      "endLine": 36,
-      "summary": "Imports from `Mathlib.Combinatorics.SimpleGraph` for graph structure and coloring, plus `Mathlib.Data.Fintype.Basic` for finite vertex sets."
+      "endLine": 38,
+      "summary": "Imports from `Mathlib.Combinatorics.SimpleGraph` for graph structure and coloring, plus `Mathlib.Data.Fintype.Basic` for finite vertex sets. All declarations are wrapped in `namespace Erdos761` to avoid the `Orientation` name collision with `Mathlib.LinearAlgebra.Orientation`."
     },
     {
       "id": "sec-761-definitions",
       "title": "Core Definitions",
-      "startLine": 38,
-      "endLine": 99,
+      "startLine": 39,
+      "endLine": 98,
       "summary": "Defines `Orientation G` (directed edge assignment), `colorClassEdge` (directed edge relation within a color class), `IsAcyclicColoring` (no monochromatic directed **cycle** via `Relation.TransGen` — the correct mathematical definition from Neumann-Lara 1982), `HasAcyclicColoring`, `dichromNumber` $\\delta(G)$, `IsCochromatic` (each class is clique or independent set), and `cochromNumber` $\\zeta(G)$."
     },
     {
       "id": "sec-761-bridge",
       "title": "Bridge Lemma",
-      "startLine": 101,
-      "endLine": 127,
+      "startLine": 99,
+      "endLine": 122,
       "summary": "The key `isAcyclicColoring_of_no_mono_edge` theorem: if no directed edge is monochromatic (the stronger condition), then no directed cycle is monochromatic (the acyclic condition). This bridges proper-coloring arguments to the cycle-free definition."
     },
     {
       "id": "sec-761-properties",
-      "title": "Basic Properties",
-      "startLine": 129,
-      "endLine": 159,
-      "summary": "Establishes $\\delta(G) \\le |V|$ (injective colorings are acyclic), $\\zeta(G) \\le |V|$ (proper colorings are cochromatic), and the bipartite bound $\\delta(G) \\le 2$ for 2-colorable graphs."
+      "title": "Proved Properties (formerly axioms)",
+      "startLine": 123,
+      "endLine": 287,
+      "summary": "The `section ProvedProperties` block establishes the structural results, all fully proved: $\\delta(G) \\le \\chi(G)$ and $\\zeta(G) \\le \\chi(G)$ (`dichrom_le_chrom`, `cochrom_le_chrom`), the colorability bounds `dichrom_le_of_colorable` / `cochrom_le_of_colorable`, the lifts to Mathlib's `SimpleGraph.chromaticNumber` (`dichrom_le_chromaticNumber`, `cochrom_le_chromaticNumber`), the bipartite bound $\\delta(G) \\le 2$ (`bipartite_dichrom_le_two`), `acyclic_orientation_exists`, and subgraph monotonicity $H \\subseteq G \\Rightarrow \\delta(H) \\le \\delta(G)$ (`dichrom_mono`)."
     },
     {
       "id": "sec-761-conjectures",
-      "title": "Main Conjectures (OPEN)",
-      "startLine": 161,
-      "endLine": 183,
-      "summary": "States the two open questions as axioms: **Question 1** (Erdős-Neumann-Lara): $\\forall k,\\, \\exists f(k)$ such that $\\chi(G) \\ge f(k) \\Rightarrow \\delta(G) \\ge k$. **Question 2** (Erdős-Gimbel): $\\forall k,\\, \\exists g(k)$ such that $\\zeta(G) \\ge g(k) \\Rightarrow \\exists H \\subseteq G$ with $\\delta(H) \\ge k$."
-    },
-    {
-      "id": "sec-761-structural",
-      "title": "Known Cases and Structural Results",
-      "startLine": 185,
-      "endLine": 251,
-      "summary": "Includes the odd cycle placeholder, subgraph monotonicity $H \\subseteq G \\Rightarrow \\delta(H) \\le \\delta(G)$ (fully proved), arbitrary orientation construction, and the theorem that proper colorings are acyclic for any orientation."
+      "title": "Open Conjectures (2 axioms)",
+      "startLine": 288,
+      "endLine": 314,
+      "summary": "States the two open questions as axioms: **Question 1** (Erdős-Neumann-Lara) `erdos_761_question1`: $\\forall k,\\, \\exists f(k)$ such that $\\chi(G) \\ge f(k) \\Rightarrow \\delta(G) \\ge k$. **Question 2** (Erdős-Gimbel) `erdos_761_question2`: $\\forall k,\\, \\exists g(k)$ such that $\\zeta(G) \\ge g(k) \\Rightarrow \\exists H \\subseteq G$ with $\\delta(H) \\ge k$. These two `axiom` declarations are the only assumptions in the file."
     }
   ],
   "overview": {


### PR DESCRIPTION
Two gallery entries had section line ranges that drifted from their current Lean sources, so the gallery rendered the wrong source regions.

**erdos-761** (Proofs/Erdos761Problem.lean, 314 lines): the "Main Conjectures (OPEN)" section pointed at lines 161-183 — actually *proved* theorems inside the ProvedProperties block. The real open-conjecture axioms (erdos_761_question1/2) live at 297/308, so the gallery rendered proved theorems under the open-questions heading. Sections also stopped at 251, leaving the final 63 lines (dichrom_mono + the OPEN CONJECTURES axiom block) undocumented. Rebuilt to 5 banner-aligned sections.

**erdos-196** (Proofs/Erdos196Problem.lean, 155 lines): "Non-Extendability" and "Erdős–Szekeres Connection" were misaligned — the latter pointed at 138-145 (inside another theorem's proof body) while its actual marker is at 151 — and the final 10 lines were undocumented. Two phantom sub-sections split the file's single "Known Results" marker; merged them. Realigned all 8 sections to the file's /- ## ... -/ markers.

Metadata-only; axiom/sorry counts unchanged. Line ranges verified against actual source markers.