### PR TITLE
research(cayley-hamilton-cyclic-vector-all-fields): fix stale lineCount 268→266 (base + oq-01)

### DIFF
--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields-oq-01/meta.json
@@ -26,7 +26,7 @@
     "badge": "original",
     "sorries": 0,
     "axiomCount": 0,
-    "lineCount": 268,
+    "lineCount": 266,
     "theoremCount": 8,
     "definitionCount": 2,
     "assumptions": "No axioms or sorries. All proofs use Mathlib's UniqueFactorizationMonoid, Polynomial, and Matrix APIs.",
@@ -77,7 +77,7 @@
       "Proofs.CayleyHamiltonMinpolyOQ05OQ01OQ04WIP04"
     ],
     "namespace": "CayleyHamiltonCyclicVectorAllFields",
-    "lineCount": 268,
+    "lineCount": 266,
     "axiomCount": 0,
     "theoremCount": 8,
     "definitionCount": 2,

--- a/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
+++ b/src/data/proofs/cayley-hamilton-cyclic-vector-all-fields/meta.json
@@ -22,7 +22,7 @@
         "sorries": 0,
         "axiomCount": 0,
         "theoremCount": 8,
-        "lineCount": 268,
+        "lineCount": 266,
         "assumptions": "",
         "mathlib_version": "4.26.0",
         "mathlibDependencies": [
@@ -127,7 +127,7 @@
             "Polynomial"
         ],
         "namespace": "CayleyHamiltonCyclicVectorAllFields",
-        "lineCount": 268,
+        "lineCount": 266,
         "axiomCount": 0,
         "theoremCount": 8,
         "definitionCount": 2,


### PR DESCRIPTION
## Summary

Build-free metadata correction. The `cayley-hamilton-cyclic-vector-all-fields` base gallery and its `-oq-01` variant both point to `Proofs/CayleyHamiltonCyclicVectorAllFields.lean`, which is **266 lines** (`wc -l`), but both galleries' `meta.lineCount` and `leanFile.lineCount` read **268** — a stale lag from a prior 2-line trim.

All other metadata is already correct: sections end at line 266 (full coverage of the §I–§V banners), and theorem/def/axiom counts (8/2/0) match the file. No Lean source touched.

## Test plan

- [x] `wc -l` confirms the file is 266 lines
- [x] Both `meta.json` files validate as JSON
- [x] `git diff` touches only the 4 lineCount fields (2 per gallery)
- [x] Theorem/def/axiom counts and section ranges already match the file