### PR TITLE
research(divisibility-truncation-general): realign gallery sections to full file (6→7) + fix stale counts

### DIFF
--- a/src/data/proofs/divisibility-truncation-general/meta.json
+++ b/src/data/proofs/divisibility-truncation-general/meta.json
@@ -47,9 +47,9 @@
     ],
     "dateAdded": "2026-02-21",
     "axiomCount": 0,
-    "lineCount": 255,
+    "lineCount": 284,
     "assumptions": "None. Fully verified with 0 axioms and 0 sorries.",
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 0
   },
   "overview": {
@@ -77,20 +77,20 @@
       "id": "setup",
       "title": "Setup",
       "startLine": 1,
-      "endLine": 36,
+      "endLine": 43,
       "summary": "Module documentation, imports, and the div-mod identity lemma."
     },
     {
       "id": "positive-osculator",
       "title": "Positive Osculator Theorem",
-      "startLine": 37,
-      "endLine": 81,
+      "startLine": 44,
+      "endLine": 85,
       "summary": "General theorem for d | n ↔ d | (n/10 + c*(n%10)) when d | 10c-1."
     },
     {
       "id": "negative-osculator",
       "title": "Negative Osculator Theorem",
-      "startLine": 82,
+      "startLine": 86,
       "endLine": 125,
       "summary": "General theorem for d | n ↔ d | (n/10 - c*(n%10)) when d | 10c+1."
     },
@@ -112,8 +112,15 @@
       "id": "summary",
       "title": "Summary Theorem",
       "startLine": 242,
-      "endLine": 255,
+      "endLine": 266,
       "summary": "Master theorem packaging the five classical cases."
+    },
+    {
+      "id": "extended-coverage",
+      "title": "Extended Coverage (Osculators Beyond 19)",
+      "startLine": 267,
+      "endLine": 284,
+      "summary": "`extended_truncation_coverage` bundles the truncation divisibility rules for the next primes coprime to 10 — 23, 29, 31, 37, 41, 43 — each a direct instance of the parametric `truncation_pos` / `truncation_neg` theorems (no new machinery, only each prime's osculator constant). Answers the follow-up 'extend coverage beyond 19'."
     }
   ],
   "conclusion": {
@@ -134,9 +141,9 @@
       "Nat"
     ],
     "namespace": "DivisibilityTruncationGeneral",
-    "lineCount": 255,
+    "lineCount": 284,
     "axiomCount": 0,
-    "theoremCount": 15,
+    "theoremCount": 17,
     "definitionCount": 0,
     "path": "Proofs/DivisibilityTruncationGeneral.lean",
     "sorries": 0


### PR DESCRIPTION
## Summary
Build-free gallery-metadata fix for `divisibility-truncation-general` (`DivisibilityTruncationGeneral.lean`) — no Lean source change.

- **Hidden tail theorem**: the file grew to 284 lines but the gallery sections stopped at 255, hiding `extended_truncation_coverage` (lines 267–283 — truncation divisibility rules for d = 23, 29, 31, 37, 41, 43). Added an "Extended Coverage" section (6→7).
- **Stale counts**: `lineCount` 255 → 284 and `theoremCount` 15 → 17 (17 public theorems + 1 private lemma `div_mod_cast`), in both the `meta` and `leanFile` blocks.
- **Section boundary fix**: extended the Summary section to the end of its theorem block (255 → 266), and corrected the Setup/Positive-Osculator boundary so the `div_mod_cast` helper (line 39) sits in Setup rather than the Positive Osculator section.

## Verification (build-free)
- `wc -l` = 284 ✓; 17 public `theorem`s + 1 `private lemma`; `definitionCount` 0 ✓, `axiomCount` 0 ✓, `sorries` 0 ✓.
- `maxEndLine` now 284 (full coverage). JSON validated; only the `sections` array and the `lineCount`/`theoremCount` fields changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)