### PR TITLE
research(erdos-1166): rebuild stale gallery sections to full file (10→13)

### DIFF
--- a/src/data/proofs/erdos-1166/meta.json
+++ b/src/data/proofs/erdos-1166/meta.json
@@ -108,81 +108,92 @@
       "id": "header-and-imports",
       "title": "Problem Statement and Imports",
       "startLine": 1,
-      "endLine": 31,
-      "summary": "Documents the problem statement, its resolution, key ingredients (Erdős–Révész bound and Erdős–Taylor theorem), and imports Mathlib modules for finite sets, real analysis, logarithms, and powers.",
-      "mathContext": "Verified: Documents the problem statement, its resolution, key ingredients (Erdős–Révész bound and Erdős–Taylor theorem), and imports Mathlib modules for finite sets, real analysis, logarithms, and powers."
+      "endLine": 36,
+      "summary": "Header comment stating Erdős #1166 (most-visited points of a planar random walk), its affirmative resolution |⋃_{k≤n} F(k)| ≪ (log n)² a.s., the two key ingredients (|F(n)| ≤ 3 a.s. and the Erdős–Taylor (log n)² bound), and the axiom-reduction log (RandomWalk/visitCount/AlmostSurely de-axiomatized; 3 axioms remain). Imports Mathlib."
     },
     {
       "id": "random-walk-definitions",
-      "title": "Random Walk on $\\mathbb{Z}^2$",
-      "startLine": 32,
-      "endLine": 46,
-      "summary": "Defines the integer lattice, origin, and axiomatizes random walks as an abstract type with trajectories starting at the origin.",
-      "mathContext": "Formal definition: Defines the integer lattice, origin, and axiomatizes random walks as an abstract type with trajectories starting at the origin."
+      "title": "Random Walk on ℤ²",
+      "startLine": 37,
+      "endLine": 52,
+      "summary": "LatticePoint = ℤ × ℤ, origin, and RandomWalk as a structure (trajectory : ℕ → LatticePoint with starts_at_origin) — a concrete definition, not an axiom."
     },
     {
       "id": "visit-counts",
       "title": "Visit Counts and Properties",
-      "startLine": 47,
-      "endLine": 62,
-      "summary": "Axiomatizes the visit count function $f_k(x, \\omega)$ with non-negativity, monotonicity in $k$, and initial visit to the origin.",
-      "mathContext": "Axiomatized: Axiomatizes the visit count function $f_k(x, \\omega)$ with non-negativity, monotonicity in $k$, and initial visit to the origin."
+      "startLine": 53,
+      "endLine": 76,
+      "summary": "visitCount ω k x as a noncomputable def (card of the filtered range), with visitCount_nonneg, visitCount_mono (monotone in k) and visitCount_origin (origin visited at step 0)."
     },
     {
       "id": "max-visit-count",
-      "title": "Maximum Visit Count $T_k$",
-      "startLine": 63,
-      "endLine": 83,
-      "summary": "Defines the maximum visit count $T_k$ and proves it is always at least 1, combining the origin's visit count with monotonicity.",
-      "mathContext": "Formal definition: Defines the maximum visit count $T_k$ and proves it is always at least 1, combining the origin's visit count with monotonicity."
+      "title": "Maximum Visit Count T_k",
+      "startLine": 77,
+      "endLine": 130,
+      "summary": "maxVisitCount ω k = Finset.sup of visitCount over visited points, with maxVisitCount_is_max, maxVisitCount_achieved, maxVisitCount_pos (≥ 1), maxVisitCount_mono_succ and maxVisitCount_le_of_le (monotonicity)."
     },
     {
       "id": "most-visited-set",
-      "title": "Most-Visited Set $F(k)$",
-      "startLine": 84,
-      "endLine": 98,
-      "summary": "Axiomatizes the set of points achieving maximum visit count, with membership characterization and nonemptiness.",
-      "mathContext": "Axiomatized: Axiomatizes the set of points achieving maximum visit count, with membership characterization and nonemptiness."
+      "title": "Set of Most-Visited Points F(k)",
+      "startLine": 131,
+      "endLine": 188,
+      "summary": "mostVisitedSet ω k as the filter of visited points achieving the max, with mem_mostVisitedSet, mostVisitedSet_nonempty, and the nesting lemmas mostVisited_nesting and mostVisited_nesting_range (F(a) ⊆ F(b) when T is constant on [a,b])."
     },
     {
       "id": "cumulative-set",
-      "title": "Cumulative Most-Visited Set",
-      "startLine": 99,
-      "endLine": 120,
-      "summary": "Defines $\\bigcup_{k \\leq n} F(k)$ with containment and subset axioms, and proves monotonicity of the cumulative set.",
-      "mathContext": "Formal definition: Defines $\\bigcup_{k \\leq n} F(k)$ with containment and subset axioms, and proves monotonicity of the cumulative set."
+      "title": "Cumulative Most-Visited Points",
+      "startLine": 189,
+      "endLine": 216,
+      "summary": "cumulativeMostVisited ω n = ⋃_{k≤n} F(k) as a biUnion, with cumulativeMostVisited_contains, _subset and _mono."
+    },
+    {
+      "id": "nesting-cumulative-bounds",
+      "title": "Nesting-Based Cumulative Bounds",
+      "startLine": 217,
+      "endLine": 315,
+      "summary": "The combinatorial core: biUnion_subset_last_of_constant_T (a constant-T interval's union collapses to its last F), mostVisited_subset_trajectory, and cumulative_card_bound — a sorry-free induction on interval length showing |⋃ F(k)| ≤ 3·(T_b − T_a + 1) when |F(k)| ≤ 3 throughout."
     },
     {
       "id": "almost-surely",
       "title": "Almost Sure Events",
-      "startLine": 121,
-      "endLine": 135,
-      "summary": "Axiomatizes almost sure events with monotonicity and conjunction properties, abstracting away the probability space.",
-      "mathContext": "Axiomatized: Axiomatizes almost sure events with monotonicity and conjunction properties, abstracting away the probability space."
+      "startLine": 316,
+      "endLine": 341,
+      "summary": "AlmostSurely modeled via Mathlib filters: axiom asProbFilter : Filter RandomWalk, AlmostSurely P := ∀ᶠ ω in asProbFilter, P ω (a def), and almostSurely_mono / almostSurely_and derived from Filter.Eventually.mono and Filter.inter_mem."
     },
     {
       "id": "key-ingredients",
-      "title": "Key Ingredients: Erdős–Révész and Erdős–Taylor",
-      "startLine": 136,
-      "endLine": 155,
-      "summary": "States the two main ingredients: $|F(n)| \\leq 3$ a.s. for large $n$ (Erdős–Révész) and $T_n \\leq C(\\log n)^2$ a.s. (Erdős–Taylor).",
-      "mathContext": "States the two main ingredients: $|F(n)| \\leq 3$ a.s. for large $n$ (Erdős–Révész) and $T_n \\leq C(\\$\\log n$)^2$ a.s. (Erdős–Taylor)."
+      "title": "Key Results: |F(n)| ≤ 3 and Erdős–Taylor",
+      "startLine": 342,
+      "endLine": 355,
+      "summary": "axiom mostVisited_bounded_eventually (a.s. |F(n)| ≤ 3 for large n, the Erdős–Révész input related to #1165) and a note that the former erdosTaylor_upper_bound axiom is now derived from erdosTaylor_constant."
     },
     {
       "id": "main-theorem",
-      "title": "Main Theorem and Proof Structure",
-      "startLine": 156,
-      "endLine": 219,
-      "summary": "States the main result $|\\bigcup_{k \\leq n} F(k)| = O((\\log n)^2)$ a.s., derives the polylogarithmic form, provides the proof structure combining both ingredients, and connects to Problem #1165.",
-      "mathContext": "States the main result $|\\bigcup_{k \\leq n} F(k)| = $O((\\$\\log n$)$^2)$ a.s., derives the polylogarithmic form, provides the proof structure combining both ingredients, and connects to Problem #1165."
+      "title": "Main Theorem: Erdős Problem #1166",
+      "startLine": 356,
+      "endLine": 398,
+      "summary": "erdos1166_main: a.s. |⋃_{k≤n} F(k)| ≤ C·(log n)² for large n, assembled from the two ingredients; and erdos1166_polylog repackaging it as ≤ (log n)^α."
     },
     {
-      "id": "recurrence-and-constant",
-      "title": "Pólya Recurrence and Erdős–Taylor Constant",
-      "startLine": 222,
-      "endLine": 259,
-      "summary": "States Pólya's 2D recurrence theorem, the divergence of $T_n$, and the precise Erdős–Taylor constant $T_n/(\\log n)^2 \\to 1/\\pi$ a.s., with a derivation of the upper bound from the constant.",
-      "mathContext": "States Pólya's 2D recurrence theorem, the divergence of $T_n$, and the precise Erdős–Taylor constant $T_n/(\\$\\log n$)^2 \\to 1/\\$\\pi$$ a.s., with a derivation of the upper bound from the constant."
+      "id": "proof-structure",
+      "title": "Proof Structure",
+      "startLine": 399,
+      "endLine": 494,
+      "summary": "erdos1166_from_ingredients: the sorry-free assembly. Splits the cumulative set into an early part (≤ N₁ visited points) and a late part bounded by cumulative_card_bound via nesting, then absorbs N₁+3 into (log n)² past a threshold to conclude |⋃ F(k)| ≤ (3C+1)(log n)²."
+    },
+    {
+      "id": "connection-1165",
+      "title": "Connection to Erdős Problem #1165",
+      "startLine": 495,
+      "endLine": 508,
+      "summary": "connection_to_1165 re-exposes the |F(n)| ≤ 3 result (the subject of #1165), plus a note that the orphan Pólya-recurrence and maxVisitCount_tendsto_infty axioms were removed (unused by the proof chain)."
+    },
+    {
+      "id": "erdos-taylor-constant",
+      "title": "The Erdős–Taylor Constant",
+      "startLine": 509,
+      "endLine": 547,
+      "summary": "axiom erdosTaylor_constant (T_n/(log n)² → 1/π a.s., the precise planar maximum-occupation asymptotic) and erdosTaylor_implies_bound, which extracts the C·(log n)² upper bound actually consumed by the main theorem."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The gallery `meta.json` for **erdos-1166** (most-visited points of a planar random walk) carried sections from a much older revision of `Erdos1166Problem.lean` (547 lines):
  - They stopped at line **259 of 547** (52% hidden) and the labels no longer matched the source `-- ## ` markers.
  - Section 9 described **"Pólya Recurrence"** — axioms that were since removed as orphans (file lines 504–507).
  - Several summaries overclaimed **"Axiomatizes"** for declarations that are now plain `def`s (RandomWalk is a `structure`; `visitCount`/`AlmostSurely` are `def`s — the file header documents this de-axiomatization).

## Sections (10 → 13)
Rebuilt against the current markers, surfacing the previously-hidden proof material:
| Section | Range |
|---------|-------|
| Nesting-Based Cumulative Bounds (`cumulative_card_bound` induction) | 217–315 |
| Proof Structure (`erdos1166_from_ingredients` assembly) | 399–494 |
| Connection to Erdős #1165 | 495–508 |
| The Erdős–Taylor Constant | 509–547 |

Summaries corrected to reflect the de-axiomatized definitions.

## Test plan
- [x] Section ranges map to the `-- ## ` markers in the source
- [x] Counts correct (0 sorries, 3 axioms, 25 theorems, 8 defs)
- [x] Non-section meta keys verified byte-identical
- [x] Build-free metadata-only change