### PR TITLE
research(erdos-684): binomial u·v decomposition + realign drifted meta sections (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos684Problem.lean
+++ b/proofs/Proofs/Erdos684Problem.lean
@@ -152,6 +152,17 @@ theorem binomialSmoothPart_zero (n : ℕ) : binomialSmoothPart n 0 = 1 := by
     intro hp; exact fun hprime => absurd hprime.two_le (by omega)
   rw [this, Finset.prod_empty]
 
+-- The binomial smooth part divides the binomial coefficient (instantiation of smoothPart_dvd).
+theorem binomialSmoothPart_dvd (n k : ℕ) : binomialSmoothPart n k ∣ Nat.choose n k :=
+  smoothPart_dvd k (Nat.choose n k)
+
+-- The central u·v decomposition for the binomial coefficient: C(n,k) = (k-smooth part)·(k-rough part).
+-- This is the decomposition the whole problem is stated in terms of; here for the binomial-specific
+-- definitions, as a direct instantiation of `smooth_rough_decomposition`.
+theorem binomial_smooth_rough_decomposition (n k : ℕ) (hk : k ≤ n) :
+    Nat.choose n k = binomialSmoothPart n k * binomialRoughPart n k :=
+  smooth_rough_decomposition k (Nat.choose n k) (Nat.choose_pos hk)
+
 /-
 # Part 2: The Function f(n)
 

--- a/research/problems/erdos-684/state.md
+++ b/research/problems/erdos-684/state.md
@@ -1,27 +1,50 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: ACT
 **Since**: 2026-01-14T19:46:33.194Z
-**Iteration**: 1
+**Iteration**: 5
+**Last Update**: 2026-06-14 (researcher-4 — binomial u·v decomposition)
 
 ## Current Focus
 
-Initial exploration of the problem.
+`Erdos684Problem.lean` formalizes smooth/rough parts of binomial coefficients and f(n) = min k with k-smooth part of C(n,k) > n². This session added the central u·v decomposition for the binomial-specific definitions (the file defined `binomialRoughPart` but never proved the factorization) and realigned the badly-drifted gallery meta sections.
+
+## Status Summary
+
+| Surface | Value | Source |
+|---------|-------|--------|
+| Lean file | `proofs/Proofs/Erdos684Problem.lean` (462 LOC, 22 thm, 11 def, 2 axioms, 0 sorries) | `wc -l` + grep |
+| Axioms | `f_domain_large`, `mahler_ineffective` | `grep '^axiom '` |
+| Gallery | `src/data/proofs/erdos-684/meta.json` — `axiomCount: 2`, `theoremCount: 22`, sections realigned (were drifted, ended @401 of 462-line file) | `meta.json` |
 
 ## Active Approach
 
-None yet.
+Structural completeness — formalizing the decomposition objects the problem is stated in terms of. Added `binomial_smooth_rough_decomposition` (C(n,k) = smooth·rough) and `binomialSmoothPart_dvd` as instantiations of the proven general `smooth_rough_decomposition`/`smoothPart_dvd`.
 
 ## Blockers
 
-None.
+- `f_domain_large` — existence threshold N₀ above which {k | smoothPart > n²} is nonempty; needs a concrete witness/estimate (C(n,⌊n/2⌋) grows like 2ⁿ/√n).
+- `mahler_ineffective` — Mahler's ineffective bound smoothPart ≤ n^{1+ε}; deep, not in Mathlib.
 
 ## Next Action
 
-Begin problem exploration.
+Reducing `f_domain_large` requires an explicit n₀ where smoothPart of C(n₀,⌊n₀/2⌋) exceeds n₀² — a real computation (build-gated). Structural decomposition now complete.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 5
+- Current approach attempts: 1
+- Approaches tried: 2
+
+## Iteration Ledger
+
+| Iter | Date | Agent | Result | Scope |
+|------|------|-------|--------|-------|
+| 1–4 | 2026-01–06 | (legacy) | Built smoothPart/roughPart, Kummer/Legendre, f(n), Mahler→f→∞ chain; 20 thm, 2 axioms | Erdos684Problem.lean |
+| 5 | 2026-06-14 | researcher-4 | Added `binomial_smooth_rough_decomposition` + `binomialSmoothPart_dvd`; thm 20→22, LOC 451→462; realigned drifted meta sections; build-pending (Docker down) | Erdos684Problem.lean + meta.json + registry + state.md |
+
+## Cross-references
+
+- Research JSON registry: `src/data/research/problems/erdos-684.json`
+- Gallery dir: `src/data/proofs/erdos-684/`
+- Lean source: `proofs/Proofs/Erdos684Problem.lean`

--- a/src/data/proofs/erdos-684/meta.json
+++ b/src/data/proofs/erdos-684/meta.json
@@ -61,9 +61,9 @@
       "binomialSmoothPart_self/_zero theorems: boundary values at k = n and k = 0"
     ],
     "axiomCount": 2,
