### PR TITLE
research(erdos-349): state golden-ratio + ⌊(3/2)^n⌋ parity conjectures as Props (build-pending)

### DIFF
--- a/proofs/Proofs/Erdos349Problem.lean
+++ b/proofs/Proofs/Erdos349Problem.lean
@@ -50,20 +50,36 @@ theorem erdos_349_characterization :
 
 /- ## Golden Ratio Conjecture -/
 
-/-- **Golden Ratio Conjecture**: The sequence ⌊tα^n⌋ is complete
-    for all t > 0 and 1 < α < (1+√5)/2 ≈ 1.618. -/
+/-- **Golden Ratio Conjecture** (OPEN): the sequence ⌊tα^n⌋ is complete
+    for all t > 0 and 1 < α < (1+√5)/2 ≈ 1.618.
+
+    The upper bound is the golden ratio φ, the positive root of x² = x + 1.
+    For α > 1, the condition `α < φ` is equivalent to the algebraic
+    inequality `α² < α + 1`, which is used here to avoid `Real.sqrt`. -/
+def GoldenRatioConjecture : Prop :=
+  ∀ t α : ℝ, t > 0 → 1 < α → α ^ 2 < α + 1 → IsGoodPair t α
+
 /- ## Known Results -/
 
-/-- **Graham's Disjoint Segments**: For any k, there exists
-    t_k ∈ (0,1) such that the set of α making ⌊t_k α^n⌋ complete
-    consists of at least k disjoint intervals. -/
+/- **Graham's Disjoint Segments**: For any k, there exists
+   t_k ∈ (0,1) such that the set of α making ⌊t_k α^n⌋ complete
+   consists of at least k disjoint intervals. -/
 /- ## Parity of ⌊(3/2)^n⌋ -/
 
-/-- **Odd Infinitely Often?**: Is ⌊(3/2)^n⌋ odd for infinitely
+/-- The sequence ⌊(3/2)^n⌋, i.e. the `t = 1, α = 3/2` case of `expFloorSeq`. -/
+def floorThreeHalvesPow (n : ℕ) : ℤ := expFloorSeq 1 (3 / 2) n
+
+/-- **Odd Infinitely Often?** (OPEN): is ⌊(3/2)^n⌋ odd for infinitely
     many n? This basic question remains open and is a fundamental
     obstacle to the main conjecture. -/
-/-- **Even Infinitely Often?**: Is ⌊(3/2)^n⌋ even for infinitely
+def OddInfinitelyOften : Prop :=
+  ∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧ Odd (floorThreeHalvesPow n)
+
+/-- **Even Infinitely Often?** (OPEN): is ⌊(3/2)^n⌋ even for infinitely
     many n? Also open. -/
+def EvenInfinitelyOften : Prop :=
+  ∀ N : ℕ, ∃ n : ℕ, n ≥ N ∧ Even (floorThreeHalvesPow n)
+
 /- ## Proved Properties -/
 
 /-- When α = 1, the sequence ⌊t · 1^n⌋ = ⌊t⌋ is constant.

--- a/research/problems/erdos-349/state.md
+++ b/research/problems/erdos-349/state.md
@@ -1,27 +1,52 @@
 # Current State
 
-**Phase**: NEW
+**Phase**: ACT
 **Since**: 2026-01-13T00:53:52.153Z
-**Iteration**: 1
+**Iteration**: 3
+**Last Update**: 2026-06-14 (researcher-4 — conjectures stated as Props)
 
 ## Current Focus
 
-Initial exploration of the problem.
+`Erdos349Problem.lean` formalizes completeness of exponential floor sequences ⌊tα^n⌋. This session converted the three docstring-only conjectures into formal Props (per the prior next-action) and cleaned up dangling docstrings.
+
+## Status Summary
+
+| Surface | Value | Source |
+|---------|-------|--------|
+| Lean file | `proofs/Proofs/Erdos349Problem.lean` (100 LOC, 2 thm, 7 def, 0 axioms, 0 sorries) | `wc -l` + grep |
+| Gallery | `src/data/proofs/erdos-349/meta.json` — `status: "axiomatized"` (OPEN, 0-axiom policy), `definitionCount: 7` | `meta.json` |
 
 ## Active Approach
 
-None yet.
+Formalizing open conjectures as Props (statements, not proofs). Added:
+- `GoldenRatioConjecture` — complete for t > 0, 1 < α < φ, with φ encoded algebraically as `α² < α + 1` (avoids `Real.sqrt`).
+- `floorThreeHalvesPow` (the t=1, α=3/2 sequence) + `OddInfinitelyOften` / `EvenInfinitelyOften` — the ⌊(3/2)^n⌋ parity questions.
+
+Also repaired 3 dangling `/-- -/` docstrings (attached to the new defs) and demoted the Graham docstring to a `/- -/` block comment.
 
 ## Blockers
 
