### PR TITLE
research(lagrange-four-squares): surface hidden sections + Verification Checks (6->11)

### DIFF
--- a/src/data/proofs/lagrange-four-squares/meta.json
+++ b/src/data/proofs/lagrange-four-squares/meta.json
@@ -115,9 +115,44 @@
       "id": "two-squares-connection",
       "title": "Connection to Two Squares Theorem",
       "startLine": 129,
-      "endLine": 365,
+      "endLine": 143,
       "summary": "Cross-reference to Fermat's Two Squares Theorem showing the contrast between universal four squares and restrictive two squares.",
       "mathContext": "Fermat: $n = a^2 + b^2 \\iff$ every prime $p \\equiv 3 \\pmod{4}$ divides $n$ to even power. Two squares is far more restrictive than four."
+    },
+    {
+      "id": "part2-three-square",
+      "title": "Part II: Legendre’s Three-Square Theorem",
+      "startLine": 144,
+      "endLine": 187,
+      "summary": "IsSumOfThreeSquares and IsObstructed predicates, worked obstructions (7, 15, 28), the axiomatized Legendre-Gauss three-square theorem, and form_8k7_needs_four."
+    },
+    {
+      "id": "part3-representation-counts",
+      "title": "Part III: Representation Counts and r₄(n)",
+      "startLine": 188,
+      "endLine": 234,
+      "summary": "Jacobi’s four-square count: r4 and sumDivisorsNot4 definitions, the prime formula r4(p)=8(p+1), and jacobi_implies_lagrange."
+    },
+    {
+      "id": "part4-waring",
+      "title": "Part IV: Waring’s Problem and g(k)",
+      "startLine": 235,
+      "endLine": 334,
+      "summary": "IsSumOfPowers and waringG definitions, lagrange_is_waring_2 (g(2)=4), and the axiomatized Hilbert-Waring g(k) existence plus Wieferich g(3)=9."
+    },
+    {
+      "id": "part5-quaternions",
+      "title": "Part V: Quaternions and the Algebraic Structure",
+      "startLine": 335,
+      "endLine": 366,
+      "summary": "LipschitzQuaternion structure and norm, norm multiplicativity (Euler’s identity in disguise), and every_nat_is_quaternion_norm recasting Lagrange via quaternion norms."
+    },
+    {
+      "id": "verification-checks",
+      "title": "Verification Checks",
+      "startLine": 367,
+      "endLine": 392,
+      "summary": "#check exports for the three-square theorem, representation counts, Waring’s problem, and quaternion declarations."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The base **lagrange-four-squares** gallery `sections` array hid most of the Lean file `Proofs/LagrangeFourSquares.lean` behind one over-broad section:

- The "Connection to Two Squares Theorem" section spanned lines **129-365**, swallowing four distinct banner sections: **Part II** (Legendre's Three-Square Theorem), **Part III** (Representation Counts / r₄(n)), **Part IV** (Waring's Problem and g(k)), and **Part V** (Quaternions and the Algebraic Structure).
- The **Verification Checks** tail (lines 367-392, the `#check` exports) was uncovered.

Narrowed the two-squares section to its actual content (129-143) and added the five hidden sections, giving full **1-392** coverage (6 → 11 sections).

Metadata-only change (no Lean source touched). Counts left unchanged. Part of the lagrange-four-squares family scan (companion to #23479).

🤖 Generated with [Claude Code](https://claude.com/claude-code)