### PR TITLE
research(roth-theorem-k3-oq-02): realign gallery sections to 4 source Parts + fix stale counts

### DIFF
--- a/src/data/proofs/roth-theorem-k3-oq-02/meta.json
+++ b/src/data/proofs/roth-theorem-k3-oq-02/meta.json
@@ -47,9 +47,9 @@
       "Edge-disjointness lower bound: edge removal requires >= |A|N edges",
       "Statement of Roth's theorem via triangle removal as alternative to Fourier proof"
     ],
-    "lineCount": 465,
-    "theoremCount": 16,
-    "definitionCount": 7,
+    "lineCount": 534,
+    "theoremCount": 18,
+    "definitionCount": 4,
     "mathlib_version": "4.26.0"
   },
   "overview": {
@@ -75,39 +75,32 @@
       "id": "graph-construction",
       "title": "Part I: Ruzsa-Szemerédi Graph Construction",
       "startLine": 1,
-      "endLine": 47,
-      "summary": "Defines the vertex type RSVertex = Fin 3 × ZMod N and the adjacency relation rsAdj encoding differences in A. Proves symmetry and irreflexivity, constructing the SimpleGraph. 0 sorries.",
+      "endLine": 91,
+      "summary": "Defines the vertex type RSVertex = Fin 3 × ZMod N and the adjacency relation rsAdj encoding differences in A. Proves rsAdj_symm (symmetry) and rsAdj_loopless (irreflexivity), then assembles the SimpleGraph ruzsaSzemerediGraph. 0 sorries.",
       "mathContext": "Graph $G(A)$ on $3N$ vertices: $(0,x) \\sim (1,y) \\iff y-x \\in A$, $(1,y) \\sim (2,z) \\iff z-y \\in A$, $(0,x) \\sim (2,z) \\iff \\exists a \\in A,\\; z-x = 2a$."
-    },
-    {
-      "id": "section-48",
-      "title": "Part I: Ruzsa-Szemerédi Graph Construction (continued)",
-      "startLine": 48,
-      "endLine": 94,
-      "summary": "Continuation of Part I: Ruzsa-Szemerédi Graph Construction."
     },
     {
       "id": "triangle-ap",
       "title": "Part II: Triangle ↔ 3-AP Correspondence",
-      "startLine": 95,
-      "endLine": 183,
-      "summary": "Defines APTriple structure (a,b,c ∈ A with a+b=2c). Proves triangle_yields_ap_triple (forward: triangle → AP triple) and ap_triple_yields_triangle (reverse: AP triple + base point → triangle). 0 sorries.",
+      "startLine": 92,
+      "endLine": 185,
+      "summary": "Provides the edge-extraction helpers rsAdj_xy_mem, rsAdj_yz_mem, rsAdj_xz_exists and defines the APTriple structure (a,b,c ∈ A with a+b=2c). Proves triangle_yields_ap_triple (forward: triangle → AP triple) and ap_triple_yields_triangle (reverse: AP triple + base point → triangle). 0 sorries.",
       "mathContext": "Triangle $(0,x),(1,y),(2,z)$ in $G(A)$ $\\iff$ $\\exists a,b,c \\in A$: $a = y-x$, $b = z-y$, $a+b = 2c$."
     },
     {
       "id": "edge-disjointness",
       "title": "Part III: Edge-Disjointness When AP-Free",
-      "startLine": 184,
-      "endLine": 269,
-      "summary": "Proves ap_free_forces_equal: AP-free forces a=b=c in any AP triple. Proves xy_edge_unique_triangle: each XY-edge determines a unique triangle. Proves ap_free_triangle_exists: explicit triangle construction for each a ∈ A. 0 sorries.",
+      "startLine": 186,
+      "endLine": 340,
+      "summary": "Proves ap_free_forces_equal: AP-free forces a=b=c in any AP triple. Proves xy_edge_unique_triangle, yz_edge_unique_triangle, and xz_edge_unique_triangle: each edge determines a unique triangle when AP-free (the XZ case needs N odd). Proves ap_free_triangle_exists: explicit triangle construction for each a ∈ A and base x. 0 sorries.",
       "mathContext": "AP-free $A$ $\\implies$ every triangle is $(x, x+a, x+2a)$ for unique $a \\in A$, $x \\in \\mathbb{Z}/N\\mathbb{Z}$. Each edge in exactly one triangle."
     },
     {
       "id": "roth-via-trl",
       "title": "Part IV: Roth's Theorem via Triangle Removal",
-      "startLine": 270,
-      "endLine": 465,
-      "summary": "Contains 2 sorry'd private helpers: rs_tc_ap_free_le (triangle count upper bound ≤ 6|A|N) and rs_removal_lb (edge removal lower bound |R| ≥ |A|N in finite setting). Proves ap_free_min_removal: hitting every edge-disjoint triangle requires R to intersect each (0 sorries — uses fully proved ap_free_triangle_exists). Proves roth_via_triangle_removal: full Roth theorem via TRL (0 sorries in theorem itself, but calls the 2 sorry'd helpers above). Proves roth_proofs_agree: Fourier proof implies TRL proof.",
+      "startLine": 341,
+      "endLine": 534,
+      "summary": "Proves rsVertex_card (|RSVertex N| = 3N). Contains the 2 sorry'd private helpers rs_tc_ap_free_le (triangle count upper bound ≤ 6|A|N) and rs_removal_lb (edge removal lower bound |R| ≥ |A|N in finite setting). Proves ap_free_min_removal (0 sorries, uses ap_free_triangle_exists). Proves roth_via_triangle_removal: full Roth theorem via TRL through the 12-step density-vs-removal contradiction (0 sorries in the theorem itself, but calls the 2 sorry'd helpers). Proves roth_proofs_agree: the Fourier proof implies the TRL proof.",
       "mathContext": "Edge-disjoint triangles $\\implies$ $|R| \\geq |A| \\cdot N$. Triangle removal lemma: $|R| \\leq \\delta' \\cdot 9N^2$. Contradiction for $|A| \\geq \\delta N$."
     }
   ],
@@ -180,10 +173,10 @@
       "Finset"
     ],
     "namespace": "Szemeredi.Roth.TriangleRemoval",
-    "lineCount": 465,
+    "lineCount": 534,
     "axiomCount": 0,
-    "theoremCount": 16,
-    "definitionCount": 7,
+    "theoremCount": 18,
+    "definitionCount": 4,
     "path": "Proofs/RothTriangleRemoval.lean",
     "sorries": 2
   },


### PR DESCRIPTION
## Summary
The gallery metadata for `roth-theorem-k3-oq-02` (Roth's Theorem via Triangle Removal) had drifted behind its Lean source `Proofs/RothTriangleRemoval.lean`, which has grown to 534 lines while the meta froze at 465.

- **Section coverage**: Part IV's section started at line 270 (mid Part III) and ended at 465, so the tail of `roth_via_triangle_removal` (466–512) and the entire `roth_proofs_agree` theorem (514–532) were hidden from the gallery. Re-pinned all four sections to the real `PART` banners (lines 29 / 92 / 186 / 341), giving contiguous 1–534 coverage.
- **Counts**: `lineCount` 465 → 534, `theoremCount` 16 → 18 (private lemmas count per gallery convention), `definitionCount` 7 → 4 (1 abbrev + 2 defs + 1 structure).
- `sorries` (2) and `axiomCount` (0) re-verified unchanged and correct.

Metadata-only; no Lean source changed.

## Test plan
- [x] `jq empty` validates JSON
- [x] Sections cover 1–534 contiguously, boundaries match `PART` banners
- [x] Counts match `grep` of the source file