### PR TITLE
audit(schauder-fixed-point-oq-03-oq-01): realign stale sections + full-file coverage (9 → 10)

### DIFF
--- a/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
+++ b/src/data/proofs/schauder-fixed-point-oq-03-oq-01/meta.json
@@ -90,64 +90,71 @@
       "id": "header",
       "title": "Documentation and Imports",
       "startLine": 1,
-      "endLine": 50,
+      "endLine": 65,
       "summary": "Module docstring explaining the proof strategy, status (2 axioms), the choice of graph-approximate selections (over the strictly stronger pointwise form, which is provably false under USC alone), references, and Lean imports."
     },
     {
       "id": "definitions",
-      "title": "Set-Valued Map Definitions",
-      "startLine": 56,
-      "endLine": 70,
-      "summary": "Defines SetValuedMap (correspondence), IsFixedPoint ($x \\in F(x)$), and IsUpperHemicontinuous (preimages of open sets are open)."
+      "title": "Part I: Set-Valued Map Definitions",
+      "startLine": 66,
+      "endLine": 163,
+      "summary": "Defines SetValuedMap (correspondence), IsFixedPoint ($x \\in F(x)$), and IsUpperHemicontinuous (preimages of open sets are open). Imported from the parent framework."
     },
     {
       "id": "brouwer-axiom",
-      "title": "Axiom 1: Brouwer's FPT",
-      "startLine": 72,
-      "endLine": 87,
-      "summary": "Axiomatizes Brouwer's fixed point theorem for compact convex subsets of $\\mathbb{R}^n$ — the topological engine of the proof."
+      "title": "Part II: Axiom 1 — Brouwer's FPT (Closed Unit Ball)",
+      "startLine": 164,
+      "endLine": 329,
+      "summary": "Axiomatizes Brouwer's fixed point theorem on the closed unit ball of $\\mathbb{R}^n$ (`brouwer_unit_ball`) — the topological engine of the proof."
+    },
+    {
+      "id": "brouwer-theorem",
+      "title": "Brouwer's FPT on Compact Convex Sets (Theorem 1)",
+      "startLine": 330,
+      "endLine": 533,
+      "summary": "Derives Brouwer's FPT for an arbitrary compact convex subset of $\\mathbb{R}^n$ as a theorem (`brouwer_fpt`, formerly Axiom 1) from the closed-unit-ball axiom, via a projection/retraction argument (`exists_continuous_proj_convex`)."
     },
     {
       "id": "approx-selection",
-      "title": "Graph-Approximate Selections and Axiom 2",
-      "startLine": 89,
-      "endLine": 142,
-      "summary": "Defines IsGraphApproxSelection (Cellina–Browder form) and axiomatizes the existence of continuous $\\varepsilon$-graph-approximate selections for UHC maps with convex values. Docstring explains why the pointwise form is unprovable under USC + convex values alone (S6 counterexample) and outlines the PartitionOfUnity construction for the graph form."
+      "title": "Axiom 2: Graph-Approximate Selections",
+      "startLine": 534,
+      "endLine": 1226,
+      "summary": "Defines IsGraphApproxSelection (Cellina–Browder form) and axiomatizes the existence of continuous $\\varepsilon$-graph-approximate selections for UHC maps with convex values. Docstring explains why the pointwise form is unprovable under USC + convex values alone (S6 counterexample) and develops the supporting scaffolds (partition of unity, Lebesgue number, thickening witnesses) for the graph form."
     },
     {
       "id": "seq-compact-theorem",
       "title": "Sequential Compactness (derived from Mathlib)",
-      "startLine": 144,
-      "endLine": 154,
+      "startLine": 1227,
+      "endLine": 1239,
       "summary": "Sequential compactness in pseudo-metric spaces, derived in one line from Mathlib's `IsCompact.isSeqCompact`. Previously stated as Axiom 3."
     },
     {
+      "id": "structural-lemma",
+      "title": "Part III: Limit Argument — Approximate FPs Imply True FPs",
+      "startLine": 1240,
+      "endLine": 1373,
+      "summary": "Structural lemma abstracting the limit argument: if approximate fixed points exist for all $\\varepsilon > 0$, compactness and closedness yield a true fixed point. Fully proved using sequential compactness, the squeeze theorem, and a UHC closed-graph case split."
+    },
+    {
       "id": "kakutani-proof",
-      "title": "Kakutani's FPT from Brouwer",
-      "startLine": 290,
-      "endLine": 352,
+      "title": "Part IV: Kakutani's FPT from Brouwer",
+      "startLine": 1374,
+      "endLine": 1437,
       "summary": "The main theorem combining the two axioms: call the graph-selection axiom with $\\varepsilon/2$, get a Brouwer fixed point, apply the triangle inequality to convert the $(\\varepsilon/2, \\varepsilon/2)$ graph witness into an $\\varepsilon$-diagonal witness, hand off to the limit lemma. Fully proved."
     },
     {
       "id": "commentary",
-      "title": "Mathematical Commentary",
-      "startLine": 354,
-      "endLine": 407,
+      "title": "Part V: Mathematical Commentary (Why This Matters)",
+      "startLine": 1438,
+      "endLine": 1470,
       "summary": "Discussion of why the proof matters, Mathlib infrastructure gaps (partition of unity, general Brouwer), why the pointwise selection is unprovable, and alternative proof paths (simplicial approximation, Michael selection)."
-    },
-    {
-      "id": "structural-lemma",
-      "title": "Approximate FPs Imply True FPs",
-      "startLine": 156,
-      "endLine": 288,
-      "summary": "Structural lemma abstracting the limit argument: if approximate fixed points exist for all $\\varepsilon > 0$, compactness and closedness yield a true fixed point. Fully proved using sequential compactness, the squeeze theorem, and a UHC closed-graph case split."
     },
     {
       "id": "summary-checks",
       "title": "Summary and Type Checks",
-      "startLine": 409,
-      "endLine": 414,
-      "summary": "#check commands verifying the types of the four main declarations."
+      "startLine": 1471,
+      "endLine": 1531,
+      "summary": "#check commands verifying the types of the main declarations."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Integrity Issue

**Proof**: schauder-fixed-point-oq-03-oq-01
**Problem**: Gallery `sections` had badly stale line numbers and undercovered the Lean source.

## Evidence

- **Lean file**: `proofs/Proofs/SchauderFixedPointOQ03OQ01.lean` — 1531 lines, organized into `-- Part I … Part IV` banners plus `## Part V` / `## Summary`.
- **meta.json claimed**: 9 sections whose ranges reflect an older, shorter file — they stop at line 414, leaving ~1115 lines (73%) uncovered, and individual ranges are far off (e.g. "Kakutani's FPT from Brouwer" meta@290-352 vs the real Part IV banner @1374; "Approximate FPs Imply True FPs" meta@156-288 vs real Part III @1240).

## Fix

- Realigned every section to its verified line position, pinned to the file's `-- Part N` banners and declaration sites (`brouwer_unit_ball`@196, `brouwer_fpt`@371, `approx_selection_exists`@563, `seq_compact_of_compact`@1232).
- Added the missing **Theorem 1** section (`brouwer_fpt`: Brouwer on compact convex sets — formerly Axiom 1, now derived as a theorem from the unit-ball axiom).
- Updated the Axiom 1 section to reflect that the axiom is now stated on the closed unit ball (`brouwer_unit_ball`).
- Coverage is now contiguous and gap-free, 1 → 1531 (full file).

No claim changes: `status=axiomatized`, `badge=axiom`, `axiomCount=2` (brouwer_unit_ball + approx_selection_exists), `sorries=0` — all verified accurate and unchanged.

---
Discovered during gallery integrity audit (section-undercoverage scan, gap=1117).