### PR TITLE
research(descartes-rule-of-signs-oq-03): add missing tail Summary section (10→11)

### DIFF
--- a/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
+++ b/src/data/proofs/descartes-rule-of-signs-oq-03/meta.json
@@ -157,6 +157,13 @@
       "startLine": 339,
       "endLine": 412,
       "summary": "Concrete examples: x - c has 1 positive root, x + c has none, cauchyBound(X - C c) = ‖c‖₊ + 1. IVT-based root existence: if p(a) < 0 < p(b), there exists a root in [a,b]. Negative root summary combines negative_root_iff with Cauchy bound."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 414,
+      "endLine": 440,
+      "summary": "Closing module docstring recapping the OQ-03 bridge between Descartes' Rule of Signs and constructive root-bound computation, with a numbered list of the named theorems (all proved, 0 sorries), followed by the closing `end DescartesConstructiveBounds`."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
- The `descartes-rule-of-signs-oq-03` gallery `sections` array stopped at line 412 while the Lean file is 440 lines.
- The uncovered tail (414–438) is the closing **Summary** docstring recapping the OQ-03 bridge between Descartes' Rule of Signs and constructive root-bound computation, plus the closing `end DescartesConstructiveBounds`.

## Changes
- Added a **Summary** section (lines 414–440) so the gallery renders the full source (10 → 11 sections, contiguous 1–440).

## Verification
- Counts (29 theorems/lemmas / 4 definitions / 0 axioms / 0 sorries) and `lineCount` (440) were already correct and are unchanged.
- The first 10 sections were already contiguous and correctly aligned to the Part markers; only the tail was missing.
- No Lean source changed — metadata-only realignment. JSON validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)