### PR TITLE
research(cayley-hamilton-minpoly-oq-02-oq-02): realign sections + add hidden PART 5 Summary (5→6)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-02-oq-02/meta.json
@@ -89,41 +89,49 @@
       "id": "header-imports",
       "title": "Module Header: The Counterexample Strategy",
       "startLine": 1,
-      "endLine": 58,
+      "endLine": 54,
       "summary": "Documentation header stating the open question (does same minpoly + charpoly imply similarity?) and the answer: NO. Describes the counterexample: two 4x4 nilpotent matrices with Jordan types [2,2] and [2,1,1] share characteristic polynomial X^4 and minimal polynomial X^2 but are not similar (rank(A) = 2 vs rank(B) = 1). Imports Mathlib matrix theory and the parent CayleyHamiltonMinpolyOQ02.",
       "mathContext": "Counterexample: $A$ has Jordan type $[2,2]$, $B$ has Jordan type $[2,1,1]$. Both have $\\chi_A = \\chi_B = X^4$ and $\\mu_A = \\mu_B = X^2$, but $\\text{rank}(A) = 2 \\neq 1 = \\text{rank}(B)$, so $A \\not\\sim B$."
     },
     {
       "id": "definitions",
-      "title": "Counterexample Matrices",
-      "startLine": 59,
-      "endLine": 81,
+      "title": "PART 1: Define the Counterexample Matrices",
+      "startLine": 55,
+      "endLine": 82,
       "summary": "Defines matA (Jordan type [2,2]: A(0,1)=A(2,3)=1, else 0) and matB (Jordan type [2,1,1]: B(0,1)=1, else 0) over an arbitrary field K.",
       "mathContext": "$A = \\begin{pmatrix} 0&1&0&0\\\\0&0&0&0\\\\0&0&0&1\\\\0&0&0&0 \\end{pmatrix}$, $B = \\begin{pmatrix} 0&1&0&0\\\\0&0&0&0\\\\0&0&0&0\\\\0&0&0&0 \\end{pmatrix}$"
     },
     {
       "id": "nilpotency",
-      "title": "Nilpotency and Nonzero",
-      "startLine": 87,
-      "endLine": 109,
+      "title": "PART 2: Both Are Nilpotent of Order 2",
+      "startLine": 83,
+      "endLine": 110,
       "summary": "Proves A^2 = B^2 = 0 (both nilpotent of order at most 2) and A != 0, B != 0 (nilpotent of order exactly 2).",
       "mathContext": "$A^2 = B^2 = 0$ (entry-by-entry computation). $A \\neq 0$ since $A_{01} = 1$. $B \\neq 0$ since $B_{01} = 1$."
     },
     {
       "id": "same-minpoly",
-      "title": "Same Minimal Polynomial X^2",
-      "startLine": 115,
-      "endLine": 228,
+      "title": "PART 3: Same Minimal Polynomial (X²)",
+      "startLine": 111,
+      "endLine": 229,
       "summary": "Shows X^2 annihilates both matrices, X does not annihilate either, and deduces minpoly = X^2 for both. Minimality proved via UFD classification: minpoly divides X^2 with X prime, so minpoly = X^j; j != 0 (degree > 0) and j != 1 (A != 0), so j = 2.",
       "mathContext": "Since $A^2 = 0$, $\\text{minpoly}(A) \\mid X^2$. Since $A \\neq 0$, $\\text{minpoly}(A) \\nmid X$. The only monic divisors of $X^2$ are $\\{1, X, X^2\\}$; ruling out $1$ and $X$ gives $\\text{minpoly}(A) = X^2$."
     },
     {
       "id": "not-similar",
-      "title": "Non-Similarity (Main Result)",
-      "startLine": 234,
-      "endLine": 350,
+      "title": "PART 4: Non-Similarity (Main Result)",
+      "startLine": 230,
+      "endLine": 351,
       "summary": "Proves A and B are not similar via the intertwining matrix argument: AP = PB forces det(P) = 0. Uses pigeonhole on the Leibniz formula.",
       "mathContext": "If $B = P^{-1}AP$ then $AP = PB$. Entry analysis shows $P_{1j} = P_{3j} = 0$ for $j \\neq 1$. In $\\det(P) = \\sum_\\sigma \\text{sgn}(\\sigma) \\prod_i P_{\\sigma(i),i}$, each term needs $\\sigma(\\{0,2,3\\}) \\subseteq \\{0,2\\}$, impossible by pigeonhole."
+    },
+    {
+      "id": "summary",
+      "title": "PART 5: Summary",
+      "startLine": 352,
+      "endLine": 390,
+      "summary": "Summary docstring: the converse of similarity-invariance is FALSE — same minpoly (X²) and charpoly (X⁴) do not imply similarity. Recaps the Jordan-type [2,2] vs [2,1,1] counterexample, explains why minpoly/charpoly miss the block-size distribution, identifies invariant factors as the correct similarity invariant, and lists open follow-up questions (rational canonical form, Jordan normal form, full classification).",
+      "mathContext": "The correct invariant is the multiset of invariant factors: $A$ has $(X^2, X^2)$, $B$ has $(X^2, X, X)$. Same largest factor (minpoly) and same product (charpoly), but different factor multisets, hence $A \\not\\sim B$. Over an algebraically closed field, similarity is determined by elementary divisors (Jordan type)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Build-free gallery metadata fix. `CayleyHamiltonMinpolyOQ02OQ02.lean` (390 lines) had its **PART 5: Summary** docstring (352–390) hidden entirely (gap=40), and the back-half section ranges drifted slightly off the `-- PART N` banners.

Re-pinned all sections to the five source banners with contiguous full-file coverage and added the missing PART 5 (5 → 6):

| Section | Range |
|---|---|
| Module Header: The Counterexample Strategy | 1–54 |
| PART 1: Define the Counterexample Matrices | 55–82 |
| PART 2: Both Are Nilpotent of Order 2 | 83–110 |
| PART 3: Same Minimal Polynomial (X²) | 111–229 |
| PART 4: Non-Similarity (Main Result) | 230–351 |
| PART 5: Summary (new) | 352–390 |

The hidden Summary recaps the Jordan-type [2,2] vs [2,1,1] counterexample, explains why minpoly/charpoly miss the block-size distribution, and identifies invariant factors as the correct similarity invariant.

## Verification
- `maxEnd` now 390 = `leanFile.lineCount` = actual `wc -l`; sections monotonic & contiguous.
- Metadata-only; all non-`sections` content byte-identical (`jq 'del(.sections)'` diff).
- No Lean rebuild required.

## Notes
Surfaced via cayley-hamilton family scan. Single-slug file. No `loom:review-requested` — math PR for deployer auto-merge.