### PR TITLE
audit(abel-ruffini-galois-extensions-oq-07): realign drifted sections (9→11, full-file coverage)

### DIFF
--- a/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
+++ b/src/data/proofs/abel-ruffini-galois-extensions-oq-07/meta.json
@@ -182,74 +182,90 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: Statement, Imports, and Roadmap",
+      "startLine": 1,
+      "endLine": 54,
+      "summary": "Module docstring stating Burnside's pᵃqᵇ theorem (every finite group of order pᵃ·qᵇ is solvable), Mathlib imports, and the file roadmap describing the axiom-free reductions and the single remaining axiom for the residual case.",
+      "mathContext": "Burnside's theorem (1904): for primes $p, q$ and naturals $a, b$, every group of order $p^a q^b$ is solvable. The file structures the proof as a hierarchy of axiom-free special cases (prime powers, squarefree orders, normal-Sylow reductions, $p^2 q$/$p q^2$ shapes) with a single explicit axiom covering the genuinely-open residual."
+    },
+    {
       "id": "p-group-chain",
       "title": "Part I: p-group lemma (axiom-free)",
-      "startLine": 54,
-      "endLine": 64,
+      "startLine": 55,
+      "endLine": 66,
       "summary": "`pGroup_isSolvable`: for any finite group `G` with `IsPGroup p G` (and `Fact p.Prime`), `IsSolvable G`. Single-line proof via `IsPGroup.isNilpotent` + `infer_instance` for `IsNilpotent → IsSolvable`. Axiom-free.",
       "mathContext": "$p$-groups are nilpotent (an inductive consequence of the non-trivial centre), and nilpotent groups are solvable (the lower central series refines the derived series). Both facts are in Mathlib."
     },
     {
       "id": "trivial-cases",
       "title": "Part II: Trivial cases (a = 0, b = 0, p = q)",
-      "startLine": 66,
-      "endLine": 99,
+      "startLine": 67,
+      "endLine": 101,
       "summary": "`burnside_pq_a_zero`: when $a = 0$, $|G| = q^b$ so $G$ is a $q$-group; apply Part I. `burnside_pq_b_zero`: symmetric to $a = 0$. `burnside_pq_same_prime`: when $p = q$, $|G| = p^{a+b}$ so $G$ is a $p$-group of combined exponent. All three axiom-free.",
       "mathContext": "These cases are all instances of $|G| = $ prime power, hence covered by Part I. The arithmetic step is: $p^0 \\cdot q^b = q^b$, $p^a \\cdot q^0 = p^a$, $p^a \\cdot p^b = p^{a+b}$ — each obtained via `simpa` or `pow_add`."
     },
     {
       "id": "squarefree-case",
       "title": "Part II.5: Squarefree-order case (axiom-free, via IsZGroup)",
-      "startLine": 101,
-      "endLine": 142,
+      "startLine": 102,
+      "endLine": 144,
       "summary": "`squarefreeOrder_isSolvable`: bridges `Squarefree (Nat.card G) → IsSolvable G` via Mathlib's `IsZGroup.of_squarefree` + `[IsZGroup G] [Finite G] → IsSolvable G` instance. `burnside_pq_pq_case`: specializes to `a = b = 1` (`|G| = p · q`, `p ≠ q`) using `Nat.coprime_primes` + `Prime.squarefree` + `Nat.squarefree_mul`. Both axiom-free.",
       "mathContext": "A finite group of squarefree order is a Z-group (every Sylow subgroup is cyclic), and Z-groups are solvable. This subsumes the `a = b = 1` Burnside case (`|G| = pq` is squarefree when `p ≠ q` are prime) and extends beyond two primes for squarefree orders (e.g. `|G| = 30 = 2·3·5` is solvable axiom-free). It does NOT extend to `|G| = pᵃqᵇ` with `a ≥ 2` or `b ≥ 2`: `p²` violates squarefreeness, so the `2 ≤ a ∨ 2 ≤ b` case still needs new infrastructure."
     },
     {
       "id": "axiom",
       "title": "Part III: Non-trivial case (axiomatized, narrowed to 2 ≤ a ∨ 2 ≤ b)",
-      "startLine": 144,
-      "endLine": 176,
+      "startLine": 145,
+      "endLine": 185,
       "summary": "`burnside_pq_nontrivial`: axiom asserting Burnside's theorem in the residual case `p ≠ q`, `a ≥ 1`, `b ≥ 1`, AND `2 ≤ a ∨ 2 ≤ b`. The hypothesis was narrowed in Iteration 4: the `a = b = 1` sub-case is now axiom-free (Part II.5). Carries proof sketches for both the character-theoretic (Burnside 1904) and character-free (Goldschmidt-Matsuyama 1970s) routes.",
       "mathContext": "This is the genuinely-open Lean content: orders divisible by `p²` or `q²` for distinct primes. A formalized proof would be a substantial Mathlib upstream contribution (~400-1000 lines depending on route)."
     },
     {
       "id": "normal-sylow-reductions",
       "title": "Part III.5: Normal-Sylow reductions (axiom-free, Iteration 5)",
-      "startLine": 178,
-      "endLine": 263,
+      "startLine": 186,
+      "endLine": 272,
       "summary": "`isSolvable_of_normal_quotient_solvable`: solvability is closed under group extensions (repackaging `solvable_of_ker_le_range` against `1 → N → G → G/N → 1`). `burnside_pq_with_normal_pSylow`: if `|G| = pᵃqᵇ` and `G` admits a normal subgroup of order `pᵃ`, then `G` is solvable (axiom-free). `burnside_pq_with_normal_qSylow`: symmetric reduction via a normal subgroup of order `qᵇ`.",
       "mathContext": "These reductions turn 'exhibit a normal Sylow subgroup' into a complete axiom-free discharge of `burnside_pq_nontrivial`. Combined with Sylow-counting analyses on specific shapes (`|G| = p² · q`, `|G| = p · q²`, …), they enable axiom-free closure of those cases — as concretely realized in Part III.6."
     },
     {
       "id": "p-squared-q",
-      "title": "Part III.6: |G| = p² · q axiom-free, case `p > q` (Iteration 7)",
-      "startLine": 265,
-      "endLine": 354,
-      "summary": "`sylow_count_eq_one_of_lt_prime` (private helper): if `n ∣ q` (q prime), `n ≡ 1 [MOD p]`, and `q < p`, then `n = 1`. `burnside_p_squared_q_p_gt_q`: axiom-free Burnside for `|G| = p² · q` in the case `p > q` — Sylow's third theorem (`card_sylow_modEq_one` + `Sylow.card_dvd_index`) forces `n_p = 1`; the unique Sylow `p`-subgroup is normal (`Sylow.normal_of_subsingleton`); `burnside_pq_with_normal_pSylow` discharges.",
-      "mathContext": "First sub-case of `|G| = p² · q`. By Sylow's third theorem, `n_p ≡ 1 [MOD p]` and `n_p ∣ q`. Since `q` is prime, `n_p ∈ {1, q}`; the case `n_p = q` would require `q ≡ 1 [MOD p]`, i.e. `p ∣ q - 1`, contradicting `q < p`. The remaining sub-cases (`p < q ≠ 3` symmetric, exceptional `(p, q) = (2, 3) |G| = 12`) are tracked for S7.5/S8."
+      "title": "Part III.6: |G| = p² · q and p · q² axiom-free (all sub-cases, incl. |G| = 12)",
+      "startLine": 273,
+      "endLine": 1601,
+      "summary": "The large axiom-free core for orders with one squared prime. Starts with the `p > q` discharge (`sylow_count_eq_one_of_lt_prime`, `burnside_p_squared_q_p_gt_q`) and the `q < p` Sylow-uniqueness theorems (`burnside_p_pow_a_q_q_lt_p`, `burnside_p_q_pow_b_p_lt_q`, `burnside_p_squared_q_p_lt_q` via `sylow_count_eq_one_of_lt_prime_pow_two`), then builds the exceptional `|G| = 12` machinery (cube-identity set partition: `sylow_three_card_eq_three_of_card_twelve`, `cube_id_set_eq_disjoint_union`, `sylow_two_inter_cube_id_eq_singleton_one`, `cube_id_card_eq_nine_of_partition_ingredients`, `sylow_two_unique_when_n3_four`) culminating in `burnside_p_squared_q_twelve`, and finishes the mirror `p · q²` cases (`burnside_p_q_squared_p_lt_q`, `burnside_p_q_squared_q_lt_p`, `burnside_p_q_squared_twelve_mirror`). All axiom-free.",
+      "mathContext": "Closes every $|G| = p^2 q$ and $|G| = p q^2$ shape via Sylow counting. Generic case: Sylow's third theorem forces a unique (hence normal) Sylow subgroup whenever one prime exceeds the other, discharged through the Part III.5 normal-Sylow reductions. The hard exceptional case is $|G| = 12 = 2^2 \\cdot 3$ where $n_2$ and $n_3$ can both be $>1$ a priori; it is resolved by a counting argument on the set of cube-identity elements ($\\{g : g^3 = 1\\}$ has 9 elements forcing $n_2 = 1$), the A₄ analysis. This section is the bulk of the file's machine-checked content (~1330 lines)."
+    },
+    {
+      "id": "consolidated-theorems",
+      "title": "Part III.7: Consolidated (a,b) ∈ {(2,1),(1,2)} theorems",
+      "startLine": 1602,
+      "endLine": 1674,
+      "summary": "`burnside_p_squared_q` and `burnside_p_q_squared`: top-level axiom-free theorems that consolidate the per-case results of Part III.6 into clean statements for the `(a, b) = (2, 1)` and `(a, b) = (1, 2)` shapes, dispatching internally on the `p` vs `q` ordering (and the `|G| = 12` exception) so callers need not case-split.",
+      "mathContext": "These are the public-facing entry points for the squared-prime cases: given `Nat.card G = p^2 * q` (resp. `p * q^2`) with `p ≠ q` prime, conclude `IsSolvable G` axiom-free by combining the `p > q`, `p < q`, and exceptional-12 theorems from Part III.6."
     },
     {
       "id": "main-theorem",
       "title": "Part IV: Main theorem",
-      "startLine": 356,
-      "endLine": 396,
+      "startLine": 1675,
+      "endLine": 1754,
       "summary": "`burnside_pq`: combines the three axiom-free trivial cases with the squarefree-order case (a = b = 1) and the conjectural `burnside_pq_nontrivial` axiom into the unified statement `Nat.card G = p^a · q^b → IsSolvable G`. Case-splits on `a = 0`, `b = 0`, `p = q`, then `a = 1 ∧ b = 1` (axiom-free), with the residue dispatched to the (narrowed) axiom.",
       "mathContext": "The case split is exhaustive: any combination of $(a, b, p, q)$ with $a = 0$ or $b = 0$ or $p = q$ falls into Part II; `a = b = 1` with `p ≠ q` falls into Part II.5; the residue (`p ≠ q`, `2 ≤ a ∨ 2 ≤ b`) is exactly the axiom's hypothesis."
     },
     {
       "id": "sanity-checks",
       "title": "Part V: Sanity checks",
-      "startLine": 398,
-      "endLine": 471,
+      "startLine": 1755,
+      "endLine": 1828,
       "summary": "Six `example`s that exercise the axiom-free portions of the file at the boundaries: trivial group ($|G| = 1 = 2^0 \\cdot 3^0$), prime-order group ($|G| = p = p^1 \\cdot 2^0$), pure prime-power group ($|G| = p^a = p^a \\cdot 2^0$), `|G| = pq` squarefree, three-prime squarefree ($|G| = 30 = 2 \\cdot 3 \\cdot 5$), `|G| = 12` with normal Sylow-2 (A₄-style), and the new Iteration-7 example `|G| = 75 = 5^2 \\cdot 3` axiom-free via `burnside_p_squared_q_p_gt_q`.",
       "mathContext": "These examples never invoke the axiom — they confirm that the trivial-case branches, the squarefree route, and the new `p² · q` (`p > q`) discharge all handle their respective shapes axiom-free."
     },
     {
       "id": "sharpness",
       "title": "Part VI: Sharpness witness",
-      "startLine": 473,
-      "endLine": 528,
+      "startLine": 1829,
+      "endLine": 1973,
       "summary": "`alternatingGroupFin5_card`: $|A_5| = 2^2 \\cdot 3 \\cdot 5$ via `Nat.card_eq_fintype_card` + `native_decide`. `alternatingGroupFin5_not_solvable`: A₅ is not solvable, via `solvable_of_ker_le_range (alternatingGroup (Fin 5)).subtype Equiv.Perm.sign` then `Equiv.Perm.not_solvable (Fin 5)`. `burnside_pq_sharp`: conjunction of the two — the canonical sharpness witness.",
       "mathContext": "Burnside permits at most TWO distinct prime factors. $|A_5| = 60 = 2^2 \\cdot 3 \\cdot 5$ has three distinct primes — exactly one more — and A₅ is the smallest non-solvable group. So `burnside_pq` is sharp: no extension to three distinct primes can hold. A₅ ALSO defeats the squarefree route (`squarefreeOrder_isSolvable` does not apply since 60 has $2^2$). The proof uses the kernel-of-sign + range-of-subtype short exact sequence A₅ → S₅ → ℤ/2 to lift solvability of A₅ to S₅, then contradicts the Mathlib fact `Equiv.Perm.not_solvable` for $n \\geq 5$."
     }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `abel-ruffini-galois-extensions-oq-07` (Burnside's pᵃqᵇ theorem)

### Problem
The 9 `sections` in `meta.json` covered only lines 1–528 of a **1973-line** Lean file, and the back half was mapped to the **wrong content**:

- `Part IV: Main theorem` claimed lines **356–396**, but the actual `PART IV` banner is at **line 1676**.
- `Part III.6` ended at line **354**, yet the next banner (`PART III.7`) begins at **line 1602** — so ~1330 lines of axiom-free machinery were silently folded out of view.
- `PART III.7` (Consolidated theorems, line 1602) and the preamble were entirely absent from the section list.

The hidden span (lines 355–1601) contains the bulk of the file's machine-checked content: the `|G| = 12` exceptional-case partition argument and all the `p·q²` mirror theorems.

### Fix
Realigned to **11 sections** with boundaries taken directly from the file's own `-- ═══ / PART N` banners (verified at lines 55, 67, 102, 145, 186, 273, 1602, 1675, 1755, 1829), giving gap-free coverage of lines **1–1973**. Added the missing preamble and `PART III.7` sections, and expanded the `PART III.6` summary to reflect its true scope.

### Counts (verified, unchanged)
- `axiomCount: 1` ✓ (single `burnside_pq_nontrivial` axiom in Part III)
- `sorries: 0` ✓
- `status: axiomatized` / `badge: axiom` — correct (open residual case behind one explicit axiom)

No prose claims were altered; only section line-ranges/titles/summaries were corrected to match the source.

---
Discovered during gallery integrity audit (section-drift / banner-marker undercoverage vein).