### PR TITLE
research(central-limit-theorem-oq-01-oq-01-oq-04): realign drifted sections + fix stale axiom prose

### DIFF
--- a/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
+++ b/src/data/proofs/central-limit-theorem-oq-01-oq-01-oq-04/meta.json
@@ -65,51 +65,51 @@
     {
       "id": "definitions",
       "title": "Multivariate Setup and Definitions",
-      "startLine": 37,
-      "endLine": 82,
+      "startLine": 38,
+      "endLine": 83,
       "summary": "Defines quadForm (quadratic form ξᵀΣξ), vecInner (dot product), gaussCharFun (Gaussian characteristic function), IsOperatorStable (existence of matrix normalizations), HasScalarExponent (scalar n^{-c}·I case), and InOperatorDomainOfAttraction."
     },
     {
       "id": "quadform",
       "title": "Quadratic Form Lemmas",
       "startLine": 84,
-      "endLine": 130,
+      "endLine": 145,
       "summary": "Proves quadForm_scale (scaling by c gives c² factor) and the key lemma quadForm_scale_inv_sqrt: quadForm(ξ/√n) = (1/n)·quadForm(ξ). Also proves gaussCharFun_zero (= 1 at origin) and gaussCharFun_norm_le_one (S6 ACT discharge: |φ_Σ| ≤ 1 for PosSemidef Σ via PosSemidef.dotProduct_mulVec_nonneg + Complex.norm_exp_ofReal + Real.exp_le_one_iff)."
     },
     {
       "id": "gaussian",
       "title": "Gaussian Operator-Stability",
-      "startLine": 132,
-      "endLine": 175,
-      "summary": "Proves exp_neg_div_pow (core identity) and gaussian_operator_stable (main result: (φ_Σ(ξ/√n))^n = φ_Σ(ξ)). Axiomatizes gaussian_has_scalar_exponent and gaussian_is_operator_stable at Mathlib v4.26.0 — their original v4.25 proofs used Real.rpow_one_div_eq_pow_inv (renamed) and a conv-mode ext block (no longer valid)."
+      "startLine": 146,
+      "endLine": 234,
+      "summary": "Proves exp_neg_div_pow (core identity (exp(-x/n))^n = exp(-x)) and gaussian_operator_stable ((φ_Σ(ξ/√n))^n = φ_Σ(ξ)). gaussian_has_scalar_exponent (scalar exponent c = 1/2, zero drift) and gaussian_is_operator_stable (matrix-witness form, A_n = n^{-1/2}·I) are fully PROVED here — discharging the former Mathlib-v4.26.0 axiomatized versions."
     },
     {
       "id": "scalar",
       "title": "Scalar Specialization and 1D Connection",
-      "startLine": 177,
-      "endLine": 220,
+      "startLine": 235,
+      "endLine": 298,
       "summary": "Defines univariateEmbed (1D → R^1 embedding), proves univariate_embed_stable and alpha_stable_is_operator_stable (1D α-stable embeds as HasScalarExponent(1/α)). Connects to parent file's stableCharFun and DomainOfAttraction framework."
     },
     {
       "id": "structural",
       "title": "Structural Properties",
-      "startLine": 222,
-      "endLine": 245,
+      "startLine": 299,
+      "endLine": 360,
       "summary": "Proves operator_stable_linear_image (closure under invertible linear images — Meerschaert-Scheffler 2001 Thm 7.2.1; discharged from axiom to theorem in S17 ACT 2026-06-12 via the conjugation/transpose witness A'ₙ = B⁻¹AₙB, b'ₙ = Bᵀbₙ under an [Invertible B] hypothesis) and const_one_is_operator_stable (trivial example)."
     },
     {
       "id": "axioms",
       "title": "Axiomatized Hard Results",
-      "startLine": 247,
-      "endLine": 295,
-      "summary": "Axiom scalar_exponent_ge_half: scalar-exponent operator-stable laws have c ≥ 1/2 (Hudson-Mason 1982, scalar specialization — replaces the matrix-eigenvalue form whose statement required Matrix.eigenvalues, removed in Mathlib v4.26.0). Axiom meerschaert_scheffler: domain of attraction ↔ matrix regular variation (MS 2001)."
+      "startLine": 361,
+      "endLine": 420,
+      "summary": "scalar_exponent_ge_half (Hudson–Mason 1982 scalar bound c ≥ 1/2) is now a THEOREM, but vacuously proved: its non-degeneracy hypothesis hnd is logically unsatisfiable (instantiating at v = 0 gives False) — an S14-ACT bug report flagging the encoding for a future genuine non-degeneracy hypothesis. The only real axiom is meerschaert_scheffler (the ℝ^d Meerschaert–Scheffler domain-of-attraction biconditional, the Gnedenko–Kolmogorov generalization)."
     },
     {
       "id": "corollaries",
       "title": "Classical Limit Theorems as Corollaries",
-      "startLine": 297,
-      "endLine": 322,
-      "summary": "Axiomatizes gaussian_in_own_doa (Gaussian is in its own DOA — the multivariate CLT) and finite_cov_in_gaussian_doa (finite-cov → Gaussian DOA). Both axiomatized at Mathlib v4.26.0 — the original proofs invoked Filter.tendsto_const_nhds on a function-valued sequence that is only pointwise constant, which v4.26.0's stricter elaborator no longer accepts."
+      "startLine": 421,
+      "endLine": 529,
+      "summary": "gaussian_in_own_doa (the Gaussian lies in its own operator domain of attraction — multivariate CLT self-similarity) and finite_cov_in_gaussian_doa are both PROVED here (S15/S16 ACT), discharging the former v4.26.0 axiomatized versions; finite_cov_in_gaussian_doa is a vacuous discharge via the degenerate const-1 witness, flagged as a too-weak-hypothesis bug report awaiting a genuine finite-covariance condition."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary
- The gallery `meta.json` for **central-limit-theorem-oq-01-oq-01-oq-04** (multivariate operator-stable distributions) had two drift problems in `CentralLimitTheoremOQ01OQ01OQ04.lean` (529 lines):
  - Section ranges **lagged the `-- PART` banners by ~100 lines** from section 2 onward, hiding the file tail (sections stopped at line **322 of 529**).
  - Several summaries still claimed **"Axiomatizes"** for results that have since been discharged to proved theorems. The file now has **1 axiom** (`meerschaert_scheffler`); `leanFile.axiomCount` agrees.

## Fix
Realigned all 7 sections to PART I–VII and corrected the axiom prose:
| Result | Status in file |
|--------|----------------|
| `gaussian_has_scalar_exponent`, `gaussian_is_operator_stable` (PART III) | **proved** |
| `scalar_exponent_ge_half` (PART VI) | now a **vacuously-proved theorem** (S14 ACT bug report) |
| `gaussian_in_own_doa`, `finite_cov_in_gaussian_doa` (PART VII) | **proved** (S15/S16 ACT) |
| `meerschaert_scheffler` (PART VI) | the one remaining **axiom** |

## Test plan
- [x] Section ranges map to the `-- PART` banners in the source
- [x] Counts correct (0 sorries, 1 axiom, 15 theorems, 7 defs)
- [x] Non-section meta keys verified byte-identical
- [x] Build-free metadata-only change