### PR TITLE
research(hilbert-15): re-pin gallery sections to banners + add Exports (8->10)

### DIFF
--- a/src/data/proofs/hilbert-15/meta.json
+++ b/src/data/proofs/hilbert-15/meta.json
@@ -75,67 +75,74 @@
       "id": "docstring",
       "title": "Module Docstring",
       "startLine": 9,
-      "endLine": 72,
+      "endLine": 74,
       "summary": "Historical exposition of Schubert's enumerative calculus (1879), Hilbert's request for rigor (1900), and the 20th-century resolution via intersection theory, Schubert classes, and Littlewood-Richardson coefficients."
     },
     {
       "id": "grassmannian",
       "title": "Part I: The Grassmannian",
-      "startLine": 73,
-      "endLine": 105,
+      "startLine": 75,
+      "endLine": 107,
       "summary": "Defines Grassmannian k n K as the subtype {V : Submodule K (Fin n → K) // finrank K V = k}, with CoeSort instance and grassmannian_rank theorem.",
       "mathContext": "$\\text{Gr}(k, n) = \\{V \\leq K^n : \\dim V = k\\}$. Dimension: $\\dim \\text{Gr}(k,n) = k(n-k)$."
     },
     {
       "id": "lines-in-p3",
       "title": "Part II: Lines in P³",
-      "startLine": 106,
-      "endLine": 142,
+      "startLine": 108,
+      "endLine": 162,
       "summary": "Defines LineInP3 as Gr(2,4), SubspacesMeet (V ⊓ W ≠ ⊥), LinesMeet, LinesMeet' (finrank of span < 4), and proves their equivalence via the Grassmann dimension formula."
     },
     {
       "id": "four-lines",
       "title": "Part III: The Four Lines Theorem",
-      "startLine": 143,
-      "endLine": 218,
+      "startLine": 163,
+      "endLine": 238,
       "summary": "Defines FourLinesGeneralPosition (no two meet), IsTransversal (meets all four), Transversals (the set), and axiomatizes exactly 2 transversals via both existential and ncard formulations.",
       "mathContext": "Four lines in general position in $\\mathbb{P}^3$: exactly 2 lines meet all four. Schubert computation: $\\sigma_1^4 = 2\\sigma_{22}$ in $H^*(\\text{Gr}(2,4))$."
     },
     {
       "id": "schubert-numbers",
       "title": "Part IV: Classical Schubert Numbers",
-      "startLine": 219,
-      "endLine": 250,
+      "startLine": 239,
+      "endLine": 270,
       "summary": "Records schubertNumber_FourLines = 2, schubertNumber_CubicSurface = 27, schubertNumber_FiveConics = 3264, schubertNumber_FivePoints = 1 as ℕ constants.",
       "mathContext": "Classical enumerative results: 2 lines meet 4 general lines, 27 lines on a cubic surface, 3264 conics tangent to 5 conics (Steiner's corrected count)."
     },
     {
       "id": "schubert-varieties",
       "title": "Part V: Schubert Varieties and Classes",
-      "startLine": 251,
-      "endLine": 302,
+      "startLine": 271,
+      "endLine": 322,
       "summary": "Defines Partition (weakly decreasing list), fitsIn (k × (n-k) box), SchubertClass, and axiomatizes the Schubert basis theorem (bijection with fitting partitions, distinctness)."
     },
     {
       "id": "lr-rule",
       "title": "Part VI: Littlewood-Richardson Rule",
-      "startLine": 303,
-      "endLine": 356,
+      "startLine": 323,
+      "endLine": 376,
       "summary": "Axiomatizes littlewoodRichardsonCoeff, littlewood_richardson_rule (expansion exists with correct partition sizes), and pieris_rule (special case for single-row partitions)."
     },
     {
       "id": "four-lines-schubert",
       "title": "Part VII: Four Lines via Schubert Calculus",
-      "startLine": 357,
-      "endLine": 398,
+      "startLine": 377,
+      "endLine": 418,
       "summary": "Defines partition_1 and partition_22, axiomatizes sigma1_fourth_power (LR coefficient = 2), and proves four_lines_via_schubert by rfl."
     },
     {
       "id": "status",
       "title": "Part VIII: Problem Status",
-      "startLine": 399,
-      "endLine": 452,
-      "summary": "Documents resolution timeline (1930s-1984), summarizes with hilbert_15_statement, and #check verifies all major exports."
+      "startLine": 419,
+      "endLine": 456,
+      "summary": "Documents the resolution timeline (1930s-1984) and summarizes the answer with hilbert_15_statement."
+    },
+    {
+      "id": "exports",
+      "title": "Exports",
+      "startLine": 457,
+      "endLine": 470,
+      "summary": "#check verifies all major exports: Grassmannian, LineInP3, LinesMeet, four_lines_theorem, transversal_count, schubertNumber_FourLines, SchubertClass, schubert_basis_theorem, littlewood_richardson_rule, four_lines_via_schubert."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The base **hilbert-15** gallery `sections` array had drifted from `Proofs/Hilbert15SchubertCalculus.lean`:

- **Misalignment**: back-half sections were pinned ~20 lines *before* their actual `/-! ═══ PART N ═══` banners (e.g. "Part V" at line 251 vs banner at 271; "Part VIII" at 399 vs 419).
- **Undercoverage**: the EXPORTS block (lines 457-470, the `#check` declarations) was uncovered; sections stopped at 452 while the file is 470 lines.

Re-pinned all sections to the actual banner openers (75/108/163/239/271/323/377/419) and added the missing **Exports** section, giving full 9-470 coverage.

Metadata-only change (no Lean source touched). Third of the same family scan — companion to #23476 (oq-02) and #23477 (oq-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)