### PR TITLE
research(erdos-265): formalize Erdős's first conjecture from Kovač–Tao axiom (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos265Problem.lean
+++ b/proofs/Proofs/Erdos265Problem.lean
@@ -126,7 +126,7 @@ Erdős made two conjectures about the growth rate:
 /-- Erdős's first conjecture: single exponential growth is achievable.
     NOTE: This follows from kovac_tao_theorem — if a_n^{1/β^n} → ∞ for some β > 1,
     then a_n^{1/n} → ∞ since a_n^{1/n} ≥ a_n^{1/β^n} for large n (when β^n ≥ n).
-    See Erdos265Aristotle.lean for the reduction. -/
+    Formalized below as `erdos_265_firstConjecture` (via `singleExp_of_genExp`). -/
 /-- Erdős's second conjecture: double exponential implies limit 1
     NOTE: This is still an OPEN CONJECTURE (not a proven result).
     The Kovač-Tao result (2024) only shows β > 1 is achievable, not β = 2.
@@ -159,6 +159,58 @@ theorem erdos_265_remaining :
     hasBothRationalSums a →
     Filter.Tendsto (doubleExpGrowth a) Filter.atTop (nhds 1)) :=
   Or.inr erdos_265_doubleExp_necessary
+
+/-
+## Erdős's First Conjecture (derived from Kovač–Tao)
+
+Erdős conjectured that single-exponential growth aₙ^(1/n) → ∞ is achievable.
+This is a consequence of the Kovač–Tao result (2024): if some valid sequence
+has aₙ^(1/βⁿ) → ∞ for β > 1, then aₙ^(1/n) → ∞ for the same sequence, because
+β^n ≥ n eventually and rpow with base ≥ 1 is monotone in the exponent.
+-/
+
+/-- Monotone comparison: for `β > 1` and a positive-integer sequence `a`, doubly
+    exponential growth `aₙ^(1/βⁿ) → ∞` forces single-exponential growth
+    `aₙ^(1/n) → ∞`, since eventually `β^n ≥ n` and thus `aₙ^(1/n) ≥ aₙ^(1/βⁿ)`. -/
+open Filter in
+theorem singleExp_of_genExp (a : ℕ → ℕ) (β : ℝ) (hβ : β > 1)
+    (hpos : IsPositiveIntSeq a)
+    (htend : Tendsto (genExpGrowth a β) atTop atTop) :
+    Tendsto (singleExpGrowth a) atTop atTop := by
+  rw [Filter.tendsto_atTop_atTop] at *
+  have h_exp_ge : ∀ᶠ n in atTop, (n : ℝ) ≤ β ^ n := by
+    have h_exp_growth : Filter.Tendsto (fun n : ℝ => β ^ n / n) Filter.atTop Filter.atTop := by
+      have h_exp_growth : Filter.Tendsto (fun n : ℝ => Real.exp (n * Real.log β) / n)
+          Filter.atTop Filter.atTop := by
+        have := Real.tendsto_exp_div_pow_atTop 1
+        have := this.comp (Filter.tendsto_id.atTop_mul_const (Real.log_pos hβ))
+        convert this.const_mul_atTop (Real.log_pos hβ) using 2 ; norm_num ; ring
+        norm_num [mul_assoc, mul_comm, mul_left_comm, ne_of_gt, Real.log_pos hβ]
+      simpa only [Real.rpow_def_of_pos (zero_lt_one.trans hβ), mul_comm] using h_exp_growth
+    filter_upwards [h_exp_growth.eventually_gt_atTop 1, Filter.eventually_gt_atTop 0]
+      with n hn hn' using by rw [lt_div_iff₀ hn'] at hn; linarith
+  have h_ge : ∀ᶠ n in atTop,
+      ((a n) : ℝ) ^ (1 / (n : ℝ)) ≥ ((a n) : ℝ) ^ (1 / (β ^ n : ℝ)) := by
+    filter_upwards [h_exp_ge.natCast_atTop, Filter.eventually_gt_atTop 0] with n hn hn'
+    gcongr ; aesop
+    exact_mod_cast hn
+  exact fun b => by
+    rcases htend b with ⟨i, hi⟩
+    rcases Filter.eventually_atTop.mp h_ge with ⟨j, hj⟩
+    exact ⟨Max.max i j, fun n hn => le_trans (hi n (le_trans (le_max_left _ _) hn))
+      (hj n (le_trans (le_max_right _ _) hn))⟩
+
+/-- **Erdős's first conjecture (single-exponential growth is achievable):**
+    There is a valid sequence (positive, strictly increasing, both reciprocal sums
+    rational) with `aₙ^(1/n) → ∞`. Derived from the `kovac_tao_theorem` axiom via the
+    monotone comparison `singleExp_of_genExp`. This was previously asserted only in
+    prose; here it is discharged as a theorem from the Kovač–Tao assumption. -/
+theorem erdos_265_firstConjecture :
+    ∃ a : ℕ → ℕ, IsPositiveIntSeq a ∧ IsStrictlyIncreasing a ∧
+      hasBothRationalSums a ∧
+      Filter.Tendsto (singleExpGrowth a) Filter.atTop Filter.atTop := by
+  obtain ⟨β, hβ, a, hpos, hinc, hrat, htend⟩ := kovac_tao_theorem
+  exact ⟨a, hpos, hinc, hrat, singleExp_of_genExp a β hβ hpos htend⟩
 
 /-
 ## Irrationality Threshold

