### PR TITLE
audit(erdos-963): realign stale sections to full-file coverage (9→11) + de-axiomatize prose

### DIFF
--- a/src/data/proofs/erdos-963/meta.json
+++ b/src/data/proofs/erdos-963/meta.json
@@ -31,7 +31,7 @@
     "historicalContext": "Erdős formulated this problem in the 1960s as part of his extensive work on additive combinatorics and subset sum structures. The concept of dissociated sets (also called *Sidon sets of order 1* or *$B_1$ sequences*) originated with Simon Sidon's 1932 study of sets whose pairwise sums are all distinct. Dissociated sets generalize this: not just pairwise sums but *all* $2^k$ subset sums must be distinct. The problem appears as [Va99, 1.22] in Vaughan's compilation. Erdős proved the greedy lower bound $f(n) \\ge \\lfloor\\log_3 n\\rfloor$ himself, observing that after selecting $k$ elements for a dissociated subset, at most $3^k - 1$ further values are excluded (each element of the ambient set can be expressed as a sum-or-difference involving at most one new element per existing subset sum). The conjectured improvement to $\\lfloor\\log_2 n\\rfloor$ would be essentially tight, since the trivial upper bound gives $f(n) \\le \\lfloor\\log_2 n\\rfloor + 1$. This problem connects deeply to the work of Halász (1977) on discrepancy of subset sums, Freiman's structure theorem for sets with small sumsets, and the modern probabilistic combinatorics program of Alon, Kleitman, and others on distinct subset sums (cf. Erdős Problem #1, the \\$500 problem on distinct subset sums).",
     "problemStatement": "Let $f(n)$ be the maximum $k$ such that every $n$-element $A \\subseteq \\mathbb{R}$ contains a dissociated subset of size $\\ge k$. Is $f(n) \\ge \\lfloor\\log_2 n\\rfloor$?",
     "text": "Let f(n) be the maximum k such that every n-element subset A ⊆ ℝ contains a dissociated subset B ⊆ A with |B| ≥ k. Estimate f(n); is f(n) ≥ ⌊log₂ n⌋? Erdős showed f(n) ≥ ⌊log₃ n⌋ via greedy.",
