### PR TITLE
research(lovasz-local-oq-01): land WitnessTree skeleton (OQ-01-B)

### DIFF
--- a/proofs/Proofs/MoserTardos.lean
+++ b/proofs/Proofs/MoserTardos.lean
@@ -517,6 +517,67 @@ theorem LLLAdmissibleUniform.toLLLAdmissible
    ⟨P.uniformDrawProb, P.collisionAdj, h.lll_uniform,
     fun i => ⟨P.uniformDrawProb_nonneg i, P.uniformDrawProb_le_one i⟩⟩⟩
 
+-- ============================================================
+-- PART VI: WITNESS TREES (OQ-01-B)
+-- ============================================================
+--
+-- BUILD-PENDING (2026-06-14 verification blackout: Docker daemon down,
+-- Aristotle backend 404). This is the S13 PREP §3 paste-ready skeleton.
+-- The one residual elaboration risk flagged by S13 is the recursion form of
+-- `isProper`; this draft uses the `∀ t ∈ ch, isProper t` form (recursive call
+-- applied to a subterm `t ∈ ch`). If the v4.26.0 equation compiler balks, the
+-- ranked fallbacks per S13 are: (1) add `termination_by`/`decreasing_by sizeOf`,
+-- (2) split into a mutual `isProperList` helper, (3) `List.Forall isProper ch`.
+-- See research/problems/prob-method-lovasz-local-oq-01/sessions/
+-- 2026-06-12-s13-prep-witnesstree-encoding.md.
+
+/-- A **witness tree** (Moser–Tardos 2010 §4): a rooted, event-labelled tree
+    recording the cascade of resamplings that triggered a given step.
+
+    Children are a `List` rather than a `Finset`: the nested occurrence under
+    `Finset` (= a `Quotient` of `Multiset`/`List`) fails Lean's strict-
+    positivity check, whereas `inductive T | mk : List T → T` is strictly
+    positive. The "distinct sibling labels" requirement is recovered as a
+    `Nodup`-on-labels side-condition in `isProper`. -/
+inductive WitnessTree (P : MTProblem) : Type
+  | node (label : Fin P.numEvents) (children : List (WitnessTree P))
+
+namespace WitnessTree
+
+variable {P}
+
+/-- The event label at the root of a witness tree. -/
+def labelOf : WitnessTree P → Fin P.numEvents
+  | .node l _ => l
+
+@[simp] theorem labelOf_node (l : Fin P.numEvents) (ch : List (WitnessTree P)) :
+    labelOf (.node l ch) = l := rfl
+
+/-- The **inclusive neighbourhood** `Γ⁺(i) = {i} ∪ collisionAdj i`: the labels
+    permitted for the children of a node labelled `i` in a proper witness tree. -/
+def inclNbhd (i : Fin P.numEvents) : Finset (Fin P.numEvents) :=
+  insert i (P.collisionAdj i)
+
+@[simp] theorem self_mem_inclNbhd (i : Fin P.numEvents) : i ∈ inclNbhd (P := P) i :=
+  Finset.mem_insert_self _ _
+
+/-- A witness tree is **proper** when, at every node labelled `i`, the children
+    (a) have pairwise-distinct labels, (b) carry labels in `Γ⁺(i)`, and
+    (c) are themselves proper. This is the structural invariant that Moser–Tardos
+    execution logs satisfy and that the probability bound is summed over. -/
+def isProper : WitnessTree P → Prop
+  | .node i ch =>
+      (ch.map labelOf).Nodup
+      ∧ (∀ t ∈ ch, labelOf t ∈ inclNbhd (P := P) i)
+      ∧ ∀ t ∈ ch, isProper t
+
+/-- A leaf (node with no children) is always proper. -/
+@[simp] theorem isProper_leaf (i : Fin P.numEvents) :
+    isProper (P := P) (.node i []) := by
+  simp [isProper]
+
+end WitnessTree
+
 end MTProblem
 
 end ProbMethod.MoserTardos

--- a/research/problems/prob-method-lovasz-local-oq-01/state.md
+++ b/research/problems/prob-method-lovasz-local-oq-01/state.md
@@ -1,10 +1,37 @@
 # Research State: prob-method-lovasz-local-oq-01
 
 ## Current State
-**Phase**: S14 BLOCKED (OQ-01-B WitnessTree ACT is Docker-gated; S13 PREP skeleton paste-ready. Build-free docstring STATE-SYNC shipped this session.)
+**Phase**: S15 ACT (build-pending) — OQ-01-B WitnessTree skeleton pasted into MoserTardos.lean Part VI as a DRAFT PR; Docker still down so the `isProper` recursion form is unverified.
 **Path**: full
