### PR TITLE
audit(mean-value-theorem-oq-02-oq-04-oq-01): realign drifted sections to file (6→7)

### DIFF
--- a/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
+++ b/src/data/proofs/mean-value-theorem-oq-02-oq-04-oq-01/meta.json
@@ -23,7 +23,7 @@
     "badge": "axiom",
     "sorries": 0,
     "axiomCount": 1,
-    "lineCount": 758,
+    "lineCount": 771,
     "assumptions": "1 axiom (inherited from additionalFiles only; main file declares 0 new axioms): taylor_lagrange_remainder in the grandparent file MeanValueTheoremOQ02.lean (qualitative pointwise Lagrange remainder, used to ground the Taylor-polynomial framework reused via MeanValueTheoremOQ02.taylorPolynomial / taylorPolynomial_zero). The parent file's axiom analytic_taylor_remainder_uniform_bound was retracted (S2 retraction; MeanValueTheoremOQ02OQ04.lean now declares 0 axioms) — its mathematical falsity is established by the Runge counterexample fully formalized in section 2. The S1-S2 explicit-form RHS paired with partialSum n is also shown false (off-by-one refutation in section 3a via constant-1 witness on Complex, S3 contribution). After S7, zero sorries remain. The finite-radius form cauchy_diag_norm_bound_at_radius (the per-degree Cauchy coefficient estimate at a strict intermediate radius r prime in (0, R)) was discharged in S7 via Mathlibs Complex.norm_iteratedDeriv_le_of_forall_mem_sphere_norm_le. The boundary form cauchy_diag_norm_bound (with norm of w over R) is PROVEN by limit-extraction (ContinuousAt + Filter.Tendsto along nhdsWithin Iio R + le_of_tendsto, S5 contribution). The section 3b main theorem analytic_taylor_remainder_uniform_bound_complex is fully proven.",
     "dateAdded": "2026-05-12",
     "mathlib_version": "4.26.0",
