### PR TITLE
research(erdos-106-oq-02): realign stale gallery sections to full-file coverage (5→13)

### DIFF
--- a/src/data/proofs/erdos-106-oq-02/meta.json
+++ b/src/data/proofs/erdos-106-oq-02/meta.json
@@ -53,41 +53,105 @@
       "id": "rotated-squares",
       "title": "Rotated Squares in the Plane",
       "startLine": 1,
-      "endLine": 65,
-      "summary": "Defines RotatedSquare structure with center, side, angle; interior and closure via inverse rotation; DisjointInteriors predicate; axis-parallel constructor as angle=0 special case.",
-      "mathContext": "RotatedSquare: center $(c_x, c_y)$, side $s > 0$, angle $\\theta$. Point $p$ in interior iff rotating $p - c$ by $-\\theta$ lands in $(-s/2, s/2)^2$."
+      "endLine": 61,
+      "summary": "Defines the RotatedSquare structure (center, side length, angle), its interior and closure via inverse rotation into the axis-parallel frame, and the DisjointInteriors predicate.",
+      "mathContext": "RotatedSquare: center $(c_x, c_y)$, side $s > 0$, angle $\\theta$. Point $p$ lies in the interior iff rotating $p - c$ by $-\\theta$ lands in $(-s/2, s/2)^2$; the closure replaces strict with non-strict inequalities."
+    },
+    {
+      "id": "axis-parallel-containment",
+      "title": "Axis-Parallel Squares and Unit-Square Containment",
+      "startLine": 62,
+      "endLine": 82,
+      "summary": "Constructs an axis-parallel square as the angle = 0 special case, defines the unit square [0,1]², and the ContainedInUnit predicate (closure ⊆ unit square).",
+      "mathContext": "axisParallel: a RotatedSquare with $\\theta = 0$. $\\text{unitSquare}' = [0,1]^2$; a square is contained in the unit square iff its closure is a subset."
     },
     {
       "id": "packings",
       "title": "General and Axis-Parallel Packings",
-      "startLine": 66,
-      "endLine": 110,
-      "summary": "Defines GeneralPacking (allows rotation) and AxisParallelPacking (angle=0 restriction), both as Fin n-indexed families with containment and disjointness. Defines objective functions f_rot and g_ap as suprema.",
-      "mathContext": "GeneralPacking: $(S_i)_{i=1}^n$ rotated squares with $\\overline{S_i} \\subseteq [0,1]^2$, pairwise disjoint interiors. $f_{\\text{rot}}(n) = \\sup_P \\sum s_i$."
+      "startLine": 83,
+      "endLine": 108,
+      "summary": "Defines GeneralPacking (n possibly-rotated, contained, pairwise-disjoint squares) and AxisParallelPacking (the angle = 0 restriction extending GeneralPacking), each with a sumSides objective.",
+      "mathContext": "A packing is a family $\\{s_i\\}_{i \\in \\text{Fin } n}$ with $s_i$ contained in $[0,1]^2$ and pairwise disjoint interiors. $\\text{sumSides} = \\sum_i (s_i).\\text{side}$."
     },
     {
-      "id": "relationship",
+      "id": "objective-functions",
+      "title": "The Objective Functions f_rot and g",
+      "startLine": 109,
+      "endLine": 120,
+      "summary": "Defines f_rot(n) and g(n) as the suprema of achievable side-length sums over general (rotation-allowed) and axis-parallel packings respectively.",
+      "mathContext": "$f_{\\text{rot}}(n) = \\sup\\{\\,s : \\exists P \\in \\text{GeneralPacking}(n),\\ P.\\text{sumSides} = s\\,\\}$ and $g(n)$ the same over axis-parallel packings."
+    },
+    {
+      "id": "g-le-frot",
       "title": "Relationship: g(n) ≤ f_rot(n)",
-      "startLine": 111,
-      "endLine": 130,
-      "summary": "Proves that every axis-parallel packing is a general packing, so the achievable sums for g are a subset of those for f_rot.",
-      "mathContext": "$g(n) \\leq f_{\\text{rot}}(n)$ since axis-parallel packings are a special case of general packings."
+      "startLine": 121,
+      "endLine": 139,
+      "summary": "Proves every axis-parallel packing is a general packing, so the achievable-sum set for g is a subset of that for f_rot, giving g(n) ≤ f_rot(n).",
+      "mathContext": "AxisParallelPacking extends GeneralPacking, so $\\{s : \\exists P_{\\text{ap}}\\} \\subseteq \\{s : \\exists P_{\\text{gen}}\\}$, hence $g(n) \\le f_{\\text{rot}}(n)$."
     },
     {
-      "id": "bounds",
-      "title": "Area Bounds and Monotonicity",
-      "startLine": 131,
-      "endLine": 165,
-      "summary": "Axiomatizes the Cauchy-Schwarz bound f_rot(n) ≤ √n (rotation preserves area), monotonicity, and values at perfect squares.",
-      "mathContext": "Rotation preserves area: $s^2$ per square. Cauchy-Schwarz: $(\\sum s_i)^2 \\leq n \\cdot \\sum s_i^2 \\leq n$, so $f_{\\text{rot}}(n) \\leq \\sqrt{n}$."
+      "id": "area-bound-axioms",
+      "title": "Area Bound Axioms: f_rot(n) ≤ √n",
+      "startLine": 140,
+      "endLine": 157,
+      "summary": "States the three remaining axioms: rotation preserves area (vol = side²), the Cauchy-Schwarz area bound f_rot(n) ≤ √n, and monotonicity of f_rot.",
+      "mathContext": "Rotation preserves area, so $\\sum s_i^2 \\le 1$; Cauchy-Schwarz gives $(\\sum s_i)^2 \\le n \\sum s_i^2 \\le n$, hence $f_{\\text{rot}}(n) \\le \\sqrt n$. f_rot is monotone in $n$."
+    },
+    {
+      "id": "axiom-elimination",
+      "title": "Axiom Elimination: Containment Geometry and Provable Bounds",
+      "startLine": 158,
+      "endLine": 506,
+      "summary": "The section AxiomElimination proves (previously axiomatized) facts directly: edge-midpoint closure membership, the side·|cos θ| ≤ 1 and side·|sin θ| ≤ 1 bounds, side ≤ √2, boundedness/nonemptiness of the achievable sets, g(n) ≤ f_rot(n), g(n) ≤ √n, and the perfect-square values g(k²) = k and f_rot(k²) = k via the k×k grid.",
+      "mathContext": "For a contained square, $s|\\cos\\theta| \\le 1$ and $s|\\sin\\theta| \\le 1$, so $s \\le \\sqrt2$. The $k\\times k$ grid of unit/k squares realizes $g(k^2) = k$, and $f_{\\text{rot}}(k^2) = k$ follows from $g(k^2) \\le f_{\\text{rot}}(k^2) \\le \\sqrt{k^2}$."
+    },
+    {
+      "id": "bku-derived",
+      "title": "BKU Theorem and Derived Bounds at k²+1",
+      "startLine": 507,
+      "endLine": 538,
+      "summary": "States the BKU (2024) axis-parallel result g(k²+1) = k as an axiom, then derives f_rot's upper bound √n, the lower bound f_rot(k²+1) ≥ k, and the upper bound f_rot(k²+1) ≤ √(k²+1).",
+      "mathContext": "BKU: $g(k^2+1) = k$. Monotonicity gives $f_{\\text{rot}}(k^2+1) \\ge f_{\\text{rot}}(k^2) = k$, while the area bound gives $f_{\\text{rot}}(k^2+1) \\le \\sqrt{k^2+1}$."
     },
     {
       "id": "open-question",
-      "title": "The Open Question: Does Rotation Help?",
-      "startLine": 166,
-      "endLine": 219,
-      "summary": "States rotationHelps (∃ n, f_rot(n) > g(n)) and rotationNeverHelps (∀ n, f_rot(n) = g(n)). Proves agreement at perfect squares, at n=2, and that rotation_never_helps + BKU → general Erdős conjecture.",
-      "mathContext": "Open: $\\exists n, f_{\\text{rot}}(n) > g(n)$? No known example. If no, then $f(k^2+1) = k$ by BKU."
+      "title": "The Main Open Question",
+      "startLine": 539,
+      "endLine": 564,
+      "summary": "Formalizes the open question via rotationHelps (∃ n, f_rot(n) > g(n)), axisParallelSuboptimal (witness n ≥ 2), and rotationNeverHelps (∀ n, f_rot(n) = g(n)); proves that rotationNeverHelps reduces the general case to BKU.",
+      "mathContext": "Open: $\\exists n,\\ f_{\\text{rot}}(n) > g(n)$? No example is known. If rotation never helps, then $f_{\\text{rot}}(k^2+1) = g(k^2+1) = k$ by BKU."
+    },
+    {
+      "id": "erdos-equivalence",
+      "title": "Equivalence with the General Erdős Conjecture",
+      "startLine": 565,
+      "endLine": 593,
+      "summary": "Defines the general Erdős conjecture f_rot(k²+1) = k and proves rotationNeverHelps + BKU imply it; proves agreement of f_rot and g at n = 1 and at all perfect squares.",
+      "mathContext": "$\\text{erdos106GeneralConjecture}: \\forall k \\ge 1,\\ f_{\\text{rot}}(k^2+1) = k$. Follows from rotationNeverHelps and BKU. Also $f_{\\text{rot}}(k^2) = g(k^2) = k$ for all $k \\ge 1$."
+    },
+    {
+      "id": "structural-observations",
+      "title": "Structural Observations",
+      "startLine": 594,
+      "endLine": 617,
+      "summary": "Observes that if rotation ever helps it cannot be at a perfect square (since the functions agree there), and proves f_rot(2) = g(2) = 1, extending Erdős's original two-square argument to rotated squares.",
+      "mathContext": "Rotation cannot help at $k^2$ since $f_{\\text{rot}}(k^2) = g(k^2)$. At $n=2$, axiom $f_{\\text{rot}}(2) = 1$ combined with $g(2) = g(1^2+1) = 1$ gives agreement."
+    },
+    {
+      "id": "boundary-cases",
+      "title": "Boundary Cases: n = 0 and the Dichotomy",
+      "startLine": 618,
+      "endLine": 701,
+      "summary": "Builds the empty packings of 0 squares to prove f_rot(0) = g(0) = 0 unconditionally, then proves the dichotomy rotationHelps ↔ ¬rotationNeverHelps and that the 'witness n ≥ 2' form is equivalent to the unrestricted form (rotation cannot help at n ∈ {0,1}).",
+      "mathContext": "The empty packing gives achievable-sum singleton $\\{0\\}$, so $f_{\\text{rot}}(0) = g(0) = 0$. Combined with agreement at $n \\in \\{0,1\\}$, axisParallelSuboptimal $\\leftrightarrow$ rotationHelps."
+    },
+    {
+      "id": "tight-bounds-k2-plus-1",
+      "title": "Tight Bounds at k²+1: Rotation Benefit in [0, 1)",
+      "startLine": 702,
+      "endLine": 749,
+      "summary": "Proves √(k²+1) < k+1, hence f_rot(k²+1) ∈ [k, k+1), and concludes the rotation benefit f_rot(k²+1) − g(k²+1) lies in [0, 1): rotation can improve on the axis-parallel value but never by a full unit.",
+      "mathContext": "$(k+1)^2 = k^2+2k+1 > k^2+1$ gives $\\sqrt{k^2+1} < k+1$, so $f_{\\text{rot}}(k^2+1) \\in [k, k+1)$ and the benefit $f_{\\text{rot}}(k^2+1) - g(k^2+1) \\in [0,1)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The gallery meta for `erdos-106-oq-02` listed **5 sections covering only lines 1–219** of the 749-line `Erdos106OQ02.lean`, hiding **71%** of the source (axiom-elimination proofs, BKU/derived bounds, the open-question formalization, structural observations, boundary cases, and the tight rotation-benefit bounds).
- The 5th section was also **mislabeled**: "The Open Question" pointed at the closure-membership lemmas at 166–219, not the actual open-question definitions at line 539.
- Rebuilt the `sections` array to **13 entries** aligned to the file's `## ` docstring banners and the §-banner, covering all 749 lines.

## What did NOT change
- Source `.lean` file is untouched.
- All counts verified still accurate and unchanged: `theoremCount` 39, `axiomCount` 5, `sorries` 0, `lineCount` 749.
- All non-`sections` meta content is byte-identical to `HEAD`.

## Test plan
- [x] `node` JSON parse of meta.json succeeds
- [x] Sections cover lines 1–749 with no gaps
- [x] Diff touches only the `sections` array