### PR TITLE
audit(lebesgue-measure-oq-06): realign drifted gallery sections (6→8, full-file coverage)

### DIFF
--- a/src/data/proofs/lebesgue-measure-oq-06/meta.json
+++ b/src/data/proofs/lebesgue-measure-oq-06/meta.json
@@ -75,51 +75,67 @@
   "sections": [
     {
       "id": "preamble",
-      "title": "Imports, Setup, and Core Definitions",
+      "title": "Imports, Setup, and Module Docstring",
       "startLine": 1,
-      "endLine": 39,
-      "summary": "Imports Mathlib, defines unitBall3 (the closed unit ball in ℝ³), and presents the module docstring describing the Banach-Tarski paradox, Hausdorff's 1914 free subgroup, and the proof strategy.",
-      "mathContext": "The unit ball $B^3 = \\{x \\in \\mathbb{R}^3 : \\|x\\| \\leq 1\\}$ is defined as `Set.closedBall 0 1` in `EuclideanSpace ℝ (Fin 3)`. The ambient type uses Mathlib's `EuclideanSpace` infrastructure, which provides the necessary metric and group action structure for the Banach-Tarski formalization."
+      "endLine": 41,
+      "summary": "Imports Mathlib, opens the BanachTarski namespace with the Set/MeasureTheory/Pointwise/ENNReal/Matrix scopes, and presents the module docstring describing the Banach-Tarski paradox, Hausdorff's 1914 free subgroup, and the proof strategy.",
+      "mathContext": "The file works inside `namespace BanachTarski` over an abstract ambient type `α`. The geometric concrete types (`EuclideanSpace ℝ (Fin 3)`, the unit ball, the unit sphere) are introduced later in §III; the opening section fixes only the Mathlib infrastructure (Pointwise group actions, ENNReal measure values, Matrix notation) used throughout."
     },
     {
       "id": "equidecomposable",
       "title": "§I: Equidecomposable Sets",
-      "startLine": 40,
-      "endLine": 83,
-      "summary": "Defines G-equidecomposability of sets A and B: A can be partitioned into finitely many pieces, each moved by a group element so the images partition B. Proves reflexivity (every set is equidecomposable to itself). Defines IsParadoxical: a set equidecomposable to two disjoint subsets.",
+      "startLine": 42,
+      "endLine": 114,
+      "summary": "Defines G-equidecomposability of sets A and B: A can be partitioned into finitely many pieces, each moved by a group element so the images partition B. Proves reflexivity (equidecomposable_refl) and symmetry (equidecomposable_symm). Defines IsParadoxical: a set equidecomposable to two disjoint subsets.",
       "mathContext": "Definition: $A \\sim_G B$ iff $\\exists n \\in \\mathbb{N}$, pieces $P_i \\subseteq A$ partitioning $A$, and $g_i \\in G$ such that $\\bigsqcup_i g_i(P_i) = B$. Reflexivity: use $n=1$, $P_0 = A$, $g_0 = e$ (identity). Paradoxical: $A$ is $G$-paradoxical iff $\\exists B, C \\subseteq A$ disjoint with $A \\sim_G B$ and $A \\sim_G C$."
     },
     {
       "id": "no-measure",
       "title": "§II: Paradoxical Sets Cannot Be Measured",
-      "startLine": 85,
-      "endLine": 144,
-      "summary": "Proves that if A is G-paradoxical, any G-invariant finitely-additive measure must assign A measure 0 or ∞. The key lemma: a + a = a implies a = 0 or a = ⊤ in ℝ≥0∞ (proved).",
+      "startLine": 115,
+      "endLine": 177,
+      "summary": "Proves paradoxical_no_finite_measure: if A is G-paradoxical, any G-invariant finitely-additive measure must assign A measure 0 or ∞. The key lemma ennreal_add_self_eq_self (a + a = a implies a = 0 or a = ⊤ in ℝ≥0∞) is fully proved.",
       "mathContext": "If $A \\sim B$, $A \\sim C$, $B \\cap C = \\emptyset$, $B,C \\subseteq A$, and $\\mu$ is $G$-invariant and finitely additive: $\\mu(A) = \\mu(B) + \\mu(C) = \\mu(A) + \\mu(A)$. So $\\mu(A) + \\mu(A) = \\mu(A)$, which in $\\mathbb{R}_{\\geq 0}^\\infty$ implies $\\mu(A) = 0$ or $\\mu(A) = \\infty$."
     },
     {
       "id": "main-statement",
-      "title": "§III–V: Banach-Tarski Statement and Hausdorff Free Subgroup",
-      "startLine": 146,
-      "endLine": 235,
-      "summary": "States the main Banach-Tarski paradox for the unit ball in ℝ³ as a theorem with sorry. Includes RigidMotion3, unitBall3, unitSphere3 definitions. States Hausdorff's free subgroup theorem (sorry) and the full banach_tarski statement requiring AC.",
-      "mathContext": "The full statement: $\\exists n, \\{P_i\\}_{i<n}, g_1^{(i)}, g_2^{(i)}$ such that $\\{P_i\\}$ partitions $B^3$, $B^3 = \\bigsqcup_i g_1^{(i)}(P_i)$, and $B^3 + 2e_1 = \\bigsqcup_i g_2^{(i)}(P_i)$. Hausdorff's rotation matrices have entries involving $\\sqrt{1 - 1/9} = 2\\sqrt{2}/3$. The sorry is justified: any proof of `banach_tarski` must use AC (Solovay's model shows ZF alone cannot prove it)."
+      "title": "§III: The Banach-Tarski Paradox (Statement)",
+      "startLine": 178,
+      "endLine": 194,
+      "summary": "Introduces the concrete geometric setting: RigidMotion3 (isometries of ℝ³ as a proxy for SE(3)), unitBall3 (the closed unit ball), and unitSphere3 (the unit sphere S²). These are the objects the paradox decomposes.",
+      "mathContext": "$B^3 = \\{x \\in \\mathbb{R}^3 : \\|x\\| \\leq 1\\}$ is `Metric.closedBall 0 1` and $S^2$ is `Metric.sphere 0 1` in `EuclideanSpace ℝ (Fin 3)`. `RigidMotion3 := EuclideanSpace ℝ (Fin 3) ≃ᵢ EuclideanSpace ℝ (Fin 3)` models the orientation-preserving isometry group; the actual rotation subgroup SE(3) acts on these sets in the assembly."
     },
     {
-      "id": "non-measurable-pieces",
-      "title": "§V Corollary: Banach-Tarski Pieces Are Non-Measurable",
-      "startLine": 236,
-      "endLine": 253,
-      "summary": "States and sketches the proof that at least one piece in the Banach-Tarski decomposition is necessarily non-Lebesgue-measurable, with detailed proof outline in comments.",
-      "mathContext": "If all pieces $P_i$ were measurable, then by isometry invariance $\\lambda(g_j(P_i)) = \\lambda(P_i)$, and finite additivity over the two reassemblies gives $\\lambda(B^3) + \\lambda(B^3) = \\lambda(B^3)$. Since $\\lambda(B^3) = \\frac{4}{3}\\pi \\in (0, \\infty)$, the ENNReal lemma `eq_zero_or_top_of_add_eq_self` gives contradiction. This is why the paradox does not violate physics: the pieces are unmeasurable and carry no well-defined volume."
+      "id": "free-subgroup",
+      "title": "§IV: Free Subgroup of SO(3) — Integer Orbit Setup",
+      "startLine": 195,
+      "endLine": 413,
+      "summary": "Builds the integer-orbit model of Hausdorff's free subgroup. Defines the four scaled generator actions (scaledActPhi/PhiInv/Psi/PsiInv) on ℤ[√2]³, the mod-3 invariant predicates (inv_phi, inv_phi_inv, inv_psi, inv_psi_inv, anyInv), and proves the transition lemmas (12 valid transitions trans_*) and base cases (base_phi, etc.) showing each generator preserves its labeled invariant.",
+      "mathContext": "Each rotation generator is represented by a scaled integer matrix over $\\mathbb{Z}[\\sqrt 2]$: applying a generator multiplies the orbit of $e_2 = (0,1,0)$ by $3^n$ after $n$ steps, so $\\varphi = (1/3)M_\\varphi$ acts as the integer matrix $3M_\\varphi$. The freeness argument tracks a mod-3 invariant on coordinates that distinguishes which generator was last applied — the algebraic engine behind Hausdorff's theorem (irrationality of $\\arccos(1/3)/\\pi$)."
+    },
+    {
+      "id": "word-automaton",
+      "title": "Part B: Word Evaluation, Automaton, and Free Subgroup Freeness",
+      "startLine": 414,
+      "endLine": 859,
+      "summary": "Word-level automaton infrastructure: applyGen/evalWord evaluate a reduced word left-to-right on the integer orbit (evalWord_append proved), labeledInv tracks the last-letter invariant (labeledInv_base, labeledInv_step over 12 valid + 4 forbidden transitions, anyInv_of_labeledInv all 0 sorries), culminating in evalWord_nonempty_anyInv and the hausdorff_free_subgroup theorem establishing that φ, ψ generate a free group of rank 2.",
+      "mathContext": "A reduced word $w \\in F_2$ acting on $e_2$ never returns it to the identity orbit: by induction on word length, each non-cancelling letter forces a fresh mod-3 invariant, so $\\text{evalWord}\\,w\\,e_2$ satisfies $\\text{anyInv}$ and is therefore $\\neq e_2$. This is the orbit-non-triviality argument (orbit_ne) that proves $\\langle \\varphi, \\psi \\rangle \\cong F_2$ — the core algebraic ingredient of the Banach-Tarski construction."
+    },
+    {
+      "id": "main-theorem",
+      "title": "§V: The Main Theorem and Non-Measurable Pieces",
+      "startLine": 860,
+      "endLine": 963,
+      "summary": "States the full banach_tarski result as an explicit axiom (the ~800-line geometric assembly via the Hausdorff paradox + Axiom of Choice, provably unprovable in ZF alone) and proves banach_tarski_pieces_nonmeasurable: at least one piece of the decomposition is necessarily non-Lebesgue-measurable.",
+      "mathContext": "The full statement: $\\exists n, \\{P_i\\}_{i<n}, g^{(i)}, h^{(i)}$ such that $\\{P_i\\}$ partitions $B^3$, $B^3 = \\bigsqcup_i g^{(i)}(P_i)$, and a second copy $= \\bigsqcup_i h^{(i)}(P_i)$. Non-measurability: if every $P_i$ were measurable, isometry invariance plus finite additivity would force $\\lambda(B^3) + \\lambda(B^3) = \\lambda(B^3)$ with $\\lambda(B^3) = \\frac{4}{3}\\pi \\in (0,\\infty)$ — contradiction via ennreal_add_self_eq_self. Declared `axiom` per the integrity policy since Solovay (1970) shows any proof must use AC essentially."
     },
     {
       "id": "amenability",
-      "title": "§VI: Amenability and the Group-Theoretic Source",
-      "startLine": 249,
-      "endLine": 295,
-      "summary": "Defines amenable groups. Proves free_group_paradoxical (F₂ is paradoxical under its own left action — key step toward Banach-Tarski). Proves int_amenable (ℤ is amenable via Cesàro window-shift). Proves free_group_not_amenable (F₂ non-amenable). All fully proved, no sorry.",
-      "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, $\\mu(A \\cup B) = \\mu(A) + \\mu(B)$ for disjoint $A, B$, and $\\mu(gA) = \\mu(A)$ for all $g \\in G$. Abelian groups are amenable (via Markov-Kakutani). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1})$ and $F_2 = W(b) \\sqcup bW(b^{-1})$ give two paradoxical coverings. `int_amenable` can likely be proved using Mathlib's Hahn-Banach (`NormedSpace.HahnBanach`) to construct a Banach limit extending the Cesàro mean on $\\ell^\\infty(\\mathbb{Z})$."
+      "title": "§VI: Relationship to Amenability",
+      "startLine": 964,
+      "endLine": 1517,
+      "summary": "Defines IsAmenable and develops Tarski's group-theoretic source of the paradox. Proves int_amenable (ℤ is amenable via Cesàro window-shift), the free-group word-set cover lemmas (free_group_cover_a/b and disjointness), free_group_paradoxical (F₂ is paradoxical under its own left regular action), and free_group_not_amenable. All fully proved, no sorry.",
+      "mathContext": "A group $G$ is amenable iff $\\exists \\mu: 2^G \\to [0,\\infty]$ with $\\mu(G)=1$, finite additivity, and left-invariance $\\mu(gA) = \\mu(A)$. $\\mathbb{Z}$ is amenable via the Cesàro density $\\mu_N(A) = |A \\cap \\{-N,\\dots,N\\}|/(2N+1)$ (shift changes the count by $\\le |n|$, vanishing along an ultrafilter). $F_2$ is not amenable: $F_2 = W(a) \\sqcup aW(a^{-1}) = W(b) \\sqcup bW(b^{-1})$ gives two paradoxical coverings — exactly Tarski's equivalence between non-amenability and paradoxicality."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `lebesgue-measure-oq-06` (Banach-Tarski Paradox)

### Problem
The 6 `sections` in `meta.json` covered only lines 1–295 of a **1517-line** Lean file (≈80% of the proof hidden from the gallery section view) and several were mislabeled:

- `§III–V: Banach-Tarski Statement and Hausdorff Free Subgroup` claimed lines **146–235**, but `hausdorff_free_subgroup` is actually at **line 554**.
- `§VI: Amenability` claimed lines **249–295**, but `SECTION VI` begins at **line 965**.

The hidden tail contains the real mathematical meat: the integer-orbit free-subgroup construction, the word automaton + freeness proof, the `banach_tarski` axiom, non-measurability of the pieces, `int_amenable`, and `free_group_paradoxical`/`free_group_not_amenable`.

### Fix
Realigned to **8 sections** with boundaries taken directly from the file's own `-- === SECTION N ===` / `PART B` banners (verified at lines 42, 115, 178, 195, 414, 860, 964), giving gap-free coverage of lines **1–1517**. Section summaries/mathContext updated to match the declarations actually present in each range.

### Counts (verified, unchanged)
- `axiomCount: 1` ✓ (`axiom banach_tarski` at line 888)
- `sorries: 0` ✓
- `status: axiomatized` / `badge: axiom` — correct per integrity policy (open geometric assembly behind one explicit axiom)

No prose claims were altered; only section line-ranges/titles/summaries were corrected to match the source.

---
Discovered during gallery integrity audit (section-drift / undercoverage vein).