### PR TITLE
research(ballot-problem-oq-03-oq-02): realign stale sections + fix theoremCount/lineCount

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-02/meta.json
@@ -79,8 +79,8 @@
     "dateAdded": "2026-03-22",
     "mathlib_version": "4.26.0",
     "axiomCount": 0,
-    "lineCount": 2583,
-    "theoremCount": 28,
+    "lineCount": 2589,
+    "theoremCount": 94,
     "prerequisites": [
       "Matrix determinants and permutation signs (Mathlib)",
       "Binomial coefficients (Mathlib)",
@@ -195,35 +195,59 @@
     },
     {
       "id": "gv-involution-construction",
-      "title": "Parts 7f–7l: Full GV Involution Construction",
+      "title": "Parts 7f–7g: GV Involution Construction and Infrastructure",
       "startLine": 736,
-      "endLine": 1797,
-      "summary": "wellFormed condition, non-identity permutation crossing theorem, column entry prefix lemmas (take_at_column_entry, take_east_count_within_column), northThenEast canonical paths, canonical crossing selection (Nat.find + lex encoding via crossingCode), tail-swap PathMN construction with length/East-count preservation, and involution assembly (gvCanonInv). gvCanon_membership is fully proved (118 lines). gvCanon_sign_reversal and gvCanon_no_fixed are proved.",
-      "mathContext": "The canonical involution $\\iota$ maps $(\\sigma, \\vec{P})$ to $((i\\;j) \\circ \\sigma, \\vec{P'})$ where $(i,j)$ is the lexicographically first crossing pair and $\\vec{P'}$ swaps tails of paths $i$ and $j$ at the crossing column. $\\iota$ is sign-reversing and fixed-point-free on cancellable tuples."
+      "endLine": 1012,
+      "summary": "PART 7f assembles the gvCanonInv involution skeleton over tagged path tuples; PART 7g supplies the supporting infrastructure: column-entry prefix lemmas (take_at_column_entry, take_east_count_within_column) and northThenEast canonical paths.",
+      "mathContext": "The canonical involution $\\iota$ maps $(\\sigma, \\vec{P})$ to $((i;j)\\circ\\sigma, \\vec{P'})$ where $(i,j)$ is the lexicographically first crossing pair and $\\vec{P'}$ swaps tails of paths $i,j$ at the crossing column."
+    },
+    {
+      "id": "gv-cancellation-northeast",
+      "title": "Parts 7g-2 & 7h: Involution Cancellation and northThenEast Membership",
+      "startLine": 1013,
+      "endLine": 1276,
+      "summary": "PART 7g-2 develops the structured cancellation proof for the GV involution; PART 7h establishes gvCanon membership using the northThenEast canonical path representation.",
+      "mathContext": "Membership in the cancellable set is decided by the existence of a crossing; northThenEast paths give a canonical witness used to keep the involution within the tagged-tuple Finset."
+    },
+    {
+      "id": "prefix-canonical-tailswap",
+      "title": "Parts 7i–7j: Prefix Lemma and Canonical Tail-Swap Involution",
+      "startLine": 1277,
+      "endLine": 1610,
+      "summary": "PART 7i proves the prefix lemma needed for the self-inverse argument; PART 7j defines the canonical GV involution with tail-swap, selecting the crossing via Nat.find over a lexicographic crossingCode encoding.",
+      "mathContext": "The crossing column is the least index (Nat.find) at which two paths share a lattice point, encoded lexicographically by crossingCode so that the choice is canonical and order-independent."
+    },
+    {
+      "id": "tailswap-pathmn",
+      "title": "Part 7k: Tail-Swap PathMN Construction",
+      "startLine": 1611,
+      "endLine": 1937,
+      "summary": "PART 7k builds the tail-swapped PathMN with explicit length and East-count preservation (splitPosAt split positions, tailSwap_n_ci/tailSwap_n_cj parameter matching), the geometric core that keeps swapped paths well-formed.",
+      "mathContext": "Swapping the tails of paths $i,j$ after the shared crossing point preserves each path's total length $m + (b - a)$ and its per-column East-step counts, so the result is again a valid PathMN tuple."
+    },
+    {
+      "id": "involution-properties-cancellation",
+      "title": "Part 7l: Involution Properties and Cancellation Theorem",
+      "startLine": 1938,
+      "endLine": 2525,
+      "summary": "PART 7l proves the involution's defining properties: value-extraction lemmas, canonCrossN_preserved (the crossing invariant), gvCanon_self_inverse (ι² = id), gvCanon_sign_reversal, gvCanon_no_fixed, then cancellable_sum_eq_zero (via Finset.sum_involution) and the headline gv_involution_cancellation: the signed permutation sum equals niTupleCount.",
+      "mathContext": "The two key invariants are $\\mathrm{canonCrossN}(\\iota(t)) = \\mathrm{canonCrossN}(t)$ and $\\iota^2 = \\mathrm{id}$, giving $\\sum_{\\text{cancellable}}\\mathrm{sgn}(\\sigma) = 0$ and hence $\\sum_\\sigma \\mathrm{sgn}(\\sigma)\\,|\\mathrm{PermPathTuple}(\\sigma)| = \\mathrm{niTupleCount}$."
     },
     {
       "id": "lgv-lemma",
       "title": "Part 8: The r×r LGV Lemma",
-      "startLine": 1798,
-      "endLine": 1835,
-      "summary": "gv_involution_cancellation (proved via Finset.sum_involution from cancellable_sum_eq_zero + NI counting bijection) and lgv_lemma_rxr (theorem: niTupleCount = det pathMatrix).",
-      "mathContext": "$|\\{\\text{NI tuples}\\}| = \\det\\bigl[\\binom{m + (b_j - a_i)}{m}\\bigr]_{i,j=1}^r$"
+      "startLine": 2526,
+      "endLine": 2540,
+      "summary": "lgv_lemma_rxr: niTupleCount = det(pathMatrix), proved by combining the algebraic bridge (det = signed permutation sum) with the GV involution cancellation. Generalizes the 2×2 case from BallotProblemOQ03.lean.",
+      "mathContext": "$|\\{\\text{NI tuples}\\}| = \\det\\bigl[\\binom{m+(b_j-a_i)}{m}\\bigr]_{i,j=1}^{r}$"
     },
     {
       "id": "corollaries",
-      "title": "Parts 9–10: Corollaries and Applications",
-      "startLine": 1836,
-      "endLine": 1885,
-      "summary": "Non-negativity of det, r=1 vacuous NI, lgv_universality, and an applications survey: Schur polynomials (Jacobi-Trudi), Catalan numbers, Aztec diamond tilings, plane partitions.",
-      "mathContext": "$\\det M \\geq 0$ since $\\det M = \\mathrm{niTupleCount} \\in \\mathbb{N}$. For $r=1$, every singleton path tuple is vacuously non-intersecting, so $\\mathrm{niTupleCount} = \\binom{m + (b_1-a_1)}{m}$."
-    },
-    {
-      "id": "self-inverse-and-cancellation",
-      "title": "Self-Inverse Proof and Final Cancellation",
-      "startLine": 1886,
-      "endLine": 2091,
-      "summary": "gvCanon_membership proof completion (118 lines, fully proved), canonCrossN_preserved (proved: canonical crossing invariant), gvCanon_self_inverse (proved: double tail-swap = id), cancellable_sum_eq_zero (proved via Finset.sum_involution), and the final gv_involution_cancellation theorem.",
-      "mathContext": "The two key invariants are now proved: $\\mathrm{canonCrossN}(\\iota(t)) = \\mathrm{canonCrossN}(t)$ and $\\iota^2 = \\mathrm{id}$. The full chain is: $\\sum_{\\text{cancellable}} \\mathrm{sgn}(\\sigma) = 0 \\Rightarrow \\mathrm{niTupleCount} = \\det M$."
+      "title": "Parts 9–10: Corollaries and Combinatorial Applications",
+      "startLine": 2541,
+      "endLine": 2589,
+      "summary": "PART 9 corollaries: non-negativity of the path-matrix determinant, r = 1 vacuous non-intersection, and lgv_universality. PART 10 surveys applications — Schur polynomials (Jacobi-Trudi), Catalan numbers, Aztec diamond tilings, and MacMahon plane partitions.",
+      "mathContext": "$\\det M \\ge 0$ since $\\det M = \\mathrm{niTupleCount} \\in \\mathbb{N}$. For $r=1$ every singleton tuple is vacuously non-intersecting, so $\\mathrm{niTupleCount} = \\binom{m+(b_1-a_1)}{m}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The gallery meta for `ballot-problem-oq-03-oq-02` drifted against the heavily-refactored 2589-line `BallotProblemOQ03OQ02.lean` (the LGV-lemma formalization):

- **sections (14 → 17):** old sections stopped at line 2091, hiding the final ~498 lines — including the *actual* **Part 8 r×r LGV Lemma** (`lgv_lemma_rxr` @2535), **Part 9 Corollaries** (@2541), and **Part 10 Applications** (@2563). The back-half was also **mislabeled**: "Part 8: r×r LGV Lemma" pointed at line 1798, which is in fact PART 7k tail-swap split-position lemmas.
- **theoremCount (28 → 94):** old count included only the 28 public theorems/lemmas and omitted all **66 private** ones (36 private theorem + 30 private lemma).
- **lineCount (2583 → 2589).**

Rebuilt the back half (7 sections) aligned to the file's real `PART 7f–7l` and `Part 8/9/10` banners → full 77–2589 coverage. The accurate front sections (Parts 1–7e) are unchanged.

## What did NOT change
- Source `.lean` is untouched.
- `status` stays `verified` (0 axioms, 0 sorries).
- `definitionCount` 46 confirmed correct (44 defs + 1 structure + 1 abbrev).
- Only `sections`, `theoremCount`, `lineCount` differ from `HEAD`.

## Test plan
- [x] meta.json parses; sections tile 77–2589 (one pre-existing 1-line gap @379), no overlaps
- [x] theoremCount cross-checked: 26 thm + 2 lemma + 36 private thm + 30 private lemma = 94
- [x] Diff limited to the three drifted fields