### PR TITLE
research(greens-theorem family): realign stale gallery sections (4 entries)

### DIFF
--- a/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
+++ b/research/problems/greens-theorem-oq-02-oq-02/knowledge.md
@@ -64,3 +64,21 @@ Note: `Measure.AbsolutelyContinuous` is AC of **measures** (μ ≪ ν), not of f
 
 **Next Steps**
 - Build FTC-for-AC bridge lemma; discharge axiom by Fubini once Docker restored.
+
+### Session 2026-06-14 (Session 2) — Docker blackout: family-meta section-realign
+
+**Mode**: BLOCKED (Docker down — `docker info` times out >25s; the FTC-for-AC build path from Session 1 is gated).
+
+**What I Did**
+- Re-confirmed the OQ's build path (`ftc_of_absolutelyContinuous`, ~200–400 lines) is gated by the Docker blackout. No Lean committed.
+- Pivoted to the build-free vein: scanned the whole `greens-theorem*` gallery family for section/count drift.
+- Fixed stale gallery metadata in 4 sibling entries (pure metadata, no Lean changes):
+  - `greens-theorem-oq-01-oq-01-oq-03`: added missing **§ VII. Atomless Measure Generalization** section (228–292); 67-line tail was hidden.
+  - `greens-theorem-oq-01-oq-02`: re-pinned all 5 Part ranges (file grew ~20 lines, sections never re-synced); synced stale `leanFile` counts (lineCount 227→247, theoremCount 5→6).
+  - `greens-theorem-oq-04`: rebuilt sections array 11→12 (split lumped "Parts VIII-IX", fixed shifted ranges and Part IV/V/XI/XII banner titles to match the file).
+  - `greens-theorem-oq-02` (parent of this OQ): re-pinned Part IV/V ranges + lineCount 507→518. theoremCount=19 is correct (3 apparent extras were docstring false positives).
+
+**Verified clean (no fix)**: `greens-theorem`, `greens-theorem-oq-01` (gaps = trailing `end`/blank only); `greens-theorem-oq-03` (def 15/ax 3 grep counts were ```lean docstring false positives — real counts 14/2 match meta).
+
+**Next Steps (unchanged from Session 1)**
+- When Docker restored: build FTC-for-AC bridge lemma; discharge `greens_theorem_l1curl` by Fubini reduction to two 1D FTC-for-AC applications over the rectangle.

--- a/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-01-oq-03/meta.json
@@ -140,6 +140,14 @@
       "endLine": 226,
       "summary": "Block-comment analysis documenting why volume.restrict (Icc a b) = volume.restrict (Ioo a b) is not in Mathlib, the contribution path to Mathlib.MeasureTheory.Measure.Lebesgue.Basic as a @[simp] lemma, and a summary table of all six theorems proved in this file.",
       "mathContext": "Mathlib's interval-measure infrastructure canonically uses Ioc (left-open right-closed) because Ioc forms a π-system on $\\mathbb{R}$, which is the right combinatorial input for Carathéodory-style measure construction. The Icc↔Ioo equivalence under any atomless measure is mathematically trivial but absent as a standalone lemma — exactly the kind of gap a gallery proof can highlight for upstream contribution."
+    },
+    {
+      "id": "atomless-generalization",
+      "title": "§ VII. Atomless Measure Generalization",
+      "startLine": 228,
+      "endLine": 292,
+      "summary": "Generalizes the Lebesgue-specific restriction equality away from volume to any measure with null endpoints. Proves restrict_Icc_eq_Ioo_of_null_endpoints (endpoint-null hypothesis form), derives restrict_Icc_eq_Ioo_of_noAtoms (NoAtoms typeclass form) as a corollary via measure_singleton, and records an example showing the original Lebesgue volume_restrict_Icc_eq_Ioo now factors as a one-line corollary.",
+      "mathContext": "The boundary-null argument never uses sigma-finiteness or any Lebesgue-specific structure — only that the two endpoints carry zero mass, i.e. $\\mu\\{a\\} = \\mu\\{b\\} = 0$. This isolates the genuine hypothesis (no atoms at the boundary) and packages it both as an explicit endpoint condition and via Mathlib's MeasureTheory.NoAtoms typeclass, answering the conclusion's open question on generalizing to arbitrary atomless Borel measures."
     }
   ],
   "conclusion": {

--- a/src/data/proofs/greens-theorem-oq-01-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-01-oq-02/meta.json
@@ -58,39 +58,39 @@
       "id": "definition",
       "title": "Part I: Path Line Integral via intervalIntegral",
       "startLine": 67,
-      "endLine": 92,
+      "endLine": 113,
       "summary": "pathLineIntegral P Q γx γy γx' γy' a b := ∫ t in a..b, P(γx t, γy t) · γx'(t) + Q(γx t, γy t) · γy'(t). Definition uses intervalIntegral directly. Companion lemma pathLineIntegral_swap_endpoints proves the orientation-reversal sign convention via integral_symm.",
       "mathContext": "The classical definition ∫_γ (P dx + Q dy) = ∫_a^b (P γx' + Q γy') dt rendered as a single intervalIntegral. The orientation lemma ∫_γ⁻¹ = -∫_γ is the standard fact that reversing the parameter flips the line integral."
     },
     {
       "id": "edges",
       "title": "Part II: Edge Specializations (Bridge to OQ-01)",
-      "startLine": 94,
-      "endLine": 125,
+      "startLine": 114,
+      "endLine": 146,
       "summary": "pathLineIntegral_horizontal_segment: on the smooth segment t ↦ (t, c), the path integral collapses to ∫ x in a..b, P(x,c) — exactly the bottom-edge integral from rectLineIntegral. pathLineIntegral_vertical_segment is the symmetric statement for t ↦ (k, t). Both proofs are integral_congr + simp.",
       "mathContext": "On a horizontal line segment γ(t) = (t, c), the velocity is (1, 0), so the integrand reduces to P(γ(t)). On a vertical segment γ(t) = (k, t), the velocity is (0, 1), reducing to Q(γ(t)). These are the same integrals OQ-01 calls 'edge integrals'."
     },
     {
       "id": "bridge",
       "title": "Part III: Rectangular Boundary as Four Smooth Edges",
-      "startLine": 127,
-      "endLine": 169,
+      "startLine": 147,
+      "endLine": 190,
       "summary": "rectBoundaryPathIntegral: four-edge counterclockwise parametrization of ∂([a,b]×[c,d]) — bottom, right, top (parametrized backward), left (parametrized backward). pathLineIntegral_rect_boundary_eq_rectLineIntegral: this assembly equals rectLineIntegral on the nose. Proof uses the edge specializations, two applications of pathLineIntegral_swap_endpoints (for top and left), and ring.",
       "mathContext": "Counterclockwise traversal of the rectangle boundary pairs two left-to-right or bottom-to-top sweeps with two right-to-left or top-to-bottom sweeps. The latter pair contributes negatively under the orientation lemma, exactly matching the −∫P(x,d) dx − ∫Q(a,y) dy of rectLineIntegral."
     },
     {
       "id": "axiom",
       "title": "Part IV: General Green's Theorem (Axiomatized)",
-      "startLine": 171,
-      "endLine": 208,
+      "startLine": 191,
+      "endLine": 229,
       "summary": "greens_theorem_smooth_boundary: the planar Green identity ∮_γ (P dx + Q dy) = ∬_D (∂Q/∂x − ∂P/∂y) for a parametrized piecewise-smooth simple closed curve γ bounding a measurable region D. This isolates the genuine Mathlib gap into a single statement — the line-integral side is fully expressible via pathLineIntegral, and the double-integral side via Mathlib's set integral.",
       "mathContext": "The fully general planar Green's theorem requires Jordan-curve / Stokes-type 2-D infrastructure that Mathlib does not yet expose in this form. The axiom is mathematically standard (a theorem of classical analysis); the formalization gap is purely about packaging."
     },
     {
       "id": "summary",
       "title": "Part V: Summary Corollary",
-      "startLine": 210,
-      "endLine": 225,
+      "startLine": 230,
+      "endLine": 246,
       "summary": "oq02_summary: restates the bridge identity rectBoundaryPathIntegral = rectLineIntegral as the headline result — the smooth-curve framework strictly extends OQ-01's rectangular formulation, with the four-edge parametrization recovering the rectangular case exactly.",
       "mathContext": "The framework defined here is a true extension: every result OQ-01 proves about rectLineIntegral lifts to rectBoundaryPathIntegral, and the framework additionally accepts arbitrary smooth and piecewise-smooth boundaries (with the general identity captured by greens_theorem_smooth_boundary)."
     }
@@ -142,11 +142,11 @@
       "Proofs.GreensTheoremOQ01"
     ],
     "namespace": "GreensTheoremOQ01OQ02",
-    "lineCount": 227,
+    "lineCount": 247,
     "axiomCount": 1,
-    "theoremCount": 5,
+    "theoremCount": 6,
     "definitionCount": 2,
-    "substantiveTheoremCount": 5,
+    "substantiveTheoremCount": 6,
     "mainTheorems": [
       {
         "name": "pathLineIntegral",

--- a/src/data/proofs/greens-theorem-oq-02/meta.json
+++ b/src/data/proofs/greens-theorem-oq-02/meta.json
@@ -55,7 +55,7 @@
       "19 supporting lemmas on Lipschitz curves, line integrals, L¹ fields, and consequences"
     ],
     "dateAdded": "2026-04-04",
-    "lineCount": 507,
+    "lineCount": 518,
     "assumptions": "1 axiom (greens_theorem_l1curl — Whitney's 1957 theorem). 19 theorems with 0 sorries. Supporting results are fully proved using Mathlib's LipschitzWith, MeasureTheory, and trigonometric libraries.",
     "theoremCount": 19,
     "definitionCount": 6
@@ -108,15 +108,15 @@
       "id": "whitneys-theorem",
       "title": "Part IV: Whitney's Theorem and Consequences",
       "startLine": 311,
-      "endLine": 440,
+      "endLine": 451,
       "summary": "greens_theorem_l1curl axiom (Whitney 1957), lineIntegral_zero_curl, lineIntegral_l1curl_smul, greens_oq1_from_l1curl.",
       "mathContext": "Whitney (1957): $\\oint_C (P\\,dx + Q\\,dy) = \\iint_D (\\partial Q/\\partial x - \\partial P/\\partial y)\\,dA$ holds when $C$ is Lipschitz and the curl is $L^1$. Proved as axiom; supporting consequences fully proved."
     },
     {
       "id": "unit-circle",
       "title": "Part V: Unit Circle Example",
-      "startLine": 441,
-      "endLine": 507,
+      "startLine": 452,
+      "endLine": 518,
       "summary": "unitCircle def, unitCircle_lipschitz (K=1, proved via sup_le for product edist), unitCircle_closed (γ(0)=γ(2π) from cos/sin periodicity), unitCircleCurve instance, unitCircle_diameter_bound.",
       "mathContext": "$\\gamma(t) = (\\cos t, \\sin t)$ is Lipschitz-1 since $\\text{edist}(\\cos x, \\cos y) \\leq \\text{edist}(x,y)$ and $\\text{edist}(\\sin x, \\sin y) \\leq \\text{edist}(x,y)$ by Mathlib's `lipschitzWith_cos` and `lipschitzWith_sin`. The product edist is $\\leq \\sup$, closed by `sup_le`."
     }
@@ -215,7 +215,7 @@
       "Real"
     ],
     "namespace": "GreensTheoremOQ02",
-    "lineCount": 507,
+    "lineCount": 518,
     "axiomCount": 1,
     "theoremCount": 19,
     "definitionCount": 6,

--- a/src/data/proofs/greens-theorem-oq-04/meta.json
+++ b/src/data/proofs/greens-theorem-oq-04/meta.json
@@ -113,87 +113,95 @@
       "id": "structure",
       "title": "Part I: Multiply-Connected Region Structure",
       "startLine": 46,
-      "endLine": 92,
+      "endLine": 109,
       "summary": "Defines `MultiplyConnectedRegion` with an outer `TypeIRegion`, a list of hole `TypeIRegion`s, and a containment proof. Defines the point set as outer minus holes, the number of holes (first Betti number), and `simplyConnectedOf` as the zero-hole case. Proves the simply-connected point set equals the outer region.",
       "mathContext": "A multiply-connected region D = D_outer \\ (H_1 \\cup ... \\cup H_n) with first Betti number beta_1 = n."
     },
     {
       "id": "area",
       "title": "Part II: Area of Multiply-Connected Regions",
-      "startLine": 93,
-      "endLine": 124,
+      "startLine": 110,
+      "endLine": 136,
       "summary": "Defines the area as outer area minus sum of hole areas. Proves that simply-connected regions have zero hole area and area equal to the outer region.",
       "mathContext": "Area(D) = Area(D_outer) - sum_i Area(H_i) when holes are pairwise disjoint."
     },
     {
       "id": "annular",
       "title": "Part III: Annular Region",
-      "startLine": 125,
-      "endLine": 172,
+      "startLine": 137,
+      "endLine": 181,
       "summary": "Constructs the annular region (disk of radius R minus disk of radius r) as a multiply-connected region. Proves the inner disk is contained in the outer disk (via nlinarith on x^2+y^2 bounds). Proves annular area = pi(R^2 - r^2) from the disk area axiom.",
       "mathContext": "The annulus {(x,y) | r^2 <= x^2+y^2 <= R^2} is the prototypical multiply-connected region with one hole."
     },
     {
       "id": "integrals",
-      "title": "Part IV: Line and Curl Integrals",
-      "startLine": 173,
-      "endLine": 228,
+      "title": "Part IV: Green’s Theorem for Multiply-Connected Regions",
+      "startLine": 182,
+      "endLine": 248,
       "summary": "Defines `typeILineIntegral` (4 edge integrals around a TypeI boundary), `multiplyConnectedLineIntegral` (outer minus hole sum), and `multiplyConnectedCurlIntegral` (iterated integral difference). Proves these reduce to ordinary integrals for simply-connected regions.",
       "mathContext": "The corrected line integral: outer boundary integral minus sum of hole boundary integrals, accounting for orientation."
     },
     {
       "id": "greens-theorem",
-      "title": "Part V: Green's Theorem for Multiply-Connected Regions",
-      "startLine": 229,
-      "endLine": 267,
+      "title": "Part V: Green’s Theorem — The Main Result",
+      "startLine": 249,
+      "endLine": 308,
       "summary": "PROVED: `greens_theorem_multiply_connected` — the corrected line integral equals the curl integral over the multiply-connected region. Proved from `greens_theorem_typeI` (OQ-03) by applying it to each TypeI subregion and using congruence on the hole sum.",
       "mathContext": "The main theorem: corrected boundary integral = double integral of curl over D. Proved by reduction to the simply-connected case."
     },
     {
       "id": "zero-curl",
-      "title": "Part VI: Zero-Curl Corollary - Topological Obstruction",
-      "startLine": 268,
-      "endLine": 315,
+      "title": "Part VI: Zero-Curl Corollary — The Topological Obstruction",
+      "startLine": 309,
+      "endLine": 364,
       "summary": "PROVED: when curl = 0, the outer circulation equals the sum of inner circulations. This is the topological obstruction to exactness of curl-free fields. Connects to de Rham cohomology, Cauchy's integral formula, and the Aharonov-Bohm effect.",
       "mathContext": "curl(F) = 0 implies circulation_outer = sum_i circulation_i. Proved from the axiom by showing the integral of zero vanishes."
     },
     {
       "id": "single-hole",
       "title": "Part VII: Single-Hole Special Case",
-      "startLine": 316,
-      "endLine": 397,
+      "startLine": 365,
+      "endLine": 422,
       "summary": "Constructs single-hole regions and PROVES: (1) line integral = outer - inner, (2) deformation invariance for curl-free fields (outer integral = inner integral), (3) area = outer area - hole area.",
       "mathContext": "The clean one-hole formula used in complex analysis: the integral around any curve encircling the hole is constant for curl-free fields."
     },
     {
-      "id": "annular-decomp",
-      "title": "Parts VIII-IX: Annular Decompositions",
-      "startLine": 398,
-      "endLine": 435,
-      "summary": "PROVES the annular curl integral and line integral decompose into outer disk minus inner disk contributions.",
-      "mathContext": "Explicit decomposition for the annulus: the prototype for Laurent series domains."
+      "id": "iterated-integral",
+      "title": "Part VIII: Iterated Integral over Multiply-Connected Regions",
+      "startLine": 423,
+      "endLine": 448,
+      "summary": "PROVES singleHole_area (single-hole region area = outer area minus hole area) and annular_curl_integral_decomp (the annular curl integral decomposes into outer-disk minus inner-disk iterated integrals). Establishes that the double integral over a multiply-connected region decomposes additively over disjoint holes.",
+      "mathContext": "The double integral over D = D_outer \\ (H_1 cup ... cup H_n) decomposes additively for disjoint holes: integral_D F dA = integral_{D_outer} F dA - sum_i integral_{H_i} F dA."
+    },
+    {
+      "id": "annular-line-decomp",
+      "title": "Part IX: Annular Line Integral Decomposition",
+      "startLine": 449,
+      "endLine": 465,
+      "summary": "PROVES annular_line_integral_decomp — the corrected multiply-connected line integral on an annulus decomposes into the outer-circle integral minus the inner-circle integral. This is the prototype decomposition underlying Laurent-series domains.",
+      "mathContext": "For the annulus the corrected line integral is circulation_outer - circulation_inner: oint_{outer circle} F.dr - oint_{inner circle} F.dr."
     },
     {
       "id": "additivity",
-      "title": "Part X: Multiple Holes - Additivity",
-      "startLine": 436,
-      "endLine": 470,
+      "title": "Part X: Multiple Holes — Additivity",
+      "startLine": 466,
+      "endLine": 500,
       "summary": "PROVES that adding a hole to a multiply-connected region subtracts the new hole's boundary integral from the total. Uses list append and sum decomposition.",
       "mathContext": "The correction is additive: each additional hole subtracts its boundary integral."
     },
     {
       "id": "de-rham",
-      "title": "Part XI: De Rham Cohomology Connection",
-      "startLine": 471,
-      "endLine": 504,
+      "title": "Part XI: Connection to De Rham Cohomology",
+      "startLine": 501,
+      "endLine": 536,
       "summary": "Defines the period vector (line integral around each hole) and PROVES that the sum of periods equals the outer circulation when curl = 0. This formalizes the de Rham cohomology structure H^1(D) = R^n.",
       "mathContext": "The period vector determines a closed 1-form up to an exact form. dim H^1_dR(D) = n holes."
     },
     {
       "id": "stokes",
-      "title": "Part XII: Stokes' Theorem Interpretation",
-      "startLine": 505,
-      "endLine": 552,
+      "title": "Part XII: Boundary Orientation and Stokes’ Interpretation",
+      "startLine": 537,
+      "endLine": 587,
       "summary": "Defines the oriented boundary integral and PROVES the Stokes' theorem form: integral over oriented boundary = integral of exterior derivative. This connects the multiply-connected Green's theorem to the general Stokes' theorem framework.",
       "mathContext": "Stokes' theorem: integral_{partial M} omega = integral_M d(omega) with the full oriented boundary."
     }


### PR DESCRIPTION
## Summary

The `greens-theorem-oq-02-oq-02` build path (an `ftc_of_absolutelyContinuous` bridge lemma, ~200–400 lines) remains gated by the Docker blackout, so no Lean was committed. Pivoted to the build-free vein and fixed stale gallery metadata across the `greens-theorem` family. **Pure metadata — no Lean source changed.**

- **oq-01-oq-01-oq-03**: added the missing **§ VII. Atomless Measure Generalization** section (lines 228–292). A 67-line tail with two theorems (`restrict_Icc_eq_Ioo_of_null_endpoints`, `restrict_Icc_eq_Ioo_of_noAtoms`) was hidden from the gallery. Counts already correct.
- **oq-01-oq-02**: re-pinned all 5 Part ranges (file grew ~20 lines; sections lagged) and synced stale `leanFile` counts (`lineCount` 227→247, `theoremCount` 5→6). `meta.meta` counts were already correct.
- **oq-04**: rebuilt the sections array 11→12 — split the lumped "Parts VIII–IX" into separate Part VIII / Part IX, fixed shifted line ranges, and corrected Part IV/V/XI/XII titles to match the file's `## Part` banners.
- **oq-02** (parent of the claimed OQ): re-pinned Part IV/V ranges and `lineCount` 507→518. `theoremCount`=19 is correct — three apparent "extra" theorems were docstring false positives.

**Verified clean (no change needed):** `greens-theorem`, `greens-theorem-oq-01` (gaps were only trailing `end`/blank lines); `greens-theorem-oq-03` (grep over-counted defs/axioms due to a ```lean docstring code block — real counts 14/2 match meta).

## Test plan
- [x] `jq empty` passes on all 4 edited meta.json files
- [x] Family scan confirms section coverage gaps closed (was 67/23/36/12 lines hidden → now only trailing blank/`end`)
- [x] No Lean source files touched (metadata-only)