### PR TITLE
research(binary-gcd-oq-03): rebuild stale gallery sections (10→14)

### DIFF
--- a/src/data/proofs/binary-gcd-oq-03/meta.json
+++ b/src/data/proofs/binary-gcd-oq-03/meta.json
@@ -48,10 +48,18 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Module Header and Overview",
+      "startLine": 1,
+      "endLine": 32,
+      "summary": "Module docstring describing the Lehmer–Schönhage hybrid GCD formalization (matrix-cofactor acceleration with Euclidean fallback), imports (Nat.GCD.Basic, Nat.Log, Int.GCD, Mathlib.Tactic), and the LehmerGcd namespace.",
+      "mathContext": "Lehmer's method accelerates Euclidean GCD by running several quotient steps on single-precision top-bit approximations, accumulating them into a 2×2 cofactor matrix $M$ with $\\det M = \\pm 1$, then applying $M$ to the full-precision pair — preserving $\\gcd(a,b)$."
+    },
+    {
       "id": "cofactor-matrices",
       "title": "Part I: 2×2 Integer Cofactor Matrices",
       "startLine": 33,
-      "endLine": 70,
+      "endLine": 71,
       "summary": "Defines CofactorMatrix structure with α, β, γ, δ fields. Includes identity, determinant, multiplication, and application. Proves det(Id)=1 and det(M·N)=det(M)·det(N).",
       "mathContext": "A cofactor matrix $M = \\begin{pmatrix} \\alpha & \\beta \\\\ \\gamma & \\delta \\end{pmatrix}$ tracks how $(a,b)$ transforms through Euclidean steps. The identity matrix leaves $(a,b)$ unchanged. Matrix multiplication composes transformations."
     },
@@ -59,7 +67,7 @@
       "id": "gcd-invariance",
       "title": "Part II: GCD Invariance Under Det ±1 Matrices",
       "startLine": 72,
-      "endLine": 158,
+      "endLine": 159,
       "summary": "Core theoretical results. dvd_of_det_unit: Cramer's rule for divisibility. common_divisors_preserved: iff between Nat and Int divisibility. gcd_cofactor_eq: Int.gcd(αa+βb, γa+δb) = Nat.gcd(a,b) for det ±1 matrices.",
       "mathContext": "If $\\det(M) = \\pm 1$, then $M$ is invertible over $\\mathbb{Z}$, so $\\gcd(\\alpha a + \\beta b, \\gamma a + \\delta b) = \\gcd(a, b)$. The proof uses Cramer's rule: $a = \\delta u - \\beta v$ and $b = \\alpha v - \\gamma u$ when $\\det = 1$."
     },
@@ -67,7 +75,7 @@
       "id": "lehmer-cofactor",
       "title": "Part III: Lehmer Cofactor Step",
       "startLine": 160,
-      "endLine": 218,
+      "endLine": 219,
       "summary": "Defines lehmerInnerStep (one Euclidean step on approximations with cofactor accumulation), euclidStepMatrix [[0,1],[1,-q]], and lehmerCofactors (iterated inner loop). The step matrix has det = -1.",
       "mathContext": "One Euclidean step $(a,b) \\to (b, a - qb)$ with quotient $q = \\lfloor a/b \\rfloor$ is represented by the step matrix $S_q = \\begin{pmatrix} 0 & 1 \\\\ 1 & -q \\end{pmatrix}$ with $\\det(S_q) = -1$. Accumulating $k$ steps gives $M = S_{q_1} \\cdot S_{q_2} \\cdots S_{q_k}$ with $\\det(M) = (-1)^k$."
     },
@@ -75,57 +83,81 @@
       "id": "det-preservation",
       "title": "Part IV: Determinant Preservation",
       "startLine": 220,
