### PR TITLE
research(erdos-1093): fixed-k slices of both conjecture parts

### DIFF
--- a/proofs/Proofs/Erdos1093Problem.lean
+++ b/proofs/Proofs/Erdos1093Problem.lean
@@ -255,3 +255,40 @@ theorem finitely_many_for_fixed_k (k : ℕ) :
   obtain ⟨hn2k, hnsp, hndef⟩ := hn
   simp only [Set.mem_Iic]
   exact Nat.cast_le.mp ((hels n k hn2k hnsp hndef).trans (Nat.le_ceil _))
+
+/-
+## Section X: Fixed-k Slices of the Two Conjecture Parts
+-/
+
+/-- Converse to `deficiency_pos_of_smooth`: positive deficiency yields a witness
+index i < k with n - i being k-smooth. -/
+theorem exists_smooth_of_deficiency_pos {n k : ℕ} (h : 0 < deficiency n k) :
+    ∃ i < k, IsKSmooth k (n - i) := by
+  unfold deficiency at h
+  obtain ⟨i, hi⟩ := Finset.card_pos.mp h
+  rw [Finset.mem_filter, Finset.mem_range] at hi
+  exact ⟨i, hi.1, hi.2⟩
+
+/-- For fixed k, only finitely many n ≥ 2k have deficiency exactly 1.
+This is the fixed-k slice of Part (i) (`ErdosProblem1093i`): the infinitude
+conjectured there must therefore arise from unboundedly many distinct k, not
+from any single value of k. -/
+theorem finitely_many_deficiency_eq_one_for_fixed_k (k : ℕ) :
+    Set.Finite { n : ℕ | 2 * k ≤ n ∧ NoSmallPrimeFactors n k ∧ deficiency n k = 1 } := by
+  apply (finitely_many_for_fixed_k k).subset
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn ⊢
+  obtain ⟨h1, h2, h3⟩ := hn
+  exact ⟨h1, h2, by omega⟩
+
+/-- For fixed k, only finitely many n ≥ 2k have deficiency > 1. This is the
+fixed-k slice of Part (ii) (`ErdosProblem1093ii`); the open content is whether
+finiteness survives the union over all k (where the ELS bound C·2^k·√k grows
+exponentially). -/
+theorem finitely_many_deficiency_gt_one_for_fixed_k (k : ℕ) :
+    Set.Finite { n : ℕ | 2 * k ≤ n ∧ NoSmallPrimeFactors n k ∧ deficiency n k > 1 } := by
+  apply (finitely_many_for_fixed_k k).subset
+  intro n hn
+  simp only [Set.mem_setOf_eq] at hn ⊢
+  obtain ⟨h1, h2, h3⟩ := hn
+  exact ⟨h1, h2, by omega⟩

--- a/src/data/proofs/erdos-1093/meta.json
+++ b/src/data/proofs/erdos-1093/meta.json
@@ -20,10 +20,10 @@
     "erdosUrl": "https://erdosproblems.com/1093",
     "erdosProblemStatus": "open",
     "axiomCount": 1,