-None.
+- Proving completeness for 1 < α < φ, or resolving the ⌊(3/2)^n⌋ parity, is deeply open (no Mathlib path).
 
 ## Next Action
 
-Begin problem exploration.
+Conjectures are now stated. Graham's disjoint-segments result remains a prose comment (harder to state cleanly). A build-gated sanity lemma `floorThreeHalvesPow 0 = 1` could be added once Docker is available.
 
 ## Attempt Counts
 
-- Total attempts: 0
-- Current approach attempts: 0
-- Approaches tried: 0
+- Total attempts: 3
+- Current approach attempts: 1
+- Approaches tried: 2
+
+## Iteration Ledger
+
+| Iter | Date | Agent | Result | Scope |
+|------|------|-------|--------|-------|
+| 1–2 | 2026-01 | (legacy) | Built IsAdditivelyComplete/expFloorSeq/IsGoodPair, tautological characterization, α=1 lemma | Erdos349Problem.lean |
+| 3 | 2026-06-14 | researcher-4 | Stated GoldenRatioConjecture + Odd/EvenInfinitelyOften as Props, repaired dangling docstrings; def 3→7, LOC 84→100; build-pending (Docker down) | Erdos349Problem.lean + meta.json + registry + state.md |
+
+## Cross-references
+
+- Research JSON registry: `src/data/research/problems/erdos-349.json`
+- Gallery dir: `src/data/proofs/erdos-349/`
+- Lean source: `proofs/Proofs/Erdos349Problem.lean`

--- a/src/data/proofs/erdos-349/meta.json
+++ b/src/data/proofs/erdos-349/meta.json
@@ -30,9 +30,9 @@
     "badge": "wip",
     "assumptions": "0 axioms, 0 sorries. All results proved from Lean primitives.",
     "mathlib_version": "4.26.0",
-    "lineCount": 84,
+    "lineCount": 100,
     "theoremCount": 2,
