### PR TITLE
research(bezout-identity-oq-04-oq-01): realign gallery sections to source markers (8→11)

### DIFF
--- a/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
+++ b/src/data/proofs/bezout-identity-oq-04-oq-01/meta.json
@@ -81,68 +81,92 @@
   },
   "sections": [
     {
+      "id": "preamble",
+      "title": "Preamble: Open Question and Key Results",
+      "startLine": 1,
+      "endLine": 42,
+      "summary": "Module docstring stating open question bezout-identity-oq-04-oq-01 — how to characterize all solutions of an integer matrix system Ax = b — and its answer: Smith Normal Form A = UDV characterizes solvability and the full solution set. Lists the key results (unimodular group, SNF structure/existence, solvability criterion, classical Bézout recovery, null-space and solution-lattice structure) and what the file builds on (BezoutIdentityOQ04, Mathlib matrix/determinant API).",
+      "mathContext": "Open question: extend the 1-D Bézout solution lattice to matrix systems $Ax = b$ over $\\mathbb{Z}$. Answer: via Smith Normal Form $A = UDV$, solvability and the affine solution lattice are fully determined by the invariant factors $d_1 \\mid d_2 \\mid \\cdots \\mid d_k$."
+    },
+    {
       "id": "unimodular",
       "title": "Unimodular Matrices",
-      "startLine": 48,
-      "endLine": 76,
-      "summary": "Defines IsUnimodular (det = ±1), proves equivalence with |det| = 1, and establishes closure: identity is unimodular, product of unimodulars is unimodular.",
+      "startLine": 43,
+      "endLine": 91,
+      "summary": "Defines IsUnimodular (det = ±1), proves isUnimodular_iff_abs_det (equivalence with |det| = 1), and establishes closure: isUnimodular_one (identity), IsUnimodular.mul (products), IsUnimodular.transpose, and IsUnimodular.det_ne_zero.",
       "mathContext": "A matrix $M \\in M_n(\\mathbb{Z})$ is **unimodular** iff $\\det(M) = \\pm 1$. By Cramer's rule with integer adjugate, $M^{-1} = (\\det M)^{-1} \\mathrm{adj}(M)$, which has integer entries iff $\\det M = \\pm 1$. The unimodular group $\\mathrm{GL}_n(\\mathbb{Z})$ is the group of units of the ring $M_n(\\mathbb{Z})$."
     },
     {
       "id": "snf-structure",
       "title": "Smith Normal Form Structure",
-      "startLine": 80,
-      "endLine": 108,
-      "summary": "Defines SmithNormalForm m n as a structure with unimodular U, V, diagonal D, and divisibility chain d_k | d_{k+1}. Defines isDecompOf as A = U * D * V.",
+      "startLine": 92,
+      "endLine": 126,
+      "summary": "Defines SmithNormalForm m n as a structure with unimodular U, V, diagonal D, and divisibility chain d_k | d_{k+1}. Defines SmithNormalForm.isDecompOf as A = U * D * V.",
       "mathContext": "The **Smith Normal Form** of $A \\in M_{m \\times n}(\\mathbb{Z})$ is the decomposition $A = UDV$ where $U \\in \\mathrm{GL}_m(\\mathbb{Z})$, $V \\in \\mathrm{GL}_n(\\mathbb{Z})$, and $D = \\mathrm{diag}(d_1, \\ldots, d_k, 0, \\ldots, 0)$ with $d_1 \\mid d_2 \\mid \\cdots \\mid d_k$, all $d_i > 0$."
     },
     {
       "id": "snf-existence",
-      "title": "Smith Normal Form Existence",
-      "startLine": 112,
-      "endLine": 131,
-      "summary": "Axiomatizes snf_exists: every integer matrix admits an SNF decomposition. The constructive proof (row/column reduction via Euclidean algorithm on entries) is described but not implemented.",
-      "mathContext": "**Existence** is proved constructively: pick the smallest nonzero $|a_{ij}|$, move to $(1,1)$, clear row and column using Euclidean division. If any remaining entry isn't divisible by $a_{11}$, add its row to row 1 and repeat (this strictly decreases $|a_{11}|$). Then recurse on the $(m-1) \\times (n-1)$ submatrix."
+      "title": "Existence of Smith Normal Form",
+      "startLine": 127,
+      "endLine": 168,
+      "summary": "Axiomatizes snf_exists (axiom @146): every integer matrix admits an SNF decomposition (the constructive Euclidean row/column reduction is described in prose but not implemented). Proves snf_exists_zero: the zero matrix has a trivial SNF.",
+      "mathContext": "**Existence** holds constructively: pick the smallest nonzero $|a_{ij}|$, move to $(1,1)$, clear row and column using Euclidean division. If any remaining entry isn't divisible by $a_{11}$, add its row to row 1 and repeat (this strictly decreases $|a_{11}|$). Then recurse on the $(m-1) \\times (n-1)$ submatrix. Here the general case is taken as axiom snf_exists."
+    },
+    {
+      "id": "diagonal-extraction",
+      "title": "Diagonal Entry Extraction",
+      "startLine": 169,
+      "endLine": 184,
+      "summary": "Defines SmithNormalForm.invariantFactor (the i-th diagonal invariant factor d_i) and SmithNormalForm.rank (the number of nonzero invariant factors), the accessors used by the solvability criterion.",
+      "mathContext": "From $D = \\mathrm{diag}(d_1, \\ldots, d_k, 0, \\ldots)$: $\\mathrm{invariantFactor}(i) = d_i$ and $\\mathrm{rank} = \\#\\{i : d_i \\neq 0\\} = r$, the rank of $A$ over $\\mathbb{Q}$."
     },
     {
       "id": "solvability",
-      "title": "Solvability Criterion",
-      "startLine": 133,
-      "endLine": 168,
-      "summary": "Axiomatizes snf_solvability_criterion: Ax=b has solutions iff d_i | (Ub)_i for each nonzero invariant factor d_i, and (Ub)_i = 0 for zero factors. Includes invariantFactor and rank extraction functions.",
+      "title": "Solvability Criterion for Integer Systems",
+      "startLine": 185,
+      "endLine": 204,
+      "summary": "Axiomatizes snf_solvability_criterion (axiom @196): Ax=b has an integer solution iff d_i | (Ub)_i for each nonzero invariant factor d_i and (Ub)_i = 0 for zero factors.",
       "mathContext": "Let $D = UAV$ be the SNF. Then $Ax = b \\Leftrightarrow DV^{-1}x = Ub$. Setting $y = V^{-1}x$, this becomes $Dy = Ub$: a diagonal system where $d_i y_i = (Ub)_i$, solvable iff $d_i \\mid (Ub)_i$ for $d_i \\neq 0$ and $(Ub)_i = 0$ otherwise."
     },
     {
       "id": "classical-bezout",
-      "title": "Classical Bézout Recovery",
-      "startLine": 170,
-      "endLine": 199,
-      "summary": "Proves snf_1x2_invariant_factor (1×2 SNF invariant factor matches gcd up to associates) by extracting U₀₀ ∈ {±1} and using det V ∈ {±1} to invert the decomposition. Proves bezout_from_snf directly: ∃x y, ax+by=c ↔ gcd(a,b)|c, recovering the classical result without SNF machinery.",
+      "title": "Classical Bézout Recovery (The 1×2 Case)",
+      "startLine": 205,
+      "endLine": 311,
+      "summary": "Proves snf_1x2_invariant_factor (1×2 SNF invariant factor matches gcd up to associates) by extracting U₀₀ ∈ {±1} and using det V ∈ {±1} to invert the decomposition. Proves bezout_from_snf directly: ∃x y, ax+by=c ↔ gcd(a,b)|c, recovering the classical Bézout result.",
       "mathContext": "For the $1 \\times 2$ matrix $[a, b]$, the SNF is $[\\gcd(a,b), 0]$ with $U = [1]$ and appropriate $V$. The solvability criterion reduces to $\\gcd(a,b) \\mid c$, which is exactly the classical Bézout criterion."
     },
     {
       "id": "null-space",
-      "title": "Integer Null Space Structure",
-      "startLine": 201,
-      "endLine": 232,
-      "summary": "Defines intNullSpace {x | Ax = 0} and proves ℤ-submodule properties: zero membership, closure under addition (via mulVec_add), closure under scalar multiplication (via mulVec_smul).",
+      "title": "Homogeneous Kernel: Integer Null Space Structure",
+      "startLine": 312,
+      "endLine": 355,
+      "summary": "Defines intNullSpace {x | Ax = 0} and proves ℤ-submodule properties: zero_mem_intNullSpace, intNullSpace_add (mulVec_add), intNullSpace_smul (mulVec_smul), intNullSpace_neg, and intNullSpace_sub.",
       "mathContext": "The **null space** $\\ker(A) = \\{x \\in \\mathbb{Z}^n : Ax = 0\\}$ is a free $\\mathbb{Z}$-module of rank $n - r$ where $r$ is the number of nonzero invariant factors. By the structure theorem for finitely generated modules over PIDs, $\\mathbb{Z}^n / \\ker(A) \\cong \\mathbb{Z}^r$."
     },
     {
       "id": "solution-lattice",
       "title": "Solution Lattice Structure",
-      "startLine": 234,
-      "endLine": 270,
+      "startLine": 356,
+      "endLine": 381,
       "summary": "Proves solution_iff_particular_plus_null: Ax=b ↔ (x-x₀) ∈ ker(A), so solutions form the affine lattice x₀ + ker(A). Proof uses mulVec_sub for both directions.",
       "mathContext": "The solution set of $Ax = b$ is the **affine lattice** $\\{x_0 + h : h \\in \\ker(A)\\}$, a coset of the null space. This generalizes the 1D lattice $\\{(x_0 + bt/d, y_0 - at/d)\\}$ from BezoutIdentityOQ04 to arbitrary dimensions."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
-      "startLine": 272,
-      "endLine": 295,
-      "summary": "Three worked examples: (1) 6x+10y+15z=1 solvable (witness x=1,y=1,z=-1), (2) 6x+10y+15z=7 solvable, (3) 6x+10y=3 unsolvable (2|6x+10y but 2∤3).",
+      "startLine": 382,
+      "endLine": 409,
+      "summary": "Three worked examples: three_var_example (6x+10y+15z=1 solvable, witness x=1,y=1,z=-1), three_var_example_7 (6x+10y+15z=7 solvable), and two_var_no_solution (6x+10y=3 unsolvable since 2|6x+10y but 2∤3).",
       "mathContext": "Example (3) demonstrates the solvability obstruction: $\\gcd(6,10) = 2$ does not divide 3, so $6x + 10y = 3$ has no solution. The proof constructs the explicit divisibility witness $6x + 10y = 2(3x + 5y)$ and uses omega to derive $2 \\nmid 3$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary: The Answer to OQ-04-OQ-01",
+      "startLine": 410,
+      "endLine": 473,
+      "summary": "Closing docstring tying the results into the complete picture of Smith Normal Form for linear Diophantine systems, documenting the 2 axioms used (snf_exists, snf_solvability_criterion), confirming 0 sorries, and noting the algebraic closure properties of the integer solution lattice.",
+      "mathContext": "Complete answer: every system $Ax = b$ over $\\mathbb{Z}$ is solvable iff the SNF invariant-factor divisibility conditions hold, and its full solution set is the affine lattice $x_0 + \\ker(A)$ — generalizing classical Bézout from the $1 \\times n$ case to arbitrary integer matrices."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
`Proofs/BezoutIdentityOQ04OQ01.lean` grew to 473 lines and its `/-! ##` section markers drifted well past the frozen gallery metadata:

- The meta's back half was **line-shifted behind the source** — e.g. "Solvability Criterion" was pinned at 133-168 while the real marker is at line 185; "Integer Null Space Structure" at 201-232 vs the real marker at 312.
- Section coverage stopped at line 295, hiding ~38% of the file (`bezout_from_snf`, the full integer null-space module-structure lemmas, the solution-lattice theorem, the worked examples, and the closing summary).

Fixes:
- Re-pinned all sections to the ten real `/-! ##` markers → contiguous **1-473** coverage.
- Added three sections that were entirely absent: the **module preamble** (1-42, open-question statement + key results), **"Diagonal Entry Extraction"** (169-184: `invariantFactor` / `rank` accessors), and the closing **"Summary"** (410-473).
- Anchored the two axioms to their real homes: `snf_exists` (@146, Existence section) and `snf_solvability_criterion` (@196, Solvability section).

Counts re-verified and unchanged: 17 theorems, 6 definitions, 0 sorries, 2 axioms; `axiomatized`/`axiom` status correct. Metadata-only.

## Test plan
- [x] `jq empty` validates JSON
- [x] Sections cover 1-473 contiguously (gap=1 between every pair)
- [x] Boundaries match the `/-! ##` markers; axioms fall in the correct sections