### PR TITLE
research(cantor-diagonalization-oq-03-oq-01-incomplete-01): realign mislabeled/hidden sections (5→8)

### DIFF
--- a/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
+++ b/src/data/proofs/cantor-diagonalization-oq-03-oq-01-incomplete-01/meta.json
@@ -56,40 +56,64 @@
       "id": "header-imports",
       "title": "Module Header and Imports",
       "startLine": 1,
-      "endLine": 34,
+      "endLine": 41,
       "summary": "Module header with imports, docstring, and namespace setup."
     },
     {
       "id": "evalstruct",
-      "title": "Evaluation Structures (Copied from Parent)",
-      "startLine": 35,
+      "title": "SECTION I: Evaluation Structures (from parent)",
+      "startLine": 42,
       "endLine": 65,
       "summary": "Re-states EvalStructure, IsPointSurjective, and lawvere_abstract for self-containedness. These are proved identically to the parent file.",
       "mathContext": "An evaluation structure $(\\text{Ob}, \\text{Val}, \\text{eval})$ models the evaluation map $\\text{ev}: B^A \\times A \\to B$ at the global-element level. Point-surjectivity says every function $\\text{Ob} \\to \\text{Val}$ is representable."
     },
     {
       "id": "categorical",
-      "title": "Categorical Evaluation Structure",
-      "startLine": 67,
-      "endLine": 100,
+      "title": "SECTION II: Categorical Evaluation Structure",
+      "startLine": 66,
+      "endLine": 89,
       "summary": "Re-states CategoricalEval (from parent). Obj, Hom, exp, Pt, apply, ptSurj. HasFixedPoint definition.",
       "mathContext": "A CategoricalEval models a CCC: objects, morphisms, exponentials, global elements, and the evaluation map. The apply field is $\\text{ev}(-, -) : \\text{Pt}(B^A) \\times \\text{Pt}(A) \\to \\text{Pt}(B)$."
     },
     {
       "id": "main",
-      "title": "lawvere_categorical (FIXED)",
-      "startLine": 102,
-      "endLine": 145,
-      "summary": "The corrected categorical Lawvere theorem (0 sorries). Makes e : Pt A → Pt(exp A B) explicit. Proof: construct EvalStructure from (e, apply), apply lawvere_abstract.",
+      "title": "SECTION III: The Categorical Lawvere Theorem (COMPLETED)",
+      "startLine": 90,
+      "endLine": 139,
+      "summary": "The corrected categorical Lawvere theorem (0 sorries). Makes e : Pt A → Pt(exp A B) explicit. Proof: construct EvalStructure from (e, apply), apply lawvere_abstract. Also no_categorical_surjection.",
       "mathContext": "The morphism $e: A \\to B^A$ at the level of global elements is $e: \\text{Pt}(A) \\to \\text{Pt}(B^A)$. Point-surjectivity: $\\forall g: \\text{Pt}(A) \\to \\text{Pt}(B), \\exists a, \\forall x, \\text{ev}(e(a), x) = g(x)$."
     },
     {
       "id": "cantor",
-      "title": "Categorical Cantor and Connections",
-      "startLine": 148,
-      "endLine": 185,
-      "summary": "categorical_cantor: no e : A → (A → Prop) is point-surjective (via Not having no fixed point). categorical_specializes_to_type_theoretic: Function.Surjective e → lawvere_categorical applies.",
+      "title": "SECTION IV: Categorical Cantor's Theorem",
+      "startLine": 140,
+      "endLine": 177,
+      "summary": "typeUniverse: the type-universe CategoricalEval instance. categorical_cantor: no e : A → (A → Prop) is point-surjective, via the fact that internal negation Not has no fixed point (¬v = v is impossible).",
       "mathContext": "In a topos, $B = \\Omega$ (subobject classifier) with internal negation $\\neg: \\Omega \\to \\Omega$. Since $\\neg P = P$ is impossible for any proposition $P$, Lawvere prevents any $A \\twoheadrightarrow \\Omega^A$."
+    },
+    {
+      "id": "sorry-wellformed",
+      "title": "SECTION V: Well-Formedness of the Original Sorry",
+      "startLine": 178,
+      "endLine": 198,
+      "summary": "sorry_diagnosis_resolved: diagnoses the parent file's original sorry as a type error — the sorry was a constant of type Pt(exp A B) independent of a, where an explicit morphism e : Pt A → Pt(exp A B) was intended. Making e explicit resolves it, reducing to lawvere_categorical.",
+      "mathContext": "The intended hypothesis is $\\exists a, \\forall x, \\text{ev}(e(a), x) = g(x)$ for an explicit $e: \\text{Pt}(A) \\to \\text{Pt}(B^A)$, not a single constant term. Point-surjectivity of this explicit $e$ suffices for the fixed-point conclusion."
+    },
+    {
+      "id": "type-theoretic-connection",
+      "title": "SECTION VI: Connection to Type-Theoretic Version",
+      "startLine": 199,
+      "endLine": 230,
+      "summary": "categorical_specializes_to_type_theoretic: the parent's type-theoretic Lawvere theorem is the special case of lawvere_categorical with C = typeUniverse, apply = function application, and hSurj = Function.Surjective e.",
+      "mathContext": "Specializing the categorical theorem to $C = $ Type with $\\text{apply} = $ function application and $\\text{Pt} = \\text{id}$ recovers the classical statement: a surjection $e: A \\to (A \\to B)$ forces every endomorphism of $B$ to have a fixed point."
+    },
+    {
+      "id": "summary-checks",
+      "title": "Summary Checks",
+      "startLine": 231,
+      "endLine": 240,
+      "summary": "#check sanity statements for the four key results: lawvere_categorical, no_categorical_surjection, categorical_cantor, categorical_specializes_to_type_theoretic.",
+      "mathContext": "Final verification that the principal theorems type-check as stated."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Build-free gallery metadata fix. `CantorDiagonalizationOQ03OQ01Incomplete01.lean` (240 lines) had 5 meta sections, but the source carries 6 `-- SECTION N` banners plus a Summary-checks block. SECTIONs IV/V/VI and the Summary checks were mislabeled or hidden — the tail (186–240) was uncovered (gap=55), and the back-half ranges drifted off the banners.

Re-pinned all sections to the source banners with contiguous full-file coverage (5 → 8):

| Section | Range |
|---|---|
| Module Header and Imports | 1–41 |
| SECTION I: Evaluation Structures (from parent) | 42–65 |
| SECTION II: Categorical Evaluation Structure | 66–89 |
| SECTION III: The Categorical Lawvere Theorem (COMPLETED) | 90–139 |
| SECTION IV: Categorical Cantor's Theorem | 140–177 |
| SECTION V: Well-Formedness of the Original Sorry | 178–198 |
| SECTION VI: Connection to Type-Theoretic Version | 199–230 |
| Summary Checks | 231–240 |

## Verification
- `maxEnd` now 240 = `leanFile.lineCount` = actual `wc -l`; sections monotonic & contiguous.
- Metadata-only; all non-`sections` content byte-identical (`jq 'del(.sections)'` diff).
- No Lean rebuild required.

## Notes
Surfaced via cantor family scan. No `loom:review-requested` — math PR for deployer auto-merge.