### PR TITLE
research(cayley-hamilton-reduction-oq-02-oq-01): non-derogatory + linear charpoly corollaries

### DIFF
--- a/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean
+++ b/proofs/Proofs/CayleyHamiltonReductionOQ02OQ01.lean
@@ -338,6 +338,16 @@ theorem charpoly_companionMatrix {d : ℕ} [NeZero d] (p : F[X])
     rw [h0, h1, map_one]
   rw [hq, hq_eq, mul_one]
 
+/-- **The companion matrix is non-derogatory**: its minimal and characteristic
+polynomials coincide (both equal p). This is the defining property that makes
+companion matrices the building blocks of the rational canonical form — each
+invariant factor pᵢ is realised by a single companion block whose minimal
+polynomial is its full characteristic polynomial. -/
+theorem minpoly_eq_charpoly_companionMatrix {d : ℕ} [NeZero d] (p : F[X])
+    (hp : p.Monic) (hdeg : p.natDegree = d) :
+    minpoly F (companionMatrix (d := d) p) = (companionMatrix (d := d) p).charpoly := by
+  rw [minpoly_companionMatrix hp hdeg, charpoly_companionMatrix hp hdeg]
+
 /-! ## Part 4: Trivial Case — Linear Polynomial -/
 
 /-- For p(x) = x - c, the companion matrix is the 1×1 matrix [c].
@@ -351,6 +361,15 @@ theorem companionMatrix_linear (c : F) :
   subst_vars
   simp [Polynomial.coeff_sub, Polynomial.coeff_X, Polynomial.coeff_C]
   ring
+
+/-- The characteristic polynomial of the 1×1 companion block of `X - C c` is
+`X - C c` itself — the eigenvalue `c` read off directly. A concrete instance of
+`charpoly_companionMatrix` for the RCF base case. -/
+theorem charpoly_companionMatrix_linear (c : F) :
+    (companionMatrix (d := 1) (X - C c)).charpoly = X - C c := by
+  apply charpoly_companionMatrix
+  · exact monic_X_sub_C c
+  · exact Polynomial.natDegree_X_sub_C c
 
 /-! ## Part 5: RCF Roadmap
 
@@ -391,6 +410,8 @@ A is similar to the block diagonal matrix
 #check @charpoly_companionMatrix
 #check @minpoly_companionMatrix
 #check @aeval_companionMatrix
+#check @minpoly_eq_charpoly_companionMatrix
 #check @companionMatrix_linear
+#check @charpoly_companionMatrix_linear
 
 end CayleyHamiltonReductionOQ02OQ01

--- a/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-reduction-oq-02-oq-01/meta.json
@@ -40,10 +40,10 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 396,
+    "lineCount": 417,
     "assumptions": "Main file (CayleyHamiltonReductionOQ02OQ01.lean): 0 axioms, 0 sorries; all three key theorems fully proved (aeval_companionMatrix via orbit argument, charpoly_companionMatrix, minpoly_companionMatrix) using Mathlib supporting lemmas. Aristotle companion (CayleyHamiltonReductionOQ02OQ01Aristotle.lean) carries 12 routine helper-lemma stubs (minpoly_dvd_of_aeval_zero, dvd_antisymm_monic, orbit_basis_independent, etc.) staged for automated proof search; these are not imported by the main file.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 1,
     "additionalFiles": [
       "Proofs/CayleyHamiltonReductionOQ02OQ01Aristotle.lean"
@@ -74,7 +74,7 @@
       "id": "entry-lemmas",
       "title": "Part 2: Basic Entry Properties",
       "startLine": 82,
-      "endLine": 108,
+      "endLine": 109,
       "summary": "Three lemmas characterizing the three entry types: `companionMatrix_subdiag` (subdiagonal = 1), `companionMatrix_last_col` (last column = −coeff), `companionMatrix_zero` (elsewhere = 0).",
       "mathContext": "Each entry is a direct `if-then-else` on the indices. The proofs use `Matrix.ext` + `simp` with the definition. The `companion_col_action` lemma derives the column action: $C(p) \\cdot e_i = e_{i+1}$ for $i < d-1$ and $C(p) \\cdot e_{d-1} = -\\sum_{k<d} a_k e_k$. This is the key fact for the orbit argument."
     },
@@ -82,7 +82,7 @@
       "id": "orbit",
       "title": "Part 3: Orbit of Standard Basis Vectors",
       "startLine": 110,
-      "endLine": 168,
+      "endLine": 169,
       "summary": "Proves C(p)ᵏ·e₀ = eₖ for k < d by induction using the column action lemmas. The orbit {e₀, ..., e_{d-1}} equals the standard basis.",
       "mathContext": "The induction: base case $C^0 e_0 = e_0$; step $C^{k+1} e_0 = C \\cdot (C^k e_0) = C \\cdot e_k = e_{k+1}$ (using the subdiagonal action for $k < d-1$). This confirms the isomorphism $F^d \\cong F[X]/(p)$ as $F[X]$-modules, with $e_k \\leftrightarrow X^k \\bmod p$."
     },
