### PR TITLE
research(ehrhart-cube-proven-oq-02): realign drifted gallery sections to full file (8→11)

### DIFF
--- a/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
+++ b/src/data/proofs/ehrhart-cube-proven-oq-02/meta.json
@@ -80,57 +80,78 @@
       "id": "formula-definition",
       "title": "Section I: The Ehrhart Formula",
       "startLine": 45,
-      "endLine": 50,
+      "endLine": 56,
       "summary": "crossEhrhart d n = Σ_{k=0}^d 2^k · C(d,k) · C(n,k). The central Delannoy formula, counting lattice points in n·B_d."
     },
     {
       "id": "base-cases",
       "title": "Section II: Base Cases and Small Dimensions",
-      "startLine": 55,
-      "endLine": 85,
+      "startLine": 57,
+      "endLine": 88,
       "summary": "d=0: L=1. d=1: L=2n+1 (segment). d=2: L=2n²+2n+1 (diamond). Spot checks via native_decide up to d=3, n=4."
     },
     {
       "id": "structural-properties",
       "title": "Section III: Structural Properties",
-      "startLine": 90,
+      "startLine": 89,
       "endLine": 108,
       "summary": "crossEhrhart_pos: L ≥ 1 (origin always in polytope). crossEhrhart_mono: L is increasing in n."
     },
     {
       "id": "hockey-stick",
       "title": "Section IV: Hockey-Stick Identity",
-      "startLine": 112,
+      "startLine": 109,
       "endLine": 138,
       "summary": "sum_choose_range: Σ_{m<n} C(m,k) = C(n,k+1) by induction. sum_shift_hockey: converts Σ_k f(k)·C(n,k+1) to Σ_{m<n} Σ_k f(k)·C(m,k) via sum_comm."
     },
     {
       "id": "algebraic-expansion",
       "title": "Section V: Key Algebraic Expansion",
-      "startLine": 142,
-      "endLine": 205,
+      "startLine": 139,
+      "endLine": 193,
       "summary": "crossEhrhart_expand: L(B_{d+1},n) = L(B_d,n) + 2·Σ_k 2^k C(d,k) C(n,k+1). Proved by: (1) sum_range_succ' to extract k=0, (2) Pascal C(d+1,k+1) = C(d,k)+C(d,k+1), (3) distribution, (4) key identity 1+2·Σ C(d,k+1)C(n,k+1) = Σ C(d,k)C(n,k)."
     },
     {
       "id": "geometric-recursion",
       "title": "Section VI: Geometric Recursion",
-      "startLine": 209,
-      "endLine": 225,
+      "startLine": 194,
+      "endLine": 215,
       "summary": "crossEhrhart_succ_d: L(B_{d+1},n) = L(B_d,n) + 2·Σ_{m<n} L(B_d,m). One-line proof: expand + hockey-stick."
+    },
+    {
+      "id": "low-dim-formulas",
+      "title": "Section VIb: Low-Dimensional Formulas",
+      "startLine": 216,
+      "endLine": 237,
+      "summary": "crossEhrhart_d2: L(B_2,n) = 2n²+2n+1 proved by induction using crossEhrhart_succ_d (each step adds L(B_1,n+1)+L(B_1,n) = 4n+4). Spot checks via native_decide up to d=3, n=4."
     },
     {
       "id": "polynomial-identification",
       "title": "Section VII: Ehrhart Polynomial",
-      "startLine": 240,
-      "endLine": 324,
+      "startLine": 238,
+      "endLine": 323,
       "summary": "crossEhrhart_is_poly: ∃ P : ℚ[X] of degree ≤ d with P(n) = crossEhrhart d n. Constructed via two helper lemmas (natDegree_descPochhammer_le, eval_descPochhammer_natCast) using Mathlib's descPochhammer; the polynomial is P = Σ_k C((2^k C(d,k))/k!) · descPochhammer ℚ k, with the k! denominator cancelling the descFactorial = k!·C(n,k) factor."
     },
     {
       "id": "lattice-connection",
       "title": "Section VIII: Lattice Point Connection",
-      "startLine": 327,
-      "endLine": 353,
-      "summary": "crossBall: Finset model of n·B_d lattice points via Fin d → Fin(2n+1) with L¹-norm constraint. crossBall_card: card = crossEhrhart d n (proved for d=0; inductive step has 1 sorry for Finset slicing)."
+      "startLine": 324,
+      "endLine": 462,
+      "summary": "crossBall: Finset model of n·B_d lattice points via Fin d → Fin(2n+1) with centered L¹-weight constraint. Helper lemmas cweight_le_iff / cweight_translate / cweight_sum_range establish the per-coordinate interval bounds, and fiber_card_eq_crossBall_card gives the translation bijection between a cweight-≤-M filter set and crossBall d M."
+    },
+    {
+      "id": "slicing-decomposition",
+      "title": "Section VIIIb: Slicing Decomposition (S6)",
+      "startLine": 463,
+      "endLine": 674,
+      "summary": "Closes crossBall_card sorry-free (2026-05-08). crossBall_succ_d_fiber_card: each last-coordinate fiber of crossBall (d+1) n bijects with crossBall d M_j via Fin.init/Fin.snoc. crossBall_succ_d_slice (Step A) sums fibers over j; sum_crossBall_pair (Step B) collapses the sum via the j ↔ 2n−j pairing to (crossBall d n).card + 2·Σ_{m<n}(crossBall d m).card; crossBall_card then closes the induction against crossEhrhart_succ_d."
+    },
+    {
+      "id": "summary-exports",
+      "title": "Section IX: Summary and Exports",
+      "startLine": 675,
+      "endLine": 720,
+      "summary": "Lemma dependency graph (hockey-stick → sum interchange → Pascal expansion → geometric recursion), comparison table with the cube ((n+1)^d) and simplex (C(n+d,d)) Ehrhart polynomials, open questions (Delannoy-number identity, half-integer dilations), and #check exports of the main theorems."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The gallery `meta.json` for **ehrhart-cube-proven-oq-02** described only the first 353 of 720 lines of `EhrhartCrossPolytope.lean` (51% of the file hidden).
- Realigned all 8 existing section ranges to the `-- PART` banners and added the 3 missing sections so the gallery renders the whole proof.
- Fixed stale prose: Section VIII's summary claimed `crossBall_card`'s "inductive step has 1 sorry for Finset slicing". That sorry was closed in the S6 work (2026-05-08); the file is sorry-free (0 sorries, 0 axioms, 22 theorems).

## Sections (8 → 11)
| # | Section | Range |
|---|---------|-------|
| 6 | **VIb: Low-Dimensional Formulas** (new) | 216–237 |
| 9 | **VIIIb: Slicing Decomposition (S6)** (new) | 463–674 |
| 10 | **IX: Summary and Exports** (new) | 675–720 |

All other sections keep their titles/summaries with corrected line ranges. Only the `sections` array changed — every other meta key is byte-identical; counts were already correct.

## Test plan
- [x] Section ranges map to `-- PART` banners in the source
- [x] Non-section meta keys verified byte-identical
- [x] Build-free metadata-only change (no Lean rebuild required)