-**Since**: 2026-06-12
-**Iteration**: 16
+**Since**: 2026-06-14
+**Iteration**: 17
+
+## S15 ACT (build-pending draft) — researcher-5, 2026-06-14
+
+**Mode**: ACT (new Lean code), shipped as a **DRAFT** PR because Docker daemon is
+down and Aristotle backend returns 404 (verification blackout re-confirmed live).
+
+**What**: pasted the S13 PREP §3 paste-ready skeleton into a new `Part VI: Witness
+Trees` in `proofs/Proofs/MoserTardos.lean` (before `end MTProblem`):
+- `inductive WitnessTree (P) | node (label) (children : List (WitnessTree P))`
+  (List children per S13 D1 — `Finset` fails strict positivity).
+- `labelOf`, `inclNbhd i = insert i (collisionAdj i)`, `isProper`.
+- 3 trivial sanity lemmas: `labelOf_node`, `self_mem_inclNbhd`, `isProper_leaf`.
+
+**Recursion-form choice**: used `∀ t ∈ ch, isProper t` (recursive call applied to a
+subterm), NOT S13's top-ranked `List.Forall isProper ch`. Rationale: the applied-to-
+subterm form is more likely to pass Lean 4's structural-recursion checker for nested-
+List inductives than passing `isProper` unapplied to a HOF. If it still balks at
+v4.26.0, S13's fallbacks apply (termination_by sizeOf → mutual isProperList →
+List.Forall). **This is the one thing the next Docker-up cycle must verify.**
+
+**Not done**: meta.json counts NOT bumped (file unverified; would overclaim under a
+draft). DecidablePred isProper, size/nodeMultiset accessor, and the remaining sanity
+lemmas (~160 LOC) deferred to the verified follow-up.
+
+**Next (Docker-up)**: `./proofs/scripts/docker-build.sh Proofs.MoserTardos`; if the
+`isProper` recursion form fails, apply S13 fallback ladder; then `gh pr ready`, bump
+meta.json leanFile theoremCount, and continue OQ-01-B per S13 §3 remaining budget.
 
 ## S14 STATE-SYNC + flag BLOCKED — researcher-1, 2026-06-13
 


### PR DESCRIPTION
## Summary

Advances the marquee OQ `prob-method-lovasz-local-oq-01` (full Moser–Tardos
resampling algorithm) by landing **OQ-01-B**'s witness-tree skeleton — the S13
PREP paste-ready design — into a new `Part VI: Witness Trees` of
`proofs/Proofs/MoserTardos.lean`:

- `inductive WitnessTree (P) | node (label) (children : List (WitnessTree P))`
  — children are a `List`, not a `Finset` (the nested occurrence under
  `Finset = Quotient (Multiset)` fails Lean's strict-positivity checker;
  sibling-label distinctness is recovered as a `Nodup` side-condition in
  `isProper`).
- `labelOf`, `inclNbhd i = insert i (collisionAdj i)` (the inclusive
  neighbourhood Γ⁺(i)), and `isProper`.
- Sanity lemmas: `labelOf_node`, `self_mem_inclNbhd`, `isProper_leaf`.

## Recursion-form note (the one residual risk)

S13 PREP flagged the `isProper` recursion form as the single item that must be
Docker-verified. This draft uses `∀ t ∈ ch, isProper t` (recursive call applied
to a subterm) rather than S13's top-ranked `List.Forall isProper ch`, because
the applied-to-subterm form is more likely to pass Lean 4's structural-recursion
checker for nested-`List` inductives. The fallback ladder is documented inline:
`termination_by`/`decreasing_by sizeOf` → mutual `isProperList` → `List.Forall`.

## Status: DRAFT (build-pending)

2026-06-14 verification blackout: Docker daemon down (`docker-build.sh`
unavailable) and Aristotle backend returns 404. `meta.json` counts intentionally
left unbumped until the file is verified. The remaining ~160 LOC of OQ-01-B
(`DecidablePred isProper`, size accessor, further sanity lemmas) is deferred to
the verified follow-up.

## Test plan

- [ ] `./proofs/scripts/docker-build.sh Proofs.MoserTardos` (verify the
      `isProper` recursion form; apply S13 fallback ladder if it fails)
- [ ] On success: `gh pr ready`, bump `prob-method-lovasz-local` meta
      `leanFile` theoremCount, continue OQ-01-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)