@@ -90,23 +90,23 @@
       "id": "key-theorems",
       "title": "Part 3b: Annihilation, Charpoly, Minpoly",
       "startLine": 170,
-      "endLine": 211,
-      "summary": "Three core theorems: p(C(p)) = 0 (orbit annihilation), charpoly(C(p)) = p (from minpoly = p), minpoly(C(p)) = p (orbit independence). All proved with 0 sorries.",
+      "endLine": 350,
+      "summary": "Helper lemmas plus the three core theorems: p(C(p)) = 0 (orbit annihilation), minpoly(C(p)) = p (orbit independence), charpoly(C(p)) = p (from minpoly = p), and the non-derogatory corollary minpoly_eq_charpoly_companionMatrix (minpoly = charpoly). All proved with 0 sorries.",
       "mathContext": "Annihilation ($p(C) = 0$): using the orbit, $p(C) \\cdot e_0 = (C^d + a_{d-1}C^{d-1} + \\cdots + a_0) \\cdot e_0 = e_d + \\sum a_k e_k$. The last-column action gives $e_d = C^{d-1} \\cdot e_{d-1} = -\\sum a_k e_k$ (the last column entry), so $p(C) \\cdot e_0 = 0$. Since $e_0$ generates all of $F^d$ under $C$, $p(C) = 0$."
     },
     {
       "id": "linear-case",
       "title": "Part 4: Linear Polynomial Base Case",
-      "startLine": 213,
-      "endLine": 225,
-      "summary": "Proves C(x−c) = [c] for the 1×1 companion matrix, connecting companion blocks to eigenvalues.",
+      "startLine": 351,
+      "endLine": 373,
+      "summary": "Proves C(x−c) = [c] for the 1×1 companion matrix and its charpoly = X − C c (charpoly_companionMatrix_linear), connecting companion blocks to eigenvalues.",
       "mathContext": "For $p = X - c$ (degree 1), $C(p)$ is the $1 \\times 1$ matrix $[c]$. The companion matrix of a linear factor is thus exactly the eigenvalue, confirming that the Jordan block with eigenvalue $c$ is $C(X-c) = [c]$ in the degree-1 case."
     },
     {
       "id": "rcf-roadmap",
       "title": "Part 5: Full RCF Roadmap",
-      "startLine": 226,
-      "endLine": 259,
+      "startLine": 374,
+      "endLine": 417,
       "summary": "Documents the ~1800-line gap to a complete Lean formalization of the rational canonical form: SNF (~800), companion (~200), block assembly (~300), uniqueness (~200).",
       "mathContext": "The complete RCF theorem requires: (1) Smith Normal Form for $F[X]$-matrices (Euclidean domain algorithm, ~800 lines); (2) companion block diagonalization from SNF invariant factors (~200 lines); (3) similarity proof assembling the block structure (~300 lines); (4) uniqueness of invariant factors (~200 lines). Completed formalizations exist in Coq (Cano-Dénès 2012) and Isabelle (Divasón-Thiemann 2016)."
     }
@@ -182,9 +182,9 @@
       "BigOperators"
     ],
     "namespace": "CayleyHamiltonReductionOQ02OQ01",
-    "lineCount": 396,
+    "lineCount": 417,
     "axiomCount": 0,
-    "theoremCount": 18,
+    "theoremCount": 20,
     "definitionCount": 1,
     "sorries": 0,
     "path": "Proofs/CayleyHamiltonReductionOQ02OQ01.lean",


### PR DESCRIPTION
## Summary

This `verified` file on companion matrices (the building block of the rational canonical form) proves `aeval_companionMatrix` (p(C(p))=0), `minpoly_companionMatrix` (=p), and `charpoly_companionMatrix` (=p). Its docstring asserts "companion is non-derogatory" but never stated that as a theorem, and the linear base case lacked a charpoly statement.

Adds two corollaries of the already-verified theorems:

- `minpoly_eq_charpoly_companionMatrix` — the companion matrix is **non-derogatory**: `minpoly F (C(p)) = charpoly(C(p))` (both equal `p`). A 2-rewrite of `minpoly_companionMatrix` + `charpoly_companionMatrix`.
- `charpoly_companionMatrix_linear` — `charpoly` of the 1×1 companion block of `X - C c` is `X - C c` (concrete RCF base case).

The file stays `verified` (0 axioms, 0 sorries). Meta updated: `theoremCount` 18→20, `lineCount` 396→417, and **corrects pre-existing section-line drift** — the `sections` ranges ended at L259 though the file is 417 lines; all six ranges realigned to the actual `Part` markers.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.CayleyHamiltonReductionOQ02OQ01` (Docker unavailable here — **build-pending draft**)
- [x] Both additions are trivial corollaries: `minpoly_eq_charpoly` is two rewrites of existing theorems; `charpoly_..._linear` is `apply charpoly_companionMatrix` + `monic_X_sub_C` + `natDegree_X_sub_C`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)