### PR TITLE
research(shannon-channel-coding-oq-03): realign drifted gallery sections to full file (9→11)

### DIFF
--- a/src/data/proofs/shannon-channel-coding-oq-03/meta.json
+++ b/src/data/proofs/shannon-channel-coding-oq-03/meta.json
@@ -88,73 +88,89 @@
     {
       "id": "definitions",
       "title": "Information-Theoretic Definitions",
-      "startLine": 36,
-      "endLine": 75,
-      "summary": "Self-contained definitions of Shannon entropy, conditional entropy, and the Gibbs inequality (sorry), independent of the main ShannonEntropy.lean due to a pre-existing build issue.",
+      "startLine": 41,
+      "endLine": 103,
+      "summary": "Self-contained definitions of Shannon entropy and conditional entropy, plus a fully proved Gibbs inequality (KL divergence non-negativity via log x ≤ x - 1), independent of the main ShannonEntropy.lean due to a pre-existing build issue.",
       "mathContext": "$H(X) = -\\sum_x p(x)\\log p(x)$, $H(X|Y) = -\\sum_{x,y} p(x,y)\\log(p(x,y)/p(y))$"
     },
     {
       "id": "map-error",
       "title": "MAP Error Probability",
-      "startLine": 63,
-      "endLine": 76,
-      "summary": "Defines MAP error probability P_e^{MAP} = 1 - ∑_y max_x P(X=x,Y=y) as 1 minus the sum of maximum probabilities per y-slice.",
+      "startLine": 105,
+      "endLine": 118,
+      "summary": "Defines maxProb (the maximum probability per y-slice) and the MAP error probability P_e^{MAP} = 1 - ∑_y max_x P(X=x,Y=y) as 1 minus the sum of maximum probabilities per y-slice.",
       "mathContext": "$P_e^{\\text{MAP}} = 1 - \\sum_y \\max_x P(X=x,Y=y)$"
     },
     {
       "id": "core-algebra",
       "title": "Core Algebraic Inequality (Proved)",
-      "startLine": 80,
-      "endLine": 102,
-      "summary": "PROVED: For any probability distribution q, ∑q(x)² ≤ max q(x). The proof uses that q(x) ≤ max(q), so q(x)² ≤ max(q)·q(x), and summing gives ∑q² ≤ max(q)·1.",
+      "startLine": 119,
+      "endLine": 138,
+      "summary": "PROVED (sum_sq_le_max): For any probability distribution q, ∑q(x)² ≤ max q(x). The proof uses that q(x) ≤ max(q), so q(x)² ≤ max(q)·q(x), and summing gives ∑q² ≤ max(q)·1.",
       "mathContext": "$\\sum_x q(x)^2 \\leq \\max_x q(x)$ for any probability distribution $q$"
     },
     {
       "id": "slice-bound",
-      "title": "Per-Slice Bound (Proved)",
-      "startLine": 103,
-      "endLine": 121,
-      "summary": "PROVED: For each y, ∑_x P(x,y)²/P(Y=y) ≤ max_x P(x,y). Follows by applying the core algebraic inequality to the conditional distribution P(X=x|Y=y).",
+      "title": "Slice-wise Bound (Proved)",
+      "startLine": 139,
+      "endLine": 182,
+      "summary": "PROVED (slice_sq_le_max): For each y, ∑_x P(x,y)²/P(Y=y) ≤ max_x P(x,y). Follows by applying the core algebraic inequality to the conditional distribution P(X=x|Y=y), handling the degenerate P(Y=y)=0 slice separately.",
       "mathContext": "$\\sum_x \\frac{P(x,y)^2}{P(Y=y)} \\leq \\max_x P(x,y)$ for each $y$"
     },
     {
       "id": "formula-pe-ge-map",
       "title": "Formula P_e Bounds MAP P_e (Proved)",
-      "startLine": 122,
-      "endLine": 139,
-      "summary": "PROVED: P_e^{MAP} ≤ P_e^{formula}, where the formula uses ∑_y ∑_x P²/P(Y). This means the gallery's formula P_e is a conservative upper bound on the actual MAP error probability.",
+      "startLine": 183,
+      "endLine": 194,
+      "summary": "PROVED (formula_pe_ge_map_pe): P_e^{MAP} ≤ P_e^{formula}, where the formula uses ∑_y ∑_x P²/P(Y). This means the gallery's formula P_e is a conservative upper bound on the actual MAP error probability.",
       "mathContext": "$P_e^{\\text{MAP}} \\leq 1 - \\sum_y \\frac{\\sum_x P(x,y)^2}{P(Y=y)} = P_e^{\\text{formula}}$"
     },
     {
       "id": "per-element-fano",
       "title": "Per-Element Fano Bound (Proved)",
-      "startLine": 140,
-      "endLine": 166,
-      "summary": "PROVED: For a single distribution q with |α| ≥ 2, H(q) ≤ h(1-max q) + (1-max q)·log(|α|-1). Uses Gibbs inequality with a bimodal reference distribution concentrating p* = max(q) on the mode.",
+      "startLine": 195,
+      "endLine": 317,
+      "summary": "PROVED (fano_per_element): For a single distribution q with |α| ≥ 2, H(q) ≤ h(1-max q) + (1-max q)·log(|α|-1). Uses Gibbs inequality with a bimodal reference distribution concentrating p* = max(q) on the mode, with a degenerate (p*=1) case handled separately.",
       "mathContext": "$H(q) \\leq h(1-p^*) + (1-p^*)\\log(n-1)$ where $p^* = \\max_x q(x)$"
     },
     {
       "id": "map-fano-bound",
-      "title": "MAP Fano Bound via Jensen (Proved)",
-      "startLine": 168,
-      "endLine": 191,
-      "summary": "PROVED: H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(|X|-1). Aggregates per-slice bounds using Jensen's inequality for the concave binary entropy function h.",
+      "title": "Conditional Entropy Fano Bound — MAP Version (Proved)",
+      "startLine": 318,
+      "endLine": 469,
+      "summary": "PROVED (fano_map_bound): H(X|Y) ≤ h(P_e^{MAP}) + P_e^{MAP}·log(|X|-1). Decomposes H(X|Y) = ∑_y P(Y=y)·H(X|Y=y), applies the per-element Fano bound per slice, then aggregates with Jensen's inequality for the concave binary entropy function h.",
       "mathContext": "$H(X|Y) \\leq h(P_e^{\\text{MAP}}) + P_e^{\\text{MAP}}\\log(|X|-1)$"
+    },
+    {
+      "id": "cauchy-schwarz",
+      "title": "Cauchy-Schwarz for Sums (Helper, Proved)",
+      "startLine": 470,
+      "endLine": 503,
+      "summary": "PROVED (cauchy_schwarz_sum): (∑ f)² ≤ |α|·∑ f² for any f on a finite type. Proved via non-negative variance: 0 ≤ n·∑(f-mean)² = n·∑f² - (∑f)².",
+      "mathContext": "$\\left(\\sum_x f(x)\\right)^2 \\leq |\\alpha| \\cdot \\sum_x f(x)^2$"
+    },
+    {
+      "id": "per-slice-collision",
+      "title": "Per-Slice Collision Bound (Helper, Proved)",
+      "startLine": 504,
+      "endLine": 531,
+      "summary": "PROVED (per_slice_bound): For non-negative f with |α| = n, ∑ f(x)²/(∑ f) ≥ (∑ f)/n. Follows from Cauchy-Schwarz, (∑f)² ≤ n·∑f², after handling the ∑f = 0 case.",
+      "mathContext": "$\\frac{\\sum_x f(x)}{|\\alpha|} \\leq \\sum_x \\frac{f(x)^2}{\\sum_x f(x)}$"
     },
     {
       "id": "monotonicity",
       "title": "Monotonicity of Fano Bound (Proved)",
-      "startLine": 193,
-      "endLine": 209,
-      "summary": "PROVED: f(p) = h(p) + p·log(c) is non-decreasing on [0, c/(1+c)] for c ≥ 1. Derivative argument: f'(p) = log((1-p)c/p) ≥ 0 iff p ≤ c/(1+c).",
+      "startLine": 532,
+      "endLine": 600,
+      "summary": "PROVED (fano_func_mono): f(p) = h(p) + p·log(c) is non-decreasing on [0, c/(1+c)] for c ≥ 1. Derivative argument via monotoneOn_of_deriv_nonneg: f'(p) = log((1-p)c/p) ≥ 0 iff p ≤ c/(1+c).",
       "mathContext": "$f(p) = h(p) + p\\log c$ is monotone on $[0, c/(1+c)]$, so $p_1 \\leq p_2 \\leq c/(1+c) \\Rightarrow f(p_1) \\leq f(p_2)$"
     },
     {
       "id": "main-theorem",
       "title": "Fano's Inequality (Main Theorem)",
-      "startLine": 211,
-      "endLine": 255,
-      "summary": "Main theorem: H(X|Y) ≤ h(P_e) + P_e·log(|X|-1) for formula P_e. Chains together MAP Fano bound → monotonicity → formula P_e version. The main file is complete: all supporting lemmas and the main theorem are fully proved with 0 sorries and 0 axioms (the Aristotle companion file holds 4 supporting-lemma sorries, not required by the main theorem).",
+      "startLine": 601,
+      "endLine": 664,
+      "summary": "Main theorem (fano_theorem): H(X|Y) ≤ h(P_e) + P_e·log(|X|-1) for formula P_e. Chains together MAP Fano bound → monotonicity → formula P_e version. The main file is complete: all supporting lemmas and the main theorem are fully proved with 0 sorries and 0 axioms (the Aristotle companion file holds 4 supporting-lemma sorries, not required by the main theorem).",
       "mathContext": "$H(X|Y) \\leq h(P_e) + P_e \\cdot \\log(|\\mathcal{X}|-1)$"
     }
   ],


