### PR TITLE
research(bounded-prime-gaps-oq-03-oq-01): realign drifted gallery sections to full file (5→8)

### DIFF
--- a/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
+++ b/src/data/proofs/bounded-prime-gaps-oq-03-oq-01/meta.json
@@ -55,42 +55,66 @@
   },
   "sections": [
     {
-      "id": "minimum-diameter",
-      "title": "Minimum Diameter of Admissible k-Tuples",
-      "startLine": 32,
-      "endLine": 55,
-      "summary": "Defines the opaque function D(k) for the minimum admissible k-tuple diameter and axiomatizes known computed values: D(2) = 2, D(3) = 6, and D(50) = 246 from Engelsma's exhaustive 2013 computation.",
+      "id": "part-i-min-diameter",
+      "title": "Part I: Minimum Diameter of Admissible k-Tuples",
+      "startLine": 1,
+      "endLine": 53,
+      "summary": "Imports and overview, then defines `fsDiameter` (max − min of a Finset) and the opaque `minAdmissibleDiameter` D(k) — the minimum diameter over admissible k-tuples of size k.",
       "mathContext": "$D(k) = \\min\\{\\mathrm{diam}(\\mathcal{H}) : \\mathcal{H} \\text{ admissible},\\, |\\mathcal{H}|=k\\}$. Known values: $D(2)=2$, $D(3)=6$, $D(50)=246$ (Engelsma 2013)."
     },
     {
-      "id": "small-tuples",
-      "title": "Small Admissible Tuples (Verified)",
-      "startLine": 56,
-      "endLine": 85,
+      "id": "part-ia-non-admissibility",
+      "title": "Part I-a: Non-Admissibility Lemmas",
+      "startLine": 54,
+      "endLine": 82,
+      "summary": "Proves `not_admissible_consecutive` (k consecutive integers cover all residues mod a prime ≤ k) and `not_admissible_ap_diff2`, the obstruction lemmas that force admissible tuples to have gaps.",
+      "mathContext": "Admissibility requires that for every prime p the tuple omits a residue class mod p. A block of consecutive integers (or a difference-2 arithmetic progression long enough) hits every class mod some small prime, so it is inadmissible — this is what makes D(k) grow."
+    },
+    {
+      "id": "part-ib-diameter-bounds",
+      "title": "Part I-b: Diameter Bounds for Admissible Sets",
+      "startLine": 83,
+      "endLine": 166,
+      "summary": "Proves `finset_card_le_diameter_succ` (|H| ≤ diam(H)+1) and the private lower bounds `admissible_pair_diam_ge_2` and `admissible_triple_diam_ge_6`, certifying the minimal diameters for k = 2 and k = 3.",
+      "mathContext": "The cardinality-vs-diameter bound is the elementary backbone: any size-k set of naturals spans at least k−1. Combined with the mod-2/mod-3 admissibility obstructions this pins diam ≥ 2 for pairs and diam ≥ 6 for triples."
+    },
+    {
+      "id": "part-ic-small-d-values",
+      "title": "Part I-c: D(2)=2, D(3)=6 (proved), D(50)=246 (axiom)",
+      "startLine": 167,
+      "endLine": 205,
+      "summary": "Machine-checks `minAdmissibleDiameter_2 : D(2) = 2` and `minAdmissibleDiameter_3 : D(3) = 6` from the Part I-b bounds and explicit witnesses, and axiomatizes `minAdmissibleDiameter_50 : D(50) = 246` (Engelsma's 2013 exhaustive computation).",
+      "mathContext": "$D(2)=2$, $D(3)=6$ are proved here; $D(50)=246$ is one of the two axioms in the file, standing in for Engelsma's 2013 exhaustive search — the value underlying the Maynard–Tao 246 barrier."
+    },
+    {
+      "id": "part-ii-small-tuples",
+      "title": "Part II: Small Admissible Tuples (Verified)",
+      "startLine": 206,
+      "endLine": 235,
       "summary": "Constructs concrete admissible tuples {0,2}, {0,2,6}, and {0,2,6,8} as Finsets and verifies their cardinalities and diameters using native_decide, providing machine-checked witnesses for the smallest admissible k-tuples.",
       "mathContext": "A $k$-tuple $\\mathcal{H}=\\{h_1,\\ldots,h_k\\}$ is admissible if for every prime $p$, $\\mathcal{H} \\pmod{p}$ omits at least one residue class. Witnesses: $\\{0,2\\}$, $\\{0,2,6\\}$, $\\{0,2,6,8\\}$."
     },
     {
-      "id": "asymptotic-growth",
-      "title": "Asymptotic Growth of D(k)",
-      "startLine": 86,
-      "endLine": 103,
-      "summary": "States the fundamental bounds on D(k): a linear lower bound from the pigeonhole/covering argument and a near-linear upper bound D(k) <= C * k * (log k)^2 from greedy construction via the prime number theorem. Both remain as sorry targets.",
+      "id": "part-iii-asymptotic",
+      "title": "Part III: Asymptotic Growth of D(k)",
+      "startLine": 236,
+      "endLine": 320,
+      "summary": "States and proves the linear lower bound `diameter_lower_bound` (k ≤ D(k)+1, via pigeonhole) and the constructive `exists_admissible_k_tuple`; the near-linear upper bound D(k) ≤ C·k·(log k)² is captured by the axiom `diameter_upper_bound_exists` (from the prime number theorem). No sorries remain.",
       "mathContext": "$k - 1 \\le D(k) \\le C\\,k\\,(\\log k)^2$. Lower bound: pigeonhole on residue classes. Upper bound: greedy construction using the prime number theorem."
     },
     {
-      "id": "maynard-tao-barrier",
-      "title": "The Maynard-Tao Barrier",
-      "startLine": 104,
-      "endLine": 136,
+      "id": "part-iv-maynard-tao",
+      "title": "Part IV: The Maynard-Tao Barrier",
+      "startLine": 321,
+      "endLine": 353,
       "summary": "Formalizes the Maynard-Tao sieve framework as a structure with parameters (k, m, bound) and proves two key instances: k=2 giving bound 2 (twin primes) and k=50 giving bound 246 (Polymath 8b). Establishes barrier_246 showing D(50) = 246 is sharp.",
       "mathContext": "Maynard-Tao: if $k \\ge k_0$ then $\\liminf_{n\\to\\infty}(p_{n+1}-p_n) \\le D(k)$. At $k_0=50$: $\\liminf(p_{n+1}-p_n) \\le D(50) = 246$."
     },
     {
-      "id": "beyond-maynard-tao",
-      "title": "Improving Beyond Maynard-Tao",
-      "startLine": 137,
-      "endLine": 162,
+      "id": "part-v-improving",
+      "title": "Part V: Improving Beyond Maynard-Tao",
+      "startLine": 354,
+      "endLine": 389,
       "summary": "Explores routes past the 246 barrier: the Elliott-Halberstam conjecture would reduce the bound to 12, and the twin prime conjecture is equivalent to D(2) being achievable. Axiomatizes the conditional EH improvement.",
       "mathContext": "Elliott-Halberstam: $\\sum_{q\\le x^\\theta} \\max_{(a,q)=1}|\\pi(x;q,a)-\\frac{\\mathrm{li}(x)}{\\varphi(q)}| \\ll \\frac{x}{(\\log x)^A}$ for all $\\theta < 1$. Conditionally: $\\liminf(p_{n+1}-p_n) \\le 12$."
     }


### PR DESCRIPTION
## Summary

The `bounded-prime-gaps-oq-03-oq-01` gallery sections covered only lines 32–162 of a 389-line Lean file (58% hidden) and **lumped** the file's four `-- Part I…` sub-banners (I, I-a, I-b, I-c) into a single "Minimum Diameter" entry, leaving Parts II–V mis-ranged.

Rebuilt to **8 sections** following the file's `-- Part …` banners:

- **Part I** (D(k) / `minAdmissibleDiameter` defs), **I-a** (non-admissibility lemmas), **I-b** (diameter bounds for admissible sets), **I-c** (`D(2)=2`, `D(3)=6` proved; `D(50)=246` axiom — Engelsma 2013)
- **Part II** Small Admissible Tuples, **III** Asymptotic Growth, **IV** The Maynard–Tao Barrier, **V** Improving Beyond Maynard–Tao

Also fixed a **stale summary**: Part III previously claimed the asymptotic bounds "remain as sorry targets", but the file has **0 sorries** — the lower bound is proved (`diameter_lower_bound`) and the upper bound is the axiom `diameter_upper_bound_exists`.

Existing summaries and `mathContext` are preserved where they map. Counts (23 thm / 6 def / 2 axiom / 0 sorry) and `lineCount` (389) were already correct — only the `sections` array changed.

## Test plan

- [x] `maxEnd` of sections now equals `lineCount` (389)
- [x] Ranges monotonic, non-overlapping, verified against the `-- Part …` banners
- [x] Stale "sorry targets" wording corrected to match the axiom/proved reality
- [x] No changes to counts or any non-section field

🤖 Generated with [Claude Code](https://claude.com/claude-code)