### PR TITLE
research(hilbert-15-oq-01): realign stale gallery sections to full file (6->10)

### DIFF
--- a/src/data/proofs/hilbert-15-oq-01/meta.json
+++ b/src/data/proofs/hilbert-15-oq-01/meta.json
@@ -67,52 +67,74 @@
   },
   "sections": [
     {
-      "id": "part-i",
+      "id": "chow-ring",
       "title": "Part I: The Chow Ring of Gr(2,4)",
-      "startLine": 60,
-      "endLine": 90,
-      "summary": "ChowGr24 structure: 6 integer coefficients for the Schubert basis. Zero, one, addition, negation, scalar multiplication.",
-      "mathContext": "An element of $A^*(\\mathrm{Gr}(2,4))$ is a formal $\\mathbb{Z}$-linear combination $a_0 \\sigma_\\emptyset + a_1 \\sigma_1 + a_2 \\sigma_2 + a_{11} \\sigma_{11} + a_{21} \\sigma_{21} + a_{22} \\sigma_{22}$."
+      "startLine": 66,
+      "endLine": 101,
+      "summary": "ChowGr24 structure: integer linear combinations of the 6 Schubert classes, with Zero/One/Add/Neg/SMul instances."
     },
     {
-      "id": "part-ii",
+      "id": "schubert-basis",
       "title": "Part II: Schubert Basis Elements",
-      "startLine": 92,
-      "endLine": 115,
-      "summary": "The 6 Schubert basis classes σ_∅, σ₁, σ₂, σ₁₁, σ₂₁, σ₂₂ as ChowGr24 values.",
-      "mathContext": "Schubert classes indexed by partitions fitting in a $2 \\times 2$ box: $\\emptyset, (1), (2), (1,1), (2,1), (2,2)$."
+      "startLine": 102,
+      "endLine": 121,
+      "summary": "The six Schubert basis classes sigma_0, sigma_1, sigma_2, sigma_11, sigma_21, sigma_22 with their geometric meanings."
     },
     {
-      "id": "part-iii",
+      "id": "ring-multiplication",
       "title": "Part III: Ring Multiplication",
-      "startLine": 117,
-      "endLine": 175,
-      "summary": "basisMul: complete 6×6 multiplication table from Littlewood–Richardson. Full ring multiplication by bilinear extension.",
-      "mathContext": "The Littlewood–Richardson rule gives $\\sigma_\\mu \\cdot \\sigma_\\nu = \\sum_\\rho c^\\rho_{\\mu\\nu} \\sigma_\\rho$ where $c^\\rho_{\\mu\\nu}$ counts LR tableaux."
+      "startLine": 122,
+      "endLine": 203,
+      "summary": "basisMul encodes the full Littlewood-Richardson multiplication table (incl. the nontrivial zero sigma_2*sigma_11=0); Mul instance extends it bilinearly."
     },
     {
-      "id": "part-iv-v",
-      "title": "Parts IV–V: Multiplication Results and Four Lines",
-      "startLine": 177,
-      "endLine": 225,
-      "summary": "Key products verified by native_decide. The four lines theorem: σ₁⁴ = 2σ₂₂, giving the intersection number 2.",
-      "mathContext": "$\\sigma_1^2 = \\sigma_2 + \\sigma_{11}$, $\\sigma_1^3 = 2\\sigma_{21}$, $\\sigma_1^4 = 2\\sigma_{22}$. Exactly 2 lines meet 4 general lines in $\\mathbb{P}^3$."
+      "id": "key-multiplication-results",
+      "title": "Part IV: Key Multiplication Results",
+      "startLine": 204,
+      "endLine": 230,
+      "summary": "All seven basis products verified by native_decide, including sigma_1^2 = sigma_2 + sigma_11 and the nontrivial zero sigma_2*sigma_11 = 0."
     },
     {
-      "id": "part-vi-vii",
-      "title": "Parts VI–VII: Poincaré Duality and Giambelli",
-      "startLine": 227,
-      "endLine": 275,
-      "summary": "Poincaré duality: degree(σ_λ · σ_{λ*}) = 1. Giambelli: σ₁₁ = σ₁² − σ₂.",
-      "mathContext": "Poincaré duality pairs $\\sigma_\\lambda$ with $\\sigma_{\\lambda^*}$ where $\\lambda^* = (2-\\lambda_2, 2-\\lambda_1)$. Giambelli: $\\sigma_{11} = \\det\\begin{pmatrix} \\sigma_1 & \\sigma_2 \\\\ 1 & \\sigma_1 \\end{pmatrix} = \\sigma_1^2 - \\sigma_2$."
+      "id": "four-lines-theorem",
+      "title": "Part V: The Four Lines Theorem via Schubert Calculus",
+      "startLine": 231,
+      "endLine": 256,
+      "summary": "sigma_1^4 = 2*sigma_22: exactly 2 lines meet 4 general lines in P^3; intersection number extracted via the degree map."
     },
     {
-      "id": "part-viii",
-      "title": "Part VIII: Enumerative Applications",
-      "startLine": 277,
-      "endLine": 310,
-      "summary": "Classical enumerative results: 1 line through a point meeting 2 lines, overdetermined system has 0 solutions.",
-      "mathContext": "$\\deg(\\sigma_1^2 \\cdot \\sigma_{11}) = 1$: one line through a point meets 2 general lines. $\\deg(\\sigma_1^3 \\cdot \\sigma_{11}) = 0$: overdetermined."
+      "id": "poincare-duality",
+      "title": "Part VI: Poincaré Duality",
+      "startLine": 257,
+      "endLine": 280,
+      "summary": "Poincaré pairing degree(sigma_lambda * sigma_lambda*) = 1 verified for all dual pairs, with sigma_2 and sigma_11 self-dual; non-dual pair pairs to 0."
+    },
+    {
+      "id": "giambelli-formula",
+      "title": "Part VII: Giambelli's Formula",
+      "startLine": 281,
+      "endLine": 302,
+      "summary": "Giambelli's determinantal formula verified: sigma_11 = sigma_1^2 - sigma_2 and sigma_21 = sigma_1 * sigma_2."
+    },
+    {
+      "id": "enumerative-applications",
+      "title": "Part VIII: More Enumerative Applications",
+      "startLine": 303,
+      "endLine": 325,
+      "summary": "Classical enumerative counts via the Chow ring: lines through a point meeting two lines (=1), lines in a plane meeting two lines (=1), and an overdetermined system (=0)."
+    },
+    {
+      "id": "ring-properties",
+      "title": "Part IX: Ring Properties",
+      "startLine": 326,
+      "endLine": 336,
+      "summary": "Commutativity of the basis multiplication table and sigma_0 as identity, both proved by decide."
+    },
+    {
+      "id": "conclusion",
+      "title": "Conclusion",
+      "startLine": 337,
+      "endLine": 351,
+      "summary": "Recap: the Chow ring of Gr(2,4) fully formalized (0 axioms, 0 sorries) with the LR table, four lines theorem, Poincaré duality, Giambelli's formula, and enumerative results."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery `sections` array for **hilbert-15-oq-01** had drifted from `Proofs/Hilbert15OQ01.lean`:

- **Undercoverage**: sections stopped at line 310, but the file is 351 lines. Part IX (Ring Properties) and the Conclusion were hidden from the gallery.
- **Misalignment**: the back-half section labels were shifted. "Parts IV–V" was pinned at lines 177-225 though Part V (Four Lines Theorem) actually begins at line 231; "Parts VI–VII" and "Part VIII" were likewise off-by-one+.

Rebuilt all 10 sections aligned to the real `Part I-IX + Conclusion` banners, now covering lines 66-351.

## Verification
Counts already matched the source (no change needed):
- theoremCount = 22 ✓
- definitionCount = 9 ✓
- axiomCount = 0 ✓
- sorryCount = 0 ✓
- lineCount = 351 ✓

Metadata-only change (no Lean source touched). Companion to #23476 (hilbert-15-oq-02) from the same family scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)