### PR TITLE
research(hilbert-10-oq-01-oq-02): fix stale public-only counts (thm 90→96, def 9→16)

### DIFF
--- a/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
+++ b/src/data/proofs/hilbert-10-oq-01-oq-02/meta.json
@@ -137,8 +137,8 @@
     ],
     "assumptions": "One axiom: `koenigsmann_2016_universal` — ℤ is Π₂-definable in ℚ. This is PROVED in Koenigsmann (Annals 2016) via an explicit polynomial built from Hilbert symbols and quaternion algebras over ℚ; axiomatized here pending a Lean formalization of that construction. All other results in this file (Σ₁ → ¬H10/ℚ-decidable, Mazur → ¬Σ₁, the Σ₁/Π₁ and Σ₂/Π₂ dualities and their specializations to ℤ ⊂ ℚ, the Π₁(ℚ\\ℤ) re-exports, the Π₁ ⊆ Σ₂ containment, and the Σ₂(ℚ\\ℤ) corollary of Koenigsmann) are NOT new axioms — they are logical consequences of the OQ-01 axioms together with the Σ₁/Π₁ and Σ₂/Π₂ equivalences proved here. Both duality theorems use classical excluded middle (`Classical.byContradiction`) to convert ¬¬p to p; the Σ₂/Π₂ duality and the Σ₂(ℚ\\ℤ) corollary use it twice, the Σ₁/Π₁ duality once.",
     "mathlib_version": "4.26.0",
-    "theoremCount": 90,
-    "definitionCount": 9
+    "theoremCount": 96,
+    "definitionCount": 16
   },
   "overview": {
     "historicalContext": "After MRDP (1970) settled H10/$\\mathbb{Z}$ negatively, attention turned to H10/$\\mathbb{Q}$ — open since at least Robinson 1949. The companion file `hilbert-10-oq-01` surveys the broad landscape; this file (OQ-01-OQ-02) zooms in on the precise model-theoretic content separating the OPEN question from Koenigsmann's celebrated 2016 Annals theorem.\n\nThe distinction is between two layers of the arithmetic hierarchy over $\\mathbb{Q}$:\n\n- **$\\Sigma_1$ (Diophantine, purely existential):** $\\mathbb{Z}$ is the projection of a rational-solution set of one polynomial equation. Equivalently, there exists $P \\in \\mathbb{Q}[t, x_1, \\ldots, x_k]$ with $t \\in \\mathbb{Z} \\iff \\exists x \\in \\mathbb{Q}^k, P(t,x) = 0$. **OPEN.**\n- **$\\Pi_2$ (universal-existential, $\\forall\\exists$):** there exists $P$ with $t \\in \\mathbb{Z} \\iff \\forall y \\in \\mathbb{Q}^n, \\exists z \\in \\mathbb{Q}^m, P(t,y,z) = 0$. **PROVED by Koenigsmann (2016).**\n\nThe Σ₁ direction is the substantive open question because it is precisely Σ₁ definability that yields the implication 'ℤ Diophantine over ℚ ⟹ H10/ℚ undecidable' (via MRDP). Π₂ definability does not carry this implication, so Koenigsmann's theorem leaves H10/ℚ untouched.\n\nMazur's conjecture (1992), a topological constraint on rational-point sets, would refute the $\\Sigma_1$ definition of $\\mathbb{Z}$ in $\\mathbb{Q}$ but is consistent with $\\Pi_2$.",
@@ -287,8 +287,8 @@
     "namespace": "Hilbert10Rationals",
     "lineCount": 3174,
     "axiomCount": 1,
-    "theoremCount": 90,
-    "definitionCount": 9,
+    "theoremCount": 96,
+    "definitionCount": 16,
     "path": "Proofs/Hilbert10OQ01OQ02.lean",
     "sorries": 0
   },


### PR DESCRIPTION
## Summary
`Proofs/HilbertTenthOQ01OQ02.lean` grew to 3174 lines, but its gallery counts froze on a **public-only** basis:
- `theoremCount: 90` omits the file's 6 `private lemma` declarations → total **96**.
- `definitionCount: 9` omits its 7 `private def` declarations (`zeroPoly`, `onePoly`, `parameterPoly`, `shiftPoly`, `evenProj`, `oddProj`, `interleave`) → total **16**.

Both the hilbert-10 family and the corpus convention count totals: sibling `hilbert-10-oq-04`'s `definitionCount` includes its private def, and `theoremCount` is established to include private lemmas (cf. erdos-382 #23397). So this file's public-only counts were stale drift left over from before the private helpers were added.

Updated `theoremCount` and `definitionCount` in both the `meta` and `leanFile` blocks. Section coverage is already full (1-3174), and `sorries` (0) / `axiomCount` (1) are unchanged. Metadata-only.

## Test plan
- [x] `jq empty` validates JSON
- [x] `grep -cE '^(private )?(theorem|lemma) '` = 96; `def`+`abbrev` (incl private) = 16