### PR TITLE
research(erdos-1017-oq-01): rebuild stale gallery sections to match full source (7→10)

### DIFF
--- a/src/data/proofs/erdos-1017-oq-01/meta.json
+++ b/src/data/proofs/erdos-1017-oq-01/meta.json
@@ -103,59 +103,83 @@
   "sections": [
     {
       "id": "framework",
-      "title": "Edge Clique Partition Framework",
+      "title": "Part I: Edge Clique Partition Framework",
       "startLine": 38,
-      "endLine": 67,
+      "endLine": 90,
       "summary": "Defines `EdgeCliquePartition` (structure with cliques, isClique, covers), `cliquePartitionNum` (sInf of partition sizes), and `usesOnlyEdgesAndTriangles`.",
       "mathContext": "An edge clique partition decomposes $E(G)$ into complete subgraphs. The clique partition number $\\text{cp}(G)$ is the minimum size."
     },
     {
       "id": "turan-bound",
-      "title": "Turán Number ⌊n²/4⌋",
-      "startLine": 69,
-      "endLine": 89,
+      "title": "Part II: Turán Number ⌊n²/4⌋",
+      "startLine": 91,
+      "endLine": 139,
       "summary": "Defines `turanBound n = n²/4` with concrete values (0-4) and monotonicity proof.",
       "mathContext": "$\\text{ex}(n, K_3) = \\lfloor n^2/4 \\rfloor$ by Turán's theorem."
     },
     {
       "id": "egp",
-      "title": "Erdős-Goodman-Pósa Theorem",
-      "startLine": 91,
-      "endLine": 112,
+      "title": "Part III: Erdős-Goodman-Pósa Theorem (1966)",
+      "startLine": 140,
+      "endLine": 164,
       "summary": "Axiomatizes EGP: every graph partitions into ≤ ⌊n²/4⌋ cliques using only edges and triangles. Proves corollary `cliquePartitionNum_le_turan`.",
       "mathContext": "$f(n,k) \\leq \\lfloor n^2/4 \\rfloor$ for all $n, k$ (Erdős-Goodman-Pósa 1966)."
     },
     {
       "id": "extremal",
-      "title": "Extremal Example: K_{k,k}",
-      "startLine": 114,
-      "endLine": 163,
+      "title": "Part IV: Extremal Example — Complete Bipartite Graph",
+      "startLine": 165,
+      "endLine": 459,
       "summary": "Constructs `completeBipartite` with `DecidableRel` instance. Proves `egp_tight_example: cp(K_{k,k}) = k²` and `egp_tight_matches_turan: k² = turanBound(2k)`.",
       "mathContext": "$K_{k,k}$ is triangle-free with $k^2$ edges. Since each edge must be its own clique, $\\text{cp}(K_{k,k}) = k^2 = \\lfloor (2k)^2/4 \\rfloor$."
     },
     {
       "id": "open-question",
-      "title": "The Open Question",
-      "startLine": 165,
-      "endLine": 200,
+      "title": "Part V: The Open Question — Dense Graphs with Large Cliques",
+      "startLine": 460,
+      "endLine": 515,
       "summary": "Defines `isDense` (more edges than Turán bound), states `erdos1017_question` formally, and proves savings from K₃, K₄, K₅.",
       "mathContext": "**Open**: Can dense graphs with $K_4$ improve on $\\lfloor n^2/4 \\rfloor$?"
     },
     {
       "id": "k4free",
-      "title": "K₄-Free Case: Győri-Keszegh (2017)",
-      "startLine": 202,
-      "endLine": 247,
+      "title": "Part VI: K₄-Free Case — Győri-Keszegh (2017)",
+      "startLine": 516,
+      "endLine": 565,
       "summary": "Axiomatizes Győri-Keszegh as the full partition formula `cp(G) = ⌊n²/4⌋ - m`. Proves `k4free_improves`: dense K₄-free graphs have cp < ⌊n²/4⌋. The previously separate `gyori_keszegh_triangles` axiom (m distinct 3-cliques) was eliminated as redundant.",
       "mathContext": "For $K_4$-free graphs: $\\text{cp}(G) = \\lfloor n^2/4 \\rfloor - m$ where $m$ is the excess over $\\lfloor n^2/4 \\rfloor$ (Győri-Keszegh 2017)."
     },
     {
       "id": "connections",
-      "title": "Lovász Covering and Connections",
-      "startLine": 249,
-      "endLine": 285,
-      "summary": "Axiomatizes Lovász covering bound, clique partition ≤ n(n-1)/2, and triangle supersaturation (Razborov 2010).",
+      "title": "Part VII: Lovász Covering Bound (1968)",
+      "startLine": 566,
+      "endLine": 581,
+      "summary": "Axiomatizes the Lovász (1968) covering bound and the clique-partition ≤ n(n−1)/2 edge bound, the classical covering input to the dense-graph estimates.",
       "mathContext": "Related bounds: Lovász covering, edge-coloring duality ($\\text{cp}(G) = \\chi'(\\bar{G})$), and Razborov supersaturation."
+    },
+    {
+      "id": "connections-consequences",
+      "title": "Part VIII: Connections and Consequences",
+      "startLine": 582,
+      "endLine": 611,
+      "summary": "Derived consequences tying the framework together: the clique partition is bounded by the edge count, and triangle supersaturation (Razborov 2010) connects density to the number of triangles available for savings.",
+      "mathContext": "$\\mathrm{cp}(G) \\le |E(G)|$, and dense graphs contain $\\gg n^3$ triangles (supersaturation), bounding the achievable clique-partition savings."
+    },
+    {
+      "id": "additional-results",
+      "title": "Part IX: Additional Proved Results",
+      "startLine": 612,
+      "endLine": 649,
+      "summary": "Further proved corollaries, notably that dense graphs under the K₄-free constraint improve strictly more than the general dense case, sharpening the savings comparison.",
+      "mathContext": "Under the $K_4$-free constraint, dense graphs achieve strictly larger clique-partition savings than the general dense bound."
+    },
+    {
+      "id": "verification",
+      "title": "Part X: Verification",
+      "startLine": 650,
+      "endLine": 696,
+      "summary": "#check verification block confirming the core framework (EdgeCliquePartition, cliquePartitionNum) and the main results type-check as stated.",
+      "mathContext": "Static `#check` confirmation that the declared framework and theorems elaborate correctly."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The `erdos-1017-oq-01` gallery view's 7 sections stopped at line **285** while the shared `Erdos1017OQ01.lean` is 696 lines. Part IV "Extremal Example" grew to line **459** (meta capped it at 163), shifting Parts V–VII early, and Parts **VIII** (Connections and Consequences), **IX** (Additional Proved Results), and **X** (Verification) had **no coverage at all**. Roughly **412 lines (59%)** were hidden.

Rebuilt to **10 sections** aligned to the file's `PART N:` banners, covering lines 38–696. (The base `erdos-1017` slug already covers the file; this brings the oq-01 view to parity.) Reuses accurate front summaries; adds the three missing tail sections.

## What did NOT change
- Source `.lean` untouched; counts confirmed accurate and unchanged: theoremCount 37, definitionCount 9, axiomCount 2, sorries 0, lineCount 696.
- Only the `sections` array differs from `HEAD`.

## Test plan
- [x] Sections tile 38–696 with no gaps/overlaps
- [x] Each section starts at the file's real `PART N:` banner
- [x] Diff limited to `sections`