### PR TITLE
research(infinitude-primes-4k3): realign mispositioned tail sections (7->8)

### DIFF
--- a/src/data/proofs/infinitude-primes-4k3/meta.json
+++ b/src/data/proofs/infinitude-primes-4k3/meta.json
@@ -128,15 +128,22 @@
       "id": "sec-main-theorem",
       "title": "Main Theorem: Infinitely Many Primes ≡ 3 (mod 4)",
       "startLine": 150,
-      "endLine": 199,
-      "summary": "infinitely_many_primes_3_mod_4: ∀ n, ∃ p prime, p > n ∧ p % 4 = 3. Construction: N = 4(n+1)!-1 ≡ 3 (mod 4) (by omega from factorial_pos). By has_prime_factor_3_mod_4, N has a prime factor p ≡ 3 (mod 4). If p ≤ n, then p ∣ (n+1)! (by Nat.dvd_factorial) → p ∣ 4(n+1)! → p ∣ 1 (from N + 1 = 4(n+1)!), contradicting hp.not_dvd_one. primes_3_mod_4_infinite and no_largest_prime_3_mod_4 follow by Set.infinite_of_not_bddAbove."
+      "endLine": 216,
+      "summary": "infinitely_many_primes_3_mod_4: for all n there is a prime p > n with p % 4 = 3, via N = 4(n+1)!-1 (which is 3 mod 4); has_prime_factor_3_mod_4 gives a prime factor p = 3 (mod 4), and p <= n would force p | 1 (since N+1 = 4(n+1)!), a contradiction. infinitely_many_primes_3_mod_4_bounded strengthens this with the explicit witness interval (n, 4(n+1)!-1]."
     },
     {
-      "id": "sec-examples",
+      "id": "sec-corollaries",
+      "title": "Corollaries",
+      "startLine": 217,
+      "endLine": 234,
+      "summary": "primes_3_mod_4_infinite (the set {p prime, p = 3 mod 4} is infinite, via Set.infinite_of_not_bddAbove) and no_largest_prime_3_mod_4, both immediate consequences of the main theorem."
+    },
+    {
+      "id": "sec-concrete-examples",
       "title": "Concrete Examples",
-      "startLine": 209,
-      "endLine": 228,
-      "summary": "Five `example` statements verifying that 3, 7, 11, 19, 23 are primes ≡ 3 (mod 4), each proved by `decide` or `Nat.prime_three`. These serve as sanity checks and illustrate the density of such primes: 3,7,11,19,23,31,43,47,... occupy every other odd residue class mod 4."
+      "startLine": 235,
+      "endLine": 256,
+      "summary": "Five `example` statements verifying 3, 7, 11, 19, 23 are primes = 3 (mod 4), each by `decide`/`Nat.prime_three`, plus #check exports of the main results."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
The gallery `sections` array for **infinitude-primes-4k3** had its tail mispositioned vs `Proofs/InfinitudePrimes4k3.lean`:

- The **"Concrete Examples"** section was pinned at lines 209-228, but those lines actually contain the *corollary theorems* (`primes_3_mod_4_infinite`, `no_largest_prime_3_mod_4`) and the tail of `infinitely_many_primes_3_mod_4_bounded` — not examples.
- The real `## Examples` block (lines 235-256, five `example`s + `#check` exports) was **uncovered** (sections stopped at 228).
- The **Main Theorem** section ended at line 199, omitting the `infinitely_many_primes_3_mod_4_bounded` strengthened variant (197-216).

Extended Main Theorem to 216, added a **Corollaries** section (217-234), and placed **Concrete Examples** at its real location (235-256). Full 1-256 coverage.

## Verification
Counts already matched the source (no change needed):
- theoremCount = 8 ✓, definitionCount = 0 ✓, axiomCount = 0 ✓, sorryCount = 0 ✓, lineCount = 256 ✓

Metadata-only change (no Lean source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)