### PR TITLE
research(four-square-distribution-oq-01): fix stale theoremCount 128 → 142

### DIFF
--- a/src/data/proofs/four-square-distribution-oq-01/meta.json
+++ b/src/data/proofs/four-square-distribution-oq-01/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 2932,
-    "theoremCount": 128,
+    "theoremCount": 142,
     "definitionCount": 10,
     "assumptions": "Axiomatized: jacobi_r4_formula — for all n ≥ 1, the integer-tuple count r₄(n) equals 8·σ*(n). Numerically verified for n = 1..10. The general statement is open in this formalization because Mathlib lacks the q-expansion / Fourier-coefficient infrastructure for jacobiTheta and the identification of θ⁴ with the weight-2 Eisenstein series E₂(τ) − 4·E₂(4τ).",
     "mathlibDependencies": [


### PR DESCRIPTION
## Summary
The gallery metadata for `four-square-distribution-oq-01` reported `theoremCount: 128`, which counts only the public theorems/lemmas and omits the file's 14 `private lemma` declarations.

Per the corpus convention that `theoremCount` includes private lemmas (cf. the erdos-382 restoration in #23397), `Proofs/FourSquareDistributionOQ01.lean` has **128 public + 14 private = 142**.

Everything else re-verified and unchanged:
- 32 sections, contiguous 1-2932 (full coverage)
- `definitionCount` 10, `sorries` 0, `axiomCount` 1 (`jacobi_r4_formula`), `lineCount` 2932

Metadata-only.

## Test plan
- [x] `jq empty` validates JSON
- [x] `grep -cE '^(private )?(theorem|lemma) '` on the source = 142