### PR TITLE
research(lagrange-four-squares-oq-04): extend Section VI + add Verification (6->7)

### DIFF
--- a/src/data/proofs/lagrange-four-squares-oq-04/meta.json
+++ b/src/data/proofs/lagrange-four-squares-oq-04/meta.json
@@ -103,9 +103,16 @@
       "id": "corollaries",
       "title": "Section VI: Corollaries and Examples",
       "startLine": 162,
-      "endLine": 210,
+      "endLine": 213,
       "summary": "Derives consequences: three_sq_of_not_7_mod_8, three_sq_1_mod_8, three_or_four_squares (every n is sum of 3 or 4 squares). Concrete examples: 7, 15, 28, 112 need four squares.",
       "mathContext": "Examples: $7 = 4^0(8 \\cdot 0 + 7)$, $28 = 4^1(8 \\cdot 0 + 7)$, $112 = 4^2(8 \\cdot 0 + 7)$."
+    },
+    {
+      "id": "verification",
+      "title": "Verification",
+      "startLine": 214,
+      "endLine": 226,
+      "summary": "#check exports for the key lemmas: sq_mod_8, three_sq_not_7_mod_8, four_dvd_three_sq, obstructed_not_three_squares, not_obstructed_is_three_squares, and legendre_three_squares'."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Two small section gaps in **lagrange-four-squares-oq-04** vs `Proofs/LagrangeFourSquaresOQ04.lean`:

- Section VI ("Corollaries") ended at line 210, cutting off its last two worked examples (lines 212-213).
- The trailing **Verification** block (lines 214-226, the `#check` exports) was uncovered.

Extended Section VI to line 213 and added the Verification section for full **30-226** coverage.

## Verification
Counts left unchanged and confirmed accurate:
- theoremCount = 11 ✓
- axiomCount = 3 — the documented dependency-chain count (1 axiom here + 2 in the imported `ThreeSquares.lean`); `leanFile.axiomCount = 1` correctly reflects this file's own count. ✓
- sorryCount = 0 ✓, lineCount = 226 ✓

Metadata-only change. Completes the lagrange-four-squares family scan (#23479, #23480, #23483).

🤖 Generated with [Claude Code](https://claude.com/claude-code)