@@ -178,49 +178,60 @@
   ],
   "sections": [
     {
-      "id": "header-and-imports",
-      "title": "File Header: Imports and Refutation Summary",
+      "id": "header",
+      "title": "File Header, Imports, and Refutation Summary",
       "startLine": 1,
-      "endLine": 110,
-      "summary": "Imports Mathlib (for AnalyticOn, Set.Ioo/Icc, FormalMultilinearSeries) and the parent files Proofs.MeanValueTheoremOQ02 (for taylorPolynomial and taylorPolynomial_zero) and Proofs.MeanValueTheoremOQ02OQ04 (for namespacing context only — the parent file's axiom is not invoked). The module docstring states the OQ-01 question, the answer (NO, the parent axiom is mathematically false), gives the explicit Runge counterexample with all numerical values, identifies the Runge phenomenon as the root cause, and lays out the corrected complex-disk version's Mathlib chain."
+      "endLine": 142,
+      "summary": "Module docstring explaining that OQ-04's parent axiom (a real-interval Taylor sup bound) is FALSE as stated and is refuted here using the Runge function 1/(1+x²) as a witness, plus the corrected complex-disk Cauchy bound. Imports Mathlib analysis (power series, Cauchy integral, analyticity) and the parent Proofs.MeanValueTheoremOQ02; opens the noncomputable section, Real/Set scopes, and the namespace.",
+      "mathContext": "Runge phenomenon: $f(x)=1/(1+x^2)$ is bounded and real-analytic on $\\mathbb R$ yet equispaced polynomial interpolation diverges; the correct uniform bound lives on the complex disk $\\mathrm{ball}(a,R)\\subset\\mathbb C$."
     },
     {
-      "id": "namespace-setup",
-      "title": "Noncomputable Section and Namespace",
-      "startLine": 112,
-      "endLine": 116,
-      "summary": "Opens noncomputable section, the Real and Set namespaces (for |·|, Set.Ioo, Set.Icc), and declares the file's MeanValueTheoremOQ02OQ04OQ01 namespace."
+      "id": "sec1-runge",
+      "title": "§1. The Runge Function and Its Basic Properties",
+      "startLine": 143,
+      "endLine": 203,
+      "summary": "Defines runge x = 1/(1+x²) and proves its elementary facts: runge_one_add_sq_pos (1+x²>0), runge_abs_le_one (|runge|≤1), runge_zero, runge_one (=1/2), and runge_analyticOn_R (real-analytic on (−100,100) via AnalyticAt combinators + AnalyticAt.div).",
+      "mathContext": "$0<1+x^2$, $0\\le\\mathrm{runge}\\,y\\le 1$, and $\\mathrm{runge}$ is real-analytic on $(-100,100)$."
     },
     {
-      "id": "runge-and-blocks",
-      "title": "§1: The Runge Function and Its Basic Properties",
-      "startLine": 118,
-      "endLine": 175,
-      "summary": "Defines `runge x := 1 / (1 + x^2)`. Proves the building blocks: runge_one_add_sq_pos (denominator > 0 via sq_nonneg + linarith), runge_abs_le_one (uniform sup bound, via div_le_one and abs_of_nonneg), runge_zero (= 1, by norm_num), runge_one (= 1/2, by norm_num), and runge_analyticOn_R (analytic on (-100, 100), proved by composing analyticOn_id, analyticOn_const, AnalyticOn.pow, AnalyticOn.add, AnalyticOn.div with the nonzero-denominator lemma).",
-      "mathContext": "The Runge function 1/(1+x²) is the canonical witness to the gap between real and complex analyticity. It is real-analytic on all of ℝ and bounded by 1, but its complex extension has poles at ±i, limiting the Cauchy radius around 0 to 1. Verified building blocks: |runge y| ≤ 1 uniformly, runge(0)=1, runge(1)=1/2, AnalyticOn ℝ on the open interval (-100, 100)."
+      "id": "sec2-refutation",
+      "title": "§2. Refutation of the OQ-04 Axiom Statement",
+      "startLine": 204,
+      "endLine": 285,
+      "summary": "Repackages the parent OQ-04 axiom as a predicate OQ04_AxiomStatement (real-interval analyticity + sup bound ⟹ Taylor remainder ≤ M·rⁿ⁺¹/(Rⁿ(R−r))) and proves oq04_parent_axiom_is_false_in_principle: the predicate is false. The refutation does NOT invoke the parent axiom, so this file declares no new axioms.",
+      "mathContext": "The real-sup-bound hypothesis is too weak: a function bounded on a real interval need not have complex analyticity controlling the Taylor tail, so the claimed remainder bound fails."
     },
     {
-      "id": "refutation",
-      "title": "§2: Refutation of the OQ-04 Axiom Statement",
-      "startLine": 177,
-      "endLine": 240,
-      "summary": "Defines OQ04_AxiomStatement as a Prop-valued predicate exactly capturing the parent file's axiom signature. Proves oq04_axiom_is_false by specializing the predicate at the Runge witness (a=0, R=100, M=1, r=1, n=0, x=1), substituting taylorPolynomial_zero to reduce the LHS to runge(1) - runge(0) = 1/2 - 1, then deriving the contradiction 1/2 ≤ 1/99 by norm_num. The corollary oq04_parent_axiom_is_false_in_principle restates this finding for the parent axiom by name, providing a clear pointer for downstream consumers.",
-      "mathContext": "The refutation is constructive in three steps: (1) verify every hypothesis of the parent axiom on the Runge witness; (2) extract the resulting bound |f(x) - f(a)| ≤ M·r/(R-r) at n=0; (3) substitute numerical values to obtain |1/2 - 1| ≤ 1/99, i.e. 1/2 ≤ 1/99, which fails by norm_num. The 50× gap (1/2 vs 1/99) makes the refutation robust to any reasonable interpretation of the axiom's constants."
+      "id": "sec3-corrected",
+      "title": "§3. Corrected Statement (Complex-Disk Sup Bound) and Off-by-One Fix",
+      "startLine": 286,
+      "endLine": 406,
+      "summary": "Documents the S3 off-by-one correction (the S1–S2 statement paired partialSum n with an RHS that is off by a factor r/R and is false at n=0) and refutes the uncorrected form: def OriginalRemainderForm (the partialSum n RHS) and originalRemainderForm_is_false (constant-1 witness on ball(0,1) at (R,M,r,n,z)=(1,1,1/4,0,0)).",
+      "mathContext": "Mathlib's partialSum n truncates at degree n−1, so the geometric tail $\\sum_{k\\ge n} M(r/R)^k = M r^n R/(R^n(R-r))$, not $M r^{n+1}/(R^n(R-r))$; the §3b fix uses partialSum (n+1)."
     },
     {
-      "id": "corrected-statement",
-      "title": "§3: Corrected Complex-Disk Statement (with sorry)",
-      "startLine": 242,
-      "endLine": 270,
-      "summary": "States `analytic_taylor_remainder_uniform_bound_complex`: the correct Cauchy uniform bound for `f : ℂ → ℂ` holomorphic on the complex disk Metric.ball a R with uniform sup bound M, with the corrected RHS M · r^(n+1) / (R^n · (R-r)) (note the explicit R^n in the denominator). Proof is `sorry`, deferred to S2 with explicit Mathlib chain documented inline: HasFPowerSeriesOnBall.uniform_geometric_approx' + FormalMultilinearSeries.norm_mul_pow_le_mul_pow_of_lt_radius + geometric tail summation.",
-      "mathContext": "The corrected statement matches Mathlib's API: HasFPowerSeriesOnBall replaces AnalyticOn ℝ + Ioo, Metric.ball replaces Ioo, and the corrected RHS is the standard Cauchy bound M·r^(n+1)/(R^n(R-r)). The sorry marks a formalization gap (chaining three Mathlib lemmas), not a mathematical gap—the corrected statement is a known theorem of complex analysis."
+      "id": "sec3b-corrected-explicit",
+      "title": "§3b. Corrected Statement with partialSum (n+1): Cauchy Bound Lemmas",
+      "startLine": 407,
+      "endLine": 694,
+      "summary": "Builds the corrected explicit complex-disk Cauchy uniform bound (index-shifted to partialSum (n+1) to match the parent's degree-n Taylor polynomial): geometric_tail_identity (pure algebra), cauchy_diag_norm_bound_at_radius and cauchy_diag_norm_bound (per-degree Cauchy coefficient bound ‖p k‖ ≤ M(‖w‖/R)ᵏ), and analytic_taylor_remainder_uniform_bound_complex (the assembled bound). All proven (the historical sorries were discharged at S7).",
+      "mathContext": "Explicit form: $\\|f z - p.\\mathrm{partialSum}(n+1)(z-a)\\| \\le M\\,r^{n+1}/(R^n(R-r))$ on $\\|z-a\\|\\le r<R$, from the Cauchy coefficient bound + geometric tail."
     },
     {
-      "id": "verification",
-      "title": "§4: Verification: #check Sanity Block",
-      "startLine": 272,
-      "endLine": 280,
-      "summary": "Eight #check commands confirm the elaborated types of all theorems and definitions: runge, runge_analyticOn_R, runge_abs_le_one, runge_zero, runge_one, oq04_axiom_is_false, oq04_parent_axiom_is_false_in_principle, analytic_taylor_remainder_uniform_bound_complex. Closes the namespace."
+      "id": "sec3a-existential",
+      "title": "§3a. Existential Cauchy-Style Geometric Approximation (proven)",
+      "startLine": 695,
+      "endLine": 753,
+      "summary": "analytic_taylor_remainder_uniform_geometric_complex: the Mathlib-native existential bound (∃ K∈(0,1), C>0) translating HasFPowerSeriesOnBall.uniform_geometric_approx' from the y-centered form to the z-centered form via z = a + y. Requires only that f admits a power-series expansion, not a sup bound M — that is the hypothesis the parent OQ-04 axiom wrongly drops.",
+      "mathContext": "$\\exists K\\in(0,1),\\,C>0:\\ \\|f z - p.\\mathrm{partialSum}\\,n\\,(z-a)\\| \\le C\\,(K\\,\\|z-a\\|/r)^n$ on $\\mathrm{ball}(a,r)$."
+    },
+    {
+      "id": "sec4-verification",
+      "title": "§4. Verification (#check Block)",
+      "startLine": 754,
+      "endLine": 771,
+      "summary": "#check sanity block confirming the signatures of all public declarations: runge and its lemmas, the two refutation theorems, OriginalRemainderForm + its refutation, and the four corrected-bound theorems.",
+      "mathContext": "No new mathematics — type-checking sanity block ensuring every named result elaborates."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue: Section Drift (undercoverage + misalignment)

**Proof**: `mean-value-theorem-oq-02-oq-04-oq-01`
**Problem**: meta.json `sections` froze on an early ~280-line layout. The recorded §3 (242–270) and §4 (272–280) point at the wrong place — in the current 771-line file the real markers are **§3 @286, §3b @407, §3a @695, §4 @754**. Lines 281–771 (64% of the file) were unsectioned and invisible to the gallery source renderer, including the corrected complex-disk Cauchy bound lemmas (§3b) and the existential geometric approximation (§3a).

## Evidence

- `max(section.endLine) = 280`, but `wc -l = 771` and `meta.meta.lineCount` recorded `758` (also stale).
- The old "§3: Corrected Complex-Disk Statement" claimed lines 242–270; the actual `## §3` marker is at line 286, and `## §4. Verification` is at line 754 (not 272).

## Fix

- Rebuild **7 sections** aligned to the actual `§`-markers:
  - `1–142` Header / Imports / Refutation summary
  - `143–203` §1 Runge function
  - `204–285` §2 Refutation of the OQ-04 axiom statement
  - `286–406` §3 Corrected statement + off-by-one fix
  - `407–694` §3b Corrected explicit Cauchy bound lemmas
  - `695–753` §3a Existential geometric approximation
  - `754–771` §4 Verification (#check block)
- Fix `meta.lineCount` 758 → 771 (actual `wc -l`).

## Counts

- `sorries` (0): confirmed accurate — no tactic-level `sorry` remains (the §3b Cauchy lemmas were discharged at S7; the 14 `sorry` tokens are historical docstring narration).
- `axiomCount` (1): **left unchanged**. The file has 0 `axiom` declarations and states it adds no new axioms (line 209), so this may be an overcount — but `#print axioms` could not be run in this environment to rule out a transitive parent-axiom dependency. Flagged here for a build-verified follow-up rather than flipped to 0.

---
Metadata-only; no Lean source touched. Discovered during gallery integrity audit.