### PR TITLE
research(randomized-maxcut-oq-03): prove full-cut ⟺ bipartite iff + register file in build

### DIFF
--- a/proofs/Proofs.lean
+++ b/proofs/Proofs.lean
@@ -2720,6 +2720,7 @@ import Proofs.RamseysTheoremOQ02
 import Proofs.RamseysTheoremOQ04
 import Proofs.RandomizedMaxCut
 import Proofs.RandomizedMaxcutOQ02
+import Proofs.RandomizedMaxCutOQ03
 import Proofs.RandomizedMaxcutOQ04
 import Proofs.RelativizedHalting
 import Proofs.RelativizedHaltingBridge

--- a/proofs/Proofs/RandomizedMaxCutOQ03.lean
+++ b/proofs/Proofs/RandomizedMaxCutOQ03.lean
@@ -32,6 +32,7 @@ A graph admits a full cut **iff** it is bipartite (admits a proper 2-colouring
 ## Main results
 * `maxCut_eq_edges_of_fullCut` : a full cut forces `MaxCut(G) = |E|`.
 * `rand_approx_tight_of_fullCut` : tightness from any full cut.
+* `isFullCut_iff_isProper2Coloring` : full cut ⟺ proper 2-colouring (the iff).
 * `rand_approx_tight_of_proper2Coloring` : tightness for any bipartite graph.
 * `rand_approx_tight_completeBipartite` : concrete witness `K_{m,n}`.
 
@@ -110,6 +111,25 @@ lemma fullCut_of_proper2Coloring (G : SimpleGraph V) [DecidableRel G.Adj]
     rw [edgeInCut_ofAssignment_iff]
     exact hf hadj
 
+/-- Conversely, a full cut is a proper 2-colouring: if `f` cuts every edge then
+    adjacent vertices receive different colours. -/
+lemma proper2Coloring_of_fullCut (G : SimpleGraph V) [DecidableRel G.Adj]
+    (f : V → Bool) (hf : IsFullCut G f) : IsProper2Coloring G f := by
+  intro u v hadj
+  have he : s(u, v) ∈ G.edgeFinset := by
+    rw [SimpleGraph.mem_edgeFinset, SimpleGraph.mem_edgeSet]
+    exact hadj
+  have hcut := hf s(u, v) he
+  rwa [edgeInCut_ofAssignment_iff] at hcut
+
+/-- **Full cut ⟺ proper 2-colouring.** An assignment cuts every edge of `G`
+    exactly when it is a proper 2-colouring. This is the precise sense, asserted
+    in the module docstring, in which the tight instances of the randomized
+    1/2-approximation are exactly the bipartite graphs. -/
+theorem isFullCut_iff_isProper2Coloring (G : SimpleGraph V) [DecidableRel G.Adj]
+    (f : V → Bool) : IsFullCut G f ↔ IsProper2Coloring G f :=
+  ⟨proper2Coloring_of_fullCut G f, fullCut_of_proper2Coloring G f⟩
+
 /-- **Tightness on bipartite graphs.** Any graph with a proper 2-colouring (i.e.
     any bipartite graph) makes the randomized 1/2-approximation tight:
     `E[|C|] = MaxCut(G)/2`. -/
@@ -148,6 +168,7 @@ theorem rand_approx_tight_completeBipartite (m n : ℕ) :
     (isProper2Coloring_completeBipartite m n)
 
 #check @rand_approx_tight_of_fullCut
+#check @isFullCut_iff_isProper2Coloring
 #check @rand_approx_tight_of_proper2Coloring
 #check @rand_approx_tight_completeBipartite
 


### PR DESCRIPTION
## Summary

`RandomizedMaxCutOQ03.lean` proves tightness of the randomized 1/2-approximation on bipartite graphs. Its module docstring states "A graph admits a full cut **iff** it is bipartite," but the file only formalized one direction (`fullCut_of_proper2Coloring`). This PR closes the gap and fixes a build-registration oversight:

- **`proper2Coloring_of_fullCut`** — the missing converse: an assignment that cuts every edge assigns adjacent vertices different colours (reuses the file's own `edgeInCut_ofAssignment_iff` and the `mem_edgeFinset`/`mem_edgeSet` rewrite).
- **`isFullCut_iff_isProper2Coloring`** — the packaged `iff` the docstring asserts.
- **Build registration**: `import Proofs.RandomizedMaxCutOQ03` was missing from `proofs/Proofs.lean` (siblings `RandomizedMaxcutOQ02`/`OQ04` are present, but this file — note the capital `C` — was never added). Added it so the aggregate target actually builds the file.

## Verification

The new proofs mirror the existing `fullCut_of_proper2Coloring` exactly, in reverse, using lemmas already exercised in the file. **Drafted** because (a) the Docker build host is currently unresponsive and (b) this file was previously absent from the aggregate build, so registering it should be confirmed with a clean build before merge.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.RandomizedMaxCutOQ03`
- [ ] `./proofs/scripts/build-safe-subset.sh` (confirm registration doesn't break the aggregate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)