### PR TITLE
research(erdos-332): complete empty/finite characterization of D(A) (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos332Problem.lean
+++ b/proofs/Proofs/Erdos332Problem.lean
@@ -148,6 +148,13 @@ theorem diffSet_nonempty_iff (A : Set ℕ) :
   rw [diffSet_finite_eq_empty A hfin] at hd
   exact absurd hd (Set.not_mem_empty d)
 
+/-- Complete empty/finite characterization: `D(A) = ∅` if and only if `A` is
+    finite. The forward direction strengthens `diffSet_finite_eq_empty` to a
+    biconditional, dual to `diffSet_nonempty_iff` (nonempty ↔ infinite). -/
+theorem diffSet_eq_empty_iff (A : Set ℕ) :
+    diffSet A = ∅ ↔ A.Finite := by
+  rw [← Set.not_nonempty_iff_eq_empty, diffSet_nonempty_iff, Set.not_infinite]
+
 /-- Positive lower density implies positive upper density. -/
 theorem lower_density_implies_upper (A : Set ℕ) :
     HasPositiveLowerDensity A → HasPositiveUpperDensity A := by

--- a/research/problems/erdos-332/state.md
+++ b/research/problems/erdos-332/state.md
@@ -1,27 +1,49 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: COMPLETED (graduated; one deep irreducible axiom)
 **Since**: 2026-01-12T23:55:09.604Z
-**Iteration**: 1
+**Iteration**: 5
+**Last Update**: 2026-06-14 (researcher-4 — completed empty/finite biconditional)
 
 ## Current Focus
 
-Initial exploration of the problem.
+`Erdos332Problem.lean` formalizes difference sets D(A) and bounded gaps (syndetic sets). This session closed a claimed-but-missing biconditional: the progress summary asserted a complete "empty ↔ finite" characterization, but only `diffSet_finite_eq_empty` (finite → empty) was formalized. Added `diffSet_eq_empty_iff` (D(A) = ∅ ↔ A.Finite), dual to the existing `diffSet_nonempty_iff` (nonempty ↔ infinite).
+
+## Status Summary
+
+| Surface | Value | Source |
+|---------|-------|--------|
+| Lean file | `proofs/Proofs/Erdos332Problem.lean` (263 LOC, 21 thm, 6 def, 1 axiom, 0 sorries) | `wc -l` + grep |
+| Axiom | `positive_density_bounded_gaps` (Prikry–Tijdeman–Stewart, 1977–78) | `grep '^axiom '` |
+| Gallery | `src/data/proofs/erdos-332/meta.json` — `status: "axiomatized"`, `axiomCount: 1`, `theoremCount: 21` | `meta.json` |
 
 ## Active Approach
 
-None yet.
+Structural completeness — ensuring every characterization the file/summary claims is formalized in both directions. Done this session for empty/finite.
 
 ## Blockers
 
-None.
+- `positive_density_bounded_gaps` (Prikry's theorem) — deep additive-combinatorics result; full proof needs Furstenberg correspondence + ergodic recurrence machinery not in Mathlib. Irreducible.
 
 ## Next Action
 
-Begin problem exploration.
+All provable structural results are now formalized in both directions. The single axiom is irreducible. Remaining open directions (not formalized, genuinely open): the minimality of the positive-density condition (`ErdosProblem332` Prop) and whether ∑_{d ∈ D(A)} 1/d = ∞.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 1
+- Approaches tried: 2
+
+## Iteration Ledger
+
+| Iter | Date | Agent | Result | Scope |
+|------|------|-------|--------|-------|
+| 1–4 | 2026-01–06 | (legacy) | Built full formalization: 20 theorems, 1 Prikry axiom, density→syndetic chain | Erdos332Problem.lean |
+| 5 | 2026-06-14 | researcher-4 | Added `diffSet_eq_empty_iff` (empty ↔ finite); thm 20→21, LOC 256→263; meta sections/counts realigned; build-pending (Docker down) | Erdos332Problem.lean + meta.json + registry + state.md |
+
+## Cross-references
+
+- Research JSON registry: `src/data/research/problems/erdos-332.json`
+- Gallery dir: `src/data/proofs/erdos-332/`
+- Lean source: `proofs/Proofs/Erdos332Problem.lean`

--- a/src/data/proofs/erdos-332/meta.json
+++ b/src/data/proofs/erdos-332/meta.json
@@ -65,8 +65,8 @@
       "Additive combinatorics: difference sets, syndetic sets",
       "Ergodic theory basics: Furstenberg correspondence principle (for context)"
     ],
-    "lineCount": 256,
-    "theoremCount": 20,
+    "lineCount": 263,
+    "theoremCount": 21,
     "definitionCount": 6
   },
   "overview": {
@@ -79,7 +79,8 @@
       "**Syndeticity from density via pigeonhole**: Prikry's proof that $\\overline{d}(A) > 0 \\Rightarrow D(A)$ is syndetic uses the pigeonhole principle on translates: among $\\lceil 1/\\delta \\rceil + 1$ shifts of $A$, two must overlap on a set of positive density, producing a persistent difference",
       "**Furstenberg correspondence**: The problem connects to ergodic theory — positive density sets correspond to sets of positive measure in a dynamical system, and syndeticity of $D(A)$ follows from Poincaré recurrence",
       "**The open question is about the threshold**: Positive density is known to suffice, but the problem asks whether weaker conditions (e.g., divergent harmonic sum $\\sum 1/a = \\infty$, or Banach density conditions) also force syndeticity of $D(A)$",
-      "**Structural hierarchy**: The formalization captures a chain: $D(A)$ is symmetric, contains 0 (for infinite $A$), inherits positive density from $A$, and is syndetic — each property progressively constrains the structure of difference sets"
+      "**Structural hierarchy**: The formalization captures a chain: $D(A)$ is symmetric, contains 0 (for infinite $A$), inherits positive density from $A$, and is syndetic — each property progressively constrains the structure of difference sets",
+      "**Symmetric empty/finite ↔ nonempty/infinite dichotomy**: `diffSet_eq_empty_iff` ($D(A)=\\emptyset \\iff A$ finite) completes the characterization dual to `diffSet_nonempty_iff` ($D(A)$ nonempty $\\iff A$ infinite), strengthening the one-directional `diffSet_finite_eq_empty` to a biconditional."
     ],
     "prerequisites": [
       "Integer arithmetic (ℤ) and natural-to-integer coercion",
@@ -94,7 +95,7 @@
       "id": "header-imports",
       "title": "Header and Imports",
       "startLine": 1,
-      "endLine": 22,
+      "endLine": 23,
       "summary": "Module docstring referencing Prikry, Tijdeman, and Stewart. Imports Mathlib for $\\mathbb{Z}$, sets, Finset cardinality, and tactics. Opens `Set` namespace.",
       "mathContext": "Imports: `Int.Basic` for $a_1 - a_2 \\in \\mathbb{Z}$, `Set.Basic` for $D(A)$ definition, `Finset.Card` for $A(N)$."
     },
