### PR TITLE
research(furstenberg-oq02): connect invariant σ-algebra to ergodicity

### DIFF
--- a/proofs/Proofs/FurstenbergCorrespondenceOQ02.lean
+++ b/proofs/Proofs/FurstenbergCorrespondenceOQ02.lean
@@ -336,6 +336,35 @@ theorem invariant_univ {α : Type*} [m : MeasurableSpace α] (T : α → α) :
     @MeasurableSet α (invariantSigmaAlgebra T) Set.univ :=
   ⟨MeasurableSet.univ, preimage_univ⟩
 
+/-- Finite unions of invariant sets are invariant (dual of `invariant_inter`). -/
+theorem invariant_union {α : Type*} [m : MeasurableSpace α] {T : α → α}
+    {s t : Set α}
+    (hs : @MeasurableSet α (invariantSigmaAlgebra T) s)
+    (ht : @MeasurableSet α (invariantSigmaAlgebra T) t) :
+    @MeasurableSet α (invariantSigmaAlgebra T) (s ∪ t) := by
+  refine ⟨hs.1.union ht.1, ?_⟩
+  rw [preimage_union, hs.2, ht.2]
+
+/-- The complement of an invariant set is invariant. -/
+theorem invariant_compl {α : Type*} [m : MeasurableSpace α] {T : α → α}
+    {s : Set α} (hs : @MeasurableSet α (invariantSigmaAlgebra T) s) :
+    @MeasurableSet α (invariantSigmaAlgebra T) sᶜ := by
+  refine ⟨hs.1.compl, ?_⟩
+  rw [preimage_compl, hs.2]
+
+/-- **Ergodicity = triviality of the invariant σ-algebra.** For an ergodic
+    system, every set measurable with respect to the invariant σ-algebra is
+    null or co-null. This connects the newly-defined `invariantSigmaAlgebra`
+    to Mathlib's `Ergodic` infrastructure: the σ-algebra of invariant sets is
+    μ-trivial exactly in the ergodic case, which is the conceptual backbone of
+    the ergodic decomposition surveyed in this file. -/
+theorem ergodic_invariantSigmaAlgebra_null_or_conull
+    {α : Type*} [MeasurableSpace α] {μ : Measure α} {T : α → α}
+    (hE : Ergodic T μ) {s : Set α}
+    (hs : @MeasurableSet α (invariantSigmaAlgebra T) s) :
+    μ s = 0 ∨ μ sᶜ = 0 :=
+  hE.preErgodic.ae_empty_or_univ hs.1 hs.2
+
 /-!
 ### Multiple Recurrence: What Ergodic Decomposition Would Give Us
 
@@ -409,5 +438,8 @@ Completing the ergodic decomposition would:
 #check invariantSigmaAlgebra       -- Invariant σ-algebra (new, this file)
 #check invariant_preimage_eq       -- Preimage stability (new, this file)
 #check invariant_inter             -- Intersection closure (new, this file)
+#check invariant_union             -- Union closure (new, this file)
+#check invariant_compl             -- Complement closure (new, this file)
+#check @ergodic_invariantSigmaAlgebra_null_or_conull  -- Ergodic ⇒ trivial (new)
 
 end FurstenbergOQ02

--- a/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
+++ b/src/data/proofs/furstenberg-correspondence-oq-02/meta.json
@@ -56,10 +56,10 @@
     ],
     "dateAdded": "2026-03-30",
     "axiomCount": 0,
-    "lineCount": 413,
+    "lineCount": 445,
     "assumptions": "0 axioms. 0 sorries. Survey file with demonstrated infrastructure.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 2
   },
   "sections": [
@@ -90,15 +90,15 @@
     {
       "title": "Infrastructure Demonstration",
       "startLine": 265,
-      "endLine": 310,
-      "description": "Defines the invariant σ-algebra in Lean 4 and proves basic properties (preimage stability, intersection closure).",
+      "endLine": 386,
+      "description": "Defines the invariant σ-algebra in Lean 4 and proves its Boolean-algebra closure properties (preimage stability, intersection, union, complement, univ) plus ergodic_invariantSigmaAlgebra_null_or_conull — for an ergodic system the invariant σ-algebra is μ-trivial (every invariant-measurable set is null or co-null), the conceptual backbone of the ergodic decomposition.",
       "summary": "Infrastructure Demonstration",
       "id": "infrastructure-demonstration"
     },
     {
       "title": "Feasibility Assessment",
-      "startLine": 315,
-      "endLine": 380,
+      "startLine": 387,
+      "endLine": 445,
       "description": "Final assessment: YES, feasible. Recommends Approach C via Mathlib disintegration as the lowest-effort path (~1200 lines).",
       "summary": "Feasibility Assessment",
       "id": "feasibility-assessment"
@@ -169,9 +169,9 @@
       "MeasurableSpace"
     ],
     "namespace": "FurstenbergOQ02",
-    "lineCount": 413,
+    "lineCount": 445,
     "axiomCount": 0,
-    "theoremCount": 4,
+    "theoremCount": 7,
     "definitionCount": 2,
     "sorries": 0,
     "path": "Proofs/FurstenbergCorrespondenceOQ02.lean"


### PR DESCRIPTION
## Summary

`FurstenbergCorrespondenceOQ02.lean` is a feasibility survey for the ergodic decomposition theorem. It defines the **invariant σ-algebra** (`invariantSigmaAlgebra`) and proves a few closure facts (`invariant_preimage_eq`, `invariant_inter`, `invariant_univ`, `invariantSigmaAlgebra_le`), but omits the natural companion lemmas and — more importantly — never states the theorem its entire thesis rests on: *ergodicity = triviality of the invariant σ-algebra*.

This PR adds three axiom-free theorems, all reusing patterns already present in the file and Mathlib lemmas already cited in its `example`s:

- `invariant_union` — finite unions of invariant sets are invariant (dual of the existing `invariant_inter`)
- `invariant_compl` — complement of an invariant set is invariant
- `ergodic_invariantSigmaAlgebra_null_or_conull` — for an ergodic system, every invariant-σ-algebra-measurable set is null or co-null (`hE.preErgodic.ae_empty_or_univ`). This directly connects the newly-defined `invariantSigmaAlgebra` to Mathlib's `Ergodic` infrastructure and is the conceptual backbone of the surveyed decomposition.

`#check` block and `meta.json` (theoremCount 4→7, lineCount 413→445, realigned the two trailing section boundaries) updated to match.

## Verification

Proofs reuse the exact tactic shapes already in the file: `invariant_union`/`invariant_compl` mirror `invariant_inter` (`refine ⟨…, ?_⟩; rw [preimage_…, hs.2, …]`), and `ergodic_invariantSigmaAlgebra_null_or_conull` is the line-90 `example`'s term applied to `hs.1`/`hs.2`. Marked **draft** because the Docker build host is currently unresponsive; promote once a clean `docker-build.sh Proofs.FurstenbergCorrespondenceOQ02` is confirmed.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.FurstenbergCorrespondenceOQ02`
- [ ] `pnpm build` (gallery meta renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)