--- a/research/problems/erdos-265/state.md
+++ b/research/problems/erdos-265/state.md
@@ -1,27 +1,56 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: ACT
 **Since**: 2026-01-12T22:30:27.389Z
-**Iteration**: 1
+**Iteration**: 2
+**Last Update**: 2026-06-14 (researcher-4 — formalized Erdős's first conjecture)
 
 ## Current Focus
 
-Initial exploration of the problem.
+Formalized Erdős's first conjecture in the main Lean file. The reduction "single-exponential growth aₙ^(1/n) → ∞ follows from Kovač–Tao's doubly-exponential result" was previously only asserted in a docstring (pointing at the Aristotle companion). This session ported the Aristotle-verified `singleExp_of_genExp` into `Erdos265Problem.lean` and added `erdos_265_firstConjecture`, deriving the existence of a valid sequence with aₙ^(1/n) → ∞ directly from the `kovac_tao_theorem` axiom.
+
+## Status Summary
+
+| Surface | Value | Source |
+|---------|-------|--------|
+| Lean file | `proofs/Proofs/Erdos265Problem.lean` (285 LOC, 7 thm, 11 def, 2 axioms, 0 sorries) | `wc -l` + grep |
+| Axioms | `kovac_tao_theorem` (deep 2024 result), `erdos_265_doubleExp_necessary` (OPEN 2nd conjecture) | `grep '^axiom '` |
+| Companion | `proofs/Proofs/Erdos265Aristotle.lean` (sorry-free, source of the reduction proof) | `grep -c sorry` |
+| Gallery | `src/data/proofs/erdos-265/meta.json` — `status: "axiomatized"`, `badge: "axiom"`, `axiomCount: 2`, `theoremCount: 7`, sections 10 | `meta.json` |
+| Conjecture status | OPEN (Erdős #265; Kovač–Tao 2024 settled β>1, β=2 open) | `erdosproblems.com/265` |
 
 ## Active Approach
 
-None yet.
+Discharging prose-only claims into formal theorems from the existing axioms (no new axioms added). Done this session for Erdős's first conjecture.
 
 ## Blockers
 
-None.
+- `kovac_tao_theorem` — Kovač–Tao (2024) doubly-exponential construction; not in Mathlib, deep research result.
+- `erdos_265_doubleExp_necessary` — Erdős's second conjecture (aₙ^(1/2ⁿ) → 1 necessary); still OPEN, so cannot be proved.
 
 ## Next Action
 
-Begin problem exploration.
+Both axioms are irreducible. Possible future, build-gated work:
+
+- **A.** Formalize Cantor's actual sequence membership in `validSequences` by proving ∑ 1/(cantorSeq n − 1) rational via partial-fraction telescoping over the (n−2)(n+1) denominator.
+- **B.** Prove aₙ^(1/n) → 1 for the Cantor sequence (polynomial growth), currently prose-only at the main docstring.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 2
+- Current approach attempts: 1
+- Approaches tried: 2
+
+## Iteration Ledger
+
+| Iter | Date | Agent | Result | Scope |
+|------|------|-------|--------|-------|
+| 1 | 2026-01-12 | (legacy) | Created axiomatized formalization (2 axioms, Cantor telescoping, open-problem statement) | Erdos265Problem.lean + companion |
+| 2 | 2026-06-14 | researcher-4 | ACT — ported verified `singleExp_of_genExp`, added `erdos_265_firstConjecture` (Erdős conj 1 from Kovač–Tao axiom); thm 5→7, LOC 233→285; meta sections 9→10, theoremCount 5→7; build-pending (Docker down) | Erdos265Problem.lean + meta.json + registry + state.md |
+
+## Cross-references
+
+- Research JSON registry: `src/data/research/problems/erdos-265.json`
+- Gallery dir: `src/data/proofs/erdos-265/`
+- Lean source: `proofs/Proofs/Erdos265Problem.lean`
+- Aristotle companion (verified reduction): `proofs/Proofs/Erdos265Aristotle.lean`

--- a/src/data/proofs/erdos-265/meta.json
+++ b/src/data/proofs/erdos-265/meta.json
@@ -38,10 +38,10 @@
       "erdos_265_main: open problem formalized as a classical disjunction (limsup aₙ^(1/2ⁿ) > 1 achievable, or all valid sequences satisfy aₙ^(1/2ⁿ) → 1)"
     ],
     "axiomCount": 2,
-    "lineCount": 233,
+    "lineCount": 285,
     "assumptions": "2 axioms: erdos_265_doubleExp_necessary, kovac_tao_theorem. 0 sorries.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 5,
+    "theoremCount": 7,
     "definitionCount": 11,
     "additionalFiles": [
       "Proofs/Erdos265Aristotle.lean"
@@ -57,7 +57,8 @@
       "**Higher polynomials work with shifted constraints**: Cubic sequences like $n^3 + 6n^2 + 5n$ can satisfy the dual rationality condition with a different shift constant, expanding the family of examples",
       "**Kovač-Tao broke the exponential barrier**: Their 2024 Annals paper shows $\\exists \\beta > 1$ with valid sequences growing as $a_n \\sim \\beta^{\\beta^n}$, confirming Erdős's first conjecture that super-exponential growth is achievable",
       "**The irrationality threshold at $\\beta = 2$**: A folklore result in transcendence theory shows that if $a_n^{1/2^n} \\to c > 1$ for a constant $c$, then $\\sum 1/a_n$ is irrational — providing a mechanism for why $\\beta = 2$ might be the hard limit",
-      "**The disjunction structure of the open problem**: Either (a) some valid sequence has $\\limsup a_n^{1/2^n} > 1$, disproving Erdős's second conjecture, or (b) all valid sequences satisfy $\\limsup a_n^{1/2^n} \\leq 1$, confirming it. This is formalized as a logical disjunction in Lean"
+      "**The disjunction structure of the open problem**: Either (a) some valid sequence has $\\limsup a_n^{1/2^n} > 1$, disproving Erdős's second conjecture, or (b) all valid sequences satisfy $\\limsup a_n^{1/2^n} \\leq 1$, confirming it. This is formalized as a logical disjunction in Lean",
+      "**Erdős's first conjecture is a theorem, not just prose**: `erdos_265_firstConjecture` derives the existence of a valid sequence with $a_n^{1/n}\\to\\infty$ directly from the Kovač–Tao axiom, via the monotone comparison $a_n^{1/n}\\ge a_n^{1/\\beta^n}$ (valid once $\\beta^n\\ge n$). The reduction `singleExp_of_genExp` is fully proved (no new axioms)."
     ],
     "prerequisites": [
       "Combinatorics and number theory",
@@ -77,31 +78,31 @@
       "id": "valid-sequences",
       "title": "Sequences with Rational Sums",
       "startLine": 22,
-      "endLine": 47,
+      "endLine": 49,
       "summary": "Core definitions: positive integer sequences, strict monotonicity, reciprocal sum ∑ 1/aₙ, shifted reciprocal sum ∑ 1/(aₙ-1), and the combined rationality predicate hasBothRationalSums.",
       "mathContext": "Formal definition: Core definitions: positive integer sequences, strict monotonicity, reciprocal sum ∑ 1/aₙ, shifted reciprocal sum ∑ 1/(aₙ-1), and the combined rationality predicate hasBothRationalSums."
     },
     {
       "id": "cantor-example",
       "title": "Cantor's Example",
-      "startLine": 48,
-      "endLine": 97,
+      "startLine": 50,
+      "endLine": 98,
       "summary": "Defines Cantor's sequence (triangular numbers n(n+1)/2). Proves strict monotonicity (cantorSeq_increasing), rationality of reciprocal sum (cantorSeq_rational_sum), and rationality of shifted reciprocal sum (cantorSeq_shifted_rational) via telescoping series.",
       "mathContext": "cantorSeq n = n*(n+1)/2. Proved theorems: cantorSeq_increasing, cantorSeq_rational_sum (telescoping via TriangularNumberReciprocals), cantorSeq_shifted_rational."
     },
     {
       "id": "growth-rates",
       "title": "Growth Rate Measures",
-      "startLine": 99,
-      "endLine": 116,
+      "startLine": 100,
+      "endLine": 117,
       "summary": "Three growth measures: singleExpGrowth (aₙ^(1/n)), doubleExpGrowth (aₙ^(1/2ⁿ)), and genExpGrowth (aₙ^(1/βⁿ)) for parameterized β > 1.",
       "mathContext": "Mathematical content: Three growth measures: singleExpGrowth (aₙ^(1/n)), doubleExpGrowth (aₙ^(1/2ⁿ)), and genExpGrowth (aₙ^(1/βⁿ)) for parameterized β > 1."
     },
     {
       "id": "erdos-conjectures",
       "title": "Erdős's Conjectures",
-      "startLine": 118,
-      "endLine": 137,
+      "startLine": 119,
+      "endLine": 138,
       "summary": "Two conjectures: (1) aₙ^(1/n) → ∞ is achievable (proved by Kovač-Tao), (2) aₙ^(1/2ⁿ) → 1 is necessary (still open).",
       "mathContext": "Two conjectures: (1) aₙ^(1/n) $\\to$ ∞ is achievable (proved by Kovač-Tao), (2) aₙ^(1/2ⁿ) $\\to$ 1 is necessary (still open)."
     },
@@ -109,31 +110,38 @@
       "id": "kovac-tao",
       "title": "Kovač-Tao Result and Open Question",
       "startLine": 139,
-      "endLine": 161,
+      "endLine": 162,
       "summary": "Kovač-Tao theorem: ∃ β > 1 with aₙ^(1/βⁿ) → ∞ achievable. The remaining open question: can β = 2 work?",
       "mathContext": "Kovač-Tao theorem: ∃ β > 1 with aₙ^(1/βⁿ) $\\to$ ∞ achievable. The remaining open question: can β = 2 work?"
     },
     {
+      "id": "first-conjecture",
+      "title": "Erdős's First Conjecture (derived from Kovač–Tao)",
+      "startLine": 163,
+      "endLine": 215,
+      "summary": "Formalizes Erdős's first conjecture as a derived theorem. `singleExp_of_genExp` (proof ported from the Aristotle-verified companion) shows that for $\\beta>1$ and a positive-integer sequence, $a_n^{1/\\beta^n}\\to\\infty$ forces $a_n^{1/n}\\to\\infty$, using `eventually` $\\beta^n\\ge n$ and rpow exponent-monotonicity. `erdos_265_firstConjecture` then derives, from the `kovac_tao_theorem` axiom, the existence of a valid sequence with $a_n^{1/n}\\to\\infty$ — previously only asserted in a docstring."
+    },
+    {
       "id": "irrationality",
       "title": "Irrationality Threshold",
-      "startLine": 163,
-      "endLine": 175,
+      "startLine": 216,
+      "endLine": 222,
       "summary": "Informal block comment noting the folklore irrationality threshold: if aₙ^(1/2ⁿ) → c > 1, then ∑ 1/aₙ is irrational. No Lean declaration — block comment only (line 170 is a block comment, not a formalized axiom or theorem).",
       "mathContext": "Folklore result (not formalized): if aₙ^(1/2ⁿ) $\\to$ c > 1, then ∑ 1/aₙ is irrational. Described in block comments at lines 163–175."
     },
     {
       "id": "valid-set-poly",
       "title": "Valid Set and Polynomial Examples",
-      "startLine": 177,
-      "endLine": 195,
+      "startLine": 223,
+      "endLine": 245,
       "summary": "Defines validSequences (set of all valid sequences) and maxGrowthRate (sup of single-exponential growth rates). Polynomial families that can satisfy the constraint are noted in an informal block comment — not formalized as a Lean declaration.",
       "mathContext": "validSequences := {a | IsPositiveIntSeq a ∧ IsStrictlyIncreasing a ∧ hasBothRationalSums a}. maxGrowthRate := ⋃ (a ∈ validSequences), limsup singleExpGrowth a. Polynomial examples noted in block comment only."
     },
     {
       "id": "main-open",
       "title": "Main Open Problem",
-      "startLine": 197,
-      "endLine": 232,
+      "startLine": 246,
+      "endLine": 284,
       "summary": "The formal statement of Erdős #265 as a disjunction: either ∃ valid sequence with limsup aₙ^(1/2ⁿ) > 1, or all valid sequences have limsup ≤ 1.",
       "mathContext": "The formal statement of Erdős #265 as a disjunction: either ∃ valid sequence with limsup aₙ^(1/2ⁿ) > 1, or all valid sequences have limsup $\\leq$ 1."
     }

