### PR TITLE
research(cayley-hamilton-minpoly-oq-04): cover uncovered header + hidden Summary (7→9)

### DIFF
--- a/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
+++ b/src/data/proofs/cayley-hamilton-minpoly-oq-04/meta.json
@@ -104,6 +104,12 @@
   ],
   "sections": [
     {
+      "title": "Module Header and Imports",
+      "startLine": 1,
+      "endLine": 52,
+      "summary": "Documentation header stating the main theorem (a matrix M is nonderogatory, μ_M = χ_M, iff it has a cyclic vector v with {v, Mv, ..., M^{n-1}v} a basis), the four main results, the forward-direction proof strategy, references (Horn & Johnson, Hoffman & Kunze), and dependencies. Imports Mathlib charpoly/minpoly, linear independence, and opens the Nonderogatory namespace over a field K."
+    },
+    {
       "title": "Part I: Definitions",
       "startLine": 53,
       "endLine": 88,
@@ -118,19 +124,19 @@
     {
       "title": "Part III: Forward Direction (Cyclic → Nonderogatory)",
       "startLine": 134,
-      "endLine": 167,
+      "endLine": 168,
       "summary": "cyclic_implies_nonderogatory: applies bridge lemma after proving natDeg(minpoly) = n. Key steps: (1) natDeg(minpoly) ≤ natDeg(charpoly) = n from minpoly | charpoly; (2) by contradiction assume natDeg(minpoly) < n; (3) minpoly.aeval gives (aeval M (minpoly K M)).mulVec v = 0; (4) IsCyclicVector forces minpoly = 0; (5) contradiction with Monic.ne_zero. Clean by_contra + omega proof."
     },
     {
       "title": "Part IV: Backward Direction (Nonderogatory → Cyclic, Axiomatized)",
       "startLine": 169,
-      "endLine": 206,
+      "endLine": 207,
       "summary": "Comment discusses three approaches: (1) PID structure theorem V ≅ K[X]/(d₁) ⊕ ... ⊕ K[X]/(d_k), minpoly = charpoly forces k = 1; (2) Jordan Normal Form for alg. closed fields; (3) union of proper subspaces for infinite fields. axiom nonderogatory_has_cyclic_vector: IsNonderogatory M → ∃ v, IsCyclicVector M v. Holds over ALL fields (finite included), ruling out Approach 3 for the general statement."
     },
     {
       "title": "Part V: Full Characterization",
       "startLine": 208,
-      "endLine": 223,
+      "endLine": 224,
       "summary": "nonderogatory_iff_cyclic_vector: full iff combining the proved forward direction and the axiomatized backward direction. nonderogatory_has_cyclic_vector provides the → direction, cyclic_implies_nonderogatory provides the ← direction."
     },
     {
@@ -142,8 +148,14 @@
     {
       "title": "Part VII: Degree Characterization",
       "startLine": 254,
-      "endLine": 284,
+      "endLine": 281,
       "summary": "nonderogatory_iff_natDegree_eq: IsNonderogatory M ↔ natDeg(minpoly) = n. derogatory_iff_natDegree_lt: ¬IsNonderogatory M ↔ natDeg(minpoly) < n (requires Nontrivial hypothesis). Both proved cleanly by combining bridge lemma with charpoly_natDegree_eq_dim."
+    },
+    {
+      "title": "Summary",
+      "startLine": 282,
+      "endLine": 316,
+      "summary": "Closing summary docstring recapping the definitions (IsCyclicVector, IsNonderogatory), main results (cyclic_implies_nonderogatory proved; nonderogatory_has_cyclic_vector axiom; nonderogatory_iff_cyclic_vector), the degree characterizations, the bridge lemma, and the proof status: 0 sorries with a single axiom (nonderogatory_has_cyclic_vector, requiring the PID module structure theorem)."
     }
   ],
   "sorries": 0


### PR DESCRIPTION
## Summary
Build-free gallery metadata fix. `CayleyHamiltonMinpolyOQ04.lean` (316 lines): the module header/imports (1–52) was uncovered (sections started at line 53) and the closing **Summary** docstring (282–316) was hidden (gap=32).

Added a "Module Header and Imports" section and a "Summary" section, fixed Part VII to end at the Summary banner (@281), and closed inter-part gaps for contiguous full-file coverage (7 → 9 sections).

## Verification
- `maxEnd` now 316 = `leanFile.lineCount` = actual `wc -l`; sections monotonic & contiguous.
- Metadata-only; all non-`sections` content byte-identical (`jq 'del(.sections)'` diff).
- No Lean rebuild required.

## Notes
Surfaced via cayley-hamilton family scan. Single-slug file. No `loom:review-requested` — math PR for deployer auto-merge.