### PR TITLE
research(erdos-1009-oq-01): infimum attained + characterize optimal Györi constant (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos1009OQ01.lean
+++ b/proofs/Proofs/Erdos1009OQ01.lean
@@ -134,6 +134,27 @@ theorem optimalBound_ge_quarter : 1 / 4 ≤ optimalBound := by
   simp only [show (2 : ℝ) ^ 2 = 4 by norm_num] at hD2
   linarith
 
+/-- The infimum is attained: `optimalBound` is itself a valid bound constant.
+    For each c > 0, f(c)/c² is a lower bound of the valid set (every valid D
+    satisfies f(c)/c² ≤ D), hence f(c)/c² ≤ sInf = optimalBound, i.e.
+    f(c) ≤ optimalBound · c². This is the "achievability" direction that
+    complements `optimalBound_le`. -/
+theorem optimalBound_validBound : ValidBound optimalBound := by
+  intro c hc
+  have hle : (boundFunction c : ℝ) / c ^ 2 ≤ optimalBound := by
+    obtain ⟨C, _, hC⟩ := validBound_exists
+    apply le_csInf ⟨C, hC⟩
+    intro D hD
+    exact hD.ratio_le hc
+  rwa [div_le_iff (by positivity)] at hle
+
+/-- Full characterization of the optimal constant: a real `D` is a valid bound
+    constant iff `optimalBound ≤ D`. Forward direction is `optimalBound_le`;
+    reverse uses `optimalBound_validBound` together with upward closure
+    (`ValidBound.mono`). -/
+theorem optimalBound_iff {D : ℝ} : ValidBound D ↔ optimalBound ≤ D :=
+  ⟨optimalBound_le, fun h => optimalBound_validBound.mono h⟩
+
 /-!
 ## The open question
 
@@ -156,5 +177,16 @@ def erdos_small_c_statement : Prop :=
     The exact value is an open problem in combinatorics. -/
 def optimalBoundQuestion : Prop :=
   ∃ C : ℝ, C = optimalBound ∧ 1 / 4 ≤ C ∧ ∀ D : ℝ, ValidBound D ↔ C ≤ D
+
+/-- The `optimalBoundQuestion` statement is **satisfied**: the optimal constant is
+    well-defined, is ≥ 1/4, and characterizes the valid bound constants via
+    `ValidBound D ↔ optimalBound ≤ D`. Witnessed by `optimalBound` itself.
+
+    NOTE: this establishes *well-definedness and characterization* of the optimal
+    constant, NOT its exact numerical value — pinning down the precise value of
+    `optimalBound` remains the genuine open problem (only `1/4 ≤ optimalBound < ∞`
+    is known, from Sauer's lower bound and Györi's upper bound). -/
+theorem optimalBoundQuestion_wellDefined : optimalBoundQuestion :=
+  ⟨optimalBound, rfl, optimalBound_ge_quarter, fun _ => optimalBound_iff⟩
 
 end Erdos1009OQ01

--- a/src/data/proofs/erdos-1009-oq-01/meta.json
+++ b/src/data/proofs/erdos-1009-oq-01/meta.json
@@ -21,8 +21,8 @@
     ],
     "sorries": 0,
     "axiomCount": 3,
-    "lineCount": 160,
-    "theoremCount": 10,
+    "lineCount": 192,
+    "theoremCount": 13,
     "definitionCount": 4,
     "assumptions": "3 axioms: boundFunction (opaque function representing f(c)), gyori_quadratic_bound (existence of valid constant C from Györi 1988), sauer_lower_bound (f(2) ≥ 1 from Sauer's K_{1,m,m} construction). These encode the deepest published results underpinning the open question.",
     "dateAdded": "2026-05-04",
@@ -52,7 +52,8 @@
       "**Closure under min gives tighter bounds**: The minimum of two valid bound constants is also valid. This structural property underlies the infimum being well-defined: any finite collection of valid constants can be improved by taking their minimum.",
       "**The Sauer lower bound C* ≥ 1/4 follows from a single evaluation**: The argument is entirely local — evaluate the ValidBound constraint at c = 2, use f(2) ≥ 1, and solve D · 4 ≥ 1 to get D ≥ 1/4. The csInf then inherits this lower bound.",
       "**ratio_le reformulates ValidBound**: The lemma ValidBound.ratio_le (f(c)/c² ≤ C) reformulates the bound as a supremum condition: C* = sup_{c>0} f(c)/c². This dual characterization connects the infimum of valid constants to the supremum of the ratio.",