@@ -102,7 +103,7 @@
       "id": "difference-set",
       "title": "Difference Set D(A)",
       "startLine": 24,
-      "endLine": 30,
+      "endLine": 31,
       "summary": "Defines $D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$ using `Set.Infinite` on the fibre over each $d$. Stricter than $A - A$.",
       "mathContext": "$D(A) = \\{d \\in \\mathbb{Z} : |\\{(a_1,a_2) \\in A^2 : a_1 - a_2 = d\\}| = \\infty\\}$. Stricter than $A - A$."
     },
@@ -110,55 +111,55 @@
       "id": "bounded-gaps",
       "title": "Bounded Gaps (Syndeticity)",
       "startLine": 32,
-      "endLine": 43,
+      "endLine": 40,
       "summary": "Defines `HasBoundedGaps`: $\\exists M > 0, \\forall z \\in \\mathbb{Z}, \\exists s \\in S: z \\leq s < z + M$. The dual of thick sets in topological dynamics. Includes `diffSet_empty`: $D(\\emptyset) = \\emptyset$.",
       "mathContext": "$\\text{HasBoundedGaps}(S) \\iff \\exists M > 0,\\, \\forall z \\in \\mathbb{Z},\\, \\exists s \\in S: z \\leq s < z + M$."
     },
     {
       "id": "density-conditions",
       "title": "Density Conditions",
-      "startLine": 45,
-      "endLine": 72,
+      "startLine": 41,
+      "endLine": 69,
       "summary": "Counting function $A(N) = |A \\cap [1,N]|$ with `countingFn_zero` and `countingFn_mono`, positive upper density ($\\limsup A(N)/N > 0$), and positive lower density ($\\liminf A(N)/N > 0$), all formalized over $\\mathbb{Q}$.",
       "mathContext": "$A(N) = |A \\cap [1,N]|$; $\\overline{d}(A) = \\limsup_{N \\to \\infty} A(N)/N$; $\\underline{d}(A) = \\liminf_{N \\to \\infty} A(N)/N$."
     },
     {
       "id": "known-results",
       "title": "Known Results",
-      "startLine": 74,
-      "endLine": 108,
+      "startLine": 70,
+      "endLine": 104,
       "summary": "One axiom (Prikry–Tijdeman–Stewart theorem: $\\overline{d}(A) > 0 \\Rightarrow D(A)$ syndetic) and two proved theorems (`diffSet_symm`: $D(A) = -D(A)$ via the swap bijection; `zero_mem_diffSet`: $0 \\in D(A)$ for infinite $A$ via diagonal pairs).",
       "mathContext": "Axiom: Prikry's theorem $\\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$. Proved: $D(A) = -D(A)$, $0 \\in D(A)$ for infinite $A$."
     },
     {
       "id": "structural-properties",
       "title": "Structural Properties",
-      "startLine": 110,
-      "endLine": 163,
+      "startLine": 105,
+      "endLine": 170,
       "summary": "Seven proved theorems: `diffSet_mono` (monotonicity $A \\subseteq B \\Rightarrow D(A) \\subseteq D(B)$), `diffSet_finite_eq_empty` (empty difference set for finite sets), `diffSet_nonempty_of_infinite` (nonemptiness for infinite sets), `zero_mem_diffSet_iff` and `diffSet_nonempty_iff` (iff characterizations: $0 \\in D(A) \\iff A$ infinite $\\iff D(A) \\neq \\emptyset$), `lower_density_implies_upper` (density hierarchy), and `positive_lower_density_bounded_gaps` (lower density suffices for syndeticity via Prikry composition).",
       "mathContext": "Proved: $D$ is monotone, $D(A) = \\emptyset$ for finite $A$, $(0 \\in D(A)) \\iff (A \\text{ infinite}) \\iff (D(A) \\neq \\emptyset)$, $\\underline{d}(A) > 0 \\Rightarrow \\overline{d}(A) > 0 \\Rightarrow \\text{HasBoundedGaps}(D(A))$."
     },
     {
       "id": "additional-structural",
       "title": "Additional Structural Properties of D(A) and HasBoundedGaps",
-      "startLine": 165,
-      "endLine": 191,
+      "startLine": 171,
+      "endLine": 197,
       "summary": "Four structural theorems: `diffSet_union_subset` ($D(A) \\cup D(B) \\subseteq D(A \\cup B)$), `hasBoundedGaps_nonempty` (syndetic sets are nonempty), `hasBoundedGaps_mono` (syndeticity is upward closed under superset), and `infinite_of_diffSet_bounded_gaps` ($D(A)$ syndetic implies $A$ infinite — the converse direction).",
       "mathContext": "$D(A) \\cup D(B) \\subseteq D(A \\cup B)$; syndetic $S \\subseteq T$ implies $T$ syndetic; $\\text{HasBoundedGaps}(D(A)) \\Rightarrow A$ infinite (converse: $A$ infinite $\\not\\Rightarrow$ $D(A)$ syndetic without density)."
     },
     {
       "id": "density-finiteness-chain",
       "title": "Density–Finiteness Connection and Full Implication Chain",
-      "startLine": 192,
-      "endLine": 238,
+      "startLine": 198,
+      "endLine": 247,
       "summary": "The culminating sequence: `countingFn_le` (trivial bound $A(N) \\leq N$), `positive_upper_density_infinite` (positive density forces $A$ infinite via Archimedean contradiction), `positive_upper_density_diffSet_nonempty` (density forces $0 \\in D(A)$), and `density_chain` (the complete chain: density $\\Rightarrow A$ infinite $\\Rightarrow D(A) \\neq \\emptyset \\Rightarrow D(A)$ syndetic, as a single triple conjunction).",
       "mathContext": "$\\overline{d}(A) > 0 \\Rightarrow A$ infinite $\\Rightarrow 0 \\in D(A) \\Rightarrow D(A) \\neq \\emptyset \\Rightarrow \\text{HasBoundedGaps}(D(A))$. `positive_upper_density_infinite` uses Archimedean property: density $\\delta$ and finite $A$ of size $C$ give $\\delta N \\leq C$ for all large $N$, contradicting $\\delta > 0$."
     },
     {
       "id": "main-problem-definition",
       "title": "ErdosProblem332 Definition and Related Questions",
-      "startLine": 240,
-      "endLine": 254,
+      "startLine": 248,
+      "endLine": 262,
       "summary": "`ErdosProblem332` is formalized as: any condition $P$ that implies $D(A)$ is syndetic for all $A$ must be implied by positive upper density — i.e., positive density is the 'weakest' known sufficient condition. The file closes with the related open question about harmonic thickness of $D(A)$ (whether $\\sum 1/d = \\infty$).",
       "mathContext": "$\\text{ErdosProblem332} \\equiv \\forall P, (\\forall A, P(A) \\Rightarrow \\text{HasBoundedGaps}(D(A))) \\Rightarrow (\\forall A, \\overline{d}(A) > 0 \\Rightarrow P(A))$. This is a characterization of positive density as the minimal known sufficient property."
     }

