### PR TITLE
research(pascals-hexagon): rebuild gallery sections to match source (10→23)

### DIFF
--- a/src/data/proofs/pascals-hexagon/meta.json
+++ b/src/data/proofs/pascals-hexagon/meta.json
@@ -72,84 +72,188 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Imports and Setup",
+      "id": "preamble",
+      "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 54,
-      "summary": "Imports `Mathlib.LinearAlgebra.CrossProduct` and `Mathlib.LinearAlgebra.Matrix.Determinant.Basic` for cross products and determinants in $\\mathbb{R}^3$.",
-      "mathContext": "Imports cross product $\\mathbf{u} \\times \\mathbf{v} \\in \\mathbb{R}^3$ and the matrix determinant $\\det : M_{3 \\times 3}(\\mathbb{R}) \\to \\mathbb{R}$, which together provide the computational backbone for projective incidence geometry."
+      "endLine": 55,
+      "summary": "Module docstring (what is proved, historical context, approach, status checklist, Mathlib dependencies) and imports.",
+      "mathContext": "Pascal's theorem (1639): if a hexagon is inscribed in a conic, the three intersection points of opposite sides are collinear (the *Pascal line*). The file models the real projective plane ℝP² by nonzero vectors in ℝ³."
     },
     {
-      "id": "projective-points-lines",
-      "title": "Projective Points and Lines",
-      "startLine": 55,
-      "endLine": 73,
-      "summary": "Defines `ProjPoint` and `ProjLine` as `Fin 3 → ℝ` (vectors in $\\mathbb{R}^3$), with `valid` predicates ensuring nonzero representatives in $\\mathbb{RP}^2$.",
-      "mathContext": "Points and lines in $\\mathbb{RP}^2$ are represented as nonzero vectors $p, l \\in \\mathbb{R}^3 \\setminus \\{0\\}$. A point $p$ lies on line $l$ iff $p \\cdot l = \\sum_{i=0}^{2} p_i l_i = 0$. The $\\mathrm{valid}$ predicate ensures the representative is nonzero."
+      "id": "proj-setup",
+      "title": "PART 1: Projective Geometry Setup",
+      "startLine": 56,
+      "endLine": 74,
+      "summary": "`ProjPoint`/`ProjLine` as elements of `Fin 3 → ℝ` with validity predicates `ProjPoint.valid`/`ProjLine.valid` (nonzero).",
+      "mathContext": "Points and lines of ℝP² are homogeneous coordinates in ℝ³ ∖ {0}; the point–line duality is the symmetry of this representation."
     },
     {
-      "id": "fundamental-operations",
-      "title": "Fundamental Operations",
-      "startLine": 74,
-      "endLine": 87,
-      "summary": "Defines `lineThrough`, `lineIntersection` (both via cross product), and `pointOnLine` (via dot product $p \\cdot l = 0$).",
-      "mathContext": "The line through points $p, q$ is $\\ell = p \\times q$, and the intersection of lines $\\ell, m$ is $P = \\ell \\times m$. Both use the same cross product operation, reflecting projective point-line duality in $\\mathbb{RP}^2$. Incidence is $p \\cdot \\ell = 0$."
+      "id": "fundamental-ops",
+      "title": "PART 2: Fundamental Operations",
+      "startLine": 75,
+      "endLine": 88,
+      "summary": "`lineThrough p q` and `lineIntersection l m` via the cross product, and incidence `pointOnLine p l = (p ⬝ l = 0)`.",
+      "mathContext": "In homogeneous coordinates the join of two points and the meet of two lines are both the cross product; incidence is the vanishing dot product $p \\cdot l = 0$."
     },
     {
-      "id": "collinearity-concurrency",
-      "title": "Collinearity and Concurrency",
-      "startLine": 88,
-      "endLine": 108,
-      "summary": "Defines `threeVectorMatrix`, `collinear` ($\\det(p,q,r) = 0$), and `concurrent` ($\\det(l,m,n) = 0$) — dual predicates via the same determinant condition.",
-      "mathContext": "Three points $P, Q, R$ are collinear iff $\\det(P \\mid Q \\mid R) = 0$, and three lines $\\ell, m, n$ are concurrent iff $\\det(\\ell \\mid m \\mid n) = 0$. Both conditions reduce to the vanishing of a $3 \\times 3$ determinant, a manifestation of point-line duality."
+      "id": "collinearity",
+      "title": "PART 3: Collinearity and Concurrency",
+      "startLine": 89,
+      "endLine": 109,
+      "summary": "`threeVectorMatrix`, `collinear p q r` (determinant of the coordinate matrix is 0), and the dual `concurrent l m n`.",
+      "mathContext": "Three points are collinear iff the determinant of their coordinate matrix vanishes; dually three lines are concurrent under the same determinant condition."
     },
     {
-      "id": "conic-sections",
-      "title": "Conic Sections",
-      "startLine": 109,
-      "endLine": 133,
-      "summary": "Defines `Conic` as a symmetric $3 \\times 3$ matrix $C$, `conicQuadraticForm` ($p^T C p = \\sum_{i,j} C_{ij} p_i p_j$), `pointOnConic`, non-degeneracy ($\\det C \\neq 0$), and symmetry.",
-      "mathContext": "A conic is a symmetric matrix $C \\in \\mathrm{Sym}_3(\\mathbb{R})$ with quadratic form $Q(p) = p^T C p = \\sum_{i,j} C_{ij} p_i p_j$. A point lies on the conic iff $Q(p) = 0$. Non-degeneracy requires $\\det C \\neq 0$, and all non-degenerate conics are projectively equivalent."
+      "id": "conics",
+      "title": "PART 4: Conic Sections",
+      "startLine": 110,
+      "endLine": 134,
+      "summary": "`Conic` as a 3×3 matrix, `conicQuadraticForm`, membership `pointOnConic p C = (pᵀ C p = 0)`, and `Conic.nondegenerate`/`Conic.symmetric`.",
+      "mathContext": "A conic is the zero locus of a quadratic form $p^\\top C p = 0$ for a symmetric 3×3 matrix $C$; non-degeneracy is $\\det C \\neq 0$."
     },
     {
       "id": "inscribed-hexagon",
-      "title": "Inscribed Hexagon and Pascal Points",
-      "startLine": 134,
-      "endLine": 172,
-      "summary": "Defines `InscribedHexagon C` with 6 vertices on conic $C$, and the three Pascal points: $P = (A \\times B) \\times (D \\times E)$, $Q = (B \\times C') \\times (E \\times F)$, $R = (C' \\times D) \\times (F \\times A)$.",
-      "mathContext": "An inscribed hexagon $ABCDEF$ has all six vertices on conic $C$: $Q(A) = Q(B) = \\cdots = Q(F) = 0$. The three Pascal points are intersections of opposite sides: $P = \\overline{AB} \\cap \\overline{DE}$, $Q = \\overline{BC} \\cap \\overline{EF}$, $R = \\overline{CD} \\cap \\overline{FA}$, computed as $(A \\times B) \\times (D \\times E)$, etc."
+      "title": "PART 5: Hexagon Inscribed in Conic",
+      "startLine": 135,
+      "endLine": 173,
+      "summary": "`InscribedHexagon C` (six points on the conic) and the three Pascal intersection points `pascalP`/`pascalQ`/`pascalR` of opposite sides.",
+      "mathContext": "A hexagon $ABCDEF$ on $C$ has three pairs of opposite sides; their meets $P = AB \\cap DE$, $Q = BC \\cap EF$, $R = CD \\cap FA$ are the points Pascal's theorem asserts are collinear."
     },
     {
       "id": "pascal-constraint",
-      "title": "Pascal's Constraint",
-      "startLine": 173,
-      "endLine": 187,
-      "summary": "Defines `pascalConstraint`: compute opposite-side intersections $P, Q, R$ via cross products, then check $\\det(P, Q, R) = 0$.",
-      "mathContext": "The Pascal constraint asserts $\\det(P \\mid Q \\mid R) = 0$ where $P, Q, R$ are the opposite-side intersections. By Cayley-Bacharach, two degenerate cubics $\\overline{AB} \\cup \\overline{CD} \\cup \\overline{EF}$ and $\\overline{BC} \\cup \\overline{DE} \\cup \\overline{FA}$ meet in $3 \\times 3 = 9$ points (Bezout), 6 on the conic, forcing the remaining 3 to be collinear."
+      "title": "PART 6: Pascal's Constraint",
+      "startLine": 174,
+      "endLine": 188,
+      "summary": "`pascalConstraint A B C D E F`: the collinearity condition on the three opposite-side intersection points expressed directly in the six vertices.",
+      "mathContext": "The Pascal constraint is the determinant equation $\\det[P, Q, R] = 0$ relating the six vertices — the algebraic content of the theorem."
     },
     {
       "id": "main-theorem",
-      "title": "Pascal's Hexagon Theorem",
-      "startLine": 188,
-      "endLine": 231,
-      "summary": "The axiom `conic_implies_pascal_constraint` and **Theorem** `pascal_hexagon_theorem` (Wiedijk #28): for hexagon inscribed in conic, Pascal points $P, Q, R$ are collinear.",
-      "mathContext": "**Pascal's Theorem** (Wiedijk #28): For hexagon $ABCDEF$ inscribed in a non-degenerate conic $C$, the three points $P = \\overline{AB} \\cap \\overline{DE}$, $Q = \\overline{BC} \\cap \\overline{EF}$, $R = \\overline{CD} \\cap \\overline{FA}$ satisfy $\\det(P \\mid Q \\mid R) = 0$, i.e., they are collinear. The line $PQR$ is the Pascal line."
+      "title": "PART 7: Main Theorem",
+      "startLine": 189,
+      "endLine": 232,
+      "summary": "`axiom conic_implies_pascal_constraint` (the synthetic projective fact) and `pascal_hexagon_theorem`, which derives collinearity of the Pascal points for any inscribed hexagon from it.",
+      "mathContext": "Pascal's theorem: points on a non-degenerate conic satisfy the Pascal constraint. The hard projective content is isolated as one axiom, partially eliminated in PARTs 11–20a."
     },
     {
       "id": "special-cases",
-      "title": "Special Cases: Pappus's Theorem",
-      "startLine": 232,
-      "endLine": 248,
-      "summary": "Defines `collinearOnLine` for Pappus's theorem — the degenerate case where the conic is a pair of lines $l_1 \\cup l_2$.",
-      "mathContext": "When the conic degenerates to a line pair $C = \\ell_1 \\cup \\ell_2$ (i.e., $\\det C = 0$ and $C$ factors), Pascal's theorem specializes to Pappus's theorem (c. 340 AD): if $A, C, E \\in \\ell_1$ and $B, D, F \\in \\ell_2$, then $\\overline{AB} \\cap \\overline{DE}$, $\\overline{BC} \\cap \\overline{EF}$, $\\overline{CD} \\cap \\overline{FA}$ are collinear."
+      "title": "PART 8: Special Cases (Pappus)",
+      "startLine": 233,
+      "endLine": 249,
+      "summary": "Pappus's theorem as the degenerate-conic case, with `collinearOnLine` capturing collinearity of three points on a fixed line.",
+      "mathContext": "When the conic degenerates to two lines, Pascal's theorem specializes to Pappus's hexagon theorem, with the inscribed points split between the two components."
     },
     {
       "id": "brianchon-dual",
-      "title": "Brianchon's Dual Theorem",
-      "startLine": 249,
-      "endLine": 321,
-      "summary": "Defines `hexagonDiagonal1/2/3` for Brianchon's theorem (1806): if a hexagon is circumscribed about a conic, the three main diagonals $AD$, $BE$, $CF$ are concurrent. Includes historical notes on the 60 Pascal lines.",
-      "mathContext": "**Brianchon's Theorem** (1806), dual to Pascal's: if hexagon $ABCDEF$ is circumscribed about a conic (each side tangent to $C$), then the three main diagonals $\\overline{AD}$, $\\overline{BE}$, $\\overline{CF}$ are concurrent, i.e., $\\det(\\overline{AD} \\mid \\overline{BE} \\mid \\overline{CF}) = 0$. The $6!/(2 \\cdot 6) = 60$ orderings of six conic points yield 60 Pascal lines."
+      "title": "PART 9: Dual Theorem (Brianchon's Theorem)",
+      "startLine": 250,
+      "endLine": 275,
+      "summary": "Brianchon's theorem (the projective dual) via `hexagonDiagonal1/2/3`: for a hexagon circumscribed about a conic the three main diagonals are concurrent.",
+      "mathContext": "By projective duality (points↔lines, collinear↔concurrent), Pascal's theorem for inscribed hexagons becomes Brianchon's theorem for circumscribed hexagons."
+    },
+    {
+      "id": "historical-notes",
+      "title": "PART 10: Historical Notes",
+      "startLine": 276,
+      "endLine": 309,
+      "summary": "Docstring historical notes on Pascal (1639), Brianchon, and the theorem's role in projective geometry. No declarations.",
+      "mathContext": "Pascal proved the theorem at sixteen; it generalizes Pappus (the conic-degenerate case) and is foundational in synthetic projective geometry."
+    },
+    {
+      "id": "std-conic-axiom-elim",
+      "title": "PART 11: Proof for Standard Conic (Axiom Elimination)",
+      "startLine": 310,
+      "endLine": 373,
+      "summary": "Begins eliminating the axiom for the standard conic: `stdConicPoint`/`stdConic`, membership `stdConicPoint_on_conic`, and `pascal_std_conic_parametrized` proving the Pascal constraint for six parametrized points.",
+      "mathContext": "For the standard conic, points are $(t, t^2, 1)$; the Pascal constraint becomes a polynomial identity in the six parameters, provable by direct computation (`ring`/`field_simp`)."
+    },
+    {
+      "id": "scalar-triple-product",
+      "title": "PART 11b: Scalar Triple Product Formula",
+      "startLine": 374,
+      "endLine": 404,
+      "summary": "`stdConic_det_factored`: a factored form of the 3×3 determinant arising in the parametric computation.",
+      "mathContext": "The determinant in the parametric Pascal constraint factors as a product of vertex-parameter differences (a Vandermonde-type expression), making the collinearity identity transparent."
+    },
+    {
+      "id": "projective-invariance",
+      "title": "PART 12: Projective Invariance (Toward General Conics)",
+      "startLine": 405,
+      "endLine": 514,
+      "summary": "`projTransform` (action of an invertible matrix on points) plus invariance lemmas `threeVectorMatrix_projTransform`, `collinear_projTransform`, `crossProduct_projTransform`, `pascalConstraint_projTransform`.",
+      "mathContext": "Projective transformations are invertible 3×3 matrices on homogeneous coordinates. Collinearity and the Pascal constraint are projective invariants, so a standard-conic result transports to any projectively-equivalent conic."
+    },
+    {
+      "id": "parametric-coverage",
+      "title": "PART 13: Parametric Coverage of Standard Conic",
+      "startLine": 515,
+      "endLine": 591,
+      "summary": "`stdConicInfinity` (the conic's point at infinity), `stdConicInfinity_on_conic`, `stdConic_infinity_char`, and `stdConicPoint_covers` (every conic point is parametrized or the infinity point).",
+      "mathContext": "The affine parametrization $(t, t^2, 1)$ misses exactly the infinity point $[0:1:0]$; together they cover the whole projective conic, needed for the all-cases assembly."
+    },
+    {
+      "id": "crossproduct-bilinear",
+      "title": "PART 14: Bilinearity of Cross Product (Scaling)",
+      "startLine": 592,
+      "endLine": 610,
+      "summary": "`crossProduct_smul_left`/`crossProduct_smul_right`: the cross product scales linearly in each argument.",
+      "mathContext": "Homogeneous coordinates are defined up to scaling, so the cross-product join/meet operations must respect scalar multiplication; these lemmas certify well-definedness on projective classes."
+    },
+    {
+      "id": "infinity-cases",
+      "title": "PART 15: Pascal's Theorem — Point at Infinity Cases",
+      "startLine": 611,
+      "endLine": 684,
+      "summary": "Six lemmas `pascal_std_conic_infinity_{F,A,B,C,D,E}` proving the Pascal constraint when one vertex is the conic's point at infinity.",
+      "mathContext": "When one hexagon vertex is the infinity point $[0:1:0]$ the parametric identity degenerates; each case is handled so the standard-conic result holds for every vertex configuration."
+    },
+    {
+      "id": "scale-invariance",
+      "title": "PART 16: Scale Invariance of Pascal Constraint",
+      "startLine": 685,
+      "endLine": 754,
+      "summary": "`det_threeVectorMatrix_smul` and `pascalConstraint_smul`: the Pascal constraint is invariant under independent rescaling of the six homogeneous representatives.",
+      "mathContext": "Since each vertex is a projective point (up to scale), the constraint must be unchanged when representatives are rescaled; the determinant scales by the product of factors, preserving vanishing."
+    },
+    {
+      "id": "assembly-finite",
+      "title": "PART 17: Assembly — Pascal's Theorem for Standard Conic",
+      "startLine": 755,
+      "endLine": 807,
+      "summary": "`stdConic_point_classification` and `pascal_stdConic_allFinite`, assembling the parametrized cases into Pascal's theorem for the standard conic when all six vertices are finite.",
+      "mathContext": "Combining the parametric identity (PART 11) with scale invariance (PART 16) yields the all-finite case; the infinity cases (PART 15) complete the standard conic."
+    },
+    {
+      "id": "coincident-vertices",
+      "title": "PART 18: Coincident Vertex Lemmas",
+      "startLine": 808,
+      "endLine": 948,
+      "summary": "Fifteen `pascalConstraint_*_eq_*` private theorems covering every degenerate hexagon where two vertices coincide (adjacent, opposite, and skew pairs).",
+      "mathContext": "Pascal's theorem must also hold for degenerate hexagons with repeated vertices (limiting tangent-line configurations); each of the 15 coincidence patterns is discharged so the all-cases theorem has no gaps."
+    },
+    {
+      "id": "std-conic-all-cases",
+      "title": "PART 19: Pascal's Theorem for Standard Conic (All Cases)",
+      "startLine": 949,
+      "endLine": 1073,
+      "summary": "`pascal_std_conic`: the fully general statement for the standard conic, combining the finite, infinity, and coincident-vertex cases into one axiom-free theorem.",
+      "mathContext": "Case analysis on which vertices are finite/infinite/coincident reduces every configuration to a previously-proved lemma, eliminating the axiom for the standard conic entirely."
+    },
+    {
+      "id": "toward-axiom-elim",
+      "title": "PART 20: Toward Eliminating the Axiom",
+      "startLine": 1074,
+      "endLine": 1104,
+      "summary": "Roadmap docstring for removing `conic_implies_pascal_constraint` in general via Sylvester's law of inertia and Mathlib's spectral theorem. No declarations.",
+      "mathContext": "Any non-degenerate symmetric conic is projectively equivalent to the standard one (diagonalize via Sylvester's law / `Matrix.IsHermitian.spectral_theorem`); with projective invariance (PART 12) this upgrades the standard-conic theorem to all conics."
+    },
+    {
+      "id": "quadraticform-bridge",
+      "title": "PART 20a: Mathlib QuadraticForm Bridge (for Sylvester's Law)",
+      "startLine": 1105,
+      "endLine": 1278,
+      "summary": "Bridge lemmas linking `conicQuadraticForm` to Mathlib's `Matrix.toQuadraticMap'` (`conicQF_eq_dotProduct`, `mathlibQF_eq_dotProduct`, `conicQF_eq_mathlibQF`, `mathlibQF_separatingLeft`, `projTransform_valid_of_det_ne_zero`) and `proof_sketch_conic_implies_pascal`, whose lone remaining `sorry` (line 1245) is the matrix-extraction step of the general diagonalization.",
+      "mathContext": "Connects the ad-hoc quadratic form to Mathlib's `QuadraticForm` API so Sylvester's law applies; the open step is extracting an explicit diagonalizing transformation from an `IsometryEquiv`, flagged in-file as the hard 6-case weight analysis."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery metadata for `pascals-hexagon` listed only **10 sections** ending at line 321 — hiding ~957 lines (≈75%) of the 1278-line proof and conflating PARTs 9–11 into one entry.

The Lean source has **22 numbered `PART` banners** (1 through 20a) plus a preamble, spanning the full axiom-elimination program:
- PART 1–6: projective setup (points/lines, operations, collinearity, conics, inscribed hexagon, Pascal constraint)
- PART 7–10: axiomatized main theorem, Pappus special case, Brianchon dual, historical notes
- PART 11–17: standard-conic parametric proof, projective invariance, parametric coverage, scaling/bilinearity, infinity cases, scale invariance, all-finite assembly
- PART 18–19: 15 coincident-vertex lemmas + the all-cases standard-conic theorem
- PART 20–20a: roadmap to general conics + the Mathlib `QuadraticForm` bridge (home of the lone `sorry`)

This PR realigns every section to the `=== PART N ===` banners (full coverage, lines 1–1278, no overlaps) and adds the 13 missing sections with accurate summaries and mathContext.

## Verification
- All ranges monotonic, non-overlapping, covering lines 1–1278.
- Scalar counts confirmed against source and unchanged: `theoremCount` 46, `definitionCount` 28, `lineCount` 1278, `sorries` 1 (real `sorry` @1245), `axiomCount` 1 (`conic_implies_pascal_constraint` @208).
- Metadata-only change; no Lean source touched.

## Test plan
- [x] meta.json parses as valid JSON
- [x] diff confined to the `sections` array