### PR TITLE
research(erdos-1040): realign drifted gallery sections to full file (11→15)

### DIFF
--- a/src/data/proofs/erdos-1040/meta.json
+++ b/src/data/proofs/erdos-1040/meta.json
@@ -61,92 +61,123 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Documentation",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Module docstring for Erdős Problem #1040: for a closed infinite set $F \\subseteq \\mathbb{C}$, let $\\mu(F)$ be the infimum of $|\\{z : |f(z)| < 1\\}|$ over polynomials $f(z)=\\prod(z-z_i)$ with roots $z_i \\in F$ — is $\\mu(F)$ determined by the transfinite diameter of $F$, and in particular is $\\mu(F)=0$ whenever $\\rho(F)\\ge 1$? Records the EHP 1958 and Erdős–Netanyahu (1973) background and imports Mathlib.",
+      "mathContext": "Erdős, Herzog, Piranian problem. Known: YES for line segments and discs (EHP 1958); $\\rho(F)<1 \\Rightarrow$ sublevel set contains a disc; Erdős–Netanyahu (1973) bounds for bounded connected $F$."
+    },
+    {
       "id": "transfinite-diameter",
       "title": "Transfinite Diameter (Logarithmic Capacity)",
       "summary": "Defines the $n$-th diameter $d_n(F)$ as the supremum of geometric means of pairwise distances over $n$-point configurations in $F$, then the transfinite diameter $\\rho(F) = \\inf_n d_n(F)$. Includes an alternative liminf definition and an axiom asserting their equivalence via Fekete's lemma.",
-      "startLine": 26,
-      "endLine": 47,
+      "startLine": 28,
+      "endLine": 46,
       "mathContext": "$d_n(F) = \\sup\\left\\{\\left(\\prod_{i<j} |z_i - z_j|\\right)^{2/(n(n-1))} : z_i \\in F\\right\\}$, $\\rho(F) = \\inf_n d_n(F) = \\lim_n d_n(F)$ by Fekete's lemma."
     },
     {
       "id": "polynomials",
       "title": "Polynomials with Roots in F",
       "summary": "Introduces the `PolynomialInF` structure packaging a monic polynomial $f(z) = \\prod(z - z_i)$ with roots in $F$, its evaluation map, the sublevel set $S(f) = \\{z : |f(z)| < 1\\}$, and the Lebesgue measure $|S(f)|$ using `MeasureTheory.volume`.",
-      "startLine": 48,
-      "endLine": 74,
+      "startLine": 47,
+      "endLine": 73,
       "mathContext": "$f(z) = \\prod_{i=1}^n (z - z_i)$, $z_i \\in F$, $S(f) = \\{z : |f(z)| < 1\\}$, $|S(f)| = \\text{Leb}(S(f))$."
     },
     {
       "id": "mu-function",
       "title": "The Function μ(F)",
       "summary": "Defines the central quantity $\\mu(F) = \\inf_f |S(f)|$ as an infimum over all polynomials with roots in $F$, in extended non-negative reals. Provides a real-valued coercion `muReal` for comparisons with $\\rho(F)$.",
-      "startLine": 75,
-      "endLine": 86,
+      "startLine": 74,
+      "endLine": 85,
       "mathContext": "$\\mu(F) = \\inf\\{|S(f)| : f \\text{ monic}, \\text{roots}(f) \\subseteq F\\} \\in [0, \\infty]$."
     },
     {
+      "id": "degree-0-bug",
+      "title": "The Degree-0 Bug and Corrected Definition",
+      "startLine": 86,
+      "endLine": 143,
+      "summary": "Documents a subtle definitional bug and its fix. The constant degree-0 polynomial evaluates to $1$ everywhere (`degree_zero_eval_eq_one`), so its sublevel set is empty (`degree_zero_sublevel_empty`) with measure $0$ (`degree_zero_sublevel_measure`); hence the naive `mu F = 0` for ALL $F$ (`mu_eq_zero`), trivializing the conjecture. The fix `muPosDeg` restricts the infimum to polynomials of degree $\\ge 1$ (matching EHP 1958) and is shown anti-monotone (`muPosDeg_mono`). All four theorems are fully proved.",
+      "mathContext": "Bug: $\\deg f = 0 \\Rightarrow S(f)=\\emptyset \\Rightarrow \\mu(F)=0$ for all $F$. Fix: $\\mu_{\\ge 1}(F) = \\inf\\{|S(f)| : \\deg f \\ge 1\\}$, anti-monotone in $F$."
+    },
+    {
       "id": "conjecture",
-      "title": "The Main Conjecture",
-      "summary": "States the two conjectures: `muDeterminedByDiameter` (same $\\rho$ implies same $\\mu$) and the stronger `diameterOneConjecture` ($\\rho \\geq 1$ implies $\\mu = 0$). Records the problem as open via an axiom negating excluded middle.",
-      "startLine": 87,
-      "endLine": 106,
+      "title": "The Main Conjecture (using corrected μ)",
+      "summary": "States the two conjectures with the corrected $\\mu_{\\ge1}$: `muDeterminedByDiameter` (equal transfinite diameter implies equal $\\mu$) and the stronger `diameterOneConjecture` ($\\rho(F)\\ge 1 \\Rightarrow \\mu_{\\ge1}(F)=0$). A comment notes the former `axiom problem_open : ¬(P ∨ ¬P)` was removed because it negated classical excluded middle and made the axiom system inconsistent — the problem's openness is left implicit, not axiomatized.",
+      "startLine": 144,
+      "endLine": 165,
       "mathContext": "Conjecture 1: $\\rho(F) = \\rho(G) \\implies \\mu(F) = \\mu(G)$. Conjecture 2: $\\rho(F) \\geq 1 \\implies \\mu(F) = 0$."
     },
     {
       "id": "known-results",
       "title": "Known Results: Line Segments and Discs",
-      "summary": "Axiomatizes the EHP 1958 results: for line segments and closed discs, $\\mu$ is determined by $\\rho$. Includes the classical formulas $\\rho([a,b]) = |b-a|/4$ (from Chebyshev theory) and $\\rho(\\overline{B}(c,r)) = r$ (from roots of unity).",
-      "startLine": 107,
-      "endLine": 134,
+      "summary": "Defines `isLineSegment` and `isClosedDisc` and records the EHP 1958 determinacy results. `lineSegment_determined_trivial`/`disc_determined_trivial` hold trivially for uncorrected $\\mu$ (since $\\mu=0$ always); `lineSegment_determined`/`disc_determined` are proved (vacuously, $f$ depends on $F$) for the corrected $\\mu_{\\ge1}$. The disc capacity formula $\\rho(\\overline{B}(c,r))=r$ is axiomatized as `disc_diameter`.",
+      "startLine": 166,
+      "endLine": 204,
       "mathContext": "$\\rho([a,b]) = |b-a|/4$ (Chebyshev), $\\rho(\\overline{B}(c,r)) = r$ (roots of unity). EHP 1958: $\\mu$ is a function of $\\rho$ for these sets."
     },
     {
       "id": "small-diameter",
-      "title": "Small Transfinite Diameter: Disc Containment",
+      "title": "Small Transfinite Diameter: Disc in Sublevel Set",
       "summary": "When $\\rho(F) < 1$, every sublevel set contains a disc of radius $\\geq c > 0$ depending on $F$. This implies $\\mu(F) > 0$ for sets of small capacity. Defines the disc constant $c(F)$ as the supremum of achievable radii.",
-      "startLine": 135,
-      "endLine": 150,
+      "startLine": 205,
+      "endLine": 220,
       "mathContext": "$\\rho(F) < 1 \\implies \\exists c > 0: \\forall f,\\; B(z_0, c) \\subseteq S(f)$, hence $\\mu(F) \\geq \\pi c^2 > 0$."
     },
     {
       "id": "erdos-netanyahu",
       "title": "Erdős-Netanyahu Result (1973)",
       "summary": "For bounded connected $F$ with $0 < \\rho(F) < 1$, Erdős and Netanyahu gave explicit disc radius bounds $r(\\rho)$ as a function of the transfinite diameter alone, strengthening the qualitative small-diameter result with quantitative control.",
-      "startLine": 151,
-      "endLine": 162,
+      "startLine": 221,
+      "endLine": 224,
       "mathContext": "$F$ bounded connected, $0 < \\rho(F) < 1 \\implies$ inscribed disc radius $\\geq r(\\rho(F))$ for explicit function $r$."
     },
     {
       "id": "problem-1039",
       "title": "Relationship to Problem 1039",
       "summary": "The unit disc $\\overline{B}(0,1)$ with $\\rho = 1$ connects to Problem 1039 (inscribed disc radius in sublevel sets). Includes a proved theorem `unitDisc_diameter` deriving $\\rho(\\overline{B}(0,1)) = 1$ from the disc capacity formula.",
-      "startLine": 163,
-      "endLine": 178,
+      "startLine": 225,
+      "endLine": 240,
       "mathContext": "$\\rho(\\overline{B}(0,1)) = 1$ (critical threshold). Problem 1039 asks about inscribed disc radius vs sublevel area."
     },
     {
       "id": "diameter-properties",
       "title": "Properties of Transfinite Diameter",
-      "summary": "Structural theorems for $\\rho$: non-negativity (PROVED). Monotonicity, finite set degeneracy, and scaling are commented out. Non-negativity proved via nthDiameter_nonneg and le_csInf.",
-      "startLine": 179,
-      "endLine": 203,
-      "mathContext": "$F \\subseteq G \\implies \\rho(F) \\leq \\rho(G)$; $\\rho(F) \\geq 0$; $|F| < \\infty \\implies \\rho(F) = 0$; $\\rho(cF) = |c|\\rho(F)$."
+      "summary": "Structural theorems for the transfinite diameter, now substantially proved. `nthDiameter_nonneg` and `transfiniteDiameter_nonneg`: non-negativity. `transfiniteDiameter_mono_of_bounded`: monotonicity for bounded supersets (a long proof bounding pairwise-distance products by $(\\mathrm{diam}\\,G+1)^{n^2}$); the unrestricted monotone version is shown unprovable with $\\mathbb{R}$-valued `nthDiameter` (sSup convention breaks it). `nthDiameter_eq_zero_of_finite` and `finite_diameter_zero`: finite sets have transfinite diameter $0$ (pigeonhole). The general scaling law $\\rho(cF)=|c|\\rho(F)$ is commented out (false as stated for the $\\inf$-over-all-$n$ definition, with a worked counterexample).",
+      "startLine": 241,
+      "endLine": 452,
+      "mathContext": "$\\rho(F)\\ge 0$; $F\\subseteq G$, $G$ bounded $\\Rightarrow \\rho(F)\\le\\rho(G)$; $|F|<\\infty \\Rightarrow \\rho(F)=0$. Scaling $\\rho(cF)=|c|\\rho(F)$ fails for the $\\inf_{n\\ge0}$ definition (clamped at $\\le1$ by $n=0,1$)."
     },
     {
       "id": "mu-properties",
       "title": "Properties of μ",
       "summary": "Structural theorems: anti-monotonicity ($F \\subseteq G \\implies \\mu(G) \\leq \\mu(F)$, note reversal, PROVED) and infimum approximation ($\\mu(F)$ can be approached within $\\varepsilon$ by some polynomial, PROVED). muPosDeg_pos_of_small_diameter (PROVED) establishes $\\mu(F) > 0$ when $\\rho(F) < 1$ via disc containment and Complex.volume_ball.",
-      "startLine": 204,
-      "endLine": 217,
+      "startLine": 453,
+      "endLine": 522,
       "mathContext": "$F \\subseteq G \\implies \\mu(G) \\leq \\mu(F)$ (anti-monotone). $\\forall \\varepsilon > 0, \\exists f: |S(f)| < \\mu(F) + \\varepsilon$."
     },
     {
       "id": "open-question",
       "title": "The Open Question and Current State",
       "summary": "Names the main open question `erdos_1040_question` and states the current knowledge. Split into two parts: Part 1 ($\\mu = 0$ for segments/discs with $\\rho \\geq 1$, axiomatized via EHP 1958) and Part 2 ($\\mu > 0$ when $\\rho < 1$, PROVED via muPosDeg_pos_of_small_diameter). Also includes OQ-05 extensions of Erdős-Netanyahu bounds.",
-      "startLine": 218,
-      "endLine": 249,
+      "startLine": 523,
+      "endLine": 556,
       "mathContext": "Known: $\\rho(F) \\geq 1 \\implies \\mu(F) = 0$ for segments and discs; $\\rho(F) < 1 \\implies \\mu(F) > 0$ for all $F$. General case open since 1958."
+    },
+    {
+      "id": "oq-05",
+      "title": "OQ-05: Extension of Erdős–Netanyahu Bound",
+      "startLine": 557,
+      "endLine": 617,
+      "summary": "Formalizes the open extension question OQ-05: does the Erdős–Netanyahu quantitative disc-radius bound $r(\\rho)$ extend beyond bounded connected sets? Defines `erdos_netanyahu_unbounded` (unbounded sets), `erdos_netanyahu_disconnected` (disconnected sets), and the unifying `erdos_netanyahu_general`, with proved implications `..._general_implies_unbounded`/`..._implies_disconnected`. `unbounded_connected_diameter_challenge` observes the qualitative disc containment (`small_diameter_disc`) already holds without boundedness — only the quantitative $r(\\rho)$ bound is open.",
+      "mathContext": "OQ-05: does a disc radius $r(\\rho)$ depending only on $\\rho(F)$ exist for unbounded or disconnected closed infinite $F$ with $0<\\rho(F)<1$? The qualitative containment holds unconditionally; the quantitative bound is open."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 618,
+      "endLine": 640,
+      "summary": "Closing docstring recapping the problem: whether $\\mu(F)$ is determined by the transfinite diameter. Restates the known cases (line segments and discs via EHP 1958; positive-radius disc containment when $\\rho(F)<1$; Erdős–Netanyahu 1973 bounds), the conjecture ($\\mu(F)=0$ when $\\rho(F)\\ge 1$), the OPEN status of the general case, and the OQ-05 extension question."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The erdos-1040 gallery sections stopped at line 249 of a 640-line Lean file, and every label from the 4th section onward was mispinned (the meta's "Main Conjecture" range actually pointed at the Degree-0 Bug discussion).
- Re-pinned all sections to their true `##` docstring ranges and surfaced four previously hidden sections: **The Degree-0 Bug and Corrected Definition** (the `mu_eq_zero` trivialization and the `muPosDeg` fix), the full **Properties of the Transfinite Diameter** block (bounded-monotonicity + finite-set proofs), **OQ-05: Extension of the Erdős–Netanyahu Bound**, and the closing **Summary**.
- Fixed two stale prose claims: the "axiom negating excluded middle" was removed from the source (now only a comment), and the bounded-monotonicity / finite-diameter theorems are proved (not "commented out").

## Verification
- Non-section meta content byte-identical to `HEAD` (only the `sections` array changed).
- Counts unchanged and already accurate: 22 theorems / 20 defs / 4 axioms / 0 sorries; `leanFile.lineCount` 640 matches the source.
- Build-free metadata-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)