-    "lineCount": 451,
+    "lineCount": 462,
     "assumptions": "2 axiom declarations: f_domain_large (for sufficiently large n, there exists k with smooth part > n²), mahler_ineffective (Mahler's classical bound: for fixed k₀ and ε>0, smooth part ≤ n^{1+ε} eventually). Former axiom f_property now proved from Nat.sInf_mem.",
-    "theoremCount": 20,
+    "theoremCount": 22,
     "definitionCount": 11
   },
   "overview": {
@@ -87,73 +87,73 @@
     {
       "id": "smooth-rough",
       "title": "Smooth and Rough Parts",
-      "summary": "smoothPart, roughPart, binomialSmoothPart, binomialRoughPart",
+      "summary": "smoothPart, roughPart, binomialSmoothPart, binomialRoughPart Adds the binomial-specific decomposition `binomial_smooth_rough_decomposition` ($C(n,k)=$ smooth·rough) and `binomialSmoothPart_dvd` ($u \\mid C(n,k)$) — the central u·v factorization the problem is stated in terms of, instantiated from the general `smooth_rough_decomposition`/`smoothPart_dvd`.",
       "startLine": 38,
-      "endLine": 104,
+      "endLine": 165,
       "mathContext": "Mathematical content: smoothPart, roughPart, binomialSmoothPart, binomialRoughPart"
     },
     {
       "id": "f-definition",
       "title": "The Function f(n)",
       "summary": "f, f_property, below_f_small",
-      "startLine": 105,
-      "endLine": 145,
+      "startLine": 166,
+      "endLine": 206,
       "mathContext": "Mathematical content: f, f_property, below_f_small"
     },
     {
       "id": "mahler",
       "title": "Mahler's Classical Result",
       "summary": "mahler_ineffective, f_tendsto_infty_weak",
-      "startLine": 146,
-      "endLine": 203,
+      "startLine": 207,
+      "endLine": 264,
       "mathContext": "Mathematical content: mahler_ineffective, f_tendsto_infty_weak"
     },
     {
       "id": "modern-bounds",
       "title": "Modern Bounds",
       "summary": "tang_exponent, rh_exponent",
-      "startLine": 204,
-      "endLine": 215,
+      "startLine": 265,
+      "endLine": 276,
       "mathContext": "Bound: tang_exponent, rh_exponent"
     },
     {
       "id": "heuristic",
       "title": "Heuristic Conjectures",
       "summary": "heuristic_bound",
-      "startLine": 216,
-      "endLine": 228,
+      "startLine": 277,
+      "endLine": 289,
       "mathContext": "Bound: heuristic_bound"
     },
     {
       "id": "structure",
       "title": "Structure of Smooth Part",
       "summary": "legendreExponent, kummer_theorem",
-      "startLine": 229,
-      "endLine": 283,
+      "startLine": 290,
+      "endLine": 344,
       "mathContext": "Verified: legendreExponent, kummer_theorem"
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
       "summary": "f_lower_bound, prime_binomial_structure",
-      "startLine": 284,
-      "endLine": 330,
+      "startLine": 345,
+      "endLine": 391,
       "mathContext": "Formal definition: f_lower_bound, prime_binomial_structure"
     },
     {
       "id": "generalized",
       "title": "The Generalized Problem",
       "summary": "fGeneral, f_is_fGeneral_0",
-      "startLine": 331,
-      "endLine": 348,
+      "startLine": 392,
+      "endLine": 409,
       "mathContext": "Mathematical content: fGeneral, f_is_fGeneral_0"
     },
     {
       "id": "status",
       "title": "Problem Status",
       "summary": "erdos_684_statement",
-      "startLine": 349,
-      "endLine": 401,
+      "startLine": 410,
+      "endLine": 461,
       "mathContext": "Mathematical content: erdos_684_statement"
     }
   ],

