### PR TITLE
research(basel-oq-01-01-02-03): fix theoremCount undercount (73→77)

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02-oq-03/meta.json
@@ -19,7 +19,7 @@
     "sorries": 0,
     "axiomCount": 1,
     "lineCount": 1802,
-    "theoremCount": 73,
+    "theoremCount": 77,
     "definitionCount": 1,
     "assumptions": "Axiomatized: hanson_bound — for all n, lcm(1,...,n) ≤ 3^n. Numerically verified for n ∈ {1..10, 12, 15, 20} via decide/native_decide. Hanson's original 1972 proof uses Beta-integral identities and Chebyshev-style prime-power bounds; neither is in Mathlib. Provable easier bounds (lcm | n!, lcm ≤ n!, lcm ≤ n^n) are included with no axioms.",
     "originalContributions": [


### PR DESCRIPTION
## Summary
Build-free metadata accuracy fix for the Hanson's-bound (Basel) gallery entry.

`meta.theoremCount` was **73**, counting only top-level `theorem` declarations and omitting the file's other theorem-like declarations:
- `lemma sum_mod_pow_lt_of_pow_dvd_succ` (L1468)
- `private theorem prod_dvd_of_pairwise_coprime` (L170)
- `private lemma pow_sub_one_mod_pow` (L1590)
- `private lemma witness_mod_pow_lt` (L1620)

Per the gallery convention (theoremCount includes private and plain lemmas — cf. erdos-382 11+7=18, four-square-distribution-oq-01 incl. its 14 private lemmas), the correct count is **77**.

## Verification
- `grep -cE '^(theorem|lemma|private lemma|private theorem) '` → 77
- All 73 `^theorem` confirmed real (none inside block comments)
- No Lean source changes. Unchanged & re-verified: axiomCount 1 (`hanson_bound`), sorries 0, lineCount 1802, definitionCount 1, section coverage 1–1802.

## Test plan
- [x] Counts cross-checked against source
- [ ] `pnpm build` (metadata-only; deployer validates)