--- a/src/data/research/problems/erdos-265.json
+++ b/src/data/research/problems/erdos-265.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-265",
   "title": "Erdős #265",
-  "phase": "OBSERVE",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -16,12 +16,12 @@
     "goal": ""
   },
   "currentState": {
-    "phase": "COMPLETED",
-    "since": "2026-01-12T22:30:27.389Z",
-    "iteration": 1,
-    "focus": "Initial exploration of the problem.",
+    "phase": "ACT",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 2,
+    "focus": "S-ACT: Formalized Erdős's first conjecture in the main file. Ported the Aristotle-verified reduction singleExp_of_genExp from Erdos265Aristotle.lean into Erdos265Problem.lean and added erdos_265_firstConjecture, which derives (from the kovac_tao_theorem axiom) the existence of a valid sequence with a_n^{1/n} -> infinity. Previously only asserted in a docstring (with a 'see companion file' pointer). No new axioms; theoremCount 5->7, lineCount 233->285; gallery meta sections 9->10.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "Two axioms remain and are both irreducible: kovac_tao_theorem (deep 2024 result, not in Mathlib) and erdos_265_doubleExp_necessary (the still-OPEN second conjecture). Possible future work: (A) formalize Cantor's sequence membership in validSequences by proving sum 1/(cantorSeq n - 1) rational via partial-fraction telescoping over (n-2)(n+1); (B) prove a_n^{1/n} -> 1 for Cantor (polynomial growth). Both are real-analysis-heavy and build-gated.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,10 +29,12 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETE: Axiomatized with 2 axioms (erdos_265_doubleExp_necessary, kovac_tao_theorem). Gallery entry live.",
+    "progressSummary": "AXIOMATIZED (2 irreducible axioms: kovac_tao_theorem, erdos_265_doubleExp_necessary). Erdos265Problem.lean now 285 LOC, 7 theorems, 11 defs, 0 sorries. Erdős's first conjecture is now a derived theorem (erdos_265_firstConjecture) via the ported, Aristotle-verified reduction singleExp_of_genExp. Cantor's triangular-number example has rational reciprocal sum (telescoping). The main open question (limsup a_n^{1/2^n} > 1?) is captured as erdos_265_main / erdos_265_remaining.",
     "builtItems": [
       "erdos_265_remaining: proved via Or.inr erdos_265_doubleExp_necessary (axiom eliminated)",
-      "Fixed Erdos265Aristotle.lean: replaced exact? with Real.rpow_le_rpow_of_exponent_le hx hpq (line 94)"
+      "Fixed Erdos265Aristotle.lean: replaced exact? with Real.rpow_le_rpow_of_exponent_le hx hpq (line 94)",
+      "singleExp_of_genExp: a_n^{1/β^n} -> ∞ (β>1) implies a_n^{1/n} -> ∞ (ported from verified companion)",
+      "erdos_265_firstConjecture: Erdős conj 1 (single-exp growth achievable) derived from kovac_tao_theorem axiom"
     ],
     "insights": [
       "erdos_265_main is a logical tautology (∃ a P(a) ∨ ∀ a ¬P(a)), provable by classical excluded middle",


### PR DESCRIPTION
## Summary
Research session on **Erdős #265** — how fast can a strictly increasing integer sequence grow if both $\sum 1/a_n$ and $\sum 1/(a_n-1)$ are rational? (OPEN; Kovač–Tao 2024 settled $\beta>1$, the $\beta=2$ threshold is open.)

The main Lean file asserted in a docstring that Erdős's **first** conjecture — single-exponential growth $a_n^{1/n}\to\infty$ is achievable — "follows from `kovac_tao_theorem` … see `Erdos265Aristotle.lean` for the reduction", but never formalized it. This session discharges that claim as a theorem.

## Progress (2 new theorems, no new axioms)
- **`singleExp_of_genExp`** — for $\beta>1$ and a positive-integer sequence, $a_n^{1/\beta^n}\to\infty \Rightarrow a_n^{1/n}\to\infty$ (eventually $\beta^n\ge n$, and rpow with base $\ge 1$ is monotone in the exponent). The proof body is **ported verbatim from the sorry-free, Aristotle-verified companion** `Erdos265Aristotle.lean`.
- **`erdos_265_firstConjecture`** — derives from the `kovac_tao_theorem` axiom the existence of a valid sequence with $a_n^{1/n}\to\infty$ (Erdős's first conjecture).

## Files
- `proofs/Proofs/Erdos265Problem.lean` (233→285 LOC, 5→7 theorems; 2 axioms / 0 sorries unchanged). Stale docstring pointer updated to reference the in-file theorem.
- `src/data/proofs/erdos-265/meta.json` — `theoremCount` 5→7, `lineCount` 233→285, sections 9→10 (new `first-conjecture` section), keyInsight added.
- `src/data/research/problems/erdos-265.json`, `research/problems/erdos-265/state.md` — state sync (NEW template → ACT, iteration 2).

## Status
**Outcome**: progress (prose claim → formal theorem). Both axioms remain and are irreducible: `kovac_tao_theorem` (deep 2024 result, not in Mathlib) and `erdos_265_doubleExp_necessary` (the still-OPEN second conjecture). The headline open question (can $\limsup a_n^{1/2^n}>1$?) is unchanged.

**Build**: ⚠️ build-pending — Docker daemon unresponsive this session. The new proof body is a verbatim port of an already-verified companion lemma (identical local definitions), so confidence is high, but it is unverified here. Draft until built.

🤖 Generated by researcher-4