-      "endLine": 253,
+      "endLine": 252,
       "summary": "lehmerInnerStep_det: each step flips det sign. lehmerCofactors_det_unit: after any number of steps from Id, det remains ±1. Proved by induction on fuel.",
       "mathContext": "Since $\\det(S_q) = -1$ for each step, $\\det(M') = \\det(M) \\cdot \\det(S_q) = -\\det(M)$. Starting from $\\det(I) = 1$, the determinant alternates $1, -1, 1, -1, \\ldots$, always $\\pm 1$."
     },
     {
       "id": "euclidean-gcd",
       "title": "Part V: The Euclidean Algorithm",
-      "startLine": 255,
-      "endLine": 285,
+      "startLine": 253,
+      "endLine": 284,
       "summary": "Defines euclidGcd by well-founded recursion on b. Proves euclidGcd_eq_gcd: euclidGcd a b = Nat.gcd a b by strong induction, using gcd_mod_eq for the key step.",
       "mathContext": "The standard Euclidean algorithm: $\\gcd(a, b) = \\gcd(b, a \\bmod b)$ when $b > 0$, with base case $\\gcd(a, 0) = a$. Termination follows from $a \\bmod b < b$."
     },
     {
       "id": "bit-extraction",
       "title": "Part VI: Bit Extraction",
-      "startLine": 287,
-      "endLine": 306,
+      "startLine": 285,
+      "endLine": 305,
       "summary": "topBits: extract top w bits by right-shifting. topBits_approx: n = topBits(n).1 * 2^shift + n mod 2^shift.",
       "mathContext": "For Lehmer's method, we approximate $a$ by $\\hat{a} = \\lfloor a / 2^s \\rfloor$ where $s = \\max(0, \\lceil \\log_2 a \\rceil - w)$, ensuring $\\hat{a}$ fits in $w$ bits."
     },
     {
       "id": "hybrid-algorithm",
       "title": "Part VII: The Lehmer-Schönhage Hybrid GCD",
-      "startLine": 308,
-      "endLine": 370,
+      "startLine": 306,
+      "endLine": 369,
       "summary": "Defines lehmerReduce (one Lehmer step or Euclidean fallback), lehmerThreshold (64), and lehmerGcd (the full hybrid with fuel-based termination). For large inputs: extract top bits, compute cofactors, apply. For small inputs: Euclidean.",
       "mathContext": "The hybrid algorithm: for $\\max(a,b) \\geq T$ (threshold), extract the top $w$ bits, run $\\leq w$ Euclidean steps on the approximations to get cofactor matrix $M$, apply $M$ to $(a,b)$. For $\\max(a,b) < T$, use the standard Euclidean algorithm directly."
     },
     {
-      "id": "correctness",
-      "title": "Parts VIII-IX: Correctness",
-      "startLine": 372,
-      "endLine": 389,
-      "summary": "gcd_euclidStep: Nat.gcd(b, a%b) = Nat.gcd(a,b). euclidGcd correctness restatement.",
+      "id": "euclid-step-correct",
+      "title": "Part VIII: GCD Correctness of Euclidean Step",
+      "startLine": 370,
+      "endLine": 378,
+      "summary": "gcd_euclidStep: Nat.gcd(b, a%b) = Nat.gcd(a,b), the single-step Euclidean recurrence (via gcd_mod_eq).",
       "mathContext": "The Euclidean recurrence $\\gcd(a, b) = \\gcd(b, a \\bmod b)$ ensures each Euclidean fallback step preserves the GCD."
     },
     {
+      "id": "euclid-gcd-correct",
+      "title": "Part IX: Correctness of Euclidean GCD",
+      "startLine": 379,
+      "endLine": 387,
+      "summary": "lehmerGcd_euclidGcd_correct: euclidGcd a b = Nat.gcd a b — the small-input fallback computes the standard GCD (restating euclidGcd_eq_gcd from Part V).",
+      "mathContext": "By induction on the well-founded recursion, the fallback $\\text{euclidGcd}$ agrees with $\\text{Nat.gcd}$, so the hybrid is correct whenever it bottoms out in the Euclidean branch."
+    },
+    {
+      "id": "computational-verification",
+      "title": "Part X: Computational Verification",
+      "startLine": 388,
+      "endLine": 416,
+      "summary": "native_decide examples checking euclidGcd against Nat.gcd (89/55, 100/75, 1000000/999999, …), cofactor-matrix determinants (det Id = 1, det(euclidStepMatrix 3) = -1), top-bit extraction (topBits 255 8, topBits 1000 8), and that lehmerCofactors accumulation keeps det ±1.",
+      "mathContext": "Concrete evaluation sanity-checks: the decidable kernel computes the algorithm on specific inputs and confirms agreement with $\\text{Nat.gcd}$ and the $\\det = \\pm 1$ invariant, complementing the symbolic proofs."
+    },
+    {
       "id": "cofactor-application",
-      "title": "Part XI: Cofactor Application",
-      "startLine": 420,
-      "endLine": 435,
-      "summary": "cofactor_apply_gcd: bridges CofactorMatrix.det to the scalar det hypothesis in gcd_cofactor_eq. The key connector between the abstract theory and the concrete algorithm.",
+      "title": "Part XI: GCD Preservation Under Cofactor Application",
+      "startLine": 417,
+      "endLine": 429,
+      "summary": "cofactor_apply_gcd: bridges CofactorMatrix.det to the scalar det hypothesis in gcd_cofactor_eq. The key connector between the abstract theory (Parts I-IV) and the concrete algorithm.",
       "mathContext": "Specializes $\\gcd_{\\text{cofactor}}$ to the CofactorMatrix structure: $\\gcd(M \\cdot (a,b)) = \\gcd(a,b)$ when $\\det(M) = \\pm 1$."
     },
     {
       "id": "step-count",
-      "title": "Part XII: Lehmer Step Count",
-      "startLine": 437,
-      "endLine": 461,
+      "title": "Part XII: Lehmer Step Count Advantage",
+      "startLine": 430,
+      "endLine": 455,
       "summary": "lehmerCofactorSteps: counts Euclidean steps computed in one Lehmer iteration. lehmerCofactorSteps_pos: at least 1 step when progress is made.",
       "mathContext": "Each Lehmer reduction performs $O(w)$ cheap single-precision Euclidean steps simultaneously, reducing the full-precision input by a factor of $\\sim 2^w$. This is the source of Lehmer's speedup over plain Euclidean GCD."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 456,
+      "endLine": 488,
+      "summary": "Closing docstring recapping the proved results (0 axioms, 0 sorries): GCD invariance under det ±1 matrices, determinant tracking, Euclidean-fallback correctness, the algorithm definitions, and GCD preservation under cofactor application — with notes on the hybrid architecture and O(n²/w) complexity vs O(n²) plain Euclidean. Closes with `end LehmerGcd`.",
+      "mathContext": "Complexity: each Lehmer step performs $O(w)$ single-precision Euclidean steps, reducing the input by $\\sim 2^w$, for $O(n^2/w)$ bit operations vs $O(n^2)$ plain Euclidean; Schönhage's recursive variant reaches $O(M(n)\\log n)$ with fast multiplication."
     }
   ],
   "crossReferences": [


### PR DESCRIPTION
## Summary
- The `binary-gcd-oq-03` (Lehmer-Schönhage hybrid GCD) gallery `sections` array had drifted on several axes:
  - **No header section** — coverage started at line 33, omitting the module docstring + imports.
  - **Lumped sections** — "Parts VIII-IX" were merged into one entry.
  - **Missing Part X** — Part X (Computational Verification, lines 388–416) was an uncovered gap between the merged VIII-IX entry and Part XI.
  - **Lagging ranges** — Parts XI/XII line ranges trailed their `-- PART N` banners (XI listed 420–435 vs actual 417–429; XII 437–461 vs 430–455), and several mid-file Parts lagged by 1–2 lines.
  - **Uncovered tail** — the closing Summary docstring (456–488) was not covered.

## Changes
- Re-mapped to **14 contiguous banner-aligned sections** with full coverage (lines 1–488): added the header, split Parts VIII/IX/X, realigned Parts XI/XII, and added the Summary.

## Verification
- Counts (15 theorems / 14 definitions / 0 axioms / 0 sorries) and `lineCount` (488) were already correct and are unchanged.
- No Lean source changed — metadata-only realignment. JSON validated; non-section content byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)