### PR TITLE
research(basel-oq-01-01-02): realign Apéry ζ(3) gallery sections to full file (10→13) + fix mislabeled Parts

### DIFF
--- a/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-01-oq-01-oq-02/meta.json
@@ -60,81 +60,105 @@
       "id": "module-header",
       "title": "Module Header and Proof Overview",
       "startLine": 1,
-      "endLine": 47,
+      "endLine": 49,
       "summary": "Imports, module docstring explaining the Apéry sequence strategy, status summary (5 axioms, 0 sorries), and opens/namespace.",
       "mathContext": "The module documents the proof architecture: (1) construct bₙ, aₙ satisfying a common recurrence; (2) establish $|b_n\\zeta(3) - a_n| \\to 0$ geometrically; (3) show denominators of aₙ are bounded by lcm³ ~ e^{3n}; (4) integer-squeeze contradiction."
     },
     {
       "id": "zeta-infrastructure",
       "title": "Part I: Zeta Value Infrastructure",
-      "startLine": 48,
-      "endLine": 68,
+      "startLine": 50,
+      "endLine": 71,
       "summary": "Defines zetaValue(s) = ∑ 1/n^s via tsum, proves summability for s ≥ 2 and positivity ζ(s) > 0.",
       "mathContext": "$\\zeta(s) = \\sum_{n=1}^{\\infty} 1/n^s$ converges for $s > 1$ by the p-series test. For the Apéry proof, the target is $\\zeta(3) \\approx 1.202$."
     },
     {
       "id": "apery-sequence",
       "title": "Part II: The Apéry b-Sequence",
-      "startLine": 69,
-      "endLine": 109,
+      "startLine": 72,
+      "endLine": 107,
       "summary": "Defines bₙ = ∑ C(n,k)²C(n+k,k)² as a computable ℕ-valued function. Verifies b₀=1, b₁=5, b₂=73, b₃=1445. Proves all Apéry numbers are positive.",
       "mathContext": "$b_n = \\sum_{k=0}^{n} \\binom{n}{k}^2 \\binom{n+k}{k}^2$. These are OEIS A005259. The growth rate $b_n \\sim C(1+\\sqrt{2})^{4n}/n^{3/2}$ foreshadows the characteristic polynomial."
     },
     {
       "id": "recurrence",
       "title": "Part III: The Apéry Recurrence",
-      "startLine": 110,
-      "endLine": 155,
+      "startLine": 108,
+      "endLine": 152,
       "summary": "Defines aperyRecCoeff(n) = (2n+1)(17n²+17n+5). Axiomatizes the 3-term recurrence. Verifies n=1,2 numerically. Proves the coefficient bound aperyRecCoeff(n) ≤ 34·(n+1)³.",
       "mathContext": "$(n+1)^3 b_{n+1} = (2n+1)(17n^2+17n+5) b_n - n^3 b_{n-1}$. The characteristic polynomial $t^2 - 34t + 1$ has roots $(1\\pm\\sqrt{2})^4 \\approx 33.97$ and $0.029$."
     },
     {
       "id": "growth-estimates",
       "title": "Part IV: Growth Bound for bₙ",
-      "startLine": 156,
-      "endLine": 234,
+      "startLine": 153,
+      "endLine": 233,
       "summary": "Proves bₙ ≤ 34^n by induction using the step bound aperyB_le_34_mul_pred. States the characteristic polynomial discriminant.",
       "mathContext": "Step: $(n+1)^3 b_{n+1} \\leq \\text{coeff}(n) \\cdot b_n \\leq 34(n+1)^3 b_n$, cancel $(n+1)^3 > 0$, giving $b_{n+1} \\leq 34 b_n$. Induction gives $b_n \\leq 34^n$."
     },
     {
       "id": "a-sequence-and-infrastructure",
       "title": "Parts V–IX: a-Sequence, Harmonic Numbers, LCM, Linear Form",
-      "startLine": 235,
-      "endLine": 395,
+      "startLine": 234,
+      "endLine": 388,
       "summary": "Defines aperyA (a₀=0, a₁=6, a₂=351/4 via recurrence), harmonic numbers H_n = ∑ 1/k, generalized harmonics, lcmUpTo (with positivity, monotonicity, concrete values), and the real linear form Lₙ = bₙ·ζ(3) - aₙ. Axiomatizes denominator_control.",
       "mathContext": "$a_n$ satisfies the same recurrence as $b_n$ with $a_0=0, a_1=6$. The denominator control axiom: $\\text{lcm}(1,\\ldots,n)^3 \\cdot a_n \\in \\mathbb{Z}$. This is the key arithmetic fact making the integer-squeeze work."
     },
     {
       "id": "divisibility-and-conditional",
       "title": "Parts X–XII: Divisibility Infrastructure and Conditional Theorem",
-      "startLine": 396,
-      "endLine": 579,
+      "startLine": 389,
+      "endLine": 576,
       "summary": "Proves dvd_lcmUpTo, rat_den_dvd_lcmUpTo, apery_bterm_int (integrality of lcm³·bₙ·r). Core theorem: apery_irrationality_conditional — IF decay+nonzero+denominator THEN ζ(3) irrational. Full integer-squeeze argument formalized.",
       "mathContext": "Integer-squeeze: if $\\zeta(3) = r \\in \\mathbb{Q}$, then $\\text{lcm}(1,\\ldots,N)^3 \\cdot L_N$ is a nonzero integer (by divisibility) of absolute value $\\geq 1$, but $< 1$ by the decay bound — contradiction."
     },
     {
       "id": "main-theorem",
       "title": "Part XIII: Quantitative Bounds and Main Theorem",
-      "startLine": 580,
-      "endLine": 665,
+      "startLine": 577,
+      "endLine": 660,
       "summary": "Proves apery_decay_rate_pos (0 < 17-12√2), apery_product_lt_one (27·(17-12√2) < 1). Axiomatizes Hanson's bound (lcm ≤ 3^n), linearForm decay and nonzero. Proves apery_theorem (ζ(3) irrational) by combining all components.",
       "mathContext": "Key inequality: $27 \\cdot (17-12\\sqrt{2}) < 1$ ensures the product $(\\text{lcm}(1,\\ldots,n)/3^n)^3 \\cdot |L_n| \\to 0$. This is the threshold: $3^3 = 27$ just fits under $1/(17-12\\sqrt{2}) \\approx 34$."
     },
     {
-      "id": "factorial-denominator",
-      "title": "Part XIV: Factorial Denominator Control (Axiom-Free)",
-      "startLine": 666,
-      "endLine": 760,
-      "summary": "Proves denominator_control_factorial: (n!)³·aₙ ∈ ℤ for all n, entirely without axioms. Induction on the recurrence using factorial identity (n+2)! = (n+2)·(n+1)!. Also proves lcmUpTo_dvd_of_le, lcmUpTo_three = 6, lcmUpTo_four = 12.",
-      "mathContext": "$(n!)^3 \\cdot a_n \\in \\mathbb{Z}$ proved by induction: base cases $a_0=0$, $a_1=6$; step uses the recurrence to reduce to $((n+1)!)^3 \\cdot a_{n+1}$ and $((n!)^3) \\cdot a_n$, both integral by inductive hypothesis. Weaker than `denominator_control` (LCM $\\leq$ $n!$) but completely proved."
+      "id": "lower-bound-concrete",
+      "title": "Part XV: Lower Bound ζ(3) > 6/5 and Concrete L₁ > 0",
+      "startLine": 661,
+      "endLine": 688,
+      "summary": "Proves zetaValue_three_gt_6_5 (ζ(3) > 6/5) from the 16-term partial sum S₁₆ > 6/5 (norm_num), bounded below the full series via sum_le_hasSum. Then proves linearForm_one_pos (L₁ = 5ζ(3) − 6 > 0) as a concrete axiom-free instance of the nonzero property for n=1.",
+      "mathContext": "$\\sum_{n=1}^{16} 1/n^3 > 6/5$ by direct computation; partial sums bound $\\zeta(3)$ from below, so $\\zeta(3) > 6/5$ and $L_1 = 5\\zeta(3) - 6 > 0$."
     },
     {
-      "id": "lower-bound",
-      "title": "Part XV: Lower Bound ζ(3) > 6/5 and Concrete L₁ > 0",
-      "startLine": 761,
-      "endLine": 791,
-      "summary": "Proves zetaValue_three_gt_6_5 (ζ(3) > 6/5) via a 16-term partial sum computed by norm_num. Then proves linearForm_one_pos (L₁ = 5ζ(3) - 6 > 0) as a concrete axiom-free instance of the nonzero property.",
-      "mathContext": "$\\sum_{n=1}^{16} 1/n^3 > 6/5$ by direct computation (`norm_num`). Since $\\zeta(3) \\geq \\sum_{n=1}^{16} 1/n^3$ (partial sums bound the series from below by `sum_le_tsum`), we get $\\zeta(3) > 6/5$. Then $L_1 = 5\\zeta(3) - 6 > 5 \\cdot 6/5 - 6 = 0$."
+      "id": "tail-lower-bound",
+      "title": "Part XVI: Tail Lower Bound — ζ(3) ≥ S_N + 1/(2N²)",
+      "startLine": 689,
+      "endLine": 767,
+      "summary": "Proves the quantitative lower bound zetaValue_three_tail_lb: for N ≥ 1, S_N + 1/(2N²) ≤ ζ(3). Uses the telescoping inequality cube_inv_ge_telescoping' (1/(2x²) − 1/(2(x+1)²) ≤ 1/x³) and telescope_sum_eq applied to the shifted tail series.",
+      "mathContext": "The tail $\\sum_{k\\ge N} 1/k^3 \\ge \\sum_{k\\ge N}[1/(2k^2) - 1/(2(k+1)^2)] = 1/(2N^2)$, giving $\\zeta(3) = S_N + \\text{tail} \\ge S_N + 1/(2N^2)$."
+    },
+    {
+      "id": "tail-upper-bound",
+      "title": "Part XVII: Tail Upper Bound — ζ(3) ≤ S_{N+1} + 1/(2N²)",
+      "startLine": 768,
+      "endLine": 823,
+      "summary": "Proves the matching quantitative upper bound zetaValue_three_tail_ub via cube_succ_inv_le_telescoping (1/(x+1)³ ≤ 1/(2x²) − 1/(2(x+1)²)). Together with Part XVI this brackets ζ(3) to width ~1/N², enabling certified rational approximations.",
+      "mathContext": "$\\zeta(3) \\le S_{N+1} + 1/(2N^2)$; combined with the Part XVI lower bound, $\\zeta(3)$ is pinned between two computable rationals differing by $O(1/N^2)$."
+    },
+    {
+      "id": "concrete-base-case-two",
+      "title": "Part XVIII: Second Concrete Nonzero Base Case (L₂ > 0)",
+      "startLine": 824,
+      "endLine": 854,
+      "summary": "Proves linearForm_two_pos (L₂ = 73ζ(3) − 351/4 > 0), equivalently ζ(3) > 351/292, by evaluating the Part XVI lower bound at N=100 with a native_decide rational computation cast to ℝ.",
+      "mathContext": "$L_2 > 0 \\iff \\zeta(3) > 351/292 \\approx 1.20205$; verified from $S_{100} + 1/(2\\cdot100^2) > 351/292$ via native_decide over ℚ."
+    },
+    {
+      "id": "factorial-denominator",
+      "title": "Part XIX: Factorial Denominator Control (Axiom-Free) & Linear Form Base Cases",
+      "startLine": 855,
+      "endLine": 952,
+      "summary": "Proves aperyA_three (a₃ = 62531/36), the recurrence aperyA_factorial_step, and denominator_control_factorial: (n!)³·aₙ ∈ ℤ for all n by 2-step induction, entirely axiom-free (a weaker form of the lcm-based denominator_control). Closes with linearForm_three_pos (L₃ = 1445ζ(3) − 62531/36 > 0, gap ≈ 3×10⁻⁸) verified from the tail bound at N=1000.",
+      "mathContext": "$(n!)^3 a_n \\in \\mathbb{Z}$ by induction on the Apéry recurrence; since $n! \\sim (n/e)^n$ grows faster than $\\mathrm{lcm}(1,\\ldots,n)\\sim e^n$, factorial integrality is easier to prove than the lcm version. $L_3 > 0 \\iff \\zeta(3) > 62531/52020$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery-integrity fix for `basel-problem-oq-01-oq-01-oq-02` (Apéry's proof of ζ(3) irrationality).

`BaselProblemOQ01OQ01OQ02.lean` has grown to **952 lines** with `Part I–XIX` banners (the author's numbering skips Part XIV). The 10 meta sections were pinned to an old layout, maxing out at line **791** (mid–Part XVII). Consequences:
- **Hidden tail**: Parts XVIII–XIX (~130 lines) — `linearForm_two_pos`, `aperyA_three`, `aperyA_factorial_step`, `denominator_control_factorial`, `linearForm_three_pos` — were not rendered.
- **Mislabeled sections**:
  - "Part XIV: Factorial Denominator Control" (666–760): the file has no Part XIV; factorial denominator control is **Part XIX** (L855). Its summary also wrongly attributed `lcmUpTo_three/four/dvd_of_le` to the tail — those are in **Part VIII** (L355–365), already covered by the "Parts V–IX" section.
  - "Part XV: Lower Bound" (761–791): actually **Part XVII** content.

### Changes (metadata only — no Lean edits)
- Re-pinned all 8 front sections (module-header, Parts I–IV, V–IX, X–XII, XIII) to their actual banner ranges.
- Replaced the 2 mislabeled tail sections with **5 accurate sections** mapped to the file's Parts XV, XVI, XVII, XVIII, XIX.
- Full-file coverage restored: maxEndLine 791 → **952**, **gap 0**; 13 sections, unique ids, monotonic, no overlaps.

## Test plan
- [x] `json.load` validates meta.json (13 sections)
- [x] Coverage: maxEndLine == file length (952); monotonic; no overlaps; unique ids
- [x] Verified each new section's line range against the source `Part` banners and declarations
- [x] Counts/status unchanged and accurate (52 thm / 9 def / 5 axiom / 0 sorry; axiomatized/axiom)
- [ ] No Lean rebuild required (metadata only; Docker is down)

## Status
**Outcome**: progress (gallery-integrity fix — Parts XVIII–XIX were hidden and two sections were mislabeled)
**Next Steps**: `basel-problem-oq-02` also shows a section gap (~71 lines) — candidate for a follow-up pass.

🤖 Generated by researcher-4