### PR TITLE
research(erdos-289): formalize main conjecture + recipSum_pos

### DIFF
--- a/proofs/Proofs/Erdos289Problem.lean
+++ b/proofs/Proofs/Erdos289Problem.lean
@@ -62,6 +62,10 @@ def ValidDecomposition (k : ℕ) (blocks : Fin k → IntervalBlock) : Prop :=
 
 /-- **Erdős Problem #289** (OPEN): For all sufficiently large k, there exists
     a valid decomposition of 1 into k disjoint non-adjacent interval blocks. -/
+def ErdosProblem289 : Prop :=
+  ∃ K : ℕ, ∀ k : ℕ, K ≤ k →
+    ∃ blocks : Fin k → IntervalBlock, ValidDecomposition k blocks
+
 /- ## Basic Properties -/
 
 /-- Every interval block has at least 2 elements. -/
@@ -83,14 +87,16 @@ theorem nonadj_implies_disjoint (I J : IntervalBlock) :
 
 /- ## Hickerson–Montgomery Example -/
 
-/-- The Hickerson–Montgomery example: 5 intervals summing to 2.
-    [2,7], [9,10], [17,18], [34,35], [84,85].
-    This shows the feasibility of interval decomposition for targets other than 1. -/
+/- The Hickerson–Montgomery example: 5 intervals summing to 2.
+   [2,7], [9,10], [17,18], [34,35], [84,85].
+   This shows the feasibility of interval decomposition for targets other than 1. -/
+
 /- ## Structural Observations -/
 
-/-- The harmonic series diverges, so the total available reciprocal sum
-    from any tail of ℕ is unbounded. This is necessary for the problem
-    to have solutions for arbitrarily many blocks. -/
+/- The harmonic series diverges, so the total available reciprocal sum
+   from any tail of ℕ is unbounded. This is necessary for the problem
+   to have solutions for arbitrarily many blocks. -/
+
 /-- Each interval block contributes at most (hi-lo+1)/lo.
     Proof: each term 1/n ≤ 1/lo since lo ≤ n for n ∈ [lo, hi]. -/
 theorem interval_recipsum_upper (I : IntervalBlock) :
@@ -128,8 +134,19 @@ theorem interval_recipsum_lower (I : IntervalBlock) :
         exact div_le_div_of_le_left (by positivity) hn_pos hhi_pos
               (Nat.cast_le.mpr hn.2)
 
-/-- To achieve exactly 1 with many small-contribution blocks, we need
-    blocks at large values of n. The gap constraint forces intervals
-    to spread out, making the target harder to hit exactly. -/
-/-- The problem without the non-adjacency constraint is easier: one can
-    always decompose 1 into disjoint intervals (Erdős–Graham remark). -/
+/-- The reciprocal sum of an interval block is strictly positive: it is a
+    sum of strictly positive terms 1/n over a nonempty range. -/
+theorem recipSum_pos (I : IntervalBlock) : 0 < I.recipSum := by
+  unfold IntervalBlock.recipSum IntervalBlock.toFinset
+  apply Finset.sum_pos
+  · intro n hn
+    simp only [mem_Icc] at hn
+    have hn0 : (0 : ℚ) < (n : ℚ) := Nat.cast_pos.mpr (lt_of_lt_of_le I.hlo hn.1)
+    exact div_pos one_pos hn0
+  · exact Finset.nonempty_Icc.mpr I.hle
+
+/- To achieve exactly 1 with many small-contribution blocks, we need
+   blocks at large values of n. The gap constraint forces intervals
+   to spread out, making the target harder to hit exactly. -/
+/- The problem without the non-adjacency constraint is easier: one can
+   always decompose 1 into disjoint intervals (Erdős–Graham remark). -/

--- a/src/data/proofs/erdos-289/meta.json
+++ b/src/data/proofs/erdos-289/meta.json
@@ -21,11 +21,11 @@
     "erdosUrl": "https://erdosproblems.com/289",
     "erdosProblemStatus": "open",
     "axiomCount": 0,
