### PR TITLE
research(binomial-theorem-oq-02-oq-01-oq-01-oq-03): realign gallery sections to full file (444→712)

### DIFF
--- a/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/binomial-theorem-oq-02-oq-01-oq-01-oq-03/meta.json
@@ -92,43 +92,43 @@
       "id": "sec-cdf-defs",
       "title": "CDF Definitions: Binomial and Multinomial Marginal",
       "range": null,
-      "startLine": 95,
-      "endLine": 115
+      "startLine": 141,
+      "endLine": 162
     },
     {
       "id": "sec-stdnormal",
       "title": "Standard Normal CDF (concrete def + structural lemmas, incl. continuity)",
       "range": null,
-      "startLine": 117,
-      "endLine": 232
+      "startLine": 163,
+      "endLine": 364
     },
     {
       "id": "sec-binomial-clt-axiom",
       "title": "Axiom: Classical de Moivre-Laplace (Binomial CLT)",
       "range": null,
-      "startLine": 234,
-      "endLine": 251
+      "startLine": 365,
+      "endLine": 385
     },
     {
       "id": "sec-reduction",
       "title": "Reduction Lemma: Multinomial Marginal CDF = Binomial CDF",
       "range": null,
-      "startLine": 253,
-      "endLine": 325
+      "startLine": 386,
+      "endLine": 467
     },
     {
       "id": "sec-structural",
       "title": "Structural Properties of binomialCDF (Phase-4 prep)",
       "range": null,
-      "startLine": 327,
-      "endLine": 416
+      "startLine": 468,
+      "endLine": 680
     },
     {
       "id": "sec-main",
       "title": "Main Theorem: Multinomial Marginal CLT (Derived)",
       "range": null,
-      "startLine": 418,
-      "endLine": 444
+      "startLine": 681,
+      "endLine": 712
     }
   ],
   "overview": {


### PR DESCRIPTION
## Summary
- All 6 gallery sections in `meta.json` had stale line ranges: coverage ended at line **444** while the Lean file is **712 lines** — 38% of the source (including the full structural-properties library and the main theorem) was hidden from the gallery.
- Section markers had drifted ~250 lines as the file grew across sessions S6–S12. Re-pinned each of the 6 sections to its actual `/-! ## ... -/` banner.
- **No content/count changes.** Titles, ids, and every count field are unchanged and already correct (1 axiom, 3 defs, 16 theorems, 712 lines — all match source). Non-section JSON keys are byte-identical.

| Section | Old range | New range |
|---|---|---|
| CDF Definitions | 95–115 | 141–162 |
| Standard Normal CDF | 117–232 | 163–364 |
| Axiom: de Moivre–Laplace | 234–251 | 365–385 |
| Reduction Lemma | 253–325 | 386–467 |
| Structural Properties | 327–416 | 468–680 |
| Main Theorem (derived) | 418–444 | 681–712 |

Build-free metadata fix; no Lean source touched.

## Test plan
- [x] Each new `startLine` lands on its `/-! ## -/` banner (verified against source)
- [x] Full-file contiguous coverage 141→712
- [x] `jq 'del(.sections)'` diff confirms all other meta fields byte-identical