### PR TITLE
research(birthday-problem-oq-03-oq-01-oq-01): rebuild gallery sections to full file (6→12)

### DIFF
--- a/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
+++ b/src/data/proofs/birthday-problem-oq-03-oq-01-oq-01/meta.json
@@ -55,52 +55,100 @@
   },
   "sections": [
     {
-      "id": "recurrence",
-      "title": "The Slot-Based Recurrence",
-      "startLine": 45,
-      "endLine": 65,
-      "summary": "Defines R n e s (slot recurrence) and birthdayCount3 n d = R n d 0. Core recurrence lemmas: R_zero, R_succ.",
-      "mathContext": "The state $(e, s)$ models the remaining capacity: $e$ empty slots (can receive $1$ or $2$ more) and $s$ single slots (can receive exactly $1$ more). Total capacity: $2e + s$."
+      "id": "module-overview",
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 40,
+      "summary": "File docstring: the slot-based recurrence optimization for counting k=3 birthday assignments, its O(n²) efficiency vs O(d^n) naive enumeration, and the axiom-free status (formerly 2 axioms, eliminated via native_decide).",
+      "mathContext": "Header only. Defines the problem: count f : Fin n → Fin d with all fibers ≤ 2, tracked via slot state (e empty, s single)."
     },
     {
-      "id": "capacity",
-      "title": "Capacity and Zero Theorems",
-      "startLine": 67,
-      "endLine": 88,
-      "summary": "R_exceeds_capacity: R n e s = 0 when n > 2e+s. Proved by induction on n with case analysis on e=0 and s=0.",
-      "mathContext": "If $n > 2e + s$, there are not enough slot-places for all $n$ people. The proof: in the inductive step, both recursive calls have reduced capacity, so both evaluate to $0$ by induction hypothesis."
+      "id": "recurrence",
+      "title": "Section I: The Slot-Based Recurrence",
+      "startLine": 41,
+      "endLine": 58,
+      "summary": "Defines R n e s (ways to place n people into e empty + s single slots) by recursion on n, and birthdayCount3 n d := R n d 0.",
+      "mathContext": "R 0 e s = 1; R (n+1) e s = e·R n (e-1) (s+1) + s·R n e (s-1). Nat subtraction is safe because the coefficient kills the call at e=0 or s=0."
+    },
+    {
+      "id": "core-recurrence",
+      "title": "Section II: Core Recurrence Properties",
+      "startLine": 59,
+      "endLine": 91,
+      "summary": "Simp lemmas R_zero, R_succ, plus the capacity bound: R n e s = 0 when 2e+s < n, and birthdayCount3_over_capacity (count is 0 when 2d < n).",
+      "mathContext": "R_exceeds_capacity is proved by induction on n, case-splitting e and s to discharge each summand via Nat subtraction arithmetic (omega)."
     },
     {
       "id": "formulas",
-      "title": "Birthday Count Formulas",
-      "startLine": 90,
-      "endLine": 115,
-      "summary": "birthdayCount3 0 d = 1, birthdayCount3 1 d = d, birthdayCount3 2 d = d². Small decide checks for n=3.",
-      "mathContext": "For $n \\leq 2$, the max-2 constraint never binds: all $d^n$ assignments are valid. For $n=3$: exactly $d$ assignments have all 3 on the same day, giving $d^3 - d$ valid ones."
+      "title": "Section III: Basic Birthday Count Formulas",
+      "startLine": 92,
+      "endLine": 118,
+      "summary": "Closed forms for small n: birthdayCount3 0 d = 1, 1 d = d, 2 d = d²; decide-checks for n=3 at d=3,4,5,10; and zero-at-limit (count is 0 at n = 2d+1).",
+      "mathContext": "Base cases by simp/ring on the recurrence; the n=3 small-d values are confirmed by decide as anchors for the general n=3 formula in Section X."
     },
     {
       "id": "bounds",
-      "title": "Upper Bound and Polynomial Inequality",
-      "startLine": 117,
-      "endLine": 140,
-      "summary": "R_le_pow: R n e s ≤ (e+s)^n. birthdayCount3_le_pow: count ≤ d^n. Both proved by induction.",
-      "mathContext": "The bound $R(n, e, s) \\leq (e+s)^n$ follows because each person has at most $e+s$ choices at each step in the unconstrained case. The inductive step requires case analysis to handle Nat subtraction safely."
+      "title": "Section IV: Bounds on the Count",
+      "startLine": 119,
+      "endLine": 152,
+      "summary": "R n e s ≤ (e+s)^n (count bounded by unconstrained placements) and its corollary birthdayCount3 n d ≤ d^n.",
+      "mathContext": "R_le_pow by induction on n, case-splitting e and s to handle Nat subtraction (e-1+(s+1) ≤ e+s fails at e=0), then Nat.mul_le_mul_left + pow monotonicity."
+    },
+    {
+      "id": "recurrence-unfolding",
+      "title": "Section V: Recurrence Unfolding",
+      "startLine": 153,
+      "endLine": 167,
+      "summary": "One- and two-step unfoldings of birthdayCount3 (n+1) and (n+2) exposing the slot transitions.",
+      "mathContext": "birthdayCount3 (n+1) d = d·R n (d-1) 1; the (n+2) form splits into empty→single and single→full branches."
     },
     {
       "id": "verifications",
-      "title": "Verified Thresholds for Small d",
-      "startLine": 142,
-      "endLine": 185,
-      "summary": "Verified by decide: k=3 threshold is n=4 for d=3, n=6 for d=4, n=8 for d=5. All threshold verifications are machine-checked.",
-      "mathContext": "P(no triple) = birthdayCount3 n d / d^n. The threshold is the smallest $n$ where P(triple) > 1/2, i.e., $2 \\cdot \\text{birthdayCount3}(n, d) < d^n$."
+      "title": "Section VI: Computational Verifications (via decide)",
+      "startLine": 168,
+      "endLine": 195,
+      "summary": "decide-verified counts and threshold inequalities for d=3,4,5 (e.g. threshold_d4_lower/upper bracketing the k=3 half-probability point).",
+      "mathContext": "Each P(no triple) = birthdayCount3 n d / d^n; the threshold is where 2·(valid count) crosses d^n. Small d is feasible with plain decide."
     },
     {
       "id": "threshold365",
-      "title": "k=3 Threshold for d=365",
-      "startLine": 187,
-      "endLine": 210,
-      "summary": "birthday_threshold_lower/upper: the n=88 threshold for d=365, proved by native_decide. birthday_threshold_statement: combined result.",
-      "mathContext": "For $d = 365$ days, $n = 88$ people gives $> 50\\%$ chance of a triple birthday coincidence. Verified via native_decide using the O(n²) slot recurrence with GMP-backed compiled evaluation."
+      "title": "Section VII: The k=3 Birthday Threshold for d=365",
+      "startLine": 196,
+      "endLine": 221,
+      "summary": "The headline result: via native_decide, the exact k=3 threshold for d=365 is n=88 (2·birthdayCount3 88 365 < 365^88 ≤ 2·birthdayCount3 87 365).",
+      "mathContext": "native_decide runs the O(88²)≈7744-evaluation slot recurrence over ~200-digit integers using GMP-backed compiled evaluation; the naive d^88 enumeration is infeasible."
+    },
+    {
+      "id": "efficiency",
+      "title": "Section VIII: Efficiency Analysis",
+      "startLine": 222,
+      "endLine": 233,
+      "summary": "State-space bounds: at most n/2+1 reachable states per layer, and a concrete efficiency-ratio check 88² < 365⁴.",
+      "mathContext": "Quantifies the O(n²) vs O(d^n) gap that makes the d=365 native_decide tractable."
+    },
+    {
+      "id": "small-d-d7",
+      "title": "Section IX: Verified Small-d Threshold (d=7)",
+      "startLine": 234,
+      "endLine": 267,
+      "summary": "The exact k=3 threshold for d=7 is n=8, proved by native_decide (threshold_d7_lower/upper/threshold_d7).",
+      "mathContext": "Includes a comment with hand-confirmed R values; small d makes the unmemoized native_decide computation cheap."
+    },
+    {
+      "id": "general-formula-n3",
+      "title": "Section X: General Formula for n=3",
+      "startLine": 268,
+      "endLine": 290,
+      "summary": "Closed-form proofs: R 1 e s = e+s, R 2 (d-1) 1 = d²-1, and the general birthdayCount3 3 d = d³ - d = d(d-1)(d+1).",
+      "mathContext": "Among d³ functions Fin 3 → Fin d, exactly d map all three to one day; subtracting gives the max-2-per-day count d³-d. Proved by unfolding the recurrence + ring/omega."
+    },
+    {
+      "id": "threshold-d10",
+      "title": "Section XI: Verified Threshold for d=10",
+      "startLine": 291,
+      "endLine": 317,
+      "summary": "The exact k=3 threshold for d=10 is n=12 (threshold_d10_lower/upper/threshold_d10), plus closing #check summary of the file's key results.",
+      "mathContext": "native_decide confirms n=12 despite the loose asymptotic prediction n≈7.5 — asymptotics are inaccurate at small d."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Meta had **6 sections** covering only lines 45–210 while the Lean file is **317 lines**. The last 4 `-- SECTION` banners were **missing entirely** (107 lines / 34% hidden):
  - VIII Efficiency Analysis
  - IX Verified Small-d Threshold (d=7)
  - X General Formula for n=3 (the closed form `birthdayCount3 3 d = d³ − d`)
  - XI Verified Threshold for d=10
- Several existing titles were also **mislabeled** vs the source (e.g. old "Capacity and Zero Theorems" vs the actual Section II "Core Recurrence Properties").
- Rebuilt to **12 sections** (module header + the 11 `-- SECTION` banners) with accurate titles and fresh per-section `summary`/`mathContext`, contiguous full-file coverage 1→317.
- **No content/count changes.** Counts unchanged and correct: 0 axioms, 43 theorems (incl. 2 `@[simp] theorem`), 2 defs, 0 sorries, 317 lines. A Node guard confirmed all non-section JSON keys are byte-identical.

## Test plan
- [x] Each `startLine` lands on its `-- SECTION N` banner / file header
- [x] Contiguous full-file coverage 1→317, monotonic
- [x] Section titles match the source `-- SECTION` banner names
- [x] Non-section meta fields byte-identical (verified programmatically)