### PR TITLE
research(erdos-687): rebuild stale gallery sections to match reorganized source (9→15)

### DIFF
--- a/src/data/proofs/erdos-687/meta.json
+++ b/src/data/proofs/erdos-687/meta.json
@@ -47,76 +47,124 @@
   },
   "sections": [
     {
-      "id": "imports",
-      "title": "Part 0: Imports",
-      "startLine": 29,
-      "endLine": 32,
-      "summary": "Imports `Mathlib.Tactic`, `Data.Nat.Prime.Basic`, and `Order.ConditionallyCompleteLattice.Basic` for prime number predicates, `sSup`, and `BddAbove`.",
-      "mathContext": "Mathematical content: Imports `Mathlib.Tactic`, `Data.Nat.Prime.Basic`, and `Order.ConditionallyCompleteLattice.Basic` for prime number predicates, `sSup`, and `BddAbove`."
+      "id": "overview-imports",
+      "title": "Overview and Imports",
+      "startLine": 1,
+      "endLine": 45,
+      "summary": "Module docstring: Erdős Problem #687 (OPEN, $1,000 prize) asks for the growth of Y(x), the largest d such that some interval of length d can be sieved coprime to all primes ≤ x. Imports and related-problem references.",
+      "mathContext": "Y(x) is the largest gap coverable by residue classes mod the primes $\\le x$; the prize asks whether $Y(x) = x^{o(1)}$ or grows polynomially."
     },
     {
-      "id": "definitions",
-      "title": "Part I: Core Definitions",
-      "startLine": 33,
-      "endLine": 55,
-      "summary": "Defines `primorial(x) = \\prod_{p \\le x} p$, `IsCovered` for integers satisfying a congruence $n \\equiv a_p \\pmod{p}$, `jacobsthalSet(x)` of achievable covering lengths, and $Y(x) = \\text{sSup}(\\text{jacobsthalSet}(x))$.",
-      "mathContext": "Defines `primorial(x) = \\prod_{p \\le x} p$, `IsCovered` for integers satisfying a congruence $n \\equiv a_p \\pmod{p}$, `jacobsthalSet(x)` of achievable covering lengths, and $Y(x) = \\text{sSup}(\\text{jacobsthalSet}(x))$."
+      "id": "core-definitions",
+      "title": "Core Definitions",
+      "startLine": 46,
+      "endLine": 66,
+      "summary": "Defines the primorial (product of all primes ≤ x) and jacobsthalSet x (the set of achievable gap lengths y via residue-class coverings of the primes ≤ x).",
+      "mathContext": "$\\text{primorial}(x) = \\prod_{p \\le x} p$; $y \\in \\text{jacobsthalSet}(x)$ iff some choice of residues $a_p$ covers $[1,y]$."
     },
     {
-      "id": "jacobsthal",
-      "title": "Part II: The Jacobsthal Function",
-      "startLine": 56,
-      "endLine": 64,
-      "summary": "Defines $g(n) = \\sup\\{d \\mid \\exists m, \\forall k \\in (m, m+d), \\exists p \\mid n \\text{ with } p \\mid k\\}$, the largest gap between consecutive integers coprime to $n$.",
-      "mathContext": "Formal definition: Defines $g(n) = \\sup\\{d \\mid \\exists m, \\forall k \\in (m, m+d), \\exists p \\mid n \\text{ with } p \\mid k\\}$, the largest gap between consecutive integers coprime to $n$."
+      "id": "jacobsthal-function",
+      "title": "The Jacobsthal Function",
+      "startLine": 67,
+      "endLine": 75,
+      "summary": "Defines the Jacobsthal function g(n): the largest gap between consecutive integers coprime to n (one more than the longest run of integers each sharing a factor with n).",
+      "mathContext": "$g(n) = 1 + \\max$ length of a run of consecutive integers all non-coprime to $n$."
     },
     {
       "id": "basic-properties",
-      "title": "Part III: Basic Properties",
-      "startLine": 65,
-      "endLine": 80,
-      "summary": "Proves `jacobsthalSet` is nonempty (via $y = 0$ vacuously) and axiomatizes it is bounded above (by CRT periodicity of the primorial), enabling the use of `sSup`.",
-      "mathContext": "Verified: Proves `jacobsthalSet` is nonempty (via $y = 0$ vacuously) and axiomatizes it is bounded above (by CRT periodicity of the primorial), enabling the use of `sSup`."
+      "title": "Basic Properties of jacobsthalSet",
+      "startLine": 76,
+      "endLine": 84,
+      "summary": "Basic structural facts: jacobsthalSet x is always nonempty and contains 0 (vacuously, no integers in [1,0]).",
+      "mathContext": "$\\text{jacobsthalSet}(x) \\ne \\emptyset$ and $0 \\in \\text{jacobsthalSet}(x)$ for all $x$."
     },
     {
-      "id": "structural",
-      "title": "Part IV: Structural Properties",
-      "startLine": 81,
-      "endLine": 104,
-      "summary": "Proves `jacobsthalSet` is monotone ($x_1 \\le x_2 \\Rightarrow \\text{jacobsthalSet}(x_1) \\subseteq \\text{jacobsthalSet}(x_2)$) by extending coverings to new primes. Derives $Y(x)$ monotonicity via `csSup_le_csSup`.",
-      "mathContext": "Proves `jacobsthalSet` is monotone ($x_1 \\le x_2 \\Rightarrow \\text{jacobsthalSet}(x_1) \\subseteq \\text{jacobsthalSet}(x_2)$) by extending coverings to new primes. Derives $Y(x)$ monotonicity via `csSup_le_csSup`."
+      "id": "crt-boundedness",
+      "title": "CRT Induction: jacobsthalSet is Bounded",
+      "startLine": 85,
+      "endLine": 177,
+      "summary": "Proves jacobsthalSet x is bounded via a Chinese Remainder Theorem induction (prod_primes_pos' and supporting lemmas), the technical core showing Y(x) is well-defined and finite.",
+      "mathContext": "By CRT over the primes $\\le x$, only finitely many gap lengths are coverable, so $\\sup \\text{jacobsthalSet}(x) = Y(x) < \\infty$."
     },
     {
-      "id": "connection",
-      "title": "Part V: Connection to Jacobsthal Function",
-      "startLine": 105,
-      "endLine": 110,
-      "summary": "Axiomatizes $Y(x) = g(\\text{primorial}(x))$, the fundamental equivalence between covering length and the Jacobsthal function of the primorial.",
-      "mathContext": "Axiomatized: Axiomatizes $Y(x) = g(\\text{primorial}(x))$, the fundamental equivalence between covering length and the Jacobsthal function of the primorial."
+      "id": "structural-properties",
+      "title": "Structural Properties",
+      "startLine": 178,
+      "endLine": 216,
+      "summary": "Downward closure: if y ∈ jacobsthalSet x and y' ≤ y, then y' ∈ jacobsthalSet x, so the set is an initial segment determined by its supremum Y(x).",
+      "mathContext": "$y \\in \\text{jacobsthalSet}(x) \\wedge y' \\le y \\Rightarrow y' \\in \\text{jacobsthalSet}(x)$."
     },
     {
-      "id": "conjecture",
-      "title": "Part VI: Main Conjecture ($1,000)",
-      "startLine": 111,
-      "endLine": 118,
-      "summary": "States the \\$1,000 prize conjecture: $\\forall \\varepsilon > 0$, eventually $Y(x) \\le x^{1+\\varepsilon}$, formalized using `Filter.atTop` and `Filter.Eventually`.",
-      "mathContext": "Mathematical content: States the \\$1,000 prize conjecture: $\\forall \\varepsilon > 0$, eventually $Y(x) \\le x^{1+\\varepsilon}$, formalized using `Filter.atTop` and `Filter.Eventually`."
+      "id": "concrete-values",
+      "title": "Concrete Values",
+      "startLine": 217,
+      "endLine": 266,
+      "summary": "Concrete membership computations such as 1 ∈ jacobsthalSet 2 (choosing residue a₂ = 1 covers all odd numbers including 1), establishing small base values.",
+      "mathContext": "Explicit covering choices give small-x membership facts like $1 \\in \\text{jacobsthalSet}(2)$."
     },
     {
-      "id": "bounds",
-      "title": "Part VII: Known Bounds",
-      "startLine": 119,
-      "endLine": 141,
-      "summary": "Axiomatizes Iwaniec's upper bound $Y(x) \\le C x^2$, the FGKMT lower bound $Y(x) \\ge c x (\\log x)(\\log \\log \\log x)/(\\log \\log x)$, and the Maier–Pomerance conjecture $Y(x) \\le C x (\\log x)^{2+\\varepsilon}$.",
-      "mathContext": "Axiomatizes Iwaniec's upper bound $Y(x) \\le C x^2$, the FGKMT lower bound $Y(x) \\ge c x (\\log x)(\\log \\log \\log x)/(\\log \\log x)$, and the Maier–Pomerance conjecture $Y(x) \\le C x (\\log x)^{2+\\varepsilon}$."
+      "id": "monotonicity",
+      "title": "Monotonicity",
+      "startLine": 267,
+      "endLine": 290,
+      "summary": "Monotonicity: jacobsthalSet x₁ ⊆ jacobsthalSet x₂ whenever x₁ ≤ x₂ (a covering for the smaller prime set extends to the larger), hence Y is nondecreasing.",
+      "mathContext": "$x_1 \\le x_2 \\Rightarrow \\text{jacobsthalSet}(x_1) \\subseteq \\text{jacobsthalSet}(x_2)$, so $Y$ is monotone."
     },
     {
-      "id": "trivial-bound",
-      "title": "Part VIII: Trivial Lower Bound",
-      "startLine": 142,
-      "endLine": 148,
-      "summary": "Axiomatizes $Y(x) \\ge x + 1$ for $x \\ge 2$: every integer in $[1, x]$ has a prime factor $\\le x$, so taking $a_p = 0$ covers at least $[1, x]$.",
-      "mathContext": "Axiomatized: Axiomatizes $Y(x) \\ge x + 1$ for $x \\ge 2$: every integer in $[1, x]$ has a prime factor $\\le x$, so taking $a_p = 0$ covers at least $[1, x]$."
+      "id": "connection-jacobsthal",
+      "title": "Connection to the Jacobsthal Function",
+      "startLine": 291,
+      "endLine": 303,
+      "summary": "Relates Y to the classical Jacobsthal function: Y(x) = jacobsthal(primorial(x)) − 1, tying the covering formulation to gaps coprime to the primorial.",
+      "mathContext": "$Y(x) = g(\\text{primorial}(x)) - 1$."
+    },
+    {
+      "id": "known-bounds",
+      "title": "Known Bounds",
+      "startLine": 304,
+      "endLine": 326,
+      "summary": "Records the best known upper bound, Iwaniec (1978): Y(x) ≪ x², stated as the headline external result.",
+      "mathContext": "Iwaniec (1978): $Y(x) \\ll x^2$."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "Main Conjecture ($1,000)",
+      "startLine": 327,
+      "endLine": 402,
+      "summary": "The $1,000 conjecture that Y(x) grows sub-polynomially, with the supporting asymptotic helper that any C·(log x)^k is eventually dominated by x^ε (polynomial growth beats powers of logarithm).",
+      "mathContext": "Conjecture: $Y(x) = x^{o(1)}$; helper: $\\forall C,k,\\varepsilon > 0,\\ C(\\log x)^k \\le x^\\varepsilon$ eventually."
+    },
+    {
+      "id": "concrete-computations",
+      "title": "Concrete Computations",
+      "startLine": 403,
+      "endLine": 423,
+      "summary": "Computational helper lemmas for small x, e.g. no_prime_le_one (no prime p satisfies p ≤ 1), used to discharge edge cases in the concrete-value proofs.",
+      "mathContext": "Edge-case helpers such as: no prime $p$ satisfies $p \\le 1$."
+    },
+    {
+      "id": "trivial-lower-bound-removed",
+      "title": "Trivial Lower Bound — False (Removed)",
+      "startLine": 424,
+      "endLine": 443,
+      "summary": "Documents a previously-axiomatized lower bound Y(x) ≥ x + 1 that turned out to be FALSE: the argument that every integer in [1,x] has a prime factor ≤ x does not force the covering bound, so the axiom was removed.",
+      "mathContext": "The claimed $Y(x) \\ge x + 1$ is false; a covering need not realize every integer in $[1,x]$ as non-coprime."
+    },
+    {
+      "id": "y2-concrete",
+      "title": "Y(2) = 1: First Nontrivial Concrete Value",
+      "startLine": 444,
+      "endLine": 466,
+      "summary": "Proves Y(2) = 1: for x = 2 the only prime is 2, so any covering picks a single parity class and no y ≥ 2 lies in jacobsthalSet 2.",
+      "mathContext": "$Y(2) = 1$: a single residue mod 2 cannot cover two consecutive integers, so $y \\ge 2 \\notin \\text{jacobsthalSet}(2)$."
+    },
+    {
+      "id": "y3-concrete",
+      "title": "Y(3) = 3: Second Nontrivial Concrete Value",
+      "startLine": 467,
+      "endLine": 547,
+      "summary": "Proves Y(3) = 3: the covering a₂ = 1 (odds) and a₃ = 2 (≡ 2 mod 3) covers {1,2,3}, and 3 is the supremum, giving the second nontrivial exact value.",
+      "mathContext": "$Y(3) = 3$: residues $a_2 = 1,\\ a_3 = 2$ cover $\\{1,2,3\\}$, and no longer interval is coverable."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The meta's 9 "Part"-labelled sections stopped at line **148** and no longer matched the reorganized 547-line `Erdos687Problem.lean` (which uses `/- ## Title -/` banners). The back half was mislabeled (e.g. "Structural Properties" pointed at line 81, but the banner is at **178**), and six sections had **no coverage**:
- CRT-induction boundedness proof (85–177)
- Concrete Values (217–266)
- Monotonicity (267–290)
- Concrete Computations (403–423)
- Y(2) = 1 and Y(3) = 3 concrete-value sections (444–547)

Roughly **400 lines (73%)** were hidden. Rebuilt to **15 sections** aligned to the file's actual `## Title` banners, covering lines 1–547 — including the "Trivial Lower Bound — FALSE (removed)" note documenting the retracted axiom.

## What did NOT change
- Source `.lean` untouched; counts confirmed accurate and unchanged: theoremCount 26, definitionCount 5, axiomCount 4, sorries 0, lineCount 547.
- `status` stays `axiomatized` (open $1,000 problem).
- Only the `sections` array differs from `HEAD`.

## Test plan
- [x] Sections tile 1–547 with no gaps/overlaps
- [x] Each section starts at a real `## Title` banner
- [x] Diff limited to `sections`