### PR TITLE
audit(erdos-1000): realign stale gallery sections to full-file coverage (12→20)

### DIFF
--- a/src/data/proofs/erdos-1000/meta.json
+++ b/src/data/proofs/erdos-1000/meta.json
@@ -56,97 +56,161 @@
       "id": "imports",
       "title": "Imports and Docstring",
       "startLine": 1,
-      "endLine": 33,
+      "endLine": 39,
       "summary": "Module docstring describing the problem (Cassels 1950, Erdős 1964, Haight), `import Mathlib`, namespace and opens.",
       "mathContext": "Sets up the formalization environment. The single `import Mathlib` provides Finset, Nat.GCD, real number casts, and Filter/Topology for limit predicates."
     },
     {
       "id": "generalized-totient",
       "title": "Part I: Core Definitions",
-      "startLine": 35,
-      "endLine": 51,
+      "startLine": 40,
+      "endLine": 57,
       "summary": "Defines `IncreasingSeq` (strictly monotone positive integer sequence), `reducedDenom m n = n / gcd(m,n)` (reduced denominator of m/n), and `phiA A k` (generalized totient: count of m ≤ n_k whose reduced denominator avoids all previous terms).",
       "mathContext": "$\\varphi_A(k) = |\\{m \\leq n_k : \\frac{n_k}{\\gcd(m, n_k)} \\neq n_j \\text{ for all } j < k\\}|$. When $A = \\mathbb{N}$, this reduces to Euler's totient $\\varphi(n_k)$."
     },
     {
       "id": "basic-properties",
       "title": "Part II: Basic Properties",
-      "startLine": 53,
-      "endLine": 95,
+      "startLine": 58,
+      "endLine": 101,
       "summary": "Proves `phiA_le` ($\\varphi_A(k) \\leq n_k$), `phiA_zero` ($\\varphi_A(0) = n_0$), defines `densityRatio` ($\\rho_A(k) = \\varphi_A(k)/n_k$), and proves $0 \\leq \\rho_A(k) \\leq 1$ and $\\rho_A(0) = 1$.",
       "mathContext": "The density ratio $\\rho_A(k) = \\varphi_A(k)/n_k \\in [0, 1]$ measures what fraction of denominators are 'new' at step $k$. The first ratio is always 1 since there are no prior terms to exclude."
     },
     {
       "id": "cesaro-average",
       "title": "Part III: Cesàro Average",
-      "startLine": 97,
-      "endLine": 115,
+      "startLine": 102,
+      "endLine": 121,
       "summary": "Defines `cesaroAvg A N = (1/N) Σ_{k<N} ρ_A(k)` and proves `cesaroAvg_nonneg` ($C_A(N) \\geq 0$) and `cesaroAvg_le_one` ($C_A(N) \\leq 1$ for $N > 0$).",
       "mathContext": "$C_A(N) = \\frac{1}{N} \\sum_{k=0}^{N-1} \\frac{\\varphi_A(k)}{n_k} \\in [0, 1]$. This is the Cesàro mean of the density sequence."
     },
     {
       "id": "natural-sequence",
       "title": "Part IV: The Natural Sequence",
-      "startLine": 117,
-      "endLine": 189,
+      "startLine": 122,
+      "endLine": 194,
       "summary": "Defines `naturalSeq` ($A = \\{1,2,3,\\ldots\\}$) and proves the key theorem `naturalSeq_phiA_eq_totient`: $\\varphi_A(k) = \\varphi(k+1)$ (Euler's totient). The proof handles $k = 0$ by `native_decide` and $k \\geq 1$ by showing the filter condition (reduced denominator avoids previous terms) is equivalent to coprimality, then bridging between `Icc` and `range` Finsets.",
       "mathContext": "For $A = \\mathbb{N}$: the reduced denominator of $m/(k+2)$ avoids $\\{1, \\ldots, k+1\\}$ iff $\\gcd(m, k+2) = 1$, because $\\frac{k+2}{\\gcd(m, k+2)} = k+2$ iff $\\gcd = 1$. The Icc/range bridge uses the facts that $\\gcd(n,n) = n \\neq 1$ and $\\gcd(n,0) = n \\neq 1$ for $n \\geq 2$."
     },
     {
       "id": "structural-lower-bound",
       "title": "Part IV-B: Structural Lower Bound",
-      "startLine": 192,
-      "endLine": 248,
+      "startLine": 195,
+      "endLine": 251,
       "summary": "Proves two key structural lemmas: `phiA_ge_totient` ($\\varphi_A(k) \\geq \\varphi(n_k)$ for any increasing sequence $A$) and `densityRatio_ge_totient_ratio` ($\\rho_A(k) \\geq \\varphi(n_k)/n_k$). The proof shows that every $m$ coprime to $n_k$ has reduced denominator $n_k$, which exceeds all previous terms by strict monotonicity.",
       "mathContext": "For any $A$ and $k$: if $\\gcd(m, n_k) = 1$ then the reduced denominator is $n_k / 1 = n_k > n_j$ for all $j < k$. So the set $\\{m \\leq n_k : \\gcd(m, n_k) = 1\\}$ (of size $\\varphi(n_k)$) is a subset of the $\\varphi_A(k)$ filter. This lower bound is the foundation for Erdős' no-zero-limit theorem."
     },
     {
+      "id": "exact-divisor-decomposition",
+      "title": "Part IV-C: Exact Divisor Decomposition",
+      "startLine": 252,
+      "endLine": 403,
+      "summary": "Proves the exact divisor decomposition of φ_A. Lemmas `reducedDenom_eq_iff` (n/gcd(m,n)=e ⟺ gcd(m,n)=n/e), `reducedDenom_dvd`, `gcdClass_card` (cardinality of each reduced-denominator class), the main theorem `phiA_decomposition` (φ_A(k) decomposes as a sum over unused divisors of φ(e)), `phiA_decomposition_zero` (k=0 specialization), and `phiA_ge_totient'` (re-deriving the φ(n_k) lower bound from the decomposition).",
+      "mathContext": "$\\varphi_A(k) = \\sum_{e \\mid n_k,\\ e \\text{ unused}} \\#\\{m \\le n_k : n_k/\\gcd(m,n_k) = e\\} = \\sum_{e \\mid n_k,\\ e \\text{ unused}} \\varphi(e)$. Each reduced-denominator class $\\{m : n_k/\\gcd(m,n_k)=e\\}$ has exactly $\\varphi(e)$ elements, giving an exact (not just lower-bound) formula for $\\varphi_A$."
+    },
+    {
       "id": "complement-formula",
-      "title": "Part IV-D: Complement Formula and Structural Bounds",
-      "startLine": 403,
-      "endLine": 486,
+      "title": "Part IV-D: Complement Formula and Used-Divisor Bounds",
+      "startLine": 404,
+      "endLine": 510,
       "summary": "Seven new infrastructure theorems: `phiA_add_used` (φ_A(k) + used_sum = n_k, complement of the decomposition), `used_sum_le` (used φ-sum ≤ n_k − φ(n_k)), `used_card_le` (at most k divisors are used), `phiA_pos` (φ_A(k) ≥ 1), `densityRatio_pos` (ρ_A(k) > 0), `densityRatio_complement` (ρ_A(k) = 1 − used/n_k in ℝ), and `densityRatio_ge_of_prime` (ρ_A(k) ≥ 1/2 when n_k is prime).",
       "mathContext": "The complement formula $\\varphi_A(k) = n_k - \\sum_{e | n_k, e \\text{ used}} \\varphi(e)$ reveals the dual structure: for $\\rho_A(k) \\to 0$, the used divisors must capture almost all of $n_k$'s divisor-totient sum. The prime lower bound shows that whenever $n_k$ is prime, $\\rho_A(k) \\geq 1/2$, since primes have only the trivial divisor 1 available for 'use'."
     },
     {
       "id": "main-predicates",
       "title": "Part V: Main Predicates",
-      "startLine": 488,
-      "endLine": 496,
+      "startLine": 511,
+      "endLine": 520,
       "summary": "Defines `VanishingAverage A` ($C_A(N) \\to 0$) and `DensityToZero A` ($\\rho_A(k) \\to 0$) as filter-limit predicates.",
       "mathContext": "$\\text{VanishingAverage}(A) :\\Leftrightarrow \\lim_{N \\to \\infty} C_A(N) = 0$. $\\text{DensityToZero}(A) :\\Leftrightarrow \\lim_{k \\to \\infty} \\rho_A(k) = 0$."
     },
     {
+      "id": "special-cases-no-zero-limit",
+      "title": "Part V-B: Special Cases of No-Zero-Limit",
+      "startLine": 521,
+      "endLine": 548,
+      "summary": "Two proved theorems establishing density does not vanish in special cases: `not_density_zero_of_infinitely_many_primes` (if n_k is prime infinitely often then ρ_A ↛ 0, since primes force ρ_A(k) ≥ 1/2) and `naturalSeq_not_density_zero` (the natural sequence ℕ has ρ_A ↛ 0, a corollary via the infinitude of primes).",
+      "mathContext": "These are unconditional instances of Erdős' no-zero-limit phenomenon: whenever $n_k$ is prime, $\\rho_A(k) \\ge 1/2$, so any sequence hitting primes infinitely often cannot have $\\rho_A \\to 0$. The natural sequence is the canonical example."
+    },
+    {
+      "id": "complement-densitytozero-infra",
+      "title": "Part V-C: Complement and DensityToZero Infrastructure",
+      "startLine": 549,
+      "endLine": 566,
+      "summary": "Infrastructure connecting the density ratio to its complement and the two limit predicates: `one_sub_densityRatio` (1 − ρ_A(k) equals the used-divisor deficit in ℝ) and `densityToZero_implies_vanishing` (pointwise ρ_A → 0 implies the Cesàro average C_A(N) → 0).",
+      "mathContext": "$1 - \\rho_A(k) = \\text{usedSum}(A,k)/n_k$, the fraction of denominators captured by earlier terms. Pointwise convergence $\\rho_A \\to 0$ transfers to the Cesàro mean $C_A(N) \\to 0$ by the standard Cesàro-of-a-convergent-sequence argument."
+    },
+    {
       "id": "erdos-results",
-      "title": "Part VI: Erdős' Results (1964)",
-      "startLine": 498,
-      "endLine": 510,
+      "title": "Part VI: Erdős’ Results (1964)",
+      "startLine": 567,
+      "endLine": 596,
       "summary": "PROVED theorem `erdos_no_zero_limit` ($\\rho_A(k) \\not\\to 0$ for any $A$, derived from `erdos_dichotomy`: convergence to 0 implies frequently near 0, dichotomy gives frequently near 1, contradicting convergence). One axiom: `erdos_dichotomy` (if $\\liminf \\rho_A = 0$ then $\\limsup \\rho_A = 1$, via the Euler product for $\\varphi(n)/n$).",
       "mathContext": "PROVED: $\\neg \\text{DensityToZero}(A)$ for all $A$ — if $\\rho_A \\to 0$ then $\\rho_A < \\varepsilon$ eventually hence frequently, dichotomy gives $\\rho_A > 1-\\varepsilon$ frequently, taking $\\varepsilon = 1/2$ yields contradiction. Axiom: $\\liminf \\rho_A = 0 \\Rightarrow \\limsup \\rho_A = 1$."
     },
     {
-      "id": "haight-resolution",
-      "title": "Part VII: Haight's Resolution",
-      "startLine": 531,
-      "endLine": 538,
-      "summary": "Axiom `haight_resolution`: $\\exists A$ with $C_A(N) \\to 0$. Resolves Erdős' problem affirmatively. The construction uses rapidly growing highly composite numbers.",
-      "mathContext": "$\\exists A : \\text{IncreasingSeq},\\; \\text{VanishingAverage}(A)$. The answer to Erdős' question is YES, contrary to his expectation."
+      "id": "cassels-result",
+      "title": "Part VII: Cassels’ Result (1950)",
+      "startLine": 597,
+      "endLine": 598,
+      "summary": "Section header for Cassels' 1950 result; the corresponding theorem `cassels_liminf_zero` is stated and proved immediately below under Part VIII (Haight's Resolution), from which it follows as a corollary.",
+      "mathContext": "Cassels (1950) showed $\\exists A$ with $\\liminf_N C_A(N) = 0$. In this file it is derived from Haight's stronger vanishing-average result, so the proof appears under Part VIII."
     },
     {
-      "id": "cassels-result",
-      "title": "Part VIII: Cassels' Result (1950) — Proved",
-      "startLine": 540,
-      "endLine": 552,
-      "summary": "PROVED theorem `cassels_liminf_zero`: there exists $A$ with $\\liminf C_A(N) = 0$. Derived as a corollary of Haight's stronger result (haight_resolution): convergence to 0 implies the liminf is 0, via Filter.Eventually.frequently.",
-      "mathContext": "$\\exists A : \\text{IncreasingSeq},\\; \\forall \\varepsilon > 0,\\; \\exists^\\infty N,\\; C_A(N) < \\varepsilon$. Formerly an axiom, now proved: Haight's $\\text{Tendsto} \\Rightarrow \\text{Eventually} \\Rightarrow \\text{Frequently}$."
+      "id": "haight-resolution",
+      "title": "Part VIII: Haight’s Resolution",
+      "startLine": 599,
+      "endLine": 617,
+      "summary": "Axiom `haight_resolution` (∃ A with C_A(N) → 0, resolving Erdős' problem affirmatively via rapidly growing highly composite numbers) and the proved theorem `cassels_liminf_zero` (∃ A with liminf C_A(N) = 0), obtained as a corollary of haight_resolution via Filter.Eventually.frequently.",
+      "mathContext": "$\\exists A : \\text{IncreasingSeq},; \\text{VanishingAverage}(A)$ (Haight, axiom). Cassels' liminf result then follows: $\\text{Tendsto} \\Rightarrow \\text{Eventually} \\Rightarrow \\text{Frequently}$."
     },
     {
       "id": "corollaries",
       "title": "Part IX: Corollaries",
-      "startLine": 554,
-      "endLine": 634,
+      "startLine": 618,
+      "endLine": 697,
       "summary": "Four proved theorems synthesizing the axioms: `vanishing_avg_visits_zero` (vanishing average implies $\\rho_A$ frequently visits near 0, via a split-sum argument), `haight_oscillation` (Haight's sequence oscillates between near 0 and near 1), `no_density_zero` (no sequence has $\\rho_A \\to 0$), and `pointwise_cesaro_gap` ($\\exists A$ with $C_A(N) \\to 0$ but $\\rho_A(k) \\not\\to 0$, a concrete separation between pointwise and Cesàro convergence).",
       "mathContext": "The key proved result `vanishing_avg_visits_zero` is a 40-line argument: assuming $\\rho_A(k) \\geq \\varepsilon$ eventually, the Cesàro sum is bounded below by $\\varepsilon(N - K)/N \\to \\varepsilon$, contradicting $C_A(N) \\to 0$. The corollaries combine this with the axioms via short compositions."
+    },
+    {
+      "id": "infra-no-zero-limit",
+      "title": "Part X: Infrastructure Toward Proving erdos_no_zero_limit",
+      "startLine": 698,
+      "endLine": 866,
+      "summary": "A large block of proved infrastructure aimed at making `erdos_no_zero_limit` axiom-free. Includes `not_densityToZero_of_frequently_ge`, `not_densityToZero_of_frequently_prime`, `usedSum_zero`, `densityRatio_ge_inv`, `cesaroAvg_ge_totient_avg`, `phiA_ge_unused_subset`, `divisor_gt_prev_unused`, `phiA_ge_large_divisor_sum`, `phiA_ge_self_and_quotient`, `sum_deficit_eq_sum_used_ratio`, `sum_deficit_lt`, and `cesaroAvg_pos`.",
+      "mathContext": "These lemmas bound $\\varphi_A(k)$ from below using individual large divisors and unused-divisor subsets, and convert the Cesàro average into a totient average. They build toward eliminating the `erdos_dichotomy` axiom by a direct counting argument."
+    },
+    {
+      "id": "growth-density-floor",
+      "title": "Part XI: Growth Bound and Density Floor",
+      "startLine": 867,
+      "endLine": 945,
+      "summary": "Density-floor results driven by sequence growth: `usedSum_le_card_mul`, `densityRatio_ge_one_sub_growth`, `densityRatio_gt_half_of_fast_growth`, `not_densityToZero_of_fast_growth`, and `phiA_ge_seq_sub_growth`.",
+      "mathContext": "When $n_k$ grows fast relative to $k$, the used divisors cannot capture most of $n_k$, forcing $\\rho_A(k)$ to stay bounded away from 0 (indeed $> 1/2$ under sufficiently fast growth). This rules out $\\rho_A \\to 0$ for fast-growing sequences."
+    },
+    {
+      "id": "sum-switching",
+      "title": "Part XII: Sum-Switching Identity for Double-Counting",
+      "startLine": 946,
+      "endLine": 1005,
+      "summary": "Double-counting infrastructure over divisor pairs: defines `divPairs`, `divPairs_fiber_k`, `divPairs_fiber_j`, and proves `divPairs_fiber_j_card_le` bounding the j-fiber cardinality.",
+      "mathContext": "The set of pairs $(k, j)$ with $j < k$ and a 'used' divisor relation is counted two ways (by k-fiber and by j-fiber). The j-fiber bound limits how many times a single earlier term can be reused, the key estimate for the double-counting argument."
+    },
+    {
+      "id": "growth-low-density",
+      "title": "Part XIII: Growth Constraints from Low Density",
+      "startLine": 1006,
+      "endLine": 1090,
+      "summary": "Theorems extracting growth constraints from low density: `low_density_growth_constraint`, `consecutive_low_density_ratio`, `cesaroAvg_eq_one_sub_avg_deficit`, `deficit_count_bound`, and `density_somewhere_pos`.",
+      "mathContext": "Low $\\rho_A(k)$ forces the deficit (used-divisor mass) to be large, which constrains how the sequence can grow. The identity $C_A(N) = 1 - \\text{avg deficit}$ converts low average density into a large average deficit, bounding the number of low-density indices."
+    },
+    {
+      "id": "euler-totient-bridge",
+      "title": "Part XIV: Euler-Totient Bridge for Dichotomy",
+      "startLine": 1091,
+      "endLine": 1149,
+      "summary": "Final bridge toward the Erdős dichotomy via the Euler product for φ(n)/n: `low_density_euler_bound`, `densityRatio_recovery_from_growth`, and `frequently_high_density_of_eps_fast_growth`.",
+      "mathContext": "Connects low density to the Euler-totient bound $\\varphi(n)/n = \\prod_{p \\mid n}(1 - 1/p)$, showing that after a low-density step the ratio recovers (returns frequently near 1). This is the analytic heart of the dichotomy $\\liminf \\rho_A = 0 \\Rightarrow \\limsup \\rho_A = 1$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The gallery `meta.json` for **erdos-1000** had badly drifted section metadata. Top-level `sections` covered only lines 1–634 of a **1149-line** source, and from Part V onward the line ranges were stale. The gallery renders these sections, so ~45% of the proof (Parts X–XIV plus several sub-parts) was hidden and three sections were mislabeled.

## Fixes

- **Add 8 missing sections** present in the source but absent from meta:
  - Part IV-C: Exact Divisor Decomposition (`phiA_decomposition`)
  - Part V-B: Special Cases of No-Zero-Limit
  - Part V-C: Complement and DensityToZero Infrastructure
  - Parts X–XIV: infrastructure toward an axiom-free `erdos_no_zero_limit`, growth/density-floor bounds, sum-switching double-counting, growth-from-low-density, and the Euler-totient dichotomy bridge.
- **Re-pin drifted ranges** for Parts V–IX to the actual in-source `## Part N` markers.
- **Fix swapped titles**: in the source, Part VII is *Cassels' Result (1950)* and Part VIII is *Haight's Resolution* — the meta had these two reversed.

Coverage now spans lines **1–1149** (full file). All 20 section titles match the in-source `## Part N` markers 1:1; ranges are contiguous with no gaps or overlaps. Metadata-only change (no Lean source touched); axiom/theorem counts untouched.

## Test plan

- [x] `jq empty` validates JSON
- [x] Section ranges contiguous 1→1149, no gaps/overlaps
- [x] All 20 `Part N` titles align 1:1 with source markers