### PR TITLE
research(cantor-oq01010201): prove ℵ₁ is the least permitted value for 2^ℵ₀

### DIFF
--- a/proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean
+++ b/proofs/Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean
@@ -29,6 +29,9 @@ and develop the object-level scaffold around it.
 4. `aleph_two_permitted` — ℵ₂ is permitted (PFA value)
 5. `aleph_succ_permitted` — every successor aleph is permitted
 6. `permitted_unbounded` — the permitted-value class is proper (unbounded)
+   - `aleph_one_le_of_permitted` — every permitted value is `≥ ℵ₁`
+   - `aleph_one_least_permitted` — `ℵ₁` is the least permitted value
+   - `isPermittedValue_iff_aleph_one_le` — textbook "regular, `≥ ℵ₁`" form
 
 ### Easton functions (function-level):
 7. `IsEastonFunction F` — structure capturing the three Easton constraints
@@ -148,6 +151,44 @@ theorem not_permitted_of_le_aleph0 (κ : Cardinal.{0}) (h : κ ≤ ℵ₀) :
   rintro ⟨_, hgt⟩
   exact absurd (lt_of_lt_of_le hgt h) (lt_irrefl _)
 
+/-- Every permitted value is at least `ℵ₁`. This is the textbook
+    "uncountable" phrasing of the lower bound: for a cardinal,
+    `ℵ₀ < κ ⟺ ℵ₁ ≤ κ`, since `ℵ₁ = Order.succ ℵ₀`. Derived from the
+    definitional `ℵ₀ < κ` via `Order.succ_le_of_lt`. -/
+theorem aleph_one_le_of_permitted (κ : Cardinal.{0}) (h : IsPermittedValue κ) :
+    Cardinal.aleph 1 ≤ κ := by
+  rcases h with ⟨_, hgt⟩
+  rw [show (1 : Ordinal.{0}) = Order.succ 0 from by rw [Order.succ_eq_add_one, zero_add],
+      Cardinal.aleph_succ, Cardinal.aleph_zero]
+  exact Order.succ_le_of_lt hgt
+
+/-- **ℵ₁ is the least permitted value**: it is itself permitted, and it
+    lies below every permitted value. Object-level statement that `ℵ₁`
+    is the minimum of the Easton spectrum — the smallest cardinal
+    consistent with both Cantor's lower bound and König's constraint.
+    There is no gap below it (CH realizes exactly this minimum). -/
+theorem aleph_one_least_permitted :
+    IsPermittedValue (Cardinal.aleph 1) ∧
+      ∀ κ : Cardinal.{0}, IsPermittedValue κ → Cardinal.aleph 1 ≤ κ :=
+  ⟨aleph_one_permitted, aleph_one_le_of_permitted⟩
+
+/-- Reformulation of `IsPermittedValue` in the textbook "regular and
+    `≥ ℵ₁`" form, equivalent to the definitional "regular and `ℵ₀ < κ`"
+    because `ℵ₀ < κ ⟺ ℵ₁ ≤ κ` for cardinals. -/
+theorem isPermittedValue_iff_aleph_one_le (κ : Cardinal.{0}) :
+    IsPermittedValue κ ↔ κ.IsRegular ∧ Cardinal.aleph 1 ≤ κ := by
+  constructor
+  · intro h
+    obtain ⟨hreg, _⟩ := h
+    exact ⟨hreg, aleph_one_le_of_permitted κ h⟩
+  · rintro ⟨hreg, hle⟩
+    refine ⟨hreg, ?_⟩
+    have h1 : ℵ₀ < Cardinal.aleph 1 := by
+      rw [show (1 : Ordinal.{0}) = Order.succ 0 from by rw [Order.succ_eq_add_one, zero_add],
+          Cardinal.aleph_succ, Cardinal.aleph_zero]
+      exact Order.lt_succ _
+    exact lt_of_lt_of_le h1 hle
+
 /-
 ═══════════════════════════════════════════════════════════════════════════════
 PART II: EASTON FUNCTIONS — FUNCTION-LEVEL CONSTRAINTS
@@ -248,6 +289,9 @@ PART IV: VERIFICATION
 #check @aleph_two_permitted
 #check @aleph_succ_permitted
 #check @permitted_unbounded
+#check @aleph_one_le_of_permitted
+#check @aleph_one_least_permitted
+#check @isPermittedValue_iff_aleph_one_le
 #check @IsEastonFunction
 #check @isEastonFunction_continuum
 #check @isEastonFunction_nonempty

--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -24,10 +24,10 @@
     "additionalFiles": [
       "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean"
     ],