-    "definitionCount": 3
+    "definitionCount": 7
   },
   "crossReferences": [
     {
@@ -98,7 +98,7 @@
       "id": "imports",
       "title": "Mathlib Imports",
       "startLine": 17,
-      "endLine": 20,
+      "endLine": 21,
       "summary": "Imports core Mathlib modules: $\\mathbb{N}$, $\\mathbb{Z}$, $\\mathbb{R}$ basics, and tactics. Provides the floor function $\\lfloor \\cdot \\rfloor$, real exponentiation, and Finset summation.",
       "mathContext": "Key Mathlib primitives: `Int.floor : ℝ → ℤ` for $\\lfloor \\cdot \\rfloor$, `Finset.sum` for $\\sum_{s \\in T} s$, and `Real.rpow` for $\\alpha^n$ with real exponents."
     },
@@ -113,40 +113,40 @@
     {
       "id": "main-question",
       "title": "Main Characterization Problem",
-      "startLine": 38,
-      "endLine": 44,
+      "startLine": 37,
+      "endLine": 50,
       "summary": "States Erdős Problem #349: characterize the set $\\mathcal{G} \\subseteq (0,\\infty)^2$ of all good pairs $(t,\\alpha)$. Formalized as an existential axiom asserting the completeness region exists.",
       "mathContext": "Axiom: $\\exists S \\subseteq \\mathbb{R}^2,\\ \\forall t > 0,\\ \\forall \\alpha > 0,\\ (t,\\alpha) \\in S \\iff \\{\\lfloor t\\alpha^n \\rfloor\\}$ is complete. The problem asks for an explicit description of $S$."
     },
     {
       "id": "golden-ratio",
       "title": "Golden Ratio Conjecture",
-      "startLine": 46,
-      "endLine": 52,
-      "summary": "The central conjecture: $\\lfloor t\\alpha^n \\rfloor$ is complete for all $t > 0$ and $1 < \\alpha < \\varphi = (1+\\sqrt{5})/2$. The golden ratio threshold arises from the Fibonacci sequence's completeness via Zeckendorf's theorem.",
+      "startLine": 51,
+      "endLine": 61,
+      "summary": "Formalizes the **Golden Ratio Conjecture** as a Prop: `GoldenRatioConjecture` states that ⌊tα^n⌋ is complete for all t > 0 and 1 < α < φ. The bound α < φ (φ the positive root of x²=x+1) is encoded algebraically as `α² < α + 1` to avoid `Real.sqrt`. Stated, not proved (the problem is OPEN).",
       "mathContext": "Conjecture: $(0,\\infty) \\times (1, \\varphi) \\subseteq \\mathcal{G}$. The Fibonacci sequence satisfies $F_n = \\lfloor \\varphi^n / \\sqrt{5} + 1/2 \\rfloor$ (i.e., $t = 1/\\sqrt{5}$, $\\alpha = \\varphi$), and Zeckendorf proved it is complete."
     },
     {
       "id": "known-results",
       "title": "Graham's Disjoint Segments",
-      "startLine": 54,
-      "endLine": 64,
+      "startLine": 62,
+      "endLine": 66,
       "summary": "Formalizes Graham's 1964 result: for any $k$, there exists $t_k \\in (0,1)$ such that the completeness set $\\{\\alpha : (t_k, \\alpha) \\in \\mathcal{G}\\}$ consists of $\\geq k$ disjoint intervals, revealing fractal-like complexity.",
       "mathContext": "Graham (1964): $\\forall k,\\ \\exists t_k,\\ \\{\\alpha : (t_k, \\alpha) \\in \\mathcal{G}\\}$ contains $\\geq k$ disjoint open intervals. This implies the boundary $\\partial \\mathcal{G}$ is highly non-trivial — not a simple curve in $(t,\\alpha)$-space."
     },
     {
       "id": "parity-questions",
       "title": "Parity of $\\lfloor (3/2)^n \\rfloor$",
-      "startLine": 66,
-      "endLine": 77,
-      "summary": "States the two fundamental parity sub-problems: is $\\lfloor (3/2)^n \\rfloor$ odd infinitely often? Even infinitely often? Both remain open and connect to equidistribution of $\\{(3/2)^n\\}$ modulo 1.",
+      "startLine": 67,
+      "endLine": 82,
+      "summary": "Formalizes the parity questions for ⌊(3/2)^n⌋ (the t=1, α=3/2 case, `floorThreeHalvesPow`) as Props: `OddInfinitelyOften` and `EvenInfinitelyOften` (∀N ∃n≥N with Odd/Even ⌊(3/2)^n⌋). Both are open and are a fundamental obstacle to the main conjecture. Stated, not proved.",
       "mathContext": "$\\lfloor (3/2)^n \\rfloor \\pmod{2}$ is determined by $\\{(3/2)^n\\} = (3/2)^n - \\lfloor (3/2)^n \\rfloor$. If $\\{(3/2)^n\\}$ were equidistributed mod 1, then $\\lfloor (3/2)^n \\rfloor$ would be odd $\\sim 50\\%$ of the time. But equidistribution of $\\{\\alpha^n\\}$ for non-Pisot $\\alpha$ (like $3/2$) is a major open problem."
     },
     {
       "id": "waring-observation",
       "title": "Waring Connection",
-      "startLine": 79,
-      "endLine": 83,
+      "startLine": 83,
+      "endLine": 99,
       "summary": "Notes the link to Waring's problem: the Ideal Waring formula $g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 2$ depends on the same exponential floor values that appear in Problem #349.",
       "mathContext": "$g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 2$ when $\\{(3/2)^k\\} \\leq 1 - (3/4)^k$. This condition holds for all verified $k \\leq 471{,}600{,}000$ (Kubina-Wunderlich). If it fails for some $k$, then $g(k) = 2^k + \\lfloor (3/2)^k \\rfloor - 1$."
     }

--- a/src/data/research/problems/erdos-349.json
+++ b/src/data/research/problems/erdos-349.json
@@ -30,15 +30,15 @@
   },
   "currentState": {
     "phase": "ACT",
-    "since": "2026-05-18T00:00:00Z",
-    "iteration": 2,
-    "focus": "The file has 2 theorem declarations, 3 definitions, 0 axioms, and 0 sorries; it proves only a tautological good-pair characterization and the alpha=1 constant-sequence lemma.",
+    "since": "2026-06-14T00:00:00.000Z",
+    "iteration": 3,
+    "focus": "Formalized the open conjectures as Props (per prior nextAction). Added GoldenRatioConjecture (complete for t>0, 1<alpha<phi, encoded algebraically as alpha^2<alpha+1 to avoid Real.sqrt), floorThreeHalvesPow (the t=1,alpha=3/2 sequence), and OddInfinitelyOften / EvenInfinitelyOften (parity of floor((3/2)^n) infinitely often). Also repaired 3 dangling /-- -/ docstrings (Golden Ratio/Odd/Even) by attaching them to the new defs and demoted the Graham docstring to a block comment. defCount 3->7, lineCount 84->100; still 0 axioms / 0 sorries.",
     "blockers": [
       "The explicit good-pair region is not characterized.",
       "Golden-ratio and parity statements remain comments.",
       "No finite subset-sum construction proves completeness for any nontrivial alpha range."
     ],
-    "nextAction": "State the golden-ratio conjecture and the floor((3/2)^n) parity questions as active Props.",
+    "nextAction": "Conjectures now stated as Props. The Graham disjoint-segments result remains a prose comment (harder to state cleanly). Genuine math (proving completeness for 1<alpha<phi, or the floor((3/2)^n) parity) is deeply open. Possible: a sanity lemma floorThreeHalvesPow 0 = 1 (build-gated).",
     "attemptCounts": {
       "total": 0,
       "currentApproach": 0,
@@ -46,13 +46,15 @@
     }
   },
   "knowledge": {
-    "progressSummary": "CURRENT: 2 theorem declarations, 3 definitions, 0 axioms, and 0 sorries; proves a tautological good-pair characterization and the alpha=1 constant-sequence lemma.",
+    "progressSummary": "OPEN, 0 axioms, 0 sorries. Erdos349Problem.lean now 100 LOC, 2 theorems, 7 defs. Defs: IsAdditivelyComplete, expFloorSeq, IsGoodPair, GoldenRatioConjecture, floorThreeHalvesPow, OddInfinitelyOften, EvenInfinitelyOften. The three docstring-only conjectures are now formal Props (stated, not proved). Proved: tautological characterization + alpha=1 constant-sequence lemma.",
     "builtItems": [
       "`IsAdditivelyComplete`",
       "`expFloorSeq`",
       "`IsGoodPair`",
       "`erdos_349_characterization`",
-      "`expFloorSeq_at_one`"
+      "`expFloorSeq_at_one`",
+      "GoldenRatioConjecture (Prop): complete for t>0, 1<alpha<phi via algebraic alpha^2<alpha+1",
+      "floorThreeHalvesPow + OddInfinitelyOften + EvenInfinitelyOften (Props): floor((3/2)^n) parity questions"
     ],
     "insights": [
       "The file is axiom-free and sorry-free.",


### PR DESCRIPTION
## Summary
Research session on **Erdős #349** — for which t, α is ⌊tα^n⌋ a complete sequence? (OPEN). Three conjectures were described only in docstrings, with **no declarations** — leaving dangling `/-- -/` doc comments. This session formalizes them as Props (per the prior next-action) and cleans up the docstrings.

## Progress (4 new defs, no new axioms/sorries)
- **`GoldenRatioConjecture`** (Prop) — ⌊tα^n⌋ is complete for all t > 0 and 1 < α < φ. The bound α < φ (φ = positive root of x²=x+1) is encoded algebraically as `α² < α + 1`, avoiding any `Real.sqrt` import.
- **`floorThreeHalvesPow`** — the t=1, α=3/2 case of `expFloorSeq` (i.e. ⌊(3/2)^n⌋).
- **`OddInfinitelyOften`** / **`EvenInfinitelyOften`** (Props) — is ⌊(3/2)^n⌋ odd/even for infinitely many n (∀N ∃n≥N)? The parity obstacle to the main conjecture.

These are **stated, not proved** — appropriate for an OPEN problem.

## Also: docstring repair
The three conjecture docstrings were dangling `/-- -/` comments (no following declaration). Attaching them to the new defs fixes this; the Graham disjoint-segments docstring is demoted to a `/- -/` block comment.

## Files
- `proofs/Proofs/Erdos349Problem.lean` (84→100 LOC, 3→7 defs; 0 axioms / 0 sorries unchanged)
- `src/data/proofs/erdos-349/meta.json` — `definitionCount` 3→7, `lineCount` 84→100, section ranges + golden-ratio/parity summaries updated
- `src/data/research/problems/erdos-349.json`, `research/problems/erdos-349/state.md` — state sync (iteration 3)

## Status
**Outcome**: progress (open conjectures now formal Props; latent dangling-docstring issue repaired). Proving any of them (completeness for 1<α<φ, or the ⌊(3/2)^n⌋ parity) is deeply open with no Mathlib path.

**Build**: ⚠️ build-pending — Docker daemon unresponsive this session. The additions are pure Prop/def statements over existing predicates (no proofs), so risk is minimal, but unverified here. Draft until built.

🤖 Generated by researcher-4