### PR DESCRIPTION
## Summary

The gallery meta for **shannon-channel-coding-oq-03** (Fano's Inequality) had badly drifted section line ranges: the `sections[]` array stopped at line 255 of a 664-line source file (**62% of the proof hidden** from the gallery renderer), and the first two sections overlapped (`definitions` 36–75 vs `map-error` 63–76).

This is a **build-free, metadata-only** realignment:

- Re-pinned all nine existing sections to their true `-- Section N` banner ranges in `ShannonChannelCodingOQ03.lean`.
- Added the two **missing helper sections** that were never in the meta: Section 7.5 *Cauchy-Schwarz for Sums* (`cauchy_schwarz_sum`, 470–503) and Section 7.6 *Per-Slice Collision Bound* (`per_slice_bound`, 504–531). Sections now span the full file (41–664), monotonic and non-overlapping.
- Fixed stale prose in the `definitions` summary that described the Gibbs inequality as "(sorry)" — it is fully proved (`gibbs_inequality`, lines 62–103).

No count fields changed: still 10 theorems / 4 definitions / 0 axioms / 0 sorries, `lineCount` 664. The `.lean` source is untouched.

## Test plan

- [x] `meta.json` parses as valid JSON
- [x] Sections are monotonic, non-overlapping, and cover lines 41–664 (maxEnd == lineCount)
- [x] Section ranges verified against `-- Section N` banners in the source
- [x] No `.lean` / proof changes — metadata only