-    "lineCount": 255,
+    "lineCount": 298,
     "assumptions": "The parent file is now axiom-free (Phase-3a-fix discharged both sorries; S8 Lever A residual deleted the two vacuous True-codomain axioms easton_permitted_realizable and easton_consistency, which were Phase-3a placeholders). The slug-level axiomatization (4 axioms) now lives entirely in the Phase3b companion file CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean, which carries the genuine Easton 1970 realizability claim with non-trivial codomain: ConsistencyOfContinuumValue : Cardinal.{0} → Prop and ConsistencyOfContinuumFunction : (Cardinal.{0} → Cardinal.{0}) → Prop are abstract predicates (2 axioms); easton_permitted_realizable_strong (every permitted κ > ℵ₀ realizable as 2^ℵ₀, with ConsistencyOfContinuumValue codomain) and easton_consistency_strong (every Easton function realizable as continuum function on regulars, with ConsistencyOfContinuumFunction codomain) are the strong-Easton claims (2 axioms). All 7 supporting theorems in the parent file are now fully machine-checked from Mathlib (axiom-free): IsPermittedValue scaffold, aleph_one_permitted, aleph_two_permitted, aleph_succ_permitted, permitted_satisfies_konig, permitted_unbounded, IsEastonFunction structure, isEastonFunction_continuum, isEastonFunction_nonempty. The Phase3b file derives 5 callable theorems demonstrating the strong axioms have non-trivial output (consistencyOfContinuumFunction_continuum, consistencyOfContinuumValue_aleph_{one,two,succ,unbounded}). Slug-level axiom count: 4 (all Phase3b).",
     "mathlib_version": "4.26.0",
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 2
   },
   "overview": {
@@ -63,32 +63,32 @@
       "id": "permitted-values",
       "title": "Permitted Values: Pointwise Characterization",
       "startLine": 61,
-      "endLine": 124,
-      "summary": "Defines IsPermittedValue κ := κ.IsRegular ∧ ℵ₀ < κ. Proves permitted_satisfies_konig (König), aleph_one_permitted (CH value), aleph_two_permitted (PFA value), aleph_succ_permitted (every successor aleph), and permitted_unbounded (proper class). 6 theorems, 0 axioms, 0 sorries.",
+      "endLine": 190,
+      "summary": "Defines IsPermittedValue κ := κ.IsRegular ∧ ℵ₀ < κ. Proves permitted_satisfies_konig (König), aleph_one_permitted (CH value), aleph_two_permitted (PFA value), aleph_succ_permitted (every successor aleph), permitted_unbounded (proper class), not_permitted_of_le_aleph0 (Cantor converse), aleph_one_le_of_permitted (every permitted value ≥ ℵ₁), aleph_one_least_permitted (ℵ₁ is the least permitted value / minimum of the Easton spectrum), and isPermittedValue_iff_aleph_one_le (textbook 'regular, ≥ ℵ₁' reformulation). 10 theorems, 0 axioms, 0 sorries.",
       "mathContext": "$\\mathsf{IsPermittedValue}(\\kappa) \\iff \\kappa$ is regular and $\\aleph_0 < \\kappa$. Concretely: $\\aleph_1, \\aleph_2, \\aleph_n, \\ldots, \\aleph_{\\omega+1}, \\aleph_{\\omega_1+1}, \\ldots$ are all permitted. The unbounded-class theorem $\\forall \\alpha\\, \\exists \\kappa\\, (\\aleph_\\alpha < \\kappa \\land \\mathsf{IsPermittedValue}(\\kappa))$ rules out any cardinal upper bound on $2^{\\aleph_0}$."
     },
     {
       "id": "easton-functions",
       "title": "Easton Functions: Function-Level Constraints",
-      "startLine": 125,
-      "endLine": 173,
+      "startLine": 191,
+      "endLine": 257,
       "summary": "Defines IsEastonFunction F as a structure with three fields: succ_le (F(κ) ≥ κ⁺), monotone (F monotone on regular cardinals), konig_pointwise (cf(F(κ)) > κ). Proves isEastonFunction_continuum (2^· is Easton) and isEastonFunction_nonempty (the constraint set is non-vacuous). 3 theorems, 0 axioms, 0 sorries.",
       "mathContext": "The structure $\\mathsf{IsEastonFunction}\\,F$ captures the function-level Easton conditions on regular cardinals: $F(\\kappa) \\geq \\kappa^+$, $\\kappa \\leq \\lambda \\Rightarrow F(\\kappa) \\leq F(\\lambda)$, $\\mathrm{cf}(F(\\kappa)) > \\kappa$. The witness $F(\\kappa) = 2^\\kappa$ satisfies all three from Mathlib's Cantor, power_le_power_right, and lt_cof_power lemmas."
     },
     {
       "id": "easton-axioms-pointer",
       "title": "Easton Consistency: Pointer to Phase3b Companion File",
-      "startLine": 174,
-      "endLine": 213,
+      "startLine": 258,
+      "endLine": 279,
       "summary": "Part III now redirects the reader to the Phase3b companion file CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean, where Easton's 1970 realizability theorem is axiomatized with non-trivial codomain (ConsistencyOfContinuumValue / ConsistencyOfContinuumFunction). The earlier vacuous True-codomain axioms in this file were retired in S8 Lever A residual; they had no mathematical content beyond what the Phase3b _strong siblings carry.",
       "mathContext": "Pointer narrative. The genuine $\\mathsf{Easton}\\,(1970)$ statement lives in the Phase3b companion: $\\mathsf{Con}(\\mathsf{ZFC}) \\Rightarrow \\mathsf{Con}(\\mathsf{ZFC} + (\\forall \\kappa\\,\\mathrm{regular} \\geq \\aleph_0:\\, 2^\\kappa = F(\\kappa)))$ for every Easton function $F$, packaged via the abstract ConsistencyOf predicates."
     },
     {
       "id": "verification",
       "title": "Verification Section",
-      "startLine": 213,
-      "endLine": 230,
-      "summary": "#check declarations confirm all 7 theorems, 1 definition, and 1 structure type-check correctly. Closes the namespace CantorDiagOQ01OQ01OQ02OQ01. The previous two #check directives for the deleted axioms (easton_permitted_realizable, easton_consistency) were removed in S8 Lever A residual.",
+      "startLine": 280,
+      "endLine": 298,
+      "summary": "#check declarations confirm all public theorems, 1 definition, and 1 structure type-check correctly. Closes the namespace CantorDiagOQ01OQ01OQ02OQ01. The previous two #check directives for the deleted axioms (easton_permitted_realizable, easton_consistency) were removed in S8 Lever A residual.",
       "mathContext": "Sanity check: every public symbol in the parent file has its expected type signature."
     }
   ],
