### PR TITLE
research(erdos-szekeres): rebuild stale gallery sections (6→7)

### DIFF
--- a/src/data/proofs/erdos-szekeres/meta.json
+++ b/src/data/proofs/erdos-szekeres/meta.json
@@ -43,7 +43,7 @@
     "wiedijkNumber": 73,
     "axiomCount": 2,
     "assumptions": "2 axiom declarations: erdos_szekeres_existence_axiom (monotone subsequence exists), erdos_szekeres_tight_axiom (bound (r-1)(s-1)+1 is tight)",
-    "lineCount": 280,
+    "lineCount": 344,
     "mathlib_version": "4.26.0",
     "theoremCount": 8,
     "definitionCount": 6,
@@ -71,6 +71,14 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "File Header and Overview",
+      "startLine": 1,
+      "endLine": 56,
+      "summary": "Imports and module documentation: statement of the Erdős–Szekeres theorem (Wiedijk's 100 Theorems #73), historical context (Erdős & Szekeres 1935, the Happy Ending Problem), the pigeonhole proof idea on (longest-inc, longest-dec) pairs, and the Mathlib dependencies. Opens namespace ErdosSzekeres with Finset and Function.",
+      "mathContext": "Goal: any sequence of $\\ge (r-1)(s-1) + 1$ distinct reals has an increasing subsequence of length $r$ or a decreasing subsequence of length $s$. Proof idea: assign each position $i$ the pair $(a_i, b_i)$ of longest inc/dec subsequence lengths ending at $i$; the pairs are distinct, so $(r-1)(s-1)+1$ of them cannot fit in $\\{1,\\dots,r-1\\}\\times\\{1,\\dots,s-1\\}$."
+    },
+    {
       "id": "subsequence-definitions",
       "title": "Subsequence Definitions",
       "startLine": 58,
@@ -79,43 +87,43 @@
       "mathContext": "$\\text{IncreasingSubseq}(f, k)$: positions $p : \\text{Fin}\\, k \\to \\text{Fin}\\, n$ with $\\text{StrictMono}(p)$ and $\\text{StrictMono}(f \\circ p)$. Decreasing uses $\\text{StrictAnti}$ for values."
     },
     {
+      "id": "subsequence-lengths",
+      "title": "Length of Longest Subsequences",
+      "startLine": 86,
+      "endLine": 112,
+      "summary": "The predicates HasIncreasingEndingAt / HasDecreasingEndingAt: there exists an increasing (resp. decreasing) subsequence of a given length whose last index is position i and whose earlier indices are < i.",
+      "mathContext": "$\\text{HasIncreasingEndingAt}(f, i, \\ell)$: $\\exists k : \\text{Fin}\\,\\ell \\to \\text{Fin}\\,n$, $\\text{StrictMono}(k)$, every $k_j < i$ or ($j = \\ell-1$ and $k_j = i$), and $\\text{StrictMono}(f \\circ k)$. The index condition is phrased via $j.\\text{val} = \\ell - 1$ to stay within $\\text{Fin}\\,\\ell$."
+    },
+    {
+      "id": "singleton-base-cases",
+      "title": "Singleton Subsequence and Length Lower Bounds (ACT-1)",
+      "startLine": 114,
+      "endLine": 178,
+      "summary": "ACT-1 (erdos-szekeres-oq-01): the constant map at i witnesses both HasIncreasingEndingAt f i 1 and HasDecreasingEndingAt f i 1 (lemmas hasIncreasingEndingAt_one / hasDecreasingEndingAt_one). Defines maxIncLen / maxDecLen via Nat.findGreatest and proves the lower bounds one_le_maxIncLen / one_le_maxDecLen.",
+      "mathContext": "$\\text{maxIncLen}(f, i) = \\text{Nat.findGreatest}(\\text{HasIncreasingEndingAt}(f,i),\\, i.\\text{val}+1)$. The singleton witness gives $1 \\le \\text{maxIncLen}(f,i)$ (and dually for $\\text{maxDecLen}$), the base case for the pigeonhole pairing."
+    },
+    {
       "id": "main-theorem",
       "title": "The Main Theorem",
-      "startLine": 111,
-      "endLine": 153,
-      "summary": "Statement of the Erdős–Szekeres theorem (axiomatized via `erdos_szekeres_existence_axiom`). The theorem is stated and the pigeonhole approach is described in comments, but the proof body delegates to the axiom.",
-      "mathContext": "$n \\ge (r-1)(s-1) + 1 \\implies$ any injective $f : \\text{Fin}\\, n \\to \\alpha$ has an increasing subsequence of length $r$ or decreasing of length $s$. Axiomatized; intended proof via pigeonhole on $(a_i, b_i)$ pairs."
-    },
-    {
-      "id": "classic-form",
-      "title": "Classic Form",
-      "startLine": 142,
-      "endLine": 154,
-      "summary": "The n²+1 corollary: any sequence of n²+1 elements has a monotonic subsequence of length n+1.",
-      "mathContext": "$n = m^2 + 1 \\implies$ any injective sequence of length $n$ has a monotonic subsequence of length $m + 1$. Special case $r = s = m + 1$: $(m+1-1)(m+1-1) + 1 = m^2 + 1$."
-    },
-    {
-      "id": "tightness",
-      "title": "Tightness of Bound",
-      "startLine": 155,
-      "endLine": 184,
-      "summary": "Tightness bound statement (axiomatized via `erdos_szekeres_tight_axiom`). The block-decomposition construction is described in comments but not formalized.",
-      "mathContext": "$\\exists f : \\text{Fin}\\, ((r-1)(s-1)) \\to \\mathbb{N}$ injective with no increasing length $r$ and no decreasing length $s$. Axiomatized; intended construction: $s-1$ increasing blocks of $r-1$ elements, blocks in decreasing order."
+      "startLine": 180,
+      "endLine": 252,
+      "summary": "The Erdős–Szekeres theorem in three forms. Existence form (erdos_szekeres_existence) and tightness (erdos_szekeres_tight) each delegate to a stated axiom (erdos_szekeres_existence_axiom, erdos_szekeres_tight_axiom); the classic n²+1 form (erdos_szekeres_classic) is derived from existence with r = s = m+1.",
+      "mathContext": "Existence: $n \\ge (r-1)(s-1)+1 \\implies$ increasing length $r$ or decreasing length $s$. Classic: a sequence of $m^2+1$ elements has a monotonic subsequence of length $m+1$. Tightness: $\\exists f$ on $(r-1)(s-1)$ elements with no increasing length $r$ and no decreasing length $s$ ($s-1$ increasing blocks of $r-1$, blocks in decreasing order)."
     },
     {
       "id": "examples",
       "title": "Concrete Examples",
-      "startLine": 185,
-      "endLine": 230,
-      "summary": "Examples demonstrating the theorem on specific sequences.",
-      "mathContext": "For $r = s = 3$: sequence $[3, 4, 1, 2]$ has length $(3-1)(3-1) = 4$. No increasing length 3 (blocked), no decreasing length 3 (only 2 blocks). Adding one more element forces a monotonic triple."
+      "startLine": 254,
+      "endLine": 297,
+      "summary": "Worked examples: two_element_monotonic (any 2-element sequence is monotonic), and increasing_example / decreasing_example exhibiting [1,2,3] and [3,2,1] as length-3 subsequences of themselves.",
+      "mathContext": "For $r = s = 3$: the sequence $[3, 4, 1, 2]$ of length $(3-1)(3-1) = 4$ has no increasing length 3 (blocked) and no decreasing length 3 (only 2 blocks); adding one more element forces a monotonic triple."
     },
     {
       "id": "ramsey-perspective",
       "title": "Ramsey-Theoretic Perspective",
-      "startLine": 231,
-      "endLine": 280,
-      "summary": "The Erdős–Szekeres number and its connection to Ramsey theory.",
+      "startLine": 299,
+      "endLine": 344,
+      "summary": "The Erdős–Szekeres number erdosSzekeresNumber r s = (r-1)(s-1)+1, its symmetry (erdosSzekeres_symmetric), small-value examples, and the lower bound erdosSzekeresNumber_ge_two — viewed as a special case of Ramsey's theorem for ordered sets.",
       "mathContext": "$ES(r,s) = (r-1)(s-1) + 1$. 2-color pairs $(i,j)$ by comparing $f(i)$ vs $f(j)$. The theorem guarantees a red $r$-clique (increasing) or blue $s$-clique (decreasing). $ES(r,s) = ES(s,r)$ by symmetry."
     }
   ],