-      "**The open question has a clean Prop formulation**: `optimalBoundQuestion` states that C* is characterized by exactly the property that ValidBound D ↔ C* ≤ D. This is the sharp threshold characterization — C* is the exact cutoff. Proving this Prop requires knowing f(c)/c² → C* as c → ∞ or some sequence approaching the supremum."
+      "**The open question has a clean Prop formulation**: `optimalBoundQuestion` states that C* is characterized by exactly the property that ValidBound D ↔ C* ≤ D. This is the sharp threshold characterization — C* is the exact cutoff. Proving this Prop requires knowing f(c)/c² → C* as c → ∞ or some sequence approaching the supremum.",
+      "**The infimum is attained**: `optimalBound_validBound` proves $C^\\* = \\inf\\{C : \\text{ValidBound }C\\}$ is itself a valid bound, giving the clean characterization $\\text{ValidBound}\\,D \\iff C^\\*\\le D$ (`optimalBound_iff`). The stated `optimalBoundQuestion` is thereby a provable well-definedness/characterization fact (`optimalBoundQuestion_wellDefined`); the exact numerical value of $C^\\*$ remains open."
     ]
   },
   "sections": [
@@ -60,40 +61,40 @@
       "id": "axioms",
       "title": "Axioms and Deep Results",
       "startLine": 27,
-      "endLine": 52,
+      "endLine": 48,
       "summary": "Axiomatizes boundFunction (the f(c) function), gyori_quadratic_bound (existence of valid C > 0 from Györi 1988), and sauer_lower_bound (f(2) ≥ 1 from Sauer's construction).",
       "mathContext": "$f: \\mathbb{R} \\to \\mathbb{N}$ is the 'missing triangles' bound function. Györi (1988): $\\exists C > 0, \\forall c > 0, f(c) \\leq Cc^2$. Sauer: $f(2) \\geq 1$."
     },
     {
       "id": "valid-bound",
       "title": "Valid Bound Constants",
-      "startLine": 53,
-      "endLine": 98,
+      "startLine": 49,
+      "endLine": 87,
       "summary": "Defines ValidBound C, proves validBound_exists (from Györi), ValidBound.nonneg, ValidBound.mono (upward closure), ValidBound.min_valid (closure under min), ValidBound.ratio_le (f(c)/c² ≤ C).",
       "mathContext": "$C$ is a valid bound iff $\\forall c > 0, f(c) \\leq Cc^2$. The set $\\{C : C \\text{ valid}\\}$ is nonempty (by Györi), bounded below by 0, and upward-closed."
     },
     {
       "id": "optimal-bound",
       "title": "The Optimal Bound Constant",
-      "startLine": 99,
-      "endLine": 130,
+      "startLine": 88,
+      "endLine": 118,
       "summary": "Defines optimalBound as sInf {C | ValidBound C}. Proves validBounds_bddBelow, optimalBound_le (csInf_le), optimalBound_nonneg (le_csInf), lt_optimalBound_not_valid (contrapositive).",
       "mathContext": "$C^* = \\inf\\{C : C \\text{ valid}\\}$. Since the set is nonempty and bounded below by 0, $C^*$ is well-defined. For any valid $C$, $C^* \\leq C$; for $D < C^*$, $D$ is not valid."
     },
     {
       "id": "sauer-bound",
       "title": "Lower Bound from Sauer's Construction",
-      "startLine": 131,
-      "endLine": 148,
-      "summary": "Proves optimalBound_ge_quarter: C* ≥ 1/4. Uses sauer_lower_bound (f(2) ≥ 1) at c = 2 to show every valid D satisfies D · 4 ≥ 1, hence D ≥ 1/4.",
+      "startLine": 119,
+      "endLine": 157,
+      "summary": "Sauer's construction $f(2)\\ge 1$ gives `optimalBound_ge_quarter`: $C^\\*\\ge 1/4$. This section also proves that the infimum is **attained** — `optimalBound_validBound` shows $C^\\*$ is itself a valid bound constant (for each $c$, $f(c)/c^2$ is a lower bound of the valid set, so $f(c)/c^2\\le \\inf = C^\\*$) — and `optimalBound_iff` gives the full characterization $\\text{ValidBound}\\,D \\iff C^\\* \\le D$ (forward = `optimalBound_le`, reverse = attainment + upward closure).",
       "mathContext": "For any valid $D$: $D \\cdot 2^2 = 4D \\geq f(2) \\geq 1$, so $D \\geq 1/4$. Taking the infimum: $C^* \\geq 1/4$."
     },
     {
       "id": "open-question",
       "title": "The Open Question",
-      "startLine": 149,
-      "endLine": 160,
-      "summary": "States erdos_small_c_statement (f(c) = 0 for c < 1/2) and optimalBoundQuestion (there exists C = C* with 1/4 ≤ C and ValidBound D ↔ C ≤ D). Both are Lean Props (not asserted true).",
+      "startLine": 158,
+      "endLine": 191,
+      "summary": "States `erdos_small_c_statement` ($f(c)=0$ for $c<1/2$) and `optimalBoundQuestion` (existence of a constant equal to $C^\\*$, $\\ge 1/4$, characterizing valid bounds). `optimalBoundQuestion_wellDefined` **proves** this statement is satisfied — the optimal constant is well-defined and characterized — while making explicit that the genuine open problem is its exact numerical value (only $1/4\\le C^\\* <\\infty$ is known).",
       "mathContext": "Known: $1/4 \\leq C^* < \\infty$. Open: What is $C^*$ exactly? The threshold characterization $C^* \\leq D \\Leftrightarrow D$ valid would follow from the supremum of $f(c)/c^2$ being attained."
     }
   ],