-    "proofStrategy": "The formalization defines dissociated subsets via the injectivity of the subset-sum map, introduces $f(n)$ as the supremum of guaranteed dissociated subset sizes, states the main conjecture and known bounds ($\\lfloor\\log_3 n\\rfloor \\le f(n) \\le \\lfloor\\log_2 n\\rfloor + 1$), and proves structural base cases (empty and singleton sets) while axiomatizing the deeper combinatorial results.",
+    "proofStrategy": "The formalization defines dissociated subsets via the injectivity of the subset-sum map, introduces $f(n)$ as the supremum of guaranteed dissociated subset sizes, and states the main conjecture $f(n) \\ge \\lfloor\\log_2 n\\rfloor$ as the Prop `ErdosProblem963` (left open). It then proves — with no axioms and no sorries — Erdős's greedy lower bound $f(n) \\ge \\lfloor\\log_3 n\\rfloor$, the trivial upper bound $f(n) \\le n - 1$, the $2^k$ subset-sum count, the structural lemmas (empty/singleton/subset closure), the extension lemma and its $3^k - 1$ difference-sum cardinality bound that drive the greedy construction, and the powers-of-two example. The $\\log_3$–$\\log_2$ gap to the conjecture remains the open part.",
     "keyInsights": [
       "**Subset-sum injectivity**: A dissociated set of size $k$ has exactly $2^k$ distinct subset sums, since the map $S \\mapsto \\sum_{b \\in S} b$ is injective on the power set — this is the defining property formalized as `IsDissociatedSubset`",
       "**Binary representation paradigm**: Powers of 2 form the canonical dissociated set because binary representation guarantees unique subset sums — this provides the extremal example showing the upper bound is essentially tight",
@@ -48,74 +48,90 @@
     {
       "id": "imports",
       "title": "Imports and Setup",
-      "startLine": 23,
-      "endLine": 28,
-      "summary": "Imports Mathlib's `Combinatorics.Additive.Dissociated` module (which defines dissociated sets in the group-theoretic sense), along with `Finset.Card`, `Data.Real.Basic`, logarithmic functions, and general tactics.",
-      "mathContext": "Imports Mathlib's `Combinatorics.Additive.Dissociated` module (which defines dissociated sets in the group-theoretic sense), along with `Finset.Card`, `Data.Real.Basic`, logarithmic functions, and general tactics."
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Imports Mathlib's `Combinatorics.Additive.Dissociated` module along with `Finset.Card`, `Data.Real.Basic`, logarithmic functions, and general tactics; opens the working namespace.",
+      "mathContext": "Sets up the environment for studying dissociated subsets (subset-sum-injective sets) of finite real sets."
     },
     {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 29,
-      "endLine": 41,
-      "summary": "Defines `IsDissociatedSubset A B` requiring $B \\subseteq A$ with the subset-sum map injective on $\\mathcal{P}(B)$, and `maxDissociatedSize n = \\sup\\{k : \\forall |A|=n,\\, \\exists B \\subseteq A \\text{ dissociated with } |B| \\ge k\\}$.",
-      "mathContext": "Defines `IsDissociatedSubset A B` requiring $B \\subseteq A$ with the subset-sum map injective on $\\mathcal{P}(B)$, and `maxDissociatedSize n = \\sup\\{k : \\forall |A|=n,\\, \\exists B \\subseteq A \\text{ dissociated with } |B| \\ge k\\}$."
+      "startLine": 33,
+      "endLine": 45,
+      "summary": "Defines `IsDissociatedSubset A B` (B ⊆ A with the subset-sum map injective on 𝒫(B)) and `maxDissociatedSize n` (the largest k such that every n-element real set contains a dissociated subset of size ≥ k).",
+      "mathContext": "$\\mathrm{IsDissociatedSubset}(A,B)$ requires $B \\subseteq A$ and that $S \\mapsto \\sum S$ is injective on subsets of $B$. $f(n) = \\mathrm{maxDissociatedSize}(n)$ is the extremal function studied in Erdős #963."
     },
     {
       "id": "counting",
       "title": "Subset Sum Counting",
-      "startLine": 42,
-      "endLine": 48,
-      "summary": "Axiomatizes that a dissociated set of size $k$ yields exactly $2^k$ distinct subset sums, the fundamental counting identity underlying both bounds.",
-      "mathContext": "Axiomatizes that a dissociated set of size $k$ yields exactly $$2^{k}$$ distinct subset sums, the fundamental counting identity underlying both bounds."
+      "startLine": 46,
+      "endLine": 58,
+      "summary": "Proves `dissociated_subset_sum_count`: a dissociated set of size k yields exactly 2^k distinct subset sums, via `Finset.card_image_of_injOn` and `Finset.card_powerset`.",
+      "mathContext": "$|\\{\\,\\sum S : S \\subseteq B\\,\\}| = 2^{|B|}$ when $B$ is dissociated — the fundamental counting identity underlying both the lower and upper bounds."
     },
     {
       "id": "conjecture",
       "title": "Main Conjecture",
-      "startLine": 49,
-      "endLine": 56,
-      "summary": "States the central open problem: $f(n) \\ge \\lfloor\\log_2 n\\rfloor$ for all $n \\ge 1$. This is axiomatized as `erdos_963_conjecture`.",
-      "mathContext": "Axiomatized: States the central open problem: $f(n) \\ge \\lfloor\\log_2 n\\rfloor$ for all $n \\ge 1$. This is axiomatized as `erdos_963_conjecture`."
+      "startLine": 59,
+      "endLine": 66,
+      "summary": "Defines the central open problem as the Prop `ErdosProblem963`: for all n ≥ 1, maxDissociatedSize n ≥ ⌊log₂ n⌋. This is stated (not asserted or axiomatized) — the file proves partial bounds toward it.",
+      "mathContext": "$\\mathrm{ErdosProblem963} :\\Leftrightarrow \\forall n \\ge 1,; f(n) \\ge \\lfloor \\log_2 n \\rfloor$. The conjecture is encoded as a `Prop` definition and left open."
     },
     {
       "id": "greedy-bound",
       "title": "Greedy Lower Bound",
-      "startLine": 57,
-      "endLine": 66,
-      "summary": "Axiomatizes Erdős's greedy argument: $f(n) \\ge \\lfloor\\log_3 n\\rfloor$, based on the observation that at most $3^k - 1$ elements are excluded after choosing $k$ dissociated elements.",
-      "mathContext": "Axiomatizes Erdős's greedy argument: $f(n) \\ge \\lfloor\\log_3 n\\rfloor$, based on the observation that at most $$3^{k}$ - 1$ elements are excluded after choosing $k$ dissociated elements."
+      "startLine": 67,
+      "endLine": 119,
+      "summary": "Proves `greedy_lower_bound`: for all n ≥ 1, maxDissociatedSize n ≥ ⌊log₃ n⌋, formalizing Erdős's greedy argument (at most 3^k − 1 elements are excluded after choosing k dissociated elements).",
+      "mathContext": "$f(n) \\ge \\lfloor \\log_3 n \\rfloor$ (PROVED). The greedy bound is weaker than the conjectured $\\lfloor \\log_2 n \\rfloor$; closing the $\\log_3$–$\\log_2$ gap is the open problem."
+    },
+    {
+      "id": "structural-properties",
+      "title": "Structural Properties",
+      "startLine": 120,
+      "endLine": 165,
+      "summary": "Proves the structural lemmas: `empty_dissociated` (∅ is dissociated), `singleton_dissociated` (any nonzero singleton is dissociated), `dissociated_subset` (dissociation is inherited by subsets), `dissociated_card_le`, and `zero_not_in_dissociated`.",
+      "mathContext": "Basic closure and base-case properties of dissociated sets, used by the greedy construction and the bounds. A dissociated set cannot contain 0 (since {0} and ∅ would share the sum 0)."
     },
     {
       "id": "upper-bound",
-      "title": "Trivial Upper Bound",
-      "startLine": 67,
-      "endLine": 74,
-      "summary": "Axiomatizes $f(n) \\le \\lfloor\\log_2 n\\rfloor + 1$: a dissociated set of size $k$ needs $2^k$ distinct sums from at most $n+1$ possible values (including 0).",
-      "mathContext": "Axiomatizes $f(n) \\le \\lfloor\\log_2 n\\rfloor + 1$: a dissociated set of size $k$ needs $$2^{k}$$ distinct sums from at most $n+1$ possible values (including 0)."
+      "title": "Upper Bound",
+      "startLine": 166,
+      "endLine": 210,
+      "summary": "Proves `trivial_upper_bound`: for all n ≥ 1, maxDissociatedSize n ≤ n − 1.",
+      "mathContext": "$f(n) \\le n - 1$ (PROVED). This crude upper bound follows from cardinality constraints; tightening it toward $\\lfloor \\log_2 n \\rfloor + O(1)$ is part of the open question."
     },
     {
-      "id": "base-cases",
-      "title": "Structural Base Cases",
-      "startLine": 75,
-      "endLine": 124,
-      "summary": "Proves that the empty set is trivially dissociated (`empty_dissociated`) and any singleton $\\{a\\} \\subseteq A$ is dissociated (`singleton_dissociated`), establishing the inductive base for dissociated subset constructions.",
-      "mathContext": "Proves that the empty set is trivially dissociated (`empty_dissociated`) and any singleton $\\{a\\} \\subseteq A$ is dissociated (`singleton_dissociated`), establishing the inductive base for dissociated subset constructions."
+      "id": "extension-lemma",
+      "title": "Extension Lemma for Greedy Construction",
+      "startLine": 211,
+      "endLine": 295,
+      "summary": "Defines `diffSumFinset B` (the set of pairwise difference-sums of B) and proves `dissociated_insert` and `dissociated_extend`: a dissociated set can be extended by any element avoiding the forbidden difference-sum set.",
+      "mathContext": "The key construction lemma: if $a \\notin \\mathrm{diffSumFinset}(B)$ then $B \\cup \\{a\\}$ remains dissociated. This drives the greedy lower bound by guaranteeing an extendable element exists when the ambient set is large enough."
     },
     {
-      "id": "powers-of-two",
-      "title": "Powers of 2 Example",
-      "startLine": 125,
-      "endLine": 130,
-      "summary": "Axiomatizes that $\\{2^0, 2^1, \\ldots, 2^{k-1}\\}$ is dissociated: binary representation uniqueness guarantees distinct subset sums, providing the extremal example.",
-      "mathContext": "Axiomatizes that $\\{$2^{0}$, $2^{1}$, \\ldots, $$2^{{k-1}$}$\\}$ is dissociated: binary representation uniqueness guarantees distinct subset sums, providing the extremal example."
+      "id": "cardinality-bound",
+      "title": "Cardinality Bound for diffSumFinset",
+      "startLine": 296,
+      "endLine": 510,
+      "summary": "Proves `diffSumFinset_card_le`: the difference-sum set of a size-k dissociated set has at most 3^k − 1 elements (the count of forbidden extension values), supplying the quantitative core of the greedy argument.",
+      "mathContext": "$|\\mathrm{diffSumFinset}(B)| \\le 3^{|B|} - 1$. Each element of $B$ contributes a coefficient in $\\{-1,0,1\\}$, giving at most $3^k$ difference-sums and $3^k-1$ nonzero forbidden values."
     },
     {
-      "id": "monotonicity-and-gap",
-      "title": "Monotonicity and Log-Base Gap",
-      "startLine": 131,
-      "endLine": 137,
-      "summary": "Axiomatizes that $f$ is non-decreasing ($m \\le n \\Rightarrow f(m) \\le f(n)$) and that $\\lfloor\\log_3 n\\rfloor \\le \\lfloor\\log_2 n\\rfloor$ for $n \\ge 2$, quantifying the gap between the known and conjectured bounds.",
-      "mathContext": "Axiomatizes that $f$ is non-decreasing ($m \\le n \\Rightarrow f(m) \\le f(n)$) and that $\\lfloor\\log_3 n\\rfloor \\le \\lfloor\\log_2 n\\rfloor$ for $n \\ge 2$, quantifying the gap between the known and conjectured bounds."
+      "id": "greedy-construction",
+      "title": "Greedy Construction",
+      "startLine": 511,
+      "endLine": 681,
+      "summary": "Proves the greedy existence theorem `greedy_dissociated` and the worked example/comparison results: `powers_of_two_dissociated` ({2^0,…,2^{k−1}} is dissociated by binary uniqueness), `maxDissociatedSize_mono` (f is non-decreasing), and `log_base_gap` (⌊log₃ n⌋ ≤ ⌊log₂ n⌋), quantifying the gap between the proved and conjectured bounds.",
+      "mathContext": "Combines the extension lemma and the 3^k−1 cardinality bound to build a dissociated subset greedily, yielding the $\\log_3$ lower bound. The powers-of-two example shows the conjectured $\\log_2$ rate is attainable; `log_base_gap` measures the shortfall of the greedy method."
+    },
+    {
+      "id": "upper-bound-infra",
+      "title": "Upper Bound Infrastructure",
+      "startLine": 682,
+      "endLine": 706,
+      "summary": "Supporting Finset lemmas for the bounds, including `Finset.max'_ge_card_sub_one` (the maximum of a finite set of naturals is at least its cardinality minus one).",
+      "mathContext": "General-purpose `Finset` cardinality/extremal helpers feeding the upper-bound and counting arguments."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The gallery `meta.json` for **erdos-963** froze at an older ~137-line layout while the source grew to **706 lines**. Two issues:

1. **Section undercoverage** — top-level `sections` stopped at line 137, hiding ~80% of the file (lines 138–706: Extension Lemma, Cardinality Bound, Greedy Construction, Upper Bound Infrastructure). The stale "Powers of 2 Example" and "Monotonicity and Log-Base Gap" sections actually describe theorems (`powers_of_two_dissociated`, `maxDissociatedSize_mono`, `log_base_gap`) that now live inside Greedy Construction (lines 511–681).
2. **Stale "axiomatized" prose** — the file has **0 axioms and 0 sorries**, yet six section summaries and the `proofStrategy` described proved theorems (`dissociated_subset_sum_count`, `greedy_lower_bound`, `trivial_upper_bound`, …) as "axiomatized".

## Fixes

- Rebuilt `sections` to the **11 actual `## ` source markers**, contiguous full coverage **1–706**.
- De-axiomatized the prose: proved theorems are now described as proved.
- Fixed a **factual error**: the proved `trivial_upper_bound` is `f(n) ≤ n − 1`, not the previously-stated `f(n) ≤ ⌊log₂ n⌋ + 1` (the literature bound, retained only in `historicalContext`).
- **Status unchanged** (`axiomatized`) per the open-problem policy — the main conjecture `ErdosProblem963` remains an unasserted `Prop`.

Metadata-only; no Lean source touched.

## Test plan

- [x] `jq empty` validates JSON
- [x] Section ranges contiguous 1→706, no gaps/overlaps
- [x] All 11 titles align with source `## ` markers
- [x] Verified 0 axioms / 0 sorries via grep; no structure-encoded assumptions