@@ -220,7 +228,7 @@
       "Function"
     ],
     "namespace": "ErdosSzekeres",
-    "lineCount": 280,
+    "lineCount": 344,
     "axiomCount": 2,
     "theoremCount": 8,
     "definitionCount": 6,


### PR DESCRIPTION
## Summary
- The Erdős–Szekeres base gallery `sections` array had drifted on several axes:
  - **No header section** — coverage started at line 58, omitting imports + the module docstring (theorem statement, history, proof idea, Mathlib deps).
  - **Internal gap** — lines 85–110 (the `Length of Longest Subsequences` predicates) were uncovered.
  - **Self-overlap** — "Classic Form" (142–154) sat inside "The Main Theorem" (111–153).
  - **Tail uncovered** — 65 lines (281–345) after the last section, including all the ACT-1 additions (singleton base cases, `maxIncLen`/`maxDecLen`, length lower bounds) and the Ramsey-number lemmas.

## Changes
- Re-mapped to **7 contiguous sections** aligned to the file's `## ` markers with full coverage (lines 1–344).
- Folded "Classic Form" and "Tightness of Bound" into **The Main Theorem** (they live under that single marker with no own `## ` markers).
- Bumped `lineCount` 280 → 344 in both the `meta` and `leanFile` blocks.

## Verification
- Counts (8 theorems / 6 definitions / 2 axioms / 0 sorries) and the `axiomatized`/`axiom` status were already correct and are unchanged.
- No Lean source changed — metadata-only realignment so the gallery renders the complete proof.
- JSON validated; non-section content byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)