### PR TITLE
research(erdos-152): realign drifted gallery sections to full file (8→9)

### DIFF
--- a/src/data/proofs/erdos-152/meta.json
+++ b/src/data/proofs/erdos-152/meta.json
@@ -47,67 +47,75 @@
   "sections": [
     {
       "id": "header",
-      "title": "Problem Statement and References",
+      "title": "Problem Statement, Status & References",
       "startLine": 1,
-      "endLine": 14,
-      "summary": "Documents the problem from Erdős-Sárközy-Sós (1994), J. Number Theory. States both the weak (unbounded) and strong ($\\gg |A|^2$) forms.",
-      "mathContext": "Bound: Documents the problem from Erdős-Sárközy-Sós (1994), J. Number Theory. States both the weak (unbounded) and strong ($\\gg |A|^2$) forms."
+      "endLine": 36,
+      "summary": "States Erdős #152 (Erdős–Sárközy–Sós 1994): a large finite Sidon set A has many isolated elements in A+A. The weak form (∀M, eventually ≥M isolated; equivalently Tendsto f atTop atTop) was resolved by DeepMind AlphaProof Nexus on 2026-05-21, formalized in companion Erdos152ProblemAPN.lean. The strong (≫|A|²) and infinite forms remain open.",
+      "mathContext": "Bound: States Erdős #152 (Erdős–Sárközy–Sós 1994): a large finite Sidon set A has many isolated elements in A+A. The weak form (∀M, eventually ≥M isolated; equivalently Tendsto f atTop atTop) was resolved by DeepMind AlphaProof Nexus on 2026-05-21, formalized in companion Erdos152ProblemAPN.lean. The strong (≫|A|²) and infinite forms remain open."
     },
     {
       "id": "imports",
       "title": "Imports",
-      "startLine": 15,
-      "endLine": 23,
-      "summary": "Imports Mathlib Sidon set library, pointwise finset operations, and filter basics. Opens `Pointwise` scope.",
-      "mathContext": "Mathematical content: Imports Mathlib Sidon set library, pointwise finset operations, and filter basics. Opens `Pointwise` scope."
+      "startLine": 37,
+      "endLine": 46,
+      "summary": "Imports Mathlib's Sidon-set, Finset (Basic, Pointwise), and Order.Filter infrastructure, and opens the Pointwise scope for the sumset notation A + A.",
+      "mathContext": "Bound: Imports Mathlib's Sidon-set, Finset (Basic, Pointwise), and Order.Filter infrastructure, and opens the Pointwise scope for the sumset notation A + A."
     },
     {
       "id": "sidon-sumsets",
-      "title": "Sidon Sets and Sumsets",
-      "startLine": 24,
-      "endLine": 36,
-      "summary": "Defines `IsSidonFinset` (distinct pairwise sums) and `sumsetFinset A = A + A`. The Sidon property gives $|A+A| = \\binom{n+1}{2}$.",
-      "mathContext": "Formal definition: Defines `IsSidonFinset` (distinct pairwise sums) and `sumsetFinset A = A + A`. The Sidon property gives $|A+A| = \\binom{n+1}{2}$."
+      "title": "Section I: Sidon Sets and Sumsets",
+      "startLine": 47,
+      "endLine": 59,
+      "summary": "Defines IsSidonFinset A (all pairwise sums a+b distinct as unordered pairs) and the pointwise sumset sumsetFinset A = A + A.",
+      "mathContext": "Bound: Defines IsSidonFinset A (all pairwise sums a+b distinct as unordered pairs) and the pointwise sumset sumsetFinset A = A + A."
     },
     {
       "id": "isolated-elements",
-      "title": "Isolated Elements",
-      "startLine": 37,
-      "endLine": 50,
-      "summary": "Defines `IsIsolated` ($s \\pm 1 \\notin A+A$) and `isolatedCount` via `Finset.filter`. The central counting function of the problem.",
-      "mathContext": "Formal definition: Defines `IsIsolated` ($s \\pm 1 \\notin A+A$) and `isolatedCount` via `Finset.filter`. The central counting function of the problem."
-    },
-    {
-      "id": "weak-conjecture",
-      "title": "Weak Conjecture: Unbounded Isolated Count",
-      "startLine": 51,
-      "endLine": 61,
-      "summary": "States `ErdosProblem152`: $\\forall M, \\exists N_0, \\forall$ Sidon $A$ with $|A| \\geq N_0$, $I(A) \\geq M$.",
-      "mathContext": "Mathematical content: States `ErdosProblem152`: $\\forall M, \\exists N_0, \\forall$ Sidon $A$ with $|A| \\geq N_0$, $I(A) \\geq M$."
-    },
-    {
-      "id": "strong-conjecture",
-      "title": "Strong Conjecture: $\\gg |A|^2$ Isolated Elements",
-      "startLine": 62,
+      "title": "Section II: Isolated Elements",
+      "startLine": 60,
       "endLine": 73,
-      "summary": "States `ErdosProblem152Strong`: $\\exists c > 0$ with $I(A) \\geq c|A|^2$ for all Sidon $A$. A constant fraction of the sumset is isolated.",
-      "mathContext": "Mathematical content: States `ErdosProblem152Strong`: $\\exists c > 0$ with $I(A) \\geq c|A|^2$ for all Sidon $A$. A constant fraction of the sumset is isolated."
+      "summary": "Defines IsIsolated A s (s ∈ A+A but s-1, s+1 ∉ A+A) and the noncomputable count isolatedCount A of isolated sumset elements.",
+      "mathContext": "Bound: Defines IsIsolated A s (s ∈ A+A but s-1, s+1 ∉ A+A) and the noncomputable count isolatedCount A of isolated sumset elements."
     },
     {
-      "id": "sumset-bounds",
-      "title": "Sumset Size and Range Bounds",
+      "id": "conjecture",
+      "title": "Section III: The Conjecture",
       "startLine": 74,
-      "endLine": 89,
-      "summary": "Axiomatizes $|A+A| = n(n+1)/2$ and $\\max A \\geq n^2 - n + 1$ for Sidon sets of size $n$.",
-      "mathContext": "Axiomatizes $|A+A| = n(n+1)/2$ and $\\max A \\geq $n^{2}$ - n + 1$ for Sidon sets of size $n$."
+      "endLine": 84,
+      "summary": "States ErdosProblem152: the weak form asserting that for every M there is a threshold N₀ beyond which every Sidon set of size ≥ N₀ has at least M isolated elements.",
+      "mathContext": "Bound: States ErdosProblem152: the weak form asserting that for every M there is a threshold N₀ beyond which every Sidon set of size ≥ N₀ has at least M isolated elements."
     },
     {
-      "id": "related",
-      "title": "Pigeonhole and Infinite Version",
-      "startLine": 90,
-      "endLine": 108,
-      "summary": "Pigeonhole: $I(A) \\geq 1$ for $|A| \\geq 5$. Infinite version: does $I(A \\cap [1,N]) \\to \\infty$ for infinite Sidon $A$?",
-      "mathContext": "Mathematical content: Pigeonhole: $I(A) \\geq 1$ for $|A| \\geq 5$. Infinite version: does $I(A \\cap [1,N]) \\to \\infty$ for infinite Sidon $A$?"
+      "id": "stronger-conjecture",
+      "title": "Section IV: The Stronger Conjecture",
+      "startLine": 85,
+      "endLine": 96,
+      "summary": "States ErdosProblem152Strong: there is an absolute constant c > 0 with isolatedCount A ≥ c·|A|² for every Sidon set A — a positive proportion of the sumset is isolated.",
+      "mathContext": "Bound: States ErdosProblem152Strong: there is an absolute constant c > 0 with isolatedCount A ≥ c·|A|² for every Sidon set A — a positive proportion of the sumset is isolated."
+    },
+    {
+      "id": "proved-properties",
+      "title": "Section V: Proved Properties of Sidon Sets and Their Sumsets",
+      "startLine": 97,
+      "endLine": 145,
+      "summary": "Verified structural lemmas: sumset_mem and sumset_self_double (membership of a+b and 2a in A+A); sidon_no_three_ap / sidon_no_three_ap' (Sidon sets have no nontrivial 3-term APs: a+c=2b ⟹ a=b=c); and sidon_sum_ne_double (distinct a,b give a+b ≠ 2a).",
+      "mathContext": "Bound: Verified structural lemmas: sumset_mem and sumset_self_double (membership of a+b and 2a in A+A); sidon_no_three_ap / sidon_no_three_ap' (Sidon sets have no nontrivial 3-term APs: a+c=2b ⟹ a=b=c); and sidon_sum_ne_double (distinct a,b give a+b ≠ 2a)."
+    },
+    {
+      "id": "sumset-size",
+      "title": "Section VI: Sumset Size and Range Bounds",
+      "startLine": 146,
+      "endLine": 360,
+      "summary": "Quantitative Sidon facts: sidon_ordered_pair_inj (ordered-pair injectivity), card_ordered_pairs (|{(a,b):a≤b}| = n(n+1)/2 via swap involution and diagonal split), sidon_sumset_size (|A+A| = n(n+1)/2), sidon_diff_injective (distinct differences), and sidon_set_range_lower_bound (max element ≥ n(n-1)/2 by injecting differences into a range).",
+      "mathContext": "Bound: Quantitative Sidon facts: sidon_ordered_pair_inj (ordered-pair injectivity), card_ordered_pairs (|{(a,b):a≤b}| = n(n+1)/2 via swap involution and diagonal split), sidon_sumset_size (|A+A| = n(n+1)/2), sidon_diff_injective (distinct differences), and sidon_set_range_lower_bound (max element ≥ n(n-1)/2 by injecting differences into a range)."
+    },
+    {
+      "id": "related-results",
+      "title": "Section VII: Related Results — Gap Existence & Infinite Version",
+      "startLine": 361,
+      "endLine": 493,
+      "summary": "gap_existence_pigeonhole: every Sidon set of size ≥ 5 has at least one isolated element, by a case analysis on the endpoints (2M always has no right neighbor; the second-smallest element handles the m=0 case) using difference injectivity. Closes with ErdosProblem152Infinite, the open infinite-set formulation. (Source mislabels this as a second 'Section VI'.)",
+      "mathContext": "Bound: gap_existence_pigeonhole: every Sidon set of size ≥ 5 has at least one isolated element, by a case analysis on the endpoints (2M always has no right neighbor; the second-smallest element handles the m=0 case) using difference injectivity. Closes with ErdosProblem152Infinite, the open infinite-set formulation. (Source mislabels this as a second 'Section VI'.)"
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Gallery `sections` for erdos-152 stopped at line 108 of the 493-line `Erdos152Problem.lean` (only ~22% covered), with ranges misaligned to an older revision of the file.
- Rebuilt the array 8→9 sections, tiling lines 1-493 along the source's banner structure: Problem Statement/Status/References, Imports, Sidon Sets & Sumsets, Isolated Elements, the Conjecture (weak), the Stronger Conjecture (≫|A|²), Proved Properties, Sumset Size & Range Bounds, and Related Results (gap existence + infinite version).
- Each section has an accurate summary of its definitions/theorems. Note the source mislabels its final block as a second "Section VI" — the gallery section title corrects this to VII.

## Verification
- `leanFile` counts (56 thm / 26 def / 0 axiom / 493 LC) confirmed correct against the source and left unchanged.
- Rebuild script asserted all non-`.sections` JSON is byte-identical; `jq` validates the file.
- Build-free metadata-only change (Docker daemon down this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)