### PR TITLE
research(general-quartic): realign drifted gallery sections to full 758-line file

### DIFF
--- a/src/data/proofs/general-quartic/meta.json
+++ b/src/data/proofs/general-quartic/meta.json
@@ -75,45 +75,66 @@
   "sections": [
     {
       "id": "definitions",
-      "title": "Basic Definitions",
+      "title": "Part I: Basic Definitions",
       "startLine": 1,
-      "endLine": 66,
-      "summary": "Defines quartic polynomial, depressed quartic, and resolvent cubic forms."
+      "endLine": 79,
+      "summary": "Module docstring on Ferrari's method (1540) and its mathematical background, then the core definitions: `quarticPoly` (x⁴+ax³+bx²+cx+d), `depressedQuartic` (y⁴+py²+qy+r), and `resolventCubic` (8m³+20pm²+(16p²−8r)m+(4p³−4pr−q²))."
     },
     {
       "id": "depression",
-      "title": "Depressed Form Reduction",
-      "startLine": 67,
-      "endLine": 96,
-      "summary": "Shows any quartic reduces to depressed form via substitution y = x + a/4."
+      "title": "Part II: Depressed Form Reduction",
+      "startLine": 80,
+      "endLine": 92,
+      "summary": "`depressionCoeffs`: the (p,q,r) of the depressed form obtained from the substitution y = x + a/4."
+    },
+    {
+      "id": "proved-results-and-axioms",
+      "title": "Proved Results and Remaining Axioms",
+      "startLine": 93,
+      "endLine": 306,
+      "summary": "The depressed-quartic forward/backward transforms (proved via `linear_combination`), the sound Ferrari-factorization substrate `ferrari_factorization_id` and `ferrari_hβ2_of_resolvent`, the α≠0 (non-degenerate) factorization directions `ferrari_factorization_forward_ne`/`backward_ne`, `resolvent_cubic_has_root` (FTA), `quartic_to_depressed`, and the 3 remaining axioms `quartic_has_four_roots`, `biquadratic_forward`, `biquadratic_backward`."
     },
     {
       "id": "ferrari-method",
-      "title": "Ferrari's Method",
-      "startLine": 97,
-      "endLine": 136,
-      "summary": "Ferrari's factorization theorem and existence of resolvent root."
+      "title": "Part III: Ferrari's Method",
+      "startLine": 307,
+      "endLine": 340,
+      "summary": "`ferrari_factorization`: the depressed quartic factors into two quadratics at any non-degenerate resolvent root (iff form, delegating to the `_ne` lemmas), and `resolvent_has_root`."
     },
     {
       "id": "roots",
-      "title": "The Four Roots",
-      "startLine": 137,
-      "endLine": 176,
-      "summary": "Explicit Ferrari formulas for all four roots."
+      "title": "Part IV: The Four Roots",
+      "startLine": 341,
+      "endLine": 443,
+      "summary": "`quartic_four_roots` (FTA), the explicit `ferrariRoots` formula (α=√(2m+p), β=q/(2α), two discriminants), and `ferrari_roots_verify_ne` — the four roots satisfy the depressed quartic when 2m+p≠0, with the documented latent-false-axiom counterexample at α=0 (e.g. (p,q,r,m)=(0,0,1,0))."
+    },
+    {
+      "id": "verification",
+      "title": "Part V: Verification",
+      "startLine": 444,
+      "endLine": 460,
+      "summary": "`ferrari_roots_are_roots`: packages `ferrari_roots_verify_ne` as the statement that all four Ferrari roots solve the depressed quartic (non-degenerate resolvent root)."
     },
     {
       "id": "special-cases",
-      "title": "Special Cases",
-      "startLine": 177,
-      "endLine": 196,
-      "summary": "Biquadratic case simplification when q = 0."
+      "title": "Part VI: Special Cases",
+      "startLine": 461,
+      "endLine": 477,
+      "summary": "`biquadratic_simple`: the q=0 biquadratic case y⁴+py²+r=0 characterized as a quadratic in y²."
+    },
+    {
+      "id": "biquadratic-limit-oq02c",
+      "title": "Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c)",
+      "startLine": 478,
+      "endLine": 709,
+      "summary": "Discharges the α=0 boundary of `ferrariRoots`: `resolvent_cubic_q_zero`, `resolvent_root_neg_p_half_at_q_zero` (the trivial degenerate root m=−p/2), the Newton-polygon-cleaned `resolvent_cubic_eval_s_form` (s=2m+p), the Pan-witness scaffolding (`pan_witness_cleaned_resolvent`, `pan_witness_t_zero_factorisation` s²(s−2), `pan_witness_t_zero_nondegenerate_root` m=3/2), and `ferrari_biquad_limit`: for (p,r)≠(0,0) a non-degenerate resolvent root exists and each Ferrari root squared lands in the biquadratic pair {(−p±√(p²−4r))/2}."
     },
     {
       "id": "history",
-      "title": "Historical Context",
-      "startLine": 197,
-      "endLine": 344,
-      "summary": "Ferrari's discovery and connection to Abel-Ruffini/Galois theory."
+      "title": "Part VII: Historical Context and Significance",
+      "startLine": 710,
+      "endLine": 758,
+      "summary": "Ferrari's discovery (1540), why solvability by radicals stops at degree 4, and the connection to Abel-Ruffini and the solvable Galois group S₄ ▷ A₄ ▷ V₄ ▷ {e}."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `general-quartic` gallery `meta.json` listed **6 sections** whose line ranges (max `endLine` 344) mapped to an old ~344-line version of `GeneralQuartic.lean`. The file is now **758 lines**, so the gallery rendered wrong source ranges and hid more than half the proof — Parts III–VII at their real positions plus the entire **230-line Part VI.5** (the OQ-02 biquadratic-limit / Pan-witness research core: `resolvent_cubic_eval_s_form`, the Pan-witness scaffolding, and `ferrari_biquad_limit`).

Rebuilds the `sections` array to **9 contiguous, accurate ranges** covering lines 1–758:

| Lines | Section |
|-------|---------|
| 1–79 | Part I: Basic Definitions |
| 80–92 | Part II: Depressed Form Reduction |
| 93–306 | Proved Results and Remaining Axioms |
| 307–340 | Part III: Ferrari's Method |
| 341–443 | Part IV: The Four Roots |
| 444–460 | Part V: Verification |
| 461–477 | Part VI: Special Cases |
| 478–709 | Part VI.5: Biquadratic-Limit Removable Singularity (OQ-02.c) |
| 710–758 | Part VII: Historical Context |

Counts were already synced (21 theorems, 3 axioms, 5 defs, 758 lines) and are unchanged — this is a **pure section-line realignment, no Lean source change** (no build required).

## Test plan

- [x] `python3 -m json.tool` validates; sections are contiguous (1→758, no gaps/overlaps), each range verified against the file's `Part` markers.
- [x] No `.lean` change; counts unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)