### PR TITLE
research(erdos-1145): realign drifted back-half sections to full file

### DIFF
--- a/src/data/proofs/erdos-1145/meta.json
+++ b/src/data/proofs/erdos-1145/meta.json
@@ -86,31 +86,31 @@
       "id": "ruzsa-counterexample",
       "title": "Necessity via Ruzsa's Counterexample",
       "startLine": 190,
-      "endLine": 257,
+      "endLine": 619,
       "summary": "**Proved** (from axiomatized Ruzsa properties): The ratio condition $a_n/b_n \\to 1$ is **necessary**. Ruzsa's binary digit construction gives $A, B$ with $A+B = \\mathbb{N}$ but $r_{A,B}(n) = 1$ for all $n \\geq 1$, and $a_n/b_n \\to 1/2 \\neq 1$. The $n = 0$ case requires a separate argument bounding the pair set by a singleton.",
       "mathContext": "Ruzsa: $A$ = even binary positions, $B$ = odd positions. Unique representations, bounded $r = 1$, $a_n/b_n \\to 1/2$."
     },
     {
       "id": "average-representation",
       "title": "Average Representation Growth",
-      "startLine": 259,
-      "endLine": 280,
+      "startLine": 620,
+      "endLine": 691,
       "summary": "**Proved**: The unconditional counting lower bound $\\sum_{n \\leq N} r_{A,B}(n) \\geq A(\\lfloor N/2 \\rfloor) \\cdot B(\\lfloor N/2 \\rfloor)$. Proof: form $P = (A \\cap [1,N/2]) \\times (B \\cap [1,N/2])$; each pair sums to $\\leq N$; fiberwise decomposition gives $|P| = \\sum_n |P_n| \\leq \\sum_n r_{A,B}(n)$. **Corollary** (informal): when $A,B$ have positive lower density $\\delta$, the average $r_{A,B}(n)$ over $[1,N]$ is $\\geq \\delta^2 N/4 \\to \\infty$, proving the Erdős–Sárközy conjecture in the positive-density case.",
       "mathContext": "$\\sum_{n=0}^{N} r_{A,B}(n) \\geq A(\\lfloor N/2 \\rfloor) \\cdot B(\\lfloor N/2 \\rfloor)$. Fiberwise proof via `Finset.card_eq_sum_card_fiberwise`."
     },
     {
       "id": "partial-results",
       "title": "Partial Results (Grekos et al.)",
-      "startLine": 282,
-      "endLine": 291,
+      "startLine": 692,
+      "endLine": 696,
       "summary": "Axiomatized partial result of Grekos, Haddad, Helou, and Pihko: under the full hypotheses, $r_{A,B}(n) \\geq 6$ infinitely often. This is the best known unconditional bound but far from the conjectured unboundedness.",
       "mathContext": "$\\forall M,\\, \\exists n > M,\\, r_{A,B}(n) \\geq 6$ (Grekos et al.)."
     },
     {
       "id": "structural-results",
       "title": "Structural Results",
-      "startLine": 293,
-      "endLine": 333,
+      "startLine": 697,
+      "endLine": 737,
       "summary": "**Proved**: (1) Symmetry: $r_{A,B}(n) = r_{B,A}(n)$ via a bijection $(a,b) \\mapsto (b,a)$. (2) Vanishing: $r_{A,B}(n) = 0$ for $n > 2N$ when $A, B \\subseteq [0,N]$.",
       "mathContext": "Commutativity via pair-swap bijection; large-$n$ vanishing by bound on components."
     }


### PR DESCRIPTION
## Summary
Part VII "Necessity of the Asymptotic Ratio Condition" (the Ruzsa counterexample proof) grew to line **619** in the 737-line `Erdos1145Problem.lean`, but the meta capped it at 257, so Parts VIII–X were shifted ~360 lines early and sections stopped at **333** — hiding **~405 lines (55%)**. Real banners: `## Part VIII` @620, `## Part IX` @692, `## Part X` @697.

Extends Part VII → 190–619 and re-pins Part VIII (620–691), Part IX (692–696), Part X (697–737) → full-file coverage. Front sections (Parts I–VI) already aligned and are unchanged.

## What did NOT change
- Source `.lean` untouched; counts confirmed accurate and unchanged: theoremCount 39, definitionCount 9, axiomCount 1, sorries 0, lineCount 737.
- Only the `sections` array differs from `HEAD`.

## Test plan
- [x] Sections tile to 737 with no overlaps
- [x] Re-pinned ranges start at the file's real `## Part N` banners
- [x] Diff limited to `sections`