### PR TITLE
research(ballot-problem-oq-01-oq-02): re-pin drifted back-half gallery sections (full-file coverage)

### DIFF
--- a/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/ballot-problem-oq-01-oq-02/meta.json
@@ -150,31 +150,31 @@
       "id": "fiber-analysis-reduction",
       "title": "Part VII+VIII: Fiber Analysis and Main Theorem",
       "startLine": 314,
-      "endLine": 504,
+      "endLine": 618,
       "summary": "Section FiberAnalysis: projectionFiber, fiber_same_length, fiber_same_leader_positions (sequences in same fiber agree on leader positions at each index). Section ProperReduction: multiCountedSequence, multiStaysPositive, project_multi_to_counted, multi_stays_iff_projected (Iff.rfl), multiProjectionFiber, multiPositiveFiber, fiber_stays_iff_target, positive_fiber_dichotomy (fibers are entirely inside or outside multiStaysPositive). uniformOn_fiber_transfer theorem. multi_candidate_ballot theorem (2-line proof via uniformOn_fiber_transfer + Ballot.ballot_problem).",
       "mathContext": "fiber_same_leader_positions: position i has leader iff target[i] = 1, proved by extracting getElem from projection equality. positive_fiber_dichotomy: ext s; simp [multiPositiveFiber, Set.mem_inter_iff, and_iff_left_iff_imp]; exact (fiber_stays_iff_target ...).mpr htarget. multi_candidate_ballot: rw [uniformOn_fiber_transfer m hm a b hab]; exact Ballot.ballot_problem b a hab."
     },
     {
       "id": "fiber-bijection",
       "title": "Part VIII-B: Fiber Bijection Infrastructure",
-      "startLine": 506,
-      "endLine": 758,
+      "startLine": 619,
+      "endLine": 873,
       "summary": "Constructs an explicit bijection between fibers. extractOpponents s target: filter s-positions where target=-1. reconstructSeq target ops: rebuild a sequence from target pattern and opponent values. fiberSwap t1 t2 s: extract from s using t1, rebuild using t2. Lemmas: extractOpponents_cons_neg/one (positional computation), reconstruct_extract_cancel (reconstruct ∘ extract = id on fiber members), extractOpponents_nonleader (ops are non-leader), reconstructSeq_projects (rebuild projects to target), extract_reconstruct_cancel, extractOpponents_count, fiberSwap_cancel (swap-swap = id).",
       "mathContext": "reconstruct_extract_cancel: induction on s, case split x = leader (target head = 1, use extractOpponents_cons_one and IH) or x ≠ leader (target head = -1, use extractOpponents_cons_neg and IH). fiberSwap_cancel chains extract_count, reconstruct_projects, extract_reconstruct_cancel, and reconstruct_extract_cancel."
     },
     {
       "id": "fiber-cardinality",
       "title": "Part VIII-C: Fiber Cardinality Theorem (Proved, not Axiomatized)",
-      "startLine": 760,
-      "endLine": 877,
+      "startLine": 874,
+      "endLine": 992,
       "summary": "pm1_length_eq: ±1 list length = count(1) + count(-1) (by induction). fiberSwap_mem_multiProjectionFiber: fiberSwap sends fiber(t1) to fiber(t2) — proved by tracking leader count, length, and projection of the reconstructed sequence. multiProjectionFiber_finite: each fiber is finite (subset of fixed-length lists over Fin m, bounded by Set.finite_range of List.ofFn). fiber_card_uniform: all fibers over countedSequence a b have equal Set.ncard — proved by constructing injections in both directions using fiberSwap and applying Set.ncard_le_ncard_of_injOn.",
       "mathContext": "fiber_card_uniform: inj12 := Set.InjOn (fiberSwap m hm1 t1 t2) on fiber(t1) — injectivity from fiberSwap_cancel (cancellation gives s1 = s2 if swap(s1) = swap(s2)). maps12 := fiberSwap maps fiber(t1) into fiber(t2). ncard equality: le_antisymm (ncard_le_ncard_of_injOn maps12 inj12 fin2) (ncard_le_ncard_of_injOn maps21 inj21 fin1)."
     },
     {
       "id": "concrete-open-challenges",
       "title": "Part IX: Reference, Concrete Examples, and Full Ordering Problem",
-      "startLine": 879,
-      "endLine": 934,
+      "startLine": 993,
+      "endLine": 1047,
       "summary": "#check @Ballot.ballot_problem as reference. Four norm_num examples: (3,1,1)→1/5, (5,2,1,1)→1/9, (5,0,0)→1, (4,3)→1/7. The full ordering open problem: P(a₁>a₂>...>aₘ throughout) = det||(aᵢ-aⱼ)/(aᵢ+aⱼ)|| via LGV. Definitions: pairwiseRatio a b := (a-b)/(a+b) and threeCandidateProduct a b c. Verification: threeCandidateProduct 4 2 1 = 1/15.",
       "mathContext": "Ballot.ballot_problem type: uniformOn (countedSequence p q) staysPositive = (↑p - ↑q)/(↑p + ↑q). The argument order (p q with q < p) differs from our usage (b a hab). threeCandidateProduct 4 2 1 = (2/6)·(1/3)·(3/5) = (1/3)·(1/3)·(3/5) = 1/15. The LGV determinant formula requires the Lindström-Gessel-Viennot lemma for non-intersecting lattice path counting."
     }


### PR DESCRIPTION
## Summary
Build-free gallery metadata fix. `BallotProblemOQ01OQ02.lean` grew to 1047 lines (Part VIII expanded), shifting the back-half `Part` banners past their recorded line ranges. Four sections were misaligned and the tail (935–1047) was hidden entirely.

| Section | Old range | New range |
|---|---|---|
| Part VII+VIII: Fiber Analysis and Main Theorem | 314–504 | 314–618 |
| Part VIII-B: Fiber Bijection Infrastructure | 506–758 | 619–873 |
| Part VIII-C: Fiber Cardinality Theorem | 760–877 | 874–992 |
| Part IX: Reference, Concrete Examples, Full Ordering Problem | 879–934 | 993–1047 |

The hidden tail contains Part IX (classical ballot reference), the concrete `norm_num` examples, and the Full Ordering Problem (LGV determinant) open challenge.

## Verification
- Section **content** descriptions were already accurate; only `startLine`/`endLine` drifted as the source grew.
- `maxEnd` now 1047 = `leanFile.lineCount` = actual `wc -l`; sections monotonic & contiguous.
- Metadata-only; all non-`sections` content byte-identical (`jq 'del(.sections)'` diff).
- No Lean rebuild required.

## Notes
Surfaced while the claimed slug `ballot-problem-oq-02-oq-05` (Donsker FCLT) remains Docker-gated and axiom-carrying. No `loom:review-requested` — math PR for deployer auto-merge.