### PR TITLE
audit(erdos-1131): realign stale back-half sections to full-file coverage (665→1076) + fix stale (sorry) prose

### DIFF
--- a/src/data/proofs/erdos-1131/meta.json
+++ b/src/data/proofs/erdos-1131/meta.json
@@ -116,39 +116,39 @@
       "id": "integration-lemmas",
       "title": "Integration and Substitution Lemmas",
       "startLine": 365,
-      "endLine": 409,
+      "endLine": 506,
       "summary": "Six fully proved lemmas for evaluating $\\int_{-1}^{1} T_j(x)^2\\,dx$: `two_cos_mul_sin` (product-to-sum), `integral_sin_mul` ($\\int_0^\\pi \\sin(k\\theta)\\,d\\theta$ by FTC with antiderivative $-\\cos(k\\theta)/k$), `cos_nat_mul_pi` ($\\cos(m\\pi)=(-1)^m$ by induction), `integral_cos_mul_sin` ($\\int_0^\\pi \\cos(2j\\theta)\\sin\\theta\\,d\\theta = -2/(4j^2-1)$ via product-to-sum decomposition), `integral_cos_substitution` (change of variables $x=\\cos\\theta$ via `integral_comp_mul_deriv`), and `integral_chebyshev_sq` ($\\int_{-1}^{1} T_j(x)^2\\,dx = 1-1/(4j^2-1)$ combining substitution with cos² identity).",
       "mathContext": "$\\int_0^\\pi \\sin(k\\theta)\\,d\\theta = \\frac{1-\\cos(k\\pi)}{k}$. Change of variables: $\\int_{-1}^{1} f(x)\\,dx = \\int_0^\\pi f(\\cos\\theta)\\sin\\theta\\,d\\theta$. $\\int_{-1}^{1} T_j(x)^2\\,dx = 1 - \\frac{1}{4j^2-1}$."
     },
     {
       "id": "dct-orthogonality",
-      "title": "DCT Orthogonality Infrastructure",
-      "startLine": 410,
-      "endLine": 563,
-      "summary": "Discrete Cosine Transform orthogonality at Chebyshev angles, forming the backbone of the Chebyshev expansion. `two_cos_mul_cos` (product-to-sum for cosines, proved). `frequency_abel_sum`: Abel summation identity $2\\sin\\beta\\sum\\cos(2j\\beta)=(1-(-1)^s)\\sin\\beta$ using telescoping (proved). `frequency_cosine_sum_even`/`_odd`: frequency sums equal 0 (even $s$) or 1 (odd $s$), proved by factoring out $\\sin\\beta\\ne 0$. `dct_diagonal`: $1+2\\sum_{j=1}^{n-1}\\cos^2(j\\theta_k)=n$ (proved via `frequency_cosine_sum_odd`). `dct_offdiag`: $1+2\\sum\\cos(j\\theta_k)\\cos(j\\theta_m)=0$ for $k\\ne m$ (proved via product-to-sum + parity case split). `chebyshev_interp`: Lagrange interpolation exactness for Chebyshev polynomials (sorry — needs polynomial uniqueness). `chebyshev_sq_expansion`: $\\sum l_k^2 = (1/n)(1+2\\sum T_j^2)$ (sorry — needs chebyshev_interp + bilinear expansion).",
+      "title": "Part V½: DCT Orthogonality Infrastructure",
+      "startLine": 507,
+      "endLine": 986,
+      "summary": "Discrete Cosine Transform orthogonality at Chebyshev angles, forming the backbone of the Chebyshev expansion. `two_cos_mul_cos` (product-to-sum for cosines, proved). `frequency_abel_sum`: Abel summation identity $2\\sin\\beta\\sum\\cos(2j\\beta)=(1-(-1)^s)\\sin\\beta$ using telescoping (proved). `frequency_cosine_sum_even`/`_odd`: frequency sums equal 0 (even $s$) or 1 (odd $s$), proved by factoring out $\\sin\\beta\\ne 0$. `dct_diagonal`: $1+2\\sum_{j=1}^{n-1}\\cos^2(j\\theta_k)=n$ (proved via `frequency_cosine_sum_odd`). `dct_offdiag`: $1+2\\sum\\cos(j\\theta_k)\\cos(j\\theta_m)=0$ for $k\\ne m$ (proved via product-to-sum + parity case split). `chebyshev_interp`: Lagrange interpolation exactness for Chebyshev polynomials (proved). `chebyshev_sq_expansion`: $\\sum l_k^2 = (1/n)(1+2\\sum T_j^2)$ (proved, via chebyshev_interp + bilinear expansion).",
       "mathContext": "DCT orthogonality: $\\frac{1}{n}\\sum_{k=0}^{n-1}\\cos(j\\theta_k)\\cos(m\\theta_k)=\\frac{1}{2}\\delta_{jm}$ for $1\\le j,m\\le n-1$, where $\\theta_k=\\frac{(2k+1)\\pi}{2n}$. Chebyshev expansion: $\\sum_k l_k(x)^2=\\frac{1}{n}\\bigl(1+2\\sum_{j=1}^{n-1}T_j(x)^2\\bigr)$."
     },
     {
       "id": "chebyshev-integral-results",
       "title": "Chebyshev Integral: Exact Value and Estimates",
-      "startLine": 565,
-      "endLine": 629,
+      "startLine": 987,
+      "endLine": 1042,
       "summary": "Four fully proved theorems on the Chebyshev integral. `chebyshev_integral_trace`: trace formula $I = (1/n)(2n - 2\\sum 1/(4j^2-1))$, proved by combining `chebyshev_sq_expansion` with `integral_chebyshev_sq`. `chebyshev_integral_exact`: $I = 2 - 2(n-1)/(n(2n-1))$, proved by combining the trace formula with `partial_fraction_sum`. `chebyshev_integral_lt_two`: $I < 2$ since the correction term is positive. `chebyshev_integral_estimate`: $\\exists c>0$ with $|I-(2-c/n)|\\le c/n^2$, proved by taking $c = n(2-I)$.",
       "mathContext": "$I_{\\text{Cheb}}(n) = 2 - \\frac{2(n-1)}{n(2n-1)} < 2$. Asymptotically: $I_{\\text{Cheb}} = 2 - \\frac{1}{n} + O(1/n^2)$."
     },
     {
       "id": "conjecture",
       "title": "Part IV: The Conjecture (OPEN)",
-      "startLine": 631,
-      "endLine": 648,
+      "startLine": 1043,
+      "endLine": 1060,
       "summary": "Defines `minLagrangeIntegral n` as $\\inf\\{I(\\mathbf{x}) : \\mathbf{x} \\in [-1,1]^n\\}$ using `sInf`. States the open conjecture as an axiom `erdos_1131_conjecture`: for every $\\varepsilon > 0$ there exists $N_0$ such that $|\\min I_n - (2 - 1/n)| \\le \\varepsilon/n$ for all $n \\ge N_0$, encoding $\\min I = 2 - (1+o(1))/n$.",
       "mathContext": "Erdős conjecture: $\\min_{x_1,\\ldots,x_n \\in [-1,1]} I(x_1,\\ldots,x_n) = 2 - \\frac{1+o(1)}{n}$ as $n \\to \\infty$."
     },
     {
       "id": "main-theorem",
       "title": "Part V: Main Theorem (Proved)",
-      "startLine": 649,
-      "endLine": 665,
+      "startLine": 1061,
+      "endLine": 1076,
       "summary": "The main formalized result `erdos_1131`: for any $n \\ge 1$ and any distinct nodes in $[-1,1]$, $I \\ge 2/n$. Proved by direct application of `lagrangeIntegral_lower_bound`. This establishes the universal lower bound while the tighter asymptotic behavior remains open (axiomatized conjecture).",
       "mathContext": "$I(x_1,\\ldots,x_n) \\ge \\frac{2}{n}$ for all distinct configurations in $[-1,1]$."
     }