@@ -110,9 +110,9 @@
       "Mathlib.Tactic"
     ],
     "namespace": "CantorDiagOQ01OQ01OQ02OQ01",
-    "lineCount": 255,
+    "lineCount": 298,
     "axiomCount": 0,
-    "theoremCount": 10,
+    "theoremCount": 13,
     "definitionCount": 2,
     "path": "Proofs/CantorDiagonalizationOQ01OQ01OQ02OQ01.lean",
     "sorries": 0,


### PR DESCRIPTION
## Summary

The file `CantorDiagonalizationOQ01OQ01OQ02OQ01.lean` characterizes the *permitted values* of the continuum 2^ℵ₀ (the regular uncountable cardinals) and proves ℵ₁, ℵ₂, and every successor aleph are permitted, plus `permitted_unbounded` (proper class). But it never states the natural **minimum** fact: ℵ₁ is the *least* permitted value — the bottom of the Easton spectrum — nor the textbook "regular and ≥ ℵ₁" reformulation of `IsPermittedValue`.

This PR adds three axiom-free theorems, all derived from Mathlib by reusing the file's own `aleph_one_permitted` rewrite chain (`aleph 1 = succ ℵ₀`):

- `aleph_one_le_of_permitted` — every permitted value is `≥ ℵ₁` (via `Order.succ_le_of_lt`)
- `aleph_one_least_permitted` — ℵ₁ is permitted and lies below every permitted value (minimum of the Easton spectrum)
- `isPermittedValue_iff_aleph_one_le` — `IsPermittedValue κ ↔ κ.IsRegular ∧ ℵ₁ ≤ κ`

Docstring "What This File Proves" list, the `#check` verification block, and `meta.json` (theoremCount 10→13, lineCount 255→298, realigned section boundaries) updated to match.

## Verification

Proofs are hand-verified reuse of the file's existing verified tactic patterns (the same `show (1:Ordinal) = Order.succ 0 … aleph_succ, aleph_zero` chain used by `aleph_one_permitted`/`aleph_two_permitted`, and `Order.succ_le_of_lt` used across sibling Cantor files). Marked **draft** because the Docker build host is currently unresponsive; promote to ready once a clean `docker-build.sh Proofs.CantorDiagonalizationOQ01OQ01OQ02OQ01` is confirmed.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.CantorDiagonalizationOQ01OQ01OQ02OQ01`
- [ ] `pnpm build` (gallery meta renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)