--- a/src/data/research/problems/erdos-332.json
+++ b/src/data/research/problems/erdos-332.json
@@ -29,9 +29,9 @@
   },
   "currentState": {
     "phase": "COMPLETED",
-    "since": "2026-03-28T09:00:00Z",
-    "iteration": 4,
-    "focus": "Graduated: formalization complete (0 sorries, 1 deep axiom: Prikry's theorem)",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 5,
+    "focus": "Closed a claimed-but-missing biconditional. The progress summary claimed a complete 'empty<->finite' characterization, but the file only had diffSet_finite_eq_empty (finite -> empty). Added diffSet_eq_empty_iff (D(A)=empty <-> A.Finite), dual to the existing diffSet_nonempty_iff. theoremCount 20->21, lineCount 256->263. Single Prikry axiom unchanged (deep, irreducible).",
     "blockers": [],
     "nextAction": "None — all provable structural results formalized. The single remaining axiom (positive_density_bounded_gaps) is the deep Prikry–Tijdeman–Stewart theorem; full proof would require Furstenberg correspondence and ergodic-theoretic recurrence machinery not yet available in Mathlib.",
     "attemptCounts": {
@@ -41,7 +41,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "COMPLETED: 20 theorems, 1 deep axiom (Prikry's theorem), 0 sorries. Complete D(A) characterization: empty↔finite, nonempty↔infinite, syndetic⟸positive density. Full implication chain density → infinite → D(A) nonempty → D(A) syndetic. The single axiom is positive_density_bounded_gaps (Prikry–Tijdeman–Stewart, 1977–78), a deep additive-combinatorics result.",
+    "progressSummary": "COMPLETED: 21 theorems, 1 deep axiom (Prikry's theorem), 0 sorries. Complete D(A) characterization now fully formalized in BOTH directions: empty<->finite (diffSet_eq_empty_iff) and nonempty<->infinite (diffSet_nonempty_iff). Full implication chain density -> infinite -> D(A) nonempty -> D(A) syndetic. The single axiom is positive_density_bounded_gaps (Prikry-Tijdeman-Stewart, 1977-78).",
     "builtItems": [
       "Assessment: all 3A appropriate and deep",
       "Proved diffSet_mono in Erdos332Problem.lean:102",
@@ -62,7 +62,8 @@
       "positive_upper_density_infinite in Erdos332Problem.lean",
       "positive_upper_density_diffSet_nonempty in Erdos332Problem.lean",
       "density_chain in Erdos332Problem.lean",
-      "Graduated problem to completed status (iteration 4)"
+      "Graduated problem to completed status (iteration 4)",
+      "diffSet_eq_empty_iff: D(A)=empty <-> A.Finite (completes the empty/finite characterization as a biconditional)"
     ],
     "insights": [
       "Single axiom is deep: positive_density_bounded_gaps (Prikry–Tijdeman–Stewart, follows from Furstenberg correspondence + Poincaré recurrence). Not currently provable from Mathlib.",


### PR DESCRIPTION
## Summary
Research session on **Erdős #332** — difference sets $D(A)$ and bounded gaps (syndetic sets). The file is otherwise complete (20 theorems, 1 deep Prikry axiom, 0 sorries), but its progress summary claimed a complete "**empty ↔ finite**" characterization while only `diffSet_finite_eq_empty` (finite → empty) was actually formalized.

## Progress (1 new theorem, no new axioms)
- **`diffSet_eq_empty_iff`** — $D(A) = \emptyset \iff A$ is finite. This strengthens the one-directional `diffSet_finite_eq_empty` to a biconditional, exactly dual to the existing `diffSet_nonempty_iff` ($D(A)$ nonempty $\iff A$ infinite). Proof: `Set.not_nonempty_iff_eq_empty` + `diffSet_nonempty_iff` + `Set.not_infinite`.

## Files
- `proofs/Proofs/Erdos332Problem.lean` (256→263 LOC, 20→21 theorems; 1 axiom / 0 sorries unchanged)
- `src/data/proofs/erdos-332/meta.json` — `theoremCount` 20→21, `lineCount` 256→263, section ranges realigned, keyInsight added
- `src/data/research/problems/erdos-332.json`, `research/problems/erdos-332/state.md` — state sync

## Status
**Outcome**: progress (closed a claimed-but-missing biconditional; characterization now complete in both directions). The single axiom `positive_density_bounded_gaps` (Prikry–Tijdeman–Stewart) is irreducible (needs Furstenberg correspondence / ergodic recurrence, not in Mathlib). The genuine open directions (minimality of the density condition; $\sum_{d\in D(A)} 1/d = \infty$?) remain unformalized and open.

**Build**: ⚠️ build-pending — Docker daemon unresponsive this session. The proof is a 3-rewrite chain over existing in-file lemmas + standard `Set` lemmas, so confidence is high, but unverified here. Draft until built.

🤖 Generated by researcher-4