### PR TITLE
research(erdos-890): both conjectures at k=1 + sharp k=1 liminf (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos890Problem.lean
+++ b/proofs/Proofs/Erdos890Problem.lean
@@ -207,4 +207,31 @@ theorem conjecture1_k1 : LiminfAtMost (cumulativeOmega 1) (1 + pi 1) := by
                      calc ω p = 1 := omega_prime hp
                        _ ≤ 1 + pi 1 := by omega⟩
 
+/-- ω(n) ≥ 1 whenever n > 1: a non-unit has at least one distinct prime factor. -/
+theorem omega_ge_one {n : ℕ} (hn : 1 < n) : 1 ≤ ω n := by
+  have hne : n.primeFactors.Nonempty := Nat.nonempty_primeFactors.mpr hn
+  simp only [ArithmeticFunction.omega]
+  exact Finset.one_le_card.mpr hne
+
+/-- **Sharp lower bound at k = 1.**
+    Since ω(n) ≥ 1 for every n ≥ 2, the liminf of S₁(n) = ω(n) is ≥ 1.
+    This sharpens the k = 1 instance of `erdos_selfridge_lower_bound`, which only
+    gives ≥ 1 + π(1) − 1 = 0 (because π(1) = 0). Combined with `conjecture1_k1`
+    (liminf ≤ 1 + π(1) = 1), this pins the k = 1 liminf to exactly 1. -/
+theorem liminf_k1_sharp_lower : LiminfAtLeast (cumulativeOmega 1) 1 := by
+  refine ⟨2, fun n hn => ?_⟩
+  rw [cumulativeOmega_one]
+  exact omega_ge_one (by omega)
+
+-- ## Part IX: Conjecture 2 Verified for k = 1
+
+/-- **Conjecture 2 verified for k = 1:**
+    For k = 1, S₁(n) = ω(n), so the limsup-ratio statement for S₁ is exactly the
+    classical Hardy–Ramanujan result `lim sup ω(n)·log log n / log n = 1`. -/
+theorem conjecture2_k1 : ErdosConjecture890_limsup 1 := by
+  have h : cumulativeOmega 1 = fun n => ω n := funext cumulativeOmega_one
+  unfold ErdosConjecture890_limsup
+  rw [h]
+  exact classical_omega_limsup
+
 end Erdos890

--- a/research/problems/erdos-890/state.md
+++ b/research/problems/erdos-890/state.md
@@ -2,18 +2,18 @@
 
 **Phase**: AXIOMATIZED
 **Since**: 2026-01-15T10:57:29.901Z
-**Iteration**: 2
-**Last Update**: 2026-05-17T06:30:00Z (S2 STATE-SYNC)
+**Iteration**: 3
+**Last Update**: 2026-06-14 (S3 ACT — k=1 base cases completed)
 
 ## Current Focus
 
-S2 STATE-SYNC: Reconcile research JSON registry, this state.md, and gallery `meta.json` with the actual Lean file. Before S2, registry top-level `phase` and `currentState.phase` were both `ACT` from 2026-03-13 (T-65d) and state.md was still on the initial NEW template from 2026-01-15. Gallery `meta.json` already correctly marked `status: "axiomatized"` and `badge: "axiom"`.
+S3 ACT: Completed both conjectures at the base case $k=1$. Added `conjecture2_k1` (Conjecture 2 at $k=1$ is exactly the Hardy–Ramanujan axiom `classical_omega_limsup`, via `cumulativeOmega_one`), plus `omega_ge_one` ($\omega(n)\geq 1$ for $n>1$) and `liminf_k1_sharp_lower` ($\liminf S_1(n)\geq 1$), which sharpens the trivial $k=1$ instance of the Erdős–Selfridge axiom and pins the $k=1$ liminf to exactly 1. Build-pending (Docker unavailable this session); proofs anchored to the file's already-compiling `omega_prime` simp pattern + standard Mathlib `Nat.nonempty_primeFactors`/`Finset.one_le_card`.
 
 ## Status Summary
 
 | Surface | Value | Source |
 |---------|-------|--------|
-| Lean file | `proofs/Proofs/Erdos890Problem.lean` (210 LOC, 9 thm, 6 def, 2 axioms, 0 sorries) | `wc -l` + canonical inclusive grep |
+| Lean file | `proofs/Proofs/Erdos890Problem.lean` (237 LOC, 12 thm, 7 def, 2 axioms, 0 sorries) | `wc -l` + canonical inclusive grep |
 | Axioms | `erdos_selfridge_lower_bound`, `classical_omega_limsup` | `grep '^axiom '` |
 | Gallery dir | `src/data/proofs/erdos-890/` (annotations.json + index.ts + meta.json) | `ls` |
 | Gallery badge | `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2` | `src/data/proofs/erdos-890/meta.json` |
@@ -21,9 +21,7 @@ S2 STATE-SYNC: Reconcile research JSON registry, this state.md, and gallery `met
 
 ## Active Approach
 
-None as of S2 — slug is at AXIOMATIZED rest state with both conjectures open.
-
-The lone proven Lean result is `conjecture1_k1` (Conjecture 1 verified for k=1, via `Nat.exists_infinite_primes`). The sandwich theorem `erdos_890_liminf_sandwich` pins the liminf to {k+π(k)-1, k+π(k)} conditional on Conjecture 1 holding for general k. Monotonicity `S_{k+1}(n) ≥ S_k(n)` via `Finset.sum_le_sum_of_subset`.
+Base-case completion (S3). Both conjectures are now verified at $k=1$ in Lean: `conjecture1_k1` (liminf $\leq 1+\pi(1)$ via `Nat.exists_infinite_primes`) and `conjecture2_k1` (limsup case $=$ Hardy–Ramanujan axiom). `liminf_k1_sharp_lower` adds $\liminf S_1(n)\geq 1$, pinning the $k=1$ liminf to exactly 1. The sandwich theorem `erdos_890_liminf_sandwich` pins the general liminf to {k+π(k)-1, k+π(k)} conditional on Conjecture 1. Monotonicity `S_{k+1}(n) ≥ S_k(n)` via `Finset.sum_le_sum_of_subset`. General $k$ for either conjecture remains open (needs sieve / Pólya $k$-smooth-gaps machinery absent from Mathlib).
 
 ## Blockers
 
@@ -51,6 +49,7 @@ Slug is AXIOMATIZED with 2 deep classical axioms encoding the lone proven lower 
 |------|------|-------|--------|-------|
 | 1 | 2026-01-15 → 2026-03-13 | (legacy) | ACT — proved Conjecture 1 k=1 + 4 structural lemmas + 2 axioms (Erdos890Problem.lean 210 LOC) | initial creation through #5884 |
 | 2 | 2026-05-17 | researcher-11 | AXIOMATIZED STATE-SYNC — registry phase ACT→AXIOMATIZED, state.md rewrite from NEW template, leanFiles[0].lineCount 211→210, attemptCounts.total 0→1, lastUpdate refresh, focus/nextAction refresh, progressSummary extension | doc-only, 2 files |
+| 3 | 2026-06-14 | researcher-4 | ACT — proved `conjecture2_k1` (Conj. 2 at k=1 = Hardy–Ramanujan axiom), `omega_ge_one`, `liminf_k1_sharp_lower` (sharp k=1 liminf ≥ 1); file 210→237 LOC, 9→12 thm; meta sections 7→10 (Parts VII–IX were uncovered), theoremCount 9→12, lineCount→237. Build-pending (Docker down) | Erdos890Problem.lean + meta.json + state.md |
 
 ## Cross-references
 

--- a/src/data/proofs/erdos-890/meta.json
+++ b/src/data/proofs/erdos-890/meta.json
@@ -21,23 +21,24 @@
     "erdosUrl": "https://erdosproblems.com/890",
     "erdosProblemStatus": "open",
     "axiomCount": 2,
-    "lineCount": 210,
+    "lineCount": 237,
     "assumptions": "2 axioms: erdos_selfridge_lower_bound, classical_omega_limsup. See Lean source for complete statements.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 9,
+    "theoremCount": 12,
     "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős and Selfridge studied $S_k(n) = \\sum_{i=0}^{k-1} \\omega(n+i)$ in their 1967 paper [ErSe67], where $\\omega(m)$ counts the distinct prime divisors of $m$. The Hardy-Ramanujan theorem (1917) established that $\\omega(n) \\sim \\log\\log n$ for 'almost all' $n$, and the Erdős-Kac theorem (1940) showed $(\\omega(n) - \\log\\log n)/\\sqrt{\\log\\log n}$ is asymptotically normal. For the cumulative function $S_k(n)$, Erdős and Selfridge proved the lower bound $\\liminf_{n \\to \\infty} S_k(n) \\geq k + \\pi(k) - 1$ using Pólya's 1918 theorem that $k$-smooth numbers (those with all prime factors $\\leq k$) have unbounded gaps: among $n, n+1, \\ldots, n+k-1$, all but at most one must have a prime factor $> k$. This yields at least $k + \\pi(k) - 1$ distinct prime factors in total. The two open conjectures sharpen this: (1) $\\liminf S_k(n) \\leq k + \\pi(k)$, which combined with the lower bound would pin the liminf to $k + \\pi(k) - 1$ or $k + \\pi(k)$; and (2) $\\limsup S_k(n) \\cdot \\log\\log n / \\log n = 1$, generalizing the classical single-integer result to consecutive blocks. The problem connects to Jacobsthal's function $g(k)$ (the maximal gap in $\\{1, \\ldots, m\\}$ coprime to the first $k$ primes) and to recent work on the distribution of $\\omega$ in short intervals.",
     "problemStatement": "Let $\\omega(n)$ denote the number of distinct prime factors of $n$, and define $S_k(n) = \\sum_{i=0}^{k-1} \\omega(n+i)$. Two conjectures: (1) For every $k \\geq 1$, $\\liminf_{n \\to \\infty} S_k(n) \\leq k + \\pi(k)$. (2) $\\limsup_{n \\to \\infty} S_k(n) \\cdot \\frac{\\log\\log n}{\\log n} = 1$. Both remain open.",
     "text": "Is lim inf S_k(n) ≤ k + π(k) where S_k(n) = ∑ ω(n+i)? Is lim sup S_k(n) · log log n / log n = 1? Known: lim inf ≥ k + π(k) − 1 (Erdős–Selfridge). OPEN.",
-    "proofStrategy": "The formalization defines `cumulativeOmega k n` using Mathlib's `ArithmeticFunction.omega` and `Finset.range k`. Liminf and limsup are captured by custom predicates `LiminfAtMost`, `LiminfAtLeast`, and `LimsupRatioIsOne` (using $\\varepsilon$-neighborhoods with `Real.log`). The Erdős-Selfridge lower bound and Hardy-Ramanujan $\\omega$ limsup are axiomatized. Four theorems are proved in Lean: monotonicity $S_{k+1}(n) \\geq S_k(n)$ via `Finset.sum_le_sum_of_subset`, the lower bound at $k=1$, the sandwich theorem conditional on Conjecture 1, and a restated lower bound.",
+    "proofStrategy": "The formalization defines `cumulativeOmega k n` using Mathlib's `ArithmeticFunction.omega` and `Finset.range k`. Liminf and limsup are captured by custom predicates `LiminfAtMost`, `LiminfAtLeast`, and `LimsupRatioIsOne` (using $\\varepsilon$-neighborhoods with `Real.log`). The Erdős-Selfridge lower bound and Hardy-Ramanujan $\\omega$ limsup are axiomatized. Twelve theorems are proved in Lean, including: monotonicity $S_{k+1}(n) \\geq S_k(n)$ via `Finset.sum_le_sum_of_subset`; the sum-splitting identity $S_{k+j}(n)=S_k(n)+S_j(n+k)$; the sandwich theorem conditional on Conjecture 1; both conjectures verified at $k=1$ ($\\liminf S_1 \\leq 1+\\pi(1)$ from the infinitude of primes, and the limsup case reduced exactly to the Hardy–Ramanujan axiom); and a sharp lower bound $\\liminf S_1(n) \\geq 1$ that pins the $k=1$ liminf to exactly 1.",
     "keyInsights": [
       "**Cumulative prime factors**: $S_k(n) = \\sum_{i<k} \\omega(n+i)$ counts total distinct prime factors across $k$ consecutive integers. For $k = 1$, this reduces to $\\omega(n)$ itself.",
       "**Erdős-Selfridge lower bound**: The product $n(n+1)\\cdots(n+k-1)$ is divisible by all primes $\\leq k$, so $S_k(n) \\geq k + \\pi(k) - 1$ eventually. The proof uses Pólya's 1918 theorem that $k$-smooth numbers have gaps tending to infinity.",
       "**Tight sandwich**: If Conjecture 1 holds, $\\liminf S_k(n) \\in \\{k + \\pi(k) - 1,\\, k + \\pi(k)\\}$ — determined to within 1. The Lean `erdos_890_liminf_sandwich` theorem formalizes this conditional result.",
       "**Limsup generalization**: The classical Hardy-Ramanujan result $\\limsup \\omega(n) \\cdot \\log\\log n / \\log n = 1$ is conjectured to hold for $S_k(n)$ as well, meaning the maximum growth rate is dominated by a single highly composite integer in each block.",
-      "**Monotonicity**: $S_{k+1}(n) \\geq S_k(n)$ is proved in Lean via `Finset.sum_le_sum_of_subset`, since $\\text{range}\\,k \\subseteq \\text{range}\\,(k+1)$."
+      "**Monotonicity**: $S_{k+1}(n) \\geq S_k(n)$ is proved in Lean via `Finset.sum_le_sum_of_subset`, since $\\text{range}\\,k \\subseteq \\text{range}\\,(k+1)$.",
+      "**Both conjectures resolved at $k=1$**: For $k=1$, $S_1(n)=\\omega(n)$, so Conjecture 1 reduces to $\\liminf\\omega(n)\\leq 1$ (proved from the infinitude of primes) and Conjecture 2 reduces *exactly* to the classical Hardy–Ramanujan limsup. Since $\\omega(n)\\geq 1$ for $n\\geq 2$, the $k=1$ liminf is pinned to exactly $1$, sharpening the Erdős–Selfridge axiom's trivial $k=1$ bound of $0$."
     ],
     "prerequisites": [
       "Arithmetic functions: the distinct prime factor counting function $\\omega(n)$, its properties under multiplication, and its relationship to the prime factorization of $n$",
@@ -93,8 +94,29 @@
       "id": "structural",
       "title": "Structural Theorems",
       "startLine": 132,
-      "endLine": 172,
+      "endLine": 171,
       "summary": "Proves `cumulativeOmega_mono`: $S_k(n) \\leq S_{k+1}(n)$ via `Finset.sum_le_sum_of_subset`. Proves `erdos_890_lower_bound_k1`: the Erdős-Selfridge bound at $k=1$. Proves `erdos_890_liminf_sandwich`: conditional on Conjecture 1, $k + \\pi(k) - 1 \\leq \\liminf S_k(n) \\leq k + \\pi(k)$. Proves `erdos_890_known_lower_bound`: restates the Erdős-Selfridge axiom."
+    },
+    {
+      "id": "additional-structural",
+      "title": "Additional Structural Lemmas",
+      "startLine": 172,
+      "endLine": 187,
+      "summary": "Computes the boundary cases of the cumulative sum: `cumulativeOmega_zero` gives $S_0(n)=0$ (empty sum) and `cumulativeOmega_one` gives $S_1(n)=\\omega(n)$ (single term). `cumulativeOmega_add` proves the splitting identity $S_{k+j}(n) = S_k(n) + S_j(n+k)$ via `Finset.sum_range_add`, enabling divide-and-conquer over consecutive blocks."
+    },
+    {
+      "id": "conjecture1-k1",
+      "title": "Conjecture 1 Verified for k = 1",
+      "startLine": 188,
+      "endLine": 225,
+      "summary": "`omega_prime` shows $\\omega(p)=1$ for prime $p$. `conjecture1_k1` proves the $k=1$ case of Conjecture 1: $\\liminf S_1(n) \\leq 1 + \\pi(1)$, using the infinitude of primes (each prime $p$ has $S_1(p)=\\omega(p)=1$). `omega_ge_one` shows $\\omega(n)\\geq 1$ for $n>1$, and `liminf_k1_sharp_lower` uses it to prove $\\liminf S_1(n) \\geq 1$ — sharpening the trivial $k=1$ instance of the Erdős–Selfridge axiom (which only gives $\\geq \\pi(1)=0$) and pinning the $k=1$ liminf to exactly 1."
+    },
+    {
+      "id": "conjecture2-k1",
+      "title": "Conjecture 2 Verified for k = 1",
+      "startLine": 226,
+      "endLine": 237,
+      "summary": "`conjecture2_k1` proves the $k=1$ case of Conjecture 2: since $S_1(n)=\\omega(n)$, the limsup-ratio statement for $S_1$ is exactly the classical Hardy–Ramanujan result $\\limsup \\omega(n)\\cdot\\log\\log n/\\log n = 1$, discharged via the `classical_omega_limsup` axiom."
     }
   ],
   "conclusion": {

--- a/src/data/research/problems/erdos-890.json
+++ b/src/data/research/problems/erdos-890.json
@@ -17,15 +17,15 @@
   },
   "currentState": {
     "phase": "AXIOMATIZED",
-    "since": "2026-01-15T10:57:29.901Z",
-    "iteration": 2,
-    "focus": "S2 STATE-SYNC: registry was at phase ACT iter 1 since 2026-03-13 (T-65d) despite Lean file Erdos890Problem.lean encoding 2 axioms (erdos_selfridge_lower_bound, classical_omega_limsup) — should be AXIOMATIZED. state.md was still on initial NEW template (Phase: NEW, iteration 1, focus 'Initial exploration') from 2026-01-15. Gallery meta.json already correctly marked status=axiomatized, badge=axiom, axiomCount=2. Single Lean file at 210 LOC (registry had +1 off-by-one: 211→210), 9 theorems, 6 defs, 2 axioms, 0 sorries. Conjecture 1 verified for k=1 via Nat.exists_infinite_primes; sandwich theorem conditional on Conjecture 1; both Erdős-Selfridge lower bound and Hardy-Ramanujan limsup remain axiomatized as deep classical results not in Mathlib.",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "S3 ACT: Completed both conjectures at the base case k=1. Added conjecture2_k1 (Conjecture 2 at k=1 reduces exactly to the Hardy-Ramanujan axiom classical_omega_limsup via cumulativeOmega_one), omega_ge_one (omega(n)>=1 for n>1), and liminf_k1_sharp_lower (liminf S_1(n) >= 1, sharpening the trivial k=1 instance of the Erdos-Selfridge axiom and pinning the k=1 liminf to exactly 1). Lean file 210->237 LOC, 9->12 theorems; gallery meta sections 7->10 (Parts VII-IX were uncovered). Build-pending (Docker unavailable); proofs anchored to the file's compiling omega_prime simp pattern plus standard Mathlib Nat.nonempty_primeFactors / Finset.one_le_card.",
     "blockers": [
       "Mathlib lacks the Erdős-Selfridge S_k(n) ≥ k + π(k) - 1 lower bound (1967 paper, requires Pólya's k-smooth gaps theorem).",
       "Mathlib lacks the Hardy-Ramanujan limsup ω(n)·log log n / log n = 1 (1917 result).",
       "Both conjectures themselves are open since Erdős-Selfridge 1967."
     ],
-    "nextAction": "Slug is AXIOMATIZED with 2 deep classical axioms encoding the lone proven lower bound (Erdős-Selfridge) and the limsup base case (Hardy-Ramanujan). Forward levers: (A) extend conjecture1_kN to general k using sandwich approach; (B) reformulate axioms in terms of Mathlib's Nat.primeCounting and ArithmeticFunction.omega API once Pólya k-smooth gaps lands in Mathlib; (C) explore Jacobsthal function g(k) connection. None of these blockers unblock without upstream Mathlib infrastructure.",
+    "nextAction": "Both conjectures verified at k=1; general k for either remains open (needs sieve / Polya k-smooth-gaps machinery absent from Mathlib). Forward levers: (A) attempt k=2 liminf (liminf S_2(n) <= 2+pi(2)=3) if a constructive infinitely-often witness can be built without sieve theory; (B) reformulate axioms via Mathlib Nat.primeCounting/ArithmeticFunction.omega once Polya gaps land; (C) Jacobsthal g(k) connection.",
     "attemptCounts": {
       "total": 1,
       "currentApproach": 0,
@@ -33,17 +33,22 @@
     }
   },
   "knowledge": {
-    "progressSummary": "AXIOMATIZED: Erdos890Problem.lean — 210 LOC, 9 theorems, 6 defs, 2 axioms, 0 sorries. Definitions: cumulativeOmega, LiminfAtMost, LiminfAtLeast, LimsupRatioIsOne, ErdosConjecture890_liminf, ErdosConjecture890_limsup. Axioms: erdos_selfridge_lower_bound (S_k(n) ≥ k + π(k) - 1), classical_omega_limsup (Hardy-Ramanujan). Proven: conjecture1_k1 (k=1 case via Nat.exists_infinite_primes), omega_prime (ω(p)=1), cumulativeOmega_one/zero/add (sum splitting), monotonicity S_{k+1} ≥ S_k, erdos_890_liminf_sandwich (conditional pin to {k+π(k)-1, k+π(k)}). Forward lever: extend k=1 to general k once Mathlib gains Pólya k-smooth gaps API.",
+    "progressSummary": "AXIOMATIZED: Erdos890Problem.lean - 237 LOC, 12 theorems, 7 defs, 2 axioms, 0 sorries. Both conjectures now verified at k=1: conjecture1_k1 (liminf S_1 <= 1+pi(1) via Nat.exists_infinite_primes) and conjecture2_k1 (limsup case = Hardy-Ramanujan axiom). liminf_k1_sharp_lower gives liminf S_1(n) >= 1 (via omega_ge_one), pinning the k=1 liminf to exactly 1. Axioms erdos_selfridge_lower_bound and classical_omega_limsup remain deep classical results not in Mathlib. General k open.",
     "builtItems": [
       "conjecture1_k1: Conjecture 1 verified for k=1 using Nat.exists_infinite_primes",
       "omega_prime: ω(p)=1 for prime p, proved from primeFactors characterization",
       "cumulativeOmega_one: S_1(n)=ω(n), cumulativeOmega_zero: S_0(n)=0",
-      "cumulativeOmega_add: sum splitting S_{k+j}=S_k+S_j"
+      "cumulativeOmega_add: sum splitting S_{k+j}=S_k+S_j",
+      "conjecture2_k1: Conjecture 2 verified for k=1 (= Hardy-Ramanujan axiom via cumulativeOmega_one)",
+      "omega_ge_one: omega(n) >= 1 for n > 1 (nonempty primeFactors)",
+      "liminf_k1_sharp_lower: liminf S_1(n) >= 1, sharp k=1 lower bound pinning liminf to 1"
     ],
     "insights": [
       "Conjecture 1 holds for k=1: lim inf ω(n) ≤ 1+π(1)=1, proved using infinitude of primes (every prime has ω(p)=1).",
       "Sum splitting: S_{k+j}(n) = S_k(n) + S_j(n+k), enabling divide-and-conquer analysis.",
-      "Both axioms (Erdős-Selfridge lower bound, Hardy-Ramanujan limsup) are deep published results, not provable from Mathlib."
+      "Both axioms (Erdős-Selfridge lower bound, Hardy-Ramanujan limsup) are deep published results, not provable from Mathlib.",
+      "Conjecture 2 at k=1 is LITERALLY the classical Hardy-Ramanujan limsup result, since S_1(n)=omega(n); it discharges directly against the classical_omega_limsup axiom.",
+      "omega(n) >= 1 for all n >= 2 sharpens the k=1 Erdos-Selfridge lower bound from the trivial pi(1)=0 to 1, pinning liminf S_1 to exactly 1."
     ],
     "mathlibGaps": [],
     "nextSteps": [],


### PR DESCRIPTION
## Summary
Research session on **Erdős #890** — the sum $S_k(n)=\sum_{0\le i<k}\omega(n+i)$ over consecutive integers (OPEN; Erdős–Selfridge 1967). The Lean file already proved Conjecture 1 at $k=1$ but (a) never connected **Conjecture 2 at $k=1$** to its Hardy–Ramanujan axiom, and (b) the $k=1$ instance of the Erdős–Selfridge lower-bound axiom was trivial ($\ge \pi(1)=0$). This session completes both conjectures at the base case $k=1$.

## Progress (3 new theorems)
- **`conjecture2_k1`** — Conjecture 2 at $k=1$ is *exactly* the classical Hardy–Ramanujan limsup, since $S_1(n)=\omega(n)$; discharged against the existing `classical_omega_limsup` axiom via `cumulativeOmega_one`. Uses only existing-file declarations.
- **`omega_ge_one`** — $\omega(n)\ge 1$ for $n>1$ (nonempty `primeFactors`), mirroring the file's already-compiling `omega_prime` simp pattern.
- **`liminf_k1_sharp_lower`** — $\liminf S_1(n)\ge 1$, sharpening the trivial $k=1$ axiom instance and (with `conjecture1_k1`) pinning the $k=1$ liminf to exactly $1$.

## Files
- `proofs/Proofs/Erdos890Problem.lean` (210→237 LOC, 9→12 theorems; 2 axioms / 0 sorries unchanged)
- `src/data/proofs/erdos-890/meta.json` — `theoremCount` 9→12, `lineCount` 210→237, sections 7→10 (Parts VII–IX were previously uncovered), proofStrategy + keyInsight refresh
- `src/data/research/problems/erdos-890.json`, `research/problems/erdos-890/state.md` — state sync (iteration 3)

## Status
**Outcome**: progress (base case $k=1$ completed for both conjectures). General $k$ remains open — needs Pólya $k$-smooth-gaps / sieve machinery absent from Mathlib. The two deep axioms (Erdős–Selfridge lower bound, Hardy–Ramanujan limsup) are genuinely not provable from Mathlib and are retained.

**Build**: ⚠️ build-pending — Docker daemon was unresponsive this session, so the new proofs are unverified. Draft until built. Proofs are anchored to the file's existing compiling `omega_prime` simp pattern plus standard Mathlib lemmas (`Nat.nonempty_primeFactors`, `Finset.one_le_card`).

🤖 Generated by researcher-4