### PR TITLE
research(erdos-895 + oq-01): realign drifted gallery sections to full files

### DIFF
--- a/src/data/proofs/erdos-895-oq-01/meta.json
+++ b/src/data/proofs/erdos-895-oq-01/meta.json
@@ -54,7 +54,7 @@
     "mathlib_version": "4.26.0",
     "theoremCount": 13,
     "definitionCount": 6,
-    "lineCount": 289
+    "lineCount": 319
   },
   "overview": {
     "historicalContext": "**Hajnal's Generalization of Erd\u0151s Problem #895**\n\nThe parent problem, Erd\u0151s #895, was solved by Ben Barber (2015) using SAT verification: every triangle-free graph on $\\{1,\\ldots,n\\}$ for $n \\geq 18$ contains three mutually non-adjacent vertices $a$, $b$, $a+b$. This is the $k=2$ base case of a more ambitious conjecture by Andr\u00e1s Hajnal.\n\nHajnal asks: does every sufficiently large triangle-free graph contain an **independent Hindman set** \u2014 a base $B = \\{a_1, \\ldots, a_k\\}$ with $k \\geq 2$ such that ALL finite nonempty sub-sums of $B$ form a mutually non-adjacent set in the graph?\n\nThe $k=2$ case gives FS($\\{a,b\\}$) = $\\{a, b, a+b\\}$, which is exactly Barber's result. The challenge for $k \\geq 3$ is that sums can grow (possibly exceeding $n$) while graph independence must be maintained for all sub-sums simultaneously.\n\n**Connection to Hindman's Theorem (1974):** Hindman proved that for any finite coloring of $\\mathbb{N}$, there exists an infinite Hindman set that is monochromatic. Hajnal's conjecture replaces 'monochromatic' with 'graph-independent' and works in the finite setting \u2014 a fundamentally different kind of constraint.",
@@ -108,56 +108,56 @@
       "id": "core-definitions",
       "title": "Core Definitions",
       "summary": "Graph-on-interval, triangle-free predicate, additive triple, and the hindmanSet (Hindman finite-sums set FS(B)).",
-      "startLine": 33,
-      "endLine": 49,
+      "startLine": 35,
+      "endLine": 52,
       "mathContext": "Sets up $G$ on vertices $\\{0,\\ldots,n-1\\}$ via `Fin n`, defines triangle-freeness ($\\nexists$ three mutually adjacent vertices), additive triples ($a + b = c$ with $a,b > 0$), and $\\mathrm{FS}(B) = \\{\\sum_{i \\in T} a_i : \\emptyset \\neq T \\subseteq B\\}$ as a `Set \u2115`."
     },
     {
       "id": "hindman-structure",
       "title": "Hindman Set Structure",
       "summary": "Monotonicity, singleton membership, and pair-sum characterization of hindmanSet.",
-      "startLine": 51,
-      "endLine": 77,
+      "startLine": 53,
+      "endLine": 110,
       "mathContext": "Four sorry-free lemmas: $a \\in B \\Rightarrow a \\in \\mathrm{FS}(B)$; $B_1 \\subseteq B_2 \\Rightarrow \\mathrm{FS}(B_1) \\subseteq \\mathrm{FS}(B_2)$; for $B = \\{a,b\\}$ with $a \\neq b$, both $a, b$ and the sum $a+b$ are in $\\mathrm{FS}(\\{a,b\\})$ (via `Finset.sum_pair`)."
     },
     {
       "id": "hajnal-conjecture",
       "title": "Hajnal's Conjecture",
       "summary": "Formal statement of Hajnal's generalization of Erd\u0151s #895 and its axiomatization as an open problem.",
-      "startLine": 79,
-      "endLine": 91,
+      "startLine": 111,
+      "endLine": 124,
       "mathContext": "$\\exists N, \\forall n \\geq N, \\forall G$ triangle-free on `Fin n`, $\\exists B \\subseteq V$ with $|B| \\geq 2$ such that $\\mathrm{FS}(B.\\mathrm{image}\\,(\\cdot.\\mathrm{val}))$ is a graph-independent set. Asserted via `axiom hajnal_conjecture` (OPEN as of 2026)."
     },
     {
       "id": "k2-reduction",
       "title": "The k=2 Reduction",
       "summary": "Hajnal k=2 base {a,b} with a+b < n yields an independent additive triple (a, b, a+b) \u2014 recovers Erd\u0151s-Barber.",
-      "startLine": 93,
-      "endLine": 129,
+      "startLine": 125,
+      "endLine": 162,
       "mathContext": "Theorem `hajnal_k2_gives_additive_triple`: given `hindep` for the 2-element base and the in-range condition $a.\\mathrm{val} + b.\\mathrm{val} < n$, the witness $d := \\langle a + b, \\text{hsum}\\rangle$ together with `hindmanSet_pair_*` lemmas produces an independent triple. This is the formal sense in which Hajnal $\\Rightarrow$ Erd\u0151s-Barber on the $k=2$ slice."
     },
     {
       "id": "triangle-free-neighborhoods",
       "title": "Triangle-Free Neighborhoods Are Independent",
       "summary": "Defining lemma: in a triangle-free graph, no two distinct neighbors of v are adjacent (used as Case 1 of the bound).",
-      "startLine": 131,
-      "endLine": 147,
+      "startLine": 163,
+      "endLine": 181,
       "mathContext": "`triangleFree_nbhd_independent` and its corollary `triangleFree_indep_high_deg`: if $\\deg(v) \\geq \\sqrt{n}$ then $N(v)$ is an independent set of size $\\geq \\sqrt{n}$ (Case 1)."
     },
     {
       "id": "greedy-bounded-degree",
       "title": "Greedy Independent Set on Bounded-Degree Subgraphs",
       "summary": "Strong induction on candidate-set cardinality: greedy removal of v and N(v) gives \u03b1 \u2265 |C|/(\u0394+1).",
-      "startLine": 149,
-      "endLine": 242,
+      "startLine": 182,
+      "endLine": 279,
       "mathContext": "Private lemma `greedy_indep_of_bounded_deg`: if $\\Delta(G[C]) \\leq \\Delta$, greedy step removes $\\leq \\Delta + 1$ vertices and recurses, yielding $|C| \\leq |S|(\\Delta+1)$. Wrapper `indep_from_bounded_deg` specializes to $C = V$."
     },
     {
       "id": "independence-bound",
       "title": "Independence Number Bound \u03b1(G) \u2265 \u221an",
       "summary": "Two-case proof: high-degree vertex (Case 1) or all-low-degree (Case 2 via greedy) yields an independent set of size \u2265 \u221an.",
-      "startLine": 244,
-      "endLine": 271,
+      "startLine": 280,
+      "endLine": 319,
       "mathContext": "`triangleFree_independence_bound`: split on $\\exists v$ with $\\deg(v) \\geq \\sqrt{n}$. Case 1 reuses `triangleFree_indep_high_deg`. Case 2: all $\\deg \\leq \\sqrt{n} - 1$, so greedy gives $n \\leq |S| \\cdot \\sqrt{n}$; combined with `Nat.sqrt_le'` ($\\lfloor\\sqrt{n}\\rfloor^2 \\leq n$) and `Nat.le_of_mul_le_mul_right` we conclude $|S| \\geq \\sqrt{n}$."
     }
   ],
