### PR TITLE
research(feuerbachs-theorem-oq-02): realign gallery sections to full file (7→15)

### DIFF
--- a/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
+++ b/src/data/proofs/feuerbachs-theorem-oq-02/meta.json
@@ -68,60 +68,124 @@
   },
   "sections": [
     {
-      "id": "3d-infrastructure",
-      "title": "Points, Distances, and Vectors in R^3",
-      "startLine": 46,
-      "endLine": 87,
-      "summary": "Definitions of Point3, dist3, midpoint3, dot product, cross product for 3D geometry.",
-      "mathContext": "Basic infrastructure for coordinate geometry in three dimensions, analogous to the 2D infrastructure in FeuerbachsTheoremDefs.lean."
+      "id": "part1-points-distances",
+      "title": "PART 1: Points and Distances in ℝ³",
+      "startLine": 47,
+      "endLine": 105,
+      "summary": "Core 3D coordinate infrastructure: Point3, dist3 and dist3_sq (with dist3_nonneg and dist3_sq_eq), midpoint3, dot product dot3, vector vec3, cross product cross3, and the two scalar-triple-product vanishing lemmas.",
+      "mathContext": "Basic infrastructure for coordinate geometry in three dimensions, analogous to the 2D infrastructure in FeuerbachsTheoremDefs.lean. The scalar-triple-product identities dot3 u (cross3 u v) = 0 underpin the later circumcenter computation."
     },
     {
-      "id": "tetrahedron",
-      "title": "Tetrahedron Structure",
-      "startLine": 92,
-      "endLine": 120,
-      "summary": "Non-degenerate tetrahedron with four vertices and positive volume condition via scalar triple product.",
-      "mathContext": "The non-degeneracy condition uses det(B-A, C-A, D-A) ≠ 0, ensuring the four vertices are non-coplanar."
+      "id": "part2-tetrahedron",
+      "title": "PART 2: Tetrahedron Structure",
+      "startLine": 106,
+      "endLine": 131,
+      "summary": "Non-degenerate Tetrahedron structure with four vertices, plus signedVolume6 (scalar triple product) and volume (|signedVolume6|/6).",
+      "mathContext": "The non-degeneracy condition uses det(B-A, C-A, D-A) ≠ 0, ensuring the four vertices are non-coplanar (positive volume)."
     },
     {
-      "id": "orthocentric",
-      "title": "The Orthocentric Condition",
-      "startLine": 148,
-      "endLine": 176,
-      "summary": "Definition of orthocentric tetrahedra and proof that the third perpendicularity condition follows from the first two.",
-      "mathContext": "An orthocentric tetrahedron has AB ⊥ CD and AC ⊥ BD. We prove AD ⊥ BC follows by algebraic manipulation of the dot product. This is the key structural condition for the 3D Feuerbach theorem."
+      "id": "part3-edges-faces",
+      "title": "PART 3: Edge Lengths and Face Areas",
+      "startLine": 132,
+      "endLine": 181,
+      "summary": "The six edge lengths (edge_AB … edge_CD), the four triangular face areas via the cross-product formula |u × v|/2, and the total surfaceArea.",
+      "mathContext": "Each face area is computed as half the norm of the cross product of two edge vectors of that face. The total surface area S feeds the inradius formula r = 3V/S."
     },
     {
-      "id": "special-points",
-      "title": "Special Points: Centroid, Circumcenter, Monge Point",
-      "startLine": 181,
-      "endLine": 235,
-      "summary": "Definitions of centroid, edge midpoints, face centroids, circumcenter, and the Monge point M = 4G - 3O.",
-      "mathContext": "The Monge point is the 3D analogue of the orthocenter. For general tetrahedra, altitudes are NOT concurrent, but the Monge point always exists. For orthocentric tetrahedra, it coincides with the orthocenter."
+      "id": "part4-orthocentric",
+      "title": "PART 4: The Orthocentric Condition",
+      "startLine": 182,
+      "endLine": 205,
+      "summary": "Definition of OrthocentricTetrahedron (AB ⊥ CD and AC ⊥ BD) and the theorem orthocentric_third_perp proving the third condition AD ⊥ BC follows from the first two.",
+      "mathContext": "An orthocentric tetrahedron has all four altitudes concurrent. Only two of the three opposite-edge perpendicularity conditions need be imposed; the third follows algebraically (proved by nlinarith). This is the key structural hypothesis for the 3D Feuerbach question."
     },
     {
-      "id": "insphere-exspheres",
-      "title": "Insphere and Exspheres",
-      "startLine": 240,
-      "endLine": 305,
-      "summary": "Definitions of incenter, inradius, four excenters, and four exradii using face-area-weighted coordinates.",
-      "mathContext": "The incenter is the face-area-weighted average of vertices: I = (S_A·A + S_B·B + S_C·C + S_D·D) / S. The inradius is r = 3V/S. Excenters use negative weights."
+      "id": "part5-special-points",
+      "title": "PART 5: Special Points of a Tetrahedron",
+      "startLine": 206,
+      "endLine": 244,
+      "summary": "Definitions of the centroid G, the six edge midpoints (midpoint_AB … midpoint_CD), and the four face centroids (faceCentroid_A … faceCentroid_D).",
+      "mathContext": "The centroid is the average of the four vertices; edge midpoints and face centroids are the distinguished points whose sphere membership the twenty-four-point sphere candidate concerns."
     },
     {
-      "id": "twenty-four-point-sphere",
-      "title": "The Twenty-Four-Point Sphere",
-      "startLine": 310,
-      "endLine": 325,
-      "summary": "Definition of the twenty-four-point sphere: center is midpoint of circumcenter and Monge point, radius is R/3.",
-      "mathContext": "The twenty-four-point sphere is the 3D analogue of the nine-point circle. It passes through the 6 edge midpoints, 4 face centroids, and 14 other distinguished points."
+      "id": "part6-circumsphere-monge",
+      "title": "PART 6: Circumsphere and Monge Point",
+      "startLine": 245,
+      "endLine": 350,
+      "summary": "The circumcenter via Cramer's rule, three helper lemmas (circumcenter_dot_eq{,_v,_w}) establishing the defining dot-product equations, the theorem circumcenter_equidist (equidistant from all four vertices), the circumradius, and the Monge point M = 4G − 3O.",
+      "mathContext": "The circumcenter displacement P = O − A solves 2(u·P) = |u|² for each edge vector u; this gives |OX|² − |OA|² = 0 for X ∈ {B,C,D}. The Monge point lies on the Euler line; for an orthocentric tetrahedron O, G, H, M sit at parameter ratios 0:1:2:4 and H = midpoint(O, M)."
     },
     {
-      "id": "feuerbach-3d-refutation",
-      "title": "Refutation of the (N₂₄, R/3)-Sphere Candidate",
-      "startLine": 459,
-      "endLine": 521,
-      "summary": "Closed-form symbolic counterexample showing that for the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)), the (N₂₄, R/3)-sphere is NOT internally tangent to the insphere; the previously sorry-stated tangency theorems have been removed.",
-      "mathContext": "At T₀: O = (1, 3/2, 3), R = 7/2, N₂₄ = (0, 0, 0), face areas (S_A, S_B, S_C, S_D) = (9, 6, 3, 3√14), V = 6, r = 6/(6 + √14), I = (r, r, r). Hence dist(N₂₄, I) = r√3 and |R/3 − r| = 7/6 − r, which differ in closed form (squaring: 3r² ≠ (7/6 − r)²). The same tetrahedron also refutes the midedge-sphere variant (center G, radius R/2)."
+      "id": "part7-insphere-exspheres",
+      "title": "PART 7: Insphere and Exspheres",
+      "startLine": 351,
+      "endLine": 426,
+      "summary": "Definitions of the incenter, inradius r = 3V/S, the four excenters (excenter_A … excenter_D), and the four exradii (exradius_A … exradius_D), all via face-area-weighted vertex coordinates.",
+      "mathContext": "The incenter is the face-area-weighted average of vertices: I = (S_A·A + S_B·B + S_C·C + S_D·D) / S. Each excenter negates one face's weight; the corresponding exradius divides 3V by the signed face-area sum."
+    },
+    {
+      "id": "part8-twenty-four-point-sphere",
+      "title": "PART 8: The Twenty-Four-Point Sphere",
+      "startLine": 427,
+      "endLine": 445,
+      "summary": "Definition of the twenty-four-point sphere center N₂₄ = midpoint(O, M) and its radius R/3, with documentation flagging that R/3 does not correspond to the midedge sphere (center G, radius R/2).",
+      "mathContext": "Proposed as the 3D analogue of the nine-point circle (radius R/2 in 2D). The accompanying docstrings warn that this radius does not match the edge-midpoint sphere and may not be a classical geometric sphere."
+    },
+    {
+      "id": "part9-tangency-defs",
+      "title": "PART 9: Tangency Definitions for Spheres",
+      "startLine": 446,
+      "endLine": 459,
+      "summary": "Predicates spheresInternallyTangent (dist = |r₁ − r₂|) and spheresExternallyTangent (dist = r₁ + r₂).",
+      "mathContext": "Standard sphere-tangency conditions used to state (and refute) the candidate 3D Feuerbach tangency claims."
+    },
+    {
+      "id": "part10-feuerbach-3d-refutation",
+      "title": "PART 10: The 3D Feuerbach Conjecture — Refuted as Stated",
+      "startLine": 460,
+      "endLine": 514,
+      "summary": "Closed-form symbolic counterexample showing that for the orthocentric tetrahedron T₀ = ((2,0,0),(0,3,0),(0,0,6),(0,0,0)) the (N₂₄, R/3)-sphere is NOT internally tangent to the insphere; the five previously sorry-stated tangency theorems and the bundled feuerbach_3d_theorem were removed, with literature pointers to Murakami (1952) and Court (1934).",
+      "mathContext": "At T₀: O = (1, 3/2, 3), R = 7/2, N₂₄ = (0, 0, 0), face areas (S_A, S_B, S_C, S_D) = (9, 6, 3, 3√14), V = 6, r = 6/(6 + √14), I = (r, r, r). Hence dist(N₂₄, I) = r√3 and |R/3 − r| = 7/6 − r, which differ in closed form (squaring: 3r² ≠ (7/6 − r)²). The midedge-sphere variant (center G, radius R/2) is also refuted at T₀."
+    },
+    {
+      "id": "part11-twenty-four-point-properties",
+      "title": "PART 11: Twenty-Four-Point Sphere Properties (Proved)",
+      "startLine": 515,
+      "endLine": 559,
+      "summary": "Four proved identities: monge_point_euler_line (M = 4G − 3O), twentyFourPointCenter_midpoint, twentyFourPointRadius_eq, centroid_on_euler_line (G = (3O + M)/4), and twentyFourPointCenter_is_2G_minus_O (N₂₄ = 2G − O).",
+      "mathContext": "These establish the 3D Euler line relations: the centroid divides the O–M segment in ratio 3:1, and N₂₄ = 2G − O equals the orthocenter H for orthocentric tetrahedra."
+    },
+    {
+      "id": "part12-volume-inradius",
+      "title": "PART 12: Volume-Inradius Relation (Proved)",
+      "startLine": 560,
+      "endLine": 569,
+      "summary": "Theorem volume_eq_inradius_surfaceArea: V = r·S/3 (equivalently r = 3V/S) for any tetrahedron with positive surface area.",
+      "mathContext": "The 3D analogue of the triangle relation Area = r·s; follows directly from the inradius definition by field_simp."
+    },
+    {
+      "id": "part13-general-counterexample",
+      "title": "PART 13: Counterexample — General Tetrahedra",
+      "startLine": 570,
+      "endLine": 587,
+      "summary": "Axiom feuerbach_3d_fails_general: there exists a non-orthocentric tetrahedron for which the (N₂₄, R/3)-sphere is not internally tangent to the insphere, showing the orthocentric hypothesis is necessary.",
+      "mathContext": "Unlike the 2D Feuerbach theorem (which holds for all triangles), the 3D analogue requires extra hypotheses. This is the file's single axiom; per PART 10 the orthocentric hypothesis alone is still insufficient with this sphere."
+    },
+    {
+      "id": "part14-edge-midpoints",
+      "title": "PART 14: Edge Midpoints on the Twenty-Four-Point Sphere",
+      "startLine": 588,
+      "endLine": 690,
+      "summary": "Corrects two former false axioms and proves the true results: edge_midpoints_equidist_from_centroid (all six midpoints equidistant from G, orthocentric case), edge_midpoints_paired_equidist_from_centroid (opposite-edge pairs equidistant for any tetrahedron), and edge_midpoints_dist_sq_formula (exact squared distances (|AC|²+|BD|²)/16 and (|AB|²+|CD|²)/16).",
+      "mathContext": "The edge midpoints lie on a sphere centered at the centroid G, not at N₂₄. The three opposite-pair equalities hold universally; the orthocentric conditions bridge across pairs to give full equidistance. Former axioms edge_midpoints_on_sphere and face_centroids_on_sphere were removed as mathematically false."
+    },
+    {
+      "id": "part15-summary",
+      "title": "PART 15: Summary",
+      "startLine": 691,
+      "endLine": 769,
+      "summary": "Closing docstring inventory: the 11 proved results (0 sorries), the single axiom feuerbach_3d_fails_general, the corrections applied across the 2026-04-27 / 05-02 / 05-03 revisions, and the key insights on the tetrahedron Euler line and the still-open Murakami formulation.",
+      "mathContext": "Records that all five tangency sorries were removed after the PART 10 refutation, and that identifying the correct 3D Feuerbach sphere (Murakami's face-circumcircle construction) remains an open formalization target."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
The `feuerbachs-theorem-oq-02` gallery `meta.json` had a stale, mislabeled `sections` array: **7 sections** whose ranges stopped at line **521**, while `FeuerbachsTheoremOQ02.lean` is **769 lines** organized into **15 explicit `PART` banners** — roughly **32% of the file (lines 521–769) was hidden** from the gallery, and several early section labels/ranges no longer matched the source.

This rebuilds the `sections` array to all **15 PARTs** with correct line ranges (47→769, fully covering the file) and accurate summaries/mathContext drawn from the source.

## What changed
- `sections`: 7 → 15, full-file coverage, monotonic non-overlapping ranges.
- Newly surfaced sections: PART 3 (edge lengths/face areas), PART 6 (circumsphere & Monge point), PART 9 (tangency definitions), PART 11 (twenty-four-point properties), PART 12 (volume–inradius), PART 13 (general counterexample axiom), PART 14 (edge midpoints), PART 15 (summary).
- **No count changes**: `theoremCount` (13, = non-private theorems), `definitionCount` (50), `axiomCount` (1), `lineCount` (769) were already correct and match `leanFile`.
- Every non-`sections` key is **byte-identical** to `origin/main` (verified).

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections are monotonic, non-overlapping, and cover lines 47–769
- [x] Section titles/ranges match the `-- PART N` banners in the Lean source
- [x] All other meta keys unchanged vs `origin/main`

Build-free metadata-only change (no Lean rebuild required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)