### PR DESCRIPTION
## Gallery Integrity Audit

**Proof**: `erdos-1131` (axiomatized, badge `axiom` — honestly discloses the single open conjecture)

### Issue 1 — Back-half section undercoverage & mislabeling

The `sections` array compressed lines 410–1076 of a **1076-line file** into a 665-line range (~411 lines / 38% hidden). The front nine sections (1–409) were aligned; sections 9–13 were badly off:

| section | claimed | reality |
|---|---|---|
| Integration and Substitution Lemmas | 365–409 | 365–**506** |
| DCT Orthogonality Infrastructure (Part V½) | 410–563 | **507–986** |
| Chebyshev Integral: Exact Value and Estimates | 565–629 | **987–1042** |
| Part IV: The Conjecture (OPEN) | 631–648 | **1043–1060** |
| Part V: Main Theorem (Proved) | 649–665 | **1061–1076** |

Remapped to true ranges → full-file coverage, monotonic.

### Issue 2 — Stale "(sorry)" prose

The DCT section summary still described `chebyshev_interp` and `chebyshev_sq_expansion` as `(sorry — needs ...)`. Both are **fully proved** — the file has **0 sorries** (verified; the `assumptions` field already states "0 sorries — all supporting lemmas fully proved"). Updated the summary to "(proved)".

### Unchanged (correctly disclosed)
The single axiom `erdos_1131_conjecture` (line 1056), `axiomCount: 1`, `status: axiomatized`, badge `axiom`, and the conjecture/main-theorem section descriptions are all accurate. Data-only change (meta.json).