### PR TITLE
research(erdos-5): formalize conjecture + S ⊆ [0,∞) containment in companion file

### DIFF
--- a/proofs/Proofs/Erdos5Problem.lean
+++ b/proofs/Proofs/Erdos5Problem.lean
@@ -24,6 +24,7 @@ import Mathlib.Tactic
 import Mathlib.Data.Nat.Prime.Basic
 import Mathlib.Data.Nat.Prime.Nth
 import Mathlib.Data.Real.Basic
+import Mathlib.Analysis.SpecialFunctions.Log.Basic
 import Mathlib.Topology.Basic
 
 /- ## Definitions -/
@@ -59,8 +60,8 @@ def IsLimitPointOfGaps (C : ℝ) : Prop :=
 
 /- ## Known Results -/
 
-/-- 0 ∈ S: Goldston–Pintz–Yıldırım (2009) proved
-    lim inf (p_{n+1} - p_n) / log(p_n) = 0. -/
+/- 0 ∈ S: Goldston–Pintz–Yıldırım (2009) proved
+   lim inf (p_{n+1} - p_n) / log(p_n) = 0. -/
 /-- ∞ ∈ S: Westzynthius (1931) proved the gaps can be arbitrarily large
     relative to log(p_n). Formally: for every M, there exist infinitely many n
     with g(n) > M. -/
@@ -74,11 +75,58 @@ theorem hildebrand_maier_large_gaps (C : ℝ) (hC : 0 < C) :
     ∀ N : ℕ, ∃ n : ℕ, N ≤ n ∧ normalizedGap n > C :=
   gaps_unbounded C
 
-/-- Merikoski (2020): at least 1/3 of any bounded interval [0, T]
-    is covered by S. Formally: the Lebesgue measure of
-    S ∩ [0, T] is at least T/3 for all T > 0. -/
+/- Merikoski (2020): at least 1/3 of any bounded interval [0, T]
+   is covered by S. Formally: the Lebesgue measure of
+   S ∩ [0, T] is at least T/3 for all T > 0. -/
+
+/- ## Basic Properties -/
+
+/-- The n-th prime is at least 2, since 2 is the smallest prime. -/
+theorem nthPrime_ge_two (n : ℕ) : 2 ≤ nthPrime n :=
+  (nthPrime_prime n).two_le
+
+/-- log(p_n) > 0 for every n, since p_n ≥ 2 > 1. -/
+theorem log_nthPrime_pos (n : ℕ) : 0 < Real.log (nthPrime n) := by
+  apply Real.log_pos
+  have h : (2 : ℝ) ≤ (nthPrime n : ℝ) := by exact_mod_cast nthPrime_ge_two n
+  linarith
+
+/-- The normalized gap is strictly positive for every n: the numerator
+    p_{n+1} - p_n is positive (strict monotonicity) and log(p_n) > 0. -/
+theorem normalizedGap_pos (n : ℕ) : 0 < normalizedGap n := by
+  unfold normalizedGap
+  apply div_pos
+  · have h : nthPrime n < nthPrime (n + 1) := nthPrime_strictMono (Nat.lt_succ_self n)
+    have hz : (0 : ℤ) < (nthPrime (n + 1) : ℤ) - (nthPrime n : ℤ) := by
+      have hlt : (nthPrime n : ℤ) < (nthPrime (n + 1) : ℤ) := by exact_mod_cast h
+      omega
+    exact_mod_cast hz
+  · exact log_nthPrime_pos n
+
+/-- Normalized gaps are non-negative for every n. -/
+theorem normalizedGap_nonneg (n : ℕ) : 0 ≤ normalizedGap n :=
+  (normalizedGap_pos n).le
+
+/-- Every limit point C of the normalized gap sequence is non-negative.
+    Equivalently, S ⊆ [0, ∞) — the trivial containment of Erdős's conjecture,
+    holding unconditionally since every g(n) ≥ 0. -/
+theorem limitPoint_nonneg {C : ℝ} (hC : IsLimitPointOfGaps C) : 0 ≤ C := by
+  by_contra h
+  push_neg at h
+  obtain ⟨n, _, hn⟩ := hC (-C) (by linarith) 0
+  rw [abs_lt] at hn
+  have hg : 0 ≤ normalizedGap n := normalizedGap_nonneg n
+  linarith [hn.2]
+
 /- ## The Conjecture -/
 
-/-- Erdős Problem #5: The set S of limit points of (p_{n+1} - p_n)/log(p_n)
-    equals [0, ∞). That is, for every C ≥ 0, C is a limit point of
-    the normalized gap sequence. -/
+/-- **Erdős Problem #5** (the full conjecture): the set S of limit points of
+    g(n) = (p_{n+1} - p_n)/log(p_n) equals [0, ∞). That is, every C ≥ 0 is a
+    limit point of the normalized gap sequence.
+
+    The containment S ⊆ [0, ∞) is the trivial direction, proved unconditionally
+    in `limitPoint_nonneg`. The reverse — that every non-negative real is
+    actually attained as a limit point — is the open part of the problem.
+    Westzynthius (`gaps_unbounded`) handles the ∞ endpoint; GPY handles 0. -/
+def ErdosProblem5 : Prop :=
+  ∀ C : ℝ, 0 ≤ C → IsLimitPointOfGaps C


### PR DESCRIPTION
## Summary

The `Erdos5Problem.lean` companion file for Erdős Problem #5 (limit points of normalized prime gaps, `g(n) = (p_{n+1}-p_n)/log p_n`) ended at a **prose-only** description of the conjecture with no formal statement, and never proved the trivial containment for its own `normalizedGap` definition.

This PR completes the companion:

- `nthPrime_ge_two`, `log_nthPrime_pos` — `p_n ≥ 2 ⇒ log(p_n) > 0`
- `normalizedGap_pos` / `normalizedGap_nonneg` — every `g(n) > 0` (integer-gap numerator positive via strict monotonicity; positive denominator)
- `limitPoint_nonneg` — every limit point `C` satisfies `C ≥ 0`, i.e. **S ⊆ [0,∞)**, the unconditional/trivial half of Erdős's conjecture
- `ErdosProblem5 : Prop` — formal statement of the open conjecture `S = [0,∞)`

The proofs mirror the already-verified template in the main file `Erdos5PrimeGaps.lean` (lines 344–387), so confidence is high. **No new axioms.** Also converts two pre-existing dangling `/-- -/` doc-comments (GPY, Merikoski — attached to no declaration) into plain block comments so they unambiguously parse.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos5Problem` (Docker unavailable in this environment — **build-pending draft**)
- [x] Proofs are structurally identical to verified lemmas in the sibling main file

🤖 Generated with [Claude Code](https://claude.com/claude-code)