### PR TITLE
research(cantor-oq-01-01-02-01): realign gallery sections (230→255) + lemma-name fix

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-01-oq-01-oq-02-oq-01/meta.json
@@ -31,9 +31,9 @@
     "definitionCount": 2
   },
   "overview": {
-    "historicalContext": "Easton's 1970 theorem (PhD thesis, Annals of Math. Logic 1) is one of the most striking results in set-theoretic cardinal arithmetic. It completely answers the question 'how arbitrary can the continuum function 2^κ be on regular cardinals?' — by showing that ALL functions F : Reg → Card satisfying three minimal constraints (F(κ) ≥ κ⁺, monotonicity, cf(F(κ)) > κ) are realizable in some forcing extension of ZFC. The constraints are necessary (provable from Mathlib's lt_cof_power and power_le_power_right) but the realizability direction requires class-sized partial orders — Easton product forcing — which extends Cohen's 1963 set-forcing technique to violate GCH simultaneously at every regular cardinal. This file formalizes the converse to OQ-01-OQ-01-OQ-02 (which lists EXCLUDED values): instead of enumerating what 2^ℵ₀ cannot be, it characterizes what 2^ℵ₀ CAN be.",
+    "historicalContext": "Easton's 1970 theorem (PhD thesis, Annals of Math. Logic 1) is one of the most striking results in set-theoretic cardinal arithmetic. It completely answers the question 'how arbitrary can the continuum function 2^κ be on regular cardinals?' — by showing that ALL functions F : Reg → Card satisfying three minimal constraints (F(κ) ≥ κ⁺, monotonicity, cf(F(κ)) > κ) are realizable in some forcing extension of ZFC. The constraints are necessary (provable from Mathlib's lt_cof_power and power_le_power_left) but the realizability direction requires class-sized partial orders — Easton product forcing — which extends Cohen's 1963 set-forcing technique to violate GCH simultaneously at every regular cardinal. This file formalizes the converse to OQ-01-OQ-01-OQ-02 (which lists EXCLUDED values): instead of enumerating what 2^ℵ₀ cannot be, it characterizes what 2^ℵ₀ CAN be.",
     "problemStatement": "Identify the cardinals consistent with both Cantor's lower bound (2^ℵ₀ > ℵ₀) and König's constraint (cf(2^ℵ₀) > ℵ₀), and formalize Easton's claim that every such 'permitted value' is realizable as 2^ℵ₀ in some forcing extension of ZFC.",
-    "proofStrategy": "Two-tier approach. (1) PERMITTED VALUES (object-level): Define IsPermittedValue κ := κ.IsRegular ∧ ℵ₀ < κ. Prove from Mathlib that every regular uncountable cardinal satisfies König's constraint, and that successor alephs ℵ_{α+1} are always permitted (giving an inexhaustible supply of permitted values). (2) EASTON FUNCTIONS (function-level): Define IsEastonFunction F as a structure capturing the three constraints succ_le, monotone, konig_pointwise on regular cardinals. Prove that the actual continuum function κ ↦ 2^κ is an Easton function (witness for non-vacuity) using Mathlib's Cardinal.cantor, Cardinal.power_le_power_right, and Cardinal.lt_cof_power. (3) AXIOMATIZE the realizability direction: easton_permitted_realizable (pointwise) and easton_consistency (function-level), with True codomain as placeholder for a future Consistent-of-ZFC predicate.",
+    "proofStrategy": "Two-tier approach. (1) PERMITTED VALUES (object-level): Define IsPermittedValue κ := κ.IsRegular ∧ ℵ₀ < κ. Prove from Mathlib that every regular uncountable cardinal satisfies König's constraint, and that successor alephs ℵ_{α+1} are always permitted (giving an inexhaustible supply of permitted values). (2) EASTON FUNCTIONS (function-level): Define IsEastonFunction F as a structure capturing the three constraints succ_le, monotone, konig_pointwise on regular cardinals. Prove that the actual continuum function κ ↦ 2^κ is an Easton function (witness for non-vacuity) using Mathlib's Cardinal.cantor, Cardinal.power_le_power_left, and Cardinal.lt_cof_power. (3) AXIOMATIZE the realizability direction: easton_permitted_realizable (pointwise) and easton_consistency (function-level), with True codomain as placeholder for a future Consistent-of-ZFC predicate.",
     "keyInsights": [
       "The two ZFC-provable Easton constraints (Cantor + König) are EXACTLY the binding constraints — there are no further restrictions. This is the deep content of Easton's theorem and what makes the cardinal-arithmetic-on-regulars problem 'almost completely free' (Jech 2003)",
       "Defining IsPermittedValue at the cardinal level (rather than the ordinal level used in OQ-03) gives a more direct converse to the parent file's exclusion theorems: continuum_ne_singular says 'cardinals with cofinality ≤ ℵ₀ are excluded' and aleph_succ_permitted says 'successor alephs are permitted' — these are mirror statements at the same level of abstraction",
@@ -55,40 +55,40 @@
       "id": "module-header",
       "title": "Module Header: Permitted-Values Problem and Imports",
       "startLine": 1,
-      "endLine": 60,
+      "endLine": 67,
       "summary": "Documents the converse direction (every regular κ ≥ ℵ₁ is permitted) versus the parent file's exclusion direction (singular cardinals are excluded). Imports Mathlib's Cardinal.Basic, Ordinal, Cofinality, and the parent file Proofs.CantorDiagonalizationOQ01OQ01OQ02 for König-constraint reuse.",
       "mathContext": "ZFC's two binding constraints on $2^{\\aleph_0}$: $\\aleph_0 < 2^{\\aleph_0}$ (Cantor) and $\\mathrm{cf}(2^{\\aleph_0}) > \\aleph_0$ (König). The permitted values are exactly the cardinals satisfying both — the regular uncountable cardinals."
     },
     {
       "id": "permitted-values",
       "title": "Permitted Values: Pointwise Characterization",
-      "startLine": 61,
-      "endLine": 124,
-      "summary": "Defines IsPermittedValue κ := κ.IsRegular ∧ ℵ₀ < κ. Proves permitted_satisfies_konig (König), aleph_one_permitted (CH value), aleph_two_permitted (PFA value), aleph_succ_permitted (every successor aleph), and permitted_unbounded (proper class). 6 theorems, 0 axioms, 0 sorries.",
+      "startLine": 68,
+      "endLine": 150,
+      "summary": "Defines IsPermittedValue κ := κ.IsRegular ∧ ℵ₀ < κ. Proves permitted_satisfies_konig (König), aleph_one_permitted (CH value), aleph_two_permitted (PFA value), aleph_succ_permitted (every successor aleph), permitted_unbounded (proper class), and not_permitted_of_le_aleph0 (Cantor obstruction converse: no countable cardinal is permitted). 6 theorems, 1 definition, 0 axioms, 0 sorries.",
       "mathContext": "$\\mathsf{IsPermittedValue}(\\kappa) \\iff \\kappa$ is regular and $\\aleph_0 < \\kappa$. Concretely: $\\aleph_1, \\aleph_2, \\aleph_n, \\ldots, \\aleph_{\\omega+1}, \\aleph_{\\omega_1+1}, \\ldots$ are all permitted. The unbounded-class theorem $\\forall \\alpha\\, \\exists \\kappa\\, (\\aleph_\\alpha < \\kappa \\land \\mathsf{IsPermittedValue}(\\kappa))$ rules out any cardinal upper bound on $2^{\\aleph_0}$."
     },
     {
       "id": "easton-functions",
       "title": "Easton Functions: Function-Level Constraints",
-      "startLine": 125,
-      "endLine": 173,
-      "summary": "Defines IsEastonFunction F as a structure with three fields: succ_le (F(κ) ≥ κ⁺), monotone (F monotone on regular cardinals), konig_pointwise (cf(F(κ)) > κ). Proves isEastonFunction_continuum (2^· is Easton) and isEastonFunction_nonempty (the constraint set is non-vacuous). 3 theorems, 0 axioms, 0 sorries.",
-      "mathContext": "The structure $\\mathsf{IsEastonFunction}\\,F$ captures the function-level Easton conditions on regular cardinals: $F(\\kappa) \\geq \\kappa^+$, $\\kappa \\leq \\lambda \\Rightarrow F(\\kappa) \\leq F(\\lambda)$, $\\mathrm{cf}(F(\\kappa)) > \\kappa$. The witness $F(\\kappa) = 2^\\kappa$ satisfies all three from Mathlib's Cantor, power_le_power_right, and lt_cof_power lemmas."
+      "startLine": 151,
+      "endLine": 217,
+      "summary": "Defines IsEastonFunction F as a structure with three fields: succ_le (F(κ) ≥ κ⁺), monotone (F monotone on regular cardinals), konig_pointwise (cf(F(κ)) > κ). Proves isEastonFunction_continuum (2^· is Easton), isEastonFunction_nonempty (the constraint set is non-vacuous), IsEastonFunction.lt_apply (κ < F κ — generalized Cantor bound), and IsEastonFunction.aleph0_lt_apply (ℵ₀ < F κ). 4 theorems, 1 structure, 0 axioms, 0 sorries.",
+      "mathContext": "The structure $\\mathsf{IsEastonFunction}\\,F$ captures the function-level Easton conditions on regular cardinals: $F(\\kappa) \\geq \\kappa^+$, $\\kappa \\leq \\lambda \\Rightarrow F(\\kappa) \\leq F(\\lambda)$, $\\mathrm{cf}(F(\\kappa)) > \\kappa$. The witness $F(\\kappa) = 2^\\kappa$ satisfies all three from Mathlib's Cantor, power_le_power_left (varies the exponent for fixed base 2), and lt_cof_power lemmas. The derived bounds $\\kappa < F(\\kappa)$ and $\\aleph_0 < F(\\kappa)$ hold for every Easton function on regular infinite cardinals."
     },
     {
       "id": "easton-axioms-pointer",
       "title": "Easton Consistency: Pointer to Phase3b Companion File",
-      "startLine": 174,
-      "endLine": 213,
+      "startLine": 218,
+      "endLine": 239,
       "summary": "Part III now redirects the reader to the Phase3b companion file CantorDiagonalizationOQ01OQ01OQ02OQ01Phase3b.lean, where Easton's 1970 realizability theorem is axiomatized with non-trivial codomain (ConsistencyOfContinuumValue / ConsistencyOfContinuumFunction). The earlier vacuous True-codomain axioms in this file were retired in S8 Lever A residual; they had no mathematical content beyond what the Phase3b _strong siblings carry.",
       "mathContext": "Pointer narrative. The genuine $\\mathsf{Easton}\\,(1970)$ statement lives in the Phase3b companion: $\\mathsf{Con}(\\mathsf{ZFC}) \\Rightarrow \\mathsf{Con}(\\mathsf{ZFC} + (\\forall \\kappa\\,\\mathrm{regular} \\geq \\aleph_0:\\, 2^\\kappa = F(\\kappa)))$ for every Easton function $F$, packaged via the abstract ConsistencyOf predicates."
     },
     {
       "id": "verification",
       "title": "Verification Section",
-      "startLine": 213,
-      "endLine": 230,
-      "summary": "#check declarations confirm all 7 theorems, 1 definition, and 1 structure type-check correctly. Closes the namespace CantorDiagOQ01OQ01OQ02OQ01. The previous two #check directives for the deleted axioms (easton_permitted_realizable, easton_consistency) were removed in S8 Lever A residual.",
+      "startLine": 240,
+      "endLine": 255,
+      "summary": "Nine #check declarations confirm the core definitions and theorems (IsPermittedValue, permitted_satisfies_konig, aleph_one/two/succ_permitted, permitted_unbounded, IsEastonFunction, isEastonFunction_continuum/_nonempty) type-check correctly, then close the namespace CantorDiagOQ01OQ01OQ02OQ01. The previous two #check directives for the deleted axioms (easton_permitted_realizable, easton_consistency) were removed in S8 Lever A residual.",
       "mathContext": "Sanity check: every public symbol in the parent file has its expected type signature."
     }
   ],


