### PR TITLE
research(angle-trisection-oq-05-03): realign sections to source markers (6→8)

### DIFF
--- a/src/data/proofs/angle-trisection-oq-05-oq-03/meta.json
+++ b/src/data/proofs/angle-trisection-oq-05-oq-03/meta.json
@@ -74,52 +74,68 @@
   },
   "sections": [
     {
+      "id": "module-header",
+      "title": "Module Header, Imports, and Setup",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "Module docstring stating the open question (minimum number of simultaneous origami folds to construct a root of a degree-d polynomial) and its answer minFoldLevel(d) = prime-sequence index of the largest prime factor of d. Imports Mathlib prime API and the parents AngleTrisectionOQ05OQ01 (k-fold constructibility framework) / OQ05OQ02 (exact fold levels for primes); opens the namespace and installs the classical DecidablePred instance used by minFoldLevel.",
+      "mathContext": "k-fold constructibility = $p_k$-smoothness (all prime factors $\\leq$ the $k$-th prime $p_k$); minFoldLevel(d) is the least $k \\geq 1$ with d $p_k$-smooth, i.e. the index of d's largest prime factor in the prime sequence."
+    },
+    {
       "id": "generalized-mono",
       "title": "Generalized Monotonicity",
-      "startLine": 28,
-      "endLine": 42,
+      "startLine": 41,
+      "endLine": 52,
       "summary": "Proves constructible_mono_le: if d is k-fold constructible and k ≤ k', then d is k'-fold constructible. Generalizes the +1 version from OQ-01 to arbitrary increase using Nat.nth_strictMono.",
       "mathContext": "The strict monotonicity of the prime sequence ($p_k < p_{k+1}$) implies $p_k \\leq p_{k'}$ for $k \\leq k'$, so $p_k$-smooth implies $p_{k'}$-smooth for any $k \\leq k'$."
     },
     {
       "id": "multiplicativity",
       "title": "Multiplicativity of k-Fold Constructibility",
-      "startLine": 44,
-      "endLine": 58,
+      "startLine": 53,
+      "endLine": 67,
       "summary": "Proves constructible_mul_iff: IsKFoldConstructible(m*n) k ↔ IsKFoldConstructible m k ∧ IsKFoldConstructible n k. Uses Nat.Prime.dvd_mul for the forward direction.",
       "mathContext": "A product $m \\cdot n$ is $p$-smooth iff both $m$ and $n$ are $p$-smooth: the prime factors of $m \\cdot n$ are exactly the prime factors of $m$ together with those of $n$."
     },
     {
       "id": "min-fold-def",
       "title": "Minimum Fold Level: Definition and Characterization",
-      "startLine": 60,
-      "endLine": 110,
+      "startLine": 68,
+      "endLine": 99,
       "summary": "Defines minFoldLevel via Nat.find. Proves: minFoldLevel_pos (≥ 1), minFoldLevel_constructible (attained), minFoldLevel_minimal (not constructible below), minFoldLevel_le_of_constructible (upper bound), minFoldLevel_le_iff (complete ↔ characterization).",
       "mathContext": "$\\mathrm{minFoldLevel}(d) = \\min\\{k \\geq 1 : d \\text{ is } k\\text{-fold constructible}\\}$. The complete characterization: $\\mathrm{minFoldLevel}(d) \\leq k \\iff d$ is $k$-fold constructible (for $k \\geq 1$)."
     },
     {
       "id": "prime-fold-levels",
       "title": "Exact Fold Level for Primes and Concrete Values",
-      "startLine": 112,
-      "endLine": 170,
+      "startLine": 100,
+      "endLine": 157,
       "summary": "Proves minFoldLevel(foldPrimeBound j) = j for j ≥ 1. Computes concrete values: minFoldLevel 1 = 1, minFoldLevel 2 = 1, minFoldLevel 3 = 1, minFoldLevel 5 = 2, minFoldLevel 7 = 3, minFoldLevel 11 = 4.",
       "mathContext": "The $j$-th prime $p_j$ requires exactly $j$ simultaneous folds: it is $j$-fold constructible (since $p_j = p_j$) but not $(j-1)$-fold (since $p_j > p_{j-1}$)."
     },
     {
       "id": "multiplicative-property",
       "title": "Multiplicative Property and Product Computations",
-      "startLine": 172,
-      "endLine": 225,
+      "startLine": 158,
+      "endLine": 237,
       "summary": "Proves minFoldLevel(m*n) = max(minFoldLevel m, minFoldLevel n). Computes: minFoldLevel 6 = 1, minFoldLevel 10 = 2, minFoldLevel 15 = 2, minFoldLevel 14 = 3, minFoldLevel 42 = 3.",
       "mathContext": "The minimum fold level of a product is the max of the individual levels: $\\mathrm{minFoldLevel}(2 \\cdot 3 \\cdot 7) = \\max(1, 1, 3) = 3$."
     },
     {
       "id": "unboundedness",
       "title": "Unboundedness of minFoldLevel",
-      "startLine": 227,
-      "endLine": 232,
+      "startLine": 238,
+      "endLine": 249,
       "summary": "Proves minFoldLevel is unbounded: for any K, there exists d with minFoldLevel(d) > K. The witness is foldPrimeBound(K+1) = p_{K+1}.",
       "mathContext": "No fixed fold count suffices for all degrees: for each $K$, the $(K+1)$-th prime $p_{K+1}$ requires exactly $K+1$ folds. The set of fold levels is $\\{1, 2, 3, \\ldots\\}$, achieved by successive primes."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 250,
+      "endLine": 272,
+      "summary": "Closing summary docstring restating the answer (minFoldLevel(d) = max{ j ≥ 1 : p_j ∣ d }) and listing the eight key results: generalized monotonicity, multiplicativity, the Nat.find definition, the ≤-characterization, exact prime fold levels, the max-multiplicative property, concrete computations (e.g. minFoldLevel 42 = 3), and unboundedness. Records status: 0 axioms, 0 sorries.",
+      "mathContext": "The dominant-prime-factor description: minFoldLevel(d) is determined by the largest prime dividing d (e.g. $42 = 2\\cdot3\\cdot7$ has dominant prime $7 = p_3$, so minFoldLevel $= 3$)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Gallery-metadata fix for `angle-trisection-oq-05-oq-03` (minimum simultaneous origami folds to construct a degree-d root). No Lean change.

The `sections` array drifted ~12 lines early and omitted two sections:
- started at line 28 (mid-preamble) instead of the first `/-! ## ... -/` marker (@41);
- stopped at line 232, hiding the closing **Summary** docstring (250–272);
- ranges were mismatched against the file's markers (@41, 53, 68, 100, 158, 238, 250).

Re-mapped all sections to those markers and added a **Module Header** (1–40) and a
**Summary** (250–272) section for full contiguous **1–272** coverage (6 → 8 sections).

`leanFile` counts (theoremCount 21, axiomCount 0, sorries 0, lineCount 272) were
already accurate and are unchanged.

## Test plan

- [x] `meta.json` parses; non-section content byte-identical; sections contiguous; last endLine == lineCount (272)
- [ ] `pnpm build` (gallery render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)