### PR TITLE
research(erdos-685): fix section boundary + remove false axiom claims (file has 0 axioms)

### DIFF
--- a/src/data/proofs/erdos-685/meta.json
+++ b/src/data/proofs/erdos-685/meta.json
@@ -66,7 +66,7 @@
     "historicalContext": "Erdős studied the prime factorization structure of binomial coefficients throughout his career. The function ω(n), counting distinct prime divisors, is a fundamental quantity in analytic number theory. For binomial coefficients C(n,k), Kummer's theorem relates the p-adic valuation to carries in base-p addition, but counting the number of distinct primes dividing C(n,k) is a subtler question.\n\nThe conjecture gives a precise asymptotic formula: ω(C(n,k)) ~ k · Σ_{k<p<n} 1/p, where the sum runs over primes in the interval (k,n). By Mertens' theorem, this prime reciprocal sum is approximately log(log n/log k), so the formula predicts ω(C(n,k)) ~ k · log(log n/log k). The result should hold in the 'middle range' n^ε < k ≤ n^{1-ε}, where both k and n/k grow polynomially.\n\nThe trivial lower bound ω(C(n,k)) ≥ log C(n,k)/log n comes from the fact that each prime factor of C(n,k) is at most n. This bound is tight when k is near n (specifically for k > n^{1-o(1)}), since then C(n,k) is small and its prime factors are constrained. Erdős speculated that the conjecture might extend to k as small as (log n)^c.",
     "problemStatement": "For n^ε < k ≤ n^{1-ε}, is ω(C(n,k)) = (1+o(1))·k·Σ_{k<p<n} 1/p?",
     "text": "For n^ε < k ≤ n^{1-ε}, is ω(C(n,k)) = (1+o(1))·k·Σ_{k<p<n} 1/p? Trivial lower bound: log C(n,k)/log n, tight when k > n^{1-o(1)}.",
-    "proofStrategy": "We define omega as the prime factors count using Nat.primeFactors, and primeSumInRange for the prime reciprocal sum. The main conjecture ErdosProblem685 is stated as an asymptotic equality with explicit error terms. The trivial lower bound and its tightness for k near n are axioms. Basic properties omega_one, omega_choose_zero, and omega_choose_one are proved.",
+    "proofStrategy": "We define omega as the prime factors count using Nat.primeFactors, and primeSumInRange for the prime reciprocal sum. The main conjecture ErdosProblem685 is stated as an asymptotic equality with explicit error terms (a Prop, not yet proved). The trivial lower bound and its tightness for k near n are documented as prose only — not formalized. Six basic properties of omega are proved directly: omega_one, omega_choose_zero, omega_choose_one, omega_eq_zero_iff, omega_pos_of_one_lt, and omega_prime.",
     "keyInsights": [
       "**Asymptotic Formula**: ω(C(n,k)) ~ k · Σ 1/p over primes in (k,n), combining the prime counting function with the structure of binomial coefficients",
       "**Mertens Connection**: By Mertens' theorem, the prime sum is ≈ log(log n/log k), giving ω(C(n,k)) ~ k · log(log n/log k) in the middle range",
@@ -105,20 +105,20 @@
       "id": "lower",
       "title": "Trivial Lower Bound",
       "startLine": 43,
-      "endLine": 56,
-      "summary": "Trivial bound ω(C(n,k)) ≥ log C(n,k)/log n and tightness for k > n^{1-ε}."
+      "endLine": 46,
+      "summary": "Documents (as prose, not yet formalized) the trivial bound ω(C(n,k)) ≥ log C(n,k)/log n and its tightness for k > n^{1-ε}."
     },
     {
       "id": "basic",
       "title": "Basic Properties",
-      "startLine": 57,
+      "startLine": 47,
       "endLine": 96,
       "summary": "Six proved theorems: `omega_one` ($\\omega(1) = 0$), `omega_choose_zero` ($\\omega(\\binom{n}{0}) = 0$), `omega_choose_one` ($\\omega(\\binom{n}{1}) = \\omega(n)$), `omega_eq_zero_iff` ($\\omega(n) = 0 \\iff n \\leq 1$, proved via `Nat.primeFactors_eq_empty`), `omega_pos_of_one_lt` ($n > 1 \\Rightarrow \\omega(n) > 0$), and `omega_prime` ($\\omega(p) = 1$ for prime $p$, via `Nat.Prime.primeFactors_eq`).",
       "mathContext": "$\\omega(1) = 0$, $\\omega(\\binom{n}{0}) = \\omega(1) = 0$, $\\omega(\\binom{n}{1}) = \\omega(n)$. The characterization $\\omega(n) = 0 \\iff n \\leq 1$ uses `Nat.primeFactors_eq_empty`. For primes: $\\omega(p) = |\\{p\\}| = 1$."
     }
   ],
   "conclusion": {
-    "summary": "The formalization captures Erdős Problem 685 on distinct prime divisors of binomial coefficients, the trivial lower bound, and its tightness near k = n. Three theorems are proved directly; two bounds and one characterization are axiomatized.",
+    "summary": "The formalization states Erdős Problem 685 on distinct prime divisors of binomial coefficients as a Lean Prop (ErdosProblem685) and proves six basic properties of the prime-divisor-count function ω directly. The trivial lower bound and its tightness near k = n are documented as prose but not yet formalized. The file has 0 axioms and 0 sorries; the main conjecture itself remains open.",
     "implications": "A resolution would quantify the prime factor structure of binomial coefficients across the full range of k, connecting Kummer's theorem to asymptotic prime counting and extending Mertens' theorem to combinatorial settings.",
     "openQuestions": [
       "Is ω(C(n,k)) = (1+o(1))·k·Σ 1/p for n^ε < k ≤ n^{1-ε}?",


### PR DESCRIPTION
## Summary
Gallery metadata accuracy fix for the Erdős 685 file (`status: axiomatized` + wip is correct per the open-problem policy, but the file itself has **0 axioms, 0 sorries, 6 proved theorems**). No math change.

## Problems
1. **Section boundary**: the file's `/- ## Basic properties -/` header (line 47) and its first two theorems (`omega_one` @50, `omega_choose_zero` @54) were filed under the **"Trivial Lower Bound"** meta section (43–56), while **"Basic Properties"** (57–96) started mid-section and excluded its own header + first two theorems.
2. **False "axiom" claims**: `proofStrategy` stated "the trivial lower bound and its tightness ... are axioms" and the `conclusion` said "two bounds and one characterization are axiomatized" — but `grep -c "^axiom"` = **0**. The trivial lower bound appears only as prose docstrings (lines 45–46), never formalized. Both also undercounted the proved theorems (3 of 6 listed).

## Fixes
- "Trivial Lower Bound" → 43–46; "Basic Properties" → 47–96 (now includes its header + all 6 theorems).
- Rewrote `proofStrategy` and `conclusion.summary` to state accurately: ErdosProblem685 is a Prop (open, not proved), the trivial lower bound is prose-only, and all six ω-properties are proved directly. No false axiomatization.

## Build impact
None — metadata only.