### PR DESCRIPTION
## Summary

Gallery-metadata fix for `cantor-diagonalization-oq-01-oq-01-oq-02-oq-01`. No Lean change.

- **Section drift**: the parent Lean file grew 230→255 lines (3 theorems added —
  `not_permitted_of_le_aleph0`, `IsEastonFunction.lt_apply`,
  `IsEastonFunction.aleph0_lt_apply`), but the meta `sections` stopped at line 230
  and were all shifted early, hiding the file tail and the added theorems from the
  gallery renderer. Re-mapped all 5 sections to the file's four `PART` banners
  (I @68, II @151, III @218, IV @240) for full contiguous **1–255** coverage, and
  refreshed the stale per-section theorem lists/counts.
- **Factual fix**: the overview `historicalContext`/`proofStrategy` and the
  Easton-functions `mathContext` cited `Cardinal.power_le_power_right` for the
  monotonicity constraint, but the code (line 191) and the file's own naming note
  use `power_le_power_left` (varies the exponent for fixed base 2). Corrected.

`leanFile` counts (theoremCount 10, lineCount 255) were already accurate and are
unchanged. The slug remains `axiomatized` (4 irreducible Easton-1970 class-forcing
axioms in the Phase3b companion) — untouched here.

## Test plan

- [x] `meta.json` parses (validated with `JSON.parse`)
- [x] sections contiguous, no gaps/overlaps, last endLine == lineCount (255)
- [ ] `pnpm build` (gallery render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)