### PR TITLE
research(lagrange-four-squares-oq-02): rebuild scrambled gallery sections (9->21)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-02/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-02/meta.json
@@ -91,67 +91,151 @@
   ],
   "sections": [
     {
-      "id": "sec-reptype",
-      "title": "RepType Structure and Core Definitions",
+      "id": "header",
+      "title": "Header: Open Question and Roadmap",
       "startLine": 1,
+      "endLine": 46,
+      "summary": "Imports and module docstring framing the open question: how the r4(n) representations distribute among orderings (representation types)."
+    },
+    {
+      "id": "part1-reptype",
+      "title": "Part 1: Representation Type (Sorted 4-tuple)",
+      "startLine": 47,
+      "endLine": 81,
+      "summary": "RepType n structure (sorted a1<=a2<=a3<=a4 with a1^2+...+a4^2=n) plus nonzeroCount, multinomial permutations, signFactor 2^nonzeroCount, and contribution = permutations*signFactor."
+    },
+    {
+      "id": "part2-enumeration",
+      "title": "Part 2: Decidable Enumeration of Types",
+      "startLine": 82,
       "endLine": 115,
-      "summary": "Imports Mathlib.NumberTheory.SumFourSquares. Defines RepType (sorted 4-tuple structure with sum constraint), RepType.nonzeroCount (count of nonzero entries), RepType.permutations (multinomial 24/∏mᵢ!), RepType.signFactor (2^nonzeroCount), RepType.contribution (permutations × signFactor). Defines enumTypes (list monad search), typeCount, tupleContribution, and totalFromEnum. All definitions are computable."
+      "summary": "Computable enumTypes search over sorted 4-tuples, typeCount, tupleContribution, and totalFromEnum summing all type contributions to recover r4(n)."
     },
     {
-      "id": "sec-verification",
-      "title": "Computational Verification of Enumeration",
+      "id": "part3-verification",
+      "title": "Part 3: Verification of Enumeration",
       "startLine": 116,
-      "endLine": 165,
-      "summary": "Type counts for small n: typeCount_0 through typeCount_10, extended through typeCount_25. Contribution sums matching r₄(n): totalFromEnum_1 = 8 through totalFromEnum_16. Multinomial coefficient values: multinomial [4]=1, [3,1]=4, [2,2]=6, [2,1,1]=12, [1,1,1,1]=24. All proved by native_decide."
+      "endLine": 143,
+      "summary": "native_decide checks of typeCount and totalFromEnum for small n (0..10), confirming the enumeration reproduces known r4(n) values."
     },
     {
-      "id": "sec-structural-bounds",
-      "title": "Structural Bounds and Sign Factor Theory",
-      "startLine": 236,
-      "endLine": 295,
-      "summary": "nonzeroCount_le_four, signFactor_le_sixteen (≤ 16 = 2⁴), permutations_le_twentyfour (≤ 24 = 4!), contribution_le_384. Five theorems: signFactor_zero/one/two/three/four_nonzero (each nonzero count determines sign factor by simp). sorted_zeros_left_3 and sorted_zeros_left_2 (sorted tuple propagates zeros leftward via omega)."
+      "id": "part4-multinomial",
+      "title": "Part 4: Direct Multinomial Coefficient",
+      "startLine": 144,
+      "endLine": 162,
+      "summary": "multinomial signature function 4!/prod(mult!) with verified values for the five partition patterns of 4 ([4],[3,1],[2,2],[2,1,1],[1,1,1,1])."
     },
     {
-      "id": "sec-type-families",
-      "title": "General Type Family Theorems (6 Families)",
+      "id": "part5-type-families",
+      "title": "Part 5: General Type Family Definitions and Theorems",
       "startLine": 163,
-      "endLine": 540,
-      "summary": "Six general type families, each proved for ALL valid parameters: trivialType(k): (0,0,0,k) → contribution 8; allEqualType(k): (k,k,k,k) → 16; threeEqualType(k): (0,k,k,k) → 32; twoPairType(a,b): (a,a,b,b) with a<b → 96; twoEqualType(k): (0,0,k,k) → 24; twoNonzeroDistinct(a,b): (0,0,a,b) with a<b → 48. Each proved by the pattern: (1) native_decide for k=1, (2) congr+simp for permutation equality, (3) signFactor from nonzeroCount lemma."
+      "endLine": 231,
+      "summary": "trivialType (0,0,0,k) family with the general theorem that its contribution is exactly 8 for all k>0 (pattern-only dependence), plus computational checks."
     },
     {
-      "id": "sec-contribution-table",
-      "title": "Complete Contribution Value Table",
-      "startLine": 540,
-      "endLine": 590,
-      "summary": "Documents the complete 10-value contribution table: multiplicity patterns (4), (3,1), (2,2), (2,1,1), (1,1,1,1) × nonzero counts give values {1,8,16,24,32,48,64,96,192,384}. Seven concrete theorems verify each cell: contribution_one_is_zero=1, pattern_31_4nz=64, pattern_22_2nz=24, pattern_211_3nz=96, pattern_211_4nz=192, pattern_1111_3nz=192, allDistinctType_contribution=384."
+      "id": "part6-structural-bounds",
+      "title": "Part 6: Structural Bounds",
+      "startLine": 232,
+      "endLine": 259,
+      "summary": "Universal bounds: nonzeroCount<=4, signFactor<=16, permutations<=24, and contribution<=384 for any type."
     },
     {
-      "id": "sec-orbit-stabilizer",
-      "title": "Orbit-Stabilizer Analysis",
+      "id": "part7-signfactor",
+      "title": "Part 7: Nonzero Count Determines Sign Factor",
+      "startLine": 260,
+      "endLine": 278,
+      "summary": "signFactor = 1,2,4,8,16 for nonzeroCount = 0,1,2,3,4 respectively."
+    },
+    {
+      "id": "part8-zero-pattern",
+      "title": "Part 8: Sorted Tuple Determines Zero Pattern",
+      "startLine": 279,
+      "endLine": 291,
+      "summary": "In a sorted type, a3=0 forces a1=a2=0 and a2=0 forces a1=0 (zeros propagate left)."
+    },
+    {
+      "id": "part9-extended-verification",
+      "title": "Part 9: Extended Type Count and Contribution Verification",
+      "startLine": 292,
+      "endLine": 312,
+      "summary": "Further native_decide checks of typeCount and totalFromEnum for n up to 25."
+    },
+    {
+      "id": "part10-extremal",
+      "title": "Part 10: Extremal Types",
+      "startLine": 313,
+      "endLine": 327,
+      "summary": "The all-distinct type (1,2,3,4) for n=30 attains the maximal contribution 384, with symmetry ratio 384/16 = 24 = 4!."
+    },
+    {
+      "id": "part11-perfect-square",
+      "title": "Part 11: Perfect Square Analysis",
+      "startLine": 328,
+      "endLine": 338,
+      "summary": "Non-trivial contributions (totalFromEnum minus the trivial type) for perfect squares n = 4, 9, 16."
+    },
+    {
+      "id": "part12-all-equal",
+      "title": "Part 12: General All-Equal Type (k,k,k,k) Theorem",
+      "startLine": 339,
+      "endLine": 379,
+      "summary": "allEqualType (k,k,k,k) with the general theorem contribution = 16 for all k>0 (nonzeroCount 4, signFactor 16, permutations 1)."
+    },
+    {
+      "id": "part13-three-equal",
+      "title": "Part 13: General Three-Equal Type (0,k,k,k) Theorem",
+      "startLine": 380,
+      "endLine": 413,
+      "summary": "threeEqualType (0,k,k,k) with the general theorem contribution = 32 for all k>0 (signFactor 8, permutations 4)."
+    },
+    {
+      "id": "part14-two-pair",
+      "title": "Part 14: General Two-Pair Type (a,a,b,b) Theorem",
+      "startLine": 414,
+      "endLine": 453,
+      "summary": "twoPairType (a,a,b,b), 0<a<b, with the general theorem contribution = 96 (signFactor 16, permutations 6)."
+    },
+    {
+      "id": "part15-two-equal",
+      "title": "Part 15: General Two-Equal Type (0,0,k,k) Theorem",
+      "startLine": 454,
+      "endLine": 484,
+      "summary": "twoEqualType (0,0,k,k) with the general theorem contribution = 24 for all k>0 (signFactor 4, permutations 6)."
+    },
+    {
+      "id": "part16-two-nonzero-distinct",
+      "title": "Part 16: General Two-Nonzero-Distinct Type (0,0,a,b) Theorem",
+      "startLine": 485,
+      "endLine": 521,
+      "summary": "twoNonzeroDistinct (0,0,a,b), 0<a<b, with the general theorem contribution = 48 (signFactor 4, permutations 12)."
+    },
+    {
+      "id": "part17-nonzero-lower-bound",
+      "title": "Part 17: Nonzero Count Lower Bound",
+      "startLine": 522,
+      "endLine": 555,
+      "summary": "For n>0: largest entry a4>0, nonzeroCount>=1, signFactor>=1, and signFactor>=2."
+    },
+    {
+      "id": "part18-contribution-table",
+      "title": "Part 18: Complete Contribution Table",
+      "startLine": 556,
+      "endLine": 587,
+      "summary": "Tabulates every multiplicity pattern x nonzero-count combination with worked native_decide witnesses; the contribution value set is {1,8,16,24,32,48,64,96,192,384}."
+    },
+    {
+      "id": "part19-orbit-stabilizer",
+      "title": "Part 19: Orbit-Stabilizer Analysis",
       "startLine": 588,
       "endLine": 616,
-      "summary": "Proves orbit_stabilizer theorems for all 6 type families: 384/(trivialType k).contribution=48, 384/(allEqualType k).contribution=24, 384/(threeEqualType k).contribution=12, 384/(twoPairType).contribution=4, 384/(twoEqualType k).contribution=16, 384/(twoNonzeroDistinct).contribution=8. stabilizer_product_trivial: 48=3!×2³; stabilizer_product_allEqual: 24=4!. symmetry_ratio: 384/16=24=4!."
+      "summary": "Full symmetry group |S4|*2^4 = 384; each type's stabilizer size computed as 384/contribution for all six general families."
     },
     {
-      "id": "sec-perfect-squares",
-      "title": "Perfect Square Analysis",
-      "startLine": 329,
-      "endLine": 340,
-      "summary": "For perfect squares n = k², analyzes the nontrivial contribution (total minus the trivial type): for n=4: 24-8=16 (from allEqualType); for n=9: 104-8=96 (nontrivial types); for n=16: 24-8=16 (allEqualType). These numerical checks verify the interplay between trivial and nontrivial type contributions to the known r₄(n) values."
-    },
-    {
-      "id": "sec-nonzero-bounds",
-      "title": "Nonzero Count Lower Bounds for n > 0",
-      "startLine": 523,
-      "endLine": 556,
-      "summary": "a₄_pos_of_n_pos, nonzeroCount_pos_of_n_pos, signFactor_ge_two_of_n_pos. For any n>0, the sorted tuple has at least one nonzero entry (the largest), giving sign factor ≥ 2. Proved by contradiction using the sum constraint sum_eq."
-    },
-    {
-      "id": "sec-summary",
-      "title": "Proof Summary and Mathematical Insights",
+      "id": "summary",
+      "title": "Summary",
       "startLine": 617,
       "endLine": 651,
-      "summary": "Summary table of 12 theorem categories (general theorems, multinomial theory, type enumeration, verification, structural bounds, sign factor theory, zero pattern theory, symmetry analysis, perfect squares, contribution table, orbit-stabilizer). 10 key mathematical insights enumerated."
+      "summary": "Tabulated recap of all results (0 axioms, 0 sorries) and key insights: per-family constant contributions, the contribution value set, orbit-stabilizer structure, and the 24:1 symmetry ratio."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
The gallery `sections` array for **lagrange-four-squares-oq-02** was scrambled, overlapping, and non-monotonic. The entries ran:

`1-115`, `116-165`, then jumped back to `236-295`, then `163-540` (overlapping the prior two), `540-590`, `588-616`, back to `329-340`, back to `523-556`, then `617-651`.

These out-of-order ranges mis-mapped the gallery to the wrong source lines. The Lean file `Proofs/LagrangeFourSquaresOQ02.lean` has a clean structure of a header + **19 numbered Parts** + Summary.

Rebuilt all 21 sections, one per `## Part N` banner, with monotonic full **1-651** coverage.

## Verification
Counts already matched the source (no change needed):
- theoremCount = 105 ✓
- definitionCount = 17 ✓
- axiomCount = 0 ✓
- sorryCount = 0 ✓
- lineCount = 651 ✓

Metadata-only change (no Lean source touched). Part of the lagrange-four-squares family scan (companions #23479, #23480).

🤖 Generated with [Claude Code](https://claude.com/claude-code)