### PR TITLE
research(erdos-402): realign drifted gallery sections to full file (6→10)

### DIFF
--- a/src/data/proofs/erdos-402/meta.json
+++ b/src/data/proofs/erdos-402/meta.json
@@ -86,52 +86,83 @@
   },
   "sections": [
     {
+      "id": "header",
+      "title": "Problem Statement and References",
+      "startLine": 1,
+      "endLine": 86,
+      "summary": "Provenance and module docstring. The file was edited by Aristotle (Harmonic) — the header records the Lean/Mathlib versions, the `negate_state` tactic used for refutations, and which results Aristotle proved (`erdos_402_ratio_bound`, `erdos_402_range`) or negated (`erdos_402_equality_cases`). The problem docstring states Erdős #402 (Graham's GCD Conjecture): for any finite $A\\subset\\mathbb{N}$ there exist $a,b\\in A$ with $\\gcd(a,b)\\le a/|A|$. Status: SOLVED (Graham 1970 conjecture; Szegedy 1986 / Zaharescu 1987 for large sets; Balasubramanian–Soundararajan 1996 in full).",
+      "mathContext": "$\\forall A\\subseteq\\mathbb{N}^+$ finite, $\\exists a,b\\in A:\\gcd(a,b)\\le\\lfloor a/|A|\\rfloor$. Graham's additional conjecture characterizes the primitive equality cases as $\\{1,\\dots,n\\}$, $\\{L/k\\}$, or $\\{2,3,4,6\\}$."
+    },
+    {
       "id": "main-statement",
       "title": "Main Statement",
-      "startLine": 35,
-      "endLine": 47,
+      "startLine": 87,
+      "endLine": 100,
       "summary": "**Graham's GCD Conjecture**: $\\forall A \\subseteq \\mathbb{N}^+$ finite, $\\exists a,b \\in A: \\gcd(a,b) \\le \\lfloor a/|A| \\rfloor$. Main theorem left as `sorry`.",
       "mathContext": "$\\forall A \\subseteq \\mathbb{N}^+,\\, A \\ne \\emptyset: \\exists a, b \\in A: \\gcd(a,b) \\le \\lfloor a / |A| \\rfloor$. Proved by Balasubramanian-Soundararajan (1996)."
     },
     {
       "id": "equivalent-formulation",
       "title": "Equivalent Formulation",
-      "startLine": 48,
-      "endLine": 64,
+      "startLine": 101,
+      "endLine": 129,
       "summary": "**MinGcdRatio** and equivalent formulation: $\\exists a,b \\in A: \\gcd(a,b)/a \\le 1/|A|$ over $\\mathbb{Q}$. Proved by Aristotle from the main conjecture.",
       "mathContext": "$\\min_{a,b \\in A} \\frac{\\gcd(a,b)}{a} \\le \\frac{1}{|A|}$. Equivalent rational formulation of Graham's conjecture."
     },
     {
       "id": "special-cases",
       "title": "Special Cases",
-      "startLine": 65,
-      "endLine": 82,
+      "startLine": 130,
+      "endLine": 148,
       "summary": "**Singleton**: $\\gcd(a,a) = a \\le a/1$. **Range** $\\{1,\\ldots,n\\}$: proved by Aristotle via case analysis on $n$.",
       "mathContext": "Singleton: $\\gcd(a,a) = a = a/1$. Range $\\{1,\\ldots,n\\}$: $\\gcd(1,n) = 1 \\le 1/n$ (taking $a = 1$, $b = n$)."
     },
     {
       "id": "graham-special-set",
       "title": "The {2, 3, 4, 6} Example",
-      "startLine": 83,
-      "endLine": 103,
+      "startLine": 149,
+      "endLine": 169,
       "summary": "**GrahamSpecialSet** $= \\{2,3,4,6\\}$ with $|A| = 4$. Verified: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$ — sporadic equality case.",
       "mathContext": "$A = \\{2,3,4,6\\}$: $\\gcd(4,3) = 1 = \\lfloor 4/4 \\rfloor$. Equality case: one of three primitive families achieving $\\gcd(a,b) = \\lfloor a/|A| \\rfloor$."
     },
     {
       "id": "equality-characterization",
       "title": "Graham's Equality Characterization",
-      "startLine": 104,
-      "endLine": 136,
-      "summary": "**HasNoCommonDivisor** ($\\gcd(A) = 1$) and **IsGrahamEqualityCase**: three primitive families. Aristotle discovered $\\{1,2,4\\}$ counterexample — characterization incomplete.",
+      "startLine": 170,
+      "endLine": 191,
+      "summary": "Defines `HasNoCommonDivisor A` ($\\gcd$ of all elements is $1$, i.e. $A$ primitive) and `IsGrahamEqualityCase A` (the disjunction of Graham's three conjectured primitive equality families: $\\{1,\\dots,n\\}$, $\\{L/1,\\dots,L/n\\}$ with $L=\\mathrm{lcm}(1,\\dots,n)$, or $\\{2,3,4,6\\}$). These predicates set up the additional-conjecture analysis disproved in the next section.",
       "mathContext": "Primitive equality cases: $\\{1,\\ldots,n\\}$, $\\{\\text{lcm}(1,\\ldots,n)/1, \\ldots, \\text{lcm}(1,\\ldots,n)/n\\}$, or $\\{2,3,4,6\\}$. A set is primitive if $\\gcd(A) = 1$."
+    },
+    {
+      "id": "equality-disproved",
+      "title": "Equality Characterization: DISPROVED",
+      "startLine": 192,
+      "endLine": 256,
+      "summary": "Aristotle's automated search refuted Graham's additional conjecture as formalized (\"all pairs satisfy $\\gcd(a,b)\\ge a/|A|$\"). `counterexample_124_satisfies`: the set $\\{1,2,4\\}$ meets the pairwise condition; `counterexample_124_primitive`: it is primitive; `counterexample_124_not_equality_case`: it is none of the three Graham families (a three-case `rcases` ruling out $\\{1,\\dots,n\\}$ via the missing $3$, the $L/k$ image via $3\\nmid L$ and a cardinality bound, and $\\{2,3,4,6\\}$ by `decide`). So $\\{1,2,4\\}$ is a genuine counterexample to the pairwise formalization.",
+      "mathContext": "$\\{1,2,4\\}$ is primitive and satisfies $\\gcd(a,b)\\ge a/|A|$ for all pairs, yet is not one of $\\{1,\\dots,n\\}$, $\\{L/k\\}$, or $\\{2,3,4,6\\}$ — disproving the pairwise version of Graham's additional conjecture."
     },
     {
       "id": "key-lemmas",
       "title": "Key Lemmas",
-      "startLine": 137,
-      "endLine": 328,
-      "summary": "**gcd_one_suffices**: $\\gcd(a,b) = 1 \\wedge |A| \\le a \\implies 1 \\le \\lfloor a/|A| \\rfloor$. **one_in_singleton_set**: $\\{1\\}$ trivially satisfies the bound.",
-      "mathContext": "$\\gcd(a,b) = 1 \\wedge |A| \\le a \\implies \\gcd(a,b) = 1 \\le \\lfloor a/|A| \\rfloor$. Finding a coprime pair suffices when the set is small relative to its elements."
+      "startLine": 257,
+      "endLine": 490,
+      "summary": "Proved supporting lemmas and the small-cardinality cases. `gcd_one_suffices`/`one_in_singleton_set`: a coprime pair (or the element $1$) discharges the bound when $|A|\\le a$. `dvd_lt_imp_le_half` and the private divisor lemmas (`dvd_gt_third_imp_eq_half`, `dvd_gt_quarter_cases`, `mult_of_dvd_lt_double`/`_triple`, `element_eq_half`, `element_in_thirds`) drive the quotient analysis. The conjecture is fully proved for pairs (`erdos_402_pair`) and triples (`erdos_402_triple`). Structural facts: `max_ge_card_of_pos`, `erdos_402_contains_one`, `erdos_402_coprime_with_max`, `erdos_402_small_min`.",
+      "mathContext": "If $d\\mid n$ and $d<n$ then $d\\le n/2$; if $n/3<d\\mid n$ then $d=n/2$; quotient $d/\\gcd(d,x)\\in\\{2,3\\}$ when $\\gcd>d/4$. Pair and triple cases proved directly."
+    },
+    {
+      "id": "four-element",
+      "title": "Four-Element Case",
+      "startLine": 491,
+      "endLine": 666,
+      "summary": "`erdos_402_quadruple`: a complete proof of Graham's conjecture for any 4-element set. If some $\\gcd(d,x)\\le d/4$ the pair $(d,x)$ works; otherwise all gcds exceed $d/4$, forcing each quotient $d/\\gcd(d,x)\\in\\{2,3\\}$. At most one element has $\\gcd=d/2$ and at most two have $\\gcd=d/3$, so achieving three such elements forces $6\\mid d$ and $\\{a,b,c\\}=\\{d/3,d/2,2d/3\\}$, where $\\gcd(2d/3,d/2)=(2d/3)/4$ closes the bound. Fully proved via the divisor-quotient lemmas of the previous section.",
+      "mathContext": "For 4 distinct positive naturals with max $d$: either a pair has $\\gcd\\le d/4$, or $6\\mid d$ and $\\{d/3,d/2,2d/3\\}$ realizes equality $\\gcd(2d/3,d/2)=(2d/3)/4$."
+    },
+    {
+      "id": "summary",
+      "title": "Summary",
+      "startLine": 667,
+      "endLine": 693,
+      "summary": "Closing status docstring. Problem #402 is SOLVED (answer YES; Szegedy 1986 / Zaharescu 1987 for large sets, Balasubramanian–Soundararajan 1996 in full). Records the formalization scope: the main conjecture is stated with 1 `sorry` (the BS sieve argument is not formalized); the singleton, range, pair, triple, and quadruple cases are proved (quadruple fully via divisor-quotient analysis); structural lemmas and the ℚ ratio formulation are proved; and the $\\{1,2,4\\}$ counterexample disproves Graham's additional equality conjecture."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The erdos-402 gallery sections were shifted ~50 lines early and stopped at line 328 of a 693-line Lean file.
- Re-pinned every section to its true `/-! ## -/` banner range (10 total) and surfaced three hidden sections: the Aristotle-provenance / problem-statement **header**, the **"Equality Characterization: DISPROVED"** block (the `{1,2,4}` counterexample to Graham's additional conjecture, found by Aristotle), the fully-proved **Four-Element Case** (`erdos_402_quadruple`), and the closing **Summary**.
- Split the previously lumped equality section into the definitions (`HasNoCommonDivisor` / `IsGrahamEqualityCase`) and the separate DISPROVED counterexample.

## Verification
- Non-section meta content byte-identical to `origin/main` (only the `sections` array changed).
- Counts unchanged and already accurate: 25 theorems / 4 defs / 0 axioms / 1 sorry (the main conjecture awaits the Balasubramanian–Soundararajan sieve argument); `leanFile.lineCount` 693 matches the source.
- Build-free metadata-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)