### PR TITLE
research(erdos-380): realign drifted gallery sections to full file (6→8)

### DIFF
--- a/src/data/proofs/erdos-380/meta.json
+++ b/src/data/proofs/erdos-380/meta.json
@@ -78,50 +78,66 @@
     {
       "id": "greatest-prime-factor",
       "title": "Greatest Prime Factor",
-      "startLine": 22,
-      "endLine": 39,
-      "summary": "Defines `greatestPrimeFactor : ℕ → ℕ` concretely via `Nat.primeFactors.max'` and proves three properties: `gpf_prime` (primality for $n \\geq 2$), `gpf_dvd` (divisibility $P(n) \\mid n$), and `gpf_largest` (maximality: $p$ prime, $p \\mid n \\implies p \\leq P(n)$).  Returns 0 for $n \\leq 1$.  Previously axiomatized (4 axioms); now fully proved.",
-      "mathContext": "$P(n) = \\max\\{p \\text{ prime} : p \\mid n\\}$ for $n \\ge 2$, $P(1) = 0$. Defined via `Nat.primeFactors.max'` with proved primality, divisibility, and maximality."
+      "startLine": 26,
+      "endLine": 64,
+      "summary": "Defines greatestPrimeFactor concretely via Nat.primeFactors.max' (previously 4 axioms, now all proved). Proves gpf_prime (primality for n≥2), gpf_dvd (P(n) ∣ n), and gpf_largest (P(n) is the largest prime divisor).",
+      "mathContext": "$P(n)=\\max\\{p\\text{ prime}: p\\mid n\\}$, computed from `Nat.primeFactors`. All three structural properties follow from the definition — no axioms."
     },
     {
       "id": "bad-intervals",
       "title": "Bad Intervals",
-      "startLine": 40,
-      "endLine": 53,
-      "summary": "Defines `IsBadInterval u v` requiring $u \\leq v$ and $P(\\Pi)^2 \\mid \\Pi$ where $\\Pi = \\prod_{m=u}^{v} m$.  Defines `InBadInterval n` as $\\exists u \\leq n \\leq v$ with $[u, v]$ bad.  Uses `Finset.Icc` and `Finset.prod id` for the interval product.",
-      "mathContext": "$\\text{IsBadInterval}(u,v) \\iff u \\le v \\wedge P(\\prod_{m=u}^{v} m)^2 \\mid \\prod_{m=u}^{v} m$. $\\text{InBadInterval}(n) \\iff \\exists u \\le n \\le v: \\text{IsBadInterval}(u,v)$."
+      "startLine": 65,
+      "endLine": 78,
+      "summary": "Defines IsBadInterval u v (requires u≤v and P(Π)² ∣ Π where Π = ∏_{m=u}^{v} m) and InBadInterval n (∃ u≤n≤v with [u,v] bad).",
+      "mathContext": "An interval $[u,v]$ is bad if the greatest prime factor of its product $\\Pi=\\prod_{m=u}^v m$ divides $\\Pi$ with exponent $\\ge 2$."
     },
     {
       "id": "counting-functions",
       "title": "Counting Functions",
-      "startLine": 54,
-      "endLine": 63,
-      "summary": "Defines `badCount x` = $|\\{n \\in [1, x] : \\text{InBadInterval}(n)\\}|$ and `gpfSquareCount x` = $|\\{n \\in [2, x] : P(n)^2 \\mid n\\}|$.  Both noncomputable due to decidability of the predicates.  The inclusion $G(x) \\leq B(x)$ follows from singleton bad intervals.",
-      "mathContext": "$B(x) = |\\{n \\in [1,x] : \\text{InBadInterval}(n)\\}|$. $\\text{gpfSquareCount}(x) = |\\{n \\in [2,x] : P(n)^2 \\mid n\\}|$."
+      "startLine": 79,
+      "endLine": 89,
+      "summary": "Defines badCount(x) = |{n ≤ x : InBadInterval n}| and gpfSquareCount(x) = |{n ∈ [2,x] : P(n)² ∣ n}|, both noncomputable.",
+      "mathContext": "$B(x)=|\\{n\\le x: n\\text{ in a bad interval}\\}|$ and $G(x)=|\\{n\\le x: P(n)^2\\mid n\\}|$ — the densities compared in the conjecture."
     },
     {
       "id": "main-conjecture",
       "title": "Main Conjecture",
-      "startLine": 64,
-      "endLine": 73,
-      "summary": "States `ErdosProblem380` as ratio convergence: $\\forall \\varepsilon > 0, \\exists x_0, \\forall x \\geq x_0: G(x) > 0 \\wedge |B(x)/G(x) - 1| < \\varepsilon$.  Uses $\\mathbb{Q}$ for the ratio to avoid real number infrastructure.",
-      "mathContext": "$B(x) \\sim \\text{gpfSquareCount}(x)$ as $x \\to \\infty$, i.e., $\\frac{B(x)}{\\text{gpfSquareCount}(x)} \\to 1$."
+      "startLine": 90,
+      "endLine": 99,
+      "summary": "States ErdosProblem380 as ratio convergence B(x)/G(x) → 1 (using ℚ to avoid reals).",
+      "mathContext": "Conjecture: $\\forall\\varepsilon>0,\\ \\exists x_0,\\ \\forall x\\ge x_0:\\ G(x)>0\\wedge|B(x)/G(x)-1|<\\varepsilon$, i.e. almost all bad integers come from $P(n)^2\\mid n$."
     },
     {
       "id": "known-bounds",
       "title": "Known Bounds",
-      "startLine": 74,
-      "endLine": 89,
-      "summary": "Axiomatizes `erdos_graham_lower` ($B(x) \\geq x^{1-\\varepsilon}$ for large $x$) and `gpfSquare_asymptotic` (GPF-square count exceeds $x^{1-\\varepsilon}$, consistent with the precise $x/\\exp(c\\sqrt{\\log x \\cdot \\log\\log x})$ asymptotic).",
-      "mathContext": "$B(x) > x^{1-o(1)}$ (Erdős-Graham 1980). $\\text{gpfSquareCount}(x) \\sim \\frac{x}{\\exp(c\\sqrt{\\log x \\cdot \\log\\log x})}$ for some $c > 0$."
+      "startLine": 100,
+      "endLine": 123,
+      "summary": "States the single axiom gpfSquare_asymptotic (the GPF-square count exceeds x^{1−ε}) and PROVES erdos_graham_lower (B(x) ≥ x^{1−ε} for large x) via the chain x^{1−ε} ≤ G(x) ≤ B(x) using badCount_ge_gpfSquareCount.",
+      "mathContext": "$B(x)>x^{1-\\varepsilon}$ for every $\\varepsilon>0$ and large $x$ — derived from $G(x)\\le B(x)$ and the asymptotic lower bound on $G(x)$ (the only axiom in the file)."
     },
     {
       "id": "bad-primes",
       "title": "Bad Intervals and Primes",
-      "startLine": 90,
-      "endLine": 97,
-      "summary": "Axiomatizes `bad_interval_no_prime`: short bad intervals ($v < 2u$) contain no primes.  If a prime $p \\in [u, v]$ with $v < 2p$, then $p$ appears exactly once in $\\Pi$, contradicting $P^2 \\mid \\Pi$.  Connects to prime gap distribution via Bertrand's postulate.",
-      "mathContext": "If $\\text{IsBadInterval}(u,v)$ and $v < 2u$, then $\\nexists p \\in [u,v]: p$ prime. Short bad intervals must be prime-free."
+      "startLine": 124,
+      "endLine": 268,
+      "summary": "PROVES bad_interval_no_prime (short bad intervals v<2u contain no primes) and bad_interval_no_prime_general (any bad interval is prime-free), plus bad_interval_v_bound (v < 2u for bad [u,v], via Bertrand's postulate).",
+      "mathContext": "If prime $p\\in[u,v]$ with $v<2p$ then $p$ appears once in $\\Pi$, so $P(\\Pi)=p$ divides $\\Pi$ only once — contradicting badness. Bertrand forces $v<2u$."
+    },
+    {
+      "id": "singleton-intervals",
+      "title": "Singleton Intervals",
+      "startLine": 269,
+      "endLine": 297,
+      "summary": "Links singleton intervals to gpfSquareCount: singleton_bad_iff ([n,n] bad ⟺ P(n)² ∣ n), gpfSquare_in_bad (each such n is in bad interval [n,n]), and badCount_ge_gpfSquareCount (B(x) ≥ G(x)).",
+      "mathContext": "$[n,n]$ is bad $\\iff P(n)^2\\mid n$, so the singletons inject $G(x)$ into the bad integers: $B(x)\\ge G(x)$."
+    },
+    {
+      "id": "very-bad-intervals",
+      "title": "Very Bad Intervals and Powerful Numbers",
+      "startLine": 298,
+      "endLine": 396,
+      "summary": "Defines IsPowerful, IsVeryBadInterval, veryBadCount, powerfulCount. Proves veryBad_is_bad, veryBad_interval_no_prime, singleton_veryBad_iff ([n,n] very bad ⟺ n powerful), powerful_in_veryBad, and the counting_chain powerfulCount ≤ veryBadCount ≤ badCount with gpfSquareCount ≤ badCount. States VeryBadConjecture.",
+      "mathContext": "A very bad interval has every prime dividing its product squared. Singleton $[n,n]$ very bad $\\iff n$ powerful; powerful numbers count $\\sim c\\sqrt{x}$, giving $\\text{powerfulCount}\\le\\text{veryBadCount}\\le\\text{badCount}$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- Gallery `meta.json` for **erdos-380** had 6 sections **shifted ~15–25 lines early** and **truncated at line 97** of a **396-line** file (≈75% hidden).
- Two summaries carried **stale "Axiomatizes" prose**: Known Bounds claimed `erdos_graham_lower` was an axiom and Bad Intervals and Primes claimed `bad_interval_no_prime` was an axiom — both are now **proved theorems**. The file has a **single axiom**, `gpfSquare_asymptotic`.
- Remapped all six sections to the current `/- ## -/` banners, corrected the axiomatization prose, and added the two hidden tail sections — **Singleton Intervals** and **Very Bad Intervals and Powerful Numbers** — covering lines **26–396**.

## Notes
- Counts (17 thm / 12 def / 1 ax) and `lineCount` (396) were already correct — **only the sections array drifted**. No Lean source touched; build-free metadata change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)