### PR TITLE
research(erdos-1052): realign drifted/mislabeled gallery sections to full file (8→10)

### DIFF
--- a/src/data/proofs/erdos-1052/meta.json
+++ b/src/data/proofs/erdos-1052/meta.json
@@ -134,68 +134,84 @@
   ],
   "sections": [
     {
+      "id": "problem-history-imports",
+      "title": "Problem History and Imports",
+      "startLine": 1,
+      "endLine": 27,
+      "summary": "Module docstring stating Erdős Problem #1052: a unitary divisor d of n satisfies gcd(d, n/d) = 1, and a unitary perfect number equals the sum of its proper unitary divisors. Lists the main results (the three small witnesses, the parity machinery, multiplicativity, and the even-ness theorem), the five known unitary perfect numbers, and Wall's 1972 reference. Imports `Mathlib`; opens `namespace Erdos1052`.",
+      "mathContext": "The known unitary perfect numbers are 6, 60, 90, 87360, and 146361946186458562560000 — only five are known, and it is conjectured there are finitely many. The file's deepest result is that every such number is even."
+    },
+    {
       "id": "definitions",
       "title": "Core Definitions",
-      "startLine": 26,
-      "endLine": 42,
-      "summary": "Defines properUnitaryDivisors (n : ℕ) : Finset ℕ via Finset.Ico 1 n filtered by d ∣ n ∧ d.Coprime (n / d). Defines IsUnitaryPerfect as sum equality plus positivity. Derives Decidable instance for native_decide.",
-      "mathContext": "$\\text{properUnitaryDivisors}(n) = \\{d \\in [1,n) : d \\mid n \\wedge \\gcd(d, n/d) = 1\\}$. $\\text{IsUnitaryPerfect}(n) \\iff \\sum_{d \\in \\text{properUnitaryDivisors}(n)} d = n \\wedge n > 0$. Decidable instance enables `native_decide`."
+      "startLine": 28,
+      "endLine": 44,
+      "summary": "Defines `properUnitaryDivisors (n : ℕ) : Finset ℕ` via `Finset.Ico 1 n` filtered by `d ∣ n ∧ d.Coprime (n / d)`, `IsUnitaryPerfect` as sum-equality plus positivity, and the `Decidable` instance enabling `native_decide`.",
+      "mathContext": "$\\text{properUnitaryDivisors}(n) = \\{d \\in [1,n) : d \\mid n \\wedge \\gcd(d, n/d) = 1\\}$. $\\text{IsUnitaryPerfect}(n) \\iff \\sum_{d} d = n \\wedge n > 0$."
     },
     {
       "id": "basic-properties",
       "title": "Basic Properties",
-      "startLine": 43,
-      "endLine": 59,
-      "summary": "Proves one_mem_properUnitaryDivisors (1 is always unitary for n > 1) and mem_properUnitaryDivisors (membership ↔ characterization) using simp and omega.",
-      "mathContext": "$1 \\in \\text{properUnitaryDivisors}(n)$ for $n > 1$, since $1 \\mid n$ and $\\gcd(1, n) = 1$. Membership characterized by: $d \\in [1,n) \\wedge d \\mid n \\wedge \\gcd(d, n/d) = 1$."
+      "startLine": 45,
+      "endLine": 70,
+      "summary": "Membership lemmas `one_mem_properUnitaryDivisors` (1 is always a proper unitary divisor for n > 1) and `mem_properUnitaryDivisors` (the unfolding characterization), plus `odd_of_unitaryDivisor_of_odd` (every unitary divisor of an odd number is odd).",
+      "mathContext": "That unitary divisors of an odd n are odd is the seed of the parity argument: it forces every term in $\\sigma^*(n)$ to inherit a fixed parity structure, which the next section exploits."
     },
     {
       "id": "parity-lemmas",
       "title": "Parity Lemmas",
-      "startLine": 60,
-      "endLine": 99,
-      "summary": "Proves odd_of_unitaryDivisor_of_odd (odd n, d | n implies d odd) via contradiction and dvd_trans. Proves sum_odd_parity by Finset.induction using Odd.add_even / Odd.add_odd arithmetic.",
-      "mathContext": "If $n$ is odd and $d \\mid n$, then $d$ is odd (since $2 \\mid d$ would give $2 \\mid n$). Key lemma: $\\sum_{x \\in S} x$ is odd $\\iff |S|$ is odd, when all $x$ are odd. Proved by Finset induction."
+      "startLine": 71,
+      "endLine": 110,
+      "summary": "Proves `sum_odd_parity`: a sum over a finset of odd numbers has odd parity iff the finset has odd cardinality (by Finset induction).",
+      "mathContext": "This is the combinatorial parity engine: it converts the parity of $\\sum_{d} d$ over odd unitary divisors into a count of those divisors, mod 2 — the lever used to derive a contradiction from an odd unitary perfect number."
     },
     {
-      "id": "unitary-structure",
+      "id": "unitary-divisor-structure",
       "title": "Unitary Divisor Structure",
-      "startLine": 100,
-      "endLine": 130,
-      "summary": "Proves unitary_iff_no_common_prime (coprime ↔ no common prime divisor) via Nat.exists_prime_and_dvd. Proves unitary_complement via Nat.div_div_self and Coprime.symm. Defines unitaryDivisorSum.",
-      "mathContext": "$\\gcd(d, n/d) = 1 \\iff \\neg\\exists p$ prime with $p \\mid d$ and $p \\mid n/d$. Complement: if $d$ is a unitary divisor of $n$, so is $n/d$. $\\sigma^*(n) = \\sum_{d \\mid n,\\, \\gcd(d,n/d)=1} d$."
+      "startLine": 111,
+      "endLine": 141,
+      "summary": "Structural lemmas: `unitary_iff_no_common_prime` (d is a unitary divisor iff d and n/d share no prime), `unitary_complement` (the complement n/d of a unitary divisor is again unitary), and the definition `unitaryDivisorSum n` (σ*(n), summing all unitary divisors including n).",
+      "mathContext": "The unitary divisors form a complemented sublattice: $d \\mapsto n/d$ is an involution preserving unitarity. This self-duality underlies the multiplicativity of $\\sigma^*$ developed next."
     },
     {
-      "id": "main-theorem",
-      "title": "Main Theorem: Even Unitary Perfect Numbers",
-      "startLine": 131,
-      "endLine": 151,
-      "summary": "Axiomatizes even_of_isUnitaryPerfect with detailed proof sketch: σ*(n) = ∏(1 + pᵢ^aᵢ) factors, odd n makes all factors even, 2^ω(n) | 2n forces contradiction for k ≥ 2, k = 1 gives 1 = p^a impossible, k = 0 gives n = 1 not perfect.",
-      "mathContext": "For $n = p_1^{a_1} \\cdots p_k^{a_k}$: $\\sigma^*(n) = \\prod_{i=1}^{k}(1 + p_i^{a_i})$. If $n$ odd: each $1 + p_i^{a_i}$ is even, so $2^k \\mid \\sigma^*(n) = 2n$, giving $2^{k-1} \\mid n$ — contradiction for $k \\geq 2$."
+      "id": "multiplicativity-lemmas",
+      "title": "Supporting Lemmas for Multiplicativity",
+      "startLine": 142,
+      "endLine": 211,
+      "summary": "Four `private` coprimality lemmas powering the multiplicativity bijection: `gcd_mul_left_eq` (gcd(d₁·d₂, m) = d₁ when d₁ ∣ m and d₂ coprime to m), `div_gcd_dvd_right`, `gcd_coprime_div_of_unitary`, and `div_gcd_coprime_div_of_unitary` — showing that for coprime m, n a unitary divisor d of m·n splits as (gcd(d,m), d/gcd(d,m)) into unitary divisors of m and n.",
+      "mathContext": "These lemmas establish that the map $d \\mapsto (\\gcd(d,m),\\, d/\\gcd(d,m))$ is a well-defined bijection from unitary divisors of $mn$ to pairs from $m$ and $n$ — the technical core of $\\sigma^*$ being multiplicative on coprime arguments."
     },
     {
-      "id": "examples",
+      "id": "verified-examples",
       "title": "Verified Examples",
-      "startLine": 152,
-      "endLine": 167,
-      "summary": "Proves isUnitaryPerfect_6, isUnitaryPerfect_60, isUnitaryPerfect_90 by native_decide — the Lean kernel evaluates the Finset computation and checks sum = n.",
-      "mathContext": "$6 = 2 \\cdot 3$: unitary divisors $\\{1,2,3\\}$, sum $= 6$. $60 = 2^2 \\cdot 3 \\cdot 5$: unitary divisors $\\{1,3,4,5,12,15,20\\}$, sum $= 60$. $90 = 2 \\cdot 3^2 \\cdot 5$: unitary divisors $\\{1,2,5,9,10,18,45\\}$, sum $= 90$."
+      "startLine": 212,
+      "endLine": 232,
+      "summary": "Computational confirmations by `native_decide` that 6, 60, 90, and 87360 (Wall's 1972 fourth known) are unitary perfect, each annotated with its prime factorization and proper-unitary-divisor set.",
+      "mathContext": "6 = 2·3, 60 = 2²·3·5, 90 = 2·3²·5, 87360 = 2⁶·3·5·7·13. Each is verified by native compilation of the decidable `IsUnitaryPerfect` instance enumerating proper unitary divisors."
     },
     {
       "id": "further-properties",
       "title": "Further Properties",
-      "startLine": 168,
-      "endLine": 226,
-      "summary": "Proves unitaryDivisors_primePow (only 1 and p^k for prime powers). Axiomatizes unitaryDivisorSum_mul_coprime (multiplicativity) and properUnitaryDivisors_pairing (d ↔ n/d pairing).",
-      "mathContext": "For $p^k$ prime power: unitary divisors are exactly $\\{1, p^k\\}$ (proved). Multiplicativity: $\\sigma^*(mn) = \\sigma^*(m)\\sigma^*(n)$ for $\\gcd(m,n)=1$ (axiom). Pairing: $d \\mapsto n/d$ gives an involution on unitary divisors (axiom)."
+      "startLine": 233,
+      "endLine": 362,
+      "summary": "The multiplicativity infrastructure: `unitaryDivisors_primePow` (the only unitary divisors of pᵏ are 1 and pᵏ), `unitaryDivisorSum_prime_pow` (σ*(pᵏ) = 1 + pᵏ), the headline `unitaryDivisorSum_mul_coprime` (σ* is multiplicative on coprime arguments, via `Finset.sum_nbij'` with the gcd-splitting bijection), and `properUnitaryDivisors_pairing` (existential d ↦ n/d pairing structure).",
+      "mathContext": "Multiplicativity $\\sigma^*(mn) = \\sigma^*(m)\\sigma^*(n)$ for $\\gcd(m,n)=1$, combined with the prime-power formula $\\sigma^*(p^k) = 1 + p^k$, reduces $\\sigma^*$ to a product over prime-power blocks — the engine for the even-ness theorem."
     },
     {
-      "id": "conjecture",
-      "title": "Open Conjecture",
-      "startLine": 227,
-      "endLine": 236,
-      "summary": "States erdos_1052_conjecture : { n : ℕ | IsUnitaryPerfect n }.Finite as an axiom — the OPEN finiteness conjecture.",
-      "mathContext": "$\\{n \\in \\mathbb{N} \\mid \\text{IsUnitaryPerfect}(n)\\}$ is finite. Only 5 known: $6, 60, 90, 87360, 146361946186458562560000$. Open since 1972."
+      "id": "all-even-proof",
+      "title": "Proof: All Unitary Perfect Numbers are Even",
+      "startLine": 363,
+      "endLine": 514,
+      "summary": "The main theorem `even_of_isUnitaryPerfect`: every unitary perfect number is even. Private helpers `pow_factorization_dvd`, `coprime_pow_factorization_div`, `unitaryDivisorSum_one`, `unitaryDivisorSum_eq_proper_add`, and `even_unitaryDivisorSum_of_odd` (σ*(m) is even for odd m > 1) feed the argument: for unitary perfect n, σ*(n) = 2n; decompose n = pᵃ·m by the smallest prime factor; multiplicativity gives σ*(n) = (1+pᵃ)·σ*(m); if n were odd, the m = 1 case forces pᵃ = 1 (impossible) and the m > 1 case makes both factors even, yielding 4 ∣ 2n hence 2 ∣ n — a contradiction.",
+      "mathContext": "For odd n, $1 + p^a$ is even (p^a odd) and $\\sigma^*(m)$ is even (odd m > 1 has an odd prime factor giving an even $1+q^b$ factor). Their product equals $2n$, so $4 \\mid 2n$, forcing $2 \\mid n$ — contradicting n odd. This rules out odd unitary perfect numbers entirely."
+    },
+    {
+      "id": "main-conjecture",
+      "title": "The Main Conjecture (OPEN)",
+      "startLine": 515,
+      "endLine": 523,
+      "summary": "States the open Erdős Problem #1052 in a docstring: are there only finitely many unitary perfect numbers? Only five are known (6, 60, 90, 87360, 146361946186458562560000). Closes `namespace Erdos1052`.",
+      "mathContext": "The finiteness question is genuinely open and is carried as commentary, not as a Lean `axiom` — the file proves only unconditional structural facts, with the conjecture left as a stated open problem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `erdos-1052` (Unitary Perfect Numbers) gallery meta listed 8 sections covering only lines **26-236** of the **523-line** source (`Proofs/Erdos1052Problem.lean`) — **55% hidden** — and the covered region was **mislabeled**:

- "Main Theorem: Even Unitary Perfect Numbers" was pinned at 131-151, where there is no such banner (line 143 is "Supporting Lemmas for Multiplicativity").
- "Verified Examples" (152), "Further Properties" (168), and "Open Conjecture" (227) pointed well short of the real `## ` banners at **213**, **234**, and **516**.

Entirely missing from the gallery: the four multiplicativity coprimality lemmas, the prime-power formula `σ*(pᵏ) = 1 + pᵏ`, the multiplicativity theorem `unitaryDivisorSum_mul_coprime`, and the **main result** `even_of_isUnitaryPerfect` (all unitary perfect numbers are even, lines 363-514).

Rebuilt to **10 sections** aligned to the source's `## ` banners with contiguous full-file coverage:

| # | Lines | Section |
|---|-------|---------|
| 1 | 1-27 | Problem History and Imports |
| 2 | 28-44 | Core Definitions |
| 3 | 45-70 | Basic Properties |
| 4 | 71-110 | Parity Lemmas |
| 5 | 111-141 | Unitary Divisor Structure |
| 6 | 142-211 | Supporting Lemmas for Multiplicativity |
| 7 | 212-232 | Verified Examples |
| 8 | 233-362 | Further Properties |
| 9 | 363-514 | Proof: All Unitary Perfect Numbers are Even |
| 10 | 515-523 | The Main Conjecture (OPEN) |

## Notes

- **Metadata-only change.** No Lean source touched; no build required.
- Counts (15 theorems / 3 defs / 0 axioms) are correct and unchanged.
- All non-`sections` meta content is byte-identical (verified programmatically).

## Test plan
- [x] `meta.json` parses as valid JSON
- [x] Sections contiguous and cover lines 1-523 (full file)
- [x] Section boundaries align with `## ` banner positions in the source
- [x] Non-section meta content unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)