### PR TITLE
research(basel-oq-02): rebuild gallery sections to full file (12→10, fix out-of-order/overlap + hidden tail)

### DIFF
--- a/src/data/proofs/basel-problem-oq-02/meta.json
+++ b/src/data/proofs/basel-problem-oq-02/meta.json
@@ -81,100 +81,84 @@
   },
   "sections": [
     {
-      "id": "zeta-definition",
-      "title": "Zeta Values at Natural Numbers",
-      "startLine": 30,
-      "endLine": 36,
-      "summary": "Definition of zetaValue(s) = ∑ 1/n^s as a tsum over ℕ.",
-      "mathContext": "$\\zeta(s) = \\sum_{n=1}^{\\infty} \\frac{1}{n^s}$ for $s > 1$. Defined via `tsum` (topological sum) in Lean, converging absolutely for $s \\geq 2$. Euler computed $\\zeta(2k) = (-1)^{k+1} B_{2k} (2\\pi)^{2k} / (2(2k)!)$ where $B_{2k}$ are Bernoulli numbers."
+      "id": "zeta-values-natural",
+      "title": "Part 1: Zeta Values at Natural Numbers",
+      "startLine": 39,
+      "endLine": 46,
+      "summary": "Defines zetaValue(s) = ∑' 1/nˢ and proves summable_zetaValue (convergence for s ≥ 2).",
+      "mathContext": "$\\zeta(s) = \\sum_{n\\ge 1} 1/n^s$, convergent for $s \\ge 2$."
     },
     {
-      "id": "even-closed-forms",
-      "title": "Known Even Zeta Values",
-      "startLine": 38,
-      "endLine": 46,
-      "summary": "ζ(2) = π²/6 and ζ(4) = π⁴/90 proved directly from Mathlib.",
-      "mathContext": "$\\zeta(2) = \\pi^2/6$ (Basel problem, Euler 1734) and $\\zeta(4) = \\pi^4/90$. Both are instances of Euler's general formula $\\zeta(2k) = (-1)^{k+1} B_{2k} (2\\pi)^{2k}/(2(2k)!)$. The closed forms involve $\\pi^{2k}$, making even zeta values transcendental — in stark contrast to odd zeta values where no closed form is known."
+      "id": "zetavalue-infrastructure",
+      "title": "Part 2: General zetaValue Infrastructure",
+      "startLine": 47,
+      "endLine": 79,
+      "summary": "Basic positivity and nonvanishing facts: zetaValue_term_nonneg, zetaValue_ge_one, zetaValue_pos, zetaValue_ne_zero for s ≥ 2.",
+      "mathContext": "For $s \\ge 2$, $\\zeta(s) \\ge 1 > 0$, hence $\\zeta(s) \\neq 0$."
+    },
+    {
+      "id": "known-even-zeta",
+      "title": "Part 3: Known Even Zeta Values",
+      "startLine": 80,
+      "endLine": 91,
+      "summary": "Closed forms zetaValue_two = π²/6 and zetaValue_four = π⁴/90, drawn from Mathlib's Bernoulli-number evaluations.",
+      "mathContext": "$\\zeta(2) = \\pi^2/6$ and $\\zeta(4) = \\pi^4/90$."
     },
     {
       "id": "deep-axioms",
-      "title": "Deep Axioms",
-      "startLine": 48,
-      "endLine": 59,
-      "summary": "Lindemann's theorem (π transcendental) and Apéry's theorem (ζ(3) irrational) axiomatized.",
-      "mathContext": "Two deep axioms: (1) $\\pi \\notin \\overline{\\mathbb{Q}}$ (Lindemann 1882) and (2) $\\zeta(3) \\notin \\mathbb{Q}$ (Apéry 1978). Lindemann proved $e^\\alpha$ is transcendental for nonzero algebraic $\\alpha$; since $e^{i\\pi} = -1$, this forces $\\pi$ transcendental. Apéry's proof used rapidly convergent series for $\\zeta(3)$ with carefully constructed rational approximations."
+      "title": "Part 4: Deep Axioms (Results Not Yet in Mathlib)",
+      "startLine": 92,
+      "endLine": 106,
+      "summary": "States the two deep external axioms: pi_transcendental (π transcendental over ℚ) and apery_theorem (ζ(3) irrational).",
+      "mathContext": "Lindemann (1882): $\\pi$ is transcendental. Apéry (1978): $\\zeta(3)$ is irrational. Both are inputs not yet available in Mathlib."
     },
     {
-      "id": "conjectures",
-      "title": "The Open Conjectures",
-      "startLine": 61,
-      "endLine": 75,
-      "summary": "Transcendence and irrationality conjectures for odd zeta values.",
-      "mathContext": "Two conjectures: (1) $\\zeta(2k+1) \\notin \\overline{\\mathbb{Q}}$ for all $k \\geq 1$ (transcendence), (2) $\\zeta(2k+1) \\notin \\mathbb{Q}$ for all $k \\geq 1$ (irrationality). The transcendence conjecture implies the irrationality conjecture. Neither has been proved for any single value beyond $\\zeta(3)$."
+      "id": "even-zeta-transcendence",
+      "title": "Part 5: Even Zeta Value Transcendence",
+      "startLine": 107,
+      "endLine": 178,
+      "summary": "Proves transcendental_pow_of_transcendental (helper comp_ne_zero_of_pos_natDegree) and derives zetaValue_two_transcendental and zetaValue_four_transcendental from pi_transcendental.",
+      "mathContext": "Since $\\pi$ is transcendental so is $\\pi^k$; thus $\\zeta(2)=\\pi^2/6$ and $\\zeta(4)=\\pi^4/90$ are transcendental."
     },
     {
-      "id": "structural-part1",
-      "title": "Basic Structural Relationships",
-      "startLine": 77,
-      "endLine": 96,
-      "summary": "Transcendence ⟹ irrationality, conjecture specializes to Apéry and ζ(3)∧ζ(5).",
-      "mathContext": "The logical chain: $\\alpha \\notin \\overline{\\mathbb{Q}} \\Rightarrow \\alpha \\notin \\mathbb{Q}$ (transcendence implies irrationality). Specializing the conjecture: $\\forall k \\geq 1,\\, \\zeta(2k+1) \\notin \\mathbb{Q}$ implies both Apéry's result ($\\zeta(3) \\notin \\mathbb{Q}$) and the conjecture that $\\zeta(5) \\notin \\mathbb{Q}$ — each as an individual corollary."
-    },
-    {
-      "id": "even-odd-contrast",
-      "title": "Even vs Odd Zeta Values",
-      "startLine": 98,
-      "endLine": 107,
-      "summary": "Definition of the rational multiple property for even zeta values.",
-      "mathContext": "Even zeta values satisfy $\\zeta(2k) = r_k \\cdot \\pi^{2k}$ with $r_k \\in \\mathbb{Q}^\\times$ (e.g., $r_1 = 1/6$, $r_2 = 1/90$). Odd zeta values have NO known analogous representation — this even/odd dichotomy is one of the deepest mysteries in analytic number theory."
-    },
-    {
-      "id": "even-transcendence",
-      "title": "Even Zeta Transcendence",
-      "startLine": 109,
-      "endLine": 128,
-      "summary": "ζ(2) and ζ(4) transcendence theorems, fully proved from Lindemann axiom via transcendental_pow_of_transcendental.",
-      "mathContext": "$\\pi \\notin \\overline{\\mathbb{Q}} \\Rightarrow \\pi^2 \\notin \\overline{\\mathbb{Q}} \\Rightarrow \\pi^2/6 \\notin \\overline{\\mathbb{Q}}$, i.e., $\\zeta(2)$ is transcendental. Similarly for $\\zeta(4) = \\pi^4/90$. The chain uses: (1) $\\alpha$ transcendental $\\Rightarrow \\alpha^n$ transcendental for $n \\geq 1$, (2) nonzero rational times transcendental is transcendental."
-    },
-    {
-      "id": "rivoal-zudilin",
-      "title": "Deep Results on Odd Zeta Irrationality",
-      "startLine": 221,
-      "endLine": 237,
-      "summary": "Axiomatizes Rivoal's theorem (infinitely many odd ζ irrational, Set.Infinite formulation) and Zudilin's theorem (one of ζ(5,7,9,11) irrational, 4-way disjunction).",
-      "mathContext": "Rivoal (2000): the set $\\{k \\geq 1 : \\zeta(2k+1) \\notin \\mathbb{Q}\\}$ is infinite — proved via very-well-poised hypergeometric series. Zudilin (2001): $\\zeta(5) \\notin \\mathbb{Q} \\lor \\zeta(7) \\notin \\mathbb{Q} \\lor \\zeta(9) \\notin \\mathbb{Q} \\lor \\zeta(11) \\notin \\mathbb{Q}$ — refined from Ball-Rivoal. Both axiomatized (deep results not in Mathlib)."
-    },
-    {
-      "id": "irrationality-landscape",
-      "title": "The Irrationality Landscape",
-      "startLine": 239,
-      "endLine": 277,
-      "summary": "Proved sorry-free: irrationality conjecture implies Rivoal and Zudilin; transcendence conjecture recovers all known results as corollaries.",
-      "mathContext": "The implication landscape: $\\forall k,\\, \\zeta(2k+1) \\notin \\mathbb{Q}$ implies Rivoal's 'infinitely many irrational' and Zudilin's 'one of $\\{\\zeta(5),\\zeta(7),\\zeta(9),\\zeta(11)\\}$ irrational'. The stronger transcendence conjecture $\\forall k,\\, \\zeta(2k+1) \\notin \\overline{\\mathbb{Q}}$ recovers ALL known results as corollaries — a strong consistency check."
-    },
-    {
-      "id": "odd-conjectures",
-      "title": "Odd Zeta Transcendence and Irrationality Conjectures",
-      "startLine": 186,
+      "id": "open-conjecture",
+      "title": "Part 6: The Open Conjecture",
+      "startLine": 179,
       "endLine": 196,
-      "summary": "Defines $\text{odd\\_zeta\\_transcendence\\_conjecture}$: all $\\zeta(2k+1)$ for $k \\geq 1$ are transcendental. Defines the weaker $\text{odd\\_zeta\\_irrationality\\_conjecture}$: all odd zeta values are irrational. Notes that no specific odd zeta value beyond $\\zeta(3)$ has been proved irrational.",
-      "mathContext": "Transcendence conjecture: $\\zeta(2k+1) \\in \\overline{\\mathbb{Q}}^c$ for all $k \\geq 1$. Irrationality conjecture: $\\zeta(2k+1) \notin \\mathbb{Q}$ for all $k \\geq 1$."
+      "summary": "Defines the open conjectures as Props: odd_zeta_transcendence_conjecture and odd_zeta_irrationality_conjecture (all ζ(2k+1) transcendental / irrational).",
+      "mathContext": "Open problem: are all odd zeta values $\\zeta(2k+1)$ irrational (or transcendental)? Only $\\zeta(3)$ is currently known irrational."
     },
     {
       "id": "structural-relationships",
-      "title": "Structural Relationships Between Conjectures",
+      "title": "Part 7: Structural Relationships",
       "startLine": 197,
       "endLine": 219,
-      "summary": "Proves the logical chain: transcendence conjecture implies irrationality conjecture, which implies Apery's theorem ($\\zeta(3)$ irrational) as the $k=1$ case, and further implies joint irrationality of $\\zeta(3)$ and $\\zeta(5)$.",
-      "mathContext": "Logical hierarchy: $\text{Transcendental}(\\zeta(2k+1)) \\Rightarrow \text{Irrational}(\\zeta(2k+1)) \\Rightarrow \text{Irrational}(\\zeta(3)) \\wedge \text{Irrational}(\\zeta(5))$."
+      "summary": "Logical implications among the conjectures: transcendence_implies_irrationality, conjecture_implies_apery, apery_weaker_than_conjecture.",
+      "mathContext": "Transcendence $\\Rightarrow$ irrationality; the odd-zeta conjecture implies Apéry's theorem, so it is strictly stronger."
+    },
+    {
+      "id": "deep-results-odd",
+      "title": "Part 8: Deep Results on Odd Zeta Irrationality",
+      "startLine": 220,
+      "endLine": 255,
+      "summary": "States the known partial results as axioms: rivoal_theorem (infinitely many ζ(2k+1) irrational), zudilin_theorem (one of ζ(5),ζ(7),ζ(9),ζ(11) irrational), fischler_sprang_zudilin_2019 (quantitative density).",
+      "mathContext": "Rivoal (2000), Zudilin (2001), Fischler–Sprang–Zudilin (2019): partial progress toward the odd-zeta irrationality conjecture."
+    },
+    {
+      "id": "irrationality-landscape",
+      "title": "Part 9: The Irrationality Landscape",
+      "startLine": 256,
+      "endLine": 293,
+      "summary": "Derives the known results from the stronger conjecture: conjecture_implies_rivoal, conjecture_implies_zudilin, conjecture_implies_all_known.",
+      "mathContext": "The full odd-zeta conjecture implies every currently known partial result, placing them in a single hierarchy."
     },
     {
       "id": "even-odd-divide",
-      "title": "The Even-Odd Divide and Problem Status",
-      "startLine": 220,
-      "endLine": 274,
-      "summary": "Defines $\text{even\\_zeta\\_rational\\_multiple}$: $\\zeta(2k) = q \\cdot \\pi^{2k}$ for rational $q$. Verifies transcendence of $\\zeta(2)$ and $\\zeta(4)$ from axiomatized Lindemann. Proves the arithmetic hierarchy: $\\zeta(2)$ transcendental, $\\zeta(3)$ irrational (Apery), $\\zeta(5)$ status unknown.",
-      "mathContext": "Even-odd dichotomy: $\\zeta(2k) = c_k \\pi^{2k}$ (transcendental via Lindemann) vs. $\\zeta(2k+1)$ with no known closed form. Arithmetic hierarchy: transcendental \\supset irrational \\supset algebraic."
+      "title": "Part 10: The Even–Odd Divide",
+      "startLine": 294,
+      "endLine": 348,
+      "summary": "Contrasts even vs odd: even_zeta_rational_multiple, even_zeta_values_transcendental, even_zeta_transcendental_at_1/at_2, even_odd_hierarchy, and the problem_status summary string.",
+      "mathContext": "Even $\\zeta(2k)$ are known transcendental (rational multiples of $\\pi^{2k}$); odd $\\zeta(2k+1)$ remain open beyond $\\zeta(3)$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Build-free gallery-integrity fix for `basel-problem-oq-02` (odd vs even zeta values: irrationality/transcendence landscape).

`BaselProblemOQ02.lean` uses `-- ## Part 1..10` banners over 348 lines. The meta had **12 sections that were out of order and overlapping** — e.g. a 221–237 section listed before a 186–196 section, and "The Even-Odd Divide" (220–274) overlapped three others. They also maxed out at line **277**, hiding **Part 10's tail** (294–348: the even-zeta transcendence theorems, `even_odd_hierarchy`, and the `problem_status` summary).

### Changes (metadata only — no Lean edits)
- Rebuilt the sections array to **10 clean sections**, each mapped to its `## Part N` banner, in order, no overlaps.
- Full-file coverage restored: maxEndLine 277 → **348**, **gap 0**.
- Summaries rewritten to match the actual declarations in each Part.
- Only the sections array changed; **all other meta fields are byte-for-byte identical** (verified by key-wise comparison against HEAD).

## Test plan
- [x] `json.load` validates meta.json (10 sections)
- [x] Coverage: maxEndLine == 348; monotonic; no overlaps; unique ids
- [x] Each section range matched to file `## Part N` banner positions
- [x] Non-section keys identical to HEAD (semantic diff = sections only)
- [x] Counts/status unchanged (20 thm / 6 def / 5 axiom / 0 sorry; axiomatized/axiom)
- [ ] No Lean rebuild required (metadata only; Docker is down)

## Status
**Outcome**: progress (gallery-integrity fix — sections were unordered/overlapping and Part 10 was hidden)

🤖 Generated by researcher-4