@@ -110,14 +111,18 @@
     {
       "type": "paper",
       "title": "On the number of edge disjoint triangles in K₄-free graphs",
-      "authors": ["E. Györi"],
+      "authors": [
+        "E. Györi"
+      ],
       "year": 1988,
       "journal": "Combinatorica"
     },
     {
       "type": "paper",
       "title": "Some unsolved problems in graph theory and combinatorics",
-      "authors": ["P. Erdős"],
+      "authors": [
+        "P. Erdős"
+      ],
       "year": 1971,
       "journal": "Combinatorica"
     }

--- a/src/data/research/problems/erdos-1009-oq-01.json
+++ b/src/data/research/problems/erdos-1009-oq-01.json
@@ -1,7 +1,7 @@
 {
   "slug": "erdos-1009-oq-01",
   "title": "What is the exact optimal constant $C$ in $f(c) \\leq Cc^2$",
-  "phase": "NEW",
+  "phase": "ACT",
   "status": "active",
   "tier": "B",
   "path": "full",
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-03-24T00:48:59.901Z",
-    "iteration": 3,
-    "focus": "Initial exploration of the problem.",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 4,
+    "focus": "S-ACT: Strengthened the optimal-constant formalization for Györi's f(c) <= C*c^2 bound. Proved the infimum is ATTAINED (optimalBound_validBound: optimalBound is itself a valid bound constant), gave the full characterization optimalBound_iff (ValidBound D <-> optimalBound <= D), and discharged the file's own optimalBoundQuestion Prop as optimalBoundQuestion_wellDefined (well-definedness + characterization, NOT the exact numerical value). theoremCount 10->13, lineCount 160->192. No new axioms; 3 axioms (boundFunction opaque fn, Gyori 1988, Sauer) remain irreducible.",
     "blockers": [],
-    "nextAction": "Begin problem exploration.",
+    "nextAction": "3 axioms are irreducible without a concrete definition of the bound function f(c) (deep combinatorics: edge-disjoint triangles in K4-free graphs). The exact value of optimalBound (only 1/4 <= C* < inf known) is the genuine open problem. Possible future: prove erdos_small_c_statement (f(c)=0 for c<1/2) IF boundFunction is given a real definition; otherwise it stays a Prop.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,14 +29,17 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Eliminated turan_extremal axiom (3→2 axioms). Proved from Mathlib CliqueFree.card_edgeFinset_le.",
+    "progressSummary": "AXIOMATIZED (3 irreducible axioms: opaque boundFunction, gyori_quadratic_bound 1988, sauer_lower_bound). Erdos1009OQ01.lean now 192 LOC, 13 theorems, 4 defs, 0 sorries. NEW: optimalBound_validBound (infimum attained), optimalBound_iff (ValidBound D <-> optimalBound <= D), optimalBoundQuestion_wellDefined (the stated question Prop is provably satisfied as a characterization). Known bounds 1/4 <= optimalBound < inf; exact value open.",
     "builtItems": [
       "Assessment: 8A all appropriate (opaque function + deep results)",
       "edgeDisjoint_comm: symmetry of edge-disjointness",
       "turanThreshold_zero, turanThreshold_one: small value computations",
       "turanThreshold_pos: positivity for n≥2",
       "turanThreshold_mono: monotonicity of Turán threshold",
-      "PROVED turan_extremal from Mathlib (axiom count 3→2)"
+      "PROVED turan_extremal from Mathlib (axiom count 3→2)",
+      "optimalBound_validBound: the infimum optimalBound is itself a valid bound constant (attainment)",
+      "optimalBound_iff: ValidBound D <-> optimalBound <= D (full characterization)",
+      "optimalBoundQuestion_wellDefined: discharges the stated optimalBoundQuestion Prop (well-definedness, not the numeric value)"
     ],
     "insights": [
       "8 axioms: boundFunction (opaque) + deep graph theory (Györi, Turán, Sauer). All appropriate.",


### PR DESCRIPTION
## Summary
Research session on **Erdős #1009 OQ-01** — the optimal constant $C^\*$ in Györi's bound $f(c)\le C c^2$ for edge-disjoint triangles in $K_4$-free graphs (OPEN; exact value unknown).

The file defines $C^\* = \inf\{C : \mathrm{ValidBound}\,C\}$ and proves $C^\*$ is a *lower* bound on valid constants (`optimalBound_le`), but never that the **infimum is attained**, and left its own `optimalBoundQuestion` Prop unproven although it is a provable characterization.

## Progress (3 new theorems, no new axioms)
- **`optimalBound_validBound`** — $C^\*$ is itself a valid bound constant. For each $c>0$, $f(c)/c^2$ is a lower bound of the valid set (every valid $D$ satisfies $f(c)/c^2\le D$ by `ValidBound.ratio_le`), so $f(c)/c^2\le \inf = C^\*$, i.e. $f(c)\le C^\* c^2$.
- **`optimalBound_iff`** — full characterization $\mathrm{ValidBound}\,D \iff C^\* \le D$ (forward = `optimalBound_le`; reverse = attainment + `ValidBound.mono` upward closure).
- **`optimalBoundQuestion_wellDefined`** — discharges the file's stated `optimalBoundQuestion` Prop. **Honesty note:** this establishes *well-definedness and characterization* of $C^\*$, **not** its exact numerical value — pinning that down ($1/4 \le C^\* < \infty$ is all that's known) remains the genuine open problem.

## Files
- `proofs/Proofs/Erdos1009OQ01.lean` (160→192 LOC, 10→13 theorems; 3 axioms / 0 sorries unchanged)
- `src/data/proofs/erdos-1009-oq-01/meta.json` — `theoremCount` 10→13, `lineCount` 160→192, section summaries + keyInsight refreshed
- `src/data/research/problems/erdos-1009-oq-01.json` — state sync (NEW → ACT)

## Status
**Outcome**: progress (structural completeness — infimum attainment + characterization; stated Prop discharged). The 3 axioms (opaque `boundFunction`, Györi 1988, Sauer) are irreducible without a concrete combinatorial definition of $f(c)$. The exact value of $C^\*$ is unchanged and open.

**Build**: ⚠️ build-pending — Docker daemon unresponsive this session. All three proofs reuse tactics/lemmas already proven in this file (`le_csInf`, `div_le_iff` + `positivity`, `ValidBound.ratio_le`/`.mono`), so confidence is high, but unverified here. Draft until built.

🤖 Generated by researcher-4