### PR TITLE
audit(frobenius-number-oq-03): add missing S6 sections for file tail (8→10)

### DIFF
--- a/src/data/proofs/frobenius-number-oq-03/meta.json
+++ b/src/data/proofs/frobenius-number-oq-03/meta.json
@@ -112,15 +112,31 @@
       "id": "s4a-tight-sylvester-upper-bound",
       "title": "S4a — Tight Sylvester Upper Bound",
       "startLine": 225,
-      "endLine": 253,
+      "endLine": 252,
       "summary": "Proves `frobeniusNumber3_le_sylvester_bound_tight`: for `Nat.Coprime a b` with `1 ≤ a, 1 ≤ b`, `frobeniusNumber3 a b c ≤ (a - 1) * (b - 1) - 1`. Refines S3c's loose bound to the tight `- 1` form, matching the classical 2-generator Sylvester identity g(a, b) = a*b - a - b = (a - 1)*(b - 1) - 1. The proof reuses the same contrapositive of S3b's bridge as S3c but tightens the containment to a strict inequality `n < (a - 1) * (b - 1)` on every element of the non-representable set; in ℕ, this implies `n ≤ (a - 1) * (b - 1) - 1` via omega (including the degenerate `a = 1 ∨ b = 1` case where the non-representable set is empty, `csSup_empty = ⊥ = 0`, and the RHS ℕ-subtraction underflows to 0). Single `by_cases` on `Set.Nonempty`, mirroring the S3a structural API pattern."
     },
     {
       "id": "s5-large-representable3-three-consecutive",
       "title": "S5 — large_representable3 for Three Consecutive Integers",
-      "startLine": 255,
-      "endLine": 281,
+      "startLine": 253,
+      "endLine": 280,
       "summary": "Proves `large_representable3_three_consecutive`: for `1 ≤ n`, every `m ≥ (n - 1) * n` is `Representable3 n (n + 1) (n + 2) m`. Direct specialization of S3b's `large_representable3_via_two_gen` bridge to the three-consecutive family — `a := n`, `b := n + 1` (consecutive integers are coprime via `Nat.coprime_self_add_right` reducing to `Nat.coprime_one_right`), `c := n + 2`. The bound `(n - 1) * n = n² - n` is the Sylvester quantity instantiated at `(a - 1) * (b - 1) = (n - 1) * (n + 1 - 1)` after a single `omega`-discharged `n + 1 - 1 = n` rewrite. Loose compared to Roberts' tight d = 1 closed form `g(n, n+1, n+2) = ⌊(n - 2) / 2⌋ · n + (n - 1) ≈ n²/2` (asymptotically half this bound) but unconditional and the foundation for the Roberts closed-form chain (S6 = Roberts 3-AP, S6+ = Fibonacci / Mersenne triples). Closes the namespace."
+    },
+    {
+      "id": "s6-pair-symmetric",
+      "title": "S6 — Pair-Symmetric Sylvester Bounds ((a,c) and (b,c) variants)",
+      "startLine": 281,
+      "endLine": 389,
+      "summary": "Exploits the slot-symmetry of Representable3 to add the (a,c) and (b,c) analogues of the S3b/S3c/S4 results: representable3_of_ac_gen, representable3_of_bc_gen, large_representable3_via_ac/_bc, frobeniusNumber3_le_sylvester_bound_ac/_bc, set_non_representable3_finite_of_coprime_ac/_bc, and frobeniusNumber3_le_min_sylvester_bound (min over the three pair-bounds). Consequence: the non-representable set is finite whenever ANY pair of (a,b,c) is coprime, not just (a,b).",
+      "mathContext": "Representable3 is symmetric in its three slots, so the Sylvester bound holds under gcd(a,c)=1 or gcd(b,c)=1; e.g. a=4,b=6,c=5 is finite via gcd(a,c)=gcd(b,c)=1 despite gcd(a,b)=2."
+    },
+    {
+      "id": "s6-consecutive-criterion",
+      "title": "S6 — Exact Representability Criterion for Three Consecutive Generators",
+      "startLine": 390,
+      "endLine": 440,
+      "summary": "representable3_consecutive_iff: a two-sided characterization for the consecutive family (n, n+1, n+2). Since n·x+(n+1)·y+(n+2)·z = n·s + (y+2z) with s = x+y+z and the remainder y+2z ranging over [0,2s], m is representable iff n·s ≤ m ≤ (n+2)·s for some s. This interval-covering reformulation is the structural key to Roberts' tight d=1 closed form.",
+      "mathContext": "$\\mathrm{Representable3}\\,n\\,(n{+}1)\\,(n{+}2)\\,m \\iff \\exists s,\\ n s \\le m \\le (n{+}2)s$, where $s$ is the total generator count $x+y+z$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Integrity Issue: Section Drift (undercoverage, tail)

**Proof**: `frobenius-number-oq-03`
**Problem**: meta.json `sections` covered only lines 1–281 (S1–S5), but the file is **440 lines**. Lines 281–440 (36% of the file) — two further `### S6` sections — were unsectioned and invisible to the gallery source renderer.

## Evidence

- `max(section.endLine) = 281` (after the old S5), but `wc -l = 440`.
- The file has `### S6 — Pair-symmetric Sylvester bounds` at line 281 and `### S6 — Exact representability criterion for three consecutive generators` at line 390, neither sectioned.

## Fix

- Append **2 sections**:
  - `281–389` S6 — Pair-symmetric Sylvester bounds ((a,c)/(b,c) variants + `frobeniusNumber3_le_min_sylvester_bound`)
  - `390–440` S6 — Exact representability criterion for consecutive generators (`representable3_consecutive_iff`)
- Tighten two boundaries that overran the next marker line: S4a `225–253 → 225–252`, S5 `255–281 → 253–280`.

`lineCount` (440), `sorries` (0), `axiomCount` (0) confirmed accurate — unchanged. (Unlike the sibling CLT/MVT cases, the existing 1–281 ranges were already well-aligned; this is a pure tail-undercoverage fix.)

---
Metadata-only; no Lean source touched. Discovered during gallery integrity audit.