### PR TITLE
Enrich Ehrhart Cross-Polytope (oq-02): full-file section coverage

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -77,60 +77,100 @@
   },
   "sections": [
     {
+      "id": "overview-header",
+      "title": "Overview, Imports, and Namespace",
+      "startLine": 1,
+      "endLine": 44,
+      "summary": "Module docstring framing the result: an axiom-free, sorry-free Lean proof that the lattice-point count of the dilated $d$-dimensional cross-polytope (hyperoctahedron) $n \\cdot B_d$ equals $\\sum_{k} 2^k \\binom{d}{k}\\binom{n}{k}$, and that this count is a polynomial of degree $d$ in $n$. Imports Mathlib combinatorics/polynomial APIs and opens `namespace EhrhartCrossPolytope`.",
+      "mathContext": "The cross-polytope $B_d = \\{x \\in \\mathbb{R}^d : \\sum_i |x_i| \\le 1\\}$ is the $\\ell^1$ unit ball. Ehrhart theory: for a lattice polytope $P$, $L(nP)$ agrees with a degree-$\\dim P$ polynomial in $n$; this file proves the cross-polytope instance constructively."
+    },
+    {
       "id": "formula-definition",
-      "title": "Section I: The Ehrhart Formula",
+      "title": "Part I: The Ehrhart Formula",
       "startLine": 45,
-      "endLine": 50,
-      "summary": "crossEhrhart d n = Σ_{k=0}^d 2^k · C(d,k) · C(n,k). The central Delannoy formula, counting lattice points in n·B_d."
+      "endLine": 56,
+      "summary": "Defines `crossEhrhart d n = Σ_{k=0}^d 2^k · C(d,k) · C(n,k)`, the central Delannoy formula counting lattice points in `n·B_d`.",
+      "mathContext": "$L(B_d, n) = \\sum_{k=0}^{d} 2^k \\binom{d}{k}\\binom{n}{k}$. The $2^k$ accounts for sign choices on the $k$ nonzero coordinates; $\\binom{d}{k}$ picks which coordinates are nonzero; $\\binom{n}{k}$ distributes the $\\ell^1$ budget. This equals the central Delannoy number $D(d,n)$."
     },
     {
       "id": "base-cases",
-      "title": "Section II: Base Cases and Small Dimensions",
-      "startLine": 55,
-      "endLine": 85,
-      "summary": "d=0: L=1. d=1: L=2n+1 (segment). d=2: L=2n²+2n+1 (diamond). Spot checks via native_decide up to d=3, n=4."
+      "title": "Part II: Base Cases and Small Dimensions",
+      "startLine": 57,
+      "endLine": 88,
+      "summary": "`crossEhrhart_d0` ($d=0$: $L=1$), `crossEhrhart_n0` ($n=0$: only the origin), and `crossEhrhart_d1` ($d=1$: the segment $[-n,n]$ gives $2n+1$ points).",
+      "mathContext": "$L(B_0,n)=1$ (a point), $L(B_d,0)=1$ (origin only), $L(B_1,n)=2n+1$ (integers in $[-n,n]$). These anchor the inductions in later parts."
     },
     {
       "id": "structural-properties",
-      "title": "Section III: Structural Properties",
-      "startLine": 90,
+      "title": "Part III: Structural Properties",
+      "startLine": 89,
       "endLine": 108,
-      "summary": "crossEhrhart_pos: L ≥ 1 (origin always in polytope). crossEhrhart_mono: L is increasing in n."
+      "summary": "`crossEhrhart_pos`: $L \\ge 1$ (the origin always lies in the polytope). `crossEhrhart_mono`: $L$ is non-decreasing in the dilation $n$.",
+      "mathContext": "Positivity holds because the $k=0$ term is $1$. Monotonicity in $n$ follows from $\\binom{n}{k} \\le \\binom{n+1}{k}$ termwise — larger dilations contain more lattice points."
     },
     {
       "id": "hockey-stick",
-      "title": "Section IV: Hockey-Stick Identity",
-      "startLine": 112,
+      "title": "Part IV: Hockey-Stick Identity",
+      "startLine": 109,
       "endLine": 138,
-      "summary": "sum_choose_range: Σ_{m<n} C(m,k) = C(n,k+1) by induction. sum_shift_hockey: converts Σ_k f(k)·C(n,k+1) to Σ_{m<n} Σ_k f(k)·C(m,k) via sum_comm."
+      "summary": "`sum_choose_range`: $\\sum_{m<n} \\binom{m}{k} = \\binom{n}{k+1}$ by induction. `sum_shift_hockey`: converts $\\sum_k f(k)\\binom{n}{k+1}$ to $\\sum_{m<n}\\sum_k f(k)\\binom{m}{k}$ via `Finset.sum_comm`.",
+      "mathContext": "The hockey-stick identity $\\sum_{m=0}^{n-1}\\binom{m}{k} = \\binom{n}{k+1}$ is the discrete analogue of $\\int x^k = x^{k+1}/(k+1)$; it converts the closed-form sum into a telescoping sum over smaller dilations, enabling the geometric recursion."
     },
     {
       "id": "algebraic-expansion",
-      "title": "Section V: Key Algebraic Expansion",
-      "startLine": 142,
-      "endLine": 205,
-      "summary": "crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2·Σ_k 2^k C(d,k) C(n,k+1). Proved by: (1) sum_range_succ' to extract k=0, (2) Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), (3) distribution, (4) key identity 1+2·Σ C(d,k+1)C(n,k+1) = Σ C(d,k)C(n,k)."
+      "title": "Part V: Key Algebraic Expansion",
+      "startLine": 139,
+      "endLine": 193,
+      "summary": "`crossEhrhart_expand`: $L(B_{d+1},n) = L(B_d,n) + 2\\sum_k 2^k\\binom{d}{k}\\binom{n}{k+1}$. Proved by extracting the $k=0$ term, applying Pascal's rule $\\binom{d+1}{k+1}=\\binom{d}{k}+\\binom{d}{k+1}$, distributing, and the identity $1 + 2\\sum_k\\binom{d}{k+1}\\binom{n}{k+1} = \\sum_k\\binom{d}{k}\\binom{n}{k}$.",
+      "mathContext": "This is the algebraic heart: it relates dimension $d+1$ to dimension $d$ purely via binomial identities (Pascal's rule + index shifting), independent of any geometric model. It is the bridge consumed by the geometric recursion in Part VI."
     },
     {
       "id": "geometric-recursion",
-      "title": "Section VI: Geometric Recursion",
-      "startLine": 209,
-      "endLine": 225,
-      "summary": "crossEhrhart_succ_d: L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m). One-line proof: expand + hockey-stick."
+      "title": "Part VI: Main Geometric Recursion",
+      "startLine": 194,
+      "endLine": 215,
+      "summary": "`crossEhrhart_succ_d`: $L(B_{d+1},n) = L(B_d,n) + 2\\sum_{m<n} L(B_d,m)$. One-line proof combining the Part V expansion with the Part IV hockey-stick identity.",
+      "mathContext": "Slicing $B_{d+1}$ along the last coordinate $x_{d+1}=j$ leaves a copy of $B_d$ scaled by $n-|j|$; summing over $j \\in [-n,n]$ gives $L(B_d,n) + 2\\sum_{m<n}L(B_d,m)$. This is the recursion that makes the count manifestly polynomial."
+    },
+    {
+      "id": "low-dim-formulas",
+      "title": "Part VIb: Low-Dimensional Formulas",
+      "startLine": 216,
+      "endLine": 237,
+      "summary": "`crossEhrhart_d2`: the 2-dimensional cross-polytope (a diamond / square rotated $45°$) has $L(B_2,n) = 2n^2 + 2n + 1$ lattice points, proved directly from the recursion rather than by `decide`.",
+      "mathContext": "$L(B_2,n) = 2n^2+2n+1$ is the centered square (Aztec-diamond) count. Derived from `crossEhrhart_succ_d` with $d=1$: $L(B_2,n) = (2n+1) + 2\\sum_{m<n}(2m+1) = 2n^2+2n+1$."
     },
     {
       "id": "polynomial-identification",
-      "title": "Section VII: Ehrhart Polynomial",
-      "startLine": 240,
-      "endLine": 324,
-      "summary": "crossEhrhart_is_poly: ∃ P : ℚ[X] of degree ≤ d with P(n) = crossEhrhart d n. Constructed via two helper lemmas (natDegree_descPochhammer_le, eval_descPochhammer_natCast) using Mathlib's descPochhammer; the polynomial is P = Σ_k C((2^k C(d,k))/k!) · descPochhammer ℚ k, with the k! denominator cancelling the descFactorial = k!·C(n,k) factor."
+      "title": "Part VII: Ehrhart Polynomial Identification",
+      "startLine": 238,
+      "endLine": 323,
+      "summary": "`crossEhrhart_is_poly`: there exists $P \\in \\mathbb{Q}[X]$ of degree $\\le d$ with $P(n) = $ `crossEhrhart d n`. Built via helper lemmas `natDegree_descPochhammer_le` and `eval_descPochhammer_natCast` using Mathlib's `descPochhammer`; the polynomial is $P = \\sum_k \\frac{2^k\\binom{d}{k}}{k!}\\,\\mathrm{descPochhammer}_{\\mathbb{Q}}\\,k$, with $k!$ cancelling the $\\mathrm{descFactorial} = k!\\binom{n}{k}$ factor.",
+      "mathContext": "The Ehrhart polynomial: $\\binom{n}{k} = \\frac{n(n-1)\\cdots(n-k+1)}{k!}$ is a degree-$k$ polynomial in $n$, so the sum over $k \\le d$ has degree $d$. `descPochhammer` $\\mathbb{Q}\\,k$ evaluates to the falling factorial, the polynomial avatar of $k!\\binom{n}{k}$."
     },
     {
       "id": "lattice-connection",
-      "title": "Section VIII: Lattice Point Connection",
-      "startLine": 327,
-      "endLine": 353,
-      "summary": "crossBall: Finset model of n·B_d lattice points via Fin d → Fin(2n+1) with L¹-norm constraint. crossBall_card: card = crossEhrhart d n (proved for d=0; inductive step has 1 sorry for Finset slicing)."
+      "title": "Part VIII: Connection to Lattice Points",
+      "startLine": 324,
+      "endLine": 462,
+      "summary": "Builds the explicit `Finset` model `crossBall d n` of the lattice points of `n·B_d` as maps `Fin d → Fin(2n+1)` whose centered-weight ($\\ell^1$) sum is at most `n`, with supporting `cweight` lemmas (`cweight_le_iff`, `cweight_translate`, `cweight_sum_individual`, `cweight_sum_range`) and the fiber bijection `fiber_card_eq_crossBall_card` matching slices to lower-dimensional balls.",
+      "mathContext": "A lattice point of $n\\cdot B_d$ is an integer vector with $\\sum_i|x_i| \\le n$. Centering coordinates in $\\{0,\\dots,2n\\}$ via the weight $|a-n|$ turns the $\\ell^1$ ball into a `Finset` condition, making `card` computations available — the combinatorial counterpart of the algebraic `crossEhrhart`."
+    },
+    {
+      "id": "slicing-decomposition",
+      "title": "Part VIII.b: Slicing Decomposition (S6)",
+      "startLine": 463,
+      "endLine": 674,
+      "summary": "Completes the geometric proof. `crossBall_succ_d_fiber_card` computes the per-fiber cardinality; `crossBall_succ_d_slice` is the slicing identity expressing `crossBall (d+1) n` as a disjoint union over the last coordinate; `sum_crossBall_pair` reorganizes the resulting sum; and the main theorem `crossBall_card : (crossBall d n).card = crossEhrhart d n` is proved unconditionally — discharging the former slicing `sorry` and making the proof fully verified.",
+      "mathContext": "$|crossBall\\,(d{+}1)\\,n| = \\sum_{j=-n}^{n} |crossBall\\,d\\,(n-|j|)| = L(B_d,n) + 2\\sum_{m<n}L(B_d,m)$, matching `crossEhrhart_succ_d`. Closing this is what upgrades the entry to `status: verified`, `badge: original` (0 axioms, 0 sorries)."
+    },
+    {
+      "id": "summary-exports",
+      "title": "Part IX: Summary and Exports",
+      "startLine": 675,
+      "endLine": 721,
+      "summary": "Closing docstring with the key-lemma dependency graph (hockey-stick → sum interchange → Pascal expansion → geometric recursion), a comparison table of Ehrhart formulas for the cube $(n+1)^d$, simplex $\\binom{n+d}{d}$, and cross-polytope, and generated open questions (Delannoy-number identity, rational-dilation quasipolynomial). Ends with `#check` exports of the headline results.",
+      "mathContext": "Comparison of lattice-polytope counts: cube $B_\\infty$ gives $(n+1)^d$, simplex $\\Delta^d$ gives $\\binom{n+d}{d}$, cross-polytope $B_d$ gives $\\sum_k 2^k\\binom{d}{k}\\binom{n}{k}$ — the central Delannoy numbers. The open questions point to the Delannoy connection and rational (quasipolynomial) extensions."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

Enrichment pass for `ehrhart-cube-proven-oq-02` (Ehrhart Polynomial of the Cross-Polytope: Axiom-Free Proof).

The `sections` array covered only lines **45–353 of the 721-line** Lean file (51% hidden) and the final section carried **stale prose**. Rebuilt **8 → 12 sections** with accurate summaries and `mathContext`, mapping each `-- PART` banner to its real range.

### Changes
- **Added** an `Overview, Imports, and Namespace` header section (`1-44`, previously uncovered).
- **Added** three entirely-hidden sections: `Part VIb: Low-Dimensional Formulas` (`216-237`), `Part VIII.b: Slicing Decomposition (S6)` (`463-674`), and `Part IX: Summary and Exports` (`675-721`).
- **Aligned** all part ranges to their banner boundaries (now contiguous, `1–721`).

### Corrected stale prose
- The old `Part VIII` summary claimed `crossBall_card` was *"proved for d=0; inductive step has 1 sorry for Finset slicing."* Part VIII.b (the S6 slicing decomposition) **discharged that sorry** — `crossBall_card` is now unconditional, consistent with the entry's `status: verified` / `badge: original` (**0 axioms, 0 sorries**).

### Integrity
- Non-section meta content is **byte-identical** (verified programmatically).
- Sections contiguous, covering lines `1–721`.

### Build note
JSON validated by `pnpm research:build` (exit 0). Per-proof JSON is fetched at runtime, independent of the app compile step.