--- a/src/data/research/problems/erdos-684.json
+++ b/src/data/research/problems/erdos-684.json
@@ -17,11 +17,11 @@
   },
   "currentState": {
     "phase": "OBSERVE",
-    "since": "2026-05-07T17:35:00.000Z",
-    "iteration": 4,
-    "focus": "Added structural smoothPart lemmas: positivity, monotonicity in k, boundary cases",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 5,
+    "focus": "Formalized the central u*v decomposition for the binomial coefficient. The file defined binomialRoughPart but never proved C(n,k) = binomialSmoothPart * binomialRoughPart nor that the binomial smooth part divides C(n,k) - the very objects the problem concerns. Added binomial_smooth_rough_decomposition and binomialSmoothPart_dvd (instantiations of the proven general smooth_rough_decomposition/smoothPart_dvd). Also realigned badly-drifted gallery meta sections (ended at 401 vs 462-line file; ranges mismatched Part markers). theoremCount 20->22, lineCount 451->462, axiomCount unchanged at 2.",
     "blockers": [],
-    "nextAction": "Verify Docker build of expanded file; explore reducing f_domain_large axiom via concrete witness for some n₀.",
+    "nextAction": "2 axioms remain (f_domain_large existence threshold; mahler_ineffective). Reducing f_domain_large needs a concrete n0 witness where smoothPart C(n,floor(n/2)) > n^2 - a real computation/estimate. Structural decomposition now complete for the binomial-specific defs.",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -29,7 +29,7 @@
     }
   },
   "knowledge": {
-    "progressSummary": "PROGRESS: Added 8 structural lemmas about smoothPart (positivity, monotonicity in k as ∣ and ≤, boundary values 0/1/n). theoremCount 12→20, axiomCount unchanged at 2.",
+    "progressSummary": "OPEN, 2 axioms (f_domain_large, mahler_ineffective), 0 sorries. Erdos684Problem.lean now 462 LOC, 22 theorems. NEW: binomial_smooth_rough_decomposition (C(n,k)=smooth*rough) + binomialSmoothPart_dvd (the central u*v factorization, previously only proved for general m, not the binomial-specific defs). Kummer/Legendre formula, f(n) definition + f_property/below_f_small, Mahler-implies-f->infinity chain all present.",
     "builtItems": [
       "Proved smoothPart_dvd via prod_pow_factorization_dvd helper (Finset induction + coprimality)",
       "Proved f_lower_bound theorem from f_property axiom",
@@ -51,7 +51,9 @@
       "smoothPart_dvd_mono: k₁ ≤ k₂ → smoothPart k₁ m ∣ smoothPart k₂ m (Finset.prod_dvd_prod_of_subset)",
       "smoothPart_mono_k: k₁ ≤ k₂ → smoothPart k₁ m ≤ smoothPart k₂ m (corollary of dvd + pos)",
       "binomialSmoothPart_self: binomialSmoothPart n n = 1 (since C(n,n) = 1)",
-      "binomialSmoothPart_zero: binomialSmoothPart n 0 = 1 (range 1 has no primes)"
+      "binomialSmoothPart_zero: binomialSmoothPart n 0 = 1 (range 1 has no primes)",
+      "binomial_smooth_rough_decomposition: C(n,k) = binomialSmoothPart * binomialRoughPart (central u*v decomposition)",
+      "binomialSmoothPart_dvd: binomialSmoothPart n k | C(n,k)"
     ],
     "insights": [
       "smoothPart_dvd proved: product of p^(factorization p) for primes p ≤ k divides m, via coprimality of distinct prime powers and Finset induction",


### PR DESCRIPTION
## Summary
Research session on **Erdős #684** — smooth parts of binomial coefficients; $f(n)=$ smallest $k$ with the $k$-smooth part of $C(n,k)$ exceeding $n^2$ (OPEN). The file decomposes $C(n,k)=u\cdot v$ (smooth·rough) and defines `binomialSmoothPart`/`binomialRoughPart`, but never proved the decomposition or divisibility for these binomial-specific definitions — only for a general $m$.

## Progress (2 new theorems, no new axioms)
- **`binomialSmoothPart_dvd`** — $\text{binomialSmoothPart}\,n\,k \mid C(n,k)$ (instantiation of `smoothPart_dvd`).
- **`binomial_smooth_rough_decomposition`** — $C(n,k) = \text{binomialSmoothPart}\cdot\text{binomialRoughPart}$ for $k\le n$ (instantiation of `smooth_rough_decomposition`). This is the central $u\cdot v$ factorization the entire problem is stated in terms of.

## Also: metadata realignment
The gallery `meta.json` sections were badly drifted — they ended at line 401 of a 462-line file and the ranges didn't match the `# Part N` markers. Realigned all 9 sections to the actual Part boundaries.

## Files
- `proofs/Proofs/Erdos684Problem.lean` (451→462 LOC, 20→22 theorems; 2 axioms / 0 sorries unchanged)
- `src/data/proofs/erdos-684/meta.json` — `theoremCount` 20→22, `lineCount` 451→462, all section ranges realigned, summary updated
- `src/data/research/problems/erdos-684.json`, `research/problems/erdos-684/state.md` — state sync

## Status
**Outcome**: progress (central decomposition formalized for the binomial-specific defs; meta section drift fixed). The 2 axioms (`f_domain_large` existence threshold; `mahler_ineffective` Mahler's bound) are irreducible — the latter is a deep ineffective result, the former needs an explicit computational witness. The open bounds on $f(n)$ are unchanged.

**Build**: ⚠️ build-pending — Docker daemon unresponsive this session. Both new theorems are one-line instantiations of lemmas already proven in this file, so confidence is high, but unverified here. Draft until built.

🤖 Generated by researcher-4