### PR TITLE
research(hilbert-13-oq-04): realign gallery sections to 9 source Parts + cover tail

### DIFF
--- a/src/data/proofs/hilbert-13-oq-04/meta.json
+++ b/src/data/proofs/hilbert-13-oq-04/meta.json
@@ -124,58 +124,74 @@
     {
       "id": "covering-dimension",
       "title": "Covering Dimension",
-      "startLine": 79,
-      "endLine": 126,
+      "startLine": 62,
+      "endLine": 118,
       "summary": "Definition of Lebesgue covering dimension via finite open cover refinements: dim(X) <= n if every finite open cover has a refinement of order <= n+1.",
       "mathContext": "The Lebesgue covering dimension (or topological dimension) is the standard dimension notion for separable metrizable spaces. For compact metric spaces it coincides with the small and large inductive dimensions."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties of Covering Dimension",
-      "startLine": 128,
-      "endLine": 151,
+      "startLine": 119,
+      "endLine": 141,
       "summary": "Monotonicity (dim <= n implies dim <= n+1) and the dimension-0 characterization (disjoint refinements).",
       "mathContext": "These are foundational properties that establish covering dimension as a well-behaved topological invariant."
     },
     {
       "id": "standard-spaces",
       "title": "Dimension of Standard Spaces",
-      "startLine": 153,
-      "endLine": 184,
+      "startLine": 142,
+      "endLine": 214,
       "summary": "The unit cube [0,1]^n has covering dimension exactly n (axiomatized upper and lower bounds).",
       "mathContext": "The fact that dim([0,1]^n) = n is a deep result requiring the Lebesgue covering theorem for the lower bound and explicit refinement constructions for the upper bound."
     },
     {
       "id": "generalized-ka",
       "title": "Generalized Kolmogorov-Arnold Representation",
-      "startLine": 186,
-      "endLine": 249,
+      "startLine": 215,
+      "endLine": 281,
       "summary": "The generalized KA representation structure for compact metric spaces and Ostrand's separating maps theorem.",
       "mathContext": "Every continuous function on a compact metrizable space of dimension n can be decomposed into 2n+1 compositions of continuous univariate functions with continuous maps from X to R."
     },
     {
       "id": "sternfeld",
       "title": "Sternfeld's Characterization",
-      "startLine": 251,
-      "endLine": 298,
+      "startLine": 282,
+      "endLine": 322,
       "summary": "Complete characterization: a compact metrizable space has the superposition property with 2n+1 maps iff its covering dimension is at most n.",
       "mathContext": "Sternfeld (1985) proved the definitive result linking dimension theory to function representation, showing that covering dimension is both necessary and sufficient for superposition."
     },
     {
       "id": "classical-recovery",
       "title": "Connection to the Classical Theorem",
-      "startLine": 300,
-      "endLine": 318,
+      "startLine": 323,
+      "endLine": 344,
       "summary": "Recovering the classical KA theorem as a special case: [0,1]^n has dimension n, so the generalized theorem applies.",
       "mathContext": "The classical Kolmogorov-Arnold theorem for [0,1]^n follows immediately from the generalized theorem and the fact that dim([0,1]^n) = n."
     },
     {
       "id": "sharpness",
       "title": "Sharpness: 2n+1 is Optimal",
-      "startLine": 320,
-      "endLine": 348,
+      "startLine": 345,
+      "endLine": 373,
       "summary": "The number 2n+1 in the KA theorem is sharp: 2n compositions do not suffice for n-dimensional spaces.",
       "mathContext": "The optimality of 2n+1 uses cohomological obstructions and properties of Menger compacta (universal n-dimensional spaces)."
+    },
+    {
+      "id": "dimension-embeddings",
+      "title": "Dimension and Embeddings",
+      "startLine": 374,
+      "endLine": 440,
+      "summary": "Monotonicity of covering dimension under continuous maps: covDimLE_of_embedding shows a topological embedding into an n-dimensional space bounds the subspace's dimension by n.",
+      "mathContext": "If $X$ embeds topologically into $Y$ with $\\dim Y \\le n$, then $\\dim X \\le n$ — covering dimension is monotone under embeddings."
+    },
+    {
+      "id": "open-problems",
+      "title": "Open Problems",
+      "startLine": 441,
+      "endLine": 480,
+      "summary": "Remaining open questions raised by the generalized KA theorem, stated as Lean Props: smooth_generalization_open (does a smooth/differentiable analogue hold?) and computational_complexity_open (complexity of computing the inner/outer functions).",
+      "mathContext": "Open directions: smoothness of the superposition functions and the computational complexity of constructing KA representations."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Gallery metadata fix for the Kolmogorov-Arnold / Hilbert-13 generalization proof (axiomatized, 6 deep axioms, 0 sorries, 480 lines). No math change.

## Problem
`proofs/Proofs/Hilbert13GeneralSpaces.lean` has **9** `/-! ═══ PART N` banner sections (opens at 62/119/142/215/282/323/345/374/441), but `meta.json` listed only **7** sections with drifted ranges:
- "Covering Dimension" started at 79 (mid-`OpenCover` structure) instead of the PART I banner at 62;
- "Generalized KA" was tagged 186–249, straddling PART III/IV (real PART IV banner is 215);
- every section's range was shifted off its banner.
- **PART VIII "Dimension and Embeddings"** (`covDimLE_of_embedding`) and **PART IX "Open Problems"** (`smooth_generalization_open`, `computational_complexity_open`), lines 374–480, were entirely missing from the gallery.

## Fix
Realigned all 7 existing section ranges to their PART banner opens and added the 2 missing sections. The 9 sections now cover the file contiguously (62–480). The 6 axioms (KA representation, Sternfeld, Ostrand, sharpness) are deep results, correctly axiomatized — unchanged.

## Build impact
None — metadata only.