### PR TITLE
research(erdos-1173): prove the full conjecture implies its weak form

### DIFF
--- a/proofs/Proofs/Erdos1173Problem.lean
+++ b/proofs/Proofs/Erdos1173Problem.lean
@@ -214,4 +214,22 @@ theorem free_set_subset (γ : Ordinal) (f : SetMapping γ)
     IsFreeSet γ f T :=
   fun a b ha hb hab => hfree a b (hTS ha) (hTS hb) hab
 
+/-- Every set mapping has a free set of cardinality 0 (the empty set). -/
+theorem hasFreeSetOfCard_zero (γ : Ordinal) (f : SetMapping γ) :
+    HasFreeSetOfCard γ f 0 :=
+  ⟨∅, free_set_empty γ f, Cardinal.mk_emptyCollection _⟩
+
+/-- **The full conjecture implies the weak partial result.** A free set of
+    cardinality ℵ_{ω+1} contains a subset of cardinality ℵ_ω (since
+    `aleph_omega < aleph_omega_succ`), and a subset of a free set is free.
+    Hence `erdos_1173 → erdos_1173_weak`: the weak form is a logical
+    consequence of the full conjecture, not an independent open question. -/
+theorem erdos_1173_implies_weak : erdos_1173 → erdos_1173_weak := by
+  intro h hgch f hbound hdisj
+  obtain ⟨S, hSfree, hScard⟩ := h hgch f hbound hdisj
+  have hle : aleph_omega ≤ Cardinal.mk S := by
+    rw [hScard]; exact le_of_lt aleph_omega_lt_succ
+  obtain ⟨T, hTS, hTcard⟩ := Cardinal.le_mk_iff_exists_subset.mp hle
+  exact ⟨T, free_set_subset omega_omega_succ f S T hSfree hTS, hTcard⟩
+
 end Erdos1173

--- a/src/data/proofs/erdos-1173/meta.json
+++ b/src/data/proofs/erdos-1173/meta.json
@@ -60,9 +60,9 @@
       "free_set_subset"
     ],
     "axiomCount": 0,
-    "lineCount": 217,
+    "lineCount": 235,
     "assumptions": "0 axioms, 0 sorries. Previously cited axiom names have been removed from the Lean source. The 'axiomatized' status reflects that the main result is not yet fully formalized in Lean.",
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 11
   },
   "overview": {
@@ -139,6 +139,14 @@
       "endLine": 167,
       "summary": "Axiomatizes the Erdős–Hajnal theorem for $\\aleph_1$ (free sets of size $\\aleph_1$ for countably bounded mappings on $\\omega_1$). Defines `erdos_1173_weak`: the weak conjecture asking for a free set of size $\\aleph_\\omega$ instead of $\\aleph_{\\omega+1}$.",
       "mathContext": "The $\\aleph_1$ case (Erdős-Hajnal): $f : \\omega_1 \\to [\\omega_1]^{\\le \\aleph_0}$ with $|f(\\alpha) \\cap f(\\beta)| < \\aleph_0$ has a free set of size $\\aleph_1$. Here $\\aleph_0$ is regular, so Hajnal's theorem applies directly. `erdos_1173_weak`: replace the conclusion $|S| = \\aleph_{\\omega+1}$ with $|S| = \\aleph_\\omega$ — a weaker (but potentially more tractable) target."
+    },
+    {
+      "id": "basic-properties",
+      "title": "Basic Properties",
+      "startLine": 182,
+      "endLine": 235,
+      "summary": "Proved structural lemmas about free sets and the cardinal constants: `aleph_omega_lt_succ` ($\\aleph_\\omega < \\aleph_{\\omega+1}$), `gch_power` ($2^{\\aleph_\\omega} = \\aleph_{\\omega+1}$ under GCH), `free_set_empty`, `free_set_singleton`, `free_set_subset`, `hasFreeSetOfCard_zero`, and `erdos_1173_implies_weak` (the full conjecture implies the weak form).",
+      "mathContext": "Monotonicity facts ($\\aleph_\\omega < \\aleph_{\\omega+1}$, $2^{\\aleph_\\omega} = \\aleph_{\\omega+1}$) and the free-set lattice basics: $\\emptyset$ and singletons are free, freeness is downward-closed under $\\subseteq$, and a 0-cardinality free set always exists. The capstone `erdos_1173_implies_weak`: if the full conjecture yields a free $S$ with $|S| = \\aleph_{\\omega+1}$, then since $\\aleph_\\omega < \\aleph_{\\omega+1}$ some subset $T \\subseteq S$ has $|T| = \\aleph_\\omega$ (`Cardinal.le_mk_iff_exists_subset`), and $T$ is free by `free_set_subset` — so the weak form is a logical consequence, not an independent open question."
     }
   ],
   "conclusion": {
@@ -174,9 +182,9 @@
       "Ordinal"
     ],
     "namespace": "Erdos1173",
-    "lineCount": 217,
+    "lineCount": 235,
     "axiomCount": 0,
-    "theoremCount": 7,
+    "theoremCount": 9,
     "definitionCount": 11,
     "path": "Proofs/Erdos1173Problem.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary

`Erdos1173Problem.lean` scaffolds Erdős Problem #1173 (free sets for set mappings under GCH). It states the full conjecture (`erdos_1173`, free set of size ℵ_{ω+1}) and a weak partial form (`erdos_1173_weak`, free set of size ℵ_ω) as two separate `def`s, plus supporting GCH/free-set lemmas — but never relates the two. This PR adds two axiom-free theorems:

- `hasFreeSetOfCard_zero` — every set mapping trivially has a free set of cardinality 0 (the empty set), a companion to the existing `free_set_empty`
- `erdos_1173_implies_weak` — **the full conjecture implies the weak form**. A free set `S` of cardinality ℵ_{ω+1} contains a subset `T ⊆ S` of cardinality ℵ_ω (since `aleph_omega < aleph_omega_succ`, via `Cardinal.le_mk_iff_exists_subset`), and `free_set_subset` makes `T` free. Hence `erdos_1173 → erdos_1173_weak`: the weak form is not an independent open question.

The main conjecture remains **open** (status/badge unchanged). `meta.json` updated (theoremCount 7→9, lineCount 217→235) with a new "Basic Properties" section documenting the previously-uncovered PART 7.

## Verification

Lemma signatures checked against the Mathlib v4.26.0 source: `Cardinal.le_mk_iff_exists_subset {c α s} : c ≤ #s ↔ ∃ p, p ⊆ s ∧ #p = c` (SetTheory/Cardinal/Basic.lean) and `Cardinal.mk_emptyCollection`. The proof reuses the file's own `aleph_omega_lt_succ` and `free_set_subset`. Marked **draft** because the Docker build host is currently unresponsive; promote once a clean `docker-build.sh Proofs.Erdos1173Problem` is confirmed.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.Erdos1173Problem`
- [ ] `pnpm build` (gallery meta renders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)