-    "lineCount": 257,
-    "assumptions": "1 axiom: els_upper_bound (ELS 1993 upper bound theorem). Former many_deficiency_one_examples axiom eliminated by 16 individually verified native_decide examples spanning k=3..28. Section VIII adds 5 additional verified examples (including all known deficiency-2 pairs). Section IX proves finitely_many_for_fixed_k as a zero-sorry corollary of the ELS axiom.",
+    "lineCount": 294,
+    "assumptions": "1 axiom: els_upper_bound (ELS 1993 upper bound theorem). Former many_deficiency_one_examples axiom eliminated by 16 individually verified native_decide examples spanning k=3..28. Section VIII adds 5 additional verified examples (including all known deficiency-2 pairs). Section IX proves finitely_many_for_fixed_k as a zero-sorry corollary of the ELS axiom. Section X adds the fixed-k slices of both conjecture parts (finitely_many_deficiency_eq_one_for_fixed_k, finitely_many_deficiency_gt_one_for_fixed_k) as subset corollaries, plus exists_smooth_of_deficiency_pos (converse of deficiency_pos_of_smooth).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 44,
+    "theoremCount": 47,
     "definitionCount": 6
   },
   "overview": {
@@ -116,6 +116,14 @@
       "endLine": 257,
       "summary": "Theorem `finitely_many_for_fixed_k`: for fixed $k$, $\\{n : 2k \\leq n \\wedge \\text{NoSmallPrimeFactors}(n,k) \\wedge d(n,k) \\geq 1\\}$ is finite. Proof: apply `Set.Finite.subset (Set.finite_Iic \\lceil C \\cdot 2^k \\sqrt{k} \\rceil_+)` using `Nat.le_ceil` and `Nat.cast_le`.",
       "mathContext": "Theorem `finitely_many_for_fixed_k`: for fixed $k$, $\\{n : 2k \\leq n \\wedge \\text{NoSmallPrimeFactors}(n,k) \\wedge d(n,k) \\geq 1\\}$ is finite. Proof: apply `Set.Finite.subset (Set.finite_Iic \\lceil C \\cdot 2^k \\sqrt{k} \\rceil_+)` using `Nat.le_ceil` and `Nat.cast_le`."
+    },
+    {
+      "id": "fixed-k-slices",
+      "title": "Fixed-k Slices of the Two Conjecture Parts",
+      "startLine": 259,
+      "endLine": 294,
+      "summary": "`exists_smooth_of_deficiency_pos` (converse of `deficiency_pos_of_smooth`), and the fixed-k slices of both conjecture parts: `finitely_many_deficiency_eq_one_for_fixed_k` (Part i) and `finitely_many_deficiency_gt_one_for_fixed_k` (Part ii), each an immediate subset corollary of `finitely_many_for_fixed_k`.",
+      "mathContext": "`exists_smooth_of_deficiency_pos` (converse of `deficiency_pos_of_smooth`), and the fixed-k slices of both conjecture parts: `finitely_many_deficiency_eq_one_for_fixed_k` (Part i) and `finitely_many_deficiency_gt_one_for_fixed_k` (Part ii), each an immediate subset corollary of `finitely_many_for_fixed_k`."
     }
   ],
   "conclusion": {
@@ -241,9 +249,9 @@
     ],
     "opens": [],
     "namespace": null,
-    "lineCount": 257,
+    "lineCount": 294,
     "axiomCount": 1,
-    "theoremCount": 44,
+    "theoremCount": 47,
     "definitionCount": 6,
     "path": "Proofs/Erdos1093Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

Erdős Problem #1093 (deficiency of binomial coefficients) asks: (i) are there infinitely many pairs `(n,k)` with deficiency exactly 1, and (ii) only finitely many with deficiency > 1? The file already proved `finitely_many_for_fixed_k` — for fixed `k`, the set of `n ≥ 2k` with `NoSmallPrimeFactors` and `deficiency ≥ 1` is finite (a corollary of the ELS `n ≤ C·2^k·√k` axiom) — but never connected it to the two stated conjecture parts.

This PR adds **Section X** tying that finiteness result to both parts:

- `exists_smooth_of_deficiency_pos` — converse of the existing `deficiency_pos_of_smooth`: positive deficiency yields a witnessing `i < k` with `n - i` k-smooth.
- `finitely_many_deficiency_eq_one_for_fixed_k` — fixed-k slice of **Part (i)** (`ErdosProblem1093i`). Since each `k` admits only finitely many deficiency-1 `n`, the conjectured infinitude must come from unboundedly many distinct `k`.
- `finitely_many_deficiency_gt_one_for_fixed_k` — fixed-k slice of **Part (ii)** (`ErdosProblem1093ii`), the known partial result; the open content is whether finiteness survives the union over all `k`.

Both finiteness corollaries are immediate `Set.Finite.subset` applications of `finitely_many_for_fixed_k` (`{=1}` and `{>1}` ⊆ `{≥1}`). **No new axioms.**

Meta updated: `theoremCount` 44→47, `lineCount` 257→294, new `fixed-k-slices` section entry.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos1093Problem` (Docker unavailable here — **build-pending draft**)
- [x] Proofs use only standard Mathlib lemmas (`Set.Finite.subset`, `Finset.card_pos`, `Finset.mem_filter`/`mem_range`, `omega`) and mirror the file's existing `finitely_many_for_fixed_k` / `deficiency_pos_of_smooth` style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)