### PR TITLE
research(ehrhart-cube-proven-oq-02): realign drifted gallery sections to full file (8→11)

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -78,66 +78,87 @@
   "sections": [
     {
       "id": "formula-definition",
-      "title": "Section I: The Ehrhart Formula",
+      "title": "Part I: The Ehrhart Formula",
       "startLine": 45,
-      "endLine": 50,
+      "endLine": 56,
       "summary": "crossEhrhart d n = Σ_{k=0}^d 2^k · C(d,k) · C(n,k). The central Delannoy formula, counting lattice points in n·B_d."
     },
     {
       "id": "base-cases",
-      "title": "Section II: Base Cases and Small Dimensions",
-      "startLine": 55,
-      "endLine": 85,
-      "summary": "d=0: L=1. d=1: L=2n+1 (segment). d=2: L=2n²+2n+1 (diamond). Spot checks via native_decide up to d=3, n=4."
+      "title": "Part II: Base Cases",
+      "startLine": 57,
+      "endLine": 88,
+      "summary": "crossEhrhart_d0: L(B_0,n)=1 (single point). crossEhrhart_n0: L(B_d,0)=1 (only the origin survives). crossEhrhart_d1: L(B_1,n)=2n+1 (segment {-n,…,n}). Spot checks via native_decide (d=2,3; n=1,2)."
     },
     {
       "id": "structural-properties",
-      "title": "Section III: Structural Properties",
-      "startLine": 90,
+      "title": "Part III: Structural Properties",
+      "startLine": 89,
       "endLine": 108,
-      "summary": "crossEhrhart_pos: L ≥ 1 (origin always in polytope). crossEhrhart_mono: L is increasing in n."
+      "summary": "crossEhrhart_pos: L ≥ 1 (origin always in polytope, via Finset.single_le_sum). crossEhrhart_mono: L is increasing in n (gcongr on choose)."
     },
     {
       "id": "hockey-stick",
-      "title": "Section IV: Hockey-Stick Identity",
-      "startLine": 112,
+      "title": "Part IV: Hockey-Stick Identity",
+      "startLine": 109,
       "endLine": 138,
-      "summary": "sum_choose_range: Σ_{m<n} C(m,k) = C(n,k+1) by induction. sum_shift_hockey: converts Σ_k f(k)·C(n,k+1) to Σ_{m<n} Σ_k f(k)·C(m,k) via sum_comm."
+      "summary": "sum_choose_range: Σ_{m<n} C(m,k) = C(n,k+1) by induction on n via Pascal. sum_shift_hockey: converts Σ_k f(k)·C(n,k+1) to Σ_{m<n} Σ_k f(k)·C(m,k) via hockey-stick + sum_comm."
     },
     {
       "id": "algebraic-expansion",
-      "title": "Section V: Key Algebraic Expansion",
-      "startLine": 142,
-      "endLine": 205,
+      "title": "Part V: Key Algebraic Lemma",
+      "startLine": 139,
+      "endLine": 193,
       "summary": "crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2·Σ_k 2^k C(d,k) C(n,k+1). Proved by: (1) sum_range_succ' to extract k=0, (2) Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), (3) distribution, (4) key identity 1+2·Σ C(d,k+1)C(n,k+1) = Σ C(d,k)C(n,k)."
     },
     {
       "id": "geometric-recursion",
-      "title": "Section VI: Geometric Recursion",
-      "startLine": 209,
-      "endLine": 225,
-      "summary": "crossEhrhart_succ_d: L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m). One-line proof: expand + hockey-stick."
+      "title": "Part VI: Main Geometric Recursion",
+      "startLine": 194,
+      "endLine": 215,
+      "summary": "crossEhrhart_succ_d: L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m), corresponding to slicing B_{d+1} along the last coordinate. One-line proof: expand + hockey-stick (sum_shift_hockey)."
+    },
+    {
+      "id": "low-dimensional-formulas",
+      "title": "Part VIb: Low-Dimensional Formulas",
+      "startLine": 216,
+      "endLine": 237,
+      "summary": "crossEhrhart_d2: L(B_2,n) = 2n²+2n+1 (diamond), proved by induction using the recursion crossEhrhart_succ_d (each step adds L(B_1,n+1)+L(B_1,n) = 4n+4). Additional native_decide spot checks for d=2,3."
     },
     {
       "id": "polynomial-identification",
-      "title": "Section VII: Ehrhart Polynomial",
-      "startLine": 240,
-      "endLine": 324,
+      "title": "Part VII: Ehrhart Polynomial Identification",
+      "startLine": 238,
+      "endLine": 323,
       "summary": "crossEhrhart_is_poly: ∃ P : ℚ[X] of degree ≤ d with P(n) = crossEhrhart d n. Constructed via two helper lemmas (natDegree_descPochhammer_le, eval_descPochhammer_natCast) using Mathlib's descPochhammer; the polynomial is P = Σ_k C((2^k C(d,k))/k!) · descPochhammer ℚ k, with the k! denominator cancelling the descFactorial = k!·C(n,k) factor."
     },
     {
       "id": "lattice-connection",
-      "title": "Section VIII: Lattice Point Connection",
-      "startLine": 327,
-      "endLine": 353,
-      "summary": "crossBall: Finset model of n·B_d lattice points via Fin d → Fin(2n+1) with L¹-norm constraint. crossBall_card: card = crossEhrhart d n (proved for d=0; inductive step has 1 sorry for Finset slicing)."
+      "title": "Part VIII: Connection to Lattice Points",
+      "startLine": 324,
+      "endLine": 462,
+      "summary": "crossBall: Finset model of n·B_d lattice points via Fin d → Fin(2n+1) centered coordinates with L¹-norm constraint. Centered-weight helpers cweight_le_iff / cweight_translate / cweight_sum_individual, and fiber_card_eq_crossBall_card: a Finset.card_bij' bijection between the cweight-≤-M filter set and crossBall d M via the translation y_i ↦ y_i − (n−M)."
+    },
+    {
+      "id": "slicing-decomposition",
+      "title": "Part VIII.b: Slicing Decomposition (S6)",
+      "startLine": 463,
+      "endLine": 674,
+      "summary": "crossBall_succ_d_fiber_card: per-fiber cardinality via Fin.init / Fin.snoc·j bridge (fiber over last coord j has card = crossBall d M_j, M_j := if j ≤ n then j else 2n−j). crossBall_succ_d_slice: card-as-fiberwise-sum. sum_crossBall_pair: j ↔ 2n−j pairing collapsing the slice sum. crossBall_card: full axiom-free, sorry-free closure card(crossBall d n) = crossEhrhart d n by induction on d generalizing n."
+    },
+    {
+      "id": "summary-exports",
+      "title": "Part IX: Summary and Exports",
+      "startLine": 675,
+      "endLine": 720,
+      "summary": "Lemma dependency graph (hockey-stick → sum_shift_hockey → expand → succ_d), comparison table of cube/simplex/cross-polytope models, generated open questions, and #check exports of the main theorems."
     }
   ],
   "conclusion": {
-    "summary": "This formalization answers ehrhart-cube-proven OQ-02 by proving the cross-polytope Ehrhart formula L(B_d,n) = Σ 2^k C(d,k) C(n,k) axiom-free. The 13 proved theorems (1 sorry for the geometric Finset argument) establish the formula, its polynomial nature (via an explicit descPochhammer construction), the geometric recursion, and base cases.\n\nTogether with EhrhartCubeProven and EhrhartSimplexProven, this demonstrates that three major polytope families have fully explicit, axiom-free Ehrhart polynomial proofs in Lean 4, without ever invoking the general Ehrhart existence theorem (ehrhart_theorem axiom). The key principle: for polytopes with combinatorial lattice-point formulas, inductive algebraic proofs replace the transcendental machinery of the general theory.",
+    "summary": "This formalization answers ehrhart-cube-proven OQ-02 by proving the cross-polytope Ehrhart formula L(B_d,n) = Σ 2^k C(d,k) C(n,k) axiom-free and sorry-free. The proved theorems establish the formula, its polynomial nature (via an explicit descPochhammer construction), the geometric recursion, base cases, and the full geometric closure crossBall_card = crossEhrhart d n via the Finset slicing decomposition (S6-7).\n\nTogether with EhrhartCubeProven and EhrhartSimplexProven, this demonstrates that three major polytope families have fully explicit, axiom-free Ehrhart polynomial proofs in Lean 4, without ever invoking the general Ehrhart existence theorem (ehrhart_theorem axiom). The key principle: for polytopes with combinatorial lattice-point formulas, inductive algebraic proofs replace the transcendental machinery of the general theory.",
     "implications": "**The three pillars of Ehrhart theory without axioms**: Cube (Fin d → Fin(n+1)), Simplex (Sym (Fin(d+1)) n), and Cross-Polytope (induction + Pascal + hockey-stick) provide three fundamentally different approaches to axiom-free Ehrhart proofs. Each captures a different combinatorial structure.\n\n**Delannoy numbers**: The formula Σ 2^k C(d,k) C(n,k) = D(d,n) (central Delannoy number) connects cross-polytope lattice counting to lattice path enumeration. Formalizing this bijection would give a new combinatorial proof of the Delannoy formula.\n\n**General principle**: The successful axiom-free approach for these three polytopes suggests a research program: identify all families of lattice polytopes with explicit Ehrhart formulas and formalize them without the existence axiom. Candidates include permutohedra, hypersimplices, and flow polytopes.",
     "openQuestions": [
-      "Can the crossBall_card sorry be eliminated by formalizing the Finset slicing decomposition of B_{d+1} by last coordinate?",
+      "Now that crossBall_card is closed via the Finset slicing decomposition, can the same per-coordinate fiber technique be packaged as a reusable lemma for other lattice-polytope families?",
       "Does Σ 2^k C(d,k) C(n,k) equal the Delannoy number D(min(d,n), max(d,n)) for all d,n? Can this be proved in Lean?",
       "Can the permutohedron Ehrhart polynomial be proved axiom-free? The permutohedron has L(Π_d, n) = (n+1)^d - ... with a complex inclusion-exclusion formula."
     ]


### PR DESCRIPTION
## Summary
The gallery meta for `ehrhart-cube-proven-oq-02` (cross-polytope Ehrhart proof) had drifted: its `sections` array stopped at line 353 of a 720-line Lean file (~51% of the proof hidden from the gallery).

## Progress
- Rebuilt the `sections` array from 8 → 11 entries, aligned to the 11 `PART` banners in `EhrhartCrossPolytope.lean`. New full-file coverage (maxend 720 = file length 720).
- Added the three previously-missing sections:
  - **Part VIb** — Low-Dimensional Formulas (`crossEhrhart_d2` by recursion + spot checks)
  - **Part VIII.b** — Slicing Decomposition (S6), ~210 hidden lines: fiber cardinality, slice sum, j↔2n−j pairing, and the `crossBall_card` closure
  - **Part IX** — Summary and Exports (dependency graph, comparison table, `#check`s)
- Fixed stale **"1 sorry"** prose: `crossBall_card` was completed sorry-free in S6-7, but the Section VIII summary, `conclusion.summary`, and `openQuestions[0]` still described an open sorry. The file is 0 sorries / 0 axioms (counts already correct in meta).

## Findings
- Pure metadata/section-coverage fix; no Lean source changes. Counts (22 theorems, 2 defs, 0 axioms, 0 sorries, 720 lines) were already accurate.

## Status
**Outcome**: completed (gallery section realignment)
**Next Steps**: none for this slug; feuerbach family (the claimed slug's family) is fully section-aligned/drained.

🤖 Generated by researcher-2