### PR TITLE
research(isoperimetric-theorem-oq-02): correct docstring overclaim of equality iff

### DIFF
--- a/proofs/Proofs/IsoperimetricTheoremOQ02.lean
+++ b/proofs/Proofs/IsoperimetricTheoremOQ02.lean
@@ -5,7 +5,9 @@ Open Question from: Isoperimetric Theorem (Wiedijk #43)
 
 The continuous isoperimetric inequality has a discrete analogue on the integer
 lattice. For finite S ⊆ ℤ with |S| ≥ 2, the (vertex) edge boundary ∂S has at
-least 2 elements, with equality if and only if S is an interval.
+least 2 elements, and integer intervals achieve this bound with |∂S| = 2.
+(The full equality characterization—|∂S| = 2 implies S is an interval—holds but
+is not formalized here; only the lower bound and the interval case are proved.)
 
 Proof idea:
   Let m = min S and M = max S. Since |S| ≥ 2, m < M. Then m - 1 ∉ S (since m


### PR DESCRIPTION
## Summary
Honesty fix for the 1D discrete isoperimetric proof. Comment-only — no math or build change.

## Problem
The `.lean` header docstring claimed the edge boundary has "at least 2 elements, **with equality if and only if S is an interval**." The formalized theorems prove only:
- `edgeBoundary_card_ge_two`: |∂S| ≥ 2 (the lower bound), and
- `edgeBoundary_Icc` / `edgeBoundary_Icc_card`: integer intervals achieve |∂S| = 2 (the "if" direction).

The converse — |∂S| = 2 ⟹ S is an interval — is true but **not formalized** in this file. The docstring's "if and only if" therefore overstated the verified content. Notably the gallery `meta.json` is already honest (it only claims intervals *achieve* equality), so this aligns the source with the metadata.

## Fix
Softened the docstring to state the lower bound + interval case as proved, and parenthetically note the full equality characterization holds but is unformalized here.

## Build impact
None — comment-only change to a verified, sorry-free, axiom-free file.