@@ -254,7 +254,7 @@
     "namespace": "Erdos895OQ01Problem",
     "imports": ["Mathlib"],
     "opens": ["Finset", "SimpleGraph"],
-    "lineCount": 289,
+    "lineCount": 319,
     "theoremCount": 13,
     "definitionCount": 6,
     "axiomCount": 1,

--- a/src/data/proofs/erdos-895/meta.json
+++ b/src/data/proofs/erdos-895/meta.json
@@ -118,27 +118,51 @@
     },
     {
       "id": "ramsey",
-      "title": "Ramsey Connection",
-      "summary": "R(3,3) = 6 and independence bounds",
+      "title": "Connection to Ramsey Theory",
+      "summary": "Ramsey-theoretic infrastructure: triangle-free graphs, R(3,3) = 6 (ramsey_3_3), and the independence bound that triangle-free graphs have independence number ≥ √n (triangleFree_independence_bound). Provides the combinatorial backbone for the additive-triple analysis.",
       "startLine": 98,
-      "endLine": 110,
-      "mathContext": "Bound: R(3,3) = 6 and independence bounds"
+      "endLine": 257,
+      "mathContext": "$R(3,3) = 6$; triangle-free graphs on $n$ vertices have independence number $\\geq \\sqrt{n}$."
     },
     {
       "id": "schur",
-      "title": "Schur Numbers",
-      "summary": "Connection to sum-free sets and Schur's theorem",
-      "startLine": 111,
-      "endLine": 134,
-      "mathContext": "Verified: Connection to sum-free sets and Schur's theorem"
+      "title": "Connection to Schur Numbers",
+      "summary": "Sum-free sets, the Schur number S(k), S(2) = 4 (schur_2), and erdos895_implies_schur_variant linking the Erdős #895 graph result to a Schur-like statement about colorings. Relates additive triples a + b = c to monochromatic Schur triples.",
+      "startLine": 258,
+      "endLine": 337,
+      "mathContext": "$S(2) = 4$: $\\{1,2,3,4\\}$ is 2-colorable with no monochromatic Schur triple, but $\\{1,\\dots,5\\}$ is not."
     },
     {
       "id": "hajnal",
-      "title": "Hajnal's Generalization",
-      "summary": "The open question about Hindman sets",
-      "startLine": 135,
-      "endLine": 187,
-      "mathContext": "Mathematical content: The open question about Hindman sets"
+      "title": "Hajnal's Generalization (OPEN)",
+      "summary": "Hajnal's conjecture (hajnalConjecture): triangle-free graphs have independent Hindman sets. Stated as an open problem; hajnal_conjecture_open records that it remains unresolved.",
+      "startLine": 338,
+      "endLine": 354,
+      "mathContext": "Hajnal's conjecture (open): every triangle-free graph admits an independent Hindman set."
+    },
+    {
+      "id": "density",
+      "title": "Density Considerations",
+      "summary": "Mantel's theorem (mantel_theorem): a triangle-free graph on n vertices has at most n²/4 edges, and dense_triangleFree_independence deriving independence-number consequences for dense triangle-free graphs.",
+      "startLine": 355,
+      "endLine": 440,
+      "mathContext": "Mantel: a triangle-free graph on $n$ vertices has $\\leq n^2/4$ edges."
+    },
+    {
+      "id": "computational-verification",
+      "title": "Computational Verification",
+      "summary": "erdos895_sat_verified records the SAT/computational verification of the n ≥ 18 threshold (the Barber result), stated with a sorry standing in for the external solver certificate.",
+      "startLine": 441,
+      "endLine": 448,
+      "mathContext": "The threshold-18 result was verified by exhaustive SAT search over graphs on $\\{1,\\dots,n\\}$."
+    },
+    {
+      "id": "main-results-summary",
+      "title": "Main Results Summary",
+      "summary": "erdos_895_summary bundles the main results — Barber's threshold theorem, the n=17 sharpness counterexample, and the Ramsey/Schur connections — into a single summary statement, followed by #check commands.",
+      "startLine": 449,
+      "endLine": 462,
+      "mathContext": "Summary: Erdős #895 holds for $n \\geq 18$ (Barber), sharp at $n = 17$."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
Two slugs in the Erdős #895 family had badly drifted `sections` arrays:

- **erdos-895** (462 lines): meta stopped at line 187 (~60% hidden) and the back half was mislabeled — "Schur Numbers" was tagged lines 111-134 but the section actually lives at 258-337; "Hajnal" was tagged 135-187 but is at 338-354. Remapped all sections to the file's `/- ## -/` banners (8→11 sections), extended "Connection to Ramsey Theory" to its true 98-257 span, and added three undocumented tail sections: **Density Considerations**, **Computational Verification**, and **Main Results Summary**.
- **erdos-895-oq-01** (319 lines): the file had grown but `meta.lineCount`/`leanFile.lineCount` were stale at 289, and all 7 sections lagged ~30-50 lines behind the actual `-- ## -/` banners (e.g. "Hajnal's Conjecture" tagged 79-91 vs actual 111-124). Remapped every range to the banners/declarations and fixed both stale lineCount fields → 319.

## Verification
- Both files now cover their full source contiguously (tail gap 0, no internal gaps).
- Counts unchanged and correct: erdos-895 = 18 thm / 14 def / 0 ax / 3 sorries; oq-01 = 13 thm / 6 def / 1 ax / 0 sorries.
- JSON validated for both; only `sections` (and the two stale lineCount fields on oq-01) changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)