### PR TITLE
research(nth-root-irrational): realign drifted gallery sections (base 7→10, oq-01 5→8)

### DIFF
--- a/src/data/proofs/nth-root-irrational-oq-01/meta.json
+++ b/src/data/proofs/nth-root-irrational-oq-01/meta.json
@@ -95,7 +95,7 @@
     },
     {
       "id": "core-theorem",
-      "title": "Irreducible Polynomial Has No Rational Root",
+      "title": "Part I: Irreducible Polynomial Has No Rational Root",
       "startLine": 38,
       "endLine": 60,
       "summary": "Proves irreducible_no_rational_root: if p in Q[X] is irreducible with degree >= 2, then p has no rational root. The proof uses the factorization p = (X - r) * q from a root r, then applies irreducibility to show either X - r or q is a unit, both leading to contradictions.",
@@ -103,27 +103,51 @@
     },
     {
       "id": "irrationality-lift",
-      "title": "Irrational Roots of Irreducible Polynomials",
+      "title": "Part II: Irrational Roots of Irreducible Polynomials",
       "startLine": 61,
+      "endLine": 78,
+      "summary": "Proves irrational_root_of_irreducible: lifts the rational non-root result to real roots via injectivity of algebraMap Q -> R, so any real root of an irreducible degree >= 2 polynomial is irrational.",
+      "mathContext": "If $\\alpha \\in \\mathbb{R}$ satisfies $p(\\alpha) = 0$ for irreducible $p$ with $\\deg(p) \\geq 2$, then $\\alpha \\notin \\mathbb{Q}$, since a rational root would contradict irreducibility."
+    },
+    {
+      "id": "degree-characterization",
+      "title": "Part III: Algebraic Degree Characterization",
+      "startLine": 79,
       "endLine": 90,
-      "summary": "Proves irrational_root_of_irreducible and irrational_of_minpoly_degree_ge_two. The first lifts the rational non-root result to real roots via injectivity of algebraMap Q -> R. The second applies this to minimal polynomials.",
-      "mathContext": "If $\\alpha \\in \\mathbb{R}$ satisfies $p(\\alpha) = 0$ for irreducible $p$ with $\\deg(p) \\geq 2$, then $\\alpha \\notin \\mathbb{Q}$. Equivalently, $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\geq 2 \\implies \\alpha$ is irrational."
+      "summary": "Proves irrational_of_minpoly_degree_ge_two: if the minimal polynomial of an integral element alpha over Q has degree >= 2, then alpha is irrational. Applies the irreducibility lift to minpoly.",
+      "mathContext": "If $\\alpha$ is integral over $\\mathbb{Q}$ with $\\deg(\\text{minpoly}_{\\mathbb{Q}}(\\alpha)) \\geq 2$, then $\\alpha \\notin \\mathbb{Q}$. Equivalently, $[\\mathbb{Q}(\\alpha):\\mathbb{Q}] \\geq 2 \\implies \\alpha$ is irrational."
     },
     {
       "id": "eisenstein",
-      "title": "Eisenstein Criterion for X^n - p",
+      "title": "Part IV: Eisenstein Criterion for X^n - p",
       "startLine": 91,
       "endLine": 155,
-      "summary": "Proves X^n - p is irreducible over Z (via Eisenstein at the prime ideal (p)) and then over Q (via the Gauss lemma). The Eisenstein verification checks: leading coefficient not in (p), lower coefficients in (p), constant term not in (p^2), and the polynomial is primitive (monic).",
+      "summary": "Proves X^n - p is irreducible over Z (via Eisenstein at the prime ideal (p)) and then over Q (via the Gauss lemma). The Eisenstein verification checks: leading coefficient not in (p), lower coefficients in (p), constant term not in (p^2), and the polynomial is primitive (monic). Also proves deg(X^n - c) = n for c != 0.",
       "mathContext": "For prime $p$ and $n \\geq 2$: $X^n - p \\in \\mathbb{Z}[X]$ is irreducible by Eisenstein's criterion at $(p)$, hence irreducible in $\\mathbb{Q}[X]$ by the Gauss lemma. Also proves $\\deg(X^n - c) = n$ for $c \\neq 0$."
     },
     {
       "id": "nth-root-irrationality",
-      "title": "Irrationality of Nth Roots of Primes",
+      "title": "Part V: Structural Irrationality of Nth Roots of Primes",
       "startLine": 156,
+      "endLine": 174,
+      "summary": "Proves irrational_nthRoot_of_prime: for prime p and n >= 2, p^(1/n) is irrational, by exhibiting it as a root of the irreducible polynomial X^n - p and applying the irrationality lift.",
+      "mathContext": "For prime $p$ and $n \\geq 2$: $p^{1/n}$ is a root of the irreducible polynomial $X^n - p$, hence irrational."
+    },
+    {
+      "id": "concrete-applications",
+      "title": "Part VI: Concrete Applications",
+      "startLine": 175,
+      "endLine": 194,
+      "summary": "Concrete irrationality results obtained from irrational_nthRoot_of_prime: sqrt(2), cbrt(2), cbrt(3), and the fifth root of 7.",
+      "mathContext": "Instances of the structural theorem: $\\sqrt{2}$, $\\sqrt[3]{2}$, $\\sqrt[3]{3}$, $\\sqrt[5]{7}$ are all irrational, each via irreducibility of the corresponding $X^n - p$."
+    },
+    {
+      "id": "structural-hierarchy",
+      "title": "Part VII: The Structural Hierarchy",
+      "startLine": 195,
       "endLine": 209,
-      "summary": "Proves irrational_nthRoot_of_prime: for prime p and n >= 2, p^(1/n) is irrational. Combines Eisenstein irreducibility with the irrationality lift. Concrete applications: sqrt(2), cbrt(2), cbrt(3), 5th-root(7). The structural_subsumes_counting theorem highlights that this approach subsumes counting arguments.",
-      "mathContext": "For prime $p$ and $n \\geq 2$: $p^{1/n}$ is a root of the irreducible polynomial $X^n - p$, hence irrational. Concrete: $\\sqrt{2}$, $\\sqrt[3]{2}$, $\\sqrt[3]{3}$, $\\sqrt[5]{7}$ are all irrational."
+      "summary": "Proves structural_subsumes_counting, showing the irreducible-polynomial approach (Level 3) subsumes counting arguments (Level 2) by reducing irrationality to a single algebraic property.",
+      "mathContext": "The irreducible-polynomial method subsumes elementary counting arguments: for any prime $p$ and $n \\geq 2$, irrationality of $p^{1/n}$ follows from one algebraic fact (irreducibility of $X^n - p$) rather than case-specific divisibility counting."
     }
   ],
   "crossReferences": [

--- a/src/data/proofs/nth-root-irrational/meta.json
+++ b/src/data/proofs/nth-root-irrational/meta.json
@@ -112,25 +112,49 @@
       "id": "not-perfect-power",
       "title": "Not-a-Perfect-Power Lemmas",
       "startLine": 100,
-      "endLine": 231,
+      "endLine": 249,
       "summary": "Concrete proofs that specific small numbers are not perfect squares, cubes, 4th or 5th powers.",
-      "mathContext": "Concrete verifications that specific small integers are not perfect powers: $2, 3, 5$ are not perfect squares; $2, 3, 5$ are not perfect cubes; etc. Each proved by exhaustive case analysis or `omega`/`norm_num`."
+      "mathContext": "Concrete verifications that specific small integers are not perfect powers: $2, 3, 5$ are not perfect squares; $2, 3, 5$ are not perfect cubes; $2, 3$ are not perfect fourth powers; $2$ is not a perfect fifth power. Each proved by exhaustive case analysis or `omega`/`norm_num`."
     },
     {
-      "id": "corollaries",
-      "title": "Concrete Corollaries",
-      "startLine": 232,
-      "endLine": 276,
-      "summary": "Specific irrationality results: sqrt(2,3,5), cbrt(2,3,5), 4thrt(2,3), 5thrt(2).",
-      "mathContext": "Specific irrationality results: $\\sqrt{2}, \\sqrt{3}, \\sqrt{5} \\notin \\mathbb{Q}$; $\\sqrt[3]{2}, \\sqrt[3]{3}, \\sqrt[3]{5} \\notin \\mathbb{Q}$; $\\sqrt[4]{2}, \\sqrt[4]{3} \\notin \\mathbb{Q}$; $\\sqrt[5]{2} \\notin \\mathbb{Q}$. Each instantiates the general theorem."
+      "id": "corollaries-sqrt",
+      "title": "Concrete Corollaries: Square Roots",
+      "startLine": 250,
+      "endLine": 263,
+      "summary": "Specific irrationality results for square roots: sqrt(2), sqrt(3), sqrt(5).",
+      "mathContext": "Square-root instances of the general theorem: $\\sqrt{2}, \\sqrt{3}, \\sqrt{5} \\notin \\mathbb{Q}$, each obtained from the corresponding not-a-perfect-square lemma."
+    },
+    {
+      "id": "corollaries-cbrt",
+      "title": "Concrete Corollaries: Cube Roots",
+      "startLine": 264,
+      "endLine": 277,
+      "summary": "Specific irrationality results for cube roots: cbrt(2), cbrt(3), cbrt(5).",
+      "mathContext": "Cube-root instances of the general theorem: $\\sqrt[3]{2}, \\sqrt[3]{3}, \\sqrt[3]{5} \\notin \\mathbb{Q}$, each obtained from the corresponding not-a-perfect-cube lemma."
+    },
+    {
+      "id": "corollaries-fourth",
+      "title": "Concrete Corollaries: Fourth Roots",
+      "startLine": 278,
+      "endLine": 287,
+      "summary": "Specific irrationality results for fourth roots: 4thrt(2), 4thrt(3).",
+      "mathContext": "Fourth-root instances of the general theorem: $\\sqrt[4]{2}, \\sqrt[4]{3} \\notin \\mathbb{Q}$, each obtained from the corresponding not-a-perfect-fourth-power lemma."
+    },
+    {
+      "id": "corollaries-fifth",
+      "title": "Fifth Roots",
+      "startLine": 288,
+      "endLine": 293,
+      "summary": "Specific irrationality result for fifth roots: 5thrt(2).",
+      "mathContext": "Fifth-root instance of the general theorem: $\\sqrt[5]{2} \\notin \\mathbb{Q}$, obtained from the not-a-perfect-fifth-power lemma."
     },
     {
       "id": "converse",
-      "title": "The Converse: Perfect Powers",
-      "startLine": 277,
+      "title": "The Characterization (Converse: Perfect Powers)",
+      "startLine": 294,
       "endLine": 312,
       "summary": "Shows the characterization is tight: perfect nth powers give integer nth roots.",
-      "mathContext": "The characterization is tight: $\\sqrt[n]{m^n} = m \\in \\mathbb{Z}$ for any positive integer $m$. Thus $\\sqrt[n]{k} \\in \\mathbb{Q} \\iff k$ is a perfect $n$th power."
+      "mathContext": "The characterization is tight: $\\sqrt[n]{m^n} = m \\in \\mathbb{Z}$ for any positive integer $m$. Thus $\\sqrt[n]{k} \\in \\mathbb{Q} \\iff k$ is a perfect $n$th power. Closing examples confirm $\\sqrt{4}=2$, $\\sqrt[3]{8}=2$, $\\sqrt[3]{27}=3$, $\\sqrt[4]{16}=2$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Build-free gallery metadata fix for the `nth-root-irrational` family. Both galleries had stale `sections[]` arrays that drifted from their Lean source banners.

**Base** (`NthRootIrrational.lean`, 312 lines): 7 → 10 sections
- `Not-a-Perfect-Power Lemmas` undercovered (ended @231; the fifth-power lemma proof actually runs to @249).
- The tail was mislabeled: `Concrete Corollaries` (232-276) and `The Converse: Perfect Powers` (277-312) did not match the source banners — lines 277-293 are Fourth/Fifth-root corollaries, and the converse/characterization only begins @294.
- Rebuilt to the 10 source `## ` banners with contiguous, monotonic, full-file coverage.

**OQ-01** (`NthRootIrrationalOQ01.lean`, 209 lines): 5 → 8 sections
- 7 `Part` banners but only 5 meta sections. **Parts III (Algebraic Degree Characterization), VI (Concrete Applications), VII (The Structural Hierarchy)** were swallowed into neighboring sections.
- Re-pinned all 8 sections (preamble + Parts I–VII).

## Verification
- Metadata-only change; for both files all non-`sections` content is byte-identical (verified via `jq 'del(.sections)'` diff).
- Coverage: base maxEnd=312=lineCount, oq-01 maxEnd=209=lineCount; both monotonic & contiguous.
- No Lean rebuild required.

## Notes
Surfaced while the claimed slug `nth-root-irrational-oq-03` (transcendence) remains externally-gated (Mathlib PR + Docker). No `loom:review-requested` label — math PR for deployer auto-merge.