### PR TITLE
research(sperner family): realign two gallery sections to full file coverage

### DIFF
--- a/src/data/proofs/sperner-ndim-oq-03-oq-01/meta.json
+++ b/src/data/proofs/sperner-ndim-oq-03-oq-01/meta.json
@@ -76,11 +76,19 @@
     },
     {
       "id": "pipeline",
-      "title": "Part IV: Sperner-Brouwer Pipeline Entry",
-      "startLine": 115,
-      "endLine": 118,
+      "title": "Part IV: Sperner-Brouwer Pipeline Entry (L106–119)",
+      "startLine": 106,
+      "endLine": 119,
       "summary": "pipeline_1d: alias of brouwer_1d as the dimension-1 entry point of the Sperner-to-Brouwer pipeline.",
       "mathContext": "The 1D case is the base case of the Sperner pipeline; higher dimensions use displacement coloring from OQ-03."
+    },
+    {
+      "id": "sec-summary",
+      "title": "Summary (L120–144)",
+      "startLine": 120,
+      "endLine": 144,
+      "summary": "Closing docstring cataloguing the file's 4 theorems (0 sorries, 0 axioms): brouwer_1d (Part I), contractive_fixed_point_unique (Part II), contractive_iterate_converges (Part III), pipeline_1d (Part IV). States the key insight that in 1D Brouwer is exactly the IVT applied to f − id, with the higher-dimensional Sperner route deferred to SpernerNDimOQ03.lean.",
+      "mathContext": "Pedagogical wrap-up: the 1-dimensional Brouwer fixed-point theorem as the IVT specialised to f − id, serving as the clean base case of the approximate-to-exact fixed-point argument whose n-dimensional generalisation needs Sperner's lemma."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
+++ b/src/data/proofs/sperner-simplicial-bridge-oq-01/meta.json
@@ -16,7 +16,9 @@
     "definitionCount": 3,
     "lineCount": 270,
     "sorries": 0,
-    "imports": ["Proofs.SpernerSimplicialBridge"],
+    "imports": [
+      "Proofs.SpernerSimplicialBridge"
+    ],
     "tags": [
       "combinatorics",
       "topology",
@@ -44,8 +46,12 @@
     "sorries": 0,
     "theoremCount": 13,
     "definitionCount": 3,
-    "imports": ["import Proofs.SpernerSimplicialBridge"],
-    "opens": ["Finset"],
+    "imports": [
+      "import Proofs.SpernerSimplicialBridge"
+    ],
+    "opens": [
+      "Finset"
+    ],
     "namespace": "Sperner.SimplicialComplex"
   },
   "sections": [
@@ -86,10 +92,18 @@
     },
     {
       "id": "main-theorem",
-      "title": "Headline Theorem: `sperner_mixed_panchromatic_at_dim`",
+      "title": "Headline Theorem: `sperner_mixed_panchromatic_at_dim` (L209–237)",
       "startLine": 209,
-      "endLine": 231,
+      "endLine": 237,
       "summary": "The file's headline (lines 170-180) is a single term-mode application of the parent's `exists_panchromatic`. Hypothesis: `MixedPseudomanifold K` and `Odd (boundaryDoorCount (d := d) K c)`. Conclusion: a panchromatic top cell exists in `topCellsOfDim K d`. Proof body passes the parent five arguments — `topCellsOfDim K d` as `topCells`, `(fun _ hs => card_of_mem_topCellsOfDim hs)` as `hcard`, `hpseudo_of_mixed hmixed` as `hpseudo`, `c`, and `hbdry` — and lets the elaborator unfold `boundaryDoorCount` to match the parent's expected shape. The proof is mechanical bookkeeping; all the mathematical content sits in the predicate definitions and lift lemmas of the previous four sections. The `section MixedSperner … end MixedSperner` block (lines 123, 182) scopes the `[LinearOrder E]` instance to this part of the file."
+    },
+    {
+      "id": "sec-mixed-aggregators",
+      "title": "Mixed-Dimension Sperner Aggregators (L238–270)",
+      "startLine": 238,
+      "endLine": 270,
+      "summary": "Two ergonomic re-exports of the headline theorem: sperner_mixed_panchromatic (alias with d implicit) and sperner_mixed_panchromatic_global (global existential — if any dimension d and coloring c give an odd boundary-door count, a panchromatic top cell exists at that dimension). Both reduce directly to sperner_mixed_panchromatic_at_dim.",
+      "mathContext": "Caller-facing wrappers around the mixed-dimension Sperner theorem. The global form quantifies existentially over the dimension, packaging the per-dimension guarantee into a single 'some panchromatic cell exists somewhere in the complex' statement for the mixed pseudomanifold K."
     }
   ],
   "mainTheorems": [
@@ -160,21 +174,27 @@
   },
   "references": [
     {
-      "authors": ["De Longueville, Mark"],
+      "authors": [
+        "De Longueville, Mark"
+      ],
       "year": 2013,
       "title": "A Course in Topological Combinatorics",
       "venue": "Springer Universitext",
       "note": "Chapter 2 develops Sperner's lemma for non-pure simplicial complexes via dimension-graded stratification — the canonical reference for the mixed-pseudomanifold framework formalised here."
     },
     {
-      "authors": ["Sperner, Emanuel"],
+      "authors": [
+        "Sperner, Emanuel"
+      ],
       "year": 1928,
       "title": "Neuer Beweis für die Invarianz der Dimensionszahl und des Gebietes",
       "venue": "Abhandlungen aus dem Mathematischen Seminar der Universität Hamburg, vol. 6, pp. 265-272",
       "note": "The classical Sperner paper; works in the pure (uniform-dimension) setting that this entry generalises."
     },
     {
-      "authors": ["Henle, Michael"],
+      "authors": [
+        "Henle, Michael"
+      ],
       "year": 1979,
       "title": "A Combinatorial Introduction to Topology",
       "venue": "W. H. Freeman, San Francisco",


### PR DESCRIPTION
## Summary

Build-free gallery-metadata fixes for two sperner-family galleries whose `sections[]` stopped short of their (already-correct) `lineCount`, hiding tail content from the viewer.

### `sperner-simplicial-bridge-oq-01` (270 LOC)
Sections stopped at line 231, hiding two aggregator theorems.
- Headline-theorem section `[209-231]` cut off mid-proof → extended to **237**
- **+ section** `Mixed-Dimension Sperner Aggregators` (L238–270) — `sperner_mixed_panchromatic` (alias) + `sperner_mixed_panchromatic_global` (global existential)

### `sperner-ndim-oq-03-oq-01` (144 LOC)
- Part IV section `[115-118]` missed the Part IV banner (L107) and the tail of `pipeline_1d` → remapped to `[106-119]`
- **+ section** `Summary` (L120–144) — the closing docstring cataloguing the file's 4 theorems

## Unchanged

`lineCount` was already correct for both; counts unchanged. Doc-only, no Lean edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)