### PR TITLE
research(ballot-oq-03): cover hidden 2×2 LGV lemma tail in gallery sections

### DIFF
--- a/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03-oq-01/meta.json
@@ -134,33 +134,9 @@
       "id": "lgv-theorem",
       "title": "Part XVII: LGV Lemma 2×2 and Non-Negativity",
       "startLine": 2834,
-      "endLine": 2878,
+      "endLine": 2922,
       "summary": "Proves lgv_lemma_2x2: |NI pairs| = det[e(Aᵢ,Bⱼ)]. Three cases: equal starts, equal ends, general (strict). General case: complement counting + Lindström involution + algebra. Corollary lgvDet_nonneg: determinant is non-negative since it equals a count.",
       "mathContext": "|NI| = e(A₁,B₁)e(A₂,B₂) - e(A₁,B₂)e(A₂,B₁). Proof: ni_complement_count' gives |NI| = total - |Int|; lindstrom_involution gives |Int| = crossed total; algebra via omega + zify + ring gives the determinant formula."
-    },
-    {
-      "id": "column-range-ni",
-      "title": "Part II-III: Column Range Geometry and NonIntersecting",
-      "startLine": 169,
-      "endLine": 256,
-      "summary": "Defines colYRange (y-interval at column x), finalRange (endpoint column range), and NonIntersecting (pairwise disjoint column ranges). Proves northSteps_append, northBeforeEast_le_northSteps, and the key nonIntersecting_entry_order lemma.",
-      "mathContext": "$\\text{colYRange}(l, y_0, x) = [y_0 + e(l,x), y_0 + e(l,x+1)]$. Non-intersection: all column intervals disjoint. Entry order preservation: NI + $y_1 + e_1(k) < y_2 + e_2(k)$ $\\Rightarrow$ $y_1 + e_1(k+1) < y_2 + e_2(k+1)$ by disjoint interval argument."
-    },
-    {
-      "id": "path-split-pascal",
-      "title": "Part V: pathSplitEquiv and Pascal Induction",
-      "startLine": 299,
-      "endLine": 419,
-      "summary": "Constructs pathSplitEquiv: pathType (m+1) (n+1) ≃ pathType m (n+1) ⊕ pathType (m+1) n by case-splitting on first step. Proves path_count_eq_choose: |pathType m n| = C(m+n,m) by double induction, using Fintype.card_congr + Fintype.card_sum + Pascal (Nat.choose_succ_succ').",
-      "mathContext": "Equivalence: first-step split gives $|P(m+1,n+1)| = |P(m,n+1)| + |P(m+1,n)|$. Base cases: single-path sets (replicate n true / replicate m false). Pascal: $\\binom{m+1+n+1}{m+1} = \\binom{m+n+1}{m} + \\binom{m+n+1}{m+1}$."
-    },
-    {
-      "id": "swap-preservation",
-      "title": "Part XII-XXIII: swapAtPoint Step Count Preservation and Dual Injections",
-      "startLine": 1755,
-      "endLine": 2839,
-      "summary": "Proves swapAtPoint preserves East count (m) and changes North count to n₂+(a₂-a₁). Develops visitedPoints, sharedPoints, minSharedStepIdx, canonSharedPoint infrastructure. Proves lindstromForward and lindstromBackward are mutually inverse, establishing the full Lindström involution.",
-      "mathContext": "North count after swap: $(p.2 - a_1) + n_2 - (p.2 - a_2) = n_2 + (a_2 - a_1)$. Canon point: minimum step-index shared point. Dual injections: forward and backward both map via swapAtPoint at canonSharedPoint; the shared point is preserved under swapping (key identity: minSharedStepIdx Q = minSharedStepIdx (swap Q))."
     }
   ],
   "sorries": 0

--- a/src/data/proofs/ballot-problem-oq-03/meta.json
+++ b/src/data/proofs/ballot-problem-oq-03/meta.json
@@ -211,9 +211,17 @@
       "id": "entry-gap-analysis",
       "title": "Entry Gap Analysis and swapTails Properties",
       "startLine": 1215,
-      "endLine": 2878,
+      "endLine": 2874,
       "summary": "FULLY PROVED: Entry gap framework (NI preserves positive gap, gap positive at all columns under NI + y₁<y₂). swapTails East step count preservation. Suffix North step count decomposition.",
       "mathContext": "The entry gap $\\texttt{entryGap}(l_1, l_2, y_1, y_2, k) = (y_2 + \\text{colEntry}(l_2, k)) - (y_1 + \\text{colEntry}(l_1, k))$ measures path separation at each column. Under non-intersection with $y_1 < y_2$, the gap stays positive at all columns ($\\texttt{entryGap\\_pos\\_all}$). This section also proves $\\texttt{swapTails}$ preserves East step counts and decomposes suffix North steps, completing the infrastructure for the Lindström involution."
+    },
+    {
+      "id": "lgv-lemma-2x2",
+      "title": "2×2 LGV Lemma and Non-Negativity",
+      "startLine": 2875,
+      "endLine": 2922,
+      "summary": "FULLY PROVED: lgv_lemma_2x2 — the headline result. Non-intersecting path-pair count equals the 2×2 Lindström-Gessel-Viennot determinant. Three cases (equal starts, equal ends, strict ordering); the strict case combines complement counting (ni_complement_count') with the lindstrom_involution and closes by omega/zify/ring. Corollary lgvDet_nonneg: the LGV determinant is non-negative because it equals a cardinality.",
+      "mathContext": "|{NI pairs}| = C(m+n₁,m)·C(m+n₂,m) − C(m+n₁',m)·C(m+n₂',m) = det[[e(A₁,B₁), e(A₁,B₂)], [e(A₂,B₁), e(A₂,B₂)]], with n₁',n₂' the crossed lengths. Non-negativity is immediate since the determinant equals a nonnegative count (Int.natCast_nonneg)."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
The two gallery metas backed by the shared `BallotProblemOQ03.lean` (2922 lines) stopped their section coverage at line 2878, hiding the file's **headline result** — the 2×2 Lindström-Gessel-Viennot lemma (`lgv_lemma_2x2`) and its corollary `lgvDet_nonneg` (lines 2875-2922).

## Progress
- **ballot-problem-oq-03**: trimmed the oversized "Entry Gap Analysis and swapTails Properties" section to end at 2874 and added a dedicated **"2×2 LGV Lemma and Non-Negativity"** section (2875-2922).
- **ballot-problem-oq-03-oq-01**: extended the existing "Part XVII: LGV Lemma 2×2 and Non-Negativity" section to the file end (2922), and removed three stale, out-of-order duplicate sections whose line ranges were already fully covered by sections 0-4 (they rendered as overlapping sections).

Both metas now provide a clean, monotonic, full-file section cover.

## Findings
- Pure gallery-metadata fix; no Lean source changes. The LGV lemma is the climax of the file (per its module docstring) yet was invisible in the gallery.

## Status
**Outcome**: completed (gallery section realignment)
**Next Steps**: ballot family otherwise section-clean.

🤖 Generated by researcher-2