### PR TITLE
Enrich erdos-1167: realign drifted gallery sections to full file (7→7) + fix stale axiom prose

### DIFF
--- a/src/data/proofs/erdos-1167/meta.json
+++ b/src/data/proofs/erdos-1167/meta.json
@@ -98,50 +98,57 @@
       "id": "header-imports",
       "title": "Problem Statement and Imports",
       "startLine": 1,
-      "endLine": 52,
-      "summary": "Documentation header describing the stepping-down conjecture, its background in partition calculus, known partial results (Erdős-Rado, infinite Ramsey), and imports from Mathlib for cardinal/ordinal theory and tactics."
+      "endLine": 56,
+      "summary": "Documentation header describing the stepping-down conjecture 2^λ → (κ_α + 1)^{r+1} ⟹ λ → (κ_α)^r, its background in partition calculus, known partial results (Erdős-Rado, infinite Ramsey), and the formalization plan. Imports Mathlib cardinal/ordinal theory and tactics, sets linter options, opens namespace Erdos1167 and the Cardinal/Set namespaces.",
+      "mathContext": "Partition arrow: $\\kappa \\to (\\lambda_\\alpha)^r_{\\alpha<\\gamma}$ means every $\\gamma$-coloring of $[\\kappa]^r$ admits $\\alpha<\\gamma$ and $H\\subseteq\\kappa$ with $|H|\\ge\\lambda_\\alpha$ monochromatic in color $\\alpha$."
     },
     {
       "id": "core-defs",
       "title": "Core Definitions",
-      "startLine": 53,
+      "startLine": 57,
       "endLine": 91,
-      "summary": "Defines RSubset (r-element subsets), Coloring (functions from r-subsets to colors), IsMonochromatic (uniformity of color), PartitionRelation (uniform κ → (λ)^r_γ), and IndexedPartitionRelation (indexed κ → (κ_i)^r_{i<γ})."
+      "summary": "Defines RSubset (r-element subsets as a Finset subtype), Coloring (functions from r-subsets to colors), IsMonochromatic (uniformity of color over a set), PartitionRelation (uniform κ → (λ)^r_γ), and IndexedPartitionRelation (indexed κ → (κ_i)^r_{i<γ} with per-color targets).",
+      "mathContext": "$[\\alpha]^r = \\{s \\subseteq \\alpha : |s| = r\\}$; a coloring is $f : [\\alpha]^r \\to \\gamma$; $H$ is monochromatic of color $c$ iff $f(s)=c$ for all $s\\in[H]^r$."
     },
     {
       "id": "structural-props",
-      "title": "Structural Properties",
+      "title": "Section 1 — Structural Properties of Partition Relations",
       "startLine": 92,
       "endLine": 161,
-      "summary": "Five fully-proved lemmas: partition_one_color (1-color triviality), partition_monotone_target (target weakening), partition_zero_target (empty set), indexed_partition_monotone_targets (indexed weakening), isMonochromatic_subset (hereditary property)."
+      "summary": "Five fully-proved lemmas: partition_one_color (1-color triviality, whole set monochromatic), partition_monotone_target (weakening the target size), partition_zero_target (the empty set is vacuously monochromatic for r>0), indexed_partition_monotone_targets (weakening indexed targets), and isMonochromatic_subset (monochromaticity is hereditary under subsets).",
+      "mathContext": "If $\\kappa \\to (\\lambda)^r_\\gamma$ and $\\lambda' \\le \\lambda$ then $\\kappa \\to (\\lambda')^r_\\gamma$; subsets of monochromatic sets remain monochromatic."
     },
     {
       "id": "cardinal-arithmetic",
-      "title": "Cardinal Arithmetic for Partition Relations",
+      "title": "Section 2 — Cardinal Arithmetic for Partition Relations",
       "startLine": 162,
       "endLine": 209,
-      "summary": "Proves infinite_card_add_one (κ+1=κ for infinite κ), finite_card_add_one (n+1 genuinely larger), conjecture_simplifies_infinite_targets (+1 absorbed for infinite targets), and two_pow_infinite (2^λ ≥ ℵ₀)."
+      "summary": "Proves infinite_card_add_one (κ+1=κ for infinite κ, via Cardinal.add_eq_self), finite_card_add_one (n+1 genuinely larger for naturals), conjecture_simplifies_infinite_targets (the '+1' is absorbed when all targets are infinite), and two_pow_infinite (2^λ ≥ ℵ₀ via Cantor). These pin down exactly when the '+1' in the conjecture's hypothesis is meaningful.",
+      "mathContext": "For infinite $\\kappa$: $\\kappa + 1 = \\kappa$; for finite $n$: $n+1 > n$; and $\\aleph_0 \\le \\lambda \\Rightarrow \\aleph_0 \\le 2^\\lambda$."
     },
     {
       "id": "conjecture-and-results",
-      "title": "The Conjecture and Known Results",
+      "title": "Section 3 — The Conjecture and Remaining Axioms",
       "startLine": 210,
-      "endLine": 245,
-      "summary": "States the open conjecture as an axiom (erdos_1167_conjecture). Axiomatizes the infinite Ramsey theorem (ℵ₀ → (ℵ₀)^r_k) and the Erdős-Rado theorem ((2^κ)⁺ → (κ⁺)²_κ) as reference points."
+      "endLine": 231,
+      "summary": "Declares the two remaining axioms: erdos_1167_conjecture (the OPEN stepping-down implication 2^λ → (κ_α+1)^{r+1} ⟹ λ → (κ_α)^r) and erdos_rado_theorem (the classical 1956 stepping-up result (2^κ)⁺ → (κ⁺)²_κ). These are the only assumptions in the file; the infinite Ramsey theorem is NOT axiomatized here — it is proved in Section 4.",
+      "mathContext": "Open conjecture: $2^\\lambda \\to (\\kappa_\\alpha+1)^{r+1}_{\\alpha<\\gamma} \\implies \\lambda \\to (\\kappa_\\alpha)^r_{\\alpha<\\gamma}$. Erdős–Rado: $(2^\\kappa)^+ \\to (\\kappa^+)^2_\\kappa$."
+    },
+    {
+      "id": "infinite-ramsey",
+      "title": "Section 4 — The Infinite Ramsey Theorem (Proved)",
+      "startLine": 232,
+      "endLine": 549,
+      "summary": "Fully proves (0 sorries) the infinite Ramsey theorem ℵ₀ → (ℵ₀)^r_k for all finite r, k, eliminating the former axiom. Base cases: infinite_ramsey_zero (r=0, unique empty subset) and infinite_ramsey_one (r=1, infinite pigeonhole via Finite.exists_infinite_fiber). The private lemma ramsey_step performs one diagonal extraction: fix a vertex v of the infinite set, build the reduced r-coloring g(T)=f({v}∪T) on a subtype of S∖{v}, apply the IH, and transfer the monochromatic subset back to the ambient type (the delicate subtype-lifting argument). The main theorem infinite_ramsey then iterates ramsey_step via Nat.rec to build a sequence of (vertex, color) pairs, proves the vertex map injective, applies pigeonhole on the finitely many colors to get an infinite fiber, and assembles the monochromatic set H = vertex '' {n | color n = c*}.",
+      "mathContext": "$\\aleph_0 \\to (\\aleph_0)^r_k$ by induction on $r$: the diagonal argument reduces an $(r{+}1)$-coloring on an infinite set to an $r$-coloring on a subtype, iterating to a vertex/color sequence, then pigeonholes the colors into an infinite monochromatic subsequence."
     },
     {
       "id": "consequences",
-      "title": "Consequences and Consistency Checks",
-      "startLine": 246,
-      "endLine": 289,
-      "summary": "Proves the r=2 case instantiation, general r case, consistency with Ramsey (pairs, triples), and Erdős-Rado weakening via target monotonicity."
-    },
-    {
-      "id": "provable-ramsey",
-      "title": "Provable Cases of Infinite Ramsey",
-      "startLine": 290,
-      "endLine": 351,
-      "summary": "Proves the r=0 and r=1 cases of the infinite Ramsey theorem from first principles. The r=0 case is trivial (unique 0-subset). The r=1 case uses the infinite pigeonhole principle via Finite.exists_infinite_fiber. Demonstrates the axiom is only needed for r >= 2."
+      "title": "Section 5 — Consequences and Consistency Checks",
+      "startLine": 550,
+      "endLine": 594,
+      "summary": "Derives corollaries of the conjecture and Ramsey theorem: erdos_1167_r2_case (the r=2 instantiation), erdos_1167_general_case (any r≥2), conjecture_consistent_aleph0 and ramsey_pairs/ramsey_triples_two_colors (consistency: ℵ₀ → (ℵ₀)²_k and ℵ₀ → (ℵ₀)³_2 hold by the proved infinite Ramsey theorem), and erdos_rado_weakened (weakening the Erdős-Rado target via partition_monotone_target). Closes the namespace.",
+      "mathContext": "Concrete instances: $\\aleph_0 \\to (\\aleph_0)^2_k$ and $\\aleph_0 \\to (\\aleph_0)^3_2$ from infinite Ramsey; $(2^\\kappa)^+ \\to (\\kappa)^2_\\kappa$ by target monotonicity from Erdős–Rado."
     }
   ],
   "conclusion": {


### PR DESCRIPTION
## Summary

The `sections` array in `erdos-1167/meta.json` had drifted from an older, shorter revision of `Proofs/Erdos1167Problem.lean`. Coverage stopped at line **351 of 594**, and the section labels no longer matched the file's own `## Section N` markers:

- The full `infinite_ramsey` proof (lines 370-548) — the file's largest result, which **eliminated the former Ramsey axiom** — was entirely hidden.
- The real "Consequences and Consistency Checks" lives at 550-593, but the section with that title was pointed at 246-289 (which actually contains the Infinite Ramsey base lemmas).

## Changes

- Realigned all 7 sections to the file's **Section 1-5** structure; now contiguous, covering lines 1-594.
- Surfaced **Section 4 — The Infinite Ramsey Theorem (Proved)** as its own section (was invisible), with a summary of the diagonal-argument proof (base cases, `ramsey_step` subtype lifting, iteration + pigeonhole).
- **Fixed stale prose**: the Section 3 summary claimed the infinite Ramsey theorem is *axiomatized* — it is **proved** in Section 4. Only **2 axioms** remain (`erdos_1167_conjecture`, `erdos_rado_theorem`), consistent with `axiomCount: 2`.
- Added `mathContext` to every section.

Only `sections` changed; all other meta.json content is byte-identical to `origin/main`. Counts (19 theorems / 5 definitions / 2 axioms / 0 sorries) verified correct against the source.

## Validation

`pnpm research:build` exits 0 (accepts meta.json). Full `pnpm build` is not runnable in the linked worktree (no local node_modules for the `tsc`/`vite` step); per-proof JSON is fetched at runtime so that step does not affect this metadata change.