### PR TITLE
research(szemeredi-hypergraph-core): add uncovered Follow-Up Directions section (5->6)

### DIFF
--- a/src/data/proofs/szemeredi-hypergraph-core/meta.json
+++ b/src/data/proofs/szemeredi-hypergraph-core/meta.json
@@ -112,9 +112,16 @@
       "id": "graph-bridge",
       "title": "Bridge to Graph Case",
       "startLine": 154,
-      "endLine": 175,
+      "endLine": 171,
       "summary": "Constructs a 2-uniform hypergraph from a SimpleGraph, connecting the hypergraph framework back to the graph regularity pipeline.",
       "mathContext": "For a simple graph $G$, the 2-uniform hypergraph has edges $\\{\\{u,v\\} : uv \\in E(G)\\}$."
+    },
+    {
+      "id": "follow-up-directions",
+      "title": "Follow-Up Directions",
+      "startLine": 172,
+      "endLine": 213,
+      "summary": "Roadmap docstring for the full Gowers (2007) relative hypergraph regularity: simplicial complexes, relative density conditioned on the (k-1)-skeleton, IsGowersRegular, the Nagle-Rodl-Schacht counting lemma, and references."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
The gallery `sections` array for **szemeredi-hypergraph-core** stopped at line 175, while `Proofs/SzemerediHypergraphCore.lean` is 213 lines. The trailing **Follow-Up Directions** docstring (lines 172-213) — a roadmap for the full Gowers (2007) relative hypergraph regularity (simplicial complexes, relative density, `IsGowersRegular`, the Nagle–Rödl–Schacht counting lemma, references) — was uncovered.

Trimmed Part V to where `fromSimpleGraph` ends (line 171) and added the **Follow-Up Directions** section for full **35-213** coverage.

## Verification
Counts already matched the source: theoremCount = 4 ✓, definitionCount = 7 ✓, axiomCount = 0 ✓, sorryCount = 0 ✓, lineCount = 213 ✓

Metadata-only change (no Lean source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)