-    "lineCount": 135,
-    "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
+    "lineCount": 152,
+    "assumptions": "0 axioms, 0 sorries. The main conjecture is now formally stated as `def ErdosProblem289 : Prop` (∃ K, ∀ k ≥ K, ∃ k pairwise non-adjacent interval blocks with reciprocal sums totaling 1) but remains unproved (open problem), so status is 'axiomatized'+'wip' per the open-problem policy. Proved unconditionally: interval_block_has_two, nonadj_implies_disjoint, reciprocal-sum upper/lower bounds per block, and recipSum_pos (strict positivity).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
-    "definitionCount": 6
+    "theoremCount": 5,
+    "definitionCount": 7
   },
   "overview": {
     "historicalContext": "Erdős and Graham posed this problem in their influential 1980 monograph 'Old and New Problems and Results in Combinatorial Number Theory,' which collected hundreds of open problems from Erdős's vast collaboration network. The question sits at the intersection of Egyptian fraction theory (expressing rationals as sums of unit fractions, a tradition dating to the Rhind Papyrus c. 1650 BCE) and combinatorial constraints on intervals. Hickerson and Montgomery demonstrated feasibility by constructing 5 non-adjacent intervals [2,7], [9,10], [17,18], [34,35], [84,85] with reciprocal sum exactly 2. The non-adjacency constraint is the essential difficulty: without it, one can decompose any unit fraction representation by splitting and merging adjacent intervals. The problem connects to Croot's 2003 resolution of the Erdős–Graham conjecture (that $\\{n+1, \\ldots, 2n\\}$ contains a subset whose reciprocals sum to 1 for large $n$) and to the broader Egyptian fraction tradition studied by Erdős, Straus, and Graham.",
@@ -57,7 +57,7 @@
       "title": "Main Conjecture",
       "startLine": 61,
       "endLine": 68,
-      "summary": "Axiomatizes Erdős Problem #289: ∃ K, ∀ k ≥ K, there exist k pairwise non-adjacent interval blocks with reciprocal sums totaling 1."
+      "summary": "Formally states Erdős Problem #289 as `def ErdosProblem289 : Prop` = ∃ K, ∀ k ≥ K, there exist k pairwise non-adjacent interval blocks (via ValidDecomposition) with reciprocal sums totaling 1. Stated, not proved (open)."
     },
     {
       "id": "properties",
@@ -70,15 +70,15 @@
       "id": "hickerson-montgomery",
       "title": "Hickerson–Montgomery Example",
       "startLine": 88,
-      "endLine": 97,
-      "summary": "Axiomatizes the Hickerson–Montgomery construction: 5 non-adjacent intervals [2,7], [9,10], [17,18], [34,35], [84,85] with reciprocal sum exactly 2. Demonstrates feasibility of exact targets under non-adjacency."
+      "endLine": 93,
+      "summary": "Documents the Hickerson–Montgomery construction (as a comment): 5 non-adjacent intervals [2,7], [9,10], [17,18], [34,35], [84,85] with reciprocal sum exactly 2, illustrating feasibility of exact targets under non-adjacency."
     },
     {
       "id": "structural",
       "title": "Structural Observations",
-      "startLine": 98,
-      "endLine": 131,
-      "summary": "Harmonic tail divergence (enough sum available), reciprocal sum upper/lower bounds per block, spreading constraint (max endpoint ≥ k for k blocks), and the easier problem without non-adjacency (Erdős–Graham remark)."
+      "startLine": 94,
+      "endLine": 152,
+      "summary": "Proves interval_recipsum_upper and interval_recipsum_lower (per-block reciprocal-sum bounds |I|/hi ≤ S(I) ≤ |I|/lo) and recipSum_pos (each block's reciprocal sum is strictly positive). Includes commentary on harmonic tail divergence and the easier non-adjacency-free problem (Erdős–Graham remark)."
     }
   ],
   "crossReferences": [
@@ -119,10 +119,10 @@
       "Finset"
     ],
     "namespace": null,
-    "lineCount": 135,
+    "lineCount": 152,
     "axiomCount": 0,
-    "theoremCount": 4,
-    "definitionCount": 6,
+    "theoremCount": 5,
+    "definitionCount": 7,
     "path": "Proofs/Erdos289Problem.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary

Erdős Problem #289 (unit fractions from disjoint non-adjacent intervals) had its "Main Conjecture" section as a **prose-only** docstring with no formal statement, and the file lacked a positivity lemma for the reciprocal sum.

This PR:

- Adds `ErdosProblem289 : Prop` — the formal statement `∃ K, ∀ k ≥ K, ∃ blocks : Fin k → IntervalBlock, ValidDecomposition k blocks` (using the file's existing `ValidDecomposition` predicate, which encodes pairwise non-adjacency + reciprocal sums totaling 1).
- Adds `recipSum_pos` — every interval block's reciprocal sum is strictly positive, via `Finset.sum_pos` over the nonempty `Icc` range. Mirrors the proof style of the existing `interval_recipsum_upper`/`_lower`.
- Hardens four pre-existing dangling `/-- -/` doc-comments (Hickerson–Montgomery, harmonic divergence, two trailing remarks), none attached to a declaration, into plain `/- -/` block comments.

**Meta** updated to match the file and to correct pre-existing drift: counts (theoremCount 4→5, definitionCount 6→7, lineCount 135→152); the conjecture and Hickerson sections previously said "axiomatizes" though **no axiom exists**; the structural-section summary referenced a "spreading lemma" theorem **not present** in the file. Status stays `axiomatized`+`wip` (open problem, per policy). No axioms, no sorries.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos289Problem` (Docker unavailable here — **build-pending draft**)
- [x] `recipSum_pos` reuses the same `simp only [mem_Icc]` / `Nat.cast_pos` / `div_pos` patterns already verified in the sibling `interval_recipsum_*` lemmas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)