### PR TITLE
research(erdos-281): fix gallery section boundary for Main Theorem definition

### DIFF
--- a/src/data/proofs/erdos-281/meta.json
+++ b/src/data/proofs/erdos-281/meta.json
@@ -102,15 +102,15 @@
       "id": "divergence-coprime",
       "title": "Divergence and Coprime Results",
       "startLine": 215,
-      "endLine": 231,
-      "summary": "Informal block comments noting the divergence-of-reciprocals and coprime conditions that inform the axiom. Defines `ErdosProblem281 : Prop`, the formal statement of the problem."
+      "endLine": 219,
+      "summary": "Informal block comments noting the divergence-of-reciprocals and coprime conditions that inform the axiom."
     },
     {
       "id": "main-theorem",
       "title": "Main Theorem and Equivalence",
-      "startLine": 232,
+      "startLine": 220,
       "endLine": 250,
-      "summary": "Erdős Problem 281 statement and axiomatized proof. The biconditional `full_covering_iff_uniform` combines hard (axiom) and easy (proved) directions.",
+      "summary": "Defines `ErdosProblem281 : Prop`, the formal problem statement, followed by the axiomatized proof. The biconditional `full_covering_iff_uniform` combines hard (axiom) and easy (proved) directions.",
       "mathContext": "$\\text{HasFullCovering} \\iff \\text{HasUniformFiniteCoverage}$ for valid strictly increasing moduli"
     }
   ],


### PR DESCRIPTION
## Summary
Small gallery metadata accuracy fix for Erdős Problem 281 (honestly axiomatized — 1 axiom for the hard direction, badge=axiom; unchanged).

## Problem
The `ErdosProblem281 : Prop` definition — the formal problem statement at lines 220–231 — was inside the section titled **"Divergence and Coprime Results"** (215–231). The following section, **"Main Theorem and Equivalence"** (232–250), claimed to contain "Erdős Problem 281 statement" but its range excluded the def. A gallery reader clicking "Main Theorem" would not see the theorem's definition.

## Fix
Moved the boundary to line 220 — the file's own `## Main Theorem (Erdős Problem 281)` marker:
- "Divergence and Coprime Results" → 215–219 (its informal block-comment notes only)
- "Main Theorem and Equivalence" → 220–250 (def + axiom + equivalence corollary), summary updated.

## Build impact
None — metadata only; the Lean source and axiom status are untouched.