### PR TITLE
research(cevas-non-euclidean-oq-02): realign sections + add Euclidean/Spherical parts (6→8)

### DIFF
--- a/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
+++ b/src/data/proofs/cevas-theorem-non-euclidean-oq-02/meta.json
@@ -54,45 +54,61 @@
       "id": "preamble",
       "title": "Module Overview: Menelaus as Signed-Ratio Dual of Ceva",
       "startLine": 1,
-      "endLine": 35,
+      "endLine": 34,
       "summary": "Module docstring explaining the Menelaus theorem as the transversal (collinear) analogue of Ceva's theorem (concurrent). States the hyperbolic Menelaus formula with sinh distances, explains why sinh is the right measure function (odd function preserving signs), and cites Papadopoulos and Ungar as references. Also lists the imports (Mathlib real analysis, trig, ExpDeriv) and opens the namespace.",
       "mathContext": "Menelaus product: $\\frac{\\sinh(BD)}{\\sinh(DC)} \\cdot \\frac{\\sinh(CE)}{\\sinh(EA)} \\cdot \\frac{\\sinh(AF)}{\\sinh(FB)} = -1$. Sign convention: positive when D is internal (between B and C), negative when external. The -1 target reflects an odd number of external division points on the transversal."
     },
     {
       "id": "generalized-menelaus",
       "title": "Generalized Menelaus Framework",
-      "startLine": 36,
-      "endLine": 85,
+      "startLine": 35,
+      "endLine": 80,
       "summary": "Defines the GeneralizedMenelausConfig structure with signed measures and proves the algebraic core: the product of three signed ratios equals -1 iff the numerator product equals the negative of the denominator product."
     },
     {
       "id": "sinh-properties",
       "title": "Properties of sinh for Signed Distances",
-      "startLine": 87,
-      "endLine": 100,
+      "startLine": 81,
+      "endLine": 96,
       "summary": "Proves sinh_eq_zero_iff (sinh x = 0 iff x = 0) and the derived sinh_ne_zero_of_ne_zero, establishing that sinh preserves the non-degeneracy of signed distances."
     },
     {
       "id": "hyperbolic-menelaus",
       "title": "Hyperbolic Menelaus Theorem",
-      "startLine": 102,
-      "endLine": 160,
+      "startLine": 97,
+      "endLine": 157,
       "summary": "Defines HyperbolicMenelausConfig with signed hyperbolic distances, converts to the generalized framework via sinh, and proves the hyperbolic Menelaus theorem by reduction to the algebraic core."
     },
     {
+      "id": "euclidean-menelaus",
+      "title": "Part 4: Euclidean Menelaus (Direct Ratios)",
+      "startLine": 158,
+      "endLine": 168,
+      "summary": "euclidean_menelaus: the flat-space (K=0) Menelaus theorem as the direct specialization of the generalized framework with the identity measure function (no sinh/sin), recovering the classical signed-ratio product = -1 collinearity criterion.",
+      "mathContext": "With measure = id, the generalized product reduces to $\\frac{BD}{DC}\\cdot\\frac{CE}{EA}\\cdot\\frac{AF}{FB} = -1$ characterizing collinearity of D, E, F on the sides (extended) of triangle ABC."
+    },
+    {
+      "id": "spherical-menelaus",
+      "title": "Part 5: Spherical Menelaus Theorem",
+      "startLine": 169,
+      "endLine": 232,
+      "summary": "Defines SphericalMenelausConfig with signed spherical distances, converts to the generalized framework via sin (SphericalMenelausConfig.toGeneralized, sphericalMenelausProduct_eq_generalized), and proves spherical_menelaus by reduction to the algebraic core — the positive-curvature (K=+1) member of the trichotomy.",
+      "mathContext": "On the sphere the measure function is $\\sin$ (odd, sign-preserving like sinh), giving $\\frac{\\sin(BD)}{\\sin(DC)}\\cdot\\frac{\\sin(CE)}{\\sin(EA)}\\cdot\\frac{\\sin(AF)}{\\sin(FB)} = -1$ for collinear (great-circle) D, E, F."
+    },
+    {
       "id": "ceva-menelaus-relationship",
-      "title": "Ceva-Menelaus Sign Relationship",
-      "startLine": 162,
-      "endLine": 210,
+      "title": "Part 6: Ceva–Menelaus Sign Relationship",
+      "startLine": 233,
+      "endLine": 274,
       "summary": "Proves that Ceva (product = 1) and Menelaus (product = -1) share the same algebraic structure, differing only in the target value. Includes a midpoint specialization example.",
       "mathContext": "Ceva: $\\frac{BD}{DC} \\cdot \\frac{CE}{EA} \\cdot \\frac{AF}{FB} = 1$ iff cevians $AD, BE, CF$ concurrent. Menelaus: same product $= -1$ iff $D, E, F$ collinear. Both are special values of the cross-ratio $(B,D;C,\\infty)$, reflecting the projective duality between concurrence and collinearity."
     },
     {
       "id": "summary",
       "title": "Summary: Architecture and Connection to Parent",
-      "startLine": 211,
-      "endLine": 233,
-      "summary": "Documentation section summarizing what is proved (6 results: generalized framework, hyperbolic Menelaus, Euclidean specialization, Ceva-Menelaus relationship, sinh auxiliary, midpoint example) and the architectural pattern (Generalized config → specialized configs → main theorems via toGeneralized conversion). Notes the connection to the parent CevasTheoremNonEuclidean.lean.",
+      "startLine": 275,
+      "endLine": 309,
+      "summary": "Closing summary docstring: lists the 7 proved results (0 sorries, 0 axioms) — generalized framework, hyperbolic Menelaus, Euclidean Menelaus, spherical Menelaus, Ceva-Menelaus relationship, sinh auxiliary, midpoint example — and the curvature trichotomy table (spherical/sin = +1, Euclidean/id = 0, hyperbolic/sinh = -1; Ceva = 1, Menelaus = -1 in every geometry). Notes the GeneralizedConfig → specialized config → main theorem architecture and the connection to the parent CevasTheoremNonEuclidean.lean.",
       "mathContext": "Architectural pattern: GeneralizedMenelausConfig (algebraic core) → toGeneralized conversion (measure function swap: $\\text{id} \\to \\sinh$) → HyperbolicMenelausConfig (hyperbolic Menelaus). The algebraic biconditional is proved once and reused for all geometries."
     }
   ],


### PR DESCRIPTION
## Summary

Gallery-metadata fix for `cevas-theorem-non-euclidean-oq-02` (Menelaus as the signed-ratio dual of Ceva, across the curvature trichotomy). No Lean change.

The `sections` array drifted from the 309-line source:
- **PART 4 (Euclidean Menelaus, @158) and PART 5 (Spherical Menelaus, @169) were missing.**
- The "Ceva-Menelaus Sign Relationship" section was **misranged** — meta 162–210
  actually covered the Euclidean + Spherical parts, while the real PART 6 is @233.
- The Summary section stopped at 233, hiding the closing Summary docstring (275–309).

Re-mapped all sections to the file's `PART` banners and added the Euclidean and
Spherical sections for full contiguous **1–309** coverage (6 → 8 sections); refreshed
the Summary to reflect the full curvature trichotomy (spherical/sin, Euclidean/id,
hyperbolic/sinh).

`leanFile` counts (theoremCount 10, axiomCount 0, sorries 0, lineCount 309) were
already accurate and are unchanged.

## Test plan

- [x] `meta.json` parses; non-section content byte-identical; sections contiguous; last endLine == lineCount (309)
- [ ] `pnpm build` (gallery render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)